### PR TITLE
WordPress PR Previewer: Improve error messages, retry if the artifact isn't ready yet

### DIFF
--- a/packages/playground/website/public/previewer.css
+++ b/packages/playground/website/public/previewer.css
@@ -139,12 +139,17 @@ button:focus {
 	padding: 0 10px;
 }
 #error {
+	max-width: 600px;
 	text-align: center;
-	padding: 0 10px;
+	padding: 20px;
+	margin-top: 5vh;
 	margin-bottom: 5vh;
-	color: #8b0000;
-	font-weight: bold;
-	font-size: 1.5em;
+	background: #8b0000;
+	color: #fff;
+	font-size: 1.2em;
+}
+#error:empty {
+	display: none;
 }
 
 #submit {

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -154,7 +154,7 @@
 					} else {
 						let retryIn = 30000;
 						function renderRetryIn() {
-							errorDiv.innerText = `Waiting for GitHub to finish building PR ${prNumber}. Retrying in ${
+							errorDiv.innerText = `Waiting for GitHub to finish building PR ${prNumber}. This might take 15 minutes or more! Retrying in ${
 								retryIn / 1000
 							}...`;
 						}

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -246,6 +246,13 @@
 						prepareForRunningInsideWebBrowser: true,
 					},
 					{
+						step: 'runPHP',
+						code: `<?php
+							$_GET['step'] = 'upgrade_db';
+							require '/wordpress/wp-admin/upgrade.php';
+						`,
+					},
+					{
 						step: 'login',
 						username: 'admin',
 						password: 'password',

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -103,6 +103,7 @@
 		});
 
 		// If there's a PR query parameter, call previewPr with its value
+		let cleanupRetry = null;
 		const urlParams = new URLSearchParams(window.location.search);
 		const prNumber = urlParams.get('pr');
 		if (prNumber) {
@@ -111,6 +112,10 @@
 		}
 
 		async function previewPr(prNumber) {
+			if (cleanupRetry) {
+				cleanupRetry();
+			}
+
 			submitting = true;
 			errorDiv.innerText = '';
 			submitButton.classList.add('loading');
@@ -120,7 +125,7 @@
 			if (
 				prNumber
 					.toLowerCase()
-					.includes('github.com/wordpress/gutenberg/pull')
+					.includes('github.com/wordpress/wordpress-develop/pull')
 			) {
 				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
 			}
@@ -128,9 +133,54 @@
 			// Verify that the PR exists and that GitHub CI finished building it
 			const zipArtifactUrl = `/plugin-proxy.php?org=WordPress&repo=wordpress-develop&workflow=Test%20Build%20Processes&artifact=wordpress-build-${prNumber}&pr=${prNumber}`;
 			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
-			const response = await fetch(zipArtifactUrl, { method: 'HEAD' });
+			const response = await fetch(zipArtifactUrl + '&verify_only=true');
 			if (response.status !== 200) {
-				errorDiv.innerText = `The PR ${prNumber} does not exist or GitHub CI did not finish building it yet.`;
+				let error = 'invalid_pr_number';
+				try {
+					const json = await response.json();
+					if (json.error) {
+						error = json.error;
+					}
+				} catch (e) {}
+
+				if (error === 'invalid_pr_number') {
+					errorDiv.innerText = `The PR ${prNumber} does not exist.`;
+				} else if (
+					error === 'artifact_not_found' ||
+					error === 'artifact_not_available'
+				) {
+					if (parseInt(prNumber) < 5749) {
+						errorDiv.innerText = `The PR ${prNumber} predates the Pull Request previewer and requires a rebase before it can be previewed.`;
+					} else {
+						let retryIn = 30000;
+						function renderRetryIn() {
+							errorDiv.innerText = `Waiting for GitHub to finish building PR ${prNumber}. Retrying in ${
+								retryIn / 1000
+							}...`;
+						}
+						renderRetryIn();
+						const timerInterval = setInterval(() => {
+							retryIn -= 1000;
+							if (retryIn <= 0) {
+								retryIn = 0;
+							}
+							renderRetryIn();
+						}, 1000);
+						const scheduledRetry = setTimeout(() => {
+							previewPr(prNumber);
+						}, retryIn);
+						cleanupRetry = () => {
+							clearInterval(timerInterval);
+							clearTimeout(scheduledRetry);
+							cleanupRetry = null;
+						};
+					}
+				} else if (error === 'artifact_invalid') {
+					errorDiv.innerText = `The PR ${prNumber} requires a rebase before it can be previewed.`;
+				} else {
+					errorDiv.innerText = `The PR ${prNumber} couldn't be previewed due to an unexpected error. Please try again later or fill an issue in the WordPress Playground repository.`;
+					// https://github.com/WordPress/wordpress-playground/issues/new
+				}
 				submitting = false;
 				submitButton.classList.remove('loading');
 				submitButton.disabled = false;


### PR DESCRIPTION
## What is this PR doing?

Improves the error messages in the WordPress PR previewer, especially when the WordPress build artifact is not yet ready.

## What problem is it solving?

The previewer link [is posted on every wordpress-develop PR](https://github.com/WordPress/wordpress-develop/pull/5738) before the initial build artifact is ready. Simply displaying a generic error message would be very confusing to users.

## How is the problem addressed?

Clearly explains the situation in the error messages, and, in case the build artifact isn't ready, retries the preview every 30 seconds.

## Testing Instructions

Try previewing:

* Older PRs without the WordPress build artifact
* PR 5738 where the build artifact is corrupted
* A new PR that you just opened before the build artifact is there

And confirm the error messages clearly communicate the problems Playground is experiencing:

<img width="300" alt="CleanShot 2023-12-09 at 22 56 12@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/ad4e675b-245a-4c6c-a601-2cf5e22f4fa3">

<img width="300" alt="CleanShot 2023-12-10 at 00 44 34@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/65c12f26-97b0-4b49-90bc-2814dff85cec">


