### PR TITLE
Puzzle app: add analytics

### DIFF
--- a/packages/playground/puzzle/index.html
+++ b/packages/playground/puzzle/index.html
@@ -12,6 +12,18 @@
 		<link rel="apple-touch-icon" href="/logo192.png" />
 		<link rel="manifest" href="/manifest.json" />
 		<title>WordPress Playground</title>
+		<script
+			async
+			src="https://www.googletagmanager.com/gtag/js?id=G-SVTNFCP8T7"
+		></script>
+		<script>
+			window.dataLayer = window.dataLayer || [];
+			function gtag() {
+				dataLayer.push(arguments);
+			}
+			gtag('js', new Date());
+			gtag('config', 'G-SVTNFCP8T7');
+		</script>
 	</head>
 
 	<body>

--- a/packages/playground/puzzle/src/site-builder/blueprints/elementor.json
+++ b/packages/playground/puzzle/src/site-builder/blueprints/elementor.json
@@ -20,16 +20,6 @@
 			"options": {
 				"activate": true
 			}
-		},
-		{
-			"step": "installPlugin",
-			"pluginZipFile": {
-				"resource": "wordpress.org/plugins",
-				"slug": "image-optimization"
-			},
-			"options": {
-				"activate": true
-			}
 		}
 	]
 }


### PR DESCRIPTION
## Motivation for the change, related issues

We need to measure how successful was the puzzle app at promoting Playground during WCEU.
To do this we are adding Google Analytics.

We also had to remove the image-optimizer plugin from a blueprint because Playground doesn't support Exif.

## Implementation details

## Testing Instructions (or ideally a Blueprint)
