### PR TITLE
Website: Add .htaccess file to prevent caching of index.html and enable importing the client.js library

### DIFF
--- a/packages/playground/website/.htaccess
+++ b/packages/playground/website/.htaccess
@@ -1,0 +1,7 @@
+<FilesMatch "index\.html">
+Header unset ETag
+Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+</FilesMatch>
+<FilesMatch "(client\/|blueprint-schema\.json)">
+Header set Access-Control-Allow-Origin "*"
+</FilesMatch>

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -19,7 +19,7 @@
 					"cp -r ./client ./wasm-wordpress-net/",
 					"cp -r ./remote/* ./wasm-wordpress-net/",
 					"cp -r ./website/* ./wasm-wordpress-net/",
-					"cat ./remote/.htaccess > ./wasm-wordpress-net/.htaccess"
+					"cat ./remote/.htaccess ./website/.htaccess > ./wasm-wordpress-net/.htaccess"
 				],
 				"cwd": "dist/packages/playground",
 				"parallel": false


### PR DESCRIPTION
Adds a .htaccess file to playground.wordpress.net that does the following:

1. Prevents caching of the main index.html file. Otherwise the browser may try to load outdated JavaScript, CSS, and WASM assets and and up in a broken state.
2. Adds the Access-Control-Allow-Origin header for the blueprint-schema.json file and the hosted client.js library to enable `import()`-ing both.

## Testing instructions

None. I tested this in an Apache setup, then manually updated the production .htaccess file, and it all worked as expected.

Related to #855
Closes #873
