### PR TITLE
Documentation: Host your own Playground

### DIFF
--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -74,10 +74,6 @@ The Apache `.htaccess` file looks like this.
 AddType application/wasm .wasm
 AddType	application/octet-stream .data
 
-<FilesMatch "iframe-worker.html$">
-  Header set Origin-Agent-Cluster: ?1
-</FilesMatch>
-
 Header set Cross-Origin-Resource-Policy: cross-origin
 Header set Cross-Origin-Embedder-Policy: credentialless
 RewriteEngine on
@@ -97,10 +93,6 @@ location ~* .data$ {
   types {
     application/octet-stream data;
   }
-}
-
-location /iframe-worker.html {
-  add_header Origin-Agent-Cluster ?1;
 }
 
 location /plugin-proxy {

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -23,9 +23,35 @@ const client = await startPlaygroundWeb({
 });
 ```
 
-## Build static assets
+## Static assets
 
-Create a shallow clone of the Playground repository.
+There are several ways to get the static assets necessary to host the Playground.
+
+In order of convenience and ease:
+
+-   Download pre-built package
+-   Build from fork using GitHub Action
+-   Build locally
+
+### Download pre-built package
+
+To host the Playground as is, without making changes, you can download the built artifact from [the latest successful GitHub Action](https://github.com/WordPress/wordpress-playground/actions/workflows/build-website.yml?query=is%3Asuccess).
+
+-   Click on **Deploy to playground.wordpress.net**.
+-   In the section **Artifacts** at the bottom of the page, click `playground-website`.
+-   It's a zip package with the same files deployed to the public site.
+
+### Build from fork using GitHub Action
+
+To customize the Playground, you can [fork the Git repository](https://github.com/WordPress/wordpress-playground/fork).
+
+Build it from the fork's GitHub page by going to: **Actions -> Deploy to playground.wordpress.net -> Run workflow**.
+
+### Build locally
+
+The most flexible and customizable method is to build the site locally.
+
+Create a shallow clone of the Playground repository, or your own fork.
 
 ```sh
 git clone -b trunk --single-branch --depth 1 git@github.com:WordPress/wordpress-playground.git
@@ -38,7 +64,7 @@ npm install
 npm run build:website
 ```
 
-This command internally runs the `nx` task `build:wasm-wordpress-net`. It copies the built assets from packages `remote` and `website` into a new folder at the path.
+This command internally runs the `nx` task `build:wasm-wordpress-net`. It copies the built assets from packages `remote` and `website` into a new folder at the following path:
 
 ```
 dist/packages/playground/wasm-wordpress-net
@@ -46,7 +72,9 @@ dist/packages/playground/wasm-wordpress-net
 
 The entire service of the Playground consists of the content of this folder.
 
-It includes:
+## Summary of included files
+
+The static assets include:
 
 -   Data and WASM files for all available PHP and WordPress versions
 -   `remote.html` - the core of Playground

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -4,7 +4,7 @@ You can host the Playground on your own domain instead of `playground.wordpress.
 
 This is useful for having full control over its content and behavior, as well as removing dependency on a third-party remote endpoint. It can provide a customized user experience, for example: preinstalled plugins, default theme, site settings, and demo content.
 
-Also, if you expect to see heavy traffic, it's good etiquette to provide your own server/CDN resources to serve the static file assets, instead of relying on the `wordpress.net` server.
+Also, if you expect to see heavy traffic, it's good etiquette to provide your own server/CDN resources to serve the static file assets, rather than relying on the `wordpress.net` server.
 
 #### Usage
 
@@ -46,7 +46,7 @@ This command internally runs the `nx` task `build:wasm-wordpress-net`. It copies
 dist/packages/playground/wasm-wordpress-net
 ```
 
-The content of this folder consists the entire service of the Playground.
+The entire service of the Playground consists of the content of this folder.
 
 It includes:
 
@@ -55,7 +55,7 @@ It includes:
 -   `index.html` - the shell, or browser chrome
 -   Web Worker script
 
-You can deploy the content of the folder `wasm-wordpress-net` to your server using SSH, such as `scp` or `rsync`.
+You can deploy the content of the folder to your server using SSH, such as `scp` or `rsync`.
 
 It is a static site, except for these dynamic aspects.
 
@@ -121,7 +121,7 @@ You may need to adjust the above according to server specifics, particularly how
 
 ## Customize `wp.data`
 
-The file `wp.data` is a bundle of all the files for the WordPress instance running in Playground. There's a data file for each available WordPress version.
+The file `wp.data` is a bundle of all the files for the virtual file system in Playground. There's a data file for each available WordPress version.
 
 Edit the build script in `packages/playground/compile-wordpress/Dockerfile` to create a custom bundle that includes preinstalled plugins or content.
 
@@ -145,15 +145,13 @@ RUN cd wordpress/wp-content/mu-plugins && \
     done;
 ```
 
-You can download plugins from URLs other than the WordPress plugin directory, use Git to pull them from elsewhere.
-
-It's also possible to copy from a local folder - for example, before `RUN`:
+You can download plugins from URLs other than the WordPress plugin directory, or use Git to pull them from elsewhere. It's also possible to copy from a local folder. For example, before `RUN`:
 
 ```
 COPY ./build-assets/*.zip /root/
 ```
 
-Then put the plugin zip files in `packages/playground/compile-wordpress/build-assets`. You may want to add their paths to `.gitignore`.
+Then put the plugin zip files in `packages/playground/compile-wordpress/build-assets`. In this case, you may want to add their paths to `.gitignore`.
 
 ### Import content
 
@@ -168,4 +166,4 @@ RUN cd wordpress ; \
     ../wp-cli.phar --allow-root import /root/content.xml --authors=create
 ```
 
-This assumes that you have put a WXR export file named `content.xml` in the folder `packages/playground/compile-wordpress/build-assets`. You may want to add its path to `.gitignore`.
+This assumes that you have put a WXR export file named `content.xml` in the folder `packages/playground/compile-wordpress/build-assets`. You can add its path to `.gitignore`.

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -94,7 +94,16 @@ For these to work, you need a server environment with Apache and PHP installed.
 
 As an alternative to Apache, here is an example of using NGINX to serve the Playground.
 
-The Apache `.htaccess` file looks like this.
+:::info Refer to source files
+
+This example may go out of date. It is recommended to refer to the source files.
+
+- [packages/playground/remote/public/.htaccess](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/remote/public/.htaccess)
+- [packages/playground/website/public/.htaccess](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/.htaccess)
+
+:::
+
+The combined Apache `.htaccess` file looks like this.
 
 ```htaccess
 AddType application/wasm .wasm

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -50,20 +50,19 @@ The content of this folder consists the entire service of the Playground.
 
 It includes:
 
-- Data and WASM files for all available PHP and WordPress versions
-- `remote.html` - the core of Playground
-- `index.html` - the shell, or browser chrome
-- Web Worker script
+-   Data and WASM files for all available PHP and WordPress versions
+-   `remote.html` - the core of Playground
+-   `index.html` - the shell, or browser chrome
+-   Web Worker script
 
 You can deploy the content of the folder `wasm-wordpress-net` to your server using SSH, such as `scp` or `rsync`.
 
 It is a static site, except for these dynamic aspects.
 
-- Apache server directive `.htaccess` file - the result of combining `.htaccess` from the packages `remote` and `website`
-- Plugin download proxy, `plugin-proxy.php`
- 
-For these to work, you need a server environment with Apache and PHP installed.
+-   Apache server directive `.htaccess` file - the result of combining `.htaccess` from the packages `remote` and `website`
+-   Plugin download proxy, `plugin-proxy.php`
 
+For these to work, you need a server environment with Apache and PHP installed.
 
 ## NGINX configuration
 
@@ -120,12 +119,11 @@ add_header "Cross-Origin-Embedder-Policy" "credentialless";
 
 You may need to adjust the above according to server specifics, particularly how to invoke PHP for the path `/plugin-proxy`.
 
-
 ## Customize `wp.data`
 
 The file `wp.data` is a bundle of all the files for the WordPress instance running in Playground. There's a data file for each available WordPress version.
 
-Edit the build script in `packages/playground/compile-wordpress/Dockerfile` to create a custom bundle that includes preinstalled plugins or content. 
+Edit the build script in `packages/playground/compile-wordpress/Dockerfile` to create a custom bundle that includes preinstalled plugins or content.
 
 ### Install plugins
 
@@ -171,5 +169,3 @@ RUN cd wordpress ; \
 ```
 
 This assumes that you have put a WXR export file named `content.xml` in the folder `packages/playground/compile-wordpress/build-assets`. You may want to add its path to `.gitignore`.
-
-

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -146,11 +146,13 @@ add_header "Cross-Origin-Embedder-Policy" "credentialless";
 
 You may need to adjust the above according to server specifics, particularly how to invoke PHP for the path `/plugin-proxy`.
 
-## Customize `wp.data`
+## Customize bundled data
 
 The file `wp.data` is a bundle of all the files for the virtual file system in Playground. There's a data file for each available WordPress version.
 
-Edit the build script in `packages/playground/compile-wordpress/Dockerfile` to create a custom bundle that includes preinstalled plugins or content.
+The package at `packages/playground/compile-wordpress` is responsible for building these data files.
+
+Edit the build script in `Dockerfile` to create a custom bundle that includes preinstalled plugins or content.
 
 ### Install plugins
 
@@ -172,13 +174,15 @@ RUN cd wordpress/wp-content/mu-plugins && \
     done;
 ```
 
-You can download plugins from URLs other than the WordPress plugin directory, or use Git to pull them from elsewhere. It's also possible to copy from a local folder. For example, before `RUN`:
+You can download plugins from URLs other than the WordPress plugin directory, or use Git to pull them from elsewhere.
+
+It's also possible to copy from a local folder. For example, before `RUN`:
 
 ```
 COPY ./build-assets/*.zip /root/
 ```
 
-Then put the plugin zip files in `packages/playground/compile-wordpress/build-assets`. In this case, you may want to add their paths to `.gitignore`.
+Then put the plugin zip files in `build-assets`. In this case, you may want to add their paths to `.gitignore`.
 
 ### Import content
 
@@ -193,4 +197,4 @@ RUN cd wordpress ; \
     ../wp-cli.phar --allow-root import /root/content.xml --authors=create
 ```
 
-This assumes that you have put a WXR export file named `content.xml` in the folder `packages/playground/compile-wordpress/build-assets`. You can add its path to `.gitignore`.
+This assumes that you have put a WXR export file named `content.xml` in the folder `build-assets`. You can add its path to `.gitignore`.

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -98,8 +98,8 @@ As an alternative to Apache, here is an example of using NGINX to serve the Play
 
 This example may go out of date. It is recommended to refer to the source files.
 
-- [packages/playground/remote/public/.htaccess](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/remote/public/.htaccess)
-- [packages/playground/website/public/.htaccess](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/.htaccess)
+-   [packages/playground/remote/public/.htaccess](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/remote/public/.htaccess)
+-   [packages/playground/website/public/.htaccess](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/.htaccess)
 
 :::
 
@@ -134,6 +134,10 @@ location /plugin-proxy {
   try_files plugin-proxy.php /plugin-proxy.php$is_args$args;
   include fastcgi_params;
   fastcgi_pass php;
+}
+
+location /scope:.* {
+  rewrite ^scope:.*?/(.*)$ $1 last;
 }
 
 add_header "Cross-Origin-Resource-Policy" "cross-origin";

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -2,9 +2,7 @@
 
 You can host the Playground on your own domain instead of `playground.wordpress.net`.
 
-This is useful for having full control over its content and behavior, as well as removing dependency on a third-party remote endpoint. It can provide a customized user experience, for example: preinstalled plugins, default theme, site settings, and demo content.
-
-Also, if you expect to see heavy traffic, it's good etiquette to provide your own server/CDN resources to serve the static file assets, rather than relying on the `wordpress.net` server.
+This is useful for having full control over its content and behavior, as well as removing dependency on a third-party server. It can provide a more customized user experience, for example: a playground with preinstalled plugins and themes, default site settings, or demo content.
 
 #### Usage
 

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -30,7 +30,7 @@ There are several ways to get the static assets necessary to host the Playground
 In order of convenience and ease:
 
 -   Download pre-built package
--   Build from fork using GitHub Action
+-   Fork the repository and build via the GitHub Action job
 -   Build locally
 
 ### Download pre-built package

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -101,10 +101,6 @@ location /plugin-proxy {
   fastcgi_pass php;
 }
 
-location /scope:.* {
-  rewrite ^scope:.*?/(.*)$ $1 last;
-}
-
 add_header "Cross-Origin-Resource-Policy" "cross-origin";
 add_header "Cross-Origin-Embedder-Policy" "credentialless";
 ```

--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -30,7 +30,7 @@ There are several ways to get the static assets necessary to host the Playground
 In order of convenience and ease:
 
 -   Download pre-built package
--   Fork the repository and build via the GitHub Action job
+-   Fork the repository and build with GitHub Action
 -   Build locally
 
 ### Download pre-built package
@@ -41,7 +41,7 @@ To host the Playground as is, without making changes, you can download the built
 -   In the section **Artifacts** at the bottom of the page, click `playground-website`.
 -   It's a zip package with the same files deployed to the public site.
 
-### Build from fork using GitHub Action
+### Fork the repository and build with GitHub Action
 
 To customize the Playground, you can [fork the Git repository](https://github.com/WordPress/wordpress-playground/fork).
 

--- a/packages/docs/site/docs/_fragments/_playground_wp_net_may_stop_working.md
+++ b/packages/docs/site/docs/_fragments/_playground_wp_net_may_stop_working.md
@@ -2,4 +2,4 @@
 
 The site at https://playground.wordpress.net is there to support the community, but there are no guarantees it will continue to work if the traffic grows significantly.
 
-If you need certain availability, you should host your own WordPress Playground copy.
+If you need certain availability, you should [host your own WordPress Playground](../11-architecture/18-host-your-own-playground.md).

--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -95,8 +95,8 @@
 			"options": {
 				"commands": ["docusaurus start"],
 				"cwd": "packages/docs/site"
-			}
-			// "dependsOn": ["build:json"]
+			},
+			"dependsOn": ["build:json"]
 		},
 
 		"lint": {

--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -95,8 +95,8 @@
 			"options": {
 				"commands": ["docusaurus start"],
 				"cwd": "packages/docs/site"
-			},
-			"dependsOn": ["build:json"]
+			}
+			// "dependsOn": ["build:json"]
 		},
 
 		"lint": {


### PR DESCRIPTION
## What?

Start a documentation page to describe how to self-host your own instance of Playground. Resolves #459.
