### PR TITLE
Revert "Set web worker startup options with messages instead of query strings"

### DIFF
--- a/packages/php-wasm/web/src/lib/worker-thread/spawn-php-worker-thread.ts
+++ b/packages/php-wasm/web/src/lib/worker-thread/spawn-php-worker-thread.ts
@@ -20,10 +20,6 @@ export async function spawnPHPWorkerThread(
 			(error as any).filename = e.filename;
 			reject(error);
 		};
-		worker.postMessage({
-			type: 'startup-options',
-			startupOptions,
-		});
 		// There is no way to know when the worker script has started
 		// executing, so we use a message to signal that.
 		function onStartup(event: { data: string }) {

--- a/packages/playground/remote/src/lib/worker-utils.ts
+++ b/packages/playground/remote/src/lib/worker-utils.ts
@@ -32,24 +32,18 @@ export type ParsedStartupOptions = {
 	siteSlug: string;
 };
 
-const getReceivedParams = async () => {
-	return new Promise<ReceivedStartupOptions>((resolve) => {
-		self.addEventListener('message', async (event) => {
-			if (event.data.type === 'startup-options') {
-				resolve({
-					wpVersion: event.data.startupOptions.wpVersion,
-					phpVersion: event.data.startupOptions.phpVersion,
-					storage: event.data.startupOptions.storage,
-					sapiName: event.data.startupOptions.sapiName,
-					phpExtensions: event.data.startupOptions['php-extension'],
-					siteSlug: event.data.startupOptions['site-slug'],
-				});
-			}
-		});
-	});
-};
-
-const receivedParams: ReceivedStartupOptions = await getReceivedParams();
+export const receivedParams: ReceivedStartupOptions = {};
+const url = self?.location?.href;
+if (typeof url !== 'undefined') {
+	const params = new URL(self.location.href).searchParams;
+	receivedParams.wpVersion = params.get('wpVersion') || undefined;
+	receivedParams.phpVersion = params.get('phpVersion') || undefined;
+	receivedParams.storage = params.get('storage') || undefined;
+	// Default to CLI to support the WP-CLI Blueprint step
+	receivedParams.sapiName = params.get('sapiName') || 'cli';
+	receivedParams.phpExtensions = params.getAll('php-extension');
+	receivedParams.siteSlug = params.get('site-slug') || undefined;
+}
 
 export const requestedWPVersion = receivedParams.wpVersion || '';
 export const startupOptions = {


### PR DESCRIPTION
Reverts WordPress/wordpress-playground#1574