### PR TITLE
Fix troubleshoot-and-debug link

### DIFF
--- a/packages/playground/website/src/components/start-error-modal/index.tsx
+++ b/packages/playground/website/src/components/start-error-modal/index.tsx
@@ -29,7 +29,7 @@ export function StartErrorModal() {
 				point out the specific step causing the issue. You can then
 				double-check your blueprint. For more help, you can also{' '}
 				<a
-					href="https://wordpress.github.io/wordpress-playground/blueprints/troubleshoot-and-debug-blueprints"
+					href="https://wordpress.github.io/wordpress-playground/blueprints/troubleshoot-and-debug/"
 					target="_blank"
 					rel="noreferrer"
 				>


### PR DESCRIPTION
## Motivation for the change, related issues

The troubleshoot-and-debug link changed, so we need to update it.

## Implementation details

Updated the link.

## Testing Instructions (or ideally a Blueprint)

- click link and confirm it works