### PR TITLE
Eliminate 404s due to nested files-to-serve-via-php dir

### DIFF
--- a/packages/playground/website-deployment/apply-update.sh
+++ b/packages/playground/website-deployment/apply-update.sh
@@ -44,9 +44,11 @@ function set_aside_files_to_serve_via_php() {
         mv "$FILE_TO_SERVE_VIA_PHP" "$TARGET_DIR/"
     done
 }
+
 echo Configure which files should be served by Nginx and which by PHP
 cd ~/website-update
 find -type f \
+    | grep -v files-to-serve-via-php \
     | match_files_to_serve_via_php \
     | set_aside_files_to_serve_via_php
 


### PR DESCRIPTION
## What is this PR doing?

Fixes website breakage due to a files-to-serve-via-php directory being nested within another files-to-serve-via-php-directory. When this occurs, files are more nested than expected and cannot be found.

## What problem is it solving?

During deployment we list files within a directory structure and move them conditionally. Because this is done with a `find` piped to bash functions that move files to `files-to-serve-via-php` within the same parent dir, it appears moved files are later discovered by `find` causing them to be moved again and creating a nested directory structure.

## How is the problem addressed?

By filtering out paths that include the string `files-to-serve-via-php` to prevent them from being moved again.

## Testing Instructions

- Manually login to the test site via PHP and run apply-update.sh manually.