### PR TITLE
Ignore the __MACOSX folder when unzipping a plugin or a theme

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/install-asset.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-asset.ts
@@ -57,9 +57,11 @@ export async function installAsset(
 		});
 
 		// Find the path asset folder name
-		const files = await playground.listFiles(tmpUnzippedFilesPath, {
+		let files = await playground.listFiles(tmpUnzippedFilesPath, {
 			prependPath: true,
 		});
+		// _unzip_file_ziparchive in WordPress skips the __MACOSX files, and so should we here.
+		files = files.filter((name) => !name.endsWith('/__MACOSX'));
 
 		/**
 		 * If the zip only contains a single entry that is directory,


### PR DESCRIPTION
## Description

When you unzip a plugin or a theme on a Mac, you may get a __MACOSX folder inside of it. This folder prevented the plugin or theme from being installed properly. Therefore, in this PR we ignore it.

## Testing Instructions

1. Download https://downloads.wordpress.org/plugins/gutenberg.zip
2. Extract it
3. Zip it again with a __MACOSX folder inside
4. Host it somewhere locally, e.g. the `playground/packages/website/public` directory
5. Try to install it using a Blueprint URL like this one: `http://localhost:5400/website-server/#%7B%22login%22:true,%22plugins%22:[%22http://localhost:5400/website-server/gutenberg.zip%22]%7D`
6. Confirm it worked

cc @tellyworth 