### PR TITLE
Plugin proxy – handle artifacts hosted on windows.net 

### DIFF
--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -117,7 +117,7 @@
 			// Verify that the PR exists and that GitHub CI finished building it
 			const zipArtifactUrl = `/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
 			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
-			const response = await fetch(zipArtifactUrl, { method: 'HEAD' });
+			const response = await fetch(zipArtifactUrl + '&verify_only=true');
 			if (response.status !== 200) {
 				errorDiv.innerText = `The PR ${prNumber} does not exist or GitHub CI did not finish building it yet.`;
 				submitting = false;


### PR DESCRIPTION
Fixes an issue reported by @gziolo:

> https://github.com/WordPress/gutenberg/pull/57256 - I can’t preview this PR using Playground https://playground.wordpress.net/gutenberg.html. What do I miss? All CI checks are green.

The culprit was that GitHub hosts that artifact on another domain: `productionresultssa0.blob.core.windows.net`. The current `file_get_contents` call follows the redirection URL and resends the same HTTP headers. That used to be fine, but now the windows.net host rejects those headers.

This PR ensures we don't implicitly follow the 302 redirect, but parse the target URL and send an explicit request with a fresh set of HTTP headers. As a bonus, this makes the download much faster as we now use the `streamHttpResponse` function which immediately passes the response bytes back to the browser instead of buffering the entire response first.

This PR also switches from HEAD-request-based PR validation to the same Query params–based one as the wordpress.html previewer uses.

## Testing instructions

Try to preview the above PR in the Gutenberg PR previewer on https://playground.wordpress.net/gutenberg.html and confirm that it works now (this fix is already deployed).