### PR TITLE
Fix logger test for inconsistent short month

### DIFF
--- a/packages/php-wasm/logger/src/test/logger.spec.ts
+++ b/packages/php-wasm/logger/src/test/logger.spec.ts
@@ -11,6 +11,8 @@ describe('Logger', () => {
 		const logs = logger.getLogs();
 		expect(logs.length).toBe(1);
 		expect(logs[0]).toMatch(
+			// TODO: Replace with the following regex pattern:
+			///\[\d{2}-[A-Za-z]{3,4}-\d{4} \d{2}:\d{2}:\d{2} UTC\] JavaScript Warn: test/
 			/\[\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2} UTC\] JavaScript Warn: test/
 		);
 	});

--- a/packages/php-wasm/logger/src/test/logger.spec.ts
+++ b/packages/php-wasm/logger/src/test/logger.spec.ts
@@ -11,9 +11,7 @@ describe('Logger', () => {
 		const logs = logger.getLogs();
 		expect(logs.length).toBe(1);
 		expect(logs[0]).toMatch(
-			// TODO: Replace with the following regex pattern:
-			///\[\d{2}-[A-Za-z]{3,4}-\d{4} \d{2}:\d{2}:\d{2} UTC\] JavaScript Warn: test/
-			/\[\d{2}-[A-Za-z]{3}-\d{4} \d{2}:\d{2}:\d{2} UTC\] JavaScript Warn: test/
+			/\[\d{2}-[A-Za-z]{3,4}-\d{4} \d{2}:\d{2}:\d{2} UTC\] JavaScript Warn: test/
 		);
 	});
 


### PR DESCRIPTION
## Motivation for the change, related issues

While working on another logger related change (#1701), I found that logger message date formatting is getting different output depending upon platform.

For example, the following expression:
```js
new Intl.DateTimeFormat('en-GB', {
		year: 'numeric',
		month: 'short',
		day: '2-digit',
		timeZone: 'UTC',
}).format(new Date())
```

Yields `"03 Sep 2024"` in Safari and `'03 Sept 2024'` in Chrome.

And now, on my machine, the unit tests on the `trunk` branch fail because Node.js is formatting with a 4-char month while the unit tests expect a 3-char month.

## Implementation details

AFAIK, these differences do no matter to us, so we can just make the logger tests tolerate both 3 and 4-char short months.

## Testing Instructions (or ideally a Blueprint)

- CI with unit tests