### PR TITLE
Blueprints: Add ifAlreadyInstalled to installPlugin and installTheme steps

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -564,33 +564,6 @@
 						},
 						"step": {
 							"type": "string",
-							"const": "importFile"
-						},
-						"file": {
-							"$ref": "#/definitions/FileReference",
-							"description": "The file to import"
-						}
-					},
-					"required": ["file", "step"]
-				},
-				{
-					"type": "object",
-					"additionalProperties": false,
-					"properties": {
-						"progress": {
-							"type": "object",
-							"properties": {
-								"weight": {
-									"type": "number"
-								},
-								"caption": {
-									"type": "string"
-								}
-							},
-							"additionalProperties": false
-						},
-						"step": {
-							"type": "string",
 							"const": "importWordPressFiles"
 						},
 						"wordPressFilesZip": {
@@ -619,6 +592,11 @@
 								}
 							},
 							"additionalProperties": false
+						},
+						"ifAlreadyInstalled": {
+							"type": "string",
+							"enum": ["overwrite", "skip", "error"],
+							"description": "What to do if the asset already exists."
 						},
 						"step": {
 							"type": "string",
@@ -651,6 +629,11 @@
 								}
 							},
 							"additionalProperties": false
+						},
+						"ifAlreadyInstalled": {
+							"type": "string",
+							"enum": ["overwrite", "skip", "error"],
+							"description": "What to do if the asset already exists."
 						},
 						"step": {
 							"type": "string",

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.ts
@@ -1,5 +1,5 @@
 import { StepHandler } from '.';
-import { installAsset } from './install-asset';
+import { InstallAssetOptions, installAsset } from './install-asset';
 import { activatePlugin } from './activate-plugin';
 import { zipNameToHumanName } from '../utils/zip-name-to-human-name';
 
@@ -23,7 +23,8 @@ import { zipNameToHumanName } from '../utils/zip-name-to-human-name';
  * }
  * </code>
  */
