### PR TITLE
PHP: Don't report exit code as error

### DIFF
--- a/packages/php-wasm/universal/src/lib/wasm-error-reporting.ts
+++ b/packages/php-wasm/universal/src/lib/wasm-error-reporting.ts
@@ -140,6 +140,9 @@ export function showCriticalErrorBox(message: string) {
 		return;
 	}
 	logged = true;
+	if (message?.trim().startsWith('Program terminated with exit')) {
+		return;
+	}
 	console.log(`${redBg}\n${eol}\n${bold}  WASM ERROR${reset}${redBg}`);
 	for (const line of message.split('\n')) {
 		console.log(`${eol}  ${line} `);


### PR DESCRIPTION
This commit removes the following red error message from the console:

WASM ERROR
Program terminated with exit(1)

It is not very useful, programs typically exit with different codes.
