### PR TITLE
Devex: Expose window.playground for quick testing and debugging

### DIFF
--- a/packages/docs/site/docs/10-javascript-api/01-index.md
+++ b/packages/docs/site/docs/10-javascript-api/01-index.md
@@ -26,7 +26,7 @@ import JSApiShortExample from '@site/docs/\_fragments/\_js_api_short_example.mdx
 :::info /remote.html is a special URL
 
 `/remote.html` is a special URL that loads the Playground
-API endpoint instead of the demo app with the browser UI. Read more about the difference between `/` and `/remote.html` [on this page](./02-index-html-vs-remote-html.md).
+API endpoint instead of the demo app with the browser UI. Read more about the difference between `/` and `/remote.html` and [on this page](./02-index-html-vs-remote-html.md).
 
 :::
 
@@ -37,3 +37,15 @@ Now that you have a `client` object, you can use it to control the website insid
 -   [Playground API Client](./03-playground-api-client.md)
 -   [Blueprint JSON](./04-blueprint-json-in-api-client.md)
 -   [Blueprint functions](./05-blueprint-functions-in-api-client.md)
+
+## Debugging and testing
+
+For quick testing and debugging, the JavaScript API client is exposed as `window.playground` by both `index.html` and `remote.html`.
+
+```javascript
+> await playground.listFiles("/")
+(6) ['tmp', 'home', 'dev', 'proc', 'internal', 'wordpress']
+```
+
+Note that in `index.html`, `playground` is a Proxy object and you won't get any autocompletion from the browser. In `remote.html`,
+however, `playground` is a class instance and you will benefit from browser's autocompletion.

--- a/packages/docs/site/docs/10-javascript-api/02-index-html-vs-remote-html.md
+++ b/packages/docs/site/docs/10-javascript-api/02-index-html-vs-remote-html.md
@@ -25,6 +25,15 @@ That last part is how the public API works. The parent window (`index.html`) sen
 
 Sending messages is cumbersome so the PlaygroundClient class provides an object-oriented API that handles the messages internally.
 
+For quick testing and debugging, `remote.html` also exposes the JavaScript API client as `window.playground`. You can use it from your devtools as follows:
+
+```javascript
+> await playground.listFiles("/")
+(6) ['tmp', 'home', 'dev', 'proc', 'internal', 'wordpress']
+```
+
+`playground` is a class instance in this context and you will benefit from browser's autocompletion.
+
 ## Index.html
 
 `index.html` is an independent app built around `remote.html` using the WordPress Playground API client.
@@ -32,3 +41,12 @@ Sending messages is cumbersome so the PlaygroundClient class provides an object-
 It renders the browser UI, version selectors, and renders WordPress by embedding `remote.html` via an iframe. UI features like an address bar or a version selector are implemented by communicating with `remote.html` using `PlaygroundClient`.
 
 `index.html` monitors the query parameters it receives and triggers the appropriate `PlaygroundClient` methods. For instance, `?plugin=coblocks` triggers `installPluginsFromDirectory( client, ['coblocks'] )`. This mechanism forms the basis of the Query API.
+
+For quick testing and debugging, `index.html` also exposes the JavaScript API client as `window.playground`. You can use it from your devtools as follows:
+
+```javascript
+> await playground.listFiles("/")
+(6) ['tmp', 'home', 'dev', 'proc', 'internal', 'wordpress']
+```
+
+Note that `playground` is a Proxy object in this context and you won't get any autocompletion from the browser.

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -64,7 +64,7 @@
 			}
 			import { bootPlaygroundRemote } from './src/index';
 			try {
-				await bootPlaygroundRemote();
+				window.playground = await bootPlaygroundRemote();
 			} catch (e) {
 				console.error(e);
 				document.body.className = 'has-error';

--- a/packages/playground/website/src/lib/hooks.ts
+++ b/packages/playground/website/src/lib/hooks.ts
@@ -43,6 +43,7 @@ export function usePlayground({ blueprint, storage }: UsePlaygroundOptions) {
 			// Blueprint fails.
 			onClientConnected: (playground) => {
 				playgroundTmp = playground;
+				(window as any)['playground'] = playground;
 			},
 		}).finally(async () => {
 			if (playgroundTmp) {


### PR DESCRIPTION
@dd32 mentioned:

> My current workaround has been to just upload a plugin that does what I want to do, which gets tedious :slightly_smiling_face: I’d love if the JS API was exposed to the dev console though

This PR provides just that.

 ## Testing instructions

Go to browser devtools and run `await playground.listFiles("/")` in both index.html context and remote.html context. Confirm it yielded a list of files.

Note that in `index.html`, `playground` is a Proxy object and you won't get any autocompletion from the browser. In `remote.html`, however, `playground` is a class instance and you will benefit from browser's autocompletion.
