### PR TITLE
PHP: Explore building with pthreads

### DIFF
--- a/packages/php-wasm/compile/Dockerfile
+++ b/packages/php-wasm/compile/Dockerfile
@@ -499,7 +499,7 @@ RUN source /root/emsdk/emsdk_env.sh && \
 
 # Silence the errors "munmap() failed: [28] Invalid argument"
 # @TODO: Identify the root cause behind these errors and fix them properly
-RUN echo '#define ZEND_MM_ERROR 0' >> /root/php-src/main/php_config.h; 
+RUN echo '#define ZEND_MM_ERROR 1' >> /root/php-src/main/php_config.h; 
 RUN echo '#define ZEND_DEBUG 1' >> /root/php-src/main/php_config.h; 
 
 # With HAVE_UNISTD_H=1 PHP complains about the missing getdtablesize() function 

--- a/packages/php-wasm/compile/Dockerfile
+++ b/packages/php-wasm/compile/Dockerfile
@@ -339,15 +339,16 @@ RUN if [ "$WITH_LIBZIP" = "yes" ]; then \
             echo -n ' --with-zlib --with-zlib-dir=/root/lib --with-zip' >> /root/.php-configure-flags; \
             echo -n ' -I /root/zlib -I /root/libzip' >> /root/.emcc-php-wasm-flags; \
             echo -n ' /root/lib/lib/libzip.a /root/lib/lib/libz.a' >> /root/.emcc-php-wasm-sources; \
-        fi && \
-        /root/replace.sh 's/pharcmd=pharcmd/pharcmd=/g' /root/php-src/configure && \
-        /root/replace.sh 's/pharcmd_install=install-pharcmd/pharcmd_install=/g' /root/php-src/configure; \
+        fi; \
     fi;
+
+RUN /root/replace.sh 's/pharcmd=pharcmd/pharcmd=/g' /root/php-src/configure
+RUN /root/replace.sh 's/pharcmd_install=install-pharcmd/pharcmd_install=/g' /root/php-src/configure;
 
 # Add ncurses if needed and libedit if needed
 COPY --from=emscripten-libedit /root/lib /root/lib-libedit
 COPY --from=emscripten-ncurses /root/lib /root/lib-ncurses
-RUN if [ "$WITH_CLI_SAPI" = "yes" ]; \
+RUN if [ "$WITH_CLI_SAPI" = "disabled" ]; \
     then \
         /root/copy-lib.sh lib-ncurses && \
         /root/copy-lib.sh lib-libedit && \
@@ -499,6 +500,7 @@ RUN source /root/emsdk/emsdk_env.sh && \
 # Silence the errors "munmap() failed: [28] Invalid argument"
 # @TODO: Identify the root cause behind these errors and fix them properly
 RUN echo '#define ZEND_MM_ERROR 0' >> /root/php-src/main/php_config.h; 
+RUN echo '#define ZEND_DEBUG 1' >> /root/php-src/main/php_config.h; 
 
 # With HAVE_UNISTD_H=1 PHP complains about the missing getdtablesize() function 
 RUN /root/replace.sh 's/define HAVE_UNISTD_H 1/define HAVE_UNISTD_H 0/g' /root/php-src/main/php_config.h
@@ -923,6 +925,7 @@ RUN mkdir /root/output
 COPY ./build-assets/phpwasm-emscripten-library.js /root/phpwasm-emscripten-library.js
 RUN source /root/emsdk/emsdk_env.sh && \
     export EXPORTED_FUNCTIONS=$'["_php_wasm_init", \n\
+"_run_php", \n\
 "_phpwasm_destroy_uploaded_files_hash", \n\
 "_phpwasm_init_uploaded_files_hash", \n\
 "_phpwasm_register_uploaded_file", \n\
@@ -943,8 +946,9 @@ RUN source /root/emsdk/emsdk_env.sh && \
 "_wasm_set_request_port", \n\
 "_wasm_set_request_uri", \n\
 "_wasm_set_skip_shebang" '"$(cat /root/.EXPORTED_FUNCTIONS)"']'; \
-    emcc -O3 \
+    emcc -O0 -g2 \
     --js-library /root/phpwasm-emscripten-library.js \
+    -pthread \
     -I .  \
     -I ext   \
     -I ext/json   \
