### PR TITLE
Website: Add nice redirects for the new docs site

### DIFF
--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -188,6 +188,34 @@ function playground_maybe_redirect( $requested_path ) {
 		);
 	}
 
+	if ( str_ends_with( $requested_path, '/builder' ) ) {
+		return array(
+			'location' => 'https://playground.wordpress.net/builder/builder.html',
+			'status' => 301
+		);
+	}
+
+	if ( str_ends_with( $requested_path, '/wordpress' ) ) {
+		return array(
+			'location' => 'https://playground.wordpress.net/wordpress.html',
+			'status' => 301
+		);
+	}
+
+	if ( str_ends_with( $requested_path, '/gutenberg' ) ) {
+		return array(
+			'location' => 'https://playground.wordpress.net/gutenberg.html',
+			'status' => 301
+		);
+	}
+
+	if ( str_ends_with( $requested_path, '/proxy' ) ) {
+		return array(
+			'location' => 'https://github-proxy.com/',
+			'status' => 301
+		);
+	}
+
 	if ( str_ends_with( $requested_path, '/wordpress-browser.html' ) ) {
 		return array(
 			'location' => '/',


### PR DESCRIPTION
This the following redirections as per @juanmaguitar request:

* from https://playground.wordpress.net/builder to https://playground.wordpress.net/builder/builder.html
* from https://playground.wordpress.net/wordpress to  https://playground.wordpress.net/wordpress.html
* from https://playground.wordpress.net/gutenberg to  https://playground.wordpress.net/gutenberg.html
* from https://playground.wordpress.net/proxy to  https://github-proxy.com/

In this way it would become easier to access (and remember) some of the tools related to Playground:

* https://playground.wordpress.net/ → Playground instance
* https://playground.wordpress.net /docs  → Playground Docs (redirection already active)
* https://playground.wordpress.net /builder  → Playground Blueprints Builder
* https://playground.wordpress.net /wordpress  → Playground PR viewer for WordPress
* https://playground.wordpress.net /gutenberg  → Playground PR viewer for Gutenberg
* https://playground.wordpress.net /proxy  → Playground Proxy Service

 ## Testing instructions

Unfortunately the only way to test is by merging and deploying the website.
