### PR TITLE
Scoped WordPress instances to support multiple browser tabs 

### DIFF
--- a/dist-web/app.js
+++ b/dist-web/app.js
@@ -44,7 +44,9 @@
       alert("Service workers are not supported in this browser.");
       throw new Exception("Service workers are not supported in this browser.");
     }
-    await navigator.serviceWorker.register(url);
+    await navigator.serviceWorker.register(url, {
+      scope: "./subdirectory"
+    });
     const serviceWorkerChannel = new BroadcastChannel("wordpress-service-worker");
     serviceWorkerChannel.addEventListener("message", async function onMessage(event) {
       console.debug(`[Main] "${event.data.type}" message received from a service worker`);
@@ -67,10 +69,6 @@
     navigator.serviceWorker.startMessages();
     await sleep(0);
     const wordPressDomain = new URL(url).origin;
-    const response = await fetch(`${wordPressDomain}/wp-admin/atomlib.php`);
-    if (!response.ok) {
-      window.location.reload();
-    }
   }
   async function createWordPressWorker({ backend, wordPressSiteUrl: wordPressSiteUrl2 }) {
     while (true) {
@@ -156,7 +154,7 @@
     const wasmWorker = await createWordPressWorker(
       {
         backend: getWorkerBackend(wasmWorkerBackend, wasmWorkerUrl),
-        wordPressSiteUrl
+        wordPressSiteUrl: wordPressSiteUrl + "/subdirectory"
       }
     );
     await registerServiceWorker(
@@ -166,7 +164,7 @@
       }
     );
     console.log("[Main] Workers are ready");
-    document.querySelector("#wp").src = "/wp-login.php";
+    document.querySelector("#wp").src = "/subdirectory/wp-login.php";
   }
   init();
 })();

