### PR TITLE
Build: Ship the default TypeScript .d.ts declaration files, not rollups

### DIFF
--- a/packages/php-wasm/fs-journal/project.json
+++ b/packages/php-wasm/fs-journal/project.json
@@ -6,7 +6,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -32,19 +32,6 @@
 				"emptyOutDir": false,
 				"outputPath": "dist/packages/php-wasm/fs-journal"
 			}
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/php-wasm/fs-journal/src/rollup.d.ts -- packages/php-wasm/fs-journal/src/index.ts",
-					"rimraf dist/packages/php-wasm/fs-journal/lib/*.d.ts",
-					"rimraf dist/packages/php-wasm/fs-journal/*.d.ts",
-					"cp packages/php-wasm/fs-journal/src/rollup.d.ts dist/packages/php-wasm/fs-journal/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"test": {
 			"executor": "nx:noop",

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -42,6 +42,16 @@
 			"options": {
 				"command": "node packages/php-wasm/node/build.js",
 				"parallel": false
+			},
+			"dependsOn": ["build:mkdir"]
+		},
+		"build:mkdir": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"mkdir dist/packages/php-wasm/node"
+				],
+				"parallel": false
 			}
 		},
 		"recompile-php": {

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -15,8 +15,7 @@
 				"commands": [
 					"cp packages/php-wasm/node/README.md dist/packages/php-wasm/node"
 				]
-			},
-			"dependsOn": ["build:rollup-declarations"]
+			}
 		},
 		"build:copy-wasms": {
 			"executor": "nx:run-commands",
@@ -25,21 +24,7 @@
 					"cp -rf packages/php-wasm/node/public/* dist/packages/php-wasm/node"
 				],
 				"parallel": false
-			},
-			"dependsOn": ["build:rollup-declarations"]
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/php-wasm/node/src/rollup.d.ts -- packages/php-wasm/node/src/index.ts",
-					"rimraf dist/packages/php-wasm/node/lib/*.d.ts",
-					"rimraf dist/packages/php-wasm/node/*.d.ts",
-					"cp packages/php-wasm/node/src/rollup.d.ts dist/packages/php-wasm/node/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:package-json"]
+			}
 		},
 		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -15,7 +15,8 @@
 				"commands": [
 					"cp packages/php-wasm/node/README.md dist/packages/php-wasm/node"
 				]
-			}
+			},
+			"dependsOn": ["build:mkdir"]
 		},
 		"build:copy-wasms": {
 			"executor": "nx:run-commands",
@@ -33,7 +34,8 @@
 				"tsConfig": "packages/php-wasm/node/tsconfig.lib.json",
 				"outputPath": "dist/packages/php-wasm/node",
 				"buildTarget": "php-wasm-node:build:bundle:production"
-			}
+			},
+			"dependsOn": ["build:mkdir"]
 		},
 		"build:bundle": {
 			"executor": "@nx/esbuild:esbuild",
@@ -48,9 +50,7 @@
 		"build:mkdir": {
 			"executor": "nx:run-commands",
 			"options": {
-				"commands": [
-					"mkdir -p dist/packages/php-wasm/node"
-				],
+				"commands": ["mkdir -p dist/packages/php-wasm/node"],
 				"parallel": false
 			}
 		},

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -49,7 +49,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"mkdir dist/packages/php-wasm/node"
+					"mkdir -p dist/packages/php-wasm/node"
 				],
 				"parallel": false
 			}

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -24,7 +24,8 @@
 					"cp -rf packages/php-wasm/node/public/* dist/packages/php-wasm/node"
 				],
 				"parallel": false
-			}
+			},
+			"dependsOn": ["build:package-json"]
 		},
 		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",

