### PR TITLE
PHP: Remove addServerGlobalEntry() method, accept $_SERVER as php.run() property

### DIFF
--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -672,7 +672,6 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 			throw rethrown;
 		} finally {
 			this.#wasmErrorsTarget?.removeEventListener('error', errorListener);
-			this.#serverEntries = {};
 		}
 
 		const { headers, httpStatusCode } = this.#getResponseHeaders();

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -304,7 +304,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 				] = headers[name];
 			}
 			for (const key in $_SERVER) {
-				this.#setServerGlobalEntry(key, request.$_SERVER![key]);
+				this.#setServerGlobalEntry(key, $_SERVER![key]);
 			}
 
 			const env = request.env || {};

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -59,7 +59,6 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 	#sapiName?: string;
 	#webSapiInitialized = false;
 	#wasmErrorsTarget: UnhandledRejectionsTarget | null = null;
-	#serverEntries: Record<string, string> = {};
 	#eventListeners: Map<string, Set<PHPEventListener>> = new Map();
 	#messageListeners: MessageListener[] = [];
 	requestHandler?: PHPBrowser;
@@ -271,7 +270,12 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 			const headers = normalizeHeaders(request.headers || {});
 			const host = headers['host'] || 'example.com:443';
 
-			this.#setRequestHostAndProtocol(host, request.protocol || 'http');
+			const port = this.#inferPortFromHostAndProtocol(
+				host,
+				request.protocol || 'http'
+			);
+			this.#setRequestHost(host);
+			this.#setRequestPort(port);
 			this.#setRequestHeaders(headers);
 			if (request.body) {
 				heapBodyPointer = this.#setRequestBody(request.body);
@@ -279,7 +283,29 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 			if (typeof request.code === 'string') {
 				this.#setPHPCode(' ?>' + request.code);
 			}
-			this.#addServerGlobalEntriesInWasm();
+
+			const $_SERVER = request.$_SERVER || {};
+			$_SERVER['HTTPS'] =
+				$_SERVER['HTTPS'] || port === 443 ? 'on' : 'off';
+			for (const name in headers) {
+				let HTTP_prefix = 'HTTP_';
+				/**
+				 * Some headers are special and don't have the HTTP_ prefix.
+				 */
+				if (
+					['content-type', 'content-length'].includes(
+						name.toLowerCase()
+					)
+				) {
+					HTTP_prefix = '';
+				}
+				$_SERVER[
+					`${HTTP_prefix}${name.toUpperCase().replace(/-/g, '_')}`
+				] = headers[name];
+			}
+			for (const key in $_SERVER) {
+				this.#setServerGlobalEntry(key, request.$_SERVER![key]);
+			}
 
 			const env = request.env || {};
 			for (const key in env) {
@@ -412,14 +438,25 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 		}
 	}
 
-	#setRequestHostAndProtocol(host: string, protocol: string) {
+	#setRequestHost(host: string) {
 		this[__private__dont__use].ccall(
 			'wasm_set_request_host',
 			null,
 			[STRING],
 			[host]
 		);
+	}
 
+	#setRequestPort(port: number) {
+		this[__private__dont__use].ccall(
+			'wasm_set_request_port',
+			null,
+			[NUMBER],
+			[port]
+		);
+	}
+
+	#inferPortFromHostAndProtocol(host: string, protocol: string) {
 		let port;
 		try {
 			port = parseInt(new URL(host).port, 10);
@@ -430,16 +467,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 		if (!port || isNaN(port) || port === 80) {
 			port = protocol === 'https' ? 443 : 80;
 		}
-		this[__private__dont__use].ccall(
-			'wasm_set_request_port',
-			null,
-			[NUMBER],
-			[port]
-		);
-
-		if (protocol === 'https' || (!protocol && port === 443)) {
-			this.addServerGlobalEntry('HTTPS', 'on');
-		}
+		return port;
 	}
 
 	#setRequestMethod(method: string) {
