### PR TITLE
Fix cache busting for HTML files and wp.data

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -252,7 +252,7 @@ function buildHTMLFile(filePath) {
 	const outdir = globalOutDir;
 	let content = fs.readFileSync(filePath).toString();
 	content = content.replace(
-		/(<script[^>]+src=")([^"]+)("><\/script>)/,
+		/(<script[^>]+src=")([^"]+)(" type="module"><\/script>)/,
 		`$1$2?${CACHE_BUSTER}$3`
 	);
 	const filename = filePath.split('/').pop();

--- a/src/wordpress-playground/wordpress/Dockerfile
+++ b/src/wordpress-playground/wordpress/Dockerfile
@@ -156,13 +156,15 @@ RUN mv wordpress /wordpress && \
     --no-node \
     --preload /wordpress \
     --js-output=/root/output/wp.js && \
-    mv /root/output/wp.data /root/output/$OUT_FILENAME.data
+    if [ "$OUT_FILENAME" != "wp" ]; then \
+      mv /root/output/wp.data /root/output/$OUT_FILENAME.data; \
+    fi
 
 COPY ./build-assets/esm-prefix.js ./build-assets/esm-suffix.js /root/
 
 # It's useful to add a "cache busting" query string to the .data file URL.
 # This tells web browsers it's a new file and they should reload it.
-RUN export CACHE_BUSTER=$(md5sum /root/output/wp.data | awk '{print $1}'); \
+RUN export CACHE_BUSTER=$(md5sum /root/output/$OUT_FILENAME.data | awk '{print $1}'); \
     cat /root/output/wp.js \
     | sed "s#wp\.data#/$OUT_FILENAME.data?$CACHE_BUSTER#g" \
     > /tmp/wp.js && \


### PR DESCRIPTION
- In the function `buildHTMLFile` in `esbuild.js`, the regular expression for matching script tags to add the cache buster string was missing `type="module"`
- In the Dockerfile for building `wp.data`, the `md5sum` command was using the file name `wp.data` instead of the version-specific `wp-6.1.data`, etc.