### PR TITLE
PHP: Use /internal/shared/php.ini by default

### DIFF
--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
@@ -26,6 +26,8 @@ const LibraryExample = {
 			// The files from the preload directory are preloaded using the
 			// auto_prepend_file php.ini directive.
 			FS.mkdir('/internal/shared/preload');
+			// Create a default php.ini file.
+			FS.writeFile('/internal/shared/php.ini', '');
 
 			PHPWASM.EventEmitter = ENVIRONMENT_IS_NODE
 				? require('events').EventEmitter

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -70,7 +70,7 @@ export class PHPExecutionFailureError extends Error {
 export abstract class BasePHP implements IsomorphicLocalPHP, Disposable {
 	protected [__private__dont__use]: any;
 	#phpIniOverrides: [string, string][] = [];
-	#phpIniPath?: string;
+	#phpIniPath = '/internal/shared/php.ini';
 	#sapiName?: string;
 	#webSapiInitialized = false;
 	#wasmErrorsTarget: UnhandledRejectionsTarget | null = null;
@@ -289,7 +289,11 @@ export abstract class BasePHP implements IsomorphicLocalPHP, Disposable {
 				heapBodyPointer = this.#setRequestBody(request.body);
 			}
 			if (typeof request.code === 'string') {
-				this.#setPHPCode(' ?>' + request.code);
+				// @TODO: prepend the auto_prepend_file even when running code and not a file
+				this.#setPHPCode(
+					' ?><?php require_once "/internal/shared/auto_prepend_file.php"; ?>' +
+						request.code
+				);
 			}
 
 			const $_SERVER = this.#prepareServerEntries(

--- a/packages/php-wasm/universal/src/lib/base-php.ts
+++ b/packages/php-wasm/universal/src/lib/base-php.ts
@@ -289,11 +289,7 @@ export abstract class BasePHP implements IsomorphicLocalPHP, Disposable {
 				heapBodyPointer = this.#setRequestBody(request.body);
 			}
 			if (typeof request.code === 'string') {
-				// @TODO: prepend the auto_prepend_file even when running code and not a file
-				this.#setPHPCode(
-					' ?><?php require_once "/internal/shared/auto_prepend_file.php"; ?>' +
-						request.code
-				);
+				this.#setPHPCode(' ?>' + request.code);
 			}
 
 			const $_SERVER = this.#prepareServerEntries(

--- a/packages/playground/cli/src/setup-php.ts
+++ b/packages/playground/cli/src/setup-php.ts
@@ -35,7 +35,6 @@ export async function createPhp(
 	 */
 	php.initializeRuntime(await createPhpRuntime());
 	php.setSapiName('cli');
-	php.setPhpIniPath('/internal/shared/php.ini');
 	php.setPhpIniEntry('openssl.cafile', '/internal/shared/ca-bundle.crt');
 	php.setPhpIniEntry('memory_limit', '256M');
 	php.setPhpIniEntry('allow_url_fopen', '1');

--- a/packages/playground/remote/src/lib/worker-utils.ts
+++ b/packages/playground/remote/src/lib/worker-utils.ts
@@ -84,6 +84,8 @@ export async function createPhp(
 	if (startupOptions.sapiName) {
 		await php.setSapiName(startupOptions.sapiName);
 	}
+	php.mkdir('/usr/local/etc');
+	php.writeFile('/usr/local/etc/php.ini', 'disable_functions = ');
 	php.setPhpIniEntry('memory_limit', '256M');
 	php.setSpawnHandler(spawnHandlerFactory(requestHandler.processManager));
 

--- a/packages/playground/remote/src/lib/worker-utils.ts
+++ b/packages/playground/remote/src/lib/worker-utils.ts
@@ -84,8 +84,6 @@ export async function createPhp(
 	if (startupOptions.sapiName) {
 		await php.setSapiName(startupOptions.sapiName);
 	}
-	php.mkdir('/usr/local/etc');
-	php.writeFile('/usr/local/etc/php.ini', 'disable_functions = ');
 	php.setPhpIniEntry('memory_limit', '256M');
 	php.setSpawnHandler(spawnHandlerFactory(requestHandler.processManager));
 


### PR DESCRIPTION
## What is this PR doing?

Before this PR, PHP attempts to load `/usr/local/etc/php.ini` by default which doesn't exist at best, or is a mounted host system-wide php.ini at worst.

After this PR, PHP loads `/internal/shared/php.ini` which is always Playground-specific.

## Testing Instructions

Confirm the unit tests pass.

Also run this in the browser console and confirm it yields the `/internal/shared/php.ini` path:

```js
(await playground.run({
	code: '<?php echo php_ini_loaded_file();',
})).text
```
