### PR TITLE
Update 0-playground.php - open the github link in newtab instead of opening in the playground window

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/wp-content/mu-plugins/0-playground.php
+++ b/packages/playground/blueprints/src/lib/steps/apply-wordpress-patches/wp-content/mu-plugins/0-playground.php
@@ -25,7 +25,7 @@ add_filter('plugins_api_result', function ($res) {
 	if ($res instanceof WP_Error) {
 		$res = new WP_Error(
 			'plugins_api_failed',
-			'Enable networking support in Playground settings to access the Plugins directory. Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85">experimental, opt-in feature</a>. If you don\'t want to use it, you can still upload plugins or install them using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a> (e.g. ?plugin=coblocks).'
+			'Enable networking support in Playground settings to access the Plugins directory. Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85" target="_blank">experimental, opt-in feature</a>. If you don\'t want to use it, you can still upload plugins or install them using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a> (e.g. ?plugin=coblocks).'
 		);
 	}
 	return $res;
@@ -42,7 +42,7 @@ add_filter('gettext', function ($translation) {
 	}
 
 	if ($translation === 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.') {
-		return 'Enable networking support in Playground settings to access the Themes directory. Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85">experimental, opt-in feature</a>. If you don\'t want to use it, you can still upload themes or install them using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a> (e.g. ?theme=pendant).';
+		return 'Enable networking support in Playground settings to access the Themes directory. Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85" target="_blank">experimental, opt-in feature</a>. If you don\'t want to use it, you can still upload themes or install them using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a> (e.g. ?theme=pendant).';
 	}
 	return $translation;
 });


### PR DESCRIPTION
Opening in same window shows error.

## What is this PR doing?
Opens the Github link in new tab

## What problem is it solving?
Opening the link in same window shows error in playground view

## How is the problem addressed?
Added attribute to open the link in new tab.

## Testing Instructions
<img width="1026" alt="image" src="https://github.com/WordPress/wordpress-playground/assets/459367/252c6cfc-30bd-40b8-8825-4cd50fd647cf">

