### PR TITLE
PHP: Add listFiles options to IsomorphicLocalPHP and WebPHPEndpoint

### DIFF
--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -5,6 +5,7 @@ export type {
 	PHPOutput,
 	PHPRunOptions,
 	UniversalPHP,
+	ListFilesOptions,
 	RmDirOptions,
 	HTTPMethod,
 	PHPRequest,

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -222,9 +222,10 @@ export interface IsomorphicLocalPHP extends RequestHandler {
 	 * Lists the files and directories in the given directory.
 	 *
 	 * @param  path - The directory path to list.
+	 * @param  options - Options for the listing.
 	 * @returns The list of files and directories in the given directory.
 	 */
-	listFiles(path: string): string[];
+	listFiles(path: string, options?: ListFilesOptions): string[];
 
 	/**
 	 * Checks if a directory exists in the PHP filesystem.

--- a/packages/php-wasm/web/src/lib/web-php-endpoint.ts
+++ b/packages/php-wasm/web/src/lib/web-php-endpoint.ts
@@ -1,6 +1,7 @@
 import type {
 	BasePHP,
 	IsomorphicLocalPHP,
+	ListFilesOptions,
 	PHPRequest,
 	PHPResponse,
 	PHPRunOptions,
@@ -145,8 +146,8 @@ export class WebPHPEndpoint implements IsomorphicLocalPHP {
 	}
 
 	/** @inheritDoc @php-wasm/web!WebPHP.listFiles */
-	listFiles(path: string): string[] {
-		return _private.get(this)!.php.listFiles(path);
+	listFiles(path: string, options?: ListFilesOptions): string[] {
+		return _private.get(this)!.php.listFiles(path, options);
 	}
 
 	/** @inheritDoc @php-wasm/web!WebPHP.isDir */

--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -164,7 +164,7 @@ export class VFSResource extends Resource {
 
 	/** @inheritDoc */
 	get name() {
-		return this.resource.path;
+		return this.resource.path.split('/').pop() || '';
 	}
 }
 

--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -164,7 +164,7 @@ export class VFSResource extends Resource {
 
 	/** @inheritDoc */
 	get name() {
-		return this.resource.path.split('/').pop() || '';
+		return this.resource.path;
 	}
 }
 

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -51,8 +51,7 @@ foreach ( ( glob( $plugin_path . '/*.php' ) ?: array() ) as $file ) {
 echo 'NO_ENTRY_FILE';
 `,
 	});
-	if (result.errors) throw new Error(result.errors);
-	if (result.text === 'NO_ENTRY_FILE') {
+	if (result.text.endsWith('NO_ENTRY_FILE')) {
 		throw new Error('Could not find plugin entry file.');
 	}
 };

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -51,7 +51,8 @@ foreach ( ( glob( $plugin_path . '/*.php' ) ?: array() ) as $file ) {
 echo 'NO_ENTRY_FILE';
 `,
 	});
-	if (result.text.endsWith('NO_ENTRY_FILE')) {
+	if (result.errors) throw new Error(result.errors);
+	if (result.text === 'NO_ENTRY_FILE') {
 		throw new Error('Could not find plugin entry file.');
 	}
 };

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
@@ -15,6 +15,7 @@ describe('Blueprint step installPlugin', () => {
 
 	it('should install a plugin', async () => {
 		// Create test plugin
+
 		const pluginName = 'test-plugin';
 
 		php.mkdir(`/${pluginName}`);
@@ -27,10 +28,7 @@ describe('Blueprint step installPlugin', () => {
 		const zipFileName = `${pluginName}-0.0.1.zip`;
 
 		await php.run({
-			code: `<?php $zip = new ZipArchive(); 
-						 $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); 
-						 $zip->addFile("/${pluginName}/index.php"); 
-						 $zip->close();`,
+			code: `<?php $zip = new ZipArchive(); $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); $zip->addFile("/${pluginName}/index.php"); $zip->close();`,
 		});
 
 		php.rmdir(`/${pluginName}`);
@@ -64,51 +62,5 @@ describe('Blueprint step installPlugin', () => {
 		php.unlink(zipFileName);
 
 		expect(php.fileExists(`${pluginsPath}/${pluginName}`)).toBe(true);
-	});
-
-	it('should install a plugin even when it is zipped directly without a root-level folder', async () => {
-		// Create test plugin
-		const pluginName = 'test-plugin';
-
-		php.writeFile('/index.php', `/**\n * Plugin Name: Test Plugin`);
-
-		// Note the package name is different from plugin folder name
-		const zipFileName = `${pluginName}-0.0.1.zip`;
-
-		await php.run({
-			code: `<?php $zip = new ZipArchive(); 
-						 $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); 
-						 $zip->addFile("/index.php"); 
-						 $zip->close();`,
-		});
-
-		expect(php.fileExists(zipFileName)).toBe(true);
-
-		// Create plugins folder
-		const rootPath = await php.documentRoot;
-		const pluginsPath = `${rootPath}/wp-content/plugins`;
-
-		php.mkdir(pluginsPath);
-
-		await runBlueprintSteps(
-			compileBlueprint({
-				steps: [
-					{
-						step: 'installPlugin',
-						pluginZipFile: {
-							resource: 'vfs',
-							path: zipFileName,
-						},
-						options: {
-							activate: false,
-						},
-					},
-				],
-			}),
-			php
-		);
-
-		php.unlink(zipFileName);
-		expect(php.fileExists(`${pluginsPath}/${pluginName}-0.0.1`)).toBe(true);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
@@ -15,7 +15,6 @@ describe('Blueprint step installPlugin', () => {
 
 	it('should install a plugin', async () => {
 		// Create test plugin
-
 		const pluginName = 'test-plugin';
 
 		php.mkdir(`/${pluginName}`);
@@ -28,7 +27,10 @@ describe('Blueprint step installPlugin', () => {
 		const zipFileName = `${pluginName}-0.0.1.zip`;
 
 		await php.run({
-			code: `<?php $zip = new ZipArchive(); $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); $zip->addFile("/${pluginName}/index.php"); $zip->close();`,
+			code: `<?php $zip = new ZipArchive(); 
+						 $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); 
+						 $zip->addFile("/${pluginName}/index.php"); 
+						 $zip->close();`,
 		});
 
 		php.rmdir(`/${pluginName}`);
@@ -62,5 +64,51 @@ describe('Blueprint step installPlugin', () => {
 		php.unlink(zipFileName);
 
 		expect(php.fileExists(`${pluginsPath}/${pluginName}`)).toBe(true);
+	});
+
+	it('should install a plugin even when it is zipped directly without a root-level folder', async () => {
+		// Create test plugin
+		const pluginName = 'test-plugin';
+
+		php.writeFile('/index.php', `/**\n * Plugin Name: Test Plugin`);
+
+		// Note the package name is different from plugin folder name
+		const zipFileName = `${pluginName}-0.0.1.zip`;
+
+		await php.run({
+			code: `<?php $zip = new ZipArchive(); 
+						 $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); 
+						 $zip->addFile("/index.php"); 
+						 $zip->close();`,
+		});
+
+		expect(php.fileExists(zipFileName)).toBe(true);
+
+		// Create plugins folder
+		const rootPath = await php.documentRoot;
+		const pluginsPath = `${rootPath}/wp-content/plugins`;
+
+		php.mkdir(pluginsPath);
+
+		await runBlueprintSteps(
+			compileBlueprint({
+				steps: [
+					{
+						step: 'installPlugin',
+						pluginZipFile: {
+							resource: 'vfs',
+							path: zipFileName,
+						},
+						options: {
+							activate: false,
+						},
+					},
+				],
+			}),
+			php
+		);
+
+		php.unlink(zipFileName);
+		expect(php.fileExists(`${pluginsPath}/${pluginName}-0.0.1`)).toBe(true);
 	});
 });

--- a/packages/playground/website/src/lib/make-blueprint.tsx
+++ b/packages/playground/website/src/lib/make-blueprint.tsx
@@ -52,6 +52,10 @@ function applyGutenbergPRSteps(prNumber: number): StepDefinition[] {
 			path: '/wordpress/pr',
 		},
 		{
+			step: 'mkdir',
+			path: '/tmp',
+		},
+		{
 			step: 'writeFile',
 			path: '/wordpress/pr/pr.zip',
 			data: {

--- a/packages/playground/website/src/lib/make-blueprint.tsx
+++ b/packages/playground/website/src/lib/make-blueprint.tsx
@@ -52,10 +52,6 @@ function applyGutenbergPRSteps(prNumber: number): StepDefinition[] {
 			path: '/wordpress/pr',
 		},
 		{
-			step: 'mkdir',
-			path: '/tmp',
-		},
-		{
 			step: 'writeFile',
 			path: '/wordpress/pr/pr.zip',
 			data: {

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -35,6 +35,7 @@ try {
 		blueprint.preferredVersions!.wp =
 			query.get('wp') || blueprint.preferredVersions!.wp || 'latest';
 	}
+	console.log(blueprint);
 } catch (e) {
 	blueprint = makeBlueprint({
 		php: query.get('php') || '8.0',

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -35,7 +35,6 @@ try {
 		blueprint.preferredVersions!.wp =
 			query.get('wp') || blueprint.preferredVersions!.wp || 'latest';
 	}
-	console.log(blueprint);
 } catch (e) {
 	blueprint = makeBlueprint({
 		php: query.get('php') || '8.0',


### PR DESCRIPTION
The options argument for listFiles was added to BasePHP in #462. This commit adds it to an interface and a Web PHP Endpoint so that it can be used across the board in web and node.js applications

To test, confirm the CI is green.

Note for the future: Ideally something would flash red in the CI if BasePHP interface is updated without adjusting the other to. I completely forgot about them.

cc @eliot-akira 