### PR TITLE
Update error modal description label

### DIFF
--- a/packages/playground/website/public/logger.php
+++ b/packages/playground/website/public/logger.php
@@ -47,7 +47,7 @@ if (empty($token)) {
 if (!isset($_POST['description']) || empty($_POST['description'])) {
     response(false, 'No description provided');
 }
-$text = "What happened?\n\n" . $_POST['description'];
+$text = "How can we recreate this error?\n\n" . $_POST['description'];
 
 if (isset($_POST['logs']) && !empty($_POST['logs'])) {
     $text .= "\n\nLogs\n\n" . $_POST['logs'];

--- a/packages/playground/website/src/components/error-report-modal/index.tsx
+++ b/packages/playground/website/src/components/error-report-modal/index.tsx
@@ -144,8 +144,8 @@ export function ErrorReportModal() {
 				<>
 					<main>
 						<TextareaControl
-							label="What happened?"
-							help="Describe what caused the error and how can we reproduce it."
+							label="How can we recreate this error?"
+							help="Describe what caused the error and how can we recreate it."
 							value={text}
 							onChange={setText}
 							className={css.errorReportModalTextarea}


### PR DESCRIPTION
## What is this PR doing?

Updates the error modal description label.

## What problem is it solving?

Users rarely add steps to recreate the error when reporting issues, so we should make it more clear.

## How is the problem addressed?

By updating the description label. 

## Testing Instructions

Read the label and ensure it makes sense

