### PR TITLE
Blueprints: Detect silent failures when activating plugins and theme

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
@@ -28,7 +28,7 @@ describe('Blueprint step activatePlugin()', () => {
 			`<?php /**\n * Plugin Name: Test Plugin */`
 		);
 		await activatePlugin(php, {
-			pluginPath: docroot + '/wp-content/plugins/test-plugin.php',
+			pluginPath: 'test-plugin.php',
 		});
 
 		const response = await php.run({
@@ -39,6 +39,24 @@ describe('Blueprint step activatePlugin()', () => {
 			`,
 		});
 		expect(response.text).toBe('true');
+	});
+
+	it('should detect a silent failure in activating the plugin', async () => {
+		const docroot = php.documentRoot;
+		php.writeFile(
+			`/${docroot}/wp-content/plugins/test-plugin.php`,
+			`<?php /**\n * Plugin Name: Test Plugin */`
+		);
+		php.writeFile(
+			`/${docroot}/wp-content/mu-plugins/0-exit.php`,
+			`<?php exit(0); `
+		);
+		expect(
+			async () =>
+				await activatePlugin(php, {
+					pluginPath: 'test-plugin.php',
+				})
+		).rejects.toThrow(/Plugin test-plugin.php could not be activated/);
 	});
 
 	it('should run the activation hooks as a priviliged user', async () => {
@@ -56,7 +74,7 @@ describe('Blueprint step activatePlugin()', () => {
 			`
 		);
 		await activatePlugin(php, {
-			pluginPath: docroot + '/wp-content/plugins/test-plugin.php',
+			pluginPath: 'test-plugin.php',
 		});
 
 		expect(php.fileExists(createdFilePath)).toBe(true);

--- a/packages/playground/blueprints/src/lib/steps/activate-theme.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.spec.ts
@@ -80,4 +80,28 @@ describe('Blueprint step activateTheme()', () => {
 
 		expect(php.fileExists(createdFilePath)).toBe(true);
 	});
+
+	it('should detect a silent failure in activating the theme', async () => {
+		const docroot = php.documentRoot;
+		php.mkdir(`${docroot}/wp-content/themes/test-theme`);
+		php.writeFile(
+			`${docroot}/wp-content/themes/test-theme/style.css`,
+			`/**
+* Theme Name: Test Theme
+* Theme URI: https://example.com/test-theme
+* Author: Test Author
+*/
+			`
+		);
+		php.writeFile(
+			`/${docroot}/wp-content/mu-plugins/0-exit.php`,
+			`<?php exit(0); `
+		);
+		expect(
+			async () =>
+				await activateTheme(php, {
+					themeFolderName: 'test-theme',
+				})
+		).rejects.toThrow(/Theme test-theme could not be activated/);
+	});
 });

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -77,7 +77,11 @@ $plugins = glob($plugins_root . "/*");
 
 $deactivated_plugins = [];
 foreach($plugins as $plugin_path) {
+	if (str_ends_with($plugin_path, '/index.php')) {
+		continue;
+	}
 	if (!is_dir($plugin_path)) {
+		$deactivated_plugins[] = substr($plugin_path, strlen($plugins_root) + 1);
 		deactivate_plugins($plugin_path);
 		continue;
 	}


### PR DESCRIPTION
The `activatePlugin` and `activateTheme` steps may fail silently and without any feedback for the developer. This PR adds safeguards in place to throw an error if the specified plugin or theme is not active once the step is finished.

 ## Testing instructions

Confirm the CI checks passed
