### PR TITLE
wp-now: Default to 'playground' mode when no files are detected

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -44,7 +44,8 @@ wp-now php my-file.php
     -   **wp-content** mode: Presence of `plugins` and `themes` subdirectories.
 -   **wordpress**: Runs the directory as a WordPress installation when WordPress files are detected. An existing `wp-config.php` file will be used if it exists; if it doesn't exist, it will be created along with a SQLite database.
 -   **wordpress-develop**: Same as `wordpress` mode, except the `build` directory is served as the web root.
--   **index**: Starts a PHP webserver in the working directory and simply passes requests to `index.php`.
+-   **index**: When an `index.php` file is present, starts a PHP webserver in the working directory and simply passes requests to the `index.php`.
+-   **playground**: If no other conditions are matched, launches a virtualized WordPress site.
 
 ### Arguments
 

--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -45,7 +45,7 @@ wp-now php my-file.php
 -   **wordpress**: Runs the directory as a WordPress installation when WordPress files are detected. An existing `wp-config.php` file will be used if it exists; if it doesn't exist, it will be created along with a SQLite database.
 -   **wordpress-develop**: Same as `wordpress` mode, except the `build` directory is served as the web root.
 -   **index**: When an `index.php` file is present, starts a PHP webserver in the working directory and simply passes requests to the `index.php`.
--   **playground**: If no other conditions are matched, launches a virtualized WordPress site.
+-   **playground**: If no other conditions are matched, launches a completely virtualized WordPress site.
 
 ### Arguments
 
@@ -60,7 +60,7 @@ Of these, `wp-now php` currently supports the `--path=<path>`, `--php=<version>`
 
 ## Technical Details
 
