### PR TITLE
Add EditorConfig properties for indent style and size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
-tab_width = 4
+indent_size = 4
 
 [*.md]
 max_line_length = off

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,8 @@ root = true
 charset = utf-8
 insert_final_newline = true
 trim_trailing_whitespace = true
+indent_style = tab
+tab_width = 4
 
 [*.md]
 max_line_length = off


### PR DESCRIPTION
## What?

This PR updates the [`.editorconfig`](https://github.com/WordPress/wordpress-playground/blob/trunk/.editorconfig) file with additional properties `indent_style` and `indent_size`, with equivalent configuration as the [`.prettierrc`](https://github.com/WordPress/wordpress-playground/blob/trunk/.prettierrc) file. Resolves #425

## Why?

The [EditorConfig](https://editorconfig.org/) file is often used by code editors to adjust configuration per project. For example, the VS Code extension [editorconfig-vscode](https://github.com/editorconfig/editorconfig-vscode) looks for an `.editorconfig` file in any open project and adjusts the behavior of the TAB key based on its configuration.

## How?

Update the `.editorconfig` file.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Open one of the project files with a code editor that supports `.editorconfig`.
3. Press the `TAB` key to insert hard tab with width 4.
