### PR TITLE
Polyfills for Node.js v18 and JSDOM runtimes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13992,6 +13992,10 @@
 			"resolved": "packages/php-wasm/node",
 			"link": true
 		},
+		"node_modules/@php-wasm/node-polyfills": {
+			"resolved": "packages/php-wasm/node-polyfills",
+			"link": true
+		},
 		"node_modules/@php-wasm/progress": {
 			"resolved": "packages/php-wasm/progress",
 			"link": true
@@ -17835,6 +17839,10 @@
 		},
 		"node_modules/@wp-playground/storage": {
 			"resolved": "packages/playground/storage",
+			"link": true
+		},
+		"node_modules/@wp-playground/stream-compression": {
+			"resolved": "packages/playground/stream-compression",
 			"link": true
 		},
 		"node_modules/@wp-playground/sync": {
@@ -44912,7 +44920,7 @@
 			"version": "0.1.5",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -44921,7 +44929,7 @@
 			"version": "0.3.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -44930,16 +44938,20 @@
 			"version": "0.3.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
+		},
+		"packages/php-wasm/node-polyfills": {
+			"version": "0.0.1",
+			"license": "GPL-2.0-or-later"
 		},
 		"packages/php-wasm/progress": {
 			"name": "@php-wasm/progress",
 			"version": "0.3.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -44948,7 +44960,7 @@
 			"version": "0.3.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -44957,7 +44969,7 @@
 			"version": "0.3.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -44965,7 +44977,7 @@
 			"name": "@php-wasm/util",
 			"version": "0.3.1",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -44974,7 +44986,7 @@
 			"version": "0.3.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -44983,7 +44995,7 @@
 			"version": "0.3.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -44991,7 +45003,7 @@
 			"name": "@wp-playground/blueprints",
 			"version": "0.3.1",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -45000,7 +45012,7 @@
 			"version": "0.3.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -45009,7 +45021,7 @@
 			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		},
@@ -45027,6 +45039,10 @@
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later"
 		},
+		"packages/playground/stream-compression": {
+			"version": "0.0.1",
+			"license": "GPL-2.0-or-later"
+		},
 		"packages/playground/sync": {
 			"name": "@wp-playground/sync",
 			"version": "0.0.1",
@@ -45038,7 +45054,7 @@
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"engines": {
-				"node": ">=16.15.1",
+				"node": ">=18.18.2",
 				"npm": ">=8.11.0"
 			}
 		}

--- a/packages/php-wasm/node-polyfills/.eslintrc.json
+++ b/packages/php-wasm/node-polyfills/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/packages/php-wasm/node-polyfills/README.md
+++ b/packages/php-wasm/node-polyfills/README.md
@@ -1,0 +1,16 @@
+# php-wasm-node-polyfills
+
+Polyfills JavaScript classes and methods required by WordPress Playground.
+
+Ensures compatibility with the following environments:
+
+-   Node.js >= 18
+-   JSDom
+
+## Building
+
+Run `nx build php-wasm-node-polyfills` to build the library.
+
+## Running unit tests
+
+Run `nx test php-wasm-node-polyfills` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/php-wasm/node-polyfills/package.json
+++ b/packages/php-wasm/node-polyfills/package.json
@@ -1,0 +1,33 @@
+{
+	"name": "@php-wasm/node-polyfills",
+	"version": "0.0.1",
+	"description": "PHP.wasm – polyfills for Node.js",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"author": "The WordPress contributors",
+	"contributors": [
+		{
+			"name": "Adam Zielinski",
+			"email": "adam@adamziel.com",
+			"url": "https://github.com/adamziel"
+		}
+	],
+	"type": "module",
+	"main": "./index.cjs",
+	"module": "./index.js",
+	"exports": {
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./package.json": "./package.json"
+	},
+	"publishConfig": {
+		"access": "public",
+		"directory": "../../../dist/packages/php-wasm/node-polyfills"
+	},
+	"license": "GPL-2.0-or-later"
+}

