### PR TITLE
Rebuild WordPress within an hour of a beta release

### DIFF
--- a/.github/workflows/refresh-wordpress.yml
+++ b/.github/workflows/refresh-wordpress.yml
@@ -5,6 +5,7 @@ on:
     # Every day at 8am UTC
     schedule:
         - cron: '0 8 * * *'
+        - cron: '0,30 16-23 * * 2'
 
 jobs:
     build_and_deploy:
@@ -12,8 +13,7 @@ jobs:
         if: >
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
-                github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak'
+                github.actor == 'dmsnell'
             )
 
         runs-on: ubuntu-latest


### PR DESCRIPTION
A temporary workaround for refreshing WordPress during the 6.5 release cycle, we could get away with the following "Rebuild WordPress" workflow schedule, that is "run every 30 minutes on Tuesdays after 4pm UTC" since betas are shipped on Tuesdays.

Related to https://github.com/WordPress/wordpress-playground/issues/1058
