### PR TITLE
Support wp_crop_image in import wxr

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -42,6 +42,9 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 	await playground.run({
 		code: `<?php
 		require ${phpVar(docroot)} . '/wp-load.php';
+		if ( ! function_exists( 'wp_crop_image' ) ) {
+			require ${phpVar(docroot)} . '/wp-admin/includes/image.php';
+		}
 		kses_remove_filters();
 		$admin_id = get_users(array('role' => 'Administrator') )[0];
 		$importer = new WXR_Importer( array(


### PR DESCRIPTION
## What is this PR doing?

It adds support for wp_crop_image in the importWXR step. 

## What problem is it solving?

It allows cropping images during WXR imports. 

## How is the problem addressed?

By requiring `/wp-admin/includes/image.php` if `wp_crop_image` doesn't exist

## Testing Instructions

- Checkout this branch
- [Open this blueprint](http://127.0.0.1:5400/website-server/?blueprint-url=https://raw.githubusercontent.com/wptrainingteam/tt4-book-reviews/master/_playground/blueprint.json)
- Confirm that there are no PHP errors and that new posts are imported with images


![image](https://github.com/WordPress/wordpress-playground/assets/1199991/02f14faa-bbf0-4c41-87cc-434ae0340ad2)
