### PR TITLE
allow-modals on sandboxed iframe

### DIFF
--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -48,7 +48,7 @@
 		<iframe
 			id="wp"
 			title="The WordPress site"
-			sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-downloads"
+			sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-downloads allow-modals"
 		></iframe>
 		<script type="module">
 			if (window.top != window.self) {


### PR DESCRIPTION
## What is this PR doing?
set `allow-modal` on sandboxed iframe

## What problem is it solving?
Allow the website on the playground to show alerts


The team at @lubusIN is testing a set of plugins in the playground and while testing https://wordpress.org/plugins/wp-content-copy-protection/ we noticed that alerts from the plugin are not working. The plugin uses JS to show alerts on the user's right-click.

related #674 
