### PR TITLE
Fixing build regression [PATHS] 

### DIFF
--- a/packages/php-wasm/compile/libedit/Dockerfile
+++ b/packages/php-wasm/compile/libedit/Dockerfile
@@ -1,8 +1,8 @@
 FROM playground-php-wasm:base
 
 RUN mkdir -p /root/lib/include /root/lib/lib
-COPY ../libncurses/dist/root/lib/include /root/lib/include
-COPY ../libncurses/dist/root/lib/lib /root/lib/lib
+COPY ./libncurses/dist/root/lib/include /root/lib/include
+COPY ./libncurses/dist/root/lib/lib /root/lib/lib
 
 RUN /root/copy-lib.sh lib-ncurses
 RUN wget https://www.thrysoee.dk/editline/libedit-20221030-3.1.tar.gz && \

--- a/packages/php-wasm/compile/libiconv/Dockerfile
+++ b/packages/php-wasm/compile/libiconv/Dockerfile
@@ -1,8 +1,8 @@
 FROM playground-php-wasm:base
 
 RUN mkdir -p /root/lib/include /root/lib/lib
-COPY ../libz/dist/root/lib/include /root/lib/include
-COPY ../libz/dist/root/lib/lib /root/lib/lib
+COPY ./libz/dist/root/lib/include /root/lib/include
+COPY ./libz/dist/root/lib/lib /root/lib/lib
 
 RUN set -euxo pipefail; \
 	wget https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz; \

--- a/packages/php-wasm/compile/libopenssl/Dockerfile
+++ b/packages/php-wasm/compile/libopenssl/Dockerfile
@@ -1,8 +1,8 @@
 FROM playground-php-wasm:base
 
 RUN mkdir -p /root/lib/include /root/lib/lib
-COPY ../libz/dist/root/lib/include /root/lib/include
-COPY ../libz/dist/root/lib/lib /root/lib/lib
+COPY ./libz/dist/root/lib/include /root/lib/include
+COPY ./libz/dist/root/lib/lib /root/lib/lib
 
 RUN /root/copy-lib.sh lib-libz
 RUN set -euxo pipefail && \

--- a/packages/php-wasm/compile/libpng16/Dockerfile
+++ b/packages/php-wasm/compile/libpng16/Dockerfile
@@ -1,8 +1,8 @@
 FROM playground-php-wasm:base
 
 RUN mkdir -p /root/lib/include /root/lib/lib
-COPY ../libz/dist/root/lib/include /root/lib/include
-COPY ../libz/dist/root/lib/lib /root/lib/lib
+COPY ./libz/dist/root/lib/include /root/lib/include
+COPY ./libz/dist/root/lib/lib /root/lib/lib
 
 RUN wget http://prdownloads.sourceforge.net/libpng/libpng-1.6.39.tar.gz?download -O libpng-1.6.39.tar.gz
 RUN tar -xzf libpng-1.6.39.tar.gz
@@ -16,4 +16,4 @@ RUN     source /root/emsdk/emsdk_env.sh && \
             --target wasm32-unknown-emscripten \
             --prefix=/root/install/
 RUN source /root/emsdk/emsdk_env.sh && EMCC_SKIP="-lc -lz" EMCC_FLAGS="-sSIDE_MODULE" emmake make
-RUN source /root/emsdk/emsdk_env.sh && emmake make install 
+RUN source /root/emsdk/emsdk_env.sh && emmake make install

--- a/packages/php-wasm/compile/libsqlite3/Dockerfile
+++ b/packages/php-wasm/compile/libsqlite3/Dockerfile
@@ -1,8 +1,8 @@
 FROM playground-php-wasm:base
 
 RUN mkdir -p /root/lib/include /root/lib/lib
-COPY ../libz/dist/root/lib/include /root/lib/include
-COPY ../libz/dist/root/lib/lib /root/lib/lib
+COPY ./libz/dist/root/lib/include /root/lib/include
+COPY ./libz/dist/root/lib/lib /root/lib/lib
 
 RUN set -euxo pipefail &&\
     wget --no-check-certificate https://www.sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \

--- a/packages/php-wasm/compile/libzip/Dockerfile
+++ b/packages/php-wasm/compile/libzip/Dockerfile
@@ -2,8 +2,8 @@ FROM playground-php-wasm:base
 
 ARG LIBZIP_VERSION
 RUN mkdir -p /root/lib/include /root/lib/lib
-COPY ../libz/dist/root/lib/include /root/lib/include
-COPY ../libz/dist/root/lib/lib /root/lib/lib
+COPY ./libz/dist/root/lib/include /root/lib/include
+COPY ./libz/dist/root/lib/lib /root/lib/lib
 
 RUN     cd /root && \
         curl -k https://libzip.org/download/libzip-$LIBZIP_VERSION.tar.gz -o libzip-$LIBZIP_VERSION.tar.gz && \

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -18,18 +18,18 @@ RUN cd php-src && ./buildconf --force
 
 # Bring in the libraries
 RUN mkdir -p /root/lib/include /root/lib/lib /libs
