### PR TITLE
Use Node.js Polyfills in the Blueprints package

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -1,3 +1,6 @@
+// Blueprints require WordPress Playground's Node polyfills.
+import '@php-wasm/node-polyfills';
+
 export * from './lib/steps';
 export * from './lib/steps/handlers';
 export { runBlueprintSteps, compileBlueprint } from './lib/compile';

--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -4,7 +4,7 @@ import {
 } from '@php-wasm/progress';
 import { UniversalPHP } from '@php-wasm/universal';
 import { Semaphore } from '@php-wasm/util';
-import { File, zipNameToHumanName } from './steps/common';
+import { zipNameToHumanName } from './steps/common';
 
 export const ResourceTypes = [
 	'vfs',

--- a/packages/playground/blueprints/src/lib/steps/common.ts
+++ b/packages/playground/blueprints/src/lib/steps/common.ts
@@ -57,34 +57,6 @@ export async function fileToUint8Array(file: File) {
 	return new Uint8Array(await file.arrayBuffer());
 }
 
-/**
- * Polyfill the File class in JSDOM which lacks arrayBuffer() method
- *
- * - [Implement Blob.stream, Blob.text and Blob.arrayBuffer](https://github.com/jsdom/jsdom/issues/2555)
- *
- * When a Resource (../resources.ts) resolves to an instance of File, the
- * resulting object is missing the arrayBuffer() method in JSDOM environment
- * during tests.
- *
- * Import the polyfilled File class below to ensure its buffer is available to
- * functions like writeFile (./client-methods.ts) and fileToUint8Array (above).
- */
-class FilePolyfill extends File {
-	buffers: BlobPart[];
-	constructor(buffers: BlobPart[], name: string) {
-		super(buffers, name);
-		this.buffers = buffers;
-	}
-	override async arrayBuffer(): Promise<ArrayBuffer> {
-		return this.buffers[0] as ArrayBuffer;
-	}
-}
-
-const FileWithArrayBuffer =
-	File.prototype.arrayBuffer instanceof Function ? File : FilePolyfill;
-
-export { FileWithArrayBuffer as File };
-
 export async function runPhpWithZipFunctions(
 	playground: UniversalPHP,
 	code: string

--- a/packages/playground/blueprints/vite.config.ts
+++ b/packages/playground/blueprints/vite.config.ts
@@ -50,10 +50,10 @@ export default defineConfig({
 
 	test: {
 		globals: true,
+		setupFiles: ['./src/vitest-setup-file.ts'],
 		cache: {
 			dir: '../../../node_modules/.vitest',
 		},
-		setupFiles: ['./src/vitest-setup-file.ts'],
 		environment: 'jsdom',
 		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 	},


### PR DESCRIPTION
Makes Playground Blueprints compatible with Node.js v18 by using a set of polyfills shiped in https://github.com/WordPress/wordpress-playground/pull/875.

## Test plan

Confirm the CI checks passed
