### PR TITLE
Document php ini functions

### DIFF
--- a/packages/php-wasm/universal/src/lib/ini.ts
+++ b/packages/php-wasm/universal/src/lib/ini.ts
@@ -2,6 +2,13 @@ import { PHP_INI_PATH } from './base-php';
 import { UniversalPHP } from './universal-php';
 import { stringify, parse } from 'ini';
 
+/**
+ * Reads the php.ini file and returns its entries.
+ *
+ * @param php The PHP instance.
+ * @param entries Optional. If provided, only the specified entries will be returned.
+ * @returns The php.ini entries.
+ */
 export async function getPhpIniEntries(php: UniversalPHP, entries?: string[]) {
 	const ini = parse(await php.readFileAsText(PHP_INI_PATH));
 	if (entries === undefined) {
@@ -14,6 +21,12 @@ export async function getPhpIniEntries(php: UniversalPHP, entries?: string[]) {
 	return result;
 }
 
+/**
+ * Rewrites the php.ini file with the given entries.
+ *
+ * @param php The PHP instance.
+ * @param entries The entries to write to the php.ini file.
+ */
 export async function setPhpIniEntries(
 	php: UniversalPHP,
 	entries: Record<string, unknown>
@@ -29,6 +42,18 @@ export async function setPhpIniEntries(
 	await php.writeFile(PHP_INI_PATH, stringify(ini));
 }
 
+/**
+ * Sets php.ini values to the given values, executes a callback,
+ * and restores the original php.ini values. This is useful for
+ * running code with temporary php.ini values, such as when
+ * disabling network-related PHP functions just to run WordPress
+ * installer.
+ *
+ * @param php The PHP instance.
+ * @param phpIniValues The php.ini values to set.
+ * @param callback The callback to execute.
+ * @returns The result of the callback.
+ */
 export async function withPHPIniValues(
 	php: UniversalPHP,
 	phpIniValues: Record<string, string>,
@@ -37,7 +62,7 @@ export async function withPHPIniValues(
 	const iniBefore = await php.readFileAsText(PHP_INI_PATH);
 	try {
 		await setPhpIniEntries(php, phpIniValues);
-		await callback();
+		return await callback();
 	} finally {
 		await php.writeFile(PHP_INI_PATH, iniBefore);
 	}

--- a/packages/php-wasm/universal/src/lib/ini.ts
+++ b/packages/php-wasm/universal/src/lib/ini.ts
@@ -49,6 +49,20 @@ export async function setPhpIniEntries(
  * disabling network-related PHP functions just to run WordPress
  * installer.
  *
+ * @example
+ * ```ts
+ *	await withPHPIniValues(
+ *		php,
+ *		{
+ *			disable_functions: 'fsockopen',
+ *			allow_url_fopen: '0',
+ *		},
+ *		async () => await runWpInstallationWizard(php, {
+ *			options: {},
+ *		})
+ *	);
+ *	```
+ *
  * @param php The PHP instance.
  * @param phpIniValues The php.ini values to set.
  * @param callback The callback to execute.


### PR DESCRIPTION
## What is this PR doing?

Documents the php.ini-related functions introduced in https://github.com/WordPress/wordpress-playground/pull/1423.

Also, ensures `withPHPIniValues()` returns the return value of the callback.

cc @bgrgicak 

## Testing Instructions

Confirm the CI checks pass.