### PR TITLE
Trim headers in wp_http_fetch when $options['filename'] is set

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/wp-content/mu-plugins/playground-includes/wp_http_fetch.php
+++ b/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/wp-content/mu-plugins/playground-includes/wp_http_fetch.php
@@ -71,6 +71,7 @@ class Wp_Http_Fetch implements Requests_Transport
 		$before_response_body = strpos( $this->headers, "\r\n\r\n" );
 		if ( isset( $options['filename'] ) && $options['filename'] && false !== $before_response_body ) {
 			$response_body = substr( $this->headers, $before_response_body + 4 );
+			$this->headers = substr( $this->headers, 0, $before_response_body );
 			file_put_contents($options['filename'], $response_body);
 		}
 


### PR DESCRIPTION
When $options['filename'] is set, the response body should only be written to the file, and not to the output buffer. Before this PR this wasn't the case, which caused the `occasio` theme to output the following warnings:

```
Warning: Undefined array key 1 in /wordpress/wp-includes/Requests/src/Requests.php on line 763
```

The culprit was the `Requests::parse_response()` method, which assumes that the raw response buffer only contains the headers when the filename is set. This wasn't the case with the `wp_http_fetch()` transport, which caused the `parse_response()` method to parse the entire response body as headers.

## Testing instructions

Go to http://localhost:5400/website-server/?theme=occasio&networking=yes and confirm there are no warnings and the occasional theme is displayed correctly with its Google fonts.

cc @tellyworth 
