### PR TITLE
Blueprints: Support a landingPage value without the initial slash

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -241,11 +241,6 @@ export function compileBlueprint(
 		throw e;
 	}
 
-	let landingPage = blueprint.landingPage || '/';
-	if (!landingPage.startsWith('/')) {
-		landingPage = '/' + landingPage;
-	}
-
 	const steps = (blueprint.steps || []) as StepDefinition[];
 	const totalProgressWeight = steps.reduce(
 		(total, step) => total + (step.progress?.weight || 1),
@@ -304,7 +299,9 @@ export function compileBlueprint(
 				}
 			} finally {
 				try {
-					await (playground as any).goTo(landingPage);
+					await (playground as any).goTo(
+						blueprint.landingPage || '/'
+					);
 				} catch (e) {
 					/*
 					 * NodePHP exposes no goTo method.

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -241,6 +241,11 @@ export function compileBlueprint(
 		throw e;
 	}
 
+	let landingPage = blueprint.landingPage || '/';
+	if (!landingPage.startsWith('/')) {
+		landingPage = '/' + landingPage;
+	}
+
 	const steps = (blueprint.steps || []) as StepDefinition[];
 	const totalProgressWeight = steps.reduce(
 		(total, step) => total + (step.progress?.weight || 1),
@@ -299,9 +304,7 @@ export function compileBlueprint(
 				}
 			} finally {
 				try {
-					await (playground as any).goTo(
-						blueprint.landingPage || '/'
-					);
+					await (playground as any).goTo(landingPage);
 				} catch (e) {
 					/*
 					 * NodePHP exposes no goTo method.

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -130,6 +130,9 @@ export async function bootPlaygroundRemote() {
 			});
 		},
 		async goTo(requestedPath: string) {
+			if (!requestedPath.startsWith('/')) {
+				requestedPath = '/' + requestedPath;
+			}
 			/**
 			 * People often forget to type the trailing slash at the end of
 			 * /wp-admin/ URL and end up with wrong relative hrefs. Let's

--- a/packages/playground/website/cypress/e2e/blueprints.cy.ts
+++ b/packages/playground/website/cypress/e2e/blueprints.cy.ts
@@ -33,6 +33,14 @@ describe('Blueprints', () => {
 		cy.wordPressDocument().its('body').should('contain', 'Sample Page');
 	});
 
+	it('Landing page without the initial slash should work', () => {
+		const blueprint: Blueprint = {
+			landingPage: 'wp-admin/plugins.php',
+		};
+		cy.visit('/#' + JSON.stringify(blueprint));
+		cy.wordPressDocument().its('body').should('contain.text', 'Plugins');
+	});
+
 	it('enableMultisite step should enable a multisite', () => {
 		const blueprint: Blueprint = {
 			landingPage: '/',

--- a/packages/playground/website/cypress/e2e/blueprints.cy.ts
+++ b/packages/playground/website/cypress/e2e/blueprints.cy.ts
@@ -36,6 +36,7 @@ describe('Blueprints', () => {
 	it('Landing page without the initial slash should work', () => {
 		const blueprint: Blueprint = {
 			landingPage: 'wp-admin/plugins.php',
+			login: true,
 		};
 		cy.visit('/#' + JSON.stringify(blueprint));
 		cy.wordPressDocument().its('body').should('contain.text', 'Plugins');


### PR DESCRIPTION
Without this PR, a Blueprint like `{ "landingPage": "wp-admin/plugins.php" }` won't work as there is no initial slash. This PR adjusts the Playground API to prepend that slash as URLs without one should be relative to the document root anyway.

 ## Testing instructions

Confirm the E2E tests passed

cc @bph  @dmsnell 