### PR TITLE
Disable console logging when running tests

### DIFF
--- a/packages/php-wasm/logger/src/lib/logger.ts
+++ b/packages/php-wasm/logger/src/lib/logger.ts
@@ -151,10 +151,21 @@ export class Logger extends EventTarget {
 	}
 }
 
+const getDefaultHandlers = () => {
+	try {
+		if (process.env['NODE_ENV'] === 'test') {
+			return [logToMemory];
+		}
+	} catch (e) {
+		// Process.env is not available in the browser
+	}
+	return [logToMemory, logToConsole];
+};
+
 /**
  * The logger instance.
  */
-export const logger: Logger = new Logger([logToMemory, logToConsole]);
+export const logger: Logger = new Logger(getDefaultHandlers());
 
 export const formatLogEntry = (
 	message: string,


### PR DESCRIPTION
Fixes #1345

## What is this PR doing?

It makes the output of logs cleaner by hiding logger output when running tests.

## What problem is it solving?

All logger messages are currently displayed in the test run output which makes it hard to read.

## How is the problem addressed?

By determining if the current environment is a test and if yes, logToConsole is disabled.

This can still be overridden by manually initializing the logger.

## Testing Instructions

- ensure all tests pass
- check the unit test output and confirm there are no unwanted logs
