### PR TITLE
Reinstantiate Changelog generation in GitHub CI

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -45,7 +45,12 @@ jobs:
             - name: '✏️ Generate release changelog'
               run: |
                   ls ./
-                  PATH="${PATH}:${HOME}/.bun/bin" npm run changelog -- --version=${{ inputs.version }}
+                  if [ -z "${{ inputs.version }}" ]; then
+                      VERSION=current
+                  else
+                      VERSION=${{ inputs.version }}
+                  fi
+                  PATH="${PATH}:${HOME}/.bun/bin" npm run changelog -- --version=$VERSION
                   PATH="${PATH}:${HOME}/.bun/bin" bun packages/docs/site/bin/refresh-changelog.ts
             - name: '📦 Commit and push changelog'
               run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,355 @@ All notable changes to this project are documented in this file by a CI job
 that runs on every NPM release. The file follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 format.
 
-## Unreleased 
+## [v0.9.27] (2024-07-29)
 
+### Enhancements
 
+-   Support offline mode after the first Playground page load. ([#1643](https://github.com/WordPress/wordpress-playground/pull/1643))
 
+### Devrel
+
+-   Remove puzzle app package. ([#1642](https://github.com/WordPress/wordpress-playground/pull/1642))
+
+### PHP WebAssembly
+
+-   Cache Playground assets to enable offline support. ([#1535](https://github.com/WordPress/wordpress-playground/pull/1535))
+-   Rotate PHP runtime after runtime crash. ([#1628](https://github.com/WordPress/wordpress-playground/pull/1628))
+-   Throw error when PHP run() receives no code to run. ([#1646](https://github.com/WordPress/wordpress-playground/pull/1646))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel @bgrgicak @brandonpayton
+
+## [v0.9.26] (2024-07-22)
+
+### Blueprints
+
+-   Add missing blueprints library dep. ([#1640](https://github.com/WordPress/wordpress-playground/pull/1640))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@brandonpayton
+
+## [v0.9.25] (2024-07-22)
+
+### Tools
+
+-   Make sure NPM packages declare dependencies. ([#1639](https://github.com/WordPress/wordpress-playground/pull/1639))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@brandonpayton
+
+## [v0.9.24] (2024-07-22)
+
+### Bug Fixes
+
+-   Fix plugin-proxy response codes. ([#1636](https://github.com/WordPress/wordpress-playground/pull/1636))
+-   Stop publishing @wp-playground/wordpress-builds package. ([#1637](https://github.com/WordPress/wordpress-playground/pull/1637))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@bgrgicak @brandonpayton
+
+## [v0.9.23] (2024-07-22)
+
+### PHP WebAssembly
+
+-   Route requests more like a normal web server. ([#1539](https://github.com/WordPress/wordpress-playground/pull/1539))
+
+### Website
+
+-   Remove old, unused website deployment workflow. ([#1633](https://github.com/WordPress/wordpress-playground/pull/1633))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@brandonpayton
+
+## [v0.9.22] (2024-07-19)
+
+### Bug Fixes
+
+-   Remove WP 6.2 support after WP 6.6 release. ([#1632](https://github.com/WordPress/wordpress-playground/pull/1632))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@brandonpayton
+
+## [v0.9.21] (2024-07-19)
+
+### Website
+
+-   Fix manifest.json URLs. ([#1615](https://github.com/WordPress/wordpress-playground/pull/1615))
+
+### Internal
+
+-   Fix joinPaths root edge case. ([#1620](https://github.com/WordPress/wordpress-playground/pull/1620))
+
+### Various
+
+-   Disable PHP 7.0 and 7.1 version switcher end-to-end tests. ([#1626](https://github.com/WordPress/wordpress-playground/pull/1626))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@bgrgicak @brandonpayton
+
+## [v0.9.20] (2024-07-16)
+
+### Enhancements
+
+#### Boot Flow
+
+-   Backfill the assets removed from minified WordPress bundles. ([#1604](https://github.com/WordPress/wordpress-playground/pull/1604))
+-   Register service worker before spawning the worker thread. ([#1606](https://github.com/WordPress/wordpress-playground/pull/1606))
+
+### Website
+
+-   Disable website features that don't work while offline. ([#1607](https://github.com/WordPress/wordpress-playground/pull/1607))
+-   Generate a list of assets to cache for offline support. ([#1573](https://github.com/WordPress/wordpress-playground/pull/1573))
+
+### Internal
+
+-   Build: Ship the default TypeScript .d.ts declaration files, not rollups. ([#1593](https://github.com/WordPress/wordpress-playground/pull/1593))
+
+### Bug Fixes
+
+#### Boot Flow
+
+-   Fix recursive calls to backfillStaticFilesRemovedFromMinifiedBuild. ([#1614](https://github.com/WordPress/wordpress-playground/pull/1614))
+
+### Various
+
+-   Add/allow import site gutenberg pr. ([#1610](https://github.com/WordPress/wordpress-playground/pull/1610))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel @bgrgicak @smithjw1
+
+## [v0.9.19] (2024-07-15)
+
+### **Breaking Changes**
+
+-   Set web worker startup options with messages instead of query strings. ([#1574](https://github.com/WordPress/wordpress-playground/pull/1574))
+
+### Blueprints
+
+-   Add an Import Theme Starter Content step. ([#1521](https://github.com/WordPress/wordpress-playground/pull/1521))
+-   Add setSiteLanguage step to change the language. ([#1538](https://github.com/WordPress/wordpress-playground/pull/1538))
+-   Mark shorthand properties as stable, not deprecated. ([#1594](https://github.com/WordPress/wordpress-playground/pull/1594))
+
+### Documentation
+
+-   Add Blueprint 101 to Documentation. ([#1556](https://github.com/WordPress/wordpress-playground/pull/1556))
+
+### PHP WebAssembly
+
+#### Website
+
+-   Download all WordPress assets on boot. ([#1532](https://github.com/WordPress/wordpress-playground/pull/1532))
+
+### Website
+
+-   PHP CORS Proxy. ([#1546](https://github.com/WordPress/wordpress-playground/pull/1546))
+
+### Various
+
+-   Revert "Set web worker startup options with messages instead of query strings". ([#1605](https://github.com/WordPress/wordpress-playground/pull/1605))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel @bgrgicak @bph @dd32
+
+## [v0.9.18] (2024-07-09)
+
+### Website
+
+-   Remove the unused isSupportedWordPressVersion export. ([#1592](https://github.com/WordPress/wordpress-playground/pull/1592))
+
+### Internal
+
+-   Build: Polyfill \_\_dirname in php-wam/node ESM via banner option. ([#1591](https://github.com/WordPress/wordpress-playground/pull/1591))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel
+
+## [v0.9.16] (2024-07-09)
+
+### Internal
+
+-   Build: Source external deps from package.json. ([#1590](https://github.com/WordPress/wordpress-playground/pull/1590))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel
+
+## [v0.9.15] (2024-07-09)
+
+### Internal
+
+-   Build: Use regular expressions to mark packages as external. ([#1589](https://github.com/WordPress/wordpress-playground/pull/1589))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel
+
+## [v0.9.14] (2024-07-09)
+
+### Devrel
+
+-   Remove Puzzle app from the Playground website. ([#1588](https://github.com/WordPress/wordpress-playground/pull/1588))
+
+### Internal
+
+-   Vite build: Mark all imported modules as external to avoid bundling them with released packages. ([#1586](https://github.com/WordPress/wordpress-playground/pull/1586))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel @bgrgicak
+
+## [v0.9.13] (2024-07-08)
+
+### PHP WebAssembly
+
+-   php-wasm/node: Ship as ESM and CJS. ([#1585](https://github.com/WordPress/wordpress-playground/pull/1585))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel
+
+## [v0.9.12] (2024-07-08)
+
+## [v0.9.11] (2024-07-08)
+
+### PHP WebAssembly
+
+-   Build: Treat all dependencies of php-wasm/node as external. ([#1584](https://github.com/WordPress/wordpress-playground/pull/1584))
+
+### Various
+
+-   Autopublish npm packages every week. ([#1542](https://github.com/WordPress/wordpress-playground/pull/1542))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel
+
+## [v0.9.10] (2024-07-08)
+
+### Internal
+
+-   Revert "Use NPM for publishing packages instead of Lerna ". ([#1582](https://github.com/WordPress/wordpress-playground/pull/1582))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel
+
+## [v0.9.9] (2024-07-08)
+
+### Internal
+
+-   Use NPM for publishing packages instead of Lerna. ([#1581](https://github.com/WordPress/wordpress-playground/pull/1581))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel
+
+## [v0.9.4] (2024-07-03)
+
+### Documentation
+
+-   Update the Blueprint data format doc. ([#1510](https://github.com/WordPress/wordpress-playground/pull/1510))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@ndiego
+
+## [v0.9.3] (2024-07-03)
+
+### Tools
+
+#### Blueprints
+
+-   Importing regression fix – support old exported Playground ZIPs. ([#1569](https://github.com/WordPress/wordpress-playground/pull/1569))
+
+### Documentation
+
+-   Add GitHub development instructions. ([#1551](https://github.com/WordPress/wordpress-playground/pull/1551))
+
+### Internal
+
+-   Meta: GitHub Boards Automation. ([#1549](https://github.com/WordPress/wordpress-playground/pull/1549))
+-   Meta: GitHub-sourced Mindmap. ([#1559](https://github.com/WordPress/wordpress-playground/pull/1559))
+
+###
+
+-   Add cache version number. ([#1541](https://github.com/WordPress/wordpress-playground/pull/1541))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel @bgrgicak
+
+## [v0.9.1] (2024-06-26)
+
+### PHP WebAssembly
+
+-   Networking access: Fix wp_http_supports() to work without the kitchen-sink extension bundle. ([#1504](https://github.com/WordPress/wordpress-playground/pull/1504))
+-   Networking: Remove CORS workarounds for WordPress.org API. ([#1511](https://github.com/WordPress/wordpress-playground/pull/1511))
+-   Backfill remote asset listing when needed. ([#1531](https://github.com/WordPress/wordpress-playground/pull/1531))
+
+### Website
+
+-   Remove "small window mode". ([#1540](https://github.com/WordPress/wordpress-playground/pull/1540))
+-   Detect actual, loaded WP version. ([#1503](https://github.com/WordPress/wordpress-playground/pull/1503))
+
+### Various
+
+-   Remove deprecation note from shorthand steps. ([#1507](https://github.com/WordPress/wordpress-playground/pull/1507))
+-   Remove trailing semicolon from example URL for loading playground with network access. ([#1520](https://github.com/WordPress/wordpress-playground/pull/1520))
+
+### Contributors
+
+The following contributors merged PRs in this release:
+
+@adamziel @bph @brandonpayton @dd32 @oskosk
 
 ## [v0.7.20] (2024-05-21)
 


### PR DESCRIPTION
## Motivation for the change, related issues

The automated Changelog generation stopped working in May.

The root cause? The CI job didn't explicitly pass the version number to `npm run changelog`. This PR solves that and backfills all the missing changelog entries.

Fixes https://github.com/WordPress/wordpress-playground/issues/1654

## Testing instructions

Merge this PR, release new NPM packages, confirm the changelog was updated. Unfortunatly there's no better way to verify it works :(

cc @brandonpayton 