### PR TITLE
Docs: Fix the Blueprint example of the Gutenberg PR preview

### DIFF
--- a/packages/docs/site/docs/03-build-an-app/01-index.md
+++ b/packages/docs/site/docs/03-build-an-app/01-index.md
@@ -115,47 +115,43 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 
 <BlueprintExample
 blueprint={{
-		"landingPage": "/wp-admin/plugins.php?test=42test",
-		"preferredVersions": {
-			"php": "7.4"
+	"landingPage": "/wp-admin/plugins.php?test=42test",
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
 		},
-		"steps": [
-			{
-				"step": "login"
+		{
+			"step": "mkdir",
+			"path": "/wordpress/pr"
+		},
+		{
+			"step": "writeFile",
+			"path": "/wordpress/pr/pr.zip",
+			"data": {
+				"resource": "url",
+				"url": "/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=60819",
+				"caption": "Downloading Gutenberg PR 47739"
 			},
-			{
-				step: 'mkdir',
-				path: '/wordpress/pr',
-			},
-			{
-				"//": "GitHub provides doubly zipped files so we'll save it first",
-				step: 'writeFile',
-				path: '/wordpress/pr/pr.zip',
-				data: {
-					resource: 'url',
-					url: `/plugin-proxy?pr=47739&org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin`,
-					caption: "Downloading Gutenberg PR 47739",
-				},
-				progress: {
-					weight: 2,
-					caption: "Applying Gutenberg PR 47739",
-				},
-			},
-			{
-				"//": "Unzip the outer zip",
-				step: 'unzip',
-				zipPath: '/wordpress/pr/pr.zip',
-				extractToPath: '/wordpress/pr',
-			},
-			{
-				"//": "And install the inner zip!",
-				step: 'installPlugin',
-				pluginZipFile: {
-					resource: 'vfs',
-					path: '/wordpress/pr/gutenberg.zip',
-				},
-			},
-		]
+			"progress": {
+				"weight": 2,
+				"caption": "Applying Gutenberg PR 47739"
+			}
+		},
+		{
+			"step": "unzip",
+			"zipPath": "/wordpress/pr/pr.zip",
+			"extractToPath": "/wordpress/pr"
+		},
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "vfs",
+				"path": "/wordpress/pr/gutenberg.zip"
+			}
+		}
+	]
 	}} />
 
 ## Build a compatibility testing environment


### PR DESCRIPTION
## What is this PR doing?

Fixes the Playground example embedded in [this documentation page](https://wordpress.github.io/wordpress-playground/build-your-first-app#preview-pull-requests-from-your-repository), which didn't load.

## How is the problem addressed?

1. Resolved the errors displayed in the browser console.
2. Updated the Blueprint based on the [code of the official Previewer](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/gutenberg.html).
3. Replaced [the PR](https://github.com/WordPress/gutenberg/pull/60819) loaded in the example.

### Why step 3?

It seems that there's an unrelated problem with [the specific PR used](https://github.com/WordPress/gutenberg/pull/47739) in the demo:
1. It doesn't work when loading it directly in the [Gutenberg PR Previewer](https://playground.wordpress.net/gutenberg.html).
2. Other random PRs load correctly in the example.

Using 60819 can be a temporary workaround.

## Testing Instructions

1. Run `nx dev docs-site`.
2. Go to [this documentation page](https://wordpress.github.io/wordpress-playground/build-your-first-app#preview-pull-requests-from-your-repository).
4. Scroll a bit, and click the **Try it now** button.
