### PR TITLE
Accessibility: Give the URL input a title

### DIFF
--- a/packages/playground/website/src/components/address-bar/index.tsx
+++ b/packages/playground/website/src/components/address-bar/index.tsx
@@ -43,6 +43,7 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 					onBlur={() => setIsFocused(false)}
 					name="url"
 					type="text"
+					title='URL to visit in the WordPress site, like"/wp-admin"'
 					autoComplete="off"
 				/>
 			</div>


### PR DESCRIPTION
Solves an accessibility problem where the URL input has no label/
description.

To test, install axe devTools and scan the local Playground site.

Related to https://github.com/WordPress/wordpress-playground/issues/614