### PR TITLE
Docs: fix links intro fr

### DIFF
--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/intro.md
@@ -18,22 +18,22 @@ Playground is an online tool to experiment and learn about WordPress. This site 
 
 <p class="docs-hubs">The WordPress Playground documentation is distributed across four separate hubs (subsites):</p>
 
--   👉 [**Documentation**](/wordpress-playground/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
--   [**Blueprints**](/wordpress-playground/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
--   [**Developers**](/wordpress-playground/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
--   [**API Reference**](/wordpress-playground/api) – All the APIs exposed by WordPress Playground
+-   👉 [**Documentation**](/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
+-   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
+-   [**Developers**](/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
+-   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
 
 ## Navigating this documentation hub
 
 This docs hub is focused on starting with WordPress Playground and is divided into the following major sections.
 
--   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/wordpress-playground/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/wordpress-playground/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/wordpress-playground/quick-start-guide#use-a-specific-wordpress-or-php-version).
+-   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/quick-start-guide#use-a-specific-wordpress-or-php-version).
 
 -   **[Playground web instance](/web-instance)**: Learn more about the Playground instance you get at https://playground.wordpress.net/
 
 -   **[About Playground](/about)**: To learn about WordPress Playground, how safe it is, what you can do with and some of its current limitations, visit this section.
 
-    Discover how you can leverage WordPress Playground to [Build](./about/build), [Test](./about/test), and [Launch](./about/launch) your products.
+    Discover how you can leverage WordPress Playground to [Build](/about/build), [Test](/about/test), and [Launch](/about/launch) your products.
 
 -   **[Guides](/guides)**: Explore our comprehensive guides to master new skills, find step-by-step instructions, and unlock valuable insights. Dive in to learn and grow!
 


### PR DESCRIPTION
## Motivation for the change, related issues
This PR fixes the issue reported at https://github.com/WordPress/wordpress-playground/pull/1766#issuecomment-2369102589

## Implementation details

## Testing Instructions (or ideally a Blueprint)

Run `npm run build:docs` from this branch and check how the build is done succesfully
