### PR TITLE
Set emptyOutDir to false in php-wasm/web/project.json

### DIFF
--- a/packages/php-wasm/web/project.json
+++ b/packages/php-wasm/web/project.json
@@ -30,6 +30,7 @@
 			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"options": {
+				"emptyOutDir": false,
 				"outputPath": "dist/packages/php-wasm/web"
 			}
 		},

--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -66,12 +66,6 @@ export default defineConfig(({ command }) => {
 		// Configuration for building your library.
 		// See: https://vitejs.dev/guide/build.html#library-mode
 		build: {
-			// Without this option, Vite may occasionally fail with the following error:
-			// ENOTEMPTY: directory not empty, rmdir dist/packages/php-wasm/web/light
-			// That directory is implicitly created by preserve-php-loaders-imports plugin
-			// and it's fine to override it during the build.
-			// @TODO: Figure out why Vite fails only occasionally, not consistently.
-			emptyOutDir: false,
 			lib: {
 				// Could also be a dictionary or array of multiple entry points.
 				entry: 'src/index.ts',

--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -66,6 +66,12 @@ export default defineConfig(({ command }) => {
 		// Configuration for building your library.
 		// See: https://vitejs.dev/guide/build.html#library-mode
 		build: {
+			// Without this option, Vite may occasionally fail with the following error:
+			// ENOTEMPTY: directory not empty, rmdir dist/packages/php-wasm/web/light
+			// That directory is implicitly created by preserve-php-loaders-imports plugin
+			// and it's fine to override it during the build.
+			// @TODO: Figure out why Vite fails only occasionally, not consistently.
+			emptyOutDir: false,
 			lib: {
 				// Could also be a dictionary or array of multiple entry points.
 				entry: 'src/index.ts',


### PR DESCRIPTION
In CI, Vite occasionally fails with the following error: 

> ENOTEMPTY: directory not empty, rmdir dist/packages/php-wasm/web/light

That directory is implicitly created by preserve-php-loaders-imports plugin. Vite attempts to synchronously empty it, and yet some files are somehow left in there. Perhaps it’s a bug in Vite? Or something writes those files in parallel? 

For now, let's just abstain from emptying that directory. In the future, if more problems emerge, we may need to get to the bottom of that.
