### PR TITLE
PHP: Support php.mv() between devices via recursive copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
 				"@testing-library/react": "14.0.0",
 				"@tsconfig/docusaurus": "^1.0.5",
 				"@types/ajv": "1.0.0",
+				"@types/emscripten": "1.39.12",
 				"@types/file-saver": "^2.0.5",
 				"@types/jest": "^29.4.0",
 				"@types/node": "18.14.2",
@@ -15286,6 +15287,12 @@
 				"@types/ms": "*"
 			}
 		},
+		"node_modules/@types/emscripten": {
+			"version": "1.39.12",
+			"resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.12.tgz",
+			"integrity": "sha512-AQImDBgudQfMqUBfrjZYilRxoHDzTBp+ejh+g1fY67eSMalwIKtBXofjpyI0JBgNpHGzxeGAR2QDya0wxW9zbA==",
+			"dev": true
+		},
 		"node_modules/@types/eslint": {
 			"version": "8.37.0",
 			"dev": true,
@@ -17801,6 +17808,10 @@
 		},
 		"node_modules/@wp-playground/client": {
 			"resolved": "packages/playground/client",
+			"link": true
+		},
+		"node_modules/@wp-playground/common": {
+			"resolved": "packages/playground/common",
 			"link": true
 		},
 		"node_modules/@wp-playground/nx-extensions": {
@@ -44984,6 +44995,14 @@
 				"npm": ">=8.11.0"
 			}
 		},
+		"packages/playground/common": {
+			"version": "0.7.19",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.18.0",
+				"npm": ">=8.11.0"
+			}
+		},
 		"packages/playground/node": {
 			"name": "@wp-playground/node",
 			"version": "0.0.1",
@@ -45017,9 +45036,6 @@
 			"name": "@wp-playground/wordpress",
 			"version": "0.7.19",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "^0.6.6"
-			},
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"
@@ -45029,15 +45045,6 @@
 			"name": "@wp-playground/wordpress-builds",
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.18.0",
-				"npm": ">=8.11.0"
-			}
-		},
-		"packages/playground/wordpress/node_modules/@php-wasm/universal": {
-			"version": "0.6.16",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-0.6.16.tgz",
-			"integrity": "sha512-6zvhQ8yBFg+bp3m4+IAw4UdtLu/Vcq+7HHzmd9XenQWNkqd5GMvKADvpoYoFa6+B4x4ZVDf9M5o0h7Q5N2o1dQ==",
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
 			],
 			"dependencies": {
 				"@preact/signals-react": "1.3.6",
-				"@types/emscripten": "1.39.12",
 				"axios": "1.6.1",
 				"classnames": "^2.3.2",
 				"comlink": "^4.4.1",
@@ -15287,11 +15286,6 @@
 				"@types/ms": "*"
 			}
 		},
-		"node_modules/@types/emscripten": {
-			"version": "1.39.12",
-			"resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.12.tgz",
-			"integrity": "sha512-AQImDBgudQfMqUBfrjZYilRxoHDzTBp+ejh+g1fY67eSMalwIKtBXofjpyI0JBgNpHGzxeGAR2QDya0wxW9zbA=="
-		},
 		"node_modules/@types/eslint": {
 			"version": "8.37.0",
 			"dev": true,
@@ -17807,10 +17801,6 @@
 		},
 		"node_modules/@wp-playground/client": {
 			"resolved": "packages/playground/client",
-			"link": true
-		},
-		"node_modules/@wp-playground/common": {
-			"resolved": "packages/playground/common",
 			"link": true
 		},
 		"node_modules/@wp-playground/nx-extensions": {
@@ -44994,14 +44984,6 @@
 				"npm": ">=8.11.0"
 			}
 		},
-		"packages/playground/common": {
-			"version": "0.7.19",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.18.0",
-				"npm": ">=8.11.0"
-			}
-		},
 		"packages/playground/node": {
 			"name": "@wp-playground/node",
 			"version": "0.0.1",
@@ -45035,6 +45017,9 @@
 			"name": "@wp-playground/wordpress",
 			"version": "0.7.19",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "^0.6.6"
+			},
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"
@@ -45044,6 +45029,15 @@
 			"name": "@wp-playground/wordpress-builds",
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.18.0",
+				"npm": ">=8.11.0"
+			}
+		},
+		"packages/playground/wordpress/node_modules/@php-wasm/universal": {
+			"version": "0.6.16",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-0.6.16.tgz",
+			"integrity": "sha512-6zvhQ8yBFg+bp3m4+IAw4UdtLu/Vcq+7HHzmd9XenQWNkqd5GMvKADvpoYoFa6+B4x4ZVDf9M5o0h7Q5N2o1dQ==",
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
 			],
 			"dependencies": {
 				"@preact/signals-react": "1.3.6",
+				"@types/emscripten": "1.39.12",
 				"axios": "1.6.1",
 				"classnames": "^2.3.2",
 				"comlink": "^4.4.1",
@@ -15286,6 +15287,11 @@
 				"@types/ms": "*"
 			}
 		},
