### PR TITLE
wp-now: Only output WordPress version when WordPress is to be used

### DIFF
--- a/packages/wp-now/src/wp-now.ts
+++ b/packages/wp-now/src/wp-now.ts
@@ -81,13 +81,13 @@ export default async function startWPNow(
 	output?.log(`directory: ${options.projectPath}`);
 	output?.log(`mode: ${options.mode}`);
 	output?.log(`php: ${options.phpVersion}`);
-	output?.log(`wp: ${options.wordPressVersion}`);
 	if (options.mode === WPNowMode.INDEX) {
 		await applyToInstances(phpInstances, async (_php) => {
 			runIndexMode(_php, options);
 		});
 		return { php, phpInstances, options };
 	}
+	output?.log(`wp: ${options.wordPressVersion}`);
 	await Promise.all([
 		downloadWordPress(options.wordPressVersion),
 		downloadSqliteIntegrationPlugin(),


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

Only outputs the WordPress version when WordPress is used in the mode.

'index' mode:

```
Starting the server......
directory: /Users/danielbachhuber/projects/playground-test
mode: index
php: 8.0
Server running at http://127.0.0.1:8881/
```

'plugin' mode:

```
Starting the server......
directory: /Users/danielbachhuber/projects/playground-test/gutenberg
mode: plugin
php: 8.0
wp: latest
WordPress latest folder already exists. Skipping download.
SQLite folder already exists. Skipping download.
Server running at http://127.0.0.1:8881/
```

## Why?

It's misleading to output the WordPress version when no WordPress is being used.

## Testing Instructions

1. Run `nx preview wp-now start --path=/path/to/index-folder` and verify no `wp: ` is output.
2. Run `nx preview wp-now start --path=/path/to/plugin-folder` and verify the WordPress version is output.
