### PR TITLE
Memory leak: add rotatedPHP to kill and recreate PHP instances after a certain number of requests

### DIFF
--- a/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
+++ b/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
@@ -49,7 +49,7 @@ describe('rotatePHPRuntime()', () => {
 		await php.run({ code: `<?php echo "abc";` });
 		const freeAfterRotation = freeMemory(php);
 		expect(freeAfterRotation).toBeGreaterThan(freeAfter1000Requests);
-	});
+	}, 30_000);
 
 	it('Should recreate the PHP runtime after maxRequests', async () => {
 		const recreateRuntimeSpy = vitest.fn(recreateRuntime);
@@ -64,7 +64,7 @@ describe('rotatePHPRuntime()', () => {
 		// Rotate the PHP runtime
 		await php.run({ code: `` });
 		expect(recreateRuntimeSpy).toHaveBeenCalledTimes(2);
-	});
+	}, 30_000);
 
 	it('Should stop rotating after the cleanup handler is called', async () => {
 		const recreateRuntimeSpy = vitest.fn(recreateRuntime);
@@ -87,7 +87,7 @@ describe('rotatePHPRuntime()', () => {
 		await php.run({ code: `` });
 
 		expect(recreateRuntimeSpy).toHaveBeenCalledTimes(2);
-	});
+	}, 30_000);
 
 	it('Should hotswap the PHP runtime from 8.2 to 8.3', async () => {
 		let nbCalls = 0;
@@ -118,7 +118,7 @@ describe('rotatePHPRuntime()', () => {
 		).text;
 		expect(version1).toMatch(/^8\.2/);
 		expect(version2).toMatch(/^8\.3/);
-	});
+	}, 30_000);
 
 	it('Should preserve the custom SAPI name', async () => {
 		const php = new NodePHP(await recreateRuntime(), {
@@ -162,7 +162,7 @@ describe('rotatePHPRuntime()', () => {
 		expect(php.readFileAsText('/test-root/index.php')).toBe(
 			'<?php echo "hi";'
 		);
-	});
+	}, 30_000);
 
 	it('Should not overwrite the NODEFS files', async () => {
 		const php = new NodePHP(await recreateRuntime(), {
@@ -203,5 +203,5 @@ describe('rotatePHPRuntime()', () => {
 			fs.rmSync(tempFile);
 			fs.rmdirSync(tempDir);
 		}
-	});
+	}, 30_000);
 });

--- a/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
+++ b/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
@@ -21,7 +21,7 @@ describe('rotatePHPRuntime()', () => {
 			);
 
 		const recreateRuntimeSpy = vitest.fn(recreateRuntime);
-		// Rotate the PHP instance
+		// Rotate the PHP runtime
 		const php = new NodePHP(await recreateRuntime(), {
 			documentRoot: '/test-root',
 		});
@@ -45,13 +45,13 @@ describe('rotatePHPRuntime()', () => {
 		const freeAfter1000Requests = freeMemory(php);
 		expect(freeAfter1000Requests).toBeLessThan(freeInitially);
 
-		// Rotate the PHP instance
+		// Rotate the PHP runtime
 		await php.run({ code: `<?php echo "abc";` });
 		const freeAfterRotation = freeMemory(php);
 		expect(freeAfterRotation).toBeGreaterThan(freeAfter1000Requests);
 	});
 
-	it('Should recreate the PHP instance after maxRequests', async () => {
+	it('Should recreate the PHP runtime after maxRequests', async () => {
 		const recreateRuntimeSpy = vitest.fn(recreateRuntime);
 		const php = new NodePHP(await recreateRuntimeSpy(), {
 			documentRoot: '/test-root',
@@ -61,7 +61,7 @@ describe('rotatePHPRuntime()', () => {
 			recreateRuntime: recreateRuntimeSpy,
 			maxRequests: 1,
 		});
-		// Rotate the PHP instance
+		// Rotate the PHP runtime
 		await php.run({ code: `` });
 		expect(recreateRuntimeSpy).toHaveBeenCalledTimes(2);
 	});
@@ -76,7 +76,7 @@ describe('rotatePHPRuntime()', () => {
 			recreateRuntime: recreateRuntimeSpy,
 			maxRequests: 1,
 		});
-		// Rotate the PHP instance
+		// Rotate the PHP runtime
 		await php.run({ code: `` });
 		expect(recreateRuntimeSpy).toHaveBeenCalledTimes(2);
 
@@ -89,7 +89,7 @@ describe('rotatePHPRuntime()', () => {
 		expect(recreateRuntimeSpy).toHaveBeenCalledTimes(2);
 	});
 
-	it('Should hotswap the PHP instance from 8.2 to 8.3', async () => {
+	it('Should hotswap the PHP runtime from 8.2 to 8.3', async () => {
 		let nbCalls = 0;
 		const recreateRuntimeSpy = vitest.fn(() => {
 			if (nbCalls === 0) {
@@ -131,7 +131,7 @@ describe('rotatePHPRuntime()', () => {
 		});
 		php.setSapiName('custom SAPI');
 
-		// Rotate the PHP instance
+		// Rotate the PHP runtime
 		await php.run({ code: `` });
 		const result = await php.run({
 			code: `<?php echo php_sapi_name();`,
@@ -149,13 +149,13 @@ describe('rotatePHPRuntime()', () => {
 			maxRequests: 1,
 		});
 
-		// Rotate the PHP instance
+		// Rotate the PHP runtime
 		await php.run({ code: `` });
 
 		php.mkdir('/test-root');
 		php.writeFile('/test-root/index.php', '<?php echo "hi";');
 
-		// Rotate the PHP instance
+		// Rotate the PHP runtime
 		await php.run({ code: `` });
 
 		expect(php.fileExists('/test-root/index.php')).toBe(true);
@@ -174,7 +174,7 @@ describe('rotatePHPRuntime()', () => {
 			maxRequests: 1,
 		});
 
-		// Rotate the PHP instance
+		// Rotate the PHP runtime
 		await php.run({ code: `` });
 
 		php.mkdir('/test-root');
@@ -190,7 +190,7 @@ describe('rotatePHPRuntime()', () => {
 		try {
 			php.mount(tempDir, '/test-root/nodefs');
 
-			// Rotate the PHP instance
+			// Rotate the PHP runtime
 			await php.run({ code: `` });
 
 			// Expect the file to still have the same utime

--- a/packages/php-wasm/node/src/test/rotated-php.spec.ts
+++ b/packages/php-wasm/node/src/test/rotated-php.spec.ts
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { NodePHP } from '..';
+import { LatestSupportedPHPVersion, rotatedPHP } from '@php-wasm/universal';
+
+const phpFactory = () =>
+	NodePHP.load(LatestSupportedPHPVersion, {
+		requestHandler: {
+			documentRoot: '/test-root',
+		},
+	});
+
+describe('rotatedPHP()', () => {
+	it('Should recreate the PHP instance after maxRequests', async () => {
+		const createPHP = vitest.fn(phpFactory);
+		const php = await rotatedPHP({
+			maxRequests: 1,
+			createPHP,
+		});
+		// Rotate
+		await php.run({
+			code: `<?php echo 'hi';`,
+		});
+		await php.run({
+			code: `<?php echo 'hi';`,
+		});
+		expect(createPHP).toHaveBeenCalledTimes(2);
+	});
+
+	it('Should preserve the MEMFS files', async () => {
+		const createPHP = vitest.fn(phpFactory);
+		const php = await rotatedPHP({
+			maxRequests: 1,
+			createPHP,
+		});
+		php.mkdir('/test-root');
+		php.writeFile('/test-root/index.php', '<?php echo "hi";');
+		// Rotate
+		await php.run({
+			code: `<?php echo 'hi';`,
+		});
+		await php.run({
+			code: `<?php echo 'hi';`,
+		});
+		expect(php.fileExists('/test-root/index.php')).toBe(true);
+		expect(php.readFileAsText('/test-root/index.php')).toBe(
+			'<?php echo "hi";'
+		);
+	});
+	it('Should not overwrite the NODEFS files', async () => {
+		const createPHP = vitest.fn(phpFactory);
+		const php = await rotatedPHP({
+			maxRequests: 1,
+			createPHP,
+		});
+		php.mkdir('/test-root');
+		php.writeFile('/test-root/index.php', 'test');
+		php.mkdir('/test-root/nodefs');
+
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'temp-'));
+		const tempFile = path.join(tempDir, 'file');
+		fs.writeFileSync(tempFile, 'playground');
+		const date = new Date();
+		date.setFullYear(date.getFullYear() - 1);
+		fs.utimesSync(tempFile, date, date);
+		try {
+			php.mount(tempDir, '/test-root/nodefs');
+			// Rotate
+			await php.run({
+				code: `<?php echo 'hi';`,
+			});
+
+			// Expect the file to still have the same utime
+			const stats = fs.statSync(tempFile);
+			expect(Math.round(stats.atimeMs)).toBe(Math.round(date.getTime()));
+
+			// The MEMFS file should still be there
+			expect(php.fileExists('/test-root/index.php')).toBe(true);
+		} finally {
+			fs.rmSync(tempFile);
+			fs.rmdirSync(tempDir);
+		}
+	});
+});

--- a/packages/php-wasm/node/src/test/rotated-php.spec.ts
+++ b/packages/php-wasm/node/src/test/rotated-php.spec.ts
@@ -56,6 +56,22 @@ describe('rotatedPHP()', () => {
 		expect(version2).toMatch(/^8\.3/);
 	});
 
+	it('Should preserve the custom SAPI name', async () => {
+		const php = await rotatedPHP({
+			php: new NodePHP(await recreateRuntime(), {
+				documentRoot: '/test-root',
+			}),
+			recreateRuntime,
+			maxRequests: 1,
+		});
+		php.setSapiName('custom SAPI');
+		await rotate(php);
+		const result = await php.run({
+			code: `<?php echo php_sapi_name();`,
+		});
+		expect(result.text).toBe('custom SAPI');
+	});
+
 	it('Should preserve the MEMFS files', async () => {
 		const php = await rotatedPHP({
 			php: new NodePHP(await recreateRuntime(), {
@@ -73,6 +89,7 @@ describe('rotatedPHP()', () => {
 			'<?php echo "hi";'
 		);
 	});
+
 	it('Should not overwrite the NODEFS files', async () => {
 		const php = await rotatedPHP({
 			php: new NodePHP(await recreateRuntime(), {

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -170,6 +170,9 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 		};
 
 		this.#wasmErrorsTarget = improveWASMErrorReporting(runtime);
+		this.dispatchEvent({
+			type: 'runtime.initialized',
+		});
 	}
 
 	/** @inheritDoc */
@@ -777,6 +780,9 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 	}
 
 	exit(code = 0) {
+		this.dispatchEvent({
+			type: 'runtime.beforedestroy',
+		});
 		try {
 			this[__private__dont__use]._exit(code);
 		} catch (e) {

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -59,7 +59,7 @@ export type { PHPRequestHandlerConfiguration } from './php-request-handler';
 export { PHPRequestHandler } from './php-request-handler';
 export type { PHPBrowserConfiguration } from './php-browser';
 export { PHPBrowser } from './php-browser';
-export { rotatedPHP } from './rotated-php';
+export { rotatePHPRuntime } from './rotate-php-runtime';
 
 export {
 	DEFAULT_BASE_URL,

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -59,6 +59,7 @@ export type { PHPRequestHandlerConfiguration } from './php-request-handler';
 export { PHPRequestHandler } from './php-request-handler';
 export type { PHPBrowserConfiguration } from './php-browser';
 export { PHPBrowser } from './php-browser';
+export { rotatedPHP } from './rotated-php';
 
 export {
 	DEFAULT_BASE_URL,

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -1,5 +1,6 @@
 const RuntimeId = Symbol('RuntimeId');
 const loadedRuntimes: Map<number, PHPRuntime> = new Map();
+let lastRuntimeId = 0;
 
 /**
  * Loads the PHP runtime with the given arguments and data dependencies.
@@ -148,8 +149,9 @@ export async function loadPHPRuntime(
 
 	await phpReady;
 
-	const id = loadedRuntimes.size;
+	const id = ++lastRuntimeId;
 
+	PHPRuntime.id = id;
 	PHPRuntime.originalExit = PHPRuntime._exit;
 
 	PHPRuntime._exit = function (code: number) {

--- a/packages/php-wasm/universal/src/lib/rotate-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/rotate-php-runtime.ts
@@ -8,7 +8,8 @@ export interface RotateOptions<T extends BasePHP> {
 
 /**
  * Listens to PHP events and swaps the internal PHP Runtime for a fresh one
- * after a certain run() calls (which are responsible for handling HTTP requests).
+ * after a certain number of run() calls (which are responsible for handling
+ * HTTP requests).
  *
  * Why? Because PHP and PHP extension have a memory leak. Each request leaves
  * the memory a bit more fragmented and with a bit less available space than

--- a/packages/php-wasm/universal/src/lib/rotated-php.ts
+++ b/packages/php-wasm/universal/src/lib/rotated-php.ts
@@ -1,0 +1,75 @@
+import { Semaphore, joinPaths } from '@php-wasm/util';
+import { BasePHP, __private__dont__use } from './base-php';
+
+export interface RotateOptions<T extends BasePHP> {
+	createPhp: () => Promise<T>;
+	maxRequests?: number;
+}
+export async function rotatedPHP<T extends BasePHP>({
+	createPhp,
+	maxRequests = 50,
+}: RotateOptions<T>): Promise<T> {
+	let php = (await createPhp()) as T;
+	let handledCalls = 0;
+	const semaphore = new Semaphore({ concurrency: 1 });
+
+	async function rotate() {
+		const oldPhp = php;
+		const oldFS = await oldPhp[__private__dont__use].FS;
+		const oldCookies = oldPhp.requestHandler!.serializeCookies();
+		const docroot = await oldPhp.documentRoot;
+		try {
+			await oldPhp.exit();
+		} catch (e) {
+			// Ignore the exit-related exception
+		}
+
+		const newPhp = await createPhp();
+		copyPath(newPhp[__private__dont__use].FS, oldFS, docroot);
+		newPhp.requestHandler!.setCookies(oldCookies?.split(';') || []);
+
+		php = newPhp;
+	}
+
+	return new Proxy(
+		{},
+		{
+			get(target, prop: string) {
+				if (prop === 'run' || prop === 'request') {
+					return async (...args: any[]) =>
+						semaphore.run(async () => {
+							if (++handledCalls > maxRequests) {
+								handledCalls = 0;
+								await rotate();
+							}
+							return (php[prop as keyof T] as any)(...args);
+						});
+				}
+
+				return php[prop as keyof T];
+			},
+		}
+	) as T;
+}
+
+type EmscriptenFS = any;
+function copyPath(newFS: EmscriptenFS, oldFS: EmscriptenFS, path: string) {
+	let oldNode;
+	try {
+		oldNode = oldFS.lookupPath(path);
+	} catch (e) {
+		return;
+	}
+	if (!oldFS.isDir(oldNode.node.mode)) {
+		newFS.writeFile(path, oldFS.readFile(path));
+		return;
+	}
+
+	newFS.mkdirTree(path);
+	const filenames = oldFS
+		.readdir(path)
+		.filter((name: string) => name !== '.' && name !== '..');
+	for (const filename of filenames) {
+		copyPath(newFS, oldFS, joinPaths(path, filename));
+	}
+}

--- a/packages/php-wasm/universal/src/lib/rotated-php.ts
+++ b/packages/php-wasm/universal/src/lib/rotated-php.ts
@@ -7,14 +7,6 @@ export interface RotateOptions<T extends BasePHP> {
 	maxRequests: number;
 }
 
-export type Promisify<T, Methods> = {
-	[P in keyof T]: P extends Methods
-		? T[P] extends (...args: infer A) => infer R
-			? (...args: A) => Promise<R>
-			: T[P]
-		: T[P];
-};
-
 /**
  * Returns a PHP interface-compliant object that maintains a PHP instance
  * internally. After X run() and request() calls, that internal instance
@@ -33,7 +25,7 @@ export function rotatedPHP<T extends BasePHP>({
 	php,
 	recreateRuntime,
 	maxRequests,
-}: RotateOptions<T>): Promise<Promisify<T, 'run' | 'request'>> {
+}: RotateOptions<T>): T {
 	let handledCalls = 0;
 	const semaphore = new Semaphore({ concurrency: 1 });
 	return new Proxy(

--- a/packages/php-wasm/universal/src/lib/rotated-php.ts
+++ b/packages/php-wasm/universal/src/lib/rotated-php.ts
@@ -1,8 +1,9 @@
-import { Semaphore, joinPaths } from '@php-wasm/util';
-import { BasePHP, __private__dont__use } from './base-php';
+import { Semaphore } from '@php-wasm/util';
+import { BasePHP } from './base-php';
 
 export interface RotateOptions<T extends BasePHP> {
-	createPHP: () => Promise<T>;
+	php: T;
+	recreateRuntime: () => Promise<number> | number;
 	maxRequests: number;
 }
 
@@ -28,40 +29,13 @@ export type Promisify<T, Methods> = {
  *
  * https://www.php.net/manual/en/install.fpm.configuration.php#pm.max-tasks
  */
-export async function rotatedPHP<T extends BasePHP>({
-	createPHP,
+export function rotatedPHP<T extends BasePHP>({
+	php,
+	recreateRuntime,
 	maxRequests,
 }: RotateOptions<T>): Promise<Promisify<T, 'run' | 'request'>> {
-	let php = (await createPHP()) as T;
-	if (!php.requestHandler) {
-		throw new Error(
-			'The rotated PHP instance must have a request handler. Be sure to ' +
-				'pass the `requestHandler` option to `loadPHPRuntime()` or `WebPHP.load()` ' +
-				'when creating the PHP instance.'
-		);
-	}
-
 	let handledCalls = 0;
 	const semaphore = new Semaphore({ concurrency: 1 });
-
-	async function rotate() {
-		const oldPhp = php;
-		const oldFS = await oldPhp[__private__dont__use].FS;
-		const oldCookies = oldPhp.requestHandler!.serializeCookies();
-		const docroot = await oldPhp.documentRoot;
-		try {
-			await oldPhp.exit();
-		} catch (e) {
-			// Ignore the exit-related exception
-		}
-
-		const newPhp = await createPHP();
-		recreateMemFS(newPhp[__private__dont__use].FS, oldFS, docroot);
-		newPhp.requestHandler!.setCookies(oldCookies?.split(';') || []);
-
-		php = newPhp;
-	}
-
 	return new Proxy(
 		{},
 		{
@@ -71,56 +45,24 @@ export async function rotatedPHP<T extends BasePHP>({
 						semaphore.run(async () => {
 							if (++handledCalls > maxRequests) {
 								handledCalls = 0;
-								await rotate();
+								php.hotSwapPHPRuntime(await recreateRuntime());
 							}
 							return (php[prop as keyof T] as any)(...args);
 						});
+				}
+
+				const value = php[prop as keyof T];
+				if (typeof value === 'function') {
+					/**
+					 * Binding solves the following problem:
+					 * TypeError: Cannot read private member #messageListeners from an object whose class did not declare it
+					 */
+					return (...args: any[]) =>
+						(php[prop as keyof T] as any)(...args);
 				}
 
 				return php[prop as keyof T];
 			},
 		}
 	) as any;
-}
-
-type EmscriptenFS = any;
-/**
- * Copies the MEMFS directory structure from one FS in another FS.
- * Non-MEMFS nodes are ignored.
- */
-function recreateMemFS(newFS: EmscriptenFS, oldFS: EmscriptenFS, path: string) {
-	let oldNode;
-	try {
-		oldNode = oldFS.lookupPath(path);
-	} catch (e) {
-		return;
-	}
-	// MEMFS nodes have a `contents` property. NODEFS nodes don't.
-	// We only want to copy MEMFS nodes here.
-	if (!('contents' in oldNode.node)) {
-		return;
-	}
-
-	// Let's be extra careful and only proceed if newFs doesn't
-	// already have a node at the given path.
-	try {
-		newFS = newFS.lookupPath(path);
-		return;
-	} catch (e) {
-		// There's no such node in the new FS. Good,
-		// we may proceed.
-	}
-
-	if (!oldFS.isDir(oldNode.node.mode)) {
-		newFS.writeFile(path, oldFS.readFile(path));
-		return;
-	}
-
-	newFS.mkdirTree(path);
-	const filenames = oldFS
-		.readdir(path)
-		.filter((name: string) => name !== '.' && name !== '..');
-	for (const filename of filenames) {
-		recreateMemFS(newFS, oldFS, joinPaths(path, filename));
-	}
 }

--- a/packages/php-wasm/universal/src/lib/rotated-php.ts
+++ b/packages/php-wasm/universal/src/lib/rotated-php.ts
@@ -8,9 +8,8 @@ export interface RotateOptions<T extends BasePHP> {
 }
 
 /**
- * Returns a PHP interface-compliant object that maintains a PHP instance
- * internally. After X run() and request() calls, that internal instance
- * is discarded and a new one is created.
+ * Patches PHP to discard and replace the internal PHP Runtime after a certain
+ * number of run() calls (which are responsible for handling HTTP requests).
  *
  * Why? Because PHP and PHP extension have a memory leak. Each request leaves
  * the memory a bit more fragmented and with a bit less available space than
@@ -28,33 +27,14 @@ export function rotatedPHP<T extends BasePHP>({
 }: RotateOptions<T>): T {
 	let handledCalls = 0;
 	const semaphore = new Semaphore({ concurrency: 1 });
-	return new Proxy(
-		{},
-		{
-			get(target, prop: string) {
-				if (prop === 'run' || prop === 'request') {
-					return async (...args: any[]) =>
-						semaphore.run(async () => {
-							if (++handledCalls > maxRequests) {
-								handledCalls = 0;
-								php.hotSwapPHPRuntime(await recreateRuntime());
-							}
-							return (php[prop as keyof T] as any)(...args);
-						});
-				}
-
-				const value = php[prop as keyof T];
-				if (typeof value === 'function') {
-					/**
-					 * Binding solves the following problem:
-					 * TypeError: Cannot read private member #messageListeners from an object whose class did not declare it
-					 */
-					return (...args: any[]) =>
-						(php[prop as keyof T] as any)(...args);
-				}
-
-				return php[prop as keyof T];
-			},
-		}
-	) as any;
+	const originalRun = php.run;
+	php.run = async (...args: any) =>
+		semaphore.run(async () => {
+			if (++handledCalls > maxRequests) {
+				handledCalls = 0;
+				php.hotSwapPHPRuntime(await recreateRuntime());
+			}
+			return await originalRun.apply(php, args);
+		});
+	return php;
 }

--- a/packages/php-wasm/universal/src/lib/rotated-php.ts
+++ b/packages/php-wasm/universal/src/lib/rotated-php.ts
@@ -3,7 +3,7 @@ import { BasePHP, __private__dont__use } from './base-php';
 
 export interface RotateOptions<T extends BasePHP> {
 	createPhp: () => Promise<T>;
-	maxRequests?: number;
+	maxRequests: number;
 }
 
 /**
@@ -22,7 +22,7 @@ export interface RotateOptions<T extends BasePHP> {
  */
 export async function rotatedPHP<T extends BasePHP>({
 	createPhp,
-	maxRequests = 300,
+	maxRequests,
 }: RotateOptions<T>): Promise<T> {
 	let php = (await createPhp()) as T;
 	let handledCalls = 0;

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -2,10 +2,24 @@ import { Remote } from 'comlink';
 import { PHPResponse } from './php-response';
 
 /**
- * Represents an event related to the PHP filesystem.
+ * Represents an event related to the PHP request.
  */
 export interface PHPRequestEndEvent {
 	type: 'request.end';
+}
+
+/**
+ * Represents a PHP runtime initialization event.
+ */
+export interface PHPRuntimeInitializedEvent {
+	type: 'runtime.initialized';
+}
+
+/**
+ * Represents a PHP runtime destruction event.
+ */
+export interface PHPRuntimeBeforeDestroyEvent {
+	type: 'runtime.beforedestroy';
 }
 
 /**
@@ -13,7 +27,10 @@ export interface PHPRequestEndEvent {
  * This is intentionally not an extension of CustomEvent
  * to make it isomorphic between different JavaScript runtimes.
  */
-export type PHPEvent = PHPRequestEndEvent;
+export type PHPEvent =
+	| PHPRequestEndEvent
+	| PHPRuntimeInitializedEvent
+	| PHPRuntimeBeforeDestroyEvent;
 
 /**
  * A callback function that handles PHP events.

--- a/packages/php-wasm/util/src/lib/semaphore.ts
+++ b/packages/php-wasm/util/src/lib/semaphore.ts
@@ -40,7 +40,7 @@ export default class Semaphore {
 		}
 	}
 
-	async run<T>(fn: () => Promise<T>): Promise<T> {
+	async run<T>(fn: () => T | Promise<T>): Promise<T> {
 		const release = await this.acquire();
 		try {
 			return await fn();

--- a/packages/playground/remote/src/lib/opfs/bind-opfs.ts
+++ b/packages/playground/remote/src/lib/opfs/bind-opfs.ts
@@ -53,9 +53,9 @@ export async function bindOpfs({
 		 * persisted files.
 		 */
 		try {
-			if (await php.isDir(docroot)) {
-				await php.rmdir(docroot, { recursive: true });
-				await php.mkdirTree(docroot);
+			if (php.isDir(docroot)) {
+				php.rmdir(docroot, { recursive: true });
+				php.mkdirTree(docroot);
 			}
 		} catch (e) {
 			// Ignore any errors

--- a/packages/playground/remote/src/lib/opfs/journal-memfs-to-opfs.ts
+++ b/packages/playground/remote/src/lib/opfs/journal-memfs-to-opfs.ts
@@ -21,35 +21,28 @@ export function journalFSEventsToOpfs(
 	memfsRoot: string
 ) {
 	const journal: FilesystemOperation[] = [];
-	const unbind = journalFSEvents(php, memfsRoot, (entry) => {
+	const unbindJournal = journalFSEvents(php, memfsRoot, (entry) => {
 		journal.push(entry);
 	});
 	const rewriter = new OpfsRewriter(php, opfsRoot, memfsRoot);
-	/**
-	 * Calls the observer with the current delta each time PHP is ran.
-	 *
-	 * Do not do this in external code. This is a private code path that
-	 * will be maintained alongside Playground code and likely removed
-	 * in the future. It is not part of the public API. The goal is to
-	 * allow some time for a few more use-cases to emerge before
-	 * proposing a new public API like php.addEventListener( 'run' ).
-	 */
-	const originalRun = php.run;
-	php.run = async function (...args) {
-		const response = await originalRun.apply(php, args);
-		// @TODO This is way too slow in practice, we need to batch the
-		// changes into groups of parallelizable operations.
-		while (true) {
-			const entry = journal.shift();
-			if (!entry) {
-				break;
-			}
-			await rewriter.processEntry(entry);
-		}
-		return response;
-	};
 
-	return unbind;
+	async function flushJournal() {
+		const release = await php.semaphore.acquire();
+		try {
+			// @TODO This is way too slow in practice, we need to batch the
+			// changes into groups of parallelizable operations.
+			while (journal.length) {
+				await rewriter.processEntry(journal.shift()!);
+			}
+		} finally {
+			release();
+		}
+	}
+	php.addEventListener('request.end', flushJournal);
+	return function () {
+		unbindJournal();
+		php.removeEventListener('request.end', flushJournal);
+	};
 }
 
 type JournalEntry = FilesystemOperation;

--- a/packages/playground/remote/src/lib/opfs/journal-memfs-to-opfs.ts
+++ b/packages/playground/remote/src/lib/opfs/journal-memfs-to-opfs.ts
@@ -64,7 +64,6 @@ class OpfsRewriter {
 		memfsRoot: string
 	) {
 		this.memfsRoot = normalizeMemfsPath(memfsRoot);
-		this.FS = this.php[__private__dont__use].FS;
 	}
 
 	private toOpfsPath(path: string) {
@@ -105,7 +104,12 @@ class OpfsRewriter {
 					});
 				}
 			} else if (entry.operation === 'WRITE') {
-				await overwriteOpfsFile(opfsParent, name, this.FS, entry.path);
+				await overwriteOpfsFile(
+					opfsParent,
+					name,
+					this.php[__private__dont__use].FS,
+					entry.path
+				);
 			} else if (
 				entry.operation === 'RENAME' &&
 				entry.toPath.startsWith(this.memfsRoot)

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -214,14 +214,9 @@ export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 	}
 }
 
-const apiEndpoint = new PlaygroundWorkerEndpoint(
-	php,
-	monitor,
-	scope,
-	wpVersion,
-	phpVersion
+const [setApiReady, setAPIError] = exposeAPI(
+	new PlaygroundWorkerEndpoint(php, monitor, scope, wpVersion, phpVersion)
 );
-const [setApiReady, setAPIError] = exposeAPI(apiEndpoint);
 
 try {
 	await phpReady;

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -100,33 +100,6 @@ if (!wordPressAvailableInOPFS) {
 	}
 }
 
-let phpReady: Promise<any> | undefined;
-const php = await rotatedPHP({
-	maxRequests: 400,
-	createPhp: async () => {
-		const { php, phpReady: _phpReady } = WebPHP.loadSync(phpVersion, {
-			downloadMonitor: monitor,
-			requestHandler: {
-				documentRoot: DOCROOT,
-				absoluteUrl: scopedSiteUrl,
-			},
-			// We don't yet support loading specific PHP extensions one-by-one.
-			// Let's just indicate whether we want to load all of them.
-			loadAllExtensions: phpExtensions?.length > 0,
-		});
-
-		if (phpReady) {
-			await _phpReady;
-		} else {
-			// On the first run, store the promise in a variable
-			// so that we can await it later.
-			phpReady = _phpReady;
-		}
-
-		return php;
-	},
-});
-
 /** @inheritDoc PHPClient */
 export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 	/**
@@ -213,6 +186,33 @@ export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 		return replayFSJournal(php, events);
 	}
 }
+
+let phpReady: Promise<any> | undefined;
+const php = await rotatedPHP({
+	maxRequests: 400,
+	createPhp: async () => {
+		const { php, phpReady: _phpReady } = WebPHP.loadSync(phpVersion, {
+			downloadMonitor: monitor,
+			requestHandler: {
+				documentRoot: DOCROOT,
+				absoluteUrl: scopedSiteUrl,
+			},
+			// We don't yet support loading specific PHP extensions one-by-one.
+			// Let's just indicate whether we want to load all of them.
+			loadAllExtensions: phpExtensions?.length > 0,
+		});
+
+		if (phpReady) {
+			await _phpReady;
+		} else {
+			// On the first run, store the promise in a variable
+			// so that we can await it later.
+			phpReady = _phpReady;
+		}
+
+		return php;
+	},
+});
 
 const [setApiReady, setAPIError] = exposeAPI(
 	new PlaygroundWorkerEndpoint(php, monitor, scope, wpVersion, phpVersion)

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -12,7 +12,7 @@ import {
 	SupportedPHPExtension,
 	SupportedPHPVersion,
 	SupportedPHPVersionsList,
-	rotatedPHP,
+	rotatePHPRuntime,
 } from '@php-wasm/universal';
 import {
 	FilesystemOperation,
@@ -100,6 +100,11 @@ if (!wordPressAvailableInOPFS) {
 	}
 }
 
+const php = new WebPHP(undefined, {
+	documentRoot: DOCROOT,
+	absoluteUrl: scopedSiteUrl,
+});
+
 const recreateRuntime = async () =>
 	await WebPHP.loadRuntime(phpVersion, {
 		downloadMonitor: monitor,
@@ -108,11 +113,8 @@ const recreateRuntime = async () =>
 		loadAllExtensions: phpExtensions?.length > 0,
 	});
 
-const php = rotatedPHP({
-	php: new WebPHP(undefined, {
-		documentRoot: DOCROOT,
-		absoluteUrl: scopedSiteUrl,
-	}),
+rotatePHPRuntime({
+	php,
 	recreateRuntime,
 	maxRequests: 400,
 });

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -211,8 +211,7 @@ const [setApiReady, setAPIError] = exposeAPI(
 );
 
 try {
-	const runtimeId = await recreateRuntime();
-	php.initializeRuntime(runtimeId);
+	php.initializeRuntime(await recreateRuntime());
 
 	if (startupOptions.sapiName) {
 		await php.setSapiName(startupOptions.sapiName);

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -190,7 +190,7 @@ export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 let phpReady: Promise<any> | undefined;
 const php = await rotatedPHP({
 	maxRequests: 400,
-	createPhp: async () => {
+	createPHP: async () => {
 		const { php, phpReady: _phpReady } = WebPHP.loadSync(phpVersion, {
 			downloadMonitor: monitor,
 			requestHandler: {

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -116,6 +116,13 @@ const recreateRuntime = async () =>
 rotatePHPRuntime({
 	php,
 	recreateRuntime,
+	/**
+	 * 400 is an arbitrary number that should trigger a rotation
+	 * way before the memory gets too fragmented. If the memory
+	 * issue returns, let's explore:
+	 * * Lowering this number
+	 * * Adding a memory usage monitor and rotate based on that
+	 */
 	maxRequests: 400,
 });
 

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -100,6 +100,23 @@ if (!wordPressAvailableInOPFS) {
 	}
 }
 
+const recreateRuntime = async () =>
+	await WebPHP.loadRuntime(phpVersion, {
+		downloadMonitor: monitor,
+		// We don't yet support loading specific PHP extensions one-by-one.
+		// Let's just indicate whether we want to load all of them.
+		loadAllExtensions: phpExtensions?.length > 0,
+	});
+
+const php = rotatedPHP({
+	php: new WebPHP(undefined, {
+		documentRoot: DOCROOT,
+		absoluteUrl: scopedSiteUrl,
+	}),
+	recreateRuntime,
+	maxRequests: 400,
+});
+
 /** @inheritDoc PHPClient */
 export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 	/**
@@ -186,23 +203,6 @@ export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 		return replayFSJournal(php, events);
 	}
 }
-
-const recreateRuntime = async () =>
-	await WebPHP.loadRuntime(phpVersion, {
-		downloadMonitor: monitor,
-		// We don't yet support loading specific PHP extensions one-by-one.
-		// Let's just indicate whether we want to load all of them.
-		loadAllExtensions: phpExtensions?.length > 0,
-	});
-
-const php = rotatedPHP({
-	php: new WebPHP(undefined, {
-		documentRoot: DOCROOT,
-		absoluteUrl: scopedSiteUrl,
-	}),
-	recreateRuntime,
-	maxRequests: 400,
-});
 
 const [setApiReady, setAPIError] = exposeAPI(
 	new PlaygroundWorkerEndpoint(php, monitor, scope, wpVersion, phpVersion)

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -202,9 +202,7 @@ const php = rotatedPHP({
 	}),
 	recreateRuntime,
 	maxRequests: 400,
-	// The types below are incorrect as php.run and php.request now return
-	// a promise. @TODO: figure out a better solution
-}) as any as WebPHP;
+});
 
 const [setApiReady, setAPIError] = exposeAPI(
 	new PlaygroundWorkerEndpoint(php, monitor, scope, wpVersion, phpVersion)

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -187,39 +187,33 @@ export class PlaygroundWorkerEndpoint extends WebPHPEndpoint {
 	}
 }
 
-let phpReady: Promise<any> | undefined;
-const php = await rotatedPHP({
+const recreateRuntime = async () =>
+	await WebPHP.loadRuntime(phpVersion, {
+		downloadMonitor: monitor,
+		// We don't yet support loading specific PHP extensions one-by-one.
+		// Let's just indicate whether we want to load all of them.
+		loadAllExtensions: phpExtensions?.length > 0,
+	});
+
+const php = rotatedPHP({
+	php: new WebPHP(undefined, {
+		documentRoot: DOCROOT,
+		absoluteUrl: scopedSiteUrl,
+	}),
+	recreateRuntime,
 	maxRequests: 400,
-	createPHP: async () => {
-		const { php, phpReady: _phpReady } = WebPHP.loadSync(phpVersion, {
-			downloadMonitor: monitor,
-			requestHandler: {
-				documentRoot: DOCROOT,
-				absoluteUrl: scopedSiteUrl,
-			},
-			// We don't yet support loading specific PHP extensions one-by-one.
-			// Let's just indicate whether we want to load all of them.
-			loadAllExtensions: phpExtensions?.length > 0,
-		});
-
-		if (phpReady) {
-			await _phpReady;
-		} else {
-			// On the first run, store the promise in a variable
-			// so that we can await it later.
-			phpReady = _phpReady;
-		}
-
-		return php;
-	},
-});
+	// The types below are incorrect as php.run and php.request now return
+	// a promise. @TODO: figure out a better solution
+}) as any as WebPHP;
 
 const [setApiReady, setAPIError] = exposeAPI(
 	new PlaygroundWorkerEndpoint(php, monitor, scope, wpVersion, phpVersion)
 );
 
 try {
-	await phpReady;
+	const runtimeId = await recreateRuntime();
+	php.initializeRuntime(runtimeId);
+
 	if (startupOptions.sapiName) {
 		await php.setSapiName(startupOptions.sapiName);
 	}

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -102,7 +102,7 @@ if (!wordPressAvailableInOPFS) {
 
 let phpReady: Promise<any> | undefined;
 const php = await rotatedPHP({
-	maxRequests: 50,
+	maxRequests: 400,
 	createPhp: async () => {
 		const { php, phpReady: _phpReady } = WebPHP.loadSync(phpVersion, {
 			downloadMonitor: monitor,

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -113,16 +113,16 @@ const recreateRuntime = async () =>
 		loadAllExtensions: phpExtensions?.length > 0,
 	});
 
+// Rotate the PHP runtime periodically to avoid memory leak-related crashes.
+// @see https://github.com/WordPress/wordpress-playground/pull/990 for more context
 rotatePHPRuntime({
 	php,
 	recreateRuntime,
-	/**
-	 * 400 is an arbitrary number that should trigger a rotation
-	 * way before the memory gets too fragmented. If the memory
-	 * issue returns, let's explore:
-	 * * Lowering this number
-	 * * Adding a memory usage monitor and rotate based on that
-	 */
+	// 400 is an arbitrary number that should trigger a rotation
+	// way before the memory gets too fragmented. If the memory
+	// issue returns, let's explore:
+	// * Lowering this number
+	// * Adding a memory usage monitor and rotate based on that
 	maxRequests: 400,
 });
 


### PR DESCRIPTION
Supersedes https://github.com/WordPress/playground-tools/pull/110

Swaps the internal PHP runtime for a fresh one after a certain number of requests are handled.

## Rationale

PHP and PHP extension have a memory leak. Each request leaves the memory a bit more fragmented and with a bit less available space than before. Eventually, new allocations start failing.

Rotating the PHP instance may seem like a workaround, but it's actually what PHP-FPM does natively:

Implementing this solution in core enables all downstream consumers of the PHP WASM package, like `wp-now`, to benefit.

## How it works

Adds a `rotatePHP` function that keeps track of the `BasePHP.run()` calls and replaces the Emscripten runtime with a new one after a certain number of calls.

Example:

```ts
import { rotatePHPRuntime } from '@php-wasm/universal';

const loadRuntime = async () => await NodePHP.loadRuntime("8.0");

const php = new NodePHP(await loadRuntime(), {
	documentRoot: '/test-root',
});

await rotatePHPRuntime({
	php,
	recreateRuntime: loadRuntime,
	maxRequests: 50
});

// After 50 request() calls, the PHP runtime will be discarded and a new one will be created.
// It all happens internally. The caller doesn't know anything about this.
```

I started by porting the "Process Pool" idea ([see the branch](https://github.com/WordPress/wordpress-playground/compare/harvested-memory-pool?expand=1)) from https://github.com/WordPress/playground-tools/pull/110, but I realized that:

* The logic was complicated
* We only need to manage a single PHP instance, not a pool of them
* Worker thread is built to a single PHP instance and not architected to handle a pool

So I decided to simplify the logic and just manage a single PHP instance.

## Other changes

* Implements `BasePHP.hotSwapPHPRuntime()` that opens the door to switching PHP versions dynamically and without a full page reload.
* Makes the `BasePHP.semaphore` property public to enable conflict-free runtime swaps
* Adds the `runtime.initialized` and `runtime.beforedestroy` events for OPFS handlers to re-bind on runtime swap.
* Tiny unrelated change: Migrates the OPFS handler from monkey-patching the `php.run` method to relying on event listeners. The `rotatePHP` function went through a similar journey and I updated that other code path while I was on it.

## Testing instructions

confirm the CI checks pass

CC @dmsnell
