### PR TITLE
Networking access: Fix wp_http_supports() to work without the kitchen-sink extension bundle.

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -99,7 +99,7 @@ add_action('admin_print_scripts', function () {
  * This mu-plugin provides that transport. It's one of the two:
  *
  * * WP_Http_Fetch – Sends requests using browser's fetch() function.
- * * Requests_Transport_Dummy – Does not send any requests and only exists to keep
+ * * WP_Http_Dummy – Does not send any requests and only exists to keep
  * 								the Requests class happy.
  */
 $__requests_class = class_exists( '\WpOrg\Requests\Requests' ) ? '\WpOrg\Requests\Requests' : 'Requests';
@@ -107,11 +107,19 @@ if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 	require(__DIR__ . '/playground-includes/wp_http_fetch.php');
 	/**
 	 * Force the Fetch transport to be used in Requests.
-	 * The 'http_api_transports' filter was deprecated, and is no longer actively in use.
 	 */
 	add_action( 'requests-requests.before_request', function( $url, $headers, $data, $type, &$options ) {
 		$options['transport'] = 'Wp_Http_Fetch';
 	}, 10, 5 );
+
+	/**
+	 * Force wp_http_supports() to work, which uses deprecated WP_HTTP methods.
+	 * This filter is deprecated, and no longer actively used, but is needed for wp_http_supports().
+	 * @see https://core.trac.wordpress.org/ticket/37708
+	 */
+	add_filter('http_api_transports', function() {
+		return [ 'Fetch' ];
+	});
 
 	/**
 	 * Disable signature verification as it doesn't seem to work with
@@ -137,6 +145,10 @@ if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 	add_action( 'requests-requests.before_request', function( $url, $headers, $data, $type, &$options ) {
 		$options['transport'] = 'Wp_Http_Dummy';
 	}, 10, 5 );
+
+	add_filter('http_api_transports', function() {
+		return [ 'Dummy' ];
+	});
 }
 
 ?>

--- a/packages/playground/website/cypress/e2e/query-api.cy.ts
+++ b/packages/playground/website/cypress/e2e/query-api.cy.ts
@@ -85,9 +85,12 @@ describe('Query API', () => {
 
 		/**
 		 * @see https://github.com/WordPress/wordpress-playground/pull/1045
+		 * @see https://github.com/WordPress/wordpress-playground/pull/1504
 		 */
-		it('should enable networking when requested AND the kitchen sink extension bundle is enabled', () => {
-			cy.visit('/?networking=yes&url=/wp-admin/plugin-install.php');
+		it('should enable networking when requested AND the kitchen sink extension bundle is NOT enabled', () => {
+			cy.visit(
+				'/?networking=yes&php-extension-bundle=light&url=/wp-admin/plugin-install.php'
+			);
 			cy.wordPressDocument()
 				.find('.plugin-card')
 				.should('have.length.above', 4);
@@ -104,6 +107,7 @@ describe('Query API', () => {
 				features: {
 					networking: true,
 				},
+				phpExtensionBundles: ['light'],
 				steps: [
 					{
 						step: 'writeFile',


### PR DESCRIPTION
Fixes #1494 

In #1048 I introduced a regression of #819, in that `wp_http_supports( [ 'ssl' ] )` no longer returned truthful without the kitchen-sink extension bundle loaded.

This partially reverts #1048 by keeping the filters for Requests, but reinstating the deprecated WP_HTTP filters.

It's worth noting, that this is not a direct revert, as it forces the Fetch/Dummy handlers instead of simply adding them as an option. This is to match the Requests filter behaviour.

To test this, the following blueprint should land you on a plugin install page without any errors visible:
https://playground.wordpress.net/#{%22phpExtensionBundles%22:[%22light%22],%22features%22:{%22networking%22:true},%22landingPage%22:%22/wp-admin/plugin-install.php%22,%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22}]}
```
{
  "phpExtensionBundles": [
    "light"
  ],
  "features": {
    "networking": true
  },
  "landingPage": "/wp-admin/plugin-install.php",
  "steps": [
    {
      "step": "login",
      "username": "admin",
      "password": "password"
    }
  ]
}
```