### PR TITLE
Fix php bison dep for building on non-arm64 architectures

### DIFF
--- a/packages/php-wasm/compile/bison2.7/bison27.patch
+++ b/packages/php-wasm/compile/bison2.7/bison27.patch
@@ -1,6 +1,6 @@
 Subject: Use Bison 2.7 to compile PHP 5.6
 
-This workaround enables building Bison 2.7 on arm64 architecture
+This workaround enables building Bison 2.7
 so that it can be used to compile PHP 5.6.
 
 Derived from the OpenWRT project:

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -73,7 +73,7 @@ RUN if [[ "${PHP_VERSION:0:1}" -le "7" && "${PHP_VERSION:2:1}" -le "3" ]]; then 
 			rm bison-2.7.tar.gz && \
 			cd bison-2.7 && \
 			git apply --no-index /root/bison27.patch && \
-			./configure --prefix=/usr/local --with-libiconv-prefix=/usr/local/libiconv/ && \
+			./configure --prefix=/usr/local && \
 			make && \
 			make install; \
 			if [[ $? -ne 0 ]]; then \

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -57,13 +57,30 @@ RUN touch /root/.configure-flags && \
 	touch /root/.emcc-php-wasm-flags && \
 	touch /root/.EXPORTED_FUNCTIONS
 
+# Grab Bison 2.7 patch in case we need it
+COPY ./bison2.7/bison27.patch /root/bison27.patch
 
 # PHP <= 7.3 requires Bison 2.7
 # PHP >= 7.4 and Bison 3.0
 RUN if [[ "${PHP_VERSION:0:1}" -le "7" && "${PHP_VERSION:2:1}" -le "3" ]]; then \
-		mv /libs/bison2.7/usr/local/bison /usr/local/bison && \
-        ln -s /usr/local/bison/bin/bison /usr/bin/bison && \
-		ln -s /usr/local/bison/bin/yacc /usr/bin/yacc; \
+		if /libs/bison2.7/usr/local/bison/bin/bison -h >/dev/null; then \
+			mv /libs/bison2.7/usr/local/bison /usr/local/bison && \
+			ln -s /usr/local/bison/bin/bison /usr/bin/bison && \
+			ln -s /usr/local/bison/bin/yacc /usr/bin/yacc; \
+		else \
+			wget https://ftp.gnu.org/gnu/bison/bison-2.7.tar.gz && \
+			tar -xvf bison-2.7.tar.gz && \
+			rm bison-2.7.tar.gz && \
+			cd bison-2.7 && \
+			git apply --no-index /root/bison27.patch && \
+			./configure --prefix=/usr/local --with-libiconv-prefix=/usr/local/libiconv/ && \
+			make && \
+			make install; \
+			if [[ $? -ne 0 ]]; then \
+				echo 'Failed to build Bison 2.7 dependency.'; \
+				exit -1; \
+			fi; \
+		fi; \
 	else \
 		apt install -y bison; \
 	fi;


### PR DESCRIPTION
## What is this PR doing?

This PR is an alternative to PR #871.

This PR fixes an error building php-wasm for PHP 7.3 and below on non-arm64 architectures. Those PHP versions depend on Bison 2.7. We have a prebuilt version of Bison 2.7 for arm64, but that naturally doesn't work on other CPU architectures. This PR builds Bison 2.7 as a stopgap.

On non-arm64 architectures, this extra build step runs once for each supported PHP version up to PHP 7.3. This is not ideal but can be improved later.

## Testing Instructions

### Before applying this patch

On an intel machine, run `npm run recompile:php:web` and observe there is a build error.

### After applying this patch

On an intel machine, run `npm run recompile:php:web` and observe there are no longer build errors.

On an arm64 machine, run the following to make sure there are no build regressions:
`npm run recompile:php:web`