### PR TITLE
Prototype: Block-based Blueprints Editor

### DIFF
--- a/packages/playground/blueprints-builder/.eslintrc.json
+++ b/packages/playground/blueprints-builder/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*", "blueprint-schema-validator.js"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+}

--- a/packages/playground/blueprints-builder/README.md
+++ b/packages/playground/blueprints-builder/README.md
@@ -1,0 +1,11 @@
+# playground-blueprints-builder
+
+This library was generated with [Nx](https://nx.dev).
+
+## Building
+
+Run `nx build playground-blueprints-builder` to build the library.
+
+## Running unit tests
+
+Run `nx test playground-blueprints-builder` to execute the unit tests via [Jest](https://jestjs.io).

--- a/packages/playground/blueprints-builder/package.json
+++ b/packages/playground/blueprints-builder/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "@wp-playground/blueprints-builder",
+	"version": "0.9.38",
+	"exports": {
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./package.json": "./package.json"
+	},
+	"type": "module",
+	"main": "./index.cjs",
+	"module": "./index.js",
+	"typedoc": {
+		"entryPoint": "./src/index.ts",
+		"readmeFile": "./README.md",
+		"displayName": "@wp-playground/blueprints-builder",
+		"tsconfig": "./tsconfig.lib.json"
+	},
+	"publishConfig": {
+		"access": "public",
+		"directory": "../../../dist/packages/playground/blueprints-builder"
+	},
+	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
+	"engines": {
+		"node": ">=18.18.0",
+		"npm": ">=8.11.0"
+	}
+}

--- a/packages/playground/blueprints-builder/project.json
+++ b/packages/playground/blueprints-builder/project.json
@@ -1,0 +1,95 @@
+{
+	"name": "playground-blueprints-builder",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/playground/blueprints-builder/src",
+	"projectType": "library",
+	"targets": {
+		"build": {
+			"executor": "@wp-playground/nx-extensions:package-json",
+			"options": {
+				"tsConfig": "packages/playground/blueprints-builder/tsconfig.lib.json",
+				"outputPath": "dist/packages/playground/blueprints-builder",
+				"buildTarget": "playground-blueprints-builder:build:bundle:production"
+			},
+			"dependsOn": [
+				"build:blueprint-schema",
+				"build:rollup-declarations-for-schema-generation"
+			]
+		},
+		"build:blueprint-schema": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"node packages/playground/blueprints-builder/bin/generate-schema.js"
+				],
+				"parallel": false
+			},
+			"dependsOn": ["build:rollup-declarations-for-schema-generation"]
+		},
+		"build:rollup-declarations-for-schema-generation": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"mkdir -p dist/packages/playground/blueprints-builder",
+					"npx dts-bundle-generator -o packages/playground/blueprints-builder/src/rollup.d.ts -- packages/playground/blueprints-builder/src/index.ts"
+				],
+				"parallel": false
+			},
+			"dependsOn": ["build:bundle"]
+		},
+		"build:bundle": {
+			"executor": "@nx/vite:build",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"outputPath": "dist/packages/playground/blueprints-builder"
+			}
+		},
+		"publish": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "node tools/scripts/publish.mjs playground-blueprints-builder {args.ver} {args.tag}"
+			},
+			"dependsOn": ["build"]
+		},
+		"test": {
+			"executor": "nx:noop",
+			"dependsOn": ["test:vite"]
+		},
+		"test:esmcjs": {
+			"executor": "@wp-playground/nx-extensions:assert-built-esm-and-cjs",
+			"options": {
+				"outputPath": "dist/packages/playground/blueprints-builder"
+			},
+			"dependsOn": ["build"]
+		},
+		"test:vite": {
+			"executor": "@nx/vite:test",
+			"outputs": [
+				"{workspaceRoot}/coverage/packages/playground/blueprints-builder"
+			],
+			"options": {
+				"passWithNoTests": true,
+				"reportsDirectory": "../../../coverage/packages/playground/blueprints-builder"
+			}
+		},
+		"lint": {
+			"executor": "@nx/linter:eslint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": [
+					"packages/playground/blueprints-builder/**/*.ts"
+				]
+			}
+		},
+		"typecheck": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"tsc -p packages/playground/remote/tsconfig.spec.json --noEmit",
+					"tsc -p packages/playground/remote/tsconfig.lib.json --noEmit"
+				]
+			}
+		}
+	},
+	"tags": []
+}

