### PR TITLE
PHP: Add a cwd argument to hotSwapPHPRuntime()

### DIFF
--- a/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
+++ b/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
@@ -22,11 +22,10 @@ describe('rotatePHPRuntime()', () => {
 
 		const recreateRuntimeSpy = vitest.fn(recreateRuntime);
 		// Rotate the PHP runtime
-		const php = new NodePHP(await recreateRuntime(), {
-			documentRoot: '/test-root',
-		});
+		const php = new NodePHP(await recreateRuntime());
 		rotatePHPRuntime({
 			php,
+			cwd: '/test-root',
 			recreateRuntime: recreateRuntimeSpy,
 			maxRequests: 1000,
 		});
@@ -53,11 +52,10 @@ describe('rotatePHPRuntime()', () => {
 
 	it('Should recreate the PHP runtime after maxRequests', async () => {
 		const recreateRuntimeSpy = vitest.fn(recreateRuntime);
-		const php = new NodePHP(await recreateRuntimeSpy(), {
-			documentRoot: '/test-root',
-		});
+		const php = new NodePHP(await recreateRuntimeSpy());
 		rotatePHPRuntime({
 			php,
+			cwd: '/test-root',
 			recreateRuntime: recreateRuntimeSpy,
 			maxRequests: 1,
 		});
@@ -68,11 +66,10 @@ describe('rotatePHPRuntime()', () => {
 
 	it('Should stop rotating after the cleanup handler is called', async () => {
 		const recreateRuntimeSpy = vitest.fn(recreateRuntime);
-		const php = new NodePHP(await recreateRuntimeSpy(), {
-			documentRoot: '/test-root',
-		});
+		const php = new NodePHP(await recreateRuntimeSpy());
 		const cleanup = rotatePHPRuntime({
 			php,
+			cwd: '/test-root',
 			recreateRuntime: recreateRuntimeSpy,
 			maxRequests: 1,
 		});
@@ -98,11 +95,10 @@ describe('rotatePHPRuntime()', () => {
 			}
 			return recreateRuntime('8.3');
 		});
-		const php = new NodePHP(await recreateRuntimeSpy(), {
-			documentRoot: '/test-root',
-		});
+		const php = new NodePHP(await recreateRuntimeSpy());
 		rotatePHPRuntime({
 			php,
+			cwd: '/test-root',
 			recreateRuntime: recreateRuntimeSpy,
 			maxRequests: 1,
 		});
@@ -121,11 +117,10 @@ describe('rotatePHPRuntime()', () => {
 	}, 30_000);
 
 	it('Should preserve the custom SAPI name', async () => {
-		const php = new NodePHP(await recreateRuntime(), {
-			documentRoot: '/test-root',
-		});
+		const php = new NodePHP(await recreateRuntime());
 		rotatePHPRuntime({
 			php,
+			cwd: '/test-root',
 			recreateRuntime,
 			maxRequests: 1,
 		});
@@ -140,11 +135,10 @@ describe('rotatePHPRuntime()', () => {
 	});
 
 	it('Should preserve the MEMFS files', async () => {
-		const php = new NodePHP(await recreateRuntime(), {
-			documentRoot: '/test-root',
-		});
+		const php = new NodePHP(await recreateRuntime());
 		rotatePHPRuntime({
 			php,
+			cwd: '/test-root',
 			recreateRuntime,
 			maxRequests: 1,
 		});
@@ -165,11 +159,10 @@ describe('rotatePHPRuntime()', () => {
 	}, 30_000);
 
 	it('Should not overwrite the NODEFS files', async () => {
-		const php = new NodePHP(await recreateRuntime(), {
-			documentRoot: '/test-root',
-		});
+		const php = new NodePHP(await recreateRuntime());
 		rotatePHPRuntime({
 			php,
+			cwd: '/test-root',
 			recreateRuntime,
 			maxRequests: 1,
 		});

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -825,8 +825,12 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 	 * interrupting the operations of this PHP instance.
 	 *
 	 * @param runtime
+	 * @param cwd. Internal, the VFS path to recreate in the new runtime.
+	 *             This arg is temporary and will be removed once BasePHP
+	 *             is fully decoupled from the request handler and
+	 *             accepts a constructor-level cwd argument.
 	 */
-	hotSwapPHPRuntime(runtime: number) {
+	hotSwapPHPRuntime(runtime: number, cwd?: string) {
 		// Once we secure the lock and have the new runtime ready,
 		// the rest of the swap handler is synchronous to make sure
 		// no other operations acts on the old runtime or FS.
@@ -858,9 +862,8 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 		}
 
 		// Copy the MEMFS directory structure from the old FS to the new one
-		if (this.requestHandler) {
-			const docroot = this.documentRoot;
-			copyFS(oldFS, this[__private__dont__use].FS, docroot);
+		if (cwd) {
+			copyFS(oldFS, this[__private__dont__use].FS, cwd);
 		}
 	}
 

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -139,6 +139,7 @@ const recreateRuntime = async () =>
 // @see https://github.com/WordPress/wordpress-playground/pull/990 for more context
 rotatePHPRuntime({
 	php,
+	cwd: requestHandler.documentRoot,
 	recreateRuntime,
 	// 400 is an arbitrary number that should trigger a rotation
 	// way before the memory gets too fragmented. If the memory

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -139,7 +139,7 @@ const recreateRuntime = async () =>
 // @see https://github.com/WordPress/wordpress-playground/pull/990 for more context
 rotatePHPRuntime({
 	php,
-	cwd: requestHandler.documentRoot,
+	cwd: DOCROOT,
 	recreateRuntime,
 	// 400 is an arbitrary number that should trigger a rotation
 	// way before the memory gets too fragmented. If the memory


### PR DESCRIPTION
To support [Loopback Request](https://github.com/WordPress/wordpress-playground/pull/1287), we need to decouple BasePHP from the request handler. This PR removes the implicit dependency from hotSwapPHPRuntime, where `requestHandler.documentRoot` was accessed, and replaces it with an explicit `cwd` argument. In the future, that argument will be removed and the PHP constructor will accept a class-level `cwd` property.

 ## Testing instructions

Confirm the CI checks pass.