@@ -960,7 +964,7 @@ RUN source /root/emsdk/emsdk_env.sh && \
     -s INITIAL_MEMORY=1024MB \
     -s ALLOW_MEMORY_GROWTH=1         \
     -s USE_PTHREADS=1                \
-    -s ASSERTIONS=0                  \
+    -s ASSERTIONS=3                  \
     -s ERROR_ON_UNDEFINED_SYMBOLS=0  \
     -s NODEJS_CATCH_EXIT=0           \
     -s INVOKE_RUN=0                  \
@@ -1052,13 +1056,13 @@ RUN \
     # Turn the php.js file into an ES module
         # Manually turn the output into a esm module instead of relying on -s MODULARIZE=1.
         # which pollutes the global namespace and does not play well with import() mechanics.
-        echo "export const dependenciesTotalSize = $FILE_SIZE; " >> /root/output/php-module.js && \
+        echo "const dependenciesTotalSize = $FILE_SIZE; " >> /root/output/php-module.js && \
         if [ "$EMSCRIPTEN_ENVIRONMENT" = "node" ]; then \
-            echo "const dependencyFilename = __dirname + '/$WASM_FILENAME'; " >> /root/output/php-module.js; \
+            echo "const dependencyFilename = './$WASM_FILENAME'; " >> /root/output/php-module.js; \
         else \
             echo "import dependencyFilename from './$WASM_FILENAME'; " >> /root/output/php-module.js; \
         fi; \
-        echo " export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {" >> /root/output/php-module.js && \
+        echo "  module.exports = function init(RuntimeName, PHPLoader) {" >> /root/output/php-module.js && \
         cat /root/output/php.js >> /root/output/php-module.js && \
         cat /root/append-before-return.js >> /root/output/php-module.js && \
         echo " return PHPLoader; }" >> /root/output/php-module.js && \

--- a/packages/php-wasm/compile/Dockerfile
+++ b/packages/php-wasm/compile/Dockerfile
@@ -3,7 +3,7 @@
 # emscripten/emsdk:3.1.24 supports amd64 only.
 FROM ubuntu:lunar as emscripten
 
-SHELL ["/bin/bash", "-c"]
+SHELL ["/bin/bash", "-l", "-c"]
 
 ENV PKG_CONFIG_PATH /root/lib/lib/pkgconfig
 ENV TIMER "(which pv > /dev/null && pv --name '${@}' || cat)"
@@ -37,9 +37,18 @@ RUN set -euxo pipefail;\
 # Docker image, but there is no arm64 image available which makes
 # the build take forever on Apple Silicon.
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN git clone https://github.com/emscripten-core/emsdk.git && \
-    ./emsdk/emsdk install latest && \
-    /root/emsdk/emsdk activate latest
+RUN git clone https://github.com/emscripten-core/emsdk.git
+
+RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
+RUN echo 'source /root/.nvm/nvm.sh' >> /root/.bashrc
+RUN . /root/.nvm/nvm.sh && nvm install 20
+
+RUN /root/emsdk/emsdk install latest
+RUN /root/emsdk/emsdk list
+RUN /root/emsdk/emsdk activate latest
+
+RUN . /root/.nvm/nvm.sh && echo 'NODE_JS = "'$(which node)'"' >> /root/emsdk/.emscripten
+
 
 RUN mkdir -p /root/lib/lib /root/lib/include /root/lib/share /root/lib/bin
 
@@ -120,8 +129,8 @@ RUN cd libzip/build && \
             -DZLIB_LIBRARY=/root/lib/lib/libz.a \
             -DZLIB_INCLUDE_DIR=/root/lib/include \
             ..
-RUN cd libzip/build && source /root/emsdk/emsdk_env.sh && EMCC_SKIP="-lz" EMCC_FLAGS=" -sSIDE_MODULE " emmake make
-RUN cd libzip/build && source /root/emsdk/emsdk_env.sh && EMCC_SKIP="-lz" EMCC_FLAGS=" -sSIDE_MODULE " emmake make install
+RUN cd libzip/build && source /root/emsdk/emsdk_env.sh && EMCC_SKIP="-lz" EMCC_FLAGS=" -sSIDE_MODULE -sUSE_PTHREADS=1 " emmake make
+RUN cd libzip/build && source /root/emsdk/emsdk_env.sh && EMCC_SKIP="-lz" EMCC_FLAGS=" -sSIDE_MODULE -sUSE_PTHREADS=1 " emmake make install
 
 # Compile ncurses
 FROM emscripten AS emscripten-ncurses
