### PR TITLE
wp-now: Fix wordpress mode when wp-config.php already exists

### DIFF
--- a/packages/wp-now/src/wp-now.spec.ts
+++ b/packages/wp-now/src/wp-now.spec.ts
@@ -158,22 +158,6 @@ test('isWordPressDirectory detects a WordPress directory and WORDPRESS mode', ()
 	expect(inferMode(projectPath)).toBe(WPNowMode.WORDPRESS);
 });
 
-test('isWordPressDirectory returns false in a WordPress directory with a wp-config.php', () => {
-	const projectPath = __dirname;
-	jest.spyOn(fs, 'existsSync').mockImplementation((fileOrFolder) => {
-		const existingFiles = [
-			path.join(projectPath, 'wp-content'),
-			path.join(projectPath, 'wp-includes'),
-			path.join(projectPath, 'wp-load.php'),
-			path.join(projectPath, 'wp-config.php'),
-		];
-		return existingFiles.includes(fileOrFolder as string);
-	});
-
-	expect(isWordPressDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
-});
-
 test('isWordPressDirectory returns false for non-WordPress directory', () => {
 	const projectPath = __dirname;
 	jest.spyOn(fs, 'existsSync').mockReturnValue(false);

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -127,7 +127,7 @@ export default async function startWPNow(
 	console.log(`wp: ${options.wordPressVersion}`);
 	if (options.mode === WPNowMode.INDEX) {
 		await runIndexMode(php, options);
-		return;
+		return php;
 	}
 	await downloadWordPress(options.wordPressVersion);
 	await downloadSqliteIntegrationPlugin();

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -186,10 +186,10 @@ async function runWpContentMode(
 	}: WPNowOptions
 ) {
 	const wordPressPath = path.join(WORDPRESS_VERSIONS_PATH, wordPressVersion);
+	php.mount(wordPressPath, documentRoot);
 	await initWordPress(
 		php,
 		wordPressVersion,
-		wordPressPath,
 		documentRoot,
 		absoluteUrl
 	);
@@ -215,13 +215,15 @@ async function runWordPressMode(
 	php: NodePHP,
 	{ documentRoot, projectPath, absoluteUrl }: WPNowOptions
 ) {
-	await initWordPress(
-		php,
-		'user-provided',
-		projectPath,
-		documentRoot,
-		absoluteUrl
-	);
+	php.mount(projectPath, documentRoot);
+	if (!php.fileExists(`${documentRoot}/wp-config.php`)) {
+		await initWordPress(
+			php,
+			'user-provided',
+			documentRoot,
+			absoluteUrl
+		);
+	}
 	copySqlite(projectPath);
 }
 
@@ -237,10 +239,10 @@ async function runPluginOrThemeMode(
 	}: WPNowOptions
 ) {
 	const wordPressPath = path.join(WORDPRESS_VERSIONS_PATH, wordPressVersion);
+	php.mount(wordPressPath, documentRoot);
 	await initWordPress(
 		php,
 		wordPressVersion,
-		wordPressPath,
 		documentRoot,
 		absoluteUrl
 	);
@@ -264,11 +266,9 @@ async function runPluginOrThemeMode(
 async function initWordPress(
 	php: NodePHP,
 	wordPressVersion: string,
-	wordPressPath: string,
 	vfsDocumentRoot: string,
 	siteUrl: string
 ) {
-	php.mount(wordPressPath, vfsDocumentRoot);
 	php.writeFile(
 		`${vfsDocumentRoot}/wp-config.php`,
 		php.readFileAsText(`${vfsDocumentRoot}/wp-config-sample.php`)

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -187,12 +187,7 @@ async function runWpContentMode(
 ) {
 	const wordPressPath = path.join(WORDPRESS_VERSIONS_PATH, wordPressVersion);
 	php.mount(wordPressPath, documentRoot);
-	await initWordPress(
-		php,
-		wordPressVersion,
-		documentRoot,
-		absoluteUrl
-	);
+	await initWordPress(php, wordPressVersion, documentRoot, absoluteUrl);
 	fs.ensureDirSync(wpContentPath);
 
 	php.mount(projectPath, `${documentRoot}/wp-content`);
@@ -217,12 +212,7 @@ async function runWordPressMode(
 ) {
 	php.mount(projectPath, documentRoot);
 	if (!php.fileExists(`${documentRoot}/wp-config.php`)) {
-		await initWordPress(
-			php,
-			'user-provided',
-			documentRoot,
-			absoluteUrl
-		);
+		await initWordPress(php, 'user-provided', documentRoot, absoluteUrl);
 	}
 	copySqlite(projectPath);
 }
@@ -240,12 +230,7 @@ async function runPluginOrThemeMode(
 ) {
 	const wordPressPath = path.join(WORDPRESS_VERSIONS_PATH, wordPressVersion);
 	php.mount(wordPressPath, documentRoot);
-	await initWordPress(
-		php,
-		wordPressVersion,
-		documentRoot,
-		absoluteUrl
-	);
+	await initWordPress(php, wordPressVersion, documentRoot, absoluteUrl);
 
 	fs.ensureDirSync(wpContentPath);
 	fs.copySync(

--- a/packages/wp-now/src/wp-playground-wordpress/is-wordpress-directory.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/is-wordpress-directory.ts
@@ -11,7 +11,6 @@ export function isWordPressDirectory(projectPath: string): Boolean {
 	return (
 		fs.existsSync(path.join(projectPath, 'wp-content')) &&
 		fs.existsSync(path.join(projectPath, 'wp-includes')) &&
-		fs.existsSync(path.join(projectPath, 'wp-load.php')) &&
-		!fs.existsSync(path.join(projectPath, 'wp-config.php'))
+		fs.existsSync(path.join(projectPath, 'wp-load.php'))
 	);
 }


### PR DESCRIPTION
Currently, the site run in "wordpress" mode works only on the first run:

1. I have a WP project with `wp-config.php` file removed
2. I run `wp-now start`
3. It runs in "wordpress" mode, it sets up SQLite and everything works as expected
4. I stop the environment and start it again
5. It crashes with `Trace: TypeError: Cannot read properties of undefined (reading 'request')` error

It happens because now it uses "index" mode for my site, and `startWPNow()` doesn’t return the php object.

I propose to change the logic to:
- do not run `initWordPress` if there is already `wp-config.php` file
- mount project path outside `initWordPress()` method
- modify isWordPressDirectory to ignore `wp-config.php` existence
- return proper php object instead of undefined

Merges into https://github.com/WordPress/wordpress-playground/pull/302