### PR TITLE
Add inline comment next to Emscripten version as reminder to upgrade PHP libraries

### DIFF
--- a/packages/php-wasm/compile/base-image/Dockerfile
+++ b/packages/php-wasm/compile/base-image/Dockerfile
@@ -36,6 +36,9 @@ RUN set -euxo pipefail;\
 # Install Emscripten from the repository. We'd use the official
 # Docker image, but there is no arm64 image available which makes
 # the build take forever on Apple Silicon.
+# 
+# When upgrading the Emscripten version, remember to build the PHP libraries before recompiling PHP versions.
+# Reference: https://github.com/WordPress/wordpress-playground/tree/trunk/packages/php-wasm/compile#libraries
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN git clone https://github.com/emscripten-core/emsdk.git && \
     ./emsdk/emsdk install 3.1.61 && \

--- a/packages/php-wasm/compile/base-image/Dockerfile
+++ b/packages/php-wasm/compile/base-image/Dockerfile
@@ -37,8 +37,17 @@ RUN set -euxo pipefail;\
 # Docker image, but there is no arm64 image available which makes
 # the build take forever on Apple Silicon.
 # 
-# When upgrading the Emscripten version, remember to build the PHP libraries before recompiling PHP versions.
-# Reference: https://github.com/WordPress/wordpress-playground/tree/trunk/packages/php-wasm/compile#libraries
+# ---- IMPORTANT ----
+# When upgrading the Emscripten version, you will need to rebuild all the WebAssembly libraries
+# shipped in this repository before you can rebuild PHP itself. The entire build, including every
+# linked lib, must be produced by the same Emscripten version – otherwise you'll run into undefined
+# behaviors and indeterministic failures like we did in these two PRs:
+# 
+# * https://github.com/WordPress/wordpress-playground/pull/1471
+# * https://github.com/WordPress/wordpress-playground/pull/1339
+# 
+# WASM libraries to rebuild live here:
+# https://github.com/WordPress/wordpress-playground/tree/67d916b5eccfe78e26e9c953598cc1a81f316931/packages/php-wasm/compile
 RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN git clone https://github.com/emscripten-core/emsdk.git && \
     ./emsdk/emsdk install 3.1.61 && \


### PR DESCRIPTION
## Motivation for the change, related issues

This PR is related to [this comment](https://github.com/WordPress/wordpress-playground/pull/1471#issuecomment-2153402411) regarding adding a note when upgrading the Emscripten version.

## Implementation details

- Add inline comment to `base-image` `Dockerfile`.

## Testing Instructions (or ideally a Blueprint)
N/A
