### PR TITLE
wp-now: add `env node` to wp-now to execute it

### DIFF
--- a/packages/wp-now/package.json
+++ b/packages/wp-now/package.json
@@ -22,6 +22,6 @@
 	"license": "GPL-2.0-or-later",
 	"type": "module",
 	"main": "main.js",
-	"bin": "main.js",
+	"bin": "cli.js",
 	"gitHead": "e6a7ed1b4e3e804590a5d9c40d95dfb9e6281e1a"
 }

--- a/packages/wp-now/project.json
+++ b/packages/wp-now/project.json
@@ -22,6 +22,7 @@
 			"options": {
 				"commands": [
 					"node packages/wp-now/esbuild.mjs",
+					"cp packages/wp-now/public/* dist/packages/wp-now",
 					"cp packages/wp-now/package.json dist/packages/wp-now",
 					"cp packages/wp-now/README.md dist/packages/wp-now"
 				],

--- a/packages/wp-now/public/cli.js
+++ b/packages/wp-now/public/cli.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import './main.js';

--- a/packages/wp-now/src/main.ts
+++ b/packages/wp-now/src/main.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 import { runCli } from './run-cli';
 
 runCli();

--- a/packages/wp-now/src/main.ts
+++ b/packages/wp-now/src/main.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { runCli } from './run-cli';
 
 runCli();


### PR DESCRIPTION
- Related to https://github.com/WordPress/wordpress-playground/issues/231

# Proposed changes

Once the package is published in NPM we need to define node env to be executable. 


# Testing instructions
- run `yarn build`
- Observe the `cli.js` file  and `main.js` exist in `dist/packages/wp-now/` directory.