@@ -180,7 +189,7 @@ RUN     wget https://www.thrysoee.dk/editline/libedit-20221030-3.1.tar.gz && \
         # Musl is ISO 10646 compliant but doesn't define __STDC_ISO_10646__, so
         # let's define it manually. Learn more at:
         # http://lists.busybox.net/pipermail/buildroot/2016-January/149100.html
-        EMCC_SKIP="-lc -lncurses " EMCC_FLAGS=" -sSIDE_MODULE -D__STDC_ISO_10646__=201103L " \
+        EMCC_SKIP="-lc -lncurses " EMCC_FLAGS=" -sSIDE_MODULE -sUSE_PTHREADS=1 -D__STDC_ISO_10646__=201103L " \
         emmake make && \
         emmake make install
 
@@ -193,8 +202,8 @@ RUN source /root/emsdk/emsdk_env.sh && \
         --depth 1 && \
     cd libxml2 && \
     ./autogen.sh && \
-    emconfigure ./configure --with-http=no --with-ftp=no --with-python=no --with-threads=no --enable-shared=no --prefix=/root/lib/ &&\
-    EMCC_FLAGS=" -sSIDE_MODULE " emmake make && \
+    emconfigure ./configure --with-http=no --with-ftp=no --with-python=no --with-threads=yes --enable-shared=no --prefix=/root/lib/ &&\
+    EMCC_FLAGS=" -sSIDE_MODULE -sUSE_PTHREADS=1 " emmake make && \
     emmake make install
 
 # Compile Bison 2.7 (for PHP  <=7.3)
@@ -222,7 +231,7 @@ RUN     set -euxo pipefail &&\
             --build i386-pc-linux-gnu \
             --target wasm32-unknown-emscripten \
             --prefix=/root/lib/ && \
-        EMCC_SKIP="-lc" EMCC_FLAGS=" -sSIDE_MODULE " emmake make && \
+        EMCC_SKIP="-lc" EMCC_FLAGS=" -sSIDE_MODULE -sUSE_PTHREADS=1 " emmake make && \
         emmake make install
 
 # Compile OpenSSL
@@ -237,12 +246,12 @@ RUN set -euxo pipefail && \
     wget https://www.openssl.org/source/openssl-$OPENSSL_VERSION.tar.gz && \
     tar xf openssl-$OPENSSL_VERSION.tar.gz && \
     cd openssl-$OPENSSL_VERSION && \
-    emconfigure ./Configure dist -DHAVE_FORK=0 -DOPENSSL_NO_AFALGENG=1 no-threads --prefix=/root/lib && \
+    emconfigure ./Configure dist -DHAVE_FORK=0 -DOPENSSL_NO_AFALGENG=1 --prefix=/root/lib && \
     sed -i 's|^CROSS_COMPILE.*$|CROSS_COMPILE=|g' Makefile && \
-    EMCC_FLAGS=" -sSIDE_MODULE " EMCC_SKIP="-lz" emmake make -j 12 build_generated libssl.a libcrypto.a; \
+    EMCC_FLAGS=" -sSIDE_MODULE -sUSE_PTHREADS=1 " EMCC_SKIP="-lz" emmake make -j 12 build_generated libssl.a libcrypto.a; \
     cp -RL include/openssl /root/lib/include && \
     cp libcrypto.a libssl.a /root/lib/lib && \
-    EMCC_FLAGS=" -sSIDE_MODULE " EMCC_SKIP="-lz" emmake make install;
+    EMCC_FLAGS=" -sSIDE_MODULE -sUSE_PTHREADS=1 " EMCC_SKIP="-lz" emmake make install;
 
 # Compile libpng
 FROM emscripten AS emscripten-libpng
@@ -259,7 +268,7 @@ RUN     source /root/emsdk/emsdk_env.sh && \
             --build i386-pc-linux-gnu \
             --target wasm32-unknown-emscripten \
             --prefix=/root/lib/
