### PR TITLE
Update pre-commit hook to only format uncommitted files

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,4 @@
 # This, weirdly, breaks nx:
 # . "$(dirname -- "$0")/_/husky.sh"
 
-npm run format
+npm run format:uncommitted

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"dev": "nx dev playground-website",
 		"dev:interactivity": "nx dev interactive-block-playground",
 		"format": "nx format",
+		"format:uncommitted": "nx format --fix --parallel --uncommitted",
 		"lint": "nx run-many --all --target=lint",
 		"predeploy": "nx build docs-site",
 		"prepublishOnly": "npm run build",


### PR DESCRIPTION
Reduces the time needed to complete the pre-commit checks on a local machine