### PR TITLE
Add VSCode Chrome debugging support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,13 @@
     "version": "0.2.0",
     "configurations": [
       {
+        "name": "Launch Chrome",
+        "request": "launch",
+        "type": "chrome",
+        "url": "http://localhost:5400/website-server/",
+        "webRoot": "${workspaceFolder}"
+      },
+      {
         "name": "Test playground sync",
         "request": "launch",
         "runtimeArgs": [

--- a/packages/docs/site/docs/13-contributing/02-code.md
+++ b/packages/docs/site/docs/13-contributing/02-code.md
@@ -43,3 +43,18 @@ valet proxy playground.test http://localhost:5400 --secure
 ```
 
 Your dev server is now available via https://playground.test.
+
+## Debugging
+
+### Debugging with VSCode and Chrome
+
+Playground can be debugged using VSCode and Chrome. To do so, follow these steps:
+
+-   Open the project in VSCode
+-   Go to the _Run and Debug_ view (Ctrl+Shift+D)
+-   Select _Launch Chrome_ from the dropdown
+-   Click the green play button to start the debugger (F5)
+
+### Debugging PHP
+
+In the web version of Playground, you can see PHP errors in the browser console. PHP errors are also logged after every PHP request using `console.debug` in the browser console.


### PR DESCRIPTION
## What is this PR doing?

Adds support for debugging Playground using VSCode and Chrome.

## What problem is it solving?

It simplifies debugging of the Playground web version.

## How is the problem addressed?

By adding a VSCode configuration entry.

## Testing Instructions

- Checkout this branch
- Start Playground
- Open the project in VSCode
- Open the _Run and Debug_ tab
- Select _Launch Chrome_ and click Start Debugging
- Confirm that Chrome debugging works (it sometimes requires a reload)

![Screenshot 2024-03-06 at 10 34 49](https://github.com/WordPress/wordpress-playground/assets/1199991/13a534b5-47ea-458e-a0c9-d580a0b1043a)

