### PR TITLE
Fix update-changelog workflow to commit all updates

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -53,7 +53,9 @@ jobs:
                   git config --global user.email "deployment_bot@users.noreply.github.com"
                   git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   if [[ -n $(git status --porcelain CHANGELOG.md) ]]; then
-                      git commit CHANGELOG.md -m "chore: update changelog"
+                      git commit -m "chore: update changelog" \
+                          CHANGELOG.md \
+                          packages/docs/site/docs/*changelog*.md
                       git pull origin trunk --rebase
                       git push origin trunk
                   else


### PR DESCRIPTION
## What is this PR doing?

This PR tweaks the update-changelog workflow so all relevant updates are commited.

## What problem is it solving?

The previous version of the workflow didn't commit all changes and errored out due to a failed rebase.

## How is the problem addressed?

By committing all expected changes:
- CHANGELOG.md
- packages/docs/site/docs/*changelog*.md

The latter glob is there to hopefully avoid the need to tweak this workflow if the actual path, `packages/docs/site/docs/17-changelog.md`, changes numerically.

## Testing Instructions

The real test is running the workflow on GitHub, but hopefully the following manual test is sufficient given the simplicity of the update.

Test the updated commit command:
- `cd` to the project root
- Make sure `bun` is available in your PATH.
- Run `npm run changelog -- --version=`
- Run `bun packages/docs/site/bin/refresh-changelog.ts`
- Run `git status` and confirm `CHANGELOG.md` and `packages/docs/site/docs/17-changelog.md` have changes
- Run the following command:
```bash
git commit -m "TEST" \
CHANGELOG.md \
packages/docs/site/docs/*changelog*.md
```
- Run `git status` and confirm there are no uncommitted changes left
- Run `git log -n1 --name-status` and confirm the expected changes were committed
- Run `git reset --hard HEAD~1` to dispose of the TEST commit
