### PR TITLE
Playground Boot: Align the boot process between remote.html and CLI

### DIFF
--- a/packages/playground/cli/src/setup-php.ts
+++ b/packages/playground/cli/src/setup-php.ts
@@ -7,7 +7,11 @@ import {
 } from '@php-wasm/universal';
 import { rootCertificates } from 'tls';
 import { dirname } from '@php-wasm/util';
-import { envPHP_to_loadMuPlugins } from '@wp-playground/wordpress';
+import {
+	preloadPhpInfoRoute,
+	enablePlatformMuPlugins,
+	preloadRequiredMuPlugin,
+} from '@wp-playground/wordpress';
 
 export async function createPhp(
 	requestHandler: PHPRequestHandler<NodePHP>,
@@ -44,20 +48,9 @@ export async function createPhp(
 			'/internal/shared/ca-bundle.crt',
 			rootCertificates.join('\n')
 		);
-		php.writeFile(
-			'/internal/shared/preload/env.php',
-			envPHP_to_loadMuPlugins
-		);
-		php.writeFile(
-			'/internal/shared/preload/phpinfo.php',
-			`<?php
-		// Render PHPInfo if the requested page is /phpinfo.php
-		if ( '/phpinfo.php' === $_SERVER['REQUEST_URI'] ) {
-			phpinfo();
-			exit;
-		}`
-		);
-		php.mkdir('/internal/shared/mu-plugins');
+		await preloadPhpInfoRoute(php);
+		await enablePlatformMuPlugins(php);
+		await preloadRequiredMuPlugin(php);
 	} else {
 		/**
 		 * @TODO: Consider an API similar to

--- a/packages/playground/cli/src/setup-wp.ts
+++ b/packages/playground/cli/src/setup-wp.ts
@@ -16,14 +16,7 @@ import {
 	readAsFile,
 } from './download';
 import { withPHPIniValues } from './setup-php';
-<<<<<<< HEAD
 import { preloadSqliteIntegration } from '@wp-playground/wordpress';
-=======
-import {
-	playgroundMuPlugin,
-	preloadSqliteIntegration,
-} from '@wp-playground/wordpress';
->>>>>>> ba99209da (Extract preloadSqliteIntegration to a separate function)
 
 /**
  * Ensures a functional WordPress installation in php document root.
@@ -56,17 +49,11 @@ export async function setupWordPress(
 			monitor
 		),
 	]);
-<<<<<<< HEAD
 	await prepareWordPress(php, wpZip);
 	// Setup the SQLite integration if no custom database drop-in is present
 	if (!php.fileExists('/wordpress/wp-content/db.php')) {
 		await preloadSqliteIntegration(php, sqliteZip);
 	}
-=======
-
-	await prepareWordPress(php, wpZip);
-	await preloadSqliteIntegration(php, sqliteZip);
->>>>>>> ba99209da (Extract preloadSqliteIntegration to a separate function)
 
 	const preinstalledWpContentPath = path.join(
 		CACHE_FOLDER,

--- a/packages/playground/cli/src/setup-wp.ts
+++ b/packages/playground/cli/src/setup-wp.ts
@@ -16,7 +16,14 @@ import {
 	readAsFile,
 } from './download';
 import { withPHPIniValues } from './setup-php';
+<<<<<<< HEAD
 import { preloadSqliteIntegration } from '@wp-playground/wordpress';
+=======
+import {
+	playgroundMuPlugin,
+	preloadSqliteIntegration,
+} from '@wp-playground/wordpress';
+>>>>>>> ba99209da (Extract preloadSqliteIntegration to a separate function)
 
 /**
  * Ensures a functional WordPress installation in php document root.
@@ -49,11 +56,17 @@ export async function setupWordPress(
 			monitor
 		),
 	]);
+<<<<<<< HEAD
 	await prepareWordPress(php, wpZip);
 	// Setup the SQLite integration if no custom database drop-in is present
 	if (!php.fileExists('/wordpress/wp-content/db.php')) {
 		await preloadSqliteIntegration(php, sqliteZip);
 	}
+=======
+
+	await prepareWordPress(php, wpZip);
+	await preloadSqliteIntegration(php, sqliteZip);
+>>>>>>> ba99209da (Extract preloadSqliteIntegration to a separate function)
 
 	const preinstalledWpContentPath = path.join(
 		CACHE_FOLDER,

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -4,111 +4,147 @@ import { unzip } from '@wp-playground/blueprints';
 
 export * from './rewrite-rules';
 
-export const RecommendedPHPVersion = '8.0';
-
-export const envPHP_to_loadMuPlugins = `<?php
-
-// Allow adding filters/actions prior to loading WordPress.
-// $function_to_add MUST be a string.
-function playground_add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
-    global $wp_filter;
-    $wp_filter[$tag][$priority][$function_to_add] = array('function' => $function_to_add, 'accepted_args' => $accepted_args);
-}
-function playground_add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
-    playground_add_filter( $tag, $function_to_add, $priority, $accepted_args );
-}
-
-// Load our mu-plugins after customer mu-plugins
-// NOTE: this means our mu-plugins can't use the muplugins_loaded action!
-playground_add_action( 'muplugins_loaded', 'playground_load_mu_plugins', 0 );
-function playground_load_mu_plugins() {
-    // Load all PHP files from /internal/shared/mu-plugins, sorted by filename
-    $mu_plugins_dir = '/internal/shared/mu-plugins';
-    if(!is_dir($mu_plugins_dir)){
-        return;
-    }
-    $mu_plugins = glob( $mu_plugins_dir . '/*.php' );
-    sort( $mu_plugins );
-    foreach ( $mu_plugins as $mu_plugin ) {
-        require_once $mu_plugin;
-    }
-}
-`;
-
-// Entries must not render whitespaces as they'll be loaded
-// as mu-plugins and we don't want to trigger the "headers
-// already sent" PHP error.
-export const specificMuPlugins = {
-	addTrailingSlashToWpAdmin: `<?php
-    // Redirect /wp-admin to /wp-admin/
-    add_filter( 'redirect_canonical', function( $redirect_url ) {
-        if ( '/wp-admin' === $redirect_url ) {
-            return $redirect_url . '/';
+/**
+ * Preloads the platform mu-plugins from /internal/shared/mu-plugins.
+ * This avoids polluting the WordPress installation with mu-plugins
+ * that are only needed in the Playground environment.
+ *
+ * @param php
+ */
+export async function enablePlatformMuPlugins(php: UniversalPHP) {
+	await php.mkdir('/internal/shared/mu-plugins');
+	await php.writeFile(
+		'/internal/shared/preload/env.php',
+		`<?php
+    
+        // Allow adding filters/actions prior to loading WordPress.
+        // $function_to_add MUST be a string.
+        function playground_add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+            global $wp_filter;
+            $wp_filter[$tag][$priority][$function_to_add] = array('function' => $function_to_add, 'accepted_args' => $accepted_args);
         }
-        return $redirect_url;
-    } );
-    ?>`,
-	allowRedirectHosts: `<?php
-    // Needed because gethostbyname( 'wordpress.org' ) returns
-    // a private network IP address for some reason.
-    add_filter( 'allowed_redirect_hosts', function( $deprecated = '' ) {
-        return array(
-            'wordpress.org',
-            'api.wordpress.org',
-            'downloads.wordpress.org',
-        );
-    } );
-    ?>`,
-	supportPermalinksWithoutIndexPhp: `<?php
-    add_filter( 'got_url_rewrite', '__return_true' );
-    ?>`,
-	createFontsDirectory: `<?php
-    // Create the fonts directory if missing
-    if(!file_exists(WP_CONTENT_DIR . '/fonts')) {
-        mkdir(WP_CONTENT_DIR . '/fonts');
-    }
-    ?>`,
-	silenceUnfixableErrors: `<?php
-    set_error_handler(function($severity, $message, $file, $line) {
-        /**
-         * This is a temporary workaround to hide the 32bit integer warnings that
-         * appear when using various time related function, such as strtotime and mktime.
-         * Examples of the warnings that are displayed:
-         * Warning: mktime(): Epoch doesn't fit in a PHP integer in <file>
-         * Warning: strtotime(): Epoch doesn't fit in a PHP integer in <file>
-         */
-        if (strpos($message, "fit in a PHP integer") !== false) {
-            return;
+        function playground_add_action( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
+            playground_add_filter( $tag, $function_to_add, $priority, $accepted_args );
         }
-        /**
-         * Don't complain about network errors when not connected to the network.
-         */
-        if (
-            (
-                ! defined('USE_FETCH_FOR_REQUESTS') ||
-                ! USE_FETCH_FOR_REQUESTS
-            ) &&
-            strpos($message, "WordPress could not establish a secure connection to WordPress.org") !== false)
-        {
-            return;
+        
+        // Load our mu-plugins after customer mu-plugins
+        // NOTE: this means our mu-plugins can't use the muplugins_loaded action!
+        playground_add_action( 'muplugins_loaded', 'playground_load_mu_plugins', 0 );
+        function playground_load_mu_plugins() {
+            // Load all PHP files from /internal/shared/mu-plugins, sorted by filename
+            $mu_plugins_dir = '/internal/shared/mu-plugins';
+            if(!is_dir($mu_plugins_dir)){
+                return;
+            }
+            $mu_plugins = glob( $mu_plugins_dir . '/*.php' );
+            sort( $mu_plugins );
+            foreach ( $mu_plugins as $mu_plugin ) {
+                require_once $mu_plugin;
+            }
         }
-        return false;
-    });
-    ?>`,
-	configureErrorLogging: `<?php
-    $log_file = WP_CONTENT_DIR . '/debug.log';
-    error_reporting(E_ALL);
-    define('ERROR_LOG_FILE', $log_file);
-    ini_set('error_log', $log_file);
-    ini_set('ignore_repeated_errors', true);
-    ini_set('display_errors', false);
-    ini_set('log_errors', true);
-    ?>`,
-};
+    `
+	);
+}
 
-export const playgroundMuPlugin = Object.values(specificMuPlugins)
-	.map((p) => p.trim())
-	.join('\n');
+export async function preloadRequiredMuPlugin(php: UniversalPHP) {
+	// Entries must not render whitespaces. They'll be loaded
+	// as mu-plugins and we don't want to trigger the "headers
+	// already sent" PHP error.
+	const specificMuPlugins = {
+		addTrailingSlashToWpAdmin: `<?php
+        // Redirect /wp-admin to /wp-admin/
+        add_filter( 'redirect_canonical', function( $redirect_url ) {
+            if ( '/wp-admin' === $redirect_url ) {
+                return $redirect_url . '/';
+            }
+            return $redirect_url;
+        } );
+        ?>`,
+		allowRedirectHosts: `<?php
+        // Needed because gethostbyname( 'wordpress.org' ) returns
+        // a private network IP address for some reason.
+        add_filter( 'allowed_redirect_hosts', function( $deprecated = '' ) {
+            return array(
+                'wordpress.org',
+                'api.wordpress.org',
+                'downloads.wordpress.org',
+            );
+        } );
+        ?>`,
+		supportPermalinksWithoutIndexPhp: `<?php
+        add_filter( 'got_url_rewrite', '__return_true' );
+        ?>`,
+		createFontsDirectory: `<?php
+        // Create the fonts directory if missing
+        if(!file_exists(WP_CONTENT_DIR . '/fonts')) {
+            mkdir(WP_CONTENT_DIR . '/fonts');
+        }
+        ?>`,
+		silenceUnfixableErrors: `<?php
+        set_error_handler(function($severity, $message, $file, $line) {
+            /**
+             * This is a temporary workaround to hide the 32bit integer warnings that
+             * appear when using various time related function, such as strtotime and mktime.
+             * Examples of the warnings that are displayed:
+             * Warning: mktime(): Epoch doesn't fit in a PHP integer in <file>
+             * Warning: strtotime(): Epoch doesn't fit in a PHP integer in <file>
+             */
+            if (strpos($message, "fit in a PHP integer") !== false) {
+                return;
+            }
+            /**
+             * Don't complain about network errors when not connected to the network.
+             */
+            if (
+                (
+                    ! defined('USE_FETCH_FOR_REQUESTS') ||
+                    ! USE_FETCH_FOR_REQUESTS
+                ) &&
+                strpos($message, "WordPress could not establish a secure connection to WordPress.org") !== false)
+            {
+                return;
+            }
+            return false;
+        });
+        ?>`,
+		configureErrorLogging: `<?php
+        $log_file = WP_CONTENT_DIR . '/debug.log';
+        error_reporting(E_ALL);
+        define('ERROR_LOG_FILE', $log_file);
+        ini_set('error_log', $log_file);
+        ini_set('ignore_repeated_errors', true);
+        ini_set('display_errors', false);
+        ini_set('log_errors', true);
+        ?>`,
+	};
+
+	const playgroundMuPlugin = Object.values(specificMuPlugins)
+		.map((p) => p.trim())
+		.join('\n');
+	await php.writeFile(
+		'/internal/shared/mu-plugins/0-playground.php',
+		playgroundMuPlugin
+	);
+}
+
+/**
+ * Runs phpinfo() when the requested path is /phpinfo.php.
+ */
+export async function preloadPhpInfoRoute(
+	php: UniversalPHP,
+	requestPath = '/phpinfo.php'
+) {
+	await php.writeFile(
+		'/internal/shared/preload/phpinfo.php',
+		`<?php
+    // Render PHPInfo if the requested page is /phpinfo.php
+    if ( ${phpVar(requestPath)} === $_SERVER['REQUEST_URI'] ) {
+        phpinfo();
+        exit;
+    }
+    `
+	);
+}
 
 export async function preloadSqliteIntegration(
 	php: UniversalPHP,
@@ -147,59 +183,59 @@ export async function preloadSqliteIntegration(
 	await php.writeFile(
 		`/internal/shared/preload/0-sqlite.php`,
 		`<?php
-    /**
-     * Loads the SQLite integration plugin before WordPress is loaded
-     * and without creating a drop-in "db.php" file. 
-     *
-     * Technically, it creates a global $wpdb object whose only two
-     * purposes are to:
-     *
-     * * Exist – because the require_wp_db() WordPress function won't
-     *           connect to MySQL if $wpdb is already set.
-     * * Load the SQLite integration plugin the first time it's used
-     *   and replace the global $wpdb reference with the SQLite one.
-     *
-     * This lets Playground keep the WordPress installation clean and
-     * solves dillemas like:
-     *
-     * * Should we include db.php in Playground exports?
-     * * Should we remove db.php from Playground imports?
-     * * How should we treat stale db.php from long-lived OPFS sites?
-     *
-     * @see https://github.com/WordPress/wordpress-playground/discussions/1379 for
-     *      more context.
-     */
-    class Playground_SQLite_Integration_Loader {
-        public function __call($name, $arguments) {
-            $this->load_sqlite_integration();
-            if($GLOBALS['wpdb'] === $this) {
-                throw new Exception('Infinite loop detected in $wpdb – SQLite integration plugin could not be loaded');
-            }
-            return call_user_func_array(
-                array($GLOBALS['wpdb'], $name),
-                $arguments
-            );
-        }
-        public function __get($name) {
-            $this->load_sqlite_integration();
-            if($GLOBALS['wpdb'] === $this) {
-                throw new Exception('Infinite loop detected in $wpdb – SQLite integration plugin could not be loaded');
-            }
-            return $GLOBALS['wpdb']->$name;
-        }
-        public function __set($name, $value) {
-            $this->load_sqlite_integration();
-            if($GLOBALS['wpdb'] === $this) {
-                throw new Exception('Infinite loop detected in $wpdb – SQLite integration plugin could not be loaded');
-            }
-            $GLOBALS['wpdb']->$name = $value;
-        }
-        protected function load_sqlite_integration() {
-            require_once ${phpVar(SQLITE_MUPLUGIN_PATH)};
-        }
+/**
+ * Loads the SQLite integration plugin before WordPress is loaded
+ * and without creating a drop-in "db.php" file. 
+ *
+ * Technically, it creates a global $wpdb object whose only two
+ * purposes are to:
+ *
+ * * Exist – because the require_wp_db() WordPress function won't
+ *           connect to MySQL if $wpdb is already set.
+ * * Load the SQLite integration plugin the first time it's used
+ *   and replace the global $wpdb reference with the SQLite one.
+ *
+ * This lets Playground keep the WordPress installation clean and
+ * solves dillemas like:
+ *
+ * * Should we include db.php in Playground exports?
+ * * Should we remove db.php from Playground imports?
+ * * How should we treat stale db.php from long-lived OPFS sites?
+ *
+ * @see https://github.com/WordPress/wordpress-playground/discussions/1379 for
+ *      more context.
+ */
+class Playground_SQLite_Integration_Loader {
+	public function __call($name, $arguments) {
+		$this->load_sqlite_integration();
+		if($GLOBALS['wpdb'] === $this) {
+			throw new Exception('Infinite loop detected in $wpdb – SQLite integration plugin could not be loaded');
+		}
+		return call_user_func_array(
+			array($GLOBALS['wpdb'], $name),
+			$arguments
+		);
+	}
+	public function __get($name) {
+		$this->load_sqlite_integration();
+		if($GLOBALS['wpdb'] === $this) {
+			throw new Exception('Infinite loop detected in $wpdb – SQLite integration plugin could not be loaded');
+		}
+		return $GLOBALS['wpdb']->$name;
+	}
+	public function __set($name, $value) {
+		$this->load_sqlite_integration();
+		if($GLOBALS['wpdb'] === $this) {
+			throw new Exception('Infinite loop detected in $wpdb – SQLite integration plugin could not be loaded');
+		}
+		$GLOBALS['wpdb']->$name = $value;
+	}
+    protected function load_sqlite_integration() {
+        require_once ${phpVar(SQLITE_MUPLUGIN_PATH)};
     }
-    $wpdb = $GLOBALS['wpdb'] = new Playground_SQLite_Integration_Loader();
-            `
+}
+$wpdb = $GLOBALS['wpdb'] = new Playground_SQLite_Integration_Loader();
+		`
 	);
 	/**
 	 * Ensure the SQLite integration is loaded and clearly communicate
@@ -209,11 +245,11 @@ export async function preloadSqliteIntegration(
 	await php.writeFile(
 		`/internal/shared/mu-plugins/sqlite-test.php`,
 		`<?php
-            global $wpdb;
-            if(!($wpdb instanceof WP_SQLite_DB)) {
-                var_dump(isset($wpdb));
-                die("SQLite integration not loaded " . get_class($wpdb));
-            }
-            `
+		global $wpdb;
+		if(!($wpdb instanceof WP_SQLite_DB)) {
+			var_dump(isset($wpdb));
+			die("SQLite integration not loaded " . get_class($wpdb));
+		}
+		`
 	);
 }


### PR DESCRIPTION
## What is this PR doing?

Aligns the boot process between the in-browser Playground Remote and Node-oriented Playground CLI.

With this PR, both apps use a similar `createPHP()` function that:

* Sets up the SAPI name
* Sets up PHP ini entries
* Sets up the `/phpinfo.php` route
* Sets up platform-level mu0plugins
* Proxies filesystem directories from secondary PHP instances to primary
* Sets up PHP runtime rotation to avoid OOM errors in long-running primary processes

There are still the following discrepancies:

* The in-browser PHP sets up a SAPI name conditionally, Node.js one always uses `cli` (it probably shouldn't)
* The in-browser PHP uses a custom spawn handler
* The in-browser PHP uses a different set of php.ini directives
* The in-browser PHP loads more mu-plugins
* The Node.js PHP sets up CA certificates for HTTPS connections (the in-browser PHP [will fake the CA chain eventually](https://github.com/WordPress/wordpress-playground/pull/1093))

This is the first step towards a consistent Boot Protocol, see https://github.com/WordPress/wordpress-playground/discussions/1379 for more details.

## Testing Instructions

* Confirm the CI checks work
* Run `bun packages/playground/cli/src/cli.ts server --login`, confirm the server starts without issues, test wp-admin and HTTPS-reliant features like the plugin directories.

We'll need a set of unit tests for these new boot-related features, let's create them sooner than later.