### PR TITLE
Service worker: Improve error reporting in non-secure contexts

### DIFF
--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -1,5 +1,6 @@
 import Semaphore from './semaphore';
 export { Semaphore };
+export { PlaygroundError } from './playground-error';
 export type { SemaphoreOptions } from './semaphore';
 export { dirname, joinPaths, basename, normalizePath } from './paths';
 export { createSpawnHandler } from './create-spawn-handler';

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -1,6 +1,6 @@
 import Semaphore from './semaphore';
 export { Semaphore };
-export { PlaygroundError } from './playground-error';
+export { PhpWasmError } from './php-wasm-error';
 export type { SemaphoreOptions } from './semaphore';
 export { dirname, joinPaths, basename, normalizePath } from './paths';
 export { createSpawnHandler } from './create-spawn-handler';

--- a/packages/php-wasm/util/src/lib/php-wasm-error.ts
+++ b/packages/php-wasm/util/src/lib/php-wasm-error.ts
@@ -1,4 +1,4 @@
-export class PlaygroundError extends Error {
+export class PhpWasmError extends Error {
 	constructor(message: string, public userFriendlyMessage?: string) {
 		super(message);
 		if (!this.userFriendlyMessage) {

--- a/packages/php-wasm/util/src/lib/playground-error.ts
+++ b/packages/php-wasm/util/src/lib/playground-error.ts
@@ -1,0 +1,8 @@
+export class PlaygroundError extends Error {
+	constructor(message: string, public userFriendlyMessage?: string) {
+		super(message);
+		if (!this.userFriendlyMessage) {
+			this.userFriendlyMessage = message;
+		}
+	}
+}

--- a/packages/php-wasm/web/src/lib/register-service-worker.ts
+++ b/packages/php-wasm/web/src/lib/register-service-worker.ts
@@ -1,3 +1,4 @@
+import { PlaygroundError } from '@php-wasm/util';
 import type { WebPHPEndpoint } from './web-php-endpoint';
 import { responseTo } from '@php-wasm/web-service-worker';
 import { Remote } from 'comlink';
@@ -17,14 +18,17 @@ export async function registerServiceWorker<
 >(phpApi: Client, scope: string, scriptUrl: string) {
 	const sw = navigator.serviceWorker;
 	if (!sw) {
-		if (location.protocol === 'https:') {
-			throw new Error(
-				'Service workers are not supported in this browser.'
+		/**
+		 * Service workers may only run in secure contexts.
+		 * See https://w3c.github.io/webappsec-secure-contexts/
+		 */
+		if (window.isSecureContext) {
+			throw new PlaygroundError(
+				'Service workers are not supported in your browser.'
 			);
 		} else {
-			throw new Error(
-				'WordPress Playground requires service workers which are only supported ' +
-					'on HTTPS sites. This site does not use HTTPS, please retry on one that does. '
+			throw new PlaygroundError(
+				'WordPress Playground uses service workers and may only work on HTTPS and http://localhost/ sites, but the current site is neither.'
 			);
 		}
 	}

--- a/packages/php-wasm/web/src/lib/register-service-worker.ts
+++ b/packages/php-wasm/web/src/lib/register-service-worker.ts
@@ -1,4 +1,4 @@
-import { PlaygroundError } from '@php-wasm/util';
+import { PhpWasmError } from '@php-wasm/util';
 import type { WebPHPEndpoint } from './web-php-endpoint';
 import { responseTo } from '@php-wasm/web-service-worker';
 import { Remote } from 'comlink';
@@ -23,11 +23,11 @@ export async function registerServiceWorker<
 		 * See https://w3c.github.io/webappsec-secure-contexts/
 		 */
 		if (window.isSecureContext) {
-			throw new PlaygroundError(
+			throw new PhpWasmError(
 				'Service workers are not supported in your browser.'
 			);
 		} else {
-			throw new PlaygroundError(
+			throw new PhpWasmError(
 				'WordPress Playground uses service workers and may only work on HTTPS and http://localhost/ sites, but the current site is neither.'
 			);
 		}

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -72,7 +72,12 @@
 
 				const div = document.createElement('div');
 				div.className = 'error-message';
-				div.innerText = 'Ooops! WordPress Playground had a hiccup!';
+				const userFriendlyMessage =
+					e?.userFriendlyMessage ||
+					'See the developer tools for error details.';
+				div.innerHTML =
+					'Ooops! WordPress Playground had a hiccup! <br/><br/> ' +
+					userFriendlyMessage;
 				document.body.append(div);
 
 				const button = document.createElement('button');


### PR DESCRIPTION
Playground errors in some non-secure contexts suggest service workers are not supported in the current browser. This is confusing and the user is only left with a "Playground had a hiccup" error message that looks like a bug.

This PR changes the technique of checking whether
the current context is secure from a simple `https:` verification to consulting window.isSecureContext and then surfaces that information in the UI.

## Testing instructions

1. Start a new Local site on a .local domain. Make sure to use http://, not https://
1. Start Playground dev server
1. Open the local site, add the following iframe in devtools:

```html
<iframe src="http://localhost:5400/remote.html?progressbar=true&amp;php=7.4&amp;wp=latest&amp;networking=no" width="700" height="300" style="
    margin: 0 auto;
    display: block;
"></iframe>
```

1. Confirm the error message is useful and talks about HTTPS and secure contexts

![CleanShot 2024-03-11 at 13 23 39@2x](https://github.com/WordPress/wordpress-playground/assets/205419/344ea607-7f2f-487a-9946-fdc73f363991)

cc @bgrgicak 