### PR TITLE
Meta: Remove the automated formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare-playground
-            - run: npx nx format:check || npx prettier --check .
             - run: npx nx affected --target=lint
             - run: npx nx affected --target=typecheck
     test:


### PR DESCRIPTION
The automated formatting check requires frequent revisions over minor issues like an extra space in a markdown document, without offering much in return. An occasional difference in formatting style is fine as long as it self-corrects in the long run – and that's what the pre-commit formatting check should take care of.

This is an experimental change and we may have to roll it back or course-correct if I'm wrong about the self-correcting aspect and the overall formatting gets wildly out of hand.

That being said, let's give it a try and see how it works.

## Testing Instructions

Confirm the CI workflow doesn't check code formatting