### PR TITLE
Comlink API: Pass the context argument to windowEndpoint, not wrap

### DIFF
--- a/packages/php-wasm/web/src/lib/api.ts
+++ b/packages/php-wasm/web/src/lib/api.ts
@@ -22,7 +22,9 @@ export function consumeAPI<APIType>(
 	setupTransferHandlers();
 
 	const endpoint =
-		remote instanceof Worker ? remote : Comlink.windowEndpoint(remote);
+		remote instanceof Worker
+			? remote
+			: Comlink.windowEndpoint(remote, context);
 
 	/**
 	 * This shouldn't be necessary, but Comlink doesn't seem to
@@ -33,7 +35,7 @@ export function consumeAPI<APIType>(
 	 *
 	 * @TODO: Remove this workaround.
 	 */
-	const api = Comlink.wrap<APIType & WithAPIState>(endpoint, context);
+	const api = Comlink.wrap<APIType & WithAPIState>(endpoint);
 	const methods = proxyClone(api);
 	return new Proxy(methods, {
 		get: (target, prop) => {


### PR DESCRIPTION
Follows up on #1085 that correctly identified the issue with `postMessage` event handlers, but passed the context argument to the wrong function call. `wrap()` uesd in that PR is not responsible for binding the message event handler. `windowEndpoint()` is. This PR fixes the mistake.
