### PR TITLE
[Blueprints] Always virtualize the wp-config.php constants in the defineWpConfigConsts step

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.spec.ts
+++ b/packages/playground/blueprints/src/lib/compile.spec.ts
@@ -51,7 +51,6 @@ describe('Blueprints', () => {
 		// Step1: define the constants
 		const configFile = await defineWpConfigConsts(php, {
 			consts,
-			virtualize: true,
 		});
 		expect(configFile.startsWith(VFS_TMP_DIRECTORY)).toBe(true);
 		expect(

--- a/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/index.ts
+++ b/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/index.ts
@@ -99,8 +99,7 @@ class WordPressPatcher {
 			consts: {
 				WP_HOME: this.scopedSiteUrl,
 				WP_SITEURL: this.scopedSiteUrl,
-			},
-			virtualize: true,
+			}
 		});
 	}
 
@@ -152,6 +151,7 @@ class WordPressPatcher {
 
 	async prepareForRunningInsideWebBrowser() {
 		// Various tweaks
+		await this.php.mkdir(`${this.wordpressPath}/wp-content/mu-plugins`);
 		await this.php.writeFile(
 			`${this.wordpressPath}/wp-content/mu-plugins/1-show-admin-credentials-on-wp-login.php`,
 			showAdminCredentialsOnWpLogin

--- a/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/index.ts
+++ b/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/index.ts
@@ -99,7 +99,7 @@ class WordPressPatcher {
 			consts: {
 				WP_HOME: this.scopedSiteUrl,
 				WP_SITEURL: this.scopedSiteUrl,
-			}
+			},
 		});
 	}
 

--- a/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.ts
+++ b/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.ts
@@ -23,18 +23,20 @@ export interface DefineWpConfigConstsStep {
 	consts: Record<string, unknown>;
 	/**
 	 * @deprecated This option is noop and will be removed in a future version.
+	 * This option is only kept in here to avoid breaking Blueprint schema validation
+	 * for existing apps using this option.
 	 */
 	virtualize?: boolean;
 }
 
 /**
  * Defines constants to be used in wp-config.php file.
- * 
+ *
  * Technically, this creates a wp-consts.php file in an in-memory
  * /vfs-blueprints directory and sets the auto_prepend_file PHP option
  * to always load that file.
  * @see https://www.php.net/manual/en/ini.core.php#ini.auto-prepend-file
- * 
+ *
  * This step can be called multiple times, and the constants will be merged.
  *
  * @param playground The playground client.

--- a/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.ts
+++ b/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.ts
@@ -13,8 +13,7 @@ export const VFS_TMP_DIRECTORY = '/vfs-blueprints';
  * 		"step": "defineWpConfigConsts",
  * 		"consts": {
  *          "WP_DEBUG": true
- *      },
- *      "virtualize": true
+ *      }
  * }
  * </code>
  */
@@ -23,39 +22,32 @@ export interface DefineWpConfigConstsStep {
 	/** The constants to define */
 	consts: Record<string, unknown>;
 	/**
-	 * Enables the virtualization of wp-config.php and playground-consts.json files, leaving the local system files untouched.
-	 * The variables defined in the /vfs-blueprints/playground-consts.json file are loaded via the auto_prepend_file directive in the php.ini file.
-	 * @default false
-	 * @see https://www.php.net/manual/en/ini.core.php#ini.auto-prepend-file
+	 * @deprecated This option is noop and will be removed in a future version.
 	 */
 	virtualize?: boolean;
 }
 
 /**
- * Defines the wp-config.php constants
+ * Defines constants to be used in wp-config.php file.
+ * 
+ * Technically, this creates a wp-consts.php file in an in-memory
+ * /vfs-blueprints directory and sets the auto_prepend_file PHP option
+ * to always load that file.
+ * @see https://www.php.net/manual/en/ini.core.php#ini.auto-prepend-file
+ * 
+ * This step can be called multiple times, and the constants will be merged.
  *
  * @param playground The playground client.
  * @param wpConfigConst
  */
 export const defineWpConfigConsts: StepHandler<
 	DefineWpConfigConstsStep
-> = async (playground, { consts, virtualize = false }) => {
-	const documentRoot = await playground.documentRoot;
-	const basePath = virtualize ? VFS_TMP_DIRECTORY : documentRoot;
-	const jsonPath = `${basePath}/playground-consts.json`;
-	const configFilePath = `${basePath}/wp-config.php`;
-	if (virtualize) {
-		playground.mkdir(VFS_TMP_DIRECTORY);
-		playground.setPhpIniEntry('auto_prepend_file', configFilePath);
-	}
-	await updateFile(playground, jsonPath, (contents) =>
-		JSON.stringify({
-			...JSON.parse(contents || '{}'),
-			...consts,
-		})
-	);
-	await updateFile(playground, configFilePath, (contents) => {
-		if (!contents.includes('playground-consts.json')) {
+> = async (playground, { consts }) => {
+	await playground.mkdir(VFS_TMP_DIRECTORY);
+	const phpConstsFilePath = `${VFS_TMP_DIRECTORY}/wp-consts.php`;
+	const jsonPath = `${VFS_TMP_DIRECTORY}/playground-consts.json`;
+	await updateFile(playground, phpConstsFilePath, (contents) => {
+		if (!contents.includes(jsonPath)) {
 			return `<?php
 	$consts = json_decode(file_get_contents('${jsonPath}'), true);
 	foreach ($consts as $const => $value) {
@@ -67,5 +59,13 @@ export const defineWpConfigConsts: StepHandler<
 		}
 		return contents;
 	});
-	return configFilePath;
+	await updateFile(playground, jsonPath, (contents) =>
+		JSON.stringify({
+			...JSON.parse(contents || '{}'),
+			...consts,
+		})
+	);
+
+	await playground.setPhpIniEntry('auto_prepend_file', phpConstsFilePath);
+	return phpConstsFilePath;
 };

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -86,8 +86,7 @@ if (currentConfiguration.wp === '6.3') {
 		step: 'defineWpConfigConsts',
 		consts: {
 			WP_DEVELOPMENT_MODE: 'all',
-		},
-		virtualize: true,
+		}
 	});
 }
 

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -86,7 +86,7 @@ if (currentConfiguration.wp === '6.3') {
 		step: 'defineWpConfigConsts',
 		consts: {
 			WP_DEVELOPMENT_MODE: 'all',
-		}
+		},
 	});
 }
 


### PR DESCRIPTION
## Description

PR #343 added a "virtualize" option so Playground can define new PHP constants without changing the WordPress files in the filesystem.

This is incredibly useful. At the same time, mixing defineWpConfigConst calls with and without the "virtualize" option may lead to a situation where some constants are lost or when Playground tries to load a non-existing playground-consts.json file – see #735.

Since I can't think of a good rationale to keep the non-virtualized version around, let's reduce complexity and always virtualize the constants. The "virtualize" option will now be noop and is only kept to avoid breaking Blueprint schema validation for existing apps.

## Testing instructions

* Confirm unit tests pass
* Confirm the [WordPress PR previewer](http://localhost:5400/website-server/wordpress.html) loads Pull Requests without triggering any warnings

## Follow-up work

* Adjust Blueprint schema validation to tolerate the `virtualize` option so we can remove it from the type
* Call this step `definePHPConsts` as there is nothing specific to `wp-config.php` in it

Closes #735
