### PR TITLE
Fix broken docs links

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-theme.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.ts
@@ -41,7 +41,7 @@ export const activateTheme: StepHandler<ActivateThemeStep> = async (
 			Theme not found at the provided theme path: ${themeFolderPath}.
 			Check the theme path to ensure it's correct.
 			If the theme is not installed, you can install it using the installTheme step.
-			More info can be found in the Blueprint documentation: https://wordpress.github.io/wordpress-playground/blueprints-api/steps/#ActivateThemeStep
+			More info can be found in the Blueprint documentation: https://wordpress.github.io/wordpress-playground/blueprints/steps/#ActivateThemeStep
 		`);
 	}
 	const result = await playground.run({

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -39,7 +39,7 @@ export const wpCLI: StepHandler<WPCLIStep, Promise<PHPResponse>> = async (
 			}
 
 			Read more about it in the documentation.
-			https://wordpress.github.io/wordpress-playground/blueprints-api/data-format#extra-libraries`);
+			https://wordpress.github.io/wordpress-playground/blueprints/data-format#extra-libraries`);
 	}
 
 	let args: string[];

--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -37,7 +37,7 @@ export interface Mount {
 
 async function run() {
 	/**
-	 * @TODO This looks similar to Query API args https://wordpress.github.io/wordpress-playground/query-api
+	 * @TODO This looks similar to Query API args https://wordpress.github.io/wordpress-playground/developers/apis/query-api/
 	 *       Perhaps the two could be handled by the same code?
 	 */
 	const yargsObject = await yargs(process.argv.slice(2))

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -43,8 +43,8 @@ function networking_disabled() {
 	$networking_err_msg = '<div class="networking_err_msg">Network access is an <a href="https://github.com/WordPress/wordpress-playground/issues/85" target="_blank">experimental, opt-in feature</a>, which means you need to enable it to allow Playground to access the Plugins/Themes directories.
 	<p>There are two alternative methods to enable global networking support:</p>
 	<ol>
-	<li>Using the <a href="https://wordpress.github.io/wordpress-playground/query-api">Query API</a>: for example, https://playground.wordpress.net/<em>?networking=yes</em> <strong>or</strong>
-	<li> Using the <a href="https://wordpress.github.io/wordpress-playground/blueprints-api/data-format/#features">Blueprint API</a>: add <code>"features": { "networking": true }</code> to the JSON file.
+	<li>Using the <a href="https://wordpress.github.io/wordpress-playground/developers/apis/query-api/">Query API</a>: for example, https://playground.wordpress.net/<em>?networking=yes</em> <strong>or</strong>
+	<li> Using the <a href="https://wordpress.github.io/wordpress-playground/blueprints/data-format/#features">Blueprint API</a>: add <code>"features": { "networking": true }</code> to the JSON file.
 	</li></ol>
 	<p>
 	When browsing Playground as a standalone instance, you can enable networking via the settings panel: select the option "Network access (e.g. for browsing plugins)" and hit the "Apply changes" button.<p>

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -86,7 +86,7 @@
 		>
 		and the
 		<a
-			href="https://wordpress.github.io/wordpress-playground/docs/build-your-first-app#preview-pull-requests-from-your-repository"
+			href="https://wordpress.github.io/wordpress-playground/developers/build-your-first-app/#preview-pull-requests-from-your-repository"
 		>
 			documentation page</a
 		>.
@@ -100,7 +100,7 @@
 		 * Learn more at:
 		 *
 		 * * https://wordpress.github.io/wordpress-playground/
-		 * * https://wordpress.github.io/wordpress-playground/docs/build-your-first-app#preview-pull-requests-from-your-repository
+		 * * https://wordpress.github.io/wordpress-playground/developers/build-your-first-app/#preview-pull-requests-from-your-repository
 		 */
 
 		let submitting = false;

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -96,7 +96,7 @@
 		>
 		and the
 		<a
-			href="https://wordpress.github.io/wordpress-playground/docs/build-your-first-app#preview-pull-requests-from-your-repository"
+			href="https://wordpress.github.io/wordpress-playground/developers/build-your-first-app/#preview-pull-requests-from-your-repository"
 		>
 			documentation page</a
 		>.
@@ -110,7 +110,7 @@
 		 * Learn more at:
 		 *
 		 * * https://wordpress.github.io/wordpress-playground/
-		 * * https://wordpress.github.io/wordpress-playground/docs/build-your-first-app#preview-pull-requests-from-your-repository
+		 * * https://wordpress.github.io/wordpress-playground/developers/build-your-first-app/#preview-pull-requests-from-your-repository
 		 */
 
 		let submitting = false;

--- a/packages/playground/website/src/components/playground-configuration-group/form.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/form.tsx
@@ -361,7 +361,7 @@ export function PlaygroundConfigurationForm({
 							</select>
 							<br />
 							<a
-								href="https://wordpress.github.io/wordpress-playground/blueprints-api/examples#load-an-older-wordpress-version"
+								href="https://wordpress.github.io/wordpress-playground/blueprints/examples#load-an-older-wordpress-version"
 								target="_blank"
 								rel="noreferrer"
 								style={{ fontSize: '0.9em' }}

--- a/packages/playground/website/src/components/start-error-modal/index.tsx
+++ b/packages/playground/website/src/components/start-error-modal/index.tsx
@@ -29,7 +29,7 @@ export function StartErrorModal() {
 				point out the specific step causing the issue. You can then
 				double-check your blueprint. For more help, you can also{' '}
 				<a
-					href="https://wordpress.github.io/wordpress-playground/blueprints-api/troubleshoot-and-debug-blueprints"
+					href="https://wordpress.github.io/wordpress-playground/blueprints/troubleshoot-and-debug-blueprints"
 					target="_blank"
 					rel="noreferrer"
 				>


### PR DESCRIPTION
## Motivation for the change, related issues

I noticed that there was a broken link on https://playground.wordpress.net/, and came here to find many others.

## Implementation details

I checked all the links pointing to `wordpress.github.io/wordpress-playground/*` and fixed them if they 404'ed.

## Testing Instructions (or ideally a Blueprint)

Check all the updated links and confirm that they exist and are correct.