### PR TITLE
Updated the GitHub issue link to open in a new tab

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -65,7 +65,7 @@ add_action('admin_head', function () {
 
 add_action('init', 'networking_disabled');
 function networking_disabled() {
-	$networking_err_msg = '<div class="networking_err_msg">Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85">experimental, opt-in feature</a>, which means you need to enable it to allow Playground to access the Plugins/Themes directories.
+	$networking_err_msg = '<div class="networking_err_msg">Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85" target="_blank">experimental, opt-in feature</a>, which means you need to enable it to allow Playground to access the Plugins/Themes directories.
 	<p>There are two alternative methods to enable global networking support:</p>
 	<ol>
 	<li>Using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a>: for example, https://playground.wordpress.net/<em>?networking=yes</em>; <strong>or</strong>


### PR DESCRIPTION
## What is this PR doing?
Due to the Content Security Policy, the link to the GitHub issue does not open within the Playground 'Add new plugin' and 'Add new theme' pages. To fix this, add the _target_ attribute to load the link in a new tab.

## What problem is it solving?
The error occurs when someone clicks on the "experimental, opt-in feature" link within the Playground due to the CSP.

## How is the problem addressed?
Added the **target** attribute to the hyperlink to load the link in a new tab.

## Testing Instructions

1. Open playground 
2. Navigate to the **Plugins > Add New Plugins** or **Appearance > Themes > Add New Theme (button)**
3. You can notice the admin error notice mentioning "Network access is an [experimental, opt-in feature](https://github.com/WordPress/wordpress-playground/issues/85), which means you need to enable it to allow Playground to access the Plugins/Themes directories."
4. Click on the "experimental, opt-in feature" hyperlink, where you can notice the GitHub issue link is not loaded due to the CSP.