### PR TITLE
PHP: Add zif_array_filter to Asyncify list

### DIFF
--- a/packages/php-wasm/compile/Dockerfile
+++ b/packages/php-wasm/compile/Dockerfile
@@ -620,7 +620,8 @@ RUN if [ "$WITH_WS_NETWORKING_PROXY" = "yes" ]; \
 "dynCall_viiiii",\
 "dynCall_viiiiiii",\
 "dynCall_viiiiiiii",'; \
-    export ASYNCIFY_ONLY=$'"zend_call_known_instance_method_with_2_params",\
+    export ASYNCIFY_ONLY=$'"zif_array_filter",\
+"zend_call_known_instance_method_with_2_params",\
 "zend_fetch_dimension_address_read_R",\
 "_zval_dtor_func_for_ptr",\
 "ZEND_ASSIGN_DIM_SPEC_CV_CONST_HANDLER",\

--- a/packages/php-wasm/node/public/php_5_6.js
+++ b/packages/php-wasm/node/public/php_5_6.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 10176192; 
+export const dependenciesTotalSize = 10176855; 
 const dependencyFilename = __dirname + '/php_5_6.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/public/php_7_0.js
+++ b/packages/php-wasm/node/public/php_7_0.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 10389492; 
+export const dependenciesTotalSize = 10390258; 
 const dependencyFilename = __dirname + '/php_7_0.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/public/php_7_1.js
+++ b/packages/php-wasm/node/public/php_7_1.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 10583119; 
+export const dependenciesTotalSize = 10583885; 
 const dependencyFilename = __dirname + '/php_7_1.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/public/php_7_2.js
+++ b/packages/php-wasm/node/public/php_7_2.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 10992646; 
+export const dependenciesTotalSize = 10993354; 
 const dependencyFilename = __dirname + '/php_7_2.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/public/php_7_3.js
+++ b/packages/php-wasm/node/public/php_7_3.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 10916038; 
+export const dependenciesTotalSize = 10916624; 
 const dependencyFilename = __dirname + '/php_7_3.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/public/php_7_4.js
+++ b/packages/php-wasm/node/public/php_7_4.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 11015985; 
+export const dependenciesTotalSize = 11016595; 
 const dependencyFilename = __dirname + '/php_7_4.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/public/php_8_0.js
+++ b/packages/php-wasm/node/public/php_8_0.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 10172313; 
+export const dependenciesTotalSize = 10172733; 
 const dependencyFilename = __dirname + '/php_8_0.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/public/php_8_1.js
+++ b/packages/php-wasm/node/public/php_8_1.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 10044311; 
+export const dependenciesTotalSize = 10044712; 
 const dependencyFilename = __dirname + '/php_8_1.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/public/php_8_2.js
+++ b/packages/php-wasm/node/public/php_8_2.js
@@ -1,4 +1,4 @@
-export const dependenciesTotalSize = 10302665; 
+export const dependenciesTotalSize = 10303111; 
 const dependencyFilename = __dirname + '/php_8_2.wasm'; 
  export { dependencyFilename }; export function init(RuntimeName, PHPLoader) {
 var Module = typeof PHPLoader != "undefined" ? PHPLoader : {};

--- a/packages/php-wasm/node/src/lib/node-php.ts
+++ b/packages/php-wasm/node/src/lib/node-php.ts
@@ -142,7 +142,7 @@ export class NodePHP extends BasePHP {
 	 *
 	 * This method can only be used when PHP was compiled with the CLI SAPI
 	 * and it cannot be used in conjunction with `run()`.
-	 * 
+	 *
 	 * Once this method finishes running, the PHP instance is no
 	 * longer usable and should be discarded. This is because PHP
 	 * internally cleans up all the resources and calls exit().

--- a/packages/php-wasm/node/src/test/php-asyncify.spec.ts
+++ b/packages/php-wasm/node/src/test/php-asyncify.spec.ts
@@ -74,6 +74,22 @@ describe.each(phpVersions)('PHP %s – asyncify', (phpVersion) => {
 				));
 		});
 
+		describe('Array functions', () => {
+			test('array_filter', () =>
+				assertNoCrash(`
+					function top() { ${networkCall} }
+					array_filter(array('top'), 'top');
+				`));
+
+			test('array_map', () =>
+				assertNoCrash(`
+					function top() { ${networkCall} }
+					array_map(array('top'), 'top');
+				`));
+
+			// Network calls in sort() would be silly so let's skip those for now.
+		});
+
 		describe('Class method calls', () => {
 			test('Regular method', () =>
 				assertNoCrash(`


### PR DESCRIPTION
## What?

Adds `zif_array_filter` to Asyncify list to fix the WooCommerce error reported in https://github.com/WordPress/wordpress-playground/issues/392

I had no chance to test besides adding the test case and rebuilding PHP. @cpapazoglou – would you take it for a spin?

CC @danielbachhuber 
