### PR TITLE
Add a progress bar

### DIFF
--- a/build.js
+++ b/build.js
@@ -48,6 +48,7 @@ if (argv.platform === "browser") {
             'service-worker': './src/web/service-worker.js',
             'wasm-worker': './src/web/wasm-worker.js',
         },
+        target: ['es6', 'chrome90', 'firefox60','safari11'],
         outdir: './dist-web',
         external: ['xmlhttprequest'],
         define: {
@@ -75,4 +76,7 @@ if (argv.platform === "browser") {
     }
 }
 
-build(options).catch(() => process.exit(1))
+build(options).catch((e) => {
+    console.error(e);
+    process.exit(1)
+})

--- a/dist-web/app.js
+++ b/dist-web/app.js
@@ -1,32 +1,73 @@
 (() => {
+  var __defProp = Object.defineProperty;
+  var __defProps = Object.defineProperties;
+  var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
+  var __getOwnPropSymbols = Object.getOwnPropertySymbols;
+  var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __propIsEnum = Object.prototype.propertyIsEnumerable;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __spreadValues = (a, b) => {
+    for (var prop in b || (b = {}))
+      if (__hasOwnProp.call(b, prop))
+        __defNormalProp(a, prop, b[prop]);
+    if (__getOwnPropSymbols)
+      for (var prop of __getOwnPropSymbols(b)) {
+        if (__propIsEnum.call(b, prop))
+          __defNormalProp(a, prop, b[prop]);
+      }
+    return a;
+  };
+  var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
+  var __async = (__this, __arguments, generator) => {
+    return new Promise((resolve, reject) => {
+      var fulfilled = (value) => {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      };
+      var rejected = (value) => {
+        try {
+          step(generator.throw(value));
+        } catch (e) {
+          reject(e);
+        }
+      };
+      var step = (x) => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected);
+      step((generator = generator.apply(__this, __arguments)).next());
+    });
+  };
+
   // src/shared/messaging.mjs
   var DEFAULT_REPLY_TIMEOUT = 25e3;
   var lastMessageId = 0;
   function postMessageExpectReply(messageTarget, message, ...postMessageArgs) {
     const messageId = ++lastMessageId;
     messageTarget.postMessage(
-      {
-        ...message,
+      __spreadProps(__spreadValues({}, message), {
         messageId
-      },
+      }),
       ...postMessageArgs
     );
     return messageId;
   }
-  async function awaitReply(messageTarget, messageId, timeout = DEFAULT_REPLY_TIMEOUT) {
-    return new Promise((resolve, reject) => {
-      const responseHandler = (event) => {
-        if (event.data.type === "response" && event.data.messageId === messageId) {
+  function awaitReply(_0, _1) {
+    return __async(this, arguments, function* (messageTarget, messageId, timeout = DEFAULT_REPLY_TIMEOUT) {
+      return new Promise((resolve, reject) => {
+        const responseHandler = (event) => {
+          if (event.data.type === "response" && event.data.messageId === messageId) {
+            messageTarget.removeEventListener("message", responseHandler);
+            clearTimeout(failOntimeout);
+            resolve(event.data.result);
+          }
+        };
+        const failOntimeout = setTimeout(() => {
+          reject(new Error("Request timed out"));
           messageTarget.removeEventListener("message", responseHandler);
-          clearTimeout(failOntimeout);
-          resolve(event.data.result);
-        }
-      };
-      const failOntimeout = setTimeout(() => {
-        reject(new Error("Request timed out"));
-        messageTarget.removeEventListener("message", responseHandler);
-      }, timeout);
-      messageTarget.addEventListener("message", responseHandler);
+        }, timeout);
+        messageTarget.addEventListener("message", responseHandler);
+      });
     });
   }
   function responseTo(messageId, result) {
@@ -39,109 +80,129 @@
 
   // src/web/library.js
   var sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-  async function runWordPress({
-    wasmWorkerBackend: wasmWorkerBackend2,
-    wasmWorkerUrl: wasmWorkerUrl2,
-    wordPressSiteUrl: wordPressSiteUrl2,
-    serviceWorkerUrl: serviceWorkerUrl2,
-    assignScope = true
-  }) {
-    const scope = assignScope ? Math.random().toFixed(16) : void 0;
-    const wasmWorker = await createWordPressWorker({
-      backend: getWorkerBackend(wasmWorkerBackend2, wasmWorkerUrl2),
+  var noop = () => {
+  };
+  function runWordPress(_0) {
+    return __async(this, arguments, function* ({
+      wasmWorkerBackend: wasmWorkerBackend2,
+      wasmWorkerUrl: wasmWorkerUrl2,
       wordPressSiteUrl: wordPressSiteUrl2,
-      scope
+      serviceWorkerUrl: serviceWorkerUrl2,
+      assignScope = true,
+      onWasmDownloadProgress
+    }) {
+      const scope = assignScope ? Math.random().toFixed(16) : void 0;
+      const wasmWorker = yield createWordPressWorker({
+        backend: getWorkerBackend(wasmWorkerBackend2, wasmWorkerUrl2),
+        wordPressSiteUrl: wordPressSiteUrl2,
+        scope,
+        onDownloadProgress: onWasmDownloadProgress
+      });
+      yield registerServiceWorker({
+        url: serviceWorkerUrl2,
+        onRequest: (request) => __async(this, null, function* () {
+          return yield wasmWorker.HTTPRequest(request);
+        }),
+        scope
+      });
+      return wasmWorker;
     });
-    await registerServiceWorker({
-      url: serviceWorkerUrl2,
-      onRequest: async (request) => {
-        return await wasmWorker.HTTPRequest(request);
-      },
-      scope
-    });
-    return wasmWorker;
   }
-  async function registerServiceWorker({ url, onRequest, scope }) {
-    if (!navigator.serviceWorker) {
-      alert("Service workers are not supported in this browser.");
-      throw new Error("Service workers are not supported in this browser.");
-    }
-    await navigator.serviceWorker.register(url);
-    const serviceWorkerChannel = new BroadcastChannel(
-      `wordpress-service-worker`
-    );
-    serviceWorkerChannel.addEventListener(
-      "message",
-      async function onMessage(event) {
-        if (scope && event.data.scope !== scope) {
-          return;
-        }
-        console.debug(
-          `[Main] "${event.data.type}" message received from a service worker`
-        );
-        let result;
-        if (event.data.type === "request" || event.data.type === "httpRequest") {
-          result = await onRequest(event.data.request);
-        } else {
-          throw new Error(
-            `[Main] Unexpected message received from the service-worker: "${event.data.type}"`
-          );
-        }
-        if (event.data.messageId) {
-          serviceWorkerChannel.postMessage(
-            responseTo(event.data.messageId, result)
-          );
-        }
-        console.debug(`[Main] "${event.data.type}" message processed`, {
-          result
-        });
+  function registerServiceWorker(_0) {
+    return __async(this, arguments, function* ({ url, onRequest, scope }) {
+      if (!navigator.serviceWorker) {
+        alert("Service workers are not supported in this browser.");
+        throw new Error("Service workers are not supported in this browser.");
       }
-    );
-    navigator.serviceWorker.startMessages();
-    await sleep(0);
-    const wordPressDomain = new URL(url).origin;
-    const wordPressBaseUrl = scope ? `${wordPressDomain}/scope:${scope}` : wordPressDomain;
-    const response = await fetch(`${wordPressBaseUrl}/wp-admin/atomlib.php`);
-    if (!response.ok) {
-      window.location.reload();
-    }
-  }
-  async function createWordPressWorker({
-    backend,
-    wordPressSiteUrl: wordPressSiteUrl2,
-    scope
-  }) {
-    while (true) {
-      try {
-        await backend.sendMessage({ type: "is_alive" }, 50);
-        break;
-      } catch (e) {
+      yield navigator.serviceWorker.register(url);
+      const serviceWorkerChannel = new BroadcastChannel(
+        `wordpress-service-worker`
+      );
+      serviceWorkerChannel.addEventListener(
+        "message",
+        function onMessage(event) {
+          return __async(this, null, function* () {
+            if (scope && event.data.scope !== scope) {
+              return;
+            }
+            console.debug(
+              `[Main] "${event.data.type}" message received from a service worker`
+            );
+            let result;
+            if (event.data.type === "request" || event.data.type === "httpRequest") {
+              result = yield onRequest(event.data.request);
+            } else {
+              throw new Error(
+                `[Main] Unexpected message received from the service-worker: "${event.data.type}"`
+              );
+            }
+            if (event.data.messageId) {
+              serviceWorkerChannel.postMessage(
+                responseTo(event.data.messageId, result)
+              );
+            }
+            console.debug(`[Main] "${event.data.type}" message processed`, {
+              result
+            });
+          });
+        }
+      );
+      navigator.serviceWorker.startMessages();
+      yield sleep(0);
+      const wordPressDomain = new URL(url).origin;
+      const wordPressBaseUrl = scope ? `${wordPressDomain}/scope:${scope}` : wordPressDomain;
+      const response = yield fetch(`${wordPressBaseUrl}/wp-admin/atomlib.php`);
+      if (!response.ok) {
+        window.location.reload();
       }
-      await sleep(50);
-    }
-    const scopePath = scope ? `/scope:${scope}` : "";
-    if (scope) {
-      wordPressSiteUrl2 += scopePath;
-    }
-    await backend.sendMessage({
-      type: "initialize_wordpress",
-      siteURL: wordPressSiteUrl2
     });
-    return {
-      pathToInternalUrl(wordPressPath) {
-        return `${wordPressSiteUrl2}${wordPressPath}`;
-      },
-      internalUrlToPath(internalUrl) {
-        const url = new URL(internalUrl);
-        return url.toString().substr(url.origin.length).substr(scopePath.length);
-      },
-      async HTTPRequest(request) {
-        return await backend.sendMessage({
-          type: "request",
-          request
-        });
+  }
+  function createWordPressWorker(_0) {
+    return __async(this, arguments, function* ({
+      backend,
+      wordPressSiteUrl: wordPressSiteUrl2,
+      scope,
+      onDownloadProgress = noop
+    }) {
+      while (true) {
+        try {
+          yield backend.sendMessage({ type: "is_alive" }, 50);
+          break;
+        } catch (e) {
+        }
+        yield sleep(50);
       }
-    };
+      const scopePath = scope ? `/scope:${scope}` : "";
+      if (scope) {
+        wordPressSiteUrl2 += scopePath;
+      }
+      backend.addMessageListener((e) => {
+        if (e.data.type === "download_progress") {
+          onDownloadProgress(e.data);
+        }
+      });
+      yield backend.sendMessage({
+        type: "initialize_wordpress",
+        siteURL: wordPressSiteUrl2
+      });
+      return {
+        pathToInternalUrl(wordPressPath) {
+          return `${wordPressSiteUrl2}${wordPressPath}`;
+        },
+        internalUrlToPath(internalUrl) {
+          const url = new URL(internalUrl);
+          return url.toString().substr(url.origin.length).substr(scopePath.length);
+        },
+        HTTPRequest(request) {
+          return __async(this, null, function* () {
+            return yield backend.sendMessage({
+              type: "request",
+              request
+            });
+          });
+        }
+      };
+    });
   }
   function getWorkerBackend(key, url) {
     const backends = {
@@ -161,10 +222,15 @@
   function webWorkerBackend(workerURL) {
     const worker = new Worker(workerURL);
     return {
-      async sendMessage(message, timeout = DEFAULT_REPLY_TIMEOUT) {
-        const messageId = postMessageExpectReply(worker, message);
-        const response = await awaitReply(worker, messageId, timeout);
-        return response;
+      sendMessage(_0) {
+        return __async(this, arguments, function* (message, timeout = DEFAULT_REPLY_TIMEOUT) {
+          const messageId = postMessageExpectReply(worker, message);
+          const response = yield awaitReply(worker, messageId, timeout);
+          return response;
+        });
+      },
+      addMessageListener(listener) {
+        worker.onmessage = listener;
       }
     };
   }
@@ -172,10 +238,15 @@
     const worker = new SharedWorker(workerURL);
     worker.port.start();
     return {
-      async sendMessage(message, timeout = DEFAULT_REPLY_TIMEOUT) {
-        const messageId = postMessageExpectReply(worker.port, message);
-        const response = await awaitReply(worker.port, messageId, timeout);
-        return response;
+      sendMessage(_0) {
+        return __async(this, arguments, function* (message, timeout = DEFAULT_REPLY_TIMEOUT) {
+          const messageId = postMessageExpectReply(worker.port, message);
+          const response = yield awaitReply(worker.port, messageId, timeout);
+          return response;
+        });
+      },
+      addMessageListener(listener) {
+        worker.port.onmessage = listener;
       }
     };
   }
@@ -185,39 +256,49 @@
     iframe.style.display = "none";
     document.body.appendChild(iframe);
     return {
-      async sendMessage(message, timeout = DEFAULT_REPLY_TIMEOUT) {
-        const messageId = postMessageExpectReply(
-          iframe.contentWindow,
-          message,
-          "*"
-        );
-        const response = await awaitReply(window, messageId, timeout);
-        return response;
+      sendMessage(_0) {
+        return __async(this, arguments, function* (message, timeout = DEFAULT_REPLY_TIMEOUT) {
+          const messageId = postMessageExpectReply(
+            iframe.contentWindow,
+            message,
+            "*"
+          );
+          const response = yield awaitReply(window, messageId, timeout);
+          return response;
+        });
+      },
+      addMessageListener(listener) {
+        window.addEventListener("message", (e) => {
+          if (e.source.window === iframe.contentWindow) {
+            listener(e);
+          }
+        }, false);
       }
     };
   }
 
   // src/web/config.js
-  var serviceWorkerUrl = "https://wasm.wordpress.net/service-worker.js";
+  var serviceWorkerUrl = "http://127.0.0.1:8777/service-worker.js";
   var serviceWorkerOrigin = new URL(serviceWorkerUrl).origin;
   var wordPressSiteUrl = serviceWorkerOrigin;
-  var wasmWorkerUrl = "https://wasm-worker.wordpress.net/iframe-worker.php";
+  var wasmWorkerUrl = "http://127.0.0.1:8778/iframe-worker.html";
   var wasmWorkerOrigin = new URL(wasmWorkerUrl).origin;
   var wasmWorkerBackend = "iframe";
 
   // src/web/app.mjs
-  async function init() {
-    console.log("[Main] Starting WordPress...");
-    const wasmWorker = await runWordPress({
-      wasmWorkerBackend,
-      wasmWorkerUrl,
-      wordPressSiteUrl,
-      serviceWorkerUrl,
-      assignScope: true
+  window.startWordPress = function() {
+    return __async(this, arguments, function* (options = {}) {
+      console.log("[Main] Starting WordPress...");
+      const wasmWorker = yield runWordPress({
+        wasmWorkerBackend,
+        wasmWorkerUrl,
+        wordPressSiteUrl,
+        serviceWorkerUrl,
+        assignScope: true,
+        onWasmDownloadProgress: options.onWasmDownloadProgress
+      });
+      console.log("[Main] WordPress is running");
+      return wasmWorker;
     });
-    console.log("[Main] WordPress is running");
-    document.querySelector("#wp").src = wasmWorker.pathToInternalUrl(`/`);
-    window.wasmWorker = wasmWorker;
-  }
-  init();
+  };
 })();

--- a/dist-web/wasm-worker.js
+++ b/dist-web/wasm-worker.js
@@ -1,10 +1,27 @@
 (() => {
   var __create = Object.create;
   var __defProp = Object.defineProperty;
+  var __defProps = Object.defineProperties;
   var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+  var __getOwnPropDescs = Object.getOwnPropertyDescriptors;
   var __getOwnPropNames = Object.getOwnPropertyNames;
+  var __getOwnPropSymbols = Object.getOwnPropertySymbols;
   var __getProtoOf = Object.getPrototypeOf;
   var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __propIsEnum = Object.prototype.propertyIsEnumerable;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __spreadValues = (a, b) => {
+    for (var prop in b || (b = {}))
+      if (__hasOwnProp.call(b, prop))
+        __defNormalProp(a, prop, b[prop]);
+    if (__getOwnPropSymbols)
+      for (var prop of __getOwnPropSymbols(b)) {
+        if (__propIsEnum.call(b, prop))
+          __defNormalProp(a, prop, b[prop]);
+      }
+    return a;
+  };
+  var __spreadProps = (a, b) => __defProps(a, __getOwnPropDescs(b));
   var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : typeof Proxy !== "undefined" ? new Proxy(x, {
     get: (a, b) => (typeof require !== "undefined" ? require : a)[b]
   }) : x)(function(x) {
@@ -24,67 +41,101 @@
     isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
     mod
   ));
+  var __publicField = (obj, key, value) => {
+    __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+    return value;
+  };
+  var __async = (__this, __arguments, generator) => {
+    return new Promise((resolve, reject) => {
+      var fulfilled = (value) => {
+        try {
+          step(generator.next(value));
+        } catch (e) {
+          reject(e);
+        }
+      };
+      var rejected = (value) => {
+        try {
+          step(generator.throw(value));
+        } catch (e) {
+          reject(e);
+        }
+      };
+      var step = (x) => x.done ? resolve(x.value) : Promise.resolve(x.value).then(fulfilled, rejected);
+      step((generator = generator.apply(__this, __arguments)).next());
+    });
+  };
 
   // src/shared/php-wrapper.mjs
   var STR = "string";
   var NUM = "number";
   var PHPWrapper = class {
-    _initPromise;
-    call;
-    stdout = [];
-    stderr = [];
-    async init(PhpBinary, args = {}) {
-      if (!this._initPromise) {
-        this._initPromise = this._init(PhpBinary, args);
-      }
-      return this._initPromise;
+    constructor() {
+      __publicField(this, "_initPromise");
+      __publicField(this, "call");
+      __publicField(this, "stdout", []);
+      __publicField(this, "stderr", []);
+      __publicField(this, "refresh", this.clear);
     }
-    async _init(PhpBinary, args = {}) {
-      const defaults = {
-        onAbort(reason) {
-          console.error("WASM aborted: ");
-          console.error(reason);
-        },
-        print: (...chunks) => {
-          this.stdout.push(...chunks);
-        },
-        printErr: (...chunks) => {
-          this.stderr.push(...chunks);
+    init(_0) {
+      return __async(this, arguments, function* (PhpBinary, args = {}) {
+        if (!this._initPromise) {
+          this._initPromise = this._init(PhpBinary, args);
         }
-      };
-      const PHPModule = Object.assign({}, defaults, args);
-      await new PhpBinary(PHPModule);
-      this.call = PHPModule.ccall;
-      await this.call("pib_init", NUM, [STR], []);
-      return PHPModule;
+        return this._initPromise;
+      });
     }
-    async run(code) {
-      if (!this.call) {
-        throw new Error(`Run init() first!`);
-      }
-      const exitCode = this.call("pib_run", NUM, [STR], [`?>${code}`]);
-      const response = {
-        exitCode,
-        stdout: this.stdout.join("\n"),
-        stderr: this.stderr
-      };
-      this.clear();
-      return response;
+    _init(_0) {
+      return __async(this, arguments, function* (PhpBinary, args = {}) {
+        const defaults = {
+          onAbort(reason) {
+            console.error("WASM aborted: ");
+            console.error(reason);
+          },
+          print: (...chunks) => {
+            this.stdout.push(...chunks);
+          },
+          printErr: (...chunks) => {
+            this.stderr.push(...chunks);
+          }
+        };
+        const PHPModule = Object.assign({}, defaults, args);
+        yield new PhpBinary(PHPModule);
+        this.call = PHPModule.ccall;
+        yield this.call("pib_init", NUM, [STR], []);
+        return PHPModule;
+      });
     }
-    async clear() {
-      if (!this.call) {
-        throw new Error(`Run init() first!`);
-      }
-      this.call("pib_refresh", NUM, [], []);
-      this.stdout = [];
-      this.stderr = [];
+    run(code) {
+      return __async(this, null, function* () {
+        if (!this.call) {
+          throw new Error(`Run init() first!`);
+        }
+        const exitCode = this.call("pib_run", NUM, [STR], [`?>${code}`]);
+        const response = {
+          exitCode,
+          stdout: this.stdout.join("\n"),
+          stderr: this.stderr
+        };
+        this.clear();
+        return response;
+      });
     }
-    refresh = this.clear;
+    clear() {
+      return __async(this, null, function* () {
+        if (!this.call) {
+          throw new Error(`Run init() first!`);
+        }
+        this.call("pib_refresh", NUM, [], []);
+        this.stdout = [];
+        this.stderr = [];
+      });
+    }
   };
 
   // src/shared/wordpress.mjs
   if (typeof XMLHttpRequest === "undefined") {
-    import("xmlhttprequest").then(({ XMLHttpRequest: XMLHttpRequest2 }) => {
+    Promise.resolve().then(() => __toESM(__require("xmlhttprequest"), 1)).then(({ XMLHttpRequest: XMLHttpRequest2 }) => {
       global.XMLHttpRequest = XMLHttpRequest2;
     });
     global.atob = function(data) {
@@ -92,54 +143,57 @@
     };
   }
   var WordPress = class {
-    DOCROOT = "/preload/wordpress";
-    SCHEMA = "http";
-    HOSTNAME = "localhost";
-    PORT = 80;
-    HOST = "";
-    PATHNAME = "";
-    ABSOLUTE_URL = ``;
     constructor(php) {
+      __publicField(this, "DOCROOT", "/preload/wordpress");
+      __publicField(this, "SCHEMA", "http");
+      __publicField(this, "HOSTNAME", "localhost");
+      __publicField(this, "PORT", 80);
+      __publicField(this, "HOST", "");
+      __publicField(this, "PATHNAME", "");
+      __publicField(this, "ABSOLUTE_URL", ``);
       this.php = php;
     }
-    async init(urlString, options = {}) {
-      this.options = {
-        useFetchForRequests: false,
-        ...options
-      };
-      const url = new URL(urlString);
-      this.HOSTNAME = url.hostname;
-      this.PORT = url.port ? url.port : url.protocol === "https:" ? 443 : 80;
-      this.SCHEMA = (url.protocol || "").replace(":", "");
-      this.HOST = `${this.HOSTNAME}:${this.PORT}`;
-      this.PATHNAME = url.pathname.replace(/\/+$/, "");
-      this.ABSOLUTE_URL = `${this.SCHEMA}://${this.HOSTNAME}:${this.PORT}${this.PATHNAME}`;
-      await this.php.refresh();
-      const result = await this.php.run(`<?php
+    init(_0) {
+      return __async(this, arguments, function* (urlString, options = {}) {
+        this.options = __spreadValues({
+          useFetchForRequests: false
+        }, options);
+        const url = new URL(urlString);
+        this.HOSTNAME = url.hostname;
+        this.PORT = url.port ? url.port : url.protocol === "https:" ? 443 : 80;
+        this.SCHEMA = (url.protocol || "").replace(":", "");
+        this.HOST = `${this.HOSTNAME}:${this.PORT}`;
+        this.PATHNAME = url.pathname.replace(/\/+$/, "");
+        this.ABSOLUTE_URL = `${this.SCHEMA}://${this.HOSTNAME}:${this.PORT}${this.PATHNAME}`;
+        yield this.php.refresh();
+        const result = yield this.php.run(`<?php
 			${this._setupErrorReportingCode()}
 			${this._patchWordPressCode()}
 		`);
-      this.initialized = true;
-      if (result.exitCode !== 0) {
-        throw new Error(
-          {
-            message: "WordPress setup failed",
-            result
-          },
-          result.exitCode
-        );
-      }
+        this.initialized = true;
+        if (result.exitCode !== 0) {
+          throw new Error(
+            {
+              message: "WordPress setup failed",
+              result
+            },
+            result.exitCode
+          );
+        }
+      });
     }
-    async request(request) {
-      if (!this.initialized) {
-        throw new Error("call init() first");
-      }
-      const output = await this.php.run(`<?php
+    request(request) {
+      return __async(this, null, function* () {
+        if (!this.initialized) {
+          throw new Error("call init() first");
+        }
+        const output = yield this.php.run(`<?php
 			${this._setupErrorReportingCode()}
 			${this._setupRequestCode(request)}
 			${this._runWordPressCode(request.path)}
 		`);
-      return this.parseResponse(output);
+        return this.parseResponse(output);
+      });
     }
     parseResponse(result) {
       const response = {
@@ -458,36 +512,36 @@ REQUEST,
     constructor(wp, config = {}) {
       this.wp = wp;
       this.cookies = {};
-      this.config = {
+      this.config = __spreadValues({
         handleRedirects: false,
-        maxRedirects: 4,
-        ...config
-      };
+        maxRedirects: 4
+      }, config);
     }
-    async request(request, redirects = 0) {
-      const response = await this.wp.request({
-        ...request,
-        _COOKIE: this.cookies
+    request(request, redirects = 0) {
+      return __async(this, null, function* () {
+        const response = yield this.wp.request(__spreadProps(__spreadValues({}, request), {
+          _COOKIE: this.cookies
+        }));
+        if (response.headers["set-cookie"]) {
+          this.setCookies(response.headers["set-cookie"]);
+        }
+        if (this.config.handleRedirects && response.headers.location && redirects < this.config.maxRedirects) {
+          const parsedUrl = new URL(
+            response.headers.location[0],
+            this.wp.ABSOLUTE_URL
+          );
+          return this.request(
+            {
+              path: parsedUrl.pathname,
+              method: "GET",
+              _GET: parsedUrl.search,
+              headers: {}
+            },
+            redirects + 1
+          );
+        }
+        return response;
       });
-      if (response.headers["set-cookie"]) {
-        this.setCookies(response.headers["set-cookie"]);
-      }
-      if (this.config.handleRedirects && response.headers.location && redirects < this.config.maxRedirects) {
-        const parsedUrl = new URL(
-          response.headers.location[0],
-          this.wp.ABSOLUTE_URL
-        );
-        return this.request(
-          {
-            path: parsedUrl.pathname,
-            method: "GET",
-            _GET: parsedUrl.search,
-            headers: {}
-          },
-          redirects + 1
-        );
-      }
-      return response;
     }
     setCookies(cookies) {
       for (const cookie of cookies) {
@@ -522,21 +576,24 @@ REQUEST,
     IS_SHARED_WORKER
   });
   if (IS_IFRAME) {
-    window.importScripts = async function(...urls) {
-      return Promise.all(
-        urls.map((url) => {
-          const script = document.createElement("script");
-          script.src = url;
-          script.async = false;
-          document.body.appendChild(script);
-          return new Promise((resolve) => {
-            script.onload = resolve;
-          });
-        })
-      );
+    window.importScripts = function(...urls) {
+      return __async(this, null, function* () {
+        return Promise.all(
+          urls.map((url) => {
+            const script = document.createElement("script");
+            script.src = url;
+            script.async = false;
+            document.body.appendChild(script);
+            return new Promise((resolve) => {
+              script.onload = resolve;
+            });
+          })
+        );
+      });
     };
   }
   var phpLoaderScriptName;
+  var postMessageToParent;
   if (IS_IFRAME) {
     phpLoaderScriptName = "/php-web.js";
     window.addEventListener(
@@ -547,11 +604,13 @@ REQUEST,
       ),
       false
     );
+    postMessageToParent = (message) => window.parent.postMessage(message, "*");
   } else if (IS_WEBWORKER) {
     phpLoaderScriptName = "/php-webworker.js";
     onmessage = (event) => {
       handleMessageEvent(event, postMessage);
     };
+    postMessageToParent = postMessage;
   } else if (IS_SHARED_WORKER) {
     phpLoaderScriptName = "/php-webworker.js";
     self.onconnect = (e) => {
@@ -559,56 +618,83 @@ REQUEST,
       port.addEventListener("message", (event) => {
         handleMessageEvent(event, (r) => port.postMessage(r));
       });
+      postMessageToParent = port.postMessage;
       port.start();
     };
   }
-  async function handleMessageEvent(event, respond) {
-    console.debug(`[WASM Worker] "${event.data.type}" event received`, event);
-    const result = await generateResponseForMessage(event.data);
-    if (event.data.messageId) {
-      respond(responseTo(event.data.messageId, result));
-    }
-    console.debug(`[WASM Worker] "${event.data.type}" event processed`);
+  function handleMessageEvent(event, respond) {
+    return __async(this, null, function* () {
+      console.debug(`[WASM Worker] "${event.data.type}" event received`, event);
+      const result = yield generateResponseForMessage(event.data);
+      if (event.data.messageId) {
+        respond(responseTo(event.data.messageId, result));
+      }
+      console.debug(`[WASM Worker] "${event.data.type}" event processed`);
+    });
   }
   var wpBrowser;
-  async function generateResponseForMessage(message) {
-    if (message.type === "initialize_wordpress") {
-      wpBrowser = await initWPBrowser(message.siteURL);
-      return true;
-    }
-    if (message.type === "is_alive") {
-      return true;
-    }
-    if (message.type === "run_php") {
-      return await wpBrowser.wp.php.run(message.code);
-    }
-    if (message.type === "request" || message.type === "httpRequest") {
-      const parsedUrl = new URL(message.request.path, wpBrowser.wp.ABSOLUTE_URL);
-      return await wpBrowser.request({
-        ...message.request,
-        path: parsedUrl.pathname,
-        _GET: parsedUrl.search
-      });
-    }
-    console.debug(
-      `[WASM Worker] "${message.type}" event has no handler, short-circuiting`
-    );
-  }
-  async function initWPBrowser(siteUrl) {
-    console.log("[WASM Worker] Before wp.init()");
-    const php = new PHPWrapper();
-    await importScripts(phpLoaderScriptName);
-    const PHPModule = await php.init(PHP);
-    await new Promise((resolve) => {
-      PHPModule.monitorRunDependencies = (nbLeft) => {
-        if (nbLeft === 0) {
-          delete PHPModule.monitorRunDependencies;
-          resolve();
-        }
-      };
-      globalThis.PHPModule = PHPModule;
-      importScripts("/wp.js");
+  function generateResponseForMessage(message) {
+    return __async(this, null, function* () {
+      if (message.type === "initialize_wordpress") {
+        wpBrowser = yield initWPBrowser(message.siteURL);
+        return true;
+      }
+      if (message.type === "is_alive") {
+        return true;
+      }
+      if (message.type === "run_php") {
+        return yield wpBrowser.wp.php.run(message.code);
+      }
+      if (message.type === "request" || message.type === "httpRequest") {
+        const parsedUrl = new URL(message.request.path, wpBrowser.wp.ABSOLUTE_URL);
+        return yield wpBrowser.request(__spreadProps(__spreadValues({}, message.request), {
+          path: parsedUrl.pathname,
+          _GET: parsedUrl.search
+        }));
+      }
+      console.debug(
+        `[WASM Worker] "${message.type}" event has no handler, short-circuiting`
+      );
     });
+  }
+  function initWPBrowser(siteUrl) {
+    return __async(this, null, function* () {
+      console.log("[WASM Worker] Before wp.init()");
+      const downloadMonitor = new WASMDownloadMonitor();
+      downloadMonitor.addEventListener("progress", (e) => {
+        postMessageToParent(__spreadValues({
+          type: "download_progress"
+        }, e.detail));
+      });
+      const php = new PHPWrapper();
+      yield importScripts(phpLoaderScriptName);
+      const PHPModule = yield php.init(PHP, {
+        dataFileDownloads: downloadMonitor.dataFileDownloads
+      });
+      yield loadWordPressFiles(PHPModule);
+      setupPHPini(PHPModule);
+      const wp = new WordPress(php);
+      yield wp.init(siteUrl);
+      console.log("[WASM Worker] After wp.init()");
+      return new WPBrowser(wp, { handleRedirects: true });
+    });
+  }
+  function loadWordPressFiles(PHPModule) {
+    return __async(this, null, function* () {
+      yield new Promise((resolve) => {
+        PHPModule.monitorRunDependencies = (nbLeft) => {
+          if (nbLeft === 0) {
+            delete PHPModule.monitorRunDependencies;
+            resolve();
+          }
+        };
+        globalThis.PHPModule = PHPModule;
+        importScripts("/wp.js");
+        console.log({ PHPModule });
+      });
+    });
+  }
+  function setupPHPini(PHPModule) {
     PHPModule.FS.mkdirTree("/usr/local/etc");
     PHPModule.FS.writeFile(
       "/usr/local/etc/php.ini",
@@ -619,9 +705,80 @@ html_errors = 1
 display_startup_errors = On
 	`
     );
-    const wp = new WordPress(php);
-    await wp.init(siteUrl);
-    console.log("[WASM Worker] After wp.init()");
-    return new WPBrowser(wp, { handleRedirects: true });
   }
+  var WASMDownloadMonitor = class extends EventTarget {
+    constructor() {
+      super();
+      this._monitorWASMStreamingProgress();
+      this.dataFileDownloads = this._createDataFileDownloadsProxy();
+    }
+    _createDataFileDownloadsProxy() {
+      const self2 = this;
+      const dataFileDownloads = {};
+      return new Proxy(dataFileDownloads, {
+        set(obj, file, progress) {
+          self2._notify(file, progress.loaded, progress.total);
+          obj[file] = new Proxy(progress, {
+            set(nestedObj, prop, value) {
+              nestedObj[prop] = value;
+              self2._notify(file, nestedObj.loaded, nestedObj.total);
+            }
+          });
+        }
+      });
+    }
+    _monitorWASMStreamingProgress() {
+      const self2 = this;
+      const _instantiateStreaming = WebAssembly.instantiateStreaming;
+      WebAssembly.instantiateStreaming = (response, ...args) => {
+        const file = response.url.substring(
+          new URL(response.url).origin.length + 1
+        );
+        const reportingResponse = new Response(
+          new ReadableStream(
+            {
+              start(controller) {
+                return __async(this, null, function* () {
+                  const contentLength = response.headers.get("content-length");
+                  const total = parseInt(contentLength, 10);
+                  const reader = response.body.getReader();
+                  let loaded = 0;
+                  for (; ; ) {
+                    const { done, value } = yield reader.read();
+                    if (done) {
+                      self2._notify(file, total, total);
+                      break;
+                    }
+                    loaded += value.byteLength;
+                    self2._notify(file, loaded, total);
+                    controller.enqueue(value);
+                  }
+                  controller.close();
+                });
+              }
+            },
+            {
+              status: response.status,
+              statusText: response.statusText
+            }
+          )
+        );
+        for (const pair of response.headers.entries()) {
+          reportingResponse.headers.set(pair[0], pair[1]);
+        }
+        return _instantiateStreaming(reportingResponse, ...args);
+      };
+    }
+    _notify(file, loaded, total) {
+      this.dispatchEvent(
+        new CustomEvent("progress", {
+          detail: {
+            file,
+            loaded,
+            total
+          }
+        })
+      );
+    }
+  };
 })();

--- a/dist-web/wordpress-browser.html
+++ b/dist-web/wordpress-browser.html
@@ -36,7 +36,12 @@
       }
 
       .fake-window iframe {
+        position: relative;
         flex-grow: 1;
+        border: 0;
+        margin: 0;
+        padding: 0;
+        z-index: 6;
       }
 
       .outer {
@@ -139,10 +144,106 @@
         border: 1px solid #b4b4b4;
         font-size: 20px;
       }
+
+      /* Progress bar: */
+      .fake-window iframe,
+      .fake-window .progress-bar-overlay {
+        transition: opacity linear 0.5s;
+      }
+
+      .fake-window.is-loading iframe,
+      .fake-window:not(.is-loading) .progress-bar-overlay {
+        opacity: 0;
+        pointer-events: none;
+      }
+      .fake-window:not(.is-loading) iframe,
+      .fake-window.is-loading .progress-bar-overlay {
+        opacity: 1;
+      }
+
+      .progress-bar-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 5;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .progress-bar-wrapper {
+        position: relative;
+        width: 400px;
+        height: 16px;
+        margin: 4px auto;
+        border-radius: 10px;
+      }
+
+      .progress-bar-wrapper:before {
+        content: "";
+        position: absolute;
+        top: -4px;
+        left: -4px;
+        bottom: -4px;
+        right: -4px;
+        border: 1px solid #000;
+        border-radius: 2px;
+      }
+
+      .progress-bar-wrapper .progress-bar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 100%;
+        width: 0;
+        background: #000;
+        border-radius: 2px;
+        transition: opacity linear 0.25s, width ease-in 0.5s;
+      }
+
+      .progress-bar-wrapper.mode-finite .progress-bar.is-infinite,
+      .progress-bar-wrapper.mode-infinite .progress-bar.is-finite {
+        opacity: 0;
+      }
+
+      .progress-bar-wrapper.mode-finite .progress-bar.is-finite,
+      .progress-bar-wrapper.mode-infinite .progress-bar.is-infinite {
+        opacity: 1;
+      }
+
+      .progress-bar-wrapper .progress-bar.is-infinite {
+        animation: infinite-loading 2s linear infinite;
+      }
+
+      @keyframes infinite-loading {
+        0% {
+          left: 0%;
+          right: 100%;
+          width: 0%;
+        }
+        10% {
+          left: 0%;
+          right: 75%;
+          width: 25%;
+        }
+        90% {
+          right: 0%;
+          left: 75%;
+          width: 25%;
+        }
+        100% {
+          left: 100%;
+          right: 0%;
+          width: 0%;
+        }
+      }
     </style>
   </head>
   <body>
-    <div class="fake-window">
+    <div class="fake-window is-loading">
       <div class="outer">
         <div class="dot"></div>
         <div class="dot"></div>
@@ -154,27 +255,76 @@
         </div>
         <input type="submit" tabindex="-1" />
       </form>
-
-      <iframe id="wp" style="border: 0; margin: 0; padding: 0"></iframe>
+      <div
+        style="
+          flex-grow: 1;
+          display: flex;
+          flex-direction: column;
+          position: relative;
+        "
+      >
+        <div class="progress-bar-overlay">
+          <div class="progress-bar-wrapper mode-infinite">
+            <div class="progress-bar is-infinite"></div>
+            <div class="progress-bar is-finite"></div>
+          </div>
+        </div>
+        <iframe id="wp"></iframe>
+      </div>
     </div>
 
     <script src="app.js"></script>
     <script>
-      const addressBar = document.querySelector("#address-bar");
-      document.querySelector("#wp").addEventListener("load", (e) => {
-        addressBar.value = wasmWorker.internalUrlToPath(
-          e.currentTarget.contentWindow.location.href
-        );
-      });
-
-      document
-        .querySelector("#address-bar-form")
-        .addEventListener("submit", (e) => {
-          e.preventDefault();
-          document.querySelector("#wp").src = wasmWorker.pathToInternalUrl(
-            addressBar.value
+      startWordPress({ onWasmDownloadProgress }).then((wasmWorker) => {
+        const addressBar = document.querySelector("#address-bar");
+        document.querySelector("#wp").addEventListener("load", (e) => {
+          addressBar.value = wasmWorker.internalUrlToPath(
+            e.currentTarget.contentWindow.location.href
           );
         });
+
+        document
+          .querySelector("#address-bar-form")
+          .addEventListener("submit", (e) => {
+            e.preventDefault();
+            document.querySelector("#wp").src = wasmWorker.pathToInternalUrl(
+              addressBar.value
+            );
+          });
+
+        // Hide progress bar when iframe loaded
+        document.querySelector("#wp").addEventListener("load", () => {
+          document
+            .querySelector(".fake-window.is-loading")
+            .classList.remove("is-loading");
+        });
+
+        document.querySelector("#wp").src = wasmWorker.pathToInternalUrl("/");
+      });
+
+      // Handle progress events
+      const progress = {};
+      function onWasmDownloadProgress({ file, loaded, total }) {
+        if (Object.keys(progress).length === 0) {
+          const classList = document.querySelector(
+            ".progress-bar-wrapper.mode-infinite"
+          ).classList;
+          classList.remove("mode-infinite");
+          classList.add("mode-finite");
+        }
+
+        progress[file] = loaded / total;
+        const progressSum = Object.entries(progress).reduce(
+          (acc, [_, percentFinished]) => acc + percentFinished,
+          0
+        );
+        const expectedFiles = 2;
+        const totalProgressPercentage = (100 * progressSum) / expectedFiles;
+
+        document.querySelector(
+          ".progress-bar.is-finite"
+        ).style.width = `${totalProgressPercentage}%`;
+      }
     </script>
   </body>
 </html>

--- a/dist-web/wordpress.html
+++ b/dist-web/wordpress.html
@@ -9,5 +9,10 @@
       style="width: 100vw; height: 100vh; border: 0; margin: 0; padding: 0"
     ></iframe>
     <script src="app.js"></script>
+    <script>
+      startWordPress().then((wasmWorker) => {
+        document.querySelector("#wp").src = wasmWorker.pathToInternalUrl("/");
+      });
+    </script>
   </body>
 </html>

--- a/src/web/app.mjs
+++ b/src/web/app.mjs
@@ -1,26 +1,23 @@
-import { runWordPress } from './library';
+import { runWordPress } from "./library";
 import {
-	wasmWorkerUrl,
-	wasmWorkerBackend,
-	wordPressSiteUrl,
-	serviceWorkerUrl,
-} from './config';
+  wasmWorkerUrl,
+  wasmWorkerBackend,
+  wordPressSiteUrl,
+  serviceWorkerUrl,
+} from "./config";
 
-async function init() {
-	console.log('[Main] Starting WordPress...');
+window.startWordPress = async function (options = {}) {
+  console.log("[Main] Starting WordPress...");
 
-	const wasmWorker = await runWordPress({
-		wasmWorkerBackend,
-		wasmWorkerUrl,
-		wordPressSiteUrl,
-		serviceWorkerUrl,
-		assignScope: true,
-	});
+  const wasmWorker = await runWordPress({
+    wasmWorkerBackend,
+    wasmWorkerUrl,
+    wordPressSiteUrl,
+    serviceWorkerUrl,
+    assignScope: true,
+    onWasmDownloadProgress: options.onWasmDownloadProgress,
+  });
 
-	console.log('[Main] WordPress is running');
-
-	document.querySelector('#wp').src =
-		wasmWorker.pathToInternalUrl(`/`);
-	window.wasmWorker = wasmWorker;
-}
-init();
+  console.log("[Main] WordPress is running");
+  return wasmWorker;
+};

--- a/src/web/wasm-worker.js
+++ b/src/web/wasm-worker.js
@@ -1,77 +1,82 @@
 /* eslint-disable no-inner-declarations */
 
-import PHPWrapper from "../shared/php-wrapper.mjs";
-import WordPress from "../shared/wordpress.mjs";
-import WPBrowser from "../shared/wp-browser.mjs";
-import { responseTo } from "../shared/messaging.mjs";
+import PHPWrapper from '../shared/php-wrapper.mjs';
+import WordPress from '../shared/wordpress.mjs';
+import WPBrowser from '../shared/wp-browser.mjs';
+import { responseTo } from '../shared/messaging.mjs';
 
-console.log("[WASM Worker] Spawned");
+console.log('[WASM Worker] Spawned');
 
 // Infer the environment
-const IS_IFRAME = typeof window !== "undefined";
+const IS_IFRAME = typeof window !== 'undefined';
 /* eslint-disable no-undef */
 const IS_SHARED_WORKER =
-  typeof SharedWorkerGlobalScope !== "undefined" &&
-  self instanceof SharedWorkerGlobalScope;
+	typeof SharedWorkerGlobalScope !== 'undefined' &&
+	self instanceof SharedWorkerGlobalScope;
 const IS_WEBWORKER =
-  !IS_SHARED_WORKER &&
-  typeof WorkerGlobalScope !== "undefined" &&
-  self instanceof WorkerGlobalScope;
+	!IS_SHARED_WORKER &&
+	typeof WorkerGlobalScope !== 'undefined' &&
+	self instanceof WorkerGlobalScope;
 /* eslint-enable no-undef */
 
-console.log("[WASM Worker] Environment", {
-  IS_IFRAME,
-  IS_WEBWORKER,
-  IS_SHARED_WORKER,
+console.log('[WASM Worker] Environment', {
+	IS_IFRAME,
+	IS_WEBWORKER,
+	IS_SHARED_WORKER,
 });
 
 // Define polyfills
 if (IS_IFRAME) {
-  // importScripts is synchronous in a web worker.
-  // Let's make it async in an iframe so we can at await it before moving forward.
-  window.importScripts = async function (...urls) {
-    return Promise.all(
-      urls.map((url) => {
-        const script = document.createElement("script");
-        script.src = url;
-        script.async = false;
-        document.body.appendChild(script);
-        return new Promise((resolve) => {
-          script.onload = resolve;
-        });
-      })
-    );
-  };
+	// importScripts is synchronous in a web worker.
+	// Let's make it async in an iframe so we can at await it before moving forward.
+	window.importScripts = async function (...urls) {
+		return Promise.all(
+			urls.map((url) => {
+				const script = document.createElement('script');
+				script.src = url;
+				script.async = false;
+				document.body.appendChild(script);
+				return new Promise((resolve) => {
+					script.onload = resolve;
+				});
+			})
+		);
+	};
 }
 
 let phpLoaderScriptName;
+let postMessageToParent;
 // Listen to messages
 if (IS_IFRAME) {
-  phpLoaderScriptName = "/php-web.js";
-  window.addEventListener(
-    "message",
-    (event) =>
-      handleMessageEvent(event, (response) =>
-        event.source.postMessage(response, "*")
-      ),
-    false
-  );
+	phpLoaderScriptName = '/php-web.js';
+	window.addEventListener(
+		'message',
+		(event) =>
+			handleMessageEvent(event, (response) =>
+				event.source.postMessage(response, '*')
+			),
+		false
+	);
+	postMessageToParent = (message) => window.parent.postMessage(message, '*');
 } else if (IS_WEBWORKER) {
-  phpLoaderScriptName = "/php-webworker.js";
-  onmessage = (event) => {
-    handleMessageEvent(event, postMessage);
-  };
+	phpLoaderScriptName = '/php-webworker.js';
+	onmessage = (event) => {
+		handleMessageEvent(event, postMessage);
+	};
+	postMessageToParent = postMessage;
 } else if (IS_SHARED_WORKER) {
-  phpLoaderScriptName = "/php-webworker.js";
-  self.onconnect = (e) => {
-    const port = e.ports[0];
+	phpLoaderScriptName = '/php-webworker.js';
+	self.onconnect = (e) => {
+		const port = e.ports[0];
 
-    port.addEventListener("message", (event) => {
-      handleMessageEvent(event, (r) => port.postMessage(r));
-    });
+		port.addEventListener('message', (event) => {
+			handleMessageEvent(event, (r) => port.postMessage(r));
+		});
 
-    port.start(); // Required when using addEventListener. Otherwise called implicitly by onmessage setter.
-  };
+		postMessageToParent = port.postMessage;
+
+		port.start(); // Required when using addEventListener. Otherwise called implicitly by onmessage setter.
+	};
 }
 
 // Actual worker logic below:
@@ -79,88 +84,208 @@ if (IS_IFRAME) {
 // We're in a worker right now, and we're receiving the incoming
 // communication from the main window via `postMessage`:
 async function handleMessageEvent(event, respond) {
-  console.debug(`[WASM Worker] "${event.data.type}" event received`, event);
+	console.debug(`[WASM Worker] "${event.data.type}" event received`, event);
 
-  const result = await generateResponseForMessage(event.data);
+	const result = await generateResponseForMessage(event.data);
 
-  // The main window expects a response when it includes a `messageId` in the message:
-  if (event.data.messageId) {
-    respond(responseTo(event.data.messageId, result));
-  }
+	// The main window expects a response when it includes a `messageId` in the message:
+	if (event.data.messageId) {
+		respond(responseTo(event.data.messageId, result));
+	}
 
-  console.debug(`[WASM Worker] "${event.data.type}" event processed`);
+	console.debug(`[WASM Worker] "${event.data.type}" event processed`);
 }
 
 let wpBrowser;
 async function generateResponseForMessage(message) {
-  if (message.type === "initialize_wordpress") {
-    wpBrowser = await initWPBrowser(message.siteURL);
-    return true;
-  }
+	if (message.type === 'initialize_wordpress') {
+		wpBrowser = await initWPBrowser(message.siteURL);
+		return true;
+	}
 
-  if (message.type === "is_alive") {
-    return true;
-  }
+	if (message.type === 'is_alive') {
+		return true;
+	}
 
-  if (message.type === "run_php") {
-    return await wpBrowser.wp.php.run(message.code);
-  }
+	if (message.type === 'run_php') {
+		return await wpBrowser.wp.php.run(message.code);
+	}
 
-  if (message.type === "request" || message.type === "httpRequest") {
-    const parsedUrl = new URL(message.request.path, wpBrowser.wp.ABSOLUTE_URL);
-    return await wpBrowser.request({
-      ...message.request,
-      path: parsedUrl.pathname,
-      _GET: parsedUrl.search,
-    });
-  }
+	if (message.type === 'request' || message.type === 'httpRequest') {
+		const parsedUrl = new URL(
+			message.request.path,
+			wpBrowser.wp.ABSOLUTE_URL
+		);
+		return await wpBrowser.request({
+			...message.request,
+			path: parsedUrl.pathname,
+			_GET: parsedUrl.search,
+		});
+	}
 
-  console.debug(
-    `[WASM Worker] "${message.type}" event has no handler, short-circuiting`
-  );
+	console.debug(
+		`[WASM Worker] "${message.type}" event has no handler, short-circuiting`
+	);
 }
 
 async function initWPBrowser(siteUrl) {
-  console.log("[WASM Worker] Before wp.init()");
+	console.log('[WASM Worker] Before wp.init()');
 
-  // Initialize the PHP module
-  const php = new PHPWrapper();
-  // eslint-disable-next-line no-undef
-  await importScripts(phpLoaderScriptName);
-  // eslint-disable-next-line no-undef
-  const PHPModule = await php.init(PHP);
+	const downloadMonitor = new WASMDownloadMonitor();
+	downloadMonitor.addEventListener('progress', (e) => {
+		postMessageToParent({
+			type: 'download_progress',
+			...e.detail,
+		});
+	});
 
-  // Load the WordPress files
-  await new Promise((resolve) => {
-    PHPModule.monitorRunDependencies = (nbLeft) => {
-      if (nbLeft === 0) {
-        delete PHPModule.monitorRunDependencies;
-        resolve();
-      }
-    };
-    // The name PHPModule is baked into wp.js
-    globalThis.PHPModule = PHPModule;
-    // eslint-disable-next-line no-undef
-    importScripts("/wp.js");
-  });
+	// Initialize the PHP module
+	const php = new PHPWrapper();
+	// eslint-disable-next-line no-undef
+	await importScripts(phpLoaderScriptName);
+	// eslint-disable-next-line no-undef
+	const PHPModule = await php.init(PHP, {
+		dataFileDownloads: downloadMonitor.dataFileDownloads,
+	});
 
-  // Create php.ini
-  PHPModule.FS.mkdirTree("/usr/local/etc");
-  PHPModule.FS.writeFile(
-    "/usr/local/etc/php.ini",
-    `[PHP]
+	await loadWordPressFiles(PHPModule);
+	setupPHPini(PHPModule);
+
+	// We're ready to initialize WordPress!
+	const wp = new WordPress(php);
+	await wp.init(siteUrl);
+
+	console.log('[WASM Worker] After wp.init()');
+
+	return new WPBrowser(wp, { handleRedirects: true });
+}
+
+async function loadWordPressFiles(PHPModule) {
+	await new Promise((resolve) => {
+		PHPModule.monitorRunDependencies = (nbLeft) => {
+			if (nbLeft === 0) {
+				delete PHPModule.monitorRunDependencies;
+				resolve();
+			}
+		};
+		// The name PHPModule is baked into wp.js
+		globalThis.PHPModule = PHPModule;
+		// eslint-disable-next-line no-undef
+		importScripts('/wp.js');
+		console.log({ PHPModule });
+	});
+}
+
+function setupPHPini(PHPModule) {
+	PHPModule.FS.mkdirTree('/usr/local/etc');
+	PHPModule.FS.writeFile(
+		'/usr/local/etc/php.ini',
+		`[PHP]
 error_reporting = E_ERROR | E_PARSE
 display_errors = 1
 html_errors = 1
 display_startup_errors = On
 	`
-  );
+	);
+}
 
-  // We're ready to initialize WordPress!
-  const wp = new WordPress(php);
-  await wp.init(siteUrl);
+/**
+ * Creates a proxy that observes updates to Emscripten's `dataFileDownloads`
+ * property where the file download progress information is stored.
+ *
+ * Usage:
+ * ```js
+ *   const progressMonitor = new DownloadMonitor();
+ * 	 const PHPModule = await php.init(PHP, {
+ *     dataFileDownloads: progressMonitor.dataFileDownloads
+ *   });
+ *   progressMonitor.addEventListener('progress', (e) => {
+ *     console.log( e.detail.progress);
+ *   })
+ * ```
+ */
+class WASMDownloadMonitor extends EventTarget {
+	constructor() {
+		super();
 
-  console.log("[WASM Worker] After wp.init()");
+		this._monitorWASMStreamingProgress();
+		this.dataFileDownloads = this._createDataFileDownloadsProxy();
+	}
 
-  return new WPBrowser(wp, { handleRedirects: true });
+	_createDataFileDownloadsProxy() {
+		const self = this;
+		const dataFileDownloads = {};
+		// Monitor assignments like dataFileDownloads[file] = progress
+		return new Proxy(dataFileDownloads, {
+			set(obj, file, progress) {
+				self._notify(file, progress.loaded, progress.total);
+
+				// Monitor assignments like dataFileDownloads[file].total += delta
+				obj[file] = new Proxy(progress, {
+					set(nestedObj, prop, value) {
+						nestedObj[prop] = value;
+						self._notify(file, nestedObj.loaded, nestedObj.total);
+					},
+				});
+			},
+		});
+	}
+
+	_monitorWASMStreamingProgress() {
+		const self = this;
+		const _instantiateStreaming = WebAssembly.instantiateStreaming;
+		WebAssembly.instantiateStreaming = (response, ...args) => {
+			const file = response.url.substring(
+				new URL(response.url).origin.length + 1
+			);
+			const reportingResponse = new Response(
+				new ReadableStream(
+					{
+						async start(controller) {
+							const contentLength =
+								response.headers.get('content-length');
+							const total = parseInt(contentLength, 10);
+
+							const reader = response.body.getReader();
+							let loaded = 0;
+							for (;;) {
+								const { done, value } = await reader.read();
+
+								if (done) {
+									self._notify(file, total, total);
+									break;
+								}
+
+								loaded += value.byteLength;
+								self._notify(file, loaded, total);
+								controller.enqueue(value);
+							}
+							controller.close();
+						},
+					},
+					{
+						status: response.status,
+						statusText: response.statusText,
+					}
+				)
+			);
+
+			for (const pair of response.headers.entries()) {
+				reportingResponse.headers.set(pair[0], pair[1]);
+			}
+			return _instantiateStreaming(reportingResponse, ...args);
+		};
+	}
+
+	_notify(file, loaded, total) {
+		this.dispatchEvent(
+			new CustomEvent('progress', {
+				detail: {
+					file,
+					loaded,
+					total,
+				},
+			})
+		);
+	}
 }

--- a/src/web/wordpress-browser.html
+++ b/src/web/wordpress-browser.html
@@ -36,7 +36,12 @@
       }
 
       .fake-window iframe {
+        position: relative;
         flex-grow: 1;
+        border: 0;
+        margin: 0;
+        padding: 0;
+        z-index: 6;
       }
 
       .outer {
@@ -139,10 +144,106 @@
         border: 1px solid #b4b4b4;
         font-size: 20px;
       }
+      
+      /* Progress bar: */
+      .fake-window iframe,
+      .fake-window .progress-bar-overlay {
+        transition: opacity linear 0.5s
+      }
+      
+      .fake-window.is-loading iframe,
+      .fake-window:not(.is-loading) .progress-bar-overlay {
+        opacity: 0;
+        pointer-events: none;
+      }
+      .fake-window:not(.is-loading) iframe,
+      .fake-window.is-loading .progress-bar-overlay {
+        opacity: 1;
+      }
+      
+      .progress-bar-overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: 5;
+        display: flex;
+        width: 100%;
+        height: 100%;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .progress-bar-wrapper {
+        position: relative;
+        width: 400px;
+        height: 16px;
+        margin: 4px auto;
+        border-radius: 10px;
+      }
+      
+      .progress-bar-wrapper:before {
+        content: '';
+        position: absolute;
+        top: -4px;
+        left: -4px;
+        bottom: -4px;
+        right: -4px;
+        border: 1px solid #000;
+        border-radius:2px;
+      }
+      
+      .progress-bar-wrapper .progress-bar {
+        position: absolute;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        right: 100%;
+        width: 0;
+        background: #000;
+        border-radius: 2px;
+        transition: opacity linear 0.25s, width ease-in 0.5s;
+      }
+
+      .progress-bar-wrapper.mode-finite .progress-bar.is-infinite,
+      .progress-bar-wrapper.mode-infinite .progress-bar.is-finite {
+        opacity: 0;
+      }
+      
+      .progress-bar-wrapper.mode-finite .progress-bar.is-finite,
+      .progress-bar-wrapper.mode-infinite .progress-bar.is-infinite {
+        opacity: 1;
+      }
+
+      .progress-bar-wrapper .progress-bar.is-infinite {
+        animation: infinite-loading 2s linear infinite;
+      }
+
+      @keyframes infinite-loading {
+        0% {
+          left: 0%;
+          right: 100%;
+          width: 0%;
+        }
+        10% {
+          left: 0%;
+          right: 75%;
+          width: 25%;
+        }
+        90% {
+          right: 0%;
+          left: 75%;
+          width: 25%;
+        }
+        100% {
+          left: 100%;
+          right: 0%;
+          width: 0%;
+        }
+      }
     </style>
   </head>
   <body>
-    <div class="fake-window">
+    <div class="fake-window is-loading">
       <div class="outer">
         <div class="dot"></div>
         <div class="dot"></div>
@@ -154,8 +255,16 @@
         </div>
         <input type="submit" tabindex="-1" />
       </form>
-
-      <iframe id="wp" style="border: 0; margin: 0; padding: 0"></iframe>
+      <div style="flex-grow: 1; display: flex; flex-direction: column; position: relative">
+          <div class="progress-bar-overlay">
+            <div class="progress-bar-wrapper mode-infinite">
+              <div class="progress-bar is-infinite"></div>
+              <div class="progress-bar is-finite"></div>
+            </div>
+          </div>
+          <iframe id="wp"></iframe>
+        </div>
+      </div>
     </div>
 
     <script src="app.js"></script>

--- a/src/web/wordpress.html
+++ b/src/web/wordpress.html
@@ -9,5 +9,10 @@
       style="width: 100vw; height: 100vh; border: 0; margin: 0; padding: 0"
     ></iframe>
     <script src="app.js"></script>
+    <script>
+      startWordPress().then((wasmWorker) => {
+        document.querySelector("#wp").src = wasmWorker.pathToInternalUrl("/");
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## What problem does this PR solve?

Introduces a progress bar.

Loading WASM WordPress requires downloading about 20MB of files. Waiting without any feedback is a bad experience, not to mention you can never be sure whether it crashed or is still loading.

Solves #36

## Screencast

There are two loading stages:

1. The progress indicator bounces until we start loading the WASM files
2. The progress indicator morphs into a progress bar and grows to reflect the data transfer

https://user-images.githubusercontent.com/205419/195967002-8a0b5e60-a4a2-4732-a8b6-781ff94bbaa7.mp4

## How does this PR solve it?

This commit introduces a progress bar. The idea is to capture the progress events in `wasm-worker.js`, pass them on to the main thread, and then use the information to update a CSS progress bar.

We can’t simply update the WASM loading code to capture the progress events because that codeis generated by emscripten on each build. Instead, this commit introduces a`WASMDownloadMonitor` class that:

* Monkeypatches WebAssembly.instantiateStreaming to capture the `php-wasm.wasm` progress events
* Observes emscripten’s `dataFileDownloads` using ES Proxies to capture the `wp.data` progress events

It also introduces a new worker backend method called `addMessageListener`. It’s necessary to propagate the progress information from the worker to the main thread.

Finally, it reduces the `init()` method to a simple wrapper that can be configured as needed in the app. This allows the seamless `wordpress.html` to just load WordPress and be done, and the more involved `wordpress-browser.html` to handle the progress bar internally.