--- a/packages/php-wasm/node-polyfills/project.json
+++ b/packages/php-wasm/node-polyfills/project.json
@@ -1,0 +1,55 @@
+{
+	"name": "php-wasm-node-polyfills",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/php-wasm/node-polyfills/src",
+	"projectType": "library",
+	"targets": {
+		"build": {
+			"executor": "@nx/vite:build",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"outputPath": "dist/packages/php-wasm/node-polyfills"
+			}
+		},
+		"test": {
+			"executor": "nx:noop",
+			"dependsOn": ["test:vite:node", "test:vite:jsdom"]
+		},
+		"test:esmcjs": {
+			"executor": "@wp-playground/nx-extensions:assert-built-esm-and-cjs",
+			"options": {
+				"outputPath": "dist/packages/php-wasm/node-polyfills"
+			},
+			"dependsOn": ["build"]
+		},
+		"test:vite:node": {
+			"executor": "@nx/vite:test",
+			"outputs": ["{options.reportsDirectory}"],
+			"options": {
+				"config": "packages/php-wasm/node-polyfills/vitest-node.config.ts",
+				"passWithNoTests": true,
+				"reportsDirectory": "../../../coverage/packages/php-wasm/node-polyfills"
+			}
+		},
+		"test:vite:jsdom": {
+			"executor": "@nx/vite:test",
+			"outputs": ["{options.reportsDirectory}"],
+			"options": {
+				"config": "packages/php-wasm/node-polyfills/vitest-jsdom.config.ts",
+				"passWithNoTests": true,
+				"reportsDirectory": "../../../coverage/packages/php-wasm/node-polyfills"
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"packages/php-wasm/node-polyfills/**/*.ts",
+					"packages/php-wasm/node-polyfills/package.json"
+				]
+			}
+		}
+	},
+	"tags": []
+}

--- a/packages/php-wasm/node-polyfills/src/index.ts
+++ b/packages/php-wasm/node-polyfills/src/index.ts
@@ -1,0 +1,2 @@
+import './lib/blob';
+import './lib/custom-event';

--- a/packages/php-wasm/node-polyfills/src/lib/blob.spec.ts
+++ b/packages/php-wasm/node-polyfills/src/lib/blob.spec.ts
@@ -1,0 +1,57 @@
+import './blob';
+
+describe('File class', () => {
+	it('Should exist', () => {
+		expect(File).not.toBe(undefined);
+	});
+});
+
+describe('File.arrayBuffer() method', () => {
+	it('should exist', async () => {
+		expect(typeof File.prototype.arrayBuffer).toBe('function');
+	});
+	it('should resolve to a valid array buffer', async () => {
+		const inputBytes = new Uint8Array([1, 2, 3, 4]);
+		const file = new File([inputBytes], 'test');
+		const outputBuffer = await file.arrayBuffer();
+		const outputBytes = new Uint8Array(outputBuffer);
+		expect(outputBytes).toEqual(inputBytes);
+	});
+});
+
+describe('File.stream() method', () => {
+	it('should exist', async () => {
+		expect(typeof File.prototype.stream).toBe('function');
+	});
+	it('should returns a valid stream', async () => {
+		const inputBytes = new Uint8Array([1, 2, 3, 4]);
+		const file = new File([inputBytes], 'test');
+		const stream = file.stream();
+		const reader = stream.getReader();
+
+		const firstRead = await reader.read();
+		expect(firstRead.value).toEqual(inputBytes);
+		expect(firstRead.done).toBe(false);
+
+		const secondRead = await reader.read();
+		expect(secondRead.done).toBe(true);
+	});
+	//
+	it.skip('should be a valid BYOB stream that allows reading an arbitrary number of bytes', async () => {
+		const inputBytes = new Uint8Array([1, 2, 3, 4]);
+		const file = new File([inputBytes], 'test');
+		const stream = file.stream();
+		const reader = stream.getReader({ mode: 'byob' });
+
+		const firstRead = await reader.read(new Uint8Array(3));
+		expect(firstRead.value).toEqual(inputBytes.slice(0, 3));
+		expect(firstRead.done).toBe(false);
+
+		const secondRead = await reader.read(new Uint8Array(2));
+		expect(secondRead.value).toEqual(inputBytes.slice(3));
+		expect(secondRead.done).toBe(false);
+
+		const thirdRead = await reader.read(new Uint8Array(2));
+		expect(thirdRead.done).toBe(true);
+	});
+});

