### PR TITLE
wp-now: Couple of improvements to CLI output

### DIFF
--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -95,7 +95,6 @@ export async function downloadWordPress(
 		checkFinalPath: finalFolder,
 		itemName: `WordPress ${wordPressVersion}`,
 	});
-	console.log('downloaded', downloaded);
 	if (downloaded) {
 		fs.ensureDirSync(path.dirname(finalFolder));
 		fs.renameSync(path.join(tempFolder, 'wordpress'), finalFolder);

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -125,7 +125,7 @@ export default async function startWPNow(
 	php.chdir(documentRoot);
 	php.writeFile(`${documentRoot}/index.php`, `<?php echo 'Hello wp-now!';`);
 
-	console.log(`Project directory: ${options.projectPath}`);
+	console.log(`directory: ${options.projectPath}`);
 	console.log(`mode: ${options.mode}`);
 	console.log(`php: ${options.phpVersion}`);
 	console.log(`wp: ${options.wordPressVersion}`);


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

Makes a couple of improvements to the CLI output when starting:
* Use `directory:` instead of `Project directory:` for consistency with the other output.
* Removes `downloaded (true|false)` because this is communicated in other output.

## Testing Instructions

1. Run `nx preview wp-now start` and verify output appears as expected.