### PR TITLE
Download plugins and themes directly from WordPress.org, not via plugin-proxy.php

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -1,7 +1,6 @@
 export * from './lib/steps';
 export * from './lib/steps/handlers';
 export { runBlueprintSteps, compileBlueprint } from './lib/compile';
-export { setPluginProxyURL } from './lib/resources';
 export type { Blueprint } from './lib/blueprint';
 export type {
 	CompiledStep,
@@ -29,3 +28,11 @@ export type {
 	VFSReference,
 	VFSResource,
 } from './lib/resources';
+
+/**
+ * @deprecated This function is a no-op. Playground no longer uses a proxy to download plugins and themes.
+ *             To be removed in v0.3.0
+ */
+export function setPluginProxyURL() {
+
+}

--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -281,11 +281,6 @@ export class UrlResource extends FetchResource {
 	}
 }
 
-let pluginProxyURL = 'https://playground.wordpress.net/plugin-proxy';
-export function setPluginProxyURL(url: string) {
-	pluginProxyURL = url;
-}
-
 /**
  * A `Resource` that represents a WordPress core theme.
  */
@@ -301,7 +296,7 @@ export class CoreThemeResource extends FetchResource {
 	}
 	getURL() {
 		const zipName = toDirectoryZipName(this.resource.slug);
-		return `${pluginProxyURL}?theme=` + zipName;
+		return `https://downloads.wordpress.org/theme/${zipName}`;
 	}
 }
 
@@ -324,7 +319,7 @@ export class CorePluginResource extends FetchResource {
 	/** @inheritDoc */
 	getURL() {
 		const zipName = toDirectoryZipName(this.resource.slug);
-		return `${pluginProxyURL}?plugin=` + zipName;
+		return `https://downloads.wordpress.org/plugin/${zipName}`;
 	}
 }
 

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -235,6 +235,9 @@ $downloader = new PluginDownloader(
 header('Access-Control-Allow-Origin: *');
 $pluginResponse;
 try {
+    /** @deprecated Plugins and themes downloads are no longer needed now that WordPress.org serves
+     *              the proper CORS headers. This code will be removed in one of the next releases.
+     */
     if (isset($_GET['plugin'])) {
         $downloader->streamFromDirectory($_GET['plugin'], PluginDownloader::PLUGINS);
     } else if (isset($_GET['theme'])) {


### PR DESCRIPTION
WordPress.org now serves the `Access-Control-Allow-*` headers necessary to perform a direct `fetch()` without going through plugin-proxy.php. This commit thus removes the usages of plugin-proxy.php.

The plugin proxy is now only used by the Pull Request previewers. As a follow up, let's consider splitting them to a separate package or even to the playground-tools repo.

## Testing Instructions

To test, go to http://localhost:5400/website-server/?theme=pendant&plugin=gutenberg and confirm that both the Pendant theme and the Gutenberg plugins are installed, and also that the zip files are downloaded directly from wordpress.org

cc @akirk 