### PR TITLE
wp-now: Only apply sqlite for 'wp-content' when missing `wp-config.php`

### DIFF
--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -213,8 +213,8 @@ async function runWordPressMode(
 	php.mount(projectPath, documentRoot);
 	if (!php.fileExists(`${documentRoot}/wp-config.php`)) {
 		await initWordPress(php, 'user-provided', documentRoot, absoluteUrl);
+		copySqlite(projectPath);
 	}
-	copySqlite(projectPath);
 }
 
 async function runPluginOrThemeMode(


### PR DESCRIPTION
If a `wp-config.php` already exists, let's assume the user has a working database connection and doesn't need another one.