### PR TITLE
Add clear error messages in wp-admin for plugin and theme directories

### DIFF
--- a/packages/playground/remote/src/lib/web-wordpress-patches/index.ts
+++ b/packages/playground/remote/src/lib/web-wordpress-patches/index.ts
@@ -8,6 +8,8 @@ import transportDummy from './wp-content/mu-plugins/includes/requests_transport_
 import addRequests from './wp-content/mu-plugins/add_requests_transport.php?raw';
 /** @ts-ignore */
 import showAdminCredentialsOnWpLogin from './wp-content/mu-plugins/1-show-admin-credentials-on-wp-login.php?raw';
+/** @ts-ignore */
+import niceErrorMessagesForPluginsAndThemesDirectories from './wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php?raw';
 
 import { DOCROOT } from '../config';
 
@@ -73,6 +75,10 @@ class WordPressPatcher {
 		await this.php.writeFile(
 			`${this.wordpressPath}/wp-content/mu-plugins/1-show-admin-credentials-on-wp-login.php`,
 			showAdminCredentialsOnWpLogin
+		);
+		await this.php.writeFile(
+			`${this.wordpressPath}/wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php`,
+			niceErrorMessagesForPluginsAndThemesDirectories
 		);
 	}
 

--- a/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php
+++ b/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php
@@ -19,6 +19,15 @@ add_filter( 'plugins_api_result', function( $res ) {
 } );
 
 add_filter( 'gettext', function( $translation ) {
+    // There is no better hook for swapping the error message
+    // on the themes page, unfortunately.
+    global $pagenow;
+    
+    // Only change the message on /wp-admin/theme-install.php
+    if( 'theme-install.php' === $pagenow ) {
+        return $translation;
+    }
+
     if($translation === 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.') {
         return 'Playground <a href="https://github.com/WordPress/wordpress-playground/issues/85">does not yet support</a> connecting to the themes directory yet. You can still upload a theme or install it using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a> (e.g. ?theme=pendant).';
     }

--- a/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php
+++ b/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Because the in-browser Playground doesn't have access to the internet, 
+ * network-dependent features like directories don't work. Normally, you'll 
+ * see a confusing message like "An unexpected error occurred." This mu-plugin
+ * makes it more clear that the feature is not yet supported.
+ * 
+ * https://github.com/WordPress/wordpress-playground/issues/498
+ */
+
+add_filter( 'plugins_api_result', function( $res ) {
+    if($res instanceof WP_Error) {
+        $res = new WP_Error(
+            'plugins_api_failed',
+            'Playground <a href="https://github.com/WordPress/wordpress-playground/issues/85">does not yet support</a> connecting to the plugin directory yet. You can still upload plugins or install them using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a> (e.g. ?plugin=coblocks).'
+        );
+    }
+    return $res;
+} );
+
+add_filter( 'gettext', function( $translation ) {
+    if($translation === 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.') {
+        return 'Playground <a href="https://github.com/WordPress/wordpress-playground/issues/85">does not yet support</a> connecting to the themes directory yet. You can still upload a theme or install it using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a> (e.g. ?theme=pendant).';
+    }
+    return $translation;
+} );

--- a/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php
+++ b/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php
@@ -22,9 +22,9 @@ add_filter( 'gettext', function( $translation ) {
     // There is no better hook for swapping the error message
     // on the themes page, unfortunately.
     global $pagenow;
-    
+
     // Only change the message on /wp-admin/theme-install.php
-    if( 'theme-install.php' === $pagenow ) {
+    if( 'theme-install.php' !== $pagenow ) {
         return $translation;
     }
 


### PR DESCRIPTION
Because the in-browser Playground doesn't have access to the internet, network-dependent features like directories don't work. Normally, you'll see a confusing message like "An unexpected error occurred." This PR makes it clear that the feature is not yet supported.

Solves #498

## Testing Instructions

Go to "Plugins > Add" and "Themes > Add", confirm this is what you see:

<img width="1245" alt="CleanShot 2023-06-22 at 14 49 35@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/41b7ab38-d65e-4cb4-ac91-e4d1dd6f0f65">
<img width="1236" alt="CleanShot 2023-06-22 at 14 49 25@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/1fa8bfb8-b0af-4552-89b5-1c709749b53d">
