### PR TITLE
Live translations link in FAQ leads to 404 #723 Sloved

### DIFF
--- a/packages/docs/site/docs/16-faq.md
+++ b/packages/docs/site/docs/16-faq.md
@@ -11,7 +11,7 @@ In your browser! It is mindblowing, isn't it? There's a new technology called We
 
 ## Is WordPress Playground available in another language?
 
-Yes! Although it requires some work at the moment. You need to tell Playground to download and install the translation files and one way to do it is using [the Blueprints API](https://wordpress.github.io/wordpress-playground/pages/blueprints-getting-started.html). There is no step-by-step tutorial yet, but you can learn by reading the source of [Playground+Translations plugin](https://translate.wordpress.org/projects/wp-plugins/friends/dev/en-gb/default/playground/) [(GitHub link)](https://github.com/akirk/wp-glotpress-playground/blob/main/index.php).
+Yes! Although it requires some work at the moment. You need to tell Playground to download and install the translation files and one way to do it is using [the Blueprints API](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/). There is no step-by-step tutorial yet, but you can learn by reading the source of [Playground+Translations plugin](https://translate.wordpress.org/projects/wp-plugins/friends/dev/en-gb/default/playground/) [(GitHub link)](https://github.com/akirk/wp-glotpress-playground/blob/main/index.php).
 
 ## Will wp-cli be supported?
 


### PR DESCRIPTION
Added correct  link to live translation in FAQ
 Previous link was giving 404

Closes #723