-RUN source /root/emsdk/emsdk_env.sh && EMCC_SKIP="-lc -lz" EMCC_FLAGS="-sSIDE_MODULE" emmake make
+RUN source /root/emsdk/emsdk_env.sh && EMCC_SKIP="-lc -lz" EMCC_FLAGS="-sSIDE_MODULE -sUSE_PTHREADS=1" emmake make
 RUN source /root/emsdk/emsdk_env.sh && emmake make install
 
 # Clone PHP
@@ -463,6 +472,10 @@ RUN source /root/emsdk/emsdk_env.sh && \
     # --enable-json for PHP < 8.0:
     --enable-json      \
     --enable-embed=static \
+	--enable-zts  \
+	--enable-maintainer-zts \
+	--enable-pthreads  \
+	--enable-pcntl  \
     --with-layout=GNU  \
     --disable-cgi      \
     --disable-all      \
@@ -511,7 +524,7 @@ RUN echo 'extern int wasm_close(int fd);' >> /root/php-src/main/php_config.h;
 
 RUN source /root/emsdk/emsdk_env.sh && \
     # We're compiling PHP as emscripten's side module...
-    EMCC_FLAGS=" -sSIDE_MODULE -Dsetsockopt=wasm_setsockopt -Dpopen=wasm_popen -Dpclose=wasm_pclose " \
+    EMCC_FLAGS=" -sSIDE_MODULE -sUSE_PTHREADS=1 -Dsetsockopt=wasm_setsockopt -Dpopen=wasm_popen -Dpclose=wasm_pclose " \
     # ...which means we must skip all the libraries - they will be provided in the final linking step.
     EMCC_SKIP="-lz -ledit -ldl -lncurses -lzip -lpng16 -lssl -lcrypto -lxml2 -lc -lm -lsqlite3 /root/lib/lib/libxml2.a /root/lib/lib/libsqlite3.so /root/lib/lib/libsqlite3.a /root/lib/lib/libpng16.so" \
     emmake make -j8
@@ -946,6 +959,7 @@ RUN source /root/emsdk/emsdk_env.sh && \
     -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "UTF8ToString", "lengthBytesUTF8", "FS", "PROXYFS"]' \
     -s INITIAL_MEMORY=1024MB \
     -s ALLOW_MEMORY_GROWTH=1         \
+    -s USE_PTHREADS=1                \
     -s ASSERTIONS=0                  \
     -s ERROR_ON_UNDEFINED_SYMBOLS=0  \
     -s NODEJS_CATCH_EXIT=0           \

--- a/packages/php-wasm/compile/build-assets/append-before-return.js
+++ b/packages/php-wasm/compile/build-assets/append-before-return.js
@@ -10,12 +10,3 @@ DNS.address_map.addrs.localhost = '127.0.0.1';
  * so that it can be inspected later.
  */
 PHPLoader.debug = 'debug' in PHPLoader ? PHPLoader.debug : true;
-if (PHPLoader.debug) {
-    const originalHandleSleep = Asyncify.handleSleep;
-    Asyncify.handleSleep = function (startAsync) {
-        if (!ABORT) {
-            Module["lastAsyncifyStackSource"] = new Error();
-        }
-        return originalHandleSleep(startAsync);
-    }
-}

--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -94,19 +94,19 @@ const args = argParser.argv;
 const platformDefaults = {
 	all: {
 		PHP_VERSION: '8.0.24',
-		WITH_LIBZIP: 'yes',
-		WITH_SQLITE: 'yes',
+		WITH_LIBZIP: 'no',
+		WITH_SQLITE: 'no',
 	},
 	web: {},
 	node: {
-		WITH_LIBXML: 'yes',
-		WITH_LIBPNG: 'yes',
-		WITH_MBSTRING: 'yes',
-		WITH_CLI_SAPI: 'yes',
-		WITH_OPENSSL: 'yes',
-		WITH_NODEFS: 'yes',
-		WITH_MYSQL: 'yes',
-		WITH_WS_NETWORKING_PROXY: 'yes',
+		WITH_LIBXML: 'no',
+		WITH_LIBPNG: 'no',
+		WITH_MBSTRING: 'no',
+		WITH_CLI_SAPI: 'no',
+		WITH_OPENSSL: 'no',
+		WITH_NODEFS: 'no',
+		WITH_MYSQL: 'no',
+		WITH_WS_NETWORKING_PROXY: 'no',
 	},
 };
 const platform = args.PLATFORM === 'node' ? 'node' : 'web';

