### PR TITLE
PHPProcessManager: clear nextInstance when the concurrency limit is exhausted

### DIFF
--- a/packages/php-wasm/node/src/test/php-process-manager.spec.ts
+++ b/packages/php-wasm/node/src/test/php-process-manager.spec.ts
@@ -30,13 +30,28 @@ describe('PHPProcessManager', () => {
 		expect(phpFactory).toHaveBeenCalled();
 	});
 
-	it('should refuse to spawn more PHP instances than the maximum', async () => {
+	it('should refuse to spawn more PHP instances than the maximum (limit=2)', async () => {
 		const mgr = new PHPProcessManager({
 			phpFactory: async () => NodePHP.load(RecommendedPHPVersion),
 			maxPhpInstances: 2,
 			timeout: 100,
 		});
 
+		await mgr.acquirePHPInstance();
+		await mgr.acquirePHPInstance();
+		await expect(() => mgr.acquirePHPInstance()).rejects.toThrowError(
+			/Requested more concurrent PHP instances/
+		);
+	});
+
+	it('should refuse to spawn more PHP instances than the maximum (limit=3)', async () => {
+		const mgr = new PHPProcessManager({
+			phpFactory: async () => NodePHP.load(RecommendedPHPVersion),
+			maxPhpInstances: 3,
+			timeout: 100,
+		});
+
+		await mgr.acquirePHPInstance();
 		await mgr.acquirePHPInstance();
 		await mgr.acquirePHPInstance();
 		await expect(() => mgr.acquirePHPInstance()).rejects.toThrowError(

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -872,10 +872,8 @@ export abstract class BasePHP implements IsomorphicLocalPHP, Disposable {
 
 		// Delete any links between this PHP instance and the runtime
 		this.#wasmErrorsTarget = null;
-		if (this[__private__dont__use]) {
-			delete this[__private__dont__use]['onMessage'];
-			delete this[__private__dont__use];
-		}
+		delete this[__private__dont__use]['onMessage'];
+		delete this[__private__dont__use];
 	}
 
 	[Symbol.dispose]() {

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -872,8 +872,10 @@ export abstract class BasePHP implements IsomorphicLocalPHP, Disposable {
 
 		// Delete any links between this PHP instance and the runtime
 		this.#wasmErrorsTarget = null;
-		delete this[__private__dont__use]['onMessage'];
-		delete this[__private__dont__use];
+		if (this[__private__dont__use]) {
+			delete this[__private__dont__use]['onMessage'];
+			delete this[__private__dont__use];
+		}
 	}
 
 	[Symbol.dispose]() {

--- a/packages/php-wasm/universal/src/lib/php-process-manager.ts
+++ b/packages/php-wasm/universal/src/lib/php-process-manager.ts
@@ -154,6 +154,8 @@ export class PHPProcessManager<PHP extends BasePHP> implements AsyncDisposable {
 		 */
 		if (this.semaphore.remaining > 0) {
 			this.nextInstance = this.spawn({ isPrimary: false });
+		} else {
+			this.nextInstance = null;
 		}
 		return await spawnedPhp;
 	}


### PR DESCRIPTION
Fixes a bug in the [PHPProcessManager](https://github.com/WordPress/wordpress-playground/pull/1301) where `acquirePHPInstance()` would continue returning `this.nextInstance` even after the semaphore concurrency limit
was exhausted. The solution is to clear `this.nextInstance` for the next `acquirePHPInstance()` call.

 ## Testing instructions

Confirm the CI checks pass