### PR TITLE
Fake websocket connection on web to prevent creating WebSocket for SOCSFS

### DIFF
--- a/packages/php-wasm/web/src/lib/web-php.ts
+++ b/packages/php-wasm/web/src/lib/web-php.ts
@@ -16,6 +16,32 @@ export interface PHPWebLoaderOptions {
 	dataModules?: Array<DataModule | Promise<DataModule>>;
 }
 
+/**
+ * Fake a websocket connection to prevent errors in the web app
+ * from cascading and breaking the Playground.
+ */
+const fakeWebsocket = () => {
+	return {
+		websocket: {
+			decorator: (WebSocketConstructor: any) => {
+				return class FakeWebsocketConstructor extends WebSocketConstructor {
+					constructor() {
+						try {
+							super();
+						} catch (e) {
+							// pass
+						}
+					}
+
+					send() {
+						return null;
+					}
+				};
+			},
+		},
+	};
+};
+
 export class WebPHP extends BasePHP {
 	/**
 	 * Creates a new PHP instance.
@@ -66,6 +92,7 @@ export class WebPHP extends BasePHP {
 				{
 					...(options.emscriptenOptions || {}),
 					...(options.downloadMonitor?.getEmscriptenOptions() || {}),
+					...fakeWebsocket(),
 				},
 				dataModules
 			);


### PR DESCRIPTION
When initializing the `SOCKFS` from emcripten, a websocket is created automatically whether it's needed or not (whether any filesystems are `mount()`ed into the `SOCKFS`).

This can, from time to time, create errors on initialization which _might_ block loading of the Playground. These errors are benign because the websocket isn't needed or supported, but they are _thrown_ and so still cause problems.

In this patch we're providing a fake WebSocket class through the decorator mechanism so that any errors in the constructor are swallowed and made safe.

## Testing

Smoke test the Playground to ensure it loads.

Find some way to trigger the motivating bug and then see if this branch fixes it 🤷‍♂️ 