--- a/packages/php-wasm/node/public/php.worker.js
+++ b/packages/php-wasm/node/public/php.worker.js
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2015 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+// Pthread Web Worker startup routine:
+// This is the entry point file that is loaded first by each Web Worker
+// that executes pthreads on the Emscripten application.
+
+'use strict';
+
+var Module = {};
+
+// Node.js support
+var ENVIRONMENT_IS_NODE = typeof process == 'object' && typeof process.versions == 'object' && typeof process.versions.node == 'string';
+if (ENVIRONMENT_IS_NODE) {
+  // Create as web-worker-like an environment as we can.
+
+  var nodeWorkerThreads = require('worker_threads');
+
+  var parentPort = nodeWorkerThreads.parentPort;
+
+  parentPort.on('message', (data) => onmessage({ data: data }));
+
+  var fs = require('fs');
+
+  Object.assign(global, {
+    self: global,
+    require: require,
+    Module: Module,
+    location: {
+      href: __filename
+    },
+    Worker: nodeWorkerThreads.Worker,
+    importScripts: function(f) {
+      (0, eval)(fs.readFileSync(f, 'utf8') + '//# sourceURL=' + f);
+    },
+    postMessage: function(msg) {
+      parentPort.postMessage(msg);
+    },
+    performance: global.performance || {
+      now: function() {
+        return Date.now();
+      }
+    },
+  });
+}
+
+// Thread-local guard variable for one-time init of the JS state
+var initializedJS = false;
+
+function threadPrintErr() {
+  var text = Array.prototype.slice.call(arguments).join(' ');
+  // See https://github.com/emscripten-core/emscripten/issues/14804
+  if (ENVIRONMENT_IS_NODE) {
+    fs.writeSync(2, text + '\n');
+    return;
+  }
+  console.error(text);
+}
+function threadAlert() {
+  var text = Array.prototype.slice.call(arguments).join(' ');
+  postMessage({cmd: 'alert', text: text, threadId: Module['_pthread_self']()});
+}
+var err = threadPrintErr;
+self.alert = threadAlert;
+
+Module['instantiateWasm'] = (info, receiveInstance) => {
+  // Instantiate from the module posted from the main thread.
+  // We can just use sync instantiation in the worker.
+  var module = Module['wasmModule'];
+  // We don't need the module anymore; new threads will be spawned from the main thread.
+  Module['wasmModule'] = null;
+  var instance = new WebAssembly.Instance(module, info);
+  // TODO: Due to Closure regression https://github.com/google/closure-compiler/issues/3193,
+  // the above line no longer optimizes out down to the following line.
+  // When the regression is fixed, we can remove this if/else.
+  return receiveInstance(instance);
+}
+
+// Turn unhandled rejected promises into errors so that the main thread will be
+// notified about them.
+self.onunhandledrejection = (e) => {
+  throw e.reason ?? e;
+};
+
+function handleMessage(e) {
+  try {
+    if (e.data.cmd === 'load') { // Preload command that is called once per worker to parse and load the Emscripten code.
+
+    // Until we initialize the runtime, queue up any further incoming messages.
+    let messageQueue = [];
+    self.onmessage = (e) => messageQueue.push(e);
+
+    // And add a callback for when the runtime is initialized.
+    self.startWorker = (instance) => {
+      // Notify the main thread that this thread has loaded.
+      postMessage({ 'cmd': 'loaded' });
+      // Process any messages that were queued before the thread was ready.
+      for (let msg of messageQueue) {
+        handleMessage(msg);
+      }
+      // Restore the real message handler.
+      self.onmessage = handleMessage;
+    };
+
+      // Module and memory were sent from main thread
+      Module['wasmModule'] = e.data.wasmModule;
+
+      // Use `const` here to ensure that the variable is scoped only to
+      // that iteration, allowing safe reference from a closure.
+      for (const handler of e.data.handlers) {
+        Module[handler] = function() {
+          postMessage({ cmd: 'callHandler', handler, args: [...arguments] });
+        }
+      }
+
+      Module['wasmMemory'] = e.data.wasmMemory;
+
+      Module['buffer'] = Module['wasmMemory'].buffer;
+
+      Module['ENVIRONMENT_IS_PTHREAD'] = true;
+
+      if (typeof e.data.urlOrBlob == 'string') {
+        importScripts(e.data.urlOrBlob);
+      } else {
+        var objectUrl = URL.createObjectURL(e.data.urlOrBlob);
+        importScripts(objectUrl);
+        URL.revokeObjectURL(objectUrl);
+      }
+    } else if (e.data.cmd === 'run') {
+      // Pass the thread address to wasm to store it for fast access.
+      Module['__emscripten_thread_init'](e.data.pthread_ptr, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0, /*canBlock=*/1);
+
+      // Await mailbox notifications with `Atomics.waitAsync` so we can start
+      // using the fast `Atomics.notify` notification path.
+      Module['__emscripten_thread_mailbox_await'](e.data.pthread_ptr);
+
+      // Also call inside JS module to set up the stack frame for this pthread in JS module scope
+      Module['establishStackSpace']();
+      Module['PThread'].receiveObjectTransfer(e.data);
+      Module['PThread'].threadInitTLS();
+
+      if (!initializedJS) {
+        initializedJS = true;
+      }
+
+      try {
+        Module['invokeEntryPoint'](e.data.start_routine, e.data.arg);
+      } catch(ex) {
+        if (ex != 'unwind') {
+          // The pthread "crashed".  Do not call `_emscripten_thread_exit` (which
+          // would make this thread joinable).  Instead, re-throw the exception
+          // and let the top level handler propagate it back to the main thread.
+          throw ex;
+        }
+      }
+    } else if (e.data.cmd === 'cancel') { // Main thread is asking for a pthread_cancel() on this thread.
+      if (Module['_pthread_self']()) {
+        Module['__emscripten_thread_exit'](-1);
+      }
+    } else if (e.data.target === 'setimmediate') {
+      // no-op
+    } else if (e.data.cmd === 'checkMailbox') {
+      if (initializedJS) {
+        Module['checkMailbox']();
+      }
+    } else if (e.data.cmd) {
+      // The received message looks like something that should be handled by this message
+      // handler, (since there is a e.data.cmd field present), but is not one of the
+      // recognized commands:
+      err('worker.js received unknown command ' + e.data.cmd);
+      err(e.data);
+    }
+  } catch(ex) {
+    if (Module['__emscripten_thread_crashed']) {
+      Module['__emscripten_thread_crashed']();
+    }
+    throw ex;
+  }
+};
+
+self.onmessage = handleMessage;
+
+

