### PR TITLE
PR Previewer: Verify whether PR exists before redirecting

### DIFF
--- a/packages/playground/website/public/gutenberg.css
+++ b/packages/playground/website/public/gutenberg.css
@@ -31,7 +31,6 @@ input[type='text'] {
 	padding: 5px 8px;
 	outline: 0;
 	font-size: 26px;
-
 }
 input[type='text']::-webkit-inner-spin-button,
 input[type='text']::-webkit-outer-spin-button {
@@ -142,51 +141,50 @@ button:focus {
 #error {
 	text-align: center;
 	padding: 0 10px;
-    margin-bottom: 5vh;
-    color: #8b0000;
-    font-weight: bold;
-    font-size: 1.5em;
+	margin-bottom: 5vh;
+	color: #8b0000;
+	font-weight: bold;
+	font-size: 1.5em;
 }
 
 #submit {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 #submit:not(.loading) .verifying {
-    display: none;
+	display: none;
 }
 #submit.loading .go {
-    display: none;
+	display: none;
 }
 
 #submit.loading {
-    position: relative;
-    background: #00435d;
-    border-color: #00435d;
-    cursor: default;
+	position: relative;
+	background: #00435d;
+	border-color: #00435d;
+	cursor: default;
 }
 
 #submit.loading:before {
-    content: '';
-    /* position: absolute;
+	content: '';
+	/* position: absolute;
     top: 0;
     left: 0; */
-    margin-right: 5px;
-    margin-left: -5px;
-    width: 15px;
-    height: 15px;
-    border-radius: 50%;
-    border: 2px solid #fff;
-    border-top-color: transparent;
-    border-right-color: transparent;
-    animation: spin 1s linear infinite;
+	margin-right: 5px;
+	margin-left: -5px;
+	width: 15px;
+	height: 15px;
+	border-radius: 50%;
+	border: 2px solid #fff;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	animation: spin 1s linear infinite;
 }
 
 @keyframes spin {
-    to {
-        transform: rotate(360deg);
-    }
+	to {
+		transform: rotate(360deg);
+	}
 }

--- a/packages/playground/website/public/gutenberg.css
+++ b/packages/playground/website/public/gutenberg.css
@@ -30,7 +30,8 @@ input[type='text'] {
 	border-radius: 4px;
 	padding: 5px 8px;
 	outline: 0;
-	font-size: 16px;
+	font-size: 26px;
+
 }
 input[type='text']::-webkit-inner-spin-button,
 input[type='text']::-webkit-outer-spin-button {
@@ -47,14 +48,14 @@ input[type='text']:focus {
 button {
 	border-radius: 3px;
 	vertical-align: top;
-	height: 30px;
-	line-height: 28px;
-	padding: 0 12px 2px;
+	height: 40px;
+	line-height: 38px;
+	padding: 0 12px;
 	webkit-appearance: none;
 	border: 0;
 	cursor: pointer;
 	display: inline-flex;
-	font-size: 13px;
+	font-size: 30px;
 	margin: 0;
 	background: #0085ba;
 	border-color: #006a95 #00648c #00648c;
@@ -105,7 +106,7 @@ button:focus {
 	align-items: center;
 }
 #gutenberg-pr {
-	width: 60px;
+	width: 80px;
 	margin-right: 4px;
 }
 #run {
@@ -134,7 +135,58 @@ button:focus {
 	background: #191e23;
 	transition: width 0.6s ease-in-out;
 }
-.links {
+#links {
 	text-align: center;
 	padding: 0 10px;
+}
+#error {
+	text-align: center;
+	padding: 0 10px;
+    margin-bottom: 5vh;
+    color: #8b0000;
+    font-weight: bold;
+    font-size: 1.5em;
+}
+
+#submit {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+}
+
+#submit:not(.loading) .verifying {
+    display: none;
+}
+#submit.loading .go {
+    display: none;
+}
+
+#submit.loading {
+    position: relative;
+    background: #00435d;
+    border-color: #00435d;
+    cursor: default;
+}
+
+#submit.loading:before {
+    content: '';
+    /* position: absolute;
+    top: 0;
+    left: 0; */
+    margin-right: 5px;
+    margin-left: -5px;
+    width: 15px;
+    height: 15px;
+    border-radius: 50%;
+    border: 2px solid #fff;
+    border-top-color: transparent;
+    border-right-color: transparent;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
 }

--- a/packages/playground/website/public/gutenberg.css
+++ b/packages/playground/website/public/gutenberg.css
@@ -20,7 +20,7 @@ svg {
 }
 label {
 	margin-bottom: 4px;
-	font-size: 13px;
+	font-size: 16px;
 }
 input[type='text'] {
 	appearance: none;
@@ -105,7 +105,7 @@ button:focus {
 	align-items: center;
 }
 #gutenberg-pr {
-	width: 80px;
+	width: 280px;
 	margin-right: 4px;
 }
 #run {

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -27,7 +27,7 @@
 			action="https://playground.wordpress.net"
 			method="GET"
 		>
-			<label for="gutenberg-pr">Pull request:</label>
+			<label for="gutenberg-pr">Pull request number or URL:</label>
 			<div id="createFields">
 				<input
 					id="gutenberg-pr"
