### PR TITLE
Semaphore: Add timeout option

### DIFF
--- a/packages/php-wasm/util/src/lib/semaphore.spec.ts
+++ b/packages/php-wasm/util/src/lib/semaphore.spec.ts
@@ -1,4 +1,4 @@
-import Semaphore from './semaphore';
+import Semaphore, { AcquireTimeoutError } from './semaphore';
 
 describe('RequestsPerIntervaledSemaphore', () => {
 	it('should limit the number of concurrent lock holders', async () => {
@@ -39,5 +39,14 @@ describe('RequestsPerIntervaledSemaphore', () => {
 		release1();
 
 		expect(semaphore.running).toBe(1);
+	});
+	it('should wait for the lock no longer than the timeout', async () => {
+		const semaphore = new Semaphore({
+			concurrency: 1,
+			timeout: 1,
+		});
+
+		await semaphore.acquire();
+		expect(() => semaphore.acquire()).rejects.toThrow(AcquireTimeoutError);
 	});
 });

--- a/packages/php-wasm/util/src/lib/semaphore.ts
+++ b/packages/php-wasm/util/src/lib/semaphore.ts
@@ -1,7 +1,13 @@
 import { SleepFinished, sleep } from './sleep';
 
 export interface SemaphoreOptions {
+	/**
+	 * The maximum number of concurrent locks.
+	 */
 	concurrency: number;
+	/**
+	 * The maximum time to wait for a lock to become available.
+	 */
 	timeout?: number;
 }
 

--- a/packages/php-wasm/util/src/lib/sleep.ts
+++ b/packages/php-wasm/util/src/lib/sleep.ts
@@ -1,0 +1,7 @@
+export const SleepFinished = Symbol('SleepFinished');
+
+export function sleep(ms: number): Promise<typeof SleepFinished> {
+	return new Promise((resolve) => {
+		setTimeout(() => resolve(SleepFinished), ms);
+	});
+}


### PR DESCRIPTION
Adds an optional `timeout` option to the Semaphore class that throws an
error when the Semaphore cannot be acquired for `timeout` milliseconds.

Related to https://github.com/WordPress/wordpress-playground/pull/1287

 ## Testing instructions

Confirm the unit tests pass