### PR TITLE
PHP WASM Universal: use named imports in `base-php` and remove default exports

### DIFF
--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -1,6 +1,6 @@
-import {PHPBrowser} from './php-browser';
+import { PHPBrowser } from './php-browser';
 import {
-  PHPRequestHandler,
+	PHPRequestHandler,
 	PHPRequestHandlerConfiguration,
 } from './php-request-handler';
 import { PHPResponse } from './php-response';

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -1,5 +1,6 @@
-import PHPBrowser from './php-browser';
-import PHPRequestHandler, {
+import {PHPBrowser} from './php-browser';
+import {
+  PHPRequestHandler,
 	PHPRequestHandlerConfiguration,
 } from './php-request-handler';
 import { PHPResponse } from './php-response';

--- a/packages/php-wasm/universal/src/lib/php-browser.ts
+++ b/packages/php-wasm/universal/src/lib/php-browser.ts
@@ -1,4 +1,4 @@
-import type PHPRequestHandler from './php-request-handler';
+import type {PHPRequestHandler} from './php-request-handler';
 import type { PHPResponse } from './php-response';
 import { PHPRequest, RequestHandler } from './universal-php';
 
@@ -135,5 +135,3 @@ export class PHPBrowser implements RequestHandler {
 		return cookiesArray.join('; ');
 	}
 }
-
-export default PHPBrowser;

--- a/packages/php-wasm/universal/src/lib/php-browser.ts
+++ b/packages/php-wasm/universal/src/lib/php-browser.ts
@@ -1,4 +1,4 @@
-import type {PHPRequestHandler} from './php-request-handler';
+import type { PHPRequestHandler } from './php-request-handler';
 import type { PHPResponse } from './php-response';
 import { PHPRequest, RequestHandler } from './universal-php';
 

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -379,5 +379,3 @@ function inferMimeType(path: string): string {
 			return 'application-octet-stream';
 	}
 }
-
-export default PHPRequestHandler;


### PR DESCRIPTION
## Proposed changes

We are exporting twice `PHPBrowser` and `PHPRequestHandler`, one as named export and the second as default export.

In this PR I suggest removing the default export and using just the named one.

In other parts of the code I've seen, we import the named export:

https://github.com/WordPress/wordpress-playground/blob/34695fb88802ab557bf2a82988f1001fa9cbb4cc/packages/php-wasm/node/src/test/php-request-handler.spec.ts#L2-L6

https://github.com/WordPress/wordpress-playground/blob/34695fb88802ab557bf2a82988f1001fa9cbb4cc/packages/php-wasm/universal/src/lib/index.ts#L42
