### PR TITLE
Make the .zip export self-contained: Include the default theme, wp-config, and the sqlite-database-integration plugin

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/zip-functions.php
+++ b/packages/playground/blueprints/src/lib/steps/zip-functions.php
@@ -3,6 +3,7 @@
 function zipDir($root, $output, $options = array())
 {
     $root = rtrim($root, '/');
+    $additionalPaths = array_key_exists('additional_paths', $options) ? $options['additional_paths'] : array();
     $excludePaths = array_key_exists('exclude_paths', $options) ? $options['exclude_paths'] : array();
     $zip_root = array_key_exists('zip_root', $options) ? $options['zip_root'] : $root;
 
@@ -35,6 +36,9 @@ function zipDir($root, $output, $options = array())
                 }
                 closedir($handle);
             }
+        }
+        foreach ($additionalPaths as $disk_path => $zip_path) {
+            $zip->addFile($disk_path, $zip_path);
         }
         $zip->close();
         chmod($output, 0777);

--- a/packages/playground/blueprints/src/lib/steps/zip-wp-content.ts
+++ b/packages/playground/blueprints/src/lib/steps/zip-wp-content.ts
@@ -3,31 +3,73 @@ import { runPhpWithZipFunctions } from './common';
 import { wpContentFilesExcludedFromExport } from './common';
 import { UniversalPHP } from '@php-wasm/universal';
 
+interface ZipWpContentOptions {
+	/**
+	 * @private
+	 * A temporary workaround to enable including the WordPress default theme
+	 * in the exported zip file.
+	 */
+	includeDefaultTheme?: boolean;
+	/**
+	 * @private
+	 * A temporary workaround to enable including wp-config in the exported zip file.
+	 */
+	includeWpConfig?: boolean;
+}
+
 /**
  * Replace the current wp-content directory with one from the provided zip file.
  *
  * @param playground Playground client.
  * @param wpContentZip Zipped WordPress site.
  */
-export const zipWpContent = async (playground: UniversalPHP) => {
+export const zipWpContent = async (
+	playground: UniversalPHP,
+	{
+		includeDefaultTheme = false,
+		includeWpConfig = false,
+	}: ZipWpContentOptions = {}
+) => {
 	const zipPath = '/tmp/wordpress-playground.zip';
 
 	const documentRoot = await playground.documentRoot;
 	const wpContentPath = joinPaths(documentRoot, 'wp-content');
 
+	let exceptPaths = wpContentFilesExcludedFromExport;
+	/*
+	 * This is a temporary workaround to enable removing the WordPress
+	 * default theme from the exported zip file. Let's remove this
+	 * once the iterator-based file API is merged.
+	 */
+	if (includeDefaultTheme) {
+		// This is a bit backwards, so hang on!
+		// We have a list of paths to exclude.
+		// We then *remove* the default theme from that list.
+		// As a result, we *include* the default theme in the final zip.
+		// It is hacky and will be removed soon.
+		exceptPaths = exceptPaths.filter(
+			(path) => !path.startsWith('themes/twenty')
+		);
+	}
 	const js = phpVars({
 		zipPath,
 		wpContentPath,
 		documentRoot,
-		exceptPaths: wpContentFilesExcludedFromExport.map((path) =>
+		exceptPaths: exceptPaths.map((path) =>
 			joinPaths(documentRoot, 'wp-content', path)
 		),
+		additionalPaths: includeWpConfig
+			? {
+					[joinPaths(documentRoot, 'wp-config.php')]: 'wp-config.php',
+			  }
+			: {},
 	});
 	await runPhpWithZipFunctions(
 		playground,
 		`zipDir(${js.wpContentPath}, ${js.zipPath}, array(
 			'exclude_paths' => ${js.exceptPaths},
-			'zip_root'      => ${js.documentRoot}
+			'zip_root'      => ${js.documentRoot},
+			'additional_paths' => ${js.additionalPaths}
 		));`
 	);
 

--- a/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
@@ -26,6 +26,9 @@ export function DownloadAsZipMenuItem({ onClose }: Props) {
 }
 
 async function startDownload(playground: PlaygroundClient) {
-	const bytes = await zipWpContent(playground);
+	const bytes = await zipWpContent(playground, {
+		includeDefaultTheme: true,
+		includeWpConfig: true,
+	});
 	saveAs(new File([bytes], 'wordpress-playground.zip'));
 }

--- a/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/download-as-zip.tsx
@@ -27,8 +27,7 @@ export function DownloadAsZipMenuItem({ onClose }: Props) {
 
 async function startDownload(playground: PlaygroundClient) {
 	const bytes = await zipWpContent(playground, {
-		includeDefaultTheme: true,
-		includeWpConfig: true,
+		selfContained: true,
 	});
 	saveAs(new File([bytes], 'wordpress-playground.zip'));
 }


### PR DESCRIPTION
## Description

Includes the `wp-config.php` file and the default WordPress theme (like `twentytwentythree`) in the zip file exported via the "Download as .zip" button.

Without those files, the exported bundle isn't self-contained. It cannot be hosted, and any the importer needs to provide the missing files on its own. The theme and the plugins are easy to backfill, but the data stored in `wp-config.php` is lost.

## How is the problem addressed?

This PR adds a temporary private `selfContained` option to the `importWpContent`. It is `false` by default to ensure those files are not exported with GitHub PRs (the export flow relies on the same logic). The zip download button sets it to `true`.

This is a temporary workaround as we currently don't have any better tools to deal with this problem. Once the streaming/iterators API ships in https://github.com/WordPress/wordpress-playground/pull/851, we'll be able to get rid of this hack and just filter the stream of files.

## Testing Instructions

Unfortunately, this PR ships no unit tests as without #895 there isn't an easy way to test the `zipWpContent` function. Here's the manual testing steps to take:

1. Open Playground
2. Make a change in the site content
3. Export Playground into a zip file
4. Confirm that zip file contains the `wp-content.php` file as well as the `twentytwentyfour` theme and the `sqlite-database-integration` plugin
5. Refresh the Playground tab and import that zip
6. Confirm it worked and the website is functional and has the content update from before
7. Export it to GitHub, check the "include zip file" checkbox
8. Confirm the GitHub PR has no `twentytwentyfour` theme, or the `wp-config.php` file, or the `sqlite-database-integration` plugin.
9. Do the same for the zip bundled with the GitHub PR
10. Import that PR and confirm it imports cleanly

