### PR TITLE
PHP: Remove setSapiName, setPhpIniEntry, setPhpIniPath methods from the remote PHP API client

### DIFF
--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -334,7 +334,15 @@ type ChildProcess = EventEmitter & {
 };
 export type SpawnHandler = (command: string, args: string[]) => ChildProcess;
 
-export type IsomorphicRemotePHP = Remote<IsomorphicLocalPHP>;
+/**
+ * The omited methods must either be called synchronously before
+ * the PHP internal state is initialized, or with a complex argument
+ * that can't be serialized over a remote connection. Therefeore,
+ * they don't make sense in a remote PHP instance.
+ */
+export type IsomorphicRemotePHP = Remote<
+	Omit<IsomorphicLocalPHP, 'setSapiName' | 'setPhpIniEntry' | 'setPhpIniPath'>
+>;
 export type UniversalPHP = IsomorphicLocalPHP | IsomorphicRemotePHP;
 
 export type HTTPMethod =

--- a/packages/php-wasm/web/src/lib/web-php-endpoint.ts
+++ b/packages/php-wasm/web/src/lib/web-php-endpoint.ts
@@ -23,7 +23,13 @@ const _private = new WeakMap<
 /**
  * A PHP client that can be used to run PHP code in the browser.
  */
-export class WebPHPEndpoint implements IsomorphicLocalPHP {
+export class WebPHPEndpoint
+	implements
+		Omit<
+			IsomorphicLocalPHP,
+			'setSapiName' | 'setPhpIniEntry' | 'setPhpIniPath'
+		>
+{
 	/** @inheritDoc @php-wasm/universal!RequestHandler.absoluteUrl  */
 	absoluteUrl: string;
 	/** @inheritDoc @php-wasm/universal!RequestHandler.documentRoot  */
@@ -106,20 +112,6 @@ export class WebPHPEndpoint implements IsomorphicLocalPHP {
 	/** @inheritDoc @php-wasm/web!WebPHP.chdir */
 	chdir(path: string): void {
 		return _private.get(this)!.php.chdir(path);
-	}
-
-	/** @inheritDoc @php-wasm/web!WebPHP.setSapiName */
-	setSapiName(newName: string): void {
-		_private.get(this)!.php.setSapiName(newName);
-	}
-	/** @inheritDoc @php-wasm/web!WebPHP.setPhpIniPath */
-	setPhpIniPath(path: string): void {
-		return _private.get(this)!.php.setPhpIniPath(path);
-	}
-
-	/** @inheritDoc @php-wasm/web!WebPHP.setPhpIniEntry */
-	setPhpIniEntry(key: string, value: string): void {
-		return _private.get(this)!.php.setPhpIniEntry(key, value);
 	}
 
 	/** @inheritDoc @php-wasm/web!WebPHP.mkdir */


### PR DESCRIPTION
`setSapiName`, `setPhpIniEntry`, and `setPhpIniPath` are methods that must either be called synchronously before the PHP internal state is initialized, or with a complex argument that can't be serialized over a remote connection.

They can only be used in the same process before PHP is fully initialized and have never worked correctly when connecting a Playground API client to `remote.html`.

Removing them makes that apparent, prevents confusing API interactions.

In addition, it sets the stage for supporting
a [Loopback
Request](https://github.com/WordPress/wordpress-playground/pull/1287) as the backend for the API endpoint switches from a single PHP instance to a PHPRequestHandler, and here we're removing an API surface that needs to impact all existing and future PHP instances.

## Testing instructions

Confirm the CI checks pass.
