### PR TITLE
Docs: Fixes wp version option key

### DIFF
--- a/packages/docs/site/docs/10-javascript-api/04-blueprint-json-in-api-client.md
+++ b/packages/docs/site/docs/10-javascript-api/04-blueprint-json-in-api-client.md
@@ -14,7 +14,7 @@ const client = await startPlaygroundWeb({
 	remoteUrl: `https://playground.wordpress.net/remote.html`,
 	blueprint: {
 		preferredVersions: {
-			wordpress: '6.3',
+			wp: '6.3',
 			php: '8.0',
 		},
 		steps: [


### PR DESCRIPTION
Updates the `preferredVersions` option from the incorrect key`wordpress` to the correct `wp` per the Blueprints API

## What is this PR doing?

Fixes a typo in the docs. The example JS API uses `wordpress` to set the version but the Blueprints API specifies `wp` as the proper key.
