### PR TITLE
Fix docs-site build

### DIFF
--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -9,6 +9,15 @@
 		"playground-client"
 	],
 	"targets": {
+		"build:json": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"npx typedoc --plugin typedoc-plugin-mdn-links --plugin typedoc-plugin-resolve-crossmodule-references --json packages/docs/site/src/model.json"
+				],
+				"parallel": false
+			}
+		},
 		"build-docs": {
 			"executor": "nx:run-commands",
 			"options": {
@@ -18,15 +27,6 @@
 				"cwd": "packages/docs/site"
 			},
 			"dependsOn": ["build:json"]
-		},
-		"build:json": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx typedoc --plugin typedoc-plugin-mdn-links --plugin typedoc-plugin-resolve-crossmodule-references --json packages/docs/site/src/model.json"
-				],
-				"parallel": false
-			}
 		},
 		"swizzle": {
 			"executor": "nx:run-commands",

--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -28,6 +28,14 @@
 			},
 			"dependsOn": ["build:json"]
 		},
+		"build": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": ["docusaurus build"],
+				"cwd": "packages/docs/site"
+			},
+			"dependsOn": ["build-docs"]
+		},
 		"swizzle": {
 			"executor": "nx:run-commands",
 			"options": {


### PR DESCRIPTION
## What is this PR doing?

It fixes docs-site:build NX command.

## What problem is it solving?

It resolves the root cause of `npm run build` failing. 

## How is the problem addressed?

By adding `build-docs` as a dependency of `docs-site:build`. 

## Testing Instructions

- ensure all test pass
