### PR TITLE
Use the correct imports in the generated .d.ts files

### DIFF
--- a/packages/php-wasm/fs-journal/vite.config.ts
+++ b/packages/php-wasm/fs-journal/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 
 		viteTsConfigPaths({

--- a/packages/php-wasm/logger/src/lib/collectors/collect-php-logs.ts
+++ b/packages/php-wasm/logger/src/lib/collectors/collect-php-logs.ts
@@ -1,4 +1,4 @@
-import { UniversalPHP, PHPRequestErrorEvent } from '../../universal';
+import type { UniversalPHP, PHPRequestErrorEvent } from '../types';
 import { Logger } from '../logger';
 
 let lastPHPLogLength = 0;

--- a/packages/php-wasm/logger/src/lib/types.ts
+++ b/packages/php-wasm/logger/src/lib/types.ts
@@ -16,7 +16,7 @@ export interface UniversalPHP {
 
 	addEventListener(
 		event: string,
-		listener: (event: PHPRequestEndEvent | PHPRequestErrorEvent) => void
+		listener: (event: PHPRequestErrorEvent) => void
 	): void;
 }
 

--- a/packages/php-wasm/logger/tsconfig.spec.json
+++ b/packages/php-wasm/logger/tsconfig.spec.json
@@ -14,6 +14,7 @@
 		"src/**/*.spec.js",
 		"src/**/*.test.jsx",
 		"src/**/*.spec.jsx",
-		"src/**/*.d.ts"
+		"src/**/*.d.ts",
+		"src/types.ts"
 	]
 }

--- a/packages/php-wasm/logger/vite.config.ts
+++ b/packages/php-wasm/logger/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 
 		viteTsConfigPaths({

--- a/packages/php-wasm/node-polyfills/vite.config.ts
+++ b/packages/php-wasm/node-polyfills/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 	],
 

--- a/packages/php-wasm/progress/vite.config.ts
+++ b/packages/php-wasm/progress/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 
 		viteTsConfigPaths({

--- a/packages/php-wasm/scopes/vite.config.ts
+++ b/packages/php-wasm/scopes/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 
 		viteTsConfigPaths({

--- a/packages/php-wasm/stream-compression/vite.config.ts
+++ b/packages/php-wasm/stream-compression/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 		viteTsConfigPaths({
 			root: '../../../',

--- a/packages/php-wasm/universal/vite.config.ts
+++ b/packages/php-wasm/universal/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 
 		viteTsConfigPaths({

--- a/packages/php-wasm/util/vite.config.ts
+++ b/packages/php-wasm/util/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 
 		viteTsConfigPaths({

--- a/packages/php-wasm/web-service-worker/vite.config.ts
+++ b/packages/php-wasm/web-service-worker/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 
 		viteTsConfigPaths({

--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig(({ command }) => {
 			dts({
 				entryRoot: 'src',
 				tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+				pathsToAliases: false,
 			}),
 			{
 				name: 'ignore-wasm-imports',

--- a/packages/playground/blueprints/vite.config.ts
+++ b/packages/playground/blueprints/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 
 		viteTsConfigPaths({

--- a/packages/playground/client/vite.config.ts
+++ b/packages/playground/client/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 		ignoreWasmImports(),
 

--- a/packages/playground/common/vite.config.ts
+++ b/packages/playground/common/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path('tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 	],
 

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -18,6 +18,7 @@ const plugins = [
 	dts({
 		entryRoot: 'src',
 		tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+		pathsToAliases: false,
 	}),
 	/**
 	 * Copy the `.htaccess` file to the `dist` directory.

--- a/packages/playground/wordpress-builds/vite.config.ts
+++ b/packages/playground/wordpress-builds/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path('tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 		{
 			name: 'use-correct-wp-data-file-url-in-vitest-environment',

--- a/packages/playground/wordpress/vite.config.ts
+++ b/packages/playground/wordpress/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
 		dts({
 			entryRoot: 'src',
 			tsconfigPath: path('tsconfig.lib.json'),
+			pathsToAliases: false,
 		}),
 		{
 			name: 'use-correct-wp-data-file-url-in-vitest-environment',


### PR DESCRIPTION
When using @wp-playground/client with TypeScript, the IDE doesn't seem
to be able to recognize types. This is because the published types
contain fragments such as:

```ts
import { Emscripten, MountHandler, PHP } from '../../../universal';
```

Which are relative to the build directory on the building machine.

This PR sets the `pathsToAliases` option of the `vite-dts-plugin` to
false to retain the packages names in those declaration files.

```ts
import { Emscripten, MountHandler, PHP } from '@php-wasm/universal';
```

 ## Testing instruction

Run `npm run build` and grep the `dist` directory for `../../`. There
should be no matches:

```sh
grep '\.\./\.\./' -R ./ | grep '\.d\.ts' | grep import
```

Inspect a few files, such as `dist/packages/php-wasm/web/lib/get-php-loader-module.d.ts`, and confirm they import from the proper package names.

Closes https://github.com/WordPress/wordpress-playground/issues/1725

cc @brandonpayton

