### PR TITLE
Reference maintainer group in CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,1 @@
-/* @adamziel
-/.github @adamziel
-/.husky @adamziel
-/.vscode @adamziel
-/tools @adamziel
-/packages/docs  @adamziel
-/packages/nx-extensions  @adamziel
-/packages/php-wasm  @adamziel
-/packages/playground  @adamziel
+/* @WordPress/playground-maintainers


### PR DESCRIPTION
## What?

Update the CODEOWNERS file to reference a group instead of individuals.

## Why?

Groups remain persistent as people join and leave the project. This makes it possible to administer the approving group through Github's interface without making separate commits to update this file.