### PR TITLE
Schedules crawls to happen every 24h

### DIFF
--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -84,6 +84,7 @@ const config = {
 				appId: 'EKWQ08DUQS',
 				apiKey: '2fcab4cf2c3596e775de8c4ab1fa065e',
 				indexName: 'wordpress-playground',
+				schedule: 'every 1 day',
 			},
 			navbar: {
 				title: 'WordPress Playground',


### PR DESCRIPTION
This should solve #583.

Sadly, Docsearch (like the full Algolia) cannot be connected with Pull Requests or releases. But scheduling it every 24h should solve the problem. By default, the re-crawl happened every 7 days.