### PR TITLE
Docs: Fix links to proper pages

### DIFF
--- a/packages/docs/site/docs/developers/06-apis/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/01-index.md
@@ -89,7 +89,7 @@ wp_insert_post(array(
 
 :::info
 
-Blueprints play a significant role in WordPress Playground, so they have their own dedicated documentation hub. Learn more about JSON Blueprints at the [Blueprints Docs Hub](../../blueprints/01-index.md).
+Blueprints play a significant role in WordPress Playground, so they have their own dedicated documentation hub. Learn more about JSON Blueprints at the [Blueprints Docs Hub](../../blueprints/intro.md).
 
 :::
 

--- a/packages/docs/site/docs/main/intro.md
+++ b/packages/docs/site/docs/main/intro.md
@@ -33,7 +33,7 @@ This docs hub is focused on starting with WordPress Playground and is divided in
 
 -   **[About Playground](./about/index.md)**: To learn about WordPress Playground, how safe it is, what you can do with and some of its current limitations, visit this section.
 
-    Discover how you can leverage WordPress Playground to [Build](./about/build), [Test](./about/test), and [Launch](./about/test) your products.
+    Discover how you can leverage WordPress Playground to [Build](./about/build), [Test](./about/test), and [Launch](./about/launch) your products.
 
 -   **[Guides](./guides/)**: Explore our comprehensive guides to master new skills, find step-by-step instructions, and unlock valuable insights. Dive in to learn and grow!
 


### PR DESCRIPTION
This PR fixes a few links so they point to the right places