### PR TITLE
Improve playground.goTo() and playground.getCurrentURL()

### DIFF
--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -139,22 +139,32 @@ export async function bootPlaygroundRemote() {
 			// If the URL is the same, we need to force a reload
 			// because otherwise the iframe will not reload the page.
 			if (newUrl === oldUrl && wpFrame.contentWindow) {
-				wpFrame.contentWindow.location.href = newUrl;
-				return;
+				try {
+					wpFrame.contentWindow.location.href = newUrl;
+					return;
+				} catch (e) {
+					// The above call can fail if we're embedded in an
+					// environment with a restrictive CSP policy.
+				}
 			}
 			wpFrame.src = newUrl;
 		},
 		async getCurrentURL() {
-			return await playground.internalUrlToPath(
-				// The most reliable way to get the current URL is to
-				// ask the iframe directly.
-				wpFrame.contentWindow?.location.href ||
-					// If that isn't available (e.g. the iframe is not loaded
-					// yet), let's refer to the src attribute of the iframe itself.
-					// This is less reliable because the src attribute may not be
-					// updated when the iframe navigates to a new URL.
-					wpFrame.src
-			);
+			let url = '';
+			try {
+				url = wpFrame.contentWindow!.location.href;
+			} catch (e) {
+				// The above call can fail if we're embedded in an
+				// environment with a restrictive CSP policy.
+			}
+			if (!url) {
+				// If we can't get the URL from the iframe (e.g. it's not loaded
+				// yet), let's refer to the src attribute of the iframe itself.
+				// This is less reliable because the src attribute may not be
+				// updated when the iframe navigates to a new URL.
+				url = wpFrame.src;
+			}
+			return await playground.internalUrlToPath(url);
 		},
 		async setIframeSandboxFlags(flags: string[]) {
 			wpFrame.setAttribute('sandbox', flags.join(' '));

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -133,10 +133,21 @@ export async function bootPlaygroundRemote() {
 			if (requestedPath === '/wp-admin') {
 				requestedPath = '/wp-admin/';
 			}
-			wpFrame.src = await playground.pathToInternalUrl(requestedPath);
+			const newUrl = await playground.pathToInternalUrl(requestedPath);
+			const oldUrl = wpFrame.src;
+
+			// If the URL is the same, we need to force a reload
+			// because otherwise the iframe will not reload the page.
+			if (newUrl === oldUrl && wpFrame.contentWindow) {
+				wpFrame.contentWindow.location.href = newUrl;
+				return;
+			}
+			wpFrame.src = newUrl;
 		},
 		async getCurrentURL() {
-			return await playground.internalUrlToPath(wpFrame.src);
+			return await playground.internalUrlToPath(
+				wpFrame.contentWindow?.location.href || wpFrame.src
+			);
 		},
 		async setIframeSandboxFlags(flags: string[]) {
 			wpFrame.setAttribute('sandbox', flags.join(' '));

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -146,7 +146,14 @@ export async function bootPlaygroundRemote() {
 		},
 		async getCurrentURL() {
 			return await playground.internalUrlToPath(
-				wpFrame.contentWindow?.location.href || wpFrame.src
+				// The most reliable way to get the current URL is to
+				// ask the iframe directly.
+				wpFrame.contentWindow?.location.href ||
+					// If that isn't available (e.g. the iframe is not loaded
+					// yet), let's refer to the src attribute of the iframe itself.
+					// This is less reliable because the src attribute may not be
+					// updated when the iframe navigates to a new URL.
+					wpFrame.src
 			);
 		},
 		async setIframeSandboxFlags(flags: string[]) {


### PR DESCRIPTION
Fixes two issues in the `PlaygroundClient` class:

* `goTo()` now triggers a reload when the current URL is given. Previously it was ignored.
* `getCurrentURL()` now returns a fresh URL sourced from window.location instead of iframe.src. Previously it returned a stale URL as it was sourced from `iframe.src`, and `iframe.src` isn't updated when the user navigated to a new URL.

## Testing Instructions

Test these methods by calling them manually and confirming they behave as described above. Unfortunately, the current E2E setup isn't yet geared for testing specific client methods.