### PR TITLE
Refresh sqlite-database-integration from develop branch

### DIFF
--- a/packages/playground/wordpress-builds/build/refresh-sqlite-integration-plugin.js
+++ b/packages/playground/wordpress-builds/build/refresh-sqlite-integration-plugin.js
@@ -14,7 +14,7 @@ const args = parser.argv;
 
 const outputZipPath = `${args.outputDir}/sqlite-database-integration.zip`;
 const sqliteResponse = await fetch(
-	'https://github.com/WordPress/sqlite-database-integration/archive/refs/heads/main.zip'
+	'https://github.com/WordPress/sqlite-database-integration/archive/refs/heads/develop.zip'
 );
 const sqliteZip = Buffer.from(await sqliteResponse.arrayBuffer());
 await fs.writeFile(outputZipPath, sqliteZip);


### PR DESCRIPTION
## Motivation for the change, related issues

We regularly refresh the sqlite-database-integration bundle from the project's `main` branch. This used to pull the latest changes, including unreleased changes, but now, the `main` branch is only updated when a new version of the plugin is released. The latest changes are now on the `develop` branch.

## Implementation details

This PR changes our sqlite-database-integration build to pull the latest from the `develop` branch which includes unreleased changes slated for the next plugin release.

## Testing Instructions (or ideally a Blueprint)

Run `npx nx bundle-sqlite-database playground-wordpress-builds` locally and make sure it completes without issue.