### PR TITLE
Provide non-gzipped wp-cli.phar file with website build

### DIFF
--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -20,7 +20,8 @@
 					"cp -r ./remote/* ./wasm-wordpress-net/",
 					"cp -r ./website/* ./wasm-wordpress-net/",
 					"cat ./remote/.htaccess ./website/.htaccess > ./wasm-wordpress-net/.htaccess",
-					"curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar | gzip -c -9 > wasm-wordpress-net/wp-cli.phar.gz"
+					"curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > wasm-wordpress-net/wp-cli.phar",
+					"cat wasm-wordpress-net/wp-cli.phar | gzip -c -9 > wasm-wordpress-net/wp-cli.phar.gz"
 				],
 				"cwd": "dist/packages/playground",
 				"parallel": false


### PR DESCRIPTION
This PR fixes #1405 by making sure there is a non-gzipped wp-cli.phar file at the website root. Without this, the wp-cli Blueprint step can fail to download `wp-cli.phar`.
