### PR TITLE
WXR Import: Allow media files from wpthemetestdata.files.wordpress.com

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -42,6 +42,10 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 	await playground.run({
 		code: `<?php
 		require ${phpVar(docroot)} . '/wp-load.php';
+		if ( ! function_exists( 'wp_crop_image' ) ) {
+			include( ABSPATH . 'wp-admin/includes/image.php' );
+		}
+		include( ABSPATH . 'wp-admin/includes/media.php' );
 		kses_remove_filters();
 		$admin_id = get_users(array('role' => 'Administrator') )[0];
 		$importer = new WXR_Importer( array(

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -64,7 +64,11 @@ export async function setupFetchNetworkTransport(playground: UniversalPHP) {
 
 export async function handleRequest(data: RequestData, fetchFn = fetch) {
 	const hostname = new URL(data.url).hostname;
-	const fetchUrl = ['w.org', 's.w.org'].includes(hostname)
+	const fetchUrl = [
+		'w.org',
+		's.w.org',
+		'wpthemetestdata.files.wordpress.com',
+	].includes(hostname)
 		? `/plugin-proxy.php?url=${encodeURIComponent(data.url)}`
 		: data.url;
 

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -338,7 +338,7 @@ try {
         // Proxy the current request to $_GET['url'] and return the response,
         // but only if the URL is allowlisted.
         $url = $_GET['url'];
-        $allowed_domains = ['api.wordpress.org', 'w.org', 'wordpress.org', 's.w.org'];
+        $allowed_domains = ['api.wordpress.org', 'w.org', 'wordpress.org', 's.w.org', 'wpthemetestdata.files.wordpress.com'];
         $parsed_url = parse_url($url);
         if (!in_array($parsed_url['host'], $allowed_domains)) {
             http_response_code(403);


### PR DESCRIPTION
Enables fully importing the Theme Unit Testing WXR file by tunneling all the media files through plugin-proxy.php.

This PR, unfortunately, cannot be merged – there is so many media files that the import takes more than 15 minutes to complete (I actually gave up at the 15 minute mark).

We'll need to resolve https://github.com/WordPress/blueprints-library/issues/100 first
