### PR TITLE
Asyncify: Only add lastAsyncifyStackSource callback if Asyncify is defined

### DIFF
--- a/packages/php-wasm/compile/build-assets/append-before-return.js
+++ b/packages/php-wasm/compile/build-assets/append-before-return.js
@@ -10,7 +10,7 @@ DNS.address_map.addrs.localhost = '127.0.0.1';
  * so that it can be inspected later.
  */
 PHPLoader.debug = 'debug' in PHPLoader ? PHPLoader.debug : true;
-if (PHPLoader.debug) {
+if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     const originalHandleSleep = Asyncify.handleSleep;
     Asyncify.handleSleep = function (startAsync) {
         if (!ABORT) {


### PR DESCRIPTION
Web version of PHP.wasm is built without Asyncify. However, attaching the lastAsyncifyStackSource assumes Asyncify is defined and the code errors out. This commit adds a safety check to the append-before-return.js file. It was already added to each PHP JavaScript module, but somehow didn't make it to the source file from which these modules are generated.
