### PR TITLE
Add documentation for `shorthand` alternatives of Blueprint steps

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/05-steps.md
+++ b/packages/docs/site/docs/09-blueprints-api/05-steps.md
@@ -114,22 +114,22 @@ Or
 
 ```json
 	{
-  	"step": "defineWpConfigConsts",
-  	"consts": {
-  		"WP_DISABLE_FATAL_ERROR_HANDLER": true
-  	}
+		"step": "defineWpConfigConsts",
+		"consts": {
+			"WP_DISABLE_FATAL_ERROR_HANDLER": true
+		}
 	},
 	{
-  	"step": "defineWpConfigConsts",
-  	"consts": {
-    	"WP_DEBUG": true
-  	}
+		"step": "defineWpConfigConsts",
+		"consts": {
+			"WP_DEBUG": true
+		}
 	},
 	{
-  	"step": "defineWpConfigConsts",
-  	"consts": {
-    	"WP_DEBUG_DISPLAY": true
-  	}
+		"step": "defineWpConfigConsts",
+		"consts": {
+			"WP_DEBUG_DISPLAY": true
+		}
 	}
 ```
 

--- a/packages/docs/site/docs/09-blueprints-api/05-steps.md
+++ b/packages/docs/site/docs/09-blueprints-api/05-steps.md
@@ -70,7 +70,7 @@ Or
  		"pluginZipFile": {
 			"resource": "url",
 			"url": "https://raw.githubusercontent.com/adamziel/blueprints/trunk/docs/assets/hello-from-the-dashboard.zip"
-    }
+		}
 	}
 ```
 

--- a/packages/docs/site/docs/09-blueprints-api/05-steps.md
+++ b/packages/docs/site/docs/09-blueprints-api/05-steps.md
@@ -20,6 +20,132 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 
 Each step is an object that contains a `step` property that specifies the type of step to run. The rest of the properties depend on the type of step. Learn and try each step type below.
 
+## Shorthands
+
+You can specify some `steps` using a `shorthand` syntax. The following `steps` are currently supported:
+
+### `login`
+
+Use
+
+```json
+	"login": true,
+```
+
+Or
+
+```json
+{
+	"step": "login",
+	"username": "admin",
+	"password": "password"
+}
+```
+
+### `plugins`
+
+(replaces `InstallPluginStep`)
+
+Use
+
+```json
+	"plugins": [
+		"hello-dolly",
+		"https://raw.githubusercontent.com/adamziel/blueprints/trunk/docs/assets/hello-from-the-dashboard.zip"
+  ]
+```
+
+Or
+
+```json
+	{
+		"step": "installPlugin",
+		"pluginZipFile": {
+			"resource": "wordpress.org/plugins",
+			"slug": "hello-dolly"
+		}
+	},
+	{
+		"step": "installPlugin",
+ 		"pluginZipFile": {
+			"resource": "url",
+			"url": "https://raw.githubusercontent.com/adamziel/blueprints/trunk/docs/assets/hello-from-the-dashboard.zip"
+    }
+	}
+```
+
+### `siteOptions`
+
+Use
+
+```json
+	"siteOptions": {
+		"blogname": "My first Blueprint"
+	}
+```
+
+Or
+
+```json
+	"step": "setSiteOptions",
+	"options": {
+		"blogname": "My first Blueprint"
+	}
+```
+
+### `defineWpConfigConsts`
+
+(`constants` only)
+
+Use
+
+```json
+{
+	"step": "defineWpConfigConsts",
+	"consts": {
+		"WP_DISABLE_FATAL_ERROR_HANDLER": true,
+		"WP_DEBUG": true,
+		"WP_DEBUG_DISPLAY": true
+	}
+}
+```
+
+Or
+
+```json
+	{
+  	"step": "defineWpConfigConsts",
+  	"consts": {
+  		"WP_DISABLE_FATAL_ERROR_HANDLER": true
+  	}
+	},
+	{
+  	"step": "defineWpConfigConsts",
+  	"consts": {
+    	"WP_DEBUG": true
+  	}
+	},
+	{
+  	"step": "defineWpConfigConsts",
+  	"consts": {
+    	"WP_DEBUG_DISPLAY": true
+  	}
+	}
+```
+
+---
+
+The `shorthand` syntax and the `step` syntax correspond to each other. Every `step` specified with the `shorthand` syntax is added to the top of the `steps` array in arbitrary order.
+
+:::info **Which should you choose?**
+
+-   Use `shorthands` when **brevity** is your main concern.
+-   Use explicit `steps` when you need more control over the **execution order**.
+
+:::
+
+---
+
 import BlueprintStep from '@site/src/components/BlueprintsAPI/BlueprintStep';
 import { BlueprintSteps } from '@site/src/components/BlueprintsAPI/model';
 import UpdateTopLevelToc from '@site/src/components/UpdateTopLevelToc';

--- a/packages/docs/site/docs/09-blueprints-api/05-steps.md
+++ b/packages/docs/site/docs/09-blueprints-api/05-steps.md
@@ -52,7 +52,7 @@ Use
 	"plugins": [
 		"hello-dolly",
 		"https://raw.githubusercontent.com/adamziel/blueprints/trunk/docs/assets/hello-from-the-dashboard.zip"
-  ]
+	]
 ```
 
 Or

--- a/packages/docs/site/docs/09-blueprints-api/05-steps.md
+++ b/packages/docs/site/docs/09-blueprints-api/05-steps.md
@@ -44,7 +44,7 @@ Or
 
 ### `plugins`
 
-(replaces `InstallPluginStep`)
+(replaces the `installPlugin` step)
 
 Use
 


### PR DESCRIPTION
## What is this PR doing?

Adds documentation for `shorthand` variations of Blueprint `steps`.
([See context and discussion here](https://github.com/adamziel/blueprints/pull/7#issuecomment-2049492959)).

The new section covers the following:
- briefly explains what are `shorthands`
- lists supported steps (with code examples)
- describes when should people use each alternative.
