### PR TITLE
Fix footer styling issue in the "Code is Poetry" in wordpress.github.io/wordpress-playground

### DIFF
--- a/packages/docs/site/src/css/custom.css
+++ b/packages/docs/site/src/css/custom.css
@@ -107,5 +107,5 @@ li.footer__item a:hover {
 }
 
 .footerLogoLink_mPrW {
-	opacity: 1;
+	opacity: 1 !important;
 }


### PR DESCRIPTION
It seems that the original opacity style prevails in the "Code is poetry" image link after https://github.com/WordPress/wordpress-playground/pull/956 .

I will make a new PR to add "!important".

This should solve this issue: https://github.com/WordPress/wordpress-playground/issues/954
