### PR TITLE
Networking: Remove CORS workarounds for WordPress.org API.

### DIFF
--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -74,19 +74,6 @@ export async function handleRequest(data: RequestData, fetchFn = fetch) {
 		const fetchHeaders = data.headers || {};
 		if (fetchMethod == 'POST') {
 			fetchHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
-
-			/**
-			 * Removes a few custom request headers.
-			 *
-			 * This is required because the fetch API will send a CORS preflight
-			 * request if the request is cross-origin and has custom headers.
-			 *
-			 * However, the api.wordpress.org/core/version-check/1.7/ endpoint
-			 * doesn't support CORS preflight requests. These two headers
-			 * aren't critical to the request, so we can just remove them.
-			 */
-			delete fetchHeaders['wp_install'];
-			delete fetchHeaders['wp_blog'];
 		}
 
 		response = await fetchFn(fetchUrl, {


### PR DESCRIPTION
## Motivation for the change, related issues

api.WordPress.org/core/version-check now supports preflight requests, and so we can remove these header deletions that was to resolve CORS issues

See #933 for where this was added.

## Testing Instructions (or ideally a Blueprint)

The following blueprint should not have a CORS fetch failure in browser console.

https://playground.wordpress.net/?mode=seamless#{%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%226.5%22},%22phpExtensionBundles%22:[%22kitchen-sink%22],%22features%22:{%22networking%22:true},%22landingPage%22:%22/wp-admin/update-core.php%22,%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22}]}