### PR TITLE
Draft: Upgrade to TypeDoc 0.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
 				"wp-now": "bin/wp-now"
 			},
 			"devDependencies": {
-				"@convex-dev/typedoc-plugin-markdown": "3.14.0",
+				"@convex-dev/typedoc-plugin-markdown": "3.15.3",
 				"@knodes/typedoc-plugin-pages": "0.23.1",
 				"@nx/devkit": "16.2.1",
 				"@nx/esbuild": "16.2.1",
@@ -120,9 +120,8 @@
 				"ts-json-schema-generator": "1.2.0",
 				"ts-node": "10.9.1",
 				"tslib": "^2.3.0",
-				"typedoc": "0.23.27",
+				"typedoc": "0.24.7",
 				"typedoc-plugin-mdn-links": "3.0.3",
-				"typedoc-plugin-resolve-crossmodule-references": "0.3.3",
 				"typescript": "5.0.4",
 				"vite": "4.3.7",
 				"vite-plugin-dts": "~1.7.1",
@@ -2418,15 +2417,15 @@
 			}
 		},
 		"node_modules/@convex-dev/typedoc-plugin-markdown": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/@convex-dev/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.14.0.tgz",
-			"integrity": "sha512-w8FGxMhrIQwx09c6XjvHA19nLuBa6Qx12o4L8QHrVA4ATOO/sKwCc6acQSalhqCUJW/9Gm4HFzdBusvauBncfA==",
+			"version": "3.15.3",
+			"resolved": "https://registry.npmjs.org/@convex-dev/typedoc-plugin-markdown/-/typedoc-plugin-markdown-3.15.3.tgz",
+			"integrity": "sha512-SlXznzhsB+QAa7o+INukesg7M2iUKzS/qQ7JvtN7YxVVs68NNKFsrbf+zHeU1xyvaOZ28RlXfQqRBIukoLmzRQ==",
 			"dev": true,
 			"dependencies": {
 				"handlebars": "^4.7.7"
 			},
 			"peerDependencies": {
-				"typedoc": ">=0.23.0"
+				"typedoc": ">=0.24.0"
 			}
 		},
 		"node_modules/@cspotcode/source-map-support": {
@@ -3977,7 +3976,7 @@
 				"typedoc": "^0.23.0"
 			}
 		},
