### PR TITLE
Dark mode for remote.html

### DIFF
--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -42,6 +42,14 @@
 				padding: 5px 10px;
 				cursor: pointer;
 			}
+
+			@media (prefers-color-scheme: dark) {
+				body,
+				body.has-error {
+					background: #1e1e1e;
+					color: #fff;
+				}
+			}
 		</style>
 	</head>
 	<body class="is-loading">

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -83,3 +83,14 @@
 	font-family: -apple-system, BlinkMacSystemFont, sans-serif;
 	font-size: 1.1rem;
 }
+
+@media (prefers-color-scheme: dark) {
+	.overlay {
+		background: #1e1e1e;
+		color: #fff;
+	}
+
+	.wrapper {
+		background: #32363a;
+	}
+}


### PR DESCRIPTION
Introduces system dark mode support for remote.html using CSS media queries.

![image](https://github.com/WordPress/wordpress-playground/assets/28816254/d929acd0-99f5-46e6-a866-badb39e3588f)
