### PR TITLE
wp-now: Abstract downloading and loading mu-plugins

### DIFF
--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -115,3 +115,20 @@ export async function downloadSqliteIntegrationPlugin() {
 		itemName: 'Sqlite',
 	});
 }
+
+export async function downloadMuPlugins() {
+	fs.ensureDirSync(path.join(WP_NOW_PATH, 'mu-plugins'));
+	fs.writeFile(
+		path.join(WP_NOW_PATH, 'mu-plugins', '0-allow-wp-org.php'),
+		`<?php
+	// Needed because gethostbyname( 'wordpress.org' ) returns
+	// a private network IP address for some reason.
+	add_filter( 'allowed_redirect_hosts', function( $deprecated = '' ) {
+		return array(
+			'wordpress.org',
+			'api.wordpress.org',
+			'downloads.wordpress.org',
+		);
+	} );`
+	);
+}

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -14,7 +14,7 @@ import {
 	WORDPRESS_VERSIONS_PATH,
 	WP_NOW_PATH,
 } from './constants';
-import { downloadSqliteIntegrationPlugin, downloadWordPress } from './download';
+import {downloadMuPlugins, downloadSqliteIntegrationPlugin, downloadWordPress} from './download';
 import { portFinder } from './port-finder';
 import {
 	cp,
@@ -131,6 +131,7 @@ export default async function startWPNow(
 	}
 	await downloadWordPress(options.wordPressVersion);
 	await downloadSqliteIntegrationPlugin();
+	await downloadMuPlugins()
 	switch (options.mode) {
 		case WPNowMode.WP_CONTENT:
 			await runWpContentMode(php, options);
@@ -192,6 +193,7 @@ async function runWpContentMode(
 
 	php.mount(projectPath, `${documentRoot}/wp-content`);
 
+	mountMuPlugins(php, documentRoot);
 	mountSqlite(php, documentRoot);
 }
 
@@ -214,6 +216,7 @@ async function runWordPressMode(
 	if (!php.fileExists(`${documentRoot}/wp-config.php`)) {
 		await initWordPress(php, 'user-provided', documentRoot, absoluteUrl);
 	}
+	mountMuPlugins(php, documentRoot);
 	copySqlite(projectPath);
 }
 
@@ -245,6 +248,7 @@ async function runPluginOrThemeMode(
 		projectPath,
 		`${documentRoot}/wp-content/${directoryName}/${pluginName}`
 	);
+	mountMuPlugins(php, documentRoot);
 	mountSqlite(php, documentRoot);
 }
 
@@ -266,20 +270,10 @@ async function initWordPress(
 			},
 		});
 	}
-	php.mkdirTree(`${vfsDocumentRoot}/wp-content/mu-plugins`);
-	php.writeFile(
-		`${vfsDocumentRoot}/wp-content/mu-plugins/0-allow-wp-org.php`,
-		`<?php
-	// Needed because gethostbyname( 'wordpress.org' ) returns
-	// a private network IP address for some reason.
-	add_filter( 'allowed_redirect_hosts', function( $deprecated = '' ) {
-		return array(
-			'wordpress.org',
-			'api.wordpress.org',
-			'downloads.wordpress.org',
-		);
-	} );`
-	);
+}
+
+function mountMuPlugins(php: NodePHP, vfsDocumentRoot: string) {
+	php.mount(path.join(WP_NOW_PATH, 'mu-plugins'), path.join(vfsDocumentRoot, 'wp-content', 'mu-plugins'));
 }
 
 function mountSqlite(php: NodePHP, vfsDocumentRoot: string) {

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -14,7 +14,11 @@ import {
 	WORDPRESS_VERSIONS_PATH,
 	WP_NOW_PATH,
 } from './constants';
-import {downloadMuPlugins, downloadSqliteIntegrationPlugin, downloadWordPress} from './download';
+import {
+	downloadMuPlugins,
+	downloadSqliteIntegrationPlugin,
+	downloadWordPress,
+} from './download';
 import { portFinder } from './port-finder';
 import {
 	cp,
@@ -131,7 +135,7 @@ export default async function startWPNow(
 	}
 	await downloadWordPress(options.wordPressVersion);
 	await downloadSqliteIntegrationPlugin();
-	await downloadMuPlugins()
+	await downloadMuPlugins();
 	switch (options.mode) {
 		case WPNowMode.WP_CONTENT:
 			await runWpContentMode(php, options);
@@ -273,7 +277,10 @@ async function initWordPress(
 }
 
 function mountMuPlugins(php: NodePHP, vfsDocumentRoot: string) {
-	php.mount(path.join(WP_NOW_PATH, 'mu-plugins'), path.join(vfsDocumentRoot, 'wp-content', 'mu-plugins'));
+	php.mount(
+		path.join(WP_NOW_PATH, 'mu-plugins'),
+		path.join(vfsDocumentRoot, 'wp-content', 'mu-plugins')
+	);
 }
 
 function mountSqlite(php: NodePHP, vfsDocumentRoot: string) {


### PR DESCRIPTION
In this PR, I propose to abstract downloading and loading mu-plugins. That way, we won't need to create the plugins in `wp-content/` directory when 'wp-content' or 'wordpress' modes are used.

With that change, the developer's local environment won't have the new mu-plugin added to his working copy.

Related https://github.com/WordPress/wordpress-playground/issues/313