### PR TITLE
Build: Treat all dependencies of php-wasm/node as external

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
 				"docusaurus-plugin-typedoc-api": "^3.0.0",
 				"dts-bundle-generator": "^7.2.0",
 				"esbuild": "0.19.7",
+				"esbuild-node-externals": "1.13.1",
 				"esbuild-plugin-copy": "^2.1.0",
 				"esbuild-plugin-ignore": "1.1.1",
 				"eslint": "8.46.0",
@@ -23646,6 +23647,68 @@
 				"@esbuild/win32-arm64": "0.19.7",
 				"@esbuild/win32-ia32": "0.19.7",
 				"@esbuild/win32-x64": "0.19.7"
+			}
+		},
+		"node_modules/esbuild-node-externals": {
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/esbuild-node-externals/-/esbuild-node-externals-1.13.1.tgz",
+			"integrity": "sha512-ho4Lokc6iMB1lWbb2tWJ6otien+3Kfoaxe0fy7NUNgVuLnfmlW+GRINftTVUGtTVY/dapuwUu/CvFylYNwzkMA==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^5.0.0",
+				"tslib": "^2.4.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"peerDependencies": {
+				"esbuild": "0.12 - 0.21"
+			}
+		},
+		"node_modules/esbuild-node-externals/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/esbuild-node-externals/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/esbuild-node-externals/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/esbuild-plugin-copy": {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
 		"docusaurus-plugin-typedoc-api": "^3.0.0",
 		"dts-bundle-generator": "^7.2.0",
 		"esbuild": "0.19.7",
+		"esbuild-node-externals": "1.13.1",
 		"esbuild-plugin-copy": "^2.1.0",
 		"esbuild-plugin-ignore": "1.1.1",
 		"eslint": "8.46.0",

--- a/packages/php-wasm/node/esbuild.js
+++ b/packages/php-wasm/node/esbuild.js
@@ -21,7 +21,7 @@ esbuild.build({
 	},
 	bundle: true,
 	tsconfig: 'packages/php-wasm/node/tsconfig.json',
-	external: ['@php-wasm/*', '@wp-playground/*', 'ws'],
+	external: ['@php-wasm/*', '@wp-playground/*'],
 	loader: {
 		'.php': 'text',
 		'.ini': 'file',

--- a/packages/php-wasm/node/esbuild.js
+++ b/packages/php-wasm/node/esbuild.js
@@ -1,0 +1,30 @@
+const esbuild = require('esbuild');
+const { nodeExternalsPlugin } = require('esbuild-node-externals');
+
+esbuild.build({
+	entryPoints: [
+		'packages/php-wasm/node/src/index.ts',
+		'packages/php-wasm/node/src/noop.ts',
+	],
+	plugins: [nodeExternalsPlugin()],
+	supported: {
+		'dynamic-import': false,
+	},
+	format: 'cjs',
+	outExtension: { '.js': '.cjs' },
+	outdir: 'dist/packages/php-wasm/node',
+	platform: 'node',
+	assetNames: '[name]',
+	chunkNames: '[name]',
+	logOverride: {
+		'commonjs-variable-in-esm': 'silent',
+	},
+	bundle: true,
+	tsconfig: 'packages/php-wasm/node/tsconfig.json',
+	external: ['@php-wasm/*', '@wp-playground/*', 'ws'],
+	loader: {
+		'.php': 'text',
+		'.ini': 'file',
+		'.wasm': 'file',
+	},
+});

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -68,24 +68,7 @@
 				],
 				"bundle": true,
 				"format": ["cjs"],
-				"esbuildOptions": {
-					"supported": {
-						"dynamic-import": false
-					},
-					"outdir": "dist/packages/php-wasm/node",
-					"platform": "node",
-					"assetNames": "[name]",
-					"chunkNames": "[name]",
-					"logOverride": {
-						"commonjs-variable-in-esm": "silent"
-					},
-					"external": ["@php-wasm/*", "@wp-playground/*"],
-					"loader": {
-						".php": "text",
-						".ini": "file",
-						".wasm": "file"
-					}
-				},
+				"esbuildConfig": "packages/php-wasm/node/esbuild.js",
 				"thirdParty": true
 			},
 			"configurations": {

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -79,6 +79,7 @@
 					"logOverride": {
 						"commonjs-variable-in-esm": "silent"
 					},
+					"external": ["@php-wasm/*", "@wp-playground/*"],
 					"loader": {
 						".php": "text",
 						".ini": "file",


### PR DESCRIPTION
Without this PR, the released `@php-wasm/node` package bundles other `@php-wasm`
packages, which caused multiple copies of, e.g. `@php-wasm/universal` to
be loaded and resulted in variable identity issues such as
#1579.

This PR marks all the dependent packages as external and ensures the
published package is lean and only contains its own code.

 ## Testing instructions

Run `nx build php-wasm-node` and confirm the resulting
`dist/packages/php-wasm/node/index.cjs` files does not contain any
external modules## Motivation for the change, related issues
