### PR TITLE
Blueprints: add support for NodeJS

### DIFF
--- a/packages/php-wasm/progress/src/lib/progress-tracker.ts
+++ b/packages/php-wasm/progress/src/lib/progress-tracker.ts
@@ -1,3 +1,18 @@
+class CustomEventNode<T = any> extends Event {
+	detail: T;
+
+	constructor(type: string, customEventInit?: CustomEventInit<T>) {
+		super(type, customEventInit);
+		this.detail = customEventInit?.detail
+			? customEventInit.detail
+			: ({} as T);
+	}
+}
+
+const CustomEventIsomorphic =
+	typeof CustomEvent === 'function' ? CustomEvent : CustomEventNode;
+type CustomEventIsomorphic<T = any> = CustomEvent<T> | CustomEventNode<T>;
+
 /**
  * Options for customizing the progress tracker.
  */
@@ -13,7 +28,7 @@ export interface ProgressTrackerOptions {
 /**
  * Custom event providing information about a loading process.
  */
-export type LoadingEvent = CustomEvent<{
+export type LoadingEvent = CustomEventIsomorphic<{
 	/** The number representing how much was loaded. */
 	loaded: number;
 	/** The number representing how much needs to loaded in total. */
@@ -23,12 +38,12 @@ export type LoadingEvent = CustomEvent<{
 /**
  * Custom event providing progress details.
  */
-export type ProgressTrackerEvent = CustomEvent<ProgressDetails>;
+export type ProgressTrackerEvent = CustomEventIsomorphic<ProgressDetails>;
 
 /**
  * Custom event providing progress details when the task is done.
  */
-export type DoneEvent = CustomEvent<ProgressDetails>;
+export type DoneEvent = CustomEventIsomorphic<ProgressDetails>;
 
 export interface ProgressDetails {
 	/** The progress percentage as a number between 0 and 100. */
@@ -329,7 +344,7 @@ export class ProgressTracker extends EventTarget {
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const self = this;
 		this.dispatchEvent(
-			new CustomEvent('progress', {
+			new CustomEventIsomorphic('progress', {
 				detail: {
 					get progress() {
 						return self.progress;
@@ -343,6 +358,6 @@ export class ProgressTracker extends EventTarget {
 	}
 
 	private notifyDone() {
-		this.dispatchEvent(new CustomEvent('done'));
+		this.dispatchEvent(new CustomEventIsomorphic('done'));
 	}
 }

--- a/packages/php-wasm/progress/src/lib/progress-tracker.ts
+++ b/packages/php-wasm/progress/src/lib/progress-tracker.ts
@@ -9,9 +9,10 @@ class CustomEventNode<T = any> extends Event {
 	}
 }
 
-const CustomEventIsomorphic =
-	typeof CustomEvent === 'function' ? CustomEvent : CustomEventNode;
-type CustomEventIsomorphic<T = any> = CustomEvent<T> | CustomEventNode<T>;
+if (typeof CustomEvent === 'undefined') {
+	// @ts-expect-error
+	globalThis.CustomEvent = CustomEventNode;
+}
 
 /**
  * Options for customizing the progress tracker.
@@ -28,7 +29,7 @@ export interface ProgressTrackerOptions {
 /**
  * Custom event providing information about a loading process.
  */
-export type LoadingEvent = CustomEventIsomorphic<{
+export type LoadingEvent = CustomEvent<{
 	/** The number representing how much was loaded. */
 	loaded: number;
 	/** The number representing how much needs to loaded in total. */
@@ -38,12 +39,12 @@ export type LoadingEvent = CustomEventIsomorphic<{
 /**
  * Custom event providing progress details.
  */
-export type ProgressTrackerEvent = CustomEventIsomorphic<ProgressDetails>;
+export type ProgressTrackerEvent = CustomEvent<ProgressDetails>;
 
 /**
  * Custom event providing progress details when the task is done.
  */
-export type DoneEvent = CustomEventIsomorphic<ProgressDetails>;
+export type DoneEvent = CustomEvent<ProgressDetails>;
 
 export interface ProgressDetails {
 	/** The progress percentage as a number between 0 and 100. */
@@ -344,7 +345,7 @@ export class ProgressTracker extends EventTarget {
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const self = this;
 		this.dispatchEvent(
-			new CustomEventIsomorphic('progress', {
+			new CustomEvent('progress', {
 				detail: {
 					get progress() {
 						return self.progress;
@@ -358,6 +359,6 @@ export class ProgressTracker extends EventTarget {
 	}
 
 	private notifyDone() {
-		this.dispatchEvent(new CustomEventIsomorphic('done'));
+		this.dispatchEvent(new CustomEvent('done'));
 	}
 }

--- a/packages/php-wasm/progress/src/lib/progress-tracker.ts
+++ b/packages/php-wasm/progress/src/lib/progress-tracker.ts
@@ -1,3 +1,7 @@
+/**
+ * CustomEvent class for NodeJS
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent
+ */
 class CustomEventNode<T = any> extends Event {
 	detail: T;
 

--- a/packages/playground/blueprints/src/lib/steps/common.ts
+++ b/packages/playground/blueprints/src/lib/steps/common.ts
@@ -24,6 +24,18 @@ export async function updateFile(
 export async function fileToUint8Array(file: File) {
 	return new Uint8Array(await file.arrayBuffer());
 }
+/**
+ * File class in NodeJS
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/File
+ */
+class FileWithArrayBufferNode {
+	// NodeJS has no File class
+}
+
+if (typeof File === 'undefined') {
+	// @ts-expect-error
+	globalThis.File = FileWithArrayBufferNode;
+}
 
 /**
  * Polyfill the File class in JSDOM which lacks arrayBuffer() method
@@ -49,6 +61,6 @@ class FilePolyfill extends File {
 }
 
 const FileWithArrayBuffer =
-	File.prototype.arrayBuffer instanceof Function ? File : FilePolyfill;
+	File?.prototype.arrayBuffer instanceof Function ? File : FilePolyfill;
 
 export { FileWithArrayBuffer as File };

--- a/packages/playground/blueprints/src/lib/steps/common.ts
+++ b/packages/playground/blueprints/src/lib/steps/common.ts
@@ -61,6 +61,6 @@ class FilePolyfill extends File {
 }
 
 const FileWithArrayBuffer =
-	File?.prototype.arrayBuffer instanceof Function ? File : FilePolyfill;
+	File.prototype.arrayBuffer instanceof Function ? File : FilePolyfill;
 
 export { FileWithArrayBuffer as File };

--- a/packages/playground/blueprints/src/lib/steps/common.ts
+++ b/packages/playground/blueprints/src/lib/steps/common.ts
@@ -28,13 +28,13 @@ export async function fileToUint8Array(file: File) {
  * File class for NodeJS
  * @see https://developer.mozilla.org/en-US/docs/Web/API/File
  */
-class FileWithArrayBufferNode {
+class FileNode {
 	// NodeJS has no File class
 }
 
 if (typeof File === 'undefined') {
 	// @ts-expect-error
-	globalThis.File = FileWithArrayBufferNode;
+	globalThis.File = FileNode;
 }
 
 /**

--- a/packages/playground/blueprints/src/lib/steps/common.ts
+++ b/packages/playground/blueprints/src/lib/steps/common.ts
@@ -25,7 +25,7 @@ export async function fileToUint8Array(file: File) {
 	return new Uint8Array(await file.arrayBuffer());
 }
 /**
- * File class in NodeJS
+ * File class for NodeJS
  * @see https://developer.mozilla.org/en-US/docs/Web/API/File
  */
 class FileWithArrayBufferNode {


### PR DESCRIPTION
<!-- Thanks for contributing to WordPress Playground! -->

## What?
Blueprint steps use some classes available only on Browser and not NodeJS. 
This PR is an approach to make it possible to import the blueprints and make most of them work by declaring those classes when they are undefined.

<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->

## Why?

- This PR is needed to bring blueprints to `wp-now` : https://github.com/WordPress/playground-tools/pull/82

<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?

I declare `File` and `CustomEvent` when they are undefined.
The File implementation is empty, so we will need a second PR to make the steps to install themes and plugins work.

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

- Build this branch `nvm use && npm run build`
- Checkout the wp-now PR: https://github.com/WordPress/playground-tools/pull/82
- Access that folder in your terminal `cd playground-tools`
- Run: `nvm use && npm run build`
- Follow the testing instructions in the mentioned PR and run a simple blueprint in `wp-now`: `
- Observe the error about File or CustomEvent is undefined.
- Remove the folder `node_modules/@wp-playground`
- Create a symbolic link from `wordpress-playground` dist to `playground-tools/node_modules/@wp-playground`: `ln -s path/to/wordpress-playground/dist/packages/playground node_modules/@wp-playground`
- Follow the testing instructions in the mentioned PR and run a simple blueprint in `wp-now`: `node dist/packages/wp-now/main.js start --blueprint=foo.json --port=80`
- Observe `wp-now` has started correctly and the blueprint was executed too.
