### PR TITLE
Blueprints: Remove support for the "request" step

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -427,9 +427,9 @@ function isStepDefinition(
 function isStepStillSupported(
 	step: Record<string, any>
 ): step is StepDefinition {
-	if (step['step'] === 'setPhpIniEntry') {
+	if (['setPhpIniEntry', 'request'].includes(step['step'])) {
 		logger.warn(
-			`The "setPhpIniEntry" Blueprint is no longer supported and you can remove it from your Blueprint.`
+			`The "${step['step']}" Blueprint is no longer supported and you can remove it from your Blueprint.`
 		);
 		return false;
 	}


### PR DESCRIPTION
Removes the "request" step. It is not very useful – most wp-admin requests require a nonce, which it has no access to. Furthermore, it cannot be easily ported to non-browser Playground runtimes

 ## Technical implementation

Removes the "request" step from any Blueprints when executing them.

 ## Follow-up work

Remove the request() function from the Blueprints package once no other step depends on it.

 ## Testing instructions

Confirm the CI checks are green
