### PR TITLE
wp-now: Allow `plugins`, `themes` or `wp-content` for 'wp-content' mode

### DIFF
--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -126,13 +126,22 @@ test('isWpContentDirectory detects a WordPress wp-content directory and infer WP
 test('isWpContentDirectory returns false for wp-content parent directory', () => {
 	const projectPath = exampleDir + '/index';
 	expect(isWpContentDirectory(projectPath)).toBe(false);
+	expect(isWordPressDirectory(projectPath)).toBe(false);
 	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
 });
 
-test.skip('isWpContentDirectory returns false for a directory with only one directory of plugins or themes', () => {
-	const projectPath = exampleDir + '/not-wp-content';
-	expect(isWpContentDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
+test('isWpContentDirectory returns true for a directory with only themes directory', () => {
+	const projectPath = exampleDir + '/wp-content-only-themes';
+	expect(isWpContentDirectory(projectPath)).toBe(true);
+	expect(isWordPressDirectory(projectPath)).toBe(false);
+	expect(inferMode(projectPath)).toBe(WPNowMode.WP_CONTENT);
+});
+
+test('isWpContentDirectory returns true for a directory with only mu-plugins directory', () => {
+	const projectPath = exampleDir + '/wp-content-only-mu-plugins';
+	expect(isWpContentDirectory(projectPath)).toBe(true);
+	expect(isWordPressDirectory(projectPath)).toBe(false);
+	expect(inferMode(projectPath)).toBe(WPNowMode.WP_CONTENT);
 });
 
 // WordPress mode

--- a/packages/wp-now/src/wp-playground-wordpress/is-wp-content-directory.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/is-wp-content-directory.ts
@@ -8,7 +8,7 @@ import path from 'path';
  * @returns A boolean value indicating whether the project is a WordPress wp-content directory.
  */
 export function isWpContentDirectory(projectPath: string): Boolean {
-  const muPluginsExists = fs.existsSync(path.join(projectPath, 'mu-plugins'));
+	const muPluginsExists = fs.existsSync(path.join(projectPath, 'mu-plugins'));
 	const pluginsExists = fs.existsSync(path.join(projectPath, 'plugins'));
 	const themesExists = fs.existsSync(path.join(projectPath, 'themes'));
 	if (muPluginsExists || pluginsExists || themesExists) {

--- a/packages/wp-now/src/wp-playground-wordpress/is-wp-content-directory.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/is-wp-content-directory.ts
@@ -8,10 +8,11 @@ import path from 'path';
  * @returns A boolean value indicating whether the project is a WordPress wp-content directory.
  */
 export function isWpContentDirectory(projectPath: string): Boolean {
+  const muPluginsExists = fs.existsSync(path.join(projectPath, 'mu-plugins'));
 	const pluginsExists = fs.existsSync(path.join(projectPath, 'plugins'));
 	const themesExists = fs.existsSync(path.join(projectPath, 'themes'));
-	if (!pluginsExists || !themesExists) {
-		return false;
+	if (muPluginsExists || pluginsExists || themesExists) {
+		return true;
 	}
-	return true;
+	return false;
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordpress-playground/issues/376

## What?

Allows the existence of `plugins`, `themes`, or `mu-plugins` to trigger 'wp-content' mode. Previously, 'wp-content' mode required both `themes` and `plugins`.

## Why?

Some 'wp-content' projects may only have a `themes` or `plugins` directory at the beginning.

## Testing Instructions

1. Tests should pass.
2. Run `nx preview wp-now start --path=/path/to/wp-content-project` and verify the server starts as expected.
3. Run `nx preview wp-now start --path=/path/to/plugin-project` and verify the server starts as expected.
4. Run `nx preview wp-now start --path=/path/to/wordpress-project` and verify the server starts as expected.