### PR TITLE
Remove HTML comments from Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,7 @@
-<!-- Thanks for contributing to WordPress Playground! -->
+## What is this PR doing?
 
-## What?
+## What problem is it solving?
 
-<!-- In a few words, what is the PR actually doing? Include screenshots or screencasts if applicable -->
-
-## Why?
-
-<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
-
-## How?
-
-<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
+## How is the problem addressed?
 
 ## Testing Instructions
-
-<!-- Please include step by step instructions on how to test this PR. -->
-<!-- 1. Check out the branch. -->
-<!-- 2. Run a command. -->
-<!-- 3. etc. -->


### PR DESCRIPTION
I often find myself manually removing the HTML comments from PR and commit messages to prevent including them in git history. This PR adjusts the PR template to include the necessary guidelines right in the headers and remove the need for HTML comments.
