### PR TITLE
Remote.html: Preload the SQLite database plugin, but only execute it if there's no custom db.php inside wp-content

### DIFF
--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -6,8 +6,12 @@ import {
 	getWordPressModuleDetails,
 	LatestSupportedWordPressVersion,
 	SupportedWordPressVersions,
+	sqliteDatabaseIntegration,
 } from '@wp-playground/wordpress-builds';
-import { wordPressRewriteRules } from '@wp-playground/wordpress';
+import {
+	preloadSqliteIntegration,
+	wordPressRewriteRules,
+} from '@wp-playground/wordpress';
 import { PHPRequestHandler } from '@php-wasm/universal';
 import {
 	SyncProgressCallback,
@@ -56,6 +60,14 @@ if (
 	lastOpfsDir = virtualOpfsDir;
 	wordPressAvailableInOPFS = await playgroundAvailableInOpfs(virtualOpfsDir!);
 }
+
+// The SQLite integration must always be downloaded, even when using OPFS or Native FS,
+// because it can't be assumed to exist in WordPress document root. Instead, it's installed
+// in the /internal directory to avoid polluting the mounted directory structure.
+downloadMonitor.expectAssets({
+	[sqliteDatabaseIntegration.url]: sqliteDatabaseIntegration.size,
+});
+const sqliteIntegrationRequest = monitoredFetch(sqliteDatabaseIntegration.url);
 
 // Start downloading WordPress if needed
 let wordPressRequest = null;
@@ -209,6 +221,12 @@ try {
 			wordPressAvailableInOPFS,
 		});
 	}
+
+	const sqliteIntegrationZip = await (await sqliteIntegrationRequest).blob();
+	await preloadSqliteIntegration(
+		primaryPhp,
+		new File([sqliteIntegrationZip], 'sqlite.zip')
+	);
 
 	// Always setup the current site URL.
 	await defineSiteUrl(primaryPhp, {


### PR DESCRIPTION
## What is this PR doing?

This PR always preloads the SQLite plugin in remote.html, even if the provided WordPress already ships one. The preloaded plugin will only be used if no `wp-content/db.php` drop-in plugin is found in the filesystem. This change sets the stage for:

* #1426, which ships a minified WordPress build without the SQLite plugin baked-in.
* #1425, which runs the WordPress installation wizard if the site isn't installed yet

Related to [Boot Protocol](https://github.com/WordPress/wordpress-playground/issues/1398)

## Problem solved

We want the official WordPress release `.zip` to just work in Playground. Currently it doesn't because remote.html expects a pre-processed build with the SQLite plugin already baked-in. This PR, in conjunction with #1425 and #1426, remove that requirement.

## Testing Instructions

Confirm the CI checks pass.