### PR TITLE
Blueprints: Re-activate single-file plugins when enabling a multisite

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -77,7 +77,11 @@ $plugins = glob($plugins_root . "/*");
 
 $deactivated_plugins = [];
 foreach($plugins as $plugin_path) {
+	if (str_ends_with($plugin_path, '/index.php')) {
+		continue;
+	}
 	if (!is_dir($plugin_path)) {
+		$deactivated_plugins[] = substr($plugin_path, strlen($plugins_root) + 1);
 		deactivate_plugins($plugin_path);
 		continue;
 	}


### PR DESCRIPTION
## What is this PR doing?

In Blueprints, enabling a multisite deactivates all the plugins and then re-activates them. There was a slight bug that prevented single-file plugins from being reactivated - only plugins living in subdirectories were. This PR solves it.

## Testing Instructions

1. Setup `playground.test` proxy with Laravel Valet as described in dev docs
2. Go to https://playground.test/website-server/?multisite=yes&url=/wp-admin/plugins.php&plugin=hello-dolly
3. Confirm the hello-dolly plugin is active