### PR TITLE
Rebuild WordPress every 20 minutes, short-circuit if no new version is found

### DIFF
--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -1,0 +1,46 @@
+name: 'Refresh WordPress Major&Beta'
+
+on:
+    workflow_dispatch:
+    # Every 20 minutes
+    schedule:
+        - cron: '*/20 * * * *'
+
+jobs:
+    build_and_deploy:
+        # Only run this workflow from the trunk branch and when it's triggered by dmsnell OR adamziel
+        if: >
+            github.ref == 'refs/heads/trunk' && (
+                github.actor == 'adamziel' ||
+                github.actor == 'dmsnell' ||
+                github.actor == 'bgrgicak'
+            )
+
+        runs-on: ubuntu-latest
+        environment:
+            name: wordpress-assets
+        concurrency:
+            group: check-version-and-run-build
+        steps:
+            - uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  clean: true
+                  fetch-depth: 0
+                  persist-credentials: false
+            - uses: ./.github/actions/prepare-playground
+            - name: 'Recompile WordPress'
+              shell: bash
+              run: npx nx bundle-wordpress:major-and-beta playground-wordpress
+            - name: Config git user
+              run: |
+                  git config --global user.name "deployment_bot"
+                  git config --global user.email "deployment_bot@users.noreply.github.com"
+                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
+                  git add -A
+                  git commit -a -m "Recompile WordPress major and beta versions"
+                  git pull --rebase
+                  # Push if the pull did not result in a conflict
+                  if [ $? -eq 0 ]; then
+                      git push origin HEAD:trunk
+                  fi;

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -1,8 +1,8 @@
-name: 'Refresh WordPress assets'
+name: 'Refresh WordPress Nightly'
 
 on:
     workflow_dispatch:
-    # Every day at 8am UTC
+    # Deploy the nightly version of WordPress every day at 8am UTC
     schedule:
         - cron: '0 8 * * *'
 
@@ -29,14 +29,14 @@ jobs:
             - uses: ./.github/actions/prepare-playground
             - name: 'Recompile WordPress'
               shell: bash
-              run: npx nx bundle-wordpress:all playground-wordpress
+              run: npx nx bundle-wordpress:nightly playground-wordpress
             - name: Config git user
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
                   git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   git add -A
-                  git commit -a -m "Recompile WordPress"
+                  git commit -a -m "Refresh WordPress Nightly"
                   git pull --rebase
                   # Push if the pull did not result in a conflict
                   if [ $? -eq 0 ]; then

--- a/packages/playground/wordpress/project.json
+++ b/packages/playground/wordpress/project.json
@@ -29,6 +29,22 @@
 			}
 		},
 		"bundle-wordpress:all": {
+			"executor": "nx:noop",
+			"dependsOn": [
+				"bundle-wordpress:nightly",
+				"bundle-wordpress:major-and-beta"
+			]
+		},
+		"bundle-wordpress:nightly": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"node packages/playground/wordpress/build/build.js --wp-version=nightly --output-js=packages/playground/wordpress/src/wordpress --output-assets=packages/playground/wordpress/public"
+				],
+				"parallel": false
+			}
+		},
+		"bundle-wordpress:major-and-beta": {
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
@@ -36,8 +52,7 @@
 					"node packages/playground/wordpress/build/build.js --wp-version=latest-minus-2 --output-js=packages/playground/wordpress/src/wordpress --output-assets=packages/playground/wordpress/public",
 					"node packages/playground/wordpress/build/build.js --wp-version=latest-minus-1 --output-js=packages/playground/wordpress/src/wordpress --output-assets=packages/playground/wordpress/public",
 					"node packages/playground/wordpress/build/build.js --wp-version=latest --output-js=packages/playground/wordpress/src/wordpress --output-assets=packages/playground/wordpress/public",
-					"node packages/playground/wordpress/build/build.js --wp-version=beta --output-js=packages/playground/wordpress/src/wordpress --output-assets=packages/playground/wordpress/public",
-					"node packages/playground/wordpress/build/build.js --wp-version=nightly --output-js=packages/playground/wordpress/src/wordpress --output-assets=packages/playground/wordpress/public"
+					"node packages/playground/wordpress/build/build.js --wp-version=beta --output-js=packages/playground/wordpress/src/wordpress --output-assets=packages/playground/wordpress/public"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
Related to https://github.com/WordPress/wordpress-playground/issues/1058

Splits the WordPress building flow into:

* Nightly version – rebuilt every 24 hours
* Major releases and betas – rebuilt every 20 minutes provided a new major version is available

This should ensure that new WordPress beta versions are deployed shortly after the release parties.

 ## Testing instructions

There isn't a good way of testing CI actions :( Eyeball the code, run `nx bundle-wordpress:major-and-beta playground-wordpress`, and hope for the best. I'll be monitoring GitHub actions after merging this PR.
