### PR TITLE
Remote.html: Always install the playground mu-plugin 

### DIFF
--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -264,20 +264,18 @@ try {
 				NONCE_SALT: randomString(40),
 			},
 		});
-
-		/**
-		 * Patch WordPress when it's not restored from OPFS.
-		 * The stored version, presumably, has all the patches
-		 * already applied.
-		 */
-
-		// Install the playground mu-plugin
-		await writeFiles(php, joinPaths(docroot, '/wp-content/mu-plugins'), {
-			'0-playground.php': playgroundMuPlugin,
-			'playground-includes/wp_http_dummy.php': transportDummy,
-			'playground-includes/wp_http_fetch.php': transportFetch,
-		});
 	}
+
+	// Always install the playground mu-plugin, even if WordPress is loaded
+	// from the OPFS. This ensures:
+	// * The mu-plugin is always there, even when a custom WordPress directory
+	//   is mounted.
+	// * The mu-plugin is always up to date.
+	await writeFiles(php, joinPaths(docroot, '/wp-content/mu-plugins'), {
+		'0-playground.php': playgroundMuPlugin,
+		'playground-includes/wp_http_dummy.php': transportDummy,
+		'playground-includes/wp_http_fetch.php': transportFetch,
+	});
 
 	if (virtualOpfsDir) {
 		await bindOpfs({


### PR DESCRIPTION
Installs the Playground mu-plugin even when WordPress is loaded
from the OPFS to ensure:

* The mu-plugin is always there, even when a custom WordPress directory
  is mounted.
* The mu-plugin is always up to date.

Depends on https://github.com/WordPress/wordpress-playground/pull/1004

## Testing instructions

Confirm the CI checks pass