### PR TITLE
PHPResponse class with text() and json() shorthand methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ const client = await connectPlayground(
 await client.isReady();
 await client.goTo('/wp-admin/');
 
-const result = await client.run({
+const response = await client.run({
 	code: '<?php echo "Hi!"; ',
 });
-console.log(new TextDecoder().decode(result.body));
+console.log(response.text);
 ```
 
 ## Contributing

--- a/packages/php-wasm/common/src/lib/index.ts
+++ b/packages/php-wasm/common/src/lib/index.ts
@@ -7,7 +7,6 @@ export type {
 	PHPLoaderModule,
 	PHPOutput,
 	PHPRunOptions,
-	PHPResponse,
 	PHPRuntime,
 	PHPRuntimeId,
 	WithCLI,
@@ -18,6 +17,7 @@ export type {
 	WithPHPIniBindings,
 } from './php';
 
+export type { PHPResponse } from './php-response';
 export type { ErrnoError } from './rethrow-file-system-error';
 
 export {

--- a/packages/php-wasm/common/src/lib/php-browser.ts
+++ b/packages/php-wasm/common/src/lib/php-browser.ts
@@ -1,6 +1,7 @@
 import type PHPRequestHandler from './php-request-handler';
 import type { PHPRequest } from './php-request-handler';
-import type { PHPResponse, WithRequestHandler } from './php';
+import type { WithRequestHandler } from './php';
+import type { PHPResponse } from './php-response';
 
 export interface PHPBrowserConfiguration {
 	/**

--- a/packages/php-wasm/common/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/common/src/lib/php-request-handler.ts
@@ -55,8 +55,8 @@ export interface PHPRequestHandlerConfiguration {
  * php.mkdirTree('/www');
  * php.writeFile('/www/index.php', '<?php echo "Hi from PHP!"; ');
  *
- * const output = (await php.request({ path: '/index.php' })).body;
- * console.log(new TextDecoder().decode(output));
+ * const response = await php.request({ path: '/index.php' });
+ * console.log(response.text);
  * // "Hi from PHP!"
  * ```
  *
@@ -83,8 +83,8 @@ export interface PHPRequestHandlerConfiguration {
  *     absoluteUrl: 'http://127.0.0.1'
  * });
  *
- * const output = server.request({ path: '/index.php' }).body;
- * console.log(new TextDecoder().decode(output));
+ * const response = server.request({ path: '/index.php' });
+ * console.log(response.text);
  * // "Hi from PHP!"
  * ```
  */
@@ -238,7 +238,7 @@ export class PHPRequestHandler {
 				'accept-ranges': ['bytes'],
 				'cache-control': ['public, max-age=0'],
 			},
-			this.php.readFileAsBuffer('/tmp/stdout')
+			arrayBuffer
 		);
 	}
 

--- a/packages/php-wasm/common/src/lib/php-response.ts
+++ b/packages/php-wasm/common/src/lib/php-response.ts
@@ -7,20 +7,24 @@ export class PHPResponse {
 	 * Response headers.
 	 */
 	readonly headers: Record<string, string[]>;
+
 	/**
 	 * Response body. Contains the output from `echo`,
 	 * `print`, inline HTML etc.
 	 */
 	private readonly body: ArrayBuffer;
+
 	/**
-	 * PHP errors.
+	 * Stderr contents, if any.
 	 */
 	readonly errors: string;
+
 	/**
 	 * The exit code of the script. `0` is a success, while
 	 * `1` and `2` indicate an error.
 	 */
 	readonly exitCode: number;
+
 	/**
 	 * Response HTTP status code, e.g. 200.
 	 */

--- a/packages/php-wasm/common/src/lib/php-response.ts
+++ b/packages/php-wasm/common/src/lib/php-response.ts
@@ -1,24 +1,63 @@
+/**
+ * PHP response. Body is an `ArrayBuffer` because it can
+ * contain binary data.
+ */
+export class PHPResponse {
+	/**
+	 * Response headers.
+	 */
+	readonly headers: Record<string, string[]>;
+	/**
+	 * Response body. Contains the output from `echo`,
+	 * `print`, inline HTML etc.
+	 */
+	private readonly body: ArrayBuffer;
+	/**
+	 * PHP errors.
+	 */
+	readonly errors: string;
+	/**
+	 * The exit code of the script. `0` is a success, while
+	 * `1` and `2` indicate an error.
+	 */
+	readonly exitCode: number;
+	/**
+	 * Response HTTP status code, e.g. 200.
+	 */
+	readonly httpStatusCode: number;
 
-class PHPResponse {
+	constructor(
+		httpStatusCode: number,
+		headers: Record<string, string[]>,
+		body: ArrayBuffer,
+		errors = '',
+		exitCode = 0
+	) {
+		this.httpStatusCode = httpStatusCode;
+		this.headers = headers;
+		this.body = body;
+		this.exitCode = exitCode;
+		this.errors = errors;
+	}
 
-    readonly headers;
-    readonly bytes: Uint8Array;
-    readonly exitCode: number;
-    readonly stderr;
+	/**
+	 * Response body as JSON.
+	 */
+	get json() {
+		return JSON.parse(this.text);
+	}
 
-    constructor(headers, bytes, exitCode, stderr) {
-        this.headers = headers;
-        this.bytes = bytes;
-        this.exitCode = exitCode;
-        this.stderr = stderr;
-    }
+	/**
+	 * Response body as text.
+	 */
+	get text() {
+		return new TextDecoder().decode(this.body);
+	}
 
-    get json() {
-        return JSON.parse(this.text);
-    }
-    
-    get text() {
-        return new TextDecoder().decode(this.bytes);
-    }
-
+	/**
+	 * Response body as bytes.
+	 */
+	get bytes() {
+		return this.body;
+	}
 }

--- a/packages/php-wasm/common/src/lib/php-response.ts
+++ b/packages/php-wasm/common/src/lib/php-response.ts
@@ -1,0 +1,24 @@
+
+class PHPResponse {
+
+    readonly headers;
+    readonly bytes: Uint8Array;
+    readonly exitCode: number;
+    readonly stderr;
+
+    constructor(headers, bytes, exitCode, stderr) {
+        this.headers = headers;
+        this.bytes = bytes;
+        this.exitCode = exitCode;
+        this.stderr = stderr;
+    }
+
+    get json() {
+        return JSON.parse(this.text);
+    }
+    
+    get text() {
+        return new TextDecoder().decode(this.bytes);
+    }
+
+}

--- a/packages/php-wasm/common/src/lib/rethrow-file-system-error.ts
+++ b/packages/php-wasm/common/src/lib/rethrow-file-system-error.ts
@@ -113,7 +113,6 @@ export function rethrowFileSystemError(messagePrefix = '') {
 						path !== null
 							? messagePrefix.replaceAll('{path}', path)
 							: messagePrefix;
-					console.log(`${formattedPrefix}: ${errmsg}.`);
 					throw new Error(`${formattedPrefix}: ${errmsg}`, {
 						cause: e,
 					});

--- a/packages/php-wasm/node/src/test/php-networking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-networking.spec.ts
@@ -14,10 +14,9 @@ describe.each(SupportedPHPVersions)(
             echo file_get_contents("${serverUrl}");
             `
 			);
-			const result = await php.run({
+			const { text } = await php.run({
 				scriptPath: '/tmp/test.php',
 			});
-			const text = new TextDecoder().decode(result.body);
 			expect(text).toEqual('response from express');
 		});
 	},

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -173,6 +173,20 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 				exitCode: 0,
 			});
 		});
