### PR TITLE
wp-now: use a temporary organization for `wp-now`

### DIFF
--- a/packages/wp-now/package.json
+++ b/packages/wp-now/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "wp-now",
+	"name": "@wp-now/wp-now",
 	"version": "0.0.0",
 	"description": "WordPress Playground CLI",
 	"repository": {
@@ -17,7 +17,7 @@
 	],
 	"publishConfig": {
 		"access": "public",
-		"directory": "../../../dist/packages/wp-now"
+		"directory": "../../dist/packages/wp-now"
 	},
 	"license": "GPL-2.0-or-later",
 	"type": "module",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -47,7 +47,7 @@
 			"@wp-playground/website": [
 				"packages/playground/website/src/index.ts"
 			],
-			"wp-now": ["packages/wp-now/src/index.ts"]
+			"@wp-now/wp-now": ["packages/wp-now/src/main.ts"]
 		}
 	},
 	"exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
- Related to https://github.com/WordPress/wordpress-playground/issues/231

# Proposed changes:

We want to publish `wp-now` in a different organization for testing purposes.

Ideally, the command could be available by running:

```
npm install -g @wp-now/wp-now
```