### PR TITLE
Add attribution to Oraoto and Sean Morris in php-wasm NPM packages

### DIFF
--- a/packages/php-wasm/node/README.md
+++ b/packages/php-wasm/node/README.md
@@ -34,3 +34,7 @@ const response = await php.request({
 });
 console.log(response.text);
 ```
+
+## Attribution
+
+`@php-wasm/node` started as a fork of the original PHP to WebAssembly build published by Oraoto in https://github.com/oraoto/pib and modified by Sean Morris in https://github.com/seanmorris/php-wasm.

--- a/packages/php-wasm/web/README.md
+++ b/packages/php-wasm/web/README.md
@@ -29,3 +29,7 @@ const response = await php.request({
 });
 console.log(response.text);
 ```
+
+## Attribution
+
+`@php-wasm/web` started as a fork of the original PHP to WebAssembly build published by Oraoto in https://github.com/oraoto/pib and modified by Sean Morris in https://github.com/seanmorris/php-wasm.


### PR DESCRIPTION
The two readmes are uploaded to NPM, let's add a few honorable mentions in them.

Investigate why README is displayed on https://www.npmjs.com/package/@php-wasm/node but not on https://www.npmjs.com/package/@php-wasm/web

cc @seanmorris