### PR TITLE
Pretend to activate plugin inside wp-admin

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -34,6 +34,7 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 
 	const result = await playground.run({
 		code: `<?php
+define( 'WP_ADMIN', true );
 ${requiredFiles.map((file) => `require_once( '${file}' );`).join('\n')}
 $plugin_path = '${pluginPath}';
 if (!is_dir($plugin_path)) {

--- a/packages/playground/blueprints/src/lib/steps/activate-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.ts
@@ -25,8 +25,9 @@ export const activateTheme: StepHandler<ActivateThemeStep> = async (
 	}
 	await playground.run({
 		code: `<?php
-      require_once( '${wpLoadPath}' );
-      switch_theme( '${themeFolderName}' );
-      `,
+define( 'WP_ADMIN', true );
+require_once( '${wpLoadPath}' );
+switch_theme( '${themeFolderName}' );
+`,
 	});
 };


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?

Plugins should be activated inside wp-admin.

## Why?

Breaks some plugin activation, see #523 

## How?

By defining `WP_ADMIN` so that `is_admin()` evaluates to true.

## Testing Instructions

Since [wp-now also uses the blueprint activate functions](https://github.com/WordPress/playground-tools/blob/trunk/packages/wp-now/src/wp-now.ts#L11), you can use `wp-now start` in a GlotPress directory and observe the tables to be created after this patch.