### PR TITLE
Prototype: Spawning PHP sub-processes in Web Workers

### DIFF
--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -249,6 +249,11 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 				this.#initWebRuntime();
 				this.#webSapiInitialized = true;
 			}
+			if (request.scriptPath && !this.fileExists(request.scriptPath)) {
+				throw new Error(
+					`The script path "${request.scriptPath}" does not exist.`
+				);
+			}
 			this.#setScriptPath(request.scriptPath || '');
 			this.#setRelativeRequestUri(request.relativeUri || '');
 			this.#setRequestMethod(request.method || 'GET');

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -39,7 +39,7 @@ export type {
 	SupportedPHPExtension,
 	SupportedPHPExtensionBundle,
 } from './supported-php-extensions';
-export { BasePHP, __private__dont__use } from './base-php';
+export { BasePHP, syncFSTo, __private__dont__use } from './base-php';
 export { loadPHPRuntime } from './load-php-runtime';
 export type {
 	DataModule,

--- a/packages/php-wasm/util/src/lib/create-spawn-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-spawn-handler.ts
@@ -1,3 +1,5 @@
+import { splitShellCommand } from './split-shell-command';
+
 type Listener = (...args: any[]) => any;
 
 /**
@@ -15,14 +17,18 @@ type Listener = (...args: any[]) => any;
  * @returns
  */
 export function createSpawnHandler(
-	program: (command: string, processApi: ProcessApi) => void
+	program: (command: string[], processApi: ProcessApi) => void | Promise<void>
 ): any {
-	return function (command: string) {
+	return function (command: string | string[]) {
 		const childProcess = new ChildProcess();
 		const processApi = new ProcessApi(childProcess);
 		// Give PHP a chance to register listeners
 		setTimeout(async () => {
-			await program(command, processApi);
+			const commandArray =
+				typeof command === 'string'
+					? splitShellCommand(command)
+					: command;
+			await program(commandArray, processApi);
 			childProcess.emit('spawn', true);
 		});
 		return childProcess;

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -5,5 +5,6 @@ export { dirname, joinPaths, basename, normalizePath } from './paths';
 export { createSpawnHandler } from './create-spawn-handler';
 export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
+export { splitShellCommand } from './split-shell-command';
 
 export * from './php-vars';

--- a/packages/php-wasm/util/src/lib/split-shell-command.spec.ts
+++ b/packages/php-wasm/util/src/lib/split-shell-command.spec.ts
@@ -1,0 +1,27 @@
+import { splitShellCommand } from './split-shell-command';
+
+describe('splitShellCommand', () => {
+	it('Should split a shell command into an array', () => {
+		const command =
+			'wp post create --post_title="Test post" --post_excerpt="Some content"';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'wp',
+			'post',
+			'create',
+			'--post_title=Test post',
+			'--post_excerpt=Some content',
+		]);
+	});
+
+	it('Should treat multiple spaces as a single space', () => {
+		const command = 'ls    --wordpress   --playground --is-great';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'ls',
+			'--wordpress',
+			'--playground',
+			'--is-great',
+		]);
+	});
+});

--- a/packages/php-wasm/util/src/lib/split-shell-command.ts
+++ b/packages/php-wasm/util/src/lib/split-shell-command.ts
@@ -1,0 +1,49 @@
+/**
+ * Naive shell command parser.
+ * Ensures that commands like `wp option set blogname "My blog name"` are split into
+ * `['wp', 'option', 'set', 'blogname', 'My blog name']` instead of
+ * `['wp', 'option', 'set', 'blogname', 'My', 'blog', 'name']`.
+ *
+ * @param command
+ * @returns
+ */
+export function splitShellCommand(command: string) {
+	const MODE_NORMAL = 0;
+	const MODE_IN_QUOTE = 1;
+
+	let mode = MODE_NORMAL;
+	let quote = '';
+
+	const parts: string[] = [];
+	let currentPart = '';
+	for (let i = 0; i < command.length; i++) {
+		const char = command[i];
+		if (mode === MODE_NORMAL) {
+			if (char === '"' || char === "'") {
+				mode = MODE_IN_QUOTE;
+				quote = char;
+			} else if (char.match(/\s/)) {
+				if (currentPart) {
+					parts.push(currentPart);
+				}
+				currentPart = '';
+			} else {
+				currentPart += char;
+			}
+		} else if (mode === MODE_IN_QUOTE) {
+			if (char === '\\') {
+				i++;
+				currentPart += command[i];
+			} else if (char === quote) {
+				mode = MODE_NORMAL;
+				quote = '';
+			} else {
+				currentPart += char;
+			}
+		}
+	}
+	if (currentPart) {
+		parts.push(currentPart);
+	}
+	return parts;
+}

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
@@ -1,5 +1,5 @@
 import { NodePHP } from '@php-wasm/node';
