### PR TITLE
Update the wp-cli step code example

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -9,7 +9,7 @@ import { phpVar } from '@php-wasm/util';
  *
  * <code>
  * {
- * 		"step": "wpCLI",
+ * 		"step": "wp-cli",
  * 		"command": "wp post create --post_title='Test post' --post_excerpt='Some content'"
  * }
  * </code>


### PR DESCRIPTION
@dmsnell reported:

> uh oh. I get a crash of the Playground: syntax error in Blueprints when copy/pasting from the docs
```
{
            "step": "wpCLI",
            "command": "wp post create --post_title='Test post' --post_excerpt='Some content'"
}
```
> the crash is Unhandled Promise Rejection: Error: Invalid blueprint: value of tag "step" must be in oneOf at /steps/1
>
> the docs show wpCLI but the JSON schema defines wp-cli

This PR adjusts the documentation example.
