### PR TITLE
Build: Use regular expressions to mark packages as external

### DIFF
--- a/packages/vite-extensions/vite-external-modules.ts
+++ b/packages/vite-extensions/vite-external-modules.ts
@@ -1,25 +1,3 @@
-import glob from 'glob';
-import fs from 'fs';
-
-const getPackageNames = (): string[] => {
-	const packageJsonPaths = glob
-		.sync('../php-wasm/*/package.json')
-		.concat(glob.sync('../playground/*/package.json'));
-	const packageNames: string[] = [];
-
-	packageJsonPaths.forEach((packageJsonPath) => {
-		const packageJson = JSON.parse(
-			fs.readFileSync(packageJsonPath, 'utf8')
-		);
-		packageNames.push(packageJson.name);
-	});
-
-	return packageNames;
-};
-
-// Usage
-const packageNames = getPackageNames();
-
 export const getExternalModules = () => {
 	return [
 		'yargs',
@@ -38,6 +16,7 @@ export const getExternalModules = () => {
 		'dns',
 		'ws',
 		/node_modules\//,
-		...packageNames,
+		/^@php-wasm\//,
+		/^@wp-playground\//,
 	];
 };


### PR DESCRIPTION
## Motivation for the change, related issues

Follows up on https://github.com/WordPress/wordpress-playground/pull/1586

Extracting external packages names from the `package.json` files did not work as expected due to `cwd` misconfiguration in CI. This PR replaces that logic with a regexp matching the name of the packages from this monorepo to avoid maintaining the paths entirely.

## Testing instructions

Run `nx build php-wasm-node` and confirm the resulting`dist/packages/playground/client/index.js` file and other built npm-published modules do not bundle any external modules. The only exception should be the `cli` packages.

