### PR TITLE
FS: Use the correct rm/rmdir method when moving files between mounts

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -895,13 +895,45 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 					__dirname + '/test-data/mount-contents'
 				)
 			);
-			php.mv('/nodefs/a', '/tmp/a');
+			php.mkdir('/nodefs/tmp-dir-for-mv-test');
 			expect(
-				existsSync(__dirname + '/test-data/mount-contents/a')
+				existsSync(
+					__dirname + '/test-data/mount-contents/tmp-dir-for-mv-test'
+				)
+			).toEqual(true);
+
+			php.writeFile('/nodefs/tmp-dir-for-mv-test/test.txt', 'contents');
+			php.mv('/nodefs/tmp-dir-for-mv-test', '/tmp/tmp-dir-for-mv-test');
+			expect(
+				existsSync(
+					__dirname + '/test-data/mount-contents/tmp-dir-for-mv-test'
+				)
 			).toEqual(false);
-			expect(php.fileExists('/nodefs/a')).toEqual(false);
-			expect(php.fileExists('/tmp/a')).toEqual(true);
-			expect(php.readFileAsText('/tmp/a/b/test.txt')).toEqual('contents');
+			expect(php.fileExists('/nodefs/tmp-dir-for-mv-test')).toEqual(
+				false
+			);
+			expect(php.fileExists('/tmp/tmp-dir-for-mv-test')).toEqual(true);
+			expect(
+				php.readFileAsText('/tmp/tmp-dir-for-mv-test/test.txt')
+			).toEqual('contents');
+		});
+
+		it('mv() from MEMFS to NODEFS should work', () => {
+			php.mkdir('/nodefs');
+			php.mount(
+				'/nodefs',
+				createNodeFsMountHandler(
+					__dirname + '/test-data/mount-contents'
+				)
+			);
+
+			php.writeFile('/nodefs/tmp-file-for-mv-test.txt', 'contents');
+			php.mv('/nodefs/tmp-file-for-mv-test.txt', '/tmp/test.txt');
+			expect(php.fileExists('/nodefs/tmp-file-for-mv-test.txt')).toEqual(
+				false
+			);
+			expect(php.fileExists('/tmp/test.txt')).toEqual(true);
+			expect(php.readFileAsText('/tmp/test.txt')).toEqual('contents');
 		});
 
 		it('mkdir() should create a directory', () => {

--- a/packages/php-wasm/universal/src/lib/fs-helpers.ts
+++ b/packages/php-wasm/universal/src/lib/fs-helpers.ts
@@ -102,7 +102,11 @@ export class FSHelpers {
 
 			if (movingBetweenFilesystems) {
 				FSHelpers.copyRecursive(FS, fromPath, toPath);
-				FSHelpers.rmdir(FS, fromPath, { recursive: true });
+				if (FSHelpers.isDir(FS, fromPath)) {
+					FSHelpers.rmdir(FS, fromPath, { recursive: true });
+				} else {
+					FS.unlink(fromPath);
+				}
 			} else {
 				FS.rename(fromPath, toPath);
 			}


### PR DESCRIPTION
Fixes this problem occuring when moving files between mounts:

```
Not a directory or a symbolic link to a directory
```

It occured because we always attempted to remove the source file using `rmdir` instead of choosing either `rm` or `rmdir`. This PR introduces a proper check.

Once it's merged, let's tag a new `@wp-playground/cli` release.

 ## Testing instructions

Confirm the unit tests pass## Motivation for the change, related issues
