### PR TITLE
Suppress unavoidable Deprecated notices - Networking

### DIFF
--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -89,6 +89,17 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 			}
 			set_error_handler(function($severity, $message, $file, $line) use($playground_consts) {
 				/**
+				 * We're forced to use this deprecated hook to ensure SSL operations work without
+				 * the kitchen-sink bundled. See https://github.com/WordPress/wordpress-playground/pull/1504
+				 * for more context.
+				 */
+				if (
+					strpos($message, "Hook http_api_transports is deprecated") !== false ||
+					strpos($message, "Hook http_api_transports is <strong>deprecated</strong>") !== false
+				) {
+					return;
+				}
+				/**
 				 * This is a temporary workaround to hide the 32bit integer warnings that
 				 * appear when using various time related function, such as strtotime and mktime.
 				 * Examples of the warnings that are displayed:


### PR DESCRIPTION
Suppresses the following deprecation warning:

> PHP Deprecated: Hook http_api_transports is deprecated since version 6.4.0 with no alternative available. in /wordpress/wp-includes/functions.php on line 135

We're forced to use this deprecated hook to ensure SSL operations work without the kitchen-sink bundled. See https://github.com/WordPress/wordpress-playground/pull/1504 for more context.

 ## Testing instructions

Open devtools. Then open Playground:

* With and without this PR
* With and without networking enabled

Then go to wp-admin. Confirm that with this PR the above deprecation notice is not logged.

cc @dd32 @bgrgicak

Fixes #1598