### PR TITLE
Plugin proxy: Send HTTP 400 code using http_response_code instead of the PHP header() function 

### DIFF
--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -392,7 +392,7 @@ try {
         throw new ApiException('Invalid query parameters');
     }
 } catch (ApiException $e) {
-    header('HTTP/1.1 400 Invalid request');
+    http_response_code(400);
     if (!headers_sent()) {
         header('Content-Type: application/json');
     }


### PR DESCRIPTION
## Motivation for the change, related issues

## Implementation details

## Testing Instructions (or ideally a Blueprint)
