### PR TITLE
Update `ws` package version to fix DOS vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44416,26 +44416,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/webpack-bundle-analyzer/node_modules/ws": {
-			"version": "7.5.9",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/webpack-dev-middleware": {
 			"version": "5.3.3",
 			"dev": true,
@@ -45135,7 +45115,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.13.0",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -187,7 +187,8 @@
 		"react": "^18.2.25",
 		"react-dom": "^18.2.25",
 		"typescript": "5.4.5",
-		"typedoc": "0.23.27"
+		"typedoc": "0.23.27",
+		"ws": "^8.18.0"
 	},
 	"workspaces": [
 		"packages/nx-extensions",


### PR DESCRIPTION
## Motivation for the change, related issues

Updates the `ws` dependency to remove high-severity DOS vulnerability from the `@php-wasm/node` package.

Fixes https://github.com/WordPress/wordpress-playground/issues/1578.

## Implementation details

This PR adds the latest version of `ws` to `overrides` which fixes the NPM vulnerability.

Alternatively, we could have updated the packages that use `ws` but that requires an update to Docusaurus packages. In my testing updating Docusaurus broke our docs build and I couldn't find a quick fix.

## Testing Instructions (or ideally a Blueprint)

- CI
