### PR TITLE
Move Filesystem methods to a static FSHelpers class

### DIFF
--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -53,6 +53,7 @@ export default defineConfig(function () {
 				dir: '../../../node_modules/.vitest',
 			},
 			environment: 'jsdom',
+			reporters: 'dot',
 			include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 		},
 

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -53,7 +53,6 @@ export default defineConfig(function () {
 				dir: '../../../node_modules/.vitest',
 			},
 			environment: 'jsdom',
-			reporters: 'dot',
 			include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 		},
 

--- a/packages/php-wasm/universal/src/lib/fs-helpers.ts
+++ b/packages/php-wasm/universal/src/lib/fs-helpers.ts
@@ -1,0 +1,239 @@
+import { Emscripten } from './emscripten-types';
+import {
+	getEmscriptenFsError,
+	rethrowFileSystemError,
+} from './rethrow-file-system-error';
+import { logger } from '@php-wasm/logger';
+import { dirname, joinPaths } from '@php-wasm/util';
+
+export interface RmDirOptions {
+	/**
+	 * If true, recursively removes the directory and all its contents.
+	 * Default: true.
+	 */
+	recursive?: boolean;
+}
+
+export interface ListFilesOptions {
+	/**
+	 * If true, prepend given folder path to all file names.
+	 * Default: false.
+	 */
+	prependPath: boolean;
+}
+
+export class FSHelpers {
+	/**
+	 * Reads a file from the PHP filesystem and returns it as a string.
+	 *
+	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file doesn't exist.
+	 * @param  path - The file path to read.
+	 * @returns The file contents.
+	 */
+	@rethrowFileSystemError('Could not read "{path}"')
+	static readFileAsText(FS: Emscripten.RootFS, path: string) {
+		return new TextDecoder().decode(FSHelpers.readFileAsBuffer(FS, path));
+	}
+
+	/**
+	 * Reads a file from the PHP filesystem and returns it as an array buffer.
+	 *
+	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file doesn't exist.
+	 * @param  path - The file path to read.
+	 * @returns The file contents.
+	 */
+	@rethrowFileSystemError('Could not read "{path}"')
+	static readFileAsBuffer(FS: Emscripten.RootFS, path: string): Uint8Array {
+		return FS.readFile(path);
+	}
+
+	/**
+	 * Overwrites data in a file in the PHP filesystem.
+	 * Creates a new file if one doesn't exist yet.
+	 *
+	 * @param  path - The file path to write to.
+	 * @param  data - The data to write to the file.
+	 */
+	@rethrowFileSystemError('Could not write to "{path}"')
+	static writeFile(
+		FS: Emscripten.RootFS,
+		path: string,
+		data: string | Uint8Array
+	) {
+		FS.writeFile(path, data);
+	}
+
+	/**
+	 * Removes a file from the PHP filesystem.
+	 *
+	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file doesn't exist.
+	 * @param  path - The file path to remove.
+	 */
+	@rethrowFileSystemError('Could not unlink "{path}"')
+	static unlink(FS: Emscripten.RootFS, path: string) {
+		FS.unlink(path);
+	}
+
+	/**
+	 * Moves a file or directory in the PHP filesystem to a
+	 * new location.
+	 *
+	 * @param oldPath The path to rename.
+	 * @param newPath The new path.
+	 */
+	static mv(FS: Emscripten.RootFS, fromPath: string, toPath: string) {
+		try {
+			// FS.rename moves the inode within the same filesystem.
+			// If fromPath and toPath are on different filesystems,
+			// the operation will fail. In that case, we need to do
+			// a recursive copy of all the files and remove the original.
+			// Note this is also what happens in the linux `mv` command.
+			const fromMount = FS.lookupPath(fromPath).node.mount;
+			const toMount = FSHelpers.fileExists(FS, toPath)
+				? FS.lookupPath(toPath).node.mount
+				: FS.lookupPath(dirname(toPath)).node.mount;
+			const movingBetweenFilesystems =
+				fromMount.mountpoint !== toMount.mountpoint;
+
+			if (movingBetweenFilesystems) {
+				FSHelpers.copyRecursive(FS, fromPath, toPath);
+				FSHelpers.rmdir(FS, fromPath, { recursive: true });
+			} else {
+				FS.rename(fromPath, toPath);
+			}
+		} catch (e) {
+			const errmsg = getEmscriptenFsError(e);
+			if (!errmsg) {
+				throw e;
+			}
+			throw new Error(
+				`Could not move ${fromPath} to ${toPath}: ${errmsg}`,
+				{
+					cause: e,
+				}
+			);
+		}
+	}
+
+	/**
+	 * Removes a directory from the PHP filesystem.
+	 *
+	 * @param path The directory path to remove.
+	 * @param options Options for the removal.
+	 */
+	@rethrowFileSystemError('Could not remove directory "{path}"')
+	static rmdir(
+		FS: Emscripten.RootFS,
+		path: string,
+		options: RmDirOptions = { recursive: true }
+	) {
+		if (options?.recursive) {
+			FSHelpers.listFiles(FS, path).forEach((file) => {
+				const filePath = `${path}/${file}`;
+				if (FSHelpers.isDir(FS, filePath)) {
+					FSHelpers.rmdir(FS, filePath, options);
+				} else {
+					FSHelpers.unlink(FS, filePath);
+				}
+			});
+		}
+		FS.rmdir(path);
+	}
+
+	/**
+	 * Lists the files and directories in the given directory.
+	 *
+	 * @param  path - The directory path to list.
+	 * @param  options - Options for the listing.
+	 * @returns The list of files and directories in the given directory.
+	 */
+	@rethrowFileSystemError('Could not list files in "{path}"')
+	static listFiles(
+		FS: Emscripten.RootFS,
+		path: string,
+		options: ListFilesOptions = { prependPath: false }
+	): string[] {
+		if (!FSHelpers.fileExists(FS, path)) {
+			return [];
+		}
+		try {
+			const files = FS.readdir(path).filter(
+				(name: string) => name !== '.' && name !== '..'
+			);
+			if (options.prependPath) {
+				const prepend = path.replace(/\/$/, '');
+				return files.map((name: string) => `${prepend}/${name}`);
+			}
+			return files;
+		} catch (e) {
+			logger.error(e, { path });
+			return [];
+		}
+	}
+
+	/**
+	 * Checks if a directory exists in the PHP filesystem.
+	 *
+	 * @param  path – The path to check.
+	 * @returns True if the path is a directory, false otherwise.
+	 */
+	@rethrowFileSystemError('Could not stat "{path}"')
+	static isDir(FS: Emscripten.RootFS, path: string): boolean {
+		if (!FSHelpers.fileExists(FS, path)) {
+			return false;
+		}
+		return FS.isDir(FS.lookupPath(path).node.mode);
+	}
+
+	/**
+	 * Checks if a file (or a directory) exists in the PHP filesystem.
+	 *
+	 * @param  path - The file path to check.
+	 * @returns True if the file exists, false otherwise.
+	 */
+	@rethrowFileSystemError('Could not stat "{path}"')
+	static fileExists(FS: Emscripten.RootFS, path: string): boolean {
+		try {
+			FS.lookupPath(path);
+			return true;
+		} catch (e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Recursively creates a directory with the given path in the PHP filesystem.
+	 * For example, if the path is `/root/php/data`, and `/root` already exists,
+	 * it will create the directories `/root/php` and `/root/php/data`.
+	 *
+	 * @param  path - The directory path to create.
+	 */
+	@rethrowFileSystemError('Could not create directory "{path}"')
+	static mkdir(FS: Emscripten.RootFS, path: string) {
+		FS.mkdirTree(path);
+	}
+
+	@rethrowFileSystemError('Could not copy files from "{path}"')
+	static copyRecursive(
+		FS: Emscripten.FileSystemInstance,
+		fromPath: string,
+		toPath: string
+	) {
+		const fromNode = FS.lookupPath(fromPath).node;
+		if (FS.isDir(fromNode.mode)) {
+			FS.mkdirTree(toPath);
+			const filenames = FS.readdir(fromPath).filter(
+				(name: string) => name !== '.' && name !== '..'
+			);
+			for (const filename of filenames) {
+				FSHelpers.copyRecursive(
+					FS,
+					joinPaths(fromPath, filename),
+					joinPaths(toPath, filename)
+				);
+			}
+		} else {
+			FS.writeFile(toPath, FS.readFile(fromPath));
+		}
+	}
+}

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -3,8 +3,6 @@ export type {
 	PHPOutput,
 	PHPRunOptions,
 	UniversalPHP,
-	ListFilesOptions,
-	RmDirOptions,
 	PHPEvent,
 	PHPEventListener,
 	HTTPMethod,
@@ -12,6 +10,8 @@ export type {
 	PHPRequestHeaders,
 	SpawnHandler,
 } from './universal-php';
+export { FSHelpers } from './fs-helpers';
+export type { ListFilesOptions, RmDirOptions } from './fs-helpers';
 export { PHPWorker } from './php-worker';
 export { getPhpIniEntries, setPhpIniEntries, withPHPIniValues } from './ini';
 

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -58,7 +58,6 @@ export type {
 	PHPRuntimeId,
 	RuntimeType,
 } from './load-php-runtime';
-export { rethrowFileSystemError } from './rethrow-file-system-error';
 
 export type {
 	PHPRequestHandlerConfiguration,

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -3,14 +3,13 @@ import { PHP } from './php';
 import { PHPRequestHandler } from './php-request-handler';
 import { PHPResponse } from './php-response';
 import {
-	RmDirOptions,
 	PHPRequest,
 	PHPRunOptions,
-	ListFilesOptions,
 	MessageListener,
 	PHPEvent,
 	PHPEventListener,
 } from './universal-php';
+import { RmDirOptions, ListFilesOptions } from './fs-helpers';
 
 const _private = new WeakMap<
 	PHPWorker,

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1,5 +1,4 @@
 import { PHPResponse } from './php-response';
-import { rethrowFileSystemError } from './rethrow-file-system-error';
 import { getLoadedRuntime } from './load-php-runtime';
 import type { PHPRuntimeId } from './load-php-runtime';
 import {
@@ -818,7 +817,6 @@ export class PHP implements Disposable {
 	 *
 	 * @param  path - The directory path to create.
 	 */
-	@rethrowFileSystemError('Could not create directory "{path}"')
 	mkdir(path: string) {
 		return FSHelpers.mkdir(this[__private__dont__use].FS, path);
 	}
@@ -826,7 +824,6 @@ export class PHP implements Disposable {
 	/**
 	 * @deprecated Use mkdir instead.
 	 */
-	@rethrowFileSystemError('Could not create directory "{path}"')
 	mkdirTree(path: string) {
 		return FSHelpers.mkdir(this[__private__dont__use].FS, path);
 	}
@@ -838,7 +835,6 @@ export class PHP implements Disposable {
 	 * @param  path - The file path to read.
 	 * @returns The file contents.
 	 */
-	@rethrowFileSystemError('Could not read "{path}"')
 	readFileAsText(path: string) {
 		return FSHelpers.readFileAsText(this[__private__dont__use].FS, path);
 	}
@@ -850,7 +846,6 @@ export class PHP implements Disposable {
 	 * @param  path - The file path to read.
 	 * @returns The file contents.
 	 */
-	@rethrowFileSystemError('Could not read "{path}"')
 	readFileAsBuffer(path: string): Uint8Array {
 		return FSHelpers.readFileAsBuffer(this[__private__dont__use].FS, path);
 	}
@@ -862,7 +857,6 @@ export class PHP implements Disposable {
 	 * @param  path - The file path to write to.
 	 * @param  data - The data to write to the file.
 	 */
-	@rethrowFileSystemError('Could not write to "{path}"')
 	writeFile(path: string, data: string | Uint8Array) {
 		return FSHelpers.writeFile(this[__private__dont__use].FS, path, data);
 	}
@@ -982,7 +976,6 @@ export class PHP implements Disposable {
 	 * @param  mountable - The filesystem to mount.
 	 * @param  virtualFSPath - Where to mount it in the PHP virtual filesystem.
 	 */
-	@rethrowFileSystemError('Could not mount {path}')
 	async mount(virtualFSPath: string, mountable: Mountable) {
 		await mountable.mount(this[__private__dont__use].FS, virtualFSPath);
 	}

--- a/packages/php-wasm/universal/src/lib/rethrow-file-system-error.ts
+++ b/packages/php-wasm/universal/src/lib/rethrow-file-system-error.ts
@@ -116,7 +116,7 @@ export function rethrowFileSystemError(messagePrefix = '') {
 					typeof e === 'object' ? ((e as any)?.errno as any) : null;
 				if (errno in FileErrorCodes) {
 					const errmsg = FileErrorCodes[errno];
-					const path = typeof args[0] === 'string' ? args[0] : null;
+					const path = typeof args[1] === 'string' ? args[1] : null;
 					const formattedPrefix =
 						path !== null
 							? messagePrefix.replaceAll('{path}', path)

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -155,19 +155,3 @@ export interface PHPOutput {
 	/** Stderr lines */
 	stderr: string[];
 }
-
-export interface RmDirOptions {
-	/**
-	 * If true, recursively removes the directory and all its contents.
-	 * Default: true.
-	 */
-	recursive?: boolean;
-}
-
-export interface ListFilesOptions {
-	/**
-	 * If true, prepend given folder path to all file names.
-	 * Default: false.
-	 */
-	prependPath: boolean;
-}


### PR DESCRIPTION
## What is this PR doing?

Move the implementation of the Filesystem-related methods from the PHP class to a static FSHelpers class.

This is a non-breaking change. The PHP class still has the same interface, it just delegates all the calls to FSHelpers.

The following filesystem methods are affected:
   - readFileAsText
   - readFileAsBuffer 
   - writeFile
   - unlink
   - mv
   - rmdir
   - listFiles
   - isDir
   - fileExists
   - mkdir
   - copyRecursive

## Motivation

This sets the stage for OPFSMountHandle

We keep reimplementing similar logic in different places. This PR makes operations like recursive remove usable outside of the PHP class instance.

## Testing Instructions

confirm the ci checks pass