### PR TITLE
Update the "When publishing goes wrong" documentation

### DIFF
--- a/packages/docs/site/docs/13-contributing/05-publishing.md
+++ b/packages/docs/site/docs/13-contributing/05-publishing.md
@@ -36,7 +36,7 @@ npm run release
 Internet connections drop, APIs stop responding, and GitHub rules are nasty. Stuff happens. If the publishing process fails, you may need to bump the version again and force a publish. To do so, execute the following command:
 
 ```bash
-npm run release --force-publish
+npm run release -- --force-publish
 ```
 
 ## GitHub documentation


### PR DESCRIPTION
## What?

`npm run release --force-publish` is wrong. It should be `npm run release -- --force-publish`

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->
