### PR TITLE
BasePHP: Use FS.rename for mv method

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -67,6 +67,52 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			expect(php.fileExists(testFilePath)).toEqual(false);
 		});
 
+		it('mv() should move a file', () => {
+			php.mkdir(testDirPath);
+			const file1 = testDirPath + '/1.txt';
+			const file2 = testDirPath + '/2.txt';
+			php.writeFile(file1, '1');
+			php.mv(file1, file2);
+			expect(php.fileExists(file1)).toEqual(false);
+			expect(php.fileExists(file2)).toEqual(true);
+			expect(php.readFileAsText(file2)).toEqual('1');
+		});
+
+		it('mv() should replace target file if it exists', () => {
+			php.mkdir(testDirPath);
+			const file1 = testDirPath + '/1.txt';
+			const file2 = testDirPath + '/2.txt';
+			php.writeFile(file1, '1');
+			php.writeFile(file2, '2');
+			php.mv(file1, file2);
+			expect(php.fileExists(file1)).toEqual(false);
+			expect(php.fileExists(file2)).toEqual(true);
+			expect(php.readFileAsText(file2)).toEqual('1');
+		});
+
+		it('mv() should throw a useful error when source file does not exist', () => {
+			php.mkdir(testDirPath);
+			const file1 = testDirPath + '/1.txt';
+			const file2 = testDirPath + '/2.txt';
+			expect(() => {
+				php.mv(file1, file2);
+			}).toThrowError(
+				`Could not move "${testDirPath}/1.txt": There is no such file or directory OR the parent directory does not exist.`
+			);
+		});
+
+		it('mv() should throw a useful error when target directory does not exist', () => {
+			php.mkdir(testDirPath);
+			const file1 = testDirPath + '/1.txt';
+			const file2 = testDirPath + '/nowhere/2.txt';
+			php.writeFile(file1, '1');
+			expect(() => {
+				php.mv(file1, file2);
+			}).toThrowError(
+				`Could not move "${testDirPath}/1.txt": There is no such file or directory OR the parent directory does not exist.`
+			);
+		});
+
 		it('mkdir() should create a directory', () => {
 			php.mkdir(testDirPath);
 			expect(php.fileExists(testDirPath)).toEqual(true);

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -486,7 +486,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 	/** @inheritDoc */
 	@rethrowFileSystemError('Could not move "{path}"')
 	mv(fromPath: string, toPath: string) {
-		this[__private__dont__use].FS.mv(fromPath, toPath);
+		this[__private__dont__use].FS.rename(fromPath, toPath);
 	}
 
 	/** @inheritDoc */


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

Update `BasePHP.mv` method to use `FS.rename` instead of `FS.mv` which doesn't exist.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The FS method is called `rename`, not `mv`, in both Emscripten and Node.js.

- https://emscripten.org/docs/api_reference/Filesystem-API.html#FS.rename
- https://nodejs.org/api/fs.html#fsrenameoldpath-newpath-callback


## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Run `npx nx test php-wasm-node`.
