### PR TITLE
Data modules: Reject the promise on XHR error

### DIFF
--- a/packages/playground/wordpress/build/Dockerfile
+++ b/packages/playground/wordpress/build/Dockerfile
@@ -188,8 +188,7 @@ RUN cat /root/output/wp.js \
     | sed -E "s#'[^']*wp\.data'#dependencyFilename#g" \
     | sed -E 's#xhr.onerror = #xhr.onerror = onLoadingFailed; const z = #g' \
     | sed -E 's#throw new Error\(xhr.+$#onLoadingFailed(event);#g' \
-    | sed -E 's#runWithFS#runWithFSThenResolve#g' \
-    | sed -E 's#function runWithFSThenResolve#function runWithFSThenResolve() { runWithFS(); resolve(); }; function runWithFS#g' \
+    | sed -E "s#Module\['removeRunDependency'\]\(dependencyFilename\);#Module['removeRunDependency'](dependencyFilename); resolve();#g" \
     > /tmp/wp.js && \
     mv /tmp/wp.js /root/output/wp.js;
 


### PR DESCRIPTION
Makes the WordPress data module reject the loading promise on XHR error. Before this commit, the promise would erroneously resolve even if the request failed.

Related to https://github.com/WordPress/wordpress-playground/issues/564

## Testing Instructions

Rebuild the WordPress data module as follows:

```bash
node packages/playground/wordpress/build/build.js --wp-version=latest --output-js=packages/playground/wordpress/src/wordpress --output-assets=packages/playground/wordpress/public
```

Then make the following update to the `wp-6.4.js` file:

```js
// import dependencyFilename from './wp-6.4.data?url';
const dependencyFilename = 'http://localhost:3000/assets/wp-6.4-1d0e58cc.data';
export { dependencyFilename };
```

Then create a new file called `server.js` with the following contents:

```js
// Serve static assets from dist/packages/playground/wasm-wordpress-net/, but
// break the connection when the file is 90% downloaded

const express = require('express');
const app = express();
const path = require('path');
const fs = require('fs');

const port = 3000;

app.get('/*', (req, res) => {
	const filePath = path.join(
		__dirname,
		'dist/packages/playground/wasm-wordpress-net/' + (req.query.path || 'index.html')
	);
	const stat = fs.statSync(filePath);
	const fileSize = stat.size;

	const head = {
		'Content-Length': fileSize,
        'Content-Type': 'application/wasm',
        'Access-Control-Allow-Origin': '*',
	};
	res.writeHead(200, head);
	let sentSoFar = 0;
	const stream = fs.createReadStream(filePath);
	stream.on('data', (chunk) => {
		if (sentSoFar + chunk.length > fileSize * 0.9) {
			stream.destroy();
			res.end();
			return;
		}
        res.write(chunk);
		sentSoFar += chunk.length;
	});
});

app.listen(port, () => console.log(`Example app listening on port ${port}!`));
```

Then run `node server.js` and `npm run dev` and go to http://localhost:5400/website-server/

You'll land in a version of Playground where only the first ~90% of the WordPress data module is downloaded and then the connection is cut. You should see the "oops, WordPress Playground had a hiccup" error message.