### PR TITLE
[Build] Configurable WordPress zip URL

### DIFF
--- a/wasm-build/wordpress-data/prepare-wordpress.sh
+++ b/wasm-build/wordpress-data/prepare-wordpress.sh
@@ -9,10 +9,10 @@ rm -rf wordpress
 rm -rf wordpress-static
 
 # Download specific version of WordPress
-wp_tarfile=wordpress-6.0.2.tar.gz
-wget https://wordpress.org/$wp_tarfile
-tar -xzf $wp_tarfile
-rm $wp_tarfile
+wp_zip_url=${1:-${WP_URL:-https://wordpress.org/wordpress-6.0.2.zip}}
+wget -O wp.zip $wp_zip_url
+unzip wp.zip
+rm wp.zip
 
 # Patch WordPress with sqlite support
 # https://github.com/aaemnnosttv/wp-sqlite-integration


### PR DESCRIPTION
## Description

This PR enables providing a custom bundle URL when bundling WordPress into a `.data` file. Solves #29.

The URL can be provided either as a first CLI arg:

```sh
bash prepare-wordpress.sh https://wordpress.org/nightly-builds/wordpress-latest.zip
```

Or via the WP_URL env variable:

```sh
WP_URL=https://wordpress.org/nightly-builds/wordpress-latest.zip bash prepare-wordpress.sh

# Combined with the build:wp npm script:
WP_URL=https://wordpress.org/nightly-builds/wordpress-latest.zip npm run build:wp
```

If both are provided, the CLI arg wins.