### PR TITLE
Request Handler: Urldecode the requested path

### DIFF
--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -56,6 +56,49 @@ describe.each(SupportedPHPVersions)(
 			});
 		});
 
+		it('should serve a static file with urlencoded entities in the path', async () => {
+			php.writeFile(
+				'/Screenshot 2024-04-05 at 7.13.36 AM.html',
+				`Hello World`
+			);
+			const response = await handler.request({
+				url: '/Screenshot-2024-04-05-at-7.13.36%E2%80%AFAM.html',
+			});
+			expect(response).toEqual({
+				httpStatusCode: 200,
+				headers: {
+					'content-type': ['text/html'],
+
+					'accept-ranges': ['bytes'],
+					'cache-control': ['public, max-age=0'],
+					'content-length': ['11'],
+				},
+				bytes: new TextEncoder().encode('Hello World'),
+				errors: '',
+				exitCode: 0,
+			});
+		});
+
+		it('should serve a PHP file with urlencoded entities in the path', async () => {
+			php.writeFile(
+				'/Screenshot 2024-04-05 at 7.13.36 AM.php',
+				`Hello World`
+			);
+			const response = await handler.request({
+				url: '/Screenshot 2024-04-05 at 7.13.36%E2%80%AFAM.php',
+			});
+			expect(response).toEqual({
+				httpStatusCode: 200,
+				headers: {
+					'content-type': ['text/html; charset=UTF-8'],
+					'x-powered-by': [expect.any(String)],
+				},
+				bytes: new TextEncoder().encode('Hello World'),
+				errors: '',
+				exitCode: 0,
+			});
+		});
+
 		it('should yield x-file-type=static when a static file is not found', async () => {
 			const response = await handler.request({
 				url: '/index.html',

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -62,7 +62,7 @@ describe.each(SupportedPHPVersions)(
 				`Hello World`
 			);
 			const response = await handler.request({
-				url: '/Screenshot-2024-04-05-at-7.13.36%E2%80%AFAM.html',
+				url: '/Screenshot 2024-04-05 at 7.13.36%E2%80%AFAM.html',
 			});
 			expect(response).toEqual({
 				httpStatusCode: 200,

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -76,7 +76,8 @@ export class PHPRequestHandler implements RequestHandler {
 			this.#HOSTNAME,
 			isNonStandardPort ? `:${this.#PORT}` : '',
 		].join('');
-		this.#PATHNAME = url.pathname.replace(/\/+$/, '');
+		this.#PATHNAME =
+			url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '');
 		this.#ABSOLUTE_URL = [
 			`${this.#PROTOCOL}://`,
 			this.#HOST,
@@ -125,7 +126,9 @@ export class PHPRequestHandler implements RequestHandler {
 		);
 
 		const normalizedRequestedPath = applyRewriteRules(
-			removePathPrefix(requestedUrl.pathname, this.#PATHNAME),
+			decodeURIComponent(
+				removePathPrefix(requestedUrl.pathname, this.#PATHNAME)
+			),
 			this.rewriteRules
 		);
 		const fsPath = `${this.#DOCROOT}${normalizedRequestedPath}`;
@@ -228,7 +231,9 @@ export class PHPRequestHandler implements RequestHandler {
 
 			let scriptPath;
 			try {
-				scriptPath = this.#resolvePHPFilePath(requestedUrl.pathname);
+				scriptPath = this.#resolvePHPFilePath(
+					decodeURIComponent(requestedUrl.pathname)
+				);
 			} catch (error) {
 				return new PHPResponse(
 					404,

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -1,4 +1,4 @@
-import { Semaphore } from '@php-wasm/util';
+import { Semaphore, joinPaths } from '@php-wasm/util';
 import {
 	ensurePathPrefix,
 	toRelativeUrl,
@@ -76,8 +76,7 @@ export class PHPRequestHandler implements RequestHandler {
 			this.#HOSTNAME,
 			isNonStandardPort ? `:${this.#PORT}` : '',
 		].join('');
-		this.#PATHNAME =
-			url.pathname === '/' ? '/' : url.pathname.replace(/\/+$/, '');
+		this.#PATHNAME = url.pathname.replace(/\/+$/, '');
 		this.#ABSOLUTE_URL = [
 			`${this.#PROTOCOL}://`,
 			this.#HOST,
@@ -126,12 +125,13 @@ export class PHPRequestHandler implements RequestHandler {
 		);
 
 		const normalizedRequestedPath = applyRewriteRules(
-			decodeURIComponent(
-				removePathPrefix(requestedUrl.pathname, this.#PATHNAME)
+			removePathPrefix(
+				decodeURIComponent(requestedUrl.pathname),
+				this.#PATHNAME
 			),
 			this.rewriteRules
 		);
-		const fsPath = `${this.#DOCROOT}${normalizedRequestedPath}`;
+		const fsPath = joinPaths(this.#DOCROOT, normalizedRequestedPath);
 		if (seemsLikeAPHPRequestHandlerPath(fsPath)) {
 			return await this.#dispatchToPHP(request, requestedUrl);
 		}


### PR DESCRIPTION
Applies decodeURIComponent() to dispatched paths in PHPRequestHandler.

It solves the following problem: If you try to upload a file with dots followed by spaces in the filename it won't be recognized and the file will not be uploaded.

Closes https://github.com/WordPress/wordpress-playground/issues/1202

 ## Testing instructions

* Go through steps from #1202
* Confirm the unit tests pass
