### PR TITLE
Include PHP read assets for embed templates.

### DIFF
--- a/packages/playground/wordpress/build/Dockerfile
+++ b/packages/playground/wordpress/build/Dockerfile
@@ -37,7 +37,7 @@ RUN rm -rf wordpress/wp-content/plugins/akismet
 
 # Separate WordPress static files
 RUN cp -r wordpress wordpress-static && \
-    cd wordpress-static && \ 
+    cd wordpress-static && \
     find ./ -name '*.php' -delete && \
     # Keep only the static files inside the directories like wp-admin or wp-content:
     find . -maxdepth 1 -type f -delete && \
@@ -81,12 +81,15 @@ RUN cd wordpress && \
     find ./ -type f -name '*.css' \
     -not -path '*/wp-includes/blocks/*/*.min.css' \
     -not -path '*/wp-content/themes/*/style.css' \
+    -not -path '*/wp-includes/css/wp-embed-template.min.css' \
     -delete && \
     find ./ -type f -name '*-rtl.min.css' -delete && \
     # Keep only the JS files that are read by PHP
     find ./ -type f -name '*.js' \
     -not -path '*/wp-includes/blocks/*/*.min.js' \
     -not -name 'wp-emoji-loader.min.js' \
+    -not -name '*/wp-includes/js/wp-embed.min.js' \
+    -not -name '*/wp-includes/js/wp-embed-template.min.js' \
     # This file is patched in JavaScript and needs to
     # be served from VFS. See #703
     -not -path '*/wp-includes/js/dist/block-editor*.js' \
@@ -165,7 +168,7 @@ RUN cd wordpress && \
     sed "s/<?php/<?php define( 'CONCATENATE_SCRIPTS', false );/" wp-config.php > wp-config.php.new && \
     mv wp-config.php.new wp-config.php
 
-# Bundle the .data file using Emscripten 
+# Bundle the .data file using Emscripten
 RUN mv wordpress /wordpress && \
     /emsdk/upstream/emscripten/tools/file_packager.py \
     /root/output/wp.data \

--- a/packages/playground/wordpress/build/Dockerfile
+++ b/packages/playground/wordpress/build/Dockerfile
@@ -88,8 +88,8 @@ RUN cd wordpress && \
     find ./ -type f -name '*.js' \
     -not -path '*/wp-includes/blocks/*/*.min.js' \
     -not -name 'wp-emoji-loader.min.js' \
-    -not -name '*/wp-includes/js/wp-embed.min.js' \
-    -not -name '*/wp-includes/js/wp-embed-template.min.js' \
+    -not -path '*/wp-includes/js/wp-embed.min.js' \
+    -not -path '*/wp-includes/js/wp-embed-template.min.js' \
     # This file is patched in JavaScript and needs to
     # be served from VFS. See #703
     -not -path '*/wp-includes/js/dist/block-editor*.js' \


### PR DESCRIPTION
## What is this PR doing?

⚠️ First patch: may be buggy as I was unable to test it. 

This PR modifies the docker file to include asset files accessed in the embed templates by PHP.

Fixes #915.

## What problem is it solving?

The asset files used by WordPress embeds ([example from make/core post](https://make.wordpress.org/core/2024/01/11/a-year-in-core-2023/embed/)) use PHP to access several JavaScript and CSS files.

These files are not included in the playground at present causing warnings to be thrown on those screens ([example using wp-playground](https://playground.wordpress.net/#%7B%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/?page_id=2&embed=1%22%7D)).

## How is the problem addressed?

Modification of the Dockerfile config.

## Testing Instructions

I'm afraid I wasn't able to get the environment running locally (PEBCAK, I am sure) so these instructions are based on the docs.

* As this modifies the docker file, a full recompile is required
* Run `npm run dev`
* Navigate to `/?page_id=2&embed=1` 
* Ensure the page is styled nicely
* Click "Share icon > HTML embed" and ensure the embed code includes JavaScript.