### PR TITLE
Update: Simplify base-php sapi_handle_request call

### DIFF
--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -385,7 +385,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 		let errorListener: any;
 		try {
 			// eslint-disable-next-line no-async-promise-executor
-			exitCode = await new Promise<number>(async (resolve, reject) => {
+			exitCode = await new Promise<number>((resolve, reject) => {
 				errorListener = (e: ErrorEvent) => {
 					const rethrown = new Error('Rethrown');
 					rethrown.cause = e.error;
@@ -396,25 +396,16 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 					'error',
 					errorListener
 				);
-
-				try {
-					resolve(
-						/**
-						 * This is awkward, but Asyncify makes wasm_sapi_handle_request return
-						 * Promise<Promise<number>>.
-						 *
-						 * @TODO: Determine whether this is a bug in emscripten or in our code.
-						 */
-						await await this[__private__dont__use].ccall(
-							'wasm_sapi_handle_request',
-							NUMBER,
-							[],
-							[]
-						)
-					);
-				} catch (e) {
-					reject(e);
+				const response = this[__private__dont__use].ccall(
+					'wasm_sapi_handle_request',
+					NUMBER,
+					[],
+					[]
+				);
+				if (response instanceof Promise) {
+					return response.then(resolve, reject);
 				}
+				return resolve(response);
 			});
 		} catch (e) {
 			/**


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
We decided to split #331 into two parts, to make changes clear.
Part 1 of https://github.com/WordPress/wordpress-playground/pull/331

Part 2 is https://github.com/WordPress/wordpress-playground/pull/388

This pr simplifies the logic of `#handleRequest` method by removing unnecessary async wrapping

## Why?

It was originally introduced in #331, where a 404 page for nonexisting files was introduced, in order to simplify things.

For more info, look at #331 
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

- By removing the `async` function. `async` functions return a promise by themselves and also `resolve` method is able to resolve nested promises if they returned correctly. So the original `async` function wasn't really necessary

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

N/A