+		"node_modules/@types/emscripten": {
+			"version": "1.39.12",
+			"resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.12.tgz",
+			"integrity": "sha512-AQImDBgudQfMqUBfrjZYilRxoHDzTBp+ejh+g1fY67eSMalwIKtBXofjpyI0JBgNpHGzxeGAR2QDya0wxW9zbA=="
+		},
 		"node_modules/@types/eslint": {
 			"version": "8.37.0",
 			"dev": true,
@@ -17801,6 +17807,10 @@
 		},
 		"node_modules/@wp-playground/client": {
 			"resolved": "packages/playground/client",
+			"link": true
+		},
+		"node_modules/@wp-playground/common": {
+			"resolved": "packages/playground/common",
 			"link": true
 		},
 		"node_modules/@wp-playground/nx-extensions": {
@@ -44984,6 +44994,14 @@
 				"npm": ">=8.11.0"
 			}
 		},
+		"packages/playground/common": {
+			"version": "0.7.19",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.18.0",
+				"npm": ">=8.11.0"
+			}
+		},
 		"packages/playground/node": {
 			"name": "@wp-playground/node",
 			"version": "0.0.1",
@@ -45017,9 +45035,6 @@
 			"name": "@wp-playground/wordpress",
 			"version": "0.7.19",
 			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "^0.6.6"
-			},
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"
@@ -45029,15 +45044,6 @@
 			"name": "@wp-playground/wordpress-builds",
 			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.18.0",
