### PR TITLE
Add missing `publishConfig.directory` to `@php-wasm/util` and `@wp-playground/blueprints`

### DIFF
--- a/packages/php-wasm/util/package.json
+++ b/packages/php-wasm/util/package.json
@@ -9,6 +9,7 @@
 		"tsconfig": "./tsconfig.lib.json"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+    "directory": "../../../dist/packages/php-wasm/util"
 	}
 }

--- a/packages/php-wasm/util/package.json
+++ b/packages/php-wasm/util/package.json
@@ -10,6 +10,6 @@
 	},
 	"publishConfig": {
 		"access": "public",
-    "directory": "../../../dist/packages/php-wasm/util"
+		"directory": "../../../dist/packages/php-wasm/util"
 	}
 }

--- a/packages/playground/blueprints/package.json
+++ b/packages/playground/blueprints/package.json
@@ -19,6 +19,6 @@
 	},
 	"publishConfig": {
 		"access": "public",
-    "directory": "../../../dist/packages/playground/blueprints"
+		"directory": "../../../dist/packages/playground/blueprints"
 	}
 }

--- a/packages/playground/blueprints/package.json
+++ b/packages/playground/blueprints/package.json
@@ -18,6 +18,7 @@
 		"tsconfig": "./tsconfig.lib.json"
 	},
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+    "directory": "../../../dist/packages/playground/blueprints"
 	}
 }


### PR DESCRIPTION
## Proposed changes:

- As a follow-up of https://github.com/WordPress/wordpress-playground/pull/298 , I'm adding the publish directory to `@php-wasm/util` and `@wp-playground/blueprints`.