### PR TITLE
wp-now: add  instructions for publishing to npm

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -162,6 +162,19 @@ Some similarities between `wp-env` and `wp-now` to be aware of:
 -   deployments are not possible with neither `wp-env`, nor `wp-now`;
 -   possible to switch easily the PHP version
 
+## Publishing to npm
+
+The `wp-now` package is part of a larger monorepo, sharing its space with other sibiling packages. To publish the `wp-now` package to npm, you must first understand the automated release process facilitated by lerna. This process includes automatically incrementing the version number, creating a new tag, and publishing all modified packages to npm simultaneously. Notably, all published packages share the same version number.
+
+Each package identifies a distinct organization in its package.json file. To publish the `wp-now` package, you need access to the npm organizations `@wp-playground`, `@php-wasm`, and `@wp-now`.
+
+To initiate the publishing process for the wp-now package, execute the following commands:
+
+```bash
+npm login # this is required only once and it will store the credentials in ~/.npmrc file.
+npm run release
+```
+
 ## Contributing
 
 We welcome contributions from the community! Please refer to the main [README.md](../../README.md) file for instructions on how to contribute to this project.

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -166,9 +166,9 @@ Some similarities between `wp-env` and `wp-now` to be aware of:
 
 The `wp-now` package is part of a larger monorepo, sharing its space with other sibiling packages. To publish the `wp-now` package to npm, you must first understand the automated release process facilitated by lerna. This process includes automatically incrementing the version number, creating a new tag, and publishing all modified packages to npm simultaneously. Notably, all published packages share the same version number.
 
-Each package identifies a distinct organization in its package.json file. To publish the `wp-now` package, you need access to the npm organizations `@wp-playground`, `@php-wasm`, and `@wp-now`.
+Each package identifies a distinct organization in its `package.json` file. To publish the `wp-now` package, you need access to the npm organizations `@wp-playground`, `@php-wasm`, and `@wp-now`.
 
-To initiate the publishing process for the wp-now package, execute the following commands:
+To initiate the publishing process for the all the modified packages, execute the following commands:
 
 ```bash
 npm login # this is required only once and it will store the credentials in ~/.npmrc file.


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

Add `Publishing to npm` section to `packages/wp-now/README.md`

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It was asked here https://github.com/WordPress/wordpress-playground/issues/231#issuecomment-1545035379

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I described the publishing instricutions to the `wp-now` Readme.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
1. Go to the changed files.
2. Observe the new section at the bottom of the Readme: `Publishing to npm`
3. Validate the instructions.
