### PR TITLE
Meta: Inline CI linting with cache warmup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,15 @@ on:
     pull_request:
 
 jobs:
+    # This step:
+    # * Warms up the node_modules cache
+    # * Performs linting and typechecking
+    #
+    # The linting tasks take ~5s to complete and it doesn't
+    # make sense to separate them into separate steps that would
+    # take ~25s just to run git clone and restore node_modules.
     lint-and-typecheck:
-        name: "Lint and typecheck"
+        name: 'Lint and typecheck'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
@@ -17,14 +24,14 @@ jobs:
             - run: npx nx affected --target=typecheck
     test:
         runs-on: ubuntu-latest
-        needs: [warmup-cache]
+        needs: [lint-and-typecheck]
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare-playground
             - run: npx nx affected --target=test --configuration=ci
     build:
         runs-on: ubuntu-latest
-        needs: [warmup-cache]
+        needs: [lint-and-typecheck]
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare-playground

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,25 +6,14 @@ on:
     pull_request:
 
 jobs:
-    warmup-cache:
+    lint-and-typecheck:
+        name: "Lint and typecheck"
         runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: ./.github/actions/prepare-playground
-    format:
-        runs-on: ubuntu-latest
-        needs: [warmup-cache]
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare-playground
             - run: npx nx format:check || npx prettier --check .
             - run: npx nx affected --target=lint
-    typecheck:
-        runs-on: ubuntu-latest
-        needs: [warmup-cache]
-        steps:
-            - uses: actions/checkout@v3
-            - uses: ./.github/actions/prepare-playground
             - run: npx nx affected --target=typecheck
     test:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## What?

Inlines linting and typechecking with the initial cache warmup in the GitHub workflow file. The linting tasks take ~5s to complete and separating them means they actually take longer to continue because a separate step would require ~25s just to run `git clone` and restore `node_modules` from cache.

## Testing Instructions

Confirm the CI checks under this PR are green