### PR TITLE
Throw error when PHP run() receives no code to run

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -1163,6 +1163,12 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 		});
 	});
 
+	describe('Interface', () => {
+		it('run() should throw an error when neither `code` nor `scriptFile` is provided', async () => {
+			expect(() => php.run({})).rejects.toThrowError(TypeError);
+		});
+	});
+
 	describe('Startup sequence – basics', () => {
 		/**
 		 * This test ensures that the PHP runtime can be loaded twice.

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -430,8 +430,13 @@ export class PHP implements Disposable {
 			if (typeof request.code === 'string') {
 				this.writeFile('/internal/eval.php', request.code);
 				this.#setScriptPath('/internal/eval.php');
-			} else {
+			} else if (typeof request.scriptPath === 'string') {
 				this.#setScriptPath(request.scriptPath || '');
+			} else {
+				throw new TypeError(
+					'The request object must have either a `code` or a ' +
+						'`scriptPath` property.'
+				);
 			}
 
 			const $_SERVER = this.#prepareServerEntries(


### PR DESCRIPTION
## Motivation for the change, related issues

Prior to this PR, calling PHP#run() without providing an object with a `code` or `scriptPath` property, the call errors but does not clearly communicate the issue to the caller:
`Error: PHP.run() failed with exit code 255 and the following output: PHP Fatal error:  Uncaught ValueError: Path cannot be empty in [no active file]:0`

After this change, the error is:
``TypeError: The request object must have either a `code` or a `scriptPath` property.``

## Testing Instructions (or ideally a Blueprint)

CI unit tests
