### PR TITLE
Add name to Puzzle package

### DIFF
--- a/packages/playground/puzzle/package.json
+++ b/packages/playground/puzzle/package.json
@@ -1,4 +1,5 @@
 {
+	"name": "@wp-playground/puzzle",
 	"version": "0.0.1",
 	"type": "module",
 	"private": true


### PR DESCRIPTION
## What is this PR doing?

Adds a name to the Playground Puzzle package.

## What problem is it solving?

There is an error with NPM deployments caused by the missing package name.

Related error https://github.com/WordPress/wordpress-playground/actions/runs/9176130514/job/25230708282

## How is the problem addressed?

By adding a name to the Puzzle app package.json

## Testing Instructions

- Ensure all tests pass