-		"node_modules/@knodes/typedoc-pluginutils": {
+		"node_modules/@knodes/typedoc-plugin-pages/node_modules/@knodes/typedoc-pluginutils": {
 			"version": "0.23.4",
 			"resolved": "https://registry.npmjs.org/@knodes/typedoc-pluginutils/-/typedoc-pluginutils-0.23.4.tgz",
 			"integrity": "sha512-uO7t9XxYW1DMjVFTgmRs2p431+AsmvnX4CrrB/zkauo8mZSLS3CppMKHBVE/Lk1cFO73vgfyJReRK98X/8BzUA==",
@@ -32060,14 +32059,14 @@
 			"dev": true
 		},
 		"node_modules/typedoc": {
-			"version": "0.23.27",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.27.tgz",
-			"integrity": "sha512-YKjlxX3LEhYbMCkemjlpNh1OKDiFa+ynqP0VRPsH28bEugrMTGI6l8DC6oX5kzFcUKKlYWKpZDSGWszuO/FR3g==",
+			"version": "0.24.7",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.24.7.tgz",
+			"integrity": "sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==",
 			"dev": true,
 			"dependencies": {
 				"lunr": "^2.3.9",
-				"marked": "^4.2.12",
-				"minimatch": "^7.1.3",
+				"marked": "^4.3.0",
+				"minimatch": "^9.0.0",
 				"shiki": "^0.14.1"
 			},
 			"bin": {
@@ -32077,7 +32076,7 @@
 				"node": ">= 14.14"
 			},
 			"peerDependencies": {
-				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x"
+				"typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x"
 			}
 		},
 		"node_modules/typedoc-plugin-mdn-links": {
@@ -32087,19 +32086,6 @@
 			"dev": true,
 			"peerDependencies": {
 				"typedoc": ">= 0.23.14 || 0.24.x"
-			}
-		},
-		"node_modules/typedoc-plugin-resolve-crossmodule-references": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-resolve-crossmodule-references/-/typedoc-plugin-resolve-crossmodule-references-0.3.3.tgz",
-			"integrity": "sha512-ZWWBy2WR8z9a6iXYGlyB3KrpV+JDdZv1mndYU6Eh6mInrfMCrQJi3Y5K9ihMBfuaBGB//le1nEmQLgzU3IO+dw==",
-			"deprecated": "Upgrade to typedoc >= 0.24 and remove typedoc-plugin-resolve-crossmodule-references from your dependencies",
-			"dev": true,
-			"engines": {
-				"node": ">=14"
-			},
-			"peerDependencies": {
-				"typedoc": ">=0.22 <=0.23"
 			}
 		},
 		"node_modules/typedoc/node_modules/brace-expansion": {
@@ -32112,15 +32098,15 @@
 			}
 		},
 		"node_modules/typedoc/node_modules/minimatch": {
-			"version": "7.4.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
-			"integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.0.tgz",
+			"integrity": "sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==",
 			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=16 || 14 >=14.17"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"@codemirror/view": "6.9.3"
 	},
 	"devDependencies": {
-		"@convex-dev/typedoc-plugin-markdown": "3.14.0",
+		"@convex-dev/typedoc-plugin-markdown": "3.15.3",
 		"@knodes/typedoc-plugin-pages": "0.23.1",
 		"@nx/devkit": "16.2.1",
 		"@nx/esbuild": "16.2.1",
@@ -148,9 +148,8 @@
 		"ts-json-schema-generator": "1.2.0",
 		"ts-node": "10.9.1",
 		"tslib": "^2.3.0",
-		"typedoc": "0.23.27",
+		"typedoc": "0.24.7",
 		"typedoc-plugin-mdn-links": "3.0.3",
-		"typedoc-plugin-resolve-crossmodule-references": "0.3.3",
 		"typescript": "5.0.4",
 		"vite": "4.3.7",
 		"vite-plugin-dts": "~1.7.1",
@@ -166,7 +165,8 @@
 		"rollup": "^3.2.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
-		"typescript": "5.0.4"
+		"typescript": "5.0.4",
+		"typedoc": "0.24.7"
 	},
 	"workspaces": [
 		"packages/nx-extensions",

--- a/packages/docs/site/package.json
+++ b/packages/docs/site/package.json
@@ -2,5 +2,6 @@
 	"name": "@wp-playground/docs-site",
 	"version": "0.0.1",
 	"type": "commonjs",
+	"main": "index.js",
 	"private": true
 }

--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -13,7 +13,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"npx typedoc --plugin @knodes/typedoc-plugin-pages --plugin typedoc-plugin-mdn-links --plugin typedoc-plugin-resolve-crossmodule-references --includes dist/docs-copy"
+					"npx typedoc --plugin @knodes/typedoc-plugin-pages --plugin typedoc-plugin-mdn-links --includes dist/docs-copy"
 				],
 				"parallel": false
 			}
@@ -23,7 +23,7 @@
 			"options": {
 				"commands": [
 					"rimraf dist/docs-copy",
-					"npx typedoc --plugin @convex-dev/typedoc-plugin-markdown --plugin typedoc-plugin-mdn-links --plugin typedoc-plugin-resolve-crossmodule-references",
+					"npx typedoc --plugin @convex-dev/typedoc-plugin-markdown --plugin typedoc-plugin-mdn-links",
 					"mv dist/docs dist/docs-copy"
 				],
 				"parallel": false

--- a/packages/php-wasm/node/package.json
+++ b/packages/php-wasm/node/package.json
@@ -15,12 +15,6 @@
 			"url": "https://github.com/adamziel"
 		}
 	],
