### PR TITLE
Add option to specify pr number for export via query params

### DIFF
--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -133,6 +133,9 @@ function Main() {
 				query.get('ghexport-pr-action')
 			);
 		}
+		if (query.get('ghexport-pr-number')) {
+			values.prNumber = query.get('ghexport-pr-number')?.toString();
+		}
 		if (query.get('ghexport-playground-root')) {
 			values.fromPlaygroundRoot = query.get('ghexport-playground-root')!;
 		}


### PR DESCRIPTION
## What is this PR doing?

It extends the options to pre-configure GH export via provided link so that PR number can also be specified.

## What problem is it solving?

The need occurred when updating playground link script in this repository:
https://github.com/WordPress/community-themes/pull/185

It's especially beneficial in such GH actions, or when working with non-developers that are contributing to themes.

## How is the problem addressed?

It just extends existing logic by adding a next query param check.

## Testing Instructions

Due to limitations (GH authorization not supporting local endpoints) it's not possible to easily test this change. In general, opening:
https://playground.wordpress.net/?ghexport-repo-url=https://github.com/WordPress/wordpress-playgrounds&ghexport-content-type=theme&ghexport-theme=twentytwentyfour&ghexport-pr-action=update&ghexport-pr-number=999&state=github-export

Should end up with Github Export form having PR number pre-filled:
![CleanShot 2024-05-27 at 19 31 44@2x](https://github.com/WordPress/wordpress-playground/assets/8419292/c5bc466e-a926-471b-84cb-63832b094807)

