### PR TITLE
Website: Preview the PR specified by the referer header

### DIFF
--- a/packages/playground/website/public/preview-referrer-pr.php
+++ b/packages/playground/website/public/preview-referrer-pr.php
@@ -1,0 +1,18 @@
+<?php
+
+$referrer = $_SERVER['HTTP_REFERER'];
+$prNumber = null;
+
+if (preg_match('/github\.com\/WordPress\/gutenberg\/pull\/(?<prNumber>\d+)/i', $referrer, $matches)) {
+    $prNumber = $matches['prNumber'];
+    header('Location: ./gutenberg.html?pr=' . $prNumber);
+    exit;
+} else if (preg_match('/github\.com\/WordPress\/wordpress-develop\/pull\/(?<prNumber>\d+)/i', $referrer, $matches)) {
+    $prNumber = $matches['prNumber'];
+    header('Location: ./wordpress.html?pr=' . $prNumber);
+    exit;
+} else {
+    header('HTTP/1.1 403 Forbidden');
+    echo 'Invalid referrer';
+    exit;
+}


### PR DESCRIPTION
Enables easy linking to Playground PRs from WordPress and Gutenberg GitHub PRs without interpolating the PR number in the link.

This PR adds a https://playground.wordpress.net/preview-referrer-pr.php script that looks at the Referer header, extracts the repo and the PR number from it, and redirects to the relevant PR previewer.

 ## Testing instructions

1. Run the script on a HTTPS domain (or use my link: https://adamadam.blog/referer.php)
2. Link to that script from a WordPress develop and a Gutenberg PR
3. Click those links
4. Confirm you were redirected to /wordpress.html or /gutenberg.html with a proper `?pr=` query parameter

Props to @gziolo for the idea
