### PR TITLE
Revert changes to the docs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"build": "nx run-many --all --target=build",
 		"build:website": "nx build playground-website",
-		"build:docs": "nx build-docs docs-site",
+		"build:docs": "nx build docs-site",
 		"deploy:docs": "gh-pages -d dist/docs/build -t true",
 		"dev": "nx dev playground-website",
 		"format": "nx format",

--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -9,15 +9,6 @@
 		"playground-client"
 	],
 	"targets": {
-		"build:json": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx typedoc --plugin typedoc-plugin-mdn-links --plugin typedoc-plugin-resolve-crossmodule-references --json packages/docs/site/src/model.json"
-				],
-				"parallel": false
-			}
-		},
 		"build-docs": {
 			"executor": "nx:run-commands",
 			"options": {
@@ -28,13 +19,14 @@
 			},
 			"dependsOn": ["build:json"]
 		},
-		"build": {
+		"build:json": {
 			"executor": "nx:run-commands",
 			"options": {
-				"commands": ["docusaurus build"],
-				"cwd": "packages/docs/site"
-			},
-			"dependsOn": ["build-docs"]
+				"commands": [
+					"npx typedoc --plugin typedoc-plugin-mdn-links --plugin typedoc-plugin-resolve-crossmodule-references --json packages/docs/site/src/model.json"
+				],
+				"parallel": false
+			}
 		},
 		"swizzle": {
 			"executor": "nx:run-commands",

--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -23,7 +23,8 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"npx typedoc --plugin typedoc-plugin-mdn-links --plugin typedoc-plugin-resolve-crossmodule-references --json packages/docs/site/src/model.json"
+					"npx typedoc --plugin typedoc-plugin-mdn-links --plugin typedoc-plugin-resolve-crossmodule-references --json packages/docs/site/src/model.json",
+					"echo Built `pwd`/packages/docs/site/src/model.json file"
 				],
 				"parallel": false
 			}

--- a/packages/docs/site/project.json
+++ b/packages/docs/site/project.json
@@ -9,7 +9,7 @@
 		"playground-client"
 	],
 	"targets": {
-		"build-docs": {
+		"build": {
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -564,33 +564,6 @@
 						},
 						"step": {
 							"type": "string",
-							"const": "importFile"
-						},
-						"file": {
-							"$ref": "#/definitions/FileReference",
-							"description": "The file to import"
-						}
-					},
-					"required": ["file", "step"]
-				},
-				{
-					"type": "object",
-					"additionalProperties": false,
-					"properties": {
-						"progress": {
-							"type": "object",
-							"properties": {
-								"weight": {
-									"type": "number"
-								},
-								"caption": {
-									"type": "string"
-								}
-							},
-							"additionalProperties": false
-						},
-						"step": {
-							"type": "string",
 							"const": "importWordPressFiles"
 						},
 						"wordPressFilesZip": {

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -564,6 +564,33 @@
 						},
 						"step": {
 							"type": "string",
+							"const": "importFile"
+						},
+						"file": {
+							"$ref": "#/definitions/FileReference",
+							"description": "The file to import"
+						}
+					},
+					"required": ["file", "step"]
+				},
+				{
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"progress": {
+							"type": "object",
+							"properties": {
+								"weight": {
+									"type": "number"
+								},
+								"caption": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						},
+						"step": {
+							"type": "string",
 							"const": "importWordPressFiles"
 						},
 						"wordPressFilesZip": {


### PR DESCRIPTION
## What is this PR doing?

Undoes https://github.com/WordPress/wordpress-playground/pull/1222 and 891bf3e to get the documentation site to build.

I am still unsure why does it sometime fail due to a missing `models.json` file. Perhaps it skips the `build:json` part of the process somehow? Let's keep observing the subsequent builds.