### PR TITLE
Add initial workflow for deploying the website to WP Cloud

### DIFF
--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     deploy_to_wp_cloud:
-        # Only run this workflow from the trunk branch and when it's triggered by another workflow OR dmsnell OR adamziel
+        # Only run this workflow from the trunk branch and when it's triggered by another workflow OR certain maintainers
         if: >
             github.ref == 'refs/heads/trunk' && (
                 github.event.workflow_run.conclusion == 'success' ||

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -47,7 +47,6 @@ jobs:
             - name: Deploy to playground.wordpress.net
               shell: bash
               run: |
-                  set -euo pipefail
                   ZIP_URL=$(
                       curl -L -s -S \
                            -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -1,4 +1,4 @@
-name: Continue deploying to playground.wordpress.net (don't use manually)
+name: Finish deploying to playground.wordpress.net (don't use manually)
 # Sorry, the previous job just built it and uploaded it to GitHub
 
 on:

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -80,6 +80,6 @@ jobs:
                     -C 'curl -sS -X POST -H "Auth: $ATOMIC_SITE_API_KEY" "$(php -r "require \"/scripts/env.php\"; echo SITE_API_BASE;")/edge-cache/$ATOMIC_SITE_ID/purge"' \
                     > /dev/null \
                     && echo "Edge cache purged" \
-                    || >&2 echo "Failed to purge edge cache" && false
+                    || (>&2 echo "Failed to purge edge cache" && false)
 
             # TODO in subsequent PR: Copy latest custom-redirects.php from git

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -77,6 +77,9 @@ jobs:
                   ssh -i ~/.ssh/id_ed25519 \
                     ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }} \
                     -tt \
-                    -C 'curl -sS -X POST -H "Auth: $ATOMIC_SITE_API_KEY" "$(php -r "require \"/scripts/env.php\"; echo SITE_API_BASE;")/edge-cache/$ATOMIC_SITE_ID/purge"'
+                    -C 'curl -sS -X POST -H "Auth: $ATOMIC_SITE_API_KEY" "$(php -r "require \"/scripts/env.php\"; echo SITE_API_BASE;")/edge-cache/$ATOMIC_SITE_ID/purge"' \
+                    > /dev/null
+                    && echo "Edge cache purged" \
+                    || >&2 echo "Failed to purge edge cache" && false
 
             # TODO in subsequent PR: Copy latest custom-redirects.php from git

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -7,43 +7,37 @@ on:
         types:
             - completed
 
-    # TODO: Remove once done with testing
-    pull_request:
-
 jobs:
     deploy_to_wp_cloud:
         # Only run this workflow from the trunk branch and when it's triggered by another workflow OR dmsnell OR adamziel
-        # TODO: Re-enable this before merging
-        #if: >
-        #    github.ref == 'refs/heads/trunk' && (
-        #        github.event.workflow_run.conclusion == 'success' ||
-        #        github.actor == 'adamziel' ||
-        #        github.actor == 'dmsnell' ||
-        #        github.actor == 'bgrgicak' ||
-        #        github.actor == 'brandonpayton'
-        #    )
+        if: >
+            github.ref == 'refs/heads/trunk' && (
+                github.event.workflow_run.conclusion == 'success' ||
+                github.actor == 'adamziel' ||
+                github.actor == 'dmsnell' ||
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton'
+            )
 
         # Specify runner + deployment step
         runs-on: ubuntu-latest
         environment:
-            # TODO: Update environment protection rule to only allow with "Protected branches"
             name: playground-wordpress-net-wp-cloud
         steps:
-            # TODO: Re-enable waiting for latest artifact before merging PR
-            #- name: Wait for latest build artifact
-            #  shell: bash
-            #  # Sleep to give the GitHub API time to register the artifact,
-            #  # otherwise the artifact will not be available when the webhook is called
-            #  run: |
-            #      while true; do
-            #          API_HASH=$(curl 'https://api.github.com/repos/wordpress/wordpress-playground/actions/artifacts?name=playground-website&per_page=2' \
-            #              | jq -r '.artifacts[0].workflow_run.head_sha')
-            #          if [ "$API_HASH" = "$GITHUB_SHA" ]; then
-            #              break;
-            #          fi;
-            #          echo "$API_HASH was not $GITHUB_SHA, waiting 10 seconds...";
-            #          sleep 10;
-            #      done;
+            - name: Wait for latest build artifact
+              shell: bash
+              # Sleep to give the GitHub API time to register the artifact,
+              # otherwise the artifact will not be available when the webhook is called
+              run: |
+                  while true; do
+                      API_HASH=$(curl 'https://api.github.com/repos/wordpress/wordpress-playground/actions/artifacts?name=playground-website&per_page=2' \
+                          | jq -r '.artifacts[0].workflow_run.head_sha')
+                      if [ "$API_HASH" = "$GITHUB_SHA" ]; then
+                          break;
+                      fi;
+                      echo "$API_HASH was not $GITHUB_SHA, waiting 10 seconds...";
+                      sleep 10;
+                  done;
             - name: Deploy to playground.wordpress.net
               shell: bash
               run: |
@@ -80,5 +74,4 @@ jobs:
                     > /dev/null \
                     && echo "Edge cache purged" \
                     || (>&2 echo "Failed to purge edge cache" && false)
-
-            # TODO in subsequent PR: Copy latest custom-redirects.php from git
+              # TODO in subsequent PR: Copy latest custom-redirects.php from git

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -78,7 +78,7 @@ jobs:
                     ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }} \
                     -tt \
                     -C 'curl -sS -X POST -H "Auth: $ATOMIC_SITE_API_KEY" "$(php -r "require \"/scripts/env.php\"; echo SITE_API_BASE;")/edge-cache/$ATOMIC_SITE_ID/purge"' \
