### PR TITLE
Browser: Rewrite target="_top" as target="wordpress_playground"

### DIFF
--- a/packages/playground/remote/src/lib/web-wordpress-patches/index.ts
+++ b/packages/playground/remote/src/lib/web-wordpress-patches/index.ts
@@ -10,6 +10,8 @@ import addRequests from './wp-content/mu-plugins/add_requests_transport.php?raw'
 import showAdminCredentialsOnWpLogin from './wp-content/mu-plugins/1-show-admin-credentials-on-wp-login.php?raw';
 /** @ts-ignore */
 import niceErrorMessagesForPluginsAndThemesDirectories from './wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php?raw';
+/** @ts-ignore */
+import linksTargetingTopFrameShouldTargetPlaygroundIframe from './wp-content/mu-plugins/3-links-targeting-top-frame-should-target-playground-iframe.php?raw';
 
 import { DOCROOT } from '../config';
 
@@ -79,6 +81,10 @@ class WordPressPatcher {
 		await this.php.writeFile(
 			`${this.wordpressPath}/wp-content/mu-plugins/2-nice-error-messages-for-plugins-and-themes-directories.php`,
 			niceErrorMessagesForPluginsAndThemesDirectories
+		);
+		await this.php.writeFile(
+			`${this.wordpressPath}/wp-content/mu-plugins/3-links-targeting-top-frame-should-target-playground-iframe.php`,
+			linksTargetingTopFrameShouldTargetPlaygroundIframe
 		);
 	}
 

--- a/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/3-links-targeting-top-frame-should-target-playground-iframe.php
+++ b/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/3-links-targeting-top-frame-should-target-playground-iframe.php
@@ -8,7 +8,6 @@
  * https://github.com/WordPress/wordpress-playground/issues/266
  */
 
-// Add a script to the footer that listens to clicks on links with target="_top"
 add_action('admin_print_scripts', function () {
     ?>
     <script>

--- a/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/3-links-targeting-top-frame-should-target-playground-iframe.php
+++ b/packages/playground/remote/src/lib/web-wordpress-patches/wp-content/mu-plugins/3-links-targeting-top-frame-should-target-playground-iframe.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Links with target="top" don't work in the playground iframe because of
+ * the sandbox attribute. What they really should be targeting is the
+ * playground iframe itself (name="playground"). This mu-plugin rewrites
+ * all target="_top" links to target="playground" instead.
+ * 
+ * https://github.com/WordPress/wordpress-playground/issues/266
+ */
+
+// Add a script to the footer that listens to clicks on links with target="_top"
+add_action('admin_print_scripts', function () {
+    ?>
+    <script>
+        document.addEventListener('click', function (event) {
+            if (event.target.tagName === 'A' && ['_parent', '_top'].includes(event.target.target)) {
+                event.target.target = 'wordpress-playground';
+            }
+        });
+    </script>
+    <?php
+});


### PR DESCRIPTION
WordPress is rendered in a sandboxed iframe that prevents top-level navigation. However, some links in wp-admin, such as the "activate plugin" link rendered after the plugin is uploaded, are rendered with target="_parent".

It does not make sense to target the top frame in this context. What we really want is to target the WordPress iframe.

This commit fixes that via a <script> tag that rewrites the `target` of all clicked A elements from _top and _parent to wordpress-playground.

## Testing instructions

1. Upload a plugin in wp-admin
2. Click "Activate plugin"
3. Confirm it worked and there are no errors in devtools
4. Play with other wp-admin pages and confirm no previously working links are now broken

Related: https://github.com/WordPress/wordpress-playground/issues/266
