### PR TITLE
GitHub integration: PR previews by attaching a .zip file to the exported Pull Request

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/common.ts
+++ b/packages/playground/blueprints/src/lib/steps/common.ts
@@ -7,9 +7,26 @@ import type { UniversalPHP } from '@php-wasm/universal';
  */
 export const wpContentFilesExcludedFromExport = [
 	'db.php',
+	'plugins/akismet',
+	'plugins/hello.php',
+	'plugins/wordpress-importer',
 	'plugins/sqlite-database-integration',
 	'mu-plugins/playground-includes',
+	'mu-plugins/export-wxz.php',
 	'mu-plugins/0-playground.php',
+
+	/*
+	 * Listing core themes like that here isn't ideal, especially since
+	 * developers may actually want to use one of them.
+	 * @TODO Let's give the user a choice whether or not to include them.
+	 */
+	'themes/twentytwenty',
+	'themes/twentytwentyone',
+	'themes/twentytwentytwo',
+	'themes/twentytwentythree',
+	'themes/twentytwentyfour',
+	'themes/twentytwentyfive',
+	'themes/twentytwentysix',
 ];
 
 // @ts-ignore

--- a/packages/playground/blueprints/src/lib/steps/index.ts
+++ b/packages/playground/blueprints/src/lib/steps/index.ts
@@ -37,6 +37,8 @@ export type StepDefinition = Step & {
 	};
 };
 
