### PR TITLE
[Web] Don't force-reload the Service Worker

### DIFF
--- a/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
+++ b/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
@@ -170,8 +170,7 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 				message,
 			}
 		);
-		const requestId = await broadcastMessageExpectReply(message, scope);
-		phpResponse = await awaitReply(self, requestId);
+		phpResponse = await broadcastMessageAwaitReply(message, scope);
 
 		// X-frame-options gets in a way when PHP is
 		// being displayed in an iframe.
@@ -210,8 +209,18 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
  * @param  scope   Target worker thread scope.
  * @returns The request ID to receive the reply.
  */
-export async function broadcastMessageExpectReply(message: any, scope: string) {
+export async function broadcastMessageAwaitReply(message: any, scope: string) {
 	const requestId = getNextRequestId();
+	console.log(
+		'broadcastMessageAwaitReply(',
+		message,
+		scope,
+		') {requestId: ',
+		requestId,
+		'}'
+	);
+	const responsePromise = awaitReply(self, requestId);
+
 	for (const client of await self.clients.matchAll({
 		// Sometimes the client that triggered the current fetch()
 		// event is considered uncontrolled in Google Chrome. This
@@ -232,7 +241,11 @@ export async function broadcastMessageExpectReply(message: any, scope: string) {
 			requestId,
 		});
 	}
-	return requestId;
+
+	console.log('pre await responsePromise');
+	const response = await responsePromise;
+	console.log('post await responsePromise', response);
+	return response;
 }
 
 interface ServiceWorkerConfiguration {

--- a/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
+++ b/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
@@ -170,7 +170,8 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 				message,
 			}
 		);
-		phpResponse = await broadcastMessageAwaitReply(message, scope);
+		const requestId = await broadcastMessageExpectReply(message, scope);
+		phpResponse = await awaitReply(self, requestId);
 
 		// X-frame-options gets in a way when PHP is
 		// being displayed in an iframe.
@@ -209,18 +210,8 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
  * @param  scope   Target worker thread scope.
  * @returns The request ID to receive the reply.
  */
-export async function broadcastMessageAwaitReply(message: any, scope: string) {
+export async function broadcastMessageExpectReply(message: any, scope: string) {
 	const requestId = getNextRequestId();
-	console.log(
-		'broadcastMessageAwaitReply(',
-		message,
-		scope,
-		') {requestId: ',
-		requestId,
-		'}'
-	);
-	const responsePromise = awaitReply(self, requestId);
-
 	for (const client of await self.clients.matchAll({
 		// Sometimes the client that triggered the current fetch()
 		// event is considered uncontrolled in Google Chrome. This
@@ -241,11 +232,7 @@ export async function broadcastMessageAwaitReply(message: any, scope: string) {
 			requestId,
 		});
 	}
-
-	console.log('pre await responsePromise');
-	const response = await responsePromise;
-	console.log('post await responsePromise', response);
-	return response;
+	return requestId;
 }
 
 interface ServiceWorkerConfiguration {

--- a/packages/php-wasm/web-service-worker/src/messaging.ts
+++ b/packages/php-wasm/web-service-worker/src/messaging.ts
@@ -1,6 +1,68 @@
-const DEFAULT_RESPONSE_TIMEOUT = 5000;
+const DEFAULT_RESPONSE_TIMEOUT = 25000;
 
 let lastRequestId = 0;
+
+/**
+ * Posts a message branded with a unique `requestId` to the given `target`.
+ * Then returns the `requestId` so it can be used to await a reply.
+ * Effectively, it implements the request/response dynamics on
+ * of JavaScript's `postMessage`
+ *
+ * @example
+ *
+ * In the main app:
+ *
+ * ```js
+ * import { postMessageExpectReply, awaitReply } from 'php-wasm-browser';
+ * const iframeWindow = iframe.contentWindow;
+ * const requestId = postMessageExpectReply(iframeWindow, {
+ *    type: "get_php_version"
+ * });
+ * const response = await awaitReply(iframeWindow, requestId);
+ * console.log(response);
+ * // "8.0.24"
+ * ```
+ *
+ * In the iframe:
+ *
+ * ```js
+ * import { responseTo } from 'php-wasm-browser';
+ * window.addEventListener('message', (event) => {
+ *    let response = '8.0.24';
+ *    if(event.data.type === 'get_php_version') {
+ *       response = '8.0.24';
+ *    } else {
+ *       throw new Error(`Unexpected message type: ${event.data.type}`);
+ *    }
+ *
+ *    // When `requestId` is present, the other thread expects a response:
+ *    if (event.data.requestId) {
+ *       const response = responseTo(event.data.requestId, response);
+ *       window.parent.postMessage(response, event.origin);
+ *    }
+ * });
+ * ```
+ *
+ * @param  target          An object that has a `postMessage` method.
+ * @param  message         A key-value object that can be serialized to JSON.
+ * @param  postMessageArgs Additional arguments to pass to `postMessage`.
+ * @returns The message ID for awaitReply().
+ */
+export function postMessageExpectReply(
+	target: PostMessageTarget,
+	message: Record<string, any>,
+	...postMessageArgs: any[]
+): number {
+	const requestId = getNextRequestId();
+	target.postMessage(
+		{
+			...message,
+			requestId,
+		},
+		...postMessageArgs
+	);
+	return requestId;
+}
 
 export function getNextRequestId() {
 	return ++lastRequestId;
@@ -23,11 +85,8 @@ export function awaitReply(
 	requestId: number,
 	timeout: number = DEFAULT_RESPONSE_TIMEOUT
 ): Promise<any> {
-	console.log(`called awaitReply(..., ${requestId}, ${timeout})`);
 	return new Promise((resolve, reject) => {
-		console.log('I am in a promise', { requestId });
 		const responseHandler = (event: MessageEvent) => {
-			console.log('responseHandler(', event, ')');
 			if (
 				event.data.type === 'response' &&
 				event.data.requestId === requestId
@@ -39,14 +98,11 @@ export function awaitReply(
 		};
 
 		const failOntimeout = setTimeout(() => {
-			console.log('failOntimeout()');
 			reject(new Error('Request timed out'));
 			messageTarget.removeEventListener('message', responseHandler);
 		}, timeout);
 
-		console.log('pre messageTarget.addEventListener');
 		messageTarget.addEventListener('message', responseHandler);
-		console.log('post messageTarget.addEventListener');
 	});
 }
 
@@ -74,6 +130,10 @@ export interface MessageResponse<T> {
 	type: 'response';
 	requestId: number;
 	response: T;
+}
+
+interface PostMessageTarget {
+	postMessage(message: any, ...args: any[]): void;
 }
 
 interface IsomorphicEventTarget {

--- a/packages/php-wasm/web-service-worker/src/messaging.ts
+++ b/packages/php-wasm/web-service-worker/src/messaging.ts
@@ -1,68 +1,6 @@
-const DEFAULT_RESPONSE_TIMEOUT = 25000;
+const DEFAULT_RESPONSE_TIMEOUT = 5000;
 
 let lastRequestId = 0;
-
-/**
- * Posts a message branded with a unique `requestId` to the given `target`.
- * Then returns the `requestId` so it can be used to await a reply.
- * Effectively, it implements the request/response dynamics on
- * of JavaScript's `postMessage`
- *
- * @example
- *
- * In the main app:
- *
- * ```js
- * import { postMessageExpectReply, awaitReply } from 'php-wasm-browser';
- * const iframeWindow = iframe.contentWindow;
- * const requestId = postMessageExpectReply(iframeWindow, {
- *    type: "get_php_version"
- * });
- * const response = await awaitReply(iframeWindow, requestId);
- * console.log(response);
- * // "8.0.24"
- * ```
- *
- * In the iframe:
- *
- * ```js
- * import { responseTo } from 'php-wasm-browser';
- * window.addEventListener('message', (event) => {
- *    let response = '8.0.24';
- *    if(event.data.type === 'get_php_version') {
- *       response = '8.0.24';
- *    } else {
- *       throw new Error(`Unexpected message type: ${event.data.type}`);
- *    }
- *
- *    // When `requestId` is present, the other thread expects a response:
- *    if (event.data.requestId) {
- *       const response = responseTo(event.data.requestId, response);
- *       window.parent.postMessage(response, event.origin);
- *    }
- * });
- * ```
- *
- * @param  target          An object that has a `postMessage` method.
- * @param  message         A key-value object that can be serialized to JSON.
- * @param  postMessageArgs Additional arguments to pass to `postMessage`.
- * @returns The message ID for awaitReply().
- */
-export function postMessageExpectReply(
-	target: PostMessageTarget,
-	message: Record<string, any>,
-	...postMessageArgs: any[]
-): number {
-	const requestId = getNextRequestId();
-	target.postMessage(
-		{
-			...message,
-			requestId,
-		},
-		...postMessageArgs
-	);
-	return requestId;
-}
 
 export function getNextRequestId() {
 	return ++lastRequestId;
@@ -85,8 +23,11 @@ export function awaitReply(
 	requestId: number,
 	timeout: number = DEFAULT_RESPONSE_TIMEOUT
 ): Promise<any> {
+	console.log(`called awaitReply(..., ${requestId}, ${timeout})`);
 	return new Promise((resolve, reject) => {
+		console.log('I am in a promise', { requestId });
 		const responseHandler = (event: MessageEvent) => {
+			console.log('responseHandler(', event, ')');
 			if (
 				event.data.type === 'response' &&
 				event.data.requestId === requestId
@@ -98,11 +39,14 @@ export function awaitReply(
 		};
 
 		const failOntimeout = setTimeout(() => {
+			console.log('failOntimeout()');
 			reject(new Error('Request timed out'));
 			messageTarget.removeEventListener('message', responseHandler);
 		}, timeout);
 
+		console.log('pre messageTarget.addEventListener');
 		messageTarget.addEventListener('message', responseHandler);
+		console.log('post messageTarget.addEventListener');
 	});
 }
 
@@ -130,10 +74,6 @@ export interface MessageResponse<T> {
 	type: 'response';
 	requestId: number;
 	response: T;
-}
-
-interface PostMessageTarget {
-	postMessage(message: any, ...args: any[]): void;
 }
 
 interface IsomorphicEventTarget {

--- a/packages/php-wasm/web/src/lib/api.ts
+++ b/packages/php-wasm/web/src/lib/api.ts
@@ -148,9 +148,11 @@ function setupTransferHandlers() {
 			'exitCode' in obj &&
 			'httpStatusCode' in obj,
 		serialize(obj: PHPResponse): [PHPResponseData, Transferable[]] {
+			console.log('Serializing');
 			return [obj.toRawData(), []];
 		},
 		deserialize(responseData: PHPResponseData): PHPResponse {
+			console.log('Deerializing');
 			return PHPResponse.fromRawData(responseData);
 		},
 	});

--- a/packages/php-wasm/web/src/lib/api.ts
+++ b/packages/php-wasm/web/src/lib/api.ts
@@ -148,11 +148,9 @@ function setupTransferHandlers() {
 			'exitCode' in obj &&
 			'httpStatusCode' in obj,
 		serialize(obj: PHPResponse): [PHPResponseData, Transferable[]] {
-			console.log('Serializing');
 			return [obj.toRawData(), []];
 		},
 		deserialize(responseData: PHPResponseData): PHPResponse {
-			console.log('Deerializing');
 			return PHPResponse.fromRawData(responseData);
 		},
 	});

--- a/packages/php-wasm/web/src/lib/register-service-worker.ts
+++ b/packages/php-wasm/web/src/lib/register-service-worker.ts
@@ -28,36 +28,14 @@ export async function registerServiceWorker<
 					`(expected version: ${expectedVersion}, registered version: ${actualVersion})`
 			);
 			for (const registration of registrations) {
-				let unregister = false;
+				registration.unregister();
 				try {
 					await registration.update();
-				} catch (e) {
-					// If the worker registration cannot be updated,
-					// we're probably seeing a blank page in the dev
-					// mode. Let's unregister the worker and reload
-					// the page.
-					unregister = true;
-				}
-				const waitingWorker =
-					registration.waiting || registration.installing;
-				if (waitingWorker && !unregister) {
-					if (actualVersion !== null) {
-						// If the worker exposes a version, it supports
-						// a "skip-waiting" message – let's force it to
-						// skip waiting.
-						waitingWorker.postMessage('skip-waiting');
-					} else {
-						// If the version is not exposed, we can't force
-						// the worker to skip waiting – let's unregister
-						// and reload the page.
-						unregister = true;
-					}
-				}
-				if (unregister) {
-					await registration.unregister();
-					window.location.reload();
+				} catch(e) {
+					console.warn(`[window] Failed to update the Service Worker registration:`, e);
 				}
 			}
+			window.location.reload();
 		}
 	} else {
 		console.debug(

--- a/packages/php-wasm/web/src/lib/register-service-worker.ts
+++ b/packages/php-wasm/web/src/lib/register-service-worker.ts
@@ -28,14 +28,20 @@ export async function registerServiceWorker<
 					`(expected version: ${expectedVersion}, registered version: ${actualVersion})`
 			);
 			for (const registration of registrations) {
-				registration.unregister();
 				try {
-					await registration.update();
-				} catch(e) {
-					console.warn(`[window] Failed to update the Service Worker registration:`, e);
+					await registration.unregister();
+					const waitingWorker =
+						registration.waiting || registration.installing;
+					waitingWorker?.postMessage('skip-waiting');
+				} catch (e) {
+					console.warn(
+						`[window] Failed to update the Service Worker registration:`,
+						e
+					);
 				}
 			}
-			window.location.reload();
+			console.log(' Window location reload...? ');
+			window.parent.location.reload();
 		}
 	} else {
 		console.debug(

--- a/packages/php-wasm/web/src/lib/web-php-endpoint.ts
+++ b/packages/php-wasm/web/src/lib/web-php-endpoint.ts
@@ -93,7 +93,10 @@ export class WebPHPEndpoint implements IsomorphicLocalPHP {
 
 	/** @inheritDoc @php-wasm/universal!RequestHandler.request */
 	request(request: PHPRequest, redirects?: number): Promise<PHPResponse> {
-		return _private.get(this)!.php.request(request, redirects);
+		console.log('Got request', request, { redirects });
+		const resp = _private.get(this)!.php.request(request, redirects);
+		console.log(resp.then((r) => console.log(r)));
+		return resp;
 	}
 
 	/** @inheritDoc @php-wasm/web!WebPHP.run */

--- a/packages/php-wasm/web/src/lib/web-php-endpoint.ts
+++ b/packages/php-wasm/web/src/lib/web-php-endpoint.ts
@@ -93,10 +93,7 @@ export class WebPHPEndpoint implements IsomorphicLocalPHP {
 
 	/** @inheritDoc @php-wasm/universal!RequestHandler.request */
 	request(request: PHPRequest, redirects?: number): Promise<PHPResponse> {
-		console.log('Got request', request, { redirects });
-		const resp = _private.get(this)!.php.request(request, redirects);
-		console.log(resp.then((r) => console.log(r)));
-		return resp;
+		return _private.get(this)!.php.request(request, redirects);
 	}
 
 	/** @inheritDoc @php-wasm/web!WebPHP.run */

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -122,10 +122,8 @@ export function compileBlueprint(
 				}
 
 				for (const { run, step } of compiled) {
-					console.log('before run', { run, step });
 					const result = await run(playground);
 					onStepCompleted(result, step);
-					console.log('after run', { result, step });
 				}
 				try {
 					await (playground as any).goTo(
@@ -142,7 +140,6 @@ export function compileBlueprint(
 			} finally {
 				progress.finish();
 			}
-			console.log('Fnished');
 		},
 	};
 }

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -122,8 +122,10 @@ export function compileBlueprint(
 				}
 
 				for (const { run, step } of compiled) {
+					console.log('before run', { run, step });
 					const result = await run(playground);
 					onStepCompleted(result, step);
+					console.log('after run', { result, step });
 				}
 				try {
 					await (playground as any).goTo(
@@ -140,6 +142,7 @@ export function compileBlueprint(
 			} finally {
 				progress.finish();
 			}
+			console.log('Fnished');
 		},
 	};
 }

--- a/packages/playground/blueprints/src/lib/steps/login.ts
+++ b/packages/playground/blueprints/src/lib/steps/login.ts
@@ -36,9 +36,14 @@ export const login: StepHandler<LoginStep> = async (
 	progress
 ) => {
 	progress?.tracker.setCaption(progress?.initialCaption || 'Logging in');
+	console.log('Before request');
+	playground.request({
+		url: '/wp-login.php',
+	});
 	await playground.request({
 		url: '/wp-login.php',
 	});
+	console.log('after request');
 
 	await playground.request({
 		url: '/wp-login.php',

--- a/packages/playground/blueprints/src/lib/steps/login.ts
+++ b/packages/playground/blueprints/src/lib/steps/login.ts
@@ -36,14 +36,9 @@ export const login: StepHandler<LoginStep> = async (
 	progress
 ) => {
 	progress?.tracker.setCaption(progress?.initialCaption || 'Logging in');
-	console.log('Before request');
-	playground.request({
-		url: '/wp-login.php',
-	});
 	await playground.request({
 		url: '/wp-login.php',
 	});
-	console.log('after request');
 
 	await playground.request({
 		url: '/wp-login.php',

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -108,21 +108,15 @@ async function doStartPlaygroundWeb(
 
 	// Connect the Comlink client and wait until the
 	// playground is ready.
-	console.log('Pre consume API');
 	const playground = consumeAPI<PlaygroundClient>(
 		iframe.contentWindow!
 	) as PlaygroundClient;
-	console.log('Post consume API');
 	await playground.isConnected();
-	console.log('isConnected()');
 	progressTracker.pipe(playground);
 	const downloadPHPandWP = progressTracker.stage();
 	await playground.onDownloadProgress(downloadPHPandWP.loadingListener);
-	console.log('downloadProgress()');
 	await playground.isReady();
-	console.log('ready()');
 	downloadPHPandWP.finish();
-	console.log('finish()');
 	return playground;
 }
 

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -108,15 +108,21 @@ async function doStartPlaygroundWeb(
 
 	// Connect the Comlink client and wait until the
 	// playground is ready.
+	console.log('Pre consume API');
 	const playground = consumeAPI<PlaygroundClient>(
 		iframe.contentWindow!
 	) as PlaygroundClient;
+	console.log('Post consume API');
 	await playground.isConnected();
+	console.log('isConnected()');
 	progressTracker.pipe(playground);
 	const downloadPHPandWP = progressTracker.stage();
 	await playground.onDownloadProgress(downloadPHPandWP.loadingListener);
+	console.log('downloadProgress()');
 	await playground.isReady();
+	console.log('ready()');
 	downloadPHPandWP.finish();
+	console.log('finish()');
 	return playground;
 }
 

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -28,7 +28,8 @@
 				},
 				"development-for-website": {
 					"buildTarget": "playground-remote:build:development",
-					"hmr": true
+					"hmr": true,
+					"logLevel": "silent"
 				},
 				"production": {
 					"buildTarget": "playground-remote:build:production",

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -28,8 +28,7 @@
 				},
 				"development-for-website": {
 					"buildTarget": "playground-remote:build:development",
-					"hmr": true,
-					"logLevel": "silent"
+					"hmr": true
 				},
 				"production": {
 					"buildTarget": "playground-remote:build:production",

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -13,9 +13,6 @@ import {
 } from '@php-wasm/web-service-worker';
 import { isUploadedFilePath } from './src/lib/is-uploaded-file-path';
 
-// @ts-ignore
-import { serviceWorkerVersion } from 'virtual:service-worker-version';
-
 if (!(self as any).document) {
 	// Workaround: vite translates import.meta.url
 	// to document.currentScript which fails inside of
@@ -26,11 +23,6 @@ if (!(self as any).document) {
 }
 
 initializeServiceWorker({
-	// Always use a random version in development to avoid caching issues.
-	// @ts-ignore
-	version: import.meta.env.DEV
-		? () => Math.random() + ''
-		: serviceWorkerVersion,
 	handleRequest(event) {
 		const fullUrl = new URL(event.request.url);
 		let scope = getURLScope(fullUrl);

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -4,11 +4,12 @@ declare const self: ServiceWorkerGlobalScope;
 
 import { getURLScope, removeURLScope } from '@php-wasm/scopes';
 import {
+	awaitReply,
 	convertFetchEventToPHPRequest,
 	initializeServiceWorker,
 	seemsLikeAPHPRequestHandlerPath,
 	cloneRequest,
-	broadcastMessageAwaitReply,
+	broadcastMessageExpectReply,
 } from '@php-wasm/web-service-worker';
 import { isUploadedFilePath } from './src/lib/is-uploaded-file-path';
 
@@ -104,12 +105,13 @@ async function rewriteRequest(
 
 async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {
 	if (!scopeToWpModule[scope]) {
-		scopeToWpModule[scope] = await broadcastMessageAwaitReply(
+		const requestId = await broadcastMessageExpectReply(
 			{
 				method: 'getWordPressModuleDetails',
 			},
 			scope
 		);
+		scopeToWpModule[scope] = await awaitReply(self, requestId);
 	}
 	return scopeToWpModule[scope];
 }

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -4,12 +4,11 @@ declare const self: ServiceWorkerGlobalScope;
 
 import { getURLScope, removeURLScope } from '@php-wasm/scopes';
 import {
-	awaitReply,
 	convertFetchEventToPHPRequest,
 	initializeServiceWorker,
 	seemsLikeAPHPRequestHandlerPath,
 	cloneRequest,
-	broadcastMessageExpectReply,
+	broadcastMessageAwaitReply,
 } from '@php-wasm/web-service-worker';
 import { isUploadedFilePath } from './src/lib/is-uploaded-file-path';
 
@@ -105,13 +104,12 @@ async function rewriteRequest(
 
 async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {
 	if (!scopeToWpModule[scope]) {
-		const requestId = await broadcastMessageExpectReply(
+		scopeToWpModule[scope] = await broadcastMessageAwaitReply(
 			{
 				method: 'getWordPressModuleDetails',
 			},
 			scope
 		);
-		scopeToWpModule[scope] = await awaitReply(self, requestId);
 	}
 	return scopeToWpModule[scope];
 }

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -158,6 +158,7 @@ export async function bootPlaygroundRemote() {
 		await workerApi.scope,
 		serviceWorkerUrl + ''
 	);
+	wpFrame.src = await playground.pathToInternalUrl('/');
 	setupPostMessageRelay(wpFrame, getOrigin(await playground.absoluteUrl));
 
 	setAPIReady();

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -9,8 +9,6 @@ import {
 	consumeAPI,
 	recommendedWorkerBackend,
 } from '@php-wasm/web';
-// @ts-ignore
-import { serviceWorkerVersion } from 'virtual:service-worker-version';
 
 import type { PlaygroundWorkerEndpoint } from './worker-thread';
 import type { WebClientMixin } from './playground-client';
@@ -158,11 +156,9 @@ export async function bootPlaygroundRemote() {
 	await registerServiceWorker(
 		workerApi,
 		await workerApi.scope,
-		serviceWorkerUrl + '',
-		serviceWorkerVersion
+		serviceWorkerUrl + ''
 	);
 	setupPostMessageRelay(wpFrame, getOrigin(await playground.absoluteUrl));
-	wpFrame.src = await playground.pathToInternalUrl('/');
 
 	setAPIReady();
 

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -162,7 +162,7 @@ export async function bootPlaygroundRemote() {
 		serviceWorkerVersion
 	);
 	setupPostMessageRelay(wpFrame, getOrigin(await playground.absoluteUrl));
-	wpFrame.src = await playground.pathToInternalUrl('/');
+	// wpFrame.src = await playground.pathToInternalUrl('/');
 
 	setAPIReady();
 

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -162,7 +162,7 @@ export async function bootPlaygroundRemote() {
 		serviceWorkerVersion
 	);
 	setupPostMessageRelay(wpFrame, getOrigin(await playground.absoluteUrl));
-	// wpFrame.src = await playground.pathToInternalUrl('/');
+	wpFrame.src = await playground.pathToInternalUrl('/');
 
 	setAPIReady();
 

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -45,6 +45,18 @@ import serviceWorkerPath from '../../service-worker.ts?worker&url';
 import { LatestSupportedWordPressVersion } from './get-wordpress-module';
 export const serviceWorkerUrl = new URL(serviceWorkerPath, origin);
 
+// Prevent Vite from hot-reloading this file – it would
+// cause bootPlaygroundRemote() to register another web worker
+// without unregistering the previous one. The first web worker
+// would then fight for service worker requests with the second
+// one. It's a difficult problem to debug and HMR isn't that useful
+// here anyway – let's just disable it for this file.
+// @ts-ignore
+if (import.meta.hot) {
+	// @ts-ignore
+	import.meta.hot.accept(() => {});
+}
+
 const query = new URL(document.location.href).searchParams;
 export async function bootPlaygroundRemote() {
 	assertNotInfiniteLoadingLoop();

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -5,8 +5,6 @@ import dts from 'vite-plugin-dts';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { remoteDevServerHost, remoteDevServerPort } from '../build-config';
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import virtualModule from '../vite-virtual-module';
-// eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-ts-config-paths';
 
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
@@ -18,11 +16,6 @@ const plugins = [
 		entryRoot: 'src',
 		tsConfigFilePath: join(__dirname, 'tsconfig.lib.json'),
 		skipDiagnostics: true,
-	}),
-	virtualModule({
-		name: 'service-worker-version',
-		// @TODO: compute a hash of the service worker chunk instead of using the build timestamp
-		content: `export const serviceWorkerVersion = '${Date.now()}';`,
 	}),
 ];
 export default defineConfig({

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -47,7 +47,7 @@
 			"options": {
 				"commands": [
 					"nx dev playground-remote --configuration=development-for-website",
-					"nx dev:standalone playground-website --hmr --output-style=stream-without-prefixes"
+					"sleep 1; nx dev:standalone playground-website --hmr --output-style=stream-without-prefixes"
 				],
 				"parallel": true,
 				"color": true

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -47,7 +47,7 @@
 			"options": {
 				"commands": [
 					"nx dev playground-remote --configuration=development-for-website",
-					"sleep 1; nx dev:standalone playground-website --hmr --output-style=stream-without-prefixes"
+					"nx dev:standalone playground-website --hmr --output-style=stream-without-prefixes"
 				],
 				"parallel": true,
 				"color": true

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -35,11 +35,6 @@ const proxy = {
 			throw new Error('Invalid request');
 		},
 	},
-	// Proxy requests to the remote content through this server for dev builds.
-	// See base config below.
-	'^[/]((?!website-server).)': {
-		target: `http://${remoteDevServerHost}:${remoteDevServerPort}`,
-	},
 };
 
 let buildVersion: string;
@@ -55,14 +50,8 @@ export default defineConfig(({ command }) => {
 			? // In production, both the website and the playground are served from the same domain.
 			  process?.env?.ORIGIN || 'https://playground.wordpress.net/'
 			: // In dev, the website and the playground are served from different domains.
-			  `http://${websiteDevServerHost}:${websiteDevServerPort}`;
+			  `http://${remoteDevServerHost}:${remoteDevServerPort}`;
 	return {
-		// Split traffic from this server on dev so that the iframe content and outer
-		// content can be served from the same origin. In production it's already
-		// the same host, but dev builds run two separate servers.
-		// See proxy config above.
-		base: command === 'build' ? '/' : '/website-server/',
-
 		cacheDir: '../../../node_modules/.vite/packages-playground-website',
 
 		css: {
@@ -89,9 +78,6 @@ export default defineConfig(({ command }) => {
 				'Cross-Origin-Embedder-Policy': 'credentialless',
 			},
 			proxy,
-			fs: {
-				strict: false, // Serve files from the other project directories.
-			},
 		},
 
 		plugins: [

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -35,6 +35,11 @@ const proxy = {
 			throw new Error('Invalid request');
 		},
 	},
+	// Proxy requests to the remote content through this server for dev builds.
+	// See base config below.
+	'^[/]((?!website-server).)': {
+		target: `http://${remoteDevServerHost}:${remoteDevServerPort}`,
+	},
 };
 
 let buildVersion: string;
@@ -50,8 +55,14 @@ export default defineConfig(({ command }) => {
 			? // In production, both the website and the playground are served from the same domain.
 			  process?.env?.ORIGIN || 'https://playground.wordpress.net/'
 			: // In dev, the website and the playground are served from different domains.
-			  `http://${remoteDevServerHost}:${remoteDevServerPort}`;
+			  `http://${websiteDevServerHost}:${websiteDevServerPort}`;
 	return {
+		// Split traffic from this server on dev so that the iframe content and outer
+		// content can be served from the same origin. In production it's already
+		// the same host, but dev builds run two separate servers.
+		// See proxy config above.
+		base: command === 'build' ? '/' : '/website-server/',
+
 		cacheDir: '../../../node_modules/.vite/packages-playground-website',
 
 		css: {
@@ -78,6 +89,9 @@ export default defineConfig(({ command }) => {
 				'Cross-Origin-Embedder-Policy': 'credentialless',
 			},
 			proxy,
+			fs: {
+				strict: false, // Serve files from the other project directories.
+			},
 		},
 
 		plugins: [


### PR DESCRIPTION
## Description

Auto-reloading the service worker when it's updated thrashes any `postMessage` communication that's in progress at the moment of calling `skipWaiting()`. This causes Playground to hang at the "login" step in https://github.com/WordPress/wordpress-playground/pull/559.

This PR removes the entire concept of detecting the service worker version and enforcing an update on mismatch.

The browsers handle a lot by default:

* `registration.update()` method downloads the new service-worker.js file and compares it byte-by-byte with the existing one
* The previous service worker won't die until all the browser tabs it serves are closed
* The new service worker will automatically replace the previous one afterwards

The only problem remains deploying a website that is backwards–incompatible with the previous service worker.

Let's handle that case as follows:

* Avoid changes that break the website before the service worker gets updated.
* If they can't be avoided, let's ship them with a service worker that forces a one-off skipWaiting() and reloads all served browser tabs.

cc @ellatrix @dmsnell 