### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can connect to the Playground using the JavaScript client. Here's an example
 	});
 
 	const response = await client.run({
-		// wp-load.php is only required if you want to interact with WordPresss.
+		// wp-load.php is only required if you want to interact with WordPress.
 		code: '<?php require_once "/wordpress/wp-load.php"; $posts = get_posts(); echo "Post Title: " . $posts[0]->post_title;',
 	});
 	console.log(response.text);

--- a/packages/docs/site/docs/09-blueprints-api/02-using-blueprints.md
+++ b/packages/docs/site/docs/09-blueprints-api/02-using-blueprints.md
@@ -73,7 +73,7 @@ You can also use Blueprints with the JavaScript API using the `startPlaygroundWe
 	});
 
 	const response = await client.run({
-		// wp-load.php is only required if you want to interact with WordPresss.
+		// wp-load.php is only required if you want to interact with WordPress.
 		code: '<?php require_once "/wordpress/wp-load.php"; $posts = get_posts(); echo "Post Title: " . $posts[0]->post_title;',
 	});
 	console.log(response.text);

--- a/packages/php-wasm/compile/Dockerfile
+++ b/packages/php-wasm/compile/Dockerfile
@@ -992,7 +992,7 @@ RUN \
     # Make the php.wasm URL configurable via the dependencyFilename loader argument:
         /root/replace.sh $'s/["\']php\.wasm[\'"]/dependencyFilename/g' /root/output/php.js && \
     # Patch a "property undefined" error
-        # Emscripten produces an if that checkes a stream.stream_ops.poll property. However,
+        # Emscripten produces an if that checks a stream.stream_ops.poll property. However,
         # stream.stream_ops is sometimes undefined and the check fails. Let's adjust it to
         # tolerate a null stream.stream_ops value.
         /root/replace.sh "s/if\s*\(stream\.stream_ops\.poll\)/if (stream.stream_ops?.poll)/g" /root/output/php.js && \

--- a/packages/php-wasm/compile/build-assets/php_wasm.c
+++ b/packages/php-wasm/compile/build-assets/php_wasm.c
@@ -615,7 +615,7 @@ void wasm_set_request_port(int port) {
 /*
  * Function: redirect_stream_to_file
  * ----------------------------
- *   Redirects writes from a given stream to a file with a speciied path.
+ *   Redirects writes from a given stream to a file with a specified path.
  *   Think of it as a the ">" operator in "echo foo > bar.txt" bash command.
  *
  *   This is useful to pass streams of bytes containing null bytes to JavaScript

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -12,7 +12,7 @@ const client = await startPlaygroundWeb({
 });
 
 const response = await client.run({
-	// wp-load.php is only required if you want to interact with WordPresss.
+	// wp-load.php is only required if you want to interact with WordPress.
 	code: '<?php require_once "/wordpress/wp-load.php"; $posts = get_posts(); echo "Post Title: " . $posts[0]->post_title;',
 });
 console.log(response.text);

--- a/packages/playground/compile-wordpress/build-assets/import-wxz.patch
+++ b/packages/playground/compile-wordpress/build-assets/import-wxz.patch
@@ -200,7 +200,7 @@ index 1120e12..b816826 100644
 +		}
 +
 +		if ( ! $mimetype_exists ) {
-+			return new WP_Error( 'invalid-file', 'Invalid WXZ fiel, mimetype declaration missing.' );
++			return new WP_Error( 'invalid-file', 'Invalid WXZ field, mimetype declaration missing.' );
 +		}
 +
  		foreach ( $archive_files as $file ) {

--- a/packages/playground/node/src/index.ts
+++ b/packages/playground/node/src/index.ts
@@ -27,7 +27,7 @@ export async function startPlaygroundNode(
 	 * @TODO figure out how to handle:
 	 * * WordPress installation? There are no wp.data files like in the web version
 	 * * Managing WordPress versions
-	 * * Exisiting WordPress installations
+	 * * Existing WordPress installations
 	 * * Mounting existing themes, plugins, and core WP files
 	 *
 	 * Perhaps there is too much custom logic to be able to even have

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -176,7 +176,7 @@ export async function bootPlaygroundRemote() {
 	}
 
 	/*
-	 * An asssertion to make sure Playground Client is compatible
+	 * An assertion to make sure Playground Client is compatible
 	 * with Remote<PlaygroundClient>
 	 */
 	return playground;

--- a/packages/playground/website/index.html
+++ b/packages/playground/website/index.html
@@ -15,7 +15,7 @@
 				const query = new URLSearchParams(window.location.search);
 				const shouldLazyLoadPlayground =
 					query.has('lazy') ||
-					// Initial API used "start_button" - this preserves compatability.
+					// Initial API used "start_button" - this preserves compatibility.
 					'1' === query.get('start_button');
 
 				if (


### PR DESCRIPTION
## What is this PR doing?

Fixes misspellings.

## What problem is it solving?

Typos.

---

Could we have a list of generated code/data in `.gitattributes`?
```
/package-lock.json linguist-generated
```

Something like this.
```
package-lock.json
packages/docs/site/static/diagrams.excalidraw
packages/php-wasm/compile/build-assets/zlib/
packages/php-wasm/node/public/
packages/php-wasm/node/src/test/test-data/
packages/php-wasm/web/public/php_*
packages/playground/remote/public/wp-*
packages/playground/remote/src/wordpress/
```