--   The `~/.wp-now` home directory is used to store the WP versions and the `wp-content` folders for projects using 'theme', 'plugin', and 'wp-content' modes. The path to `wp-content` directory for the 'plugin', 'theme', and 'wp-content' modes is `~/.wp-now/wp-content/${projectName}-${directoryHash}`.
+-   The `~/.wp-now` home directory is used to store the WP versions and the `wp-content` folders for projects using 'theme', 'plugin', 'wp-content', and 'playground' modes. The path to `wp-content` directory for the 'plugin', 'theme', and 'wp-content' modes is `~/.wp-now/wp-content/${projectName}-${directoryHash}`. 'playground' mode shares the same `~/.wp-now/wp-content/playground` directory, regardless of where it's started.
 -   For the database setup, `wp-now` is using [SQLite database integration plugin](https://wordpress.org/plugins/sqlite-database-integration/). The path to SQLite database is ` ~/.wp-now/wp-content/${projectName}-${directoryHash}/database/.ht.sqlite`
 
 ## Known Issues

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -26,6 +26,7 @@ export const enum WPNowMode {
 	WORDPRESS_DEVELOP = 'wordpress-develop',
 	INDEX = 'index',
 	WP_CONTENT = 'wp-content',
+	PLAYGROUND = 'playground',
 	AUTO = 'auto',
 }
 

--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -67,17 +67,17 @@ async function getAbsoluteURL() {
 	return `http://127.0.0.1:${port}`;
 }
 
-function getWpContentHomePath(projectPath: string) {
+function getWpContentHomePath(projectPath: string, mode: string) {
 	const basename = path.basename(projectPath);
 	const directoryHash = crypto
 		.createHash('sha1')
 		.update(projectPath)
 		.digest('hex');
-	return path.join(
-		getWpNowPath(),
-		'wp-content',
-		`${basename}-${directoryHash}`
-	);
+	const projectDirectory =
+		mode === WPNowMode.PLAYGROUND
+			? 'playground'
+			: `${basename}-${directoryHash}`;
+	return path.join(getWpNowPath(), 'wp-content', projectDirectory);
 }
 
 export default async function getWpNowConfig(
@@ -101,11 +101,14 @@ export default async function getWpNowConfig(
 		}
 	});
 
-	if (!options.wpContentPath) {
-		options.wpContentPath = getWpContentHomePath(options.projectPath);
-	}
 	if (!options.mode || options.mode === 'auto') {
 		options.mode = inferMode(options.projectPath);
+	}
+	if (!options.wpContentPath) {
+		options.wpContentPath = getWpContentHomePath(
+			options.projectPath,
+			options.mode
+		);
 	}
 	if (!options.absoluteUrl) {
 		options.absoluteUrl = await getAbsoluteURL();

--- a/packages/wp-now/src/tests/execute-php-file/index.php
+++ b/packages/wp-now/src/tests/execute-php-file/index.php
@@ -1,0 +1,2 @@
+<?php
+// This index.php forces the index mode instead of playground mode for these tests.

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -281,7 +281,7 @@ describe('Test starting different modes', () => {
 	};
 
 	/**
-	 * Test that startWPNow in "index", "plugin" and "theme" modes doesn't change anything in the project directory.
+	 * Test that startWPNow in "index", "plugin", "theme", and "playground" modes doesn't change anything in the project directory.
 	 */
 	test.each([
 		['index', ['index.php']],

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -29,8 +29,9 @@ async function downloadWithTimer(name, fn) {
 
 // Options
 test('getWpNowConfig with default options', async () => {
+	const projectDirectory = exampleDir + '/index';
 	const rawOptions: CliOptions = {
-		path: exampleDir + '/index',
+		path: projectDirectory,
 	};
 	const options = await getWpNowConfig(rawOptions);
 
@@ -38,7 +39,7 @@ test('getWpNowConfig with default options', async () => {
 	expect(options.wordPressVersion).toBe('latest');
 	expect(options.documentRoot).toBe('/var/www/html');
 	expect(options.mode).toBe(WPNowMode.INDEX);
-	expect(options.projectPath).toBe(exampleDir);
+	expect(options.projectPath).toBe(projectDirectory);
 });
 
 //TODO: Add it back when all options are supported as cli arguments

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -287,6 +287,7 @@ describe('Test starting different modes', () => {
 		['index', ['index.php']],
 		['plugin', ['sample-plugin.php']],
 		['theme', ['style.css']],
+		['playground', ['my-file.txt']],
 	])('startWPNow starts %s mode', async (mode, expectedDirectories) => {
 		const projectPath = path.join(tmpExampleDirectory, mode);
 

--- a/packages/wp-now/src/tests/wp-now.spec.ts
+++ b/packages/wp-now/src/tests/wp-now.spec.ts
@@ -30,7 +30,7 @@ async function downloadWithTimer(name, fn) {
 // Options
 test('getWpNowConfig with default options', async () => {
 	const rawOptions: CliOptions = {
-		path: exampleDir,
+		path: exampleDir + '/index',
 	};
 	const options = await getWpNowConfig(rawOptions);
 
@@ -87,7 +87,7 @@ test('isPluginDirectory detects a WordPress plugin in case-insensitive way and i
 test('isPluginDirectory returns false for non-plugin directory', () => {
 	const projectPath = exampleDir + '/not-plugin';
 	expect(isPluginDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
+	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
 });
 
 // Theme mode
@@ -100,14 +100,14 @@ test('isThemeDirectory detects a WordPress theme and infer THEME mode', () => {
 test('isThemeDirectory returns false for non-theme directory', () => {
 	const projectPath = exampleDir + '/not-theme';
 	expect(isThemeDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
+	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
 });
 
 test('isThemeDirectory returns false for a directory with style.css but without Theme Name', () => {
 	const projectPath = exampleDir + '/not-theme';
 
 	expect(isThemeDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
+	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
 });
 
 // WP_CONTENT mode
@@ -151,7 +151,7 @@ test('isWordPressDirectory returns false for non-WordPress directory', () => {
 	const projectPath = exampleDir + '/nothing';
 
 	expect(isWordPressDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
+	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
 });
 
 // WordPress developer mode
@@ -166,14 +166,14 @@ test('isWordPressDevelopDirectory returns false for non-WordPress-develop direct
 	const projectPath = exampleDir + '/nothing';
 
 	expect(isWordPressDevelopDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
+	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
 });
 
 test('isWordPressDevelopDirectory returns false for incomplete WordPress-develop directory', () => {
 	const projectPath = exampleDir + '/not-wordpress-develop';
 
 	expect(isWordPressDevelopDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
+	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
 });
 
 describe('Test starting different modes', () => {

--- a/packages/wp-now/src/wp-playground-wordpress/has-index-file.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/has-index-file.ts
@@ -1,0 +1,12 @@
+import fs from 'fs-extra';
+import path from 'path';
+
+/**
+ * Checks if the given path has an index.php file
+ *
+ * @param projectPath The path to the project to check.
+ * @returns A boolean value indicating whether the project has an index.php file.
+ */
+export function hasIndexFile(projectPath: string): Boolean {
+	return fs.existsSync(path.join(projectPath, 'index.php'));
+}

--- a/packages/wp-now/src/wp-playground-wordpress/index.ts
+++ b/packages/wp-now/src/wp-playground-wordpress/index.ts
@@ -1,3 +1,4 @@
+export * from './has-index-file';
 export * from './is-valid-wordpress-version';
 export * from './is-plugin-directory';
 export * from './is-theme-directory';


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordpress-playground/issues/439

## What?

Defaults to a new 'playground' mode when no files are detected. 'index' mode only runs when `index.php` is detected.

## Why?

For new users, the '404 Not found' behavior is confusing when you run `wp-now start` in an empty directory. See https://github.com/WordPress/wordpress-playground/issues/432


## Testing Instructions

Given the following steps:

```
$ mkdir my-test-directory
$ cd my-test-directory
$ nx preview wp-now start --path=my-test-directory
```

You should see a WordPress install instead of a '404 Not found' page.

If you launch two 'playground' mode instances at the same time, they should share the same database.