--- a/packages/playground/blueprints-builder/src/blocks/steps-quick-n-dirty-prototype.js
+++ b/packages/playground/blueprints-builder/src/blocks/steps-quick-n-dirty-prototype.js
@@ -82,6 +82,11 @@
             display: flex;
             flex-direction: row;
             gap: 10px;
+            align-items: stretch;
+        }
+
+        .step-container__content > :first-child:last-child {
+            flex-grow: 1;
         }
     `);
 
@@ -124,12 +129,15 @@
 					)
 						.then((response) => response.json())
 						.then((responseData) => {
-							const decodedPlugins = responseData.plugins.map(
-								(plugin) => ({
+							const decodedPlugins = responseData.plugins
+								.sort(
+									(a, b) =>
+										b.active_installs - a.active_installs
+								)
+								.map((plugin) => ({
 									name: decodeHtmlEntities(plugin.name),
 									slug: plugin.slug,
-								})
-							);
+								}));
 							setData(decodedPlugins);
 						})
 						.catch((error) => {

--- a/packages/playground/blueprints-builder/src/blocks/steps-quick-n-dirty-prototype.js
+++ b/packages/playground/blueprints-builder/src/blocks/steps-quick-n-dirty-prototype.js
@@ -1,0 +1,665 @@
+/**
+ * This isn't actually built. To test, copy this code and paste it in devtools with Gutenberg open.
+ * To do it in Playground, go to the "New post" page, open devtools and select "wp (post-new.php)"
+ * as the context before pasting the code.
+ *
+ * We will want to use `.tsx` for this. Can we do it with vite? Or do we need a webpack setup?
+ *
+ * This is intentionally built by hand. No automated JSON to blocks conversion tool will give us
+ * the great user experience we want, e.g. custom autocompleted inputs for selecting plugins from
+ * the plugin directory.
+ *
+ * I've prototyped a non-block version of this at https://github.com/adamziel/blueprints-ui-builder.
+ * Let's reuse as much of that as possible and useful here.
+ *
+ * TODOs:
+ * - [ ] Reuse the site settings form introduced in https://github.com/WordPress/wordpress-playground/pull/1731 as
+ *       a "Runtime configuration" section of the Blueprint builder. It has nice UI for selecting
+ *       the WordPress version, multisite, debug mode, etc.
+ *       Oh! Perhaps this block-based Blueprint builder could be embedded directly in that site
+ *       settings form?! That form IS a Blueprint builder after all! TBD! But it would be lovely
+ *       to have a builder integrated directly with the Playground experience AND also being a
+ *       reusable, block-based package.
+ *       TBD thinking about the applications of the PHP Blueprints library in the backend files of
+ *       the block-based Blueprint builder.
+ * - [ ] Attribute validation
+ *    - [ ] JSON schema validators
+ *    - [ ] UX – when is the validation performed? On every change? On button click? How is
+ *          it communicated to the user? How do we set the expectations that a syntactically valid
+ *          Blueprint may still fail at runtime?
+ * - [ ] Split-pane Playground preview
+ * - [ ] Blueprint -> blocks
+ * - [ ] Blocks -> Blueprint
+ * - [ ] Extensibility for "Custom steps", so what @amckirk built. A developer should be able to
+ *       ship a block with a dedicated, ergonomic UI, call it a "Step", and turn it's output into
+ *       a few JSON steps that achieve the desired outcome. Then, when editing, those JSON steps
+ *       should be rendered in a code editor as that custom block.
+ *       Tricky part: how to infer which block should be used? We can't just use sets of rules like
+ *       "this sequence of steps = this block" as there might be multiple ambigous matches. Perhaps
+ *       we'll need to explicitly label the steps with the block name. Or maybe we could introduce
+ *       "Step IDs" and map IDs to block names? Or maybe we could have a "group step" that wraps a
+ *       few "atomic steps" and does nothing on its own, but the editor can use it to map the child
+ *       steps to the right custom block?
+ * - [ ] ... probably a lot more ...
+ */
+
+(async function init() {
+	function addOrUpdateCSS(css) {
+		const styleId = 'playground-custom-css';
+		let styleElement = document.getElementById(styleId);
+
+		if (!styleElement) {
+			styleElement = document.createElement('style');
+			styleElement.id = styleId;
+			document.head.appendChild(styleElement);
+		}
+
+		styleElement.textContent = css;
+	}
+
+	addOrUpdateCSS(`
+        .step-container {
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            border: 1px solid #ddd;
+            padding: 0;
+        }
+
+        .step-container__header {
+            box-sizing: border-box;
+            width: 100%;
+            font-size: 14px;
+            border-bottom: 1px solid #ddd;
+            padding: 10px;
+        }
+        
+        .step-container__content {
+            box-sizing: border-box;
+            width: 100%;
+            padding: 10px;
+
+            display: flex;
+            flex-direction: row;
+            gap: 10px;
+        }
+    `);
+
+	function forceRegisterBlock(name, opts) {
+		try {
+			window.wp.blocks.unregisterBlockType(name);
+		} catch (e) {
+			// console.log('Block not registered yet');
+		}
+		window.wp.blocks.registerBlockType(name, opts);
+	}
+
+	function decodeHtmlEntities(encodedString) {
+		const parser = new DOMParser();
+		const dom = parser.parseFromString(
+			`<!doctype html><body>${encodedString}`,
+			'text/html'
+		);
+		return dom.body.textContent;
+	}
+
+	function useQueryPlugins(inputValue) {
+		const [data, setData] = window.wp.element.useState([]);
+		const [fetchController, setFetchController] =
+			window.wp.element.useState(null);
+
+		window.wp.element.useEffect(() => {
+			if (inputValue.trim().length > 0) {
+				if (fetchController) {
+					fetchController.abort();
+				}
+
+				const newController = new AbortController();
+				setFetchController(newController);
+
+				const debounceTimer = setTimeout(() => {
+					fetch(
+						`https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[search]=${inputValue}`,
+						{ signal: newController.signal }
+					)
+						.then((response) => response.json())
+						.then((responseData) => {
+							const decodedPlugins = responseData.plugins.map(
+								(plugin) => ({
+									name: decodeHtmlEntities(plugin.name),
+									slug: plugin.slug,
+								})
+							);
+							setData(decodedPlugins);
+						})
+						.catch((error) => {
+							if (error.name !== 'AbortError') {
+								console.error('Fetch error:', error);
+							}
+						});
+				}, 300); // 300ms debounce
+
+				return () => {
+					clearTimeout(debounceTimer);
+					if (newController) {
+						newController.abort();
+					}
+				};
+			} else {
+				setData([]);
+			}
+		}, [inputValue]);
+
+		return { data };
+	}
+
+	forceRegisterBlock('playground/step-install-plugin', {
+		title: 'Install a plugin',
+		attributes: {
+			resourceType: {
+				type: 'string',
+				default: 'wordpress.org/plugins',
+			},
+			resourceObject: {
+				type: 'object',
+				default: {
+					resource: 'wordpress.org/plugins',
+					slug: '',
+				},
+			},
+		},
+		edit: function ({ attributes, setAttributes }) {
+			return window.wp.element.createElement(
+				StepContainer,
+				{ name: 'Install a plugin' },
+				window.wp.element.createElement(ResourceTypeControl, {
+					label: 'Plugin source',
+					resourceType: attributes.resourceType,
+					allowedResources: ['wordpress.org/plugins', 'url', 'file'],
+					onChange: (newValue) =>
+						setAttributes({
+							resourceType: newValue,
+						}),
+				}),
+				window.wp.element.createElement(
+					window.wp.components.FlexItem,
+					{ style: { flexGrow: 1 } },
+					window.wp.element.createElement(ResourceControl, {
+						resourceType: attributes.resourceType,
+						initialResource: attributes.resourceObject,
+						onChange: (newValue) =>
+							setAttributes({ resourceObject: newValue }),
+					})
+				)
+			);
+		},
+	});
+
+	function useQueryThemes(inputValue) {
+		const [data, setData] = window.wp.element.useState([]);
+		const [fetchController, setFetchController] =
+			window.wp.element.useState(null);
+
+		window.wp.element.useEffect(() => {
+			if (inputValue.trim().length > 0) {
+				if (fetchController) {
+					fetchController.abort();
+				}
+
+				const newController = new AbortController();
+				setFetchController(newController);
+
+				const debounceTimer = setTimeout(() => {
+					fetch(
+						`https://api.wordpress.org/themes/info/1.2/?action=query_themes&request[per_page]=100&request[search]=${inputValue}`,
+						{ signal: newController.signal }
+					)
+						.then((response) => response.json())
+						.then((responseData) => {
+							const decodedThemes = responseData.themes.map(
+								(theme) => ({
+									name: decodeHtmlEntities(theme.name),
+									slug: theme.slug,
+									thumbnail: theme.screenshot_url,
+								})
+							);
+							setData(decodedThemes);
+						})
+						.catch((error) => {
+							if (error.name !== 'AbortError') {
+								console.error('Fetch error:', error);
+							}
+						});
+				}, 300); // 300ms debounce
+
+				return () => {
+					clearTimeout(debounceTimer);
+					if (newController) {
+						newController.abort();
+					}
+				};
+			} else {
+				setData([]);
+			}
+		}, [inputValue]);
+
+		return { data };
+	}
+
+	forceRegisterBlock('playground/step-install-theme', {
+		title: 'Install a theme',
+		attributes: {
+			resourceType: {
+				type: 'string',
+				default: 'wordpress.org/themes',
+			},
+			resourceObject: {
+				type: 'object',
+				default: {
+					resource: 'wordpress.org/themes',
+					slug: '',
+				},
+			},
+		},
+		edit: function ({ attributes, setAttributes }) {
+			return window.wp.element.createElement(
+				StepContainer,
+				{ name: 'Install a theme' },
+				window.wp.element.createElement(ResourceTypeControl, {
+					label: 'Theme source',
+					resourceType: attributes.resourceType,
+					allowedResources: ['wordpress.org/themes', 'url', 'file'],
+					onChange: (newValue) =>
+						setAttributes({
+							resourceType: newValue,
+						}),
+				}),
+				window.wp.element.createElement(
+					window.wp.components.FlexItem,
+					{ style: { flexGrow: 1 } },
+					window.wp.element.createElement(ResourceControl, {
+						resourceType: attributes.resourceType,
+						initialResource: attributes.resourceObject,
+						onChange: (newValue) =>
+							setAttributes({ resourceObject: newValue }),
+					})
+				)
+			);
+		},
+	});
+
+	// TODO: Source this from Blueprints TypeScript types.
+	const resourceTypes = [
+		'vfs',
+		'literal',
+		'wordpress.org/themes',
+		'wordpress.org/plugins',
+		'url',
+
+		// Technically not a Blueprint resource type,
+		// but we allow it here for good UX.
+		'file',
+	];
+
+	function ResourceTypeControl({
+		resourceType,
+		allowedResources,
+		onChange,
+		...restProps
+	}) {
+		const options = [
+			{
+				value: 'wordpress.org/plugins',
+				label: 'WordPress.org Plugins directory',
+			},
+			{
+				value: 'wordpress.org/themes',
+				label: 'WordPress.org Themes directory',
+			},
+			{ value: 'literal', label: 'Text' },
+			{ value: 'vfs', label: 'VFS path' },
+			{ value: 'url', label: 'URL' },
+			{ value: 'file', label: 'Uploaded file' },
+		];
+		return window.wp.element.createElement(
+			window.wp.components.SelectControl,
+			{
+				value: resourceType,
+				onChange: onChange,
+				options: options.filter((option) =>
+					allowedResources.includes(option.value)
+				),
+				...restProps,
+			}
+		);
+	}
+
+	function ResourceControl({ resourceType, initialResource, onChange }) {
+		const [perResourceState, setPerResourceState] =
+			window.wp.element.useState(() => {
+				const initialState = {};
+				resourceTypes.forEach((type) => {
+					initialState[type] = initialResource || {
+						resource: type,
+					};
+				});
+				return initialState;
+			});
+
+		const currentResource = perResourceState[resourceType];
+		const setCurrentResource = (newResource) => {
+			setPerResourceState({
+				...perResourceState,
+				[resourceType]: newResource,
+			});
+			onChange(newResource);
+		};
+
+		window.wp.element.useEffect(() => {
+			if (currentResource.resource !== resourceType) {
+				onChange(perResourceState[resourceType]);
+			}
+		}, [resourceType]);
+
+		if (resourceType === 'wordpress.org/plugins') {
+			return window.wp.element.createElement(PluginSlugInput, {
+				initialValue: currentResource.slug,
+				onChange: (newValue) =>
+					setCurrentResource({
+						...currentResource,
+						slug: newValue,
+					}),
+			});
+		}
+
+		if (resourceType === 'wordpress.org/themes') {
+			return window.wp.element.createElement(ThemeSlugInput, {
+				initialValue: currentResource.slug,
+				onChange: (newValue) =>
+					setCurrentResource({
+						...currentResource,
+						slug: newValue,
+					}),
+			});
+		}
+
+		if (resourceType === 'url') {
+			return window.wp.element.createElement(
+				window.wp.components.__experimentalInputControl,
+				{
+					value: currentResource.url,
+					type: 'url',
+					label: 'URL',
+					onChange: (newValue) =>
+						setCurrentResource({
+							...currentResource,
+							url: newValue,
+						}),
+				}
+			);
+		}
+
+		if (resourceType === 'literal') {
+			return window.wp.element.createElement(
+				window.wp.components.TextareaControl,
+				{
+					label: 'Text',
+					value: currentResource.contents,
+					onChange: (newValue) =>
+						setCurrentResource({
+							...currentResource,
+							contents: newValue,
+						}),
+				}
+			);
+		}
+
+		// Not an actual Blueprint resource type, but
+		// we still allow it for good UX.
+		if (resourceType === 'file') {
+			return window.wp.element.createElement(
+				window.wp.components.__experimentalInputControl,
+				{
+					type: 'file',
+					onChange: (e) =>
+						setCurrentResource({
+							...currentResource,
+							file: e.target.files[0],
+						}),
+					label: 'Upload a file',
+					accept: '.zip',
+				}
+			);
+		}
+
+		if (resourceType === 'vfs') {
+			return window.wp.element.createElement(
+				window.wp.components.__experimentalInputControl,
+				{
+					value: currentResource.path,
+					onChange: (newValue) =>
+						setCurrentResource({
+							...currentResource,
+							path: newValue,
+						}),
+				}
+			);
+		}
+
+		return window.wp.element.createElement(
+			'div',
+			null,
+			'Unknown resource type: ',
+			resourceType
+		);
+	}
+
+	function PluginSlugInput({ initialValue, onChange }) {
+		const uniqueId = window.wp.element.useMemo(
+			() => Math.random().toString(36).substring(2, 15),
+			[]
+		);
+
+		// Autocomplete plugin slug from the WordPress.org plugins API
+		const [inputValue, setInputValue] =
+			window.wp.element.useState(initialValue);
+		const { data: matchingPlugins } = useQueryPlugins(inputValue);
+
+		const handleInputChange = (newValue) => {
+			setInputValue(newValue);
+			onChange(newValue);
+		};
+
+		const handleOptionSelect = (selectedValue) => {
+			onChange(selectedValue);
+			// Don't update inputValue here to keep the current suggestions
+		};
+
+		return window.wp.element.createElement(
+			window.wp.element.Fragment,
+			null,
+			window.wp.element.createElement(
+				window.wp.components.__experimentalInputControl,
+				{
+					label: 'Plugin slug',
+					value: inputValue,
+					list: `plugin-slug-datalist-${uniqueId}`,
+					onChange: handleInputChange,
+					onInput: handleOptionSelect,
+				}
+			),
+			window.wp.element.createElement(
+				'datalist',
+				{ id: `plugin-slug-datalist-${uniqueId}` },
+				matchingPlugins.map((plugin) =>
+					window.wp.element.createElement(
+						'option',
+						{ value: plugin.slug, key: plugin.slug },
+						plugin.name
+					)
+				)
+			)
+		);
+	}
+
+	function ThemeSlugInput({ initialValue, onChange }) {
+		const uniqueId = window.wp.element.useMemo(
+			() => Math.random().toString(36).substring(2, 15),
+			[]
+		);
+
+		// Autocomplete plugin slug from the WordPress.org plugins API
+		const [inputValue, setInputValue] =
+			window.wp.element.useState(initialValue);
+		const { data: matchingThemes } = useQueryThemes(inputValue);
+
+		const handleInputChange = (newValue) => {
+			setInputValue(newValue);
+			onChange(newValue);
+		};
+
+		const handleOptionSelect = (selectedValue) => {
+			onChange(selectedValue);
+			// Don't update inputValue here to keep the current suggestions
+		};
+
+		return window.wp.element.createElement(
+			window.wp.element.Fragment,
+			null,
+			window.wp.element.createElement(
+				window.wp.components.__experimentalInputControl,
+				{
+					label: 'Theme slug',
+					value: inputValue,
+					list: `theme-slug-datalist-${uniqueId}`,
+					onChange: handleInputChange,
+					onInput: handleOptionSelect,
+				}
+			),
+			window.wp.element.createElement(
+				'datalist',
+				{ id: `theme-slug-datalist-${uniqueId}` },
+				matchingThemes.map((theme) =>
+					window.wp.element.createElement(
+						'option',
+						{ value: theme.slug, key: theme.slug },
+						theme.thumbnail &&
+							window.wp.element.createElement('img', {
+								src: theme.thumbnail,
+								alt: theme.name,
+								style: { width: '60px', marginRight: '8px' },
+							}),
+						theme.name
+					)
+				)
+			)
+		);
+	}
+
+	forceRegisterBlock('playground/step-rm', {
+		title: 'Remove a file',
+		attributes: {
+			path: {
+				type: 'string',
+				default: '',
+			},
+		},
+		edit: function ({ attributes, setAttributes }) {
+			return window.wp.element.createElement(
+				StepContainer,
+				{ name: 'Remove a file' },
+				window.wp.element.createElement('input', {
+					type: 'text',
+					value: attributes.path,
+					onChange: (e) => setAttributes({ path: e.target.value }),
+				})
+			);
+		},
+	});
+
+	forceRegisterBlock('playground/step-rmdir', {
+		title: 'Remove a directory',
+		attributes: {
+			path: {
+				type: 'string',
+				default: '',
+			},
+		},
+		edit: function ({ attributes, setAttributes }) {
+			return window.wp.element.createElement(
+				StepContainer,
+				{ name: 'Remove a directory' },
+				window.wp.element.createElement('input', {
+					type: 'text',
+					value: attributes.path,
+					onChange: (e) => setAttributes({ path: e.target.value }),
+				})
+			);
+		},
+	});
+
+	forceRegisterBlock('playground/step-write-file', {
+		title: 'Write a file',
+		attributes: {
+			path: {
+				type: 'string',
+				default: '',
+			},
+		},
+		edit: function ({ attributes, setAttributes }) {
+			// @TODO: Use CodeMirror and allow language selection
+			return window.wp.element.createElement(
+				StepContainer,
+				{ name: 'Write a file' },
+				window.wp.element.createElement('input', {
+					type: 'text',
+					value: attributes.path,
+					onChange: (e) => setAttributes({ path: e.target.value }),
+				})
+			);
+		},
+	});
+
+	forceRegisterBlock('playground/step-run-php', {
+		title: 'Run PHP',
+		attributes: {
+			code: {
+				type: 'string',
+				default: '',
+			},
+		},
+		edit: function ({ attributes, setAttributes }) {
+			// @TODO: Use CodeMirror with PHP highligting
+			return window.wp.element.createElement(
+				StepContainer,
+				{ name: 'Run PHP' },
+				window.wp.element.createElement(
+					window.wp.components.TextareaControl,
+					{
+						label: 'PHP code',
+						value: attributes.code,
+						onChange: (newValue) =>
+							setAttributes({ code: newValue }),
+					}
+				)
+			);
+		},
+	});
+
+	function StepContainer({ name, children }) {
+		return window.wp.element.createElement(
+			'div',
+			{ className: 'step-container' },
+			window.wp.element.createElement(
+				'div',
+				{ className: 'step-container__header' },
+				name
+			),
+			window.wp.element.createElement(
+				'div',
+				{ className: 'step-container__content' },
+				children
+			)
+		);
+	}
+})();

