### PR TITLE
Adjust link to LICENSE file

### DIFF
--- a/packages/docs/site/docs/13-contributing/01-index.md
+++ b/packages/docs/site/docs/13-contributing/01-index.md
@@ -18,4 +18,4 @@ WordPress Playground is an open-source project and welcomes all contributors fro
 
 -   As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).
 -   Contributors should review the [coding standards](./03-coding-standards.md).
--   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under [WordPress Playground License](https://github.com/WordPress/wordpress-playground/blob/HEAD/LICENSE.md).
+-   You maintain copyright over any contribution you make. By submitting a pull request you agree to release that code under [WordPress Playground License](https://github.com/WordPress/wordpress-playground/blob/HEAD/LICENSE).


### PR DESCRIPTION
## What is this PR doing?
Commit eeb6b06bb6d994dfc3a716d51d93f8ce6479c968 changed `LICENSE.md` to `LICENSE`. This PR updates a location that still uses `LICENSE.md`.
