### PR TITLE
32bit integer workaround

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -1,6 +1,20 @@
 <?php
 
 /**
+ * This is a temporary workaround to hide the 32bit integer warnings that 
+ * appear when using various time related function, such as strtotime and mktime.
+ * Examples of the warnings that are displayed:
+ * Warning: mktime(): Epoch doesn't fit in a PHP integer in <file>
+ * Warning: strtotime(): Epoch doesn't fit in a PHP integer in <file>
+ */
+set_error_handler(function($severity, $message, $file, $line) {
+  if (strpos($message, "fit in a PHP integer") !== false) {
+      return;
+  }
+  return false;
+});
+
+/**
  * Add a notice to wp-login.php offering the username and password.
  */
 add_action(


### PR DESCRIPTION
## What is this PR doing?
This is a temporary workaround to hide the 32bit integer warnings that appear when using various time related function, such as strtotime() and mktime().

## What problem is it solving?
Hiding the warning messages from being displayed on the page.

## How is the problem addressed?
Adding an error handler to ignore warning if it matches the message "fit in a PHP integer"

## Testing Instructions
add ?year=123 to any playground URL (e.g. /?year=123). Normally it would display `Warning: mktime(): Epoch doesn't fit in a PHP integer in /wordpress/wp-includes/class-wp-date-query.php on line 3`