### PR TITLE
wp-now: Remove magic WordPress loading for `php` command

### DIFF
--- a/packages/wp-now/README.md
+++ b/packages/wp-now/README.md
@@ -55,7 +55,7 @@ wp-now php my-file.php
 -   `--port=<port>`: the port number on which the server will listen. This is optional and if not provided, it will pick an open port number automatically. The default port number is set to `8881`(example of usage: `--port=3000`);
 -   `--wp=<version>`: the version of WordPress to use. This is optional and if not provided, it will use a default version. The default version is set to the [latest WordPress version](https://wordpress.org/download/releases/)(example usage: `--wp=5.8`)
 
-Of these, `wp-now php` currently supports the `--path=<path>`, `--php=<version>`, and `--wp=<version>` arguments.
+Of these, `wp-now php` currently supports the `--path=<path>` and `--php=<version>` arguments.
 
 ## Technical Details
 

--- a/packages/wp-now/src/execute-php-file.ts
+++ b/packages/wp-now/src/execute-php-file.ts
@@ -4,8 +4,6 @@ import startWPNow from './wp-now';
 import { WPNowOptions } from './config';
 import { disableOutput } from './output';
 
-const VFS_TMP_PATH = '/vfs-wp-now-tmp';
-
 /**
  *
  * Execute a PHP file given its path. For non index mode it loads WordPress context.
@@ -21,7 +19,7 @@ export async function executePHPFile(
 	options: WPNowOptions = {}
 ) {
 	disableOutput();
-	const { phpInstances, options: wpNowOptions } = await startWPNow({
+	const { phpInstances } = await startWPNow({
 		...options,
 		numberOfPhpInstances: 2,
 	});

--- a/packages/wp-now/src/execute-php-file.ts
+++ b/packages/wp-now/src/execute-php-file.ts
@@ -5,7 +5,6 @@ import { WPNowOptions } from './config';
 import { disableOutput } from './output';
 
 const VFS_TMP_PATH = '/vfs-wp-now-tmp';
-const VFS_PHP_FILE = path.join(VFS_TMP_PATH, 'parent.php');
 
 /**
  *
@@ -34,24 +33,9 @@ export async function executePHPFile(
 		throw new Error(`Could not open input file: ${absoluteFilePath}`);
 	}
 
-	let fileToExecute = absoluteFilePath;
-	if (wpNowOptions.mode !== 'index') {
-		// Load WordPress context for non index mode.
-		php.mkdirTree(VFS_TMP_PATH);
-		php.writeFile(
-			VFS_PHP_FILE,
-			`<?php
-      $_SERVER['HTTP_HOST'] = '${wpNowOptions.absoluteUrl}';
-      require_once '${path.join(wpNowOptions.documentRoot, 'wp-load.php')}';
-      require_once '${filePath}';
-    `
-		);
-		fileToExecute = VFS_PHP_FILE;
-	}
-
 	try {
 		php.useHostFilesystem();
-		await php.cli(['php', fileToExecute]);
+		await php.cli(['php', absoluteFilePath]);
 	} catch (resultOrError) {
 		const success =
 			resultOrError.name === 'ExitStatus' && resultOrError.status === 0;

--- a/packages/wp-now/src/run-cli.ts
+++ b/packages/wp-now/src/run-cli.ts
@@ -30,10 +30,6 @@ function commonParameters(yargs) {
 		.option('php', {
 			describe: 'PHP version to use.',
 			type: 'string',
-		})
-		.option('wp', {
-			describe: "WordPress version to use: e.g. '--wp=6.2'",
-			type: 'string',
 		});
 }
 
@@ -59,6 +55,10 @@ export async function runCli() {
 			'Start the server',
 			(yargs) => {
 				commonParameters(yargs);
+				yargs.option('wp', {
+					describe: "WordPress version to use: e.g. '--wp=6.2'",
+					type: 'string',
+				});
 				yargs.option('port', {
 					describe: 'Server port',
 					type: 'number',
@@ -101,7 +101,6 @@ export async function runCli() {
 					const options = await getWpNowConfig({
 						path: argv.path as string,
 						php: argv.php as SupportedPHPVersion,
-						wp: argv.wp as string,
 					});
 					await executePHPFile(argv.file as string, options);
 					process.exit(0);


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordpress-playground/issues/438

## What?

Removes the magic WordPress loading for the `wp-now php` command.

## Why?

It's not particularly intuitive that you get WordPress when you run `wp-now php`. It's more intuitive that WordPress will load if you run WP-CLI, so let's keep the behavior for that feature (https://github.com/WordPress/playground-tools/issues/25).

## Testing Instructions

Tests should pass.