### PR TITLE
Website: Add Nightly to WordPress version picker

### DIFF
--- a/.github/workflows/refresh-wordpress.yml
+++ b/.github/workflows/refresh-wordpress.yml
@@ -41,4 +41,3 @@ jobs:
                   if [ $? -eq 0 ]; then
                       git push origin HEAD:trunk
                   fi;
-                

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -28,7 +28,7 @@ import type { ValidateFunction } from 'ajv';
 
 export type CompiledStep = (php: UniversalPHP) => Promise<void> | void;
 
-const supportedWordPressVersions = ['6.2', '6.1', '6.0', '5.9'] as const;
+const supportedWordPressVersions = ['6.2', '6.1', '6.0', '5.9', 'nightly'] as const;
 type supportedWordPressVersion = (typeof supportedWordPressVersions)[number];
 export interface CompiledBlueprint {
 	/** The requested versions of PHP and WordPress for the blueprint */

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -28,7 +28,13 @@ import type { ValidateFunction } from 'ajv';
 
 export type CompiledStep = (php: UniversalPHP) => Promise<void> | void;
 
-const supportedWordPressVersions = ['6.2', '6.1', '6.0', '5.9', 'nightly'] as const;
+const supportedWordPressVersions = [
+	'6.2',
+	'6.1',
+	'6.0',
+	'5.9',
+	'nightly',
+] as const;
 type supportedWordPressVersion = (typeof supportedWordPressVersions)[number];
 export interface CompiledBlueprint {
 	/** The requested versions of PHP and WordPress for the blueprint */

--- a/packages/playground/remote/src/lib/get-wordpress-module.ts
+++ b/packages/playground/remote/src/lib/get-wordpress-module.ts
@@ -1,4 +1,10 @@
-export const SupportedWordPressVersions = ['6.2', '6.1', '6.0', '5.9', 'nightly'] as const;
+export const SupportedWordPressVersions = [
+	'6.2',
+	'6.1',
+	'6.0',
+	'5.9',
+	'nightly',
+] as const;
 export type SupportedWordPressVersion =
 	(typeof SupportedWordPressVersions)[number];
 export const LatestSupportedWordPressVersion = SupportedWordPressVersions[0];

--- a/packages/playground/remote/src/lib/get-wordpress-module.ts
+++ b/packages/playground/remote/src/lib/get-wordpress-module.ts
@@ -1,4 +1,4 @@
-export const SupportedWordPressVersions = ['6.2', '6.1', '6.0', '5.9'] as const;
+export const SupportedWordPressVersions = ['6.2', '6.1', '6.0', '5.9', 'nightly'] as const;
 export type SupportedWordPressVersion =
 	(typeof SupportedWordPressVersions)[number];
 export const LatestSupportedWordPressVersion = SupportedWordPressVersions[0];
@@ -19,6 +19,9 @@ export function getWordPressModule(wpVersion: string) {
 		case '6.2':
 			/** @ts-ignore */
 			return import('../wordpress/wp-6.2.js');
+		case 'nightly':
+			/** @ts-ignore */
+			return import('../wordpress/wp-nightly.js');
 	}
 	throw new Error(`Unsupported WordPress module: ${wpVersion}`);
 }

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -26,7 +26,6 @@ import {
 } from './opfs/opfs-memfs';
 import { applyWordPressPatches } from '@wp-playground/blueprints';
 import { journalMemfsToOpfs } from './opfs/journal-memfs-to-opfs';
-import { phpVar } from '@php-wasm/util';
 
 const startupOptions = parseWorkerStartupOptions<{
 	wpVersion?: string;
@@ -110,18 +109,12 @@ export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 	 * @returns WordPress module details, including the static assets directory and default theme.
 	 */
 	async getWordPressModuleDetails() {
-		const path = phpVar(`${this.documentRoot}/wp-includes/version.php`);
-		const majorVersion = (
-			await this.run({
-				code: `<?php
-				require(${path});
-				echo substr($wp_version, 0, 3);
-				`,
-			})
-		).text;
 		return {
-			majorVersion,
-			staticAssetsDirectory: `wp-${majorVersion.replace('_', '.')}`,
+			majorVersion: this.wordPressVersion,
+			staticAssetsDirectory: `wp-${this.wordPressVersion.replace(
+				'_',
+				'.'
+			)}`,
 			defaultTheme: (await wordPressModule)?.defaultThemeName,
 		};
 	}

--- a/packages/playground/website/src/components/site-setup-button/index.tsx
+++ b/packages/playground/website/src/components/site-setup-button/index.tsx
@@ -14,11 +14,15 @@ interface SiteSetupButton {
 	persistent: boolean;
 }
 
-const SupportedWordPressVersionsList = ['6.2', '6.1', '6.0', '5.9'];
+const SupportedWordPressVersionsList = ['nightly', '6.2', '6.1', '6.0', '5.9'];
 
-const resolveVersion = (version: string | undefined, allVersions: string[]) => {
-	if (!version || version === 'latest') {
-		return allVersions[0];
+const resolveVersion = (
+	version: string | undefined,
+	allVersions: string[],
+	_default: string
+) => {
+	if (!version || version === 'latest' || !allVersions.includes(version)) {
+		return _default;
 	}
 	return version;
 };
@@ -34,10 +38,10 @@ export default function SiteSetupButton({
 	const closeModal = () => setOpen(false);
 
 	const [playgroundWp, setPlaygroundWp] = useState(() =>
-		resolveVersion(preferredWP, SupportedWordPressVersionsList)
+		resolveVersion(preferredWP, SupportedWordPressVersionsList, '6.2')
 	);
 	const [php, setPhp] = useState(
-		resolveVersion(selectedPHP, SupportedPHPVersionsList)
+		resolveVersion(selectedPHP, SupportedPHPVersionsList, '8.0')
 	);
 	const [wp, setWp] = useState(playgroundWp);
 	const [storage, setStorage] = useState(


### PR DESCRIPTION
## What?

Adds WordPress nightly version to the version picker:

<img width="1247" alt="CleanShot 2023-06-19 at 20 46 46@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/f0a7394b-f3ac-49cd-a190-029ecc320c3a">

This, in tandem with [the workflow to rebuild WordPress](https://github.com/WordPress/wordpress-playground/pull/572), should enable previewing the latest development version of WordPress.

Note the nightly release is different from the latest WordPress Beta/RC – the latter would be still good to have.