### PR TITLE
Disable Site Health

### DIFF
--- a/dist-web/wasm-worker.js
+++ b/dist-web/wasm-worker.js
@@ -213,6 +213,16 @@
 "
 				);
 
+				// DISABLE SITE HEALTH:
+				file_put_contents(
+					'${this.DOCROOT}/wp-includes/default-filters.php',
+					preg_replace(
+						'!add_filter[^;]+wp_maybe_grant_site_health_caps[^;]+;!i',
+						'',
+						file_get_contents('${this.DOCROOT}/wp-includes/default-filters.php')
+					)
+				);
+
 				// WORKAROUND:
 				// The fsockopen transport erroneously reports itself as a working transport. Let's force
 				// it to report it won't work.

--- a/src/shared/wordpress.mjs
+++ b/src/shared/wordpress.mjs
@@ -137,6 +137,16 @@ export default class WordPress {
 					.'add_filter( "option_siteurl", function($url) { return getenv("HOST") ?: file_get_contents(__DIR__."/../.absolute-url"); }, 10000 );' . "\n"
 				);
 
+				// DISABLE SITE HEALTH:
+				file_put_contents(
+					'${this.DOCROOT}/wp-includes/default-filters.php',
+					preg_replace(
+						'!add_filter[^;]+wp_maybe_grant_site_health_caps[^;]+;!i',
+						'',
+						file_get_contents('${this.DOCROOT}/wp-includes/default-filters.php')
+					)
+				);
+
 				// WORKAROUND:
 				// The fsockopen transport erroneously reports itself as a working transport. Let's force
 				// it to report it won't work.


### PR DESCRIPTION
This disables Site Health by removing the wp_maybe_grant_site_health_caps filter from `user_has_cap`.

Fixes #35