### PR TITLE
Add Puzzle app to Website build

### DIFF
--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -7,7 +7,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:wasm-wordpress-net"]
+			"dependsOn": ["build:wasm-wordpress-net", "build:playground-puzzle"]
 		},
 		"build:wasm-wordpress-net": {
 			"executor": "nx:run-commands",

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -18,7 +18,7 @@ import {
 import virtualModule from '../vite-virtual-module';
 import { oAuthMiddleware } from './vite.oauth';
 import { fileURLToPath } from 'node:url';
-import { copyFileSync, existsSync } from 'node:fs';
+import { copyFileSync, existsSync, cpSync } from 'node:fs';
 import { join } from 'node:path';
 
 const proxy = {
@@ -126,6 +126,23 @@ export default defineConfig(({ command, mode }) => {
 							blueprintsPath,
 							join(outputDir, 'demos/blueprints.phar')
 						);
+					}
+				},
+			} as Plugin,
+			/**
+			 * Copy the Puzzle app form the `dist/packages/playground/puzzle` directory.
+			 */
+			{
+				name: 'puzzle-plugin',
+				apply: 'build',
+				writeBundle({ dir: outputDir }) {
+					const puzzleDir = path(
+						'../../../dist/packages/playground/puzzle/'
+					);
+					if (existsSync(puzzleDir) && outputDir) {
+						cpSync(puzzleDir, join(outputDir, 'puzzle'), {
+							recursive: true,
+						});
 					}
 				},
 			} as Plugin,


### PR DESCRIPTION
## What is this PR doing?

It adds support for deploying the Puzzle app to WordPress.Playground.net.

## What problem is it solving?

It will allow WCEU attendees to use the Puzzle app.

## How is the problem addressed?

By copying the Puzzle app dist folder into the Website dist folder.

## Testing Instructions

- Run 
```
npm run install
npm run build
```
- Confirm that there is a `puzzle/` folder in `dist/packages/playground/website`