--- a/packages/playground/blueprints-builder/src/index.ts
+++ b/packages/playground/blueprints-builder/src/index.ts
@@ -1,0 +1,1 @@
+export const x = 1;

--- a/packages/playground/blueprints-builder/tsconfig.json
+++ b/packages/playground/blueprints-builder/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "ES2022",
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"types": ["vitest"]
+	},
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+}

--- a/packages/playground/blueprints-builder/tsconfig.lib.json
+++ b/packages/playground/blueprints-builder/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["jest.config.ts", "src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/playground/blueprints-builder/tsconfig.spec.json
+++ b/packages/playground/blueprints-builder/tsconfig.spec.json
@@ -1,0 +1,19 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../dist/out-tsc",
+		"types": ["vitest/globals", "vitest/importMeta", "vite/client", "node"]
+	},
+	"include": [
+		"vite.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.test.tsx",
+		"src/**/*.spec.tsx",
+		"src/**/*.test.js",
+		"src/**/*.spec.js",
+		"src/**/*.test.jsx",
+		"src/**/*.spec.jsx",
+		"src/**/*.d.ts"
+	]
+}

--- a/packages/playground/blueprints-builder/vite.config.ts
+++ b/packages/playground/blueprints-builder/vite.config.ts
@@ -1,0 +1,61 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+
+import dts from 'vite-plugin-dts';
+import { join } from 'path';
+
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
+
+export default defineConfig({
+	cacheDir: '../../../node_modules/.vite/playground-blueprints-builder',
+
+	plugins: [
+		dts({
+			entryRoot: 'src',
+			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+		}),
+
+		viteTsConfigPaths({
+			root: '../../../',
+		}),
+	],
+
+	// Uncomment this if you are using workers.
+	// worker: {
+	//  plugins: [
+	//    viteTsConfigPaths({
+	//      root: '../../../',
+	//    }),
+	//  ],
+	// },
+
+	// Configuration for building your library.
+	// See: https://vitejs.dev/guide/build.html#library-mode
+	build: {
+		lib: {
+			// Could also be a dictionary or array of multiple entry points.
+			entry: 'src/index.ts',
+			name: 'playground-blueprints-builder',
+			fileName: 'index',
+			// Change this to the formats you want to support.
+			// Don't forgot to update your package.json as well.
+			formats: ['es', 'cjs'],
+		},
+		rollupOptions: {
+			external: getExternalModules(),
+		},
+	},
+
+	test: {
+		globals: true,
+		setupFiles: ['./src/vitest-setup-file.ts'],
+		cache: {
+			dir: '../../../node_modules/.vitest',
+		},
+		environment: 'jsdom',
+		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+	},
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -42,6 +42,9 @@
 			"@wp-playground/blueprints": [
 				"packages/playground/blueprints/src/index.ts"
 			],
+			"@wp-playground/blueprints-builder": [
+				"packages/playground/blueprints-builder/src/index.ts"
+			],
 			"@wp-playground/cli": ["packages/playground/cli/src/cli.ts"],
 			"@wp-playground/client": [
 				"packages/playground/client/src/index.ts"


### PR DESCRIPTION
## Motivation for the change, related issues

> [!NOTE]  
> You're the most welcome to take over this PR. I won't be able to make progress here in the short term. Do you want a kick-ass Blueprints editing experience? You can make it happen!

A quick prototype of what a block-based Blueprints editor could look like:

![CleanShot 2024-09-12 at 13 40 14@2x](https://github.com/user-attachments/assets/9396849c-dbfd-4468-8dcb-168b29d5ba2c)

### Why a UI? We have JSON already...

Why? Because writing JSON is so annoying! You can't easily write 10 lines of PHP code for the `runPHP` step, you can't reference other files from your local computer, and you need to understand a lot of ideas (like resource types).

A UI editor can provide a tremendously better experience. This prototype doesn't do any of that, but here's what we'll be able to do:

* Create custom steps, like what @akirk started exploring in https://akirk.github.io/playground-step-library/#
* Use data coming directly from local files and directories
* Use a syntax-highlighted code editor for writing PHP code
* Use an embedded Gutenberg instance for editing content in WXR exports
* Autocomplete a list of plugins and themes from the WordPress.org directory
* Confirm all external URLs are reachable
* Eliminate all syntax errors, the UI just won't accept an invalid input
* Export the Blueprint as JSON or ZIP or a git commit
* Edit existing Blueprints
* Embed directly on playground.wordpress.net (or use as a standalone app!)
* ...and so much more!

### Why Gutenberg blocks?

My first hunch was to [prototype this editor as a standalone app](https://github.com/adamziel/blueprints-ui-builder) but my intuition was wrong. Everything about building a standalone app sucked.

Here's what Gutenberg gives us for free:

* Forms
* A list view
* Autocompletion
* An entity system
* A design system
* A filterable inserter
* A way to store data
* A drag & drop sorting
* Accessible components
* Offline mode (via Playground PWA)
* Long term support and maintenance
* A distribution system for custom steps (WP plugins)
* Well-defined block API, extensible architecture, nested blocks

And there's more! The experience can be combined with existing WordPress plugins, we'll get new features for free as WordPress grows, we'll improve the WordPress ecosystem, I can keep going.

## Testing instructions

Copy this code and paste the contents of `steps-quick-n-dirty-prototype.js` to your browser's devtools with Gutenberg open. If you want to try it in Playground, go to the "New post" page, open devtools and select "wp (post-new.php)" as the execution context before pasting the code.

## Related resources

* https://akirk.github.io/playground-step-library/#
* https://github.com/adamziel/blueprints-ui-builder
* https://github.com/WordPress/blueprints-library/issues/53
* https://github.com/WordPress/wordpress-playground/pull/773

cc @akirk @dmsnell @bgrgicak @brandonpayton @dawidurbanski @griffbrad @ajitbohra 