### PR TITLE
Playground website: Cache busting for remote.html

### DIFF
--- a/packages/playground/website/src/lib/config.ts
+++ b/packages/playground/website/src/lib/config.ts
@@ -1,2 +1,2 @@
 // Provided by vite
-export { remotePlaygroundOrigin } from 'virtual:website-config';
+export { remotePlaygroundOrigin, buildVersion } from 'virtual:website-config';

--- a/packages/playground/website/src/lib/hooks.ts
+++ b/packages/playground/website/src/lib/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Blueprint, startPlaygroundWeb } from '@wp-playground/client';
 import type { PlaygroundClient } from '@wp-playground/client';
-import { remotePlaygroundOrigin } from './config';
+import { remotePlaygroundOrigin, buildVersion } from './config';
 
 interface UsePlaygroundOptions {
 	blueprint?: Blueprint;
@@ -30,7 +30,7 @@ export function usePlayground({ blueprint }: UsePlaygroundOptions) {
 
 		startPlaygroundWeb({
 			iframe,
-			remoteUrl: `${remotePlaygroundOrigin}/remote.html`,
+			remoteUrl: `${remotePlaygroundOrigin}/remote.html?v=${buildVersion}`,
 			blueprint,
 		}).then(async (playground) => {
 			playground.onNavigation((url) => setUrl(url));

--- a/packages/playground/website/src/lib/types.d.ts
+++ b/packages/playground/website/src/lib/types.d.ts
@@ -1,3 +1,5 @@
+// Defined in vite.config.ts
 declare module 'virtual:website-config' {
 	export const remotePlaygroundOrigin: string;
+	export const buildVersion: string;
 }

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { execSync } from 'node:child_process';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import ignoreWasmImports from '../ignore-wasm-imports';
@@ -35,6 +36,13 @@ const proxy = {
 		},
 	},
 };
+
+let buildVersion: string;
+try {
+	buildVersion = execSync('git rev-parse HEAD').toString().trim();
+} catch (e) {
+	buildVersion = (new Date().getTime() / 1000).toFixed(0);
+}
 
 export default defineConfig(({ command }) => {
 	const playgroundOrigin =
@@ -82,9 +90,7 @@ export default defineConfig(({ command }) => {
 				name: 'website-config',
 				content: `
 				export const remotePlaygroundOrigin = ${JSON.stringify(playgroundOrigin)};
-				export const buildVersion = ${JSON.stringify(
-					(new Date().getTime() / 1000).toFixed(0)
-				)};					`,
+				export const buildVersion = ${JSON.stringify(buildVersion)};					`,
 			}),
 		],
 

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -80,9 +80,13 @@ export default defineConfig(({ command }) => {
 			ignoreWasmImports(),
 			virtualModule({
 				name: 'website-config',
-				content: `export const remotePlaygroundOrigin = ${JSON.stringify(
+				content: `
+				export const remotePlaygroundOrigin = ${JSON.stringify(
 					playgroundOrigin
-				)};`,
+				)};
+				export const buildVersion = ${JSON.stringify(
+					(new Date().getTime() / 1000).toFixed(0)
+				)};					`,
 			}),
 		],
 

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -90,7 +90,7 @@ export default defineConfig(({ command }) => {
 				name: 'website-config',
 				content: `
 				export const remotePlaygroundOrigin = ${JSON.stringify(playgroundOrigin)};
-				export const buildVersion = ${JSON.stringify(buildVersion)};					`,
+				export const buildVersion = ${JSON.stringify(buildVersion)};`,
 			}),
 		],
 

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -81,9 +81,7 @@ export default defineConfig(({ command }) => {
 			virtualModule({
 				name: 'website-config',
 				content: `
-				export const remotePlaygroundOrigin = ${JSON.stringify(
-					playgroundOrigin
-				)};
+				export const remotePlaygroundOrigin = ${JSON.stringify(playgroundOrigin)};
 				export const buildVersion = ${JSON.stringify(
 					(new Date().getTime() / 1000).toFixed(0)
 				)};					`,


### PR DESCRIPTION
Loads remote.html from a build-dependent URL to ensure cache isn't used for loading updated releases.

I noticed new deployments to playground.wordpress.net tend to break in Chrome. The root cause is Chrome caches remote.html because the <iframe /> refers to the exact same URL before and after the deployment. As a result, Chrome tries to load the old version of JS and wasm assets that are no longer there and the cached ones are not compatible with the refreshed website.

## Testing Instructions

* Make sure `npm run dev` continues to work
* Make sure `npm run build` produces a working website in `dist/packages/wasm-wordpress-net`