### PR TITLE
Service Worker: fetch credentialless to play more nicely with server caches (#1311)

### DIFF
--- a/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
+++ b/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
@@ -57,6 +57,8 @@ async function defaultRequestHandler(event: FetchEvent) {
 	) {
 		const request = await cloneRequest(event.request, {
 			url,
+			// Omit credentials to avoid causing cache aborts due to presence of cookies
+			credentials: 'omit',
 		});
 		return fetch(request);
 	}

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -73,6 +73,8 @@ initializeServiceWorker({
 				}
 				const request = await cloneRequest(event.request, {
 					url: resolvedUrl,
+					// Omit credentials to avoid causing cache aborts due to presence of cookies
+					credentials: 'omit',
 				});
 				return fetch(request).catch((e) => {
 					if (e?.name === 'TypeError') {


### PR DESCRIPTION
Let's stop sending cookies by default with requests for static files. The presence of cookies causes our new host to abort caching static files at the edge. And this can cause the same issue with other caches as well.

This only applies to requests from the Service Worker. There are still requests for static files with cookies from the browser, but this will at least reduce the number of cookied-requests.

## Testing Instructions

- Open a new tab in Safari
- Open dev tools with networking tab selected
- `npm run dev`
- Load the dev site on Safari
- Close the "Experimental" notice which remembers the closure using a cookie.
- Reload the site.
- In the dev tools Application tab, confirm there is a `hideExperimentalNotice` cookie for the test site.
- In the dev tools Network tab, filter for .css files. Find a request that says "Source: Service Worker" and confirm that the request headers do not include a Cookie header.

NOTE:
- We cannot use Chrome to test in this way because it just shows provisional request headers in dev tools
- We cannot use Firefox to test with `npm run dev` because the dev version of the Service Sorker is a module and Firefox doesn't support modules as Service Workers.