### PR TITLE
Make unused variables an ESLint error, not just a warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,6 +41,7 @@
 				"@typescript-eslint/no-explicit-any": 0,
 				"@typescript-eslint/no-empty-interface": 0,
 				"@typescript-eslint/no-empty-function": 0,
+				"@typescript-eslint/no-unused-vars": "error",
 				"no-constant-condition": 0
 			}
 		},


### PR DESCRIPTION
We don't have any unused variables, nor do we want to have them, but keeping this as a warning means we'll occasionally commit code with unused variables. This is quite annoying in GitHub UI that shows warnings in the list of changed files in every PR even for files that weren't changed as a part of the PR.