+export { wpContentFilesExcludedFromExport } from './common';
+
 /**
  * If you add a step here, make sure to also
  * add it to the exports below.

--- a/packages/playground/blueprints/src/lib/steps/zip-wp-content.ts
+++ b/packages/playground/blueprints/src/lib/steps/zip-wp-content.ts
@@ -10,7 +10,7 @@ import { UniversalPHP } from '@php-wasm/universal';
  * @param wpContentZip Zipped WordPress site.
  */
 export const zipWpContent = async (playground: UniversalPHP) => {
-	const zipPath = `/tmp/wordpress-playground.zip`;
+	const zipPath = '/tmp/wordpress-playground.zip';
 
 	const documentRoot = await playground.documentRoot;
 	const wpContentPath = joinPaths(documentRoot, 'wp-content');

--- a/packages/playground/storage/src/lib/changeset.ts
+++ b/packages/playground/storage/src/lib/changeset.ts
@@ -13,6 +13,11 @@ export type IterateFilesOptions = {
 	 * Only used if `relativePaths` is true.
 	 */
 	pathPrefix?: string;
+
+	/**
+	 * A list of paths to exclude from the results.
+	 */
+	exceptPaths?: string[];
 };
 
 /**
@@ -26,7 +31,11 @@ export type IterateFilesOptions = {
 export async function* iterateFiles(
 	playground: UniversalPHP,
 	root: string,
-	{ relativePaths = true, pathPrefix }: IterateFilesOptions = {}
+	{
+		relativePaths = true,
+		pathPrefix,
+		exceptPaths = [],
+	}: IterateFilesOptions = {}
 ): AsyncGenerator<FileEntry> {
 	root = normalizePath(root);
 	const stack: string[] = [root];
@@ -38,6 +47,9 @@ export async function* iterateFiles(
 		const files = await playground.listFiles(currentParent);
 		for (const file of files) {
 			const absPath = `${currentParent}/${file}`;
+			if (exceptPaths.includes(absPath.substring(root.length + 1))) {
+				continue;
+			}
 			const isDir = await playground.isDir(absPath);
 			if (isDir) {
 				stack.push(absPath);

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -318,7 +318,7 @@ export default function GitHubExportForm({
 					} as Blueprint);
 
 				let targetBranchName = '';
-				if (parseInt(formValues.prNumber)) {
+				if (parseInt(formValues.prNumber, 10)) {
 					const { data } = await octokit.rest.pulls.get({
 						owner: repoDetails.owner,
 						repo: repoDetails.repo,

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect } from 'react';
 import { useState } from 'react';
-import { PlaygroundClient, zipEntireSite } from '@wp-playground/client';
+import {
+	Blueprint,
+	PlaygroundClient,
+	zipWpContent,
+} from '@wp-playground/client';
 
 import css from './style.module.css';
 import forms from '../../forms.module.css';
@@ -76,9 +80,19 @@ export default function GitHubExportForm({
 	const [repoDetails, setRepoDetails] = useState<{
 		owner: string;
 		repo: string;
-	}>({
-		owner: '',
-		repo: '',
+	}>(() => {
+		if (formValues.repoUrl) {
+			try {
+				const { owner, repo } = staticAnalyzeGitHubURL(
+					formValues.repoUrl
+				);
+				return { owner: owner!, repo: repo! };
+			} catch (e) {
+				// Ignore
+			}
+		}
+
+		return { owner: '', repo: '' };
 	});
 	function setFormValues(values: ExportFormValues) {
 		if (values.theme && !themes.includes(values.theme)) {
@@ -202,7 +216,7 @@ export default function GitHubExportForm({
 			} else if (formValues.contentType === 'plugin') {
 				updatedValues['pathInRepo'] = `/${formValues.plugin}`;
 			} else {
-				updatedValues['pathInRepo'] = '/my-directory';
+				updatedValues['pathInRepo'] = '/playground';
 			}
 			setFormValues({
 				...formValues,
@@ -274,16 +288,60 @@ export default function GitHubExportForm({
 				);
 			}
 
+			const isoDateSlug = new Date().toISOString().replace(/[:.]/g, '-');
+			const newBranchName = `playground-changes-${isoDateSlug}`;
+			let commitMessage = formValues.commitMessage;
+
 			if (formValues.includeZip) {
-				const zipPath = joinPaths(playgroundPath, 'playground.zip');
+				const zipFilename = `playground.zip`;
+				const zipPath = joinPaths(playgroundPath, zipFilename);
 				if (await playground.fileExists(zipPath)) {
 					await playground.unlink(zipPath);
 				}
-				const zipContents = await zipEntireSite(playground);
-				const zipBuffer = await zipContents.arrayBuffer();
-				await playground.writeFile(zipPath, new Uint8Array(zipBuffer));
+				const zipContents = await zipWpContent(playground);
+				await playground.writeFile(zipPath, zipContents);
+
+				const branchPreviewLink = (branchName: string) =>
+					document.location.origin +
+					'#' +
+					JSON.stringify({
+						steps: [
+							{
+								step: 'importWordPressFiles',
+								wordPressFilesZip: {
+									resource: 'url',
+									url: `https://raw.githubusercontent.com/${repoDetails.owner}/${repoDetails.repo}/${branchName}/${relativeRepoPath}/${zipFilename}`,
+								},
+							},
+						],
+					} as Blueprint);
+
+				let targetBranchName = '';
+				if (parseInt(formValues.prNumber)) {
+					const { data } = await octokit.rest.pulls.get({
+						owner: repoDetails.owner,
+						repo: repoDetails.repo,
+						pull_number: parseInt(formValues.prNumber),
+					});
+					targetBranchName = data.head.ref;
+				} else {
+					targetBranchName = newBranchName;
+				}
+
+				commitMessage +=
+					'\n\n' +
+					[
+						'Also exported as a zip file.',
+						'',
+						`* [Preview from this branch](${branchPreviewLink(
+							targetBranchName
+						)})`,
+						`* [Preview from the main branch (once this PR merges)](${branchPreviewLink(
+							defaultBranch
+						)})`,
+					].join('\n');
 			}
-			
+
 			const changes = await changeset(
 				new Map(Object.entries(comparableFiles)),
 				iterateFiles(playground, playgroundPath!, {
@@ -292,17 +350,16 @@ export default function GitHubExportForm({
 				})
 			);
 
-			const isoDateSlug = new Date().toISOString().replace(/[:.]/g, '-');
 			const pushResult = await pushToGithub(getClient(), {
 				owner: repoDetails.owner,
 				repo: repoDetails.repo,
-				commitMessage: formValues.commitMessage,
+				commitMessage,
 				changeset: changes,
 
 				shouldCreateNewPR: formValues.prAction === 'create',
 				create: {
 					againstBranch: defaultBranch,
-					branchName: `playground-changes-${isoDateSlug}`,
+					branchName: newBranchName,
 					title: prTitle,
 				},
 				update: {

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import {
 	Blueprint,
 	PlaygroundClient,
+	wpContentFilesExcludedFromExport,
 	zipWpContent,
 } from '@wp-playground/client';
 
@@ -347,6 +348,7 @@ export default function GitHubExportForm({
 				iterateFiles(playground, playgroundPath!, {
 					relativePaths: true,
 					pathPrefix: relativeRepoPath,
+					exceptPaths: wpContentFilesExcludedFromExport,
 				})
 			);
 


### PR DESCRIPTION
This PR enables previewing PRs exported to GitHub.

Technically, it adds an "export to zip" option to the GitHub export flow.

Exporting a zip does two things:

1. Exports `playground.zip` with the Pull Request
2. Adds preview links to the Pull Request description.

The preview links go to Playground.wordpress.net with the `playground.zip` file loaded via the raw.githubusercontent.com domain.

## Testing instructions

1. Create an empty GitHub repo
2. Install the adventurer theme (e.g. via `?theme=adventurer`)
3. Export a PR to your repo, remember to check the "export a .zip file" option
4. Go to the PR
5. Confirm the first preview link works
6. Merge the PR
7. Confirm the second preview link works

## Screenshots

<img width="400" alt="CleanShot 2023-12-10 at 21 11 56@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/71c9ec28-702c-47af-8f66-a4a59e5a6a8b">

<img width="321" alt="CleanShot 2023-12-10 at 21 12 20@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/5d506c41-9dbc-4113-9f68-f995be47e733">

<img width="470" alt="CleanShot 2023-12-10 at 21 12 07@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/52c99b85-1481-4204-be12-dec02f2d949e">

cc @annezazu