### PR TITLE
Remove the remotePlaygroundOrigin website setting

### DIFF
--- a/packages/playground/website/src/lib/config.ts
+++ b/packages/playground/website/src/lib/config.ts
@@ -1,2 +1,2 @@
 // Provided by vite
-export { remotePlaygroundOrigin, buildVersion } from 'virtual:website-config';
+export { buildVersion } from 'virtual:website-config';

--- a/packages/playground/website/src/lib/hooks.ts
+++ b/packages/playground/website/src/lib/hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Blueprint, startPlaygroundWeb } from '@wp-playground/client';
 import type { PlaygroundClient } from '@wp-playground/client';
-import { remotePlaygroundOrigin, buildVersion } from './config';
+import { buildVersion } from './config';
 
 interface UsePlaygroundOptions {
 	blueprint?: Blueprint;
@@ -29,7 +29,7 @@ export function usePlayground({ blueprint, persistent }: UsePlaygroundOptions) {
 		}
 		started.current = true;
 
-		const remoteUrl = new URL(remotePlaygroundOrigin);
+		const remoteUrl = new URL(window.location.origin);
 		remoteUrl.pathname = '/remote.html';
 		remoteUrl.searchParams.set('v', buildVersion);
 		if (persistent) {

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -49,13 +49,7 @@ try {
 	buildVersion = (new Date().getTime() / 1000).toFixed(0);
 }
 
-export default defineConfig(({ command }) => {
-	const playgroundOrigin =
-		command === 'build'
-			? // In production, both the website and the playground are served from the same domain.
-			  process?.env?.ORIGIN || 'https://playground.wordpress.net/'
-			: // In dev, the website and the playground are served from different domains.
-			  `http://${websiteDevServerHost}:${websiteDevServerPort}`;
+export default defineConfig(({ command, mode }) => {
 	return {
 		// Split traffic from this server on dev so that the iframe content and outer
 		// content can be served from the same origin. In production it's already
@@ -103,7 +97,6 @@ export default defineConfig(({ command }) => {
 			virtualModule({
 				name: 'website-config',
 				content: `
-				export const remotePlaygroundOrigin = ${JSON.stringify(playgroundOrigin)};
 				export const buildVersion = ${JSON.stringify(buildVersion)};`,
 			}),
 		],


### PR DESCRIPTION
As od #559 dev mode supports serving index.html and remote.html from the same origin, thus we no longer need a setting to explicitly specify the remote origin.
