### PR TITLE
wp-now: Fix wp-content mode after latest refactor

### DIFF
--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -182,17 +182,19 @@ async function runWpContentMode(
 		absoluteUrl,
 	}: WPNowOptions
 ) {
-	php.mount(projectPath, documentRoot);
+	const wordPressPath = path.join(WORDPRESS_VERSIONS_PATH, wordPressVersion);
 	await initWordPress(
 		php,
 		wordPressVersion,
-		projectPath,
+		wordPressPath,
 		documentRoot,
 		absoluteUrl
 	);
 	fs.ensureDirSync(wpContentPath);
 
 	php.mount(projectPath, `${documentRoot}/wp-content`);
+
+	mountSqlite(php, documentRoot);
 }
 
 async function runWordPressDevelopMode(


### PR DESCRIPTION
In this PR, I propose to fix the wp-content mode which is broken during the latest refactoring.

Testing steps:

1. Create a project directory with themes and plugins placed in the following directory layout:

```
% ls -al wp-content-directory
drwxr-xr-x   5 cyphelf  admin    160 May 11 19:16 plugins
drwxr-xr-x   5 cyphelf  admin    160 May 10 11:32 themes
drwxr-xr-x   3 cyphelf  admin     96 May 10 11:37 uploads
```

2. Run wp-now environment

```
cd wp-content-directory
wp-now start
```

3. Confirm that wp-now starts and it contains all plugins and themes