### PR TITLE
Prioritize passed arguments to build script

### DIFF
--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -113,10 +113,10 @@ const platform = args.PLATFORM === 'node' ? 'node' : 'web';
 /* eslint-disable prettier/prettier */
 const getArg = (name) => {
 	let value =
-		name in platformDefaults[platform]
-			? platformDefaults[platform][name]
-			: name in args
+		name in args
 			? args[name]
+			: name in platformDefaults[platform]
+			? platformDefaults[platform][name]
 			: name in platformDefaults.all
 			? platformDefaults.all[name]
 			: 'no';


### PR DESCRIPTION
Example:

```
nx recompile-php php-wasm-node --PHP_VERSION=8.0 --WITH_WS_NETWORKING_PROXY='no'
```