### PR TITLE
wp-now: Rename `<filePath>` argument to `<file>`

### DIFF
--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -74,11 +74,11 @@ export async function runCli() {
 			}
 		)
 		.command(
-			'php <filePath>',
+			'php <file>',
 			'Run the php command passing the arguments for php cli',
 			(yargs) => {
 				commonParameters(yargs);
-				yargs.positional('filePath', {
+				yargs.positional('file', {
 					describe: 'Path to the PHP file to run',
 					type: 'string',
 				});
@@ -90,7 +90,7 @@ export async function runCli() {
 						php: argv.php as SupportedPHPVersion,
 						wp: argv.wp as string,
 					});
-					await executePHPFile(argv.filePath as string, options);
+					await executePHPFile(argv.file as string, options);
 					process.exit(0);
 				} catch (error) {
 					console.error(error);


### PR DESCRIPTION
## What?

Renames the `<filePath>` argument to `<file>` for the `wp-now php` command.

## Why?

`<filePath>` is unnecessarily verbose and camelCase arguments are ugly.

## How?

Simple string replacement.

## Testing Instructions

1. Run `wp-now php file.php` and verify the file is executed as expected.