### PR TITLE
Blueprints: wp-cli step

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -1101,6 +1101,48 @@
 						}
 					},
 					"required": ["data", "path", "step"]
+				},
+				{
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"progress": {
+							"type": "object",
+							"properties": {
+								"weight": {
+									"type": "number"
+								},
+								"caption": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						},
+						"step": {
+							"type": "string",
+							"const": "wp-cli",
+							"description": "The step identifier."
+						},
+						"command": {
+							"anyOf": [
+								{
+									"type": "string"
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							],
+							"description": "The WP CLI command to run."
+						},
+						"wpCliPath": {
+							"type": "string",
+							"description": "wp-cli.phar path"
+						}
+					},
+					"required": ["command", "step"]
 				}
 			]
 		},

--- a/packages/playground/blueprints/src/lib/steps/handlers.ts
+++ b/packages/playground/blueprints/src/lib/steps/handlers.ts
@@ -25,3 +25,4 @@ export { runWpInstallationWizard } from './run-wp-installation-wizard';
 export { setSiteOptions, updateUserMeta } from './site-data';
 export { defineWpConfigConsts } from './define-wp-config-consts';
 export { zipWpContent } from './zip-wp-content';
+export { wpCLI } from './wp-cli';

--- a/packages/playground/blueprints/src/lib/steps/index.ts
+++ b/packages/playground/blueprints/src/lib/steps/index.ts
@@ -28,6 +28,7 @@ import { UnzipStep } from './unzip';
 import { ImportWordPressFilesStep } from './import-wordpress-files';
 import { ImportFileStep } from './import-file';
 import { EnableMultisiteStep } from './enable-multisite';
