### PR TITLE
Web PHP: Increase memory limit to 256 M

### DIFF
--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -241,6 +241,7 @@ const [setApiReady, setAPIError] = exposeAPI(
 
 try {
 	php.initializeRuntime(await recreateRuntime());
+	php.setPhpIniEntry('memory_limit', '256M');
 
 	if (startupOptions.sapiName) {
 		await php.setSapiName(startupOptions.sapiName);


### PR DESCRIPTION
## What is this PR doing?

Increases PHP memory limit to 256M in web browsers to unblock more memory-hungry use-cases.

Related:

* https://github.com/WordPress/wordpress-playground/issues/1128

## Testing instructions

Go to http://127.0.0.1:5400/website-server/?url=/phpinfo.php and confirm the memory limit says `256 M`