### PR TITLE
Add the `components` package with PathMappingControl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"packages/playground/*"
 			],
 			"dependencies": {
+				"@github/auto-complete-element": "3.6.2",
 				"@preact/signals-react": "1.3.6",
 				"@reduxjs/toolkit": "2.2.5",
 				"@types/ini": "4.1.0",
@@ -4594,6 +4595,19 @@
 			"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
 			"dev": true
+		},
+		"node_modules/@github/auto-complete-element": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@github/auto-complete-element/-/auto-complete-element-3.6.2.tgz",
+			"integrity": "sha512-AgkrawNa2Focapn05yc/mNVTlAOqPFlMPhqkkMygPtOddms6NYxlCuVx8OM6aCTzBeEJlYur+/CS56hk4mvwmA==",
+			"dependencies": {
+				"@github/combobox-nav": "^2.1.7"
+			}
+		},
+		"node_modules/@github/combobox-nav": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@github/combobox-nav/-/combobox-nav-2.3.1.tgz",
+			"integrity": "sha512-gwxPzLw8XKecy1nP63i9lOBritS3bWmxl02UX6G0TwMQZbMem1BCS1tEZgYd3mkrkiDrUMWaX+DbFCuDFo3K+A=="
 		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.3.0",
@@ -17954,6 +17968,10 @@
 		},
 		"node_modules/@wp-playground/common": {
 			"resolved": "packages/playground/common",
+			"link": true
+		},
+		"node_modules/@wp-playground/components": {
+			"resolved": "packages/playground/components",
 			"link": true
 		},
 		"node_modules/@wp-playground/nx-extensions": {
@@ -45516,6 +45534,13 @@
 			"name": "@wp-playground/common",
 			"version": "0.9.18",
 			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.18.0",
+				"npm": ">=8.11.0"
+			}
+		},
+		"packages/playground/components": {
+			"version": "0.9.18",
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"packages/playground/*"
 			],
 			"dependencies": {
-				"@github/auto-complete-element": "3.6.2",
 				"@preact/signals-react": "1.3.6",
 				"@reduxjs/toolkit": "2.2.5",
 				"@types/ini": "4.1.0",
@@ -4595,19 +4594,6 @@
 			"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
 			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
 			"dev": true
-		},
-		"node_modules/@github/auto-complete-element": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/@github/auto-complete-element/-/auto-complete-element-3.6.2.tgz",
-			"integrity": "sha512-AgkrawNa2Focapn05yc/mNVTlAOqPFlMPhqkkMygPtOddms6NYxlCuVx8OM6aCTzBeEJlYur+/CS56hk4mvwmA==",
-			"dependencies": {
-				"@github/combobox-nav": "^2.1.7"
-			}
-		},
-		"node_modules/@github/combobox-nav": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/@github/combobox-nav/-/combobox-nav-2.3.1.tgz",
-			"integrity": "sha512-gwxPzLw8XKecy1nP63i9lOBritS3bWmxl02UX6G0TwMQZbMem1BCS1tEZgYd3mkrkiDrUMWaX+DbFCuDFo3K+A=="
 		},
 		"node_modules/@hapi/hoek": {
 			"version": "9.3.0",
@@ -17968,10 +17954,6 @@
 		},
 		"node_modules/@wp-playground/common": {
 			"resolved": "packages/playground/common",
-			"link": true
-		},
-		"node_modules/@wp-playground/components": {
-			"resolved": "packages/playground/components",
 			"link": true
 		},
 		"node_modules/@wp-playground/nx-extensions": {
@@ -45534,13 +45516,6 @@
 			"name": "@wp-playground/common",
 			"version": "0.9.18",
 			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.18.0",
-				"npm": ">=8.11.0"
-			}
-		},
-		"packages/playground/components": {
-			"version": "0.9.18",
 			"engines": {
 				"node": ">=18.18.0",
 				"npm": ">=8.11.0"

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 	},
 	"private": true,
 	"dependencies": {
+		"@github/auto-complete-element": "3.6.2",
 		"@preact/signals-react": "1.3.6",
 		"@reduxjs/toolkit": "2.2.5",
 		"@types/ini": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
 	},
 	"private": true,
 	"dependencies": {
-		"@github/auto-complete-element": "3.6.2",
 		"@preact/signals-react": "1.3.6",
 		"@reduxjs/toolkit": "2.2.5",
 		"@types/ini": "4.1.0",

--- a/packages/playground/components/.eslintrc.json
+++ b/packages/playground/components/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/packages/playground/components/README.md
+++ b/packages/playground/components/README.md
@@ -1,0 +1,11 @@
+# playground-components
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build playground-components` to build the library.
+
+## Running unit tests
+
+Run `nx test playground-components` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/playground/components/README.md
+++ b/packages/playground/components/README.md
@@ -1,11 +1,17 @@
-# playground-components
+## Playground components
 
-This library was generated with [Nx](https://nx.dev).
+A library of reusable, dependency-free components (well, React is a dependency) that can be reused between Playground webapp, WordPress plugins, WordPress blocks, and the Blueprints builder. For example, the PathMappingControl will make a good fit for all these places.
 
-## Building
+## Design decisions
 
-Run `nx build playground-components` to build the library.
+The components in this package use `@wordpress/components` under the hood. Web components were considered for portability, but ultimately weren't used because they:
 
-## Running unit tests
+-   Wouldn't have the native WordPress look and feel
+-   Couldn't easily mix with WordPress components
+-   Had some issues around focus management
 
-Run `nx test playground-components` to execute the unit tests via [Jest](https://jestjs.io).
+## Development Instructions (or ideally a Blueprint)
+
+1. Run `nx dev playground-components`
+2. Go to http://localhost:5173/
+3. Play with the widgets and confirm they work intuitively

--- a/packages/playground/components/index.html
+++ b/packages/playground/components/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Components demo</title>
+		<base href="/" />
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="./src/demos.tsx"></script>
+	</body>
+</html>

--- a/packages/playground/components/package.json
+++ b/packages/playground/components/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@wp-playground/components",
+	"version": "0.9.18",
+	"exports": {
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./package.json": "./package.json"
+	},
+	"type": "module",
+	"main": "./index.cjs",
+	"module": "./index.js",
+	"typedoc": {
+		"entryPoint": "./src/index.ts",
+		"readmeFile": "./README.md",
+		"displayName": "@wp-playground/components",
+		"tsconfig": "./tsconfig.lib.json"
+	},
+	"publishConfig": {
+		"access": "public",
+		"directory": "../../../dist/packages/playground/components"
+	},
+	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
+	"engines": {
+		"node": ">=18.18.0",
+		"npm": ">=8.11.0"
+	}
+}

--- a/packages/playground/components/project.json
+++ b/packages/playground/components/project.json
@@ -1,0 +1,81 @@
+{
+	"name": "playground-components",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/playground/components/src",
+	"projectType": "library",
+	"targets": {
+		"build": {
+			"executor": "@nx/vite:build",
+			"outputs": ["{options.outputPath}"],
+			"defaultConfiguration": "production",
+			"options": {
+				"outputPath": "dist/packages/playground/components"
+			},
+			"configurations": {
+				"development": {
+					"mode": "development"
+				},
+				"production": {
+					"mode": "production",
+					"logLevel": "info"
+				}
+			},
+			"dependsOn": ["^build"]
+		},
+		"dev": {
+			"executor": "@nx/vite:dev-server",
+			"defaultConfiguration": "development",
+			"options": {
+				"buildTarget": "playground-components:build"
+			},
+			"configurations": {
+				"development": {
+					"buildTarget": "playground-components:build:development",
+					"hmr": true
+				},
+				"production": {
+					"buildTarget": "playground-components:build:production",
+					"hmr": false
+				}
+			}
+		},
+		"test": {
+			"executor": "nx:noop",
+			"dependsOn": ["test:vite"]
+		},
+		"test:esmcjs": {
+			"executor": "@wp-playground/nx-extensions:assert-built-esm-and-cjs",
+			"options": {
+				"outputPath": "dist/packages/playground/components"
+			},
+			"dependsOn": ["build"]
+		},
+		"test:vite": {
+			"executor": "@nx/vite:test",
+			"outputs": [
+				"{workspaceRoot}/coverage/packages/playground/components"
+			],
+			"options": {
+				"passWithNoTests": true,
+				"reportsDirectory": "../../../coverage/packages/playground/components"
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["packages/playground/components/**/*.ts"]
+			}
+		},
+		"typecheck": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"tsc -p packages/playground/remote/tsconfig.spec.json --noEmit",
+					"tsc -p packages/playground/remote/tsconfig.lib.json --noEmit"
+				]
+			}
+		}
+	},
+	"tags": []
+}

--- a/packages/playground/components/src/PathMappingControl/PathMappingControl.tsx
+++ b/packages/playground/components/src/PathMappingControl/PathMappingControl.tsx
@@ -9,6 +9,7 @@ import {
 	// @ts-expect-error
 	__experimentalInputControl as InputControl,
 	Button,
+	SelectControl,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronDown } from '@wordpress/icons';
 import '@wordpress/components/build-style/style.css';
@@ -30,6 +31,7 @@ type MappingNodeStates = Record<string, MappingNodeState>;
 
 type MappingNodeState = {
 	isOpen?: boolean;
+	pathType?: string;
 	playgroundPath?: string;
 };
 
@@ -115,7 +117,11 @@ const NodeRow: React.FC<{
 	parentMapping = '',
 }) => {
 	const path = generatePath(node, parentPath);
-	const nodeState = nodeStates[path] || { isOpen: false, playgroundPath: '' };
+	const nodeState = nodeStates[path] || {
+		isOpen: false,
+		playgroundPath: '',
+		pathType: '',
+	};
 	const nodeMapping = computeMapping({
 		node,
 		nodeState,
@@ -128,6 +134,33 @@ const NodeRow: React.FC<{
 
 	const handlePathChange = (value: string) => {
 		updateNodeState(path, { playgroundPath: value });
+	};
+
+	const handlePathSelectChange = (pathType: string) => {
+		switch (pathType) {
+			case 'plugin':
+				updateNodeState(path, {
+					pathType,
+					playgroundPath:
+						'/wordpress/wp-content/plugins/' + node.name,
+				});
+				break;
+			case 'theme':
+				updateNodeState(path, {
+					pathType,
+					playgroundPath: '/wordpress/wp-content/themes/' + node.name,
+				});
+				break;
+			case 'wp-content':
+				updateNodeState(path, {
+					pathType,
+					playgroundPath: '/wordpress/wp-content',
+				});
+				break;
+			default:
+				updateNodeState(path, { pathType, playgroundPath: '' });
+				break;
+		}
 	};
 
 	const handleKeyDown = (event: any) => {
@@ -190,15 +223,42 @@ const NodeRow: React.FC<{
 				<TreeGridCell>
 					{() => (
 						<>
-							<InputControl
-								disabled={parentMapping}
-								value={nodeMapping}
-								onChange={handlePathChange}
-								onDrag={function noRefCheck() {}}
-								onDragEnd={function noRefCheck() {}}
-								onDragStart={function noRefCheck() {}}
-								onValidate={function noRefCheck() {}}
-							/>
+							{!parentMapping && (
+								<SelectControl
+									label="Path"
+									value={nodeState.pathType}
+									onChange={handlePathSelectChange}
+									options={[
+										{ label: 'Select a path', value: '' },
+										{ label: 'Plugin', value: 'plugin' },
+										{ label: 'Theme', value: 'theme' },
+										{
+											label: 'wp-content',
+											value: 'wp-content',
+										},
+										{
+											label: 'Custom path',
+											value: 'custom-path',
+										},
+									]}
+								/>
+							)}
+							{(parentMapping || nodeState.pathType !== '') && (
+								<InputControl
+									disabled={
+										parentMapping ||
+										(nodeState.pathType?.trim() !== '' &&
+											nodeState.pathType !==
+												'custom-path')
+									}
+									value={nodeMapping}
+									onChange={handlePathChange}
+									onDrag={function noRefCheck() {}}
+									onDragEnd={function noRefCheck() {}}
+									onDragStart={function noRefCheck() {}}
+									onValidate={function noRefCheck() {}}
+								/>
+							)}
 						</>
 					)}
 				</TreeGridCell>

--- a/packages/playground/components/src/PathMappingControl/PathMappingControl.tsx
+++ b/packages/playground/components/src/PathMappingControl/PathMappingControl.tsx
@@ -1,12 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import {
-	// @ts-expect-error
 	__experimentalTreeGrid as TreeGrid,
-	// @ts-expect-error
 	__experimentalTreeGridRow as TreeGridRow,
-	// @ts-expect-error
 	__experimentalTreeGridCell as TreeGridCell,
-	// @ts-expect-error
 	__experimentalInputControl as InputControl,
 	Button,
 	SelectControl,
@@ -132,7 +128,7 @@ const NodeRow: React.FC<{
 		updateNodeState(path, { isOpen: !nodeState.isOpen });
 	};
 
-	const handlePathChange = (value: string) => {
+	const handlePathChange = (value: string | undefined) => {
 		updateNodeState(path, { playgroundPath: value });
 	};
 
@@ -246,7 +242,7 @@ const NodeRow: React.FC<{
 							{(parentMapping || nodeState.pathType !== '') && (
 								<InputControl
 									disabled={
-										parentMapping ||
+										!!parentMapping ||
 										(nodeState.pathType?.trim() !== '' &&
 											nodeState.pathType !==
 												'custom-path')

--- a/packages/playground/components/src/PathMappingControl/PathMappingControl.tsx
+++ b/packages/playground/components/src/PathMappingControl/PathMappingControl.tsx
@@ -1,0 +1,271 @@
+import React, { useEffect, useState } from 'react';
+import {
+	// @ts-expect-error
+	__experimentalTreeGrid as TreeGrid,
+	// @ts-expect-error
+	__experimentalTreeGridRow as TreeGridRow,
+	// @ts-expect-error
+	__experimentalTreeGridCell as TreeGridCell,
+	// @ts-expect-error
+	__experimentalInputControl as InputControl,
+	Button,
+} from '@wordpress/components';
+import { Icon, chevronRight, chevronDown } from '@wordpress/icons';
+import '@wordpress/components/build-style/style.css';
+import './style.css';
+
+// Define the type for the file structure
+// Define the type for the file structure
+type FileNode = {
+	name: string;
+	type: 'file' | 'folder';
+	children?: FileNode[];
+};
+
+type PathMappingFormProps = {
+	files: FileNode[];
+	initialState: MappingNodeStates;
+	onMappingChange?: (mapping: PathMapping) => void;
+};
+type PathMapping = Record<string, string>;
+type MappingNodeStates = Record<string, MappingNodeState>;
+
+type MappingNodeState = {
+	isOpen?: boolean;
+	playgroundPath?: string;
+};
+
+const PathMappingControl: React.FC<PathMappingFormProps> = ({
+	files,
+	initialState = {},
+	onMappingChange = () => {},
+}) => {
+	const [state, setState] = useState<MappingNodeStates>(initialState);
+
+	const updatePathMapping = (
+		path: string,
+		state: Partial<MappingNodeState>
+	) => {
+		setState((prevState) => ({
+			...prevState,
+			[path]: {
+				...prevState[path],
+				...state,
+			},
+		}));
+	};
+
+	useEffect(() => {
+		const pathMapping: PathMapping = {};
+		Object.keys(state).forEach((path) => {
+			if (state[path].playgroundPath) {
+				pathMapping[path] = state[path].playgroundPath!;
+			}
+		});
+		onMappingChange(pathMapping);
+	}, [state]);
+
+	const generatePath = (node: FileNode, parentPath = ''): string => {
+		return parentPath
+			? `${parentPath}/${node.name}`.replaceAll(/\/+/g, '/')
+			: node.name;
+	};
+
+	return (
+		<TreeGrid className="path-mapping-control">
+			<TreeGridRow level={0} positionInSet={0} setSize={1}>
+				<TreeGridCell>{() => <>File/Folder</>}</TreeGridCell>
+				<TreeGridCell>
+					{() => <>Absolute path in Playground</>}
+				</TreeGridCell>
+			</TreeGridRow>
+			{files.map((file, index) => (
+				<NodeRow
+					key={file.name}
+					node={file}
+					level={0}
+					position={index + 1}
+					setSize={files.length}
+					nodeStates={state}
+					updateNodeState={updatePathMapping}
+					generatePath={generatePath}
+				/>
+			))}
+		</TreeGrid>
+	);
+};
+
+const NodeRow: React.FC<{
+	node: FileNode;
+	level: number;
+	position: number;
+	setSize: number;
+	nodeStates: MappingNodeStates;
+	updateNodeState: (path: string, state: Partial<MappingNodeState>) => void;
+	generatePath: (node: FileNode, parentPath?: string) => string;
+	parentPath?: string;
+	parentMapping?: string;
+}> = ({
+	node,
+	level,
+	position,
+	setSize,
+	nodeStates,
+	updateNodeState,
+	generatePath,
+	parentPath = '',
+	parentMapping = '',
+}) => {
+	const path = generatePath(node, parentPath);
+	const nodeState = nodeStates[path] || { isOpen: false, playgroundPath: '' };
+	const nodeMapping = computeMapping({
+		node,
+		nodeState,
+		parentMapping,
+	});
+
+	const toggleOpen = () => {
+		updateNodeState(path, { isOpen: !nodeState.isOpen });
+	};
+
+	const handlePathChange = (value: string) => {
+		updateNodeState(path, { playgroundPath: value });
+	};
+
+	const handleKeyDown = (event: any) => {
+		if (event.key === 'ArrowLeft') {
+			if (nodeState.isOpen) {
+				toggleOpen();
+			} else {
+				if (node.children?.length) {
+					(
+						document.querySelector(
+							`[data-path="${parentPath}"]`
+						) as HTMLButtonElement
+					)?.focus();
+				}
+			}
+			event.preventDefault();
+			event.stopPropagation();
+		} else if (event.key === 'ArrowRight') {
+			if (nodeState.isOpen) {
+				if (node.children?.length) {
+					const firstChildPath = generatePath(node.children[0], path);
+					(
+						document.querySelector(
+							`[data-path="${firstChildPath}"]`
+						) as HTMLButtonElement
+					)?.focus();
+				}
+			} else {
+				toggleOpen();
+			}
+			event.preventDefault();
+			event.stopPropagation();
+		}
+	};
+	return (
+		<>
+			<TreeGridRow
+				level={level}
+				positionInSet={position}
+				setSize={setSize}
+			>
+				<TreeGridCell>
+					{() => (
+						<Button
+							onClick={toggleOpen}
+							onKeyDown={handleKeyDown}
+							className="file-node-button"
+							data-path={path}
+						>
+							<FileName
+								node={node}
+								isOpen={
+									node.type === 'folder' && nodeState.isOpen
+								}
+								level={level}
+							/>
+						</Button>
+					)}
+				</TreeGridCell>
+				<TreeGridCell>
+					{() => (
+						<>
+							<InputControl
+								disabled={parentMapping}
+								value={nodeMapping}
+								onChange={handlePathChange}
+								onDrag={function noRefCheck() {}}
+								onDragEnd={function noRefCheck() {}}
+								onDragStart={function noRefCheck() {}}
+								onValidate={function noRefCheck() {}}
+							/>
+						</>
+					)}
+				</TreeGridCell>
+			</TreeGridRow>
+			{nodeState.isOpen &&
+				node.children &&
+				node.children.map((child, index) => (
+					<NodeRow
+						key={child.name}
+						node={child}
+						level={level + 1}
+						position={index + 1}
+						setSize={node.children!.length}
+						nodeStates={nodeStates}
+						updateNodeState={updateNodeState}
+						generatePath={generatePath}
+						parentPath={path}
+						parentMapping={nodeMapping}
+					/>
+				))}
+		</>
+	);
+};
+
+function computeMapping({
+	node,
+	nodeState,
+	parentMapping,
+}: {
+	node: FileNode;
+	nodeState: MappingNodeState;
+	parentMapping: string;
+}): string {
+	if (parentMapping) {
+		return `${parentMapping}/${node.name}`.replace(/\/+/g, '/');
+	}
+	if (nodeState.playgroundPath) {
+		return nodeState.playgroundPath;
+	}
+	return '';
+}
+
+const FileName: React.FC<{
+	node: FileNode;
+	level: number;
+	isOpen?: boolean;
+}> = ({ node, level, isOpen }) => {
+	const indent: string[] = [];
+	for (let i = 0; i < level; i++) {
+		indent.push('&nbsp;&nbsp;&nbsp;&nbsp;');
+	}
+	return (
+		<>
+			<span
+				aria-hidden="true"
+				dangerouslySetInnerHTML={{ __html: indent.join('') }}
+			></span>
+			{node.type === 'folder' ? (
+				<Icon width={16} icon={isOpen ? chevronDown : chevronRight} />
+			) : (
+				<div style={{ width: 16 }}>&nbsp;</div>
+			)}
+			{node.name}
+		</>
+	);
+};
+
+export default PathMappingControl;

--- a/packages/playground/components/src/PathMappingControl/PathMappingControl.tsx
+++ b/packages/playground/components/src/PathMappingControl/PathMappingControl.tsx
@@ -14,8 +14,6 @@ import { Icon, chevronRight, chevronDown } from '@wordpress/icons';
 import '@wordpress/components/build-style/style.css';
 import './style.css';
 
-// Define the type for the file structure
-// Define the type for the file structure
 type FileNode = {
 	name: string;
 	type: 'file' | 'folder';

--- a/packages/playground/components/src/PathMappingControl/demo.tsx
+++ b/packages/playground/components/src/PathMappingControl/demo.tsx
@@ -35,6 +35,11 @@ export default function PathMappingControlDemo() {
 	const [mapping, setMapping] = React.useState({});
 	return (
 		<div>
+			<style>
+				{`.path-mapping-control td:last-child {
+					width: 500px;
+				}`}
+			</style>
 			<PathMappingControl
 				files={fileStructure}
 				initialState={{ '/': { isOpen: true } }}

--- a/packages/playground/components/src/PathMappingControl/demo.tsx
+++ b/packages/playground/components/src/PathMappingControl/demo.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PathMappingControl from './PathMappingControl';
+
+const fileStructure = [
+	{
+		name: '/',
+		type: 'folder' as const,
+		children: [
+			{
+				name: 'Documents',
+				type: 'folder' as const,
+				children: [
+					{ name: 'Resume.pdf', type: 'file' as const },
+					{ name: 'CoverLetter.docx', type: 'file' as const },
+				],
+			},
+			{
+				name: 'Pictures',
+				type: 'folder' as const,
+				children: [
+					{
+						name: 'Vacation',
+						type: 'folder' as const,
+						children: [
+							{ name: 'beach.png', type: 'file' as const },
+						],
+					},
+				],
+			},
+			{ name: 'todo.txt', type: 'file' as const },
+		],
+	},
+];
+export default function PathMappingControlDemo() {
+	const [mapping, setMapping] = React.useState({});
+	return (
+		<div>
+			<PathMappingControl
+				files={fileStructure}
+				initialState={{ '/': { isOpen: true } }}
+				onMappingChange={(newMapping) => setMapping(newMapping)}
+			/>
+			<h3>Mapping:</h3>
+			<pre>{JSON.stringify(mapping, null, 2)}</pre>
+		</div>
+	);
+}

--- a/packages/playground/components/src/PathMappingControl/index.ts
+++ b/packages/playground/components/src/PathMappingControl/index.ts
@@ -1,0 +1,3 @@
+import PathMappingControl from './PathMappingControl';
+
+export default PathMappingControl;

--- a/packages/playground/components/src/PathMappingControl/style.css
+++ b/packages/playground/components/src/PathMappingControl/style.css
@@ -1,0 +1,29 @@
+.path-mapping-control {
+	.file-node-button {
+		display: inline-flex;
+		text-decoration: none;
+		font-family: inherit;
+		font-weight: normal;
+		font-size: 13px;
+		margin: 0;
+		border: 0;
+		cursor: pointer;
+		-webkit-appearance: none;
+		background: none;
+		transition: box-shadow 0.1s linear;
+		height: 36px;
+		align-items: center;
+		box-sizing: border-box;
+		padding: 6px 12px;
+		border-radius: 2px;
+
+		width: 100%;
+		white-space: nowrap;
+		color: var(--wp-components-color-foreground, #1e1e1e);
+		background: transparent;
+		padding: 6px;
+	}
+	.directory-expand-button {
+		color: var(--wp-components-color-foreground, #1e1e1e) !important;
+	}
+}

--- a/packages/playground/components/src/demos.tsx
+++ b/packages/playground/components/src/demos.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PathMappingControlDemo from './PathMappingControl/demo';
+
+import { createRoot } from 'react-dom/client';
+
+// @TODO: Explore a Storybook setup instead of a custom demos page.
+
+const components = [
+	{
+		name: 'PathMappingControl',
+		component: PathMappingControlDemo,
+	},
+];
+
+function Demos() {
+	return (
+		<>
+			{components.map((component) => {
+				const Component = component.component;
+				return (
+					<div key={component.name}>
+						<h2>{component.name}</h2>
+						<Component key={component.name} />
+					</div>
+				);
+			})}
+		</>
+	);
+}
+
+const container = document.getElementById('root')!;
+const root = createRoot(container);
+root.render(<Demos />);

--- a/packages/playground/components/src/index.ts
+++ b/packages/playground/components/src/index.ts
@@ -1,0 +1,3 @@
+import PathMappingControlDemo from './PathMappingControl';
+
+export { PathMappingControlDemo };

--- a/packages/playground/components/tsconfig.json
+++ b/packages/playground/components/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "ES2022",
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"types": ["vitest"]
+	},
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+}

--- a/packages/playground/components/tsconfig.lib.json
+++ b/packages/playground/components/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts", "src/index.ts"],
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/playground/components/tsconfig.spec.json
+++ b/packages/playground/components/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"types": ["vitest/globals", "vitest/importMeta", "vite/client", "node"]
+	},
+	"include": [
+		"vite.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.test.tsx",
+		"src/**/*.spec.tsx",
+		"src/**/*.test.js",
+		"src/**/*.spec.js",
+		"src/**/*.test.jsx",
+		"src/**/*.spec.jsx",
+		"src/**/*.d.ts"
+	]
+}

--- a/packages/playground/components/vite.config.ts
+++ b/packages/playground/components/vite.config.ts
@@ -1,0 +1,61 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+import dts from 'vite-plugin-dts';
+import { join } from 'path';
+
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
+
+export default defineConfig({
+	cacheDir: '../../../node_modules/.vite/playground-components',
+
+	plugins: [
+		dts({
+			entryRoot: 'src',
+			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+		}),
+
+		viteTsConfigPaths({
+			root: '../../../',
+		}),
+	],
+
+	// Uncomment this if you are using workers.
+	// worker: {
+	//  plugins: [
+	//    viteTsConfigPaths({
+	//      root: '../../../',
+	//    }),
+	//  ],
+	// },
+
+	// Configuration for building your library.
+	// See: https://vitejs.dev/guide/build.html#library-mode
+	build: {
+		lib: {
+			// Could also be a dictionary or array of multiple entry points.
+			entry: 'src/index.ts',
+			name: 'playground-components',
+			fileName: 'index',
+			// Change this to the formats you want to support.
+			// Don't forgot to update your package.json as well.
+			formats: ['es', 'cjs'],
+		},
+		rollupOptions: {
+			external: getExternalModules(),
+		},
+	},
+
+	test: {
+		globals: true,
+		setupFiles: ['./src/vitest-setup-file.ts'],
+		cache: {
+			dir: '../../../node_modules/.vitest',
+		},
+		environment: 'jsdom',
+		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+	},
+});

--- a/packages/playground/components/vite.config.ts
+++ b/packages/playground/components/vite.config.ts
@@ -23,15 +23,6 @@ export default defineConfig({
 		}),
 	],
 
-	// Uncomment this if you are using workers.
-	// worker: {
-	//  plugins: [
-	//    viteTsConfigPaths({
-	//      root: '../../../',
-	//    }),
-	//  ],
-	// },
-
 	// Configuration for building your library.
 	// See: https://vitejs.dev/guide/build.html#library-mode
 	build: {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -49,6 +49,9 @@
 			"@wp-playground/common": [
 				"packages/playground/common/src/index.ts"
 			],
+			"@wp-playground/components": [
+				"packages/playground/components/src/index.ts"
+			],
 			"@wp-playground/nx-extensions": [
 				"packages/nx-extensions/src/index.ts"
 			],


### PR DESCRIPTION
## Motivation for the change, related issues

Adds a `PathMappingControl` React component:

![CleanShot 2024-07-12 at 15 11 01@2x](https://github.com/user-attachments/assets/8cdb2058-fc7b-48ca-b21b-a3766c1413e0)

The goal is to eventually replace the current mapping control based on text inputs:

![CleanShot 2024-07-12 at 15 13 00@2x](https://github.com/user-attachments/assets/f6efd9a6-b76c-42d2-888a-1543f166ea98)

The long-term goal is to create a library of dependency-free components (well, aside of React) to reuse between Playground webapp, WordPress plugins, WordPress blocks, and the Blueprints builder. This path mapping widget will make a good fit for all these places.

## Implementation details

The PathMappingControl uses WordPress components under the hood. Most notably, TreeGrid and Button. I considered using web components for portability, but decided against it because they:

* Wouldn't have the native WordPress look and feel
* Couldn't easily mix with WordPress components
* Had some issues around focus management

## Testing Instructions (or ideally a Blueprint)

1. Run `nx dev playground-components`
2. Go to http://localhost:5173/
3. Play with the widget and confirm it works intuitively

## Follow-up work

* Replace the text input under `Absolute path in Playground` with a UI-based picker or path autocompletion.
* Implement mapping validation to make sure there are no nested mappings, e.g. `/wordpress/wp-content` and `/wordpress/wp-content/plugins`.
* Reuse the base TreeGrid as a file browser in the Playground block (need asynchronous loading)
* 