### PR TITLE
wp-now: download wordpress and sqlite in parallel

### DIFF
--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -19,6 +19,14 @@ import getWpNowTmpPath from '../get-wp-now-tmp-path';
 
 const exampleDir = __dirname + '/mode-examples';
 
+async function downloadWithTimer(name, fn) {
+	console.log(`Downloading ${name}...`);
+	console.time(name);
+	await fn();
+	console.log(`${name} downloaded.`);
+	console.timeEnd(name);
+}
+
 // Options
 test('getWpNowConfig with default options', async () => {
 	const rawOptions: CliOptions = {
@@ -176,16 +184,10 @@ describe('Test starting different modes', () => {
 	 */
 	beforeAll(async () => {
 		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
-		console.log('Downloading WordPress...');
-		console.time('wordpress');
-		await downloadWordPress();
-		console.log('WordPress downloaded.');
-		console.timeEnd('wordpress');
-		console.log('Downloading SQLite...');
-		console.time('sqlite');
-		await downloadSqliteIntegrationPlugin();
-		console.log('SQLite downloaded.');
-		console.timeEnd('sqlite');
+		await Promise.all([
+			downloadWithTimer('wordpresss', downloadWordPress),
+			downloadWithTimer('sqlite', downloadSqliteIntegrationPlugin),
+		]);
 	});
 
 	/**

--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -88,9 +88,11 @@ export default async function startWPNow(
 		});
 		return { php, phpInstances, options };
 	}
-	await downloadWordPress(options.wordPressVersion);
-	await downloadSqliteIntegrationPlugin();
-	await downloadMuPlugins();
+	await Promise.all([
+		downloadWordPress(options.wordPressVersion),
+		downloadSqliteIntegrationPlugin(),
+		downloadMuPlugins(),
+	]);
 	const isFirstTimeProject = !fs.existsSync(options.wpContentPath);
 	await applyToInstances(phpInstances, async (_php) => {
 		switch (options.mode) {


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

Optimize WordPress and SQLite downloads to be in parallel.
Optimization for wp-now and its tests.

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

An easy optimization to improve the developer experience.

## Testing Instructions

- Remove your `~/.wp-now` folder
- Run nx preview wp-now start --path=/path/to/wordpress-plugin-or-theme``
- Observe WordPress and SQLite has been downloaded.
- Observe the WordPress instance has started successfully
- Run the tests `npx nx test wp-now`
- Observe all of them pass.