### PR TITLE
Ensure all logs are visible in the log modal

### DIFF
--- a/packages/php-wasm/logger/src/lib/handlers/log-event.ts
+++ b/packages/php-wasm/logger/src/lib/handlers/log-event.ts
@@ -1,0 +1,13 @@
+import { LogHandler } from '../log-handlers';
+import { Log, logger } from '../logger';
+
+export const logEvent: LogHandler = (log: Log, ...args: any[]): void => {
+	logger.dispatchEvent(
+		new CustomEvent('playground-log', {
+			detail: {
+				log,
+				args,
+			},
+		})
+	);
+};

--- a/packages/php-wasm/logger/src/lib/handlers/log-event.ts
+++ b/packages/php-wasm/logger/src/lib/handlers/log-event.ts
@@ -1,9 +1,11 @@
 import { LogHandler } from '../log-handlers';
 import { Log, logger } from '../logger';
 
+export const logEventType = 'playground-log';
+
 export const logEvent: LogHandler = (log: Log, ...args: any[]): void => {
 	logger.dispatchEvent(
-		new CustomEvent('playground-log', {
+		new CustomEvent(logEventType, {
 			detail: {
 				log,
 				args,

--- a/packages/php-wasm/logger/src/lib/logger.ts
+++ b/packages/php-wasm/logger/src/lib/logger.ts
@@ -1,6 +1,8 @@
 import { logEvent } from './handlers/log-event';
 import { logToMemory, logToConsole, logs } from './log-handlers';
 
+export { logEventType } from './handlers/log-event';
+
 export type Log = {
 	message: any;
 	severity?: LogSeverity;

--- a/packages/php-wasm/logger/src/lib/logger.ts
+++ b/packages/php-wasm/logger/src/lib/logger.ts
@@ -1,3 +1,4 @@
+import { logEvent } from './handlers/log-event';
 import { logToMemory, logToConsole, logs } from './log-handlers';
 
 export type Log = {
@@ -154,12 +155,12 @@ export class Logger extends EventTarget {
 const getDefaultHandlers = () => {
 	try {
 		if (process.env['NODE_ENV'] === 'test') {
-			return [logToMemory];
+			return [logToMemory, logEvent];
 		}
 	} catch (e) {
 		// Process.env is not available in the browser
 	}
-	return [logToMemory, logToConsole];
+	return [logToMemory, logToConsole, logEvent];
 };
 
 /**

--- a/packages/php-wasm/logger/src/test/logger.spec.ts
+++ b/packages/php-wasm/logger/src/test/logger.spec.ts
@@ -1,8 +1,7 @@
-import { Logger } from '../lib/logger';
-import { clearMemoryLogs, logToMemory } from '../lib/log-handlers';
+import { logger } from '../lib/logger';
+import { clearMemoryLogs } from '../lib/log-handlers';
 
 describe('Logger', () => {
-	const logger = new Logger([logToMemory]);
 	beforeEach(async () => {
 		clearMemoryLogs();
 	});
@@ -14,5 +13,12 @@ describe('Logger', () => {
 		expect(logs[0]).toMatch(
 			/\[\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2} UTC\] JavaScript Warn: test/
 		);
+	});
+
+	it('Log event should be dispatched', () => {
+		const eventListener = vitest.fn();
+		logger.addEventListener('playground-log', eventListener);
+		logger.warn('test');
+		expect(eventListener).toHaveBeenCalled();
 	});
 });

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import Modal from '../modal';
-import { logger } from '@php-wasm/logger';
+import { logEventType, logger } from '@php-wasm/logger';
 
 import css from './style.module.css';
 
@@ -22,9 +22,9 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 
 	useEffect(() => {
 		getLogs();
-		logger.addEventListener('playground-log', getLogs);
+		logger.addEventListener(logEventType, getLogs);
 		return () => {
-			logger.removeEventListener('playground-log', getLogs);
+			logger.removeEventListener(logEventType, getLogs);
 		};
 	}, [activeModal]);
 

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -20,7 +20,13 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	const [logs, setLogs] = useState<string[]>([]);
 	const [searchTerm, setSearchTerm] = useState('');
 
-	useEffect(getLogs, [activeModal]);
+	useEffect(() => {
+		getLogs();
+		logger.addEventListener('playground-log', getLogs);
+		return () => {
+			logger.removeEventListener('playground-log', getLogs);
+		};
+	}, [activeModal]);
 
 	function getLogs() {
 		setLogs(logger.getLogs());


### PR DESCRIPTION
## Motivation for the change, related issues

The log modal shows only log messages that are available during the first render but we need to show all messages, even if they are created after the logger is loaded.

For example, if a blueprint fails the logger will open automatically, but the PHP error that caused the issue will be pulled after the logger is visible. This doesn't give full context to the user and makes debugging harder. 

[Related Slack thread](https://wordpress.slack.com/archives/C04EWKGDJ0K/p1715153555183729)

## Implementation details

This PR adds a new log handler that sends a custom event on every new log entry.

The log modal is updated to listen for this event and reload logs. 

## Testing Instructions (or ideally a Blueprint)

- Checkout this branch
- Open [this Playground url](http://localhost:5400/website-server/#{%20%22landingPage%22:%20%22/wp-admin/admin.php?wt_gc_tab=wt-woocommerce-gift-cards_gift_card-product_tab&page=wt-woocommerce-gift-cards%22,%20%22preferredVersions%22:%20{%20%22php%22:%20%227.4%22,%20%22wp%22:%20%226.4%22%20},%20%22phpExtensionBundles%22:%20[%20%22kitchen-sink%22%20],%20%22features%22:%20{%20%22networking%22:%20true%20},%20%22steps%22:%20[%20{%20%22step%22:%20%22login%22,%20%22username%22:%20%22admin%22,%20%22password%22:%20%22password%22%20},%20{%20%22step%22:%20%22installPlugin%22,%20%22pluginZipFile%22:%20{%20%22resource%22:%20%22wordpress.org/plugins%22,%20%22slug%22:%20%22woocommerce%22%20},%20%22options%22:%20{%20%22activate%22:%20true%20}%20},%20{%20%22step%22:%20%22setSiteOptions%22,%20%22options%22:%20{%20%22woocommerce_currency%22:%20%22USD%22%20}%20},%20{%20%22step%22:%20%22installPlugin%22,%20%22pluginZipFile%22:%20{%20%22resource%22:%20%22wordpress.org/plugins%22,%20%22slug%22:%20%22wt-gift-cards-woocommerce%22%20},%20%22options%22:%20{%20%22activate%22:%20true%20}%20},%20{%20%22step%22:%20%22runPHP%22,%20%22code%22:%20%22%3C?php%20include%20'wordpress/wp-load.php';%20delete_transient(%20'_wc_activation_redirect'%20);%22%20}%20]%20})
- Confirm that a message like `PHP Fatal error: Uncaught Error: Call to undefined function wp_tempnam()` exists
