### PR TITLE
[Website] Improves the messaging around exporting a zip if needed, when connecting to GitHub

### DIFF
--- a/packages/playground/website/src/github/github-oauth-guard/index.tsx
+++ b/packages/playground/website/src/github/github-oauth-guard/index.tsx
@@ -112,7 +112,7 @@ function Authenticate({
 							checked={exported}
 							onChange={() => setExported(!exported)}
 						/>
-						I exported my Playground as zip.
+						I understand, and I have exported my Playground as a zip if needed.
 					</label>
 				</>
 			) : null}


### PR DESCRIPTION
Fixes #1688

## Motivation for the change, related issues

Improves the messaging around exporting a zip if needed, when connecting to GitHub

## Implementation details

## Testing Instructions (or ideally a Blueprint)

Load Playground and attempt to connect to Github. The checkbox label should include the new wording. 