-export interface InstallPluginStep<ResourceType> {
+export interface InstallPluginStep<ResourceType>
+	extends Pick<InstallAssetOptions, 'ifAlreadyInstalled'> {
 	/**
 	 * The step identifier.
 	 */
@@ -54,7 +55,7 @@ export interface InstallPluginOptions {
  */
 export const installPlugin: StepHandler<InstallPluginStep<File>> = async (
 	playground,
-	{ pluginZipFile, options = {} },
+	{ pluginZipFile, ifAlreadyInstalled, options = {} },
 	progress?
 ) => {
 	const zipFileName = pluginZipFile.name.split('/').pop() || 'plugin.zip';
@@ -62,6 +63,7 @@ export const installPlugin: StepHandler<InstallPluginStep<File>> = async (
 
 	progress?.tracker.setCaption(`Installing the ${zipNiceName} plugin`);
 	const { assetFolderPath } = await installAsset(playground, {
+		ifAlreadyInstalled,
 		zipFile: pluginZipFile,
 		targetPath: `${await playground.documentRoot}/wp-content/plugins`,
 	});

--- a/packages/playground/blueprints/src/lib/steps/install-theme.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-theme.spec.ts
@@ -1,20 +1,25 @@
 import { NodePHP } from '@php-wasm/node';
-import { compileBlueprint, runBlueprintSteps } from '../compile';
 import { RecommendedPHPVersion } from '@wp-playground/wordpress';
+import { installTheme } from './install-theme';
 
 describe('Blueprint step installTheme', () => {
 	let php: NodePHP;
+	let zipFileName = '';
+	let zipFilePath = '';
+	let rootPath = '';
+	let themesPath = '';
 	beforeEach(async () => {
 		php = await NodePHP.load(RecommendedPHPVersion, {
 			requestHandler: {
 				documentRoot: '/wordpress',
 			},
 		});
-	});
 
-	it('should install a theme', async () => {
+		rootPath = php.documentRoot;
+		themesPath = `${rootPath}/wp-content/themes`;
+		php.mkdir(themesPath);
+
 		// Create test theme
-
 		const themeName = 'test-theme';
 
 		php.mkdir(`/${themeName}`);
@@ -24,42 +29,91 @@ describe('Blueprint step installTheme', () => {
 		);
 
 		// Note the package name is different from theme folder name
-		const zipFileName = `${themeName}-0.0.1.zip`;
+		zipFileName = `${themeName}-0.0.1.zip`;
+		zipFilePath = `${themesPath}/${zipFileName}`;
 
 		await php.run({
-			code: `<?php $zip = new ZipArchive(); $zip->open("${zipFileName}", ZIPARCHIVE::CREATE); $zip->addFile("/${themeName}/index.php"); $zip->close();`,
+			code: `<?php $zip = new ZipArchive(); $zip->open("${zipFilePath}", ZIPARCHIVE::CREATE); $zip->addFile("/${themeName}/index.php"); $zip->close();`,
 		});
 
 		php.rmdir(`/${themeName}`);
 
-		expect(php.fileExists(zipFileName)).toBe(true);
+		expect(php.fileExists(zipFilePath)).toBe(true);
+	});
 
-		// Create themes folder
-		const rootPath = await php.documentRoot;
-		const themesPath = `${rootPath}/wp-content/themes`;
+	afterEach(() => {
+		php.exit();
+	});
 
-		php.mkdir(themesPath);
+	it('should install a theme', async () => {
+		await installTheme(php, {
+			themeZipFile: new File(
+				[php.readFileAsBuffer(zipFilePath)],
+				zipFileName
+			),
+			ifAlreadyInstalled: 'overwrite',
+			options: {
+				activate: false,
+			},
+		});
+		expect(php.fileExists(zipFilePath)).toBe(true);
+	});
 
-		await runBlueprintSteps(
-			compileBlueprint({
-				steps: [
-					{
-						step: 'installTheme',
-						themeZipFile: {
-							resource: 'vfs',
-							path: zipFileName,
-						},
-						options: {
-							activate: false,
-						},
+	describe('ifAlreadyInstalled option', () => {
+		beforeEach(async () => {
+			await installTheme(php, {
+				themeZipFile: new File(
+					[php.readFileAsBuffer(zipFilePath)],
+					zipFileName
+				),
+				ifAlreadyInstalled: 'error',
+				options: {
+					activate: false,
+				},
+			});
+		});
+
+		it('ifAlreadyInstalled=ovewrite should overwrite the theme if the theme already exists', async () => {
+			await installTheme(php, {
+				themeZipFile: new File(
+					[php.readFileAsBuffer(zipFilePath)],
+					zipFileName
+				),
+				ifAlreadyInstalled: 'overwrite',
+				options: {
+					activate: false,
+				},
+			});
+			expect(php.fileExists(zipFilePath)).toBe(true);
+		});
+
+		it('ifAlreadyInstalled=skip should skip the theme if the theme already exists', async () => {
+			await installTheme(php, {
+				themeZipFile: new File(
+					['invalid zip bytes, unpacking should not attempted'],
+					zipFileName
+				),
+				ifAlreadyInstalled: 'skip',
+				options: {
+					activate: false,
+				},
+			});
+			expect(php.fileExists(zipFilePath)).toBe(true);
+		});
+
+		it('ifAlreadyInstalled=error should throw an error if the theme already exists', async () => {
+			await expect(
+				installTheme(php, {
+					themeZipFile: new File(
+						[php.readFileAsBuffer(zipFilePath)],
+						zipFileName
+					),
+					ifAlreadyInstalled: 'error',
+					options: {
+						activate: false,
 					},
-				],
-			}),
-			php
-		);
-
-		php.unlink(zipFileName);
-
-		expect(php.fileExists(`${themesPath}/${themeName}`)).toBe(true);
+				})
+			).rejects.toThrow();
+		});
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/install-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-theme.ts
@@ -1,5 +1,5 @@
 import { StepHandler } from '.';
-import { installAsset } from './install-asset';
+import { InstallAssetOptions, installAsset } from './install-asset';
 import { activateTheme } from './activate-theme';
 import { zipNameToHumanName } from '../utils/zip-name-to-human-name';
 
@@ -22,7 +22,8 @@ import { zipNameToHumanName } from '../utils/zip-name-to-human-name';
  * }
  * </code>
  */
-export interface InstallThemeStep<ResourceType> {
+export interface InstallThemeStep<ResourceType>
+	extends Pick<InstallAssetOptions, 'ifAlreadyInstalled'> {
 	/**
 	 * The step identifier.
 	 */
@@ -58,13 +59,14 @@ export interface InstallThemeOptions {
  */
 export const installTheme: StepHandler<InstallThemeStep<File>> = async (
 	playground,
-	{ themeZipFile, options = {} },
+	{ themeZipFile, ifAlreadyInstalled, options = {} },
 	progress
 ) => {
 	const zipNiceName = zipNameToHumanName(themeZipFile.name);
 
 	progress?.tracker.setCaption(`Installing the ${zipNiceName} theme`);
 	const { assetFolderName } = await installAsset(playground, {
+		ifAlreadyInstalled,
 		zipFile: themeZipFile,
 		targetPath: `${await playground.documentRoot}/wp-content/themes`,
 	});


### PR DESCRIPTION
## Changes

Adds an `ifAlreadyInstalled?: 'overwrite' | 'skip' | 'error'` option to installPlugin and installTheme steps. It defaults to `overwrite`.

Consider the following Blueprint:

```json
{
    "preferredVersions": {
        "php": "latest",
        "wp": "6.4"
    },
    "steps": [
        {
            "step": "installTheme",
            "themeZipFile": {
                "resource": "wordpress.org/themes",
                "slug": "twentytwentyfour"
            }
        }
    ]
}
```

Before this PR, it would result in an error. After this PR, the installation just works. If the Blueprint author explicitly wants the installation to fail, they can specify the `ifAlreadyInstalled` option:

```json
{
    "steps": [
        {
            "step": "installTheme",
            "themeZipFile": {
                "resource": "wordpress.org/themes",
                "slug": "twentytwentyfour"
            },
            "ifAlreadyInstalled": "skip" // or "error"
        }
    ]
}
```

## Motivation

Installing a plugin or theme over a currently installed one is a common gotcha. Currently it results in an error and blocks the Blueprint execution. This behavior is, however, often undesirable as it prevents having a single Blueprint that installs a twentytwentyfour theme on different versions of WordPress.

An addition of the `ifAlreadyInstalled` option puts the Blueprint author in control and provides a sensible default behavior where the installation will "just work" by replacing the already installed version of the plugin or theme.

Closes https://github.com/WordPress/wordpress-playground/issues/1157
Related to https://github.com/adamziel/blueprints/pull/19

 ## Testing instructions

Confirm the unit tests pass

cc @bgrgicak @brandonpayton 
