### PR TITLE
Add browser full screen mode

### DIFF
--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -53,6 +53,11 @@ export default function BrowserChrome({
 					<div className={css.toolbarButtons}>{toolbarButtons}</div>
 				</div>
 				<div className={css.content}>{children}</div>
+				<div className={css.experimentalNotice}>
+					This is a cool fun experimental WordPress running in your
+					browser :) All your changes are private and gone after a
+					page refresh.
+				</div>
 			</div>
 		</div>
 	);

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import css from './style.module.css';
 import AddressBar from '../address-bar';
 import classNames from 'classnames';
@@ -8,7 +8,7 @@ interface BrowserChromeProps {
 	toolbarButtons?: Array<React.ReactElement | false | null>;
 	url?: string;
 	showAddressBar?: boolean;
-	isFullSize?: boolean;
+	initialIsFullSize?: boolean;
 	onUrlChange?: (url: string) => void;
 }
 
@@ -16,10 +16,12 @@ export default function BrowserChrome({
 	children,
 	url,
 	onUrlChange,
-	isFullSize,
 	showAddressBar = true,
 	toolbarButtons,
+	initialIsFullSize = false,
 }: BrowserChromeProps) {
+	const [isFullSize, setIsFullSize] = useState(initialIsFullSize);
+
 	const addressBarClass = classNames(css.addressBarSlot, {
 		[css.isHidden]: !showAddressBar,
 	});
@@ -31,7 +33,18 @@ export default function BrowserChrome({
 		<div className={wrapperClass} data-cy="simulated-browser">
 			<div className={css.window}>
 				<div className={css.toolbar}>
-					<WindowControls />
+					<div className={css.windowControls}>
+						<div
+							className={`${css.windowControl} ${css.isNeutral}`}
+						></div>
+						<div
+							className={`${css.windowControl} ${css.isNeutral}`}
+						></div>
+						<div
+							className={`${css.windowControl} ${css.isNeutral} ${css.isActive}`}
+							onClick={() => setIsFullSize(!isFullSize)}
+						></div>
+					</div>
 
 					<div className={addressBarClass}>
 						<AddressBar url={url} onUpdate={onUrlChange} />
@@ -40,22 +53,7 @@ export default function BrowserChrome({
 					<div className={css.toolbarButtons}>{toolbarButtons}</div>
 				</div>
 				<div className={css.content}>{children}</div>
-				<div className={css.experimentalNotice}>
-					This is a cool fun experimental WordPress running in your
-					browser :) All your changes are private and gone after a
-					page refresh.
-				</div>
 			</div>
-		</div>
-	);
-}
-
-function WindowControls() {
-	return (
-		<div className={css.windowControls}>
-			<div className={`${css.windowControl} ${css.isNeutral}`}></div>
-			<div className={`${css.windowControl} ${css.isNeutral}`}></div>
-			<div className={`${css.windowControl} ${css.isNeutral}`}></div>
 		</div>
 	);
 }

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -41,7 +41,7 @@ export default function BrowserChrome({
 							className={`${css.windowControl} ${css.isNeutral}`}
 						></div>
 						<div
-							className={`${css.windowControl} ${css.isNeutral} ${css.isActive}`}
+							className={`${css.windowControl} ${css.isGreen} ${css.isActive}`}
 							onClick={() => setIsFullSize(!isFullSize)}
 						></div>
 					</div>

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -30,7 +30,7 @@ body.is-embedded .fake-window-wrapper {
 
 .wrapper.has-small-window {
 	padding: 15px 60px 55px 60px;
-	
+
 	.window {
 		max-width: 1200px;
 		height: 100%;
@@ -134,7 +134,7 @@ body.is-embedded .fake-window-wrapper {
 }
 
 .window-control::before {
-	content: "";
+	content: '';
 	position: absolute;
 	box-sizing: border-box;
 	top: 50%;

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -25,6 +25,7 @@ body.is-embedded .fake-window-wrapper {
 
 .wrapper {
 	height: 100%;
+	transition: padding ease-in 0.25s;
 }
 
 .wrapper.has-small-window {
@@ -40,6 +41,7 @@ body.is-embedded .fake-window-wrapper {
 .wrapper.has-full-size-window {
 	padding: 0;
 	.window {
+		max-width: 100vw;
 		width: 100%;
 		height: 100%;
 		border-radius: 0;
@@ -53,6 +55,7 @@ body.is-embedded .fake-window-wrapper {
 	overflow: hidden;
 
 	animation: pulse 6s ease-in infinite;
+	transition: all ease-in 0.25s;
 }
 
 @keyframes pulse {
@@ -120,28 +123,48 @@ body.is-embedded .fake-window-wrapper {
 
 .window-control {
 	display: flex;
+	width: 22px;
+	height: 20px;
+	border-radius: 50%;
+	position: relative;
+}
+
+.window-control:first-child {
+	margin-left: -6px;
+}
+
+.window-control::before {
+	content: "";
+	position: absolute;
+	box-sizing: border-box;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 	width: 10px;
 	height: 10px;
-	background: #f9f9f9;
 	border-radius: 50%;
-	margin: 0 12px 0 0;
 }
 
-.window-control.is-neutral {
+.window-control.is-neutral::before {
 	background: #a5afbc;
+	border: 1px solid #a5afbc;
 }
 
-.window-control.is-red {
+.window-control.is-active {
+	cursor: pointer;
+}
+
+.window-control.is-red::before {
 	background: #ff6057;
 	border: 1px solid #e14640;
 }
 
-.window-control.is-amber {
+.window-control.is-amber::before {
 	background: #ffbd2e;
 	border: 1px solid #dfa123;
 }
 
-.window-control.is-green {
+.window-control.is-green::before {
 	background: #27c93f;
 	border: 1px solid #1dad2b;
 }

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -45,7 +45,7 @@ export default function PlaygroundViewport({
 				<JustViewport iframeRef={iframeRef} />
 			) : (
 				<BrowserChrome
-					isFullSize={displayMode === 'browser-full-screen'}
+					initialIsFullSize={displayMode === 'browser-full-screen'}
 					showAddressBar={!!playground}
 					url={url}
 					toolbarButtons={toolbarButtons}


### PR DESCRIPTION
## What is this PR doing?

Makes the fullscreen button interactive so that the user can switch between the small and the large browser window. Many designers provided feedback that they need all the screen space they can get, let's give it to them!

https://github.com/WordPress/wordpress-playground/assets/205419/8b952b33-6a81-4453-a2f0-4b8eab25b78f

## Testing instructions

Confirm the fullscreen button toggles between a small and a large "browser window" inside Playground 

Closes #823
