### PR TITLE
Autopublish npm packages every week

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -12,6 +12,9 @@ on:
                 description: 'Dist tag (latest, next, etc.)'
                 required: false
                 default: 'latest'
+    schedule:
+        # Auto-publish every Monday
+        - cron: '0 9 * * 1'
 
 jobs:
     release:
@@ -52,4 +55,4 @@ jobs:
             # Version bump, release, tag a new version on GitHub
             - name: Release new version of NPM packages
               shell: bash
-              run: npx lerna@6.6.2 publish ${{ inputs.version_bump }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag }}
+              run: npx lerna@6.6.2 publish ${{ inputs.version_bump || "patch" }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || "latest" }}


### PR DESCRIPTION
## Motivation for the change, related issues

Publishes Playground packages every week to enable integrators to stay on top of the latest changes.

The manual "publish when needed" approach we've used so far is no longer suitable. It was based on an assumption that the most interested developers will keep up with the project and ask for a new release when needed. In reality people tend to keep up with the npm packages, not the GitHub repo. A few developers reached out and directly asked for more frequent releases. 

This PR ensures there's a patch release every Monday. Let's see how well it works and continue iterating on the approach should any problems arise. In the future, we might want to explore formal release trains, beta periods, and such, but today I believe we can get away with a much leaner approach.