### PR TITLE
wp-now: Validate entire configuration before command is run

### DIFF
--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -5,7 +5,7 @@ import {
 import crypto from 'crypto';
 import { inferMode } from './wp-now';
 import { portFinder } from './port-finder';
-import { isValidWordpressVersion } from './wp-playground-wordpress';
+import { isValidWordPressVersion } from './wp-playground-wordpress';
 import getWpNowPath from './get-wp-now-path';
 
 import path from 'path';
@@ -135,7 +135,7 @@ export default async function getWpNowConfig(
 	if (!options.absoluteUrl) {
 		options.absoluteUrl = await getAbsoluteURL();
 	}
-	if (!isValidWordpressVersion(options.wordPressVersion)) {
+	if (!isValidWordPressVersion(options.wordPressVersion)) {
 		throw new Error(
 			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
 		);

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -5,6 +5,7 @@ import {
 import crypto from 'crypto';
 import { inferMode } from './wp-now';
 import { portFinder } from './port-finder';
+import { isValidWordpressVersion } from './wp-playground-wordpress';
 import getWpNowPath from './get-wp-now-path';
 
 import path from 'path';
@@ -133,6 +134,11 @@ export default async function getWpNowConfig(
 	}
 	if (!options.absoluteUrl) {
 		options.absoluteUrl = await getAbsoluteURL();
+	}
+	if (!isValidWordpressVersion(options.wordPressVersion)) {
+		throw new Error(
+			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
+		);
 	}
 	if (
 		options.phpVersion &&

--- a/packages/wp-now/src/download.ts
+++ b/packages/wp-now/src/download.ts
@@ -5,14 +5,14 @@ import unzipper from 'unzipper';
 import os from 'os';
 import { IncomingMessage } from 'http';
 import { DEFAULT_WORDPRESS_VERSION, SQLITE_URL } from './constants';
-import { isValidWordpressVersion } from './wp-playground-wordpress';
+import { isValidWordPressVersion } from './wp-playground-wordpress';
 import { output } from './output';
 import getWpNowPath from './get-wp-now-path';
 import getWordpressVersionsPath from './get-wordpress-versions-path';
 import getSqlitePath from './get-sqlite-path';
 
 function getWordPressVersionUrl(version = DEFAULT_WORDPRESS_VERSION) {
-	if (!isValidWordpressVersion(version)) {
+	if (!isValidWordPressVersion(version)) {
 		throw new Error(
 			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
 		);

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -41,6 +41,19 @@ export async function runCli() {
 	return yargs(hideBin(process.argv))
 		.scriptName('wp-now')
 		.usage('$0 <cmd> [args]')
+		.check(async (argv) => {
+			try {
+				await getWpNowConfig({
+					path: argv.path as string,
+					php: argv.php as SupportedPHPVersion,
+					wp: argv.wp as string,
+					port: argv.port as number,
+				});
+			} catch (error) {
+				return error.message;
+			}
+			return true;
+		})
 		.command(
 			'start',
 			'Start the server',

--- a/packages/wp-now/src/wp-playground-wordpress/is-valid-wordpress-version.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/is-valid-wordpress-version.ts
@@ -12,7 +12,7 @@
  * @param version The version string to check.
  * @returns A boolean value indicating whether the version string is a valid WordPress version.
  */
-export function isValidWordpressVersion(version: string): boolean {
+export function isValidWordPressVersion(version: string): boolean {
 	const versionPattern =
 		/^latest$|^(?:(\d+)\.(\d+)(?:\.(\d+))?)((?:-beta(?:\d+)?)|(?:-RC(?:\d+)?))?$/;
 	return versionPattern.test(version);

--- a/packages/wp-now/src/wp-playground-wordpress/tests/is-valid-wordpress-version.test.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/tests/is-valid-wordpress-version.test.ts
@@ -1,17 +1,17 @@
 /*
  * Test for isValidWordpressVersion
  */
-import { isValidWordpressVersion } from '../is-valid-wordpress-version';
+import { isValidWordPressVersion } from '../is-valid-wordpress-version';
 
-test('isValidWordpressVersion', () => {
+test('isValidWordPressVersion', () => {
 	// Accepted versions
 	// Check https://wordpress.org/download/releases/
-	expect(isValidWordpressVersion('latest')).toBe(true);
-	expect(isValidWordpressVersion('6.2')).toBe(true);
-	expect(isValidWordpressVersion('6.0.1')).toBe(true);
-	expect(isValidWordpressVersion('6.2-beta1')).toBe(true);
-	expect(isValidWordpressVersion('6.2-RC1')).toBe(true);
+	expect(isValidWordPressVersion('latest')).toBe(true);
+	expect(isValidWordPressVersion('6.2')).toBe(true);
+	expect(isValidWordPressVersion('6.0.1')).toBe(true);
+	expect(isValidWordPressVersion('6.2-beta1')).toBe(true);
+	expect(isValidWordPressVersion('6.2-RC1')).toBe(true);
 	// Rejected versions
-	expect(isValidWordpressVersion('v6.2')).toBe(false);
-	expect(isValidWordpressVersion('6.2-rc1')).toBe(false);
+	expect(isValidWordPressVersion('v6.2')).toBe(false);
+	expect(isValidWordPressVersion('6.2-rc1')).toBe(false);
 });


### PR DESCRIPTION
See https://github.com/WordPress/wordpress-playground/issues/405

## What?

Calls `getWpNowConfig()` on a `yargs.check()` callback to validate the entire configuration before `start` or `php` commands are run.

## Why?

`getWpNowConfig()` can pick up additional values from `.wp-env.json`. We want to make sure the validation of those values is caught by `yargs`.

## How?

The `yargs.check()` callback runs `getWpNowConfig()` and listens for an exception.

I don't love that we're calling `getWpNowConfig()` twice because it seems like some side effect could occur. However, this seems like the most appropriate way to incorporate a check into `yargs`.

## Testing Instructions

1. Run `nx preview wp-now start --wp=invalid` and verify an error message appears as expected.
2. Clone Gutenberg somewhere: `git@github.com:WordPress/gutenberg.git`
3. Run `nx preview wp-now start --path=/path/to/gutenberg-clone` and verify an error message appears as expected.
4. Run `nx preview wp-now start` for a happy path and verify `wp-now` starts as expected.