### PR TITLE
Unzip: Only delete a temporary zip file after unzipping, do not delete the original zip

### DIFF
--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -20,6 +20,7 @@ export const RecommendedPHPVersion = '8.0';
 /**
  * Unzip a zip file inside Playground.
  */
+const tmpPath = '/tmp/file.zip';
 export const unzipFile = async (
 	php: UniversalPHP,
 	zipPath: string | File,
@@ -27,7 +28,7 @@ export const unzipFile = async (
 ) => {
 	if (zipPath instanceof File) {
 		const zipFile = zipPath;
-		zipPath = '/tmp/file.zip';
+		zipPath = tmpPath;
 		await php.writeFile(
 			zipPath,
 			new Uint8Array(await zipFile.arrayBuffer())
@@ -41,8 +42,8 @@ export const unzipFile = async (
 		php,
 		`unzip(${js.zipPath}, ${js.extractToPath});`
 	);
-	if (php.fileExists(zipPath)) {
-		await php.unlink(zipPath);
+	if (php.fileExists(tmpPath)) {
+		await php.unlink(tmpPath);
 	}
 };
 


### PR DESCRIPTION
Fixes a regression introduced in
https://github.com/WordPress/wordpress-playground/pull/1400 that caused the original zip file to be deleted.

To test, confirm you can preview https://github.com/WordPress/wordpress-develop/pull/6318 on this branch.

Closes #1409