-                    > /dev/null
+                    > /dev/null \
                     && echo "Edge cache purged" \
                     || >&2 echo "Failed to purge edge cache" && false
 

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -47,7 +47,7 @@ jobs:
             - name: Deploy to playground.wordpress.net
               shell: bash
               run: |
-                  set -euxo pipefail
+                  set -euo pipefail
                   ZIP_URL=$(
                       curl -L -s -S \
                            -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -73,5 +73,9 @@ jobs:
                   chmod 0600 ~/.ssh/*
                   rsync -avz -e "ssh -i ~/.ssh/id_ed25519" --delete playground-website/ ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:/srv/htdocs/playground-files
 
+                  # Purge edge cache
+                  ssh -i ~/.ssh/id_ed25519 \
+                    ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}
+                    -C 'curl -sS -X POST -H "Auth: $ATOMIC_SITE_API_KEY" "$(php -r "require \"/scripts/env.php\"; echo SITE_API_BASE;")/edge-cache/$ATOMIC_SITE_ID/purge"'
+
             # TODO in subsequent PR: Copy latest custom-redirects.php from git
-            # TODO in subsequent PR: Copy latest purge cache script from website file and run it

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -75,7 +75,8 @@ jobs:
 
                   # Purge edge cache
                   ssh -i ~/.ssh/id_ed25519 \
-                    ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}
+                    ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }} \
+                    -tt \
                     -C 'curl -sS -X POST -H "Auth: $ATOMIC_SITE_API_KEY" "$(php -r "require \"/scripts/env.php\"; echo SITE_API_BASE;")/edge-cache/$ATOMIC_SITE_ID/purge"'
 
             # TODO in subsequent PR: Copy latest custom-redirects.php from git

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -45,7 +45,9 @@ jobs:
             #          sleep 10;
             #      done;
             - name: Deploy to playground.wordpress.net
+              shell: bash
               run: |
+                  set -euxo pipefail
                   ZIP_URL=$(
                       curl -L -s -S \
                            -H "Accept: application/vnd.github+json" \
@@ -53,13 +55,14 @@ jobs:
                            https://api.github.com/repos/wordpress/wordpress-playground/actions/artifacts\?name\=playground-website\&per_page\=1 \
                            | jq -r '.artifacts[0].archive_download_url'
                   )
+                  echo "Zip URL: $ZIP_URL"
 
                   curl -L -s -S \
                        -H "Accept: application/vnd.github+json" \
                        -H "Authorization: Bearer $GITHUB_TOKEN" \
                        -H "X-GitHub-Api-Version: 2022-11-28" \
                        -o playground-website.zip \
-                       $ZIP_URL
+                       "$ZIP_URL"
 
                   unzip playground-website.zip
                   tar -xzf wasm-wordpress-net.tar.gz

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -13,14 +13,15 @@ on:
 jobs:
     build_and_deploy:
         # Only run this workflow from the trunk branch and when it's triggered by another workflow OR dmsnell OR adamziel
-        if: >
-            github.ref == 'refs/heads/trunk' && (
-                github.event.workflow_run.conclusion == 'success' ||
-                github.actor == 'adamziel' ||
-                github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak' ||
-                github.actor == 'brandonpayton'
-            )
+        # TODO: Re-enable this before merging
+        #if: >
+        #    github.ref == 'refs/heads/trunk' && (
+        #        github.event.workflow_run.conclusion == 'success' ||
+        #        github.actor == 'adamziel' ||
+        #        github.actor == 'dmsnell' ||
+        #        github.actor == 'bgrgicak' ||
+        #        github.actor == 'brandonpayton'
+        #    )
 
         # Specify runner + deployment step
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -26,7 +26,8 @@ jobs:
         # Specify runner + deployment step
         runs-on: ubuntu-latest
         environment:
-            name: playground-wordpress-net
+            # TODO: Update environment protection rule to only allow with "Protected branches"
+            name: playground-wordpress-net-wp-cloud
         steps:
             - name: Wait for latest build artifact
               shell: bash

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -67,6 +67,7 @@ jobs:
                   tar -xzf wasm-wordpress-net.tar.gz
                   mv dist/packages/playground/wasm-wordpress-net/ playground-website/
 
+                  mkdir -p ~/.ssh
                   echo "${{ secrets.DEPLOY_WEBSITE_TARGET_HOST_KEY }}" >> ~/.ssh/known_hosts
                   echo "${{ secrets.DEPLOY_WEBSITE_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
                   rsync -avz -e "ssh -i ~/.ssh/id_ed25519" playground-website/ ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:/srv/htdocs/playground-files

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -71,7 +71,7 @@ jobs:
                   echo "${{ secrets.DEPLOY_WEBSITE_TARGET_HOST_KEY }}" >> ~/.ssh/known_hosts
                   echo "${{ secrets.DEPLOY_WEBSITE_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
                   chmod 0600 ~/.ssh/*
-                  rsync -avz -e "ssh -i ~/.ssh/id_ed25519" playground-website/ ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:/srv/htdocs/playground-files
+                  rsync -avz -e "ssh -i ~/.ssh/id_ed25519" --delete playground-website/ ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:/srv/htdocs/playground-files
 
             # TODO in subsequent PR: Copy latest custom-redirects.php from git
             # TODO in subsequent PR: Copy latest purge cache script from website file and run it

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -11,7 +11,7 @@ on:
     pull_request:
 
 jobs:
-    build_and_deploy:
+    deploy_to_wp_cloud:
         # Only run this workflow from the trunk branch and when it's triggered by another workflow OR dmsnell OR adamziel
         # TODO: Re-enable this before merging
         #if: >
@@ -44,13 +44,27 @@ jobs:
             #          echo "$API_HASH was not $GITHUB_SHA, waiting 10 seconds...";
             #          sleep 10;
             #      done;
-            - uses: actions/checkout@v3
-            - uses: actions/download-artifact@v2
-              with:
-                  name: playground-website
-                  path: playground-website
             - name: Deploy to playground.wordpress.net
               run: |
+                  ZIP_URL=$(
+                      curl -L -s -S \
+                           -H "Accept: application/vnd.github+json" \
+                           -H "X-GitHub-Api-Version: 2022-11-28" \
+                           https://api.github.com/repos/wordpress/wordpress-playground/actions/artifacts\?name\=playground-website\&per_page\=1 \
+                           | jq -r '.artifacts[0].archive_download_url'
+                  )
+
+                  curl -L -s -S \
+                       -H "Accept: application/vnd.github+json" \
+                       -H "Authorization: Bearer $GITHUB_TOKEN" \
+                       -H "X-GitHub-Api-Version: 2022-11-28" \
+                       -o playground-website.zip \
+                       $ZIP_URL
+
+                  unzip playground-website.zip
+                  tar -xzf wasm-wordpress-net.tar.gz
+                  mv dist/packages/playground/wasm-wordpress-net/ playground-website/
+
                   echo "$DEPLOY_WEBSITE_TARGET_HOST_KEY" >> ~/.ssh/known_hosts
                   echo "$DEPLOY_WEBSITE_PRIVATE_KEY" > ~/.ssh/id_ed25519
                   rsync -avz -e "ssh -i ~/.ssh/id_ed25519" playground-website/ $DEPLOY_WEBSITE_TARGET_USER@$DEPLOY_WEBSITE_TARGET_HOST:/srv/htdocs/playground-files

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -70,6 +70,7 @@ jobs:
                   mkdir -p ~/.ssh
                   echo "${{ secrets.DEPLOY_WEBSITE_TARGET_HOST_KEY }}" >> ~/.ssh/known_hosts
                   echo "${{ secrets.DEPLOY_WEBSITE_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+                  chmod 0600 ~/.ssh/*
                   rsync -avz -e "ssh -i ~/.ssh/id_ed25519" playground-website/ ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:/srv/htdocs/playground-files
 
             # TODO in subsequent PR: Copy latest custom-redirects.php from git

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -55,7 +55,6 @@ jobs:
                            https://api.github.com/repos/wordpress/wordpress-playground/actions/artifacts\?name\=playground-website\&per_page\=1 \
                            | jq -r '.artifacts[0].archive_download_url'
                   )
-                  echo "Zip URL: $ZIP_URL"
 
                   curl -L -s -S \
                        -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -1,0 +1,55 @@
+name: Continue deploying to playground.wordpress.net (don't use manually)
+# Sorry, the previous job just built it and uploaded it to GitHub
+
+on:
+    workflow_run:
+        workflows: [Deploy to playground.wordpress.net]
+        types:
+            - completed
+
+    # TODO: Remove once done with testing
+    pull_request:
+
+jobs:
+    build_and_deploy:
+        # Only run this workflow from the trunk branch and when it's triggered by another workflow OR dmsnell OR adamziel
+        if: >
+            github.ref == 'refs/heads/trunk' && (
+                github.event.workflow_run.conclusion == 'success' ||
+                github.actor == 'adamziel' ||
+                github.actor == 'dmsnell' ||
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton'
+            )
+
+        # Specify runner + deployment step
+        runs-on: ubuntu-latest
+        environment:
+            name: playground-wordpress-net
+        steps:
+            - name: Wait for latest build artifact
+              shell: bash
+              # Sleep to give the GitHub API time to register the artifact,
+              # otherwise the artifact will not be available when the webhook is called
+              run: |
+                  while true; do
+                      API_HASH=$(curl 'https://api.github.com/repos/wordpress/wordpress-playground/actions/artifacts?name=playground-website&per_page=2' \
+                          | jq -r '.artifacts[0].workflow_run.head_sha')
+                      if [ "$API_HASH" = "$GITHUB_SHA" ]; then
+                          break;
+                      fi;
+                      echo "$API_HASH was not $GITHUB_SHA, waiting 10 seconds...";
+                      sleep 10;
+                  done;
+            - uses: actions/download-artifact@v2
+              with:
+                  name: playground-website
+                  path: playground-website
+            - name: Deploy to playground.wordpress.net
+              run: |
+                  echo "$DEPLOY_WEBSITE_TARGET_HOST_KEY" >> ~/.ssh/known_hosts
+                  echo "$DEPLOY_WEBSITE_PRIVATE_KEY" > ~/.ssh/id_ed25519
+                  rsync -avz -e "ssh -i ~/.ssh/id_ed25519" playground-website/ $DEPLOY_WEBSITE_TARGET_USER@$DEPLOY_WEBSITE_TARGET_HOST:/srv/htdocs/playground-files
+
+            # TODO in subsequent PR: Copy latest custom-redirects.php from git
+            # TODO in subsequent PR: Copy latest purge cache script from website file and run it

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -44,6 +44,7 @@ jobs:
             #          echo "$API_HASH was not $GITHUB_SHA, waiting 10 seconds...";
             #          sleep 10;
             #      done;
+            - uses: actions/checkout@v3
             - uses: actions/download-artifact@v2
               with:
                   name: playground-website

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -29,20 +29,21 @@ jobs:
             # TODO: Update environment protection rule to only allow with "Protected branches"
             name: playground-wordpress-net-wp-cloud
         steps:
-            - name: Wait for latest build artifact
-              shell: bash
-              # Sleep to give the GitHub API time to register the artifact,
-              # otherwise the artifact will not be available when the webhook is called
-              run: |
-                  while true; do
-                      API_HASH=$(curl 'https://api.github.com/repos/wordpress/wordpress-playground/actions/artifacts?name=playground-website&per_page=2' \
-                          | jq -r '.artifacts[0].workflow_run.head_sha')
-                      if [ "$API_HASH" = "$GITHUB_SHA" ]; then
-                          break;
-                      fi;
-                      echo "$API_HASH was not $GITHUB_SHA, waiting 10 seconds...";
-                      sleep 10;
-                  done;
+            # TODO: Re-enable waiting for latest artifact before merging PR
+            #- name: Wait for latest build artifact
+            #  shell: bash
+            #  # Sleep to give the GitHub API time to register the artifact,
+            #  # otherwise the artifact will not be available when the webhook is called
+            #  run: |
+            #      while true; do
+            #          API_HASH=$(curl 'https://api.github.com/repos/wordpress/wordpress-playground/actions/artifacts?name=playground-website&per_page=2' \
+            #              | jq -r '.artifacts[0].workflow_run.head_sha')
+            #          if [ "$API_HASH" = "$GITHUB_SHA" ]; then
+            #              break;
+            #          fi;
+            #          echo "$API_HASH was not $GITHUB_SHA, waiting 10 seconds...";
+            #          sleep 10;
+            #      done;
             - uses: actions/download-artifact@v2
               with:
                   name: playground-website

--- a/.github/workflows/deploy-website-next.yml
+++ b/.github/workflows/deploy-website-next.yml
@@ -59,7 +59,7 @@ jobs:
 
                   curl -L -s -S \
                        -H "Accept: application/vnd.github+json" \
-                       -H "Authorization: Bearer $GITHUB_TOKEN" \
+                       -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
                        -H "X-GitHub-Api-Version: 2022-11-28" \
                        -o playground-website.zip \
                        "$ZIP_URL"
@@ -68,9 +68,9 @@ jobs:
                   tar -xzf wasm-wordpress-net.tar.gz
                   mv dist/packages/playground/wasm-wordpress-net/ playground-website/
 
-                  echo "$DEPLOY_WEBSITE_TARGET_HOST_KEY" >> ~/.ssh/known_hosts
-                  echo "$DEPLOY_WEBSITE_PRIVATE_KEY" > ~/.ssh/id_ed25519
-                  rsync -avz -e "ssh -i ~/.ssh/id_ed25519" playground-website/ $DEPLOY_WEBSITE_TARGET_USER@$DEPLOY_WEBSITE_TARGET_HOST:/srv/htdocs/playground-files
+                  echo "${{ secrets.DEPLOY_WEBSITE_TARGET_HOST_KEY }}" >> ~/.ssh/known_hosts
+                  echo "${{ secrets.DEPLOY_WEBSITE_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+                  rsync -avz -e "ssh -i ~/.ssh/id_ed25519" playground-website/ ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:/srv/htdocs/playground-files
 
             # TODO in subsequent PR: Copy latest custom-redirects.php from git
             # TODO in subsequent PR: Copy latest purge cache script from website file and run it


### PR DESCRIPTION
## What is this PR doing?

This PR adds a workflow for deploying the playground.wordpress.net website to WP Cloud

Related to #1197

## What problem is it solving?

Sometimes the website has availability issues due to its current shared hosting environment. Switching to WP Cloud is intended to address those issues.

## Testing Instructions

- Make sure the new workflow completed successfully
- Test Playground using the temporary staging URL https://playground-dot-wordpress-dot-net.atomicsites.blog/ 

NOTE: There are some outstanding issues with rate-limiting that break certain aspects of WordPress Playground on the test site, but Playground should still load the WP home page. The rate-limiting issues will be addressed separately, and possibly with the host itself rather than in a follow-up PR.
