### PR TITLE
Explore weird register_shutdown_function behavior

### DIFF
--- a/packages/php-wasm/node/bin/rebuild-while-asyncify-functions-missing.mjs
+++ b/packages/php-wasm/node/bin/rebuild-while-asyncify-functions-missing.mjs
@@ -50,7 +50,8 @@ function getHash() {
 	return createHash('sha1')
 		.update(
 			fs.readFileSync(
-				new URL('../../compile/Dockerfile', import.meta.url).pathname
+				new URL('../../compile/php/Dockerfile', import.meta.url)
+					.pathname
 			)
 		)
 		.digest('hex');

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -654,6 +654,9 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 		}
 
 		const { headers, httpStatusCode } = this.#getResponseHeaders();
+		console.log(
+			'Preparing the PHP response based on /internal/stdout and /internal/stderr...'
+		);
 		return new PHPResponse(
 			httpStatusCode,
 			headers,


### PR DESCRIPTION
cc @bgrgicak 

This doesn't solve the issue we've seen with WooCommerce. While trying to set up a test case for that, I ran into another issue where doing anything asynchronous in the shutdown handler somehow breaks the stdout output stream. The PHP code is still running, though, and is capable of writing files. Something must be off with the `wasm_sapi_request_shutdown` C function.