### PR TITLE
GitHub: Don't delete all the files when exporting a theme

### DIFF
--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -299,7 +299,7 @@ export default function GitHubExportForm({
 			} else if (formValues.contentType === 'plugin') {
 				fromPlaygroundRoot = `${docroot}/wp-content/plugins/${formValues.plugin}`;
 				relativeExportPaths = [
-					`/wp-content/plugins/${formValues.plugin}`,
+					`./`,
 				];
 				prTitle = `Update plugin ${formValues.plugin}`;
 			} else if (formValues.contentType === 'custom-paths') {

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -297,7 +297,7 @@ export default function GitHubExportForm({
 				relativeExportPaths = [`./`];
 				prTitle = `Update theme ${formValues.theme}`;
 			} else if (formValues.contentType === 'plugin') {
-				fromPlaygroundRoot = docroot;
+				fromPlaygroundRoot = `${docroot}/wp-content/plugins/${formValues.plugin}`;
 				relativeExportPaths = [
 					`/wp-content/plugins/${formValues.plugin}`,
 				];

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -293,15 +293,13 @@ export default function GitHubExportForm({
 				relativeExportPaths = ['/wp-content'];
 				prTitle = 'Update wp-content';
 			} else if (formValues.contentType === 'theme') {
-				fromPlaygroundRoot = docroot;
-				relativeExportPaths = [
-					`${docroot}/wp-content/themes/${formValues.theme}`,
-				];
+				fromPlaygroundRoot = `${docroot}/wp-content/themes/${formValues.theme}`;
+				relativeExportPaths = [`./`];
 				prTitle = `Update theme ${formValues.theme}`;
 			} else if (formValues.contentType === 'plugin') {
 				fromPlaygroundRoot = docroot;
 				relativeExportPaths = [
-					`${docroot}/wp-content/plugins/${formValues.plugin}`,
+					`/wp-content/plugins/${formValues.plugin}`,
 				];
 				prTitle = `Update plugin ${formValues.plugin}`;
 			} else if (formValues.contentType === 'custom-paths') {
@@ -380,9 +378,7 @@ export default function GitHubExportForm({
 					allPlaygroundFiles.push({
 						path: joinPaths(
 							toPathInRepo,
-							file.path.substring(
-								formValues.fromPlaygroundRoot.length
-							)
+							file.path.substring(fromPlaygroundRoot.length)
 						),
 						read: file.read,
 					});


### PR DESCRIPTION
Fixes themes and plugins export that got affected by #1174:

* Uses the theme/plugin directory as the content root
* Uses the adjusted `fromPlaygroundRoot` value instead of the one coming from the form.

Closes https://github.com/WordPress/wordpress-playground/issues/1296

 ## Testing instructions

* Import https://github.com/Automattic/themes/tree/trunk/foam from GitHub and export it immediately. There should be no files changed in the PR.
* Confirm https://github.com/adamziel/playground-docs-workflow still works with this PR

