### PR TITLE
Move DefineSiteUrlStep doc warning so it displays in docs

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/define-site-url.ts
+++ b/packages/playground/blueprints/src/lib/steps/define-site-url.ts
@@ -3,9 +3,6 @@ import { defineWpConfigConsts } from './define-wp-config-consts';
 
 /**
  * Changes the site URL of the WordPress installation.
- * Beware: Using this step makes no sense on playground.wordpress.net.
- * It is useful when you're building a custom Playground-based tool like wp-now,
- * or deploying Playground on a custom domain.
  *
  * @inheritDoc defineSiteUrl
  */
@@ -17,6 +14,10 @@ export interface DefineSiteUrlStep {
 
 /**
  * Sets WP_HOME and WP_SITEURL constants for the WordPress installation.
+ *
+ * Beware: Using this step makes no sense on playground.wordpress.net.
+ * It is useful when you're building a custom Playground-based tool like wp-now,
+ * or deploying Playground on a custom domain.
  *
  * @param playground The playground client.
  * @param siteUrl


### PR DESCRIPTION
## What is this PR doing?

In https://github.com/WordPress/wordpress-playground/commit/05df9eec874a7fa33d46318ff4a7e4bba8dfa833 @adamziel has made a comment about `DefineSiteUrlStep` step. This comment is not showing in docs.

I moved that comment to a place where this doc is displayed

## What problem is it solving?

@adamziel comment is currently not displaying properly in the docs

<img width="661" alt="Zrzut ekranu 2024-04-15 o 15 29 41" src="https://github.com/WordPress/wordpress-playground/assets/3775068/3d5da9cb-1a8f-4fa6-8ebb-e90a91f4dd97">


## How is the problem addressed?

Move the comment to a place where the docs are sourced

## Testing Instructions

- `npm run build:docs`
- Open `dist/docs/build/blueprints-api/steps/index.html`
- Confirm the comment is there under the `DefineSiteUrlStep`  step