### PR TITLE
Playground CLI: add mountAfterBlueprint option

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -81,6 +81,12 @@ async function run() {
 			type: 'array',
 			string: true,
 		})
+		.option('mountAfterBlueprint', {
+			describe:
+				'Mount a directory to the PHP runtime after the Blueprint has been ran. You can provide --mount-after-blueprint multiple times. Format: /host/path:/vfs/path',
+			type: 'array',
+			string: true,
+		})
 		.option('login', {
 			describe: 'Should log the user in',
 			type: 'boolean',
@@ -334,6 +340,10 @@ async function run() {
 				} finally {
 					reap();
 				}
+			}
+
+			if (args.mountAfterBlueprint) {
+				mountResources(php, args.mountAfterBlueprint);
 			}
 
 			if (command === 'build-snapshot') {


### PR DESCRIPTION
This PR adds a `mountAfterBlueprint` option to Playground CLI to enable mounting directories after the Blueprint has finished running.

 ## Motivation

🚧  TBD 🚧 

 ## Examples

```shell
npx @wp-playground/cli --mount-after-blueprint=./uploads:/wordpress/wp-content/uploads

```

## Motivation for the change, related issues

## Implementation details

## Testing Instructions (or ideally a Blueprint)
