### PR TITLE
Browser: Display PHP output when Fatal Error is trigerred

### DIFF
--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -277,17 +277,13 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 
 			const response = await this.#handleRequest();
 			if (response.exitCode !== 0) {
-				const output = {
-					stdout: response.text,
-					stderr: response.errors,
-				};
-				console.warn(`PHP.run() output was:`, output);
+				console.warn(`PHP.run() output was:`, response.text);
 				const error = new Error(
 					`PHP.run() failed with exit code ${response.exitCode} and the following output: ` +
 						response.errors
 				);
 				// @ts-ignore
-				error.output = output;
+				error.response = response;
 				// @ts-ignore
 				error.source = 'request';
 				console.error(error);

--- a/packages/php-wasm/web/src/lib/api.ts
+++ b/packages/php-wasm/web/src/lib/api.ts
@@ -159,6 +159,21 @@ function setupTransferHandlers() {
 			return PHPResponse.fromRawData(responseData);
 		},
 	});
+	// Augment Comlink's throw handler to include Error the response and source
+	// information in the serialized error object. BasePHP throws may include
+	// those information and we'll want to display them for the user.
+	const throwHandler = Comlink.transferHandlers.get('throw')!;
+	const originalSerialize = throwHandler?.serialize;
+	throwHandler.serialize = ({ value }: any) => {
+		const serialized = originalSerialize({ value }) as any;
+		if (value.response) {
+			serialized[0].value.response = value.response;
+		}
+		if (value.source) {
+			serialized[0].value.source = value.source;
+		}
+		return serialized;
+	};
 }
 
 function proxyClone(object: any): any {

--- a/packages/playground/website/cypress/e2e/website-ui.cy.ts
+++ b/packages/playground/website/cypress/e2e/website-ui.cy.ts
@@ -9,6 +9,7 @@ import {
 // @ts-ignore
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import * as SupportedWordPressVersions from '../../../wordpress/src/wordpress/wp-versions.json';
+import { Blueprint } from '@wp-playground/blueprints';
 
 describe('Playground website UI', () => {
 	beforeEach(() => cy.visit('/?networking=no'));
@@ -129,6 +130,24 @@ describe('Website UI – Networking support', () => {
 
 		cy.get('button#configurator').click();
 		cy.get('input[name=with-networking]').should('be.checked');
+	});
+
+	it('should display PHP output even when a fatal error is hit', () => {
+		const blueprint: Blueprint = {
+			landingPage: '/err.php',
+			login: true,
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/err.php',
+					data: "<?php throw new Exception('This is a fatal error'); \n",
+				},
+			],
+		};
+		cy.visit('/#' + JSON.stringify(blueprint));
+		cy.wordPressDocument()
+			.its('body')
+			.should('contain.text', 'This is a fatal error');
 	});
 
 	it('should enable networking when requested', () => {


### PR DESCRIPTION
 ## What does this PR do?

This PR restores displaying the PHP output when a PHP error is encountered. It does that by attaching `response` to the error thrown by BasePHP and augmenting the Comlink transfer handler to pass that response between workers through postMessage.

 ## What problem does it solve?

Prior to be0e783, script output was still shown for Fatal Errors. For example, when reproducing the memory-related errors under #1128, we used to see something like the following where page output was shown along with the Fatal Error that ended execution.

But now that we are no longer returning a PHPResponse when there is a non-zero exit code, the content is not updated when running the same script. The error message is printed to the console, but the partial content is not visible to the user. Instead the previous content is left in place as if the script had not run at all.

Closes https://github.com/WordPress/wordpress-playground/issues/1231

 ## Testing instructions

Ensure the E2E tests pass

