### PR TITLE
Remove Akismet

### DIFF
--- a/packages/playground/wordpress/build/Dockerfile
+++ b/packages/playground/wordpress/build/Dockerfile
@@ -31,6 +31,10 @@ RUN git clone https://github.com/WordPress/sqlite-database-integration.git \
     cp wordpress/wp-content/plugins/sqlite-database-integration/db.copy wordpress/wp-content/db.php && \
     cp wordpress/wp-config-sample.php wordpress/wp-config.php
 
+# Remove the akismet plugin as it's not likely Playground sites will
+# get many spammy comments :-)
+RUN rm -rf wordpress/wp-content/plugins/akismet
+
 # Separate WordPress static files
 RUN cp -r wordpress wordpress-static && \
     cd wordpress-static && \ 


### PR DESCRIPTION
## What is this PR doing?

Removes Akismet from the bundled wp.data as it's not likely Playground sites will experience spam.

This reduces the bundle size and the export size.

## Testing Instructions

Rebuild WordPress locally:

```
nx bundle-wordpress playground-wordpress --wp-version=latest
```

Start the dev server:

```
nx run dev
```

Go to your local Playground and confirm the akismet plugin isn't there in wp-admin.