### PR TITLE
Make iframe reference actually work

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/02-using-blueprints.md
+++ b/packages/docs/site/docs/09-blueprints-api/02-using-blueprints.md
@@ -41,12 +41,12 @@ You won't have to paste links to follow along. We'll use code examples with a "T
 You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen:
 
 ```html
-<iframe id="wp" style="width: 1200px; height: 800px"></iframe>
+<iframe id="wp-playground" style="width: 1200px; height: 800px"></iframe>
 <script type="module">
 	import { startPlaygroundWeb } from 'https://unpkg.com/@wp-playground/client/index.js';
 
 	const client = await startPlaygroundWeb({
-		iframe,
+		iframe: document.getElementById('wp-playground'),
 		remoteUrl: `https://playground.wordpress.net/remote.html`,
 		blueprint: {
 			landingPage: '/wp-admin/',


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?
## Why?

The `iframe` reference in the code example doesn't work without this change. Also gave it a slightly less generic `id` so as not to clash with other stuff.

## How?

Fixing it.

## Testing Instructions

1. Try the code
2. See it fails
3. Apply the change
4. See it works