### PR TITLE
Hash website build so service worker can detect changes

### DIFF
--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -19,6 +19,7 @@
 					"cp -r ./client ./wasm-wordpress-net/",
 					"cp -r ./remote/* ./wasm-wordpress-net/",
 					"cp -r ./website/* ./wasm-wordpress-net/",
+					"find ./website -type f -print0 | sort -z | xargs -r0 md5sum | md5sum > ./wasm-wordpress-net/website.md5",
 					"cat ./remote/.htaccess ./website/.htaccess > ./wasm-wordpress-net/.htaccess",
 					"curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > wasm-wordpress-net/wp-cli.phar",
 					"cat wasm-wordpress-net/wp-cli.phar | gzip -c -9 > wasm-wordpress-net/wp-cli.phar.gz"


### PR DESCRIPTION
## Motivation for the change, related issues

We need some way to detect whether the app has been updated since we last cached app resources. This may not be the way, but it can kick off discussion. This PR starts by adding the website hash to a standalone file, but to avoid a network request, we may prefer to embed it in a file like the service worker script. cc @bgrgicak @adamziel 

Related to #133

## Implementation details

We need to decide where to put the hash.

The hash itself is derived from a list of hashes of all website files sorted by path.

## Testing Instructions (or ideally a Blueprint)

TBD