### PR TITLE
Avoid Service Worker update issues on localhost

### DIFF
--- a/packages/playground/build-config.ts
+++ b/packages/playground/build-config.ts
@@ -1,5 +1,5 @@
-export const remoteDevServerHost = 'localhost';
+export const remoteDevServerHost = '127.0.0.1';
 export const remoteDevServerPort = 4400;
 
-export const websiteDevServerHost = 'localhost';
+export const websiteDevServerHost = '127.0.0.1';
 export const websiteDevServerPort = 5400;


### PR DESCRIPTION
## What problem is it solving?

This PR fixes #1180 - Playground on localhost sometimes fails to load due to failed service worker updates from "localhost".

## How is the problem addressed?

By switching from "localhost" to the explicit loopback address "127.0.0.1". This avoids the case where "localhost" does not directly resolve to a loopback address.

For reference:
https://w3c.github.io/webappsec-secure-contexts/#localhost
> Section 6.3 of [[RFC6761]](https://w3c.github.io/webappsec-secure-contexts/#biblio-rfc6761) lays out the resolution of localhost. and names falling within .localhost. as special, and suggests that local resolvers SHOULD/MAY treat them specially. For better or worse, resolvers often ignore these suggestions, and will send localhost to the network for resolution in a number of circumstances.
> 
> Given that uncertainty, user agents MAY treat localhost names as having [potentially trustworthy origins](https://w3c.github.io/webappsec-secure-contexts/#potentially-trustworthy-origin) if and only if they also adhere to the localhost name resolution rules spelled out in [[let-localhost-be-localhost]](https://w3c.github.io/webappsec-secure-contexts/#biblio-let-localhost-be-localhost) (which boil down to ensuring that localhost never resolves to a non-loopback address).

## Testing Instructions

Run `npm run dev` and confirm the new dev server URL is `http://127.0.0.1:5400/website-server/` and that local Playground loads successfully in your browser.