### PR TITLE
php-wasm: add publishConfig.directory to universal package.json

### DIFF
--- a/packages/php-wasm/universal/package.json
+++ b/packages/php-wasm/universal/package.json
@@ -29,7 +29,8 @@
 		"./package.json": "./package.json"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"directory": "../../../dist/packages/php-wasm/universal"
 	},
 	"type": "module",
 	"main": "./index.cjs",


### PR DESCRIPTION
# Proposed changes:

When we publish `@php-wasm/universal` the uploaded code is the source code.
I'm adding a `directory` to publish the `dist` code.
https://www.npmjs.com/package/@php-wasm/universal?activeTab=code