### PR TITLE
Remove the `tsx` extension from TypeScript imports

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/05-steps.md
+++ b/packages/docs/site/docs/09-blueprints-api/05-steps.md
@@ -20,8 +20,8 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 
 Each step is an object that contains a `step` property that specifies the type of step to run. The rest of the properties depend on the type of step. Learn and try each step type below.
 
-import BlueprintStep from '@site/src/components/BlueprintsAPI/BlueprintStep.tsx';
-import { BlueprintSteps } from '@site/src/components/BlueprintsAPI/model.tsx';
+import BlueprintStep from '@site/src/components/BlueprintsAPI/BlueprintStep';
+import { BlueprintSteps } from '@site/src/components/BlueprintsAPI/model';
 
 <span>{BlueprintSteps.map((name) => {
 toc.push({

--- a/packages/docs/site/docs/09-blueprints-api/07-json-api-and-function-api.md
+++ b/packages/docs/site/docs/09-blueprints-api/07-json-api-and-function-api.md
@@ -10,8 +10,8 @@ Blueprints are defined in JSON format, but the underlying implementation uses Ja
 
 JSON is merely a wrapper around the functions. Whether you use the JSON steps or the exported functions, you'll have to provide the same parameters (except for the step name):
 
-import BlueprintStep from '@site/src/components/BlueprintsAPI/BlueprintStep.tsx';
-import { BlueprintSteps } from '@site/src/components/BlueprintsAPI/model.tsx';
+import BlueprintStep from '@site/src/components/BlueprintsAPI/BlueprintStep';
+import { BlueprintSteps } from '@site/src/components/BlueprintsAPI/model';
 
 <span>{BlueprintSteps.map((name) => (
 <>

--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -105,6 +105,15 @@
 			"options": {
 				"lintFilePatterns": ["packages/docs/site/**/*.ts"]
 			}
+		},
+		"typecheck": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"tsc -p packages/nx-extensions/tsconfig.spec.json --noEmit",
+					"tsc -p packages/nx-extensions/tsconfig.lib.json --noEmit"
+				]
+			}
 		}
 	},
 	"tags": []

--- a/packages/docs/site/src/components/Blueprints/BlueprintExample.mdx
+++ b/packages/docs/site/src/components/Blueprints/BlueprintExample.mdx
@@ -1,4 +1,4 @@
-import { BlueprintRunButton } from './BlueprintRunButton.tsx';
+import { BlueprintRunButton } from './BlueprintRunButton';
 import CodeBlock from '@theme/CodeBlock';
 
 <div className="margin-vert--sm">

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStep.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStep.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { getStepAPI } from './model.tsx';
-import { BlueprintStepRunButton } from './BlueprintStepRunButton.tsx';
-import { BlueprintStepTabbedExample } from './BlueprintStepTabbedExample.tsx';
-import { BlueprintStepParameters } from './BlueprintStepParameters.tsx';
-import { BlueprintStepDescription } from './BlueprintStepDescription.tsx';
+import { getStepAPI } from './model';
+import { BlueprintStepRunButton } from './BlueprintStepRunButton';
+import { BlueprintStepTabbedExample } from './BlueprintStepTabbedExample';
+import { BlueprintStepParameters } from './BlueprintStepParameters';
+import { BlueprintStepDescription } from './BlueprintStepDescription';
 
 export default function BlueprintStep({ name }) {
 	const stepApi = getStepAPI(name);

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getStepAPI } from './model.tsx';
+import { getStepAPI } from './model';
 
 export function BlueprintStepDescription({ name }) {
 	const stepApi = getStepAPI(name);

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepFunctionExample.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepFunctionExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
-import { getStepAPI } from './model.tsx';
+import { getStepAPI } from './model';
 
 export function BlueprintStepFunctionExample({ name }) {
 	const stepApi = getStepAPI(name);

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepJsonExample.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepJsonExample.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
-import { getStepAPI } from './model.tsx';
+import { getStepAPI } from './model';
 
 export function BlueprintStepJsonExample({ name }) {
 	const stepApi = getStepAPI(name);

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepParameters.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepParameters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { getStepAPI } from './model.tsx';
+import { getStepAPI } from './model';
 
 export function BlueprintStepParameters({ name }) {
 	const stepApi = getStepAPI(name);

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepRunButton.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepRunButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { getStepAPI } from './model.tsx';
-import { BlueprintRunButton } from '../Blueprints/BlueprintRunButton.tsx';
+import { getStepAPI } from './model';
+import { BlueprintRunButton } from '../Blueprints/BlueprintRunButton';
 
 export function BlueprintStepRunButton({ name }) {
 	const stepApi = getStepAPI(name);

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepTabbedExample.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepTabbedExample.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import { BlueprintStepFunctionExample } from './BlueprintStepFunctionExample.tsx';
-import { BlueprintStepJsonExample } from './BlueprintStepJsonExample.tsx';
+import { BlueprintStepFunctionExample } from './BlueprintStepFunctionExample';
+import { BlueprintStepJsonExample } from './BlueprintStepJsonExample';
 
 export function BlueprintStepTabbedExample({ name }) {
 	return (

--- a/packages/playground/website/index.html
+++ b/packages/playground/website/index.html
@@ -45,7 +45,7 @@
 		</div>
 		<script type="module">
 			if (!shouldLazyLoadPlayground) {
-				import('./src/main.tsx');
+				import('./src/main');
 			}
 		</script>
 	</body>

--- a/packages/playground/website/src/components/site-setup-button/index.tsx
+++ b/packages/playground/website/src/components/site-setup-button/index.tsx
@@ -58,7 +58,7 @@ export default function SiteSetupButton({
 				setWp(details.majorVersion);
 			});
 		}
-	// eslint-disable-next-line react-hooks/exhaustive-deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [!playground]);
 
 	const handleStorageChange = (


### PR DESCRIPTION
Fixes the following TS error affecting https://github.com/WordPress/wordpress-playground/pull/563:

An import path can only end with a '.tsx' extension when 'allowImportingTsExtensions' is enabled