### PR TITLE
Blueprints importFile step: update documentation format

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-export.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-export.ts
@@ -168,7 +168,10 @@ export async function exportWXZ(playground: UniversalPHP) {
  * <code>
  * {
  * 		"step": "importFile",
- * 		"file": "https://mysite.com/import.WXR"
+ * 		"file": {
+ * 			"resource": "url",
+ * 			"url": "https://your-site.com/starter-content.wxz"
+ * 		}
  * }
  * </code>
  */


### PR DESCRIPTION
## What is this PR doing?

This PR updates a comment to help generate better docs.

## What problem is it solving?

The Blueprint steps include an `importFile` step. [The docs](https://wordpress.github.io/wordpress-playground/blueprints-api/steps/) show this example:

```json
{
    "steps": [
        {
            "step": "importFile",
            "file": "https://mysite.com/import.WXR"
        }
    ]
}
```

However, one must specify an object for `file`, like so:

```json
"file": {
	"resource": "url",
	"url": "https://your-site.com/starter-content.wxz"
}
```

## Testing Instructions

I'm not quite sure how to test this right now.
