### PR TITLE
PHPRequestHandler: Add a generic PHP argument

### DIFF
--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -9,7 +9,7 @@ describe.each(SupportedPHPVersions)(
 	'[PHP %s] PHPRequestHandler – request',
 	(phpVersion) => {
 		let php: NodePHP;
-		let handler: PHPRequestHandler;
+		let handler: PHPRequestHandler<NodePHP>;
 		beforeEach(async () => {
 			const phpLoaderModule = await getPHPLoaderModule(phpVersion);
 			const runtimeId = await loadPHPRuntime(phpLoaderModule);
@@ -384,7 +384,7 @@ describe.each(SupportedPHPVersions)(
 	'[PHP %s] PHPRequestHandler – PHP_SELF',
 	(phpVersion) => {
 		let php: NodePHP;
-		let handler: PHPRequestHandler;
+		let handler: PHPRequestHandler<NodePHP>;
 		beforeEach(async () => {
 			const phpLoaderModule = await getPHPLoaderModule(phpVersion);
 			const runtimeId = await loadPHPRuntime(phpLoaderModule);

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -60,7 +60,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP {
 	#wasmErrorsTarget: UnhandledRejectionsTarget | null = null;
 	#eventListeners: Map<string, Set<PHPEventListener>> = new Map();
 	#messageListeners: MessageListener[] = [];
-	requestHandler?: PHPRequestHandler;
+	requestHandler?: PHPRequestHandler<any>;
 
 	/**
 	 * An exclusive lock that prevent multiple requests from running at

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -91,7 +91,7 @@ export interface PHPRequestHandlerConfiguration {
  * // "Hi from PHP!"
  * ```
  */
-export class PHPRequestHandler {
+export class PHPRequestHandler<PHP extends BasePHP> {
 	#DOCROOT: string;
 	#PROTOCOL: string;
 	#HOSTNAME: string;
@@ -106,13 +106,13 @@ export class PHPRequestHandler {
 	/**
 	 * The PHP instance
 	 */
-	php: BasePHP;
+	php: PHP;
 
 	/**
 	 * @param  php    - The PHP instance.
 	 * @param  config - Request Handler configuration.
 	 */
-	constructor(php: BasePHP, config: PHPRequestHandlerConfiguration = {}) {
+	constructor(php: PHP, config: PHPRequestHandlerConfiguration = {}) {
 		this.#semaphore = new Semaphore({ concurrency: 1 });
 		const {
 			documentRoot = '/www/',


### PR DESCRIPTION
Before: `PHPRequestHandler`
After: `PHPRequestHandler<PHP extends BasePHP>`

This is a part of the [Loopback request support](https://github.com/WordPress/wordpress-playground/pull/1287)

 ## Testing instructions

Confirm the CI checks pass
