### PR TITLE
Use a separate iframe for every Playground site

### DIFF
--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -5,6 +5,8 @@ import BrowserChrome from '../browser-chrome';
 import { StorageType } from '../../types';
 import { setupPostMessageRelay } from '@php-wasm/web';
 import { usePlaygroundContext } from '../../playground-context';
+import { useSelector } from 'react-redux';
+import { PlaygroundReduxState } from '../../lib/redux-store';
 
 export const supportedDisplayModes = [
 	'browser-full-screen',
@@ -63,10 +65,14 @@ export const JustViewport = function LoadedViewportComponent({
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
+	const siteSlug = useSelector(
+		(state: PlaygroundReduxState) => state.activeSiteSlug
+	);
 	return (
 		<div className={css.fullSize}>
 			<iframe
 				id="playground-viewport"
+				key={siteSlug}
 				title="WordPress Playground wrapper (the actual WordPress site is in another, nested iframe)"
 				className={css.fullSize}
 				ref={iframeRef}

--- a/packages/playground/website/src/lib/redux-store.ts
+++ b/packages/playground/website/src/lib/redux-store.ts
@@ -41,6 +41,7 @@ export type SiteListing = {
 
 // Define the state types
 interface AppState {
+	activeSiteSlug: string | undefined;
 	activeModal: string | null;
 	offline: boolean;
 	siteListing: SiteListing;
@@ -54,6 +55,7 @@ const query = new URL(document.location.href).searchParams;
 
 // Define the initial state
 const initialState: AppState = {
+	activeSiteSlug: query.get('site-slug') || undefined,
 	activeModal:
 		query.get('modal') === 'mount-markdown-directory'
 			? 'mount-markdown-directory'
@@ -92,6 +94,12 @@ const slice = createSlice({
 		getOpfsHandle: (state) => state.opfsMountDescriptor,
 	},
 	reducers: {
+		setActiveSiteSlug: (
+			state,
+			action: PayloadAction<string | undefined>
+		) => {
+			state.activeSiteSlug = action.payload;
+		},
 		setActiveModal: (state, action: PayloadAction<string | null>) => {
 			state.activeModal = action.payload;
 		},
@@ -135,7 +143,8 @@ const slice = createSlice({
 });
 
 // Export actions
-export const { setActiveModal, setOpfsMountDescriptor } = slice.actions;
+export const { setActiveSiteSlug, setActiveModal, setOpfsMountDescriptor } =
+	slice.actions;
 
 // Redux thunk for adding a site
 export function addSite(siteInfo: SiteInfo) {
@@ -166,6 +175,7 @@ export function selectSite(siteSlug: string) {
 				create: true,
 			}
 		);
+		dispatch(setActiveSiteSlug(siteSlug));
 		dispatch(
 			setOpfsMountDescriptor({
 				device: {

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -10,9 +10,13 @@ import { SiteView } from './components/site-view/site-view';
 import { StorageTypes, StorageType } from './types';
 import { SiteManager } from './components/site-manager';
 import { useBootPlayground } from './lib/use-boot-playground';
-import { Provider } from 'react-redux';
-import { useEffect, useRef, useState } from '@wordpress/element';
-import store from './lib/redux-store';
+import { Provider, useDispatch, useSelector } from 'react-redux';
+import { useEffect, useRef } from '@wordpress/element';
+import store, {
+	PlaygroundDispatch,
+	PlaygroundReduxState,
+	setActiveSiteSlug,
+} from './lib/redux-store';
 import {
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalNavigatorScreen as NavigatorScreen,
@@ -63,9 +67,13 @@ if (currentConfiguration.wp === '6.3') {
 
 function Main() {
 	const siteViewRef = useRef<HTMLDivElement>(null);
-	const [siteSlug, setSiteSlug] = useState<string | undefined>(
-		query.get('site-slug') ?? undefined
+	const siteSlug = useSelector(
+		(state: PlaygroundReduxState) => state.activeSiteSlug
 	);
+	const dispatch = useDispatch<PlaygroundDispatch>();
+	const setSiteSlug = (slug?: string) => {
+		dispatch(setActiveSiteSlug(slug));
+	};
 
 	useEffect(() => {
 		if (siteSlug && storage !== 'browser') {


### PR DESCRIPTION
Resolves the "Playground already booted" error that occurs when `startPlaygroundWeb` is called more than once on the same iframe.

 ## Implementation

This implementation recreates the iframe every time the site slug changes. This ensures that all postMessage calls related to the new site are not processed in the context of a previously booted worker.

 ## Remaining work

I am not happy with the data flows in this PR. The `Main` component calls `useBootPlayground`, gets an iframeRef, and passes it down to the `JustViewport` component via props, where it is used in conjunction with the `siteSlug` extracted from the redux state. This roundabout logic will bite us.

Let's implement a straightforward data flow instead and either:

* Call `bootPlaygroundWeb()` in `JustViewport` and handle the iframeRef right there, or...
* Manage the playground's `iframeRef` through redux state instead of props.

I want to set the stage for keeping the "closed" iframes around for some more time to enable quick, boot-less switching between sites.

cc @brandonpayton
