### PR TITLE
Website: Fix constant names for GH export oauth

### DIFF
--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -260,8 +260,8 @@ function playground_maybe_set_environment( $requested_path ) {
 				$secrets->GITHUB_APP_CLIENT_ID,
 				$secrets->GITHUB_APP_CLIENT_SECRET,
 			) ) {
-				putenv( "GITHUB_APP_CLIENT_ID={$secrets->GITHUB_APP_CLIENT_ID}" );
-				putenv( "GITHUB_APP_CLIENT_SECRET={$secrets->GITHUB_APP_CLIENT_SECRET}" );
+				putenv( "CLIENT_ID={$secrets->GITHUB_APP_CLIENT_ID}" );
+				putenv( "CLIENT_SECRET={$secrets->GITHUB_APP_CLIENT_SECRET}" );
 			} else {
 				error_log( 'PLAYGROUND: Missing secrets for oauth.php' );
 			}


### PR DESCRIPTION
## What is this PR doing?

The custom-redirects-lib.php file is setting different environment variable names than are needed for the GitHub export oauth script.

Related to #1197

## Testing Instructions

- Tested manually on playground-dot-wordpress-dot-net.atomicsites.blog