### PR TITLE
Display more clearly storage system in top toolbar

### DIFF
--- a/packages/playground/website/src/components/playground-configuration-group/index.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/index.tsx
@@ -175,10 +175,10 @@ export default function PlaygroundConfigurationGroup({
 				PHP {currentConfiguration.php} {' - '}
 				WP {runningWp || currentConfiguration.wp} {' - '}
 				{(currentConfiguration.storage === 'opfs-host' || currentConfiguration.storage === 'device')
-					? `Local (${dirName})`
+					? 'Storage: Device (${dirName})'
 					: currentConfiguration.storage === 'opfs-browser' || currentConfiguration.storage === 'browser'
-					? 'Persistent'
-					: '⚠️ Temporary'}
+					? 'Storage: Browser'
+					: '⚠️ Storage: None'}
 			</Button>
 			{(currentConfiguration.storage === 'opfs-host' || currentConfiguration.storage === 'device') ? (
 				<SyncLocalFilesButton />

--- a/packages/playground/website/src/components/playground-configuration-group/index.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/index.tsx
@@ -175,7 +175,7 @@ export default function PlaygroundConfigurationGroup({
 				PHP {currentConfiguration.php} {' - '}
 				WP {runningWp || currentConfiguration.wp} {' - '}
 				{(currentConfiguration.storage === 'opfs-host' || currentConfiguration.storage === 'device')
-					? 'Storage: Device (${dirName})'
+					? `Storage: Device (${dirName})`
 					: currentConfiguration.storage === 'opfs-browser' || currentConfiguration.storage === 'browser'
 					? 'Storage: Browser'
 					: '⚠️ Storage: None'}


### PR DESCRIPTION
## What is this PR doing?

I have made the necessary changes to complete this proposal: https://github.com/WordPress/wordpress-playground/issues/669

## What problem is it solving?

Allows the user to quickly and unambiguously see the storage type of their WP Playground.