### PR TITLE
wp-now:Use localhost instead of 127.0.0.1

### DIFF
--- a/packages/wp-now/src/config.ts
+++ b/packages/wp-now/src/config.ts
@@ -64,7 +64,7 @@ export interface WPEnvOptions {
 
 async function getAbsoluteURL() {
 	const port = await portFinder.getOpenPort();
-	return `http://127.0.0.1:${port}`;
+	return `http://localhost:${port}`;
 }
 
 function getWpContentHomePath(projectPath: string, mode: string) {

--- a/packages/wp-now/src/start-server.ts
+++ b/packages/wp-now/src/start-server.ts
@@ -102,7 +102,7 @@ export async function startServer(
 		}
 	});
 
-	const url = `http://127.0.0.1:${port}/`;
+	const url = `http://localhost:${port}/`;
 	app.listen(port, () => {
 		output?.log(`Server running at ${url}`);
 	});


### PR DESCRIPTION
See [this comment](https://github.com/WordPress/wordpress-playground/issues/435#issuecomment-1561350598).

## What?

This PR changes the URL that `wp-now` listens on from `127.0.0.1` to localhost.

## Why?

When I run `wp-now start` in WSL (a Windows virtual environment), it listens on `127.0.0.1` (ipv4 address).
However, when I access the URL on the host OS, it resolves `to::1` (ipv6 address), so I believe this is why the server is unreachable.

## Testing Instructions

- run `nx preview wp-now start`
- Confirm that the console displays the expected logs: `Server running at http://localhost:8881/`
- Confirm that the WordPress site is displayed when accessing `http://localhost:8881/`.
- Conform that WordPress Address and Site Address settings are `http://localhost:8881/`.
- Confirm that all resources such as CSS and JS are also loaded at this URL and that no errors are output to the console.
