### PR TITLE
Fix CLI --skipWordPressSetup option

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -278,10 +278,12 @@ async function run() {
 				wpDetails = await resolveWPRelease(args.wp);
 			}
 
-			const preinstalledWpContentPath = path.join(
-				CACHE_FOLDER,
-				`prebuilt-wp-content-for-wp-${wpDetails.version}.zip`
-			);
+			const preinstalledWpContentPath =
+				wpDetails &&
+				path.join(
+					CACHE_FOLDER,
+					`prebuilt-wp-content-for-wp-${wpDetails.version}.zip`
+				);
 			const wordPressZip = !wpDetails
 				? undefined
 				: fs.existsSync(preinstalledWpContentPath)


### PR DESCRIPTION
## Motivation for the change, related issues

Without this fix, using the CLI's `--skipWordPressSetup` option interrupts CLI server setup.

```
% npx nx dev playground-cli -- server --skipWordPressSetup --mountBeforeInstall ~/src/wordpress-pg:/wordpress 

> nx run playground-cli:dev server --skipWordPressSetup --mountBeforeInstall /Users/brandon/src/wordpress-pg:/wordpress

Starting a PHP server...
Setting up WordPress latest
278 |                           wpDetails = await resolveWPRelease(args.wp);
279 |                   }
280 | 
281 |                   const preinstalledWpContentPath = path.join(
282 |                           CACHE_FOLDER,
283 |                           `prebuilt-wp-content-for-wp-${wpDetails.version}.zip`
                                        ^
TypeError: undefined is not an object (evaluating 'wpDetails.version')
      at /Users/brandon/src/playground/packages/playground/cli/src/cli.ts:283:35
      at onBind (/Users/brandon/src/playground/packages/playground/cli/src/cli.ts:254:18)
      at /Users/brandon/src/playground/packages/playground/cli/src/server.ts:45:8
```

## Implementation details

The fix is simply to check that `wpDetails` is defined before using it to avoid the TypeError.

## Testing Instructions (or ideally a Blueprint)

Run
`npx nx dev playground-cli -- server --skipWordPressSetup --mountBeforeInstall <path-to-configured-wordpress-release>:/wordpress` 
and note that the server is made available with no errors.