### PR TITLE
Plugin proxy: Allow requests to WordPress.org

### DIFF
--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -338,7 +338,7 @@ try {
         // Proxy the current request to $_GET['url'] and return the response,
         // but only if the URL is allowlisted.
         $url = $_GET['url'];
-        $allowed_domains = ['api.wordpress.org', 'w.org', 's.w.org'];
+        $allowed_domains = ['api.wordpress.org', 'w.org', 'wordpress.org', 's.w.org'];
         $parsed_url = parse_url($url);
         if (!in_array($parsed_url['host'], $allowed_domains)) {
             http_response_code(403);


### PR DESCRIPTION
This change enables testing older WordPress releases with the following Blueprint:

```json
{
    "landingPage": "/wp-admin",
    "steps": [
        {
            "step": "writeFile",
            "path": "/tmp/wordpress.zip",
            "data": {
                "resource": "url",
                "url": "https://playground.wordpress.net/plugin-proxy.php?url=https://wordpress.org/wordpress-5.9.9.zip",
                "caption": "Downloading the WordPress Release"
            }
        },
        {
            "step": "importWordPressFiles",
            "wordPressFilesZip": {
                "resource": "vfs",
                "path": "/tmp/wordpress.zip"
            },
            "pathInZip": "/wordpress",
            "progress": {
                "weight": 20,
                "caption": "Importing the WordPress release"
            }
        },
        {
            "step": "runPHP",
            "code": "<?php $_GET['step'] = 'upgrade_db'; require '/wordpress/wp-admin/upgrade.php'; "
        },
        {
            "step": "login",
            "username": "admin",
            "password": "password"
        }
    ]
}
```

[Click here to test](https://playground.wordpress.net/#eyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbiIsInN0ZXBzIjpbeyJzdGVwIjoid3JpdGVGaWxlIiwicGF0aCI6Ii90bXAvd29yZHByZXNzLnppcCIsImRhdGEiOnsicmVzb3VyY2UiOiJ1cmwiLCJ1cmwiOiJodHRwczovL3BsYXlncm91bmQud29yZHByZXNzLm5ldC9wbHVnaW4tcHJveHkucGhwP3VybD1odHRwczovL3dvcmRwcmVzcy5vcmcvd29yZHByZXNzLTUuOS45LnppcCIsImNhcHRpb24iOiJEb3dubG9hZGluZyB0aGUgV29yZFByZXNzIFJlbGVhc2UifX0seyJzdGVwIjoiaW1wb3J0V29yZFByZXNzRmlsZXMiLCJ3b3JkUHJlc3NGaWxlc1ppcCI6eyJyZXNvdXJjZSI6InZmcyIsInBhdGgiOiIvdG1wL3dvcmRwcmVzcy56aXAifSwicGF0aEluWmlwIjoiL3dvcmRwcmVzcyIsInByb2dyZXNzIjp7IndlaWdodCI6MjAsImNhcHRpb24iOiJJbXBvcnRpbmcgdGhlIFdvcmRQcmVzcyByZWxlYXNlIn19LHsic3RlcCI6InJ1blBIUCIsImNvZGUiOiI8P3BocCAkX0dFVFsnc3RlcCddID0gJ3VwZ3JhZGVfZGInOyByZXF1aXJlICcvd29yZHByZXNzL3dwLWFkbWluL3VwZ3JhZGUucGhwJzsgIn0seyJzdGVwIjoibG9naW4iLCJ1c2VybmFtZSI6ImFkbWluIiwicGFzc3dvcmQiOiJwYXNzd29yZCJ9XX0=)

The oldest WordPress version that worked for me this way is `5.9.9` – I don't think the SQLite integration plugin works with WordPress versions <= 5.8.

Related to https://github.com/WordPress/wordpress-playground/issues/994