### PR TITLE
wp-now: Fix default test by using explicit project path

### DIFF
--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -14,12 +14,16 @@ const exampleDir = __dirname + '/mode-examples';
 
 // Options
 test('parseOptions with default options', async () => {
-	const options = await parseOptions();
+	const rawOptions: Partial<WPNowOptions> = {
+		projectPath: exampleDir,
+	};
+	const options = await parseOptions(rawOptions);
+
 	expect(options.phpVersion).toBe('8.0');
 	expect(options.wordPressVersion).toBe('latest');
 	expect(options.documentRoot).toBe('/var/www/html');
 	expect(options.mode).toBe(WPNowMode.INDEX);
-	expect(options.projectPath).toBe(process.cwd());
+	expect(options.projectPath).toBe(exampleDir);
 });
 
 test('parseOptions with custom options', async () => {


### PR DESCRIPTION
In this PR, I propose to fix the test for WordPress plugins which fails when there is an untracked file called `plugin.php` in the repo root.

Fixes: https://github.com/WordPress/wordpress-playground/issues/315

**Testing instructions**

1. Create `plugin.php` file in the project root and add the following content
```
<?php
/**
 * Plugin Name: Foo  Bar
 */
```
2. Run tests
```
nx test wp-now --skip-nx-cache
```
3. Confirm they went through