### PR TITLE
PHP: Expose the content-type header as $_SERVER['CONTENT_TYPE'] instead of $_SERVER['HTTP_CONTENT_TYPE'] (and content-length, too)

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -323,6 +323,31 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			expect(bodyText).toEqual('{"foo": "bar"}');
 		});
 
+		it('Should set $_SERVER entries for provided headers', async () => {
+			const response = await php.run({
+				code: `<?php echo json_encode($_SERVER);`,
+				method: 'POST',
+				body: 'foo=bar',
+				headers: {
+					'Content-Type': 'text/plain',
+					'Content-Length': '15',
+					'User-agent': 'my-user-agent',
+					'custom-header': 'custom value',
+					'x-test': 'x custom value',
+				},
+			});
+			const json = response.json;
+			expect(json).toHaveProperty('HTTP_USER_AGENT', 'my-user-agent');
+			expect(json).toHaveProperty('HTTP_CUSTOM_HEADER', 'custom value');
+			expect(json).toHaveProperty('HTTP_X_TEST', 'x custom value');
+			/*
+			 * The following headers should be set without the HTTP_ prefix,
+			 * as PHP follows the following convention:
+			 * https://www.ietf.org/rfc/rfc3875
+			 */
+			expect(json).toHaveProperty('CONTENT_TYPE', 'text/plain');
+			expect(json).toHaveProperty('CONTENT_LENGTH', '15');
+		});
 		it('Should expose urlencoded POST data in $_POST', async () => {
 			const response = await php.run({
 				code: `<?php echo json_encode($_POST);`,
@@ -526,7 +551,7 @@ bar1
 			expect($_SERVER).toHaveProperty('REQUEST_URI', '/test.php?a=b');
 			expect($_SERVER).toHaveProperty('REQUEST_METHOD', 'POST');
 			expect($_SERVER).toHaveProperty(
-				'HTTP_CONTENT_TYPE',
+				'CONTENT_TYPE',
 				'multipart/form-data; boundary=boundary'
 			);
 			expect($_SERVER).toHaveProperty(

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -294,8 +294,17 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 			);
 		}
 		for (const name in headers) {
+			let HTTP_prefix = 'HTTP_';
+			/**
+			 * Some headers are special and don't have the HTTP_ prefix.
+			 */
+			if (
+				['content-type', 'content-length'].includes(name.toLowerCase())
+			) {
+				HTTP_prefix = '';
+			}
 			this.addServerGlobalEntry(
-				`HTTP_${name.toUpperCase().replace(/-/g, '_')}`,
+				`${HTTP_prefix}${name.toUpperCase().replace(/-/g, '_')}`,
 				headers[name]
 			);
 		}

--- a/packages/playground/blueprints/src/lib/steps/client-methods.ts
+++ b/packages/playground/blueprints/src/lib/steps/client-methods.ts
@@ -37,7 +37,7 @@ export const runPHP: StepHandler<RunPHPStep> = async (playground, { code }) => {
  * {
  * 		"step": "runPHP",
  * 		"options": {
- * 			"code": "<?php echo $_SERVER['HTTP_CONTENT_TYPE']; ?>",
+ * 			"code": "<?php echo $_SERVER['CONTENT_TYPE']; ?>",
  * 			"headers": {
  * 				"Content-type": "text/plain"
  * 			}


### PR DESCRIPTION
## Description

PHP follows https://www.ietf.org/rfc/rfc3875 and exposes content-type and content-length headers without the HTTP_ prefix – unlike almost all other headers.

See https://www.php.net/manual/en/reserved.variables.server.php#110763 and play with phpinfo() for additional confirmation.

Related to #480

## Testing instructions

* Confirm the CI continues to work
* Confirm the in-browser Playground continues to work when saving posts

cc @moonmeister