### PR TITLE
Try: Update Blueprint formatting - create a new post with runPHP step

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/08-examples.md
+++ b/packages/docs/site/docs/09-blueprints-api/08-examples.md
@@ -46,16 +46,16 @@ blueprint={{
 			{
 				"step": "runPHP",
 				"code": `<?php
-include 'wordpress/wp-load.php';
-wp_insert_post(array(
-'post_title' => 'Post title',
-'post_content' => 'Post content',
-'post_status' => 'publish',
-'post_author' => 1
-));
-`
-}
-]
+					include 'wordpress/wp-load.php';
+					wp_insert_post(array(
+						'post_title' => 'Post title',
+						'post_content' => 'Post content',
+						'post_status' => 'publish',
+						'post_author' => 1
+					));
+				`
+			}		
+		]
 }} />
 
 ## Enable an option on the Gutenberg Experiments page


### PR DESCRIPTION
## What is this PR doing?
Formatting Blueprint example

### Before
<img width="400" alt="Screenshot 2024-05-05 at 12 21 57 AM" src="https://github.com/WordPress/wordpress-playground/assets/3792502/ecd71f47-5443-4a51-8814-69c832e035a8">

### After (hopefully)
<img width="750" alt="Screenshot 2024-05-05 at 12 22 25 AM" src="https://github.com/WordPress/wordpress-playground/assets/3792502/8d27bf76-633a-484e-9e14-81e0bd03d67a">


## What problem is it solving?
_Hopefully_ makes the blueprint easier to consume. It had a couple of `WP PHP` things going on...

## How is the problem addressed?
Formatted in VS Code. Haven't built via `nx` yet so hopefully the formatting holds. 

## Testing Instructions
not entirely sure... the formatting is a bit difficult to wrangle with how I have the environment set up currently
