### PR TITLE
Remove cross-origin headers from .htaccess

### DIFF
--- a/packages/playground/remote/public/.htaccess
+++ b/packages/playground/remote/public/.htaccess
@@ -1,5 +1,2 @@
 AddType application/wasm .wasm
 AddType	application/octet-stream .data
-
-Header set Cross-Origin-Resource-Policy: cross-origin
-Header set Cross-Origin-Embedder-Policy: credentialless


### PR DESCRIPTION
#695 removed Cross-Origin-*-Policy headers from all places but the `.htaccess` file. This PR fixes that.

Closes https://github.com/WordPress/wordpress-playground/issues/701