-				"npm": ">=8.11.0"
-			}
-		},
-		"packages/playground/wordpress/node_modules/@php-wasm/universal": {
-			"version": "0.6.16",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-0.6.16.tgz",
-			"integrity": "sha512-6zvhQ8yBFg+bp3m4+IAw4UdtLu/Vcq+7HHzmd9XenQWNkqd5GMvKADvpoYoFa6+B4x4ZVDf9M5o0h7Q5N2o1dQ==",
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -44996,6 +44996,7 @@
 			}
 		},
 		"packages/playground/common": {
+			"name": "@wp-playground/common",
 			"version": "0.7.19",
 			"license": "GPL-2.0-or-later",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
 	"private": true,
 	"dependencies": {
 		"@preact/signals-react": "1.3.6",
-		"@types/emscripten": "1.39.12",
 		"axios": "1.6.1",
 		"classnames": "^2.3.2",
 		"comlink": "^4.4.1",
@@ -102,6 +101,7 @@
 		"@testing-library/react": "14.0.0",
 		"@tsconfig/docusaurus": "^1.0.5",
 		"@types/ajv": "1.0.0",
+		"@types/emscripten": "1.39.12",
 		"@types/file-saver": "^2.0.5",
 		"@types/jest": "^29.4.0",
 		"@types/node": "18.14.2",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 	"private": true,
 	"dependencies": {
 		"@preact/signals-react": "1.3.6",
+		"@types/emscripten": "1.39.12",
 		"axios": "1.6.1",
 		"classnames": "^2.3.2",
 		"comlink": "^4.4.1",

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -764,19 +764,19 @@ export abstract class BasePHP implements IsomorphicLocalPHP, Disposable {
 		const FS = this[__private__dont__use]
 			.FS as Emscripten.FileSystemInstance;
 
-		// FS.rename moves the inode within the same filesystem.
-		// If fromPath and toPath are on different filesystems,
-		// the operation will fail. In that case, we need to do
-		// a recursive copy of all the files and remove the original.
-		// Note this is also what happens in the linux `mv` command.
-		const fromMount = FS.lookupPath(fromPath).node.mount;
-		const toMount = this.fileExists(toPath)
-			? FS.lookupPath(toPath).node.mount
-			: FS.lookupPath(dirname(toPath)).node.mount;
-		const movingBetweenFilesystems =
-			fromMount.mountpoint !== toMount.mountpoint;
-
 		try {
+			// FS.rename moves the inode within the same filesystem.
+			// If fromPath and toPath are on different filesystems,
+			// the operation will fail. In that case, we need to do
+			// a recursive copy of all the files and remove the original.
+			// Note this is also what happens in the linux `mv` command.
+			const fromMount = FS.lookupPath(fromPath).node.mount;
+			const toMount = this.fileExists(toPath)
+				? FS.lookupPath(toPath).node.mount
+				: FS.lookupPath(dirname(toPath)).node.mount;
+			const movingBetweenFilesystems =
+				fromMount.mountpoint !== toMount.mountpoint;
+
 			if (movingBetweenFilesystems) {
 				copyRecursive(FS, fromPath, toPath);
 				this.rmdir(fromPath, { recursive: true });

--- a/packages/php-wasm/universal/tsconfig.json
+++ b/packages/php-wasm/universal/tsconfig.json
@@ -7,7 +7,7 @@
 		"noPropertyAccessFromIndexSignature": true,
 		"noImplicitReturns": true,
 		"noFallthroughCasesInSwitch": true,
-		"types": ["vitest", "vite/client"]
+		"types": ["vitest", "vite/client", "emscripten"]
 	},
 	"files": [],
 	"include": [],

--- a/packages/php-wasm/universal/tsconfig.lib.json
+++ b/packages/php-wasm/universal/tsconfig.lib.json
@@ -10,7 +10,6 @@
 		]
 	},
 	"include": [
-		"src/**/*.d.ts",
 		"src/**/*.ts",
 		"../web/src/php-library/parse-worker-startup-options.ts",
 		"../web/src/lib/api.ts"

--- a/packages/php-wasm/universal/tsconfig.lib.json
+++ b/packages/php-wasm/universal/tsconfig.lib.json
@@ -10,6 +10,7 @@
 		]
 	},
 	"include": [
+		"src/**/*.d.ts",
 		"src/**/*.ts",
 		"../web/src/php-library/parse-worker-startup-options.ts",
 		"../web/src/lib/api.ts"

--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -68,6 +68,12 @@ async function run() {
 			type: 'array',
 			string: true,
 		})
+		.option('mountBeforeInstall', {
+			describe:
+				'Mount a directory to the PHP runtime before installing WordPress. You can provide --mount-before-install multiple times. Format: /host/path:/vfs/path',
+			type: 'array',
+			string: true,
+		})
 		.option('login', {
 			describe: 'Should log the user in',
 			type: 'boolean',
@@ -158,11 +164,26 @@ async function run() {
 		}
 	}
 
+	function mountResources(php: NodePHP, rawMounts: string[]) {
+		const parsedMounts = rawMounts.map((mount) => {
+			const [source, vfsPath] = mount.split(':');
+			return {
+				hostPath: path.resolve(process.cwd(), source),
+				vfsPath,
+			};
+		});
+		for (const mount of parsedMounts) {
+			php.mount(mount.hostPath, mount.vfsPath);
+		}
+	}
+
 	async function prepareSite(
 		php: NodePHP,
 		wpVersion: string,
 		siteUrl: string
 	) {
+		mountResources(php, args.mountBeforeInstall || []);
+
 		// No need to unzip WordPress if it's already mounted at /wordpress
 		if (!args.skipWordPressSetup) {
 			logger.log(`Setting up WordPress ${wpVersion}`);
@@ -185,16 +206,7 @@ async function run() {
 			await setupWordPress(php, wpVersion, monitor);
 		}
 
-		const mounts: Mount[] = (args.mount || []).map((mount) => {
-			const [source, vfsPath] = mount.split(':');
-			return {
-				hostPath: path.resolve(process.cwd(), source),
-				vfsPath,
-			};
-		});
-		for (const mount of mounts) {
-			php.mount(mount.hostPath, mount.vfsPath);
-		}
+		mountResources(php, args.mount || []);
 
 		await defineSiteUrl(php, {
 			siteUrl,

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
 				'@php-wasm/progress',
 				'@php-wasm/util',
 				'@wp-playground/wordpress',
+				'@wp-playground/common',
 				'@wp-playground/blueprints',
 				'yargs',
 				'express',


### PR DESCRIPTION
Before this PR, `php.mv()` from MEMFS to NODEFS would fail. With this PR, it works.

Technically, this PR checks if `fromPath` and `toPath` belong to the same mountpoint. If yes, it calls a fast `FS.rename()` function. If not, it runs a slower recursive copy followed by recursive remove of the `fromPath`.

This runs the entire recursive copy and only then runs the recursive delete. I wonder if deleting each copied item as we go would make more sense?

This PR also brings in the Emscripten TS types as they made working with the `FS` object much easier.

## Testing Instructions

Review the new unit test and confirm it passes.
