### PR TITLE
Update the parameter used for URL paths

### DIFF
--- a/docs/embedding-wordpress-playground-on-other-websites.md
+++ b/docs/embedding-wordpress-playground-on-other-websites.md
@@ -19,7 +19,7 @@ Here's the full list of supported configuration options:
 
 * `mode=seamless` or `mode=browser` – Displays WordPress on a full-page or wraps it in a browser UI
 * `login=1` – Logs the user in as an admin.
-* `page=/wp-admin/` – Load the specified initial page displaying WordPress
+* `url=/wp-admin/` – Load the specified initial page displaying WordPress
 * `plugin=coblocks` – Installs the specified plugin. Use the plugin name from the plugins directory URL, e.g. for a URL like `https://wordpress.org/plugins/wp-lazy-loading/`, the plugin name would be `wp-lazy-loading`. You can pre-install multiple plugins by saying `plugin=coblocks&plugin=wp-lazy-loading&…`. Installing a plugin automatically logs the user in as an admin.
 * `theme=disco` – Installs the specified theme. Use the theme name from the themes directory URL, e.g. for a URL like `https://wordpress.org/themes/disco/`, the theme name would be `disco`. Installing a theme automatically logs the user in as an admin.
 * `php=8.1` – Default: 8.0 Loads the specified PHP version. Supported values: `5.6`, `7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2`.


### PR DESCRIPTION
The parameter previously documented for the URL path was `page=/wp-admin/` but that doesn't work. Elsewhere in the documentation it mentions `&url=....` which got me thinking perhaps it was not named correctly in the current documentation. That led me to confirming that indeed `url` is the correct parameter to use here.