### PR TITLE
PHP: Add `prependPath` option to `listFiles` method

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -152,6 +152,16 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 				'test2.txt',
 			]);
 		});
+
+		it('listFiles() option prependPath should prepend given path to all files returned', () => {
+			php.mkdir(testDirPath);
+			php.writeFile(testDirPath + '/test.txt', 'Hello World!');
+			php.writeFile(testDirPath + '/test2.txt', 'Hello World!');
+			expect(php.listFiles(testDirPath, { prependPath: true })).toEqual([
+				testDirPath + '/test.txt',
+				testDirPath + '/test2.txt',
+			]);
+		});
 	});
 
 	describe('Stdio', () => {

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -14,6 +14,7 @@ import {
 	PHPRequestHeaders,
 	PHPRunOptions,
 	RmDirOptions,
+	ListFilesOptions,
 } from './universal-php';
 import {
 	getFunctionsMaybeMissingFromAsyncify,
@@ -507,14 +508,21 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 
 	/** @inheritDoc */
 	@rethrowFileSystemError('Could not list files in "{path}"')
-	listFiles(path: string): string[] {
+	listFiles(
+		path: string,
+		options: ListFilesOptions = { includePath: false }
+	): string[] {
 		if (!this.fileExists(path)) {
 			return [];
 		}
 		try {
-			return this[__private__dont__use].FS.readdir(path).filter(
+			const files = this[__private__dont__use].FS.readdir(path).filter(
 				(name: string) => name !== '.' && name !== '..'
 			);
+			if (options.includePath) {
+				return files.map((name: string) => `${path}/${name}`);
+			}
+			return files;
 		} catch (e) {
 			console.error(e, { path });
 			return [];

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -520,10 +520,8 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 				(name: string) => name !== '.' && name !== '..'
 			);
 			if (options.prependPath) {
-				const prepend = path.replace(/\/$/, '')
-				return files.map(
-					(name: string) => `${prepend}/${name}`
-				);
+				const prepend = path.replace(/\/$/, '');
+				return files.map((name: string) => `${prepend}/${name}`);
 			}
 			return files;
 		} catch (e) {

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -520,7 +520,10 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 				(name: string) => name !== '.' && name !== '..'
 			);
 			if (options.prependPath) {
-				return files.map((name: string) => `${path}/${name}`);
+				const prepend = path.replace(/\/$/, '')
+				return files.map(
+					(name: string) => `${prepend}/${name}`
+				);
 			}
 			return files;
 		} catch (e) {

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -510,7 +510,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 	@rethrowFileSystemError('Could not list files in "{path}"')
 	listFiles(
 		path: string,
-		options: ListFilesOptions = { includePath: false }
+		options: ListFilesOptions = { prependPath: false }
 	): string[] {
 		if (!this.fileExists(path)) {
 			return [];
@@ -519,7 +519,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 			const files = this[__private__dont__use].FS.readdir(path).filter(
 				(name: string) => name !== '.' && name !== '..'
 			);
-			if (options.includePath) {
+			if (options.prependPath) {
 				return files.map((name: string) => `${path}/${name}`);
 			}
 			return files;

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -439,3 +439,11 @@ export interface RmDirOptions {
 	 */
 	recursive?: boolean;
 }
+
+export interface ListFilesOptions {
+	/**
+	 * If true, prepend given folder path to all file names.
+	 * Default: false.
+	 */
+	includePath: boolean;
+}

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -445,5 +445,5 @@ export interface ListFilesOptions {
 	 * If true, prepend given folder path to all file names.
 	 * Default: false.
 	 */
-	includePath: boolean;
+	prependPath: boolean;
 }


### PR DESCRIPTION
## What?

Add `prependPath` option to `PHP.listFiles` method, which will prepend given folder path to every file found in it.

## Why?

It's a common need to iterate over a list of files with each file path being an accessible path instead of only the file name. Idea mentioned in:

- https://github.com/WordPress/wordpress-playground/pull/427#discussion_r1207443739

For example, this is a common pattern:

```ts
const files = await playground.listFiles( folderPath )

for (const file of files) {
	const filePath = `${folderPath}/${file}`;
	...
}
```

Also expressed as:


```ts
const filePaths = (await playground.listFiles( folderPath )).map(
  (name: string) => `${folderPath}/${name}`)
)
```

With the new option, the above can be simplified as:

```ts
const filePaths = await playground.listFiles(folderPath, { prependPath: true })
```

## How?

- [x] Add `prependPath` option to `BasePHP.listFiles` method
- [x] Document the option and what it does
- [x] Add test

## Testing Instructions

<!-- Please include step by step instructions on how to test this PR. -->
1. Check out the branch.
2. Run `nx test playground-blueprints`
