### PR TITLE
Automated deployments to playground.wordpress.net

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,30 @@
+name: Deploy new website to playground.wordpress.net
+
+on:
+    workflow_dispatch:
+
+jobs:
+    build_and_deploy:
+        # Specify runner + deployment step
+        runs-on: ubuntu-latest
+        environment:
+            name: playground-wordpress-net
+        steps:
+            - uses: actions/checkout@v3
+            - uses: ./.github/actions/prepare-playground
+            - run: npm run build
+            - run: tar -czf wasm-wordpress-net.tar.gz dist/packages/playground/wasm-wordpress-net
+            # Store dist/packages/artifacts/wasm-wordpress-net as a build artifact
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: playground-website
+                  path: wasm-wordpress-net.tar.gz
+            # Deploy the playground.wordpress.net website by
+            # sending a CURL request to https://playground.wordpress.net/webhook.php with a header
+            # like X-Deployment-Token that has the same value as github secret DEPLOY_AUTH_TOKEN
+            - name: Deploy
+              shell: bash
+              run: |
+                  curl -X POST https://playground.wordpress.net/webhook.php \
+                      -H "X-Deployment-Token: ${{ secrets.DEPLOYMENT_KEY }}" \
+                      -H "Content-Type: application/json"

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules
 # IDEs and editors
 /.idea
 /.local
+/.playground-private
 .project
 .classpath
 .c9/


### PR DESCRIPTION
Add a custom deployment workflow to deploy WordPress Playground website

Solves https://github.com/WordPress/wordpress-playground/issues/171 and gives core contributors the ability to deploy a fresh build of https://playground.wordpress.net/. For now this is triggered manually or once a day. Let's discuss an automated deployment strategy once it's needed.

## Testing instructions

None! :-( I'll just merge this, try to run it from `trunk`, and hope for the best.

Solves https://github.com/WordPress/wordpress-playground/issues/171