### PR TITLE
Enable networking for WordPress and Gutenberg PR viewers

### DIFF
--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -156,6 +156,9 @@
 			// Redirect to the Playground site with the Blueprint to download and apply the PR
 			const blueprint = {
 				landingPage: '/wp-admin/',
+				features: {
+					networking: true,
+				},
 				steps: [
 					{
 						step: 'login',

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -222,6 +222,9 @@
 					php: '7.4',
 					wp: zipArtifactUrl,
 				},
+				features: {
+					networking: true,
+				},
 			};
 			const encoded = JSON.stringify(blueprint);
 


### PR DESCRIPTION
## Motivation for the change, related issues
Primarily allows the installation of plugins (or themes) from wporg to test with the PR under test. Updates the [WordPress](https://playground.wordpress.net/wordpress.html) and [Gutenberg](https://playground.wordpress.net/gutenberg.html) PR viewers to enable networking by default, as this option cannot be enabled after loading the PR Blueprint.

See https://github.com/WordPress/wordpress-playground/issues/1455.

## Implementation details
- Sets the networking feature to `true` on the Blueprints used to load WP and GB PRs.

## Testing Instructions (or ideally a Blueprint)
1. Navigate to the WordPress PR viewer (e.g. http://127.0.0.1:5400/website-server/wordpress.html).
2. Enter a valid PR number and click Go.
3. Once Playground has loaded, open the "Customize Playground" modal in the page header and observe the "Network access (e.g. for browsing plugins)" checkbox setting.
4. [Optional] Navigate to _Plugins > Add New Plugin_ and observe the display of plugin directory results.
5. Navigate to the Gutenberg PR viewer (e.g. http://127.0.0.1:5400/website-server/gutenberg.html) and repeat steps 2-4.

### Expected Results
- The "Network access (e.g. for browsing plugins)" checkbox should be checked.
- The "Add New Plugins" page should list results from the wporg plugin directory.
