### PR TITLE
Importing regression fix – support old exported Playground ZIPs

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -1,8 +1,7 @@
 import { StepHandler } from '.';
 import { unzip } from './unzip';
-import { dirname, joinPaths, phpVar } from '@php-wasm/util';
+import { joinPaths, phpVar } from '@php-wasm/util';
 import { UniversalPHP } from '@php-wasm/universal';
-import { wpContentFilesExcludedFromExport } from '../utils/wp-content-files-excluded-from-exports';
 import { defineSiteUrl } from './define-site-url';
 
 /**
@@ -58,28 +57,6 @@ export const importWordPressFiles: StepHandler<
 		extractToPath: importPath,
 	});
 	importPath = joinPaths(importPath, pathInZip);
-
-	// Carry over any Playground-related files, such as the
-	// SQLite database plugin, from the current wp-content
-	// into the one that's about to be imported
-	const importedWpContentPath = joinPaths(importPath, 'wp-content');
-	const wpContentPath = joinPaths(documentRoot, 'wp-content');
-	for (const relativePath of wpContentFilesExcludedFromExport) {
-		// Remove any paths that were supposed to be excluded from the export
-		// but maybe weren't
-		const excludedImportPath = joinPaths(
-			importedWpContentPath,
-			relativePath
-		);
-		await removePath(playground, excludedImportPath);
-
-		// Replace them with files sourced from the live wp-content directory
-		const restoreFromPath = joinPaths(wpContentPath, relativePath);
-		if (await playground.fileExists(restoreFromPath)) {
-			await playground.mkdir(dirname(excludedImportPath));
-			await playground.mv(restoreFromPath, excludedImportPath);
-		}
-	}
 
 	// Carry over the database directory if the imported zip file doesn't
 	// already contain one.

--- a/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wordpress-files.ts
@@ -1,7 +1,8 @@
 import { StepHandler } from '.';
 import { unzip } from './unzip';
-import { joinPaths, phpVar } from '@php-wasm/util';
+import { dirname, joinPaths, phpVar } from '@php-wasm/util';
 import { UniversalPHP } from '@php-wasm/universal';
+import { wpContentFilesExcludedFromExport } from '../utils/wp-content-files-excluded-from-exports';
 import { defineSiteUrl } from './define-site-url';
 
 /**
@@ -57,6 +58,28 @@ export const importWordPressFiles: StepHandler<
 		extractToPath: importPath,
 	});
 	importPath = joinPaths(importPath, pathInZip);
+
+	// Carry over any Playground-related files, such as the
+	// SQLite database plugin, from the current wp-content
+	// into the one that's about to be imported
+	const importedWpContentPath = joinPaths(importPath, 'wp-content');
+	const wpContentPath = joinPaths(documentRoot, 'wp-content');
+	for (const relativePath of wpContentFilesExcludedFromExport) {
+		// Remove any paths that were supposed to be excluded from the export
+		// but maybe weren't
+		const excludedImportPath = joinPaths(
+			importedWpContentPath,
+			relativePath
+		);
+		await removePath(playground, excludedImportPath);
+
+		// Replace them with files sourced from the live wp-content directory
+		const restoreFromPath = joinPaths(wpContentPath, relativePath);
+		if (await playground.fileExists(restoreFromPath)) {
+			await playground.mkdir(dirname(excludedImportPath));
+			await playground.mv(restoreFromPath, excludedImportPath);
+		}
+	}
 
 	// Carry over the database directory if the imported zip file doesn't
 	// already contain one.

--- a/packages/playground/blueprints/src/lib/utils/wp-content-files-excluded-from-exports.ts
+++ b/packages/playground/blueprints/src/lib/utils/wp-content-files-excluded-from-exports.ts
@@ -11,6 +11,7 @@ export const wpContentFilesExcludedFromExport = [
 	'mu-plugins/sqlite-database-integration',
 	'mu-plugins/playground-includes',
 	'mu-plugins/0-playground.php',
+	'mu-plugins/0-sqlite.php',
 
 	/*
 	 * Listing core themes like that here isn't ideal, especially since


### PR DESCRIPTION
## Motivation for the change, related issues

Closes #1543

Fixes importing older Playground exports via the `importWordPressFiles` step.

Playground exports before changes from the Boot Protocol (#1398) contained platform-level WordPress plugins and mu-plugins. The importer, then, removed them and replaced them with the latest version freshly sourced from the /wordpress directory.

However, after the Boot Protocol changes, Playground no longer includes any platform-level plugins in the /wordpress directory. This means that things like SQLite database integration were being removed from the imported ZIP bundle but they were not restored.

This PR ensures the `0-sqlite.php` mu-plugin file will not be imported. This way, we won't try to `require` files that the old export assumes to exist but that do not exist anymore.

## Other ideas

I've initially tried removing the entire "remove & restore" files mechanism, but that resulted in the following error:

![CleanShot 2024-07-03 at 11 28 37@2x](https://github.com/WordPress/wordpress-playground/assets/205419/10f5f1d4-7ba1-40c7-9cec-cf3ec13b8cf6)

It turned out every platform-level file **but** 0-sqlite.php was listed for removal. Eventually I would still like to adjust the import flow to remove this "remove & restore" dynamics and allow import bundles to ship their own SQLite database integration plugin, but this PR will have to do for now.

 ## Testing instructions

1. Export Playground as zip and import it again. Confirm this worked.
2. Run [this Blueprint that imports an older ZIP bundle](https://playground.wordpress.net/builder/builder.html#{%22landingPage%22:%22/%22,%22preferredVersions%22:{%22php%22:%228.0%22,%22wp%22:%22latest%22},%22phpExtensionBundles%22:[%22kitchen-sink%22],%22features%22:{%22networking%22:true},%22steps%22:[{%22step%22:%22importWordPressFiles%22,%22wordPressFilesZip%22:{%22resource%22:%22url%22,%22url%22:%22https://kybernaut.cz/blueprints/pay-for-payment-playground.zip%22}},{%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22},{%22step%22:%22installPlugin%22,%22pluginZipFile%22:{%22resource%22:%22wordpress.org/plugins%22,%22slug%22:%22woocommerce-pay-for-payment%22},%22options%22:{%22activate%22:true}}]}) and confirm it works

CC @vyskoczilova
