### PR TITLE
 fixes: Invalid blueprint: must have required property 'themeZipFile' at /steps/0

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/01-index.md
+++ b/packages/docs/site/docs/09-blueprints-api/01-index.md
@@ -54,10 +54,16 @@ Because Blueprints can be pasted in the URL, you can embed or link to a Playgrou
   		"wp": "latest"
 	},
 	"steps": [
-		{
-			"step": "installTheme",
-			"slug": "pendant"
-		}
+        {
+            "step": "installTheme",
+            "themeZipFile": {
+                "resource": "wordpress.org/themes",
+            	"slug": "pendant"
+            },
+            "options": {
+                "activate": true
+            }
+        }
 	]
 }} />
 


### PR DESCRIPTION
"step": "installTheme", needs property  "themeZipFile": fixes: Invalid blueprint: must have required property 'themeZipFile' at /steps/0

## What is this PR doing?

## What problem is it solving?

## How is the problem addressed?

## Testing Instructions
