### PR TITLE
Fix accessibility issues found by Axe

### DIFF
--- a/packages/playground/website/src/components/address-bar/index.tsx
+++ b/packages/playground/website/src/components/address-bar/index.tsx
@@ -43,7 +43,7 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 					onBlur={() => setIsFocused(false)}
 					name="url"
 					type="text"
-					title='URL to visit in the WordPress site, like"/wp-admin"'
+					aria-label='URL to visit in the WordPress site, like"/wp-admin"'
 					autoComplete="off"
 				/>
 			</div>

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -53,7 +53,7 @@ export default function BrowserChrome({
 	return (
 		<div className={wrapperClass} data-cy="simulated-browser">
 			<div className={css.window}>
-				<div className={css.toolbar}>
+				<header className={css.toolbar} aria-label="Playground toolbar">
 					<div className={css.windowControls}>
 						<div
 							className={`${css.windowControl} ${css.isNeutral}`}
@@ -72,7 +72,7 @@ export default function BrowserChrome({
 					</div>
 
 					<div className={css.toolbarButtons}>{toolbarButtons}</div>
-				</div>
+				</header>
 				<div className={css.content}>{children}</div>
 				<div className={experimentalNoticeClass} onClick={hideNotice}>
 					{close}


### PR DESCRIPTION

## What is this PR doing?

Fixes two accessibility issues found when scanning https://playground.wordpress.net (i.e., the generic instance) with axe DevTools.

See discussion in #612.

## What problem is it solving?

Makes Playground more accessible.

## How is the problem addressed?

**Testing environment:** Arc/Chromium with the Axe DevTools (axe-core version 4.8.4) extension. The _Best Practice_ option is enabled.

### Findings:
- The first test found 22 issues
- The second test, with the `wp-admin-bar` hidden using CSS, found 4 issues
- The third test, with the `Twentytwentyfour` navigation hidden using CSS, found 2 issues. Only these last two are generated by Playground.

**Left:** First scan. **Right:** Third scan:

<img width="250" alt="First-scan" src="https://github.com/WordPress/wordpress-playground/assets/63248335/48e29ff5-3a2e-4b29-8461-0b67dd6308b1">
<img width="250" alt="Playground-generated-a11y-issues" src="https://github.com/WordPress/wordpress-playground/assets/63248335/c4a9039a-c50f-4304-b34d-8a86c83c518b">

***

Both issues affect Playground's address bar area:
<img width="500" alt="Issues" src="https://github.com/WordPress/wordpress-playground/assets/63248335/12cac34a-58e1-47dc-a9a1-b40d0f74bd81">

### Solutions:
1. To solve issue number 1, **Form elements should have a visible label**:
change the `title` attribute of `<input class="_input_845jo_7" name="url" type="text" title="URL to visit in the WordPress site, like&quot;/wp-admin&quot;" autocomplete="off" value="/">` to `aria-label` (i.e., `aria-label="URL to visit in the WordPress site, like&quot;/wp-admin&quot;"`).

2. To solve issue number 2, **All page content should be contained by landmarks**:
change `<div class="_toolbar_8xy06_95">...</div>` to `<header aria-label="Playground toolbar" class="_toolbar_8xy06_95">...</header>`

See screenshot after applying the changes:
<img width="250" alt="After-the-fix" src="https://github.com/WordPress/wordpress-playground/assets/63248335/6b674899-64f9-458b-90a1-2d1bd3896ac3">

## Testing Instructions
Run a scan with axe DevTools (enable the _Best Practice_ option)