### PR TITLE
Allow an optional proxy

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -28,11 +28,3 @@ export type {
 	VFSReference,
 	VFSResource,
 } from './lib/resources';
-
-/**
- * @deprecated This function is a no-op. Playground no longer uses a proxy to download plugins and themes.
- *             To be removed in v0.3.0
- */
-export function setPluginProxyURL() {
-
-}

--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -8,6 +8,7 @@ export type {
 	CompileBlueprintOptions,
 	OnStepCompleted,
 } from './lib/compile';
+export { setPluginProxyURL } from './lib/resources';
 export type {
 	CachedResource,
 	CorePluginReference,

--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -300,7 +300,7 @@ export class CoreThemeResource extends FetchResource {
 	}
 	getURL() {
 		const zipName = toDirectoryZipName(this.resource.slug);
-		if ( pluginProxyURL !== '' ) {
+		if (pluginProxyURL !== '') {
 			return `${pluginProxyURL}?theme=` + zipName;
 		}
 		return `https://downloads.wordpress.org/theme/${zipName}`;
@@ -326,7 +326,7 @@ export class CorePluginResource extends FetchResource {
 	/** @inheritDoc */
 	getURL() {
 		const zipName = toDirectoryZipName(this.resource.slug);
-		if ( pluginProxyURL !== '' ) {
+		if (pluginProxyURL !== '') {
 			return `${pluginProxyURL}?plugin=` + zipName;
 		}
 		return `https://downloads.wordpress.org/plugin/${zipName}`;

--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -281,6 +281,10 @@ export class UrlResource extends FetchResource {
 	}
 }
 
+let pluginProxyURL = '';
+export function setPluginProxyURL(url: string) {
+	pluginProxyURL = url;
+}
 /**
  * A `Resource` that represents a WordPress core theme.
  */
@@ -296,6 +300,9 @@ export class CoreThemeResource extends FetchResource {
 	}
 	getURL() {
 		const zipName = toDirectoryZipName(this.resource.slug);
+		if ( pluginProxyURL !== '' ) {
+			return `${pluginProxyURL}?theme=` + zipName;
+		}
 		return `https://downloads.wordpress.org/theme/${zipName}`;
 	}
 }
@@ -319,6 +326,9 @@ export class CorePluginResource extends FetchResource {
 	/** @inheritDoc */
 	getURL() {
 		const zipName = toDirectoryZipName(this.resource.slug);
+		if ( pluginProxyURL !== '' ) {
+			return `${pluginProxyURL}?plugin=` + zipName;
+		}
 		return `https://downloads.wordpress.org/plugin/${zipName}`;
 	}
 }


### PR DESCRIPTION
## What is this PR doing?

Instead of removing the proxy support #711, this (tempoarily?) brings back the ability to set it. 

## What problem is it solving?

In [Translate Live](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/), we use code from a Github branch that is used by a customized proxy.

## How is the problem addressed?

Re-add `setPluginProxyURL` code so that a proxy URL can be set and if one is set, so that it's used.

## Testing Instructions

The instructions of #711 still need to work, i.e. downloads.wordpress.org is to be used directly:

> To test, go to http://localhost:5400/website-server/?theme=pendant&plugin=gutenberg and confirm that both the Pendant theme and the Gutenberg plugins are installed, and also that the zip files are downloaded directly from wordpress.org

Additionally, setting a proxy should have that be used.