--- a/dist-web/service-worker.js
+++ b/dist-web/service-worker.js
@@ -38,49 +38,83 @@
   self.addEventListener("fetch", (event) => {
     const url = new URL(event.request.url);
     const isWpOrgRequest = url.hostname.includes("api.wordpress.org");
-    const isPHPRequest = url.pathname.endsWith("/") && url.pathname !== "/" || url.pathname.endsWith(".php");
-    if (isWpOrgRequest || !isPHPRequest) {
+    if (isWpOrgRequest) {
       console.log(`[ServiceWorker] Ignoring request: ${url.pathname}`);
-      return;
     }
-    event.preventDefault();
-    return event.respondWith(
-      new Promise(async (accept) => {
-        console.log(`[ServiceWorker] Serving request: ${url.pathname}?${url.search}`);
-        console.log({ isWpOrgRequest, isPHPRequest });
-        const post = await parsePost(event.request);
-        const requestHeaders = {};
-        for (const pair of event.request.headers.entries()) {
-          requestHeaders[pair[0]] = pair[1];
-        }
-        let wpResponse;
-        try {
-          const message = {
-            type: "httpRequest",
-            request: {
-              path: url.pathname + url.search,
-              method: event.request.method,
-              _POST: post,
-              headers: requestHeaders
-            }
-          };
-          console.log("[ServiceWorker] Forwarding a request to the main app", { message });
-          const messageId = postMessageExpectReply(broadcastChannel, message);
-          wpResponse = await awaitReply(broadcastChannel, messageId);
-          console.log("[ServiceWorker] Response received from the main app", { wpResponse });
-        } catch (e) {
-          console.error(e);
-          throw e;
-        }
-        accept(new Response(
-          wpResponse.body,
-          {
-            headers: wpResponse.headers
+    const isPHPRequest = url.pathname.endsWith("/") && url.pathname !== "/" || url.pathname.endsWith(".php");
+    if (isPHPRequest) {
+      event.preventDefault();
+      return event.respondWith(
+        new Promise(async (accept) => {
+          console.log(`[ServiceWorker] Serving request: ${url.pathname}?${url.search}`);
+          console.log({ isWpOrgRequest, isPHPRequest });
+          const post = await parsePost(event.request);
+          const requestHeaders = {};
+          for (const pair of event.request.headers.entries()) {
+            requestHeaders[pair[0]] = pair[1];
           }
-        ));
-      })
-    );
+          let wpResponse;
+          try {
+            const message = {
+              type: "httpRequest",
+              request: {
+                path: url.pathname + url.search,
+                method: event.request.method,
+                _POST: post,
+                headers: requestHeaders
+              }
+            };
+            console.log("[ServiceWorker] Forwarding a request to the main app", { message });
+            const messageId = postMessageExpectReply(broadcastChannel, message);
+            wpResponse = await awaitReply(broadcastChannel, messageId);
+            console.log("[ServiceWorker] Response received from the main app", { wpResponse });
+          } catch (e) {
+            console.error(e);
+            throw e;
+          }
+          accept(new Response(
+            wpResponse.body,
+            {
+              headers: wpResponse.headers
+            }
+          ));
+        })
+      );
+    }
+    const isStaticFileRequest = url.pathname.startsWith("/subdirectory/");
+    if (isStaticFileRequest) {
+      const scopedUrl = url + "";
+      url.pathname = url.pathname.substr("/subdirectory".length);
+      const serverUrl = url + "";
+      console.log(`[ServiceWorker] Rerouting static request from ${scopedUrl} to ${serverUrl}`);
+      event.preventDefault();
+      return event.respondWith(
+        new Promise(async (accept) => {
+          const newRequest = await cloneRequest(event.request, {
+            url: serverUrl
+          });
+          accept(fetch(newRequest));
+        })
+      );
+    }
+    console.log(`[ServiceWorker] Ignoring a request to ${event.request.url}`);
   });
+  async function cloneRequest(request, overrides) {
+    const body = ["GET", "HEAD"].includes(request.method) || "body" in overrides ? void 0 : await r.blob();
+    return new Request(overrides.url || request.url, {
+      body,
+      method: request.method,
+      headers: request.headers,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      mode: request.mode,
+      credentials: request.credentials,
+      cache: request.cache,
+      redirect: request.redirect,
+      integrity: request.integrity,
+      ...overrides
+    });
+  }
   async function parsePost(request) {
     if (request.method !== "POST") {
       return void 0;

--- a/dist-web/service-worker.js
+++ b/dist-web/service-worker.js
@@ -31,7 +31,9 @@
   }
 
   // src/web/service-worker.js
-  var broadcastChannel = new BroadcastChannel("wordpress-service-worker");
+  var pathname = new URL(self.registration.scope).pathname;
+  var workerScope = pathname.replace(/\/+$/, "");
+  var broadcastChannel = new BroadcastChannel(`wordpress-service-worker-${pathname}`);
   self.addEventListener("activate", (event) => {
     event.waitUntil(clients.claim());
   });
@@ -81,10 +83,10 @@
         })
       );
     }
