### PR TITLE
Improved documentation about including WP when running PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can connect to the Playground using the JavaScript client. Here's an example
 
 	const response = await client.run({
 		// wp-load.php is only required if you want to interact with WordPresss.
-		code: '<?php require_once "/wordpress/wp-load.php"; \$posts = get_posts(); echo "Post Title: " . \$posts[0]->post_title;',
+		code: '<?php require_once "/wordpress/wp-load.php"; $posts = get_posts(); echo "Post Title: " . $posts[0]->post_title;',
 	});
 	console.log(response.text);
 </script>

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ You can connect to the Playground using the JavaScript client. Here's an example
 	});
 
 	const response = await client.run({
-		code: '<?php echo "Hi!"; ',
+		// wp-load.php is only required if you want to interact with WordPresss.
+		code: '<?php require_once "/wordpress/wp-load.php"; \$posts = get_posts(); echo "Post Title: " . \$posts[0]->post_title;',
 	});
 	console.log(response.text);
 </script>

--- a/packages/docs/site/docs/09-blueprints-api/02-using-blueprints.md
+++ b/packages/docs/site/docs/09-blueprints-api/02-using-blueprints.md
@@ -74,7 +74,7 @@ You can also use Blueprints with the JavaScript API using the `startPlaygroundWe
 
 	const response = await client.run({
 		// wp-load.php is only required if you want to interact with WordPresss.
-		code: '<?php require_once "/wordpress/wp-load.php"; \$posts = get_posts(); echo "Post Title: " . \$posts[0]->post_title;',
+		code: '<?php require_once "/wordpress/wp-load.php"; $posts = get_posts(); echo "Post Title: " . $posts[0]->post_title;',
 	});
 	console.log(response.text);
 </script>

--- a/packages/docs/site/docs/09-blueprints-api/02-using-blueprints.md
+++ b/packages/docs/site/docs/09-blueprints-api/02-using-blueprints.md
@@ -73,7 +73,8 @@ You can also use Blueprints with the JavaScript API using the `startPlaygroundWe
 	});
 
 	const response = await client.run({
-		code: '<?php echo "Hi!"; ',
+		// wp-load.php is only required if you want to interact with WordPresss.
+		code: '<?php require_once "/wordpress/wp-load.php"; \$posts = get_posts(); echo "Post Title: " . \$posts[0]->post_title;',
 	});
 	console.log(response.text);
 </script>

--- a/packages/playground/blueprints/src/lib/steps/client-methods.ts
+++ b/packages/playground/blueprints/src/lib/steps/client-methods.ts
@@ -10,7 +10,7 @@ import { fileToUint8Array } from './common';
  * <code>
  * {
  * 		"step": "runPHP",
- * 		"code": "<?php echo 'Hello World'; ?>"
+ * 		"code": "<?php require_once 'wordpress/wp-load.php'; wp_insert_post(array('post_title' => 'wp-load.php required for WP functionality', 'post_status' => 'publish')); ?>"
  * }
  * </code>
  */

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -12,7 +12,8 @@ const client = await startPlaygroundWeb({
 });
 
 const response = await client.run({
-	code: '<?php echo "Hi!"; ',
+	// wp-load.php is only required if you want to interact with WordPresss.
+	code: '<?php require_once "/wordpress/wp-load.php"; \$posts = get_posts(); echo "Post Title: " . \$posts[0]->post_title;',
 });
 console.log(response.text);
 ```

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -13,7 +13,7 @@ const client = await startPlaygroundWeb({
 
 const response = await client.run({
 	// wp-load.php is only required if you want to interact with WordPresss.
-	code: '<?php require_once "/wordpress/wp-load.php"; \$posts = get_posts(); echo "Post Title: " . \$posts[0]->post_title;',
+	code: '<?php require_once "/wordpress/wp-load.php"; $posts = get_posts(); echo "Post Title: " . $posts[0]->post_title;',
 });
 console.log(response.text);
 ```


### PR DESCRIPTION
Fixes #641

I think the title and 4 lines of documentation are pretty self explanatory.

`packages/playground/blueprints/src/lib/steps/client-methods.ts`
This feels a bit clunky. Any suggestions?