### PR TITLE
Include the admin kitchen sink for import

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -42,9 +42,8 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 	await playground.run({
 		code: `<?php
 		require ${phpVar(docroot)} . '/wp-load.php';
-		if ( ! function_exists( 'wp_crop_image' ) ) {
-			require ${phpVar(docroot)} . '/wp-admin/includes/image.php';
-		}
+		require ${phpVar(docroot)} . '/wp-admin/admin.php';
+  
 		kses_remove_filters();
 		$admin_id = get_users(array('role' => 'Administrator') )[0];
 		$importer = new WXR_Importer( array(

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -42,7 +42,7 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 	await playground.run({
 		code: `<?php
 		require ${phpVar(docroot)} . '/wp-load.php';
-		require ${phpVar(docroot)} . '/wp-admin/admin.php';
+		require ${phpVar(docroot)} . '/wp-admin/includes/admin.php';
   
 		kses_remove_filters();
 		$admin_id = get_users(array('role' => 'Administrator') )[0];


### PR DESCRIPTION
## What is this PR doing?

Similar to #1357, but taking a deeper cut at it, as import expects to be run within an admin interface.

## What problem is it solving?

The following fatal will be triggered:
```
PHP Fatal error:  Uncaught Error: Call to undefined function wp_read_audio_metadata() in /wordpress/wp-admin/includes/image.php:2
Stack trace:
#0 /wordpress/wp-content/plugins/WordPress-Importer-master/class-wxr-importer.php(1067): wp_generate_attachment_metadata(821, '/wordpress/wp-c...')
#1 /wordpress/wp-content/plugins/WordPress-Importer-master/class-wxr-importer.php(861): WXR_Importer->process_attachment(Array, Array, 'https://raw.git...')
#2 /wordpress/wp-content/plugins/WordPress-Importer-master/class-wxr-importer.php(383): WXR_Importer->process_post(Array, Array, Array, Array)
#3 /internal/eval.php(20): WXR_Importer->import('/tmp/import.wxr')
#4 {main}
  thrown in /wordpress/wp-admin/includes/image.php on line 2
```

Fixes #1444 (Since found this issue)

## How is the problem addressed?

Including includes/admin.php which pulls in all admin-related functionality, rather than just the cropping functionality.

Alternatively, this could've been done by selectively importing `includes/media.php` as well as `includes/image.php`, but I anticipate that core is likely to include other related admin functions.

## Testing Instructions

Note: This is an untested change.

Try running https://playground.wordpress.net/builder/builder.html#{%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%22latest%22},%22phpExtensionBundles%22:[%22kitchen-sink%22],%22features%22:{%22networking%22:true},%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22},{%22step%22:%22importWxr%22,%22file%22:{%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/WordPress/theme-test-data/try/cors-accessible-images/themeunittestdata.wordpress.xml%22}}]}