### PR TITLE
Docs: Use step function names instead of TypeScript type names

### DIFF
--- a/packages/docs/site/docs/09-blueprints-api/05-steps.md
+++ b/packages/docs/site/docs/09-blueprints-api/05-steps.md
@@ -23,7 +23,7 @@ Each step is an object that contains a `step` property that specifies the type o
 ---
 
 import BlueprintStep from '@site/src/components/BlueprintsAPI/BlueprintStep';
-import { BlueprintSteps } from '@site/src/components/BlueprintsAPI/model';
+import { BlueprintSteps, getStepAPI } from '@site/src/components/BlueprintsAPI/model';
 import UpdateTopLevelToc from '@site/src/components/UpdateTopLevelToc';
 
 <UpdateTopLevelToc
@@ -31,7 +31,7 @@ toc={toc}
 tocItems={
 BlueprintSteps
 .map(name => ({
-value: name,
+value: getStepAPI(name).fnDetails.name,
 id: name,
 level: 2
 }))

--- a/packages/docs/site/src/components/BlueprintsAPI/BlueprintStep.tsx
+++ b/packages/docs/site/src/components/BlueprintsAPI/BlueprintStep.tsx
@@ -10,7 +10,7 @@ export default function BlueprintStep({ name }) {
 	return (
 		<section className="margin-vert--md markdown">
 			<h2 className="anchor anchorWithStickyNavbar_blueprint" id={name}>
-				{stepApi.stepDetails.name}
+				{stepApi.fnDetails.name}
 				<a
 					href={`#${name}`}
 					className="hash-link"


### PR DESCRIPTION
## What is this PR doing?

Changing the headings for each step at https://wordpress.github.io/wordpress-playground/blueprints-api/steps to correspond with the real value of the step property in the blueprint

The `ActivatePluginStep` heading becomes `activatePlugin`, `CpStep` becomes `cp` and so on.
Closes https://github.com/WordPress/wordpress-playground/issues/1371

![CleanShot 2024-05-09 at 14 59 39@2x](https://github.com/WordPress/wordpress-playground/assets/205419/dcb62ecc-0324-40c6-ac63-2a9bad7c27fc)

cc @juanmaguitar 

## Testing

Run `nx dev docs-site` and confirm the docs site was updated as expected