### PR TITLE
Fix sqlite-database-integration rename fatal

### DIFF
--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -173,10 +173,16 @@ export async function preloadSqliteIntegration(
 	await php.mkdir('/tmp/sqlite-database-integration');
 	await unzipFile(php, sqliteZip, '/tmp/sqlite-database-integration');
 	const SQLITE_PLUGIN_FOLDER = '/internal/shared/sqlite-database-integration';
-	await php.mv(
-		'/tmp/sqlite-database-integration/sqlite-database-integration-main',
-		SQLITE_PLUGIN_FOLDER
-	);
+
+	const temporarySqlitePluginFolder = (await php.isDir(
+		'/tmp/sqlite-database-integration/sqlite-database-integration-main'
+	))
+		? // This is the name when the dev branch used to be called "main"
+		  '/tmp/sqlite-database-integration/sqlite-database-integration-main'
+		: // This is the name today when the dev branch is called "develop"
+		  '/tmp/sqlite-database-integration/sqlite-database-integration-develop';
+	await php.mv(temporarySqlitePluginFolder, SQLITE_PLUGIN_FOLDER);
+
 	// Prevents the SQLite integration from trying to call activate_plugin()
 	await php.defineConstant('SQLITE_MAIN_FILE', '1');
 	const dbCopy = await php.readFileAsText(


### PR DESCRIPTION
## Motivation for the change, related issues

This is a fix for a fatal that occurs when loading the latest sqlite-database-integration version from its `develop` branch in Playground.

Playground initialization renames a temporary sqlite-database-integration plugin directory based on the previous branch name of main like "sqlite-database-integration-main", but now that temporary directory is "sqlite-database-integration-develop".

## Implementation details

We check for the existence of the old temp directory and use that if it exists. Otherwise, we rename based on the new temp directory name.

## Testing Instructions (or ideally a Blueprint)

Tested locally via `npm run dev`.