### PR TITLE
wp-now: Remove unnecessary nvm calls

### DIFF
--- a/bin/wp-now
+++ b/bin/wp-now
@@ -13,7 +13,5 @@ if [[ "$@" != *"--path="* ]]; then
 fi
 
 cd $SCRIPT_DIR/..
-export NVM_DIR=$HOME/.nvm;
-source $NVM_DIR/nvm.sh;
-nvm use
+
 npx nx preview wp-now $ARGS


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

In this diff, I propose to remove unnecessary nvm calls from the script that allows running wp-now for development purposes 
globally.

## Why?

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- remove dependency on nvm from the code
- ensure that the script located in `bin/` doesn't make changes on the machine when it runs

Related ticket: https://github.com/WordPress/playground-tools/issues/7

## How?

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I removed the affected code. We still recommend running `nvm use` in contribution docs, but the user can skip that if wanted to manage node versions in another way.

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Check out the branch. -->
<!-- 2. Run a command. -->
<!-- 3. etc. -->

1. Link wp-now in development mode
2. Ensure wp-now still works when used globally from the plugin/theme or other project root