### PR TITLE
PHP.wasm: Report both the source and target path on failure

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -308,7 +308,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			expect(() => {
 				php.mv(file1, file2);
 			}).toThrowError(
-				`Could not move "${testDirPath}/1.txt": There is no such file or directory OR the parent directory does not exist.`
+				`Could not move ${testDirPath}/1.txt to ${testDirPath}/2.txt: There is no such file or directory OR the parent directory does not exist.`
 			);
 		});
 
@@ -320,7 +320,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			expect(() => {
 				php.mv(file1, file2);
 			}).toThrowError(
-				`Could not move "${testDirPath}/1.txt": There is no such file or directory OR the parent directory does not exist.`
+				`Could not move ${testDirPath}/1.txt to ${testDirPath}/nowhere/2.txt: There is no such file or directory OR the parent directory does not exist.`
 			);
 		});
 

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -4,7 +4,10 @@ import {
 	PHPRequestHandlerConfiguration,
 } from './php-request-handler';
 import { PHPResponse } from './php-response';
-import { rethrowFileSystemError } from './rethrow-file-system-error';
+import {
+	getEmscriptenFsError,
+	rethrowFileSystemError,
+} from './rethrow-file-system-error';
 import { getLoadedRuntime } from './load-php-runtime';
 import type { PHPRuntimeId } from './load-php-runtime';
 import {
@@ -611,9 +614,21 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 	}
 
 	/** @inheritDoc */
-	@rethrowFileSystemError('Could not move "{path}"')
 	mv(fromPath: string, toPath: string) {
-		this[__private__dont__use].FS.rename(fromPath, toPath);
+		try {
+			this[__private__dont__use].FS.rename(fromPath, toPath);
+		} catch (e) {
+			const errmsg = getEmscriptenFsError(e);
+			if (!errmsg) {
+				throw e;
+			}
+			throw new Error(
+				`Could not move ${fromPath} to ${toPath}: ${errmsg}`,
+				{
+					cause: e,
+				}
+			);
+		}
 	}
 
 	/** @inheritDoc */

--- a/packages/php-wasm/universal/src/lib/rethrow-file-system-error.ts
+++ b/packages/php-wasm/universal/src/lib/rethrow-file-system-error.ts
@@ -14,7 +14,7 @@ export interface ErrnoError extends Error {
 /**
  * @see https://github.com/emscripten-core/emscripten/blob/38eedc630f17094b3202fd48ac0c2c585dbea31e/system/include/wasi/api.h#L336
  */
-const FileErrorCodes = {
+export const FileErrorCodes = {
 	0: 'No error occurred. System call completed successfully.',
 	1: 'Argument list too long.',
 	2: 'Permission denied.',
@@ -93,6 +93,14 @@ const FileErrorCodes = {
 	75: 'Cross-device link.',
 	76: 'Extension: Capabilities insufficient.',
 } as any;
+
+export function getEmscriptenFsError(e: any) {
+	const errno = typeof e === 'object' ? ((e as any)?.errno as any) : null;
+	if (errno in FileErrorCodes) {
+		return FileErrorCodes[errno];
+	}
+}
+
 export function rethrowFileSystemError(messagePrefix = '') {
 	return function catchFileSystemError(
 		target: any,


### PR DESCRIPTION
This commit ensures the target path of `php.mv(source, target)` is included in the error message when the move fails. This makes for a better developer experience and easier debugging.

## Testing instructions

Confirm the CI tests pass – this change is accomianied by updated tests.
