### PR TITLE
importWxr: Preserve backslashes in the imported content

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/fixtures/import-wxr-slash-issue.xml
+++ b/packages/playground/blueprints/src/lib/steps/fixtures/import-wxr-slash-issue.xml
@@ -1,0 +1,60 @@
+<rss version="2.0"
+	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:wp="http://wordpress.org/export/1.2/"
+>
+
+<channel>
+	<title>My WordPress Website</title>
+	<link>https://playground.wordpress.net/scope:0.6224554755515266</link>
+	<description></description>
+	<pubDate>Mon, 08 Apr 2024 07:03:05 +0000</pubDate>
+	<language>en-US</language>
+	<wp:wxr_version>1.2</wp:wxr_version>
+	<wp:base_site_url>https://playground.wordpress.net/scope:0.6224554755515266</wp:base_site_url>
+	<wp:base_blog_url>https://playground.wordpress.net/scope:0.6224554755515266</wp:base_blog_url>
+
+		<wp:author><wp:author_id>1</wp:author_id><wp:author_login><![CDATA[admin]]></wp:author_login><wp:author_email><![CDATA[admin@localhost.com]]></wp:author_email><wp:author_display_name><![CDATA[admin]]></wp:author_display_name><wp:author_first_name><![CDATA[]]></wp:author_first_name><wp:author_last_name><![CDATA[]]></wp:author_last_name></wp:author>
+
+				
+	<generator>https://wordpress.org/?v=6.5</generator>
+
+		<item>
+		<title><![CDATA[Issue]]></title>
+		<link>https://playground.wordpress.net/scope:0.6224554755515266/?p=5</link>
+		<pubDate>Mon, 08 Apr 2024 06:59:36 +0000</pubDate>
+		<dc:creator><![CDATA[admin]]></dc:creator>
+		<guid isPermaLink="false">https://playground.wordpress.net/scope:0.6224554755515266/?p=5</guid>
+		<description></description>
+		<content:encoded><![CDATA[<!-- wp:inseri-core/text-editor {"blockId":"DSrQIjN5UjosCHJQImF5z","blockName":"textEditor","height":60,"content":"\u0022#test\u0022","contentType":"application/json"} -->
+<div class="wp-block-inseri-core-text-editor" data-attributes="{&quot;blockId&quot;:&quot;DSrQIjN5UjosCHJQImF5z&quot;,&quot;blockName&quot;:&quot;textEditor&quot;,&quot;content&quot;:&quot;\&quot;#test\&quot;&quot;,&quot;contentType&quot;:&quot;application/json&quot;,&quot;editable&quot;:false,&quot;height&quot;:60,&quot;isVisible&quot;:true,&quot;label&quot;:&quot;&quot;}">is loading ...</div>
+<!-- /wp:inseri-core/text-editor -->]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:post_id>5</wp:post_id>
+		<wp:post_date><![CDATA[2024-04-08 06:59:36]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2024-04-08 06:59:36]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2024-04-08 07:02:42]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2024-04-08 07:02:42]]></wp:post_modified_gmt>
+		<wp:comment_status><![CDATA[open]]></wp:comment_status>
+		<wp:ping_status><![CDATA[open]]></wp:ping_status>
+		<wp:post_name><![CDATA[issue]]></wp:post_name>
+		<wp:status><![CDATA[publish]]></wp:status>
+		<wp:post_parent>0</wp:post_parent>
+		<wp:menu_order>0</wp:menu_order>
+		<wp:post_type><![CDATA[post]]></wp:post_type>
+		<wp:post_password><![CDATA[]]></wp:post_password>
+		<wp:is_sticky>0</wp:is_sticky>
+										<category domain="category" nicename="uncategorized"><![CDATA[Uncategorized]]></category>
+						<wp:postmeta>
+		<wp:meta_key><![CDATA[_pingme]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+		</wp:postmeta>
+							<wp:postmeta>
+		<wp:meta_key><![CDATA[_encloseme]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+		</wp:postmeta>
+							</item>
+				</channel>
+</rss>

--- a/packages/playground/blueprints/src/lib/steps/fixtures/import-wxr-slash-issue.xml
+++ b/packages/playground/blueprints/src/lib/steps/fixtures/import-wxr-slash-issue.xml
@@ -22,7 +22,7 @@
 	<generator>https://wordpress.org/?v=6.5</generator>
 
 		<item>
-		<title><![CDATA[Issue]]></title>
+		<title><![CDATA["Issue\Issue"]]></title>
 		<link>https://playground.wordpress.net/scope:0.6224554755515266/?p=5</link>
 		<pubDate>Mon, 08 Apr 2024 06:59:36 +0000</pubDate>
 		<dc:creator><![CDATA[admin]]></dc:creator>

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
@@ -55,17 +55,22 @@ describe('Blueprint step importWxr', () => {
 <div class="wp-block-inseri-core-text-editor" data-attributes="{&quot;blockId&quot;:&quot;DSrQIjN5UjosCHJQImF5z&quot;,&quot;blockName&quot;:&quot;textEditor&quot;,&quot;content&quot;:&quot;\\&quot;#test\\&quot;&quot;,&quot;contentType&quot;:&quot;application/json&quot;,&quot;editable&quot;:false,&quot;height&quot;:60,&quot;isVisible&quot;:true,&quot;label&quot;:&quot;&quot;}">is loading ...</div>
 <!-- /wp:inseri-core/text-editor -->`;
 
-		const res = await php.run({
+		const result = await php.run({
 			code: `<?php
 			require getenv('DOCROOT') . '/wp-load.php';
 			$posts = get_posts();
-			echo $posts[0]->post_content;
+			echo json_encode([
+				'post_content' => $posts[0]->post_content,
+				'post_title' => $posts[0]->post_title,
+			]);
 			`,
 			env: {
 				DOCROOT: await php.documentRoot,
 			},
 		});
+		const json = result.json;
 
-		expect(res.text).toContain(expectedPostContent);
+		expect(json.post_content).toEqual(expectedPostContent);
+		expect(json.post_title).toEqual(`"Issue\\Issue"`);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
@@ -1,0 +1,71 @@
+import { NodePHP } from '@php-wasm/node';
+import {
+	RecommendedPHPVersion,
+	getWordPressModule,
+} from '@wp-playground/wordpress';
+import { importWxr } from './import-wxr';
+import { readFile } from 'fs/promises';
+import { unzip } from './unzip';
+import { installPlugin } from './install-plugin';
+
+describe('Blueprint step importWxr', () => {
+	let php: NodePHP;
+	beforeEach(async () => {
+		php = await NodePHP.load(RecommendedPHPVersion, {
+			requestHandler: {
+				documentRoot: '/wordpress',
+			},
+		});
+
+		await unzip(php, {
+			zipFile: await getWordPressModule(),
+			extractToPath: '/wordpress',
+		});
+
+		// Delete all posts
+		await php.run({
+			code: `<?php
+			require '/wordpress/wp-load.php';
+			$posts = get_posts();
+			foreach ($posts as $post) {
+				wp_delete_post($post->ID, true);
+			}
+			`,
+		});
+
+		// Install the WordPress importer plugin
+		const pluginZipData = await readFile(
+			__dirname + '/../../../../website/public/wordpress-importer.zip'
+		);
+		const pluginZipFile = new File([pluginZipData], 'plugin.zip');
+		await installPlugin(php, {
+			pluginZipFile,
+		});
+	});
+
+	it('Should import a WXR file with JSON-encoded UTF-8 characters', async () => {
+		const fileData = await readFile(
+			__dirname + '/fixtures/import-wxr-slash-issue.xml'
+		);
+		const file = new File([fileData], 'import.wxr');
+
+		await importWxr(php, { file });
+
+		const expectedPostContent = `<!-- wp:inseri-core/text-editor {"blockId":"DSrQIjN5UjosCHJQImF5z","blockName":"textEditor","height":60,"content":"\\u0022#test\\u0022","contentType":"application/json"} -->
+<div class="wp-block-inseri-core-text-editor" data-attributes="{&quot;blockId&quot;:&quot;DSrQIjN5UjosCHJQImF5z&quot;,&quot;blockName&quot;:&quot;textEditor&quot;,&quot;content&quot;:&quot;\\&quot;#test\\&quot;&quot;,&quot;contentType&quot;:&quot;application/json&quot;,&quot;editable&quot;:false,&quot;height&quot;:60,&quot;isVisible&quot;:true,&quot;label&quot;:&quot;&quot;}">is loading ...</div>
+<!-- /wp:inseri-core/text-editor -->`;
+
+		const res = await php.run({
+			code: `<?php
+			require getenv('DOCROOT') . '/wp-load.php';
+			$posts = get_posts();
+			echo $posts[0]->post_content;
+			`,
+			env: {
+				DOCROOT: await php.documentRoot,
+			},
+		});
+
+		expect(res.text).toContain(expectedPostContent);
+	});
+});

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -39,7 +39,7 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 		data: file,
 	});
 	const docroot = await playground.documentRoot;
-	const res = await playground.run({
+	await playground.run({
 		code: `<?php
 		require ${phpVar(docroot)} . '/wp-load.php';
 		kses_remove_filters();
@@ -59,5 +59,4 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 		$result = $importer->import( '/tmp/import.wxr' );
 		`,
 	});
-	console.log(res.text);
 };

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -50,9 +50,12 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 		) );
 		$logger = new WP_Importer_Logger_CLI();
 		$importer->set_logger( $logger );
-		add_filter( 'content_save_pre', function( $content ) {
-			return wp_slash( $content );
+
+		// Slashes from the imported content are lost if we don't call wp_slash here.
+		add_action( 'wp_insert_post_data', function( $data ) {
+			return wp_slash($data);
 		});
+
 		$result = $importer->import( '/tmp/import.wxr' );
 		`,
 	});

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -39,9 +39,10 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 		data: file,
 	});
 	const docroot = await playground.documentRoot;
-	await playground.run({
+	const res = await playground.run({
 		code: `<?php
 		require ${phpVar(docroot)} . '/wp-load.php';
+		kses_remove_filters();
 		$admin_id = get_users(array('role' => 'Administrator') )[0];
 		$importer = new WXR_Importer( array(
 			'fetch_attachments' => true,
@@ -49,7 +50,11 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 		) );
 		$logger = new WP_Importer_Logger_CLI();
 		$importer->set_logger( $logger );
+		add_filter( 'content_save_pre', function( $content ) {
+			return wp_slash( $content );
+		});
 		$result = $importer->import( '/tmp/import.wxr' );
 		`,
 	});
+	console.log(res.text);
 };


### PR DESCRIPTION
## What is this PR doing?

Preserves the backslashes in the content imported through `importWxr` by calling `wp_slash` on the entire imported data.

This issue started after the recent switch to the `humanmade/wordpress-importer` in https://github.com/WordPress/wordpress-playground/pull/1192. Turns out that importer doesn't call `wp_slash` on its own.

Closes https://github.com/WordPress/wordpress-playground/issues/1211

## Testing Instructions

Confirm the unit tests pass.

cc @aplamada @dmsnell 