### PR TITLE
Fix error on reload site click

### DIFF
--- a/packages/playground/website/src/components/playground-configuration-group/form.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/form.tsx
@@ -15,7 +15,7 @@ export interface PlaygroundConfiguration {
 	withExtensions: boolean;
 	withNetworking: boolean;
 	storage: StorageType;
-	resetSite?: boolean;
+	resetSite: boolean;
 }
 
 export interface PlaygroundConfigurationFormProps {

--- a/packages/playground/website/src/components/playground-configuration-group/reload-with-new-configuration.ts
+++ b/packages/playground/website/src/components/playground-configuration-group/reload-with-new-configuration.ts
@@ -6,7 +6,11 @@ export async function reloadWithNewConfiguration(
 	config: PlaygroundConfiguration
 ) {
 	if (config.resetSite && config.storage === 'browser') {
-		await playground?.resetVirtualOpfs();
+		try {
+			await playground?.resetVirtualOpfs();
+		} catch (error) {
+			console.error(error);
+		}
 	}
 
 	const url = new URL(window.location.toString());

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -52,6 +52,7 @@ const currentConfiguration: PlaygroundConfiguration = {
 	storage: storage || 'none',
 	withExtensions: blueprint.phpExtensionBundles?.[0] === 'kitchen-sink',
 	withNetworking: blueprint.features?.networking || false,
+	resetSite: false,
 };
 
 /*


### PR DESCRIPTION
## What is this PR doing?

This PR fixes an error when the _Delete stored data and start fresh_ button is clicked.

## What problem is it solving?

It allows users to use the _Delete stored data and start fresh_ checkbox.

## How is the problem addressed?

This PR adds a default value false to prevent form errors when the default value is undefined.
It also adds a try/catch around `resetVirtualOpfs` to ensure Playground doesn't break if `resetVirtualOpfs` isn't available.

## Testing Instructions

- Checkout this branch
- Run `npm run dev`
- Open Playground
- In the header select Browser storage and _Delete stored data and start fresh_
- Click apply changes
- Confirm that there were no errors and your site reloaded with the `storage=browser` query string