### PR TITLE
Playground CLI: Don't create /wordpress/wp-config.php on boot

### DIFF
--- a/packages/playground/cli/src/setup-wp.ts
+++ b/packages/playground/cli/src/setup-wp.ts
@@ -122,7 +122,7 @@ async function prepareWordPress(php: NodePHP, wpZip: File) {
 
 	php.mv(wpPath, '/wordpress');
 	php.writeFile(
-		'/wordpress/wp-config.php',
+		'/wp-config.php',
 		php.readFileAsText('/wordpress/wp-config-sample.php')
 	);
 }


### PR DESCRIPTION
Prevents creating a `wp-config.php` file in WordPress document root. Instead, creates it one level higher as WordPress falls back to loading it from there.

Related to https://github.com/WordPress/wordpress-playground/issues/1398. Similar to https://github.com/WordPress/wordpress-playground/pull/1382 and https://github.com/WordPress/wordpress-playground/pull/1401.

## Testing instructions

Run `bun packages/playground/cli/src/cli.ts server --login` and confirm it loads an installed WordPress.
