### PR TITLE
Rethrow human-readable FS errors from the PHP class

### DIFF
--- a/packages/php-wasm/common/src/lib/index.ts
+++ b/packages/php-wasm/common/src/lib/index.ts
@@ -1,7 +1,6 @@
 export type {
 	DataModule,
 	EmscriptenOptions,
-	ErrnoError,
 	FileInfo,
 	RuntimeType,
 	MountSettings,
@@ -18,6 +17,8 @@ export type {
 	WithNodeFilesystem,
 	WithPHPIniBindings,
 } from './php';
+
+export type { ErrnoError } from './rethrow-file-system-error';
 
 export {
 	LatestSupportedPHPVersion,

--- a/packages/php-wasm/common/src/lib/php.ts
+++ b/packages/php-wasm/common/src/lib/php.ts
@@ -3,6 +3,7 @@ import PHPRequestHandler, {
 	PHPRequest,
 	PHPRequestHandlerConfiguration,
 } from './php-request-handler';
+import { rethrowFileSystemError } from './rethrow-file-system-error';
 
 const STR = 'string';
 const NUM = 'number';
@@ -291,134 +292,6 @@ export type EmscriptenOptions = {
 export type MountSettings = {
 	root: string;
 };
-
-/**
- * Emscripten's filesystem-related Exception.
- *
- * @see https://emscripten.org/docs/api_reference/Filesystem-API.html
- * @see https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/arch/emscripten/bits/errno.h
- * @see https://github.com/emscripten-core/emscripten/blob/38eedc630f17094b3202fd48ac0c2c585dbea31e/system/include/wasi/api.h#L336
- */
-export interface ErrnoError extends Error {
-	node?: any;
-	errno: number;
-	message: string;
-}
-
-/**
- * @see https://github.com/emscripten-core/emscripten/blob/38eedc630f17094b3202fd48ac0c2c585dbea31e/system/include/wasi/api.h#L336
- */
-const FileErrorCodes = {
-	0: 'No error occurred. System call completed successfully.',
-	1: 'Argument list too long.',
-	2: 'Permission denied.',
-	3: 'Address in use.',
-	4: 'Address not available.',
-	5: 'Address family not supported.',
-	6: 'Resource unavailable, or operation would block.',
-	7: 'Connection already in progress.',
-	8: 'Bad file descriptor.',
-	9: 'Bad message.',
-	10: 'Device or resource busy.',
-	11: 'Operation canceled.',
-	12: 'No child processes.',
-	13: 'Connection aborted.',
-	14: 'Connection refused.',
-	15: 'Connection reset.',
-	16: 'Resource deadlock would occur.',
-	17: 'Destination address required.',
-	18: 'Mathematics argument out of domain of function.',
-	19: 'Reserved.',
-	20: 'File exists.',
-	21: 'Bad address.',
-	22: 'File too large.',
-	23: 'Host is unreachable.',
-	24: 'Identifier removed.',
-	25: 'Illegal byte sequence.',
-	26: 'Operation in progress.',
-	27: 'Interrupted function.',
-	28: 'Invalid argument.',
-	29: 'I/O error.',
-	30: 'Socket is connected.',
-	31: 'There is a directory under that path',
-	32: 'Too many levels of symbolic links.',
-	33: 'File descriptor value too large.',
-	34: 'Too many links.',
-	35: 'Message too large.',
-	36: 'Reserved.',
-	37: 'Filename too long.',
-	38: 'Network is down.',
-	39: 'Connection aborted by network.',
-	40: 'Network unreachable.',
-	41: 'Too many files open in system.',
-	42: 'No buffer space available.',
-	43: 'No such device.',
-	44: 'There is no such file or directory OR the parent directory does not exist.',
-	45: 'Executable file format error.',
-	46: 'No locks available.',
-	47: 'Reserved.',
-	48: 'Not enough space.',
-	49: 'No message of the desired type.',
-	50: 'Protocol not available.',
-	51: 'No space left on device.',
-	52: 'Function not supported.',
-	53: 'The socket is not connected.',
-	54: 'Not a directory or a symbolic link to a directory.',
-	55: 'Directory not empty.',
-	56: 'State not recoverable.',
-	57: 'Not a socket.',
-	58: 'Not supported, or operation not supported on socket.',
-	59: 'Inappropriate I/O control operation.',
-	60: 'No such device or address.',
-	61: 'Value too large to be stored in data type.',
-	62: 'Previous owner died.',
-	63: 'Operation not permitted.',
-	64: 'Broken pipe.',
-	65: 'Protocol error.',
-	66: 'Protocol not supported.',
-	67: 'Protocol wrong type for socket.',
-	68: 'Result too large.',
-	69: 'Read-only file system.',
-	70: 'Invalid seek.',
-	71: 'No such process.',
-	72: 'Reserved.',
-	73: 'Connection timed out.',
-	74: 'Text file busy.',
-	75: 'Cross-device link.',
-	76: 'Extension: Capabilities insufficient.',
-} as any;
-
-function rethrowFileSystemError(messagePrefix = '') {
-	return function catchFileSystemError(
-		target: any,
-		methodName: string,
-		descriptor: PropertyDescriptor
-	) {
-		const method = descriptor.value;
-		descriptor.value = function (...args: any[]) {
-			try {
-				return method.apply(this, args);
-			} catch (e) {
-				const errno =
-					typeof e === 'object' ? ((e as any)?.errno as any) : null;
-				if (errno in FileErrorCodes) {
-					const errmsg = FileErrorCodes[errno];
-					const path = typeof args[0] === 'string' ? args[0] : null;
-					const formattedPrefix =
-						path !== null
-							? messagePrefix.replaceAll('{path}', path)
-							: messagePrefix;
-					console.log(`${formattedPrefix}: ${errmsg}.`);
-					throw new Error(`${formattedPrefix}: ${errmsg}`, {
-						cause: e,
-					});
-				}
-
-				throw e;
-			}
-		};
-	};
-}
 
 /**
  * An environment-agnostic wrapper around the Emscripten PHP runtime

--- a/packages/php-wasm/common/src/lib/php.ts
+++ b/packages/php-wasm/common/src/lib/php.ts
@@ -293,6 +293,134 @@ export type MountSettings = {
 };
 
 /**
+ * Emscripten's filesystem-related Exception.
+ *
+ * @see https://emscripten.org/docs/api_reference/Filesystem-API.html
+ * @see https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/arch/emscripten/bits/errno.h
+ * @see https://github.com/emscripten-core/emscripten/blob/38eedc630f17094b3202fd48ac0c2c585dbea31e/system/include/wasi/api.h#L336
+ */
+export interface ErrnoError extends Error {
+	node?: any;
+	errno: number;
+	message: string;
+}
+
+/**
+ * @see https://github.com/emscripten-core/emscripten/blob/38eedc630f17094b3202fd48ac0c2c585dbea31e/system/include/wasi/api.h#L336
+ */
+const FileErrorCodes = {
+	0: 'No error occurred. System call completed successfully.',
+	1: 'Argument list too long.',
+	2: 'Permission denied.',
+	3: 'Address in use.',
+	4: 'Address not available.',
+	5: 'Address family not supported.',
+	6: 'Resource unavailable, or operation would block.',
+	7: 'Connection already in progress.',
+	8: 'Bad file descriptor.',
+	9: 'Bad message.',
+	10: 'Device or resource busy.',
+	11: 'Operation canceled.',
+	12: 'No child processes.',
+	13: 'Connection aborted.',
+	14: 'Connection refused.',
+	15: 'Connection reset.',
+	16: 'Resource deadlock would occur.',
+	17: 'Destination address required.',
+	18: 'Mathematics argument out of domain of function.',
+	19: 'Reserved.',
+	20: 'File exists.',
+	21: 'Bad address.',
+	22: 'File too large.',
+	23: 'Host is unreachable.',
+	24: 'Identifier removed.',
+	25: 'Illegal byte sequence.',
+	26: 'Operation in progress.',
+	27: 'Interrupted function.',
+	28: 'Invalid argument.',
+	29: 'I/O error.',
+	30: 'Socket is connected.',
+	31: 'There is a directory under that path',
+	32: 'Too many levels of symbolic links.',
+	33: 'File descriptor value too large.',
+	34: 'Too many links.',
+	35: 'Message too large.',
+	36: 'Reserved.',
+	37: 'Filename too long.',
+	38: 'Network is down.',
+	39: 'Connection aborted by network.',
+	40: 'Network unreachable.',
+	41: 'Too many files open in system.',
+	42: 'No buffer space available.',
+	43: 'No such device.',
+	44: 'There is no such file or directory OR the parent directory does not exist.',
+	45: 'Executable file format error.',
+	46: 'No locks available.',
+	47: 'Reserved.',
+	48: 'Not enough space.',
+	49: 'No message of the desired type.',
+	50: 'Protocol not available.',
+	51: 'No space left on device.',
+	52: 'Function not supported.',
+	53: 'The socket is not connected.',
+	54: 'Not a directory or a symbolic link to a directory.',
+	55: 'Directory not empty.',
+	56: 'State not recoverable.',
+	57: 'Not a socket.',
+	58: 'Not supported, or operation not supported on socket.',
+	59: 'Inappropriate I/O control operation.',
+	60: 'No such device or address.',
+	61: 'Value too large to be stored in data type.',
+	62: 'Previous owner died.',
+	63: 'Operation not permitted.',
+	64: 'Broken pipe.',
+	65: 'Protocol error.',
+	66: 'Protocol not supported.',
+	67: 'Protocol wrong type for socket.',
+	68: 'Result too large.',
+	69: 'Read-only file system.',
+	70: 'Invalid seek.',
+	71: 'No such process.',
+	72: 'Reserved.',
+	73: 'Connection timed out.',
+	74: 'Text file busy.',
+	75: 'Cross-device link.',
+	76: 'Extension: Capabilities insufficient.',
+} as any;
+
+function rethrowFileSystemError(messagePrefix = '') {
+	return function catchFileSystemError(
+		target: any,
+		methodName: string,
+		descriptor: PropertyDescriptor
+	) {
+		const method = descriptor.value;
+		descriptor.value = function (...args: any[]) {
+			try {
+				return method.apply(this, args);
+			} catch (e) {
+				const errno =
+					typeof e === 'object' ? ((e as any)?.errno as any) : null;
+				if (errno in FileErrorCodes) {
+					const errmsg = FileErrorCodes[errno];
+					const path = typeof args[0] === 'string' ? args[0] : null;
+					const formattedPrefix =
+						path !== null
+							? messagePrefix.replaceAll('{path}', path)
+							: messagePrefix;
+					console.log(`${formattedPrefix}: ${errmsg}.`);
+					throw new Error(`${formattedPrefix}: ${errmsg}`, {
+						cause: e,
+					});
+				}
+
+				throw e;
+			}
+		};
+	};
+}
+
+/**
  * An environment-agnostic wrapper around the Emscripten PHP runtime
  * that abstracts the super low-level API and provides a more convenient
  * higher-level API.
@@ -612,30 +740,38 @@ export abstract class BasePHP
 		};
 	}
 
+	/** @inheritDoc */
+	@rethrowFileSystemError('Could not create directory "{path}"')
 	mkdirTree(path: string) {
 		this.#Runtime.FS.mkdirTree(path);
 	}
 
+	/** @inheritDoc */
+	@rethrowFileSystemError('Could not read "{path}"')
 	readFileAsText(path: string) {
 		return new TextDecoder().decode(this.readFileAsBuffer(path));
 	}
 
 	/** @inheritDoc */
+	@rethrowFileSystemError('Could not read "{path}"')
 	readFileAsBuffer(path: string): Uint8Array {
 		return this.#Runtime.FS.readFile(path);
 	}
 
 	/** @inheritDoc */
+	@rethrowFileSystemError('Could not write to "{path}"')
 	writeFile(path: string, data: string | Uint8Array) {
 		this.#Runtime.FS.writeFile(path, data);
 	}
 
 	/** @inheritDoc */
+	@rethrowFileSystemError('Could not unlink "{path}"')
 	unlink(path: string) {
 		this.#Runtime.FS.unlink(path);
 	}
 
 	/** @inheritDoc */
+	@rethrowFileSystemError('Could not list files in "{path}"')
 	listFiles(path: string): string[] {
 		if (!this.fileExists(path)) {
 			return [];
@@ -650,6 +786,8 @@ export abstract class BasePHP
 		}
 	}
 
+	/** @inheritDoc */
+	@rethrowFileSystemError('Could not stat "{path}"')
 	isDir(path: string): boolean {
 		if (!this.fileExists(path)) {
 			return false;
@@ -659,6 +797,8 @@ export abstract class BasePHP
 		);
 	}
 
+	/** @inheritDoc */
+	@rethrowFileSystemError('Could not stat "{path}"')
 	fileExists(path: string): boolean {
 		try {
 			this.#Runtime.FS.lookupPath(path);
@@ -668,6 +808,8 @@ export abstract class BasePHP
 		}
 	}
 
+	/** @inheritDoc */
+	@rethrowFileSystemError('Could not mount a directory')
 	mount(settings: MountSettings, path: string) {
 		this.#Runtime.FS.mount(
 			this.#Runtime.FS.filesystems.NODEFS,
@@ -700,14 +842,6 @@ export interface PHPOutput {
 	/** Stderr lines */
 	stderr: string[];
 }
-
-/**
- * Emscripten's filesystem-related Exception.
- *
- * @see https://emscripten.org/docs/api_reference/Filesystem-API.html
- * @see https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/arch/emscripten/bits/errno.h
- */
-export type ErrnoError = Error;
 
 /**
  * Loads the PHP runtime with the given arguments and data dependencies.

--- a/packages/php-wasm/common/src/lib/rethrow-file-system-error.ts
+++ b/packages/php-wasm/common/src/lib/rethrow-file-system-error.ts
@@ -1,0 +1,124 @@
+/**
+ * Emscripten's filesystem-related Exception.
+ *
+ * @see https://emscripten.org/docs/api_reference/Filesystem-API.html
+ * @see https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/arch/emscripten/bits/errno.h
+ * @see https://github.com/emscripten-core/emscripten/blob/38eedc630f17094b3202fd48ac0c2c585dbea31e/system/include/wasi/api.h#L336
+ */
+
+export interface ErrnoError extends Error {
+	node?: any;
+	errno: number;
+	message: string;
+}
+/**
+ * @see https://github.com/emscripten-core/emscripten/blob/38eedc630f17094b3202fd48ac0c2c585dbea31e/system/include/wasi/api.h#L336
+ */
+const FileErrorCodes = {
+	0: 'No error occurred. System call completed successfully.',
+	1: 'Argument list too long.',
+	2: 'Permission denied.',
+	3: 'Address in use.',
+	4: 'Address not available.',
+	5: 'Address family not supported.',
+	6: 'Resource unavailable, or operation would block.',
+	7: 'Connection already in progress.',
+	8: 'Bad file descriptor.',
+	9: 'Bad message.',
+	10: 'Device or resource busy.',
+	11: 'Operation canceled.',
+	12: 'No child processes.',
+	13: 'Connection aborted.',
+	14: 'Connection refused.',
+	15: 'Connection reset.',
+	16: 'Resource deadlock would occur.',
+	17: 'Destination address required.',
+	18: 'Mathematics argument out of domain of function.',
+	19: 'Reserved.',
+	20: 'File exists.',
+	21: 'Bad address.',
+	22: 'File too large.',
+	23: 'Host is unreachable.',
+	24: 'Identifier removed.',
+	25: 'Illegal byte sequence.',
+	26: 'Operation in progress.',
+	27: 'Interrupted function.',
+	28: 'Invalid argument.',
+	29: 'I/O error.',
+	30: 'Socket is connected.',
+	31: 'There is a directory under that path',
+	32: 'Too many levels of symbolic links.',
+	33: 'File descriptor value too large.',
+	34: 'Too many links.',
+	35: 'Message too large.',
+	36: 'Reserved.',
+	37: 'Filename too long.',
+	38: 'Network is down.',
+	39: 'Connection aborted by network.',
+	40: 'Network unreachable.',
+	41: 'Too many files open in system.',
+	42: 'No buffer space available.',
+	43: 'No such device.',
+	44: 'There is no such file or directory OR the parent directory does not exist.',
+	45: 'Executable file format error.',
+	46: 'No locks available.',
+	47: 'Reserved.',
+	48: 'Not enough space.',
+	49: 'No message of the desired type.',
+	50: 'Protocol not available.',
+	51: 'No space left on device.',
+	52: 'Function not supported.',
+	53: 'The socket is not connected.',
+	54: 'Not a directory or a symbolic link to a directory.',
+	55: 'Directory not empty.',
+	56: 'State not recoverable.',
+	57: 'Not a socket.',
+	58: 'Not supported, or operation not supported on socket.',
+	59: 'Inappropriate I/O control operation.',
+	60: 'No such device or address.',
+	61: 'Value too large to be stored in data type.',
+	62: 'Previous owner died.',
+	63: 'Operation not permitted.',
+	64: 'Broken pipe.',
+	65: 'Protocol error.',
+	66: 'Protocol not supported.',
+	67: 'Protocol wrong type for socket.',
+	68: 'Result too large.',
+	69: 'Read-only file system.',
+	70: 'Invalid seek.',
+	71: 'No such process.',
+	72: 'Reserved.',
+	73: 'Connection timed out.',
+	74: 'Text file busy.',
+	75: 'Cross-device link.',
+	76: 'Extension: Capabilities insufficient.',
+} as any;
+export function rethrowFileSystemError(messagePrefix = '') {
+	return function catchFileSystemError(
+		target: any,
+		methodName: string,
+		descriptor: PropertyDescriptor
+	) {
+		const method = descriptor.value;
+		descriptor.value = function (...args: any[]) {
+			try {
+				return method.apply(this, args);
+			} catch (e) {
+				const errno = typeof e === 'object' ? ((e as any)?.errno as any) : null;
+				if (errno in FileErrorCodes) {
+					const errmsg = FileErrorCodes[errno];
+					const path = typeof args[0] === 'string' ? args[0] : null;
+					const formattedPrefix = path !== null
+						? messagePrefix.replaceAll('{path}', path)
+						: messagePrefix;
+					console.log(`${formattedPrefix}: ${errmsg}.`);
+					throw new Error(`${formattedPrefix}: ${errmsg}`, {
+						cause: e,
+					});
+				}
+
+				throw e;
+			}
+		};
+	};
+}

--- a/packages/php-wasm/common/src/lib/rethrow-file-system-error.ts
+++ b/packages/php-wasm/common/src/lib/rethrow-file-system-error.ts
@@ -104,13 +104,15 @@ export function rethrowFileSystemError(messagePrefix = '') {
 			try {
 				return method.apply(this, args);
 			} catch (e) {
-				const errno = typeof e === 'object' ? ((e as any)?.errno as any) : null;
+				const errno =
+					typeof e === 'object' ? ((e as any)?.errno as any) : null;
 				if (errno in FileErrorCodes) {
 					const errmsg = FileErrorCodes[errno];
 					const path = typeof args[0] === 'string' ? args[0] : null;
-					const formattedPrefix = path !== null
-						? messagePrefix.replaceAll('{path}', path)
-						: messagePrefix;
+					const formattedPrefix =
+						path !== null
+							? messagePrefix.replaceAll('{path}', path)
+							: messagePrefix;
 					console.log(`${formattedPrefix}: ${errmsg}.`);
 					throw new Error(`${formattedPrefix}: ${errmsg}`, {
 						cause: e,

--- a/packages/php-wasm/common/src/lib/rethrow-file-system-error.ts
+++ b/packages/php-wasm/common/src/lib/rethrow-file-system-error.ts
@@ -46,7 +46,7 @@ const FileErrorCodes = {
 	28: 'Invalid argument.',
 	29: 'I/O error.',
 	30: 'Socket is connected.',
-	31: 'There is a directory under that path',
+	31: 'There is a directory under that path.',
 	32: 'Too many levels of symbolic links.',
 	33: 'File descriptor value too large.',
 	34: 'Too many links.',

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -1,4 +1,4 @@
-import { getPHPLoaderModule, PHP,  } from '..';
+import { getPHPLoaderModule, PHP } from '..';
 import { loadPHPRuntime, SupportedPHPVersions } from '@php-wasm/common';
 import { existsSync, rmSync, readFileSync } from 'fs';
 

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -1,11 +1,11 @@
 import { getPHPLoaderModule, PHP, SupportedPHPVersions } from '..';
-import { loadPHPRuntime } from '@php-wasm/common';
+import { LatestSupportedPHPVersion, loadPHPRuntime } from '@php-wasm/common';
 import { existsSync, rmSync, readFileSync } from 'fs';
 
 const testDirPath = '/__test987654321';
 const testFilePath = '/__test987654321.txt';
 
-describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
+describe.each([LatestSupportedPHPVersion])('PHP %s', (phpVersion) => {
 	let php: PHP;
 	beforeEach(async () => {
 		php = await PHP.load(phpVersion);
@@ -17,6 +17,25 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 		it('writeFile() should create a file when it does not exist', () => {
 			php.writeFile(testFilePath, 'Hello World!');
 			expect(php.fileExists(testFilePath)).toEqual(true);
+		});
+
+		it('writeFile() should throw a useful error when parent directory does not exist', () => {
+			expect(() => {
+				php.writeFile('/a/b/c/d/e/f', 'Hello World!');
+			}).toThrowError(
+				'Could not write to "/a/b/c/d/e/f": There is no such file or directory OR the parent directory does not exist.'
+			);
+		});
+
+		it('writeFile() should throw a useful error when the specified path is a directory', () => {
+			php.mkdirTree('/dir');
+			expect(() => {
+				php.writeFile('/dir', 'Hello World!');
+			}).toThrowError(
+				new Error(
+					`Could not write to "/dir": There is a directory under that path.`
+				)
+			);
 		});
 
 		it('writeFile() should overwrite a file when it exists', () => {
@@ -53,6 +72,14 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			php.mkdirTree(testDirPath + '/nested/doubly/triply');
 			expect(php.isDir(testDirPath + '/nested/doubly/triply')).toEqual(
 				true
+			);
+		});
+
+		it.only('unlink() should throw a useful error when parent directory does not exist', () => {
+			expect(() => {
+				php.unlink('/a/b/c/d/e/f');
+			}).toThrowError(
+				'Could not unlink "/a/b/c/d/e/f": There is no such file or directory OR the parent directory does not exist.'
 			);
 		});
 

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -75,7 +75,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			);
 		});
 
-		it.only('unlink() should throw a useful error when parent directory does not exist', () => {
+		it('unlink() should throw a useful error when parent directory does not exist', () => {
 			expect(() => {
 				php.unlink('/a/b/c/d/e/f');
 			}).toThrowError(

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -1,11 +1,11 @@
-import { getPHPLoaderModule, PHP, SupportedPHPVersions } from '..';
-import { LatestSupportedPHPVersion, loadPHPRuntime } from '@php-wasm/common';
+import { getPHPLoaderModule, PHP,  } from '..';
+import { loadPHPRuntime, SupportedPHPVersions } from '@php-wasm/common';
 import { existsSync, rmSync, readFileSync } from 'fs';
 
 const testDirPath = '/__test987654321';
 const testFilePath = '/__test987654321.txt';
 
-describe.each([LatestSupportedPHPVersion])('PHP %s', (phpVersion) => {
+describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 	let php: PHP;
 	beforeEach(async () => {
 		php = await PHP.load(phpVersion);


### PR DESCRIPTION
## Description

This PR wraps Emscripten’s highly confusing filesystem-related errors in ones that are human-readable.

For example, writing a file in a non-existing directory triggers “Errno 44” without this PR. With this PR, it provides an error message explaining how a parent directory doesn’t exist.