### PR TITLE
Fix the login message so it doesn't override another

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -17,10 +17,10 @@ set_error_handler(function($severity, $message, $file, $line) {
 /**
  * Add a notice to wp-login.php offering the username and password.
  */
-add_action(
+add_filter(
 	'login_message',
-	function () {
-		return <<<EOT
+	function ( $message ) {
+		return $message . <<<EOT
 <div class="message info">
 	<strong>username:</strong> <code>admin</code><br><strong>password</strong>: <code>password</code>
 </div>


### PR DESCRIPTION
## What is this PR doing?

It fixes an issue in the `0-playground.php` mu-plugin which causes it to overwrite other messages on the wp-login.php screen with its own, rather than appending to them.

## What problem is it solving?

If a plugin uses the `login_message` filter to add a message to the wp-login.php screen, `0-playground.php` can overwrite it.

## How is the problem addressed?

It's addressed by using `add_filter()` instead of the incorrect `add_action()`, and by appending its message instead of overwriting it.

## Testing Instructions

1. Visit the Playground with the `?plugin=user-switching` query variable present
2. Click the "Switch Off" link in the user profile menu in the admin toolbar
3. Visit `/wp-login.php` using the URL input field
4. Confirm that a "Switch back" message and link is shown by the User Switching plugin instead if being overwritten by the playground

## Screenshots

### Before

![2024-02-21-00-43-06](https://github.com/WordPress/wordpress-playground/assets/208434/7fd2d535-6604-4105-bbe6-d110848f22d4)

### After

![2024-02-21-00-42-56](https://github.com/WordPress/wordpress-playground/assets/208434/00cd9e4e-160b-4edf-9263-adc938a4f1e8)