### PR TITLE
Blueprints: Wrap define() calls in if(!defined()) in wp-config.php

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/index.ts
+++ b/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/index.ts
@@ -9,6 +9,8 @@ import transportFetch from './wp-content/mu-plugins/playground-includes/wp_http_
 import transportDummy from './wp-content/mu-plugins/playground-includes/requests_transport_dummy.php?raw';
 /** @ts-ignore */
 import playgroundMuPlugin from './wp-content/mu-plugins/0-playground.php?raw';
+/** @ts-ignore */
+import wrapDefineCallsInIfs from './wrap-define-calls-in-ifs.php?raw';
 
 /**
  * @private
@@ -108,15 +110,6 @@ class WordPressPatcher {
 				NONCE_SALT: randomString(40),
 			},
 		});
-		await updateFile(
-			this.php,
-			`${this.wordpressPath}/wp-config.php`,
-			(contents) =>
-				contents.replaceAll(
-					/',\s+'put your unique phrase here'/g,
-					"__', ''"
-				)
-		);
 	}
 
 	async disableSiteHealth() {
@@ -143,6 +136,7 @@ class WordPressPatcher {
 
 	async prepareForRunningInsideWebBrowser() {
 		// Various tweaks
+		this.patchWpConfigDefineIfNotDefined();
 		await this.php.mkdir(`${this.wordpressPath}/wp-content/mu-plugins`);
 		await this.php.writeFile(
 			`${this.wordpressPath}/wp-content/mu-plugins/0-playground.php`,
@@ -155,6 +149,38 @@ class WordPressPatcher {
 			`${this.wordpressPath}/wp-content/mu-plugins/playground-includes/requests_transport_dummy.php`,
 			transportDummy
 		);
+	}
+
+	/**
+	 * Wraps all define calls in a conditional if(!defined()) to ensure that the default
+	 * wp-config.php constants will not class with the ones defined with the `defineWpConfigConsts`
+	 * Blueprint step.
+	 */
+	async patchWpConfigDefineIfNotDefined() {
+		const result = await this.php.run({
+			code: `${wrapDefineCallsInIfs}
+				$wp_config_path = '${this.wordpressPath}/wp-config.php';
+				if(file_exists($wp_config_path)) {
+					$contents = file_get_contents($wp_config_path);
+				} else {
+					$contents = '';
+				}
+
+				// Naively bale out if the file seems to already have the if(!defined()) guards
+				// @TODO: consider using tokens instead of this naive approach
+				if ( strpos($contents, 'if(!defined(') ) {
+					die();
+				}
+
+				file_put_contents(
+					$wp_config_path, 
+					wrap_define_calls_in_ifs($contents)
+				);
+			`,
+		});
+		if (result.errors) {
+			throw new Error(result.errors);
+		}
 	}
 
 	async addFetchNetworkTransport() {

--- a/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/wrap-define-calls-in-ifs.php
+++ b/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/wrap-define-calls-in-ifs.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * Wraps all define calls in a conditional if(!defined()) to prevent redefining
+ * constants.
+ * 
+ * Transforms:
+ * 
+ * ```
+ * define('WP_DEBUG', true);
+ * define('WP_DEBUG', false);
+ * define($const ? $a, $b, 123);
+ * ```
+ * 
+ * Into:
+ * 
+ * ```
+ * if(!defined('WP_DEBUG')) {
+ *    define('WP_DEBUG', true);
+ * }
+ * if(!defined('WP_DEBUG')) {
+ *     define('WP_DEBUG', false);
+ * }
+ * if(!defined($const ? $a : $b)) {
+ *     define($const ? $a : $b, 123);
+ * }
+ * ```
+ * 
+ * @param mixed $content
+ * @return string
+ */
+function wrap_define_calls_in_ifs($content)
+{
+    $tokens = array_reverse(token_get_all($content));
+    $output = [];
+
+    // Look through all the tokens and find the define calls
+    do {
+        $buffer = [];
+        $name_buffer = [];
+
+        // Capture everything until the define call into output.
+        // Capturing the define call into a buffer.
+        // Example:
+        //     <?php echo 'a'; define  (
+        //     ^^^^^^^^^^^^^^^^^^^^^^
+        //           output   |buffer
+        while ($token = array_pop($tokens)) {
+            if (is_array($token) && $token[0] === T_STRING && strtolower($token[1]) === 'define') {
+                $buffer[] = $token;
+                break;
+            }
+            $output[] = $token;
+        }
+
+        // Maybe we didn't find a define call and reached the end of the file?
+        if (!count($tokens)) {
+            break;
+        }
+
+        // Capture everything up to the opening parenthesis, including the parenthesis
+        // e.g. define  (
+        //           ^^^^
+        while ($token = array_pop($tokens)) {
+            $buffer[] = $token;
+            if ($token === "(") {
+                break;
+            }
+        }
+
+        // Capture the first argument – it's the first expression after the opening
+        // parenthesis and before the comma:
+        // Examples:
+        //     define("WP_DEBUG", true);
+        //            ^^^^^^^^^^^
+        //
+        //     define(count([1,2]) > 2 ? 'WP_DEBUG' : 'FOO', true);
+        //            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        $open_parenthesis = 0;
+        while ($token = array_pop($tokens)) {
+            $buffer[] = $token;
+            if ($token === "(" || $token === "[" || $token === "{") {
+                ++$open_parenthesis;
+            } elseif ($token === ")" || $token === "]" || $token === "}") {
+                --$open_parenthesis;
+            } elseif ($token === "," && $open_parenthesis === 0) {
+                break;
+            }
+            // Don't capture the comma as a part of the constant name
+            $name_buffer[] = $token;
+        }
+
+        // Capture everything until the closing parenthesis
+        //     define("WP_DEBUG", true);
+        //                       ^^^^^^
+        $open_parenthesis = 0;
+        while ($token = array_pop($tokens)) {
+            $buffer[] = $token;
+            if ($token === "(" || $token === "[" || $token === "{") {
+                ++$open_parenthesis;
+            } elseif ($token === ")" || $token === "]" || $token === "}") {
+                --$open_parenthesis;
+            }
+            if ($open_parenthesis === -1) {
+                break;
+            }
+        }
+
+        // Capture until the semicolon
+        //     define("WP_DEBUG", true)  ;
+        //                             ^^^
+        while ($token = array_pop($tokens)) {
+            $buffer[] = $token;
+            if ($token === ";") {
+                break;
+            }
+        }
+
+        // Yay, we have the define call in the buffer now. Let's wrap it in an if
+        // statement:
+        $output = array_merge(
+            $output,
+            ["if(!defined("],
+            $name_buffer,
+            [")) {\n\t"],
+            $buffer,
+            ["\n}\n"]
+        );
+    } while (count($tokens));
+
+    // Translate the output tokens back into a string
+    $output_string = '';
+    foreach ($output as $token) {
+        if (is_array($token)) {
+            $output_string .= $token[1];
+        } else {
+            $output_string .= $token;
+        }
+    }
+
+    return $output_string;
+}
+
+// // Uncomment to test:
+// $content = <<<'PHP'
+// <?php
+// define('WP_DEBUG', true);
+// define('WP_DEBUG', false);
+// define($const ? $a : $b, 123);
+// define((function() use($x) {
+//     return [$x, 'a'];
+// })(), 123);
+// PHP;
+
+// print_r(wrap_define_calls_in_ifs($content));
+

--- a/packages/playground/blueprints/src/lib/steps/common.ts
+++ b/packages/playground/blueprints/src/lib/steps/common.ts
@@ -40,7 +40,9 @@ export function zipNameToHumanName(zipName: string) {
 	);
 }
 
