### PR TITLE
Replace set_current_user call with wp_set_current_user to fix a PHP notice

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -41,7 +41,7 @@ require_once( ${phpVar(docroot)}. "/wp-load.php" );
 require_once( ${phpVar(docroot)}. "/wp-admin/includes/plugin.php" );
 
 // Set current user to admin
-set_current_user( get_users(array('role' => 'Administrator') )[0] );
+wp_set_current_user( get_users(array('role' => 'Administrator') )[0]->ID );
 
 $plugin_path = ${phpVar(pluginPath)};
 

--- a/packages/playground/blueprints/src/lib/steps/activate-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.ts
@@ -39,7 +39,7 @@ define( 'WP_ADMIN', true );
 require_once( ${phpVar(docroot)}. "/wp-load.php" );
 
 // Set current user to admin
-set_current_user( get_users(array('role' => 'Administrator') )[0] );
+wp_set_current_user( get_users(array('role' => 'Administrator') )[0]->ID );
 
 switch_theme( ${phpVar(themeFolderName)} );
 `,

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -68,7 +68,7 @@ define( 'WP_ADMIN', true );
 require_once(${phpVar(docroot)} . "/wp-load.php");
 
 // Set current user to admin
-set_current_user( get_users(array('role' => 'Administrator') )[0] );
+( get_users(array('role' => 'Administrator') )[0] );
 
 require_once(${phpVar(docroot)} . "/wp-admin/includes/plugin.php");
 $plugins_root = ${phpVar(docroot)} . "/wp-content/plugins";


### PR DESCRIPTION
Fixes the following logged message in wp-admin:

```
[16-Apr-2024 21:06:32 UTC] PHP Deprecated:  Function set_current_user is deprecated since version 3.0.0! Use wp_set_current_user() instead. in /wordpress/wp-includes/functions.php on line 135
[16-Apr-2024 21:06:32 UTC] PHP Notice:  Object of class WP_User could not be converted to int in /wordpress/wp-includes/pluggable.php on line 2
```