### PR TITLE
Local Enviroment: Make check for plugin header case insensitive

### DIFF
--- a/packages/wp-now/src/tests/mode-examples/plugin-case-insensitive/sample-plugin.php
+++ b/packages/wp-now/src/tests/mode-examples/plugin-case-insensitive/sample-plugin.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * Plugin name: Gutenberg
+ * Plugin URI: https://github.com/WordPress/gutenberg
+ * Description: Printing since 1440. This is the development plugin for the block editor, site editor, and other future WordPress core functionality.
+ * Requires at least: 6.1
+ * Requires PHP: 5.6
+ * Version: 15.8.0-rc.1
+ * Author: Gutenberg Team
+ * Text Domain: gutenberg
+ *
+ * @package gutenberg
+ */

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -68,6 +68,12 @@ test('isPluginDirectory detects a WordPress plugin and infer PLUGIN mode.', () =
 	expect(inferMode(projectPath)).toBe(WPNowMode.PLUGIN);
 });
 
+test('isPluginDirectory detects a WordPress plugin in case-insensitive way and infer PLUGIN mode.', () => {
+	const projectPath = exampleDir + '/plugin-case-insensitive';
+	expect(isPluginDirectory(projectPath)).toBe(true);
+	expect(inferMode(projectPath)).toBe(WPNowMode.PLUGIN);
+});
+
 test('isPluginDirectory returns false for non-plugin directory', () => {
 	const projectPath = exampleDir + '/not-plugin';
 	expect(isPluginDirectory(projectPath)).toBe(false);

--- a/packages/wp-now/src/wp-playground-wordpress/is-plugin-directory.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/is-plugin-directory.ts
@@ -15,7 +15,7 @@ export function isPluginDirectory(projectPath: string): Boolean {
 				path.join(projectPath, file),
 				'utf8'
 			);
-			if (fileContent.includes('Plugin Name:')) {
+			if (fileContent.toLowerCase().includes('plugin name:')) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordpress-playground/issues/366
<!-- Thanks for contributing to WordPress Playground! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
In this PR, I propose to update the condition that checks for the plugin header to be case insensitive.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the check fails for a plugin with a name header that uses a case different than "Plugin Name".

["Plugin Name" is a casing shown in recommended WordPress plugin header file](https://developer.wordpress.org/plugins/plugin-basics/header-requirements/), but the [get_file_data()](https://developer.wordpress.org/reference/functions/get_file_data/) function that parses that data uses case insensitive REGEX, so we will match that behavior.

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change the plugin header file and the text we are searching for to be lower case.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->


1. `git clone git@github.com:akirk/friends.git`
2. `cd friends`
3. `wp-now start`

Expected behavior:
```
mode: plugin
```