### PR TITLE
Restore nightly wordpress build

### DIFF
--- a/packages/playground/wordpress-builds/project.json
+++ b/packages/playground/wordpress-builds/project.json
@@ -35,11 +35,11 @@
 				"bundle-wordpress:major-and-beta"
 			]
 		},
-		"bundle-sqlite-database": {
+		"bundle-wordpress:nightly": {
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"node packages/playground/wordpress-builds/build/refresh-sqlite-integration-plugin.js --output-dir=packages/playground/wordpress-builds/src/sqlite-database-integration "
+					"node packages/playground/wordpress-builds/build/build.js --wp-version=nightly --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public"
 				],
 				"parallel": false
 			}
@@ -53,6 +53,15 @@
 					"node packages/playground/wordpress-builds/build/build.js --wp-version=latest-minus-1 --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public",
 					"node packages/playground/wordpress-builds/build/build.js --wp-version=latest --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public",
 					"node packages/playground/wordpress-builds/build/build.js --wp-version=beta --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public || true"
+				],
+				"parallel": false
+			}
+		},
+		"bundle-sqlite-database": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"node packages/playground/wordpress-builds/build/refresh-sqlite-integration-plugin.js --output-dir=packages/playground/wordpress-builds/src/sqlite-database-integration "
 				],
 				"parallel": false
 			}

--- a/packages/playground/wordpress-builds/src/wordpress/get-wordpress-module-details.ts
+++ b/packages/playground/wordpress-builds/src/wordpress/get-wordpress-module-details.ts
@@ -26,7 +26,7 @@ export function getWordPressModuleDetails(wpVersion: string = "6.5"): { size: nu
 		case 'nightly':
 			/** @ts-ignore */
 			return {
-				size: 4989289,
+				size: 4989363,
 				url: url_nightly,
 			};
 			


### PR DESCRIPTION
## What is this PR doing?

This PR restores the nightly WordPress build target which appears to have been inadvertently removed by c6d06f2af8d00b4fc4e2e1aaf3da3613f4681b5e.

## How is the problem addressed?

It restores the "bundle-wordpress:nightly" target that was present immediately before removal.

## Testing Instructions

- Run: `export FORCE_REBUILD=true; npx nx run --skip-nx-cache playground-wordpress-builds:bundle-wordpress:nightly`
- Observe that it produces a new version of the nightly build.
- Run `npm run dev` and confirm you can run Playground from the dev server using the nightly WP version

cc @adamziel 