### PR TITLE
Avoid GH board automation permissions error

### DIFF
--- a/packages/meta/bin/project_board_automation.php
+++ b/packages/meta/bin/project_board_automation.php
@@ -38,7 +38,11 @@ foreach($automation->iterateProjectItems() as $projectItem) {
             continue;
         }
 
-        if ($automation->addNeedsAuthorReplyLabelToANewItemWithThatStatus($projectItem)) {
+        if (
+            // TODO: Replace this with explicit permissions check if that is possible.
+            $projectItem['content']['repository']['nameWithOwner'] !== 'WordPress/wporg-theme-directory' &&
+            $automation->addNeedsAuthorReplyLabelToANewItemWithThatStatus($projectItem)
+        ) {
             echo "– Adding \"Need Author's reply\" label to: $humanIssueName\n";
             continue;
         }


### PR DESCRIPTION
## Motivation for the change, related issues

The GitHub board automation workflow is failing due to a permissions error when attempting to create a label for the wporg-theme-directory repo.

https://github.com/WordPress/wordpress-playground/actions/runs/10459089537/job/28962281299#step:3:7002

```
      ["message"]=>
      string(71) "adamziel does not have the correct permissions to execute `CreateLabel`"
    }
  }
}
Error processing card: WordPress/wporg-theme-directory#14 (WordPress Playground Integration Planning)
GraphQL query failed
Skipping that one and continuing...
```

## Implementation details

This change simply skips label updates for the wporg-theme-directory repo for which we do not have permission to create new labels.

## Testing Instructions (or ideally a Blueprint)

- Test by manually running the board automation workflow from this PR's branch and make sure the workflow succeeds.
- Try changing another issue's board status, rerun the workflow, and observe that the status is reflected in changed issue labels.
- Restore the original issue status, rerun the workflow, and observe the original label has been restored.
