### PR TITLE
Unit tests: Restore site-data.spec.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare-playground
+            - run: npx nx reset
             - run: npx nx affected --target=lint
             - run: npx nx affected --target=typecheck
     test-unit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare-playground
-            - run: npx nx reset
             - run: npx nx affected --target=lint
             - run: npx nx affected --target=typecheck
     test-unit:

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -515,6 +515,7 @@ RUN echo -n ' -s ASYNCIFY=1 -s ASYNCIFY_IGNORE_INDIRECT=1 ' >> /root/.emcc-php-w
 "zend_isset_isempty_dim_prop_obj_handler_SPEC_CV_CONST",\
 "zend_assign_to_object",\
 "zif_file_put_contents",\
+"ZEND_SEND_ARRAY_SPEC_HANDLER",\
 "ZEND_ASSIGN_OBJ_SPEC_CV_CONST_HANDLER",\
 "zend_std_call_user_call",\
 "zend_objects_store_del_ref_by_handle_ex",\

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -515,7 +515,6 @@ RUN echo -n ' -s ASYNCIFY=1 -s ASYNCIFY_IGNORE_INDIRECT=1 ' >> /root/.emcc-php-w
 "zend_isset_isempty_dim_prop_obj_handler_SPEC_CV_CONST",\
 "zend_assign_to_object",\
 "zif_file_put_contents",\
-"ZEND_SEND_ARRAY_SPEC_HANDLER",\
 "ZEND_ASSIGN_OBJ_SPEC_CV_CONST_HANDLER",\
 "zend_std_call_user_call",\
 "zend_objects_store_del_ref_by_handle_ex",\