+import { WPCLIStep } from './wp-cli';
 
 export type Step = GenericStep<FileReference>;
 export type StepDefinition = Step & {
@@ -68,7 +69,8 @@ export type GenericStep<Resource> =
 	| SetSiteOptionsStep
 	| UnzipStep<Resource>
 	| UpdateUserMetaStep
-	| WriteFileStep<Resource>;
+	| WriteFileStep<Resource>
+	| WPCLIStep;
 
 export type {
 	ActivatePluginStep,
@@ -99,6 +101,7 @@ export type {
 	UnzipStep,
 	UpdateUserMetaStep,
 	WriteFileStep,
+	WPCLIStep,
 };
 
 /**

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
@@ -1,5 +1,5 @@
 import { NodePHP } from '@php-wasm/node';
-import { wpCLI } from './wp-cli';
+import { splitShellCommand, wpCLI } from './wp-cli';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { unzip } from './unzip';
@@ -30,5 +30,31 @@ describe('Blueprint step wpCLI', () => {
 				"wp post create --post_title='Test post' --post_excerpt='Some content' --no-color",
 		});
 		expect(result.text).toMatch(/Success: Created post/);
+	});
+});
+
+describe('splitShellCommand', () => {
+	it('Should split a shell command into an array', () => {
+		const command =
+			'wp post create --post_title="Test post" --post_excerpt="Some content"';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'wp',
+			'post',
+			'create',
+			'--post_title=Test post',
+			'--post_excerpt=Some content',
+		]);
+	});
+
+	it('Should treat multiple spaces as a single space', () => {
+		const command = 'ls    --wordpress   --playground --is-great';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'ls',
+			'--wordpress',
+			'--playground',
+			'--is-great',
+		]);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
@@ -1,0 +1,34 @@
+import { NodePHP } from '@php-wasm/node';
+import { wpCLI } from './wp-cli';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { unzip } from './unzip';
+import { getWordPressModule } from '@wp-playground/wordpress';
+
+const phpVersion = '8.0';
+describe('Blueprint step wpCLI', () => {
+	let php: NodePHP;
+
+	beforeEach(async () => {
+		php = await NodePHP.load(phpVersion, {
+			requestHandler: {
+				documentRoot: '/wordpress',
+			},
+		});
+		php.setSapiName('cli');
+		await unzip(php, {
+			zipFile: await getWordPressModule(),
+			extractToPath: '/wordpress',
+		});
+		const wpCliPath = join(__dirname, '../../test/wp-cli.phar');
+		php.writeFile('/tmp/wp-cli.phar', readFileSync(wpCliPath));
+	});
+
+	it('should run wp-cli commands', async () => {
+		const result = await wpCLI(php, {
+			command:
+				"wp post create --post_title='Test post' --post_excerpt='Some content' --no-color",
+		});
+		expect(result.text).toMatch(/Success: Created post/);
+	});
+});

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -1,0 +1,136 @@
+import { PHPResponse } from '@php-wasm/universal';
+import { StepHandler } from '.';
+import { phpVar } from '@php-wasm/util';
+
+/**
+ * @inheritDoc wpCLI
+ * @hasRunnableExample
+ * @example
+ *
+ * <code>
+ * {
+ * 		"step": "wpCLI",
+ * 		"command": "wp post create --post_title='Test post' --post_excerpt='Some content'"
+ * }
+ * </code>
+ */
+export interface WPCLIStep {
+	/** The step identifier. */
+	step: 'wp-cli';
+	/** The WP CLI command to run. */
+	command: string | string[];
+	/** wp-cli.phar path */
+	wpCliPath?: string;
+}
+
+/**
+ * Runs PHP code.
+ */
+export const wpCLI: StepHandler<WPCLIStep, Promise<PHPResponse>> = async (
+	playground,
+	{ command, wpCliPath = '/tmp/wp-cli.phar' }
+) => {
+	if (!(await playground.fileExists(wpCliPath))) {
+		throw new Error(`wp-cli.phar not found at ${wpCliPath}`);
+	}
+
+	let args: string[];
+	if (typeof command === 'string') {
+		command = command.trim();
+		args = splitShellCommand(command);
+	} else {
+		args = command;
+	}
+
+	const cmd = args.shift();
+	if (cmd !== 'wp') {
+		throw new Error(`The first argument must be "wp".`);
+	}
+
+	await playground.writeFile('/tmp/stdout', '');
+	await playground.writeFile('/tmp/stderr', '');
+	await playground.writeFile(
+		'/wordpress/run-cli.php',
+		`<?php
+		// Set up the environment to emulate a shell script
+		// call.
+
+		// Set SHELL_PIPE to 0 to ensure WP-CLI formats
+		// the output as ASCII tables.
+		// @see https://github.com/wp-cli/wp-cli/issues/1102
+		putenv( 'SHELL_PIPE=0' );
+
+		// Set the argv global.
+		$GLOBALS['argv'] = array_merge([
+		  "/tmp/wp-cli.phar",
+		  "--path=/wordpress"
+		], ${phpVar(args)});
+
+		// Provide stdin, stdout, stderr streams outside of
+		// the CLI SAPI.
+		define('STDIN', fopen('php://stdin', 'rb'));
+		define('STDOUT', fopen('php://stdout', 'wb'));
+		define('STDERR', fopen('/tmp/stderr', 'wb'));
+
+		require( ${phpVar(wpCliPath)} );
+		`
+	);
+
+	const result = await playground.run({
+		scriptPath: '/wordpress/run-cli.php',
+	});
+
+	if (result.errors) {
+		throw new Error(result.errors);
+	}
+
+	return result;
+};
+
+/**
+ * Naive shell command parser.
+ * Ensures that commands like `wp option set blogname "My blog name"` are split into
+ * `['wp', 'option', 'set', 'blogname', 'My blog name']` instead of
+ * `['wp', 'option', 'set', 'blogname', 'My', 'blog', 'name']`.
+ *
+ * @param command
+ * @returns
+ */
+export function splitShellCommand(command: string) {
+	const MODE_NORMAL = 0;
+	const MODE_IN_QUOTE = 1;
+
+	let mode = MODE_NORMAL;
+	let quote = '';
+
+	const parts: string[] = [];
+	let currentPart = '';
+	for (let i = 0; i < command.length; i++) {
+		const char = command[i];
+		if (mode === MODE_NORMAL) {
+			if (char === '"' || char === "'") {
+				mode = MODE_IN_QUOTE;
+				quote = char;
+			} else if (char.match(/\s/)) {
+				parts.push(currentPart);
+				currentPart = '';
+			} else {
+				currentPart += char;
+			}
+		} else if (mode === MODE_IN_QUOTE) {
+			if (char === '\\') {
+				i++;
+				currentPart += command[i];
+			} else if (char === quote) {
+				mode = MODE_NORMAL;
+				quote = '';
+			} else {
+				currentPart += char;
+			}
+		}
+	}
+	if (currentPart) {
+		parts.push(currentPart);
+	}
+	return parts;
+}

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -112,7 +112,9 @@ export function splitShellCommand(command: string) {
 				mode = MODE_IN_QUOTE;
 				quote = char;
 			} else if (char.match(/\s/)) {
-				parts.push(currentPart);
+				if (currentPart) {
+					parts.push(currentPart);
+				}
 				currentPart = '';
 			} else {
 				currentPart += char;

--- a/packages/playground/website/.htaccess
+++ b/packages/playground/website/.htaccess
@@ -1,8 +1,11 @@
+Options +Multiviews
+AddEncoding x-gzip .gz
+
 <FilesMatch "index\.html">
 Header unset ETag
 Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
 </FilesMatch>
-<FilesMatch "index\.js|blueprint-schema\.json">
+<FilesMatch "index\.js|blueprint-schema\.json|wp-cli.phar">
 Header set Access-Control-Allow-Origin "*"
 Header unset ETag
 Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"

--- a/packages/playground/website/cypress/e2e/blueprints.cy.ts
+++ b/packages/playground/website/cypress/e2e/blueprints.cy.ts
@@ -53,4 +53,23 @@ describe('Blueprints', () => {
 			.find('[data-slug="wordpress-importer-git-loader"].active')
 			.should('exist');
 	});
+
+	it('wp-cli step should create a post', () => {
+		const blueprint: Blueprint = {
+			landingPage: '/wp-admin/post.php',
+			login: true,
+			steps: [
+				{
+					step: 'wp-cli',
+					command:
+						"wp post create --post_title='Test post' --post_excerpt='Some content' --no-color",
+				},
+			],
+		};
+		cy.visit('/#' + JSON.stringify(blueprint));
+		cy.wordPressDocument()
+			.its('body')
+			.find('[aria-label="“Test post” (Edit)"]')
+			.should('exist');
+	});
 });

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -19,7 +19,8 @@
 					"cp -r ./client ./wasm-wordpress-net/",
 					"cp -r ./remote/* ./wasm-wordpress-net/",
 					"cp -r ./website/* ./wasm-wordpress-net/",
-					"cat ./remote/.htaccess ./website/.htaccess > ./wasm-wordpress-net/.htaccess"
+					"cat ./remote/.htaccess ./website/.htaccess > ./wasm-wordpress-net/.htaccess",
+					"curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar | gzip -c -9 wp-cli.phar > wasm-wordpress-net/wp-cli.phar.gz"
 				],
 				"cwd": "dist/packages/playground",
 				"parallel": false

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -20,7 +20,7 @@
 					"cp -r ./remote/* ./wasm-wordpress-net/",
 					"cp -r ./website/* ./wasm-wordpress-net/",
 					"cat ./remote/.htaccess ./website/.htaccess > ./wasm-wordpress-net/.htaccess",
