### PR TITLE
PHP.run(): Throw JS exception on runtime error, remove throwOnError flag

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -939,20 +939,25 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			}
 		});
 		it('Returns the correct exit code on subsequent runs', async () => {
-			const result1 = await php.run({
+			const promise1 = php.run({
 				code: '<?php throw new Exception();',
 			});
-			expect(result1.exitCode).toBe(255);
+			// expect(result1.exitCode).toBe(255);
+			await expect(promise1).rejects.toThrow(
+				'PHP.run() failed with exit code 255'
+			);
 
 			const result2 = await php.run({
 				code: '<?php exit(0);',
 			});
 			expect(result2.exitCode).toBe(0);
 
-			const result3 = await php.run({
+			const promise3 = php.run({
 				code: '<?php exit(1);',
 			});
-			expect(result3.exitCode).toBe(1);
+			await expect(promise3).rejects.toThrow(
+				'PHP.run() failed with exit code 1'
+			);
 		});
 	});
 

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -922,19 +922,19 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			)) {
 				// Run via `code`
 				it(testName, async () => {
-					const result = await php.run({
+					const promise = php.run({
 						code: testSnippet,
 					});
-					expect(result.exitCode).toBeGreaterThan(0);
+					await expect(promise).rejects.toThrow();
 				});
 
 				// Run via the request handler
 				it(testName, async () => {
 					php.writeFile('/test.php', testSnippet);
-					const result = await php.run({
+					const promise = php.run({
 						scriptPath: '/test.php',
 					});
-					expect(result.exitCode).toBeGreaterThan(0);
+					await expect(promise).rejects.toThrow();
 				});
 			}
 		});

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -276,7 +276,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 			}
 
 			const response = await this.#handleRequest();
-			if (request.throwOnError && response.exitCode !== 0) {
+			if (response.exitCode !== 0) {
 				const output = {
 					stdout: response.text,
 					stderr: response.errors,

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -542,12 +542,6 @@ export interface PHPRunOptions {
 	 * The code snippet to eval instead of a php file.
 	 */
 	code?: string;
-
-	/**
-	 * Whether to throw an error if the PHP process exits with a non-zero code
-	 * or outputs to stderr.
-	 */
-	throwOnError?: boolean;
 }
 
 /**

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -1411,10 +1411,6 @@
 				"code": {
 					"type": "string",
 					"description": "The code snippet to eval instead of a php file."
-				},
-				"throwOnError": {
-					"type": "boolean",
-					"description": "Whether to throw an error if the PHP process exits with a non-zero code or outputs to stderr."
 				}
 			},
 			"additionalProperties": false

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -35,7 +35,6 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 
 	const docroot = await playground.documentRoot;
 	await playground.run({
-		throwOnError: true,
 		code: `<?php
 define( 'WP_ADMIN', true );
 require_once( ${phpVar(docroot)}. "/wp-load.php" );

--- a/packages/playground/blueprints/src/lib/steps/activate-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.ts
@@ -34,7 +34,6 @@ export const activateTheme: StepHandler<ActivateThemeStep> = async (
 	progress?.tracker.setCaption(`Activating ${themeFolderName}`);
 	const docroot = await playground.documentRoot;
 	await playground.run({
-		throwOnError: true,
 		code: `<?php
 define( 'WP_ADMIN', true );
 require_once( ${phpVar(docroot)}. "/wp-load.php" );

--- a/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.spec.ts
@@ -164,7 +164,7 @@ describe('rewriteDefineCalls', () => {
 define('WP_DEBUG', true);
 
 // The third define() argument is also supported:
-@define('SAVEQUERIES', false, true); 
+@define('SAVEQUERIES', false, true);
 
 // Expression
 define(true ? 'WP_DEBUG_LOG' : 'WP_DEBUG_LOG', 123);
@@ -230,9 +230,10 @@ describe('defineBeforeRun', () => {
 			SITE_URL: 'http://test.url',
 		};
 		await defineBeforeRun(php, constants);
-		const response = await php.run({
-			code: `<?php echo json_encode(['SITE_URL' => SITE_URL]);`,
-		});
-		expect(response.errors).toContain('PHP Fatal error:');
+		await expect(
+			php.run({
+				code: `<?php echo json_encode(['SITE_URL' => SITE_URL]);`,
+			})
+		).rejects.toThrow('PHP.run() failed with exit code');
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.ts
+++ b/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.ts
@@ -95,7 +95,6 @@ export async function rewriteDefineCalls(
 		consts,
 	});
 	await playground.run({
-		throwOnError: true,
 		code: `${rewriteWpConfigToDefineConstants}
 	$wp_config_path = '/tmp/code.php';
 	$wp_config = file_get_contents($wp_config_path);

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -63,7 +63,6 @@ export const enableMultisite: StepHandler<EnableMultisiteStep> = async (
 
 	// Deactivate all the plugins as required by the multisite installation.
 	const result = await playground.run({
-		throwOnError: true,
 		code: `<?php
 define( 'WP_ADMIN', true );
 require_once(${phpVar(docroot)} . "/wp-load.php");

--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -119,7 +119,6 @@ export const importWordPressFiles: StepHandler<
 		joinPaths(documentRoot, 'wp-admin', 'upgrade.php')
 	);
 	await playground.run({
-		throwOnError: true,
 		code: `<?php
             $_GET['step'] = 'upgrade_db';
             require ${upgradePhp};

--- a/packages/playground/blueprints/src/lib/steps/run-php.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-php.ts
@@ -27,5 +27,5 @@ export const runPHP: StepHandler<RunPHPStep, Promise<PHPResponse>> = async (
 	playground,
 	{ code }
 ) => {
-	return await playground.run({ code, throwOnError: true });
+	return await playground.run({ code });
 };

--- a/packages/playground/blueprints/src/lib/steps/site-data.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.ts
@@ -34,7 +34,6 @@ export const setSiteOptions: StepHandler<SetSiteOptionsStep> = async (
 ) => {
 	const docroot = await php.documentRoot;
 	await php.run({
-		throwOnError: true,
 		code: `<?php
 		include ${phpVar(docroot)} . '/wp-load.php';
 		$site_options = ${phpVar(options)};
@@ -81,7 +80,6 @@ export const updateUserMeta: StepHandler<UpdateUserMetaStep> = async (
 ) => {
 	const docroot = await php.documentRoot;
 	await php.run({
-		throwOnError: true,
 		code: `<?php
 		include ${phpVar(docroot)} . '/wp-load.php';
 		$meta = ${phpVar(meta)};

--- a/packages/playground/blueprints/src/lib/utils/run-php-with-zip-functions.ts
+++ b/packages/playground/blueprints/src/lib/utils/run-php-with-zip-functions.ts
@@ -6,7 +6,6 @@ export async function runPhpWithZipFunctions(
 	code: string
 ) {
 	return await playground.run({
-		throwOnError: true,
 		code: zipFunctions + code,
 	});
 }

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -403,7 +403,6 @@ try {
 
 					if (args.includes('-r')) {
 						result = await childPHP.run({
-							throwOnError: true,
 							code: `${cliBootstrapScript} ${
 								args[args.indexOf('-r') + 1]
 							}`,
@@ -411,7 +410,6 @@ try {
 						});
 					} else if (args[1] === 'wp-cli.phar') {
 						result = await childPHP.run({
-							throwOnError: true,
 							code: `${cliBootstrapScript} require( "/wordpress/wp-cli.phar" );`,
 							env: {
 								...options.env,
@@ -423,7 +421,6 @@ try {
 						});
 					} else {
 						result = await childPHP.run({
-							throwOnError: true,
 							scriptPath: args[1],
 							env: options.env,
 						});

--- a/packages/playground/website/demos/php-blueprints.ts
+++ b/packages/playground/website/demos/php-blueprints.ts
@@ -79,11 +79,11 @@ try {
 		 *
 		 * > echo file_get_contents('http://localhost:5400/website-server/');
 		 * > <b>Warning</b>:  PHP Request Startup: Failed to open stream: Operation timed out in <b>php-wasm run script</b> on line <b>13</b><br />
-		 * 
+		 *
 		 * The check is therefore disabled for now.
 		 */
 		require '/wordpress/blueprints.phar';
-		
+
 		$blueprint = BlueprintBuilder::create()
 			// This isn't a WordPress zip file since wordpress.org
 			// doesn't expose the right CORS headers. It is a HTTPS-hosted
@@ -105,7 +105,7 @@ try {
 				'https://downloads.wordpress.org/plugin/hello-dolly.zip',
 				// When the regular UrlDataSource is used, the second
 				// downloaded zip file always errors with:
-				// > Failed to open stream: Operation timed out 
+				// > Failed to open stream: Operation timed out
 				'https://downloads.wordpress.org/plugin/classic-editor.zip',
 				'https://downloads.wordpress.org/plugin/gutenberg.17.7.0.zip',
 			] )
@@ -120,10 +120,10 @@ try {
 			->withFile( 'wordpress.txt', 'Data' )
 			->toBlueprint()
 		;
-		
+
 		echo "Running the following Blueprint:\n";
 		echo json_encode($blueprint, JSON_PRETTY_PRINT)."\n\n";
-		
+
 		$subscriber = new class implements EventSubscriberInterface {
 			public static function getSubscribedEvents() {
 				return [
@@ -131,7 +131,7 @@ try {
 					DoneEvent::class     => 'onDone',
 				];
 			}
-		
+
 			public function onProgress( ProgressEvent $event ) {
 				post_message_to_js(json_encode([
 					'type'    => 'progress',
@@ -139,7 +139,7 @@ try {
 					'progress' => $event->progress,
 				]));
 			}
-		
+
 			public function onDone( DoneEvent $event ) {
 				post_message_to_js(json_encode([
 					'type'    => 'progress',
@@ -148,7 +148,7 @@ try {
 			}
 		};
 
-		
+
 		$results = run_blueprint(
 			$blueprint,
 			[
@@ -158,13 +158,12 @@ try {
 				'progressType'       => 'steps',
 			]
 		);
-		
+
 		echo "Blueprint execution finished!\n";
 		echo "Contents of /wordpress/wp-content/plugins:";
 		print_r(glob('/wordpress/wp-content/plugins/*'));
-		
+
 		`,
-		throwOnError: true,
 	});
 
 	outputDiv.textContent += result.text;


### PR DESCRIPTION
## What is this PR doing?

With this PR, `PHP.run()` throws an exception when `php.run()` is unsuccessful. In other words, it makes `php.run({ throwOnError: true })` the default behavior and removes the `throwOnError` flag.

## What problem is it solving?

With the introduction of the Playground logger, we want to collect all errors in the logger and let the user decide what to do with the logged errors. For this to work, we can't allow `throwOnError` to be `false`.

The early versions of Playground/PHP.wasm were meant to support this behavior, but they couldn't because of the technical limitations – the exit code captured from the PHP process did not reflect the truth about the actual success/failure.

The `throwOnError` flag was introduced together with the correct `exitCode` support. In the typical `php.run()` usage, you'll want to check for errors. Asking the developers to always inspect the `exitCode` is a mistake-prone pattern since it's easy to forget or get wrong.

With this PR, PHP.wasm does the error-checking work for the developer and reliably reports any runtime crashes using JavaScript exceptions. It also removes the non throwing– code path to reduce the number of possible ways of using the library, reduce the number of uncaught errors out in the wild, and ease the library maintenance.

### Before this PR:

```ts
const r = await php.run({
    code: `<?php noSuchFunction();`
});
console.log(r.errors); // Fatal Error: Undefined function...
```

### After this PR:

```ts
try {
    // This throws an exception:
    const r = await php.run({
        code: `<?php noSuchFunction();`
    });
} catch( e ) {
    console.log(e.output.stderr); // Fatal Error: Undefined function...
    console.log(e.output.stdout);
}
```

## How is the problem addressed?

By removing all mentions of `throwOnError` and making sure tests pass.

## Testing Instructions

- Confirm that all tests pass
