### PR TITLE
WP Now: Actually use project files in core mode

### DIFF
--- a/packages/wp-now/src/wp-playground-wordpress/is-wp-core-directory.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/is-wp-core-directory.ts
@@ -1,0 +1,16 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+/**
+ * Checks if the given path is a WordPress core directory.
+ *
+ * @param projectPath The path to the project to check.
+ * @returns Is it a WordPress core directory?
+ */
+export function isWpCoreDirectory(projectPath: string): Boolean {
+	return (
+		fs.existsSync(path.join(projectPath, 'wp-content')) &&
+		fs.existsSync(path.join(projectPath, 'wp-includes')) &&
+		fs.existsSync(path.join(projectPath, 'wp-load.php'))
+	);
+}


### PR DESCRIPTION
Without this change, the 'core' mode has no effect. With this change, it mounts the current project as WordPress in VFS.

One thing I don't like about this change is how it applies patches on top of the local WordPress copy. Thinking about the future, it would be great to only do that in VFS.

cc @sejas @wojtekn @katinthehatsite 