### PR TITLE
Catch PHP initialization errors

### DIFF
--- a/packages/php-wasm/compile/build-assets/esm-suffix.js
+++ b/packages/php-wasm/compile/build-assets/esm-suffix.js
@@ -20,6 +20,22 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
+
 return PHPLoader;
 
 // Close the opening bracket from esm-prefix.js:

--- a/packages/php-wasm/web/public/php_5_6.js
+++ b/packages/php-wasm/web/public/php_5_6.js
@@ -63,6 +63,21 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
 
 return PHPLoader;
 

--- a/packages/php-wasm/web/public/php_7_0.js
+++ b/packages/php-wasm/web/public/php_7_0.js
@@ -63,6 +63,21 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
 
 return PHPLoader;
 

--- a/packages/php-wasm/web/public/php_7_1.js
+++ b/packages/php-wasm/web/public/php_7_1.js
@@ -63,6 +63,21 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
 
 return PHPLoader;
 

--- a/packages/php-wasm/web/public/php_7_2.js
+++ b/packages/php-wasm/web/public/php_7_2.js
@@ -63,6 +63,21 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
 
 return PHPLoader;
 

--- a/packages/php-wasm/web/public/php_7_3.js
+++ b/packages/php-wasm/web/public/php_7_3.js
@@ -63,6 +63,21 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
 
 return PHPLoader;
 

--- a/packages/php-wasm/web/public/php_7_4.js
+++ b/packages/php-wasm/web/public/php_7_4.js
@@ -63,7 +63,22 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
-    
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
+
 return PHPLoader;
 
 // Close the opening bracket from esm-prefix.js:

--- a/packages/php-wasm/web/public/php_8_0.js
+++ b/packages/php-wasm/web/public/php_8_0.js
@@ -62,7 +62,22 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
         return originalHandleSleep(startAsync);
     }
 }
-	
+
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
 
 return PHPLoader;
 

--- a/packages/php-wasm/web/public/php_8_1.js
+++ b/packages/php-wasm/web/public/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './php_8_1.wasm'; 
  export { dependencyFilename }; 
-export const dependenciesTotalSize = 5653957; 
+export const dependenciesTotalSize = 5653952; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets
@@ -63,6 +63,21 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
 
 return PHPLoader;
 

--- a/packages/php-wasm/web/public/php_8_2.js
+++ b/packages/php-wasm/web/public/php_8_2.js
@@ -63,6 +63,21 @@ if (PHPLoader.debug && typeof Asyncify !== "undefined") {
     }
 }
 
+/**
+ * Data dependencies call removeRunDependency() when they are loaded.
+ * The synchronous call stack then continues to run. If an error occurs
+ * in PHP initialization, e.g. Out Of Memory error, it will not be
+ * caught by any try/catch. This override propagates the failure to
+ * PHPLoader.onAbort() so that it can be handled.
+ */
+const originalRemoveRunDependency = PHPLoader['removeRunDependency'];
+PHPLoader['removeRunDependency'] = function (...args) {
+    try {
+        originalRemoveRunDependency(...args);
+    } catch (e) {
+        PHPLoader['onAbort'](e);
+    }
+}
 
 return PHPLoader;
 


### PR DESCRIPTION
Wraps removeRunDependency to propagate PHP initialization failures. Data dependencies call removeRunDependency() when they are loaded. The synchronous call stack then continues to run. If an error occurs in PHP initialization, e.g. Out Of Memory error, it will not be caught by any try/catch. This override propagates the failure to PHPLoader.onAbort() so that it can be handled.

To test, add `throw new Error()` to the `onRuntimeInitialized()` handler. With this commit, it should trigger Playground error message.
