### PR TITLE
Gutenberg preview: check for `pr` URL param

### DIFF
--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -11,7 +11,7 @@
 </head>
 <body>
 	<div id="main">
-		<!-- 
+		<!--
 			Credit for the logo and site design goes to Andrew Duthy
 			who originally built and hosted http://gutenberg.run/
 		-->
@@ -81,17 +81,19 @@
 		const form = document.getElementById('create');
 		const errorDiv = document.getElementById('error');
 
-		form.addEventListener('submit', async function previewPr(e) {
+		// If there's a PR query parameter, call previewPr with its value
+		const urlParams = new URLSearchParams(window.location.search);
+		const prNumber = urlParams.get('pr');
+		if (prNumber) {
+			document.getElementById('pr-number').value = prNumber;
+			previewPr(prNumber);
+		}
+
+		form.addEventListener('submit', async function onSubmit(e) {
 			e.preventDefault();
 			if (submitting) {
 				return;
 			}
-
-			submitting = true;
-			errorDiv.innerText = '';
-			submitButton.classList.add('loading');
-			submitButton.disabled = true;
-
 			let prNumber = document.getElementById('pr-number').value;
 
 			// Extract number from a GitHub URL
@@ -102,6 +104,15 @@
 			) {
 				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
 			}
+
+			previewPr(prNumber);
+		});
+
+		async function previewPr(prNumber) {
+			submitting = true;
+			errorDiv.innerText = '';
+			submitButton.classList.add('loading');
+			submitButton.disabled = true;
 
 			// Verify that the PR exists and that GitHub CI finished building it
 			const zipArtifactUrl = `/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
@@ -178,6 +189,6 @@
 			};
 			const encoded = JSON.stringify(blueprint);
 			window.location = '/#' + encodeURI(encoded);
-		});
+		}
 	</script>
 </body>


### PR DESCRIPTION
## What is this PR doing?
Similar to `/wordpress.html`, this PR add URL param checking to the `/gutenberg.html` page.

Thanks to @adamziel for the tip!

## What problem is it solving?

So that we can create direct links to a Playground test environment.

## How is the problem addressed?

Steals the code from `/wordpress.html` to extract and pass a PR number from the URL to a preview function, which was abstracted from the form `onSubmit` callback.

## Testing Instructions

1. Ensure entering a PR number in the form still loads Playground.
2. Visit the page with a valid [Gutenberg PR](https://github.com/WordPress/gutenberg/pulls) number, e.g., http://localhost:5400/website-server/gutenberg.html?pr=56932 - it should also load Playground.
