### PR TITLE
Use Requests 2.0+ namespaced classnames when available.

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/wp-content/mu-plugins/0-playground.php
+++ b/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/wp-content/mu-plugins/0-playground.php
@@ -87,9 +87,10 @@ add_filter('got_url_rewrite', '__return_true');
  * * Requests_Transport_Dummy – Does not send any requests and only exists to keep
  * 								the Requests class happy.
  */
+$__requests_class = class_exists( '\WpOrg\Requests\Requests' ) ? '\WpOrg\Requests\Requests' : 'Requests';
 if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 	require(__DIR__ . '/playground-includes/wp_http_fetch.php');
-	Requests::add_transport('WP_Http_Fetch');
+	$__requests_class::add_transport('WP_Http_Fetch');
 
 	/**
 	 * Add Fetch transport to the list of transports that WordPress
@@ -117,5 +118,5 @@ if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 	});
 } else {
 	require(__DIR__ . '/playground-includes/requests_transport_dummy.php');
-	Requests::add_transport('Requests_Transport_Dummy');
+	$__requests_class::add_transport('Requests_Transport_Dummy');
 }


### PR DESCRIPTION
## What is this PR doing?

Uses the WP 6.2+ / Requests 2.0+ namespaced classes, to avoid deprecation warnings, while supporting older clients.

## What problem is it solving?

Fixes #922 PHP deprecation notices, which can be seen in [Theme Directory live previews](https://themes.trac.wordpress.org/ticket/159444#:~:text=zip%3Fnostats%3D1-,Live%20preview,-%E2%80%93%20https%3A//playground)

## How is the problem addressed?

Conditionally selecting the class to use

## Testing Instructions

Unsure, this isn't actually tested.

The variable is prefixed with `__` as technically this would be a global varaible. It might be better to `unset()` it afterwards, or wrap this functionality into a function.