### PR TITLE
PHP: Pass request body as UInt8Array

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -778,16 +778,12 @@ RUN set -euxo pipefail; \
 "FS", \n\
 "_wasm_set_sapi_name", \n\
 "_php_wasm_init", \n\
-"_phpwasm_destroy_uploaded_files_hash", \n\
-"_phpwasm_init_uploaded_files_hash", \n\
-"_phpwasm_register_uploaded_file", \n\
 "_emscripten_sleep", \n\
 "_wasm_sleep", \n\
 "_wasm_set_phpini_path", \n\
 "_wasm_set_phpini_entries", \n\
 "_wasm_add_SERVER_entry", \n\
 "_wasm_read", \n\
-"_wasm_add_uploaded_file", \n\
 "_wasm_sapi_handle_request", \n\
 "_wasm_set_content_length", \n\
 "_wasm_set_content_type", \n\

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -149,7 +149,7 @@ describe.each([SupportedPHPVersions])(
 			const response = await handler.request({
 				url: '/index.php',
 				method: 'POST',
-				formData: {
+				body: {
 					myFile: new File(['bar'], 'bar.txt'),
 				},
 			});

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -5,7 +5,7 @@ import {
 	SupportedPHPVersions,
 } from '@php-wasm/universal';
 
-describe.each([SupportedPHPVersions])(
+describe.each(SupportedPHPVersions)(
 	'[PHP %s] PHPRequestHandler – request',
 	(phpVersion) => {
 		let php: NodePHP;

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -149,11 +149,10 @@ describe.each(SupportedPHPVersions)(
 			const response = await handler.request({
 				url: '/index.php',
 				method: 'POST',
-				files: {
-					myFile: new File(['Hello World'], 'text.txt', {
-						type: 'text/plain',
-					}),
-				},
+				body: new TextEncoder().encode(`--boundary
+Content-Disposition: form-data; name="foo"
+
+bar`),
 				headers: {
 					'Content-Type': 'multipart/form-data; boundary=boundary',
 				},
@@ -170,7 +169,6 @@ describe.each(SupportedPHPVersions)(
 			const response = await handler.request({
 				url: '/index.php',
 				method: 'POST',
-				files: {},
 				body: 'foo=bar',
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -149,7 +149,7 @@ describe.each([SupportedPHPVersions])(
 			const response = await handler.request({
 				url: '/index.php',
 				method: 'POST',
-				files: {
+				formData: {
 					myFile: new File(['bar'], 'bar.txt'),
 				},
 			});

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -5,7 +5,7 @@ import {
 	SupportedPHPVersions,
 } from '@php-wasm/universal';
 
-describe.each(SupportedPHPVersions)(
+describe.each([SupportedPHPVersions])(
 	'[PHP %s] PHPRequestHandler – request',
 	(phpVersion) => {
 		let php: NodePHP;
@@ -140,7 +140,7 @@ describe.each(SupportedPHPVersions)(
 			 * the Content-type header is set to multipart/form-data. See the
 			 * phpwasm_init_uploaded_files_hash() docstring for more info.
 			 */
-			await php.writeFile(
+			php.writeFile(
 				'/index.php',
 				`<?php 
 				move_uploaded_file($_FILES["myFile"]["tmp_name"], '/tmp/moved.txt');
@@ -149,12 +149,8 @@ describe.each(SupportedPHPVersions)(
 			const response = await handler.request({
 				url: '/index.php',
 				method: 'POST',
-				body: new TextEncoder().encode(`--boundary
-Content-Disposition: form-data; name="foo"
-
-bar`),
-				headers: {
-					'Content-Type': 'multipart/form-data; boundary=boundary',
+				files: {
+					myFile: new File(['bar'], 'bar.txt'),
 				},
 			});
 			expect(response.text).toEqual('true');

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -857,12 +857,12 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 		 */
 		it('Should work with long POST body', () => {
 			php.writeFile(testScriptPath, '<?php echo "Hello world!"; ?>');
-			const body =
+			const body = new Uint8Array(
 				readFileSync(
 					new URL('./test-data/long-post-body.txt', import.meta.url)
-						.pathname,
-					'utf8'
-				) + '';
+						.pathname
+				)
+			);
 			// 0x4000 is SAPI_POST_BLOCK_SIZE
 			expect(body.length).toBeGreaterThan(0x4000);
 			expect(async () => {
@@ -900,7 +900,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 		it('Should have access to raw request data via the php://input stream', async () => {
 			const response = await php.run({
 				method: 'POST',
-				body: '{"foo": "bar"}',
+				body: new TextEncoder().encode('{"foo": "bar"}'),
 				code: `<?php echo file_get_contents('php://input');`,
 			});
 			const bodyText = new TextDecoder().decode(response.bytes);
@@ -911,7 +911,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			php.writeFile('/php/index.php', `<?php echo 'Hello World';`);
 			const response = await php.request({
 				url: '/',
-				body: '#'.repeat(1024 * 1024),
+				body: new TextEncoder().encode('#'.repeat(1024 * 1024)),
 			});
 			expect(response.httpStatusCode).toEqual(200);
 			expect(response.text).toEqual('Hello World');
@@ -923,7 +923,9 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			php.writeFile('/php/index.php', `<?php echo 'Hello World';`);
 			const response = await php.request({
 				url: '/',
-				body: '#'.repeat(1024 * 1024 * 512 + -24),
+				body: new TextEncoder().encode(
+					'#'.repeat(1024 * 1024 * 512 + -24)
+				),
 			});
 			expect(response.httpStatusCode).toEqual(200);
 			expect(response.text).toEqual('Hello World');
@@ -1017,7 +1019,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			const response = await php.run({
 				code: `<?php echo json_encode($_SERVER);`,
 				method: 'POST',
-				body: 'foo=bar',
+				body: new TextEncoder().encode('foo=bar'),
 				headers: {
 					'Content-Type': 'text/plain',
 					'Content-Length': '15',
@@ -1042,7 +1044,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			const response = await php.run({
 				code: `<?php echo json_encode($_POST);`,
 				method: 'POST',
-				body: 'foo=bar',
+				body: new TextEncoder().encode('foo=bar'),
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},
@@ -1055,7 +1057,9 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			const response = await php.run({
 				code: `<?php echo json_encode($_POST);`,
 				method: 'POST',
-				body: 'foo[]=bar1&foo[]=bar2&indexed[key]=value',
+				body: new TextEncoder().encode(
+					'foo[]=bar1&foo[]=bar2&indexed[key]=value'
+				),
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',
 				},
@@ -1070,10 +1074,10 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			const response = await php.run({
 				code: `<?php echo json_encode($_POST);`,
 				method: 'POST',
-				body: `--boundary
+				body: new TextEncoder().encode(`--boundary
 Content-Disposition: form-data; name="foo"
 
-bar`,
+bar`),
 				headers: {
 					'Content-Type': 'multipart/form-data; boundary=boundary',
 				},
@@ -1089,12 +1093,12 @@ bar`,
 						"is_uploaded" => is_uploaded_file($_FILES["myFile"]["tmp_name"])
 					));`,
 				method: 'POST',
-				body: `--boundary
+				body: new TextEncoder().encode(`--boundary
 Content-Disposition: form-data; name="myFile"; filename="text.txt"
 Content-Type: text/plain
 
 bar
---boundary--`,
+--boundary--`),
 				headers: {
 					'Content-Type': 'multipart/form-data; boundary=boundary',
 				},
@@ -1127,12 +1131,12 @@ bar
 				scriptPath: testScriptPath,
 				relativeUri: '/test.php?a=b',
 				method: 'POST',
-				body: `--boundary
+				body: new TextEncoder().encode(`--boundary
 Content-Disposition: form-data; name="myFile1"; filename="from_body.txt"
 Content-Type: text/plain
 
 bar1
---boundary--`,
+--boundary--`),
 				headers: {
 					'Content-Type': 'multipart/form-data; boundary=boundary',
 					Host: 'https://example.com:1235',

--- a/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
+++ b/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
@@ -33,16 +33,16 @@ export async function encodeAsMultipart(
 	parts.push(`--${boundary}--\r\n`);
 
 	const length = parts.reduce((acc, part) => acc + part.length, 0);
-	const body = new Uint8Array(length);
+	const bytes = new Uint8Array(length);
 	let offset = 0;
 	for (const part of parts) {
-		body.set(
+		bytes.set(
 			typeof part === 'string' ? textEncoder.encode(part) : part,
 			offset
 		);
 		offset += part.length;
 	}
-	return { body, contentType };
+	return { bytes, contentType };
 }
 
 function fileToUint8Array(file: File): Promise<Uint8Array> {

--- a/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
+++ b/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
@@ -1,0 +1,54 @@
+/**
+ * Encodes a multipart/form-data request body.
+ *
+ * @param   data - The form data to encode.
+ * @returns The encoded body and a correctly formatted content type header.
+ */
+export async function encodeAsMultipart(data: Record<string, string | File>) {
+	const boundary = `----${Math.random().toString(36).slice(2)}`;
+	const contentType = `multipart/form-data; boundary=${boundary}`;
+
+	const textEncoder = new TextEncoder();
+	const parts: (string | Uint8Array)[] = [];
+	for (const [name, value] of Object.entries(data)) {
+		parts.push(`--${boundary}\r\n`);
+		parts.push(`Content-Disposition: form-data; name="${name}"`);
+		if (value instanceof File) {
+			parts.push(`; filename="${value.name}"`);
+		}
+		parts.push(`\r\n`);
+		if (value instanceof File) {
+			parts.push(`Content-Type: application/octet-stream`);
+		}
+		parts.push(`\r\n\r\n`);
+		if (typeof value === 'string') {
+			parts.push(value);
+		} else {
+			parts.push(await fileToUint8Array(value));
+		}
+		parts.push(`\r\n`);
+	}
+	parts.push(`--${boundary}--\r\n`);
+
+	const length = parts.reduce((acc, part) => acc + part.length, 0);
+	const body = new Uint8Array(length);
+	let offset = 0;
+	for (const part of parts) {
+		body.set(
+			typeof part === 'string' ? textEncoder.encode(part) : part,
+			offset
+		);
+		offset += part.length;
+	}
+	return { body, contentType };
+}
+
+function fileToUint8Array(file: File): Promise<Uint8Array> {
+	return new Promise((resolve) => {
+		const reader = new FileReader();
+		reader.onload = () => {
+			resolve(new Uint8Array(reader.result as ArrayBuffer));
+		};
+		reader.readAsArrayBuffer(file);
+	});
+}

--- a/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
+++ b/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
@@ -4,7 +4,9 @@
  * @param   data - The form data to encode.
  * @returns The encoded body and a correctly formatted content type header.
  */
-export async function encodeAsMultipart(data: Record<string, string | File>) {
+export async function encodeAsMultipart(
+	data: Record<string, string | Uint8Array | File>
+) {
 	const boundary = `----${Math.random().toString(36).slice(2)}`;
 	const contentType = `multipart/form-data; boundary=${boundary}`;
 
@@ -21,10 +23,10 @@ export async function encodeAsMultipart(data: Record<string, string | File>) {
 			parts.push(`Content-Type: application/octet-stream`);
 		}
 		parts.push(`\r\n\r\n`);
-		if (typeof value === 'string') {
-			parts.push(value);
-		} else {
+		if (value instanceof File) {
 			parts.push(await fileToUint8Array(value));
+		} else {
+			parts.push(value);
 		}
 		parts.push(`\r\n`);
 	}

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -1,5 +1,4 @@
 export type {
-	FileInfo,
 	IsomorphicLocalPHP,
 	IsomorphicRemotePHP,
 	MessageListener,

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -205,13 +205,11 @@ export class PHPRequestHandler implements RequestHandler {
 			};
 
 			let body = request.body;
-			if (request.formData) {
+			if (typeof body === 'object' && !(body instanceof Uint8Array)) {
 				preferredMethod = 'POST';
-				const multipart = await encodeAsMultipart({
-					...request.formData,
-				});
-				body = multipart.body;
-				headers['content-type'] = multipart.contentType;
+				const { bytes, contentType } = await encodeAsMultipart(body);
+				body = bytes;
+				headers['content-type'] = contentType;
 			}
 
 			let scriptPath;

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -205,11 +205,10 @@ export class PHPRequestHandler implements RequestHandler {
 			};
 
 			let body = request.body;
-			if (request.formData || request.files) {
+			if (request.formData) {
 				preferredMethod = 'POST';
 				const multipart = await encodeAsMultipart({
 					...request.formData,
-					...request.files,
 				});
 				body = multipart.body;
 				headers['content-type'] = multipart.contentType;

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -206,10 +206,14 @@ export class PHPRequestHandler implements RequestHandler {
 			let body = request.body;
 			if (request.formData || request.files) {
 				preferredMethod = 'POST';
-				body = await new MultipartEncoder().encode({
+				const encoder = new MultipartEncoder();
+				body = await encoder.encode({
 					...request.formData,
 					...request.files,
 				});
+				headers[
+					'content-type'
+				] = `multipart/form-data; boundary=${encoder.boundary}`;
 			}
 
 			let scriptPath;
@@ -372,7 +376,7 @@ function seemsLikeADirectoryRoot(path: string) {
 
 class MultipartEncoder {
 	constructor(
-		private boundary: string = `----${Math.random().toString(36).slice(2)}`
+		public boundary: string = `----${Math.random().toString(36).slice(2)}`
 	) {}
 
 	/**

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -131,7 +131,7 @@ export interface RequestHandler {
 	 * 	headers: {
 	 * 		'X-foo': 'bar',
 	 * 	},
-	 * 	formData: {
+	 * 	body: {
 	 * 		foo: 'bar',
 	 * 	},
 	 * });

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -494,7 +494,13 @@ export interface PHPRequest {
 	 * Form data. If set, the request body will be ignored and
 	 * the content-type header will be set to `application/x-www-form-urlencoded`.
 	 */
-	formData?: Record<string, unknown>;
+	formData?: Record<string, string>;
+
+	/**
+	 * Uploaded files data. If set, the request body will be ignored and
+	 * the content-type header will be set to `multipart/form-data`.
+	 */
+	files?: Record<string, File>;
 }
 
 export interface PHPRunOptions {

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -486,7 +486,7 @@ export interface PHPRequest {
 	headers?: PHPRequestHeaders;
 
 	/**
-	 * Request body without the files.
+	 * Request body.
 	 */
 	body?: string | Uint8Array;
 
@@ -524,7 +524,7 @@ export interface PHPRunOptions {
 	headers?: PHPRequestHeaders;
 
 	/**
-	 * Request body without the files.
+	 * Request body.
 	 */
 	body?: string | Uint8Array;
 

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -492,15 +492,9 @@ export interface PHPRequest {
 
 	/**
 	 * Form data. If set, the request body will be ignored and
-	 * the content-type header will be set to `application/x-www-form-urlencoded`.
+	 * the content-type header will be set to `multipart/form-data`..
 	 */
-	formData?: Record<string, string>;
-
-	/**
-	 * Uploaded files data. If set, the request body will be ignored and
-	 * the content-type header will be set to `multipart/form-data`.
-	 */
-	files?: Record<string, File>;
+	formData?: Record<string, string | Uint8Array | File>;
 }
 
 export interface PHPRunOptions {

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -486,14 +486,9 @@ export interface PHPRequest {
 	headers?: PHPRequestHeaders;
 
 	/**
-	 * Uploaded files
-	 */
-	files?: Record<string, File>;
-
-	/**
 	 * Request body without the files.
 	 */
-	body?: string;
+	body?: string | Uint8Array;
 
 	/**
 	 * Form data. If set, the request body will be ignored and
@@ -531,12 +526,7 @@ export interface PHPRunOptions {
 	/**
 	 * Request body without the files.
 	 */
-	body?: string;
-
-	/**
-	 * Uploaded files.
-	 */
-	fileInfos?: FileInfo[];
+	body?: string | Uint8Array;
 
 	/**
 	 * The code snippet to eval instead of a php file.
@@ -562,13 +552,6 @@ export interface PHPOutput {
 
 	/** Stderr lines */
 	stderr: string[];
-}
-
-export interface FileInfo {
-	key: string;
-	name: string;
-	type: string;
-	data: Uint8Array;
 }
 
 export interface RmDirOptions {

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -487,14 +487,10 @@ export interface PHPRequest {
 
 	/**
 	 * Request body.
+	 * If an object is given, the request will be encoded as multipart
+	 * and sent with a `multipart/form-data` header.
 	 */
-	body?: string | Uint8Array;
-
-	/**
-	 * Form data. If set, the request body will be ignored and
-	 * the content-type header will be set to `multipart/form-data`..
-	 */
-	formData?: Record<string, string | Uint8Array | File>;
+	body?: string | Uint8Array | Record<string, string | Uint8Array | File>;
 }
 
 export interface PHPRunOptions {

--- a/packages/playground/blueprints/src/lib/steps/import-file.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-file.ts
@@ -79,6 +79,6 @@ function DOM(response: PHPResponse) {
 	return new DOMParser().parseFromString(response.text, 'text/html');
 }
 
-function getFormData(form: HTMLFormElement): Record<string, unknown> {
+function getFormData(form: HTMLFormElement): Record<string, string> {
 	return Object.fromEntries((new FormData(form) as any).entries());
 }

--- a/packages/playground/blueprints/src/lib/steps/import-file.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-file.ts
@@ -44,7 +44,7 @@ export const importFile: StepHandler<ImportFileStep<File>> = async (
 	const stepOneResponse = await playground.request({
 		url: `/wp-admin/${firstUrlAction}`,
 		method: 'POST',
-		formData: { import: file },
+		body: { import: file },
 	});
 
 	// Map authors of imported posts to existing users
@@ -71,7 +71,7 @@ export const importFile: StepHandler<ImportFileStep<File>> = async (
 	await playground.request({
 		url: importForm.action,
 		method: 'POST',
-		formData: data,
+		body: data,
 	});
 };
 

--- a/packages/playground/blueprints/src/lib/steps/import-file.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-file.ts
@@ -44,7 +44,7 @@ export const importFile: StepHandler<ImportFileStep<File>> = async (
 	const stepOneResponse = await playground.request({
 		url: `/wp-admin/${firstUrlAction}`,
 		method: 'POST',
-		files: { import: file },
+		formData: { import: file },
 	});
 
 	// Map authors of imported posts to existing users

--- a/packages/playground/blueprints/src/lib/steps/login.ts
+++ b/packages/playground/blueprints/src/lib/steps/login.ts
@@ -44,7 +44,7 @@ export const login: StepHandler<LoginStep> = async (
 	const response = await playground.request({
 		url: '/wp-login.php',
 		method: 'POST',
-		formData: {
+		body: {
 			log: username,
 			pwd: password,
 			rememberme: 'forever',

--- a/packages/playground/blueprints/src/lib/steps/run-wp-installation-wizard.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-wp-installation-wizard.ts
@@ -25,7 +25,7 @@ export const runWpInstallationWizard: StepHandler<
 	await playground.request({
 		url: '/wp-admin/install.php?step=2',
 		method: 'POST',
-		formData: {
+		body: {
 			language: 'en',
 			prefix: 'wp_',
 			weblog_title: 'My WordPress Website',

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -33,7 +33,7 @@ console.log(await client.readFileAsText('/index.php'));
 await client.request({
 	url: '/index.php',
 	method: 'POST',
-	formData: {
+	body: {
 		foo: 'bar',
 	},
 });

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -16,7 +16,6 @@ export type {
 	PHPRequestHeaders,
 	PHPBrowserConfiguration,
 	SupportedPHPVersion,
-	FileInfo,
 	RmDirOptions,
 	RequestHandler,
 	RuntimeType,


### PR DESCRIPTION
Removes the custom file upload handler and rely on PHP body parsing to populate the $_FILES array. Instead of encoding the body bytes as a string, parsing that string, and re-encoding it as bytes, we keep the body in a binary form and pass it directly to PHP HEAP memory.

Closes https://github.com/WordPress/wordpress-playground/issues/997
Closes https://github.com/WordPress/wordpress-playground/issues/1006
Closes https://github.com/WordPress/wordpress-playground/issues/914

 ## Testing instructions

Confirm the CI checks pass (it will take a few iterations to get them right I'm sure :D)

cc @bgrgicak @dmsnell 
