### PR TITLE
Worker boot: Parallelize WP.zip and PHP.wasm download

### DIFF
--- a/packages/php-wasm/progress/src/lib/progress-tracker.ts
+++ b/packages/php-wasm/progress/src/lib/progress-tracker.ts
@@ -10,15 +10,17 @@ export interface ProgressTrackerOptions {
 	fillTime?: number;
 }
 
-/**
- * Custom event providing information about a loading process.
- */
-export type LoadingEvent = CustomEvent<{
+export type LoadingProgress = {
 	/** The number representing how much was loaded. */
 	loaded: number;
 	/** The number representing how much needs to loaded in total. */
 	total: number;
-}>;
+};
+
+/**
+ * Custom event providing information about a loading process.
+ */
+export type LoadingEvent = CustomEvent<LoadingProgress>;
 
 /**
  * Custom event providing progress details.
@@ -286,13 +288,8 @@ export class ProgressTracker extends EventTarget {
 		return this._progressObserver;
 	}
 
-	get loadingListener() {
-		if (!this._loadingListener) {
-			this._loadingListener = (event: LoadingEvent) => {
-				this.set((event.detail.loaded / event.detail.total) * 100);
-			};
-		}
-		return this._loadingListener;
+	setFromProgressDetails(details: LoadingProgress) {
+		this.set((details.loaded / details.total) * 100);
 	}
 
 	pipe(receiver: ProgressReceiver) {

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -1,4 +1,4 @@
-import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+import { EmscriptenDownloadMonitor, LoadingProgress } from '@php-wasm/progress';
 import { PHP } from './php';
 import { PHPRequestHandler } from './php-request-handler';
 import { PHPResponse } from './php-response';
@@ -127,6 +127,10 @@ export class PHPWorker implements LimitedPHPApi {
 		return _private
 			.get(this)!
 			.requestHandler!.internalUrlToPath(internalUrl);
+	}
+
+	async getDownloadProgress(): Promise<LoadingProgress | undefined> {
+		return _private.get(this)!.monitor?.progress;
 	}
 
 	/**

--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -219,7 +219,9 @@ export abstract class FetchResource extends Resource {
 			}
 			response = await cloneResponseMonitorProgress(
 				response,
-				this.progress?.loadingListener ?? noop
+				this.progress
+					? (e) => this.progress?.setFromProgressDetails(e.detail)
+					: noop
 			);
 			if (response.status !== 200) {
 				throw new Error(`Could not download "${url}"`);

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -182,8 +182,12 @@ async function doStartPlaygroundWeb(
 	) as PlaygroundClient;
 	await playground.isConnected();
 	progressTracker.pipe(playground);
+	const currentProgress = (await playground.getDownloadProgress())!;
 	const downloadPHPandWP = progressTracker.stage();
-	await playground.onDownloadProgress(downloadPHPandWP.loadingListener);
+	downloadPHPandWP.setFromProgressDetails(currentProgress);
+	await playground.onDownloadProgress((e) => {
+		downloadPHPandWP.setFromProgressDetails(e.detail);
+	});
 	await playground.isReady();
 	downloadPHPandWP.finish();
 	return playground;


### PR DESCRIPTION
https://github.com/WordPress/wordpress-playground/pull/1390 introduced a regression in the asset loading flow.
WordPress were downloaded in parallel. After that PR,
WordPress.zip download was awaited before the PHP.wasm download
would start. In here, we're removing the extra `await` statements
to parallelize all the downloads.

**I'm not yet certain whether it solves the progress bar issue.**

This is a stopgap PR until we can clean up the worker-thread.ts boot flow and control the boot sequence from remote.html. Then, API calls like `mountOPFSDir()` or `bootPHP()` would become explicit.

Related to https://github.com/WordPress/wordpress-playground/issues/1667. 

 ## Testing instructions

* Go to http://localhost:5400/website-server/?wp=http://localhost:5400/plugin-proxy.php?url=https://wordpress.org/wordpress-6.6.1.zip
* In network devtools, confirm that PHP was downloaded without waiting for wordpress-6.6.1.zip

