### PR TITLE
Privacy sandbox: Guide the user do when service worker cannot be registered

### DIFF
--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -108,8 +108,41 @@
 						button.onclick = async () => {
 							try {
 								await document.requestStorageAccess();
-							} finally {
 								window.location.reload();
+							} catch (e) {
+								// Either the user denied storage access OR chrome is not allowing
+								// storage access to be requested from an iframe for some reason.
+
+								// The two errors are indistinguishable and just say "requestStorageAccess not allowed"
+								// https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/dom/document.cc;drc=daf56cfa413f10dee6aa15b0b1e4572fcf5578df;l=462
+								// It's confusing! But we can at least tell the user what to do.
+								div.innerHTML = `
+									<p>
+										Oops! Playground failed to start. Here's what to do:
+									</p>
+									
+									<h3>Did you disable third-party cookies?</h3>
+									<p>
+										It also disables the required Service Worker API. Please re-enable 
+										third-party cookies and try again.
+									</p>
+
+									<h3>Did you refuse to grant Playground storage access?</h3>
+									<p>
+										Click the button below and grant storage access. Note the button may 
+										not work if you have disabled third-party cookies in your browser.
+									</p>
+									`;
+								const reportIssues =
+									document.createElement('p');
+								reportIssues.innerHTML = `
+									If neither method helped, please 
+									<a href="https://github.com/WordPress/playground-tools/issues/new"
+									   target="_blank">
+										report an issue on GitHub
+									</a>.
+								`;
+								document.body.append(reportIssues);
 							}
 						};
 					}


### PR DESCRIPTION
The "Allow storage" button does not work with third-party cookies disabled. This PR adds a useful error message to help the user adjust their browser settings and run Playground.

This is related to Privacy Sandbox (#586). Embedding Playground on another domain via an <iframe> may result in a "privacy sandboxed" environment where Service workers are not available by default.

The behavior subtly differs depending on browser settings:

* Third-party cookies enabled
* Third-party cookies disabled

In each of these modes, the behavior may differ depending on which experimental flags are enabled (on chrome://flags):

* #storage-access-api
* #third-party-storage-partitioning
* #permission-storage-access-api (maybe?)

Privacy sandbox is a work in progress and the browser implementation changes over time in response to developer feedback. In Playground, we need to stay on top of these changes and react to them.

## Testing instructions

Testing this change is tedious!

1. Build Playground
2. Put it on any https:// TLD (secure context is crucial)
3. Embed it via an iframe on any other https:// TLD
4. Go through different combinations of the above settings (third-party cookies enabled, disabled, then 0, 1, 2, or 3 experimental flags enabled)
5. Confirm that each scenario yields a useful error message and that following the steps makes Playground work

CC @andreylipattsev Am I massively overcomplicating this? Is there any easier way of staying on top of the Privacy Sandbox rollout and testing PRs like this one?
