### PR TITLE
Add CJS mime type

### DIFF
--- a/packages/php-wasm/universal/src/lib/mime-types.json
+++ b/packages/php-wasm/universal/src/lib/mime-types.json
@@ -9,6 +9,7 @@
 	"bin": "application/octet-stream",
 	"bmp": "image/x-ms-bmp",
 	"cco": "application/x-cocoa",
+	"cjs": "application/javascript",
 	"css": "text/css",
 	"data": "application/octet-stream",
 	"deb": "application/octet-stream",


### PR DESCRIPTION
## Motivation for the change, related issues

When requesting a .cjs file in Playground it returns an error:
> Loading module from “https://playground.wordpress.net/client/index.cjs” was blocked because of a disallowed MIME type (“application/octet-stream”).

## Implementation details

To fix this Playground has a list of mime types that was missing the CJS mime type. 

## Testing Instructions (or ideally a Blueprint)
