### PR TITLE
Fix recursive calls to backfillStaticFilesRemovedFromMinifiedBuild

### DIFF
--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -210,7 +210,7 @@ export async function bootPlaygroundRemote() {
 		 * Download WordPress assets.
 		 */
 		async backfillStaticFilesRemovedFromMinifiedBuild() {
-			await webApi.backfillStaticFilesRemovedFromMinifiedBuild();
+			await phpApi.backfillStaticFilesRemovedFromMinifiedBuild();
 		},
 	};
 


### PR DESCRIPTION
## Motivation for the change, related issues

https://github.com/WordPress/wordpress-playground/pull/1604 accidentally introduced recursive calls to `webApi.backfillStaticFilesRemovedFromMinifiedBuild`.

## Implementation details

Update `webApi.backfillStaticFilesRemovedFromMinifiedBuild` to call `phpApi.backfillStaticFilesRemovedFromMinifiedBuild`.

## Testing Instructions (or ideally a Blueprint)

- checkout this branch
- confirm that there are no errors related to calls to `backfillStaticFilesRemovedFromMinifiedBuild` in the browser console
