### PR TITLE
WXR Import: Import posts as correct user

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -46,7 +46,8 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 			require ${phpVar(docroot)} . '/wp-admin/includes/image.php';
 		}
 		kses_remove_filters();
-		$admin_id = get_users(array('role' => 'Administrator') )[0];
+		$admin_id = get_users(array('role' => 'Administrator') )[0]->ID;
+        wp_set_current_user( $admin_id );
 		$importer = new WXR_Importer( array(
 			'fetch_attachments' => true,
 			'default_author' => $admin_id


### PR DESCRIPTION
## What is this PR doing?

This attempts to set the correct user for WXR imports.

Reading the source for the WXR importer used, it appears `default_author` should be set to the ID of the user (not the WP_User) and will otherwise also be set to the current loaded user.

https://github.com/humanmade/WordPress-Importer/blob/140a53eb597de87d786cf942c8fe74fc97432f14/class-wxr-importer.php#L794-L807

## What problem is it solving?

Fixes #1446 Imports lack an author.

## How is the problem addressed?

Using the admin ID, and calling `wp_set_current_user()`.

## Testing Instructions

Note: This is an untested change.

Run the below playground, and verify if the imported post has an author set.

https://playground.wordpress.net/?mode=seamless#{%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%22latest%22},%22phpExtensionBundles%22:[%22kitchen-sink%22],%22features%22:{%22networking%22:true},%22landingPage%22:%22wp-admin/edit.php%22,%22steps%22:[{%22step%22:%22importWxr%22,%22file%22:{%22resource%22:%22url%22,%22url%22:%22https://raw.githubusercontent.com/x3p0-dev/assets/master/x3p0-ideas/site-content.xml%22}},{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22}]}