--- a/packages/php-wasm/node-polyfills/src/lib/blob.spec.ts
+++ b/packages/php-wasm/node-polyfills/src/lib/blob.spec.ts
@@ -36,8 +36,7 @@ describe('File.stream() method', () => {
 		const secondRead = await reader.read();
 		expect(secondRead.done).toBe(true);
 	});
-	//
-	it.skip('should be a valid BYOB stream that allows reading an arbitrary number of bytes', async () => {
+	it('should be a valid BYOB stream that allows reading an arbitrary number of bytes', async () => {
 		const inputBytes = new Uint8Array([1, 2, 3, 4]);
 		const file = new File([inputBytes], 'test');
 		const stream = file.stream();

--- a/packages/php-wasm/node-polyfills/src/lib/blob.ts
+++ b/packages/php-wasm/node-polyfills/src/lib/blob.ts
@@ -141,3 +141,56 @@ if (typeof Blob.prototype.stream === 'undefined') {
 }
 
 export default {};
+
+async function isByobSupported() {
+	const inputBytes = new Uint8Array([1, 2, 3, 4]);
+	const file = new File([inputBytes], 'test');
+	const stream = file.stream();
+	try {
+		// This throws on older versions of node
+		stream.getReader({ mode: 'byob' });
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
+
+/**
+ * Polyfill the stream() method if it either doesn't exist,
+ * or is an older version shipped with e.g. Node.js 18 where
+ * BYOB streams seem to be unsupported.
+ */
+if (typeof Blob.prototype.stream === 'undefined' || !isByobSupported()) {
+	Blob.prototype.stream = function () {
+		let position = 0;
+		// eslint-disable-next-line
+		const blob = this;
+		return new ReadableStream({
+			type: 'bytes',
+			// 0.5 MB seems like a reasonable chunk size, let's adjust
+			// this if needed.
+			autoAllocateChunkSize: 512 * 1024,
+
+			async pull(controller) {
+				const view = controller.byobRequest!.view;
+
+				// Read the next chunk of data:
+				const chunk = blob.slice(position, position + view!.byteLength);
+				const buffer = await chunk.arrayBuffer();
+				const uint8array = new Uint8Array(buffer);
+
+				// Emit that chunk:
+				new Uint8Array(view!.buffer).set(uint8array);
+				const bytesRead = uint8array.byteLength;
+				controller.byobRequest!.respond(bytesRead);
+
+				// Bump the position and close this stream once
+				// we've read the entire blob.
+				position += bytesRead;
+				if (position >= blob.size) {
+					controller.close();
+				}
+			},
+		});
+	};
+}

--- a/packages/php-wasm/node-polyfills/src/lib/blob.ts
+++ b/packages/php-wasm/node-polyfills/src/lib/blob.ts
@@ -1,0 +1,143 @@
+/**
+ * WordPress Playground heavily realies on the File class. This module
+ * polyfill the File class for the different environments where
+ * WordPress Playground may run.
+ */
+if (typeof File === 'undefined') {
+	/**
+	 * Polyfill the File class that isn't shipped in Node.js version 18.
+	 *
+	 * Blob conveniently provides a lot of the same methods as File, we
+	 * just need to implement a few File-specific properties.
+	 */
+	class File extends Blob {
+		override readonly name;
+		readonly lastModified: number;
+		readonly lastModifiedDate: Date;
+		webkitRelativePath: any;
+		constructor(
+			sources: BlobPart[],
+			fileName: string,
+			options?: FilePropertyBag
+		) {
+			super(sources);
+			/*
+			 * Compute a valid last modified date as that's what the
+			 * browsers do:
+			 *
+			 * ```
+			 * > new File([], '').lastModifiedDate
+			 * Sat Dec 16 2023 10:07:53 GMT+0100 (czas środkowoeuropejski standardowy)
+			 *
+			 * > new File([], '', { lastModified: NaN }).lastModifiedDate
+			 * Thu Jan 01 1970 01:00:00 GMT+0100 (czas środkowoeuropejski standardowy)
+			 *
+			 * > new File([], '', { lastModified: 'string' }).lastModifiedDate
+			 * Thu Jan 01 1970 01:00:00 GMT+0100 (czas środkowoeuropejski standardowy)
+			 *
+			 * > new File([], '', { lastModified: {} }).lastModifiedDate
+			 * Thu Jan 01 1970 01:00:00 GMT+0100 (czas środkowoeuropejski standardowy)
+			 * ```
+			 */
+			let date;
+			if (options?.lastModified) {
+				date = new Date();
+			}
+			if (!date || isNaN(date.getFullYear())) {
+				date = new Date();
+			}
+			this.lastModifiedDate = date;
+			this.lastModified = date.getMilliseconds();
+			this.name = fileName || '';
+		}
+	}
+	global.File = File;
+}
+
+function asPromise<T>(obj: FileReader) {
+	return new Promise<T>(function (resolve, reject) {
+		obj.onload = obj.onerror = function (event: Event) {
+			obj.onload = obj.onerror = null;
+
+			if (event.type === 'load') {
+				resolve(obj.result as T);
+			} else {
+				reject(new Error('Failed to read the blob/file'));
+			}
+		};
+	});
+}
+
+/**
+ * File is a subclass of Blob. Let's polyfill the following Blob
+ * methods that are missing in JSDOM:
+ *
+ * – Blob.text()
+ * – Blob.stream()
+ * – Blob.arrayBuffer()
+ *
+ * See the related JSDom issue:
+ *
+ * – [Implement Blob.stream, Blob.text and Blob.arrayBuffer](https://github.com/jsdom/jsdom/issues/2555).
+ *
+ * @source `blob-polyfill` npm package.
+ * * By Eli Grey, https://eligrey.com
+ * * By Jimmy Wärting, https://github.com/jimmywarting
+ */
+if (typeof Blob.prototype.arrayBuffer === 'undefined') {
+	Blob.prototype.arrayBuffer = function arrayBuffer() {
+		const reader = new FileReader();
+		reader.readAsArrayBuffer(this);
+		return asPromise<Uint8Array>(reader);
+	};
+}
+
+if (typeof Blob.prototype.text === 'undefined') {
+	Blob.prototype.text = function text() {
+		const reader = new FileReader();
+		reader.readAsText(this);
+		return asPromise<string>(reader);
+	};
+}
+
+/**
+ * Polyfill the stream() method if it either doesn't exist,
+ * or is an older version shipped with e.g. Node.js 18 where
+ * BYOB streams seem to be unsupported.
+ */
+if (typeof Blob.prototype.stream === 'undefined') {
+	Blob.prototype.stream = function () {
+		let position = 0;
+		// eslint-disable-next-line
+		const blob = this;
+		return new ReadableStream({
+			type: 'bytes',
+			// 0.5 MB seems like a reasonable chunk size, let's adjust
+			// this if needed.
+			autoAllocateChunkSize: 512 * 1024,
+
+			async pull(controller) {
+				const view = controller.byobRequest!.view;
+
+				// Read the next chunk of data:
+				const chunk = blob.slice(position, position + view!.byteLength);
+				const buffer = await chunk.arrayBuffer();
+				const uint8array = new Uint8Array(buffer);
+
+				// Emit that chunk:
+				new Uint8Array(view!.buffer).set(uint8array);
+				const bytesRead = uint8array.byteLength;
+				controller.byobRequest!.respond(bytesRead);
+
+				// Bump the position and close this stream once
+				// we've read the entire blob.
+				position += bytesRead;
+				if (position >= blob.size) {
+					controller.close();
+				}
+			},
+		});
+	};
+}
+
+export default {};

--- a/packages/php-wasm/node-polyfills/src/lib/custom-event.spec.ts
+++ b/packages/php-wasm/node-polyfills/src/lib/custom-event.spec.ts
@@ -1,0 +1,18 @@
+import './custom-event';
+
+describe('CustomEvent class', () => {
+	it('Should exist', () => {
+		expect(CustomEvent).not.toBe(undefined);
+	});
+	it('Should be possible to construct', () => {
+		const instance = new CustomEvent('test', {
+			detail: {
+				custom: 'data',
+			},
+		});
+		expect(instance).not.toBe(undefined);
+		expect(instance.detail).toEqual({
+			custom: 'data',
+		});
+	});
+});

--- a/packages/php-wasm/node-polyfills/src/lib/custom-event.ts
+++ b/packages/php-wasm/node-polyfills/src/lib/custom-event.ts
@@ -1,0 +1,33 @@
+if (typeof CustomEvent === 'undefined') {
+	class CustomEvent<T = any> extends Event {
+		readonly detail: T;
+		constructor(
+			name: string,
+			options: {
+				detail?: T;
+				bubbles?: boolean;
+				cancellable?: boolean;
+				composed?: boolean;
+			} = {}
+		) {
+			super(name, options);
+			/*
+			 * The bang symbol (`!`) here is a lie to make TypeScript happy.
+			 *
+			 * Without the bang TS has the following complaint:
+			 *
+			 * > T | undefined is not assignable to type T
+			 *
+			 * In reality, it's absolutely fine for T (or `options.detail`)
+			 * to be undefined. However, the CustomEvent interface shipped
+			 * with TypeScript doesn't think so and marks `this.details` as
+			 * a required property.
+			 *
+			 * This little and harmless trick silences that error.
+			 */
+			this.detail = options.detail!;
+		}
+		initCustomEvent(): void {}
+	}
+	globalThis.CustomEvent = CustomEvent;
+}

--- a/packages/php-wasm/node-polyfills/tsconfig.json
+++ b/packages/php-wasm/node-polyfills/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "ESNext",
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+}

--- a/packages/php-wasm/node-polyfills/tsconfig.lib.json
+++ b/packages/php-wasm/node-polyfills/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node", "vite/client"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/php-wasm/node-polyfills/tsconfig.spec.json
+++ b/packages/php-wasm/node-polyfills/tsconfig.spec.json
@@ -1,0 +1,25 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"types": [
+			"vitest/globals",
+			"vitest/importMeta",
+			"vite/client",
+			"node",
+			"vitest"
+		]
+	},
+	"include": [
+		"vite.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.test.tsx",
+		"src/**/*.spec.tsx",
+		"src/**/*.test.js",
+		"src/**/*.spec.js",
+		"src/**/*.test.jsx",
+		"src/**/*.spec.jsx",
+		"src/**/*.d.ts"
+	]
+}

--- a/packages/php-wasm/node-polyfills/vite.config.ts
+++ b/packages/php-wasm/node-polyfills/vite.config.ts
@@ -1,33 +1,25 @@
-/// <reference types="vitest" />
-import { defineConfig } from 'vite';
-
-import dts from 'vite-plugin-dts';
+/// <reference types='vitest' />
 import { join } from 'path';
-
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import { viteTsConfigPaths } from '../../vite-ts-config-paths';
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import viteTsConfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-	cacheDir: '../../../node_modules/.vite/playground-blueprints',
+	cacheDir: '../../../node_modules/.vite/php-wasm-node-polyfills',
 
 	plugins: [
+		viteTsConfigPaths({
+			root: '../../../',
+		}),
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
-		}),
-
-		viteTsConfigPaths({
-			root: '../../../',
 		}),
 	],
 
 	// Uncomment this if you are using workers.
 	// worker: {
-	//  plugins: [
-	//    viteTsConfigPaths({
-	//      root: '../../../',
-	//    }),
-	//  ],
+	//  plugins: [ nxViteTsPaths() ],
 	// },
 
 	// Configuration for building your library.
@@ -36,10 +28,10 @@ export default defineConfig({
 		lib: {
 			// Could also be a dictionary or array of multiple entry points.
 			entry: 'src/index.ts',
-			name: 'playground-blueprints',
+			name: 'php-wasm-node-polyfills',
 			fileName: 'index',
 			// Change this to the formats you want to support.
-			// Don't forgot to update your package.json as well.
+			// Don't forget to update your package.json as well.
 			formats: ['es', 'cjs'],
 		},
 		rollupOptions: {
@@ -53,8 +45,8 @@ export default defineConfig({
 		cache: {
 			dir: '../../../node_modules/.vitest',
 		},
-		setupFiles: ['./src/vitest-setup-file.ts'],
-		environment: 'jsdom',
+		environment:
+			'Run this task with either "node" or "jsdom" configuration, e.g. nx run php-wasm-node-polyfills:test:node',
 		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 	},
 });

--- a/packages/php-wasm/node-polyfills/vitest-jsdom.config.ts
+++ b/packages/php-wasm/node-polyfills/vitest-jsdom.config.ts
@@ -1,0 +1,10 @@
+/// <reference types='vitest' />
+import config from './vite.config';
+
+export default {
+	...config,
+	test: {
+		...config.test,
+		environment: 'jsdom',
+	},
+};

--- a/packages/php-wasm/node-polyfills/vitest-node.config.ts
+++ b/packages/php-wasm/node-polyfills/vitest-node.config.ts
@@ -1,0 +1,10 @@
+/// <reference types='vitest' />
+import config from './vite.config';
+
+export default {
+	...config,
+	test: {
+		...config.test,
+		environment: 'node',
+	},
+};

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -150,14 +150,11 @@ describe.each(SupportedPHPVersions)(
 				url: '/index.php',
 				method: 'POST',
 				files: {
-					myFile: {
-						name: 'text.txt',
-						async arrayBuffer() {
-							return new TextEncoder().encode('Hello World')
-								.buffer;
-						},
-						type: 'text/plain',
-					} as any,
+					myFile: new File(
+						[new TextEncoder().encode('Hello World').buffer],
+						'text.txt',
+						{ type: 'text/plain' }
+					),
 				},
 				headers: {
 					'Content-Type': 'multipart/form-data; boundary=boundary',

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -150,11 +150,9 @@ describe.each(SupportedPHPVersions)(
 				url: '/index.php',
 				method: 'POST',
 				files: {
-					myFile: new File(
-						[new TextEncoder().encode('Hello World').buffer],
-						'text.txt',
-						{ type: 'text/plain' }
-					),
+					myFile: new File(['Hello World'], 'text.txt', {
+						type: 'text/plain',
+					}),
 				},
 				headers: {
 					'Content-Type': 'multipart/form-data; boundary=boundary',

--- a/packages/playground/blueprints/src/lib/steps/run-sql.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-sql.spec.ts
@@ -47,7 +47,7 @@ describe('Blueprint step runSql', () => {
 
 		// Test a single query
 		const mockFileSingle = new File(
-			[new TextEncoder().encode('SELECT * FROM wp_users;').buffer],
+			['SELECT * FROM wp_users;'],
 			'single-query.sql'
 		);
 
@@ -59,11 +59,7 @@ describe('Blueprint step runSql', () => {
 
 		// Test a multiple queries
 		const mockFileMultiple = new File(
-			[
-				new TextEncoder().encode(
-					`SELECT * FROM wp_users;\nSELECT * FROM wp_posts;\n`
-				).buffer,
-			],
+			[`SELECT * FROM wp_users;\nSELECT * FROM wp_posts;\n`],
 			'multiple-queries.sql'
 		);
 
@@ -75,11 +71,7 @@ describe('Blueprint step runSql', () => {
 
 		// Ensure it works the same if the last query is missing a trailing newline
 		const mockFileNoTrailingSpace = new File(
-			[
-				new TextEncoder().encode(
-					`SELECT * FROM wp_users;\nSELECT * FROM wp_posts;`
-				).buffer,
-			],
+			[`SELECT * FROM wp_users;\nSELECT * FROM wp_posts;`],
 			'no-trailing-newline.sql'
 		);
 

--- a/packages/playground/blueprints/src/lib/steps/run-sql.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-sql.spec.ts
@@ -46,14 +46,10 @@ describe('Blueprint step runSql', () => {
 		);
 
 		// Test a single query
-		const mockFileSingle = {
-			name: 'single-query.sql',
-			async arrayBuffer() {
-				return new TextEncoder().encode('SELECT * FROM wp_users;')
-					.buffer;
-			},
-			type: 'text/plain',
-		} as any;
+		const mockFileSingle = new File(
+			[new TextEncoder().encode('SELECT * FROM wp_users;').buffer],
+			'single-query.sql'
+		);
 
 		await runSql(php, { sql: mockFileSingle });
 
@@ -62,15 +58,14 @@ describe('Blueprint step runSql', () => {
 		expect(singleQueryResult).toBe(singleQueryExpect);
 
 		// Test a multiple queries
-		const mockFileMultiple = {
-			name: 'multiple-queries.sql',
-			async arrayBuffer() {
-				return new TextEncoder().encode(
+		const mockFileMultiple = new File(
+			[
+				new TextEncoder().encode(
 					`SELECT * FROM wp_users;\nSELECT * FROM wp_posts;\n`
-				).buffer;
-			},
-			type: 'text/plain',
-		} as any;
+				).buffer,
+			],
+			'multiple-queries.sql'
+		);
 
 		await runSql(php, { sql: mockFileMultiple });
 
@@ -79,15 +74,14 @@ describe('Blueprint step runSql', () => {
 		expect(multiQueryResult).toBe(multiQueryExpect);
 
 		// Ensure it works the same if the last query is missing a trailing newline
-		const mockFileNoTrailingSpace = {
-			name: 'no-trailing-newline.sql',
-			async arrayBuffer() {
-				return new TextEncoder().encode(
+		const mockFileNoTrailingSpace = new File(
+			[
+				new TextEncoder().encode(
 					`SELECT * FROM wp_users;\nSELECT * FROM wp_posts;`
-				).buffer;
-			},
-			type: 'text/plain',
-		} as any;
+				).buffer,
+			],
+			'no-trailing-newline.sql'
+		);
 
 		await runSql(php, { sql: mockFileNoTrailingSpace });
 		const noTrailingNewlineQueryResult = await php.readFileAsText(

--- a/packages/playground/blueprints/src/vitest-setup-file.ts
+++ b/packages/playground/blueprints/src/vitest-setup-file.ts
@@ -1,4 +1,2 @@
 // PHP.wasm requires WordPress Playground's Node polyfills.
 import '@php-wasm/node-polyfills';
-
-export * from './lib';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -51,9 +51,6 @@
 			"@wp-playground/storage": [
 				"packages/playground/storage/src/index.ts"
 			],
-			"@wp-playground/stream-compression": [
-				"packages/playground/stream-compression/src/index.ts"
-			],
 			"@wp-playground/sync": ["packages/playground/sync/src/index.ts"],
 			"@wp-playground/unit-test-utils": [
 				"packages/playground/unit-test-utils/src/index.ts"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,6 +23,9 @@
 				"packages/php-wasm/fs-journal/src/index.ts"
 			],
 			"@php-wasm/node": ["packages/php-wasm/node/src/index.ts"],
+			"@php-wasm/node-polyfills": [
+				"packages/php-wasm/node-polyfills/src/index.ts"
+			],
 			"@php-wasm/private": ["packages/php-wasm/private/src/index.ts"],
 			"@php-wasm/progress": ["packages/php-wasm/progress/src/index.ts"],
 			"@php-wasm/scopes": ["packages/php-wasm/scopes/src/index.ts"],
@@ -47,6 +50,9 @@
 			],
 			"@wp-playground/storage": [
 				"packages/playground/storage/src/index.ts"
+			],
+			"@wp-playground/stream-compression": [
+				"packages/playground/stream-compression/src/index.ts"
 			],
 			"@wp-playground/sync": ["packages/playground/sync/src/index.ts"],
 			"@wp-playground/unit-test-utils": [


### PR DESCRIPTION
## Description

Adds a new `@php-wasm/node-polyfills` package to polyfills the features missing in Node 18 and/or JSDOM environments. The goal is to make wp-now and other Playground-based Node.js packages work in Node 18, which is the current LTS release.

The polyfilled JavaScript features are:

* `CustomEvent` class
* `File` class
* `Blob.text()` and `Blob.arrayBuffer()` methods
* `Blob.arrayBuffer()` and `File.text()` methods
* `Blob.stream()` and `File.stream()` methods
* Ensures `File.stream().getReader({ mode: 'byob' })` is supported – this is relevant for #851

I adapted the Blob methods from https://github.com/bjornstar/blob-polyfill/blob/master/Blob.js as they seemed to provide just the logic needed here and they also worked right away.

This PR is a part of https://github.com/WordPress/wordpress-playground/pull/851 split out into a separate PR to make it easier to review and reason about.

Supersedes https://github.com/WordPress/wordpress-playground/pull/865

## Testing instructions

Confirm the unit tests pass. This PR ships a set of vite tests to confirm the polyfills work both in vanilla Node.js and in jsdom runtime environments.

## Alternatives considered

* https://github.com/web4more/fileapi
* https://www.npmjs.com/package/web-file-polyfill

## Related:

* https://github.com/WordPress/wordpress-playground/pull/591
* https://github.com/WordPress/playground-tools/pull/82
* https://github.com/WordPress/playground-tools/pull/116

cc @danielbachhuber @sejas @eliot-akira @dmsnell 