### PR TITLE
wp-now: add wp-now workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
 	"workspaces": [
 		"packages/nx-extensions",
 		"packages/php-wasm/*",
-		"packages/playground/*"
+		"packages/playground/*",
+		"packages/wp-now"
 	]
 }


### PR DESCRIPTION
# Proposed changes

Add `wp-now` into the workspaces to be included in the deployment.

As a follow-up of https://github.com/WordPress/wordpress-playground/pull/283
`@wp-now/wp-now` was not included in the deployment.

```
Successfully published:
 - @php-wasm/cli@0.1.39
 - @php-wasm/node@0.1.39
 - @php-wasm/progress@0.1.39
 - @php-wasm/scopes@0.1.39
 - @php-wasm/universal@0.1.39
 - @php-wasm/web@0.1.39
 - @php-wasm/web-service-worker@0.1.39
 - @wp-playground/blueprints@0.1.39
 - @wp-playground/client@0.1.39
lerna success published 9 packages
```