--- a/packages/php-wasm/stream-compression/project.json
+++ b/packages/php-wasm/stream-compression/project.json
@@ -6,7 +6,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -32,19 +32,6 @@
 				"emptyOutDir": false,
 				"outputPath": "dist/packages/php-wasm/stream-compression"
 			}
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/php-wasm/stream-compression/src/rollup.d.ts -- packages/php-wasm/stream-compression/src/index.ts",
-					"rimraf dist/packages/php-wasm/stream-compression/lib/*.d.ts",
-					"rimraf dist/packages/php-wasm/stream-compression/*.d.ts",
-					"cp packages/php-wasm/stream-compression/src/rollup.d.ts dist/packages/php-wasm/stream-compression/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"test": {
 			"executor": "@nx/vite:test",

--- a/packages/php-wasm/universal/project.json
+++ b/packages/php-wasm/universal/project.json
@@ -6,7 +6,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -32,19 +32,6 @@
 				"emptyOutDir": false,
 				"outputPath": "dist/packages/php-wasm/universal"
 			}
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/php-wasm/universal/src/rollup.d.ts -- packages/php-wasm/universal/src/index.ts",
-					"rimraf dist/packages/php-wasm/universal/lib/*.d.ts",
-					"rimraf dist/packages/php-wasm/universal/*.d.ts",
-					"cp packages/php-wasm/universal/src/rollup.d.ts dist/packages/php-wasm/universal/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"test": {
 			"executor": "nx:noop",

--- a/packages/php-wasm/util/project.json
+++ b/packages/php-wasm/util/project.json
@@ -6,7 +6,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -32,19 +32,6 @@
 				"emptyOutDir": false,
 				"outputPath": "dist/packages/php-wasm/util"
 			}
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/php-wasm/util/src/rollup.d.ts -- packages/php-wasm/util/src/index.ts",
-					"rimraf dist/packages/php-wasm/util/lib/*.d.ts",
-					"rimraf dist/packages/php-wasm/util/*.d.ts",
-					"cp packages/php-wasm/util/src/rollup.d.ts dist/packages/php-wasm/util/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"publish": {
 			"executor": "nx:run-commands",

--- a/packages/php-wasm/web/project.json
+++ b/packages/php-wasm/web/project.json
@@ -7,7 +7,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -33,19 +33,6 @@
 				"emptyOutDir": false,
 				"outputPath": "dist/packages/php-wasm/web"
 			}
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/php-wasm/web/src/rollup.d.ts -- packages/php-wasm/web/src/index.ts",
-					"rimraf dist/packages/php-wasm/web/lib/*.d.ts",
-					"rimraf dist/packages/php-wasm/web/*.d.ts",
-					"cp packages/php-wasm/web/src/rollup.d.ts dist/packages/php-wasm/web/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"recompile-php:light": {
 			"executor": "nx:run-commands",

--- a/packages/playground/blueprints/bin/generate-schema.js
+++ b/packages/playground/blueprints/bin/generate-schema.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 
 /** @type {import('ts-json-schema-generator/dist/src/Config').Config} */
 const config = {
-	path: 'dist/packages/playground/blueprints/index.d.ts',
+	path: 'packages/playground/blueprints/src/rollup.d.ts',
 	tsconfig: './tsconfig.base.json',
 	type: 'Blueprint',
 	skipTypeCheck: true,

--- a/packages/playground/blueprints/project.json
+++ b/packages/playground/blueprints/project.json
@@ -9,7 +9,7 @@
 			"dependsOn": [
 				"build:bundle",
 				"build:blueprint-schema",
-				"build:rollup-declarations"
+				"build:rollup-declarations-for-schema-generation"
 			]
 		},
 		"build:blueprint-schema": {
@@ -20,17 +20,14 @@
 				],
 				"parallel": false
 			},
-			"dependsOn": ["build:rollup-declarations"]
+			"dependsOn": ["build:rollup-declarations-for-schema-generation"]
 		},
