### PR TITLE
Urlencode branch name

### DIFF
--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -50,7 +50,7 @@ class PluginDownloader
         if (!$prDetails) {
             throw new ApiException('invalid_pr_number');
         }
-        $branchName = $prDetails->head->ref;
+        $branchName = urlencode($prDetails->head->ref);
         $ciRuns = $this->gitHubRequest("https://api.github.com/repos/$organization/$repo/actions/runs?branch=$branchName")['body'];
         if (!$ciRuns) {
             throw new ApiException('no_ci_runs');
@@ -88,8 +88,8 @@ class PluginDownloader
             }
 
             /*
-             * Short-circuit with HTTP 200 OK when we only want to 
-             * verify whether the CI artifact seems to exist but we 
+             * Short-circuit with HTTP 200 OK when we only want to
+             * verify whether the CI artifact seems to exist but we
              * don't want to download it yet.
              */
             if (array_key_exists('verify_only', $_GET)) {
@@ -349,12 +349,12 @@ try {
         /**
          * Pass through the request headers we got from WordPress via fetch(),
          * then filter out:
-         * 
+         *
          * * The browser-specific headers
          * * Headers related to security to avoid leaking any auth information
-         * 
+         *
          * ...and pass the rest to the proxied request.
-         * 
+         *
          * @return array
          */
         function get_request_headers()


### PR DESCRIPTION
Fixes #1260 

## What is this PR doing?

It ensures that the WordPress pull request test page can fetch the correct PR data.

## What problem is it solving?

When a branch name has special characters like _#_, GitHub API requests may not work as intended.

## How is the problem addressed?

By encoding the branch name.

## Testing Instructions

- Checkout this branch
- Start a local PHP server
```
cd packages/playground/website/public
docker run -d -p 8787:80 -v "$PWD":/var/www/html php:8.0-apache
```
- Add the localhost path (`http://localhost:8787`) to the [start of this url](https://github.com/WordPress/wordpress-playground/blob/9f134e046102a1d2858b0b0541abfa9182b64291/packages/playground/website/public/wordpress.html#L147)
- Replace this [line with a valid token](https://github.com/WordPress/wordpress-playground/blob/ac62f0c170d89ea0127900eeb628062db74cd2c9/packages/playground/website/public/plugin-proxy.php#L264) (from the server)
- [Open this URL](http://localhost:5400/website-server/wordpress.html?pr=6238)
- Ensure Playground is loaded