### PR TITLE
Parse shell commands in createSpawnHandler

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -294,7 +294,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('Pipe pygmalion from a file to STDOUT through a synchronous JavaScript callback', async () => {
 			const handler = createSpawnHandler(
-				(command: string | string[], processApi: any) => {
+				(command: string[], processApi: any) => {
 					processApi.on('stdin', (data: Uint8Array) => {
 						processApi.stdout(data);
 					});
@@ -311,7 +311,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('Pipe pygmalion from a file to STDOUT through a asynchronous JavaScript callback', async () => {
 			const handler = createSpawnHandler(
-				async (command: string | string[], processApi: any) => {
+				async (command: string[], processApi: any) => {
 					await new Promise((resolve) => {
 						setTimeout(resolve, 1000);
 					});
@@ -384,7 +384,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('Stdout waits for asynchronous data to arrive', async () => {
 			const handler = createSpawnHandler(
-				(command: string | string[], processApi: any) => {
+				(command: string[], processApi: any) => {
 					processApi.flushStdin();
 					processApi.stdout(new TextEncoder().encode('Hello World!'));
 					setTimeout(() => {
@@ -416,7 +416,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('feof() returns true when exhausted the synchronous data', async () => {
 			const handler = createSpawnHandler(
-				(command: string | string[], processApi: any) => {
+				(command: string[], processApi: any) => {
 					processApi.flushStdin();
 					processApi.stdout(
 						new TextEncoder().encode('Hello World!\n')
@@ -456,7 +456,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('feof() returns true when exhausted the asynchronous data', async () => {
 			const handler = createSpawnHandler(
-				(command: string | string[], processApi: any) => {
+				(command: string[], processApi: any) => {
 					processApi.flushStdin();
 					processApi.stdout(
 						new TextEncoder().encode('Hello World!\n')

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -294,7 +294,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('Pipe pygmalion from a file to STDOUT through a synchronous JavaScript callback', async () => {
 			const handler = createSpawnHandler(
-				(command: string, processApi: any) => {
+				(command: string | string[], processApi: any) => {
 					processApi.on('stdin', (data: Uint8Array) => {
 						processApi.stdout(data);
 					});
@@ -311,7 +311,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('Pipe pygmalion from a file to STDOUT through a asynchronous JavaScript callback', async () => {
 			const handler = createSpawnHandler(
-				async (command: string, processApi: any) => {
+				async (command: string | string[], processApi: any) => {
 					await new Promise((resolve) => {
 						setTimeout(resolve, 1000);
 					});
@@ -384,7 +384,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('Stdout waits for asynchronous data to arrive', async () => {
 			const handler = createSpawnHandler(
-				(command: string, processApi: any) => {
+				(command: string | string[], processApi: any) => {
 					processApi.flushStdin();
 					processApi.stdout(new TextEncoder().encode('Hello World!'));
 					setTimeout(() => {
@@ -416,7 +416,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('feof() returns true when exhausted the synchronous data', async () => {
 			const handler = createSpawnHandler(
-				(command: string, processApi: any) => {
+				(command: string | string[], processApi: any) => {
 					processApi.flushStdin();
 					processApi.stdout(
 						new TextEncoder().encode('Hello World!\n')
@@ -456,7 +456,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 
 		it('feof() returns true when exhausted the asynchronous data', async () => {
 			const handler = createSpawnHandler(
-				(command: string, processApi: any) => {
+				(command: string | string[], processApi: any) => {
 					processApi.flushStdin();
 					processApi.stdout(
 						new TextEncoder().encode('Hello World!\n')

--- a/packages/php-wasm/util/src/lib/create-spawn-handler.spec.ts
+++ b/packages/php-wasm/util/src/lib/create-spawn-handler.spec.ts
@@ -6,12 +6,14 @@ describe('createSpawnHandler', () => {
 		const testOut = 'testOut';
 		const testErr = 'testErr';
 
-		const program = vitest.fn((cmd: string, processApi: ProcessApi) => {
-			expect(cmd).toBe(command);
-			processApi.stdout(testOut);
-			processApi.stderr(testErr);
-			processApi.exit(0);
-		});
+		const program = vitest.fn(
+			(cmd: string | string[], processApi: ProcessApi) => {
+				expect(cmd).toBe(command);
+				processApi.stdout(testOut);
+				processApi.stderr(testErr);
+				processApi.exit(0);
+			}
+		);
 
 		const spawnHandler = createSpawnHandler(program);
 		const childProcess = spawnHandler(command);

--- a/packages/php-wasm/util/src/lib/create-spawn-handler.spec.ts
+++ b/packages/php-wasm/util/src/lib/create-spawn-handler.spec.ts
@@ -6,14 +6,12 @@ describe('createSpawnHandler', () => {
 		const testOut = 'testOut';
 		const testErr = 'testErr';
 
-		const program = vitest.fn(
-			(cmd: string | string[], processApi: ProcessApi) => {
-				expect(cmd).toBe(command);
-				processApi.stdout(testOut);
-				processApi.stderr(testErr);
-				processApi.exit(0);
-			}
-		);
+		const program = vitest.fn((cmd: string[], processApi: ProcessApi) => {
+			expect(cmd).toEqual([command]);
+			processApi.stdout(testOut);
+			processApi.stderr(testErr);
+			processApi.exit(0);
+		});
 
 		const spawnHandler = createSpawnHandler(program);
 		const childProcess = spawnHandler(command);

--- a/packages/php-wasm/util/src/lib/create-spawn-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-spawn-handler.ts
@@ -17,10 +17,7 @@ type Listener = (...args: any[]) => any;
  * @returns
  */
 export function createSpawnHandler(
-	program: (
-		command: string | string[],
-		processApi: ProcessApi
-	) => void | Promise<void>
+	program: (command: string[], processApi: ProcessApi) => void | Promise<void>
 ): any {
 	return function (command: string | string[], argsArray: string[] = []) {
 		const childProcess = new ChildProcess();

--- a/packages/php-wasm/util/src/lib/create-spawn-handler.ts
+++ b/packages/php-wasm/util/src/lib/create-spawn-handler.ts
@@ -23,7 +23,6 @@ export function createSpawnHandler(
 	) => void | Promise<void>
 ): any {
 	return function (command: string | string[], argsArray: string[] = []) {
-		console.log({ command, argsArray });
 		const childProcess = new ChildProcess();
 		const processApi = new ProcessApi(childProcess);
 		// Give PHP a chance to register listeners
@@ -98,7 +97,6 @@ export class ProcessApi extends EventEmitter {
 	exit(code: number) {
 		if (!this.exited) {
 			this.exited = true;
-			console.log('Emit exit!');
 			this.childProcess.emit('exit', code);
 		}
 	}

--- a/packages/php-wasm/util/src/lib/split-shell-command.spec.ts
+++ b/packages/php-wasm/util/src/lib/split-shell-command.spec.ts
@@ -1,0 +1,27 @@
+import { splitShellCommand } from './split-shell-command';
+
+describe('splitShellCommand', () => {
+	it('Should split a shell command into an array', () => {
+		const command =
+			'wp post create --post_title="Test post" --post_excerpt="Some content"';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'wp',
+			'post',
+			'create',
+			'--post_title=Test post',
+			'--post_excerpt=Some content',
+		]);
+	});
+
+	it('Should treat multiple spaces as a single space', () => {
+		const command = 'ls    --wordpress   --playground --is-great';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'ls',
+			'--wordpress',
+			'--playground',
+			'--is-great',
+		]);
+	});
+});

--- a/packages/php-wasm/util/src/lib/split-shell-command.spec.ts
+++ b/packages/php-wasm/util/src/lib/split-shell-command.spec.ts
@@ -24,4 +24,59 @@ describe('splitShellCommand', () => {
 			'--is-great',
 		]);
 	});
+
+	it('Should treat quoted segments as a single arg', () => {
+		const command = 'ls    --wordpress="This is nice"  more args';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'ls',
+			'--wordpress=This is nice',
+			'more',
+			'args',
+		]);
+	});
+
+	it('Should treat single quotes inside doubly quoted segments as a part of the segment', () => {
+		const command = 'ls    --wordpress="This \'is\' nice"  more args';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'ls',
+			"--wordpress=This 'is' nice",
+			'more',
+			'args',
+		]);
+	});
+
+	it('Should treat escaped double quotes inside doubly quoted segments as a single arg', () => {
+		const command = 'ls    --wordpress="This \\"is\\" nice"  more args';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'ls',
+			'--wordpress=This "is" nice',
+			'more',
+			'args',
+		]);
+	});
+
+	it('Should allow mixing single and double quotes', () => {
+		const command = 'ls    --wordpress="This "\'is\'" nice"  more args';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'ls',
+			'--wordpress=This is nice',
+			'more',
+			'args',
+		]);
+	});
+
+	it('Should allow mixing unquoted data and double quotes', () => {
+		const command = 'ls    --wordpress="This "is" nice"  more args';
+		const result = splitShellCommand(command);
+		expect(result).toEqual([
+			'ls',
+			'--wordpress=This is nice',
+			'more',
+			'args',
+		]);
+	});
 });

--- a/packages/php-wasm/util/src/lib/split-shell-command.ts
+++ b/packages/php-wasm/util/src/lib/split-shell-command.ts
@@ -1,0 +1,58 @@
+/**
+ * Naive shell command parser.
+ * Ensures that commands like `wp option set blogname "My blog name"` are split into
+ * `['wp', 'option', 'set', 'blogname', 'My blog name']` instead of
+ * `['wp', 'option', 'set', 'blogname', 'My', 'blog', 'name']`.
+ *
+ * @param command
+ * @returns
+ */
+export function splitShellCommand(command: string) {
+	const MODE_UNQUOTED = 0;
+	const MODE_IN_QUOTE = 1;
+
+	let mode = MODE_UNQUOTED;
+	let quote = '';
+
+	const parts: string[] = [];
+	let currentPart = '';
+	for (let i = 0; i < command.length; i++) {
+		const char = command[i];
+		if (char === '\\') {
+			// Escaped quotes are treated as normal characters
+			// This is a very naive approach to escaping, but it's good enough for now.
+			// @TODO: Iterate on this later, perhaps using bun shell.
+			// @see https://github.com/WordPress/wordpress-playground/issues/1062
+			if (command[i + 1] === '"' || command[i + 1] === "'") {
+				i++;
+			}
+			currentPart += command[i];
+		} else if (mode === MODE_UNQUOTED) {
+			if (char === '"' || char === "'") {
+				mode = MODE_IN_QUOTE;
+				quote = char;
+			} else if (char.match(/\s/)) {
+				parts.push(currentPart);
+				currentPart = '';
+			} else if (parts.length && !currentPart) {
+				// We just closed a quote to continue the same
+				// argument with different escaping style, e.g.:
+				// php -r 'require '\''vendor/autoload.php'\''
+				currentPart = parts.pop()! + char;
+			} else {
+				currentPart += char;
+			}
+		} else if (mode === MODE_IN_QUOTE) {
+			if (char === quote) {
+				mode = MODE_UNQUOTED;
+				quote = '';
+			} else {
+				currentPart += char;
+			}
+		}
+	}
+	if (currentPart) {
+		parts.push(currentPart);
+	}
+	return parts;
+}

--- a/packages/php-wasm/util/src/lib/split-shell-command.ts
+++ b/packages/php-wasm/util/src/lib/split-shell-command.ts
@@ -32,8 +32,10 @@ export function splitShellCommand(command: string) {
 				mode = MODE_IN_QUOTE;
 				quote = char;
 			} else if (char.match(/\s/)) {
-				parts.push(currentPart);
-				currentPart = '';
+				if (currentPart.trim().length) {
+					parts.push(currentPart.trim());
+				}
+				currentPart = char;
 			} else if (parts.length && !currentPart) {
 				// We just closed a quote to continue the same
 				// argument with different escaping style, e.g.:
@@ -52,7 +54,7 @@ export function splitShellCommand(command: string) {
 		}
 	}
 	if (currentPart) {
-		parts.push(currentPart);
+		parts.push(currentPart.trim());
 	}
 	return parts;
 }

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -298,7 +298,10 @@ try {
 	php.setSpawnHandler(
 		createSpawnHandler(function (command, processApi) {
 			// Mock programs required by wp-cli:
-			if (command.startsWith('/usr/bin/env stty size ')) {
+			if (
+				typeof command === 'string' &&
+				command.startsWith('/usr/bin/env stty size ')
+			) {
 				// These numbers are hardcoded because this
 				// spawnHandler is transmitted as a string to
 				// the PHP backend and has no access to local
@@ -307,7 +310,10 @@ try {
 				// @TODO: Do not hardcode this
 				processApi.stdout(`18 140`);
 				processApi.exit(0);
-			} else if (command.startsWith('less')) {
+			} else if (
+				typeof command === 'string' &&
+				command.startsWith('less')
+			) {
 				processApi.on('stdin', (data: Uint8Array) => {
 					processApi.stdout(data);
 				});

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -299,8 +299,9 @@ try {
 		createSpawnHandler(function (command, processApi) {
 			// Mock programs required by wp-cli:
 			if (
-				typeof command === 'string' &&
-				command.startsWith('/usr/bin/env stty size ')
+				command[0] === '/usr/bin/env' &&
+				command[1] === 'stty' &&
+				command[2] === 'size'
 			) {
 				// These numbers are hardcoded because this
 				// spawnHandler is transmitted as a string to
@@ -310,10 +311,7 @@ try {
 				// @TODO: Do not hardcode this
 				processApi.stdout(`18 140`);
 				processApi.exit(0);
-			} else if (
-				typeof command === 'string' &&
-				command.startsWith('less')
-			) {
+			} else if (command[0] === 'less') {
 				processApi.on('stdin', (data: Uint8Array) => {
 					processApi.stdout(data);
 				});


### PR DESCRIPTION
## What is this PR doing?

Introduces a naive shell command parser to provide equally good support for the following two types of `proc_open()` calls:

```php
proc_open([ "wp-cli.phar", "plugin", "install", "gutenberg" ]);
proc_open("wp-cli.phar plugin install gutenberg" ]);
```

The command parsing semantics are extremely naive at this point and only cover splitting the command into an array of arguments as follows:

```ts
splitShellCommand(`wp option set      blogname "My \"fancy\" blog "'name'`);
> ["wp", "option", "set", "blogname", `my "fancy" blog name`]
```

There is no support for inline ENV variables, pipes, or redirects. For those, we might need to build an actual shell binary OR turn to something like [bun shell](https://github.com/WordPress/wordpress-playground/issues/1062).

## Testing instructions

This PR ships unit tests so just confirm the CI checks pass.

## Related resources

* https://github.com/WordPress/wordpress-playground/pull/1031
* https://github.com/WordPress/wordpress-playground/issues/1062
* https://github.com/WordPress/wordpress-playground/pull/1051