### PR TITLE
Website: Update rsync command to clean up more completely

### DIFF
--- a/packages/playground/website-deployment/apply-update.sh
+++ b/packages/playground/website-deployment/apply-update.sh
@@ -92,7 +92,7 @@ find -type f \
     | set_aside_files_to_serve_via_php
 
 echo Syncing staged files to production
-rsync -av --delete ~/website-update/* /srv/htdocs/
+rsync -av --delete --no-perms --omit-dir-times ~/website-update/ /srv/htdocs/
 
 echo Purging edge cache
 curl -sS -X POST -H "Auth: $ATOMIC_SITE_API_KEY" "$SITE_API_BASE/edge-cache/$ATOMIC_SITE_ID/purge" \


### PR DESCRIPTION
## What is this PR doing?

Tightens the rsync command used to sync website files to WP Cloud so that removed files are properly removed.

Related to #1197

## What problem is it solving?

To avoid an rsync error about not being able to set mtime or permissions of `/srv/htdocs`, which is owned by root, we previously used a wildcard in the source like `rsync -av --delete source-dir/* target-dir/`. A problem with this is that, when files are removed from the relative root, they are not considered for deletion because they do not belong to a subtree matched by the wildcard.

## How is the problem addressed?

The rsync command is fixed to no longer update file permissions and to skip updating times on directories. This should keep it from attempting to update `/srv/htdocs` and erroring.

## Testing Instructions

Test manually on playground-dot-wordpress-dot-net.atomicsites.blog