### PR TITLE
Blueprints: Add resetData step to documentation.

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/reset-data.ts
+++ b/packages/playground/blueprints/src/lib/steps/reset-data.ts
@@ -1,11 +1,6 @@
 import { StepHandler } from '.';
 
 /**
- * Deletes WordPress posts and comments and sets the auto increment sequence for the
- * posts and comments tables to 0.
- *
- * @private
- * @internal
  * @inheritDoc resetData
  * @example
  *
@@ -20,6 +15,9 @@ export interface ResetDataStep {
 }
 
 /**
+ * Deletes WordPress posts and comments and sets the auto increment sequence for the
+ * posts and comments tables to 0.
+ *
  * @param playground Playground client.
  */
 export const resetData: StepHandler<ResetDataStep> = async (


### PR DESCRIPTION
`resetData` step for blueprints exists and it's the recommended way to reest data IDs. However, this step doesn't appear in the list of steps available for blueprints in the docs.

This PR adds that step to the documentation by removing the internal and private annotations.

## Testing instructions

Run `nx build docs-site` and `npm run dev:docs` locally. Go to http://localhost:3000/wordpress-playground/blueprints-api/steps#ResetDataStep and confirm the `resetData` step is there.

cc @juanmaguitar

Fixes #1653