### PR TITLE
Vite build: Mark all imported modules as external to avoid bundling them with released packages.

### DIFF
--- a/packages/php-wasm/fs-journal/vite.config.ts
+++ b/packages/php-wasm/fs-journal/vite.config.ts
@@ -6,6 +6,8 @@ import { join } from 'path';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-fs-journal',
@@ -33,7 +35,7 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/php-wasm/logger/vite.config.ts
+++ b/packages/php-wasm/logger/vite.config.ts
@@ -6,6 +6,8 @@ import { join } from 'path';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-logger',
@@ -33,7 +35,7 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/php-wasm/node-polyfills/vite.config.ts
+++ b/packages/php-wasm/node-polyfills/vite.config.ts
@@ -3,6 +3,8 @@ import { join } from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-node-polyfills',
@@ -36,7 +38,7 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -5,6 +5,8 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig(function () {
 	return {
@@ -30,16 +32,7 @@ export default defineConfig(function () {
 			rollupOptions: {
 				// Don't bundle the PHP loaders in the final build. See
 				// the preserve-php-loaders-imports plugin above.
-				external: [
-					'net',
-					'fs',
-					'path',
-					'http',
-					'tls',
-					'util',
-					'dns',
-					'ws',
-				],
+				external: getExternalModules(),
 				output: {
 					entryFileNames: '[name].js',
 					chunkFileNames: '[name].js',

--- a/packages/php-wasm/progress/vite.config.ts
+++ b/packages/php-wasm/progress/vite.config.ts
@@ -6,6 +6,8 @@ import { join } from 'path';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-progress',
@@ -44,7 +46,7 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/php-wasm/scopes/vite.config.ts
+++ b/packages/php-wasm/scopes/vite.config.ts
@@ -6,6 +6,8 @@ import { join } from 'path';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-scope',
@@ -33,7 +35,7 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/php-wasm/stream-compression/vite.config.ts
+++ b/packages/php-wasm/stream-compression/vite.config.ts
@@ -4,6 +4,8 @@ import dts from 'vite-plugin-dts';
 import * as path from 'path';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-stream-compression',
@@ -37,7 +39,7 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/php-wasm/universal/vite.config.ts
+++ b/packages/php-wasm/universal/vite.config.ts
@@ -6,6 +6,8 @@ import { join } from 'path';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-universal',
@@ -33,7 +35,7 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/php-wasm/util/vite.config.ts
+++ b/packages/php-wasm/util/vite.config.ts
@@ -2,6 +2,8 @@
 import { defineConfig } from 'vite';
 
 import viteTsConfigPaths from 'vite-tsconfig-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-util',
@@ -31,7 +33,7 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -5,6 +5,8 @@ import dts from 'vite-plugin-dts';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig(({ command }) => {
 	return {
@@ -79,7 +81,7 @@ export default defineConfig(({ command }) => {
 			rollupOptions: {
 				// Don't bundle the PHP loaders in the final build. See
 				// the preserve-php-loaders-imports plugin above.
-				external: [/php_\d_\d.js$/],
+				external: [/php_\d_\d.js$/, ...getExternalModules()],
 				output: {
 					// Ensure the PHP loaders are not hashed in the final build.
 					entryFileNames: '[name].js',

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -95,7 +95,8 @@
 							}
 						]
 					},
-					"description": "WordPress plugins to install and activate"
+					"description": "WordPress plugins to install and activate",
+					"deprecated": "This experimental option will change without warning.\nUse `steps` instead."
 				},
 				"siteOptions": {
 					"type": "object",
@@ -108,7 +109,8 @@
 							"description": "The site title"
 						}
 					},
-					"description": "WordPress site options to define"
+					"description": "WordPress site options to define",
+					"deprecated": "This experimental option will change without warning.\nUse `steps` instead."
 				},
 				"login": {
 					"anyOf": [

--- a/packages/playground/blueprints/vite.config.ts
+++ b/packages/playground/blueprints/vite.config.ts
@@ -6,6 +6,8 @@ import { join } from 'path';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/playground-blueprints',
@@ -43,8 +45,7 @@ export default defineConfig({
 			formats: ['es', 'cjs'],
 		},
 		rollupOptions: {
-			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/playground/storage/vite.config.ts
+++ b/packages/playground/storage/vite.config.ts
@@ -3,6 +3,8 @@
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import ignoreWasmImports from '../ignore-wasm-imports';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default {
 	base: '/',
@@ -36,7 +38,7 @@ export default {
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/playground/sync/vite.config.ts
+++ b/packages/playground/sync/vite.config.ts
@@ -4,6 +4,8 @@ import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import ignoreWasmImports from '../ignore-wasm-imports';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default {
 	base: '/',
@@ -37,7 +39,7 @@ export default {
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
-			external: [],
+			external: getExternalModules(),
 		},
 	},
 

--- a/packages/playground/wordpress-builds/vite.config.ts
+++ b/packages/playground/wordpress-builds/vite.config.ts
@@ -4,6 +4,8 @@ import type { Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
 export default defineConfig({
@@ -46,6 +48,7 @@ export default defineConfig({
 		//            in the app mode.
 		// @see https://github.com/vitejs/vite/issues/3295
 		assetsInlineLimit: 0,
+		external: getExternalModules(),
 		rollupOptions: {
 			input: path('src/index.ts'),
 			// These additional options are required to preserve

--- a/packages/playground/wordpress/package.json
+++ b/packages/playground/wordpress/package.json
@@ -15,6 +15,7 @@
 			"url": "https://github.com/adamziel"
 		}
 	],
+	"type": "module",
 	"main": "./index.js",
 	"typings": "./index.d.ts",
 	"license": "GPL-2.0-or-later",

--- a/packages/playground/wordpress/vite.config.ts
+++ b/packages/playground/wordpress/vite.config.ts
@@ -4,6 +4,8 @@ import type { Plugin } from 'vite';
 import dts from 'vite-plugin-dts';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 const path = (filename: string) => new URL(filename, import.meta.url).pathname;
 export default defineConfig({
@@ -48,6 +50,7 @@ export default defineConfig({
 		assetsInlineLimit: 0,
 		rollupOptions: {
 			input: path('src/index.ts'),
+			external: getExternalModules(),
 			// These additional options are required to preserve
 			// all the exports from the entry point. Otherwise,
 			// vite only preserves the ones it considers to be used.

--- a/packages/vite-extensions/vite-external-modules.ts
+++ b/packages/vite-extensions/vite-external-modules.ts
@@ -1,0 +1,43 @@
+import glob from 'glob';
+import fs from 'fs';
+
+const getPackageNames = (): string[] => {
+	const packageJsonPaths = glob
+		.sync('../php-wasm/*/package.json')
+		.concat(glob.sync('../playground/*/package.json'));
+	const packageNames: string[] = [];
+
+	packageJsonPaths.forEach((packageJsonPath) => {
+		const packageJson = JSON.parse(
+			fs.readFileSync(packageJsonPath, 'utf8')
+		);
+		packageNames.push(packageJson.name);
+	});
+
+	return packageNames;
+};
+
+// Usage
+const packageNames = getPackageNames();
+
+export const getExternalModules = () => {
+	return [
+		'yargs',
+		'express',
+		'crypto',
+		'os',
+		'net',
+		'fs',
+		'fs-extra',
+		'path',
+		'child_process',
+		'http',
+		'path',
+		'tls',
+		'util',
+		'dns',
+		'ws',
+		/node_modules\//,
+		...packageNames,
+	];
+};


### PR DESCRIPTION
Without this PR, many of the released packages bundle other packages – both from this repo and external ones. 

For example, `@wp-playground/wordpress` bundles `@php-wasm/node` which caused multiple copies of that package to be loaded and create a variable identity issues such as #1579.

This PR marks all the dependent packages as external and ensures the published packages are lean and only contains their own code.

## Testing instructions

Run `nx build php-wasm-node` and confirm the resulting`dist/packages/playground/client/index.js` file and other built npm-published modules do not bundle any external modules. The only exception should be the `cli` packages.

