### PR TITLE
Fix a cross-device mv error by using a tmp directory inside document root

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/install-asset.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-asset.ts
@@ -1,4 +1,5 @@
 import type { UniversalPHP } from '@php-wasm/universal';
+import { joinPaths } from '@php-wasm/util';
 import { writeFile } from './write-file';
 import { unzip } from './unzip';
 
@@ -33,8 +34,11 @@ export async function installAsset(
 	const zipFileName = zipFile.name;
 	const assetNameGuess = zipFileName.replace(/\.zip$/, '');
 
-	const tmpUnzippedFilesPath = `/tmp/assets/${assetNameGuess}`;
-	const tmpZipPath = `/tmp/${zipFileName}`;
+	const wpContent = joinPaths(await playground.documentRoot, 'wp-content');
+	const tmpDir = joinPaths(wpContent, crypto.randomUUID());
+	await playground.mkdir(tmpDir);
+	const tmpZipPath = joinPaths(tmpDir, zipFileName);
+	const tmpUnzippedFilesPath = joinPaths(tmpDir, 'assets', assetNameGuess);
 
 	const removeTmpFolder = () =>
 		playground.rmdir(tmpUnzippedFilesPath, {


### PR DESCRIPTION
## What is this PR doing?

Solves the [error discovered by @sejas](https://github.com/WordPress/playground-tools/pull/116#issuecomment-1747287593) caused by calling `php.mv(fromPath, toPath)` when `fromPath` is a mounted local directory and `toPath` is a MEMFS directory. Emscripten doesn't support such a scenario:

```
Proceeding without the Notification plugin. Could not install it in wp-admin. The original error was: Error: Could not move "/tmp/assets/Notification/notification": Cross-device link.
Error: Could not move "/tmp/assets/Notification/notification": Cross-device link.
    at descriptor.value (/playground-tools/node_modules/@php-wasm/node/index.cjs:67481:17)
```

The solution proposed in this PR replaces a `/tmp` directory with a randomly-named temporary directory inside  `wp-content`. `/tmp` doesn't necessarily point to a system temp directory and needs to be revisited anyway. Whether we should use a temporary directory inside `wp-content` is another matter, but that part may be revisited once the [recursive cp](https://github.com/WordPress/wordpress-playground/pull/846) feature is added.

## Testing instructions

* Confirm all the CI checks pass. 
* Build the project (`npm run build`)
* Link the packages as described in https://github.com/WordPress/playground-tools/pull/110
* Run the test plan provided in https://github.com/WordPress/playground-tools/pull/116 
