### PR TITLE
Docs: Redirect from /docs to https://wordpress.github.io/wordpress-playground

### DIFF
--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -181,6 +181,13 @@ function playground_maybe_rewrite( $original_requested_path ) {
 }
 
 function playground_maybe_redirect( $requested_path ) {
+	if ( str_ends_with( $requested_path, '/docs' ) ) {
+		return array(
+			'location' => 'https://wordpress.github.io/wordpress-playground/',
+			'status' => 301
+		);
+	}
+
 	if ( str_ends_with( $requested_path, '/wordpress-browser.html' ) ) {
 		return array(
 			'location' => '/',


### PR DESCRIPTION
## Motivation for the change, related issues

@juanmaguitar asked:

> Would it be possible to set redirections from https://playground.wordpress.net/docs and [https://w.org/playground/docs](https://wordpress.org/playground/docs) to https://wordpress.github.io/wordpress-playground/ ?

This PR adds the redirect from `https://playground.wordpress.net/docs` to `https://wordpress.github.io/wordpress-playground/`