+		it('should provide response text through .text', async () => {
+			const code = `<?php
+			echo "Hello world!";
+			`;
+			const response = await php.run({ code });
+			expect(response.text).toEqual('Hello world!');
+		});
+		it('should provide response JSON through .json', async () => {
+			const code = `<?php
+			echo json_encode(["hello" => "world"]);
+			`;
+			const response = await php.run({ code });
+			expect(response.json).toEqual({ hello: 'world' });
+		});
 	});
 
 	describe('Startup sequence – basics', () => {
@@ -458,7 +472,6 @@ bar1
 				},
 			});
 			const bodyText = new TextDecoder().decode(response.bytes);
-			console.log(bodyText);
 			const $_SERVER = JSON.parse(bodyText);
 			expect($_SERVER).toHaveProperty('REQUEST_URI', '/test.php?a=b');
 			expect($_SERVER).toHaveProperty('REQUEST_METHOD', 'POST');

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -235,7 +235,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			const response = await php.run({
 				scriptPath: testScriptPath,
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(bodyText).toEqual('Hello world!');
 		});
 
@@ -245,7 +245,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 				scriptPath: testScriptPath,
 				code: '<?php echo "Hello from a code snippet!";',
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(bodyText).toEqual('Hello from a code snippet!');
 		});
 
