### PR TITLE
Docs: Show a visible link to the Playground website

### DIFF
--- a/packages/docs/site/docs/01-start-here/01-index.md
+++ b/packages/docs/site/docs/01-start-here/01-index.md
@@ -1,13 +1,13 @@
----
+<img width="1219" alt="CleanShot 2023-12-12 at 23 11 12@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/53c38119-f666-47ec-be6a-634c3bd6af36">---
 title: Start here
 slug: /
 ---
 
 # WordPress Playground
 
-:::info **Looking for WordPress Playground website?**
+:::info **Looking for the official Playground website?**
 
-You're in the documentation. The website is at [wp.org/playground](wp.org/playground).
+WordPress Playground website was moved to [wp.org/playground](wp.org/playground). The site you're at right now is now a home for the documentation.
 
 :::
 

--- a/packages/docs/site/docs/01-start-here/01-index.md
+++ b/packages/docs/site/docs/01-start-here/01-index.md
@@ -5,6 +5,12 @@ slug: /
 
 # WordPress Playground
 
+:::info **Looking for WordPress Playground website?**
+
+You're in the documentation. The website is at [wp.org/playground](wp.org/playground).
+
+:::
+
 👋 Hi! Welcome to WordPress Playground documentation. Playground is an online tool to experiment and learn about WordPress – learn more in the [overview section](./02-overview.md).
 
 The documentation consists of two major sections:

--- a/packages/docs/site/docs/01-start-here/01-index.md
+++ b/packages/docs/site/docs/01-start-here/01-index.md
@@ -7,7 +7,7 @@ slug: /
 
 :::info **Looking for the official Playground website?**
 
-WordPress Playground website was moved to [wp.org/playground](wp.org/playground). The site you're at right now is now a home for the documentation.
+WordPress Playground website was moved to [wp.org/playground](https://wp.org/playground). The site you're at right now is now a home for the documentation.
 
 :::
 

--- a/packages/docs/site/docs/01-start-here/01-index.md
+++ b/packages/docs/site/docs/01-start-here/01-index.md
@@ -1,4 +1,4 @@
-<img width="1219" alt="CleanShot 2023-12-12 at 23 11 12@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/53c38119-f666-47ec-be6a-634c3bd6af36">---
+---
 title: Start here
 slug: /
 ---


### PR DESCRIPTION
## What is this PR doing?

The ticket at https://github.com/WordPress/wporg-main-2022/issues/355 looks into:

* Moving the Playground website from https://developer.wordpress.org/playground/ to wp.org/playground 
* Redirecting from https://developer.wordpress.org/playground/ to the documentation

However, there are already some websites out there linking to https://developer.wordpress.org/playground/.

This PR adds a visible link at the top of the main docs page for anyone who might get to the docs site there and be confused:

<img width="1207" alt="CleanShot 2023-12-12 at 23 11 22@2x" src="https://github.com/WordPress/wordpress-playground/assets/205419/4a4bb337-8a2c-404b-b148-6589138abe5f">
