### PR TITLE
Remove the unused isSupportedWordPressVersion export

### DIFF
--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -2,10 +2,7 @@ import { PHP, UniversalPHP } from '@php-wasm/universal';
 import { joinPaths, phpVar } from '@php-wasm/util';
 import { unzipFile } from '@wp-playground/common';
 export { bootWordPress } from './boot';
-export {
-	getLoadedWordPressVersion,
-	isSupportedWordPressVersion,
-} from './version-detect';
+export { getLoadedWordPressVersion } from './version-detect';
 
 export * from './rewrite-rules';
 

--- a/packages/playground/wordpress/src/version-detect.ts
+++ b/packages/playground/wordpress/src/version-detect.ts
@@ -1,5 +1,4 @@
 import type { PHPRequestHandler } from '@php-wasm/universal';
-import { SupportedWordPressVersions } from '@wp-playground/wordpress-builds';
 
 export async function getLoadedWordPressVersion(
 	requestHandler: PHPRequestHandler
@@ -42,9 +41,4 @@ export function versionStringToLoadedWordPressVersion(
 	// Return original version string if we could not parse it.
 	// This is important to allow so folks can bring their own WP builds.
 	return wpVersionString;
-}
-
-export function isSupportedWordPressVersion(wpVersion: string) {
-	const supportedVersionKeys = Object.keys(SupportedWordPressVersions);
-	return supportedVersionKeys.includes(wpVersion);
 }


### PR DESCRIPTION
The export was unused, let's remove it.

Testing instructions – confirm the CI checks are green
