### PR TITLE
Remove trailing semicolon from example URL for loading playground with network access

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -43,7 +43,7 @@ function networking_disabled() {
 	$networking_err_msg = '<div class="networking_err_msg">Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85" target="_blank">experimental, opt-in feature</a>, which means you need to enable it to allow Playground to access the Plugins/Themes directories.
 	<p>There are two alternative methods to enable global networking support:</p>
 	<ol>
-	<li>Using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a>: for example, https://playground.wordpress.net/<em>?networking=yes</em>; <strong>or</strong>
+	<li>Using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a>: for example, https://playground.wordpress.net/<em>?networking=yes</em> <strong>or</strong>
 	<li> Using the <a href="https://wordpress.github.io/wordpress-playground/blueprints-api/data-format/#features">Blueprint API</a>: add <code>"features": { "networking": true }</code> to the JSON file.
 	</li></ol>
 	<p>


### PR DESCRIPTION
It can be confusing if one attempts to copypaste that line for reloading the page as the value for `networking` ends up being `yes;`


### After
![image](https://github.com/WordPress/wordpress-playground/assets/746152/65fd2087-5e85-483f-bd1c-164cebe57e91)



### Before

<img width="1003" alt="image" src="https://github.com/WordPress/wordpress-playground/assets/746152/adf04f97-b7df-4ead-a2e1-52629f9b54fb">


## Motivation for the change, related issues

While showcasing Playground during WCEU, I found myself failing to install plugins after copy-pasting the proposed URL until I realized I was copying an unintended semicolon. 

## Implementation details

## Testing Instructions (or ideally a Blueprint)

