### PR TITLE
Require saving Playground before authenticating with GitHub

### DIFF
--- a/packages/playground/website/src/github/github-oauth-guard/index.tsx
+++ b/packages/playground/website/src/github/github-oauth-guard/index.tsx
@@ -2,6 +2,9 @@ import { Icon, Spinner } from '@wordpress/components';
 import { oAuthState } from '../state';
 import { GitHubIcon } from '../github';
 import css from './style.module.css';
+import { useContext, useState } from 'react';
+import { PlaygroundContext } from '../../playground-context';
+import classNames from 'classnames';
 
 const OAUTH_FLOW_URL = 'oauth.php?redirect=1';
 const urlParams = new URLSearchParams(window.location.search);
@@ -30,6 +33,11 @@ export default function GitHubOAuthGuard({ children }: GitHubOAuthGuardProps) {
 }
 
 function Authenticate({ authenticateUrl }: { authenticateUrl: string }) {
+	const { storage } = useContext(PlaygroundContext);
+	const [exported, setExported] = useState(false);
+	const buttonClass = classNames(css.githubButton, {
+		[css.disabled]: storage === 'none' && !exported,
+	});
 	return (
 		<div>
 			<h2 tabIndex={0} style={{ marginTop: 0, textAlign: 'center' }}>
@@ -41,13 +49,36 @@ function Authenticate({ authenticateUrl }: { authenticateUrl: string }) {
 			</p>
 			<p>
 				To enable this feature, connect your GitHub account with
-				WordPress Playground:
+				WordPress Playground.
 			</p>
+			{storage === 'none' ? (
+				<>
+					<p>
+						<b>You will lose your progress.</b> Your Playground is
+						temporary and the authentication flow will redirect you
+						to GitHub and erase all your changes. Be sure to export
+						your Playground to a zip file before proceeding.
+					</p>
+					<label style={{ cursor: 'pointer' }}>
+						<input
+							type="checkbox"
+							checked={exported}
+							onChange={() => setExported(!exported)}
+						/>
+						I exported my Playground as zip.
+					</label>
+				</>
+			) : null}
 			<p>
 				<a
 					aria-label="Connect your GitHub account"
-					className={css.githubButton}
+					className={buttonClass}
 					href={authenticateUrl}
+					onClick={(e) => {
+						if (storage === 'none' && !exported) {
+							e.preventDefault();
+						}
+					}}
 				>
 					<Icon icon={GitHubIcon} />
 					Connect your GitHub account

--- a/packages/playground/website/src/github/github-oauth-guard/style.module.css
+++ b/packages/playground/website/src/github/github-oauth-guard/style.module.css
@@ -18,3 +18,8 @@
 .github-button:hover {
 	background-color: #24292e;
 }
+
+.github-button.disabled {
+	cursor: default;
+	opacity: 0.5;
+}

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -25,6 +25,7 @@ import { GithubExportModal } from './github/github-export-form';
 import { useState } from 'react';
 import { ExportFormValues } from './github/github-export-form/form';
 import { joinPaths } from '@php-wasm/util';
+import { PlaygroundContext } from './playground-context';
 
 const query = new URL(document.location.href).searchParams;
 const blueprint = await resolveBlueprint();
@@ -81,115 +82,117 @@ function Main() {
 	>({});
 
 	return (
-		<PlaygroundViewport
-			storage={storage}
-			displayMode={displayMode}
-			blueprint={blueprint}
-			toolbarButtons={[
-				<PlaygroundConfigurationGroup
-					key="configuration"
-					initialConfiguration={currentConfiguration}
-				/>,
-				<DropdownMenu
-					key="menu"
-					icon={menu}
-					label="Additional actions"
-					className={css.dropdownMenu}
-					toggleProps={
-						{
-							className: `${buttonCss.button} ${buttonCss.isBrowserChrome}`,
-							'data-cy': 'dropdown-menu',
-						} as any
-					}
-				>
-					{({ onClose }) => (
-						<>
-							<MenuGroup>
-								<ResetSiteMenuItem
-									storage={currentConfiguration.storage}
-									onClose={onClose}
-								/>
-								<DownloadAsZipMenuItem onClose={onClose} />
-								<RestoreFromZipMenuItem onClose={onClose} />
-								<GithubImportMenuItem onClose={onClose} />
-								<GithubExportMenuItem onClose={onClose} />
-							</MenuGroup>
-							<MenuGroup label="More resources">
-								<MenuItem
-									icon={external}
-									iconPosition="left"
-									aria-label="Go to WordPress PR previewer"
-									href={
-										joinPaths(
-											document.location.pathname,
-											'wordpress.html'
-										) as any
-									}
-									target="_blank"
-								>
-									Preview WordPress Pull Request
-								</MenuItem>
-								<MenuItem
-									icon={external}
-									iconPosition="left"
-									aria-label="Go to a list of Playground demos"
-									href={
-										joinPaths(
-											document.location.pathname,
-											'demos/index.html'
-										) as any
-									}
-									target="_blank"
-								>
-									More demos
-								</MenuItem>
-								<MenuItem
-									icon={external}
-									iconPosition="left"
-									aria-label="Go to Playground documentation"
-									href={
-										'https://wordpress.github.io/wordpress-playground/' as any
-									}
-									target="_blank"
-								>
-									Documentation
-								</MenuItem>
-							</MenuGroup>
-						</>
-					)}
-				</DropdownMenu>,
-			]}
-		>
-			<GithubImportModal
-				onImported={({
-					url,
-					path,
-					files,
-					pluginOrThemeName,
-					contentType,
-					urlInformation: { owner, repo, type, pr },
-				}) => {
-					setGithubExportValues({
-						repoUrl: url,
-						prNumber: pr?.toString(),
-						pathInRepo: path,
-						prAction: pr ? 'update' : 'create',
+		<PlaygroundContext.Provider value={{ storage }}>
+			<PlaygroundViewport
+				storage={storage}
+				displayMode={displayMode}
+				blueprint={blueprint}
+				toolbarButtons={[
+					<PlaygroundConfigurationGroup
+						key="configuration"
+						initialConfiguration={currentConfiguration}
+					/>,
+					<DropdownMenu
+						key="menu"
+						icon={menu}
+						label="Additional actions"
+						className={css.dropdownMenu}
+						toggleProps={
+							{
+								className: `${buttonCss.button} ${buttonCss.isBrowserChrome}`,
+								'data-cy': 'dropdown-menu',
+							} as any
+						}
+					>
+						{({ onClose }) => (
+							<>
+								<MenuGroup>
+									<ResetSiteMenuItem
+										storage={currentConfiguration.storage}
+										onClose={onClose}
+									/>
+									<DownloadAsZipMenuItem onClose={onClose} />
+									<RestoreFromZipMenuItem onClose={onClose} />
+									<GithubImportMenuItem onClose={onClose} />
+									<GithubExportMenuItem onClose={onClose} />
+								</MenuGroup>
+								<MenuGroup label="More resources">
+									<MenuItem
+										icon={external}
+										iconPosition="left"
+										aria-label="Go to WordPress PR previewer"
+										href={
+											joinPaths(
+												document.location.pathname,
+												'wordpress.html'
+											) as any
+										}
+										target="_blank"
+									>
+										Preview WordPress Pull Request
+									</MenuItem>
+									<MenuItem
+										icon={external}
+										iconPosition="left"
+										aria-label="Go to a list of Playground demos"
+										href={
+											joinPaths(
+												document.location.pathname,
+												'demos/index.html'
+											) as any
+										}
+										target="_blank"
+									>
+										More demos
+									</MenuItem>
+									<MenuItem
+										icon={external}
+										iconPosition="left"
+										aria-label="Go to Playground documentation"
+										href={
+											'https://wordpress.github.io/wordpress-playground/' as any
+										}
+										target="_blank"
+									>
+										Documentation
+									</MenuItem>
+								</MenuGroup>
+							</>
+						)}
+					</DropdownMenu>,
+				]}
+			>
+				<GithubImportModal
+					onImported={({
+						url,
+						path,
+						files,
+						pluginOrThemeName,
 						contentType,
-						plugin: pluginOrThemeName,
-						theme: pluginOrThemeName,
-					});
-					setGithubExportFiles(files);
-				}}
-			/>
-			<GithubExportModal
-				initialValues={githubExportValues}
-				initialFilesBeforeChanges={githubExportFiles}
-				onExported={(prUrl, formValues) => {
-					setGithubExportValues(formValues);
-					setGithubExportFiles(undefined);
-				}}
-			/>
-		</PlaygroundViewport>
+						urlInformation: { owner, repo, type, pr },
+					}) => {
+						setGithubExportValues({
+							repoUrl: url,
+							prNumber: pr?.toString(),
+							pathInRepo: path,
+							prAction: pr ? 'update' : 'create',
+							contentType,
+							plugin: pluginOrThemeName,
+							theme: pluginOrThemeName,
+						});
+						setGithubExportFiles(files);
+					}}
+				/>
+				<GithubExportModal
+					initialValues={githubExportValues}
+					initialFilesBeforeChanges={githubExportFiles}
+					onExported={(prUrl, formValues) => {
+						setGithubExportValues(formValues);
+						setGithubExportFiles(undefined);
+					}}
+				/>
+			</PlaygroundViewport>
+		</PlaygroundContext.Provider>
 	);
 }
 

--- a/packages/playground/website/src/playground-context.tsx
+++ b/packages/playground/website/src/playground-context.tsx
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+import { StorageType } from './types';
+
+export const PlaygroundContext = createContext<{
+	storage: StorageType;
+}>({ storage: 'none' });


### PR DESCRIPTION
Connecting to GitHub means leaving the Playground website and losing unsaved changes. This commit makes it apparent and requires the user to confirm they  exported their work before connecting to the GitHub account.

## Testing instructions

1. Click Export to GitHub
2. Confirm you see the message as on the screenshot below
3. Confirm you can't click connect without checking the checkbox

<img width="333" alt="CleanShot 2023-12-11 at 00 34 02@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/95bf5fe5-1ac1-4612-ac28-f9bc2aca2d9f">

Then

1. Switch to the browser storage mode
2. Repeat the steps
3. Confirm the checkbox isn't there anymore

