### PR TITLE
php-cli: Don't pass the TMPDIR variable to NodePHP.load

### DIFF
--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -33,7 +33,16 @@ async function run() {
 	if (!SupportedPHPVersionsList.includes(phpVersion)) {
 		throw new Error(`Unsupported PHP version ${phpVersion}`);
 	}
-
+	
+	// npm scripts set the TMPDIR env variable
+	// PHP accepts a TMPDIR env variable and expects it to
+	// be a writable directory within the PHP filesystem.
+	// These two clash and prevent PHP from creating temporary
+	// files and directories so let's just not pass the npm TMPDIR
+	// to PHP.
+	// @see https://github.com/npm/npm/issues/4531
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { TMPDIR, ...envVariables } = process.env;
 	const php = await NodePHP.load(phpVersion, {
 		emscriptenOptions: {
 			ENV: {


### PR DESCRIPTION
## The problem

* `npm` scripts set the TMPDIR env variable
* PHP accepts a TMPDIR env variable and expects it to be a writable directory within the PHP filesystem.

These two clash and prevent PHP from creating temporary files and directories so this PR prevents exposing the npm-set `TMPDIR` env variable to PHP.

Closes #828

## Testing instructions

Run the following PHP script with and without this PR:

```php
<?php
	var_dump(sys_get_temp_dir());
	var_dump(tmpfile());
```

Run it as follows:

```
nx reset; PHP=8.2 nx start php-wasm-cli
```

Without this PR, it should print something like this:

```
string(48) "/var/folders/sb/cywb762129g3f0jzq1_p2q5h0000gp/T"
bool(false)
```

With this PR, it should print this:

```
string(4) "/tmp"
resource(4) of type (stream)
```
