### PR TITLE
Browser: Make browser-full-screen the default display mode

### DIFF
--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -43,7 +43,7 @@ const displayMode: DisplayMode = supportedDisplayModes.includes(
 	query.get('mode') as any
 )
 	? (query.get('mode') as DisplayMode)
-	: 'browser';
+	: 'browser-full-screen';
 
 const currentConfiguration: PlaygroundConfiguration = {
 	wp: blueprint.preferredVersions?.wp || 'latest',


### PR DESCRIPTION
Playground used to default to only displaying a small frame with a colorful background behind. This creates a nice metaphore of a "browser in a browser" that helps a new person understand what they are looking at. However, it isn't very useful past that point as it reduces the available screen real estate. Notably, I've heard feedback from theme designers that they are unable to test mobile breakpoints beyond the default frame width.

Anyone who actually preferred the smaller window may still use it either by clicking the green "fullscreen" button at the top left corner, or by adding `?mode=browser` to the URL, See #823 for more context.

This commit sets the "fullscreen" more as the new default. Let's see how that is received and iterate further based on that feedback.

Closes #722
