### PR TITLE
Web: Make the "Apply changes" button work in Playground settings form

### DIFF
--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -47,6 +47,14 @@ export interface StartPlaygroundOptions {
 	blueprint?: Blueprint;
 	onBlueprintStepCompleted?: OnStepCompleted;
 	/**
+	 * Called when the playground client is connected, but before the blueprint
+	 * steps are run.
+	 *
+	 * @param playground
+	 * @returns
+	 */
+	onClientConnected?: (playground: PlaygroundClient) => void;
+	/**
 	 * The SAPI name PHP will use.
 	 * @internal
 	 * @private
@@ -68,6 +76,7 @@ export async function startPlaygroundWeb({
 	progressTracker = new ProgressTracker(),
 	disableProgressBar,
 	onBlueprintStepCompleted,
+	onClientConnected = () => {},
 	sapiName,
 }: StartPlaygroundOptions): Promise<PlaygroundClient> {
 	assertValidRemote(remoteUrl);
@@ -78,7 +87,13 @@ export async function startPlaygroundWeb({
 	});
 	progressTracker.setCaption('Preparing WordPress');
 	if (!blueprint) {
-		return doStartPlaygroundWeb(iframe, remoteUrl, progressTracker);
+		const playground = await doStartPlaygroundWeb(
+			iframe,
+			remoteUrl,
+			progressTracker
+		);
+		onClientConnected(playground);
+		return playground;
 	}
 	const compiled = compileBlueprint(blueprint, {
 		progress: progressTracker.stage(0.5),
@@ -96,6 +111,7 @@ export async function startPlaygroundWeb({
 		progressTracker
 	);
 	collectPhpLogs(logger, playground);
+	onClientConnected(playground);
 	await runBlueprintSteps(compiled, playground);
 	progressTracker.finish();
 

--- a/packages/playground/website/src/components/playground-configuration-group/reload-with-new-configuration.ts
+++ b/packages/playground/website/src/components/playground-configuration-group/reload-with-new-configuration.ts
@@ -2,10 +2,10 @@ import { PlaygroundClient } from '@wp-playground/client';
 import { PlaygroundConfiguration } from './form';
 
 export async function reloadWithNewConfiguration(
-	playground: PlaygroundClient,
-	config: PlaygroundConfiguration
+	config: PlaygroundConfiguration,
+	playground?: PlaygroundClient
 ) {
-	if (config.resetSite && config.storage === 'browser') {
+	if (playground && config.resetSite && config.storage === 'browser') {
 		try {
 			await playground?.resetVirtualOpfs();
 		} catch (error) {
@@ -21,10 +21,9 @@ export async function reloadWithNewConfiguration(
 	if (config.withExtensions) {
 		url.searchParams.append('php-extension-bundle', 'kitchen-sink');
 	}
+	url.searchParams.delete('networking');
 	if (config.withNetworking) {
-		url.searchParams.append('networking', 'yes');
-	} else {
-		url.searchParams.delete('networking');
+		url.searchParams.set('networking', 'yes');
 	}
 	window.location.assign(url);
 }

--- a/packages/playground/website/src/lib/hooks.ts
+++ b/packages/playground/website/src/lib/hooks.ts
@@ -34,13 +34,21 @@ export function usePlayground({ blueprint, storage }: UsePlaygroundOptions) {
 			remoteUrl.searchParams.set('storage', storage);
 		}
 
+		let playgroundTmp: PlaygroundClient | undefined = undefined;
 		startPlaygroundWeb({
 			iframe,
 			remoteUrl: remoteUrl.toString(),
 			blueprint,
-		}).then(async (playground) => {
-			playground.onNavigation((url) => setUrl(url));
-			setPlayground(() => playground);
+			// Intercept the Playground client even if the
+			// Blueprint fails.
+			onClientConnected: (playground) => {
+				playgroundTmp = playground;
+			},
+		}).finally(async () => {
+			if (playgroundTmp) {
+				playgroundTmp.onNavigation((url) => setUrl(url));
+				setPlayground(() => playgroundTmp);
+			}
 		});
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [iframe, awaitedIframe]);


### PR DESCRIPTION
Related to https://github.com/WordPress/wordpress-playground/issues/983

The "Apply changes" button in the "Customize Playground" modal doesn't submit the form when the `playground` object isn't available. That may happen when the remote.html API did not resolve yet, but also when the Blueprint execution fails for any reason. For example, when the browser storage contains outdated code that doesn't work anymore.

This PR makes the `playground` argument to reloadWithNewConfiguration optional.

It also adds a new `onClientConnected` argument to `startPlaygroundWeb` to store the Playground client reference even if the Blueprint cannot be executed.

 ## Testing instructions

This one is tricky. You need a broken Playground instance to test this. The easiest way is to update the `0-playground.php` mu-plugin to trigger a syntax error. Once you do that, confirm the modal cannot be submitted without this PR and can with it.
