### PR TITLE
Stop publishing @wp-playground/wordpress-builds package

### DIFF
--- a/packages/playground/wordpress-builds/package.json
+++ b/packages/playground/wordpress-builds/package.json
@@ -1,4 +1,5 @@
 {
+	"private": true,
 	"name": "@wp-playground/wordpress-builds",
 	"version": "0.9.23",
 	"description": "WordPress Compilation Pipeline for the WordPress Playground",


### PR DESCRIPTION
## Motivation for the change, related issues

We are running into trouble publishing the wordpress-builds package, and it isn't really needed to begin with.

It is big, takes time to download, and is leading to problems for our users. Let's stop publishing the library and eliminate unintended dependencies on it.

Related to #1630 

## Implementation details

This PR marks the `@wp-playground/wordpress-builds` package as private, and that appears to do the trick.

## Testing Instructions (or ideally a Blueprint)

- CI
- Manually run the workflow to publish packages to NPM and retry repro instructions from #1630 to confirm the fix
```bash
npx --yes @wp-playground/cli start
```
