### PR TITLE
Docs/Guides: Normalized and fixed guides links

### DIFF
--- a/packages/docs/site/docs/main/guides/for-theme-developers.md
+++ b/packages/docs/site/docs/main/guides/for-theme-developers.md
@@ -1,6 +1,6 @@
 ---
 title: Playground for Theme Developers
-slug: /for-theme-developers
+slug: /guides/for-theme-developers
 description: WordPress Playground for Theme Developers
 ---
 

--- a/packages/docs/site/docs/main/guides/index.md
+++ b/packages/docs/site/docs/main/guides/index.md
@@ -9,18 +9,18 @@ sidebar_class_name: navbar-build-item
 
 In this section we present a selection of guides that will help you to both work with, and to better understand, a variety of topics related to WordPress Playground.
 
-## [How to ship a real WordPress site in a native iOS app via Playground?](./guides/wordpress-native-ios-app)
+## [How to ship a real WordPress site in a native iOS app via Playground?](/guides/wordpress-native-ios-app)
 
 Check "Blocknotes", the first app to run WordPress natively on iOS via WordPress Playground. It showcases the potential for seamless mobile web integration using WebAssembly and the WordPress block editor.
 
-## [Providing content for your demo with WordPress Playground](./providing-content-for-your-demo.md)
+## [Providing content for your demo with WordPress Playground](/guides/providing-content-for-your-demo)
 
 To provide a good demo of your theme or plugin via Playground, you may want to load it with default content that highlights the features of your product. Check this guide to learn how to do so.
 
-## [WordPress Playground for Theme Developers](./for-theme-developers.md)
+## [WordPress Playground for Theme Developers](/guides/for-theme-developers)
 
 This guide will show you the essential settings to fully create a theme demo using WordPress Playground and how you can leverage it during the building stage.
 
-## [WordPress Playground for Plugin Developers](./for-plugin-developers.md)
+## [WordPress Playground for Plugin Developers](/guides/for-plugin-developers)
 
 This guide will show you the basic settings to showcase your plugin using WordPress Playground and how to use it while developing your plugin.


### PR DESCRIPTION
The [WordPress Playground for Theme Developers](https://wordpress.github.io/wordpress-playground/for-theme-developers) guide link is not under `/guides` as the other guides are.

This PR changes the link definition for this guide so guides link are under `/guides`