### PR TITLE
Website: Fix custom redirects

### DIFF
--- a/packages/playground/website-deployment/apply-update.sh
+++ b/packages/playground/website-deployment/apply-update.sh
@@ -67,8 +67,11 @@ function match_files_to_serve_via_php() (
     require "custom-redirects-lib.php";
     while ( $path = fgets( STDIN ) ) {
         $path = trim( $path );
-        $filename = basename( $path );
-        if ( playground_file_needs_special_treatment($filename) ) {
+        $basename = basename( $path );
+        if (
+		playground_file_needs_special_treatment($path) ||
+		playground_file_needs_special_treatment($basename)
+	) {
             echo "$path\n";
         }
     }
@@ -88,7 +91,9 @@ echo Configure which files should be served by Nginx and which by PHP
 cd ~/website-update
 find -type f \
     | grep -v files-to-serve-via-php \
+    | sed 's#^\.##' \
     | match_files_to_serve_via_php \
+    | sed 's#^/##' \
     | set_aside_files_to_serve_via_php
 
 echo Syncing staged files to production

--- a/packages/playground/website-deployment/apply-update.sh
+++ b/packages/playground/website-deployment/apply-update.sh
@@ -69,9 +69,9 @@ function match_files_to_serve_via_php() (
         $path = trim( $path );
         $basename = basename( $path );
         if (
-		playground_file_needs_special_treatment($path) ||
-		playground_file_needs_special_treatment($basename)
-	) {
+            playground_file_needs_special_treatment($path) ||
+            playground_file_needs_special_treatment($basename)
+        ) {
             echo "$path\n";
         }
     }


### PR DESCRIPTION
## What is this PR doing?

This PR updates the deployment process to properly identify files that have custom redirect rules.

## What problem is it solving?

Playground embedded in https://wordpress.org/playground/ is showing up as the WordPress PR previewer when it should be showing the main Playground UI.

![Screenshot 2024-05-22 at 8 07 23 PM](https://github.com/WordPress/wordpress-playground/assets/530877/f89b9b2b-301d-470e-a07f-832f7d6af5f1)

This is caused by a deploy-time bug that results in static files not being properly set aside to be served with custom logic written in PHP.

## How is the problem addressed?

This PR fixes the deploy script to properly identify the files that require custom redirect logic.

After this change, the WP.org Playground iframe loads the Playground UI as expected:
![Screenshot 2024-05-22 at 8 07 52 PM](https://github.com/WordPress/wordpress-playground/assets/530877/161d1a73-c314-4d38-a3a0-32023dabdb58)

This was tested by manually swapping the src domain of the WP.org Playground iframe to point to a staging site where this deploy script was run.

## Testing Instructions

Tested manually via SSH on a staging site. Will confirm all is well after merging this by manually running the website deploy and retesting the WP.org Playground page.
