### PR TITLE
Request handler: Remove everything after # from the URL

### DIFF
--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -177,6 +177,17 @@ describe.each(SupportedPHPVersions)(
 			expect(response.text).toEqual('true');
 		});
 
+		/**
+		 * @see https://github.com/WordPress/wordpress-playground/issues/1120
+		 */
+		it('Should not propagate the # part of the URL to PHP', async () => {
+			php.writeFile('/index.php', `<?php echo $_SERVER['REQUEST_URI'];`);
+			const response = await handler.request({
+				url: '/index.php#foo',
+			});
+			expect(response.text).toEqual('/index.php');
+		});
+
 		it('Should allow mixing data and files when `body` is a JavaScript object', async () => {
 			php.writeFile(
 				'/index.php',

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -119,7 +119,8 @@ export class PHPRequestHandler implements RequestHandler {
 			request.url.startsWith('http://') ||
 			request.url.startsWith('https://');
 		const requestedUrl = new URL(
-			request.url,
+			// Remove the hash part of the URL as it's meant for the server.
+			request.url.split('#')[0],
 			isAbsolute ? undefined : DEFAULT_BASE_URL
 		);
 


### PR DESCRIPTION
Closes https://github.com/WordPress/wordpress-playground/issues/1120

Fixes a bug in the URL parsing where `#foo` is passed to PHP when requesting `/index.php#foo`.

 ## Testing instructions

Confirm the tests passed