### PR TITLE
ESLint: Disable console warnings for paths where they're not useful

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -68,12 +68,7 @@
 			}
 		},
 		{
-			"files": [
-				"packages/playground/website/demos/**/*",
-				"packages/playground/website/cypress/**/*",
-				"packages/playground/website/builder/**/*",
-				"**/bin/**/*"
-			],
+			"files": ["**/bin/**/*"],
 			"rules": {
 				"no-console": 0
 			}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -66,6 +66,17 @@
 			"rules": {
 				"no-console": 0
 			}
+		},
+		{
+			"files": [
+				"packages/playground/website/demos/**/*",
+				"packages/playground/website/cypress/**/*",
+				"packages/playground/website/builder/**/*",
+				"**/bin/**/*"
+			],
+			"rules": {
+				"no-console": 0
+			}
 		}
 	]
 }

--- a/packages/playground/website/.eslintrc.json
+++ b/packages/playground/website/.eslintrc.json
@@ -31,9 +31,9 @@
 		},
 		{
 			"files": [
-				"website/demos/**/*",
-				"website/cypress/**/*",
-				"website/builder/**/*"
+				"demos/**/*",
+				"cypress/**/*",
+				"builder/**/*"
 			],
 			"rules": {
 				"no-console": 0

--- a/packages/playground/website/.eslintrc.json
+++ b/packages/playground/website/.eslintrc.json
@@ -33,7 +33,8 @@
 			"files": [
 				"demos/**/*",
 				"cypress/**/*",
-				"builder/**/*"
+				"builder/**/*",
+				"vite.oauth.ts"
 			],
 			"rules": {
 				"no-console": 0

--- a/packages/playground/website/.eslintrc.json
+++ b/packages/playground/website/.eslintrc.json
@@ -30,6 +30,16 @@
 			}
 		},
 		{
+			"files": [
+				"website/demos/**/*",
+				"website/cypress/**/*",
+				"website/builder/**/*"
+			],
+			"rules": {
+				"no-console": 0
+			}
+		},
+		{
 			"files": ["*.ts", "*.tsx"],
 			"rules": {}
 		},


### PR DESCRIPTION
## What is this PR doing?

This PR attempts to fix warnings like those in files where we don't use the logger module:

![CleanShot 2024-05-17 at 13 34 48@2x](https://github.com/WordPress/wordpress-playground/assets/205419/4377b647-3c69-42e7-a456-8fbb96265dbc)
