### PR TITLE
Bidirectional postMessage relay: add relaying from parent window to WordPress inside Playground

### DIFF
--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -215,6 +215,7 @@ function setupPostMessageRelay(
 	wpFrame: HTMLIFrameElement,
 	expectedOrigin: string
 ) {
+	// Relay Messages from WP to Parent
 	window.addEventListener('message', (event) => {
 		if (event.source !== wpFrame.contentWindow) {
 			return;
@@ -231,6 +232,7 @@ function setupPostMessageRelay(
 		window.parent.postMessage(event.data, '*');
 	});
 
+	// Relay Messages from Parent to WP
 	window.addEventListener('message', (event) => {
 		if (event.source !== window.parent) {
 			return;

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -240,7 +240,7 @@ function setupPostMessageRelay(
 			return;
 		}
 
-		wpFrame?.contentWindow?.postMessage(event.data, event.origin);
+		wpFrame?.contentWindow?.postMessage(event.data);
 	});
 }
 

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -240,8 +240,6 @@ function setupPostMessageRelay(
 			return;
 		}
 
-		console.log("passing message to iframe's window", event);
-
 		wpFrame?.contentWindow?.postMessage(event.data, event.origin);
 	});
 }

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -230,6 +230,20 @@ function setupPostMessageRelay(
 
 		window.parent.postMessage(event.data, '*');
 	});
+
+	window.addEventListener('message', (event) => {
+		if (event.source !== window.parent) {
+			return;
+		}
+
+		if (typeof event.data !== 'object' || event.data.type !== 'relay') {
+			return;
+		}
+
+		console.log("passing message to iframe's window", event);
+
+		wpFrame?.contentWindow?.postMessage(event.data, event.origin);
+	});
 }
 
 function parseVersion<T>(value: string | undefined | null, latest: T) {


### PR DESCRIPTION
## What is this PR doing?
Currently, the ability to relay messages between WP and the site embedding `remote.html` is one direction from WP=>Playground. This adds the ability to relay messages from Playground(or 3rd party embed) ==> WP. 

## What problem is it solving?

I needed to be able to send messages down to manage state with things in WP. 

## How is the problem addressed?

I've added an event listener that checks the `message` comes from the `window.parent` which should be the site embedding `remote.html` and the proper `type: relay` and `object` stuff is included. 

> [!RESOLVED]
> **didn't** check the origin cause I was unsure if there was a secure way to confirm it was from the intended embed...maybe `window.parent.location.origin`? Not entirely sure this would do anything but I'm 100% sure I don't understand the security concerns here. 

## Testing Instructions

> [!NOTE]
> I did manual testing. I can work on correct tests if those are a thing.

> [!RESOLVED]
> I'm not sure this has been correctly tested by hand. The current issue is that my source domain(Playground) and the `remotehtml` domain are identical (`localhost:5400`). In my IRL use case, these would be different. not sure if or how to test this or if it's needed.