### PR TITLE
Remove the /plugin-proxy -> /plugin-proxy.php rewrite

### DIFF
--- a/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/11-architecture/18-host-your-own-playground.md
@@ -85,8 +85,7 @@ You can deploy the content of the folder to your server using SSH, such as `scp`
 
 It is a static site, except for these dynamic aspects.
 
--   Apache server directive `.htaccess` file - the result of combining `.htaccess` from the packages `remote` and `website`
--   Plugin download proxy, `plugin-proxy.php`
+-   Apache server directive `.htaccess` file from the package `remote`
 
 For these to work, you need a server environment with Apache and PHP installed.
 
@@ -99,7 +98,6 @@ As an alternative to Apache, here is an example of using NGINX to serve the Play
 This example may go out of date. It is recommended to refer to the source files.
 
 -   [packages/playground/remote/public/.htaccess](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/remote/public/.htaccess)
--   [packages/playground/website/public/.htaccess](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/.htaccess)
 
 :::
 
@@ -108,9 +106,6 @@ The combined Apache `.htaccess` file looks like this.
 ```htaccess
 AddType application/wasm .wasm
 AddType	application/octet-stream .data
-
-RewriteEngine on
-RewriteRule ^plugin-proxy$ plugin-proxy.php [NC]
 ```
 
 An equivalent in NGINX.
@@ -126,12 +121,6 @@ location ~* .data$ {
   types {
     application/octet-stream data;
   }
-}
-
-location /plugin-proxy {
-  try_files plugin-proxy.php /plugin-proxy.php$is_args$args;
-  include fastcgi_params;
-  fastcgi_pass php;
 }
 
 location /scope:.* {

--- a/packages/php-wasm/web/public/.htaccess
+++ b/packages/php-wasm/web/public/.htaccess
@@ -1,1 +1,2 @@
 AddType application/wasm .wasm
+AddType application/octet-stream .data

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -18,7 +18,7 @@
 					"cp -r ./blueprints/blueprint-schema.json ./wasm-wordpress-net/",
 					"cp -r ./remote/* ./wasm-wordpress-net/",
 					"cp -r ./website/* ./wasm-wordpress-net/",
-					"cat ./remote/.htaccess ./website/.htaccess > ./wasm-wordpress-net/.htaccess"
+					"cat ./remote/.htaccess > ./wasm-wordpress-net/.htaccess"
 				],
 				"cwd": "dist/packages/playground",
 				"parallel": false

--- a/packages/playground/website/public/.htaccess
+++ b/packages/playground/website/public/.htaccess
@@ -1,2 +1,0 @@
-RewriteEngine on
-RewriteRule ^plugin-proxy$ plugin-proxy.php [NC]

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -104,7 +104,7 @@
 			}
 
 			// Verify that the PR exists and that GitHub CI finished building it
-			const zipArtifactUrl = `/plugin-proxy?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
+			const zipArtifactUrl = `/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
 			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
 			const response = await fetch(zipArtifactUrl, { method: 'HEAD' });
 			if (response.status !== 200) {

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -126,7 +126,7 @@
 			}
 
 			// Verify that the PR exists and that GitHub CI finished building it
-			const zipArtifactUrl = `/plugin-proxy?org=WordPress&repo=wordpress-develop&workflow=Build%20WordPress&artifact=wordpress-build-${prNumber}&pr=${prNumber}`;
+			const zipArtifactUrl = `/plugin-proxy.php?org=WordPress&repo=wordpress-develop&workflow=Build%20WordPress&artifact=wordpress-build-${prNumber}&pr=${prNumber}`;
 			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
 			const response = await fetch(zipArtifactUrl, { method: 'HEAD' });
 			if (response.status !== 200) {


### PR DESCRIPTION
Since Plugin proxy is no longer needed for Playground core (See #711), let's remove the related .htaccess rewrite.
