### PR TITLE
WP Now: Add core-develop mode to work in wordpress-develop directory

### DIFF
--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -21,9 +21,9 @@ import {
 	isPluginDirectory,
 	isThemeDirectory,
 	isWpContentDirectory,
+	isWpCoreDirectory,
+	isWpDevelopDirectory,
 } from './wp-playground-wordpress';
-import { isWpCoreDirectory } from './wp-playground-wordpress/is-wp-core-directory';
-import { isWpDevelopDirectory } from './wp-playground-wordpress/is-wp-develop-directory';
 
 export enum WPNowMode {
 	PLUGIN = 'plugin',

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -212,19 +212,6 @@ export default class WPNow {
 		return WPNowMode.INDEX;
 	}
 
-	static #isThemeDirectory(projectPath: string): Boolean {
-		const styleCSSExists = fs.existsSync(
-			path.join(projectPath, 'style.css')
-		);
-		if (!styleCSSExists) {
-			return false;
-		}
-		const styleCSS = fs.readFileSync(
-			path.join(projectPath, 'style.css'),
-			'utf-8'
-		);
-		return styleCSS.includes('Theme Name:');
-	}
 	static #validateOptions(options: WPNowOptions) {
 		// Check the php version
 		if (

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -28,6 +28,7 @@ export enum WPNowMode {
 	PLUGIN = 'plugin',
 	THEME = 'theme',
 	CORE = 'core',
+	CORE_DEVELOP = 'core-develop',
 	INDEX = 'index',
 	WP_CONTENT = 'wp-content',
 	AUTO = 'auto',
@@ -204,6 +205,20 @@ export default class WPNow {
 			return WPNowMode.THEME;
 		}
 		return WPNowMode.INDEX;
+	}
+
+	static #isThemeDirectory(projectPath: string): Boolean {
+		const styleCSSExists = fs.existsSync(
+			path.join(projectPath, 'style.css')
+		);
+		if (!styleCSSExists) {
+			return false;
+		}
+		const styleCSS = fs.readFileSync(
+			path.join(projectPath, 'style.css'),
+			'utf-8'
+		);
+		return styleCSS.includes('Theme Name:');
 	}
 
 	static #validateOptions(options: WPNowOptions) {

--- a/packages/wp-now/src/wp-playground-wordpress/index.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/index.ts
@@ -2,3 +2,5 @@ export * from './is-valid-wordpress-version';
 export * from './is-plugin-directory';
 export * from './is-theme-directory';
 export * from './is-wp-content-directory';
+export * from './is-wp-core-directory';
+export * from './is-wp-develop-directory';

--- a/packages/wp-now/src/wp-playground-wordpress/is-wp-develop-directory.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/is-wp-develop-directory.ts
@@ -1,0 +1,25 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+/**
+ * Checks if the given path is a WordPress-develop directory.
+ *
+ * @param projectPath The path to the project to check.
+ * @returns Is it a WordPress-develop directory?
+ */
+export function isWpDevelopDirectory(projectPath: string): boolean {
+	const requiredFiles = [
+		'src',
+		'src/wp-content',
+		'src/wp-includes',
+		'src/wp-load.php',
+		'build',
+		'build/wp-content',
+		'build/wp-includes',
+		'build/wp-load.php',
+	];
+
+	return requiredFiles.every((file) =>
+		fs.existsSync(path.join(projectPath, file))
+	);
+}


### PR DESCRIPTION
This commit mounts `build` as the documentRoot. As a recap, wordpress-develop has the `src` and `build` directories where WordPress files live.

As a side note, with this commit we have six modes and quite a few special cases. I expect more to come. It would be lovely to explore whether https://github.com/WordPress/playground-tools/issues/26 would greatly simplify the logic.

Also, note this PR is against the [`wp-now-core-mode` branch](https://github.com/WordPress/wordpress-playground/pull/291) which adds a `core` mode.

cc @sejas @wojtekn @dmsnell 