-import { splitShellCommand, wpCLI } from './wp-cli';
+import { wpCLI } from './wp-cli';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { unzip } from './unzip';
@@ -30,31 +30,5 @@ describe('Blueprint step wpCLI', () => {
 				"wp post create --post_title='Test post' --post_excerpt='Some content' --no-color",
 		});
 		expect(result.text).toMatch(/Success: Created post/);
-	});
-});
-
-describe('splitShellCommand', () => {
-	it('Should split a shell command into an array', () => {
-		const command =
-			'wp post create --post_title="Test post" --post_excerpt="Some content"';
-		const result = splitShellCommand(command);
-		expect(result).toEqual([
-			'wp',
-			'post',
-			'create',
-			'--post_title=Test post',
-			'--post_excerpt=Some content',
-		]);
-	});
-
-	it('Should treat multiple spaces as a single space', () => {
-		const command = 'ls    --wordpress   --playground --is-great';
-		const result = splitShellCommand(command);
-		expect(result).toEqual([
-			'ls',
-			'--wordpress',
-			'--playground',
-			'--is-great',
-		]);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -1,6 +1,6 @@
 import { PHPResponse } from '@php-wasm/universal';
 import { StepHandler } from '.';
-import { phpVar } from '@php-wasm/util';
+import { phpVar, splitShellCommand } from '@php-wasm/util';
 
 /**
  * @inheritDoc wpCLI
@@ -86,53 +86,3 @@ export const wpCLI: StepHandler<WPCLIStep, Promise<PHPResponse>> = async (
 
 	return result;
 };
-
-/**
- * Naive shell command parser.
- * Ensures that commands like `wp option set blogname "My blog name"` are split into
- * `['wp', 'option', 'set', 'blogname', 'My blog name']` instead of
- * `['wp', 'option', 'set', 'blogname', 'My', 'blog', 'name']`.
- *
- * @param command
- * @returns
- */
-export function splitShellCommand(command: string) {
-	const MODE_NORMAL = 0;
-	const MODE_IN_QUOTE = 1;
-
-	let mode = MODE_NORMAL;
-	let quote = '';
-
-	const parts: string[] = [];
-	let currentPart = '';
-	for (let i = 0; i < command.length; i++) {
-		const char = command[i];
-		if (mode === MODE_NORMAL) {
-			if (char === '"' || char === "'") {
-				mode = MODE_IN_QUOTE;
-				quote = char;
-			} else if (char.match(/\s/)) {
-				if (currentPart) {
-					parts.push(currentPart);
-				}
-				currentPart = '';
-			} else {
-				currentPart += char;
-			}
-		} else if (mode === MODE_IN_QUOTE) {
-			if (char === '\\') {
-				i++;
-				currentPart += command[i];
-			} else if (char === quote) {
-				mode = MODE_NORMAL;
-				quote = '';
-			} else {
-				currentPart += char;
-			}
-		}
-	}
-	if (currentPart) {
-		parts.push(currentPart);
-	}
-	return parts;
-}

--- a/packages/playground/remote/src/lib/opfs/bind-opfs.ts
+++ b/packages/playground/remote/src/lib/opfs/bind-opfs.ts
@@ -13,7 +13,7 @@ import { __private__dont__use } from '@php-wasm/universal';
 import { Semaphore, joinPaths } from '@php-wasm/util';
 import type { WebPHP } from '@php-wasm/web';
 import { EmscriptenFS } from './types';
-import { journalFSEventsToOpfs } from './journal-memfs-to-opfs';
+import { journalFSEventsToOpfs } from './journal-fs-to-opfs';
 
 let unbindOpfs: (() => void) | undefined;
 export type SyncProgress = {

--- a/packages/playground/remote/src/lib/opfs/journal-fs-to-opfs.ts
+++ b/packages/playground/remote/src/lib/opfs/journal-fs-to-opfs.ts
@@ -10,7 +10,6 @@
 
 /* eslint-disable prefer-rest-params */
 import type { WebPHP } from '@php-wasm/web';
-import type { EmscriptenFS } from './types';
 import { FilesystemOperation, journalFSEvents } from '@php-wasm/fs-journal';
 import { __private__dont__use } from '@php-wasm/universal';
 import { copyMemfsToOpfs, overwriteOpfsFile } from './bind-opfs';
@@ -48,7 +47,6 @@ export function journalFSEventsToOpfs(
 type JournalEntry = FilesystemOperation;
 
 class OpfsRewriter {
-	private FS: EmscriptenFS;
 	private memfsRoot: string;
 
 	constructor(

--- a/packages/playground/remote/src/lib/opfs/journal-fs-to-php.ts
+++ b/packages/playground/remote/src/lib/opfs/journal-fs-to-php.ts
@@ -1,0 +1,91 @@
+/**
+ * Synchronize MEMFS changes from a PHP instance into another PHP instance.
+ */
+
+/* eslint-disable prefer-rest-params */
+import type { WebPHP } from '@php-wasm/web';
+import { FilesystemOperation, journalFSEvents } from '@php-wasm/fs-journal';
+import { basename, normalizePath } from '@php-wasm/util';
+
+export function journalFSEventsToPhp(
+	sourcePhp: WebPHP,
+	targetPhp: WebPHP,
+	root: string
+) {
+	root = normalizePath(root);
+
+	const journal: FilesystemOperation[] = [];
+	const unbindJournal = journalFSEvents(sourcePhp, root, (entry) => {
+		journal.push(entry);
+	});
+	const rewriter = new MemfsRewriter(sourcePhp, targetPhp, root);
+
+	async function flushJournal() {
+		// @TODO This is way too slow in practice, we need to batch the
+		// changes into groups of parallelizable operations.
+		while (journal.length) {
+			rewriter.processEntry(journal.shift()!);
+		}
+	}
+	sourcePhp.addEventListener('request.end', flushJournal);
+	return function () {
+		unbindJournal();
+		sourcePhp.removeEventListener('request.end', flushJournal);
+	};
+}
+
+type JournalEntry = FilesystemOperation;
+
+class MemfsRewriter {
+	constructor(
+		private sourcePhp: WebPHP,
+		private targetPhp: WebPHP,
+		private root: string
+	) {}
+
+	public processEntry(entry: JournalEntry) {
+		if (!entry.path.startsWith(this.root) || entry.path === this.root) {
+			return;
+		}
+		const name = basename(entry.path);
+		if (!name) {
+			return;
+		}
+
+		try {
+			if (entry.operation === 'DELETE') {
+				try {
+					if (this.targetPhp.isDir(entry.path)) {
+						this.targetPhp.rmdir(entry.path);
+					} else {
+						this.targetPhp.unlink(entry.path);
+					}
+				} catch (e) {
+					// If the directory already doesn't exist, it's fine
+				}
+			} else if (entry.operation === 'CREATE') {
+				if (entry.nodeType === 'directory') {
+					this.targetPhp.mkdir(entry.path);
+				} else {
+					this.targetPhp.writeFile(entry.path, '');
+				}
+			} else if (entry.operation === 'WRITE') {
+				this.targetPhp.writeFile(
+					entry.path,
+					this.sourcePhp.readFileAsBuffer(entry.path)
+				);
+			} else if (
+				entry.operation === 'RENAME' &&
+				entry.toPath.startsWith(this.root)
+			) {
+				this.targetPhp.mv(entry.path, entry.toPath);
+			}
+		} catch (e) {
+			// Useful for debugging – the original error gets lost in the
+			// Comlink proxy.
+			console.log({ entry, name });
+			console.error(e);
+			throw e;
+		}
+	}
+}


### PR DESCRIPTION
Related to #1026 and #1027

Adds support for spawning PHP subprocesses via `<?php proc_open(['php', 'activate_theme.php']);`. The spawned subprocess affects the filesystem used by the parent process.

## Implementation details

This PR adds a `spawnHandler` that does the following:

1. Creates another instance of WebPHP (child)
2. Populates child's FS with parent's files
3. Runs requested PHP script the child
4. Syncs the child FS changes back to the parent

[A shared filesystem didn't pan out. Synchronizing is the second best option.](https://github.com/WordPress/wordpress-playground/issues/1027)

This code snippet illustrates the idea – note the actual implementation is more nuanced:

```ts
php.setSpawnHandler(
	createSpawnHandler(async function (args, processApi) {
		const childPHP = new WebPHP();
		syncFS(php, childPHP);
		const { exitCode, stdout, stderr } = await childPHP.run({
			scriptPath: args[1]
		});
		syncFS(childPHP, php);
		processApi.stdout(stdout);
		processApi.stderr(stderr);
		processApi.exit(exitCode);
	})
);
```

## Future work

* Stream `stdout` and `stderr` from `childPHP` to `processApi` instead of buffering the output and passing everything at once


## Example of how it works

<img width="500" src="https://github.com/WordPress/wordpress-playground/assets/205419/470d79b2-2f10-4f1a-806c-5f26463766da" />

#### /wordpress/spawn.php

```php
<?php
echo "<plaintext>";
echo "Spawning /wordpress/child.php\n";
$handle = proc_open('php /wordpress/child.php', [
	0 => ['pipe', 'r'],
	1 => ['pipe', 'w'],
	2 => ['pipe', 'w'],
], $pipes);

echo "stdout: " . stream_get_contents($pipes[1]) . "\n";
echo "stderr: " . stream_get_contents($pipes[2]) . "\n";
echo "Finished\n";
echo "Contents of the created file: " . file_get_contents("/wordpress/new.txt") . "\n";
```

#### /wordpress/child.php

```php
<?php
echo "<plaintext>";
echo "Spawned, running";
error_log("Here's a message logged to stderr! " . rand());
file_put_contents("/wordpress/new.txt", "Hello, world!" . rand() . "\n");
```


## Testing instructions

* Go to http://localhost:5400/website-server/?url=/spawn.php and confirm the output looks as on the screenshot above

Unit tests, E2E tests, and more testing instructions coming soon.

cc @dmsnell @bgrgicak 