### PR TITLE
Website: Surface tools and docs in the dropdown menu

### DIFF
--- a/packages/playground/website/demos/index.html
+++ b/packages/playground/website/demos/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<head>
+	<title>Playground Time Traveling Demo</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<style>
+		* {
+			box-sizing: border-box;
+		}
+		body {
+			width: 100vw;
+			height: 100vh;
+			padding: 20px;
+		}
+	</style>
+</head>
+<body>
+	<h2>WordPress Playground demos</h2>
+	<p>
+		This is a collection of cool apps and demos built with WordPress
+		Playground.
+	</p>
+	<ul>
+		<li>
+			<a href="sync.html">Synchronization between two Playgrounds</a>
+		</li>
+		<li>
+			<a href="time-traveling.html">Time Travel</a>
+		</li>
+		<li>
+			<a href="../wordpress.html">WordPress Pull Request Previewer</a>
+		</li>
+		<li>
+			<a href="../gutenberg.html">Gutenberg Pull Request Previewer</a>
+		</li>
+	</ul>
+</body>

--- a/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
@@ -8,9 +8,6 @@ import saveAs from 'file-saver';
 type Props = { onClose: () => void };
 export function DownloadAsZipMenuItem({ onClose }: Props) {
 	const { playground } = usePlaygroundContext();
-	if (!playground) {
-		return null;
-	}
 	return (
 		<MenuItem
 			icon={download}
@@ -18,6 +15,7 @@ export function DownloadAsZipMenuItem({ onClose }: Props) {
 			id="import-open-modal--btn"
 			aria-label="Download the current playground as a .zip file"
 			onClick={() => {
+				if(!playground) return;
 				startDownload(playground);
 				onClose();
 			}}

--- a/packages/playground/website/src/components/toolbar-buttons/restore-from-zip.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/restore-from-zip.tsx
@@ -8,15 +8,16 @@ import { usePlaygroundContext } from '../playground-viewport/context';
 
 type Props = { onClose: () => void };
 export function RestoreFromZipMenuItem({ onClose }: Props) {
+	const { playground } = usePlaygroundContext();
 	const [isOpen, setOpen] = useState(false);
 	const openModal = () => {
+		if (!playground) return;
 		setOpen(true);
 	};
 	const closeModal = () => {
 		setOpen(false);
 		onClose();
 	};
-	const { playground } = usePlaygroundContext();
 	function handleImported() {
 		// eslint-disable-next-line no-alert
 		alert(
@@ -24,9 +25,6 @@ export function RestoreFromZipMenuItem({ onClose }: Props) {
 		);
 		closeModal();
 		playground!.goTo('/');
-	}
-	if (!playground) {
-		return null;
 	}
 	return (
 		<>

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -1,6 +1,6 @@
 import { createRoot } from 'react-dom/client';
-import { DropdownMenu, MenuGroup } from '@wordpress/components';
-import { menu } from '@wordpress/icons';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { menu, external } from '@wordpress/icons';
 import PlaygroundViewport from './components/playground-viewport';
 import css from './style.module.css';
 import buttonCss from './components/button/style.module.css';
@@ -21,6 +21,7 @@ import { GithubExportMenuItem } from './components/toolbar-buttons/github-export
 import { GithubExportModal } from './github/github-export-form';
 import { useState } from 'react';
 import { ExportFormValues } from './github/github-export-form/form';
+import { joinPaths } from '@php-wasm/util';
 
 const query = new URL(document.location.href).searchParams;
 const blueprint = await resolveBlueprint();
@@ -91,16 +92,59 @@ function Main() {
 					}}
 				>
 					{({ onClose }) => (
-						<MenuGroup>
-							<ResetSiteMenuItem
-								storage={currentConfiguration.storage}
-								onClose={onClose}
-							/>
-							<DownloadAsZipMenuItem onClose={onClose} />
-							<RestoreFromZipMenuItem onClose={onClose} />
-							<GithubImportMenuItem onClose={onClose} />
-							<GithubExportMenuItem onClose={onClose} />
-						</MenuGroup>
+						<>
+							<MenuGroup>
+								<ResetSiteMenuItem
+									storage={currentConfiguration.storage}
+									onClose={onClose}
+								/>
+								<DownloadAsZipMenuItem onClose={onClose} />
+								<RestoreFromZipMenuItem onClose={onClose} />
+								<GithubImportMenuItem onClose={onClose} />
+								<GithubExportMenuItem onClose={onClose} />
+							</MenuGroup>
+							<MenuGroup label="More resources">
+								<MenuItem
+									icon={external}
+									iconPosition="left"
+									aria-label="Go to WordPress PR previewer"
+									href={
+										joinPaths(
+											document.location.pathname,
+											'wordpress.html'
+										) as any
+									}
+									target="_blank"
+								>
+									Preview WordPress Pull Request
+								</MenuItem>
+								<MenuItem
+									icon={external}
+									iconPosition="left"
+									aria-label="Go to a list of Playground demos"
+									href={
+										joinPaths(
+											document.location.pathname,
+											'demos/index.html'
+										) as any
+									}
+									target="_blank"
+								>
+									More demos
+								</MenuItem>
+								<MenuItem
+									icon={external}
+									iconPosition="left"
+									aria-label="Go to Playground documentation"
+									href={
+										'https://wordpress.github.io/wordpress-playground/' as any
+									}
+									target="_blank"
+								>
+									Documentation
+								</MenuItem>
+							</MenuGroup>
+						</>
 					)}
 				</DropdownMenu>,
 			]}


### PR DESCRIPTION
Add direct access to:

* WordPress PR Previewer
* Gutenberg PR previewer
* Other tech demos
* Playground docs

Via the dropdown menu

<img width="502" alt="CleanShot 2023-11-18 at 12 53 06@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/c4d400cb-b2ff-410e-9bf8-a40689327512">
