### PR TITLE
Add npm install to demo instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See
 This repository ships with a pre-built demo that you can just run!
 
 1. Clone this repo
-2. Run `npm run dev`
+2. Run `npm install && npm run dev`
 3. Visit http://127.0.0.1:8777/
 
 If you want to build the assembly yourself, follow the instructions below.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "waasm-wordpress",
+  "name": "wasm-wordpress",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",


### PR DESCRIPTION
I noticed the README was missing a step, to install node modules before starting the `dev` script for the demo.