### PR TITLE
Blueprints: Mark shorthand properties as stable, not deprecated

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -80,8 +80,7 @@
 					"additionalProperties": {
 						"type": "string"
 					},
-					"description": "PHP Constants to define on every request",
-					"deprecated": "This experimental option will change without warning.\nUse `steps` instead."
+					"description": "PHP Constants to define on every request"
 				},
 				"plugins": {
 					"type": "array",
@@ -95,8 +94,7 @@
 							}
 						]
 					},
-					"description": "WordPress plugins to install and activate",
-					"deprecated": "This experimental option will change without warning.\nUse `steps` instead."
+					"description": "WordPress plugins to install and activate"
 				},
 				"siteOptions": {
 					"type": "object",
@@ -109,8 +107,7 @@
 							"description": "The site title"
 						}
 					},
-					"description": "WordPress site options to define",
-					"deprecated": "This experimental option will change without warning.\nUse `steps` instead."
+					"description": "WordPress site options to define"
 				},
 				"login": {
 					"anyOf": [

--- a/packages/playground/blueprints/src/lib/blueprint.ts
+++ b/packages/playground/blueprints/src/lib/blueprint.ts
@@ -61,22 +61,16 @@ export interface Blueprint {
 
 	/**
 	 * PHP Constants to define on every request
-	 * @deprecated This experimental option will change without warning.
-	 *             Use `steps` instead.
 	 */
 	constants?: Record<string, string>;
 
 	/**
 	 * WordPress plugins to install and activate
-	 * @deprecated This experimental option will change without warning.
-	 *             Use `steps` instead.
 	 */
 	plugins?: Array<string | FileReference>;
 
 	/**
 	 * WordPress site options to define
-	 * @deprecated This experimental option will change without warning.
-	 *             Use `steps` instead.
 	 */
 	siteOptions?: Record<string, string> & {
 		/** The site title */


### PR DESCRIPTION
Now that Blueprint shorthand properties like `constants`, `siteOptions`, and `plugins` are here to stay and featured in the official docs, it's probably safe to remove the warnings from the schema (see these lines).

Closes #1282
