### PR TITLE
@php-wasm/util: Publish TypeScript types

### DIFF
--- a/packages/php-wasm/util/vite.config.ts
+++ b/packages/php-wasm/util/vite.config.ts
@@ -1,6 +1,9 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
 
+import dts from 'vite-plugin-dts';
+import { join } from 'path';
+
 import viteTsConfigPaths from 'vite-tsconfig-paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { getExternalModules } from '../../vite-extensions/vite-external-modules';
@@ -9,6 +12,11 @@ export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-util',
 
 	plugins: [
+		dts({
+			entryRoot: 'src',
+			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+		}),
+
 		viteTsConfigPaths({
 			root: '../../../',
 		}),


### PR DESCRIPTION
https://github.com/WordPress/wordpress-playground/pull/1593 caused the `@php-wasm/util` package to be published without the `index.d.ts` type declarations file which causes the following TypeScript error:

```
Could not find a declaration file for module '@php-wasm/node'.
```

This PR adds the missing `dts()` plugin to vite.config.ts and enables publishing the declarations file.

I verified all the other packages (aside of `cli`, which is fine) use the `dts()` plugin. However, before we can say https://github.com/WordPress/wordpress-playground/issues/1662 is fixed, we'll need to merge this PR, release new packages, and confirm they import cleanly without any TypeScript errors.

Ideally we'd have a smoke test for that right in the CI.
