### PR TITLE
Fixed images not loading on the page

### DIFF
--- a/packages/docs/site/docs/11-architecture/09-browser-tab-orchestrates-execution.md
+++ b/packages/docs/site/docs/11-architecture/09-browser-tab-orchestrates-execution.md
@@ -8,7 +8,7 @@ Keep this point in mind as you read through the rest of the docs. At this point 
 
 Here's what a boot sequence for a minimal app looks like:
 
-![The boot sequence](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/docs/site/static/img/boot-sequence.png)
+![The boot sequence](@site/static/img/boot-sequence.png)
 
 The main app initiates the Iframe, the Service Worker, and the Worker Thread. Note how the main app doesn't use the PHP stack directly – it's all handled in the Worker Thread.
 
@@ -66,7 +66,7 @@ Keep reading to learn how all these pieces fit together.
 
 Here's what happens whenever the iframe issues a same-domain request:
 
-![The data flow](https://raw.githubusercontent.com/wordpress/wordpress-playground/trunk/pages/data-flow.png)
+![The data flow](@site/static/img/data-flow.png)
 
 A step-by-step breakdown:
 


### PR DESCRIPTION
## What is this PR doing?
Within the page https://wordpress.github.io/wordpress-playground/architecture/browser-tab-orchestrates-execution/, the images are not loading, so fixing it with the site path for the images.

## What problem is it solving?
The images not loading properly are fixed.