### PR TITLE
wp-now: Define expected directory context for assertion purpose

### DIFF
--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -231,25 +231,22 @@ describe('Test starting different modes', () => {
 	test.each([
 		['index', ['index.php']],
 		['plugin', ['sample-plugin.php']],
-		['theme', ['style.css']]
-	])(
-		'startWPNow starts %s mode',
-		async (mode, expectedDirectories) => {
-			const projectPath = path.join(tmpExampleDirectory, mode);
+		['theme', ['style.css']],
+	])('startWPNow starts %s mode', async (mode, expectedDirectories) => {
+		const projectPath = path.join(tmpExampleDirectory, mode);
 
-			const rawOptions: Partial<WPNowOptions> = {
-				projectPath: projectPath,
-			};
+		const rawOptions: Partial<WPNowOptions> = {
+			projectPath: projectPath,
+		};
 
-			await startWPNow(rawOptions);
+		await startWPNow(rawOptions);
 
-			const forbiddenPaths = ['wp-config.php'];
+		const forbiddenPaths = ['wp-config.php'];
 
-			expectForbiddenProjectFiles(forbiddenPaths, projectPath);
+		expectForbiddenProjectFiles(forbiddenPaths, projectPath);
 
-			expect(fs.readdirSync(projectPath)).toEqual(expectedDirectories);
-		}
-	);
+		expect(fs.readdirSync(projectPath)).toEqual(expectedDirectories);
+	});
 
 	/**
 	 * Test that startWPNow in "wp-content" mode mounts required files and directories, and

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -228,10 +228,13 @@ describe('Test starting different modes', () => {
 	/**
 	 * Test that startWPNow in "index", "plugin" and "theme" modes doesn't change anything in the project directory.
 	 */
-	test.each(['index', 'plugin', 'theme'])(
+	test.each([
+		['index', ['index.php']],
+		['plugin', ['sample-plugin.php']],
+		['theme', ['style.css']]
+	])(
 		'startWPNow starts %s mode',
-		async (mode) => {
-			const exampleProjectPath = path.join(exampleDir, mode);
+		async (mode, expectedDirectories) => {
 			const projectPath = path.join(tmpExampleDirectory, mode);
 
 			const rawOptions: Partial<WPNowOptions> = {
@@ -244,9 +247,7 @@ describe('Test starting different modes', () => {
 
 			expectForbiddenProjectFiles(forbiddenPaths, projectPath);
 
-			expect(fs.readdirSync(projectPath)).toEqual(
-				fs.readdirSync(exampleProjectPath)
-			);
+			expect(fs.readdirSync(projectPath)).toEqual(expectedDirectories);
 		}
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

In this PR, I propose to include the expected directory content with the tests.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To not rely on reading the example directory for assertion purposes.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

1. Run tests
```
nx test wp-now
```
