### PR TITLE
Tweak README to mention nx being installed globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Any changes you make to `.ts` files will be live-reloaded. Changes to `Dockerfil
 
 From here, the [documentation](https://wordpress.github.io/wordpress-playground/) will help you learn how WordPress Playground works and how to use it to build amazing things!
 
-And here's a few more interesting CLI:
+And here's a few more interesting CLI commands, which expect that you have `nx` installed globally:
 
 ```bash
 # Build and run PHP.wasm CLI


### PR DESCRIPTION
This is a minor tweak to make it a bit clearer how to run the CLI commands that are mentioned. It may make more sense to instead have a requirements/dependencies section that also mentions Docker Desktop and other dependencies instead though.