### PR TITLE
Website: Query API options to preconfigure the GitHub export form

### DIFF
--- a/packages/docs/site/docs/08-query-api/01-index.md
+++ b/packages/docs/site/docs/08-query-api/01-index.md
@@ -50,3 +50,22 @@ For example, the following code embeds a Playground with a preinstalled Gutenber
 To import files from a URL, such as a site zip package, they must be served with `Access-Control-Allow-Origin` header set. For reference, see: [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#the_http_response_headers).
 
 :::
+
+## GitHub Export Options
+
+The following additional query parameters may be used to pre-configure the GitHub export form:
+
+-   `gh-ensure-auth`: If set to `yes`, Playground will display a modal to ensure the
+    user is authenticated with GitHub before proceeding.
+-   `ghexport-repo-url`: The URL of the GitHub repository to export to.
+-   `ghexport-pr-action`: The action to take when exporting (create or update).
+-   `ghexport-playground-root`: The root directory in the Playground to export from.
+-   `ghexport-repo-root`: The root directory in the repository to export to.
+-   `ghexport-content-type`: The content type of the export (plugin, theme, wp-content, custom-paths).
+-   `ghexport-plugin`: Plugin path. When the content type is `plugin`, pre-select the plugin to export.
+-   `ghexport-theme`: Theme directory name. When the content type is `theme`, pre-select the theme to export.
+-   `ghexport-path`: A path relative to `ghexport-playground-root`. Can be provided multiple times. When the
+    content type is `custom-paths`, it pre-populates the list of paths to export.
+-   `ghexport-commit-message`: The commit message to use when exporting.
+-   `ghexport-allow-include-zip`: Whether to offer an option to include a zip file in the GitHub
+    export (yes, no). Optional. Defaults to `yes`.

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -485,7 +485,7 @@ export default function GitHubExportForm({
 
 				<div className={`${forms.formGroup} ${forms.formGroupLast}`}>
 					<label>
-						I am exporting a:
+						I am exporting:
 						<select
 							className={css.repoInput}
 							value={formValues.contentType}
@@ -497,12 +497,12 @@ export default function GitHubExportForm({
 							}
 						>
 							<option value="">-- Select an option --</option>
-							<option value="theme">Theme</option>
-							<option value="plugin">Plugin</option>
+							<option value="theme">A theme</option>
+							<option value="plugin">A plugin</option>
 							<option value="wp-content">
 								wp-content directory
 							</option>
-							<option value="custom-paths">custom paths</option>
+							<option value="custom-paths">Specific paths</option>
 						</select>
 					</label>
 					{errors.contentType && (

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -12,6 +12,7 @@ import Button from '../../components/button';
 import { staticAnalyzeGitHubURL } from '../analyze-github-url';
 import {
 	Changeset,
+	FileEntry,
 	GithubClient,
 	changeset,
 	createClient,
@@ -29,6 +30,7 @@ import { Spinner } from '../../components/spinner';
 import GitHubOAuthGuard from '../github-oauth-guard';
 import { ContentType } from '../import-from-github';
 import { joinPaths } from '@php-wasm/util';
+import MultiplePathsInput from './multiple-paths-input';
 
 export interface GitHubExportFormProps {
 	playground: PlaygroundClient;
@@ -61,7 +63,9 @@ export interface ExportFormValues {
 	prAction?: PullRequestAction;
 	prNumber: string;
 	contentType?: ContentType;
-	pathInRepo: string;
+	toPathInRepo: string;
+	fromPlaygroundRoot: string;
+	relativeExportPaths: string[];
 	commitMessage: string;
 	plugin?: string;
 	theme?: string;
@@ -82,7 +86,9 @@ export default function GitHubExportForm({
 		prNumber: '',
 		prAction: 'create',
 		commitMessage: 'Changes from WordPress Playground',
-		pathInRepo: '/',
+		relativeExportPaths: ['/'],
+		toPathInRepo: '/',
+		fromPlaygroundRoot: '/wordpress',
 		includeZip: false,
 		...initialValues,
 	});
@@ -114,7 +120,7 @@ export default function GitHubExportForm({
 		// and path that the user initially entered. If those change,
 		// we need to invalidate the initialFilesBeforeChanges.
 		if (
-			values.pathInRepo !== formValues.pathInRepo ||
+			values.toPathInRepo !== formValues.toPathInRepo ||
 			values.repoUrl !== formValues.repoUrl
 		) {
 			setFilesBeforeChanges(undefined);
@@ -219,13 +225,13 @@ export default function GitHubExportForm({
 				updatedValues['prAction'] = 'update';
 			}
 			if (path) {
-				updatedValues['pathInRepo'] = path;
+				updatedValues['toPathInRepo'] = path;
 			} else if (formValues.contentType === 'theme') {
-				updatedValues['pathInRepo'] = `/${formValues.theme}`;
+				updatedValues['toPathInRepo'] = `/${formValues.theme}`;
 			} else if (formValues.contentType === 'plugin') {
-				updatedValues['pathInRepo'] = `/${formValues.plugin}`;
+				updatedValues['toPathInRepo'] = `/${formValues.plugin}`;
 			} else {
-				updatedValues['pathInRepo'] = '/playground';
+				updatedValues['toPathInRepo'] = '/playground';
 			}
 			setFormValues({
 				...formValues,
@@ -242,13 +248,14 @@ export default function GitHubExportForm({
 			setError('prNumber', 'Please enter a PR number');
 			return;
 		}
-		if (!formValues.pathInRepo) {
-			setError('pathInRepo', 'Specify the path in the repo');
-			return;
-		}
 		if (!formValues.commitMessage) {
 			setError('commitMessage', 'Specify a commit message');
 			return;
+		}
+
+		let toPathInRepo = formValues.toPathInRepo.replace(/^\//g, '');
+		if (!toPathInRepo) {
+			toPathInRepo = '.';
 		}
 
 		setIsExporting(true);
@@ -261,9 +268,7 @@ export default function GitHubExportForm({
 			});
 			const defaultBranch = ghRepo.default_branch;
 
-			const relativeRepoPath = formValues.pathInRepo.replace(/^\//g, '');
-
-			let ghRawFiles: any[];
+			let ghRawFiles: any[] = [];
 			try {
 				ghRawFiles =
 					filesBeforeChanges ||
@@ -272,25 +277,39 @@ export default function GitHubExportForm({
 						repoDetails.owner,
 						repoDetails.repo,
 						defaultBranch,
-						relativeRepoPath
+						toPathInRepo
 					));
 			} catch (e) {
-				ghRawFiles = [];
+				// ignore
 			}
-			const comparableFiles = filesListToObject(ghRawFiles);
+			const ghComparableFiles = filesListToObject(ghRawFiles);
 
-			let playgroundPath: string;
+			let fromPlaygroundRoot = '';
+			let relativeExportPaths = [];
 			let prTitle: string;
 			const docroot = await playground.documentRoot;
 			if (formValues.contentType === 'wp-content') {
-				playgroundPath = `${docroot}/wp-content`;
+				fromPlaygroundRoot = docroot;
+				relativeExportPaths = ['/wp-content'];
 				prTitle = 'Update wp-content';
 			} else if (formValues.contentType === 'theme') {
-				playgroundPath = `${docroot}/wp-content/themes/${formValues.theme}`;
+				fromPlaygroundRoot = docroot;
+				relativeExportPaths = [
+					`${docroot}/wp-content/themes/${formValues.theme}`,
+				];
 				prTitle = `Update theme ${formValues.theme}`;
 			} else if (formValues.contentType === 'plugin') {
-				playgroundPath = `${docroot}/wp-content/plugins/${formValues.plugin}`;
+				fromPlaygroundRoot = docroot;
+				relativeExportPaths = [
+					`${docroot}/wp-content/plugins/${formValues.plugin}`,
+				];
 				prTitle = `Update plugin ${formValues.plugin}`;
+			} else if (formValues.contentType === 'custom-paths') {
+				fromPlaygroundRoot = formValues.fromPlaygroundRoot;
+				relativeExportPaths = formValues.relativeExportPaths
+					.map((path) => path.replace(/^\//g, ''))
+					.filter(Boolean);
+				prTitle = `Update wp-content`;
 			} else {
 				throw new Error(
 					`Unknown content type ${formValues.contentType}`
@@ -301,9 +320,9 @@ export default function GitHubExportForm({
 			const newBranchName = `playground-changes-${isoDateSlug}`;
 			let commitMessage = formValues.commitMessage;
 
-			if (formValues.includeZip) {
+			if (allowZipExport && formValues.includeZip) {
 				const zipFilename = `playground.zip`;
-				const zipPath = joinPaths(playgroundPath, zipFilename);
+				const zipPath = joinPaths(fromPlaygroundRoot, zipFilename);
 				if (await playground.fileExists(zipPath)) {
 					await playground.unlink(zipPath);
 				}
@@ -311,7 +330,10 @@ export default function GitHubExportForm({
 				await playground.writeFile(zipPath, zipContents);
 
 				const branchPreviewUrl = (branchName: string) => {
-					const zipballURL = `https://raw.githubusercontent.com/${repoDetails.owner}/${repoDetails.repo}/${branchName}/${relativeRepoPath}/${zipFilename}`;
+					const zipPath = [toPathInRepo, zipFilename]
+						.filter(Boolean)
+						.join('/');
+					const zipballURL = `https://raw.githubusercontent.com/${repoDetails.owner}/${repoDetails.repo}/${branchName}/${zipPath}`;
 					const url = new URL(document.location.origin);
 					url.pathname = document.location.pathname;
 					url.searchParams.set('import-site', zipballURL);
@@ -344,13 +366,31 @@ export default function GitHubExportForm({
 					].join('\n');
 			}
 
+			const allPlaygroundFiles: FileEntry[] = [];
+			for (const path of relativeExportPaths) {
+				const iterator = iterateFiles(
+					playground,
+					joinPaths(fromPlaygroundRoot, path),
+					{
+						exceptPaths: wpContentFilesExcludedFromExport,
+					}
+				);
+				for await (const file of iterator) {
+					allPlaygroundFiles.push({
+						path: joinPaths(
+							toPathInRepo,
+							file.path.substring(
+								formValues.fromPlaygroundRoot.length
+							)
+						),
+						read: file.read,
+					});
+				}
+			}
+
 			const changes = await changeset(
-				new Map(Object.entries(comparableFiles)),
-				iterateFiles(playground, playgroundPath!, {
-					relativePaths: true,
-					pathPrefix: relativeRepoPath,
-					exceptPaths: wpContentFilesExcludedFromExport,
-				})
+				new Map(Object.entries(ghComparableFiles)),
+				allPlaygroundFiles
 			);
 
 			const pushResult = await pushToGithub(getClient(), {
@@ -462,12 +502,86 @@ export default function GitHubExportForm({
 							<option value="wp-content">
 								wp-content directory
 							</option>
+							<option value="custom-paths">custom paths</option>
 						</select>
 					</label>
 					{errors.contentType && (
 						<div className={forms.error}>{errors.contentType}</div>
 					)}
 				</div>
+				{formValues.contentType === 'custom-paths' ? (
+					<>
+						<div
+							className={`${forms.formGroup} ${forms.formGroupLast}`}
+						>
+							<div className={`${css.pathMappingGroup}`}>
+								<label>
+									From Playground path
+									<input
+										type="text"
+										value={formValues.fromPlaygroundRoot}
+										className={css.repoInput}
+										onChange={(
+											e: React.ChangeEvent<HTMLInputElement>
+										) => {
+											setValue(
+												'fromPlaygroundRoot',
+												e.target.value
+											);
+										}}
+										placeholder="e.g. wp-content"
+										autoFocus
+									/>
+								</label>
+								<span className={css.pathMappingArrow}>➔</span>
+								<label>
+									To repository path
+									<input
+										type="text"
+										className={css.repoInput}
+										value={formValues.toPathInRepo}
+										onChange={(e) =>
+											setValue(
+												'toPathInRepo',
+												e.target.value
+											)
+										}
+									/>
+								</label>
+							</div>
+							{'fromPlaygroundRoot' in errors && (
+								<div className={forms.error}>
+									{errors.fromPlaygroundRoot}
+								</div>
+							)}
+							{'toPathInRepo' in errors && (
+								<div className={forms.error}>
+									{errors.toPathInRepo}
+								</div>
+							)}
+						</div>
+						<div
+							className={`${forms.formGroup} ${forms.formGroupLast}`}
+						>
+							<label>
+								Paths to export – relative to the path root
+								<MultiplePathsInput
+									initialValue={
+										formValues.relativeExportPaths
+									}
+									onChange={(paths) =>
+										setValue('relativeExportPaths', paths)
+									}
+								/>
+							</label>
+							{errors.relativeExportPaths && (
+								<div className={forms.error}>
+									{errors.relativeExportPaths}
+								</div>
+							)}
+						</div>
+					</>
+				) : null}
 				{formValues.contentType === 'theme' ? (
 					<div
 						className={`${forms.formGroup} ${forms.formGroupLast}`}
@@ -591,32 +705,35 @@ export default function GitHubExportForm({
 								)}
 							</div>
 						)}
-						{formValues.repoUrl && !errors.repoUrl ? (
+						{formValues.repoUrl &&
+						formValues.contentType !== 'custom-paths' ? (
+							<div
+								className={`${forms.formGroup} ${forms.formGroupLast}`}
+							>
+								<label>
+									Enter the path in the repository where the
+									changes should be committed:
+									<input
+										type="text"
+										className={css.repoInput}
+										value={formValues.toPathInRepo}
+										onChange={(e) =>
+											setValue(
+												'toPathInRepo',
+												e.target.value
+											)
+										}
+									/>
+								</label>
+								{errors.pathInRepo && (
+									<div className={forms.error}>
+										{errors.pathInRepo}
+									</div>
+								)}
+							</div>
+						) : null}
+						{formValues.repoUrl ? (
 							<>
-								<div
-									className={`${forms.formGroup} ${forms.formGroupLast}`}
-								>
-									<label>
-										Enter the path in the repository where
-										the changes should be committed:
-										<input
-											type="text"
-											className={css.repoInput}
-											value={formValues.pathInRepo}
-											onChange={(e) =>
-												setValue(
-													'pathInRepo',
-													e.target.value
-												)
-											}
-										/>
-									</label>
-									{errors.pathInRepo && (
-										<div className={forms.error}>
-											{errors.pathInRepo}
-										</div>
-									)}
-								</div>
 								<div
 									className={`${forms.formGroup} ${forms.formGroupLast}`}
 								>

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -34,6 +34,7 @@ export interface GitHubExportFormProps {
 	playground: PlaygroundClient;
 	initialValues?: Partial<ExportFormValues>;
 	initialFilesBeforeChanges?: any[];
+	allowZipExport?: boolean;
 	onExported?: (prURL: string, formValues: ExportFormValues) => void;
 	onClose: () => void;
 }
@@ -47,6 +48,13 @@ function getClient() {
 }
 
 export type PullRequestAction = 'update' | 'create';
+
+export function asPullRequestAction(value: any): PullRequestAction | undefined {
+	if (value === 'update' || value === 'create') {
+		return value;
+	}
+	return 'create';
+}
 
 export interface ExportFormValues {
 	repoUrl: string;
@@ -66,6 +74,7 @@ export default function GitHubExportForm({
 	onClose,
 	initialValues = {},
 	initialFilesBeforeChanges,
+	allowZipExport = true,
 }: GitHubExportFormProps) {
 	const [pushResult, setPushResult] = useState<PushResult>();
 	const [formValues, _setFormValues] = useState<ExportFormValues>({
@@ -631,25 +640,27 @@ export default function GitHubExportForm({
 										</div>
 									)}
 								</div>
-								<div
-									className={`${forms.formGroup} ${forms.formGroupLast}`}
-								>
-									<label>
-										<input
-											type="checkbox"
-											checked={formValues.includeZip}
-											onChange={(e) =>
-												setValue(
-													'includeZip',
-													e.target.checked
-												)
-											}
-										/>
-										Also export the changes as a zip file,
-										so they can be imported into another
-										Playground instance.
-									</label>
-								</div>
+								{allowZipExport ? (
+									<div
+										className={`${forms.formGroup} ${forms.formGroupLast}`}
+									>
+										<label>
+											<input
+												type="checkbox"
+												checked={formValues.includeZip}
+												onChange={(e) =>
+													setValue(
+														'includeZip',
+														e.target.checked
+													)
+												}
+											/>
+											Also export the changes as a zip
+											file, so they can be imported into
+											another Playground instance.
+										</label>
+									</div>
+								) : null}
 							</>
 						) : null}
 					</>

--- a/packages/playground/website/src/github/github-export-form/modal.tsx
+++ b/packages/playground/website/src/github/github-export-form/modal.tsx
@@ -9,6 +9,7 @@ export const isGitHubExportModalOpen = signal(
 );
 
 interface GithubExportModalProps {
+	allowZipExport: GitHubExportFormProps['allowZipExport'];
 	onExported?: GitHubExportFormProps['onExported'];
 	initialFilesBeforeChanges?: GitHubExportFormProps['initialFilesBeforeChanges'];
 	initialValues?: GitHubExportFormProps['initialValues'];
@@ -30,6 +31,7 @@ export function openModal() {
 }
 export function GithubExportModal({
 	onExported,
+	allowZipExport,
 	initialValues,
 	initialFilesBeforeChanges,
 }: GithubExportModalProps) {
@@ -49,6 +51,7 @@ export function GithubExportModal({
 				playground={playground!}
 				initialValues={initialValues}
 				initialFilesBeforeChanges={initialFilesBeforeChanges}
+				allowZipExport={allowZipExport}
 			/>
 		</Modal>
 	);

--- a/packages/playground/website/src/github/github-export-form/multiple-paths-input.tsx
+++ b/packages/playground/website/src/github/github-export-form/multiple-paths-input.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from 'react';
+import css from './style.module.css';
+import Button from '../../components/button';
+
+interface MultiplePathsInputProps {
+	onChange: (paths: string[]) => void;
+	initialValue: string[];
+}
+
+const MultiplePathsInput: React.FC<MultiplePathsInputProps> = ({
+	onChange,
+	initialValue,
+}) => {
+	const [customPaths, setCustomPaths] = useState(
+		!initialValue?.length ? [''] : initialValue
+	);
+
+	const handleAddPath = (e: any) => {
+		e.preventDefault();
+		setCustomPaths([...customPaths, '']);
+	};
+
+	const handleRemovePath = (index: number) => {
+		const paths = [...customPaths];
+		paths.splice(index, 1);
+		if (paths.length === 0) {
+			paths.push('');
+		}
+		setCustomPaths(paths);
+	};
+
+	const handlePathChange = (index: number, value: string) => {
+		const paths = [...customPaths];
+		paths[index] = value;
+		setCustomPaths(paths);
+	};
+
+	// Call the onChange callback whenever the paths change
+	React.useEffect(() => {
+		onChange(customPaths);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [customPaths]);
+
+	return (
+		<div className={css.multiplsPaths}>
+			{customPaths.map((path, index) => (
+				<div key={index} className={css.multipleInputsRow}>
+					<input
+						type="text"
+						className={css.repoInput}
+						value={path}
+						onChange={(e) =>
+							handlePathChange(index, e.target.value)
+						}
+					/>
+					{customPaths.length > 1 && (
+						<Button
+							className={css.multipleInputsRemoveButton}
+							onClick={() => handleRemovePath(index)}
+						>
+							-
+						</Button>
+					)}
+				</div>
+			))}
+			<Button
+				onClick={handleAddPath}
+				className={css.multipleInputsAddButton}
+			>
+				+ Add path
+			</Button>
+		</div>
+	);
+};
+
+export default MultiplePathsInput;

--- a/packages/playground/website/src/github/github-export-form/style.module.css
+++ b/packages/playground/website/src/github/github-export-form/style.module.css
@@ -36,3 +36,50 @@
 .examples-dl dd {
 	margin-bottom: 10px;
 }
+
+.path-mapping-group {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: wrap;
+	gap: 20px;
+}
+.path-mapping-group > label {
+	flex: 1;
+}
+.path-mapping-arrow {
+	width: 1.5ch;
+	text-align: center;
+	align-self: center;
+}
+
+/* mobile phones */
+@media (max-width: 600px) {
+	.path-mapping-group > label {
+		width: 100%;
+	}
+	.path-mapping-arrow {
+		display: none;
+	}
+}
+
+.multiple-inputs button {
+	width: 40px !important;
+	height: 38px !important;
+	margin-top: 5px;
+}
+
+.multiple-inputs-row {
+	display: flex;
+	flex-direction: row;
+	align-items: baseline;
+	gap: 10px;
+}
+
+.multiple-inputs-add-button {
+	margin-top: 10px;
+}
+
+.multiple-inputs-remove-button {
+	width: 40px !important;
+	height: 40px !important;
+}

--- a/packages/playground/website/src/github/github-oauth-guard/index.tsx
+++ b/packages/playground/website/src/github/github-oauth-guard/index.tsx
@@ -4,15 +4,42 @@ import { GitHubIcon } from '../github';
 import css from './style.module.css';
 import { useContext, useState } from 'react';
 import { PlaygroundContext } from '../../playground-context';
+import Modal, { defaultStyles } from '../../components/modal';
 import classNames from 'classnames';
 
 const OAUTH_FLOW_URL = 'oauth.php?redirect=1';
 const urlParams = new URLSearchParams(window.location.search);
 export const oauthCode = urlParams.get('code');
-interface GitHubOAuthGuardProps {
-	children: React.ReactNode;
+
+export function GitHubOAuthGuardModal({ children }: GitHubOAuthGuardProps) {
+	const [isModalOpen, setIsModalOpen] = useState(!oAuthState.value.token);
+
+	return (
+		<Modal
+			style={{
+				...defaultStyles,
+				content: { ...defaultStyles.content, width: 600 },
+			}}
+			isOpen={isModalOpen}
+			onRequestClose={() => {
+				setIsModalOpen(false);
+			}}
+		>
+			<GitHubOAuthGuard mayLoseProgress={false}>
+				{children}
+			</GitHubOAuthGuard>
+		</Modal>
+	);
 }
-export default function GitHubOAuthGuard({ children }: GitHubOAuthGuardProps) {
+
+interface GitHubOAuthGuardProps {
+	children?: React.ReactNode;
+	mayLoseProgress?: boolean;
+}
+export default function GitHubOAuthGuard({
+	children,
+	mayLoseProgress,
+}: GitHubOAuthGuardProps) {
 	if (oAuthState.value.isAuthorizing) {
 		return (
 			<div>
@@ -29,14 +56,30 @@ export default function GitHubOAuthGuard({ children }: GitHubOAuthGuardProps) {
 	const urlParams = new URLSearchParams();
 	urlParams.set('redirect_uri', window.location.href);
 	const oauthUrl = `${OAUTH_FLOW_URL}&${urlParams.toString()}`;
-	return <Authenticate authenticateUrl={oauthUrl} />;
+	return (
+		<Authenticate
+			authenticateUrl={oauthUrl}
+			mayLoseProgress={mayLoseProgress}
+		/>
+	);
 }
 
-function Authenticate({ authenticateUrl }: { authenticateUrl: string }) {
+interface AuthenticateProps {
+	authenticateUrl: string;
+	mayLoseProgress?: boolean;
+}
+
+function Authenticate({
+	authenticateUrl,
+	mayLoseProgress = undefined,
+}: AuthenticateProps) {
 	const { storage } = useContext(PlaygroundContext);
+	if (mayLoseProgress === undefined) {
+		mayLoseProgress = storage === 'none';
+	}
 	const [exported, setExported] = useState(false);
 	const buttonClass = classNames(css.githubButton, {
-		[css.disabled]: storage === 'none' && !exported,
+		[css.disabled]: mayLoseProgress && !exported,
 	});
 	return (
 		<div>
@@ -51,7 +94,7 @@ function Authenticate({ authenticateUrl }: { authenticateUrl: string }) {
 				To enable this feature, connect your GitHub account with
 				WordPress Playground.
 			</p>
-			{storage === 'none' ? (
+			{mayLoseProgress ? (
 				<>
 					<p>
 						<b>You will lose your progress.</b> Your Playground is

--- a/packages/playground/website/src/github/import-from-github.ts
+++ b/packages/playground/website/src/github/import-from-github.ts
@@ -8,9 +8,14 @@ import {
 } from '@wp-playground/blueprints';
 import { Files, filesListToObject } from '@wp-playground/storage';
 
-export type ContentType = 'plugin' | 'theme' | 'wp-content';
+export type ContentType = 'plugin' | 'theme' | 'wp-content' | 'custom-paths';
 export function asContentType(value: any): ContentType | undefined {
-	if (value === 'plugin' || value === 'theme' || value === 'wp-content') {
+	if (
+		value === 'plugin' ||
+		value === 'theme' ||
+		value === 'wp-content' ||
+		value === 'custom-paths'
+	) {
 		return value;
 	}
 }
@@ -31,7 +36,7 @@ export async function importFromGitHub(
 	} else if (contentType === 'wp-content') {
 		await importWpContent(php, playgroundFiles);
 	} else {
-		throw new Error(`Unknown content type: ${contentType}`);
+		throw new Error(`Unsupported import content type: ${contentType}`);
 	}
 }
 

--- a/packages/playground/website/src/github/import-from-github.ts
+++ b/packages/playground/website/src/github/import-from-github.ts
@@ -9,6 +9,11 @@ import {
 import { Files, filesListToObject } from '@wp-playground/storage';
 
 export type ContentType = 'plugin' | 'theme' | 'wp-content';
+export function asContentType(value: any): ContentType | undefined {
+	if (value === 'plugin' || value === 'theme' || value === 'wp-content') {
+		return value;
+	}
+}
 export async function importFromGitHub(
 	php: UniversalPHP,
 	gitHubFiles: any[],

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -91,14 +91,40 @@ function Main() {
 	const [githubExportFiles, setGithubExportFiles] = useState<any[]>();
 	const [githubExportValues, setGithubExportValues] = useState<
 		Partial<ExportFormValues>
-	>({
-		repoUrl: query.get('ghexport-repo-url') ?? undefined,
-		contentType: asContentType(query.get('ghexport-content-type')),
-		prAction: asPullRequestAction(query.get('ghexport-pr-action')),
-		pathInRepo: query.get('ghexport-repo-path') ?? undefined,
-		commitMessage: query.get('ghexport-commit-message') ?? undefined,
-		plugin: query.get('ghexport-plugin') ?? undefined,
-		theme: query.get('ghexport-theme') ?? undefined,
+	>(() => {
+		const values: Partial<ExportFormValues> = {};
+		if (query.get('ghexport-repo-url')) {
+			values.repoUrl = query.get('ghexport-repo-url')!;
+		}
+		if (query.get('ghexport-content-type')) {
+			values.contentType = asContentType(
+				query.get('ghexport-content-type')
+			);
+		}
+		if (query.get('ghexport-pr-action')) {
+			values.prAction = asPullRequestAction(
+				query.get('ghexport-pr-action')
+			);
+		}
+		if (query.get('ghexport-playground-root')) {
+			values.fromPlaygroundRoot = query.get('ghexport-playground-root')!;
+		}
+		if (query.get('ghexport-repo-root')) {
+			values.toPathInRepo = query.get('ghexport-repo-root')!;
+		}
+		if (query.get('ghexport-path')) {
+			values.relativeExportPaths = query.getAll('ghexport-path');
+		}
+		if (query.get('ghexport-commit-message')) {
+			values.commitMessage = query.get('ghexport-commit-message')!;
+		}
+		if (query.get('ghexport-plugin')) {
+			values.plugin = query.get('ghexport-plugin')!;
+		}
+		if (query.get('ghexport-theme')) {
+			values.theme = query.get('ghexport-theme')!;
+		}
+		return values;
 	});
 
 	return (
@@ -203,7 +229,7 @@ function Main() {
 						setGithubExportValues({
 							repoUrl: url,
 							prNumber: pr?.toString(),
-							pathInRepo: path,
+							toPathInRepo: path,
 							prAction: pr ? 'update' : 'create',
 							contentType,
 							plugin: pluginOrThemeName,


### PR DESCRIPTION
## Description

Adds a `custom-paths` export type to enable exporting a subset of a directory:

<img width="300" src="https://github.com/WordPress/wordpress-playground/assets/205419/881e0013-d338-43c1-a5bb-ad05d13ce853">

Furthermore, it adds new Query API parameters to preconfigure the GitHub export form:

* `gh-ensure-auth`: If set to `yes`, Playground will display a modal to ensure the
					user is authenticated with GitHub before proceeding.
* `ghexport-repo-url`: The URL of the GitHub repository to export to.
* `ghexport-pr-action`: The action to take when exporting (create or update).
* `ghexport-playground-root`: The root directory in the Playground to export from.
* `ghexport-repo-root`: The root directory in the repository to export to.
* `ghexport-content-type`: The content type of the export (plugin, theme, wp-content, custom-paths).
* `ghexport-plugin`: Plugin path. When the content type is `plugin`, pre-select the plugin to export.
* `ghexport-theme`: Theme directory name. When the content type is `theme`, pre-select the theme to export.
* `ghexport-path`: A path relative to `ghexport-playground-root`. Can be provided multiple times. When the
                   content type is `custom-paths`, it pre-populates the list of paths to export.
* `ghexport-commit-message`: The commit message to use when exporting.
* `ghexport-allow-include-zip`: Whether to offer an option to include a zip file in the GitHub
                                export (yes, no). Optional. Defaults to `yes`.

Related to https://github.com/adamziel/playground-docs-workflow

## Testing instructions

* Confirm the GitHub export form continues to work as it did before this PR, that is you're able to export plugins, themes, and the entire wp-content directory as pull requests.
* Go through the Query API options and confirm each does what the description says.
* Attempt exporting two directories in the `custom-paths` mode.

Also, [click here](http://localhost:5400/website-server/?gh-ensure-auth=yes&ghexport-repo-url=https%3A%2F%2Fgithub.com%2Fadamziel%2Fplayground-docs-workflow&ghexport-content-type=custom-paths&ghexport-path=plugins/wp-docs-plugin&ghexport-path=html-pages&ghexport-path=uploads&ghexport-path=blueprint.json&ghexport-commit-message=Documentation+update&ghexport-playground-root=/wordpress/wp-content&ghexport-repo-root=/wp-content&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fadamziel%2Fplayground-docs-workflow%2Ftrunk%2Fwp-content%2Fblueprint.json&ghexport-pr-action=create&ghexport-allow-include-zip=no) and confirm you're asked to authenticate with GitHub, the doc editing plugin gets installed, and that you can make changes to docs pages and export them to GitHub as a PR.