### PR TITLE
Remove legacy storage options: opfs-host and opfs-browser

### DIFF
--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -67,8 +67,7 @@ let virtualOpfsDir: FileSystemDirectoryHandle | undefined;
 let lastOpfsDir: FileSystemDirectoryHandle | undefined;
 let wordPressAvailableInOPFS = false;
 if (
-	(startupOptions.storage === 'opfs-browser' ||
-		startupOptions.storage === 'browser') &&
+	startupOptions.storage === 'browser' &&
 	// @ts-ignore
 	typeof navigator?.storage?.getDirectory !== 'undefined'
 ) {

--- a/packages/playground/website/src/components/playground-configuration-group/form.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/form.tsx
@@ -136,7 +136,7 @@ export function PlaygroundConfigurationForm({
 							Browser: stored in this browser.
 						</label>
 					</li>
-					{storage === 'opfs-browser' ? (
+					{storage === 'browser' ? (
 						<li
 							style={{ marginLeft: 40 }}
 							className={resetSite ? css.danger : ''}
@@ -149,7 +149,7 @@ export function PlaygroundConfigurationForm({
 									!!currentlyRunningWordPressVersion &&
 									wp !== currentlyRunningWordPressVersion
 								}
-								id="storage-opfs-browser-reset"
+								id="storage-browser-reset"
 								className={forms.radioInput}
 								onChange={(
 									event: React.ChangeEvent<HTMLInputElement>
@@ -159,7 +159,7 @@ export function PlaygroundConfigurationForm({
 								checked={resetSite}
 							/>
 							<label
-								htmlFor="storage-opfs-browser-reset"
+								htmlFor="storage-browser-reset"
 								className={forms.radioLabel}
 							>
 								Delete stored data and start fresh
@@ -197,7 +197,7 @@ export function PlaygroundConfigurationForm({
 							)}
 						</label>
 					</li>
-					{storage === 'opfs-host' || storage === 'device' ? (
+					{storage === 'device' ? (
 						<li>
 							<div>
 								<p>
@@ -242,7 +242,7 @@ export function PlaygroundConfigurationForm({
 					) : null}
 				</ul>
 			</div>
-			{storage !== 'device' && storage !== 'opfs-host' ? (
+			{storage !== 'device' ? (
 				<>
 					<div
 						className={`${forms.formGroup} ${forms.formGroupLinear}`}

--- a/packages/playground/website/src/components/playground-configuration-group/index.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/index.tsx
@@ -88,9 +88,7 @@ export default function PlaygroundConfigurationGroup({
 	}, [!!playground]);
 
 	const [isResumeLastDirOpen, setResumeLastDirOpen] = useState(
-		(initialConfiguration.storage === 'opfs-host' ||
-			initialConfiguration.storage === 'device') &&
-			!!lastDirectoryHandle
+		initialConfiguration.storage === 'device' && !!lastDirectoryHandle
 	);
 	const closeResumeLastDirModal = () => setResumeLastDirOpen(false);
 
@@ -185,10 +183,7 @@ export default function PlaygroundConfigurationGroup({
 
 	async function handleSubmit(config: PlaygroundConfiguration) {
 		const playground = await playgroundRef.current!.promise;
-		if (
-			config.resetSite &&
-			(config.storage === 'opfs-browser' || config.storage === 'browser')
-		) {
+		if (config.resetSite && config.storage === 'browser') {
 			if (
 				!window.confirm(
 					'This will wipe out all stored data and start a new site. Do you want to proceed?'
@@ -212,16 +207,13 @@ export default function PlaygroundConfigurationGroup({
 			>
 				PHP {currentConfiguration.php} {' - '}
 				WP {WPLabel} {' - '}
-				{currentConfiguration.storage === 'opfs-host' ||
-				currentConfiguration.storage === 'device'
+				{currentConfiguration.storage === 'device'
 					? `Storage: Device (${dirName})`
-					: currentConfiguration.storage === 'opfs-browser' ||
-					  currentConfiguration.storage === 'browser'
+					: currentConfiguration.storage === 'browser'
 					? 'Storage: Browser'
 					: '⚠️ Storage: None'}
 			</Button>
-			{currentConfiguration.storage === 'opfs-host' ||
-			currentConfiguration.storage === 'device' ? (
+			{currentConfiguration.storage === 'device' ? (
 				<SyncLocalFilesButton />
 			) : null}
 			{isResumeLastDirOpen ? (

--- a/packages/playground/website/src/components/playground-configuration-group/reload-with-new-configuration.ts
+++ b/packages/playground/website/src/components/playground-configuration-group/reload-with-new-configuration.ts
@@ -5,10 +5,7 @@ export async function reloadWithNewConfiguration(
 	playground: PlaygroundClient,
 	config: PlaygroundConfiguration
 ) {
-	if (
-		config.resetSite &&
-		(config.storage === 'opfs-browser' || config.storage === 'browser')
-	) {
+	if (config.resetSite && config.storage === 'browser') {
 		await playground?.resetVirtualOpfs();
 	}
 

--- a/packages/playground/website/src/components/toolbar-buttons/reset-site.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/reset-site.tsx
@@ -4,12 +4,7 @@ import { MenuItem } from '@wordpress/components';
 import { StorageType } from '../../types';
 
 type Props = { onClose: () => void; storage: StorageType };
-const opfsStorages: StorageType[] = [
-	'browser',
-	'device',
-	'opfs-browser',
-	'opfs-host',
-];
+const opfsStorages: StorageType[] = ['browser', 'device'];
 export function ResetSiteMenuItem({ onClose, storage }: Props) {
 	const { playground } = usePlaygroundContext();
 	return (

--- a/packages/playground/website/src/lib/hooks.ts
+++ b/packages/playground/website/src/lib/hooks.ts
@@ -5,13 +5,7 @@ import { getRemoteUrl } from './config';
 
 interface UsePlaygroundOptions {
 	blueprint?: Blueprint;
-	storage?:
-		| 'opfs-host'
-		| 'opfs-browser'
-		| 'browser'
-		| 'device'
-		| 'none'
-		| 'temporary';
+	storage?: 'browser' | 'device' | 'none';
 }
 export function usePlayground({ blueprint, storage }: UsePlaygroundOptions) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);

--- a/packages/playground/website/src/types.ts
+++ b/packages/playground/website/src/types.ts
@@ -1,9 +1,2 @@
-export const StorageTypes = [
-	'browser',
-	'device',
-	'temporary',
-	'none',
-	'opfs-host',
-	'opfs-browser',
-] as const;
+export const StorageTypes = ['browser', 'device', 'none'] as const;
 export type StorageType = (typeof StorageTypes)[number];


### PR DESCRIPTION
Query API storage options have been renamed in #636:

* opfs-host became device
* opfs-browser became browser
* temporary became none

Two months were given as a deprecation period and now this commit removes the legacy options.

Closes #670
