### PR TITLE
Update link for contributor day

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Here's a few quickstart guides to get you started:
 
 ## WordCamp Contributor Day
 
-If you're participating in a WordCamp Contributor Day, you can use the following instructions to get started: [WordCamp Contributor Day](https://wordpress.github.io/wordpress-playground/docs/wordcamp-contributor-day/).
+If you're participating in a WordCamp Contributor Day, you can use the following instructions to get started: [WordCamp Contributor Day](https://wordpress.github.io/wordpress-playground/contributing/contributor-day/).
 
 ## Backwards compatibility
 


### PR DESCRIPTION
## Motivation for the change, related issues

The link for Contributor Day was incorrect, this fixes the link.

## Implementation details

Should just work in the ReadMe

## Testing Instructions (or ideally a Blueprint)

Click to make sure the link works: https://wordpress.github.io/wordpress-playground/contributing/contributor-day/