### PR TITLE
Blueprint: Support resources defined as URLs, not just objects

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -172,6 +172,9 @@
 				},
 				{
 					"$ref": "#/definitions/UrlReference"
+				},
+				{
+					"type": "string"
 				}
 			]
 		},

--- a/packages/playground/blueprints/src/lib/compile.spec.ts
+++ b/packages/playground/blueprints/src/lib/compile.spec.ts
@@ -36,6 +36,20 @@ describe('Blueprints', () => {
 		);
 	});
 
+	it('should compile resources defined as string', async () => {
+		const compiled = compileBlueprint({
+			steps: [
+				{
+					step: 'runSql',
+					sql: 'https://playground.wordpress.net/no-such-file.sql',
+				},
+			],
+		});
+
+		const promise = runBlueprintSteps(compiled, php);
+		expect(promise).rejects.toThrow(/Error when executing the blueprint/);
+	});
+
 	it('should define the consts in a json and auto load the defined constants', async () => {
 		// Define the constants to be tested
 		const consts = {

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -190,8 +190,9 @@ export function compileBlueprint(
 						throw new Error(
 							`Error when executing the blueprint step #${i} (${JSON.stringify(
 								step
-							)}). ` +
-								`Inspect the cause of this error for more details`,
+							)}). Inspect the cause of this error for more details. Original error: ${
+								e instanceof Error ? e.message : ''
+							}`,
 							{
 								cause: e,
 							}


### PR DESCRIPTION
🚧  Work in progress 🚧 

This PR is noodling on defining Blueprint resources using strings, not just objects, e.g. this:

```ts
{
    steps: [
        {
            step: 'runSql',
            sql: 'https://playground.wordpress.net/file.sql',
        },
    ],
}
```

instead of this:

```ts
{
    steps: [
        {
            step: 'runSql',
            sql: {
                resource: 'url',
                url: 'https://playground.wordpress.net/file.sql'
            }
        },
    ],
}
```

Ambiguity is a challenge – should this Blueprint download a file, or write a string?

```ts
{
    steps: [
        {
            step: 'writeFile',
            data: 'https://playground.wordpress.net/file.sql',
        },
    ],
}
```