-		"build:rollup-declarations": {
+		"build:rollup-declarations-for-schema-generation": {
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
 					"mkdir -p dist/packages/playground/blueprints",
-					"npx dts-bundle-generator -o packages/playground/blueprints/src/rollup.d.ts -- packages/playground/blueprints/src/index.ts",
-					"rimraf dist/packages/playground/blueprints/lib/*.d.ts",
-					"rimraf dist/packages/playground/blueprints/*.d.ts",
-					"cp packages/playground/blueprints/src/rollup.d.ts dist/packages/playground/blueprints/index.d.ts"
+					"npx dts-bundle-generator -o packages/playground/blueprints/src/rollup.d.ts -- packages/playground/blueprints/src/index.ts"
 				],
 				"parallel": false
 			},

--- a/packages/playground/common/project.json
+++ b/packages/playground/common/project.json
@@ -6,7 +6,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -41,19 +41,6 @@
 				}
 			},
 			"dependsOn": ["^build"]
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/playground/common/src/rollup.d.ts -- packages/playground/common/src/index.ts",
-					"rimraf dist/packages/playground/common/lib/*.d.ts",
-					"rimraf dist/packages/playground/common/*.d.ts",
-					"cp packages/playground/common/src/rollup.d.ts dist/packages/playground/common/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"publish": {
 			"executor": "nx:run-commands",

--- a/packages/playground/storage/project.json
+++ b/packages/playground/storage/project.json
@@ -6,7 +6,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -32,19 +32,6 @@
 				"emptyOutDir": false,
 				"outputPath": "dist/packages/playground/storage"
 			}
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/playground/storage/src/rollup.d.ts -- packages/playground/storage/src/index.ts",
-					"rimraf dist/packages/playground/storage/lib/*.d.ts",
-					"rimraf dist/packages/playground/storage/*.d.ts",
-					"cp packages/playground/storage/src/rollup.d.ts dist/packages/playground/storage/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"test": {
 			"executor": "@nx/vite:test",

--- a/packages/playground/wordpress-builds/project.json
+++ b/packages/playground/wordpress-builds/project.json
@@ -6,7 +6,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -49,19 +49,6 @@
 			"options": {
 				"commands": ["rm -rf dist/packages/playground/wordpress-builds"]
 			}
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/playground/wordpress-builds/src/rollup.d.ts -- packages/playground/wordpress-builds/src/index.ts",
-					"rimraf dist/packages/playground/wordpress-builds/lib/*.d.ts",
-					"rimraf dist/packages/playground/wordpress-builds/*.d.ts",
-					"cp packages/playground/wordpress-builds/src/rollup.d.ts dist/packages/playground/wordpress-builds/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"bundle-wordpress": {
 			"executor": "nx:run-commands",

--- a/packages/playground/wordpress/project.json
+++ b/packages/playground/wordpress/project.json
@@ -6,7 +6,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:README"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -43,19 +43,6 @@
 				}
 			},
 			"dependsOn": ["^build"]
-		},
-		"build:rollup-declarations": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"npx dts-bundle-generator -o packages/playground/wordpress/src/rollup.d.ts -- packages/playground/wordpress/src/index.ts",
-					"rimraf dist/packages/playground/wordpress/lib/*.d.ts",
-					"rimraf dist/packages/playground/wordpress/*.d.ts",
-					"cp packages/playground/wordpress/src/rollup.d.ts dist/packages/playground/wordpress/index.d.ts"
-				],
-				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
 		},
 		"publish": {
 			"executor": "nx:run-commands",


### PR DESCRIPTION
pipeline. This caused the published packages to ship not just their own types but also all the types they import. This creates a lot of noise and also type identity conflicts between packages. This PR removes most of these rollup tasks, leaving only two:

* In the `@wp-playground/blueprints` package for Types->JSON schema generation
* In the `@wp-playground/client` package to make it self-contained and dependencyless.

Related to #1577

 ## Testing instructions

Run `npm run build` and confirm the built packages only export their own types.

