### PR TITLE
dependencies: remove spaces from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "yargs": "^17.5.1"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7. 33.5",
-    "@microsoft/api-extractor-model ": "7.25.2",
+    "@microsoft/api-extractor": "^7.33.5",
+    "@microsoft/api-extractor-model": "7.25.2",
     "@microsoft/tsdoc": "0.14.2",
     "@wordpress/eslint-plugin": "^13.0.0",
     "chokidar-cli": "^3.0.0",


### PR DESCRIPTION
## Proposed Changes
- Remove empty spaces from `package.json`
In https://github.com/WordPress/wordpress-wasm/pull/62/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R47-R48 we introduced some spaces that breaks the dependency installation.

Before this PR when you run `npm install` you get the following errors:

```
wordpress-wasm trunk ❯ npm install
npm ERR! code EINVALIDPACKAGENAME
npm ERR! Invalid package name "@microsoft/api-extractor-model " of package "@microsoft/api-extractor-model @7.25.2": name cannot contain leading or trailing spaces; name can only contain URL-friendly characters.
```


## Testing Instructions

* run `npm install`
* Observe the dependencies has been installed and there are no errors.
