### PR TITLE
Remove Playground branding from site list

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-manager-sidebar/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-manager-sidebar/index.tsx
@@ -71,7 +71,8 @@ export function SiteManagerSidebar({
 			className={classNames(css.siteManagerSidebar, className)}
 		>
 			<header className={css.siteManagerSidebarHeader}>
-				<Logo className={css.siteManagerSidebarLogoButton} />
+				{/* Remove Playground logo because branding isn't finalized. */}
+				{/* <Logo className={css.siteManagerSidebarLogoButton} /> */}
 			</header>
 			<nav
 				className={classNames(

--- a/packages/playground/website/src/components/site-manager/site-manager-sidebar/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-manager-sidebar/index.tsx
@@ -11,7 +11,7 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
 } from '@wordpress/components';
-import { Logo, TemporaryStorageIcon, WordPressIcon } from '../icons';
+import { TemporaryStorageIcon, WordPressIcon } from '../icons';
 import store, {
 	PlaygroundReduxState,
 	addSite as addSiteToStore,

--- a/packages/playground/website/src/components/site-manager/style.module.css
+++ b/packages/playground/website/src/components/site-manager/style.module.css
@@ -10,7 +10,8 @@ body {
 	overflow: hidden;
 	padding: var(--site-manager-border-width);
 	background-color: var(--site-manager-background-color);
-	background-image: url(../../../public/site-manager-background.svg);
+	/* Remove Playground background graphic because branding isn't finalized. */
+	/* background-image: url(../../../public/site-manager-background.svg); */
 	background-position: bottom left;
 	background-repeat: no-repeat;
 	width: 100%;


### PR DESCRIPTION
## Motivation for the change, related issues

We are removing because branding is not finalized yet. Mentioned by @sfougnier [here](https://github.com/WordPress/wordpress-playground/issues/1655#issuecomment-2278222107).

## Implementation details

This PR hides the logo and background graphic from the site manager sidebar.

## Testing Instructions (or ideally a Blueprint)

Run `npm run dev`, open the site listing, and observe the UI remains visible and functional.