### PR TITLE
wp-now: Document heuristics for determining 'plugin', 'theme' modes

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -31,7 +31,10 @@ wp-now start --wp=5.9 --php=7.4
 
 `wp-now` automatically operates in a few different modes. The selected mode depends on the directory in which it is executed:
 
--   **plugin**, **theme**, or **wp-content**: Loads the project files into a virtual filesytem with WordPress and a SQLite-based database. Everything (including WordPress core files, the database, `wp-config.php`, etc.) is stored in the user's home directory and loaded into the virtual filesystem. The latest version of WordPress will be used, unless the `--wp=<version>` argument is provided.
+-   **plugin**, **theme**, or **wp-content**: Loads the project files into a virtual filesytem with WordPress and a SQLite-based database. Everything (including WordPress core files, the database, `wp-config.php`, etc.) is stored in the user's home directory and loaded into the virtual filesystem. The latest version of WordPress will be used, unless the `--wp=<version>` argument is provided. Here are the heuristics for each mode:
+    -   **plugin** mode: Presence of a PHP file with 'Plugin Name:' in its contents.
+    -   **theme** mode: Presence of a `style.css` file with 'Theme Name:' in its contents.
+    -   **wp-content** mode: Presence of `plugins` and `themes` subdirectories.
 -   **wordpress**: Runs the directory as a WordPress installation when WordPress files are detected. An existing `wp-config.php` file will be used if it exists; if it doesn't exist, it will be created along with a SQLite database.
 -   **wordpress-develop**: Same as `wordpress` mode, except the `build` directory is served as the web root.
 -   **index**: Starts a PHP webserver in the working directory and simply passes requests to `index.php`.


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

Documents the heuristics for determining 'plugin', 'theme', and 'wp-content' modes.

## Why?

To make it more obvious to end users why `wp-now` is running in a particular mode.