### PR TITLE
@php-wasm/node: Publish index.d.ts

### DIFF
--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -7,7 +7,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README", "build:copy-wasms"]
+			"dependsOn": ["build:README", "build:dts"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -36,6 +36,18 @@
 				"buildTarget": "php-wasm-node:build:bundle:production"
 			},
 			"dependsOn": ["build:mkdir"]
+		},
+		"build:dts": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "packages/php-wasm/node",
+				"commands": [
+					"npx -p typescript tsc --project tsconfig.lib.json --declaration --allowJs --emitDeclarationOnly --outDir ../../../dist/packages/php-wasm/out-tsc-phpwasm-node",
+					"cp -r ../../../dist/packages/php-wasm/out-tsc-phpwasm-node/packages/php-wasm/node/src/* ../../../dist/packages/php-wasm/node"
+				],
+				"parallel": false
+			},
+			"dependsOn": ["build:copy-wasms"]
 		},
 		"build:bundle": {
 			"executor": "@nx/esbuild:esbuild",


### PR DESCRIPTION
https://github.com/WordPress/wordpress-playground/pull/1593 caused the `@php-wasm/util` package to be published without the `index.d.ts` type declarations file which causes the following TypeScript error:

```
Could not find a declaration file for module '@php-wasm/node'.
```

This PR adds a `build:dts` task to the `@php-wasm/node` publishing flow to ensure the type declarations get delivered to npm.

To test, we'll need to merge this PR, release new packages, and confirm they import cleanly without any TypeScript errors.

Ideally we'd have a smoke test for that right in the CI.

Related to https://github.com/WordPress/wordpress-playground/issues/1577