--- a/packages/php-wasm/node/src/lib/networking/outbound-ws-to-tcp-proxy.ts
+++ b/packages/php-wasm/node/src/lib/networking/outbound-ws-to-tcp-proxy.ts
@@ -67,6 +67,7 @@ export function addSocketOptionsSupportToWebSocketClass(
 	return class PHPWasmWebSocketConstructor extends WebSocketConstructor {
 		// @ts-ignore
 		send(chunk: any, callback: any) {
+			console.log('send', { chunk });
 			return this.sendCommand(COMMAND_CHUNK, chunk, callback);
 		}
 
@@ -75,6 +76,7 @@ export function addSocketOptionsSupportToWebSocketClass(
 			optionName: number,
 			optionValue: number
 		) {
+			console.log(this.url, { optionClass, optionName, optionValue });
 			return this.sendCommand(
 				COMMAND_SET_SOCKETOPT,
 				new Uint8Array([optionClass, optionName, optionValue]).buffer,

--- a/packages/php-wasm/node/src/lib/networking/outbound-ws-to-tcp-proxy.ts
+++ b/packages/php-wasm/node/src/lib/networking/outbound-ws-to-tcp-proxy.ts
@@ -67,7 +67,6 @@ export function addSocketOptionsSupportToWebSocketClass(
 	return class PHPWasmWebSocketConstructor extends WebSocketConstructor {
 		// @ts-ignore
 		send(chunk: any, callback: any) {
-			console.log('send', { chunk });
 			return this.sendCommand(COMMAND_CHUNK, chunk, callback);
 		}
 
@@ -76,7 +75,6 @@ export function addSocketOptionsSupportToWebSocketClass(
 			optionName: number,
 			optionValue: number
 		) {
-			console.log(this.url, { optionClass, optionName, optionValue });
 			return this.sendCommand(
 				COMMAND_SET_SOCKETOPT,
 				new Uint8Array([optionClass, optionName, optionValue]).buffer,

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -62,9 +62,6 @@ export default defineConfig(() => {
 			},
 			environment: 'jsdom',
 			include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-			onConsoleLog(): false | void {
-				return false;
-			},
 		},
 
 		define: {

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -62,6 +62,9 @@ export default defineConfig(() => {
 			},
 			environment: 'jsdom',
 			include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+			onConsoleLog(): false | void {
+				return false;
+			},
 		},
 
 		define: {

--- a/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
@@ -1,12 +1,15 @@
 import { NodePHP } from '@php-wasm/node';
-import { getWordPressModule } from '@wp-playground/wordpress';
+import {
+	RecommendedPHPVersion,
+	getWordPressModule,
+} from '@wp-playground/wordpress';
 import { setSiteOptions } from './site-data';
 import { unzip } from './unzip';
 
 describe('Blueprint step setSiteOptions()', () => {
 	let php: NodePHP;
 	beforeEach(async () => {
-		php = await NodePHP.load('7.4', {
+		php = await NodePHP.load(RecommendedPHPVersion, {
 			requestHandler: {
 				documentRoot: '/wordpress',
 			},

--- a/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
@@ -1,0 +1,37 @@
+import { NodePHP } from '@php-wasm/node';
+import {
+	RecommendedPHPVersion,
+	getWordPressModule,
+} from '@wp-playground/wordpress';
+import { setSiteOptions } from './site-data';
+import { unzip } from './unzip';
+
+describe('Blueprint step setSiteOptions()', () => {
+	let php: NodePHP;
+	beforeEach(async () => {
+		php = await NodePHP.load(RecommendedPHPVersion, {
+			requestHandler: {
+				documentRoot: '/wordpress',
+			},
+		});
+		await unzip(php, {
+			zipFile: await getWordPressModule(),
+			extractToPath: '/wordpress',
+		});
+	});
+
+	it('should set the site option', async () => {
+		await setSiteOptions(php, {
+			options: {
+				blogname: 'My test site!',
+			},
+		});
+		const response = await php.run({
+			code: `<?php
+                require '/wordpress/wp-load.php';
+                echo get_option('blogname');
+			`,
+		});
+		expect(response.text).toBe('My test site!');
+	});
+});

--- a/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
@@ -1,15 +1,12 @@
 import { NodePHP } from '@php-wasm/node';
-import {
-	RecommendedPHPVersion,
-	getWordPressModule,
-} from '@wp-playground/wordpress';
+import { getWordPressModule } from '@wp-playground/wordpress';
 import { setSiteOptions } from './site-data';
 import { unzip } from './unzip';
 
 describe('Blueprint step setSiteOptions()', () => {
 	let php: NodePHP;
 	beforeEach(async () => {
-		php = await NodePHP.load(RecommendedPHPVersion, {
+		php = await NodePHP.load('7.4', {
 			requestHandler: {
 				documentRoot: '/wordpress',
 			},

--- a/packages/playground/blueprints/src/lib/steps/site-data.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.ts
@@ -40,6 +40,7 @@ export const setSiteOptions: StepHandler<SetSiteOptionsStep> = async (
 		foreach($site_options as $name => $value) {
 			update_option($name, $value);
 		}
+		echo "Success";
 		`,
 	});
 };

--- a/packages/playground/blueprints/src/lib/steps/site-data.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.ts
@@ -40,7 +40,6 @@ export const setSiteOptions: StepHandler<SetSiteOptionsStep> = async (
 		foreach($site_options as $name => $value) {
 			update_option($name, $value);
 		}
-		echo "Success";
 		`,
 	});
 };

--- a/packages/playground/blueprints/vite.config.ts
+++ b/packages/playground/blueprints/vite.config.ts
@@ -56,5 +56,8 @@ export default defineConfig({
 		},
 		environment: 'jsdom',
 		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+		onConsoleLog(): false | void {
+			return false;
+		},
 	},
 });

--- a/packages/playground/blueprints/vite.config.ts
+++ b/packages/playground/blueprints/vite.config.ts
@@ -56,8 +56,5 @@ export default defineConfig({
 		},
 		environment: 'jsdom',
 		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-		onConsoleLog(): false | void {
-			return false;
-		},
 	},
 });


### PR DESCRIPTION
The test was removed in #1192 due to intermittent failures like these:

```
FAIL  src/lib/steps/site-data.spec.ts > Blueprint step setSiteOptions() > should set the site option
```

![CleanShot 2024-04-04 at 13 09 25@2x](https://github.com/WordPress/wordpress-playground/assets/205419/fe68c5ff-80a7-4966-82a8-fbfcc7e9a101)

They seem related to #1189, but:

* I can't reproduce it locally
* The test actually passed in #1189 and only started failing in #1192
* All the other tests pass and the Playground website works so I wonder what's going on there.
* The stack trace mentions network activity, but that call shouldn't involve any. It's almost as if the trace was coming from `php-networking.spec.ts`, but those tests actually pass.

Is the CI runner just running out of memory? But then it shouldn't be able to allocate the memory segment in the first place. Weird!

CC @brandonpayton for insights
