### PR TITLE
Update remaining localhost:5400 refs to 127.0.0.1:5400

### DIFF
--- a/packages/docs/site/docs/13-contributing/02-code.md
+++ b/packages/docs/site/docs/13-contributing/02-code.md
@@ -63,7 +63,7 @@ npx @wp-now/wp-now start --port=80
 There are a few ways to set up a local test domain, including editing your `hosts` file. If you're unsure how to do that, we suggest installing [Laravel Valet](https://laravel.com/docs/11.x/valet) and then running the following command:
 
 ```bash
-valet proxy playground.test http://localhost:5400 --secure
+valet proxy playground.test http://127.0.0.1:5400 --secure
 ```
 
 Your dev server is now available on https://playground.test.

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -385,7 +385,7 @@ RUN set -euxo pipefail; \
 		# Without this, browsers will try the wasm:// protocol and never load the source map.
 		if [ "$EMSCRIPTEN_ENVIRONMENT" = "web" ]; then \
 			export PHP_VERSION_ESCAPED="${PHP_VERSION//./_}"; \
-			echo -n ' --source-map-base http://localhost:5400/@fs/Users/cloudnik/www/Automattic/core/plugins/playground/packages/php-wasm/web/public/${PHP_VERSION_ESCAPED}/' >> /root/.emcc-php-wasm-flags; \
+			echo -n ' --source-map-base http://127.0.0.1:5400/@fs/Users/cloudnik/www/Automattic/core/plugins/playground/packages/php-wasm/web/public/${PHP_VERSION_ESCAPED}/' >> /root/.emcc-php-wasm-flags; \
 		fi; \
 	else \
 		# Preserve symbol names in node.js build – the bundle size doesn't matter as much

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -62,10 +62,10 @@
 			http-equiv="origin-trial"
 			content="At8dRmIsdzok7mB3xOCPtkm0HiJMZXwA2la1NXriF4+YT5RNkiOS4Tr31Q3Gj0L5jiI2tmMgFlSUyn41+zVbBAsAAABreyJvcmlnaW4iOiJodHRwczovL3dhc20ud29yZHByZXNzLm5ldDo0NDMiLCJmZWF0dXJlIjoiV2ViQXNzZW1ibHlKU1Byb21pc2VJbnRlZ3JhdGlvbiIsImV4cGlyeSI6MTczMDI0NjM5OX0="
 		/>
-		<!-- http://localhost:5400 -->
+		<!-- http://127.0.0.1:5400 -->
 		<meta
 			http-equiv="origin-trial"
-			content="Au01PU8vga2vhf0HqDJ50lWwIEg6FEQ1H4aJofnGlGlHyoSMvPmauo+IiVd10IzmL3Am3J/gHPUnQwT/3DEp7QAAAABieyJvcmlnaW4iOiJodHRwOi8vbG9jYWxob3N0OjU0MDAiLCJmZWF0dXJlIjoiV2ViQXNzZW1ibHlKU1Byb21pc2VJbnRlZ3JhdGlvbiIsImV4cGlyeSI6MTczMDI0NjM5OX0="
+			content="AuaTDZHAurglQMyJxoG2y5wufZyTwb9EC/7N2Gs4duBC2yR1DLRKKWEuxsg4kQR8lzc7elbKzYxN0TAlvJS9PAwAAABieyJvcmlnaW4iOiJodHRwOi8vMTI3LjAuMC4xOjU0MDAiLCJmZWF0dXJlIjoiV2ViQXNzZW1ibHlKU1Byb21pc2VJbnRlZ3JhdGlvbiIsImV4cGlyeSI6MTczMDI0NjM5OX0="
 		/>
 	</head>
 	<body class="is-loading">

--- a/packages/playground/website/demos/php-blueprints.ts
+++ b/packages/playground/website/demos/php-blueprints.ts
@@ -77,7 +77,7 @@ try {
 		 * > "check-requirements": false,
 		 * Then requiring it breaks http and https requests:
 		 *
-		 * > echo file_get_contents('http://localhost:5400/website-server/');
+		 * > echo file_get_contents('http://127.0.0.1:5400/website-server/');
 		 * > <b>Warning</b>:  PHP Request Startup: Failed to open stream: Operation timed out in <b>php-wasm run script</b> on line <b>13</b><br />
 		 *
 		 * The check is therefore disabled for now.


### PR DESCRIPTION
## Motivation for the change, related issues

There are some code and documentation references that still point to `localhost:5400` for dev even though the correct address is now `127.0.0.1:5400`.

## Implementation details

This updates the plaintext references to `127.0.0.1:5400` and also updates the JSPI origintrial string to reference the correct address. I tested this update with the `jspi` branch, and the dev server running on the `jspi` branch loads in Chrome but only after this change.

## Testing Instructions (or ideally a Blueprint)

- CI