### PR TITLE
Send WordPress API requests directly.

### DIFF
--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -37,7 +37,7 @@ export async function setupFetchNetworkTransport(playground: UniversalPHP) {
 
 export async function handleRequest(data: RequestData, fetchFn = fetch) {
 	const hostname = new URL(data.url).hostname;
-	const fetchUrl = ['api.wordpress.org', 'w.org', 's.w.org'].includes(
+	const fetchUrl = ['w.org', 's.w.org'].includes(
 		hostname
 	)
 		? `/plugin-proxy.php?url=${encodeURIComponent(data.url)}`

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -45,9 +45,19 @@ export async function handleRequest(data: RequestData, fetchFn = fetch) {
 
 	let response;
 	try {
+
+		const fetchMethod = data.method || 'GET';
+		let fetchHeaders = data.headers;
+		if ( fetchMethod == 'POST' ) {
+			if ( Array.isArray( fetchHeaders ) ) {
+				fetchHeaders = Object.assign( {}, fetchHeaders );
+			}
+			fetchHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
+		}
+
 		response = await fetchFn(fetchUrl, {
-			method: data.method || 'GET',
-			headers: data.headers,
+			method: fetchMethod,
+			headers: fetchHeaders,
 			body: data.data,
 			credentials: 'omit',
 		});

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -37,20 +37,17 @@ export async function setupFetchNetworkTransport(playground: UniversalPHP) {
 
 export async function handleRequest(data: RequestData, fetchFn = fetch) {
 	const hostname = new URL(data.url).hostname;
-	const fetchUrl = ['w.org', 's.w.org'].includes(
-		hostname
-	)
+	const fetchUrl = ['w.org', 's.w.org'].includes(hostname)
 		? `/plugin-proxy.php?url=${encodeURIComponent(data.url)}`
 		: data.url;
 
 	let response;
 	try {
-
 		const fetchMethod = data.method || 'GET';
-		let fetchHeaders = data.headers;
-		if ( fetchMethod == 'POST' ) {
-			if ( Array.isArray( fetchHeaders ) ) {
-				fetchHeaders = Object.assign( {}, fetchHeaders );
+		let fetchHeaders = data.headers || {};
+		if (fetchMethod == 'POST') {
+			if (Array.isArray(fetchHeaders)) {
+				fetchHeaders = Object.assign({}, fetchHeaders);
 			}
 			fetchHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
 

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -53,6 +53,10 @@ export async function handleRequest(data: RequestData, fetchFn = fetch) {
 				fetchHeaders = Object.assign( {}, fetchHeaders );
 			}
 			fetchHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
+
+			// Workaround for api.wordpress.org/core/version-check/1.7/ which doesn't support CORS preflight requests
+			delete fetchHeaders['wp_install'];
+			delete fetchHeaders['wp_blog'];
 		}
 
 		response = await fetchFn(fetchUrl, {


### PR DESCRIPTION
## What is this PR doing?

Sends HTTP requests directly to api.wordpress.org instead of proxying them.

For #916 while looking at the plugin/theme info, I didn't see any reason for them to be proxied, as the endpoints being used there supported CORS requests.

While testing however, I found a number of endpoints that were in use that did not have CORS headers, and as a result, I've added them:
- [x] POST /plugins/update-check/1.1/
- [x] POST /themes/update-check/1.1/
- [x] POST /core/browse-happy/1.1/
- [x] GET /core/serve-happy/1.0/
- [x] POST /core/version-check/1.7/

For some reason, while `/core/version-check/1.7/` has CORS headers (already) it's still performing an preflight (OPTIONS) request which fails. I'm not sure why that's happening.

I've had to adjust the handling for POST requests as well, as fetch() requires `Content-Type: application/x-www-form-urlencoded` to be set, which is just assumed/set by PHP.
I'm pretty sure there's a nicer way to handle the `data.headers` being an array, but this worked for me.

## What problem is it solving?

I hope this resolves #916 by removing the need to proxy it, avoiding any rate limits

## How is the problem addressed?

See above

## Testing Instructions

Unsure