### PR TITLE
Adjust invalid conditional in form.tsx to restore the PHP and WP version picker

### DIFF
--- a/packages/playground/website/src/components/playground-configuration-group/form.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/form.tsx
@@ -243,7 +243,7 @@ export function PlaygroundConfigurationForm({
 					) : null}
 				</ul>
 			</div>
-			{(storage === 'opfs-host' || storage === 'device') ? (
+			{(storage !== 'device' && storage !== 'opfs-host') ? (
 				<>
 					<div
 						className={`${forms.formGroup} ${forms.formGroupLinear}`}


### PR DESCRIPTION
Fixes issue #671 introduced in #661

cc @MarcArmengou 