### PR TITLE
Avoid errors due to log message formatting

### DIFF
--- a/packages/php-wasm/logger/src/lib/handlers/log-to-console.ts
+++ b/packages/php-wasm/logger/src/lib/handlers/log-to-console.ts
@@ -6,9 +6,19 @@ import { Log, prepareLogMessage } from '../logger';
  */
 export const logToConsole: LogHandler = (log: Log, ...args: any[]): void => {
 	if (typeof log.message === 'string') {
-		log.message = prepareLogMessage(log.message);
+		// Some errors have a read-only message property where direct
+		// assignment will throw an error. The assignment is merely for
+		// formatting, so let's assign with Reflect.set and avoid the error.
+		Reflect.set(log, 'message', prepareLogMessage(log.message));
 	} else if (log.message.message && typeof log.message.message === 'string') {
-		log.message.message = prepareLogMessage(log.message.message);
+		// Some errors have a read-only message property where direct
+		// assignment will throw an error. The assignment is merely for
+		// formatting, so let's assign with Reflect.set and avoid the error.
+		Reflect.set(
+			log.message,
+			'message',
+			prepareLogMessage(log.message.message)
+		);
 	}
 	/* eslint-disable no-console */
 	switch (log.severity) {


### PR DESCRIPTION
## Motivation for the change, related issues

Today, we attempt to reassign an error's message property for formatting purposes, but this throws an exception if the error property isn't writable or doesn't have a setter. For example:

```
TypeError: Cannot set property message of #<ErrorEvent2> which has only a getter
```

These are the assignments that occasionally lead to the error:
https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/logger/src/lib/handlers/log-to-console.ts#L9-L11

Since the assignments are just for formatting, it should be OK if we just tolerate the failed assignment using `Reflect.set()`.

Fixes #1514

## Implementation details

Use `Reflect.set()` to avoid exceptions when the assignment fails.

## Testing Instructions (or ideally a Blueprint)

- CI
- Tested manually by causing errors in the PHP runtime
