### PR TITLE
PHP: Always set the auto_prepend_file php.ini entry, even when the auto_prepend_file.php file exists

### DIFF
--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -358,6 +358,10 @@ export abstract class BasePHP implements IsomorphicLocalPHP, Disposable {
 	}
 
 	#initWebRuntime() {
+		this.setPhpIniEntry(
+			'auto_prepend_file',
+			'/internal/shared/auto_prepend_file.php'
+		);
 		if (!this.fileExists('/internal/shared/auto_prepend_file.php')) {
 			this.writeFile(
 				'/internal/shared/auto_prepend_file.php',
@@ -366,10 +370,6 @@ export abstract class BasePHP implements IsomorphicLocalPHP, Disposable {
 				require_once $file;
 			}
 		`
-			);
-			this.setPhpIniEntry(
-				'auto_prepend_file',
-				'/internal/shared/auto_prepend_file.php'
 			);
 			/**
 			 * This creates a consts.php file in an in-memory


### PR DESCRIPTION
Filesystem files are shared between PHP instances within the same PHPProcessManager, but php.ini entry are kept in WASM memory and must be set on every PHP instance separately. Therefore, the `auto_prepend_file` must always be set in `#initWebRuntime`

Fixes a regression introduced in #1386

To test, run `bun packages/playground/cli/src/cli.ts server --login` and confirm it finishes without any errors.