-    const isStaticFileRequest = url.pathname.startsWith("/subdirectory/");
+    const isStaticFileRequest = url.pathname.startsWith(`${workerScope}/`);
     if (isStaticFileRequest) {
       const scopedUrl = url + "";
-      url.pathname = url.pathname.substr("/subdirectory".length);
+      url.pathname = url.pathname.substr(workerScope.length);
       const serverUrl = url + "";
       console.log(`[ServiceWorker] Rerouting static request from ${scopedUrl} to ${serverUrl}`);
       event.preventDefault();

--- a/dist-web/wasm-worker.js
+++ b/dist-web/wasm-worker.js
@@ -96,7 +96,8 @@
     SCHEMA = "http";
     HOSTNAME = "localhost";
     PORT = 80;
-    HOST = ``;
+    HOST = "";
+    PATHNAME = "";
     ABSOLUTE_URL = ``;
     constructor(php) {
       this.php = php;
@@ -111,7 +112,8 @@
       this.PORT = url.port ? url.port : url.protocol === "https:" ? 443 : 80;
       this.SCHEMA = (url.protocol || "").replace(":", "");
       this.HOST = `${this.HOSTNAME}:${this.PORT}`;
-      this.ABSOLUTE_URL = `${this.SCHEMA}://${this.HOSTNAME}:${this.PORT}/subdirectory`;
+      this.PATHNAME = url.pathname.replace(/\/+$/, "");
+      this.ABSOLUTE_URL = `${this.SCHEMA}://${this.HOSTNAME}:${this.PORT}${this.PATHNAME}`;
       await this.php.refresh();
       const result = await this.php.run(`<?php
 			${this._setupErrorReportingCode()}
@@ -135,7 +137,7 @@
       const output = await this.php.run(`<?php
 			${this._setupErrorReportingCode()}
 			${this._setupRequestCode(request)}
-			${this._runWordPressCode(request.path.replace("/subdirectory", ""))}
+			${this._runWordPressCode(request.path)}
 		`);
       return this.parseResponse(output);
     }
@@ -411,6 +413,9 @@ ADMIN;
     }
     _runWordPressCode(requestPath) {
       let filePath = requestPath;
+      if (this.PATHNAME) {
+        filePath = filePath.substr(this.PATHNAME.length);
+      }
       if (filePath.includes(".php")) {
         filePath = filePath.split(".php")[0] + ".php";
       } else {

--- a/dist-web/wasm-worker.js
+++ b/dist-web/wasm-worker.js
@@ -111,7 +111,7 @@
       this.PORT = url.port ? url.port : url.protocol === "https:" ? 443 : 80;
       this.SCHEMA = (url.protocol || "").replace(":", "");
       this.HOST = `${this.HOSTNAME}:${this.PORT}`;
-      this.ABSOLUTE_URL = `${this.SCHEMA}://${this.HOSTNAME}:${this.PORT}`;
+      this.ABSOLUTE_URL = `${this.SCHEMA}://${this.HOSTNAME}:${this.PORT}/subdirectory`;
       await this.php.refresh();
       const result = await this.php.run(`<?php
 			${this._setupErrorReportingCode()}
@@ -135,7 +135,7 @@
       const output = await this.php.run(`<?php
 			${this._setupErrorReportingCode()}
 			${this._setupRequestCode(request)}
-			${this._runWordPressCode(request.path)}
+			${this._runWordPressCode(request.path.replace("/subdirectory", ""))}
 		`);
       return this.parseResponse(output);
     }

--- a/src/shared/wordpress.mjs
+++ b/src/shared/wordpress.mjs
@@ -30,7 +30,7 @@ export default class WordPress {
 		this.PORT = url.port ? url.port : url.protocol === 'https:' ? 443 : 80;
 		this.SCHEMA = ( url.protocol || '' ).replace( ':', '' );
 		this.HOST = `${ this.HOSTNAME }:${ this.PORT }`;
-		this.ABSOLUTE_URL = `${ this.SCHEMA }://${ this.HOSTNAME }:${ this.PORT }`;
+		this.ABSOLUTE_URL = `${ this.SCHEMA }://${ this.HOSTNAME }:${ this.PORT }/subdirectory`;
 
 		await this.php.refresh();
 
@@ -58,7 +58,7 @@ export default class WordPress {
 		const output = await this.php.run( `<?php
 			${ this._setupErrorReportingCode() }
 			${ this._setupRequestCode( request ) }
-			${ this._runWordPressCode( request.path ) }
+			${ this._runWordPressCode( request.path.replace('/subdirectory', '') ) }
 		` );
 		return this.parseResponse( output );
 	}

--- a/src/shared/wordpress.mjs
+++ b/src/shared/wordpress.mjs
@@ -13,7 +13,8 @@ export default class WordPress {
 	SCHEMA = 'http';
 	HOSTNAME = 'localhost';
 	PORT = 80;
-	HOST = ``;
+	HOST = '';
+	PATHNAME = '';
 	ABSOLUTE_URL = ``;
 
 	constructor( php ) {
@@ -25,12 +26,13 @@ export default class WordPress {
 			useFetchForRequests: false,
 			...options
 		}
-		const url = new URL( urlString );
+		const url = new URL(urlString);
 		this.HOSTNAME = url.hostname;
 		this.PORT = url.port ? url.port : url.protocol === 'https:' ? 443 : 80;
 		this.SCHEMA = ( url.protocol || '' ).replace( ':', '' );
 		this.HOST = `${ this.HOSTNAME }:${ this.PORT }`;
-		this.ABSOLUTE_URL = `${ this.SCHEMA }://${ this.HOSTNAME }:${ this.PORT }/subdirectory`;
+		this.PATHNAME = url.pathname.replace(/\/+$/, '');
+		this.ABSOLUTE_URL = `${this.SCHEMA}://${this.HOSTNAME}:${this.PORT}${this.PATHNAME}`;
 
 		await this.php.refresh();
 
@@ -58,7 +60,7 @@ export default class WordPress {
 		const output = await this.php.run( `<?php
 			${ this._setupErrorReportingCode() }
 			${ this._setupRequestCode( request ) }
-			${ this._runWordPressCode( request.path.replace('/subdirectory', '') ) }
+			${ this._runWordPressCode( request.path ) }
 		` );
 		return this.parseResponse( output );
 	}
@@ -335,6 +337,9 @@ ADMIN;
 	_runWordPressCode( requestPath ) {
 		// Resolve the .php file the request should target.
 		let filePath = requestPath;
+		if (this.PATHNAME) {
+			filePath = filePath.substr( this.PATHNAME.length );
+		}
 
 		// If the path mentions a .php extension, that's our file's path.
 		if(filePath.includes(".php")) {

--- a/src/web/app.mjs
+++ b/src/web/app.mjs
@@ -4,26 +4,24 @@ import { wordPressSiteUrl, serviceWorkerUrl, wasmWorkerUrl, wasmWorkerBackend } 
 async function init() {
 	console.log("[Main] Initializing the workers")
 
-	const tabId = Math.random().toFixed(16);
-	const subdirectory = `/${tabId}`;
+	const tabScope = Math.random().toFixed(16);
 	
-	const wasmWorker = await createWordPressWorker(
-		{
-			backend: getWorkerBackend( wasmWorkerBackend, wasmWorkerUrl ),
-			wordPressSiteUrl: wordPressSiteUrl + subdirectory
-		}
-	);
-	await registerServiceWorker(
-		serviceWorkerUrl,
+	const wasmWorker = await createWordPressWorker({
+		backend: getWorkerBackend( wasmWorkerBackend, wasmWorkerUrl ),
+		wordPressSiteUrl: wordPressSiteUrl,
+		scope: tabScope
+	});
+	await registerServiceWorker({
+		url: serviceWorkerUrl,
 		// Forward any HTTP requests to a worker to resolve them in another process.
 		// This way they won't slow down the UI interactions.
-		async (request) => {
+		onRequest: async (request) => {
 			return await wasmWorker.HTTPRequest(request);
 		},
-		subdirectory
-	);
+		scope: tabScope
+	});
     console.log("[Main] Workers are ready")
 
-	document.querySelector('#wp').src = `${subdirectory}/wp-login.php`;
+	document.querySelector('#wp').src = wasmWorker.urlFor(`/wp-login.php`);
 }
 init();

--- a/src/web/app.mjs
+++ b/src/web/app.mjs
@@ -7,7 +7,7 @@ async function init() {
 	const wasmWorker = await createWordPressWorker(
 		{
 			backend: getWorkerBackend( wasmWorkerBackend, wasmWorkerUrl ),
-			wordPressSiteUrl: wordPressSiteUrl
+			wordPressSiteUrl: wordPressSiteUrl + '/subdirectory'
 		}
 	);
 	await registerServiceWorker(
@@ -20,6 +20,6 @@ async function init() {
 	);
     console.log("[Main] Workers are ready")
 
-	document.querySelector('#wp').src = '/wp-login.php';
+	document.querySelector('#wp').src = '/subdirectory/wp-login.php';
 }
 init();

--- a/src/web/app.mjs
+++ b/src/web/app.mjs
@@ -3,11 +3,14 @@ import { wordPressSiteUrl, serviceWorkerUrl, wasmWorkerUrl, wasmWorkerBackend } 
 
 async function init() {
 	console.log("[Main] Initializing the workers")
+
+	const tabId = Math.random().toFixed(16);
+	const subdirectory = `/${tabId}`;
 	
 	const wasmWorker = await createWordPressWorker(
 		{
 			backend: getWorkerBackend( wasmWorkerBackend, wasmWorkerUrl ),
-			wordPressSiteUrl: wordPressSiteUrl + '/subdirectory'
+			wordPressSiteUrl: wordPressSiteUrl + subdirectory
 		}
 	);
 	await registerServiceWorker(
@@ -16,10 +19,11 @@ async function init() {
 		// This way they won't slow down the UI interactions.
 		async (request) => {
 			return await wasmWorker.HTTPRequest(request);
-		}
+		},
+		subdirectory
 	);
     console.log("[Main] Workers are ready")
 
-	document.querySelector('#wp').src = '/subdirectory/wp-login.php';
+	document.querySelector('#wp').src = `${subdirectory}/wp-login.php`;
 }
 init();

--- a/src/web/library.js
+++ b/src/web/library.js
@@ -4,15 +4,15 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, 50));
 
 // <SERVICE WORKER>
 // Register the service worker and handle any HTTP WordPress requests it provides us:
-export async function registerServiceWorker(url, onRequest) {
+export async function registerServiceWorker(url, onRequest, scope = '') {
 	if ( ! navigator.serviceWorker ) {
 		alert('Service workers are not supported in this browser.');
 		throw new Exception('Service workers are not supported in this browser.');
 	}
 	await navigator.serviceWorker.register(url, {
-		scope: './subdirectory'
+		scope
 	});
-	const serviceWorkerChannel = new BroadcastChannel('wordpress-service-worker');
+	const serviceWorkerChannel = new BroadcastChannel(`wordpress-service-worker-${scope}`);
 	serviceWorkerChannel.addEventListener('message', async function onMessage(event) {
 		console.debug(`[Main] "${event.data.type}" message received from a service worker`);
 

--- a/src/web/library.js
+++ b/src/web/library.js
@@ -9,7 +9,9 @@ export async function registerServiceWorker(url, onRequest) {
 		alert('Service workers are not supported in this browser.');
 		throw new Exception('Service workers are not supported in this browser.');
 	}
-	await navigator.serviceWorker.register(url);
+	await navigator.serviceWorker.register(url, {
+		scope: './subdirectory'
+	});
 	const serviceWorkerChannel = new BroadcastChannel('wordpress-service-worker');
 	serviceWorkerChannel.addEventListener('message', async function onMessage(event) {
 		console.debug(`[Main] "${event.data.type}" message received from a service worker`);
@@ -39,11 +41,11 @@ export async function registerServiceWorker(url, onRequest) {
 	await sleep(0); 
 
 	const wordPressDomain = new URL(url).origin;
-	const response = await fetch(`${wordPressDomain}/wp-admin/atomlib.php`);
-	if (!response.ok) {
-		// The service worker did not claim this page for some reason. Let's reload.
-		window.location.reload();
-	}
+	// const response = await fetch(`${wordPressDomain}/wp-admin/atomlib.php`);
+	// if (!response.ok) {
+	// 	// The service worker did not claim this page for some reason. Let's reload.
+	// 	window.location.reload();
+	// }
 }
 // </SERVICE WORKER>
 

--- a/src/web/service-worker.js
+++ b/src/web/service-worker.js
@@ -1,6 +1,8 @@
 import { postMessageExpectReply, awaitReply } from '../shared/messaging.mjs';
 
-const broadcastChannel = new BroadcastChannel( 'wordpress-service-worker' );
+const pathname = new URL(self.registration.scope).pathname;
+const workerScope = pathname.replace(/\/+$/, '');
+const broadcastChannel = new BroadcastChannel( `wordpress-service-worker-${pathname}` );
 
 /**
  * Ensure the client gets claimed by this service worker right after the registration.
@@ -16,7 +18,7 @@ const broadcastChannel = new BroadcastChannel( 'wordpress-service-worker' );
 self.addEventListener("activate", (event) => {
 	event.waitUntil(clients.claim());
 });
-  
+
 /**
  * The main method. It captures the requests and loop them back to the main
  * application using the Loopback request
@@ -72,10 +74,10 @@ self.addEventListener('fetch', (event) => {
 		);
 	}
 
-	const isStaticFileRequest = url.pathname.startsWith('/subdirectory/');
+	const isStaticFileRequest = url.pathname.startsWith(`${workerScope}/`);
 	if (isStaticFileRequest) {
 		const scopedUrl = url + '';
-		url.pathname = url.pathname.substr('/subdirectory'.length);
+		url.pathname = url.pathname.substr(workerScope.length);
 		const serverUrl = url + '';
 		console.log(`[ServiceWorker] Rerouting static request from ${scopedUrl} to ${serverUrl}`);
 


### PR DESCRIPTION
## What problem does this PR solve?

Adds support for running WASM WordPress in multiple browser tabs and solves #9.

All WordPress requests are routed through a single service worker shared between all browser tabs. The request lifecycle looks as follows:

1. A request originates in a specific tab
2. A service worker intercepts it and requests the same tab to pass it to its WASM WordPress instance
3. The tab renders it and sends the response to the service worker
4. The service worker responds to the intercepted HTTP request using the WordPress-generated response
5. The original tab receives the WordPress-generated response and displays it to the user

It's a back-and-forth conversation between a specific browser tab and the service worker.

Unfortunately, Service workers communicate with tabs using a `BroadcastChannel` – it's a messaging strategy that routes every message to every listener. As a result, each WordPress request was rendered in every tab, often causing unexpected behaviors.

## How does this PR propose to solve it?

This PR introduces a concept of WordPress `scope` and enables the service worker to post BroadcastChannel messages scoped to specific listeners.

Scoping a WordPress instance means installing it at a unique pathname starting with `/scope:<unique number>`. For example:

* In an unscoped WordPress instance, `/wp-login.php` would be available at `http://localhost:8778/wp-login.php`
* In a scoped WordPress instance, `/wp-login.php` would be available at `http://localhost:8778/scope:96253/wp-login.php`

The scope number is a random and unique number generated by a specific browser tab. The service worker is aware of this concept and will use any `/scope:` found in the request URL to tag all the related `BroadcastChannel` communication. The WASM workers running in specific browser tabs will then ignore all the `BroadcastChannel` communication with an unfamiliar `scope` attached.

## Alternatives considered

* Using the `scope` feature of ServiceWorker – it led to multiple worker registrations and was hard to reason about.
* Loading Workers from a tab-specific unique URL, e.g. `sw.js?tab_id=432` or `sw-1.js` – it led to the same problems as relying on the `scope` feature.
* Match the request with its originating tab in the ServiceWorker – There's not enough information available. The worker can't figure out the top-level client ID from a request originating in an iframe, and the top-level client wouldn't be able to tell whether the request originated in its browsing context.
* Scoping WordPress instance by a domain, e.g. `w87953.localhost` – it  would require setting up a catch-all DNS domain to even use this project. That's a steep barrier of entry.
* Displaying an error in other browser tabs – it would be a large and unnecessary limitation.

## How to test?

Run `npm run dev` and open the WASM WordPress page in a few different browser tabs. Log in, create pages, play with it, and confirm that each tab behaves as expected. Specifically:

* No tab should unexpectedly log you in or out 
* No pages and changes should leak between the browser tabs

## Follow-up work

* If a use-case arises, a tab could use `sessionStorage` to preserve the scope across page reloads.
