### PR TITLE
Blueprints: set_current_user to admin before activating plugins and themes

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
@@ -1,0 +1,64 @@
+import { NodePHP } from '@php-wasm/node';
+import {
+	RecommendedPHPVersion,
+	getWordPressModule,
+} from '@wp-playground/wordpress';
+import { unzip } from './unzip';
+import { activatePlugin } from './activate-plugin';
+import { phpVar } from '@php-wasm/util';
+
+describe('Blueprint step activatePlugin()', () => {
+	let php: NodePHP;
+	beforeEach(async () => {
+		php = await NodePHP.load(RecommendedPHPVersion, {
+			requestHandler: {
+				documentRoot: '/wordpress',
+			},
+		});
+		await unzip(php, {
+			zipFile: await getWordPressModule(),
+			extractToPath: '/wordpress',
+		});
+	});
+
+	it('should activate the plugin', async () => {
+		const docroot = php.documentRoot;
+		php.writeFile(
+			`/${docroot}/wp-content/plugins/test-plugin.php`,
+			`<?php /**\n * Plugin Name: Test Plugin */`
+		);
+		await activatePlugin(php, {
+			pluginPath: docroot + '/wp-content/plugins/test-plugin.php',
+		});
+
+		const response = await php.run({
+			code: `<?php
+				require_once '/wordpress/wp-load.php';
+				require_once ${phpVar(docroot)}. "/wp-admin/includes/plugin.php" ;
+				echo is_plugin_active('test-plugin.php') ? 'true' : 'false';
+			`,
+		});
+		expect(response.text).toBe('true');
+	});
+
+	it('should run the activation hooks as a priviliged user', async () => {
+		const docroot = php.documentRoot;
+		const createdFilePath =
+			docroot + '/activation-ran-as-a-priviliged-user.txt';
+		php.writeFile(
+			`${docroot}/wp-content/plugins/test-plugin.php`,
+			`<?php /**\n * Plugin Name: Test Plugin */
+			function myplugin_activate() {
+				if( ! current_user_can( 'activate_plugins' ) ) return;
+				file_put_contents( ${phpVar(createdFilePath)}, 'Hello World');
+			}
+			register_activation_hook( __FILE__, 'myplugin_activate' );
+			`
+		);
+		await activatePlugin(php, {
+			pluginPath: docroot + '/wp-content/plugins/test-plugin.php',
+		});
+
+		expect(php.fileExists(createdFilePath)).toBe(true);
+	});
+});

--- a/packages/playground/blueprints/src/lib/steps/activate-theme.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.spec.ts
@@ -1,0 +1,83 @@
+import { NodePHP } from '@php-wasm/node';
+import {
+	RecommendedPHPVersion,
+	getWordPressModule,
+} from '@wp-playground/wordpress';
+import { unzip } from './unzip';
+import { activateTheme } from './activate-theme';
+import { phpVar } from '@php-wasm/util';
+
+describe('Blueprint step activateTheme()', () => {
+	let php: NodePHP;
+	beforeEach(async () => {
+		php = await NodePHP.load(RecommendedPHPVersion, {
+			requestHandler: {
+				documentRoot: '/wordpress',
+			},
+		});
+		php.mkdir('/wordpress');
+		await unzip(php, {
+			zipFile: await getWordPressModule(),
+			extractToPath: '/wordpress',
+		});
+	});
+
+	it('should activate the theme', async () => {
+		const docroot = php.documentRoot;
+		php.mkdir(`${docroot}/wp-content/themes/test-theme`);
+		php.writeFile(
+			`${docroot}/wp-content/themes/test-theme/style.css`,
+			`/**
+* Theme Name: Test Theme
+* Theme URI: https://example.com/test-theme
+* Author: Test Author
+*/
+			`
+		);
+		await activateTheme(php, {
+			themeFolderName: 'test-theme',
+		});
+
+		const response = await php.run({
+			code: `<?php
+				require '/wordpress/wp-load.php';
+				echo wp_get_theme()->get('Name');
+			`,
+		});
+		expect(response.text).toBe('Test Theme');
+	});
+
+	it('should run the activation hooks as a priviliged user', async () => {
+		const docroot = php.documentRoot;
+		const createdFilePath =
+			docroot + '/activation-ran-as-a-priviliged-user.txt';
+
+		const themeDir = `${docroot}/wp-content/themes/test-theme`;
+		php.mkdir(`${themeDir}/test-theme`);
+		php.writeFile(
+			`${themeDir}/style.css`,
+			`/**
+* Theme Name: Test Theme
+* Theme URI: https://example.com/test-theme
+*/`
+		);
+		php.writeFile(
+			`${docroot}/wp-content/mu-plugins/0-on-theme-switch.php`,
+			`<?php
+			file_put_contents( ${phpVar(createdFilePath)}, 'Hello World');
+			function mytheme_activate() {
+				if( ! current_user_can( 'activate_plugins' ) ) {
+					return;
+				}
+				file_put_contents( ${phpVar(createdFilePath)}, 'Hello World' );
+			}
+			add_action( 'after_switch_theme', 'mytheme_activate' );
+			`
+		);
+		await activateTheme(php, {
+			themeFolderName: 'test-theme',
+		});
+
+		expect(php.fileExists(createdFilePath)).toBe(true);
+	});
+});

--- a/packages/playground/blueprints/src/lib/steps/activate-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.ts
@@ -1,3 +1,4 @@
+import { phpVar } from '@php-wasm/util';
 import { StepHandler } from '.';
 
 /**
@@ -32,17 +33,16 @@ export const activateTheme: StepHandler<ActivateThemeStep> = async (
 	progress
 ) => {
 	progress?.tracker.setCaption(`Activating ${themeFolderName}`);
-	const wpLoadPath = `${await playground.documentRoot}/wp-load.php`;
-	if (!playground.fileExists(wpLoadPath)) {
-		throw new Error(
-			`Required WordPress file does not exist: ${wpLoadPath}`
-		);
-	}
+	const docroot = await playground.documentRoot;
 	await playground.run({
 		code: `<?php
 define( 'WP_ADMIN', true );
-require_once( '${wpLoadPath}' );
-switch_theme( '${themeFolderName}' );
+require_once( ${phpVar(docroot)}. "/wp-load.php" );
+
+// Set current user to admin
+set_current_user( get_users(array('role' => 'Administrator') )[0] );
+
+switch_theme( ${phpVar(themeFolderName)} );
 `,
 	});
 };


### PR DESCRIPTION
Sets the current user to admin before activating plugins and themes.

## Rationale

Issue #911 uncovered a problem where activating a plugin does not create a page in the following scenario:

```php
function myplugin_activate() {
    if( current_user_can( 'activate_plugins' ) ) {
        create_page();
    }
}
register_activation_hook( __FILE__, 'myplugin_activate' );
```

The root cause is that the activatePlugin and activateTheme steps do not set the current user to admin before activating the plugin/theme.

## Testing instructions

This PR comes with unit tests – confirm the CI checks pass.

Closes #911