### PR TITLE
Allow for CORS requests to api.wordpress.org to pass

### DIFF
--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -50,7 +50,7 @@ export async function setupFetchNetworkTransport(playground: UniversalPHP) {
 
 export async function handleRequest(data: RequestData, fetchFn = fetch) {
 	const hostname = new URL(data.url).hostname;
-	const fetchUrl = ['w.org', 's.w.org'].includes(hostname)
+	let fetchUrl = ['w.org', 's.w.org'].includes(hostname)
 		? `/plugin-proxy.php?url=${encodeURIComponent(data.url)}`
 		: data.url;
 

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -63,15 +63,15 @@ export async function handleRequest(data: RequestData, fetchFn = fetch) {
 		}
 
 		/**
-  		 * Temporarily avoid CORS issues by using a specific URI.
-	 	 *
+		 * Temporarily avoid CORS issues by using a specific URI.
+		 *
 		 * This is required because the fetch API will send a CORS preflight
-   		 * request if the request is cross-origin and has custom headers.
-	  	 *
-	 	 * nginx considers requests to "/" to be static, and doesn't pass the
+		 * request if the request is cross-origin and has custom headers.
+		 *
+		 * nginx considers requests to "/" to be static, and doesn't pass the
 		 * request to PHP, and so no OPTIONS request makes it to the API.
-   		 * we can bypass this, by making a request to `/index.php`.
-	 	 */
+		 * we can bypass this, by making a request to `/index.php`.
+		 */
 		if ( hostname == 'api.wordpress.org' ) {
 			fetchUrl = fetchUrl.replace( /(\/[\d\.]+\/)($|\?)/, '$1index.php$2' );
 		}

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -73,7 +73,7 @@ export async function handleRequest(data: RequestData, fetchFn = fetch) {
 		 * we can bypass this, by making a request to `/index.php`.
 		 */
 		if ( hostname == 'api.wordpress.org' ) {
-			fetchUrl = fetchUrl.replace( /(\/[\d\.]+\/)($|\?)/, '$1index.php$2' );
+			fetchUrl = fetchUrl.replace( /(\/[\d.]+\/)($|\?)/, '$1index.php$2' );
 		}
 
 		response = await fetchFn(fetchUrl, {


### PR DESCRIPTION
## What is this PR doing?

Fixes CORS requests to WordPress.org, even with custom headers.

## What problem is it solving?

See #1003

This is a workaround until https://make.wordpress.org/systems/2024/02/07/cors-requests-for-api-wordpress-org/ is resolved.

## How is the problem addressed?

Altering the URI that fetches to api.wordpress.org make, to replace requests to `/path/` to `/path/index.php` to allow for `OPTIONS` requests to reach PHP.

## Testing Instructions

Untested. Make sure upon booting no networking errors are encountered.