### PR TITLE
Build: Polyfill __dirname in php-wam/node ESM via banner option

### DIFF
--- a/packages/php-wasm/node/build.js
+++ b/packages/php-wasm/node/build.js
@@ -36,36 +36,18 @@ async function build() {
 		},
 	});
 
-	const nodeModules = new RegExp(/^(?:.*[\\/])?node_modules(?:[\\/].*)?$/);
 	await esbuild.build({
 		entryPoints: [
 			'packages/php-wasm/node/src/index.ts',
 			'packages/php-wasm/node/src/noop.ts',
 		],
 		banner: {
-			js: "import { createRequire as topLevelCreateRequire } from 'module';\n const require = topLevelCreateRequire(import.meta.url);",
+			js: `import { createRequire as topLevelCreateRequire } from 'module';
+const require = topLevelCreateRequire(import.meta.url);
+const __dirname = new URL('.', import.meta.url).pathname;
+const __filename = new URL(import.meta.url).pathname;
+`,
 		},
-		plugins: [
-			{
-				name: 'Support __dirname in ESM',
-				setup(build) {
-					build.onLoad({ filter: /.*/ }, ({ path: filePath }) => {
-						if (!filePath.match(nodeModules)) {
-							let contents = fs.readFileSync(filePath, 'utf8');
-							const loader = path.extname(filePath).substring(1);
-							const dirname = path.dirname(filePath);
-							contents = contents
-								.replaceAll('__dirname', `"${dirname}"`)
-								.replaceAll('__filename', `"${filePath}"`);
-							return {
-								contents,
-								loader,
-							};
-						}
-					});
-				},
-			},
-		],
 		outdir: 'dist/packages/php-wasm/node',
 		platform: 'node',
 		assetNames: '[name]',


### PR DESCRIPTION
## Motivation for the change, related issues

Related to https://github.com/WordPress/wordpress-playground/issues/1587

The recent changes to [publish `@php-wasm/node` as ESM](https://github.com/WordPress/wordpress-playground/pull/1585) broke the `.wasm` files paths in the published package. Specifically, `__dirname + '/php_8_0.wasm'` became `/home/runner/work/wordpress-playground/wordpress-playground/node_modules/@php-wasm/node/php_8_0.wasm` which is undesirable.

This PR polyfills the `__dirname` variable with ESM-compliant alternatives in the ESM version of the `@php-wasm/node` package.

## Testing instructions

* Run `npm run build`
* Confirm the built `@php-wasm/node` package has the correct `.wasm` files paths.






