### PR TITLE
Add styles to ensure `iframes` are responsive

### DIFF
--- a/packages/docs/site/src/css/custom.css
+++ b/packages/docs/site/src/css/custom.css
@@ -109,3 +109,10 @@ li.footer__item a:hover {
 .footerLogoLink_mPrW {
 	opacity: 1 !important;
 }
+
+iframe {
+	aspect-ratio: 16/9;
+	max-width: 100%;
+	display: block;
+	height: auto;
+}


### PR DESCRIPTION
## What is this PR doing?

Ensures iframes are responsive.

This problem doesn't affect the Playground `iframe` embeds. Based on my tests, the fix suggested here doesn't have a negative impact on them.

## What problem is it solving?

The video added in [PR #530](https://github.com/WordPress/wordpress-playground/pull/530) creates a horizontal overflow in small screens.

This isn't an isolated issue (it can be seen [on this page, too](https://wordpress.github.io/wordpress-playground/start-using)), which is why I thought it'll be good to add some default “defensive styles” to the documentation site.
 
## How is the problem addressed?

By adding the following to the Docusaurus CSS:

```css
iframe {
  aspect-ratio: 16/9;
  max-width: 100%;
  display: block;
  height: auto;
}
```

## Testing Instructions
