### PR TITLE
wp-now: replace Sqlite plugin url due a 302 redirection

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"comlink": "^4.4.1",
 		"express-fileupload": "1.4.0",
 		"file-saver": "^2.0.5",
+		"follow-redirects": "1.15.2",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-modal": "^3.16.1",

--- a/packages/wp-now/src/constants.ts
+++ b/packages/wp-now/src/constants.ts
@@ -27,7 +27,7 @@ export const SQLITE_FILENAME = 'sqlite-database-integration';
 /**
  * The full path to the "SQLite database integration" folder.
  */
-export const SQLITE_PATH = path.join(WP_NOW_PATH, `${SQLITE_FILENAME}-main`);
+export const SQLITE_PATH = path.join(WP_NOW_PATH, `${SQLITE_FILENAME}`);
 
 /**
  * The URL for downloading the latest version of WordPress.
@@ -38,7 +38,7 @@ export const WP_DOWNLOAD_URL = 'https://wordpress.org/latest.zip';
  * The URL for downloading the "SQLite database integration" WordPress Plugin.
  */
 export const SQLITE_URL =
-	'https://github.com/WordPress/sqlite-database-integration/archive/refs/heads/main.zip';
+	'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
 
 /**
  * The default starting port for running the WP Now server.

--- a/packages/wp-now/src/constants.ts
+++ b/packages/wp-now/src/constants.ts
@@ -27,7 +27,7 @@ export const SQLITE_FILENAME = 'sqlite-database-integration';
 /**
  * The full path to the "SQLite database integration" folder.
  */
-export const SQLITE_PATH = path.join(WP_NOW_PATH, `${SQLITE_FILENAME}`);
+export const SQLITE_PATH = path.join(WP_NOW_PATH, `${SQLITE_FILENAME}-main`);
 
 /**
  * The URL for downloading the latest version of WordPress.
@@ -38,7 +38,7 @@ export const WP_DOWNLOAD_URL = 'https://wordpress.org/latest.zip';
  * The URL for downloading the "SQLite database integration" WordPress Plugin.
  */
 export const SQLITE_URL =
-	'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
+	'https://github.com/WordPress/sqlite-database-integration/archive/refs/heads/main.zip';
 
 /**
  * The default starting port for running the WP Now server.

--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra';
 import path from 'path';
-import https from 'https';
+import followRedirects from 'follow-redirects';
 import unzipper from 'unzipper';
 import { IncomingMessage } from 'http';
 import {
@@ -10,6 +10,9 @@ import {
 	WP_DOWNLOAD_URL,
 	WP_NOW_PATH,
 } from './constants';
+
+followRedirects.maxRedirects = 5;
+const { https } = followRedirects;
 
 async function downloadFileAndUnzip({
 	url,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8264,7 +8264,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.0.0, follow-redirects@^1.15.0:
+follow-redirects@1.15.2, follow-redirects@^1.0.0, follow-redirects@^1.15.0:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==


### PR DESCRIPTION
## Proposed changes

The URL `https://github.com/WordPress/sqlite-database-integration/archive/refs/heads/main.zip` is redirecting to `https://codeload.github.com/WordPress/sqlite-database-integration/zip/refs/heads/main` and our current code is not allowing redirections, which makes the download to fail.

In this PR I suggest downloading the plugin from the .org plugin url: https://downloads.wordpress.org/plugin/sqlite-database-integration.zip`

Another alternative would be allowing redirects in the download function.

## Testing instructions

- Build packages `nvm use && yarn install && yarn build`
- Delete the folder manually: `~/.wp-now/sqlite-database-integration-main`
- Run `nx preview wp-now start --path=/Users/path-to-your-theme-or-plugin"
- Observe `~/.wp-now/sqlite-database-integration` exist and WordPress has started correctly.
