### PR TITLE
Fix: Update returned value from wp-now for index mode

### DIFF
--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -127,7 +127,7 @@ export default async function startWPNow(
 	console.log(`wp: ${options.wordPressVersion}`);
 	if (options.mode === WPNowMode.INDEX) {
 		await runIndexMode(php, options);
-		return php;
+		return { php, options };
 	}
 	await downloadWordPress(options.wordPressVersion);
 	await downloadSqliteIntegrationPlugin();


### PR DESCRIPTION
Fixes starting issue for index mode, as the current implementation throws an error.

## Testing instructions

- Start wp-now and point it to a folder that has only an index.php file.
- Ensure that it doesn't throw an error