### PR TITLE
Fix: Networking broken when extra PHP extensions are enabled

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -148,6 +148,8 @@ if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 	// filter used below, WordPress tests if they are supported and will
 	// use them if their `::test()` method returns true – which it does
 	// when PHP.wasm runs with the openssl extension loaded.
+	//
+	// @see https://github.com/WordPress/wordpress-playground/pull/1045
 	$reflection = new ReflectionClass($__requests_class);
 	$property = $reflection->getProperty('transports');
 	$property->setAccessible(true);

--- a/packages/playground/website/cypress/e2e/query-api.cy.ts
+++ b/packages/playground/website/cypress/e2e/query-api.cy.ts
@@ -69,6 +69,15 @@ describe('Query API', () => {
 				.should('have.length.above', 4);
 		});
 
+		it('should enable networking when requested AND the kitchen sink extension bundle is enabled', () => {
+			cy.visit(
+				'/?php-extension-bundle=kitchen-sink&networking=yes&url=/wp-admin/plugin-install.php'
+			);
+			cy.wordPressDocument()
+				.find('.plugin-card')
+				.should('have.length.above', 4);
+		});
+
 		/**
 		 * @see https://github.com/WordPress/wordpress-playground/pull/819
 		 * @TODO: Turn this into a unit test once WordPress modules are available

--- a/packages/playground/website/cypress/e2e/query-api.cy.ts
+++ b/packages/playground/website/cypress/e2e/query-api.cy.ts
@@ -69,6 +69,9 @@ describe('Query API', () => {
 				.should('have.length.above', 4);
 		});
 
+		/**
+		 * @see https://github.com/WordPress/wordpress-playground/pull/1045
+		 */
 		it('should enable networking when requested AND the kitchen sink extension bundle is enabled', () => {
 			cy.visit(
 				'/?php-extension-bundle=kitchen-sink&networking=yes&url=/wp-admin/plugin-install.php'


### PR DESCRIPTION
The recent [removal of custom WordPress
patches](https://github.com/WordPress/wordpress-playground/pull/1004) broke the networking feature when the extra PHP extensions are enabled. It removed the default networking tranports via the http_api_transports filter, but it did not account for WordPress trying to use the Fetch and Fsockopen transports anyway whenever their `::test()` method returns true – which it does when the OpenSSL extension is available.

This PR uses the reflections API to force-replace the Requests::$transports array with one containing exclusively the Fetch transport.

Open Playground, enable PHP extensions and networking, go to WP Admin > Plugins > Add, confirm the list of plugins is visible

CC @bgrgicak @annezazu
