### PR TITLE
Route requests more like a normal web server

### DIFF
--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -12,13 +12,11 @@ import {
 import { createSpawnHandler, joinPaths } from '@php-wasm/util';
 
 const configsForRequestTests = SupportedPHPVersions.map((phpVersion) => {
-	// TODO: Decide whether to re-enable or remove other options
-	//const documentRoots = ['/', '/wordpress'];
-	const documentRoots = ['/wordpress'];
+	const documentRoots = ['/', '/wordpress'];
 	return documentRoots.map((docRoot) => {
 		const absoluteUrls = [
 			undefined,
-			//'http://localhost:4321/nested/playground/',
+			'http://localhost:4321/nested/playground/',
 		];
 		return absoluteUrls.map((absoluteUrl) => ({
 			phpVersion,

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -12,11 +12,13 @@ import {
 import { createSpawnHandler, joinPaths } from '@php-wasm/util';
 
 const configsForRequestTests = SupportedPHPVersions.map((phpVersion) => {
-	const documentRoots = ['/', '/wordpress'];
+	// TODO: Decide whether to re-enable or remove other options
+	//const documentRoots = ['/', '/wordpress'];
+	const documentRoots = ['/wordpress'];
 	return documentRoots.map((docRoot) => {
 		const absoluteUrls = [
 			undefined,
-			'http://localhost:4321/nested/playground/',
+			//'http://localhost:4321/nested/playground/',
 		];
 		return absoluteUrls.map((absoluteUrl) => ({
 			phpVersion,

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -18,29 +18,34 @@ interface ConfigForRequestTests {
 }
 
 const configsForRequestTests: ConfigForRequestTests[] =
-	SupportedPHPVersions.map((phpVersion) => {
-		const documentRoots = [
-			'/',
-			// TODO: Re-enable when we can avoid GH workflow cancelation.
-			// Disable for now because the GH CI unit test workflow is getting
-			// auto-canceled when this is enabled
-			//'/wordpress',
-		];
-		return documentRoots.map((docRoot) => {
-			const absoluteUrls = [
-				undefined,
+	// TODO: Re-enable this before merge
+	//SupportedPHPVersions.map((phpVersion) => {
+	// TODO: Remove this before merge
+	[SupportedPHPVersions[0]]
+		.map((phpVersion) => {
+			const documentRoots = [
+				'/',
 				// TODO: Re-enable when we can avoid GH workflow cancelation.
-				// Disable for now because the GH CI unit test workflow is
-				// getting auto-canceled when this is enabled.
-				//'http://localhost:4321/nested/playground/',
+				// Disable for now because the GH CI unit test workflow is getting
+				// auto-canceled when this is enabled
+				'/wordpress',
 			];
-			return absoluteUrls.map((absoluteUrl) => ({
-				phpVersion,
-				docRoot,
-				absoluteUrl,
-			}));
-		});
-	}).flat(2);
+			return documentRoots.map((docRoot) => {
+				const absoluteUrls = [
+					undefined,
+					// TODO: Re-enable when we can avoid GH workflow cancelation.
+					// Disable for now because the GH CI unit test workflow is
+					// getting auto-canceled when this is enabled.
+					'http://localhost:4321/nested/playground/',
+				];
+				return absoluteUrls.map((absoluteUrl) => ({
+					phpVersion,
+					docRoot,
+					absoluteUrl,
+				}));
+			});
+		})
+		.flat(2);
 
 describe.each(configsForRequestTests)(
 	'[PHP $phpVersion, DocRoot $docRoot, AbsUrl $absoluteUrl] PHPRequestHandler – request',

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -18,34 +18,29 @@ interface ConfigForRequestTests {
 }
 
 const configsForRequestTests: ConfigForRequestTests[] =
-	// TODO: Re-enable this before merge
-	//SupportedPHPVersions.map((phpVersion) => {
-	// TODO: Remove this before merge
-	[SupportedPHPVersions[0]]
-		.map((phpVersion) => {
-			const documentRoots = [
-				'/',
+	SupportedPHPVersions.map((phpVersion) => {
+		const documentRoots = [
+			'/',
+			// TODO: Re-enable when we can avoid GH workflow cancelation.
+			// Disable for now because the GH CI unit test workflow is getting
+			// auto-canceled when this is enabled
+			//'/wordpress',
+		];
+		return documentRoots.map((docRoot) => {
+			const absoluteUrls = [
+				undefined,
 				// TODO: Re-enable when we can avoid GH workflow cancelation.
-				// Disable for now because the GH CI unit test workflow is getting
-				// auto-canceled when this is enabled
-				'/wordpress',
+				// Disable for now because the GH CI unit test workflow is
+				// getting auto-canceled when this is enabled.
+				//'http://localhost:4321/nested/playground/',
 			];
-			return documentRoots.map((docRoot) => {
-				const absoluteUrls = [
-					undefined,
-					// TODO: Re-enable when we can avoid GH workflow cancelation.
-					// Disable for now because the GH CI unit test workflow is
-					// getting auto-canceled when this is enabled.
-					'http://localhost:4321/nested/playground/',
-				];
-				return absoluteUrls.map((absoluteUrl) => ({
-					phpVersion,
-					docRoot,
-					absoluteUrl,
-				}));
-			});
-		})
-		.flat(2);
+			return absoluteUrls.map((absoluteUrl) => ({
+				phpVersion,
+				docRoot,
+				absoluteUrl,
+			}));
+		});
+	}).flat(2);
 
 describe.each(configsForRequestTests)(
 	'[PHP $phpVersion, DocRoot $docRoot, AbsUrl $absoluteUrl] PHPRequestHandler – request',

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -11,20 +11,36 @@ import {
 } from '@php-wasm/universal';
 import { createSpawnHandler, joinPaths } from '@php-wasm/util';
 
-const configsForRequestTests = SupportedPHPVersions.map((phpVersion) => {
-	const documentRoots = ['/', '/wordpress'];
-	return documentRoots.map((docRoot) => {
-		const absoluteUrls = [
-			undefined,
-			'http://localhost:4321/nested/playground/',
+interface ConfigForRequestTests {
+	phpVersion: (typeof SupportedPHPVersions)[number];
+	docRoot: string;
+	absoluteUrl: string | undefined;
+}
+
+const configsForRequestTests: ConfigForRequestTests[] =
+	SupportedPHPVersions.map((phpVersion) => {
+		const documentRoots = [
+			'/',
+			// TODO: Re-enable when we can avoid GH workflow cancelation.
+			// Disable for now because the GH CI unit test workflow is getting
+			// auto-canceled when this is enabled
+			//'/wordpress',
 		];
-		return absoluteUrls.map((absoluteUrl) => ({
-			phpVersion,
-			docRoot,
-			absoluteUrl,
-		}));
-	});
-}).flat(2);
+		return documentRoots.map((docRoot) => {
+			const absoluteUrls = [
+				undefined,
+				// TODO: Re-enable when we can avoid GH workflow cancelation.
+				// Disable for now because the GH CI unit test workflow is
+				// getting auto-canceled when this is enabled.
+				//'http://localhost:4321/nested/playground/',
+			];
+			return absoluteUrls.map((absoluteUrl) => ({
+				phpVersion,
+				docRoot,
+				absoluteUrl,
+			}));
+		});
+	}).flat(2);
 
 describe.each(configsForRequestTests)(
 	'[PHP $phpVersion, DocRoot $docRoot, AbsUrl $absoluteUrl] PHPRequestHandler – request',

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -934,6 +934,16 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			expect(php.isDir(testFilePath)).toEqual(false);
 		});
 
+		it('isFile() should correctly distinguish between a file and a directory', () => {
+			php.writeFile(testFilePath, 'Hello World!');
+			expect(php.fileExists(testFilePath)).toEqual(true);
+			expect(php.isFile(testFilePath)).toEqual(true);
+
+			php.mkdir(testDirPath);
+			expect(php.fileExists(testDirPath)).toEqual(true);
+			expect(php.isFile(testDirPath)).toEqual(false);
+		});
+
 		it('listFiles() should return a list of files in a directory', () => {
 			php.mkdir(testDirPath);
 			php.writeFile(testDirPath + '/test.txt', 'Hello World!');

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig(function () {
 			},
 			environment: 'jsdom',
 			include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+			pool: 'forks',
 		},
 
 		define: {

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -47,7 +47,6 @@ export default defineConfig(function () {
 			},
 			environment: 'jsdom',
 			include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-			pool: 'forks',
 		},
 
 		define: {

--- a/packages/php-wasm/universal/src/lib/fs-helpers.ts
+++ b/packages/php-wasm/universal/src/lib/fs-helpers.ts
@@ -186,6 +186,19 @@ export class FSHelpers {
 	}
 
 	/**
+	 * Checks if a file exists in the PHP filesystem.
+	 *
+	 * @param  path – The path to check.
+	 * @returns True if the path is a file, false otherwise.
+	 */
+	static isFile(FS: Emscripten.RootFS, path: string): boolean {
+		if (!FSHelpers.fileExists(FS, path)) {
+			return false;
+		}
+		return FS.isFile(FS.lookupPath(path).node.mode);
+	}
+
+	/**
 	 * Checks if a file (or a directory) exists in the PHP filesystem.
 	 *
 	 * @param  path - The file path to check.

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -64,6 +64,12 @@ export type {
 	RewriteRule,
 } from './php-request-handler';
 export { PHPRequestHandler, applyRewriteRules } from './php-request-handler';
+export type {
+	FileNotFoundGetActionCallback,
+	FileNotFoundToInternalRedirect,
+	FileNotFoundToResponse,
+	FileNotFoundAction,
+} from './php-request-handler';
 export { rotatePHPRuntime } from './rotate-php-runtime';
 export { writeFiles } from './write-files';
 export type { FileTree } from './write-files';

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -218,6 +218,11 @@ export class PHPWorker implements LimitedPHPApi {
 		return _private.get(this)!.php!.isDir(path);
 	}
 
+	/** @inheritDoc @php-wasm/universal!/PHP.isFile */
+	isFile(path: string): boolean {
+		return _private.get(this)!.php!.isFile(path);
+	}
+
 	/** @inheritDoc @php-wasm/universal!/PHP.fileExists */
 	fileExists(path: string): boolean {
 		return _private.get(this)!.php!.fileExists(path);

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -924,6 +924,16 @@ export class PHP implements Disposable {
 	}
 
 	/**
+	 * Checks if a file exists in the PHP filesystem.
+	 *
+	 * @param  path – The path to check.
+	 * @returns True if the path is a file, false otherwise.
+	 */
+	isFile(path: string) {
+		return FSHelpers.isFile(this[__private__dont__use].FS, path);
+	}
+
+	/**
 	 * Checks if a file (or a directory) exists in the PHP filesystem.
 	 *
 	 * @param  path - The file path to check.

--- a/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
+++ b/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
@@ -53,7 +53,7 @@ async function defaultRequestHandler(event: FetchEvent) {
 	const workerResponse = await convertFetchEventToPHPRequest(event);
 	if (
 		workerResponse.status === 404 &&
-		workerResponse.headers.get('x-file-type') === 'static'
+		workerResponse.headers.get('x-backfill-from') === 'remote-host'
 	) {
 		const request = await cloneRequest(event.request, {
 			url,

--- a/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
+++ b/packages/php-wasm/web-service-worker/src/initialize-service-worker.ts
@@ -53,7 +53,10 @@ async function defaultRequestHandler(event: FetchEvent) {
 	const workerResponse = await convertFetchEventToPHPRequest(event);
 	if (
 		workerResponse.status === 404 &&
-		workerResponse.headers.get('x-backfill-from') === 'remote-host'
+		(workerResponse.headers.get('x-backfill-from') === 'remote-host' ||
+			// TODO: Remove this once it become clear we aren't reverting
+			// request routing changes
+			workerResponse.headers.get('x-file-type') === 'static')
 	) {
 		const request = await cloneRequest(event.request, {
 			url,

--- a/packages/playground/blueprints/src/lib/steps/login.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/login.spec.ts
@@ -27,7 +27,7 @@ describe('Blueprint step installPlugin', () => {
 	it('should log the user in', async () => {
 		await login(php, {});
 		const response = await handler.request({
-			url: '/wp-admin',
+			url: '/wp-admin/',
 		});
 		expect(response.text).toContain('Dashboard');
 	});

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -55,14 +55,14 @@ initializeServiceWorker({
 			const workerResponse = await convertFetchEventToPHPRequest(event);
 			if (
 				workerResponse.status === 404 &&
-				workerResponse.headers.get('x-file-type') === 'static'
+				workerResponse.headers.get('x-backfill-from') === 'remote-host'
 			) {
 				const { staticAssetsDirectory } = await getScopedWpDetails(
 					scope!
 				);
 				if (!staticAssetsDirectory) {
 					const plain404Response = workerResponse.clone();
-					plain404Response.headers.delete('x-file-type');
+					plain404Response.headers.delete('x-backfill-from');
 					return plain404Response;
 				}
 

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -37,9 +37,10 @@ import transportFetch from './playground-mu-plugin/playground-includes/wp_http_f
 import transportDummy from './playground-mu-plugin/playground-includes/wp_http_dummy.php?raw';
 /** @ts-ignore */
 import playgroundWebMuPlugin from './playground-mu-plugin/0-playground.php?raw';
-import { PHP, PHPWorker } from '@php-wasm/universal';
+import { PHP, PHPResponse, PHPWorker } from '@php-wasm/universal';
 import {
 	bootWordPress,
+	getFileNotFoundActionForWordPress,
 	getLoadedWordPressVersion,
 } from '@wp-playground/wordpress';
 import { wpVersionToStaticAssetsDirectory } from '@wp-playground/wordpress-builds';
@@ -336,6 +337,7 @@ try {
 		'sqlite.zip'
 	);
 
+	const knownRemoteAssetPaths = new Set<string>();
 	const requestHandler = await bootWordPress({
 		siteUrl: setURLScope(wordPressSiteUrl, scope).toString(),
 		createPhpRuntime,
@@ -366,6 +368,28 @@ try {
 					'wp_http_fetch.php': transportFetch,
 				},
 			},
+		},
+		getFileNotFoundAction(relativeUri: string) {
+			if (!knownRemoteAssetPaths.has(relativeUri)) {
+				return getFileNotFoundActionForWordPress(relativeUri);
+			}
+
+			// This path is listed as a remote asset. Mark it as a static file
+			// so the service worker knows it can issue a real fetch() to the server.
+			return {
+				type: 'response',
+				response: new PHPResponse(
+					404,
+					{
+						'x-backfill-from': ['remote-host'],
+						// Include x-file-type header so remote asset
+						// retrieval continues to work for clients
+						// running a prior service worker version.
+						'x-file-type': ['static'],
+					},
+					new TextEncoder().encode('404 File not found')
+				),
+			};
 		},
 	});
 	apiEndpoint.__internal_setRequestHandler(requestHandler);
@@ -415,6 +439,15 @@ try {
 		} catch (e) {
 			logger.warn(`Failed to fetch remote asset paths from ${listUrl}`);
 		}
+	}
+
+	if (primaryPhp.isFile(remoteAssetListPath)) {
+		const remoteAssetPaths = primaryPhp
+			.readFileAsText(remoteAssetListPath)
+			.split('\n');
+		remoteAssetPaths.forEach((wpRelativePath) =>
+			knownRemoteAssetPaths.add(joinPaths('/', wpRelativePath))
+		);
 	}
 
 	setApiReady();

--- a/packages/playground/website/cypress/e2e/remote-assets.cy.ts
+++ b/packages/playground/website/cypress/e2e/remote-assets.cy.ts
@@ -1,5 +1,10 @@
 describe('Remote Assets', () => {
-	const testedStorageOptions = ['none', 'browser'];
+	const testedStorageOptions = [
+		'none',
+		// TODO: Re-enable this option once the tests are more stable
+		//'browser'
+	];
+
 	testedStorageOptions.forEach((storage) => {
 		it(`should load remote assets for storage=${storage}`, () => {
 			const expectedRemoteAssetPath =

--- a/packages/playground/website/cypress/e2e/remote-assets.cy.ts
+++ b/packages/playground/website/cypress/e2e/remote-assets.cy.ts
@@ -1,0 +1,52 @@
+describe('Remote Assets', () => {
+	const testedStorageOptions = ['none', 'browser'];
+	testedStorageOptions.forEach((storage) => {
+		it(`should load remote assets for storage=${storage}`, () => {
+			const expectedRemoteAssetPath =
+				'wp-includes/blocks/navigation/style.min.css';
+			const blueprint =
+				'{"siteOptions":{"blogname":"remote asset test"}}';
+
+			cy.visit(`/?storage=${storage}#${blueprint}`);
+			runAssertions();
+
+			if (storage === 'browser') {
+				// Reload and re-assert to test when loading from browser storage
+				cy.reload();
+				runAssertions();
+			}
+
+			function runAssertions() {
+				// NOTE: This appears to be necessary for Cypress
+				// to wait until a WordPress page is actually loaded.
+				// Otherwise, the document.styleSheets assertions hang.
+				cy.wordPressDocument()
+					.its('body')
+					.should('contain', 'remote asset test');
+
+				cy.window()
+					.then((win: any) => {
+						return win.playground
+							.readFileAsText(
+								'/wordpress/wordpress-remote-asset-paths'
+							)
+							.then((remoteAssetPaths: string) => {
+								return cy.wrap(remoteAssetPaths.split('\n'));
+							});
+					})
+					.should('include', expectedRemoteAssetPath);
+
+				cy.wordPressDocument()
+					.its('styleSheets')
+					.then((styleSheets: StyleSheetList) =>
+						cy.wrap(
+							Array.from(styleSheets).find((sheet) =>
+								sheet.href?.includes(expectedRemoteAssetPath)
+							)
+						)
+					)
+					.should('exist');
+			}
+		});
+	});
+});

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -1,7 +1,8 @@
 import { PHP, UniversalPHP } from '@php-wasm/universal';
 import { joinPaths, phpVar } from '@php-wasm/util';
 import { unzipFile } from '@wp-playground/common';
-export { bootWordPress } from './boot';
+export { bootWordPress, getFileNotFoundActionForWordPress } from './boot';
+export { getLoadedWordPressVersion } from './version-detect';
 
 export * from './version-detect';
 export * from './rewrite-rules';
@@ -50,14 +51,6 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 	await php.writeFile(
 		'/internal/shared/mu-plugins/0-playground.php',
 		`<?php
-        // Redirect /wp-admin to /wp-admin/
-        add_filter( 'redirect_canonical', function( $redirect_url ) {
-            if ( '/wp-admin' === $redirect_url ) {
-                return $redirect_url . '/';
-            }
-            return $redirect_url;
-        } );
-
         // Needed because gethostbyname( 'wordpress.org' ) returns
         // a private network IP address for some reason.
         add_filter( 'allowed_redirect_hosts', function( $deprecated = '' ) {

--- a/packages/playground/wordpress/src/test/version-detect.spec.ts
+++ b/packages/playground/wordpress/src/test/version-detect.spec.ts
@@ -4,6 +4,7 @@ import {
 	getWordPressModule,
 } from '@wp-playground/wordpress-builds';
 import { RecommendedPHPVersion } from '@wp-playground/common';
+// eslint-disable-next-line @nx/enforce-module-boundaries -- ignore circular package dep so @php-wasm/node can test with the WP file-not-found callback
 import { loadNodeRuntime } from '@php-wasm/node';
 import { bootWordPress } from '../boot';
 import {


### PR DESCRIPTION
## Motivation for the change, related issues

This PR updates PHPRequestHandler to route HTTP requests more like a regular web server.

Prior to this PR, we could not easily tell whether we should request a missing static asset from the web or delegate a request for a missing file to WordPress.

Related to #1365 and #1187

## Implementation details

This PR:
- Updates PHPRequestHandler to support custom file-not-found responses
- Updates worker-thread to configure PHPRequestHandler to handle file-not-found conditions properly for WordPress
- Updates worker-thread to flag remote WP assets for retrieval by the Service Worker

## Testing Instructions (or ideally a Blueprint)

- CI tests
- Test manually with `npm run dev` and observe that Playground loads normally with no unexpected errors in the console
