### PR TITLE
Add missing trailing slash on `landingPage` wp-admin path

### DIFF
--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -204,7 +204,7 @@
 			const blueprint = {
 				$schema:
 					'https://playground.wordpress.net/blueprint-schema.json',
-				landingPage: urlParams.get('url') || '/wp-admin',
+				landingPage: urlParams.get('url') || '/wp-admin/',
 				steps: [
 					{
 						step: 'mkdir',


### PR DESCRIPTION
## What is this PR doing?
Adds a trailing slash to the blueprint's `landingPage` value.

## What problem is it solving?
When using the [WordPress PR previewer](https://playground.wordpress.net/wordpress.html), after WP admin loads, all menu sidebar links redirect to the homepage.

The blueprint setting for `landingPage` is [configured as `/wp-admin`](https://github.com/WordPress/wordpress-playground/blob/5b7506d1091b2d7648315718493d34503a3440bf/packages/playground/website/public/wordpress.html#L207). The missing trailing slash results in the menu sidebar links being incorrect, in turn causing link clicks to redirect to the homepage.

<img width="355" alt="Playground page path showing the WP admin path without a trailing slash" src="https://github.com/WordPress/wordpress-playground/assets/824344/7daf61f1-5ef8-4a4b-9f60-58b9fc763f03">

Navigating with the top admin bar links, or manually adding a slash to the Playground page path, can work around the issue.

## How is the problem addressed?
The trailing slash allows the generated sidebar links to include/prepend `/wp-admin/` to their links.

Compare this with the Gutenberg PR viewer, [which includes the trailing slash](https://github.com/WordPress/wordpress-playground/blob/5b7506d1091b2d7648315718493d34503a3440bf/packages/playground/website/public/gutenberg.html#L144).

## Testing Instructions
1. Open https://playground.wordpress.net/wordpress.html.
2. Paste in a PR ID or URL and click "Go".
3. ✅ In the Playground that launches, the path in the Playground address bar should include a trailing slash: `/wp-admin/`.
4. ✅ Clicking admin sidebar menu items should link to the intended admin pages.