-	"typedoc": {
-		"entryPoint": "./src/index.ts",
-		"readmeFile": "./README.md",
-		"displayName": "@php-wasm/node",
-		"tsconfig": "./tsconfig.lib.json"
-	},
 	"publishConfig": {
 		"access": "public",
 		"directory": "../../../dist/packages/php-wasm/node"

--- a/packages/php-wasm/node/typedoc.json
+++ b/packages/php-wasm/node/typedoc.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../../typedoc.base.json"],
+	"entryPoints": ["./src/index.ts"],
+	"readme": "./README.md",
+	"name": "@php-wasm/node",
+	"tsconfig": "./tsconfig.lib.json"
+}

--- a/packages/php-wasm/progress/package.json
+++ b/packages/php-wasm/progress/package.json
@@ -15,12 +15,6 @@
 			"url": "https://github.com/adamziel"
 		}
 	],
-	"typedoc": {
-		"entryPoint": "./src/index.ts",
-		"readmeFile": "./README.md",
-		"displayName": "@php-wasm/progress",
-		"tsconfig": "./tsconfig.lib.json"
-	},
 	"publishConfig": {
 		"access": "public",
 		"directory": "../../../dist/packages/php-wasm/progress"

--- a/packages/php-wasm/progress/typedoc.json
+++ b/packages/php-wasm/progress/typedoc.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../../typedoc.base.json"],
+	"entryPoints": ["./src/index.ts"],
+	"readme": "./README.md",
+	"name": "@php-wasm/progress",
+	"tsconfig": "./tsconfig.lib.json"
+}

--- a/packages/php-wasm/universal/package.json
+++ b/packages/php-wasm/universal/package.json
@@ -15,12 +15,6 @@
 			"url": "https://github.com/adamziel"
 		}
 	],
-	"typedoc": {
-		"entryPoint": "./src/index.ts",
-		"readmeFile": "./README.md",
-		"displayName": "@php-wasm/universal",
-		"tsconfig": "./tsconfig.lib.json"
-	},
 	"exports": {
 		".": {
 			"import": "./index.js",

--- a/packages/php-wasm/universal/typedoc.json
+++ b/packages/php-wasm/universal/typedoc.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../../typedoc.base.json"],
+	"entryPoints": ["./src/index.ts"],
+	"readme": "./README.md",
+	"name": "@php-wasm/universal",
+	"tsconfig": "./tsconfig.lib.json"
+}

--- a/packages/php-wasm/util/package.json
+++ b/packages/php-wasm/util/package.json
@@ -2,12 +2,6 @@
 	"name": "@php-wasm/util",
 	"version": "0.1.46",
 	"type": "commonjs",
-	"typedoc": {
-		"entryPoint": "./src/index.ts",
-		"readmeFile": "./README.md",
-		"displayName": "@php-wasm/util",
-		"tsconfig": "./tsconfig.lib.json"
-	},
 	"publishConfig": {
 		"access": "public",
 		"directory": "../../../dist/packages/php-wasm/util"

--- a/packages/php-wasm/util/typedoc.json
+++ b/packages/php-wasm/util/typedoc.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../../typedoc.base.json"],
+	"entryPoints": ["./src/index.ts"],
+	"readme": "./README.md",
+	"name": "@php-wasm/util",
+	"tsconfig": "./tsconfig.lib.json"
+}

--- a/packages/php-wasm/web/package.json
+++ b/packages/php-wasm/web/package.json
@@ -15,12 +15,6 @@
 			"url": "https://github.com/adamziel"
 		}
 	],
