### PR TITLE
Fixed wrong key typo in examples

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/08-examples.md
+++ b/packages/docs/site/docs/09-blueprints-api/08-examples.md
@@ -86,7 +86,7 @@ wp_insert_post(array(
 		},
 		{
 			"step": "importFile",
-			"pluginZipFile": {
+			"file": {
 				"resource": "url",
 				"url": "https://your-site.com/starter-content.wxz"
 			}


### PR DESCRIPTION
It's a simple typo.
I saw the error and replaced it with this.

I've tested it on my local setup.
