### PR TITLE
Stop WP rewrite rules from matching files like wp-admin.css

### DIFF
--- a/packages/playground/wordpress/src/rewrite-rules.ts
+++ b/packages/playground/wordpress/src/rewrite-rules.ts
@@ -5,7 +5,7 @@ import type { RewriteRule } from '@php-wasm/universal';
  */
 export const wordPressRewriteRules: RewriteRule[] = [
 	{
-		match: /^\/(.*?)(\/wp-(content|admin|includes).*)/g,
+		match: /^\/(.*?)(\/wp-(content|admin|includes)\/.*)/g,
 		replacement: '$2',
 	},
 ];


### PR DESCRIPTION
## What is this PR doing?

This PR fixes a bug in our WordPress rewrite rules where plugin files named things like "wp-admin.css" were having their preceding plugin-specific path removed.

This was reported in WP.org Slack (#playground-logs):
https://wordpress.slack.com/archives/C06Q5DCKZ3L/p1713585476733489

## How is the problem addressed?

This PR tweaks the pattern to only apply to directories. This fixes the problem of matching files but still leaves open the possibility of false positives when plugins or themes contain directories named /wp-admin/, /wp-includes/, etc.

## Testing Instructions

- `npm run dev`
- Open [local Playground with a blueprint that installs and activates the Material Board plugin](http://127.0.0.1:5400/website-server/?blueprint-url=https://gist.githubusercontent.com/brandonpayton/dadc7b6e7ed9c9aaea4342288d9f09d6/raw/e61680320f6d7da4788713a12feb8919485bd4f4/blueprint.json)
- Confirm that wp-admin dashboard is rendered cleanly without obvious styling issues
 
Without this fix, the appearence of the lefthand menu bar is obviously broken like:
<img src="https://github.com/WordPress/wordpress-playground/assets/530877/669958de-8e9e-41c6-af69-525e3ad18d95" height="400">