-	"typedoc": {
-		"entryPoint": "./src/index.ts",
-		"readmeFile": "./README.md",
-		"displayName": "@php-wasm/web",
-		"tsconfig": "./tsconfig.lib.json"
-	},
 	"publishConfig": {
 		"access": "public",
 		"directory": "../../../dist/packages/php-wasm/web"

--- a/packages/php-wasm/web/src/lib/api.ts
+++ b/packages/php-wasm/web/src/lib/api.ts
@@ -13,6 +13,7 @@ export type WithAPIState = {
 	 */
 	isReady: () => Promise<void>;
 };
+
 export type RemoteAPI<T> = Comlink.Remote<T & WithAPIState>;
 
 export function consumeAPI<APIType>(

--- a/packages/php-wasm/web/src/lib/web-php-endpoint.ts
+++ b/packages/php-wasm/web/src/lib/web-php-endpoint.ts
@@ -86,72 +86,72 @@ export class WebPHPEndpoint implements IsomorphicLocalPHP {
 		return _private.get(this)!.php.rmdir(path, options);
 	}
 
-	/** @inheritDoc @php-wasm/universal!RequestHandler.request */
+	/** @inheritDoc */
 	request(request: PHPRequest, redirects?: number): Promise<PHPResponse> {
 		return _private.get(this)!.php.request(request, redirects);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.run */
+	/** @inheritDoc */
 	async run(request: PHPRunOptions): Promise<PHPResponse> {
 		return _private.get(this)!.php.run(request);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.chdir */
+	/** @inheritDoc */
 	chdir(path: string): void {
 		return _private.get(this)!.php.chdir(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.setPhpIniPath */
+	/** @inheritDoc */
 	setPhpIniPath(path: string): void {
 		return _private.get(this)!.php.setPhpIniPath(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.setPhpIniEntry */
+	/** @inheritDoc */
 	setPhpIniEntry(key: string, value: string): void {
 		return _private.get(this)!.php.setPhpIniEntry(key, value);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.mkdir */
+	/** @inheritDoc */
 	mkdir(path: string): void {
 		return _private.get(this)!.php.mkdir(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.mkdirTree */
+	/** @inheritDoc */
 	mkdirTree(path: string): void {
 		return _private.get(this)!.php.mkdirTree(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.readFileAsText */
+	/** @inheritDoc */
 	readFileAsText(path: string): string {
 		return _private.get(this)!.php.readFileAsText(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.readFileAsBuffer */
+	/** @inheritDoc */
 	readFileAsBuffer(path: string): Uint8Array {
 		return _private.get(this)!.php.readFileAsBuffer(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.writeFile */
+	/** @inheritDoc */
 	writeFile(path: string, data: string | Uint8Array): void {
 		return _private.get(this)!.php.writeFile(path, data);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.unlink */
+	/** @inheritDoc */
 	unlink(path: string): void {
 		return _private.get(this)!.php.unlink(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.listFiles */
+	/** @inheritDoc */
 	listFiles(path: string): string[] {
 		return _private.get(this)!.php.listFiles(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.isDir */
+	/** @inheritDoc */
 	isDir(path: string): boolean {
 		return _private.get(this)!.php.isDir(path);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.fileExists */
+	/** @inheritDoc */
 	fileExists(path: string): boolean {
 		return _private.get(this)!.php.fileExists(path);
 	}

--- a/packages/php-wasm/web/typedoc.json
+++ b/packages/php-wasm/web/typedoc.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../../typedoc.base.json"],
+	"entryPoints": ["./src/index.ts"],
+	"readme": "./README.md",
+	"name": "@php-wasm/web",
+	"tsconfig": "./tsconfig.lib.json"
+}

--- a/packages/playground/blueprints/package.json
+++ b/packages/playground/blueprints/package.json
@@ -11,12 +11,6 @@
 	"type": "module",
 	"main": "./index.cjs",
 	"module": "./index.js",
-	"typedoc": {
-		"entryPoint": "./src/index.ts",
-		"readmeFile": "./README.md",
-		"displayName": "@wp-playground/blueprints",
-		"tsconfig": "./tsconfig.lib.json"
-	},
 	"publishConfig": {
 		"access": "public",
 		"directory": "../../../dist/packages/playground/blueprints"

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -1,10 +1,10 @@
 import { StepHandler } from '.';
 
-export interface ActivatePluginStep {
+export type ActivatePluginStep = {
 	step: 'activatePlugin';
 	/* Path to the plugin file relative to the plugins directory. */
 	pluginPath: string;
-}
+};
 
 /**
  * Activates a WordPress plugin in the Playground.

--- a/packages/playground/blueprints/typedoc.json
+++ b/packages/playground/blueprints/typedoc.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../../typedoc.base.json"],
+	"entryPoints": ["./src/index.ts"],
+	"readme": "./README.md",
+	"name": "@wp-playground/blueprints",
+	"tsconfig": "./tsconfig.lib.json"
+}

--- a/packages/playground/client/package.json
+++ b/packages/playground/client/package.json
@@ -22,12 +22,6 @@
 		},
 		"./package.json": "./package.json"
 	},
-	"typedoc": {
-		"entryPoint": "./src/index.ts",
-		"readmeFile": "./README.md",
-		"displayName": "@wp-playground/client",
-		"tsconfig": "./tsconfig.lib.json"
-	},
 	"publishConfig": {
 		"access": "public",
 		"directory": "../../../dist/packages/playground/client"

--- a/packages/playground/client/typedoc.json
+++ b/packages/playground/client/typedoc.json
@@ -1,0 +1,7 @@
+{
+	"extends": ["../../../typedoc.base.json"],
+	"entryPoints": ["./src/index.ts"],
+	"readme": "./README.md",
+	"name": "@wp-playground/client",
+	"tsconfig": "./tsconfig.lib.json"
+}

--- a/packages/playground/remote/src/lib/playground-client.ts
+++ b/packages/playground/remote/src/lib/playground-client.ts
@@ -1,5 +1,5 @@
 import { ProgressReceiver } from '@php-wasm/progress';
-import { UniversalPHP } from '@php-wasm/universal';
+import { UniversalPHP, type IsomorphicRemotePHP } from '@php-wasm/universal';
 import { RemoteAPI } from '@php-wasm/web';
 import { ProgressBarOptions } from './progress-bar';
 import type { PlaygroundWorkerEndpoint } from './worker-thread';
@@ -15,12 +15,16 @@ export interface WebClientMixin extends ProgressReceiver {
 	onDownloadProgress: PlaygroundWorkerEndpoint['onDownloadProgress'];
 }
 
+// Using interface instead of Type to ensure TypeDoc
+// generates documentation for the methods.
+
+type BaseType = RemoteAPI<PlaygroundWorkerEndpoint & WebClientMixin> &
+	IsomorphicRemotePHP;
+
 /**
  * @inheritDoc
  */
-export type PlaygroundClient = RemoteAPI<
-	PlaygroundWorkerEndpoint & WebClientMixin
->;
+export interface PlaygroundClient extends BaseType {}
 
 /*
  * Assert that PlaygroundClient is a superset of UniversalPHP.

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"includeVersion": true
+}

--- a/typedoc.js
+++ b/typedoc.js
@@ -2,10 +2,10 @@ module.exports = {
 	$schema: 'https://typedoc.org/schema.json',
 	entryPointStrategy: 'packages',
 	entryPoints: [
+		'./packages/php-wasm/universal',
 		'./packages/php-wasm/web',
 		'./packages/php-wasm/node',
 		'./packages/php-wasm/progress',
-		'./packages/php-wasm/universal',
 		'./packages/php-wasm/util',
 		'./packages/playground/blueprints',
 		'./packages/playground/client',


### PR DESCRIPTION
⚠️  Do not merge this Pull Request yet ⚠️  

In TypeDoc 0.24 `inheritDoc` no longer works as expected. For example, these `PlaygroundClient` methods have no associated comments:

<img width="500" alt="CleanShot 2023-05-19 at 13 15 17@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/a53912bd-cd89-4b35-a3d7-dc31cc062fbe">

In version 0.23, we relied on the `typedoc-plugin-resolve-crossmodule-references` which worked great. Version 0.24 claims to natively support inheriting cross-package doc in a monorepo, but in reality it doesn't work.

Let's keep this PR open until either the upgrade becomes more pressing (modern TypeScript support) or they resolve the issue.