### PR TITLE
Request Handler: Serve static files if they exist in VFS. Don't guess.

### DIFF
--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -5,7 +5,7 @@ import {
 	SupportedPHPVersions,
 } from '@php-wasm/universal';
 
-describe.each([SupportedPHPVersions])(
+describe.each(SupportedPHPVersions)(
 	'[PHP %s] PHPRequestHandler – request',
 	(phpVersion) => {
 		let php: NodePHP;

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -5,7 +5,7 @@ import {
 	SupportedPHPVersions,
 } from '@php-wasm/universal';
 
-describe.each(SupportedPHPVersions)(
+describe.each([SupportedPHPVersions])(
 	'[PHP %s] PHPRequestHandler – request',
 	(phpVersion) => {
 		let php: NodePHP;
@@ -16,7 +16,6 @@ describe.each(SupportedPHPVersions)(
 			php = new NodePHP(runtimeId);
 			handler = new PHPRequestHandler(php, {
 				documentRoot: '/',
-				isStaticFilePath: (path) => !path.endsWith('.php'),
 			});
 		});
 
@@ -52,6 +51,34 @@ describe.each(SupportedPHPVersions)(
 					'content-length': ['11'],
 				},
 				bytes: new TextEncoder().encode('Hello World'),
+				errors: '',
+				exitCode: 0,
+			});
+		});
+
+		it('should yield x-file-type=static when a static file is not found', async () => {
+			const response = await handler.request({
+				url: '/index.html',
+			});
+			expect(response).toEqual({
+				httpStatusCode: 404,
+				headers: {
+					'x-file-type': ['static'],
+				},
+				bytes: expect.any(Uint8Array),
+				errors: '',
+				exitCode: 0,
+			});
+		});
+
+		it('should not yield x-file-type=static when a PHP file is not found', async () => {
+			const response = await handler.request({
+				url: '/index.php',
+			});
+			expect(response).toEqual({
+				httpStatusCode: 404,
+				headers: {},
+				bytes: expect.any(Uint8Array),
 				errors: '',
 				exitCode: 0,
 			});
@@ -171,8 +198,6 @@ describe.each(SupportedPHPVersions)(
 			php.mkdirTree('/var/www');
 			handler = new PHPRequestHandler(php, {
 				documentRoot: '/var/www',
-				// Treat all files as dynamic
-				isStaticFilePath: () => false,
 			});
 		});
 

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -24,11 +24,6 @@ export interface PHPRequestHandlerConfiguration {
 	 * Request Handler URL. Used to populate $_SERVER details like HTTP_HOST.
 	 */
 	absoluteUrl?: string;
-	/**
-	 * Callback used by the PHPRequestHandler to decide whether
-	 * the requested path refers to a PHP file or a static file.
-	 */
-	isStaticFilePath?: (path: string) => boolean;
 }
 
 /** @inheritDoc */
@@ -46,7 +41,6 @@ export class PHPRequestHandler implements RequestHandler {
 	 * The PHP instance
 	 */
 	php: BasePHP;
-	#isStaticFilePath: (path: string) => boolean;
 
 	/**
 	 * @param  php    - The PHP instance.
@@ -57,11 +51,9 @@ export class PHPRequestHandler implements RequestHandler {
 		const {
 			documentRoot = '/www/',
 			absoluteUrl = typeof location === 'object' ? location?.href : '',
-			isStaticFilePath = () => false,
 		} = config;
 		this.php = php;
 		this.#DOCROOT = documentRoot;
-		this.#isStaticFilePath = isStaticFilePath;
 
 		const url = new URL(absoluteUrl);
 		this.#HOSTNAME = url.hostname;
@@ -122,29 +114,32 @@ export class PHPRequestHandler implements RequestHandler {
 			isAbsolute ? undefined : DEFAULT_BASE_URL
 		);
 
-		const normalizedRelativeUrl = removePathPrefix(
+		const normalizedRequestedPath = removePathPrefix(
 			requestedUrl.pathname,
 			this.#PATHNAME
 		);
-		if (this.#isStaticFilePath(normalizedRelativeUrl)) {
-			return this.#serveStaticFile(normalizedRelativeUrl);
+		const fsPath = `${this.#DOCROOT}${normalizedRequestedPath}`;
+		if (seemsLikeAPHPRequestHandlerPath(fsPath)) {
+			return await this.#dispatchToPHP(request, requestedUrl);
 		}
-		return await this.#dispatchToPHP(request, requestedUrl);
+		return this.#serveStaticFile(fsPath);
 	}
 
 	/**
 	 * Serves a static file from the PHP filesystem.
 	 *
-	 * @param  path - The requested static file path.
+	 * @param  fsPath - Absolute path of the static file to serve.
 	 * @returns The response.
 	 */
-	#serveStaticFile(path: string): PHPResponse {
-		const fsPath = `${this.#DOCROOT}${path}`;
-
+	#serveStaticFile(fsPath: string): PHPResponse {
 		if (!this.php.fileExists(fsPath)) {
 			return new PHPResponse(
 				404,
-				{},
+				// Let the service worker know that no static file was found
+				// and that it's okay to issue a real fetch() to the server.
+				{
+					'x-file-type': ['static'],
+				},
 				new TextEncoder().encode('404 File not found')
 			);
 		}
@@ -393,4 +388,33 @@ function inferMimeType(path: string): string {
 		default:
 			return 'application-octet-stream';
 	}
+}
+
+/**
+ * Guesses whether the given path looks like a PHP file.
+ *
+ * @example
+ * ```js
+ * seemsLikeAPHPRequestHandlerPath('/index.php') // true
+ * seemsLikeAPHPRequestHandlerPath('/index.php') // true
+ * seemsLikeAPHPRequestHandlerPath('/index.php/foo/bar') // true
+ * seemsLikeAPHPRequestHandlerPath('/index.html') // false
+ * seemsLikeAPHPRequestHandlerPath('/index.html/foo/bar') // false
+ * seemsLikeAPHPRequestHandlerPath('/') // true
+ * ```
+ *
+ * @param  path The path to check.
+ * @returns Whether the path seems like a PHP server path.
+ */
+export function seemsLikeAPHPRequestHandlerPath(path: string): boolean {
+	return seemsLikeAPHPFile(path) || seemsLikeADirectoryRoot(path);
+}
+
+function seemsLikeAPHPFile(path: string) {
+	return path.endsWith('.php') || path.includes('.php/');
+}
+
+function seemsLikeADirectoryRoot(path: string) {
+	const lastSegment = path.split('/').pop();
+	return !lastSegment!.includes('.');
 }

--- a/packages/playground/blueprints/src/lib/compile.spec.ts
+++ b/packages/playground/blueprints/src/lib/compile.spec.ts
@@ -16,7 +16,6 @@ describe('Blueprints', () => {
 		php = await NodePHP.load(phpVersion, {
 			requestHandler: {
 				documentRoot: '/',
-				isStaticFilePath: (path) => !path.endsWith('.php'),
 			},
 		});
 	});

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
@@ -8,7 +8,6 @@ describe('Blueprint step installPlugin', () => {
 		php = await NodePHP.load(phpVersion, {
 			requestHandler: {
 				documentRoot: '/wordpress',
-				isStaticFilePath: (path) => !path.endsWith('.php'),
 			},
 		});
 	});

--- a/packages/playground/blueprints/src/lib/steps/install-theme.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-theme.spec.ts
@@ -8,7 +8,6 @@ describe('Blueprint step installTheme', () => {
 		php = await NodePHP.load(phpVersion, {
 			requestHandler: {
 				documentRoot: '/wordpress',
-				isStaticFilePath: (path) => !path.endsWith('.php'),
 			},
 		});
 	});

--- a/packages/playground/remote/src/lib/is-uploaded-file-path.ts
+++ b/packages/playground/remote/src/lib/is-uploaded-file-path.ts
@@ -1,2 +1,0 @@
-export const isUploadedFilePath = (path: string) =>
-	/^\/wp-content\/(?:fonts|(?:mu-)?plugins|themes|uploads)\//.test(path);

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -2,7 +2,6 @@ import { WebPHP, WebPHPEndpoint, exposeAPI } from '@php-wasm/web';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import { setURLScope } from '@php-wasm/scopes';
 import { DOCROOT, wordPressSiteUrl } from './config';
-import { isUploadedFilePath } from './is-uploaded-file-path';
 import {
 	getWordPressModule,
 	LatestSupportedWordPressVersion,
@@ -85,7 +84,6 @@ const { php, phpReady } = WebPHP.loadSync(phpVersion, {
 	requestHandler: {
 		documentRoot: DOCROOT,
 		absoluteUrl: scopedSiteUrl,
-		isStaticFilePath: isUploadedFilePath,
 	},
 	// We don't yet support loading specific PHP extensions one-by-one.
 	// Let's just indicate whether we want to load all of them.


### PR DESCRIPTION
Replaces approximate rules such as

```js
if(path.startsWith('/wp-content')) {
    // serve from VFS
} else {
    // serve from remote server
}
```

With actual file existence check.

## Context

When a static file is requested from Playground, the service worker doesn't know whether to serve it from VFS or playground.wordpress.net. It tries to guess that based on approximate rules such as `path.startsWith('/wp-content')`. This usually works, but is not very reliable. For example, when you store an entirely new WordPress instance in VFS, you would expect all the static assets to be served from VFS, but that is not what the request handler would do.

This does not play well with previewing WordPress Pull Requests as we're actually replacing the entire WordPress instance in VFS with an arbitrary branch.

Related to #700
Closes #109

## Testing Instructions

1. Start Playground `npm run start`
2. Use it for a bit, go to wp-admin, confirm that static assets like CSS and JS files are loaded without issues
3. Upload something, confirm that worked too

## Breaking change

The `isStaticFilePath` option is removed in this PR..

This is a breaking change in public API and may be relevant for wp-now CC @sejas @danielbachhuber.

While that sounds scary, everything should "just work" without major changes required in wp-now, other than removing this usage of `isStaticFilePath`:

https://github.com/WordPress/playground-tools/blob/d792d7f03323aa0ec34e5885e4aebd5741d96f24/packages/wp-now/src/wp-now.ts#L53-L65
