### PR TITLE
PHP: Do not prepend a whitespace when encoding body as multipart form data

### DIFF
--- a/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
+++ b/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
@@ -22,7 +22,7 @@ export async function encodeAsMultipart(
 		if (value instanceof File) {
 			parts.push(`Content-Type: application/octet-stream`);
 		}
-		parts.push(`\r\n\r\n`);
+		parts.push(`\r\n`);
 		if (value instanceof File) {
 			parts.push(await fileToUint8Array(value));
 		} else {

--- a/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
+++ b/packages/php-wasm/universal/src/lib/encode-as-multipart.ts
@@ -21,6 +21,7 @@ export async function encodeAsMultipart(
 		parts.push(`\r\n`);
 		if (value instanceof File) {
 			parts.push(`Content-Type: application/octet-stream`);
+			parts.push(`\r\n`);
 		}
 		parts.push(`\r\n`);
 		if (value instanceof File) {

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -210,6 +210,7 @@ export class PHPRequestHandler implements RequestHandler {
 				const { bytes, contentType } = await encodeAsMultipart(body);
 				body = bytes;
 				headers['content-type'] = contentType;
+				// console.log('body', new TextDecoder().decode(body) )
 			}
 
 			let scriptPath;

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -210,7 +210,6 @@ export class PHPRequestHandler implements RequestHandler {
 				const { bytes, contentType } = await encodeAsMultipart(body);
 				body = bytes;
 				headers['content-type'] = contentType;
-				// console.log('body', new TextDecoder().decode(body) )
 			}
 
 			let scriptPath;

--- a/packages/playground/blueprints/src/lib/steps/import-file.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-file.ts
@@ -31,8 +31,10 @@ export interface ImportFileStep<ResourceType> {
  */
 export const importFile: StepHandler<ImportFileStep<File>> = async (
 	playground,
-	{ file }
+	{ file },
+	progress?
 ) => {
+	progress?.tracker?.setCaption('Importing content');
 	const importerPageOneResponse = await playground.request({
 		url: '/wp-admin/admin.php?import=wordpress',
 	});
@@ -68,11 +70,18 @@ export const importFile: StepHandler<ImportFileStep<File>> = async (
 		}
 	}
 
-	await playground.request({
+	const importResult = await playground.request({
 		url: importForm.action,
 		method: 'POST',
 		body: data,
 	});
+	if (!importResult.text.includes('All done.')) {
+		console.warn('WordPress response was: ', {
+			text: importResult.text,
+			errors: importResult.errors,
+		});
+		throw new Error('Import failed, see console for details.');
+	}
 };
 
 function DOM(response: PHPResponse) {

--- a/packages/playground/blueprints/src/lib/steps/import-file.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-file.ts
@@ -31,10 +31,8 @@ export interface ImportFileStep<ResourceType> {
  */
 export const importFile: StepHandler<ImportFileStep<File>> = async (
 	playground,
-	{ file },
-	progress?
+	{ file }
 ) => {
-	progress?.tracker?.setCaption('Importing content');
 	const importerPageOneResponse = await playground.request({
 		url: '/wp-admin/admin.php?import=wordpress',
 	});
@@ -70,18 +68,11 @@ export const importFile: StepHandler<ImportFileStep<File>> = async (
 		}
 	}
 
-	const importResult = await playground.request({
+	await playground.request({
 		url: importForm.action,
 		method: 'POST',
 		body: data,
 	});
-	if (!importResult.text.includes('All done.')) {
-		console.warn('WordPress response was: ', {
-			text: importResult.text,
-			errors: importResult.errors,
-		});
-		throw new Error('Import failed, see console for details.');
-	}
 };
 
 function DOM(response: PHPResponse) {


### PR DESCRIPTION
When Playground request handler is called with a key: value object as its body, that data is encoded as a multipart string:

```ts
await playground.request({
	url: `/wp-admin/import.php`,
	method: 'POST',
	body: { import: file },
});
```

However, the `encodeAsMultipart()` function prepended one newline too many at the beginning of each multipart section.

Most of Playground do not use the `key: value` notation and just pass the POST data as bytes, which is why the normal operating functions were preserved.

However, the importFile step relied on the `key: value` notation. Importing WXR involves submitting a form with a nonce. However, the nonce contained an extra whitespace and was rejected by WordPress. This PR ensures that extra whitespace isn't there.

 ## Testing instructions

* Ensure the CI tests pass