@@ -255,7 +255,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 				body: '{"foo": "bar"}',
 				code: `<?php echo file_get_contents('php://input');`,
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(bodyText).toEqual('{"foo": "bar"}');
 		});
 
@@ -268,7 +268,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(bodyText).toEqual('{"foo":"bar"}');
 		});
 
@@ -281,7 +281,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(bodyText).toEqual(
 				'{"foo":["bar1","bar2"],"indexed":{"key":"value"}}'
 			);
@@ -299,7 +299,7 @@ bar`,
 					'Content-Type': 'multipart/form-data; boundary=boundary',
 				},
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(bodyText).toEqual('{"foo":"bar"}');
 		});
 
@@ -320,7 +320,7 @@ bar
 					'Content-Type': 'multipart/form-data; boundary=boundary',
 				},
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			const expectedResult = {
 				files: {
 					myFile: {
@@ -358,7 +358,7 @@ bar
 					'Content-Type': 'multipart/form-data; boundary=boundary',
 				},
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(JSON.parse(bodyText)).toEqual({
 				files: {
 					myFile: {
@@ -400,7 +400,7 @@ bar1
 					'Content-Type': 'multipart/form-data; boundary=boundary',
 				},
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			const expectedResult = {
 				files: {
 					myFile1: {
@@ -457,7 +457,7 @@ bar1
 					'X-is-ajax': 'true',
 				},
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			console.log(bodyText);
 			const $_SERVER = JSON.parse(bodyText);
 			expect($_SERVER).toHaveProperty('REQUEST_URI', '/test.php?a=b');
@@ -495,7 +495,7 @@ bar1
 					echo json_encode($rows);
 				?>`,
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(JSON.parse(bodyText)).toEqual(['This is a test']);
 		});
 
@@ -512,7 +512,7 @@ bar1
 					echo json_encode($rows);
 				?>`,
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(JSON.parse(bodyText)).toEqual(['This is a test']);
 		});
 	});
@@ -532,7 +532,7 @@ bar1
 					]);
 				?>`,
 			});
