### PR TITLE
Report errors encountered during bootPlaygroundRemote()

### DIFF
--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -121,13 +121,9 @@ export async function loadPHPRuntime(
 	phpModuleArgs: EmscriptenOptions = {},
 	dataDependenciesModules: DataModule[] = []
 ): Promise<number> {
-	let resolvePhpReady: any,
-		rejectPhp: any,
-		resolveDepsReady: any,
-		rejectDeps: any;
-	const depsReady = new Promise((resolve, reject) => {
+	let resolvePhpReady: any, rejectPhp: any, resolveDepsReady: any;
+	const depsReady = new Promise((resolve) => {
 		resolveDepsReady = resolve;
-		rejectDeps = reject;
 	});
 	const phpReady = new Promise((resolve, reject) => {
 		resolvePhpReady = resolve;
@@ -163,15 +159,11 @@ export async function loadPHPRuntime(
 		},
 	});
 
-	try {
-		await Promise.all(
-			dataDependenciesModules.map(({ default: dataModule }) =>
-				dataModule(PHPRuntime)
-			)
-		);
-	} catch (e) {
-		throw e;
-	}
+	await Promise.all(
+		dataDependenciesModules.map(({ default: dataModule }) =>
+			dataModule(PHPRuntime)
+		)
+	);
 
 	if (!dataDependenciesModules.length) {
 		resolveDepsReady();

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -204,8 +204,9 @@ const makePromise = () => {
 	const methods: any = [];
 
 	const promise = new Promise((resolve, reject) => {
-		methods.push(promise, resolve, reject);
+		methods.push(resolve, reject);
 	});
+	methods.unshift(promise);
 
 	return methods as [Promise<any>, (v?: any) => void, (e?: any) => void];
 };

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -121,17 +121,21 @@ export async function loadPHPRuntime(
 	phpModuleArgs: EmscriptenOptions = {},
 	dataDependenciesModules: DataModule[] = []
 ): Promise<number> {
-	let resolvePhpReady: any, resolveDepsReady: any;
+	let resolvePhpReady: any, rejectPhp: any, resolveDepsReady: any;
 	const depsReady = new Promise((resolve) => {
 		resolveDepsReady = resolve;
 	});
-	const phpReady = new Promise((resolve) => {
+	const phpReady = new Promise((resolve, reject) => {
 		resolvePhpReady = resolve;
+		rejectPhp = reject;
 	});
 
 	const PHPRuntime = phpLoaderModule.init(currentJsRuntime, {
 		onAbort(reason) {
-			console.error('WASM aborted: ');
+			rejectPhp(reason);
+			resolveDepsReady();
+			// This can happen after PHP has been initialized so
+			// let's just log it.
 			console.error(reason);
 		},
 		ENV: {},

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -201,7 +201,7 @@ export const currentJsRuntime = (function () {
  * Creates and exposes Promise resolve/reject methods for later use.
  */
 const makePromise = () => {
-	const methods : any = [];
+	const methods: any = [];
 
 	const promise = new Promise((resolve, reject) => {
 		methods.push(promise, resolve, reject);

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -201,14 +201,14 @@ export const currentJsRuntime = (function () {
  * Creates and exposes Promise resolve/reject methods for later use.
  */
 const makePromise = () => {
-	const methods = [];
+	const methods : any = [];
 
-	const promise = new Promise( ( resolve, reject ) => {
-		methods.push( promise, resolve, reject );
-	} );
+	const promise = new Promise((resolve, reject) => {
+		methods.push(promise, resolve, reject);
+	});
 
-	return methods;
-}
+	return methods as [Promise<any>, (v?: any) => void, (e?: any) => void];
+};
 
 export type PHPRuntime = any;
 

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -123,6 +123,7 @@ export async function loadPHPRuntime(
 ): Promise<number> {
 	let resolvePhpReady: any, rejectPhp: any, resolveDepsReady: any;
 	const depsReady = new Promise((resolve) => {
+		// @TODO This also needs to be rejected on failure
 		resolveDepsReady = resolve;
 	});
 	const phpReady = new Promise((resolve, reject) => {

--- a/packages/php-wasm/web/src/lib/api.ts
+++ b/packages/php-wasm/web/src/lib/api.ts
@@ -74,14 +74,16 @@ export type PublicAPI<Methods, PipedAPI = unknown> = RemoteAPI<
 export function exposeAPI<Methods, PipedAPI>(
 	apiMethods?: Methods,
 	pipedApi?: PipedAPI
-): [() => void, PublicAPI<Methods, PipedAPI>] {
+): [() => void, (e: Error) => void, PublicAPI<Methods, PipedAPI>] {
 	setupTransferHandlers();
 
 	const connected = Promise.resolve();
 
 	let setReady: any;
-	const ready = new Promise((resolve) => {
+	let setFailed: any;
+	const ready = new Promise((resolve, reject) => {
 		setReady = resolve;
+		setFailed = reject;
 	});
 
 	const methods = proxyClone(apiMethods);
@@ -104,7 +106,7 @@ export function exposeAPI<Methods, PipedAPI>(
 			? Comlink.windowEndpoint(self.parent)
 			: undefined
 	);
-	return [setReady, exposedApi];
+	return [setReady, setFailed, exposedApi];
 }
 
 let isTransferHandlersSetup = false;

--- a/packages/php-wasm/web/src/lib/worker-thread/spawn-php-worker-thread.ts
+++ b/packages/php-wasm/web/src/lib/worker-thread/spawn-php-worker-thread.ts
@@ -10,7 +10,25 @@ export async function spawnPHPWorkerThread(
 	startupOptions: Record<string, string> = {}
 ) {
 	workerUrl = addQueryParams(workerUrl, startupOptions);
-	return new Worker(workerUrl, { type: 'module' });
+	const worker = new Worker(workerUrl, { type: 'module' });
+	return new Promise<Worker>((resolve, reject) => {
+		worker.onerror = (e) => {
+			const error = new Error(
+				`WebWorker failed to load at ${workerUrl}. ${
+					e.message ? `Original error: ${e.message}` : ''
+				}`
+			);
+			(error as any).filename = e.filename;
+			reject(error);
+		};
+		// There is no way to know when the worker script has started
+		// executing, so we use a message to signal that.
+		worker.onmessage = (event) => {
+			if (event.data === 'worker-script-started') {
+				resolve(worker);
+			}
+		};
+	});
 }
 
 function addQueryParams(

--- a/packages/php-wasm/web/src/lib/worker-thread/spawn-php-worker-thread.ts
+++ b/packages/php-wasm/web/src/lib/worker-thread/spawn-php-worker-thread.ts
@@ -23,11 +23,13 @@ export async function spawnPHPWorkerThread(
 		};
 		// There is no way to know when the worker script has started
 		// executing, so we use a message to signal that.
-		worker.onmessage = (event) => {
+		function onStartup(event: { data: string }) {
 			if (event.data === 'worker-script-started') {
 				resolve(worker);
+				worker.removeEventListener('message', onStartup);
 			}
-		};
+		}
+		worker.addEventListener('message', onStartup);
 	});
 }
 

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -275,7 +275,7 @@ function compileStep<S extends StepDefinition>(
 				}
 			);
 		} finally {
-			stepProgress.finish();
+			// stepProgress.finish();
 		}
 	};
 

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -275,7 +275,7 @@ function compileStep<S extends StepDefinition>(
 				}
 			);
 		} finally {
-			// stepProgress.finish();
+			stepProgress.finish();
 		}
 	};
 

--- a/packages/playground/compile-wordpress/Dockerfile
+++ b/packages/playground/compile-wordpress/Dockerfile
@@ -195,6 +195,10 @@ COPY ./build-assets/esm-prefix.js ./build-assets/esm-suffix.js /root/
 # This tells web browsers it's a new file and they should reload it.
 RUN cat /root/output/wp.js \
     | sed -E "s#'[^']*wp\.data'#dependencyFilename#g" \
+    | sed -E 's#xhr.onerror = #xhr.onerror = onLoadingFailed; const z = #g' \
+    | sed -E 's#throw new Error\(xhr.+$#onLoadingFailed(event);#g' \
+    | sed -E 's#runWithFS#runWithFSThenResolve#g' \
+    | sed -E 's#function runWithFSThenResolve#function runWithFSThenResolve() { runWithFS(); resolve(); }; function runWithFS#g' \
     > /tmp/wp.js && \
     mv /tmp/wp.js /root/output/wp.js;
 

--- a/packages/playground/compile-wordpress/build-assets/esm-prefix.js
+++ b/packages/playground/compile-wordpress/build-assets/esm-prefix.js
@@ -13,4 +13,10 @@ export const defaultThemeName = WP_THEME_NAME;
 // into an ESM module.
 // This replaces the Emscripten's MODULARIZE=1 which pollutes the
 // global namespace and does not play well with import() mechanics.
-export default function(PHPModule) {
+export default function (PHPModule) {   
+    return new Promise(function(resolve, reject) {
+        function onLoadingFailed(error) {
+            const wrappingError = new Error(`Failed to load data dependency module "${dependencyFilename}"${typeof error === 'string' ? ` (${error})` : ''}`);
+            wrappingError.cause = error instanceof Error ? error : null;
+            reject(wrappingError);        
+        };

--- a/packages/playground/compile-wordpress/build-assets/esm-suffix.js
+++ b/packages/playground/compile-wordpress/build-assets/esm-suffix.js
@@ -1,2 +1,3 @@
 // See esm-prefix.js
+    });
 }

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -63,7 +63,7 @@
 				const button = document.createElement('button');
 				button.innerText = 'Try again';
 				button.onclick = () => {
-					(window.parent || window).location.reload();
+					window.location.reload();
 				};
 				document.body.append(button);
 			}

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -30,6 +30,11 @@
 				justify-content: center;
 				font-size: 20px;
 				font-family: Arial, Helvetica, sans-serif;
+				line-height: 1.4;
+			}
+			body.has-error .error-message {
+				padding: 20px;
+				max-width: 800px;
 			}
 			body.has-error button {
 				margin-top: 15px;
@@ -56,7 +61,18 @@
 				document.body.innerHTML = '';
 
 				const div = document.createElement('div');
+				div.className = 'error-message';
 				div.innerText = 'Ooops! WordPress Playground had a hiccup!';
+				if (
+					e?.message?.includes(
+						'The user denied permission to use Service Worker'
+					)
+				) {
+					div.innerText =
+						'It looks like you have disabled third-party cookies in your browser. This tends to ' +
+						'also disable the ServiceWorker API used by WordPress Playground. Please re-enable ' +
+						'third-party cookies and try again.';
+				}
 
 				document.body.append(div);
 

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -21,6 +21,22 @@
 			body {
 				overflow: hidden;
 			}
+
+			body.has-error {
+				background: #f1f1f1;
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				font-size: 20px;
+				font-family: Arial, Helvetica, sans-serif;
+			}
+			body.has-error button {
+				margin-top: 15px;
+				font-size: 20px;
+				padding: 5px 10px;
+				cursor: pointer;
+			}
 		</style>
 	</head>
 	<body class="is-loading">
@@ -36,14 +52,16 @@
 			try {
 				await bootPlaygroundRemote();
 			} catch (e) {
-				document.write('<body>');
+				document.body.className = 'has-error';
+				document.body.innerHTML = '';
 
 				const div = document.createElement('div');
-				div.innerText = `Playground loading error: ${e.message}.`;
+				div.innerText = 'Ooops! WordPress Playground had a hiccup!';
+
 				document.body.append(div);
 
 				const button = document.createElement('button');
-				button.innerText = 'Retry';
+				button.innerText = 'Try again';
 				button.onclick = () => {
 					(window.parent || window).location.reload();
 				};

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -33,7 +33,22 @@
 				document.body.classList.add('is-embedded');
 			}
 			import { bootPlaygroundRemote } from './src/index';
-			bootPlaygroundRemote();
+			try {
+				await bootPlaygroundRemote();
+			} catch (e) {
+				document.write('<body>');
+
+				const div = document.createElement('div');
+				div.innerText = `Playground loading error: ${e.message}.`;
+				document.body.append(div);
+
+				const button = document.createElement('button');
+				button.innerText = 'Retry';
+				button.onclick = () => {
+					(window.parent || window).location.reload();
+				};
+				document.body.append(button);
+			}
 		</script>
 	</body>
 </html>

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -145,18 +145,23 @@ export async function bootPlaygroundRemote() {
 	// https://github.com/GoogleChromeLabs/comlink/issues/426#issuecomment-578401454
 	// @TODO: Handle the callback conversion automatically and don't explicitly re-expose
 	//        the onDownloadProgress method
-	const [setAPIReady, playground] = exposeAPI(webApi, workerApi);
+	const [setAPIReady, setAPIError, playground] = exposeAPI(webApi, workerApi);
 
-	await workerApi.isReady();
-	await registerServiceWorker(
-		workerApi,
-		await workerApi.scope,
-		serviceWorkerUrl + ''
-	);
-	wpFrame.src = await playground.pathToInternalUrl('/');
-	setupPostMessageRelay(wpFrame, getOrigin(await playground.absoluteUrl));
+	try {
+		await workerApi.isReady();
+		await registerServiceWorker(
+			workerApi,
+			await workerApi.scope,
+			serviceWorkerUrl + ''
+		);
+		wpFrame.src = await playground.pathToInternalUrl('/');
+		setupPostMessageRelay(wpFrame, getOrigin(await playground.absoluteUrl));
 
-	setAPIReady();
+		setAPIReady();
+	} catch (e) {
+		setAPIError(e as Error);
+		throw e;
+	}
 
 	/*
 	 * An asssertion to make sure Playground Client is compatible

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -145,23 +145,18 @@ export async function bootPlaygroundRemote() {
 	// https://github.com/GoogleChromeLabs/comlink/issues/426#issuecomment-578401454
 	// @TODO: Handle the callback conversion automatically and don't explicitly re-expose
 	//        the onDownloadProgress method
-	const [setAPIReady, setAPIError, playground] = exposeAPI(webApi, workerApi);
+	const [setAPIReady, playground] = exposeAPI(webApi, workerApi);
 
-	try {
-		await workerApi.isReady();
-		await registerServiceWorker(
-			workerApi,
-			await workerApi.scope,
-			serviceWorkerUrl + ''
-		);
-		wpFrame.src = await playground.pathToInternalUrl('/');
-		setupPostMessageRelay(wpFrame, getOrigin(await playground.absoluteUrl));
+	await workerApi.isReady();
+	await registerServiceWorker(
+		workerApi,
+		await workerApi.scope,
+		serviceWorkerUrl + ''
+	);
+	wpFrame.src = await playground.pathToInternalUrl('/');
+	setupPostMessageRelay(wpFrame, getOrigin(await playground.absoluteUrl));
 
-		setAPIReady();
-	} catch (e) {
-		setAPIError(e as Error);
-		throw e;
-	}
+	setAPIReady();
 
 	/*
 	 * An asssertion to make sure Playground Client is compatible

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -28,7 +28,7 @@ import { applyWordPressPatches } from '@wp-playground/blueprints';
 import { journalMemfsToOpfs } from './opfs/journal-memfs-to-opfs';
 
 // post message to parent
-self.postMessage('worker-script-started')
+self.postMessage('worker-script-started');
 
 const startupOptions = parseWorkerStartupOptions<{
 	wpVersion?: string;

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -27,6 +27,9 @@ import {
 import { applyWordPressPatches } from '@wp-playground/blueprints';
 import { journalMemfsToOpfs } from './opfs/journal-memfs-to-opfs';
 
+// post message to parent
+self.postMessage('worker-script-started')
+
 const startupOptions = parseWorkerStartupOptions<{
 	wpVersion?: string;
 	phpVersion?: string;

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -130,42 +130,46 @@ export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 	}
 }
 
-const [setApiReady] = exposeAPI(
+const [setApiReady, setAPIError] = exposeAPI(
 	new PlaygroundWorkerEndpoint(php, monitor, scope, wpVersion, phpVersion)
 );
+try {
+	await phpReady;
 
-await phpReady;
-
-if (!useOpfs || !wordPressAvailableInOPFS) {
-	/**
-	 * When WordPress is restored from OPFS, these patches are already applied.
-	 * Thus, let's not apply them again.
-	 */
-	await wordPressModule;
-	applyWebWordPressPatches(php);
-	await applyWordPressPatches(php, {
-		wordpressPath: DOCROOT,
-		patchSecrets: true,
-		disableWpNewBlogNotification: true,
-		addPhpInfo: true,
-		disableSiteHealth: true,
-	});
-}
-
-if (useOpfs) {
-	if (wordPressAvailableInOPFS) {
-		await copyOpfsToMemfs(php, opfsDir!, DOCROOT);
-	} else {
-		await copyMemfsToOpfs(php, opfsDir!, DOCROOT);
+	if (!useOpfs || !wordPressAvailableInOPFS) {
+		/**
+		 * When WordPress is restored from OPFS, these patches are already applied.
+		 * Thus, let's not apply them again.
+		 */
+		await wordPressModule;
+		applyWebWordPressPatches(php);
+		await applyWordPressPatches(php, {
+			wordpressPath: DOCROOT,
+			patchSecrets: true,
+			disableWpNewBlogNotification: true,
+			addPhpInfo: true,
+			disableSiteHealth: true,
+		});
 	}
 
-	journalMemfsToOpfs(php, opfsDir!, DOCROOT);
+	if (useOpfs) {
+		if (wordPressAvailableInOPFS) {
+			await copyOpfsToMemfs(php, opfsDir!, DOCROOT);
+		} else {
+			await copyMemfsToOpfs(php, opfsDir!, DOCROOT);
+		}
+
+		journalMemfsToOpfs(php, opfsDir!, DOCROOT);
+	}
+
+	// Always setup the current site URL.
+	await applyWordPressPatches(php, {
+		wordpressPath: DOCROOT,
+		siteUrl: scopedSiteUrl,
+	});
+
+	setApiReady();
+} catch (e) {
+	setAPIError(e as Error);
+	throw e;
 }
-
-// Always setup the current site URL.
-await applyWordPressPatches(php, {
-	wordpressPath: DOCROOT,
-	siteUrl: scopedSiteUrl,
-});
-
-setApiReady();


### PR DESCRIPTION
Aims to improve the UX at https://github.com/WordPress/wordpress-playground/issues/564 by bubbling up errors encountered when initializing workers.

This PR is meant to display an error message whenever there's a problem downloading any of the assets required to run the Playground including:

* .wasm files
* .data files
* Dynamic JavaScript imports
* Web worker
* Service worker

<img width="1246" alt="CleanShot 2023-06-21 at 20 24 20@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/cd058bc3-31cb-4ff5-b576-f58ab6b8f25e">

## Testing instructions

1. Run `npm run build`
2. Run `nx preview playground-website`
3. Delete one of the files mentioned above in the build directory (build/packages/playground-website)
4. Confirm the error message was displayed

cc @dmsnell @ellatrix 