### PR TITLE
Fix joinPaths root edge case

### DIFF
--- a/packages/php-wasm/util/src/lib/paths.spec.ts
+++ b/packages/php-wasm/util/src/lib/paths.spec.ts
@@ -20,6 +20,7 @@ describe('joinPaths', () => {
 		expect(joinPaths('wordpress', '..', '..', 'wp-content')).toEqual(
 			'../wp-content'
 		);
+		expect(joinPaths('/', '/')).toEqual('/');
 	});
 });
 

--- a/packages/php-wasm/util/src/lib/paths.ts
+++ b/packages/php-wasm/util/src/lib/paths.ts
@@ -28,14 +28,18 @@
  * @returns A joined path
  */
 export function joinPaths(...paths: string[]) {
+	function hasTrailingSlash(p: string) {
+		return p.substring(p.length - 1) === '/';
+	}
+
 	let path = paths.join('/');
 	const isAbsolute = path[0] === '/';
-	const trailingSlash = path.substring(path.length - 1) === '/';
+	const trailingSlash = hasTrailingSlash(path);
 	path = normalizePath(path);
 	if (!path && !isAbsolute) {
 		path = '.';
 	}
-	if (path && trailingSlash) {
+	if (path && trailingSlash && !hasTrailingSlash(path)) {
 		path += '/';
 	}
 	return path;


### PR DESCRIPTION
## Motivation for the change, related issues

Prior to this PR, `joinPaths( '/', '/' ) === '//'`. This PR fixes that bug so `joinPaths( '/', '/' ) === '/'`.

## Testing Instructions (or ideally a Blueprint)

CI: Unit and e2e tests
