### PR TITLE
Display logs in a modal

### DIFF
--- a/packages/playground/website/src/components/error-report-modal/index.tsx
+++ b/packages/playground/website/src/components/error-report-modal/index.tsx
@@ -9,7 +9,7 @@ import { usePlaygroundContext } from '../../playground-context';
 import { Blueprint } from '@wp-playground/blueprints';
 
 export function ErrorReportModal(props: { blueprint: Blueprint }) {
-	const { showErrorModal, setShowErrorModal } = usePlaygroundContext();
+	const { activeModal, setActiveModal } = usePlaygroundContext();
 	const [loading, setLoading] = useState(false);
 	const [text, setText] = useState('');
 	const [logs, setLogs] = useState('');
@@ -17,22 +17,26 @@ export function ErrorReportModal(props: { blueprint: Blueprint }) {
 	const [submitted, setSubmitted] = useState(false);
 	const [submitError, setSubmitError] = useState('');
 
+	function showModal() {
+		return activeModal === 'error-report';
+	}
+
 	useEffect(() => {
 		addCrashListener(logger, (e) => {
 			const error = e as CustomEvent;
 			if (error.detail?.source === 'php-wasm') {
-				setShowErrorModal(true);
+				setActiveModal('error-report');
 			}
 		});
-	}, [setShowErrorModal]);
+	}, [setActiveModal]);
 
 	useEffect(() => {
 		resetForm();
-		if (showErrorModal) {
+		if (showModal()) {
 			setLogs(logger.getLogs().join('\n'));
 			setUrl(window.location.href);
 		}
-	}, [showErrorModal, setShowErrorModal, logs, setLogs]);
+	}, [activeModal, setActiveModal, logs, setLogs]);
 
 	function resetForm() {
 		setText('');
@@ -46,7 +50,7 @@ export function ErrorReportModal(props: { blueprint: Blueprint }) {
 	}
 
 	function onClose() {
-		setShowErrorModal(false);
+		setActiveModal(false);
 		resetForm();
 		resetSubmission();
 	}
@@ -150,7 +154,7 @@ export function ErrorReportModal(props: { blueprint: Blueprint }) {
 	}
 
 	return (
-		<Modal isOpen={showErrorModal} onRequestClose={onClose}>
+		<Modal isOpen={showModal()} onRequestClose={onClose}>
 			<header className={css.errorReportModalHeader}>
 				<h2>{getTitle()}</h2>
 				<p>{getContent()}</p>

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import Modal from '../modal';
+import { addCrashListener, logger } from '@php-wasm/logger';
+
+import css from './style.module.css';
+
+import { usePlaygroundContext } from '../../playground-context';
+
+export function LogModal() {
+	const { activeModal, setActiveModal } = usePlaygroundContext();
+	const [logs, setLogs] = useState('');
+
+	useEffect(() => {
+		addCrashListener(logger, (e) => {
+			const error = e as CustomEvent;
+			if (error.detail?.source === 'php-wasm') {
+				setActiveModal('log');
+			}
+		});
+	}, [setActiveModal]);
+
+	useEffect(() => {
+		if (activeModal) {
+			setLogs(logger.getLogs().join('\n'));
+		}
+	}, [activeModal, setActiveModal, logs, setLogs]);
+
+	function onClose() {
+		setActiveModal(false);
+	}
+
+	function showModal() {
+		return activeModal === 'log';
+	}
+
+	return (
+		<Modal isOpen={showModal()} onRequestClose={onClose}>
+			<header className={css.errorReportModalHeader}>
+				<h2>Logs</h2>
+			</header>
+			<main>
+				<pre>{logs}</pre>
+			</main>
+		</Modal>
+	);
+}

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -34,6 +34,7 @@ export function LogModal() {
 			.filter((log) =>
 				log.toLowerCase().includes(searchTerm.toLowerCase())
 			)
+			.reverse()
 			.map((log, index) => (
 				<pre className={css.logModalLog} key={index}>
 					{log}

--- a/packages/playground/website/src/components/log-modal/style.module.css
+++ b/packages/playground/website/src/components/log-modal/style.module.css
@@ -1,0 +1,13 @@
+.log-modal__main {
+	padding-bottom: 20px;
+}
+
+.log-modal__search {
+	/* Title margin bottom + log margin top */
+	margin-bottom: 1.33rem;
+}
+
+.log-modal__log {
+	text-wrap: wrap;
+	margin: 0.5rem 0;
+}

--- a/packages/playground/website/src/components/modal/index.tsx
+++ b/packages/playground/website/src/components/modal/index.tsx
@@ -4,7 +4,7 @@ import css from './style.module.css';
 ReactModal.setAppElement('#root');
 
 interface ModalProps extends ReactModal.Props {
-	mergeStyles?: boolean;
+	styles?: ReactModal.Styles;
 }
 export const defaultStyles: ReactModal.Styles = {
 	content: {
@@ -29,8 +29,12 @@ export const defaultStyles: ReactModal.Styles = {
 	},
 };
 export default function Modal(props: ModalProps) {
+	const styles = {
+		overlay: { ...defaultStyles.overlay, ...props.styles?.overlay },
+		content: { ...defaultStyles.content, ...props.styles?.content },
+	};
 	return (
-		<ReactModal style={defaultStyles} {...props}>
+		<ReactModal style={styles} {...props}>
 			<div className={css.modalInner} id="modal-content">
 				<button
 					id="import-close-modal--btn"

--- a/packages/playground/website/src/components/toolbar-buttons/view-logs.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/view-logs.tsx
@@ -1,23 +1,23 @@
 import { MenuItem } from '@wordpress/components';
-import { bug } from '@wordpress/icons';
+import { details } from '@wordpress/icons';
 
 import { usePlaygroundContext } from '../../playground-context';
 
 type Props = { onClose: () => void };
-export function ReportError({ onClose }: Props) {
+export function ViewLogs({ onClose }: Props) {
 	const { setActiveModal } = usePlaygroundContext();
 	return (
 		<MenuItem
-			icon={bug}
+			icon={details}
 			iconPosition="left"
-			data-cy="report-error"
-			aria-label="Report an error in Playground"
+			data-cy="view-logs"
+			aria-label="View logs"
 			onClick={() => {
-				setActiveModal('error-report');
+				setActiveModal('log');
 				onClose();
 			}}
 		>
-			Report error
+			View logs
 		</MenuItem>
 	);
 }

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -17,6 +17,7 @@ import { ResetSiteMenuItem } from './components/toolbar-buttons/reset-site';
 import { DownloadAsZipMenuItem } from './components/toolbar-buttons/download-as-zip';
 import { RestoreFromZipMenuItem } from './components/toolbar-buttons/restore-from-zip';
 import { ReportError } from './components/toolbar-buttons/report-error';
+import { ViewLogs } from './components/toolbar-buttons/view-logs';
 import { resolveBlueprint } from './lib/resolve-blueprint';
 import { GithubImportMenuItem } from './components/toolbar-buttons/github-import-menu-item';
 import { acquireOAuthTokenIfNeeded } from './github/acquire-oauth-token-if-needed';
@@ -29,11 +30,12 @@ import {
 	asPullRequestAction,
 } from './github/github-export-form/form';
 import { joinPaths } from '@php-wasm/util';
-import { PlaygroundContext } from './playground-context';
+import { ActiveModal, PlaygroundContext } from './playground-context';
 import { collectWindowErrors, logger } from '@php-wasm/logger';
 import { ErrorReportModal } from './components/error-report-modal';
 import { asContentType } from './github/import-from-github';
 import { GitHubOAuthGuardModal } from './github/github-oauth-guard';
+import { LogModal } from './components/log-modal';
 
 collectWindowErrors(logger);
 
@@ -87,7 +89,7 @@ if (currentConfiguration.wp === '6.3') {
 acquireOAuthTokenIfNeeded();
 
 function Main() {
-	const [showErrorModal, setShowErrorModal] = useState(false);
+	const [activeModal, setActiveModal] = useState<ActiveModal | false>(false);
 	const [githubExportFiles, setGithubExportFiles] = useState<any[]>();
 	const [githubExportValues, setGithubExportValues] = useState<
 		Partial<ExportFormValues>
@@ -129,9 +131,10 @@ function Main() {
 
 	return (
 		<PlaygroundContext.Provider
-			value={{ storage, showErrorModal, setShowErrorModal }}
+			value={{ storage, activeModal, setActiveModal }}
 		>
 			<ErrorReportModal blueprint={blueprint} />
+			<LogModal />
 			<PlaygroundViewport
 				storage={storage}
 				displayMode={displayMode}
@@ -165,6 +168,7 @@ function Main() {
 									<RestoreFromZipMenuItem onClose={onClose} />
 									<GithubImportMenuItem onClose={onClose} />
 									<GithubExportMenuItem onClose={onClose} />
+									<ViewLogs onClose={onClose} />
 									<MenuItem
 										icon={external}
 										iconPosition="left"

--- a/packages/playground/website/src/playground-context.tsx
+++ b/packages/playground/website/src/playground-context.tsx
@@ -1,9 +1,15 @@
 import { createContext, useContext } from 'react';
 import { StorageType } from './types';
 
+export type ActiveModal = 'error-report' | 'log' | false;
+
 export const PlaygroundContext = createContext<{
 	storage: StorageType;
-	showErrorModal: boolean;
-	setShowErrorModal: (show: boolean) => void;
-}>({ storage: 'none', showErrorModal: false, setShowErrorModal: () => {} });
+	activeModal: ActiveModal;
+	setActiveModal: (modal: ActiveModal) => void;
+}>({
+	storage: 'none',
+	activeModal: false,
+	setActiveModal: () => {},
+});
 export const usePlaygroundContext = () => useContext(PlaygroundContext);


### PR DESCRIPTION
## What is this PR doing?

It adds a modal that displays all logs. 

## What problem is it solving?

It will make it easier for users to discover logs. In the future, we will automatically show this modal on some specific errors like blueprint errors to help users with debugging.

## How is the problem addressed?

By adding a modal component and a View logs button in the menu.

## Testing Instructions

- Checkout this branch
- Open [Playground with this blueprint](http://localhost:5400/website-server/?blueprint-url=https://gist.githubusercontent.com/bgrgicak/5fbeb98abec8221192a8b619f852148a/raw/75ff00581b76d9ed3e4844d228dce9b4eda1b163/error-log-blueprint.json)
- In the upper right menu click on _View logs_
- Confirm that the modal loads log messages
- Confirm that search filters log messages