-COPY ../bison2.7/dist/ /libs/bison2.7
-COPY ../libedit/dist/root/lib /root/lib
-COPY ../libiconv/dist/root/lib /root/lib
-COPY ../libncurses/dist/root/lib /root/lib
-COPY ../libopenssl/dist/root/lib /root/lib
-COPY ../libpng16/dist/root/lib /root/lib
-COPY ../libsqlite3/dist/root/lib /root/lib
-COPY ../libxml2/dist/root/lib /root/lib
-COPY ../libz/dist/root/lib /root/lib
-COPY ../libzip/dist/1.2.0/root/lib /libs/libzip/1.2.0
-COPY ../libzip/dist/1.9.2/root/lib /libs/libzip/1.9.2
-COPY ../oniguruma/dist/root/lib /root/lib
+COPY ./bison2.7/dist/ /libs/bison2.7
+COPY ./libedit/dist/root/lib /root/lib
+COPY ./libiconv/dist/root/lib /root/lib
+COPY ./libncurses/dist/root/lib /root/lib
+COPY ./libopenssl/dist/root/lib /root/lib
+COPY ./libpng16/dist/root/lib /root/lib
+COPY ./libsqlite3/dist/root/lib /root/lib
+COPY ./libxml2/dist/root/lib /root/lib
+COPY ./libz/dist/root/lib /root/lib
+COPY ./libzip/dist/1.2.0/root/lib /libs/libzip/1.2.0
+COPY ./libzip/dist/1.9.2/root/lib /libs/libzip/1.9.2
+COPY ./oniguruma/dist/root/lib /root/lib
 
 # Build PHP
 
@@ -91,7 +91,7 @@ RUN if [ "$WITH_LIBZIP" = "yes" ]; then \
 		/root/replace.sh 's/pharcmd=pharcmd/pharcmd=/g' /root/php-src/configure && \
 		/root/replace.sh 's/pharcmd_install=install-pharcmd/pharcmd_install=/g' /root/php-src/configure; \
 	fi;
-	
+
 
 # Add ncurses if needed and libedit if needed
 RUN if [ "$WITH_CLI_SAPI" = "yes" ]; \


### PR DESCRIPTION
## What is this PR doing?

This corrects some paths in the docker file used to copy libraries into the build image.

## What problem is it solving?

Newer versions of Docker will ignore leading `../` that lead outside of the build context, but older versions will throw an error in that case.

## How is the problem addressed?

This removes the extra `../` at the start of the paths in question. Newer versions of docker will ignore `../`s that lead outside of the build context, but older versions will throw an error. The following paths will work on later versions but fail on earlier ones:

```
# Bring in the libraries
RUN mkdir -p /root/lib/include /root/lib/lib /libs
COPY ../../../../../../../../../../bison2.7/dist/ /libs/bison2.7
COPY ../../../../../../../../../../libedit/dist/root/lib /root/lib
COPY ../../../../../../../../../../libiconv/dist/root/lib /root/lib
COPY ../../../../../../../../../../libncurses/dist/root/lib /root/lib
COPY ../../../../../../../../../../libopenssl/dist/root/lib /root/lib
COPY ../../../../../../../../../../libpng16/dist/root/lib /root/lib
COPY ../../../../../../../../../../libsqlite3/dist/root/lib /root/lib
COPY ../../../../../../../../../../libxml2/dist/root/lib /root/lib
COPY ../../../../../../../../../../libz/dist/root/lib /root/lib
COPY ../../../../../../../../../../libzip/dist/1.2.0/root/lib /libs/libzip/1.2.0
COPY ../../../../../../../../../../libzip/dist/1.9.2/root/lib /libs/libzip/1.9.2
COPY ../../../../../../../../../../oniguruma/dist/root/lib /root/lib
```

## Testing Instructions

Checkout the branch and pull dependencies:

```
git checkout sm-correcting-build-paths
npm install
```

Build the libraries:
```
cd packages/php-wasm/compile
make clean
make all
```

In a new terminal, build PHP 7.4 - 8.3: (PHP <=7.3 is fixed in https://github.com/WordPress/wordpress-playground/pull/871)

```
npm run recompile:php:web:light:8.3
npm run recompile:php:web:light:8.2
npm run recompile:php:web:light:8.1
npm run recompile:php:web:light:8.0
npm run recompile:php:web:light:7.4
```
```
npm run recompile:php:web:kitchen-sink:8.3
npm run recompile:php:web:kitchen-sink:8.2
npm run recompile:php:web:kitchen-sink:8.1
npm run recompile:php:web:kitchen-sink:8.0
npm run recompile:php:web:kitchen-sink:7.4
```
```
npm run recompile:php:node:8.3
npm run recompile:php:node:8.2
npm run recompile:php:node:8.1
npm run recompile:php:node:8.0
npm run recompile:php:node:7.4
```

Ensure the build works:

```
npm run build
npm run dev
```

Navigate to the following URLs:

* http://localhost:5400/website-server/?plugin=web-stories&php-extension-bundle=kitchen-sink&php=8.3
* http://localhost:5400/website-server/?plugin=web-stories&php-extension-bundle=kitchen-sink&php=8.2
* http://localhost:5400/website-server/?plugin=web-stories&php-extension-bundle=kitchen-sink&php=8.1
* http://localhost:5400/website-server/?plugin=web-stories&php-extension-bundle=kitchen-sink&php=8.0
* http://localhost:5400/website-server/?plugin=web-stories&php-extension-bundle=kitchen-sink&php=7.4