### PR TITLE
GitHub export: Create new commits in your fork when writing to the upstream repo isn't allowed

### DIFF
--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -861,7 +861,7 @@ async function pushToGithub(
 		>['data'];
 		if (shouldCreateNewPR) {
 			const { data: branch } = await octokit.rest.repos.getBranch({
-				owner,
+				owner: pushToOwner,
 				repo,
 				branch: againstBranch,
 			});


### PR DESCRIPTION
When the GitHub export flow used a forked repository, it would still attempt to create a branch in the upstream repository. This resulted in the following cryptic error:

> There was an unexpected error (Not Found), please try again. If the
> problem persists, please report it at https://github.com/WordPress/
> wordpress-playground/issues.

This PR ensures that branch is created in the push target

 ## Testing instructions

1. Import an `upsidedown` theme from https://github.com/Automattic/themes
2. Run `await playground.writeFile('/wordpress/wp-content/themes/upsidedown/test.txt', 'test');` in devtools
3. Try to export the changes as a PR, confirm a PR got created

Closes https://github.com/WordPress/wordpress-playground/issues/1367
