### PR TITLE
Fix package main on `@php-wasm/node`

### DIFF
--- a/packages/php-wasm/node/package.json
+++ b/packages/php-wasm/node/package.json
@@ -26,7 +26,7 @@
 		"directory": "../../../dist/packages/php-wasm/node"
 	},
 	"license": "(GPL-2.0-or-later OR MPL-2.0)",
-	"main": "index.js",
+	"main": "index.cjs",
 	"types": "index.d.ts",
 	"gitHead": "e6a7ed1b4e3e804590a5d9c40d95dfb9e6281e1a"
 }


### PR DESCRIPTION
## Proposed changes

@adamziel, in this PR I'm fixing the error we detected yesterday.

- Fix the main file in `package.json` for `@php-wasm/node`

## Testing instructions
1. Run `yarn build`
2. Run `nx start php-wasm-cli`
3. Observe that `php-wasm-cli` is executed and there is no error

### Error before this PR
```
> nx run php-wasm-cli:start

(node:21902) ExperimentalWarning: Custom ESM Loaders is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
/Users/user/wordpress-playground/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:366
    throw new ERR_MODULE_NOT_FOUND(
          ^
CustomError: Cannot find module '/Users/user/wordpress-playground/dist/packages/php-wasm/node/index.js' imported from /Users/user/wordpress-playground/dist/packages/php-wasm/cli/main.js
    at finalizeResolution (/Users/user/wordpress-playground/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:366:11)
    at moduleResolve (/Users/user/wordpress-playground/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:801:10)
    at Object.defaultResolve (/Users/user/wordpress-playground/node_modules/ts-node/dist-raw/node-internal-modules-esm-resolve.js:912:11)
    at /Users/user/wordpress-playground/node_modules/ts-node/src/esm.ts:218:35
    at entrypointFallback (/Users/user/wordpress-playground/node_modules/ts-node/src/esm.ts:168:34)
    at /Users/user/wordpress-playground/node_modules/ts-node/src/esm.ts:217:14
    at addShortCircuitFlag (/Users/user/wordpress-playground/node_modules/ts-node/src/esm.ts:409:21)
    at resolve (/Users/user/wordpress-playground/node_modules/ts-node/src/esm.ts:197:12)
    at resolve (file:///Users/user/wordpress-playground/packages/nx-extensions/src/executors/built-script/loader.mjs:37:15)
    at nextResolve (node:internal/modules/esm/loader:163:28)
```