### PR TITLE
Add missing blueprints library dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
 	},
 	"private": true,
 	"dependencies": {
+		"ajv": "8.12.0",
 		"@preact/signals-react": "1.3.6",
 		"@reduxjs/toolkit": "2.2.5",
 		"@types/ini": "4.1.0",
@@ -128,7 +129,6 @@
 		"@wordpress/data": "8.6.0",
 		"@wordpress/element": "5.6.0",
 		"@wordpress/notices": "3.29.0",
-		"ajv": "8.12.0",
 		"chalk": "5.2.0",
 		"clsx": "^1.2.1",
 		"cypress": "^13.0.0",


### PR DESCRIPTION
## Motivation for the change, related issues

The ajv library was listed as a dev dependency, but it is used by the actual blueprints library.
Without this, consumers of the `@wp-playground/blueprints` library encounter an error due to missing ajv lib.

```
npx --yes @wp-playground/cli start                           
node:internal/errors:496
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ajv' imported from /Users/brandon/src/temp/node_modules/@wp-playground/blueprints/index.js
    at new NodeError (node:internal/errors:405:5)
    at packageResolve (node:internal/modules/esm/resolve:916:9)
    at moduleResolve (node:internal/modules/esm/resolve:973:20)
    at defaultResolve (node:internal/modules/esm/resolve:1193:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:404:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:373:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:250:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:39)
    at link (node:internal/modules/esm/module_job:75:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}
```

Related to #1630 

## Implementation details

This PR switches `ajv` from a dev dependency to a normal dependency.

## Testing Instructions (or ideally a Blueprint)

CI
