### PR TITLE
wp-now: Use proper casing for 'SQLite'

### DIFF
--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -112,7 +112,7 @@ export async function downloadSqliteIntegrationPlugin() {
 		url: SQLITE_URL,
 		destinationFolder: WP_NOW_PATH,
 		checkFinalPath: SQLITE_PATH,
-		itemName: 'Sqlite',
+		itemName: 'SQLite',
 	});
 }
 


### PR DESCRIPTION
Fixes casing on message