### PR TITLE
Build the php-wasm/util package as both ESM and CJS

### DIFF
--- a/packages/nx-extensions/src/executors/assert-built-esm-and-cjs/executor.ts
+++ b/packages/nx-extensions/src/executors/assert-built-esm-and-cjs/executor.ts
@@ -29,7 +29,7 @@ export default async function runExecutor(
 	);
 	const checkForSuccess = (scriptName) =>
 		new Promise((resolve, reject) => {
-			const test = spawn('sh', ['node', scriptName], {
+			const test = spawn('node', [scriptName], {
 				cwd: testsPath,
 				stdio: 'pipe',
 			});

--- a/packages/php-wasm/util/project.json
+++ b/packages/php-wasm/util/project.json
@@ -5,14 +5,10 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
-			"executor": "@nx/esbuild:esbuild",
+			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"options": {
-				"outputPath": "dist/packages/php-wasm/util",
-				"main": "packages/php-wasm/util/src/index.ts",
-				"tsConfig": "packages/php-wasm/util/tsconfig.lib.json",
-				"assets": ["packages/php-wasm/util/*.md"],
-				"thirdParty": true
+				"outputPath": "dist/packages/php-wasm/util"
 			}
 		},
 		"publish": {
@@ -36,6 +32,13 @@
 				"passWithNoTests": true,
 				"reportsDirectory": "../../../coverage/packages/php-wasm/util"
 			}
+		},
+		"test:esmcjs": {
+			"executor": "@wp-playground/nx-extensions:assert-built-esm-and-cjs",
+			"options": {
+				"outputPath": "dist/packages/php-wasm/util"
+			},
+			"dependsOn": ["build"]
 		}
 	},
 	"tags": ["scope:independent-from-php-binaries"]

--- a/packages/php-wasm/util/vite.config.ts
+++ b/packages/php-wasm/util/vite.config.ts
@@ -21,6 +21,20 @@ export default defineConfig({
 	//  ],
 	// },
 
+	build: {
+		lib: {
+			// Could also be a dictionary or array of multiple entry points.
+			entry: 'src/index.ts',
+			name: 'php-wasm-util',
+			fileName: 'index',
+			formats: ['es', 'cjs'],
+		},
+		rollupOptions: {
+			// External packages that should not be bundled into your library.
+			external: [],
+		},
+	},
+
 	test: {
 		globals: true,
 		cache: {


### PR DESCRIPTION
Solves #1032 where the package cannot be `require`-d in node.js

Thank you for reporting @mho22 !