-					"curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar | gzip -c -9 wp-cli.phar > wasm-wordpress-net/wp-cli.phar.gz"
+					"curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar | gzip -c -9 > wasm-wordpress-net/wp-cli.phar.gz"
 				],
 				"cwd": "dist/packages/playground",
 				"parallel": false


### PR DESCRIPTION
Adds a new step to the blueprints that allows to run WP-CLI commands.

Example:

```ts
{
	"landingPage": "/wp-admin/post.php",
	"login": true,
	"steps": [
		{
			"step": "wp-cli",
			"command": "wp post create --post_title='Test post' --post_excerpt='Some content' --no-color"
		}
	]
}
```

The command may also be an array of strings to ease dealing with quotes:

```ts
{
    "landingPage": "/wp-admin/post.php",
    "login": true,
    "steps": [
        {
            "step": "wp-cli",
            "command": ["wp", "post", "create", "--post_title=Test post", "--post_excerpt=Some content", "--no-color"]
        }
    ]
}
```

 ## Trade-offs

* WP-CLI requires ~7MB of additional downloads: 1.4MB for the compressed WP-CLI.phar, and 5.6MB for the kitchen-sink PHP extensions bundle.

 ## Implementation

* Whenever the Blueprints compiler finds a `wp-cli` step, it:
   * Downloads the wp-cli.phar file
   * Forces the `kitchen-sink` PHP extensions bundle as WP-CLI requires mbstring and iconv
* `wp-cli.phar` is shipped from playground.wordpress.net. Downloading the official release from raw.githubusercontent.com transfers 7MB, while downloading the pre-compressed version from playground.wordpress.net only transfers 1.4MB.
* playground.wordpress.net now always sets the `PHP_SAPI` constant to `cli` to ensure this check in WP-CLI passes: https://github.com/wp-cli/wp-cli-bundle/blob/970d0d4c22d4a89ca890def26ec82e559625abc6/php/boot-phar.php#L3-L10

 ## Future work

* Minify wp-cli.phar to reduce its size even further. We can remove redundant whitespaces and comments, remove the JavaScript parser library that is unlikely to be useful in Playground, remove parts of the Composer library, and perhaps more. cc @schlessera @swissspidy @danielbachhuber
* Move the hardcoded WP-CLI-related parts of the Blueprint `compile()` function into a separate, modular function associated with the `wp-cli` step.

 ## Testing instructions

* Confirm the CI checks pass
* Run the local dev server, [click here](http://localhost:5400/website-server/#{%20%22landingPage%22:%20%22/wp-admin/post.php%22,%20%22login%22:%20true,%20%22steps%22:%20[%20{%20%22step%22:%20%22wp-cli%22,%20%22command%22:%20[%22wp%22,%20%22post%22,%20%22create%22,%20%22--post_title=Test%20post%22,%20%22--post_excerpt=Some%20content%22,%20%22--no-color%22]%20}%20]%20}), and confirm that a new post is created in the WordPress admin.

CC @dmsnell @bgrgicak @sejas @eliot-akira
