### PR TITLE
Add the third method to reference a blueprint JSON file via QueryParam

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/01-index.md
+++ b/packages/docs/site/docs/09-blueprints-api/01-index.md
@@ -27,10 +27,11 @@ Blueprints are JSON files for setting up your very own WordPress Playground inst
 }
 ```
 
-There are two ways to use Blueprints:
+There are three ways to use Blueprints:
 
 -   [Paste a Blueprint into the URL "fragment" on WordPress Playground website](./02-using-blueprints.md#url-fragment).
 -   [Use them with the JavaScript API](./02-using-blueprints.md#javascript-api).
+-   [Reference a blueprint JSON file via QueryParam blueprint-url](https://wordpress.github.io/wordpress-playground/query-api)
 
 ## What problems are solved by Blueprints?
 


### PR DESCRIPTION
Add using blueprint JSON file with QueryParam `blueprint-url`

## What is this PR doing?
Updated the documentation

## What problem is it solving?
Confusion as how to use the blueprint JSON file successfuly 

