### PR TITLE
PHP: Remove mentions of a custom PHP extension

### DIFF
--- a/packages/docs/site/docs/11-architecture/03-wasm-php-compiling.md
+++ b/packages/docs/site/docs/11-architecture/03-wasm-php-compiling.md
@@ -50,5 +50,4 @@ nx recompile-php php-wasm-web
 -   `EMSCRIPTEN_ENVIRONMENT` – `web` or `node`, default: `web`. The platform to build for. When building for `web`, two JavaScript loaders will be created: `php-web.js` and `php-webworker.js`. When building for Node.js, only one loader called `php-node.js` will be created.
 -   `WITH_LIBXML` – `yes` or `no`, default: `no`. Whether to build with `libxml2` and the `dom`, `xml`, and `simplexml` PHP extensions (`DOMDocument`, `SimpleXML`, ..).
 -   `WITH_LIBZIP` – `yes` or `no`, default: `yes`. Whether to build with `zlib`, `libzip`, and the `zip` PHP extension (`ZipArchive`).
--   `WITH_VRZNO` – `yes` or `no`, default: `yes` when PHP_VERSION is 7.\*. Whether to build with [the `vrzno` PHP extension](https://github.com/seanmorris/vrzno/fork) that enables running JavaScript code from PHP.
 -   `WITH_NODEFS` – `yes` or `no`, default: `no`. Whether to include [the Emscripten's NODEFS JavaScript library](https://emscripten.org/docs/api_reference/Filesystem-API.html#filesystem-api-nodefs). It's useful for loading files and mounting directories from the local filesystem when running php.wasm from Node.js.

--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -188,8 +188,6 @@ await asyncSpawn(
 		'--build-arg',
 		getArg('PHP_VERSION'),
 		'--build-arg',
-		getArg('WITH_VRZNO'),
-		'--build-arg',
 		getArg('WITH_FILEINFO'),
 		'--build-arg',
 		getArg('WITH_LIBXML'),

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -39,7 +39,6 @@ COPY ./oniguruma/dist/root/lib /root/lib
 
 # The PHP extensions to build:
 ARG WITH_CURL
-ARG WITH_VRZNO
 ARG WITH_FILEINFO
 ARG WITH_LIBXML
 ARG WITH_LIBZIP
@@ -249,18 +248,6 @@ RUN cd /root && \
 		git apply --no-index /root/php-chunk-alloc-zend-assert.patch -v \
 	) && \
 	touch php-src/patched
-
-# Add VRZNO if needed
-RUN if [ "$WITH_VRZNO" = "yes" ]; \
-	then \
-		git clone https://github.com/seanmorris/vrzno.git php-src/ext/vrzno \
-			--branch DomAccess \
-			--single-branch    \
-			--depth 1; \
-		echo -n ' --enable-vrzno' >> /root/.php-configure-flags; \
-		echo -n ' -DWITH_VRZNO=1' >> /root/.emcc-php-wasm-flags; \
-		echo -n ', "_exec_callback", "_del_callback"' >> /root/.EXPORTED_FUNCTIONS; \
-	fi
 
 # Install Mysql support if needed
 RUN if [ "$WITH_MYSQL" = "yes" ]; then \

--- a/packages/php-wasm/compile/php/php_wasm.c
+++ b/packages/php-wasm/compile/php/php_wasm.c
@@ -1594,35 +1594,3 @@ static int EMSCRIPTEN_KEEPALIVE run_php(char *code)
 
 	return EG(exit_status);
 }
-
-#ifdef WITH_VRZNO
-#include "../php-src/ext/vrzno/php_vrzno.h"
-
-/*
- * Function: exec_callback
- * ----------------------------
- *   Required by the VRZNO module.
- *
- *   @see https://github.com/seanmorris/vrzno
- */
-int EMSCRIPTEN_KEEPALIVE exec_callback(zend_function *fptr)
-{
-	int retVal = vrzno_exec_callback(fptr);
-
-	fflush(stdout);
-
-	return retVal;
-}
-
-/*
- * Function: del_callback
- * ----------------------------
- *   Required by the VRZNO module.
- *
- *   @see https://github.com/seanmorris/vrzno
- */
-int EMSCRIPTEN_KEEPALIVE del_callback(zend_function *fptr)
-{
-	return vrzno_del_callback(fptr);
-}
-#endif

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -99,8 +99,6 @@ add_action('admin_print_scripts', function () {
  * This mu-plugin provides that transport. It's one of the two:
  *
  * * WP_Http_Fetch – Sends requests using browser's fetch() function.
- *                   Only enabled when PHP was compiled with the VRZNO
- * 					 extension.
  * * Requests_Transport_Dummy – Does not send any requests and only exists to keep
  * 								the Requests class happy.
  */


### PR DESCRIPTION
## What is this PR doing?

Playground's doesn't use the custom vrzno extension and it doesn't make sense to keep it in the Dockerfile anymore
