### PR TITLE
CLI: Support fetching WordPress zips from custom URLs

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -97,9 +97,14 @@ async function run() {
 		.showHelpOnFail(false)
 		.check((args) => {
 			if (args.wp !== undefined && !isValidWordPressSlug(args.wp)) {
-				throw new Error(
-					'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
-				);
+				try {
+					// Check if is valid URL
+					new URL(args.wp);
+				} catch (e) {
+					throw new Error(
+						'Unrecognized WordPress version. Please use "latest", a URL, or a numeric version such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
+					);
+				}
 			}
 			if (args.blueprint !== undefined) {
 				const blueprintPath = path.resolve(

--- a/packages/playground/cli/src/download.ts
+++ b/packages/playground/cli/src/download.ts
@@ -1,4 +1,5 @@
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+import { createHash } from 'crypto';
 import fs from 'fs-extra';
 import os from 'os';
 import path, { basename } from 'path';
@@ -55,6 +56,17 @@ export function readAsFile(path: string, fileName?: string): File {
 }
 
 export async function resolveWPRelease(version = 'latest') {
+	// Support custom URLs
+	if (version.startsWith('https://') || version.startsWith('http://')) {
+		const shasum = createHash('sha1');
+		shasum.update(version);
+		const sha1 = shasum.digest('hex');
+		return {
+			url: version,
+			version: 'custom-' + sha1.substring(0, 8),
+		};
+	}
+
 	if (version === 'trunk' || version === 'nightly') {
 		return {
 			url: 'https://wordpress.org/nightly-builds/wordpress-latest.zip',

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
 				'@wp-playground/blueprints',
 				'yargs',
 				'express',
+				'crypto',
 				'os',
 				'net',
 				'fs',


### PR DESCRIPTION
Supports URLs as possible values of the `--wp=` Playground CLI switch.

 ## Testing instructions

Run this and confirm it downloaded WordPress from the specified URL:

```shell
bun ./packages/playground/cli/src/cli.ts server --wp=https://wordpress.org/nightly-builds/wordpress-latest.zip
```

