### PR TITLE
wp-now: Error if node doesn't meet the minimum required version

### DIFF
--- a/packages/wp-now/src/main.ts
+++ b/packages/wp-now/src/main.ts
@@ -1,3 +1,14 @@
 import { runCli } from './run-cli';
 
+const requiredMajorVersion = 18;
+
+const currentNodeVersion = parseInt(process.versions.node.split('.')[0]);
+
+if (currentNodeVersion < requiredMajorVersion) {
+	console.error(
+		`You are running Node.js version ${currentNodeVersion}, but this application requires at least Node.js ${requiredMajorVersion}. Please upgrade your Node.js version.`
+	);
+	process.exit(1);
+}
+
 runCli();


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordpress-playground/issues/429

## What?

Exits with an error if node doesn't meet the minimum required version.

```
$ wp-now
You are running Node.js version 14, but this application requires at least Node.js 18. Please upgrade your Node.js version.
```

## Why?

Without this, `wp-now` fails cryptically and provides no context for how it fails.

## Testing Instructions

TBD