--- a/packages/php-wasm/node/public/php_7_4.js
+++ b/packages/php-wasm/node/public/php_7_4.js
@@ -1,6 +1,15 @@
-const dependenciesTotalSize = 4782880; 
+const dependenciesTotalSize = 4784045; 
 const dependencyFilename = './php_7_4.wasm'; 
   module.exports = function init(RuntimeName, PHPLoader) {
+    ExitStatus = class PHPExitStatus extends Error {
+        constructor(status) {
+            super(status);
+            this.name = "ExitStatus";
+            this.message = "Program terminated with exit(" + status + ")";
+            this.status = status;
+        }
+    }
+
 // Support for growable heap + pthreads, where the buffer may change, so JS views
 // must be updated.
 function GROWABLE_HEAP_I8() {
@@ -591,6 +600,7 @@ function initRuntime() {
 function exitRuntime() {
  assert(!runtimeExited);
  checkStackCookie();
+ console.trace();
  if (ENVIRONMENT_IS_PTHREAD) return;
  ___funcs_on_exit();
  callRuntimeCallbacks(__ATEXIT__);

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -5,12 +5,24 @@ import { existsSync, rmSync, readFileSync } from 'fs';
 const testDirPath = '/__test987654321';
 const testFilePath = '/__test987654321.txt';
 
-describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
+describe.each(['7.4'])('PHP %s', (phpVersion) => {
 	let php: NodePHP;
 	beforeEach(async () => {
-		php = await NodePHP.load(phpVersion);
+		// php = await NodePHP.load(phpVersion);
 	});
 
+	it.only('test', async () => {
+		const php = await NodePHP.load('7.4');
+		expect(php).toBeDefined();
+		await php.setPhpIniEntry('disable_functions', '');
+		const out = await php.run({
+			code: `<?php 
+			echo "HI";
+			//var_dump(function_exists('pcntl_fork')); 
+			`,
+		});
+		expect(out.text).toEqual('HI');
+	});
 	describe('Filesystem', () => {
 		// Unit tests for the filesystem methods of the
 		// PHP runtime.

--- a/packages/php-wasm/node/test.js
+++ b/packages/php-wasm/node/test.js
@@ -1,0 +1,16 @@
+const load = require('./public/php_7_4.js')
+const php = load(
+    'NODE',
+    {
+        print: (str) => console.log(str),
+        printErr: (str) => console.log(str),
+        onRuntimeInitialized() {
+            php._php_wasm_init();
+            php.FS.writeFile('/script.php', `<?php echo 'Hello World'; ?>`);
+            // php._wasm_set_path_translated(`/script.php`);
+            php._wasm_set_php_code(`Hi`);
+            php._wasm_sapi_handle_request();
+            // console.log(php.)
+        }
+    }
+)

--- a/packages/php-wasm/node/test.js
+++ b/packages/php-wasm/node/test.js
@@ -2,15 +2,45 @@ const load = require('./public/php_7_4.js')
 const php = load(
     'NODE',
     {
+		onAbort(reason) {
+			console.error('WASM aborted: ');
+			console.error(reason);
+        },
+        ENV: {
+            // USE_ZEND_ALLOC: '0',
+        },
+		noInitialRun: true,
         print: (str) => console.log(str),
         printErr: (str) => console.log(str),
-        onRuntimeInitialized() {
+        async onRuntimeInitialized() {
             php._php_wasm_init();
-            php.FS.writeFile('/script.php', `<?php echo 'Hello World'; ?>`);
+            php.FS.writeFile('/script.php', `<?php
+                file_put_contents('/test.txt', 'Hi!');
+                echo 'Hello World'; ?>
+            `);
             // php._wasm_set_path_translated(`/script.php`);
-            php._wasm_set_php_code(`Hi`);
-            php._wasm_sapi_handle_request();
-            // console.log(php.)
+            php._wasm_set_php_code(`
+                <?php
+                file_put_contents('/test.txt', 'Hi!');
+                echo "Hi!";
+            `);
+            console.log('a');
+            try {
+                // This errors with bus error:
+                // const result = await php._run_php(`a`);
+
+                // This errors with zend_mm_heap corrupted:
+                const result = await php._wasm_sapi_handle_request();
+                console.log({ result });
+            } catch (e) {
+                console.error(e);
+            }
+            console.log(php.FS.readdir('/'));
+            console.log(php.FS.readdir('/tmp'));
+            // console.log(
+            //     new TextDecoder().decode(php.FS.readFile('/tmp/stdout'))
+            // );
+            // console.log(php.FS.readFile('/tmp/stderr'));
         }
     }
 )


### PR DESCRIPTION
This PR attempts to add pthreads ~and [pcntl](https://www.php.net/manual/en/function.pcntl-fork.php) support necessary to handle [pcntl_fork](https://www.php.net/manual/en/function.pcntl-fork.php). Full PHPUnit support hinges on this, and AFAIR there's a few wp-cli commands also relying on threads.~ Pthreads support doesn't seem to be necessary for any mission-critical PHP feature or package. I used to think it is required to support `fork()`, but [that's not actually the case](https://github.com/WordPress/wordpress-playground/issues/595).

I disabled all the extensions and got vanilla PHP to build. Unfortunately, the basic test.js file included in the PR leads to the following error:

```
zend_mm_heap corrupted
```

The error happens inside `php_request_startup()`. If I compile just PHP 7.4 without `php_wasm.c` and run `zend_eval_string(code, NULL, "php-wasm run script")`, the error turns into Bus Error – which is also what happens if `eval` is triggered via `_run_php` in `php_wasm.c`.

I wonder if `-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1` would help.

Related https://github.com/WordPress/playground-tools/issues/25

cc @dmsnell @danielbachhuber @sejas