### PR TITLE
Accessibility Fix: Add tooltips to import, export, and modal close buttons

### DIFF
--- a/packages/playground/website/src/components/export-button/index.tsx
+++ b/packages/playground/website/src/components/export-button/index.tsx
@@ -14,6 +14,7 @@ export default function ExportButton() {
 			id="export-playground--btn"
 			className={css.btn}
 			aria-label="Download Playground export as ZIP file"
+			title="Download Playground export as ZIP file"
 			onClick={() => playground && startDownload(playground)}
 		>
 			<svg

--- a/packages/playground/website/src/components/export-button/index.tsx
+++ b/packages/playground/website/src/components/export-button/index.tsx
@@ -10,7 +10,7 @@ export default function ExportButton() {
 		return null;
 	}
 
-	const exportButtonAriaLabel = 'Download Playground export as ZIP file';
+	const exportButtonAriaLabel = 'Download configuration .zip file';
 
 	return (
 		<button

--- a/packages/playground/website/src/components/export-button/index.tsx
+++ b/packages/playground/website/src/components/export-button/index.tsx
@@ -9,12 +9,15 @@ export default function ExportButton() {
 	if (!playground) {
 		return null;
 	}
+
+	const exportButtonAriaLabel = 'Download Playground export as ZIP file';
+
 	return (
 		<button
 			id="export-playground--btn"
 			className={css.btn}
-			aria-label="Download Playground export as ZIP file"
-			title="Download Playground export as ZIP file"
+			aria-label={exportButtonAriaLabel}
+			title={exportButtonAriaLabel}
 			onClick={() => playground && startDownload(playground)}
 		>
 			<svg

--- a/packages/playground/website/src/components/export-button/index.tsx
+++ b/packages/playground/website/src/components/export-button/index.tsx
@@ -10,7 +10,7 @@ export default function ExportButton() {
 		return null;
 	}
 
-	const exportButtonAriaLabel = 'Download configuration .zip file';
+	const exportButtonAriaLabel = 'Download Playground export as ZIP file';
 
 	return (
 		<button

--- a/packages/playground/website/src/components/import-button/index.tsx
+++ b/packages/playground/website/src/components/import-button/index.tsx
@@ -20,13 +20,16 @@ export default function ImportButton() {
 	if (!playground) {
 		return null;
 	}
+
+	const importButtonAriaLabel = 'Open Playground import window';
+
 	return (
 		<>
 			<button
 				id="import-open-modal--btn"
 				className={css.btn}
-				aria-label="Open Playground import window"
-				title="Open Playground import window"
+				aria-label={importButtonAriaLabel}
+				title={importButtonAriaLabel}
 				onClick={openModal}
 			>
 				<svg

--- a/packages/playground/website/src/components/import-button/index.tsx
+++ b/packages/playground/website/src/components/import-button/index.tsx
@@ -8,7 +8,7 @@ export default function ImportButton() {
 	const [isOpen, setOpen] = useState(false);
 	const openModal = () => setOpen(true);
 	const closeModal = () => setOpen(false);
-	const importButtonAriaLabel = 'Import configuration';
+	const importButtonAriaLabel = 'Open Playground import window';
 	const { playground } = usePlaygroundContext();
 	function handleImported() {
 		// eslint-disable-next-line no-alert

--- a/packages/playground/website/src/components/import-button/index.tsx
+++ b/packages/playground/website/src/components/import-button/index.tsx
@@ -8,7 +8,7 @@ export default function ImportButton() {
 	const [isOpen, setOpen] = useState(false);
 	const openModal = () => setOpen(true);
 	const closeModal = () => setOpen(false);
-	const importButtonAriaLabel = 'Open Playground import window';
+	const importButtonAriaLabel = 'Import configuration';
 	const { playground } = usePlaygroundContext();
 	function handleImported() {
 		// eslint-disable-next-line no-alert

--- a/packages/playground/website/src/components/import-button/index.tsx
+++ b/packages/playground/website/src/components/import-button/index.tsx
@@ -8,6 +8,7 @@ export default function ImportButton() {
 	const [isOpen, setOpen] = useState(false);
 	const openModal = () => setOpen(true);
 	const closeModal = () => setOpen(false);
+	const importButtonAriaLabel = 'Open Playground import window';
 	const { playground } = usePlaygroundContext();
 	function handleImported() {
 		// eslint-disable-next-line no-alert
@@ -20,8 +21,6 @@ export default function ImportButton() {
 	if (!playground) {
 		return null;
 	}
-
-	const importButtonAriaLabel = 'Open Playground import window';
 
 	return (
 		<>

--- a/packages/playground/website/src/components/import-button/index.tsx
+++ b/packages/playground/website/src/components/import-button/index.tsx
@@ -26,6 +26,7 @@ export default function ImportButton() {
 				id="import-open-modal--btn"
 				className={css.btn}
 				aria-label="Open Playground import window"
+				title="Open Playground import window"
 				onClick={openModal}
 			>
 				<svg

--- a/packages/playground/website/src/components/modal/index.tsx
+++ b/packages/playground/website/src/components/modal/index.tsx
@@ -36,6 +36,7 @@ export default function Modal(props: ModalProps) {
 					onClick={props.onRequestClose}
 					className={`${css.btn} ${css.btnClose}`}
 					aria-label="Close import window"
+					title="Close import window"
 				>
 					<svg
 						xmlns="http://www.w3.org/2000/svg"

--- a/packages/playground/website/src/components/modal/index.tsx
+++ b/packages/playground/website/src/components/modal/index.tsx
@@ -28,9 +28,7 @@ export const defaultStyles: ReactModal.Styles = {
 	},
 };
 
-
 export default function Modal(props: ModalProps) {
-
 	const closeBtnAriaLabel = 'Close import window';
 
 	return (

--- a/packages/playground/website/src/components/modal/index.tsx
+++ b/packages/playground/website/src/components/modal/index.tsx
@@ -27,7 +27,12 @@ export const defaultStyles: ReactModal.Styles = {
 		background: '#1e2327d0',
 	},
 };
+
+
 export default function Modal(props: ModalProps) {
+
+	const closeBtnAriaLabel = 'Close import window';
+
 	return (
 		<ReactModal style={defaultStyles} {...props}>
 			<div className={css.modalInner}>
@@ -35,8 +40,8 @@ export default function Modal(props: ModalProps) {
 					id="import-close-modal--btn"
 					onClick={props.onRequestClose}
 					className={`${css.btn} ${css.btnClose}`}
-					aria-label="Close import window"
-					title="Close import window"
+					aria-label={closeBtnAriaLabel}
+					title={closeBtnAriaLabel}
 				>
 					<svg
 						xmlns="http://www.w3.org/2000/svg"

--- a/packages/playground/website/src/components/modal/index.tsx
+++ b/packages/playground/website/src/components/modal/index.tsx
@@ -29,7 +29,7 @@ export const defaultStyles: ReactModal.Styles = {
 };
 
 export default function Modal(props: ModalProps) {
-	const closeBtnAriaLabel = 'Close';
+	const closeBtnAriaLabel = 'Close import window';
 
 	return (
 		<ReactModal style={defaultStyles} {...props}>

--- a/packages/playground/website/src/components/modal/index.tsx
+++ b/packages/playground/website/src/components/modal/index.tsx
@@ -29,7 +29,7 @@ export const defaultStyles: ReactModal.Styles = {
 };
 
 export default function Modal(props: ModalProps) {
-	const closeBtnAriaLabel = 'Close import window';
+	const closeBtnAriaLabel = 'Close';
 
 	return (
 		<ReactModal style={defaultStyles} {...props}>


### PR DESCRIPTION
## What is this PR doing?
This PR adds tooltips to the import, export, and modal close buttons. 

## What problem is it solving?
While they already have `aria-label` visually users still need the tooltips so they can understand what these icon buttons do without interacting with them first.

## How is the problem addressed?
A `title` attribute has been added to each `button` element that has the same text as the `aria-label` helper text.

## Testing Instructions
1. Run the playground
2. Hover on the import or export icons in the header, and see the tooltip appear with the helper text.

## Screenshot
<img width="1405" alt="screenshot showing the tooltip when you hover on the import button" src="https://github.com/WordPress/wordpress-playground/assets/6925260/8cb6204d-8616-47e4-ae05-7e3401842220">
