### PR TITLE
Update wp_http_fetch.php

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/playground-includes/wp_http_fetch.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/playground-includes/wp_http_fetch.php
@@ -110,7 +110,7 @@ class Wp_Http_Fetch_Base
 			} else {
 				$query = $url_parts['query'];
 			}
-			$query .= '&' . http_build_query($data, null, '&');
+			$query .= '&' . http_build_query($data, '', '&');
 			$query = trim($query, '&');
 			if (empty($url_parts['query'])) {
 				$url .= '?' . $query;


### PR DESCRIPTION
Using `''` instead of `null` to prevent the following error:

```json
{
“type”:“deprecated”,
“message”:“http_build_query(): Passing null to parameter #2 ($numeric_prefix) of type string is deprecated”,“file”:“wp-content/mu-plugins/playground-includes/wp_http_fetch.php”,“line”:113,“stack”:[“http_build_query()“,”Wp_Http_Fetch_Base::format_get()“,”Wp_Http_Fetch_Base->request()“,”WpOrg\Requests\Requests::request()“,”WP_Http->request()“,”WP_Http->get()“,”wp_remote_get()“,”WP_Community_Events->get_events()“,”wp_ajax_get_community_events()“,”do_action(‘wp_ajax_get-community-events’)“],“component”:“MU Plugin: playground-includes”
}
```
