### PR TITLE
wp-now: startWPNow should always return always an object with php and options

### DIFF
--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -94,7 +94,7 @@ export async function parseOptions(
 
 export default async function startWPNow(
 	rawOptions: Partial<WPNowOptions> = {}
-) {
+): Promise<{ php: NodePHP; options: WPNowOptions }> {
 	const options = await parseOptions(rawOptions);
 
 	const { documentRoot } = options;
@@ -127,7 +127,7 @@ export default async function startWPNow(
 	console.log(`wp: ${options.wordPressVersion}`);
 	if (options.mode === WPNowMode.INDEX) {
 		await runIndexMode(php, options);
-		return {php, options};
+		return { php, options };
 	}
 	await downloadWordPress(options.wordPressVersion);
 	await downloadSqliteIntegrationPlugin();

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -127,7 +127,7 @@ export default async function startWPNow(
 	console.log(`wp: ${options.wordPressVersion}`);
 	if (options.mode === WPNowMode.INDEX) {
 		await runIndexMode(php, options);
-		return php;
+		return {php, options};
 	}
 	await downloadWordPress(options.wordPressVersion);
 	await downloadSqliteIntegrationPlugin();


### PR DESCRIPTION
## Proposed changes

Fix `startWPNow` to always return the same type.

## Testing instructions

- Run `wp-now start` on index and other modes.
- Observe it runs as expected.