### PR TITLE
Don't let it die on plugin failure.

### DIFF
--- a/src/wordpress-wasm/example-app.tsx
+++ b/src/wordpress-wasm/example-app.tsx
@@ -62,6 +62,9 @@ async function main() {
 				await fetch('/plugin-proxy?plugin=' + preinstallPlugin),
 				progress.partialObserver(progressBudgetPerPlugin * 0.66)
 			);
+			if (response.status !== 200) {
+				return null;
+			}
 			return new File([await response.blob()], preinstallPlugin);
 		};
 
@@ -81,6 +84,9 @@ async function main() {
 			}
 			downloads.addEventListener('resolved', (e: any) => {
 				installations.enqueue(async () => {
+					if (!e.detail) {
+						return;
+					}
 					progress.slowlyIncrementBy(progressBudgetPerPlugin * 0.33);
 					await installPlugin(workerThread, e.detail as File);
 				});


### PR DESCRIPTION
When there is a problem retrieving a plugin, the application currently crashes. This PR allows the boot-up to continue. I'm not sure what approach we want to take when it fails but for now, proceeding feels like the right choice.

This PR is designed to identify the issues, I'm not certain what we want to return on error.

## How to Test
1. Load this URL: http://127.0.0.1:8777/wordpress.html?plugin=gutenberg.latest-stable.zip&plugin=beauty-box.latest-stable.zip