### PR TITLE
Add VSCode branch protection

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,8 @@
 		}
 	],
 	"git.ignoreLimitWarning": true,
-	"C_Cpp.errorSquiggles": "disabled"
+	"C_Cpp.errorSquiggles": "disabled",
+	"git.branchProtection": [
+		"trunk"
+	]
 }


### PR DESCRIPTION
## What is this PR doing?

Adds `trunk` branch protection to VSCode. 

## What problem is it solving?

I was able to directly push to `trunk` which is protected by clicking the wrong button in VSCode which shouldn't happen.
As a maintainer, I can override branch protection and VSCode did it for me this time.

## How is the problem addressed?

By adding a `branchProtection` VSCode setting.

## Testing Instructions

This can't be tested without trying to push to `trunk`.