-			const bodyText = new TextDecoder().decode(response.body);
+			const bodyText = new TextDecoder().decode(response.bytes);
 			expect(JSON.parse(bodyText)).toEqual({
 				md5: '098f6bcd4621d373cade4e832627b4f6',
 				sha1: 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3',

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -13,10 +13,10 @@ const client = await connectPlayground(
 await client.isReady();
 await client.goTo('/wp-admin/');
 
-const result = await client.run({
+const response = await client.run({
 	code: '<?php echo "Hi!"; ',
 });
-console.log(new TextDecoder().decode(result.body));
+console.log(response.text);
 ```
 
 Using TypeScript is highly recommended as this package ships with comprehensive types – hit ctrl+space in your IDE after `client.` and you'll see all the available methods.

--- a/packages/playground/client/src/lib/common.ts
+++ b/packages/playground/client/src/lib/common.ts
@@ -1,11 +1,7 @@
 import type { PHPResponse } from '@php-wasm/web';
 
 export function asDOM(response: PHPResponse) {
-	return new DOMParser().parseFromString(asText(response), 'text/html')!;
-}
-
-export function asText(response: PHPResponse) {
-	return new TextDecoder().decode(response.bytes);
+	return new DOMParser().parseFromString(response.text, 'text/html')!;
 }
 
 export function zipNameToHumanName(zipName: string) {

--- a/packages/playground/client/src/lib/common.ts
+++ b/packages/playground/client/src/lib/common.ts
@@ -5,7 +5,7 @@ export function asDOM(response: PHPResponse) {
 }
 
 export function asText(response: PHPResponse) {
-	return new TextDecoder().decode(response.body);
+	return new TextDecoder().decode(response.bytes);
 }
 
 export function zipNameToHumanName(zipName: string) {

--- a/packages/playground/client/src/lib/import-export.ts
+++ b/packages/playground/client/src/lib/import-export.ts
@@ -9,11 +9,9 @@ const databaseExportPath = '/' + databaseExportName;
 
 export async function exportFile(playground: PlaygroundClient) {
 	const databaseExportResponse = await playground.request({
-		url: '/wp-admin/export.php?download=true&&content=all',
+		url: '/wp-admin/export.php?download=true&content=all',
 	});
-	const databaseExportContent = new TextDecoder().decode(
-		databaseExportResponse.body
-	);
+	const databaseExportContent = databaseExportResponse.text;
 	await playground.writeFile(databaseExportPath, databaseExportContent);
 	const wpVersion = await playground.wordPressVersion;
 	const phpVersion = await playground.phpVersion;
@@ -62,7 +60,7 @@ export async function importFile(playground: PlaygroundClient, file: File) {
 	}
 
 	const databaseFromZipFileContent = new TextDecoder().decode(
-		databaseFromZipFileReadRequest.body
+		databaseFromZipFileReadRequest.bytes
 	);
 
 	const databaseFile = new File(
@@ -75,7 +73,7 @@ export async function importFile(playground: PlaygroundClient, file: File) {
 	});
 
 	const importerPageOneContent = new DOMParser().parseFromString(
-		new TextDecoder().decode(importerPageOneResponse.body),
+		importerPageOneResponse.text,
 		'text/html'
 	);
 
@@ -90,7 +88,7 @@ export async function importFile(playground: PlaygroundClient, file: File) {
 	});
 
 	const importerPageTwoContent = new DOMParser().parseFromString(
-		new TextDecoder().decode(stepOneResponse.body),
+		stepOneResponse.text,
 		'text/html'
 	);
 

--- a/pages/running-wordpress-in-the-browser.md
+++ b/pages/running-wordpress-in-the-browser.md
@@ -47,7 +47,7 @@ const response = await playgroundClient.request({
 });
 console.log(response.statusCode);
 // 200
-console.log(response.body);
+console.log(response.text);
 // ... the rendered wp-login.php page ...
 ```
 

--- a/pages/using-php-in-javascript.md
+++ b/pages/using-php-in-javascript.md
@@ -258,8 +258,8 @@ const server = new PHPRequestHandler(php, {
 	url: 'http://127.0.0.1',
 });
 
-const output = server.request({ path: '/index.php' }).body;
-console.log(new TextDecoder().decode(output));
+const response = server.request({ path: '/index.php' });
+console.log(response.text);
 // "Hi from PHP!"
 ```
 


### PR DESCRIPTION
## Description

People often get confused about having to deal with PHP output as an ArrayBuffer and using TextDecoder.

So - this PR adds two shorthand to PHPResponse: `.text` and `.json`.

**Before:**

```js
const result = await client.run({
    code: '<?php echo "Hi!"; ',
});
console.log(new TextDecoder().decode(result.body));
```

**After:**

```js
const response = await client.run({
 	code: '<?php echo "Hi!"; ',
});
console.log(response.text);
```
