### PR TITLE
Blueprints: Set progress caption and communicate failures in the import file step

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-file.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-file.ts
@@ -31,8 +31,10 @@ export interface ImportFileStep<ResourceType> {
  */
 export const importFile: StepHandler<ImportFileStep<File>> = async (
 	playground,
-	{ file }
+	{ file },
+	progress?
 ) => {
+	progress?.tracker?.setCaption('Importing content');
 	const importerPageOneResponse = await playground.request({
 		url: '/wp-admin/admin.php?import=wordpress',
 	});
@@ -68,11 +70,18 @@ export const importFile: StepHandler<ImportFileStep<File>> = async (
 		}
 	}
 
-	await playground.request({
+	const importResult = await playground.request({
 		url: importForm.action,
 		method: 'POST',
 		body: data,
 	});
+	if (!importResult.text.includes('All done.')) {
+		console.warn('WordPress response was: ', {
+			text: importResult.text,
+			errors: importResult.errors,
+		});
+		throw new Error('Import failed, see console for details.');
+	}
 };
 
 function DOM(response: PHPResponse) {


### PR DESCRIPTION
A follow up to https://github.com/WordPress/wordpress-playground/pull/1033

I noticed the import file step won't throw clear error information so this PR adds some. In addition, it sets the progress bar caption to "Importing content".