### PR TITLE
Accessibility: Font contrast in the URL bar

### DIFF
--- a/packages/playground/website/src/components/address-bar/style.module.css
+++ b/packages/playground/website/src/components/address-bar/style.module.css
@@ -27,7 +27,7 @@
 	border: 0;
 	background: #40464d;
 	border-radius: 8px;
-	color: #a5afbc;
+	color: #b4becb;
 	transition: color 0.5s ease;
 }
 


### PR DESCRIPTION
Form elements are required to have a contrast of at least 4.5, and the URL bar has a contrast of 4.2 between the background color and the font color. This commit makes the font lighter to satisfy the requirements.

To test, install axeDevtools and confirm the contrast issue is no longer reported.

Related: #612