### PR TITLE
Allow specifying a WordPres/WordPress branch and pulling from GitHub.

### DIFF
--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -357,8 +357,6 @@ try {
                 'Content-Disposition: attachment; filename="wordpress.zip"',
             ]
         );
-
-
     } else if (isset($_GET['url'])) {
         // Proxy the current request to $_GET['url'] and return the response,
         // but only if the URL is allowlisted.

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -355,7 +355,6 @@ try {
             null,
             [
                 'Content-Disposition: attachment; filename="wordpress.zip"',
-                "X-Proxy-Zip-Path: WordPress-{$branch}"
             ]
         );
 

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -334,8 +334,8 @@ try {
         }
 
         $downloader->streamFromGithubReleases($_GET['repo'], $_GET['name']);
-    } else if ( isset( $_GET['branch'] ) ) {
-        $branch = strtolower( $_GET['branch'] );
+    } else if ( isset( $_GET['wordpress-branch'] ) ) {
+        $branch = strtolower( $_GET['wordpress-branch'] );
         if ( $branch === 'trunk' || $branch === 'master' ) {
             $branch = 'master';
             // If the brach is of the form x.x append '-branch' to it.

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -334,6 +334,32 @@ try {
         }
 
         $downloader->streamFromGithubReleases($_GET['repo'], $_GET['name']);
+    } else if ( isset( $_GET['branch'] ) ) {
+        $branch = strtolower( $_GET['branch'] );
+        if ( $branch === 'trunk' ) {
+            $branch = 'master';
+            // If the brach is of the form x.x append '-branch' to it.
+        } elseif ( preg_match( '/^\d+\.\d+$/', $branch ) ) {
+            $branch .= '-branch';
+        } elseif ( ! preg_match( '/^\d+\.\d+-branch$/', $branch ) ) {
+            throw new ApiException( 'Invalid branch' );
+        }
+
+        $url = "https://codeload.github.com/WordPress/WordPress/zip/refs/heads/{$branch}";
+
+        streamHttpResponse(
+            $url,
+            'GET',
+            [],
+            file_get_contents('php://input'),
+            null,
+            [
+                'Content-Disposition: attachment; filename="wordpress.zip"',
+                "X-Proxy-Zip-Path: WordPress-{$branch}"
+            ]
+        );
+
+
     } else if (isset($_GET['url'])) {
         // Proxy the current request to $_GET['url'] and return the response,
         // but only if the URL is allowlisted.

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -336,7 +336,7 @@ try {
         $downloader->streamFromGithubReleases($_GET['repo'], $_GET['name']);
     } else if ( isset( $_GET['branch'] ) ) {
         $branch = strtolower( $_GET['branch'] );
-        if ( $branch === 'trunk' ) {
+        if ( $branch === 'trunk' || $branch === 'master' ) {
             $branch = 'master';
             // If the brach is of the form x.x append '-branch' to it.
         } elseif ( preg_match( '/^\d+\.\d+$/', $branch ) ) {

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -329,11 +329,24 @@ export async function unzipWordPress(php: PHP, wpZip: File) {
 	// @TODO: Don't make so many guesses about the zip file contents. Allow the
 	//        API consumer to specify the exact "coordinates" of WordPress inside
 	//        the zip archive.
-	const wpPath = php.fileExists('/tmp/unzipped-wordpress/wordpress')
+	let wpPath = php.fileExists('/tmp/unzipped-wordpress/wordpress')
 		? '/tmp/unzipped-wordpress/wordpress'
 		: php.fileExists('/tmp/unzipped-wordpress/build')
 		? '/tmp/unzipped-wordpress/build'
 		: '/tmp/unzipped-wordpress';
+
+	// One last guess if the path does not contain the sample config file.
+	if (!php.fileExists(joinPaths(wpPath, 'wp-config-sample.php'))) {
+		// Still don't know the directory structure of the zip file.
+		// 1. Get the first item in path.
+		const firstDir = php.listFiles(wpPath)[0];
+		// 2. If it's a directory that contains wp-config-sample.php, use it.
+		if (
+			php.fileExists(joinPaths(wpPath, firstDir, 'wp-config-sample.php'))
+		) {
+			wpPath = joinPaths(wpPath, firstDir);
+		}
+	}
 
 	if (
 		php.isDir(php.documentRoot) &&

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -339,12 +339,17 @@ export async function unzipWordPress(php: PHP, wpZip: File) {
 	if (!php.fileExists(joinPaths(wpPath, 'wp-config-sample.php'))) {
 		// Still don't know the directory structure of the zip file.
 		// 1. Get the first item in path.
-		const firstDir = php.listFiles(wpPath)[0];
-		// 2. If it's a directory that contains wp-config-sample.php, use it.
-		if (
-			php.fileExists(joinPaths(wpPath, firstDir, 'wp-config-sample.php'))
-		) {
-			wpPath = joinPaths(wpPath, firstDir);
+		const files = php.listFiles(wpPath);
+		if (files.length) {
+			const firstDir = files[0];
+			// 2. If it's a directory that contains wp-config-sample.php, use it.
+			if (
+				php.fileExists(
+					joinPaths(wpPath, firstDir, 'wp-config-sample.php')
+				)
+			) {
+				wpPath = joinPaths(wpPath, firstDir);
+			}
 		}
 	}
 

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -335,7 +335,9 @@ export async function unzipWordPress(php: PHP, wpZip: File) {
 		? '/tmp/unzipped-wordpress/build'
 		: '/tmp/unzipped-wordpress';
 
-	// One last guess if the path does not contain the sample config file.
+	// Dive one directory deeper if the zip root does not contain the sample
+	// config file. This is relevant when unzipping a zipped branch from the 
+	// https://github.com/WordPress/WordPress repository.
 	if (!php.fileExists(joinPaths(wpPath, 'wp-config-sample.php'))) {
 		// Still don't know the directory structure of the zip file.
 		// 1. Get the first item in path.


### PR DESCRIPTION
## Motivation for the change, related issues

As a Core contributor, it can be helpful to pull in `trunk` or the head of another branch to test changes before they are tagged, released or appear in a nightly. This is especially the case for older branches that do not have nightly builds.

This allows for the pulling in of a zip from the GitHub build repository.

## Implementation details

Update to `plugin-proxy.php`

1. Accepts the new parameter `branch`
2. Considers `trunk` and `master` as the head of the repo
3. Considers `x.x` and `x.x-branch` as the head of the specified branch

Update to `unzipWordPress()`

1. After calculating the WordPress path, it checks for the file `wp-config-sample.php`
2. If the file does not exist, adds a desperate last attempt to determine the correct directory

## Testing Instructions (or ideally a Blueprint)

1. Run `PLAYGROUND_URL=http://localhost:9999 npx nx run playground-website:build:wasm-wordpress-net`
2. Run `php -S localhost:9999 -t dist/packages/playground/wasm-wordpress-net`
3. To test with the 6.6 branch use this [blueprint](http://localhost:9999/?#%7B%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/wp-admin%22,%22login%22:true,%22preferredVersions%22:%7B%22php%22:%227.4%22,%22wp%22:%22http://localhost:9999/plugin-proxy.php?branch=6.6%22%7D%7D) pointing to localhost.
4. To test with trunk, use this [blueprint](http://localhost:9999/?#%7B%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/wp-admin%22,%22login%22:true,%22preferredVersions%22:%7B%22php%22:%227.4%22,%22wp%22:%22http://localhost:9999/plugin-proxy.php?branch=trunk%22%7D%7D) pointing to localhost.