### PR TITLE
Fix: cross-device-link error

### DIFF
--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -95,7 +95,7 @@ export async function downloadWordPress(
 	});
 	if (downloaded) {
 		fs.ensureDirSync(path.dirname(finalFolder));
-		fs.renameSync(path.join(tempFolder, 'wordpress'), finalFolder);
+		fs.moveSync(path.join(tempFolder, 'wordpress'), finalFolder);
 	} else if (404 === statusCode) {
 		output?.log(
 			`WordPress ${wordPressVersion} not found. Check https://wordpress.org/download/releases/ for available versions.`


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?
We're encountering an issue with `wp-now`'s downloading mechanism. Specifically, when `wp-now` downloads WordPress, it stores the files in the `/tmp` directory. When attempting to use `renameSync`, we're encountering an error. On Linux, it throws an `EXDEV: cross-device link not permitted` error, while on Windows it throws an `ERROR_NOT_SAME_DEVICE` error. This appears to be due to an attempt to move files across different disks or mount points.

## Why?
The issue arises because both Linux and Windows systems have restrictions regarding moving files across different mount points or drives, respectively. In the case of Linux, the EXDEV error occurs when a program tries to move a file or directory between different filesystems. Similarly, Windows throws the `ERROR_NOT_SAME_DEVICE` error when trying to move a file or directory from one volume to another.

## How?
This PR solves the issue by modifying the method used to move the downloaded files. Instead of  `renameSync`, which fails across different filesystems or disks, it will utilize a different method that can handle cross-filesystem movements. This could involve copying the files to the destination and then deleting the original, or using a different API or library function designed to handle these situations. By doing so, we can ensure that `wp-now` can correctly move downloaded files, even when operating across different filesystems or disks.

## Testing Instructions

The test is a bit tricky as someone has different disks for different parts of the system. 
I guess, but I didn't test it, that the easiest way is to test this on Windows. Given that:

1. log in to a Windows machine
2. Ensure that you have 2 hard drives
3. Run ` npx nx preview wp-now start --path=<path-with-a-plugin>` and make sure that the directory of the project, is in a different hard drive that the default (other than `C:/`
4. Ma
