### PR TITLE
PHP: Build a reusable php-wasm-web npm package

### DIFF
--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -52,7 +52,13 @@ export default defineConfig(({ command }) => {
 						typeof specifier === 'string' &&
 						specifier.match(/php_\d_\d\.js$/)
 					) {
-						return specifier.split('/').pop();
+						/**
+						 * The ../ is weird but necessary to make the final build say
+						 * import("./php_8_2.js")
+						 * and not
+						 * import("php_8_2.js")
+						 */
+						return '../' + specifier.split('/').pop();
 					}
 				},
 			},

--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -75,12 +75,7 @@ export default defineConfig(({ command }) => {
 				external: [/php_\d_\d.js$/],
 				output: {
 					// Ensure the PHP loaders are not hashed in the final build.
-					entryFileNames: (chunkInfo: any) => {
-						if (chunkInfo.name?.includes('php-')) {
-							return '[name].js';
-						}
-						return '[name]-[hash].js';
-					},
+					entryFileNames: '[name].js',
 				},
 			},
 		},


### PR DESCRIPTION
## What?

The current `php-wasm-web` package has two problems:

* The `index.js` file is released as `index-[hash].js` and can't be find by `require()`
* The imports for PHP files point to `php_8_2.js` instead of `./php_8_2.js` and are not correctly resolved by `import()`

This PR addresses both problems.

## Testing Instructions

Confirm the CI flashes green, otherwise there's no good process for testing this type of changes yet. It will come together as application packages move to other repositories.