### PR TITLE
Remove x-request-issuer header on cross-origin requests

### DIFF
--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -42,6 +42,16 @@ export async function setupFetchNetworkTransport(playground: UniversalPHP) {
 			data.headers = Object.fromEntries(data.headers);
 		}
 
+		// Let the Playground request handler know that this request is
+		// coming from PHP. We can't just add this header to all external
+		// requests because of CORS. The browser will refuse to process
+		// cross-origin requests with custom headers unless the server
+		// explicitly allows them in Access-Control-Allow-Headers.
+		const parsedUrl = new URL(data.url);
+		if (parsedUrl.hostname === window.location.hostname) {
+			data.headers['x-request-issuer'] = 'php';
+		}
+
 		return handleRequest(data);
 	});
 }

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -42,8 +42,6 @@ export async function setupFetchNetworkTransport(playground: UniversalPHP) {
 			data.headers = Object.fromEntries(data.headers);
 		}
 
-		data.headers['x-request-issuer'] = 'php';
-
 		return handleRequest(data);
 	});
 }


### PR DESCRIPTION
## What is this PR doing?

Restricts the x-request-issuer header added in https://github.com/WordPress/wordpress-playground/commit/9f134e046102a1d2858b0b0541abfa9182b64291 added to _local_ requests.

We can't just add this header to all external
requests because of CORS. The browser will refuse to process
cross-origin requests with custom headers unless the server
explicitly allows them in Access-Control-Allow-Headers.

## Testing Instructions

- Checkout this branch
- Run `npm run dev`
- Open[ local Playground and confirm that the Add Plugins page is returning data](http://localhost:5400/website-server/?php=8.0&wp=6.4&storage=none&networking=yes&url=/wp-admin/plugin-install.php)
- Open network tools and see there are no CORS errors
