### PR TITLE
Give brandonpayton permission to run Playground GH workflows

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -12,7 +12,8 @@ jobs:
                 github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak'
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton'
             )
 
         # Specify runner + deployment step

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -15,7 +15,8 @@ jobs:
                 github.event.workflow_run.conclusion == 'success' ||
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak'
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton'
             )
 
         # Specify runner + deployment step

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -20,7 +20,8 @@ jobs:
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak'
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton'
             )
 
         # Specify runner + deployment step

--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -13,7 +13,8 @@ jobs:
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak'
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton'
             )
 
         runs-on: ubuntu-latest

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -13,7 +13,8 @@ jobs:
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak'
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton'
             )
 
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR gives me permission to run Playground GitHub workflows. The initial motivation for this is so I can manually run the needed workflows immediately after the WordPress 6.5 release so playground.wordpress.net is updated in a timely manner.

If this is not needed or desired at the moment, please feel free to close. :)