### PR TITLE
PHP.wasm Node: Revert a part of #1289, do not import a .wasm file

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -1024,7 +1024,11 @@ RUN set -euxo pipefail; \
 	# Turn the php.js file into an ES module
 		# Manually turn the output into a esm module instead of relying on -s MODULARIZE=1.
 		# which pollutes the global namespace and does not play well with import() mechanics.
-		echo "import dependencyFilename from './${PHP_VERSION_ESCAPED}/$WASM_FILENAME'; " >> /root/output/php-module.js; \
+		if [ "$EMSCRIPTEN_ENVIRONMENT" = "node" ]; then \
+			echo "const dependencyFilename = __dirname + '/${PHP_VERSION_ESCAPED}/$WASM_FILENAME'; " >> /root/output/php-module.js; \
+		else \
+			echo "import dependencyFilename from './${PHP_VERSION_ESCAPED}/$WASM_FILENAME'; " >> /root/output/php-module.js; \
+		fi; \
 		echo "export { dependencyFilename }; " >> /root/output/php-module.js && \
 		echo "export const dependenciesTotalSize = $FILE_SIZE; " >> /root/output/php-module.js && \
 		cat /root/esm-prefix.js >> /root/output/php-module.js && \

--- a/packages/php-wasm/fs-journal/vite.config.ts
+++ b/packages/php-wasm/fs-journal/vite.config.ts
@@ -7,9 +7,6 @@ import { join } from 'path';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-ts-config-paths';
 
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import { viteWasmLoader } from '../../vite-wasm-loader';
-
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-fs-journal',
 
@@ -22,8 +19,6 @@ export default defineConfig({
 		viteTsConfigPaths({
 			root: '../../../',
 		}),
-
-		viteWasmLoader,
 	],
 
 	// Configuration for building your library.

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -22,9 +22,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"cp -rf packages/php-wasm/node/public/* dist/packages/php-wasm/node",
-					"node packages/php-wasm/node/bin/postprocess-php-modules.cjs dist/packages/php-wasm/node",
-					"rm -rf dist/packages/php-wasm/node/*.wasm"
+					"cp -rf packages/php-wasm/node/public/* dist/packages/php-wasm/node"
 				],
 				"parallel": false
 			},

--- a/packages/php-wasm/node/public/php_7_0.js
+++ b/packages/php-wasm/node/public/php_7_0.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './7_0_33/php_7_0.wasm'; 
+const dependencyFilename = __dirname + '/7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 13118939; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/public/php_7_1.js
+++ b/packages/php-wasm/node/public/php_7_1.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './7_1_30/php_7_1.wasm';
+const dependencyFilename = __dirname + '/7_1_30/php_7_1.wasm';
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 13643181; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/public/php_7_2.js
+++ b/packages/php-wasm/node/public/php_7_2.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './7_2_34/php_7_2.wasm'; 
+const dependencyFilename = __dirname + '/7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 14335706; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/public/php_7_3.js
+++ b/packages/php-wasm/node/public/php_7_3.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './7_3_33/php_7_3.wasm'; 
+const dependencyFilename = __dirname + '/7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 14441796; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/public/php_7_4.js
+++ b/packages/php-wasm/node/public/php_7_4.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './7_4_33/php_7_4.wasm';
+const dependencyFilename = __dirname + '/7_4_33/php_7_4.wasm';
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 14675209; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/public/php_8_0.js
+++ b/packages/php-wasm/node/public/php_8_0.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './8_0_30/php_8_0.wasm'; 
+const dependencyFilename = __dirname + '/8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 13904218; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/public/php_8_1.js
+++ b/packages/php-wasm/node/public/php_8_1.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './8_1_23/php_8_1.wasm'; 
+const dependencyFilename = __dirname + '/8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 13884035; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/public/php_8_2.js
+++ b/packages/php-wasm/node/public/php_8_2.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './8_2_10/php_8_2.wasm'; 
+const dependencyFilename = __dirname + '/8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 14143340; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/public/php_8_3.js
+++ b/packages/php-wasm/node/public/php_8_3.js
@@ -1,4 +1,4 @@
-import dependencyFilename from './8_3_0/php_8_3.wasm'; 
+const dependencyFilename = __dirname + '/8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
 export const dependenciesTotalSize = 14523141; 
 export function init(RuntimeName, PHPLoader) {

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -5,8 +5,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import { viteWasmLoader } from '../../vite-wasm-loader';
 
 export default defineConfig(function () {
 	return {
@@ -16,7 +14,6 @@ export default defineConfig(function () {
 			viteTsConfigPaths({
 				root: '../../../',
 			}),
-			viteWasmLoader,
 		],
 
 		// Configuration for building your library.

--- a/packages/playground/blueprints/vite.config.ts
+++ b/packages/playground/blueprints/vite.config.ts
@@ -6,8 +6,6 @@ import { join } from 'path';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-ts-config-paths';
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import { viteWasmLoader } from '../../vite-wasm-loader';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/playground-blueprints',
@@ -21,8 +19,6 @@ export default defineConfig({
 		viteTsConfigPaths({
 			root: '../../../',
 		}),
-
-		viteWasmLoader,
 	],
 
 	// Uncomment this if you are using workers.

--- a/packages/playground/sync/vite.config.ts
+++ b/packages/playground/sync/vite.config.ts
@@ -3,7 +3,7 @@
 import { viteTsConfigPaths } from '../../vite-ts-config-paths';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { viteWasmLoader } from '../../vite-wasm-loader';
+import ignoreWasmImports from '../ignore-wasm-imports';
 
 export default {
 	base: '/',
@@ -20,7 +20,7 @@ export default {
 		viteTsConfigPaths({
 			root: '../../../',
 		}),
-		viteWasmLoader,
+		ignoreWasmImports,
 	],
 
 	// Configuration for building your library.


### PR DESCRIPTION
https://github.com/WordPress/wordpress-playground/pull/1289 shipped a PHP.wasm building logic that used an import statement instead of composing a path of __dirname. It did that to support Bun bundling, as Bun needs those static imports to include the .wasm files in the single executable. Unfortunately, that change broke npm bundling and publishing, resulting in a broken package that doesn't ship the correct paths and builds a broken index.cjs file.
