### PR TITLE
Plugin proxy: Use UA string that is known to work well with WordPress.org API

### DIFF
--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -372,6 +372,7 @@ try {
                 }
                 $headers[$name] = $value;
             }
+            $headers['User-Agent'] = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36';
             return $headers;
         }
 


### PR DESCRIPTION
Solves #916

Do not merge yet. My assumption was that api.wordpress.org rejects the UA string, but it seems that it goes deeper than that. This CURL command actually works well with the same "problematic" UA string:

```
curl 'https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request%5Bpage%5D=1&request%5Bper_page%5D=36&request%5Blocale%5D=en_US&request%5Bbrowse%5D=popular&request%5Bwp_version%5D=6.4' --compressed -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' -H 'Accept-Language: en,en-US;q=0.5' -H 'Accept-Encoding: gzip, deflate' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Upgrade-Insecure-Requests: 1' -H 'Sec-Fetch-Dest: document' -H 'Sec-Fetch-Mode: navigate' -H 'Sec-Fetch-Site: none' -H 'Sec-Fetch-User: ?1' -H 'Pragma: no-cache' -H 'Cache-Control: no-cache'
```

Perhaps it's a combination of UA and other headers. I'd like to investigate further before merging a fix.

CC @tellyworth
