### PR TITLE
Add more asyncify-listed PHP functions to fix Studio crash

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -874,7 +874,10 @@ RUN echo -n ' -s ASYNCIFY=1 -s ASYNCIFY_IGNORE_INDIRECT=1 ' >> /root/.emcc-php-w
 "zend_llist_del_element",\
 "zend_lookup_class_ex",\
 "zend_stream_fixup",\
-"zif_spl_autoload_call"';\
+"zif_spl_autoload_call",\
+"php_error_docref",\
+"php_pcre_replace_func_impl",\
+"php_verror"';\
 	# If pointer casts are enabled, we need to asyncify both the prefixed and unprefixed names
 	if [ "${PHP_VERSION:0:1}" -lt "8" ]; then \
 		export ASYNCIFY_ONLY="$ASYNCIFY_ONLY,"$(echo "$ASYNCIFY_ONLY" | sed -E $'s/"([a-zA-Z])/"byn$fpcast-emu$\\1/g'); \

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -860,7 +860,21 @@ RUN echo -n ' -s ASYNCIFY=1 -s ASYNCIFY_IGNORE_INDIRECT=1 ' >> /root/.emcc-php-w
 "zim_ReflectionClass_newInstanceArgs",\
 "zim_reflection_class_newInstanceArgs",\
 "zim_reflection_method_invoke",\
-"zim_reflection_method_invokeArgs"'; \
+"zim_reflection_method_invokeArgs",\
+"ZEND_INCLUDE_OR_EVAL_SPEC_CV_HANDLER",\
+"ZEND_NEW_SPEC_CONST_UNUSED_HANDLER",\
+"compile_file",\
+"file_handle_dtor",\
+"open_file_for_scanning",\
+"phar_compile_file",\
+"php_zend_stream_closer",\
+"zend_fetch_class_by_name",\
+"zend_file_handle_dtor",\
+"zend_include_or_eval",\
+"zend_llist_del_element",\
+"zend_lookup_class_ex",\
+"zend_stream_fixup",\
+"zif_spl_autoload_call"';\
 	# If pointer casts are enabled, we need to asyncify both the prefixed and unprefixed names
 	if [ "${PHP_VERSION:0:1}" -lt "8" ]; then \
 		export ASYNCIFY_ONLY="$ASYNCIFY_ONLY,"$(echo "$ASYNCIFY_ONLY" | sed -E $'s/"([a-zA-Z])/"byn$fpcast-emu$\\1/g'); \

--- a/packages/php-wasm/node/public/php_7_0.js
+++ b/packages/php-wasm/node/public/php_7_0.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 13341609; 
+export const dependenciesTotalSize = 13349246; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_1.js
+++ b/packages/php-wasm/node/public/php_7_1.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 13822227; 
+export const dependenciesTotalSize = 13829883; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_2.js
+++ b/packages/php-wasm/node/public/php_7_2.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 14371503; 
+export const dependenciesTotalSize = 14380254; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_3.js
+++ b/packages/php-wasm/node/public/php_7_3.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 14496257; 
+export const dependenciesTotalSize = 14505285; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_7_4.js
+++ b/packages/php-wasm/node/public/php_7_4.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 15184093; 
+export const dependenciesTotalSize = 15202971; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_0.js
+++ b/packages/php-wasm/node/public/php_8_0.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 14694447; 
+export const dependenciesTotalSize = 14707223; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_1.js
+++ b/packages/php-wasm/node/public/php_8_1.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 14676594; 
+export const dependenciesTotalSize = 14688927; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_2.js
+++ b/packages/php-wasm/node/public/php_8_2.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 14931833; 
+export const dependenciesTotalSize = 14944243; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/node/public/php_8_3.js
+++ b/packages/php-wasm/node/public/php_8_3.js
@@ -1,6 +1,6 @@
 const dependencyFilename = __dirname + '/8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 15312039; 
+export const dependenciesTotalSize = 15324679; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_0.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11178697; 
+export const dependenciesTotalSize = 11186165; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_1.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 11612134; 
+export const dependenciesTotalSize = 11619695; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_2.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12108288; 
+export const dependenciesTotalSize = 12117139; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_3.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12191130; 
+export const dependenciesTotalSize = 12199911; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_7_4.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_7_4.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12797415; 
+export const dependenciesTotalSize = 12811747; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_0.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12392525; 
+export const dependenciesTotalSize = 12403650; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_1.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12326169; 
+export const dependenciesTotalSize = 12336959; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_2.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12567207; 
+export const dependenciesTotalSize = 12578099; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/kitchen-sink/php_8_3.js
+++ b/packages/php-wasm/web/public/kitchen-sink/php_8_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 12824240; 
+export const dependenciesTotalSize = 12835301; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_0.js
+++ b/packages/php-wasm/web/public/light/php_7_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_0_33/php_7_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5274814; 
+export const dependenciesTotalSize = 5282295; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_1.js
+++ b/packages/php-wasm/web/public/light/php_7_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_1_30/php_7_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5412612; 
+export const dependenciesTotalSize = 5420139; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_2.js
+++ b/packages/php-wasm/web/public/light/php_7_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_2_34/php_7_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5617052; 
+export const dependenciesTotalSize = 5625897; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_3.js
+++ b/packages/php-wasm/web/public/light/php_7_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_3_33/php_7_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5565812; 
+export const dependenciesTotalSize = 5574627; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_7_4.js
+++ b/packages/php-wasm/web/public/light/php_7_4.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './7_4_33/php_7_4.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5785139; 
+export const dependenciesTotalSize = 5797852; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_0.js
+++ b/packages/php-wasm/web/public/light/php_8_0.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_0_30/php_8_0.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5580319; 
+export const dependenciesTotalSize = 5589802; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_1.js
+++ b/packages/php-wasm/web/public/light/php_8_1.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_1_23/php_8_1.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5386244; 
+export const dependenciesTotalSize = 5395379; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_2.js
+++ b/packages/php-wasm/web/public/light/php_8_2.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_2_10/php_8_2.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5499123; 
+export const dependenciesTotalSize = 5508293; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets

--- a/packages/php-wasm/web/public/light/php_8_3.js
+++ b/packages/php-wasm/web/public/light/php_8_3.js
@@ -1,6 +1,6 @@
 import dependencyFilename from './8_3_0/php_8_3.wasm'; 
 export { dependencyFilename }; 
-export const dependenciesTotalSize = 5591555; 
+export const dependenciesTotalSize = 5600892; 
 export function init(RuntimeName, PHPLoader) {
     /**
      * Overrides Emscripten's default ExitStatus object which gets


### PR DESCRIPTION
## Motivation for the change, related issues, implementation details

This PR adds more PHP function names to our asyncify list to hopefully address a crash encountered by the Studio app.

## Testing Instructions (or ideally a Blueprint)

- CI