-type PatchFileCallback = (contents: string) => string | Uint8Array;
+type PatchFileCallback = (
+	contents: string
+) => string | Uint8Array | Promise<string | Uint8Array>;
 export async function updateFile(
 	php: UniversalPHP,
 	path: string,
@@ -50,7 +52,7 @@ export async function updateFile(
 	if (await php.fileExists(path)) {
 		contents = await php.readFileAsText(path);
 	}
-	await php.writeFile(path, callback(contents));
+	await php.writeFile(path, await callback(contents));
 }
 
 export async function fileToUint8Array(file: File) {


### PR DESCRIPTION
Rewrites `wp-config,.php` and wraps all `define()` calls in a conditional `if(!defined())`. The goal is to avoid conflicts between the constants defined via the `defineWpConfigConsts` Blueprint step and the ones defined in `wp-config.php`.

Related to https://github.com/WordPress/playground-tools/issues/135

## Open questions

This PR changes the contents of `wp-content.php` which is fine in the in-browser Playground environment, but may be unexpected when Playground is used for local development e.g. via local Directory Sync or `wp-now`. In particular, these changes would show up in `git diff` and could confuse the developer. One workaround could be to also add an explanatory comment like:

> // These changes were automatically added by WordPress Playground because
> // you used the `defineWpConfigConsts` Blueprint step to define a constant with
> // the same name as one already declared this file (WP_DEBUG).

However, I don't see any other solution here. If a constant is already defined, the `define()` call will issue a warning. Therefore, we must avoid conflicting `define()` calls in `wp-config.php`.

Two alternative ideas:

1. Wait until the `defineWpConfigConsts()` step is called and only then wrap the specific constants definitions that would trigger a warning.
2. Refactor the `defineWpConfigConsts()` step either add a `define()` call in `wp-config.php` or rewrite the second argument of an existing `define()` call. This makes the constant values apparent as all the values are available for inspection in the single location that the developer already knows about and will inspect for debugging. Also, it solves the problem of [including the Blueprint-defined constants in the exported Playground](https://github.com/WordPress/wordpress-playground/issues/900).

Either way, we're rewriting `wp-config.php` as we cannot leave the conflicting `define()` call as it is.

Thinking about it more, I'm leaning towards closing this PR and exploring the second alternative above. It wouldn't handle dynamic calls like `define($wpdebug, true)`, but it could wrap them in an `if()` and add an inline comment to explain the wrapping.

cc @dmsnell @danielbachhuber @swissspidy 

## Testing Instructions

Go to the following URL **without this PR applied** and confirm there are warnings like `Warning: Constant WP_DEBUG already defined`:

http://localhost:5400/website-server/#{%22landingPage%22:%22/%22,%22phpExtensionBundles%22:[%22kitchen-sink%22],%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%225.9%22},%22steps%22:[{%22step%22:%22defineWpConfigConsts%22,%22consts%22:{%22WP_DEBUG%22:true}},{%22step%22:%22defineWpConfigConsts%22,%22consts%22:{%22WP_DEBUG_ONLY%22:%22a%22}}]}

Now go there with this PR applied and confirm the warnings are gone.
