### PR TITLE
Local Environment: Open the default browser with the new domain when server starts

### DIFF
--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -33,6 +33,29 @@ const requestBodyToString = async (req) =>
 const app = express();
 app.use(fileUpload());
 
+function openInDefaultBrowser(port: number) {
+	const url = `http://127.0.0.1:${port}`;
+	let cmd: string, args: string[] | SpawnOptionsWithoutStdio;
+	switch (process.platform) {
+		case 'darwin':
+			cmd = 'open';
+			args = [url];
+			break;
+		case 'linux':
+			cmd = 'xdg-open';
+			args = [url];
+			break;
+		case 'win32':
+			cmd = 'cmd';
+			args = ['/c', `start ${url}`];
+			break;
+		default:
+			console.log(`Platform '${process.platform}' not supported`);
+			return;
+	}
+	spawn(cmd, args);
+}
+
 export async function startServer(options: WPNowOptions = {}) {
 	const port = await portFinder.getOpenPort();
 	const wpNow = await WPNow.create(options);
@@ -96,22 +119,6 @@ export async function startServer(options: WPNowOptions = {}) {
 
 	app.listen(port, () => {
 		console.log(`Server running at http://127.0.0.1:${port}/`);
-		const porturl = `http://127.0.0.1:${port}`;
-		let cmd: string, args: string[] | SpawnOptionsWithoutStdio;
-		switch (process.platform) {
-			case 'darwin':
-				cmd = 'open';
-				args = [porturl];
-				break;
-			case 'linux':
-				cmd = 'xdg-open';
-				args = [porturl];
-				break;
-			default:
-				cmd = 'cmd';
-				args = ['/c', `start ${porturl}`];
-				break;
-		}
-		spawn(cmd, args);
+		openInDefaultBrowser(port);
 	});
 }

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -3,6 +3,7 @@ import { HTTPMethod } from '@php-wasm/universal';
 import express from 'express';
 import fileUpload from 'express-fileupload';
 import { portFinder } from './port-finder';
+import {spawn, SpawnOptionsWithoutStdio} from 'child_process';
 
 function requestBodyToMultipartFormData(json, boundary) {
 	let multipartData = '';
@@ -95,5 +96,23 @@ export async function startServer(options: WPNowOptions = {}) {
 
 	app.listen(port, () => {
 		console.log(`Server running at http://127.0.0.1:${port}/`);
-	});
+		const porturl = `http://127.0.0.1:${port}`;
+		let cmd: string, args: string[] | SpawnOptionsWithoutStdio;
+		switch (process.platform) {
+		  case 'darwin':
+			cmd = 'open';
+			args = [porturl];
+			break;
+		  case 'linux':
+			cmd = 'xdg-open';
+			args = [porturl];
+			break;
+		  default:
+			cmd = 'cmd';
+			args = ['/c', `start ${porturl}`];
+			break;
+		}
+		spawn(cmd, args);
+	  });
+
 }

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -3,7 +3,7 @@ import { HTTPMethod } from '@php-wasm/universal';
 import express from 'express';
 import fileUpload from 'express-fileupload';
 import { portFinder } from './port-finder';
-import {spawn, SpawnOptionsWithoutStdio} from 'child_process';
+import { spawn, SpawnOptionsWithoutStdio } from 'child_process';
 
 function requestBodyToMultipartFormData(json, boundary) {
 	let multipartData = '';
@@ -99,20 +99,19 @@ export async function startServer(options: WPNowOptions = {}) {
 		const porturl = `http://127.0.0.1:${port}`;
 		let cmd: string, args: string[] | SpawnOptionsWithoutStdio;
 		switch (process.platform) {
-		  case 'darwin':
-			cmd = 'open';
-			args = [porturl];
-			break;
-		  case 'linux':
-			cmd = 'xdg-open';
-			args = [porturl];
-			break;
-		  default:
-			cmd = 'cmd';
-			args = ['/c', `start ${porturl}`];
-			break;
+			case 'darwin':
+				cmd = 'open';
+				args = [porturl];
+				break;
+			case 'linux':
+				cmd = 'xdg-open';
+				args = [porturl];
+				break;
+			default:
+				cmd = 'cmd';
+				args = ['/c', `start ${porturl}`];
+				break;
 		}
 		spawn(cmd, args);
-	  });
-
+	});
 }


### PR DESCRIPTION
* Closes: https://github.com/WordPress/wordpress-playground/issues/235

### **Proposed Changes**

This PR launches the default browser with the new domain when the server starts after running `nx preview wp-now start` or `nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme`.

### **Testing Instructions**

* Pull the changes from this branch to your local environment
* Run `nvm use`
* Run `yarn install`
* Run `yarn build`
* Run `nx preview wp-now start`
* Check if the default browser opens the new domain once the server starts

### Additional Notes

I researched another option for adding this feature and it would be to use [the `open` module](https://www.npmjs.com/package/open) that would first need to be installed from npm. The advantage of the `open module` module is that it removes the differences in command line syntax compared to `child_process` that I used in the PR. The disadvantage of using an `open` module is that it requires an additional dependency to be installed which adds some complexity to the project. 

I went for using `child_process` since that is something that is already built in and it did not require anything extra to be installed but it is open for discussion. I am happy to change the PR if you think the `open module` would be a better solution. 
