### PR TITLE
Fix "WP-CLI" typos

### DIFF
--- a/packages/docs/site/docs/12-limitations/01-index.md
+++ b/packages/docs/site/docs/12-limitations/01-index.md
@@ -23,7 +23,7 @@ Also, JavaScript popup windows originating in the iframe may not be displayed in
 
 ### Pthreads Support
 
-The WebAssembly version of PHP is built without pthreads support, which means you cannot use `pcntl_` functions like `pcntl_fork()` or `pcntl_exec()`. Most of the time, you don't need them, but there are a few `wp-cli` commands and a few corner-cases in PHPUnit tests that use them.
+The WebAssembly version of PHP is built without pthreads support, which means you cannot use `pcntl_` functions like `pcntl_fork()` or `pcntl_exec()`. Most of the time, you don't need them, but there are a few WP-CLI commands and a few corner-cases in PHPUnit tests that use them.
 
 You can track the progress of adding pthreads support at https://github.com/WordPress/wordpress-playground/issues/347.
 

--- a/packages/docs/site/docs/16-faq.md
+++ b/packages/docs/site/docs/16-faq.md
@@ -13,6 +13,6 @@ In your browser! It is mindblowing, isn't it? There's a new technology called We
 
 Yes! Although it requires some work at the moment. You need to tell Playground to download and install the translation files and one way to do it is using [the Blueprints API](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/). There is no step-by-step tutorial yet, but you can learn by reading the source of [Playground+Translations plugin](https://translate.wordpress.org/projects/wp-plugins/friends/dev/en-gb/default/playground/) [(GitHub link)](https://github.com/akirk/wp-glotpress-playground/blob/main/index.php).
 
-## Will wp-cli be supported?
+## Will WP-CLI be supported?
 
 Yes! Some commands already work if you include `wp-cli.phar` in the executed PHP code, and support for others is work in progress. The documentation will be progressively updated to reflect the progress.

--- a/packages/playground/website/demos/index.html
+++ b/packages/playground/website/demos/index.html
@@ -22,7 +22,7 @@
 	</p>
 	<ul>
 		<li>
-			<a href="wp-cli.html" target="_blank">wp-cli</a>
+			<a href="wp-cli.html" target="_blank">WP-CLI</a>
 		</li>
 		<li>
 			<a id="code-editor" target="_blank"

--- a/packages/playground/website/demos/terminal-component.tsx
+++ b/packages/playground/website/demos/terminal-component.tsx
@@ -121,7 +121,7 @@ export function TerminalComponent({ playground }: TerminalComponentProps) {
 			// Set up the environment to emulate a shell script
 			// call.
 
-			// Set SHELL_PIPE to 0 to ensure WP CLI formats
+			// Set SHELL_PIPE to 0 to ensure WP-CLI formats
 			// the output as ASCII tables.
 			// @see https://github.com/wp-cli/wp-cli/issues/1102
 			putenv( 'SHELL_PIPE=0' );
@@ -238,11 +238,11 @@ export function TerminalComponent({ playground }: TerminalComponentProps) {
 		// TODO: Use a nicer default font
 		term.writeln(
 			[
-				'This is a demo of \x1b[1mwp-cli\x1b[0m in the browser :)',
+				'This is a demo of \x1b[1mWP-CLI\x1b[0m in the browser :)',
 				'',
 				"Here's a few useful commands to get you started:",
 				'',
-				' \x1b[1mwp\x1b[0m           Run WP CLI command',
+				' \x1b[1mwp\x1b[0m           Run WP-CLI command',
 				' \x1b[1mls\x1b[0m           List files',
 				' \x1b[1mcat\x1b[0m          Print file contents',
 				' \x1b[1mclear\x1b[0m        Clear the screen',

--- a/packages/playground/website/demos/wp-cli.html
+++ b/packages/playground/website/demos/wp-cli.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <head>
-	<title>wp-cli running in Playground</title>
+	<title>WP-CLI running in Playground</title>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<style>


### PR DESCRIPTION
## What is this PR doing?
Fix "WP-CLI" typos.

## What problem is it solving?
"WP-CLI" is misspelled across multiple files in the repository, like "wp-cli", "WP CLI", or "`wp-cli`".

## How is the problem addressed?
Change all misspelled occurrences to "WP-CLI", which is the official name of the tool; see [wp-cli.org](https://wp-cli.org/#:~:text=WP%2DCLI%20is%20the%20command%2Dline%20interface%20for%20WordPress.).

## Testing Instructions
Verify "WP-CLI" is correctly spelled, especially on https://playground.wordpress.net/demos/ and https://playground.wordpress.net/demos/wp-cli.html.