### PR TITLE
Disable PHP 7.0 and 7.1 version switcher E2E tests

### DIFF
--- a/packages/playground/website/cypress/e2e/website-ui.cy.ts
+++ b/packages/playground/website/cypress/e2e/website-ui.cy.ts
@@ -22,9 +22,11 @@ describe('Playground website UI', () => {
 	// Test all PHP versions for completeness
 	describe('PHP version switcher', () => {
 		SupportedPHPVersions.forEach((version) => {
-			if (version === '7.0') {
-				// The SQLite integration plugin uses `private const` which is not supported in PHP 7.0
-				// @TODO: Adjust the plugin and remove this condition.
+			/**
+			 * WordPress 6.6 dropped support for PHP 7.0 and 7.1 so we need to skip these versions.
+			 * @see https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/
+			 */
+			if (['7.0', '7.1'].includes(version)) {
 				return;
 			}
 			it('should switch PHP version to ' + version, () => {


### PR DESCRIPTION
## Motivation for the change, related issues

WordPress 6.6 [dropped support](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/) for PHP 7.0 & 7.1 which caused _PHP version switcher_ [tests to start failing.](https://github.com/WordPress/wordpress-playground/actions/runs/9960731846/job/27521525518)

Fixes #1621

## Implementation details

The code will now skip both PHP 7.0 and 7.1 in _PHP version switcher_ tests.

## Testing Instructions (or ideally a Blueprint)

- ensure all tests pass