### PR TITLE
Make the site switcher work again

### DIFF
--- a/packages/playground/website/src/components/playground-configuration-group/index.tsx
+++ b/packages/playground/website/src/components/playground-configuration-group/index.tsx
@@ -160,7 +160,6 @@ export default function PlaygroundConfigurationGroup({
 			type: 'local-fs',
 			handle: dirHandle,
 		};
-		dispatch(setOpfsMountDescriptor({ device, mountpoint }));
 		if (idb) {
 			await saveDirectoryHandle(idb, dirHandle);
 		}
@@ -200,7 +199,6 @@ export default function PlaygroundConfigurationGroup({
 				...currentConfiguration,
 				storage: 'device',
 			});
-			await playground.goTo('/');
 
 			// Read current querystring and replace storage=browser with
 			// storage=device.
@@ -208,7 +206,8 @@ export default function PlaygroundConfigurationGroup({
 			url.searchParams.set('storage', 'device');
 			window.history.pushState({}, '', url.toString());
 
-			alert('You are now using WordPress from your local directory.');
+			dispatch(setOpfsMountDescriptor({ device, mountpoint }));
+			alert('You are now loading WordPress from your local directory.');
 		} finally {
 			setMounting(false);
 		}

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -1,5 +1,6 @@
 import { SiteManagerSidebar } from './site-manager-sidebar';
 import { __experimentalUseNavigator as useNavigator } from '@wordpress/components';
+import store, { selectSite } from '../../lib/redux-store';
 
 import css from './style.module.css';
 
@@ -26,7 +27,7 @@ export function SiteManager({
 		);
 	};
 
-	const onSiteClick = (siteSlug?: string) => {
+	const onSiteClick = async (siteSlug: string) => {
 		onSiteChange(siteSlug);
 		const url = new URL(window.location.href);
 		if (siteSlug) {
@@ -35,6 +36,11 @@ export function SiteManager({
 			url.searchParams.delete('site-slug');
 		}
 		window.history.pushState({}, '', url.toString());
+
+		await store.dispatch(
+			// TODO: Decide about default
+			selectSite(siteSlug)
+		);
 
 		/**
 		 * On mobile, the site editor and site preview are hidden.

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -37,10 +37,7 @@ export function SiteManager({
 		}
 		window.history.pushState({}, '', url.toString());
 
-		await store.dispatch(
-			// TODO: Decide about default
-			selectSite(siteSlug)
-		);
+		await store.dispatch(selectSite(siteSlug));
 
 		/**
 		 * On mobile, the site editor and site preview are hidden.

--- a/packages/playground/website/src/components/site-manager/site-manager-sidebar/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-manager-sidebar/index.tsx
@@ -38,7 +38,7 @@ export function SiteManagerSidebar({
 }: {
 	className?: string;
 	siteSlug?: string;
-	onSiteClick: (siteSlug?: string) => void;
+	onSiteClick: (siteSlug: string) => void;
 }) {
 	const [sites, setSites] = useState<Site[]>([]);
 

--- a/packages/playground/website/src/lib/redux-store.ts
+++ b/packages/playground/website/src/lib/redux-store.ts
@@ -75,6 +75,27 @@ const slice = createSlice({
 // Export actions
 export const { setActiveModal, setOpfsMountDescriptor } = slice.actions;
 
+export function selectSite(siteSlug: string) {
+	return async (dispatch: typeof store.dispatch) => {
+		const opfsRoot = await navigator.storage.getDirectory();
+		const opfsDir = await opfsRoot.getDirectoryHandle(
+			siteSlug === 'wordpress' ? siteSlug : 'site-' + siteSlug,
+			{
+				create: true,
+			}
+		);
+		dispatch(
+			setOpfsMountDescriptor({
+				device: {
+					type: 'opfs',
+					path: await directoryHandleToOpfsPath(opfsDir),
+				},
+				mountpoint: '/wordpress',
+			})
+		);
+	};
+}
+
 // Configure store
 const store = configureStore({
 	reducer: slice.reducer,

--- a/packages/playground/website/src/lib/use-boot-playground.ts
+++ b/packages/playground/website/src/lib/use-boot-playground.ts
@@ -29,9 +29,6 @@ export function useBootPlayground({ blueprint }: UsePlaygroundOptions) {
 
 	useEffect(() => {
 		const remoteUrl = getRemoteUrl();
-		if (started.current === remoteUrl.toString()) {
-			return;
-		}
 		if (!iframe) {
 			// Iframe ref is likely not set on the initial render.
 			// Re-render the current component to start the playground.


### PR DESCRIPTION
## Motivation for the change, related issues

The site switcher was broken by #1669. This PR is a fix for that.

Related to #1687

## Implementation details

The site that is booted depends on the redux store, so the current loaded site now depends on redux state.

## Testing Instructions (or ideally a Blueprint)

- CI
- Use `npm run dev` and manually test switching between sites
