### PR TITLE
DO NOT MERGE: Run e2e tests against WP Cloud site

### DIFF
--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -123,7 +123,7 @@
 			"configurations": {
 				"ci": {
 					"devServerTarget": "playground-website:preview:ci",
-					"baseUrl": "http://localhost/website-server/"
+					"baseUrl": "https://playground-dot-wordpress-dot-net.atomicsites.blog/"
 				}
 			},
 			"dependsOn": ["build"]

--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -118,7 +118,8 @@
 				"cypressConfig": "packages/playground/website/cypress.config.ts",
 				"testingType": "e2e",
 				"devServerTarget": "playground-website:dev:local",
-				"browser": "chrome"
+				"browser": "chrome",
+				"parallel": false
 			},
 			"configurations": {
 				"ci": {


### PR DESCRIPTION
This is a throwaway PR to run the e2e tests against the Playground website running on WP Cloud.