@@ -474,21 +502,6 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 				null,
 				[NUMBER],
 				[parseInt(headers['content-length'], 10)]
-			);
-		}
-		for (const name in headers) {
-			let HTTP_prefix = 'HTTP_';
-			/**
-			 * Some headers are special and don't have the HTTP_ prefix.
-			 */
-			if (
-				['content-type', 'content-length'].includes(name.toLowerCase())
-			) {
-				HTTP_prefix = '';
-			}
-			this.addServerGlobalEntry(
-				`${HTTP_prefix}${name.toUpperCase().replace(/-/g, '_')}`,
-				headers[name]
 			);
 		}
 	}
@@ -547,19 +560,13 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 		);
 	}
 
-	addServerGlobalEntry(key: string, value: string) {
-		this.#serverEntries[key] = value;
-	}
-
-	#addServerGlobalEntriesInWasm() {
-		for (const key in this.#serverEntries) {
-			this[__private__dont__use].ccall(
-				'wasm_add_SERVER_entry',
-				null,
-				[STRING, STRING],
-				[key, this.#serverEntries[key]]
-			);
-		}
+	#setServerGlobalEntry(key: string, value: string) {
+		this[__private__dont__use].ccall(
+			'wasm_add_SERVER_entry',
+			null,
+			[STRING, STRING],
+			[key, value]
+		);
 	}
 
 	#setEnv(name: string, value: string) {

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -211,13 +211,6 @@ export class PHPRequestHandler implements RequestHandler {
 		 */
 		const release = await this.#semaphore.acquire();
 		try {
-			this.php.addServerGlobalEntry('REMOTE_ADDR', '127.0.0.1');
-			this.php.addServerGlobalEntry('DOCUMENT_ROOT', this.#DOCROOT);
-			this.php.addServerGlobalEntry(
-				'HTTPS',
-				this.#ABSOLUTE_URL.startsWith('https://') ? 'on' : ''
-			);
-
 			let preferredMethod: PHPRunOptions['method'] = 'GET';
 
 			const headers: Record<string, string> = {
@@ -254,6 +247,13 @@ export class PHPRequestHandler implements RequestHandler {
 					),
 					protocol: this.#PROTOCOL,
 					method: request.method || preferredMethod,
+					$_SERVER: {
+						REMOTE_ADDS: '127.0.0.1',
+						DOCUMENT_ROOT: this.#DOCROOT,
+						HTTPS: this.#ABSOLUTE_URL.startsWith('https://')
+							? 'on'
+							: '',
+					},
 					body,
 					scriptPath,
 					headers,

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -248,7 +248,7 @@ export class PHPRequestHandler implements RequestHandler {
 					protocol: this.#PROTOCOL,
 					method: request.method || preferredMethod,
 					$_SERVER: {
-						REMOTE_ADDS: '127.0.0.1',
+						REMOTE_ADDR: '127.0.0.1',
 						DOCUMENT_ROOT: this.#DOCROOT,
 						HTTPS: this.#ABSOLUTE_URL.startsWith('https://')
 							? 'on'

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -540,6 +540,11 @@ export interface PHPRunOptions {
 	env?: Record<string, string>;
 
 	/**
+	 * $_SERVER entries to set for this run.
+	 */
+	$_SERVER?: Record<string, string>;
+
+	/**
 	 * The code snippet to eval instead of a php file.
 	 */
 	code?: string;


### PR DESCRIPTION
## Description

Removes the public `php.addServerGlobalEntry()` method in favor of a new `$_SERVER` property for `PHPRequest`. The provided `$_SERVER` entries only affected the next `run()` call so making them a part of the `run()` argument is more natural.

## What problem does this solve?

This PR reduces the amount of state stored in the `BasePHP` class, simplifying [the PHPProcessManager explorations](https://github.com/WordPress/wordpress-playground/pull/1287).

## Testing instructions

Confirm the unit and e2e tests pass.