### PR TITLE
PHP: Reset exit code before dispatching a request

### DIFF
--- a/packages/php-wasm/compile/php/php_wasm.c
+++ b/packages/php-wasm/compile/php/php_wasm.c
@@ -1272,6 +1272,8 @@ int EMSCRIPTEN_KEEPALIVE wasm_sapi_handle_request()
 		result = -1;
 		goto wasm_request_done;
 	}
+	
+	EG(exit_status) = 0;
 
 	TSRMLS_FETCH();
 	if (wasm_server_context->execution_mode == MODE_EXECUTE_SCRIPT)

--- a/packages/php-wasm/node/public/php_7_0.js
+++ b/packages/php-wasm/node/public/php_7_0.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12778840; 
+export const dependenciesTotalSize = 12778913; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_1.js
+++ b/packages/php-wasm/node/public/php_7_1.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 13301175; 
+export const dependenciesTotalSize = 13300912; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_2.js
+++ b/packages/php-wasm/node/public/php_7_2.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 13992133; 
+export const dependenciesTotalSize = 13992092; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_3.js
+++ b/packages/php-wasm/node/public/php_7_3.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 14098611; 
+export const dependenciesTotalSize = 14098607; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_4.js
+++ b/packages/php-wasm/node/public/php_7_4.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 14331012; 
+export const dependenciesTotalSize = 14331074; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_0.js
+++ b/packages/php-wasm/node/public/php_8_0.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 13597816; 
+export const dependenciesTotalSize = 13597709; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_1.js
+++ b/packages/php-wasm/node/public/php_8_1.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 13575986; 
+export const dependenciesTotalSize = 13575971; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_3.js
+++ b/packages/php-wasm/node/public/php_8_3.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 14212810; 
+export const dependenciesTotalSize = 14212793; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -959,6 +959,27 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 				'PHP.run() failed with exit code 1'
 			);
 		});
+		it('After failure, returns the correct exit code on subsequent runs', async () => {
+			const promise1 = php.run({
+				code: '<?php throw new Exception();',
+			});
+			// expect(result1.exitCode).toBe(255);
+			await expect(promise1).rejects.toThrow(
+				'PHP.run() failed with exit code 255'
+			);
+
+			const result2 = await php.run({
+				code: '<?php ',
+			});
+			expect(result2.exitCode).toBe(0);
+
+			const promise3 = php.run({
+				code: '<?php exit(1);',
+			});
+			await expect(promise3).rejects.toThrow(
+				'PHP.run() failed with exit code 1'
+			);
+		});
 	});
 
 	describe('Stdio', () => {

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_0.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 10638342; 
+export const dependenciesTotalSize = 10638709; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_1.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11078540; 
+export const dependenciesTotalSize = 11078277; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_2.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11712677; 
+export const dependenciesTotalSize = 11712687; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_3.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11775223; 
+export const dependenciesTotalSize = 11775233; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_4.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_4.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11945559; 
+export const dependenciesTotalSize = 11945564; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_0.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11611332; 
+export const dependenciesTotalSize = 11611342; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_1.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11541668; 
+export const dependenciesTotalSize = 11541678; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_2.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11787163; 
+export const dependenciesTotalSize = 11787173; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_3.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12043963; 
+export const dependenciesTotalSize = 12043974; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_0.js
+++ b/packages/php-wasm/web/public/light/php_7_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5285560; 
+export const dependenciesTotalSize = 5285931; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_1.js
+++ b/packages/php-wasm/web/public/light/php_7_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5429825; 
+export const dependenciesTotalSize = 5429562; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_2.js
+++ b/packages/php-wasm/web/public/light/php_7_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5772770; 
+export const dependenciesTotalSize = 5772780; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_3.js
+++ b/packages/php-wasm/web/public/light/php_7_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5700746; 
+export const dependenciesTotalSize = 5700756; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_4.js
+++ b/packages/php-wasm/web/public/light/php_7_4.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5783238; 
+export const dependenciesTotalSize = 5783248; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_0.js
+++ b/packages/php-wasm/web/public/light/php_8_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5579505; 
+export const dependenciesTotalSize = 5579515; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_1.js
+++ b/packages/php-wasm/web/public/light/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5382805; 
+export const dependenciesTotalSize = 5382815; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_2.js
+++ b/packages/php-wasm/web/public/light/php_8_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5496649; 
+export const dependenciesTotalSize = 5496659; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_3.js
+++ b/packages/php-wasm/web/public/light/php_8_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5587869; 
+export const dependenciesTotalSize = 5587879; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets


### PR DESCRIPTION
Ensures PHP returns the correct exit code after each request. Without this PR, hitting an exit code 255 once means PHP will continue returning it indefinitely.

Related to https://github.com/WordPress/wordpress-playground/pull/1249

## Testing instructions

Confirm the unit tests pass (they won't until all PHP versions are rebuilt and shipped with this PR)

cc @kozer 