### PR TITLE
Website: Stop disabling cache for non-root index.html files

### DIFF
--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -9,7 +9,7 @@ function playground_file_needs_special_treatment( $path ) {
 	return (
 		!! playground_maybe_rewrite( $path ) ||
 		!! playground_maybe_redirect( $path ) ||
-		!! playground_get_custom_response_headers( basename( $path ) ) ||
+		!! playground_get_custom_response_headers( $path ) ||
 		!! playground_maybe_set_environment( $path )
 	);
 }
@@ -128,7 +128,7 @@ function playground_handle_request() {
 	$log( "Setting Content-Type to '$content_type'" );
 	header( "Content-Type: $content_type" );
 
-	$custom_response_headers = playground_get_custom_response_headers( $filename );
+	$custom_response_headers = playground_get_custom_response_headers( $requested_path );
 	if ( ! empty( $custom_response_headers ) ) {
 		foreach ( $custom_response_headers as $custom_header ) {
 			header( $custom_header );
@@ -299,7 +299,9 @@ function playground_maybe_set_environment( $requested_path ) {
 	return false;
 }
 
-function playground_get_custom_response_headers( $filename ) {
+function playground_get_custom_response_headers( $requested_path ) {
+	$filename = basename( $requested_path );
+
 	if ( 'iframe-worker.html' === $filename ) {
 		return array( 'Origin-Agent-Cluster: ?1' );
 	} elseif ( str_ends_with( $filename, 'store.zip' ) ) {
@@ -309,7 +311,10 @@ function playground_get_custom_response_headers( $filename ) {
 			'Content-Encoding: identity',
 			'Access-Control-Allow-Origin: *',
 		);
-	} elseif ( 'index.html' === $filename ) {
+	} elseif (
+		'/' === $requested_path ||
+		'/index.html' === $requested_path
+	) {
 		return array( 'Cache-Control: max-age=0, no-cache, no-store, must-revalidate' );
 	} elseif (
 		in_array(
@@ -319,7 +324,6 @@ function playground_get_custom_response_headers( $filename ) {
 				'blueprint-schema.json',
 				'logger.php',
 				'oauth.php',
-				'puzzle.php',
 				'wp-cli.phar',
 				'wordpress-importer.zip',
 			),
@@ -344,4 +348,3 @@ function playground_resolve_to_index_file( $real_path ) {
 		return false;
 	}
 }
-


### PR DESCRIPTION
## What is this PR doing?

This PR makes it so the only `index.html` file set aside to get custom HTTP headers is `/index.html`.

## What problem is it solving?

It is a general improvement for us to be more specific about which file paths get special treatment, but we are making the change now so we can stop setting puzzle/index.html aside to be served by PHP. cc @bgrgicak

## How is the problem addressed?

When puzzle/index.html is set aside, it turns out that nginx does not delegate the request to PHP but rather responds with a 403 error. Nginx appears to do this for every existing, non-root directory. We plan to talk with the host about fixing this behavior, but in the meantime, we can avoid it here by excluding puzzle/index.html from receiving "no-cache" headers.

## Testing Instructions

I have tested these changes manually via SSH on a staging site. After merging, we will deploy the website and confirm all is well in production.