### PR TITLE
Disable website features that don't work while offline

### DIFF
--- a/packages/playground/website/src/components/offline-notice/index.tsx
+++ b/packages/playground/website/src/components/offline-notice/index.tsx
@@ -1,0 +1,14 @@
+import { Notice } from '@wordpress/components';
+import css from './style.module.css';
+
+export function OfflineNotice() {
+	return (
+		<Notice
+			status="warning"
+			isDismissible={false}
+			className={css.offlineNotice}
+		>
+			Some features may not available because you are offline.
+		</Notice>
+	);
+}

--- a/packages/playground/website/src/components/offline-notice/style.module.css
+++ b/packages/playground/website/src/components/offline-notice/style.module.css
@@ -1,0 +1,10 @@
+.offline-notice {
+	margin: 0;
+	padding-right: 5px;
+	color: #000;
+	font-size: inherit;
+
+	.components-notice__content {
+		margin-right: 0;
+	}
+}

--- a/packages/playground/website/src/components/playground-configuration-group/form.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/form.tsx
@@ -8,6 +8,8 @@ import {
 import { StorageType } from '../../types';
 import { OPFSButton } from './opfs-button';
 import Button from '../button';
+import { PlaygroundReduxState } from '../../lib/redux-store';
+import { useSelector } from 'react-redux';
 
 export interface PlaygroundConfiguration {
 	wp: string;
@@ -40,6 +42,8 @@ export function PlaygroundConfigurationForm({
 	onSubmit,
 	onSelectLocalDirectory,
 }: PlaygroundConfigurationFormProps) {
+	const offline = useSelector((state: PlaygroundReduxState) => state.offline);
+
 	const [php, setPhp] = useState(initialData.php);
 	const [storage, setStorage] = useState<StorageType>(initialData.storage);
 	const [withExtensions, setWithExtensions] = useState<boolean>(
@@ -257,6 +261,7 @@ export function PlaygroundConfigurationForm({
 							id="php-version"
 							value={php}
 							className={forms.largeSelect}
+							disabled={offline}
 							onChange={(
 								event: React.ChangeEvent<HTMLSelectElement>
 							) => {
@@ -278,6 +283,7 @@ export function PlaygroundConfigurationForm({
 							<input
 								type="checkbox"
 								name="with-extensions"
+								disabled={offline}
 								checked={withExtensions}
 								onChange={() =>
 									setWithExtensions(!withExtensions)
@@ -294,6 +300,7 @@ export function PlaygroundConfigurationForm({
 							<input
 								type="checkbox"
 								name="with-networking"
+								disabled={offline}
 								checked={withNetworking}
 								onChange={() =>
 									setWithNetworking(!withNetworking)
@@ -323,6 +330,7 @@ export function PlaygroundConfigurationForm({
 								id="wp-version"
 								value={wp}
 								className={forms.largeSelect}
+								disabled={offline}
 								onChange={(
 									event: React.ChangeEvent<HTMLSelectElement>
 								) => {

--- a/packages/playground/website/src/components/playground-configuration-group/form.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/form.tsx
@@ -8,6 +8,7 @@ import {
 import { StorageType } from '../../types';
 import { OPFSButton } from './opfs-button';
 import Button from '../button';
+import { OfflineNotice } from '../offline-notice';
 import { PlaygroundReduxState } from '../../lib/redux-store';
 import { useSelector } from 'react-redux';
 
@@ -101,6 +102,11 @@ export function PlaygroundConfigurationForm({
 			<h2 tabIndex={0} style={{ textAlign: 'center', marginTop: 0 }}>
 				Customize Playground
 			</h2>
+			{offline ? (
+				<div style={{ marginBottom: 20 }}>
+					<OfflineNotice />
+				</div>
+			) : null}
 			<div className={forms.formGroup}>
 				<label htmlFor="wp-version" className={forms.groupLabel}>
 					Storage type

--- a/packages/playground/website/src/components/toolbar-buttons/github-export-menu-item.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/github-export-menu-item.tsx
@@ -4,13 +4,15 @@ import { openModal } from '../../github/github-export-form/modal';
 
 interface Props {
 	onClose: () => void;
+	disabled?: boolean;
 }
-export function GithubExportMenuItem({ onClose }: Props) {
+export function GithubExportMenuItem({ onClose, disabled }: Props) {
 	return (
 		<MenuItem
 			icon={cloudUpload}
 			iconPosition="left"
 			aria-label="Export WordPress theme, plugin, or wp-content directory to a GitHub repository as a Pull Request."
+			disabled={disabled}
 			onClick={() => {
 				openModal();
 				onClose();

--- a/packages/playground/website/src/components/toolbar-buttons/github-import-menu-item.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/github-import-menu-item.tsx
@@ -4,13 +4,15 @@ import { openModal } from '../../github/github-import-form/modal';
 
 interface Props {
 	onClose: () => void;
+	disabled?: boolean;
 }
-export function GithubImportMenuItem({ onClose }: Props) {
+export function GithubImportMenuItem({ onClose, disabled }: Props) {
 	return (
 		<MenuItem
 			icon={cloud}
 			iconPosition="left"
 			aria-label="Import WordPress theme, plugin, or wp-content directory from a GitHub repository."
+			disabled={disabled}
 			onClick={() => {
 				openModal();
 				onClose();

--- a/packages/playground/website/src/components/toolbar-buttons/report-error.tsx
+++ b/packages/playground/website/src/components/toolbar-buttons/report-error.tsx
@@ -4,8 +4,8 @@ import { bug } from '@wordpress/icons';
 import { useDispatch } from 'react-redux';
 import { PlaygroundDispatch, setActiveModal } from '../../lib/redux-store';
 
-type Props = { onClose: () => void };
-export function ReportError({ onClose }: Props) {
+type Props = { onClose: () => void; disabled?: boolean };
+export function ReportError({ onClose, disabled }: Props) {
 	const dispatch: PlaygroundDispatch = useDispatch();
 	return (
 		<MenuItem
@@ -13,6 +13,7 @@ export function ReportError({ onClose }: Props) {
 			iconPosition="left"
 			data-cy="report-error"
 			aria-label="Report an error in Playground"
+			disabled={disabled}
 			onClick={() => {
 				dispatch(setActiveModal('error-report'));
 				onClose();

--- a/packages/playground/website/src/lib/redux-store.ts
+++ b/packages/playground/website/src/lib/redux-store.ts
@@ -14,6 +14,7 @@ export type ActiveModal =
 // Define the state types
 interface AppState {
 	activeModal: string | null;
+	offline: boolean;
 }
 
 const query = new URL(document.location.href).searchParams;
@@ -24,6 +25,7 @@ const initialState: AppState = {
 		query.get('modal') === 'mount-markdown-directory'
 			? 'mount-markdown-directory'
 			: null,
+	offline: !navigator.onLine,
 };
 
 if (initialState.activeModal !== 'mount-markdown-directory') {
@@ -45,6 +47,9 @@ const slice = createSlice({
 			}
 			state.activeModal = action.payload;
 		},
+		setOfflineStatus: (state, action: PayloadAction<boolean>) => {
+			state.offline = action.payload;
+		},
 	},
 });
 
@@ -55,6 +60,16 @@ export const { setActiveModal } = slice.actions;
 const store = configureStore({
 	reducer: slice.reducer,
 });
+
+function setupOnlineOfflineListeners(dispatch: PlaygroundDispatch) {
+	window.addEventListener('online', () => {
+		dispatch(slice.actions.setOfflineStatus(false));
+	});
+	window.addEventListener('offline', () => {
+		dispatch(slice.actions.setOfflineStatus(true));
+	});
+}
+setupOnlineOfflineListeners(store.dispatch);
 
 // Define RootState type
 export type PlaygroundReduxState = ReturnType<typeof store.getState>;

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -132,6 +132,7 @@ function Modals() {
 
 function Main() {
 	const dispatch: PlaygroundDispatch = useDispatch();
+	const offline = useSelector((state: PlaygroundReduxState) => state.offline);
 
 	const { playground, url, iframeRef } = useBootPlayground({
 		blueprint,
@@ -279,11 +280,20 @@ function Main() {
 										storage={currentConfiguration.storage}
 										onClose={onClose}
 									/>
-									<ReportError onClose={onClose} />
+									<ReportError
+										onClose={onClose}
+										disabled={offline}
+									/>
 									<DownloadAsZipMenuItem onClose={onClose} />
 									<RestoreFromZipMenuItem onClose={onClose} />
-									<GithubImportMenuItem onClose={onClose} />
-									<GithubExportMenuItem onClose={onClose} />
+									<GithubImportMenuItem
+										onClose={onClose}
+										disabled={offline}
+									/>
+									<GithubExportMenuItem
+										onClose={onClose}
+										disabled={offline}
+									/>
 									<ViewLogs onClose={onClose} />
 									<MenuItem
 										icon={external}

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -41,6 +41,7 @@ import { ErrorReportModal } from './components/error-report-modal';
 import { asContentType } from './github/import-from-github';
 import { GitHubOAuthGuardModal } from './github/github-oauth-guard';
 import { LogModal } from './components/log-modal';
+import { OfflineNotice } from './components/offline-notice';
 import { StartErrorModal } from './components/start-error-modal';
 import { MountMarkdownDirectoryModal } from './components/mount-markdown-directory-modal';
 import { useBootPlayground } from './lib/use-boot-playground';
@@ -189,6 +190,7 @@ function Main() {
 				dispatch(setActiveModal('error-report'));
 			}
 		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	// Add GA events for blueprint steps. For more information, see the README.md file.
@@ -203,6 +205,7 @@ function Main() {
 		for (const step of steps) {
 			logTrackingEvent('step', { step });
 		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [blueprint?.steps]);
 
 	return (
@@ -275,6 +278,7 @@ function Main() {
 					>
 						{({ onClose }) => (
 							<>
+								{offline ? <OfflineNotice /> : null}
 								<MenuGroup>
 									<ResetSiteMenuItem
 										storage={currentConfiguration.storage}
@@ -314,6 +318,7 @@ function Main() {
 											].join('') as any
 										}
 										target="_blank"
+										disabled={offline}
 									>
 										Edit the Blueprint
 									</MenuItem>
@@ -330,6 +335,7 @@ function Main() {
 											) as any
 										}
 										target="_blank"
+										disabled={offline}
 									>
 										Preview WordPress Pull Request
 									</MenuItem>
@@ -344,6 +350,7 @@ function Main() {
 											) as any
 										}
 										target="_blank"
+										disabled={offline}
 									>
 										More demos
 									</MenuItem>
@@ -355,6 +362,7 @@ function Main() {
 											'https://wordpress.github.io/wordpress-playground/' as any
 										}
 										target="_blank"
+										disabled={offline}
 									>
 										Documentation
 									</MenuItem>
@@ -366,6 +374,7 @@ function Main() {
 											'https://github.com/WordPress/wordpress-playground' as any
 										}
 										target="_blank"
+										disabled={offline}
 									>
 										GitHub
 									</MenuItem>


### PR DESCRIPTION
## Motivation for the change, related issues

[Playground will soon be able to work offline ](https://github.com/WordPress/wordpress-playground/pull/1600), but some features like GitHub exports still require internet to work.

When offline users shouldn't be able to:

- Change PHP versions
- Change WordPress versions 
- Enable networking
- Change if extensions are loaded or not
- Export to GitHub
- Import from GitHub
- Report error

Some of these might get offline support in the future, but they won't be available in v1.

## Implementation details

The `PlaygroundReduxState` store now has a `offline` selector.

This selector is used by the _Customize Playground_ form and the menu to disable buttons for functionalities that don't work offline.

## Testing Instructions (or ideally a Blueprint)

- Checkout this branch
- Open Playground http://127.0.0.1:5400/website-server/
- Go offline (in Chrome Dev Tools > Application > Service Worker > Offline checkbox)
- Open the _Customize Playground_
- Confirm that these features are disabled
  - Change PHP versions
  - Change WordPress versions 
  - Enable networking
  - Change if extensions are loaded or not
- Open the menu (upper right corner)
- Confirm that these features are disabled
  - Export to GitHub
  - Import from GitHub
  - Report error
![Screenshot 2024-07-12 at 13 55 19](https://github.com/user-attachments/assets/8a5f174e-22e2-409d-9fd4-a2209f71bbb9)
![Screenshot 2024-07-12 at 13 55 26](https://github.com/user-attachments/assets/11cfccd3-ff55-41df-b478-5a506b85cb81)

