### PR TITLE
Website UI: Explain the Logs modal

### DIFF
--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -61,7 +61,7 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 			<header>
 				<h2>{props.title || 'Error Logs'}</h2>
 				{props.description}
-				{filteredLogs.length > 0 ? (
+				{logs.length > 0 ? (
 					<TextControl
 						aria-label="Search"
 						placeholder="Search logs"
@@ -74,6 +74,10 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 			</header>
 			{filteredLogs.length > 0 ? (
 				<main className={css.logModalMain}>{logList()}</main>
+			) : logs.length > 0 ? (
+				<div className={css.logModalEmptyPlaceholder}>
+					No matching logs found.
+				</div>
 			) : (
 				<div className={css.logModalEmptyPlaceholder}>
 					Error logs for Playground, WordPress, and PHP will show up

--- a/packages/playground/website/src/components/log-modal/index.tsx
+++ b/packages/playground/website/src/components/log-modal/index.tsx
@@ -20,6 +20,10 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	const [logs, setLogs] = useState<string[]>([]);
 	const [searchTerm, setSearchTerm] = useState('');
 
+	const filteredLogs = logs.filter((log) =>
+		log.toLowerCase().includes(searchTerm.toLowerCase())
+	);
+
 	useEffect(() => {
 		getLogs();
 		logger.addEventListener(logEventType, getLogs);
@@ -37,20 +41,15 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	}
 
 	function logList() {
-		return logs
-			.filter((log) =>
-				log.toLowerCase().includes(searchTerm.toLowerCase())
-			)
-			.reverse()
-			.map((log, index) => (
-				<div
-					className={css.logModalLog}
-					key={index}
-					dangerouslySetInnerHTML={{
-						__html: log.replace(/Error:|Fatal:/, '<mark>$&</mark>'),
-					}}
-				/>
-			));
+		return filteredLogs.reverse().map((log, index) => (
+			<div
+				className={css.logModalLog}
+				key={index}
+				dangerouslySetInnerHTML={{
+					__html: log.replace(/Error:|Fatal:/, '<mark>$&</mark>'),
+				}}
+			/>
+		));
 	}
 
 	const styles = {
@@ -60,18 +59,30 @@ export function LogModal(props: { description?: JSX.Element; title?: string }) {
 	return (
 		<Modal isOpen={true} onRequestClose={onClose} styles={styles}>
 			<header>
-				<h2>{props.title || 'Logs'}</h2>
+				<h2>{props.title || 'Error Logs'}</h2>
 				{props.description}
-				<TextControl
-					aria-label="Search"
-					placeholder="Search logs"
-					value={searchTerm}
-					onChange={setSearchTerm}
-					autoFocus={true}
-					className={css.logModalSearch}
-				/>
+				{filteredLogs.length > 0 ? (
+					<TextControl
+						aria-label="Search"
+						placeholder="Search logs"
+						value={searchTerm}
+						onChange={setSearchTerm}
+						autoFocus={true}
+						className={css.logModalSearch}
+					/>
+				) : null}
 			</header>
-			<main className={css.logModalMain}>{logList()}</main>
+			{filteredLogs.length > 0 ? (
+				<main className={css.logModalMain}>{logList()}</main>
+			) : (
+				<div className={css.logModalEmptyPlaceholder}>
+					Error logs for Playground, WordPress, and PHP will show up
+					here when something goes wrong.
+					<br />
+					<br />
+					No problems so far – yay! 🎉
+				</div>
+			)}
 		</Modal>
 	);
 }

--- a/packages/playground/website/src/components/log-modal/style.module.css
+++ b/packages/playground/website/src/components/log-modal/style.module.css
@@ -2,6 +2,12 @@
 	padding-bottom: 20px;
 }
 
+.log-modal__empty_placeholder {
+	/* text-align: center; */
+	font-size: 1.3rem;
+	padding-bottom: 20px;
+}
+
 .log-modal__search {
 	/* Title margin bottom + log margin top */
 	margin-bottom: 1.33rem;


### PR DESCRIPTION
## Motivation for the change, related issues

@juanmaguitar asked:

> What's the purpose of the "View logs" option available in https://playground.wordpress.net/
> The modal that appears when clicking that option doesn't seem to do nothing.

It's not the first time when this question comes up, so I added a placeholder text whenever there are no logs to display:

![CleanShot 2024-08-01 at 16 03 56@2x](https://github.com/user-attachments/assets/90681be2-b1ab-4569-aafb-c64ea578e109)

## Testing Instructions (or ideally a Blueprint)

1. Go to the logs modal after Playground is loaded
2. Confirm the placeholder text shows up
3. Trigger an error in devtools: `setTimeout(() => {throw new Error('test');});`
4. Confirm the error showed up in the modal
5. Search the modal with a query that doesn't match any log line
6. Confirm you got a "No matching logs found." message
