### PR TITLE
issue #1186 add sitemap.*.xml$ to the things that generate a .php request.

### DIFF
--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -361,7 +361,11 @@ export function seemsLikeAPHPRequestHandlerPath(path: string): boolean {
 }
 
 function seemsLikeAPHPFile(path: string) {
-	return path.endsWith('.php') || path.includes('.php/');
+	return (
+		path.endsWith('.php') ||
+		path.includes('.php/') ||
+		path.match(/sitemap.*.xml$/) != null
+	);
 }
 
 function seemsLikeADirectoryRoot(path: string) {


### PR DESCRIPTION
## What is this PR doing?

#1186 The request is handled as though it is for a static file in packages/php-wasm/universal/src/lib
/php-request-handler.ts.

## What problem is it solving?

The leading sitemap plugins generate the sitemap.xml file on request

## How is the problem addressed?

add sitemap.*.xml$ to the things that generate a .php request.

## Testing Instructions

install the plugin https://github.com/RavanH/xml-sitemap-feed for instance and surf to /wp-sitemap.xml for instance.