### PR TITLE
Move yargs from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-modal": "^3.16.1",
-		"unzipper": "0.10.11"
+		"unzipper": "0.10.11",
+		"yargs": "17.7.2"
 	},
 	"resolutions": {
 		"@codemirror/state": "6.2.0",
@@ -148,8 +149,7 @@
 		"vite-plugin-wasm": "^3.2.2",
 		"vite-tsconfig-paths": "^4.0.2",
 		"vitepress": "1.0.0-alpha.60",
-		"vitest": "^0.25.8",
-		"yargs": "^17.7.1"
+		"vitest": "^0.25.8"
 	},
 	"workspaces": [
 		"packages/nx-extensions",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15848,6 +15848,19 @@ yargs@16.2.0, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yargs@17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
 yargs@^14.2:
   version "14.2.3"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
@@ -15865,7 +15878,7 @@ yargs@^14.2:
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
 
-yargs@^17.3.1, yargs@^17.6.0, yargs@^17.6.2, yargs@^17.7.1:
+yargs@^17.3.1, yargs@^17.6.0, yargs@^17.6.2:
   version "17.7.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.1.tgz#34a77645201d1a8fc5213ace787c220eabbd0967"
   integrity sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==


### PR DESCRIPTION
# Proposed changes

Move `yargs` from `devDependencies` to `dependencies`.

After executing `wp-now` I got this error.
Investigating I found that `yargs` was not detected as dependency.


```
❯ node:internal/errors:464                                                                                                                                                                                                                                                                                             14:39:48
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'yargs' imported from /Users/macbookpro/.nvm/versions/node/v16.13.2/lib/node_modules/@wp-now/wp-now/main.js
    at new NodeError (node:internal/errors:371:5)
    at packageResolve (node:internal/modules/esm/resolve:884:9)
    at moduleResolve (node:internal/modules/esm/resolve:929:18)
    at defaultResolve (node:internal/modules/esm/resolve:1044:11)
    at ESMLoader.resolve (node:internal/modules/esm/loader:422:30)
    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:222:40)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:40)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```