### PR TITLE
Blueprints: Only apply the network transports patch once

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/index.ts
+++ b/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/index.ts
@@ -176,12 +176,16 @@ class WordPressPatcher {
 			if (!(await this.php.fileExists(transport))) {
 				continue;
 			}
-			await updateFile(this.php, transport, (contents) =>
-				contents.replace(
+			await updateFile(this.php, transport, (contents) => {
+				// If the transport is already patched, don't patch it again.
+				if (contents.includes('public static function test2')) {
+					return contents;
+				}
+				return contents.replace(
 					'public static function test',
 					'public static function test( $capabilities = array() ) { return false; } public static function test2'
-				)
-			);
+				);
+			});
 		}
 
 		// Add fetch and dummy transports for HTTP requests


### PR DESCRIPTION
## What problem is solved here?

Makes the `addFetchNetworkTransport()` idempotent.

The `addFetchNetworkTransport()` function is called on Playground boot and it works well when applied to a clean WordPress build. However, in the browser storage mode it is applied on an already-patched WordPress version and creates two class methods called `test2()`. This throws a PHP fatal error on almost all `/wp-admin` pages:

```
Fatal error: Cannot redeclare WpOrg\Requests\Transport\Curl::test2() in /wordpress/wp-includes/Requests/src/Transport/Curl.php on line 2
There has been a critical error on this website. Please check your site admin email inbox for instructions. [Learn more about troubleshooting WordPress.](https://href.li/?https://wordpress.org/documentation/article/faq-troubleshooting/)
```

## How is the problem addressed?

Adds a checks to only apply the patch if it wasn't already applied.

## Testing Instructions

1. Apply this PR
2. Choose the browser storage engine and enable network access
3. Let the Playground load
4. Reload the entire Playground page
5. Go to `/wp-admin`
6. Confirm the fatal error isn't there

Closes https://github.com/WordPress/wordpress-playground/issues/825
