### PR TITLE
wp-now: Clean test tmp directory and prefetch downloads in beforeAll

### DIFF
--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -192,8 +192,12 @@ describe('Test starting different modes', () => {
 	 */
 	beforeAll(async () => {
 		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
+		console.log('Downloading WordPress...');
 		await downloadWordPress();
+		console.log('WordPress downloaded.');
+		console.log('Downloading SQLite...');
 		await downloadSqliteIntegrationPlugin();
+		console.log('SQLite downloaded.');
 	});
 
 	/**

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -9,9 +9,12 @@ import {
 	isWordPressDirectory,
 	isWordPressDevelopDirectory,
 } from '../wp-playground-wordpress';
+import {
+	downloadSqliteIntegrationPlugin,
+	downloadWordPress,
+} from '../download';
 import os from 'os';
 import crypto from 'crypto';
-import getWpNowPath from '../get-wp-now-path';
 import getWpNowTmpPath from '../get-wp-now-tmp-path';
 
 const exampleDir = __dirname + '/mode-examples';
@@ -183,6 +186,15 @@ test('isWordPressDevelopDirectory returns false for incomplete WordPress-develop
 
 describe('Test starting different modes', () => {
 	let tmpExampleDirectory;
+
+	/**
+	 * Download an initial copy of WordPress
+	 */
+	beforeAll(async () => {
+		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
+		await downloadWordPress();
+		await downloadSqliteIntegrationPlugin();
+	});
 
 	/**
 	 * Copy example directory to a temporary directory

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -193,11 +193,15 @@ describe('Test starting different modes', () => {
 	beforeAll(async () => {
 		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
 		console.log('Downloading WordPress...');
+		console.time('wordpress');
 		await downloadWordPress();
 		console.log('WordPress downloaded.');
+		console.timeEnd('wordpress');
 		console.log('Downloading SQLite...');
+		console.time('sqlite');
 		await downloadSqliteIntegrationPlugin();
 		console.log('SQLite downloaded.');
+		console.timeEnd('sqlite');
 	});
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordpress-playground/issues/383

## What?

Prefetches WordPress and SQLite in `beforeAll()`, and also makes sure `getWpNowTmpPath()` is reset.

## Why?

We want to make sure we have a pristine environment, and that it's primed with the correct files.

## Testing Instructions

Tests should pass.