### PR TITLE
Remove sandbox attribute from iframe

### DIFF
--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -53,11 +53,7 @@
 		</style>
 	</head>
 	<body class="is-loading">
-		<iframe
-			id="wp"
-			title="The WordPress site"
-			sandbox="allow-same-origin allow-scripts allow-popups allow-forms allow-downloads allow-modals"
-		></iframe>
+		<iframe id="wp" title="The WordPress site"></iframe>
 		<script type="module">
 			if (window.top != window.self) {
 				document.body.classList.add('is-embedded');
@@ -134,23 +130,23 @@
 									<p>
 										Oops! Playground failed to start. Here's what to do:
 									</p>
-									
+
 									<h3>Did you disable third-party cookies?</h3>
 									<p>
-										It also disables the required Service Worker API. Please re-enable 
+										It also disables the required Service Worker API. Please re-enable
 										third-party cookies and try again.
 									</p>
 
 									<h3>Did you refuse to grant Playground storage access?</h3>
 									<p>
-										Click the button below and grant storage access. Note the button may 
+										Click the button below and grant storage access. Note the button may
 										not work if you have disabled third-party cookies in your browser.
 									</p>
 									`;
 								const reportIssues =
 									document.createElement('p');
 								reportIssues.innerHTML = `
-									If neither method helped, please 
+									If neither method helped, please
 									<a href="https://github.com/WordPress/playground-tools/issues/new"
 									   target="_blank">
 										report an issue on GitHub


### PR DESCRIPTION
## What is this PR doing?

It removes the sandbox attribute from remote.html. 

## What problem is it solving?

It allows PDF previews in Chrome.

## How is the problem addressed?

In https://github.com/WordPress/wordpress-playground/pull/1298 we enabled PDF loading in Playground, but it still didn't allow PDF previews in Chrome while it works in Firefox ([try this blueprint)](https://playground.wordpress.net/?blueprint-url=https://gist.githubusercontent.com/bgrgicak/fbfa528412f70baf2e652f228d6e63f6/raw/405147f792b06113a2632b87c31081d0a4c01b88/generate-pdf-blueprint.json).

@dennisnissle [mentioned that it works without sandbox options](https://github.com/WordPress/wordpress-playground/issues/1223#issuecomment-2072577461).

After some testing, it turns out that any sandbox option will block PDFs from loading. I couldn't find any documentation on it but a comment from [StackOverflow suggests the same](https://stackoverflow.com/questions/40624211/open-pdf-from-chrome-iframe-failed-with-default-pdf-viewer).
There is a [note in the MDN documentation](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attributes) about embedded documents: _it is strongly discouraged to use both allow-scripts and allow-same-origin, as that lets the embedded document remove the sandbox attribute_. I assume that Chrome does something different. 

I also tried adding all sandbox options and just having a `sandbox=""`. Both kept returning the same error, so the only solution I could find was to remove it. 

## Testing Instructions

- Chekout this branch
- [Open this blueprint](http://127.0.0.1:5400/website-server/?blueprint-url=https://gist.githubusercontent.com/bgrgicak/fbfa528412f70baf2e652f228d6e63f6/raw/405147f792b06113a2632b87c31081d0a4c01b88/generate-pdf-blueprint.json&seamles=yes)
- Confirm the PDF loads