### PR TITLE
Fix post_message_to_js memory out of bounds

### DIFF
--- a/packages/php-wasm/compile/php/php_wasm.c
+++ b/packages/php-wasm/compile/php/php_wasm.c
@@ -396,7 +396,7 @@ PHP_FUNCTION(post_message_to_js)
 
 	char *response;
 	size_t response_len = js_module_onMessage(data, &response);
-	if (response != -1)
+	if (response_len != -1)
 	{
 		zend_string *return_string = zend_string_init(response, response_len, 0);
 		free(response);

--- a/packages/php-wasm/node/public/php_7_0.js
+++ b/packages/php-wasm/node/public/php_7_0.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11391244; 
+export const dependenciesTotalSize = 11391249; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_1.js
+++ b/packages/php-wasm/node/public/php_7_1.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11592290; 
+export const dependenciesTotalSize = 11592292; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_2.js
+++ b/packages/php-wasm/node/public/php_7_2.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11975896; 
+export const dependenciesTotalSize = 11975898; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_4.js
+++ b/packages/php-wasm/node/public/php_7_4.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11982999; 
+export const dependenciesTotalSize = 11983001; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_0.js
+++ b/packages/php-wasm/node/public/php_8_0.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11121730; 
+export const dependenciesTotalSize = 11121733; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_1.js
+++ b/packages/php-wasm/node/public/php_8_1.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10993619; 
+export const dependenciesTotalSize = 10993622; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_2.js
+++ b/packages/php-wasm/node/public/php_8_2.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11251124; 
+export const dependenciesTotalSize = 11251126; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_3.js
+++ b/packages/php-wasm/node/public/php_8_3.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11369682; 
+export const dependenciesTotalSize = 11369684; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_0.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 9834859; 
+export const dependenciesTotalSize = 9834861; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_1.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 9999435; 
+export const dependenciesTotalSize = 9999437; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_2.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10367006; 
+export const dependenciesTotalSize = 10367008; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_3.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10303147; 
+export const dependenciesTotalSize = 10303149; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_4.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_4.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10389411; 
+export const dependenciesTotalSize = 10389413; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_0.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 9986597; 
+export const dependenciesTotalSize = 9986599; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_1.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 9857380; 
+export const dependenciesTotalSize = 9857382; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_2.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10103120; 
+export const dependenciesTotalSize = 10103122; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_3.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10219167; 
+export const dependenciesTotalSize = 10219169; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_0.js
+++ b/packages/php-wasm/web/public/light/php_7_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5280620; 
+export const dependenciesTotalSize = 5280622; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_1.js
+++ b/packages/php-wasm/web/public/light/php_7_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5424625; 
+export const dependenciesTotalSize = 5424627; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_2.js
+++ b/packages/php-wasm/web/public/light/php_7_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5767392; 
+export const dependenciesTotalSize = 5767394; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_3.js
+++ b/packages/php-wasm/web/public/light/php_7_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5695924; 
+export const dependenciesTotalSize = 5695926; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_4.js
+++ b/packages/php-wasm/web/public/light/php_7_4.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5777161; 
+export const dependenciesTotalSize = 5777163; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_0.js
+++ b/packages/php-wasm/web/public/light/php_8_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5574901; 
+export const dependenciesTotalSize = 5574903; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_1.js
+++ b/packages/php-wasm/web/public/light/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5378073; 
+export const dependenciesTotalSize = 5378075; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_2.js
+++ b/packages/php-wasm/web/public/light/php_8_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5491931; 
+export const dependenciesTotalSize = 5491933; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_3.js
+++ b/packages/php-wasm/web/public/light/php_8_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5583110; 
+export const dependenciesTotalSize = 5583112; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets


### PR DESCRIPTION
Fixes #1112

## What is this PR doing?

It fixes a bug in post_message_to_js that broke sending messages in Node.

## What problem is it solving?

It checks if the response length of a message is larger than -1 before attempting to process the message.

## How is the problem addressed?

By checking the response length.

## Testing Instructions

- Confirm that all tests pass
