### PR TITLE
Networking: Swap Requests transports using the http_api_transports instead of patching the Requests library

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -96,6 +96,21 @@ add_action('admin_print_scripts', function () {
  */
 add_filter('got_url_rewrite', '__return_true');
 
+// Create the fonts directory if missing
+if(!file_exists(WP_CONTENT_DIR . '/fonts')) {
+	mkdir(WP_CONTENT_DIR . '/fonts');
+}
+
+/**
+ * Remove the default WordPress requests transports, fsockopen and cURL.
+ */
+add_filter('http_api_transports', function ($transports) {
+	return array_diff($transports, [
+		'curl',
+		'streams',
+	]);
+});
+
 /**
  * The default WordPress requests transports have been disabled
  * at this point. However, the Requests class requires at least
@@ -112,7 +127,7 @@ add_filter('got_url_rewrite', '__return_true');
 $__requests_class = class_exists( '\WpOrg\Requests\Requests' ) ? '\WpOrg\Requests\Requests' : 'Requests';
 if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 	require(__DIR__ . '/playground-includes/wp_http_fetch.php');
-	$__requests_class::add_transport('WP_Http_Fetch');
+	$__requests_class::add_transport('Wp_Http_Fetch');
 
 	/**
 	 * Add Fetch transport to the list of transports that WordPress
@@ -139,6 +154,11 @@ if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 		return true;
 	});
 } else {
-	require(__DIR__ . '/playground-includes/requests_transport_dummy.php');
-	$__requests_class::add_transport('Requests_Transport_Dummy');
+	require(__DIR__ . '/playground-includes/wp_http_dummy.php');
+	$__requests_class::add_transport('Wp_Http_Dummy');
+
+	add_filter('http_api_transports', function ($transports) {
+		$transports[] = 'Dummy';
+		return $transports;
+	});
 }

--- a/packages/playground/remote/src/lib/playground-mu-plugin/playground-includes/wp_http_dummy.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/playground-includes/wp_http_dummy.php
@@ -4,8 +4,13 @@
  * This transport does not perform any HTTP requests and only exists
  * to prevent the Requests class from complaining about not having any
  * transports.
+ * 
+ * The reason for calling it Wp_Http_Dummy and not something more natural like
+ * Requests_Transport_Dummy is the _get_first_available_transport(). It checks for
+ * a class named "Wp_Http_" . $transport_name – which means we must adhere to this
+ * hardcoded pattern.
  */
-class Requests_Transport_Dummy_Base
+class Wp_Http_Dummy_Base
 {
 	public $headers = '';
 
@@ -43,12 +48,12 @@ class Requests_Transport_Dummy_Base
 }
 
 if (class_exists('\WpOrg\Requests\Requests')) {
-	class Requests_Transport_Dummy extends Requests_Transport_Dummy_Base implements \WpOrg\Requests\Transport
+	class Wp_Http_Dummy extends Wp_Http_Dummy_Base implements \WpOrg\Requests\Transport
 	{
 
 	}
 } else {
-	class Requests_Transport_Dummy extends Requests_Transport_Dummy_Base implements Requests_Transport
+	class Wp_Http_Dummy extends Wp_Http_Dummy_Base implements Requests_Transport
 	{
 
 	}

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -35,7 +35,7 @@ import {
 /** @ts-ignore */
 import transportFetch from './playground-mu-plugin/playground-includes/wp_http_fetch.php?raw';
 /** @ts-ignore */
-import transportDummy from './playground-mu-plugin/playground-includes/requests_transport_dummy.php?raw';
+import transportDummy from './playground-mu-plugin/playground-includes/wp_http_dummy.php?raw';
 /** @ts-ignore */
 import playgroundMuPlugin from './playground-mu-plugin/0-playground.php?raw';
 import { joinPaths } from '@php-wasm/util';
@@ -274,35 +274,9 @@ try {
 		// Install the playground mu-plugin
 		await writeFiles(php, joinPaths(docroot, '/wp-content/mu-plugins'), {
 			'0-playground.php': playgroundMuPlugin,
-			'playground-includes/requests_transport_dummy.php': transportDummy,
+			'playground-includes/wp_http_dummy.php': transportDummy,
 			'playground-includes/wp_http_fetch.php': transportFetch,
 		});
-
-		// Create the fonts directory
-		php.mkdir(joinPaths(docroot, '/wp-content/fonts'));
-
-		// Force the fsockopen and cUrl transports to report they don't work:
-		for (const relativePath of [
-			`/wp-includes/Requests/Transport/fsockopen.php`,
-			`/wp-includes/Requests/Transport/cURL.php`,
-			`/wp-includes/Requests/src/Transport/Fsockopen.php`,
-			`/wp-includes/Requests/src/Transport/Curl.php`,
-		]) {
-			const transportAbsPath = joinPaths(docroot, relativePath);
-			// One of the transports might not exist in the latest WordPress version.
-			if (!php.fileExists(transportAbsPath)) {
-				continue;
-			}
-			let contents = php.readFileAsText(transportAbsPath);
-			if (contents.includes('public static function test2')) {
-				continue;
-			}
-			contents = contents.replace(
-				'public static function test',
-				'public static function test( $capabilities = array() ) { return false; } public static function test2'
-			);
-			php.writeFile(transportAbsPath, contents);
-		}
 	}
 
 	if (virtualOpfsDir) {


### PR DESCRIPTION
Before this PR, we were patching the default WordPress transports to always return `false` from their `test()` method which, otherwise, could return a false positive. It was a hack. It solved the problem at hand, but added complexity and maintenance burden.

This PR removes the patching and instead swaps the Requests transports from within the Playground my-plugin using the `http_api_transports` WordPress filter.

 ## Testing instructions

Confirm the CI checks pass

cc @bgrgicak
