### PR TITLE
Draft: Playground unit-test-utils module

### DIFF
--- a/packages/playground/unit-test-utils/.eslintrc.json
+++ b/packages/playground/unit-test-utils/.eslintrc.json
@@ -1,0 +1,32 @@
+{
+	"extends": ["../../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.json"],
+			"parser": "jsonc-eslint-parser",
+			"rules": {
+				"@nx/dependency-checks": [
+					"error",
+					{
+						"ignoredFiles": [
+							"{projectRoot}/vite.config.{js,ts,mjs,mts}"
+						]
+					}
+				]
+			}
+		}
+	]
+}

--- a/packages/playground/unit-test-utils/README.md
+++ b/packages/playground/unit-test-utils/README.md
@@ -1,0 +1,11 @@
+# playground-unit-test-utils
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build playground-unit-test-utils` to build the library.
+
+## Running unit tests
+
+Run `nx test playground-unit-test-utils` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/playground/unit-test-utils/package.json
+++ b/packages/playground/unit-test-utils/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "@wp-playground/unit-test-utils",
+	"version": "0.0.1",
+	"dependencies": {},
+	"main": "./index.js",
+	"module": "./index.mjs",
+	"typings": "./index.d.ts"
+}

--- a/packages/playground/unit-test-utils/project.json
+++ b/packages/playground/unit-test-utils/project.json
@@ -1,0 +1,34 @@
+{
+	"name": "playground-unit-test-utils",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/playground/unit-test-utils/src",
+	"projectType": "library",
+	"targets": {
+		"build": {
+			"executor": "@nx/vite:build",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"outputPath": "dist/packages/playground/unit-test-utils"
+			}
+		},
+		"test": {
+			"executor": "@nx/vite:test",
+			"outputs": ["{options.reportsDirectory}"],
+			"options": {
+				"passWithNoTests": true,
+				"reportsDirectory": "../../../coverage/packages/playground/unit-test-utils"
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"packages/playground/unit-test-utils/**/*.ts",
+					"packages/playground/unit-test-utils/package.json"
+				]
+			}
+		}
+	},
+	"tags": []
+}

--- a/packages/playground/unit-test-utils/src/index.ts
+++ b/packages/playground/unit-test-utils/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/playground-unit-test-utils';

--- a/packages/playground/unit-test-utils/src/lib/playground-unit-test-utils.spec.ts
+++ b/packages/playground/unit-test-utils/src/lib/playground-unit-test-utils.spec.ts
@@ -1,0 +1,7 @@
+import { playgroundUnitTestUtils } from './playground-unit-test-utils';
+
+describe('playgroundUnitTestUtils', () => {
+	it('should work', () => {
+		expect(playgroundUnitTestUtils()).toEqual('playground-unit-test-utils');
+	});
+});

--- a/packages/playground/unit-test-utils/src/lib/playground-unit-test-utils.ts
+++ b/packages/playground/unit-test-utils/src/lib/playground-unit-test-utils.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'fs';
+
+export async function getWordPressDataModule() {
+	const wpData = readFileSync(
+		__dirname + '/../../../remote/src/wordpress/wp-6.3.data'
+	);
+	const wpDataArrayBuffer = wpData.buffer.slice(
+		wpData.byteOffset,
+		wpData.byteOffset + wpData.byteLength
+	);
+	shimXHR(wpDataArrayBuffer);
+	// @ts-ignore
+	return await import(__dirname + '/../../../remote/src/wordpress/wp-6.3.js');
+}
+
+function shimXHR(response: ArrayBuffer) {
+	// Shim XMLHttpRequest to return a fixed response
+	// @ts-ignore
+	globalThis.XMLHttpRequest = class XMLHttpRequest {
+		response?: ArrayBuffer;
+		onload() {}
+		open() {
+			setTimeout(() => {
+				this.response = response;
+				this.onload();
+			}, 100);
+		}
+		send() {}
+		setRequestHeader() {}
+		getResponseHeader() {}
+		getAllResponseHeaders() {}
+		abort() {}
+		addEventListener() {}
+		removeEventListener() {}
+		dispatchEvent() {}
+		get readyState() {
+			return 4;
+		}
+		get status() {
+			return 200;
+		}
+	};
+}

--- a/packages/playground/unit-test-utils/tsconfig.json
+++ b/packages/playground/unit-test-utils/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "commonjs",
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+}

--- a/packages/playground/unit-test-utils/tsconfig.lib.json
+++ b/packages/playground/unit-test-utils/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node", "vite/client"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/playground/unit-test-utils/tsconfig.spec.json
+++ b/packages/playground/unit-test-utils/tsconfig.spec.json
@@ -1,0 +1,25 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"types": [
+			"vitest/globals",
+			"vitest/importMeta",
+			"vite/client",
+			"node",
+			"vitest"
+		]
+	},
+	"include": [
+		"vite.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.test.tsx",
+		"src/**/*.spec.tsx",
+		"src/**/*.test.js",
+		"src/**/*.spec.js",
+		"src/**/*.test.jsx",
+		"src/**/*.spec.jsx",
+		"src/**/*.d.ts"
+	]
+}

--- a/packages/playground/unit-test-utils/vite.config.ts
+++ b/packages/playground/unit-test-utils/vite.config.ts
@@ -1,0 +1,50 @@
+/// <reference types='vitest' />
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import * as path from 'path';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+
+export default defineConfig({
+	cacheDir: '../../../node_modules/.vite/playground-unit-test-utils',
+
+	plugins: [
+		nxViteTsPaths(),
+		dts({
+			entryRoot: 'src',
+			tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),
+			skipDiagnostics: true,
+		}),
+	],
+
+	// Uncomment this if you are using workers.
+	// worker: {
+	//  plugins: [ nxViteTsPaths() ],
+	// },
+
+	// Configuration for building your library.
+	// See: https://vitejs.dev/guide/build.html#library-mode
+	build: {
+		lib: {
+			// Could also be a dictionary or array of multiple entry points.
+			entry: 'src/index.ts',
+			name: 'playground-unit-test-utils',
+			fileName: 'index',
+			// Change this to the formats you want to support.
+			// Don't forget to update your package.json as well.
+			formats: ['es', 'cjs'],
+		},
+		rollupOptions: {
+			// External packages that should not be bundled into your library.
+			external: [],
+		},
+	},
+
+	test: {
+		globals: true,
+		cache: {
+			dir: '../../../node_modules/.vitest',
+		},
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+	},
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -49,6 +49,9 @@
 				"packages/playground/storage/src/index.ts"
 			],
 			"@wp-playground/sync": ["packages/playground/sync/src/index.ts"],
+			"@wp-playground/unit-test-utils": [
+				"packages/playground/unit-test-utils/src/index.ts"
+			],
 			"@wp-playground/website": [
 				"packages/playground/website/src/index.ts"
 			]


### PR DESCRIPTION
To use real WordPress in unit tests, we need to import it from somewhere. At the moment, there is no easy way to do it without running into a circular dependency problem. This PR adds a new module that has no explicit import dependencies to solve that problem. It still does have an implicit path-based dependency on the remote package, which isn't ideal. 

Perhaps a better solution would be to build WordPress `.data` artifacts to yet another dependency-free module such as `@wp-playground/wordpress`, and then all other package would import from that module without introducing a circular dependency.

Related to #463

I generated this module as follows:

```
nx generate @nx/js:library --name=unit-test-utils --unitTestRunner=vitest --bundler=vite --directory=packages/playground --importPath=@wp-playground/unit-test-utils --no-interactive
```

cc @reimic