### PR TITLE
Browser: Remove setSpawnHandler function from the public API

### DIFF
--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -443,15 +443,6 @@ export interface IsomorphicLocalPHP extends RequestHandler {
 	 * @param listener Callback function to handle the message.
 	 */
 	onMessage(listener: MessageListener): void;
-
-	/**
-	 * Registers a handler to spawns a child process when
-	 * `proc_open()`, `popen()`, `exec()`, `system()`, or `passthru()`
-	 * is called.
-	 *
-	 * @param handler Callback function to spawn a process.
-	 */
-	setSpawnHandler(handler: SpawnHandler | string): void;
 }
 
 export type MessageListener = (

--- a/packages/php-wasm/web/src/lib/web-php-endpoint.ts
+++ b/packages/php-wasm/web/src/lib/web-php-endpoint.ts
@@ -104,11 +104,6 @@ export class WebPHPEndpoint implements IsomorphicLocalPHP {
 		return _private.get(this)!.php.run(request);
 	}
 
-	/** @inheritDoc @php-wasm/web!WebPHP.setSpawnHandler */
-	setSpawnHandler(listener: string | SpawnHandler) {
-		_private.get(this)!.php.setSpawnHandler(listener);
-	}
-
 	/** @inheritDoc @php-wasm/web!WebPHP.chdir */
 	chdir(path: string): void {
 		return _private.get(this)!.php.chdir(path);

--- a/packages/php-wasm/web/src/lib/web-php-endpoint.ts
+++ b/packages/php-wasm/web/src/lib/web-php-endpoint.ts
@@ -9,7 +9,6 @@ import type {
 	RmDirOptions,
 	PHPEventListener,
 	PHPEvent,
-	SpawnHandler,
 } from '@php-wasm/universal';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -82,9 +82,6 @@ export async function bootPlaygroundRemote() {
 
 	const wpFrame = document.querySelector('#wp') as HTMLIFrameElement;
 	const webApi: WebClientMixin = {
-		setSpawnHandler(fn) {
-			return workerApi.setSpawnHandler(fn);
-		},
 		async onDownloadProgress(fn) {
 			return workerApi.onDownloadProgress(fn);
 		},

--- a/packages/playground/remote/src/lib/playground-client.ts
+++ b/packages/playground/remote/src/lib/playground-client.ts
@@ -48,8 +48,6 @@ export interface WebClientMixin extends ProgressReceiver {
 	 */
 	onDownloadProgress: PlaygroundWorkerEndpoint['onDownloadProgress'];
 
-	setSpawnHandler: PlaygroundWorkerEndpoint['setSpawnHandler'];
-
 	journalFSEvents: PlaygroundWorkerEndpoint['journalFSEvents'];
 	replayFSJournal: PlaygroundWorkerEndpoint['replayFSJournal'];
 	addEventListener: PlaygroundWorkerEndpoint['addEventListener'];


### PR DESCRIPTION
Removes the setSpawnHandler from the public API exposed on the web. Keeping it would add a lot of complexity to #1287 and we have a good handler in the worker thread. If this is needed again one day, let's explore restoring it then.

Related to #1287 

 ## Testing instrctions

* Verify the automated CI checks continue to work
* Verify the wp-cli demo continues to work
