### PR TITLE
Blueprints: Support zipped assets without top-level folder

### DIFF
--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -164,7 +164,7 @@ export class VFSResource extends Resource {
 
 	/** @inheritDoc */
 	get name() {
-		return this.resource.path;
+		return this.resource.path.split('/').pop() || '';
 	}
 }
 

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -51,8 +51,7 @@ foreach ( ( glob( $plugin_path . '/*.php' ) ?: array() ) as $file ) {
 echo 'NO_ENTRY_FILE';
 `,
 	});
-	if (result.errors) throw new Error(result.errors);
-	if (result.text === 'NO_ENTRY_FILE') {
+	if (result.text.endsWith('NO_ENTRY_FILE')) {
 		throw new Error('Could not find plugin entry file.');
 	}
 };

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
@@ -15,7 +15,6 @@ describe('Blueprint step installPlugin', () => {
 
 	it('should install a plugin', async () => {
 		// Create test plugin
-
 		const pluginName = 'test-plugin';
 
 		php.mkdir(`/${pluginName}`);
@@ -28,7 +27,10 @@ describe('Blueprint step installPlugin', () => {
 		const zipFileName = `${pluginName}-0.0.1.zip`;
 
 		await php.run({
-			code: `<?php $zip = new ZipArchive(); $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); $zip->addFile("/${pluginName}/index.php"); $zip->close();`,
+			code: `<?php $zip = new ZipArchive(); 
+						 $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); 
+						 $zip->addFile("/${pluginName}/index.php"); 
+						 $zip->close();`,
 		});
 
 		php.rmdir(`/${pluginName}`);
@@ -62,5 +64,51 @@ describe('Blueprint step installPlugin', () => {
 		php.unlink(zipFileName);
 
 		expect(php.fileExists(`${pluginsPath}/${pluginName}`)).toBe(true);
+	});
+
+	it('should install a plugin even when it is zipped directly without a root-level folder', async () => {
+		// Create test plugin
+		const pluginName = 'test-plugin';
+
+		php.writeFile('/index.php', `/**\n * Plugin Name: Test Plugin`);
+
+		// Note the package name is different from plugin folder name
+		const zipFileName = `${pluginName}-0.0.1.zip`;
+
+		await php.run({
+			code: `<?php $zip = new ZipArchive(); 
+						 $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); 
+						 $zip->addFile("/index.php"); 
+						 $zip->close();`,
+		});
+
+		expect(php.fileExists(zipFileName)).toBe(true);
+
+		// Create plugins folder
+		const rootPath = await php.documentRoot;
+		const pluginsPath = `${rootPath}/wp-content/plugins`;
+
+		php.mkdir(pluginsPath);
+
+		await runBlueprintSteps(
+			compileBlueprint({
+				steps: [
+					{
+						step: 'installPlugin',
+						pluginZipFile: {
+							resource: 'vfs',
+							path: zipFileName,
+						},
+						options: {
+							activate: false,
+						},
+					},
+				],
+			}),
+			php
+		);
+
+		php.unlink(zipFileName);
+		expect(php.fileExists(`${pluginsPath}/${pluginName}-0.0.1`)).toBe(true);
 	});
 });


### PR DESCRIPTION
Installing a plugin where the plugin files are directly at the top level does not work. This PR assumes that, unless the zip file contains only a single directory, the plugin files start at the top level.

Related: #427

Unit tests included.
Run `npm run dev` and confirm that adding ?gutenberg-pr=47739 to the URL installs the PR.

cc @eliot-akira – I completely missed that case
