### PR TITLE
Local Environment: Improve wp-now README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Another strong inspiration was the [Drupal in the browser demo](https://seanmorr
 
 A worthy mention is Wasm Labs’s closed-source [WordPress in the browser](https://wordpress.wasmlabs.dev/) shared before this project was first published. There is no public repository available, but their [technical overview](https://wasmlabs.dev/articles/wordpress-in-the-browser/) gives a breakdown of the technical decisions that project took. WordPress Playground draws inspiration from the same PHP in the browser projects and makes similar technical choices.
 
+## Using WP-NOW for local environment
+
+WordPress Playground comes with `wp-now`. `wp-now` is a Command Line Interface (CLI) tool designed to streamline the process of setting up a local WordPress environment by using only Node.js. If you are looking to set up `wp-now` specifically, you can follow [this README.md](/packages/wp-now/README.md).
+
 ## Contributing
 
 WordPress Playground is an ambitious project in its early days. If the feature you need is missing, you are more than welcome to start a discussion, open an issue, and even propose a Pull Request to implement it.

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -100,6 +100,14 @@ To install `wp-now` directly from `npm`, execute:
 npm install -g @wordpress/wp-now
 ```
 
+### Testing
+
+To run the unit tests, use the following command:
+
+```bash
+nx test wp-now
+```
+
 ### Migrating from Laravel Valet?
 
 If you are migrating from Laravel Valet, you should be aware of the differences it has with `wp-now`:

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -30,12 +30,20 @@ nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
 
 wp-now operates in four different modes:
 
--   `index`: executes a simple php file
+The mode of the `wp-now` will depend on the destination folder and whether you are working with a single plugin or a theme, `wp-content` directory or a single PHP file. 
+
+-   `index`: executes a simple php file. If your destination folder does not contain a `theme`, `plugin` or `wp-content` directory, `wp-now` will run in the `index` mode serving the content of the folder without mounting a WordPress instance. For this mode, `index.php` is recommended
 -   `theme`: loads WordPress with your selected theme included
 -   `plugin`: loads WordPress with your selected plugin included
 -   `wp-content`: loads WordPress site that contains plugins and themes from the provided wp-content directory
 
-To launch the `wp-now` in the `index`, `theme` or `plugin` mode, you can run:
+To launch the `wp-now` in the `index` mode, you can run:
+
+```bash
+nx preview wp-now start --path=/path/to/index.php-file
+```
+
+To launch the `wp-now` in the `theme` or `plugin` mode, you can run:
 
 ```bash
 nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
@@ -131,7 +139,7 @@ Some similarities between Laravel Valet and `wp-now` to be aware of:
 If you are migrating from `wp-env`, you should be aware of the differences it has with `wp-now`:
 
 -   `wp-now` supports non-WordPress projects;
--   `wp-env` is Docker-based which makes it platform indepedent (although `wp-now` does run across different platforms);
+-   `wp-now` does not need Docker;
 -   `wp-now` does not support Xdebug PHP extension;
 -   `wp-now` does not include Jest for automatic browser testing
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -30,7 +30,7 @@ nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
 
 wp-now operates in four different modes:
 
-The mode of the `wp-now` will depend on the destination folder and whether you are working with a single plugin or a theme, `wp-content` directory or a single PHP file. 
+The mode of the `wp-now` will depend on the destination folder and whether you are working with a single plugin or a theme, `wp-content` directory or a single PHP file.
 
 -   `index`: executes a simple php file. If your destination folder does not contain a `theme`, `plugin` or `wp-content` directory, `wp-now` will run in the `index` mode serving the content of the folder without mounting a WordPress instance. For this mode, `index.php` is recommended
 -   `theme`: loads WordPress with your selected theme included

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -104,6 +104,13 @@ To install `wp-now` directly from `npm`, execute:
 npm install -g @wordpress/wp-now
 ```
 
+Once installed, you can use it like so:
+
+```bash
+cd wordpress-plugin-or-theme
+wp now start
+```
+
 ### Testing
 
 To run the unit tests, use the following command:

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -4,8 +4,11 @@
 
 ## Getting Started
 
-Before getting started, make sure you have `nvm` installed. If you need to install it first,
-[follow these installation instructions](https://github.com/nvm-sh/nvm#installation).
+Before getting started:
+
+-   Make sure you have `nvm` installed. If you need to install it first,
+    [follow these installation instructions](https://github.com/nvm-sh/nvm#installation). Please note that if you are installing `wp-now` from `npm`, **this step is not necessary**;
+-   Install `yarn` by running `npm install -g yarn`
 
 Follow these steps to build and run `wp-now` locally:
 
@@ -19,7 +22,7 @@ To build the project, use the following commands in your terminal:
 
 ### Running
 
-1. Execute `sudo npm install -g nx@latest`. This will make `nx` command globally accessible in the project.
+1. Execute `npm install -g nx@latest`. This will make `nx` command globally accessible in the project.
 2. To start the web server in the plugin or theme mode (see Modes on WP-NOW section for details), run the command below. Make sure to replace `/path/to/wordpress-plugin-or-theme` with the actual path to your plugin or theme folder.
 
 ```bash
@@ -61,10 +64,10 @@ Make sure to replace `/path/to/wordpress-plugin-or-theme` or `/path/to/wp-conten
 
 `wp-now start` currently supports the following arguments:
 
--   `port`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically;
+-   `port`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically. The default port number is set to `8881`;
 -   `path`: the path to the PHP file or WordPress project to use. If not provided, it will use the current working directory;
--   `php`: the version of PHP to use. This is optional and if not provided, it will use a default version;
--   `wp`: the version of WordPress to use. This is optional and if not provided, it will use a default version.
+-   `php`: the version of PHP to use. This is optional and if not provided, it will use a default version which is `8.0`;
+-   `wp`: the version of WordPress to use. This is optional and if not provided, it will use a default version. The default version is set to the [latest WordPress version](https://wordpress.org/download/releases/).
 
 #### Examples of using `wp-now start` arguments:
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -33,7 +33,7 @@ cd wordpress-plugin-or-theme
 wp now start
 ```
 
-Additionally, you can specify the arguments such as `--port`, `--php` and `--wp`. For more details, see [Arguments supported by wp-now start section]((#arguments-supported-by-wp-now-start).
+Additionally, you can specify the arguments such as `--port`, `--php` and `--wp`. For more details, see [Arguments supported by wp-now start section](#arguments-supported-by-wp-now-start).
 
 ## Option 2: Development flow
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -33,7 +33,7 @@ cd wordpress-plugin-or-theme
 wp now start
 ```
 
-Additionally, you can specify the arguments such as `--port`, `--php` and `--wp`. For more details, see [Arguments supported by wp-now start section](#arguments-supported-by-wp-now-start).
+Additionally, you can specify the arguments such as `--port`, `--php` and `--wp`. For more details, see **Arguments supported by wp-now start section**.
 
 ## Option 2: Development flow
 
@@ -44,11 +44,11 @@ If you would like to be able to not use `wp-now` globally and manually specify t
 
 ### Modes on WP-NOW
 
-wp-now operates in four different modes:
+`wp-now` operates in four different modes:
 
 The mode of the `wp-now` will depend on the destination folder and whether you are working with a single plugin or a theme, `wp-content` directory or a single PHP file.
 
--   `index`: executes a simple php file. If your destination folder does not contain a `theme`, `plugin` or `wp-content` directory, `wp-now` will run in the `index` mode serving the content of the folder without mounting a WordPress instance. For this mode, `index.php` is recommended
+-   `index`: executes a simple PHP file. If your destination folder does not contain a `theme`, `plugin` or `wp-content` directory, `wp-now` will run in the `index` mode serving the content of the folder without mounting a WordPress instance. For this mode, `index.php` is recommended
 -   `theme`: loads WordPress with your selected theme included
 -   `plugin`: loads WordPress with your selected plugin included
 -   `wp-content`: loads WordPress site that contains plugins and themes from the provided wp-content directory
@@ -73,7 +73,7 @@ nx preview wp-now start --path=/path/to/wp-content-directory
 
 Make sure to replace `/path/to/wordpress-plugin-or-theme` or `/path/to/wp-content-directory` with the actual path to your plugin or theme folder or wp-content directory.
 
-### Arguments supported by wp-now start {#arguments-supported-by-wp-now-start}
+### Arguments supported by wp-now start
 
 `wp-now start` currently supports the following arguments:
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -125,15 +125,15 @@ If you are migrating from Laravel Valet, you should be aware of the differences 
 
 -   `wp-now` does not require you to install separately WordPress, create database, connect WordPress to that database, create your use or login. All of these steps are packaged into `wp now start` command and are running under the hood;
 -   `wp-now` works across all platforms (Mac, Linux, Windows);
--   `wp-now` does not support custom domains or SSL;
--   `wp-now` offers `theme` and `plugin` modes specific to WordPress development;
+-   `wp-now` does not support custom domains or SSL (yet!);
+-   `wp-now` works with WordPress themes and plugins even if you don't have WordPress installed;
 -   `wp-now` allows to easily switch the WordPress version with `wp-now start --wp=version.number`(make sure to replace the `version.number` with the actual WordPress version);
--   `wp-now` does not support Xdebug PHP extension
+-   `wp-now` does not support Xdebug PHP extension (yet!)
 
 Some similarities between Laravel Valet and `wp-now` to be aware of:
 
 -   could be used for non-WordPress projects;
--   deployments are not possible on Laravel Valet and `wp-now`;
+-   deployments are not possible with neither Laravel Valet, nor `wp-now`;
 -   possible to switch easily the PHP version;
 -   possibility to work on multiple WordPress sites simultaneously
 
@@ -143,14 +143,14 @@ If you are migrating from `wp-env`, you should be aware of the differences it ha
 
 -   `wp-now` supports non-WordPress projects;
 -   `wp-now` does not need Docker;
--   `wp-now` does not support Xdebug PHP extension;
+-   `wp-now` does not support Xdebug PHP extension (yet!);
 -   `wp-now` does not include Jest for automatic browser testing
 
 Some similarities between `wp-env` and `wp-now` to be aware of:
 
 -   no support for custom domains or SSL;
 -   `plugin`, `themes` and index modes are available on `wp-env` and `wp-now`;
--   deployments are not supported from `wp-now` or `wp-env`
+-   deployments are not possible with neither `wp-env`, nor `wp-now`;
 -   possible to switch easily the PHP version
 
 ## Contributing

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -5,7 +5,7 @@
 ## Getting Started
 
 Before getting started, make sure you have `nvm` installed. If you need to install it first,
-[follow these installation instructions](https://github.com/nvm-sh/nvm#installation). 
+[follow these installation instructions](https://github.com/nvm-sh/nvm#installation).
 
 Follow these steps to build and run `wp-now` locally:
 
@@ -17,10 +17,9 @@ To build the project, use the following commands in your terminal:
 2. Execute `nvm use`
 3. Execute `yarn install` followed by `yarn build`
 
-
 ### Running
 
-1. Execute `sudo npm install -g nx@latest`. This will make `nx` command globally accessible in the project. 
+1. Execute `sudo npm install -g nx@latest`. This will make `nx` command globally accessible in the project.
 2. To start the web server in the plugin or theme mode (see Modes on WP-NOW section for details), run the command below. Make sure to replace `/path/to/wordpress-plugin-or-theme` with the actual path to your plugin or theme folder.
 
 ```bash
@@ -31,10 +30,10 @@ nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
 
 wp-now operates in four different modes:
 
-* `index`: executes a simple php file
-* `theme`: loads WordPress with your selected theme included
-* `plugin`: loads WordPress with your selected plugin included
-* `wp-content`: loads WordPress site that contains plugins and themes from the provided wp-content directory
+-   `index`: executes a simple php file
+-   `theme`: loads WordPress with your selected theme included
+-   `plugin`: loads WordPress with your selected plugin included
+-   `wp-content`: loads WordPress site that contains plugins and themes from the provided wp-content directory
 
 To launch the `wp-now` in the `index`, `theme` or `plugin` mode, you can run:
 
@@ -54,10 +53,10 @@ Make sure to replace `/path/to/wordpress-plugin-or-theme` or `/path/to/wp-conten
 
 `wp-now start` currently supports the following arguments:
 
-* `port`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically;
-* `path`: the path to the PHP file or WordPress project to use. If not provided, it will use the current working directory;
-* `php`: the version of PHP to use. This is optional and if not provided, it will use a default version;
-* `wp`: the version of WordPress to use. This is optional and if not provided, it will use a default version.
+-   `port`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically;
+-   `path`: the path to the PHP file or WordPress project to use. If not provided, it will use the current working directory;
+-   `php`: the version of PHP to use. This is optional and if not provided, it will use a default version;
+-   `wp`: the version of WordPress to use. This is optional and if not provided, it will use a default version.
 
 #### Examples of using `wp-now start` arguments:
 
@@ -70,13 +69,13 @@ nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.9 --php
 Specify WordPress version and plugin or theme path:
 
 ```bash
-nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.8 
+nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.8
 ```
 
 Specify PHP version and plugin or theme path:
 
 ```bash
-nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --php=7.4 
+nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --php=7.4
 ```
 
 ### Making WP-NOW accessible globally on your local machine
@@ -93,7 +92,6 @@ Example:
 1. Navigate in the terminal to a folder where your WordPress plugin or theme lives with `cd /my-plugin-or-theme`
 2. Execute `wp start now`
 
-
 ### How to install WP-NOW from npm (not available yet)
 
 To install `wp-now` directly from `npm`, execute:
@@ -106,37 +104,35 @@ npm install -g @wordpress/wp-now
 
 If you are migrating from Laravel Valet, you should be aware of the differences it has with `wp-now`:
 
-* `wp-now` does not require you to install separately WordPress, create database, connect WordPress to that database, create your use or login. All of these steps are packaged into `wp now start` command and are running under the hood;
-* `wp-now` works across all platforms (Mac, Linux, Windows);
-* `wp-now` does not support custom domains or SSL;
-* `wp-now` offers `theme` and `plugin` modes specific to WordPress development;
-* `wp-now` allows to easily switch the WordPress version with `wp-now start --wp=version.number`(make sure to replace the `version.number` with the actual WordPress version);
-* `wp-now` does not support Xdebug PHP extension
-
+-   `wp-now` does not require you to install separately WordPress, create database, connect WordPress to that database, create your use or login. All of these steps are packaged into `wp now start` command and are running under the hood;
+-   `wp-now` works across all platforms (Mac, Linux, Windows);
+-   `wp-now` does not support custom domains or SSL;
+-   `wp-now` offers `theme` and `plugin` modes specific to WordPress development;
+-   `wp-now` allows to easily switch the WordPress version with `wp-now start --wp=version.number`(make sure to replace the `version.number` with the actual WordPress version);
+-   `wp-now` does not support Xdebug PHP extension
 
 Some similarities between Laravel Valet and `wp-now` to be aware of:
 
-* could be used for non-WordPress projects;
-* deployments are not possible on Laravel Valet and `wp-now`;
-* possible to switch easily the PHP version;
-* possibility to work on multiple WordPress sites simultaneously
+-   could be used for non-WordPress projects;
+-   deployments are not possible on Laravel Valet and `wp-now`;
+-   possible to switch easily the PHP version;
+-   possibility to work on multiple WordPress sites simultaneously
 
 ### Migrating from wp-env?
 
 If you are migrating from `wp-env`, you should be aware of the differences it has with `wp-now`:
 
-* `wp-now` supports non-WordPress projects;
-* `wp-env` is Docker-based which makes it platform indepedent (although `wp-now` does run across different platforms);
-* `wp-now` does not support Xdebug PHP extension;
-* `wp-now` does not include Jest for automatic browser testing
-
+-   `wp-now` supports non-WordPress projects;
+-   `wp-env` is Docker-based which makes it platform indepedent (although `wp-now` does run across different platforms);
+-   `wp-now` does not support Xdebug PHP extension;
+-   `wp-now` does not include Jest for automatic browser testing
 
 Some similarities between `wp-env` and `wp-now` to be aware of:
 
-* no support for custom domains or SSL;
-* `plugin`, `themes` and index modes are available on `wp-env` and `wp-now`;
-* deployments are not supported from `wp-now` or `wp-env`
-* possible to switch easily the PHP version
+-   no support for custom domains or SSL;
+-   `plugin`, `themes` and index modes are available on `wp-env` and `wp-now`;
+-   deployments are not supported from `wp-now` or `wp-env`
+-   possible to switch easily the PHP version
 
 ## Contributing
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -30,7 +30,7 @@ Once you have built `wp-now`, this is how you can use it:
 
 ```bash
 cd wordpress-plugin-or-theme
-wp now start
+wp-now start
 ```
 
 Additionally, you can specify the arguments such as `--port`, `--php` and `--wp`. For more details, see **Arguments supported by wp-now start section**.
@@ -108,7 +108,7 @@ Once installed, you can use it like so:
 
 ```bash
 cd wordpress-plugin-or-theme
-wp now start
+wp-now start
 ```
 
 ## Testing
@@ -121,7 +121,7 @@ nx test wp-now
 
 ## Other important technical details
 
--   The `~/.wp-now` home directory is used to store the WP versions and the `wp-content` folders for projects using theme and plugin mode. The path to `wp-conten` directory for the `plugin` and `theme` modes is `~/.wp-now/wp-content/${projectName}`.
+-   The `~/.wp-now` home directory is used to store the WP versions and the `wp-content` folders for projects using theme and plugin mode. The path to `wp-content` directory for the `plugin` and `theme` modes is `~/.wp-now/wp-content/${projectName}`.
 -   For the database setup, `wp-now` is using [Sqlite database integration plugin](https://wordpress.org/plugins/sqlite-database-integration/). The path to Sqlite database is ` ~/.wp-now/wp-content/${projectName}/database/.ht.sqlite`
 
 ## Migrating from Laravel Valet?

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -10,26 +10,39 @@ Before getting started:
     [follow these installation instructions](https://github.com/nvm-sh/nvm#installation). Please note that if you are installing `wp-now` from `npm`, **this step is not necessary**;
 -   Install `yarn` by running `npm install -g yarn`
 
-Follow these steps to build and run `wp-now` locally:
+## Option 1: Using WP-NOW globally across your projects
+
+---
 
 ### Building
 
 To build the project, use the following commands in your terminal:
 
 1. Clone this repository locally
-2. Execute `nvm use`
-3. Execute `yarn install` followed by `yarn build`
+2. Run `npm link` (only run it **ONCE**) to make `wp-now` available globally across your projects
+3. Execute `nvm use`
+4. Execute `yarn install` followed by `yarn build`
+5. `wp-now` should be now available globally on your machine. This means that you can run `wp-now start` from any path on your local machine
 
 ### Running
 
-1. Execute `npm install -g nx@latest`. This will make `nx` command globally accessible in the project.
-2. To start the web server in the plugin or theme mode (see Modes on WP-NOW section for details), run the command below. Make sure to replace `/path/to/wordpress-plugin-or-theme` with the actual path to your plugin or theme folder.
+Once you have built `wp-now`, this is how you can use it:
 
 ```bash
-nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
+cd wordpress-plugin-or-theme
+wp now start
 ```
 
-### Modes on WP-NOW
+Additionally, you can specify the arguments such as `--port`, `--php` and `--wp`. For more details, see [Arguments supported by wp-now start section]((#arguments-supported-by-wp-now-start).
+
+## Option 2: Development flow
+
+If you would like to be able to not use `wp-now` globally and manually specify the path to each project, you can use this development flow instead:
+
+1. Execute `npm install -g nx@latest`. This will make `nx` command globally accessible in the project.
+2. Start the web server in one of the modes specified below:
+
+### Modes on WP-NOW {#modes-on-wp-now}
 
 wp-now operates in four different modes:
 
@@ -60,7 +73,7 @@ nx preview wp-now start --path=/path/to/wp-content-directory
 
 Make sure to replace `/path/to/wordpress-plugin-or-theme` or `/path/to/wp-content-directory` with the actual path to your plugin or theme folder or wp-content directory.
 
-### Arguments supported by wp-now start
+### Arguments supported by wp-now start {#arguments-supported-by-wp-now-start}
 
 `wp-now start` currently supports the following arguments:
 
@@ -77,19 +90,11 @@ Specify plugin path, WordPress version, PHP version and port number:
 nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.9 --php=7.4 --port=3000
 ```
 
-### Making WP-NOW accessible globally on your local machine
+Please note: if you use `npm link` and are executing `wp-now` from the plugin or theme folder, you don't need to specify the path. In that case, the command would be:
 
-To make `wp-now` accessible globally on your local machine:
-
-1. Clone this repository
-2. Follow the installation steps from **Building** section on `packages/wp-now/README.md`
-3. Execute `npm link`
-4. `wp-now` should be now available globally on your machine. This means that you can run `wp-now start` from any path on your local machine
-
-Example:
-
-1. Navigate in the terminal to a folder where your WordPress plugin or theme lives with `cd /my-plugin-or-theme`
-2. Execute `wp start now`
+```bash
+wp-now start --wp=5.9 --php=7.4 --port=3000
+```
 
 ### How to install WP-NOW from npm (not available yet)
 
@@ -106,6 +111,12 @@ To run the unit tests, use the following command:
 ```bash
 nx test wp-now
 ```
+
+### Other important technical details
+
+-   The `~/.wp-now` home directory is used to store the WP versions and the `wp-content` folders for projects using theme and plugin mode. The path to `wp-conten` directory for the `plugin` and `theme` modes is `~/.wp-now/wp-content/${projectName}`.
+-   For the database setup, `wp-now` is using [Sqlite database integration plugin](https://wordpress.org/plugins/sqlite-database-integration/). The path to Sqlite database is ` ~/.wp-now/wp-content/${projectName}/database/.ht.sqlite`
+-
 
 ### Migrating from Laravel Valet?
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -64,29 +64,17 @@ Make sure to replace `/path/to/wordpress-plugin-or-theme` or `/path/to/wp-conten
 
 `wp-now start` currently supports the following arguments:
 
--   `port`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically. The default port number is set to `8881`;
--   `path`: the path to the PHP file or WordPress project to use. If not provided, it will use the current working directory;
--   `php`: the version of PHP to use. This is optional and if not provided, it will use a default version which is `8.0`;
--   `wp`: the version of WordPress to use. This is optional and if not provided, it will use a default version. The default version is set to the [latest WordPress version](https://wordpress.org/download/releases/).
+-   `--port`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically. The default port number is set to `8881`(example of usage: `--port=3000`);
+-   `--path`: the path to the PHP file or WordPress project to use. If not provided, it will use the current working directory;
+-   `--php`: the version of PHP to use. This is optional and if not provided, it will use a default version which is `8.0`(example of usage: `--php=7.4`);
+-   `--wp`: the version of WordPress to use. This is optional and if not provided, it will use a default version. The default version is set to the [latest WordPress version](https://wordpress.org/download/releases/)(example of usage: `--wp=5.8`)
 
-#### Examples of using `wp-now start` arguments:
+#### Example of using `wp-now start` arguments:
 
-Specify WordPress version, PHP version and plugin path:
-
-```bash
-nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.9 --php=7.4
-```
-
-Specify WordPress version and plugin or theme path:
+Specify plugin path, WordPress version, PHP version and port number:
 
 ```bash
-nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.8
-```
-
-Specify PHP version and plugin or theme path:
-
-```bash
-nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --php=7.4
+nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.9 --php=7.4 --port=3000
 ```
 
 ### Making WP-NOW accessible globally on your local machine
@@ -123,7 +111,7 @@ nx test wp-now
 
 If you are migrating from Laravel Valet, you should be aware of the differences it has with `wp-now`:
 
--   `wp-now` does not require you to install separately WordPress, create database, connect WordPress to that database, create your use or login. All of these steps are packaged into `wp now start` command and are running under the hood;
+-   `wp-now` does not require you to install WordPress separately, create a database, connect WordPress to that database or create a user account. All of these steps are handled by the `wp now start` command and are running under the hood;
 -   `wp-now` works across all platforms (Mac, Linux, Windows);
 -   `wp-now` does not support custom domains or SSL (yet!);
 -   `wp-now` works with WordPress themes and plugins even if you don't have WordPress installed;

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -96,7 +96,7 @@ Please note: if you use `npm link` and are executing `wp-now` from the plugin or
 wp-now start --wp=5.9 --php=7.4 --port=3000
 ```
 
-### How to install WP-NOW from npm (not available yet)
+## How to install WP-NOW from npm (not available yet)
 
 To install `wp-now` directly from `npm`, execute:
 
@@ -111,7 +111,7 @@ cd wordpress-plugin-or-theme
 wp now start
 ```
 
-### Testing
+## Testing
 
 To run the unit tests, use the following command:
 
@@ -119,13 +119,12 @@ To run the unit tests, use the following command:
 nx test wp-now
 ```
 
-### Other important technical details
+## Other important technical details
 
 -   The `~/.wp-now` home directory is used to store the WP versions and the `wp-content` folders for projects using theme and plugin mode. The path to `wp-conten` directory for the `plugin` and `theme` modes is `~/.wp-now/wp-content/${projectName}`.
 -   For the database setup, `wp-now` is using [Sqlite database integration plugin](https://wordpress.org/plugins/sqlite-database-integration/). The path to Sqlite database is ` ~/.wp-now/wp-content/${projectName}/database/.ht.sqlite`
--
 
-### Migrating from Laravel Valet?
+## Migrating from Laravel Valet?
 
 If you are migrating from Laravel Valet, you should be aware of the differences it has with `wp-now`:
 
@@ -143,7 +142,7 @@ Some similarities between Laravel Valet and `wp-now` to be aware of:
 -   possible to switch easily the PHP version;
 -   possibility to work on multiple WordPress sites simultaneously
 
-### Migrating from wp-env?
+## Migrating from wp-env?
 
 If you are migrating from `wp-env`, you should be aware of the differences it has with `wp-now`:
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -4,35 +4,139 @@
 
 ## Getting Started
 
+Before getting started, make sure you have `nvm` installed. If you need to install it first,
+[follow these installation instructions](https://github.com/nvm-sh/nvm#installation). 
+
 Follow these steps to build and run `wp-now` locally:
 
 ### Building
 
 To build the project, use the following commands in your terminal:
 
-```bash
-nvm use
-yarn install
-yarn build
-```
+1. Clone this repository locally
+2. Execute `nvm use`
+3. Execute `yarn install` followed by `yarn build`
+
 
 ### Running
 
-To start the web server and execute your WordPress plugin or theme, use the following command:
+1. Execute `sudo npm install -g nx@latest`. This will make `nx` command globally accessible in the project. 
+2. To start the web server in the plugin or theme mode (see Modes on WP-NOW section for details), run the command below. Make sure to replace `/path/to/wordpress-plugin-or-theme` with the actual path to your plugin or theme folder.
 
 ```bash
 nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
 ```
 
-Replace `/path/to/wordpress-plugin-or-theme` with the actual path to your plugin or theme folder.
+### Modes on WP-NOW
 
-### Testing
+wp-now operates in four different modes:
 
-To run the unit tests, use the following command:
+* `index`: executes a simple php file
+* `theme`: loads WordPress with your selected theme included
+* `plugin`: loads WordPress with your selected plugin included
+* `wp-content`: loads WordPress site that contains plugins and themes from the provided wp-content directory
+
+To launch the `wp-now` in the `index`, `theme` or `plugin` mode, you can run:
 
 ```bash
-nx test wp-now
+nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme
 ```
+
+To launch the `wp-now` in the `wp-content` mode, you can run:
+
+```bash
+nx preview wp-now start --path=/path/to/wp-content-directory
+```
+
+Make sure to replace `/path/to/wordpress-plugin-or-theme` or `/path/to/wp-content-directory` with the actual path to your plugin or theme folder or wp-content directory.
+
+### Arguments supported by wp-now start
+
+`wp-now start` currently supports the following arguments:
+
+* `port`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically;
+* `path`: the path to the PHP file or WordPress project to use. If not provided, it will use the current working directory;
+* `php`: the version of PHP to use. This is optional and if not provided, it will use a default version;
+* `wp`: the version of WordPress to use. This is optional and if not provided, it will use a default version.
+
+#### Examples of using `wp-now start` arguments:
+
+Specify WordPress version, PHP version and plugin path:
+
+```bash
+nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.9 --php=7.4
+```
+
+Specify WordPress version and plugin or theme path:
+
+```bash
+nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --wp=5.8 
+```
+
+Specify PHP version and plugin or theme path:
+
+```bash
+nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme --php=7.4 
+```
+
+### Making WP-NOW accessible globally on your local machine
+
+To make `wp-now` accessible globally on your local machine:
+
+1. Clone this repository
+2. Follow the installation steps from **Building** section on `packages/wp-now/README.md`
+3. Execute `npm link`
+4. `wp-now` should be now available globally on your machine. This means that you can run `wp-now start` from any path on your local machine
+
+Example:
+
+1. Navigate in the terminal to a folder where your WordPress plugin or theme lives with `cd /my-plugin-or-theme`
+2. Execute `wp start now`
+
+
+### How to install WP-NOW from npm (not available yet)
+
+To install `wp-now` directly from `npm`, execute:
+
+```bash
+npm install -g @wordpress/wp-now
+```
+
+### Migrating from Laravel Valet?
+
+If you are migrating from Laravel Valet, you should be aware of the differences it has with `wp-now`:
+
+* `wp-now` does not require you to install separately WordPress, create database, connect WordPress to that database, create your use or login. All of these steps are packaged into `wp now start` command and are running under the hood;
+* `wp-now` works across all platforms (Mac, Linux, Windows);
+* `wp-now` does not support custom domains or SSL;
+* `wp-now` offers `theme` and `plugin` modes specific to WordPress development;
+* `wp-now` allows to easily switch the WordPress version with `wp-now start --wp=version.number`(make sure to replace the `version.number` with the actual WordPress version);
+* `wp-now` does not support Xdebug PHP extension
+
+
+Some similarities between Laravel Valet and `wp-now` to be aware of:
+
+* could be used for non-WordPress projects;
+* deployments are not possible on Laravel Valet and `wp-now`;
+* possible to switch easily the PHP version;
+* possibility to work on multiple WordPress sites simultaneously
+
+### Migrating from wp-env?
+
+If you are migrating from `wp-env`, you should be aware of the differences it has with `wp-now`:
+
+* `wp-now` supports non-WordPress projects;
+* `wp-env` is Docker-based which makes it platform indepedent (although `wp-now` does run across different platforms);
+* `wp-now` does not support Xdebug PHP extension;
+* `wp-now` does not include Jest for automatic browser testing
+
+
+Some similarities between `wp-env` and `wp-now` to be aware of:
+
+* no support for custom domains or SSL;
+* `plugin`, `themes` and index modes are available on `wp-env` and `wp-now`;
+* deployments are not supported from `wp-now` or `wp-env`
+* possible to switch easily the PHP version
 
 ## Contributing
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -42,7 +42,7 @@ If you would like to be able to not use `wp-now` globally and manually specify t
 1. Execute `npm install -g nx@latest`. This will make `nx` command globally accessible in the project.
 2. Start the web server in one of the modes specified below:
 
-### Modes on WP-NOW {#modes-on-wp-now}
+### Modes on WP-NOW
 
 wp-now operates in four different modes:
 


### PR DESCRIPTION
* Closes: https://github.com/WordPress/wordpress-playground/issues/267

This PR modifies the README file for `wp-now` package. It addresses the following issues:

* specifies the need to use `nvm` ;
* clarifies the need to install `nx` command globally before running the project;
* describes different modes that `wp-now` operates in and how to use those;
* describes arguments supported by `wp-now start`;
* gives examples of how to use a variety of arguments;
* clarifies how to make `wp-now start` globally available on your local machine;
* adds installation instruction through `npm`;
* adds brief comparison to Laravel Valet and `wp-env,

**Testing Instructions**

1. Carefully read through the README file. Do you see any inconsistencies in the instruction's logic? Any logical or factual errors? Please document this in the comments.
2. Follow instructions from the README file to build and run `wp-now`. Are there any steps missing? 
3. Follow instructions for testing different modes and arguments through `wp-start now`. Anything that does not work?
4. Any other improvements to suggest?