### PR TITLE
wp-now: Mount SQLite only if db file exists, or if we initialize it

### DIFF
--- a/packages/wp-now/src/tests/mode-examples/wordpress-with-config/wp-load.php
+++ b/packages/wp-now/src/tests/mode-examples/wordpress-with-config/wp-load.php
@@ -1,0 +1,3 @@
+<?php
+
+// Loading WordPress...

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -214,11 +214,22 @@ async function runWordPressMode(
 	{ documentRoot, wpContentPath, projectPath, absoluteUrl }: WPNowOptions
 ) {
 	php.mount(projectPath, documentRoot);
-	if (!php.fileExists(`${documentRoot}/wp-config.php`)) {
-		await initWordPress(php, 'user-provided', documentRoot, absoluteUrl);
+
+	const { initializeDefaultDatabase } = await initWordPress(
+		php,
+		'user-provided',
+		documentRoot,
+		absoluteUrl
+	);
+
+	if (
+		initializeDefaultDatabase ||
+		fs.existsSync(path.join(wpContentPath, 'database'))
+	) {
+		mountSqlitePlugin(php, documentRoot);
+		mountSqliteDatabaseDirectory(php, documentRoot, wpContentPath);
 	}
-	mountSqlitePlugin(php, documentRoot);
-	mountSqliteDatabaseDirectory(php, documentRoot, wpContentPath);
+
 	mountMuPlugins(php, documentRoot);
 }
 
@@ -254,16 +265,33 @@ async function runPluginOrThemeMode(
 	mountMuPlugins(php, documentRoot);
 }
 
+/**
+ * Initialize WordPress
+ *
+ * Initializes WordPress by copying sample config file to wp-config.php if it doesn't exist,
+ * and sets up additional constants for PHP.
+ *
+ * It also returns information about whether the default database should be initialized.
+ *
+ * @param php
+ * @param wordPressVersion
+ * @param vfsDocumentRoot
+ * @param siteUrl
+ */
 async function initWordPress(
 	php: NodePHP,
 	wordPressVersion: string,
 	vfsDocumentRoot: string,
 	siteUrl: string
 ) {
-	php.writeFile(
-		`${vfsDocumentRoot}/wp-config.php`,
-		php.readFileAsText(`${vfsDocumentRoot}/wp-config-sample.php`)
-	);
+	let initializeDefaultDatabase = false;
+	if (!php.fileExists(`${vfsDocumentRoot}/wp-config.php`)) {
+		php.writeFile(
+			`${vfsDocumentRoot}/wp-config.php`,
+			php.readFileAsText(`${vfsDocumentRoot}/wp-config-sample.php`)
+		);
+		initializeDefaultDatabase = true;
+	}
 
 	const wpConfigConsts = {
 		WP_HOME: siteUrl,
@@ -276,6 +304,8 @@ async function initWordPress(
 		consts: wpConfigConsts,
 	});
 	php.setPhpIniEntry('auto_prepend_file', configFile);
+
+	return { initializeDefaultDatabase };
 }
 
 function mountMuPlugins(php: NodePHP, vfsDocumentRoot: string) {


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->
Fixes https://github.com/WordPress/wordpress-playground/issues/327

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

It changes the wp-now behavior to mount SQLite only if it's needed: if a database file exists or if we just initialized it for the first time.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We want to support a case in which the developer starts wp-now in the 'wordpress' mode and has `wp-config.php` file that points to an existing MySQL connection. At the same time, we want to support the case with a missing `wp-config.php` file by initializing a new SQLite database for the developer.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* we copy `wp-config-sample.php` to `wp-config.php` only if it doesn't exist
* we mount SQLite plugin and database directory only if database directory exists, or if we just initialized WordPress by copying sample config file

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

### Preconditions
- Have a project that contains full WordPress installation
- Clean `~/.wp.now` for that project
- Start a MySQL database server of your choice (e.g., Docker-based or one installed via Homebrew)
- Create database, import WordPress database dump

For each test case ensure to stop environment and start it again to confirm it works on subsequent runs.

### Testing steps for 'wordpress' mode with own database

1. Copy the `wp-config-sample.php` to `wp-config.php` and fill in database credentials to point to your MySQL server
2. Start the local environment using `wp-now start`
3. Confirm that the site loads and uses the existing MySQL database
4. Confirm that the project doesn't have empty directories created (mount points):
- `wp-content/database`
- `wp-content/plugins/sqlite-database-integration`
- `wp-content/db.php`
5. Confirm that the project gets the `wp-config.php` file created based on the sample

### Testing steps for 'wordpress' mode with SQLite database

1. Remove the `wp-config.php` file
2. Start the local environment using `wp-now start`
3. Confirm that the site loads and uses the fresh SQLite database
4. Confirm that the project does have empty directories created (mount points):
- `wp-content/database`
- `wp-content/plugins/sqlite-database-integration`
- `wp-content/db.php`
5. Confirm that the project gets the `wp-config.php` file created based on the sample

### Testing steps for other modes

Test that 'plugin', 'theme', and 'wp-content' modes still work as expected.
