### PR TITLE
Add Sensei to the allowed repositories for plugin proxy

### DIFF
--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -297,6 +297,12 @@ try {
                 'workflow' => 'Test Build Processes',
                 'artifact' => '#wordpress-build-\d+#'
             ],
+            [
+                'org' => 'Automattic',
+                'repo' => 'sensei',
+                'workflow' => 'Plugin Build',
+                'artifact' => '#sensei-lms-\w+#'
+            ],
         ];
         $allowed = false;
         foreach ($allowedInputs as $allowedInput) {


### PR DESCRIPTION
## What is this PR doing?

It adds Sensei to the allowed repositories for plugin proxy.

## What problem is it solving?

Allow Sensei to use the plugin proxy, so it can be added to Sensei pull requests. It's a better alternative to https://github.com/Automattic/senseilms-com-plugins/pull/305 because we don't have an extra code and GitHub token to maintain.

## How is the problem addressed?

Plugin added to the allowed array.

## Testing Instructions

- Create a GitHub token with the "repo" scope checked for test.
- Add the token hard coded in the `packages/playground/website/public/plugin-proxy.php`.
- Serve the `wordpress-playground/packages/playground/website/public` with a PHP server.
- Request `/plugin-proxy.php?org=Automattic&repo=sensei&workflow=Plugin%20Build&artifact=sensei-lms-bef4d18c802094cc0eaacc522eefdbac5bcbfa77&pr=7521`.
- Check that the request works properly.

## Pending

I still need to see how the PR previewer for Sensei will be. Originally, I was implementing it in https://senseilms.com/playground/ to be used in the PRs. But I still need to take a look now that we're adding the proxy here. I think it will be just to use the playground.wordpress.com with the plugin pointing to the proxy URL and send my blueprint as querystring.