### PR TITLE
Docs: Support Markdown in Blueprint steps descriptions 

### DIFF
--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
@@ -5,27 +5,14 @@ import ReactMarkdown from 'react-markdown';
 export function BlueprintStepDescription({ name }) {
 	const stepApi = getStepAPI(name);
 
-	return (
-		<p>
-			{stepApi.stepDetails.summary.map((part) => {
-				if (part.kind === 'code') {
-					return (
-						<>
-							{' '}
-							<code>{part.text.replace(/^`|`$/g, '')}</code>{' '}
-						</>
-					);
-				}
-				return (
-					<ReactMarkdown
-						components={{
-							p: 'span',
-						}}
-					>
-						{part.text}
-					</ReactMarkdown>
-				);
-			})}
-		</p>
-	);
+	const summary = stepApi.stepDetails.summary
+		.map((part) => {
+			if (part.kind === 'code') {
+				return '`' + part.text.replace(/^`|`$/g, '') + '`';
+			}
+			return part.text;
+		})
+		.join(' ');
+
+	return <ReactMarkdown>{summary}</ReactMarkdown>;
 }

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
@@ -12,7 +12,7 @@ export function BlueprintStepDescription({ name }) {
 			}
 			return part.text;
 		})
-		.join(' ');
+		.join('');
 
 	return <ReactMarkdown>{summary}</ReactMarkdown>;
 }

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStepDescription.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getStepAPI } from './model';
+import ReactMarkdown from 'react-markdown';
 
 export function BlueprintStepDescription({ name }) {
 	const stepApi = getStepAPI(name);
@@ -8,9 +9,22 @@ export function BlueprintStepDescription({ name }) {
 		<p>
 			{stepApi.stepDetails.summary.map((part) => {
 				if (part.kind === 'code') {
-					return <code>{part.text.replace(/^`|`$/g, '')}</code>;
+					return (
+						<>
+							{' '}
+							<code>{part.text.replace(/^`|`$/g, '')}</code>{' '}
+						</>
+					);
 				}
-				return part.text;
+				return (
+					<ReactMarkdown
+						components={{
+							p: 'span',
+						}}
+					>
+						{part.text}
+					</ReactMarkdown>
+				);
 			})}
 		</p>
 	);


### PR DESCRIPTION
Blueprints docs at
https://wordpress.github.io/wordpress-playground/blueprints-api/steps/
are automatically build from TypeScript comments in code. This PR
ensures these comments are rendered not as plaintext, but as markdown.

![CleanShot 2024-04-25 at 15 42 25@2x](https://github.com/WordPress/wordpress-playground/assets/205419/4f0459b7-18e3-4f95-9fef-451f63092191)

## Testing instructions

1. Add markdown here https://github.com/WordPress/wordpress-playground/blob/7f844e3d586c34db6a34b48c3a2794fc5dc56291/packages/playground/blueprints/src/lib/steps/site-data.ts#L28
2. Rebuild the docs
3. Confirm it renders like on the screenshot above

cc @ironnysh 