### PR TITLE
Docs: Fix installTheme step examples

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/08-examples.md
+++ b/packages/docs/site/docs/09-blueprints-api/08-examples.md
@@ -22,7 +22,7 @@ Let's see some cool things you can do with Blueprints.
 		},
 		{
 			"step": "installTheme",
-			"pluginZipFile": {
+			"themeZipFile": {
 				"resource": "wordpress.org/themes",
 				"slug": "pendant"
 			}
@@ -79,7 +79,7 @@ wp_insert_post(array(
 		},
 		{
 			"step": "installTheme",
-			"pluginZipFile": {
+			"themeZipFile": {
 				"resource": "url",
 				"url": "https://your-site.com/your-theme.zip"
 			}


### PR DESCRIPTION
## What is this PR doing?
Fixes the wrong keys used in the Blueprint examples.

## What problem is it solving?
Prevents error messages when authoring a `blueprint.json` file (or running it).

## How is the problem addressed?
I changed the key associated with `installTheme` from `pluginZipFile` to `themeZipFile`.

## Testing Instructions
