### PR TITLE
Add: Support 404 page

### DIFF
--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -239,6 +239,17 @@ export class PHPRequestHandler implements RequestHandler {
 				body = request.body;
 			}
 
+			let scriptPath;
+			try {
+				scriptPath = this.#resolvePHPFilePath(requestedUrl.pathname);
+			} catch (error) {
+				return new PHPResponse(
+					404,
+					{},
+					new TextEncoder().encode('404 File not found')
+				);
+			}
+
 			return await this.php.run({
 				relativeUri: ensurePathPrefix(
 					toRelativeUrl(requestedUrl),
@@ -248,7 +259,7 @@ export class PHPRequestHandler implements RequestHandler {
 				method: request.method || preferredMethod,
 				body,
 				fileInfos,
-				scriptPath: this.#resolvePHPFilePath(requestedUrl.pathname),
+				scriptPath,
 				headers,
 			});
 		} finally {
@@ -262,6 +273,7 @@ export class PHPRequestHandler implements RequestHandler {
 	 * Fall back to index.php as if there was a url rewriting rule in place.
 	 *
 	 * @param  requestedPath - The requested pathname.
+	 * @throws {Error} If the requested path doesn't exist.
 	 * @returns The resolved filesystem path.
 	 */
 	#resolvePHPFilePath(requestedPath: string): string {
@@ -283,6 +295,9 @@ export class PHPRequestHandler implements RequestHandler {
 		const resolvedFsPath = `${this.#DOCROOT}${filePath}`;
 		if (this.php.fileExists(resolvedFsPath)) {
 			return resolvedFsPath;
+		}
+		if (!this.php.fileExists(`${this.#DOCROOT}/index.php`)) {
+			throw new Error(`File not found: ${resolvedFsPath}`);
 		}
 		return `${this.#DOCROOT}/index.php`;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

This pr adds a 404 error if the requested path doesn't exist

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
We decided to split #331 into two parts, to make changes clear.
Part 2 of https://github.com/WordPress/wordpress-playground/pull/331

Part 1 is https://github.com/WordPress/wordpress-playground/pull/387

## Why?

When the user uses a path that doesn't have any files, the `wp-now` was throwing an error, and was no longer usable.
This pr fixes that.

Also, take a look at #331 

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

When we call `php.run` method, we build the `scriptPath` using `resolvePHPFilePath`. If the file is not there we assume that an `/index.php` file exists in the folder.

This is not correct, and we need to return a 404 `PhpRequest`.

Also, take a look at #331 

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

- Create an empty folder
- Run wp-now and make sure you add this folder as a path:  npx nx preview wp-now start --path=<your-empty-folder>
- Ensure that you don't see any errors in the console
- Ensure that you see 404 File not found in the browser
- Change the URL to something else. eg: /file-not-exist.php.
- Ensure that you still see 404 File not found
