### PR TITLE
Serve all assets in dev build from same origin

### DIFF
--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -28,8 +28,7 @@
 				},
 				"development-for-website": {
 					"buildTarget": "playground-remote:build:development",
-					"hmr": true,
-					"logLevel": "silent"
+					"hmr": true
 				},
 				"production": {
 					"buildTarget": "playground-remote:build:production",

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -47,7 +47,7 @@
 			"options": {
 				"commands": [
 					"nx dev playground-remote --configuration=development-for-website",
-					"nx dev:standalone playground-website --hmr --output-style=stream-without-prefixes"
+					"sleep 1; nx dev:standalone playground-website --hmr --output-style=stream-without-prefixes"
 				],
 				"parallel": true,
 				"color": true

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -35,6 +35,11 @@ const proxy = {
 			throw new Error('Invalid request');
 		},
 	},
+	// Proxy requests to the remote content through this server for dev builds.
+	// See base config below.
+	'^[/]((?!website-server).)': {
+		target: `http://${remoteDevServerHost}:${remoteDevServerPort}`,
+	},
 };
 
 let buildVersion: string;
@@ -50,8 +55,14 @@ export default defineConfig(({ command }) => {
 			? // In production, both the website and the playground are served from the same domain.
 			  process?.env?.ORIGIN || 'https://playground.wordpress.net/'
 			: // In dev, the website and the playground are served from different domains.
-			  `http://${remoteDevServerHost}:${remoteDevServerPort}`;
+			  `http://${websiteDevServerHost}:${websiteDevServerPort}`;
 	return {
+		// Split traffic from this server on dev so that the iframe content and outer
+		// content can be served from the same origin. In production it's already
+		// the same host, but dev builds run two separate servers.
+		// See proxy config above.
+		base: command === 'build' ? '/' : '/website-server/',
+
 		cacheDir: '../../../node_modules/.vite/packages-playground-website',
 
 		css: {
@@ -78,6 +89,9 @@ export default defineConfig(({ command }) => {
 				'Cross-Origin-Embedder-Policy': 'credentialless',
 			},
 			proxy,
+			fs: {
+				strict: false, // Serve files from the other project directories.
+			},
 		},
 
 		plugins: [


### PR DESCRIPTION
When mounting local directories in #548, problems appeared in development builds because the dev environemnt runs a separate server for the website that wraps the iframe and the for the assets inside the iframe, the "remote."

In this patch we're adjusting the config for the outer website server so that we can proxy requests for the internal frame through the same origin. This is done by adding a prefix to the URL for the dev assets on the outer frame, which then is used in a proxy rule to decide what to route.

This means that OPFS handles can be shared between the two sides of the iframe, which normally happens in production since they both come from the same origin.