### PR TITLE
Fix documentation bugs

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/05-steps.md
+++ b/packages/docs/site/docs/09-blueprints-api/05-steps.md
@@ -22,20 +22,24 @@ Each step is an object that contains a `step` property that specifies the type o
 
 import BlueprintStep from '@site/src/components/BlueprintsAPI/BlueprintStep';
 import { BlueprintSteps } from '@site/src/components/BlueprintsAPI/model';
+import UpdateTopLevelToc from '@site/src/components/UpdateTopLevelToc';
 
-<span>{!toc.length && BlueprintSteps.map((name) => {
-toc.push(
-{
+<UpdateTopLevelToc
+toc={toc}
+tocItems={
+BlueprintSteps
+.map(name => ({
 value: name,
 id: name,
 level: 2
-}
-)
-return (
-<>
-<BlueprintStep name={name} key={name} />
+}))
+} />
 
-<hr/>
-</>
-);
-})}</span>
+<span>
+	{BlueprintSteps.map((name) => (
+		<>
+			<BlueprintStep name={name} key={name} />
+			<hr/>
+		</>
+	))}
+</span>

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
@@ -4,5 +4,14 @@ import { getStepAPI } from './model';
 export function BlueprintStepDescription({ name }) {
 	const stepApi = getStepAPI(name);
 
-	return <p>{stepApi.stepDetails.summary}</p>;
+	return (
+		<p>
+			{stepApi.stepDetails.summary.map((part) => {
+				if (part.kind === 'code') {
+					return <code>{part.text.replace(/^`|`$/g, '')}</code>;
+				}
+				return part.text;
+			})}
+		</p>
+	);
 }

--- a/packages/docs/site/src/components/BlueprintsAPI/model.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/model.tsx
@@ -95,7 +95,7 @@ function replaceResourcesWithPlaceholders(json) {
 
 interface BlueprintStepDetails {
 	name: string;
-	summary: string;
+	summary: Array<{ kind: string; text: string }>;
 	examples: Array<{
 		raw: string;
 		json?: Record<string, any> & { step: string };
@@ -116,7 +116,8 @@ function getBlueprintStepDetails(name: string): BlueprintStepDetails {
 		entry.name.match(/Step$/)
 	);
 	const Step = StepDefinitions.find((entry) => entry.name === name);
-	const summary = Step?.comment?.summary?.[0]?.text || '';
+	const summary = Step?.comment?.summary?.filter((part) => part);
+	console;
 
 	const children =
 		Step?.children ||

--- a/packages/docs/site/src/components/BlueprintsAPI/model.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/model.tsx
@@ -117,7 +117,6 @@ function getBlueprintStepDetails(name: string): BlueprintStepDetails {
 	);
 	const Step = StepDefinitions.find((entry) => entry.name === name);
 	const summary = Step?.comment?.summary?.filter((part) => part);
-	console;
 
 	const children =
 		Step?.children ||

--- a/packages/docs/site/src/components/UpdateTopLevelToc.tsx
+++ b/packages/docs/site/src/components/UpdateTopLevelToc.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+
+type TocItem = {
+	value: string;
+	id: string;
+	level: number;
+};
+interface Props {
+	toc: TocItem[];
+	tocItems: TocItem[];
+}
+
+/**
+ * Adds the missing steps to the Table of Contents and triggers a re-render.
+ *
+ * This is a workaround. Docusaurus doesn't support dynamic TOC based on the
+ * h2, h3 etc elements rendered by React components. Therefore, we have to update
+ * the global `toc` variable. Once we do, we also need to trigger a TOC re-render
+ * which can be done by updating the current URL hash.
+ */
+export default function UpdateTopLevelToc({ tocItems, toc }: Props) {
+	useEffect(() => {
+		const missingItems = tocItems.filter(
+			(tocItem) =>
+				!toc.find(
+					(topLevelTocItem) => topLevelTocItem.id === tocItem.id
+				)
+		);
+		for (const tocItem of missingItems) {
+			toc.push(tocItem);
+		}
+
+		// Re-render the TOC
+		if (missingItems.length) {
+			const oldHash = window.location.hash;
+			window.location.hash = '#__reload__';
+			window.location.hash = oldHash;
+		}
+	}, [tocItems, toc]);
+	return null;
+}

--- a/packages/playground/blueprints/src/lib/steps/run-sql.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-sql.ts
@@ -14,7 +14,7 @@ import { phpVars } from '@php-wasm/util';
  *			"resource": "literal",
  *			"name": "schema.sql",
  *			"contents": "DELETE FROM wp_posts"
- *		},
+ *		}
  * }
  * </code>
  */


### PR DESCRIPTION
## Description

Fixes the following problems with Playground documentation:

* Removes extra comma in the runSqlStep comment that let to JSON parsing failure.
* Restores the Blueprint steps missing from the Blueprints Steps page contents.
* Restores missing table of contents on the steps page (#847).
* Don't cut-off the content of Blueprints summary when extracting the documentation from the comments (#826).

Closes #847 
Closes #826

## Testing instructions

1. Build an serve the docs site as `nx build docs-site; nx serve docs-site`
2. Go to http://localhost:3000/wordpress-playground/blueprints-api/steps
3. Confirm all the Blueprint steps are listed in there and the table of contents on the right-hand side of the screen does indeed list all the steps
4. Confirm the following actions don't break anything:
   * Navigate to another page, come back
   * Navigate to another page, force-reload, come back
   * Click on a TOC item, force-reload
   * Click on a header link, force-reload