### PR TITLE
Local Environment: Correct instructions for npm download in the README

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -96,12 +96,12 @@ Please note: if you use `npm link` and are executing `wp-now` from the plugin or
 wp-now start --wp=5.9 --php=7.4 --port=3000
 ```
 
-## How to install WP-NOW from npm (not available yet)
+## How to install WP-NOW from npm
 
 To install `wp-now` directly from `npm`, execute:
 
 ```bash
-npm install -g @wordpress/wp-now
+npm install -g @wp-now/wp-now
 ```
 
 Once installed, you can use it like so:

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -96,7 +96,7 @@ Please note: if you use `npm link` and are executing `wp-now` from the plugin or
 wp-now start --wp=5.9 --php=7.4 --port=3000
 ```
 
-## How to install WP-NOW from npm
+## How to install WP-NOW from npm (IN PROGRESS):
 
 To install `wp-now` directly from `npm`, execute:
 


### PR DESCRIPTION
* Related to: https://github.com/WordPress/wordpress-playground/pull/289

This PR corrects a few inconsistencies in the README file for `wp-now`:

* Removes `(not available yet)` for the npm downloads since those are possible
* Corrects the command for npm download which should be `npm install -g @wp-now/wp-now` instead of `npm install -g @wordpress/wp-now`

**Testing**:

* Read through the corrected file
* Confirm that the information looks correct