### PR TITLE
wp-now: rename downloadSqliteIntegrationPlugin function

### DIFF
--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -40,7 +40,7 @@ export async function downloadWordPress(fileName = 'latest') {
 	});
 }
 
-export async function downloadSqlite() {
+export async function downloadSqliteIntegrationPlugin() {
 	return downloadFileAndUnzip({
 		url: SQLITE_URL,
 		destinationFolder: WP_NOW_PATH,

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -13,7 +13,7 @@ import {
 	WORDPRESS_VERSIONS_PATH,
 	WP_NOW_PATH,
 } from './constants';
-import { downloadSqlite, downloadWordPress } from './download';
+import { downloadSqliteIntegrationPlugin, downloadWordPress } from './download';
 import { portFinder } from './port-finder';
 import { defineSiteUrl } from '@wp-playground/blueprints';
 
@@ -308,7 +308,7 @@ export default class WPNow {
 			return;
 		}
 		await downloadWordPress();
-		await downloadSqlite();
+		await downloadSqliteIntegrationPlugin();
 		this.mount();
 		await this.registerUser();
 		await this.autoLogin();


### PR DESCRIPTION
Suggested here https://github.com/WordPress/wordpress-playground/pull/188#discussion_r1185032015

## Proposed changes:

- rename WPNow `downloadSqlite` to `downloadSqliteIntegrationPlugin` which is more explicit.

## Testing instructions

- Build packages `nvm use && yarn install && yarn build`
- Delete the folder manually: `~/.wp-now/wordpress-versions`
- Run `nx preview wp-now start --path=/Users/path-to-your-theme-or-plugin"
- Observe `~/.wp-now/wordpress-versions/latest` exist and WordPress has started correctly.