### PR TITLE
Refactor: Revise pattern matching in uploaded file path detector.

### DIFF
--- a/packages/playground/remote/src/lib/is-uploaded-file-path.ts
+++ b/packages/playground/remote/src/lib/is-uploaded-file-path.ts
@@ -1,9 +1,2 @@
-export const isUploadedFilePath = (path: string) => {
-	return (
-		path.startsWith('/wp-content/uploads/') ||
-		path.startsWith('/wp-content/plugins/') ||
-		path.startsWith('/wp-content/mu-plugins/') ||
-		path.startsWith('/wp-content/themes/') ||
-		path.startsWith('/wp-content/fonts/')
-	);
-};
+export const isUploadedFilePath = (path: string) =>
+	/^\/wp-content\/(?:fonts|(?:mu-)?plugins|themes|uploads)\//.test(path);


### PR DESCRIPTION
This patch introduces a small change, where previously the detection for user-uploaded content paths ran multiple checks against the path for possible directories. Now, a single `RegExp` pattern checks in a single pass if the path refers to one of the intended directories. Performance impact should be negligible, but why do five times what can mostly be done once.

cc: @ironprogrammer whose work in #633 prompted this change.
