### PR TITLE
Renamed the param opfs-host from Query API, to device

### DIFF
--- a/packages/playground/website/src/types.ts
+++ b/packages/playground/website/src/types.ts
@@ -1,2 +1,2 @@
-export const StorageTypes = ['browser', 'temporary', 'opfs-host', 'opfs-browser'] as const;
+export const StorageTypes = ['browser', 'device', 'temporary', 'opfs-host', 'opfs-browser'] as const;
 export type StorageType = (typeof StorageTypes)[number];


### PR DESCRIPTION
## What is this PR doing?

Changed the param 'opfs-host' to 'device' as discussed at: https://github.com/WordPress/wordpress-playground/issues/636

Kept the old names working, for now.

## What problem is it solving?

Renamed the opfs-host parameter to simply device, to make it easier for users to remember.