### PR TITLE
Remove Puzzle app from the Playground website

### DIFF
--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -201,16 +201,6 @@ function playground_maybe_redirect( $requested_path ) {
 		);
 	}
 
-	if (
-		1 === preg_match( '#^/puzzle/[^/]+/?$#', $requested_path ) &&
-		! str_ends_with( $requested_path, '/index.html' )
-	) {
-		return array(
-			'internal' => true,
-			'location' => '/puzzle/index.html',
-		);
-	}
-
 	return false;
 }
 

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -118,23 +118,6 @@ export default defineConfig(({ command, mode }) => {
 				},
 			} as Plugin,
 			/**
-			 * Copy the Puzzle app form the `dist/packages/playground/puzzle` directory.
-			 */
-			{
-				name: 'puzzle-plugin',
-				apply: 'build',
-				writeBundle({ dir: outputDir }) {
-					const puzzleDir = path(
-						'../../../dist/packages/playground/puzzle/'
-					);
-					if (existsSync(puzzleDir) && outputDir) {
-						cpSync(puzzleDir, join(outputDir, 'puzzle'), {
-							recursive: true,
-						});
-					}
-				},
-			} as Plugin,
-			/**
 			 * Copy the `manifest.json` file to the `dist/` directory.
 			 */
 			{

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -16,7 +16,7 @@ import {
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { oAuthMiddleware } from './vite.oauth';
 import { fileURLToPath } from 'node:url';
-import { copyFileSync, existsSync, cpSync } from 'node:fs';
+import { copyFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 


### PR DESCRIPTION
## Motivation for the change, related issues

The Puzzle app was used during WCEU 2024 to scan puzzle pieces.
Now after the event is over, we need to remove the app from Playground.WordPress.net.

If we want to bring it back for a future event, we can revert this PR.

## Implementation details

The PR removes the redirect necessary for app routing to work and the build plugin which adds the Puzzle app to the Website build.

## Testing Instructions (or ideally a Blueprint)

- ensure all tests pass
- `npm run build:website && php -S localhost:9999 -t dist/packages/playground/wasm-wordpress-net`
- Open http://localhost:9999/puzzle/ and ensure you don't see the puzzle app