### PR TITLE
Preserve wp-admin SVG assets in wp.data bundle

### DIFF
--- a/packages/playground/compile-wordpress/Dockerfile
+++ b/packages/playground/compile-wordpress/Dockerfile
@@ -98,7 +98,10 @@ RUN cd wordpress && \
     -o -name '*.scss' -o -name '*.stylelintignore' -o -name '*.svg' \
     -o -name '*.ttf' -o -name '*.txt' -o -name '*.woff' \
     -o -name '*.woff2' -o -name '*.jpeg' -o -name '*.jpg' \
-    \) -delete
+    \) \
+    # Preserve the wp-admin SVG files that are read by PHP
+    -not -path '*/wp-admin/images/*.svg' \
+    -delete
 
 # Keep only the CSS files that are read by PHP
 RUN cd wordpress && \

--- a/packages/playground/remote/src/lib/web-wordpress-patches/index.ts
+++ b/packages/playground/remote/src/lib/web-wordpress-patches/index.ts
@@ -19,7 +19,6 @@ export function applyWebWordPressPatches(php: UniversalPHP) {
 	const patch = new WordPressPatcher(php, DOCROOT);
 
 	patch.replaceRequestsTransports();
-	patch.addMissingSvgs();
 }
 
 class WordPressPatcher {
@@ -86,21 +85,6 @@ class WordPressPatcher {
 			`${this.wordpressPath}/wp-content/mu-plugins/3-links-targeting-top-frame-should-target-playground-iframe.php`,
 			linksTargetingTopFrameShouldTargetPlaygroundIframe
 		);
-	}
-
-	async addMissingSvgs() {
-		// @TODO: use only on the web version, or not even there – just include these
-		// in WordPress build:
-		this.php.mkdirTree(`${this.wordpressPath}/wp-admin/images`);
-		const missingSvgs = [
-			`${this.wordpressPath}/wp-admin/images/about-header-about.svg`,
-			`${this.wordpressPath}/wp-admin/images/dashboard-background.svg`,
-		];
-		for (const missingSvg of missingSvgs) {
-			if (!(await this.php.fileExists(missingSvg))) {
-				await this.php.writeFile(missingSvg, '');
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
Restores a few SVG files that were previously stripped from the data bundle and restored as empty files via addMissingSvgs() function.

This allows us to apply one WordPress patch less (`addMissingSvgs()`).

## Testing instructions

1. Rebuild WP data bundles with `npx nx recompile-wordpress:all playground-remote`
2. Start Playground with `npm run dev`
3. Confirm the banner in wp-admin has subtle vertical lines as its background

<img width="1009" alt="CleanShot 2023-10-16 at 12 20 24@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/2b749d08-153a-4287-99d1-6f27194f05a2">
