### PR TITLE
Add GitHub development instructions

### DIFF
--- a/packages/playground/website/README.md
+++ b/packages/playground/website/README.md
@@ -10,6 +10,19 @@ To run the end to end tests locally, use the following command:
 npx nx run playground-website:e2e:dev:cypress
 ```
 
+### GitHub integration development
+
+To test the GitHub integration with Playground you will need to connect to GitHub.
+You can skip the connection flow locally by setting your GitHub personal access token in the code.
+
+To set your token add the bellow code [after this line](https://github.com/WordPress/wordpress-playground/blob/86e8b2d6792259711a127382cb0d2542996915c8/packages/playground/website/src/github/github-export-form/form.tsx#L139).
+```
+setOAuthToken('YOUR-TOKEN');
+```
+
+Replace `YOUR-TOKEN` with your [Personal access token](https://github.com/settings/tokens) (with repo scope).
+
+
 ## Tracking
 
 The WordPress Playground website uses Google Analytics to track user interactions. We use this data to better understand how Playground is being used. We do not track or store any personal information.


### PR DESCRIPTION
## Motivation for the change, related issues

When I wanted to test the export flow it wasn't straightforward to connect.

This PR adds development instructions that should make testing the GitHub integration easier in the future. 

## Implementation details

I updated the readme with development setup instructions.

## Testing Instructions (or ideally a Blueprint)

- follow the instructions
- confirm that you can test GitHub export locally