@@ -105,7 +105,8 @@
 
 			// Verify that the PR exists and that GitHub CI finished building it
 			const zipArtifactUrl = `/plugin-proxy?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
-			const response = await fetch(zipArtifactUrl + '&mode=verify');
+			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
+			const response = await fetch(zipArtifactUrl, { method: 'HEAD' });
 			if (response.status !== 200) {
 				errorDiv.innerText = `The PR ${prNumber} does not exist or GitHub CI did not finish building it yet.`;
 				submitting = false;

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -37,12 +37,16 @@
 					required
 					autofocus
 				/>
-				<button>Go</button>
+				<button id="submit">
+					<span class="go">Go</span>
+					<span class="verifying">Verifying</span>
+				</button>
 			</div>
 		</form>
+		<div id="error"></div>
 	</div>
 
-	<div class="links">
+	<div id="links">
 		Powered by
 		<a href="https://developer.wordpress.org/playground">
 			WordPress Playground
@@ -72,9 +76,22 @@
 		 * * https://wordpress.github.io/wordpress-playground/docs/build-your-first-app#preview-pull-requests-from-your-repository
 		 */
 
-		document.getElementById('create').addEventListener('submit', previewPr);
-		function previewPr(e) {
+		let submitting = false;
+		const submitButton = document.getElementById('submit');
+		const form = document.getElementById('create');
+		const errorDiv = document.getElementById('error');
+
+		form.addEventListener('submit', async function previewPr(e) {
 			e.preventDefault();
+			if (submitting) {
+				return;
+			}
+
+			submitting = true;
+			errorDiv.innerText = '';
+			submitButton.classList.add('loading');
+			submitButton.disabled = true;
+
 			let prNumber = document.getElementById('gutenberg-pr').value;
 
 			// Extract number from a GitHub URL
@@ -85,6 +102,18 @@
 			) {
 				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
 			}
+
+			const zipArtifactUrl = `/plugin-proxy?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
+			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
+			const response = await fetch(zipArtifactUrl, { method: 'HEAD' });
+			if (response.status !== 200) {
+				errorDiv.innerText = `The PR ${prNumber} does not exist or GitHub CI did not finish building it yet.`;
+				submitting = false;
+				submitButton.classList.remove('loading');
+				submitButton.disabled = false;
+				return;
+			}
+
 			const blueprint = {
 				landingPage: '/wp-admin/',
 				steps: [
@@ -111,7 +140,7 @@
 						path: '/wordpress/pr/pr.zip',
 						data: {
 							resource: 'url',
-							url: `/plugin-proxy?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`,
+							url: zipArtifactUrl,
 							caption: `Downloading Gutenberg PR ${prNumber}`,
 						},
 						progress: {
@@ -147,6 +176,6 @@
 			};
 			const encoded = JSON.stringify(blueprint);
 			window.location = '/#' + encodeURI(encoded);
-		}
+		});
 	</script>
 </body>

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -103,9 +103,9 @@
 				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
 			}
 
+			// Verify that the PR exists and that GitHub CI finished building it
 			const zipArtifactUrl = `/plugin-proxy?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
-			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
-			const response = await fetch(zipArtifactUrl, { method: 'HEAD' });
+			const response = await fetch(zipArtifactUrl + '&mode=verify');
 			if (response.status !== 200) {
 				errorDiv.innerText = `The PR ${prNumber} does not exist or GitHub CI did not finish building it yet.`;
 				submitting = false;
@@ -114,6 +114,7 @@
 				return;
 			}
 
+			// Redirect to the Playground site with the Blueprint to download and apply the PR
 			const blueprint = {
 				landingPage: '/wp-admin/',
 				steps: [

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -78,8 +78,12 @@ class PluginDownloader
                 continue;
             }
 
-            // If HTTP method is HEAD or OPTIONS, just say it's 200 OK
-            if ($_SERVER['REQUEST_METHOD'] === 'HEAD' || $_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+            /*
+             * Short-circuit if we only want to verify whether the CI 
+             * artifact seems to exist.
+             */
+            $mode = $_GET['mode'] ?? 'download';
+            if ($mode === 'verify') {
                 header('HTTP/1.1 200 OK');
                 return;
             }

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -78,6 +78,12 @@ class PluginDownloader
                 continue;
             }
 
+            // If HTTP method is HEAD or OPTIONS, just say it's 200 OK
+            if ($_SERVER['REQUEST_METHOD'] === 'HEAD' || $_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+                header('HTTP/1.1 200 OK');
+                return;
+            }
+
             $allowed_headers = array(
                 'content-length',
                 'content-disposition',

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -79,11 +79,11 @@ class PluginDownloader
             }
 
             /*
-             * Short-circuit if we only want to verify whether the CI 
-             * artifact seems to exist.
+             * HEAD method is used when we only want to verify whether the CI 
+             * artifact seems to exist – we don't want to download it. Let's
+             * short-circuit with HTTP 200 OK.
              */
-            $mode = $_GET['mode'] ?? 'download';
-            if ($mode === 'verify') {
+            if ($_SERVER['REQUEST_METHOD'] === 'HEAD') {
                 header('HTTP/1.1 200 OK');
                 return;
             }


### PR DESCRIPTION
Pasting a PR number that doesn't exist or has no GitHub CI artifact available
was a confusing experience where the Playground started but the PR was
not applied. This commit adds a check and an informative error message
to avoid the confusion.

<img width="1184" alt="CleanShot 2023-06-02 at 13 23 52@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/dd02fdc9-8d9c-4b3a-8e97-2a7dc82737f1">

## Testing instructions:

1. `npm run dev`
2. Go to http://localhost:5400/gutenberg.html
3. Use a PR that doesn't exist or has no artifact
4. Confirm the error is there
5. Use a PR that exists and finished building
6. Confirm you're redirected to Playground

