### PR TITLE
Hide the "This is experimental WordPress" notice on click

### DIFF
--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import css from './style.module.css';
 import AddressBar from '../address-bar';
+import { close } from '@wordpress/icons';
 import classNames from 'classnames';
 
 interface BrowserChromeProps {
@@ -29,6 +30,26 @@ export default function BrowserChrome({
 		[css.hasSmallWindow]: !isFullSize,
 		[css.hasFullSizeWindow]: isFullSize,
 	});
+
+	const [noticeHidden, setNoticeHidden] = useState(
+		document.cookie.includes('hideExperimentalNotice=true')
+	);
+
+	const hideNotice = () => {
+		document.cookie = 'hideExperimentalNotice=true';
+		setNoticeHidden(true);
+	};
+	useEffect(() => {
+		const hideNoticeTimeout = setTimeout(hideNotice, 20000);
+		return () => {
+			clearTimeout(hideNoticeTimeout);
+		};
+	}, []);
+
+	const experimentalNoticeClass = classNames(css.experimentalNotice, {
+		[css.isHidden]: noticeHidden,
+	});
+
 	return (
 		<div className={wrapperClass} data-cy="simulated-browser">
 			<div className={css.window}>
@@ -53,7 +74,8 @@ export default function BrowserChrome({
 					<div className={css.toolbarButtons}>{toolbarButtons}</div>
 				</div>
 				<div className={css.content}>{children}</div>
-				<div className={css.experimentalNotice}>
+				<div className={experimentalNoticeClass} onClick={hideNotice}>
+					{close}
 					This is a cool fun experimental WordPress running in your
 					browser :) All your changes are private and gone after a
 					page refresh.

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -22,6 +22,7 @@
 	svg {
 		margin-right: 10px;
 		width: 20px;
+		min-width: 20px;
 		fill: #e14640;
 	}
 

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -17,6 +17,17 @@
 	line-height: 18px;
 	align-items: center;
 	color: #1e1e1e;
+	cursor: pointer;
+
+	svg {
+		margin-right: 10px;
+		width: 20px;
+		fill: #e14640;
+	}
+
+	&.is-hidden {
+		display: none;
+	}
 }
 
 body.is-embedded .fake-window-wrapper {


### PR DESCRIPTION
Removes the "This is a cool fun experimental WordPress" notice either when it's clicked, or after 20 seconds of using Playground. Once hidden, a cookie is set to prevent the notice from showing up again.

## Testing instructions

* Open Playground
* Click the notice, confirm it got hidden
* Refresh the page, confirm it isn't there
* Open Playground again in a private mode
* Wait 20 seconds and confirm the notice gets hidden

![CleanShot 2024-03-05 at 10 31 07@2x](https://github.com/WordPress/wordpress-playground/assets/205419/05a6214b-7168-42aa-96b5-fe31aafa60eb)

Closes #1076

cc @ellatrix 