### PR TITLE
Actions: A workflow to refresh WordPress builds

### DIFF
--- a/.github/workflows/refresh-wordpress.yml
+++ b/.github/workflows/refresh-wordpress.yml
@@ -1,0 +1,26 @@
+name: 'Refresh WordPress assets'
+
+on:
+    workflow_dispatch:
+
+jobs:
+    build_and_deploy:
+        # Only run this workflow from the trunk branch
+        if: github.ref == 'refs/heads/trunk'
+        runs-on: ubuntu-latest
+        environment:
+            name: wordpress-assets
+        steps:
+            - uses: actions/checkout@v3
+            - uses: ./.github/actions/prepare-playground
+            - name: 'Recompile WordPress'
+              shell: bash
+              run: npx nx recompile-wordpress:all playground-remote
+            - name: Config git user
+              run: |
+                  git config --global user.name "deployment_bot"
+                  git config --global user.email "deployment_bot@users.noreply.github.com"
+                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
+                  git add -A
+                  git commit -a -m "Recompile WordPress"
+                  git push origin HEAD:trunk


### PR DESCRIPTION
## What?

Add a new workflow to refresh WordPress versions to keep them up to date (including the nightly build).

I don't know a good way to test a workflow living in a PR so I'll just merge it and let's iterate from there
