### PR TITLE
PHP : Set appropriate SCRIPT variables in $_SERVER superglobal

### DIFF
--- a/packages/php-wasm/compile/php/php_wasm.c
+++ b/packages/php-wasm/compile/php/php_wasm.c
@@ -1071,8 +1071,6 @@ static void wasm_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC
 	value = SG(request_info).request_uri;
 	if (value != NULL)
 	{
-		php_register_variable("SCRIPT_NAME", value, track_vars_array TSRMLS_CC);
-		php_register_variable("SCRIPT_FILENAME", value, track_vars_array TSRMLS_CC);
 		php_register_variable("REQUEST_URI", value, track_vars_array TSRMLS_CC);
 	}
 
@@ -1081,7 +1079,7 @@ static void wasm_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC
 	{
 		// Confirm path translated starts with the document root
 		/**
-		 * PHP_SELF is the script path relative to the document rooth.
+		 * PHP_SELF is the script path relative to the document root.
 		 *
 		 * For example:
 		 *
@@ -1097,7 +1095,11 @@ static void wasm_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC
 		if (strncmp(wasm_server_context->document_root, wasm_server_context->path_translated, strlen(wasm_server_context->document_root)) == 0)
 		{
 			// Substring of path translated starting after document root
+			char *script_name = wasm_server_context->path_translated + strlen(wasm_server_context->document_root);
+			char *script_filename = wasm_server_context->path_translated;
 			char *php_self = wasm_server_context->path_translated + strlen(wasm_server_context->document_root);
+			php_register_variable("SCRIPT_NAME", estrdup(script_name), track_vars_array TSRMLS_CC);
+			php_register_variable("SCRIPT_FILENAME", estrdup(script_filename), track_vars_array TSRMLS_CC);
 			php_register_variable("PHP_SELF", estrdup(php_self), track_vars_array TSRMLS_CC);
 			php_self_set = 1;
 		}
@@ -1106,6 +1108,8 @@ static void wasm_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC
 	if (php_self_set == 0 && value != NULL)
 	{
 		// Default to REQUEST_URI
+		php_register_variable("SCRIPT_NAME", value, track_vars_array TSRMLS_CC);
+		php_register_variable("SCRIPT_FILENAME", value, track_vars_array TSRMLS_CC);
 		php_register_variable("PHP_SELF", value, track_vars_array TSRMLS_CC);
 	}
 
@@ -1322,7 +1326,6 @@ int EMSCRIPTEN_KEEPALIVE wasm_sapi_handle_request()
 		run_php(wasm_server_context->php_code);
 	}
 	result = EG(exit_status);
-	
 wasm_request_done:
 	wasm_sapi_request_shutdown();
 	return result;

--- a/packages/php-wasm/node/public/php_7_0.js
+++ b/packages/php-wasm/node/public/php_7_0.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11391167; 
+export const dependenciesTotalSize = 11390946; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_1.js
+++ b/packages/php-wasm/node/public/php_7_1.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11592136; 
+export const dependenciesTotalSize = 11592146; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_2.js
+++ b/packages/php-wasm/node/public/php_7_2.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11975817; 
+export const dependenciesTotalSize = 11975838; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_3.js
+++ b/packages/php-wasm/node/public/php_7_3.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11899590; 
+export const dependenciesTotalSize = 11899637; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_0.js
+++ b/packages/php-wasm/node/public/php_8_0.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11121604; 
+export const dependenciesTotalSize = 11121635; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_1.js
+++ b/packages/php-wasm/node/public/php_8_1.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10993532; 
+export const dependenciesTotalSize = 10993556; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_2.js
+++ b/packages/php-wasm/node/public/php_8_2.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11251047; 
+export const dependenciesTotalSize = 11251041; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_3.js
+++ b/packages/php-wasm/node/public/php_8_3.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11369535; 
+export const dependenciesTotalSize = 11369578; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -1262,6 +1262,45 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			expect(json).toHaveProperty('CONTENT_TYPE', 'text/plain');
 			expect(json).toHaveProperty('CONTENT_LENGTH', '15');
 		});
+
+		it('Should have appropriate SCRIPT_NAME, SCRIPT_FILENAME and PHP_SELF entries in $_SERVER when serving request', async () => {
+			php.writeFile(
+				'/php/index.php',
+				`<?php echo json_encode($_SERVER);`
+			);
+
+			const response = await php.request({
+				url: '/',
+				method: 'GET',
+			});
+
+			const json = response.json;
+
+			expect(json).toHaveProperty('REQUEST_URI', '/');
+			expect(json).toHaveProperty('SCRIPT_NAME', '/index.php');
+			expect(json).toHaveProperty('SCRIPT_FILENAME', '/php/index.php');
+			expect(json).toHaveProperty('PHP_SELF', '/index.php');
+		});
+
+		it('Should have appropriate SCRIPT_NAME, SCRIPT_FILENAME and PHP_SELF entries in $_SERVER when running PHP code', async () => {
+			php.writeFile(
+				'/php/index.php',
+				`<?php echo json_encode($_SERVER);`
+			);
+
+			const response = await php.run({
+				code: '<?php echo json_encode($_SERVER);',
+				method: 'GET',
+			});
+
+			const json = response.json;
+
+			expect(json).toHaveProperty('REQUEST_URI', '');
+			expect(json).toHaveProperty('SCRIPT_NAME', '');
+			expect(json).toHaveProperty('SCRIPT_FILENAME', '');
+			expect(json).toHaveProperty('PHP_SELF', '');
+		});
+
 		it('Should expose urlencoded POST data in $_POST', async () => {
 			const response = await php.run({
 				code: `<?php echo json_encode($_POST);`,

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -1283,11 +1283,6 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 		});
 
 		it('Should have appropriate SCRIPT_NAME, SCRIPT_FILENAME and PHP_SELF entries in $_SERVER when running PHP code', async () => {
-			php.writeFile(
-				'/php/index.php',
-				`<?php echo json_encode($_SERVER);`
-			);
-
 			const response = await php.run({
 				code: '<?php echo json_encode($_SERVER);',
 				method: 'GET',
@@ -1299,6 +1294,36 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			expect(json).toHaveProperty('SCRIPT_NAME', '');
 			expect(json).toHaveProperty('SCRIPT_FILENAME', '');
 			expect(json).toHaveProperty('PHP_SELF', '');
+		});
+
+		it('Should have appropriate SCRIPT_NAME, SCRIPT_FILENAME and PHP_SELF entries in $_SERVER when serving request from a test file in a subdirectory', async () => {
+			php.mkdir('/php/subdirectory');
+
+			php.writeFile(
+				`/php/subdirectory/test.php`,
+				`<?php echo json_encode($_SERVER);`
+			);
+
+			const response = await php.request({
+				url: '/subdirectory/test.php',
+				method: 'GET',
+			});
+
+			const json = response.json;
+
+			expect(json).toHaveProperty(
+				'REQUEST_URI',
+				'/subdirectory/test.php'
+			);
+			expect(json).toHaveProperty(
+				'SCRIPT_NAME',
+				'/subdirectory/test.php'
+			);
+			expect(json).toHaveProperty(
+				'SCRIPT_FILENAME',
+				'/php/subdirectory/test.php'
+			);
+			expect(json).toHaveProperty('PHP_SELF', '/subdirectory/test.php');
 		});
 
 		it('Should expose urlencoded POST data in $_POST', async () => {

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_0.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 9833159; 
+export const dependenciesTotalSize = 9833093; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_1.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 9997807; 
+export const dependenciesTotalSize = 9997829; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_2.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10365643; 
+export const dependenciesTotalSize = 10365646; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_3.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10301427; 
+export const dependenciesTotalSize = 10301458; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_4.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_4.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10387709; 
+export const dependenciesTotalSize = 10387693; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_0.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 9984784; 
+export const dependenciesTotalSize = 9984818; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_1.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 9855669; 
+export const dependenciesTotalSize = 9855691; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_2.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10101415; 
+export const dependenciesTotalSize = 10101435; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_3.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10217456; 
+export const dependenciesTotalSize = 10217480; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_0.js
+++ b/packages/php-wasm/web/public/light/php_7_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5278918; 
+export const dependenciesTotalSize = 5278843; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_1.js
+++ b/packages/php-wasm/web/public/light/php_7_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5423017; 
+export const dependenciesTotalSize = 5423025; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_2.js
+++ b/packages/php-wasm/web/public/light/php_7_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5766002; 
+export const dependenciesTotalSize = 5766025; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_3.js
+++ b/packages/php-wasm/web/public/light/php_7_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5694198; 
+export const dependenciesTotalSize = 5694219; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_4.js
+++ b/packages/php-wasm/web/public/light/php_7_4.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5775470; 
+export const dependenciesTotalSize = 5775483; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_1.js
+++ b/packages/php-wasm/web/public/light/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5376368; 
+export const dependenciesTotalSize = 5376400; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_2.js
+++ b/packages/php-wasm/web/public/light/php_8_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5490209; 
+export const dependenciesTotalSize = 5490229; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_3.js
+++ b/packages/php-wasm/web/public/light/php_8_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5581412; 
+export const dependenciesTotalSize = 5581433; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets


### PR DESCRIPTION
## What is this PR doing?

Based on the issue #1090

When requesting a url, the current behavior is copying the value from `REQUEST_URI` to `SCRIPT_NAME` and `SCRIPT_FILENAME` `$_SERVER` variables.

It should actually be related to the `PHP_SELF` variable when handling request instead of `REQUEST_URI` when running code.

## What problem is it solving?

To avoid a mismatch when using `SCRIPT` variables

## Testing Instructions

```
const php = await NodePHP.load( '8.2, { requestHandler : { documentRoot : '/php' } } );

php.writeFile( 'php/index.php', "<?php echo json_encode($_SERVER);" );

const response = await php.request({
	url: '/',
	method: 'GET',
});

console.log( JSON.stringify( response.json, null, 2 );
```

This should display :

```
REQUEST_URI='/'
SCRIPT_NAME='/index.php'
SCRIPT_FILENAME='/php/index.php'
PHP_SELF='/index.php'
```

instead of currently : 

```
REQUEST_URI='/'
SCRIPT_NAME='/'
SCRIPT_FILENAME='/'
PHP_SELF='/'
```
