### PR TITLE
CLI: Distinguish between mount and mountBeforeInstall options

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -68,6 +68,12 @@ async function run() {
 			type: 'array',
 			string: true,
 		})
+		.option('mountBeforeInstall', {
+			describe:
+				'Mount a directory to the PHP runtime before installing WordPress. You can provide --mount-before-install multiple times. Format: /host/path:/vfs/path',
+			type: 'array',
+			string: true,
+		})
 		.option('login', {
 			describe: 'Should log the user in',
 			type: 'boolean',
@@ -158,11 +164,26 @@ async function run() {
 		}
 	}
 
+	function mountResources(php: NodePHP, rawMounts: string[]) {
+		const parsedMounts = rawMounts.map((mount) => {
+			const [source, vfsPath] = mount.split(':');
+			return {
+				hostPath: path.resolve(process.cwd(), source),
+				vfsPath,
+			};
+		});
+		for (const mount of parsedMounts) {
+			php.mount(mount.hostPath, mount.vfsPath);
+		}
+	}
+
 	async function prepareSite(
 		php: NodePHP,
 		wpVersion: string,
 		siteUrl: string
 	) {
+		mountResources(php, args.mountBeforeInstall || []);
+
 		// No need to unzip WordPress if it's already mounted at /wordpress
 		if (!args.skipWordPressSetup) {
 			logger.log(`Setting up WordPress ${wpVersion}`);
@@ -185,16 +206,7 @@ async function run() {
 			await setupWordPress(php, wpVersion, monitor);
 		}
 
-		const mounts: Mount[] = (args.mount || []).map((mount) => {
-			const [source, vfsPath] = mount.split(':');
-			return {
-				hostPath: path.resolve(process.cwd(), source),
-				vfsPath,
-			};
-		});
-		for (const mount of mounts) {
-			php.mount(mount.hostPath, mount.vfsPath);
-		}
+		mountResources(php, args.mount || []);
 
 		await defineSiteUrl(php, {
 			siteUrl,


### PR DESCRIPTION
With this PR, you can mount directories in Playground CLI before WordPress is installed. This enables creating the entire file structure in a local directory instead of VFS.

This is just the first step. Eventually we'll have more `mount` switches and the name `mount` will just default to one of the options.

## Testing instructions

Run this and confirm WordPress got installed in the local directory:

```shell
bun packages/playground/cli/src/cli.ts run-blueprint --mount-before-install=`pwd`/new-wordpress-site:/wordpress
ll new-wordpress-site
```

Related to #1398 