### PR TITLE
Add workflow for deploying to a staging website

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -19,9 +19,18 @@ concurrency:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow from the trunk branch and when it's triggered by another workflow OR dmsnell OR adamziel
+        # Only run this workflow when it is:
+        # - From the trunk branch
+        #     or invoked from another workflow with a non-production environment
+        # - Triggered by another workflow OR specific Playground maintainers
         if: >
-            github.ref == 'refs/heads/trunk' && (
+            (
+                github.ref == 'refs/heads/trunk' ||
+                (
+                    github.event_name == 'workflow_call' &&
+                    inputs.environment != 'playground-wordpress-net-wp-cloud'
+                )
+            ) && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -23,21 +23,21 @@ jobs:
         # - From the trunk branch
         #     or invoked from another workflow with a non-production environment
         # - Triggered by another workflow OR specific Playground maintainers
-        if: >
-            (
-                github.ref == 'refs/heads/trunk' ||
-                (
-                    github.event_name == 'workflow_call' &&
-                    inputs.environment != 'playground-wordpress-net-wp-cloud'
-                )
-            ) && (
-                github.event_name == 'workflow_run' ||
-                github.event_name == 'workflow_dispatch' ||
-                github.actor == 'adamziel' ||
-                github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak' ||
-                github.actor == 'brandonpayton'
-            )
+        # if: >
+        #     (
+        #         github.ref == 'refs/heads/trunk' ||
+        #         (
+        #             github.event_name == 'workflow_call' &&
+        #             inputs.environment != 'playground-wordpress-net-wp-cloud'
+        #         )
+        #     ) && (
+        #         github.event_name == 'workflow_run' ||
+        #         github.event_name == 'workflow_dispatch' ||
+        #         github.actor == 'adamziel' ||
+        #         github.actor == 'dmsnell' ||
+        #         github.actor == 'bgrgicak' ||
+        #         github.actor == 'brandonpayton'
+        #     )
 
         # Specify runner + deployment step
         runs-on: ubuntu-latest

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -6,6 +6,12 @@ on:
     schedule:
         - cron: '0 9,18 * * *'
 
+    # Allow this workflow to be reused
+    workflow_call:
+        inputs:
+            environment:
+                type: string
+
 concurrency:
     group: website-deployment
     # TODO: Enable cancel-in-progress once we are deploying per commit?
@@ -27,7 +33,7 @@ jobs:
         # Specify runner + deployment step
         runs-on: ubuntu-latest
         environment:
-            name: playground-wordpress-net-wp-cloud
+            name: ${{ inputs.environment || 'playground-wordpress-net-wp-cloud' }}
         steps:
             - uses: actions/checkout@v3
             - uses: ./.github/actions/prepare-playground

--- a/.github/workflows/deploy-website-to-staging.yml
+++ b/.github/workflows/deploy-website-to-staging.yml
@@ -3,6 +3,9 @@ name: Deploy to wordpress-playground-staging.atomicsites.blog
 on:
     workflow_dispatch:
 
+    # TODO: Remove this after testing
+    pull_request:
+
 concurrency:
     group: staging-website-deployment
 

--- a/.github/workflows/deploy-website-to-staging.yml
+++ b/.github/workflows/deploy-website-to-staging.yml
@@ -1,0 +1,14 @@
+name: Deploy to wordpress-playground-staging.atomicsites.blog
+
+on:
+    workflow_dispatch:
+
+concurrency:
+    group: staging-website-deployment
+
+jobs:
+    deploy-to-staging:
+        # TODO: Rename main workflow
+        uses: ./.github/workflows/build-website.yml
+        with:
+            environment: 'playground-wordpress-net-wp-cloud-staging'


### PR DESCRIPTION
## Motivation for the change, related issues

When making changes to the website deployment process and hosting code, we can reduce risk to production by testing with a staging environment first.

## Implementation details

This PR modifies the production deployment script to take a workflow environment param that can be used to deploy to a different server via SSH. Then it adds a staging workflow to invoke the production workflow with a staging environment.

## Testing Instructions (or ideally a Blueprint)

- Run the staging workflow and confirm it works
- Run the production workflow and confirm it still works
