### PR TITLE
Docs: translation i18n messages - JSON files

### DIFF
--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-blog/options.json
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+	"title": {
+		"message": "Blog",
+		"description": "The title for the blog used in SEO"
+	},
+	"description": {
+		"message": "Blog",
+		"description": "The description for the blog used in SEO"
+	},
+	"sidebar.title": {
+		"message": "Recent posts",
+		"description": "The label for the left sidebar"
+	}
+}

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current.json
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,54 @@
+{
+	"version.label": {
+		"message": "Next",
+		"description": "The label for version current"
+	},
+	"sidebar.mainSidebar.category.Documentation": {
+		"message": "Documentation",
+		"description": "The label for category Documentation in sidebar mainSidebar"
+	},
+	"sidebar.mainSidebar.category.About Playground": {
+		"message": "About Playground",
+		"description": "The label for category About Playground in sidebar mainSidebar"
+	},
+	"sidebar.mainSidebar.category.Guides": {
+		"message": "Guides",
+		"description": "The label for category Guides in sidebar mainSidebar"
+	},
+	"sidebar.mainSidebar.category.Contributing": {
+		"message": "Contributing",
+		"description": "The label for category Contributing in sidebar mainSidebar"
+	},
+	"sidebar.blueprintsSidebar.category.Blueprints": {
+		"message": "Blueprints",
+		"description": "The label for category Blueprints in sidebar blueprintsSidebar"
+	},
+	"sidebar.blueprintsSidebar.category.Tutorial": {
+		"message": "Tutorial",
+		"description": "The label for category Tutorial in sidebar blueprintsSidebar"
+	},
+	"sidebar.blueprintsSidebar.category.Steps": {
+		"message": "Steps",
+		"description": "The label for category Steps in sidebar blueprintsSidebar"
+	},
+	"sidebar.developersSidebar.category.Developers": {
+		"message": "Developers",
+		"description": "The label for category Developers in sidebar developersSidebar"
+	},
+	"sidebar.developersSidebar.category.Local Development": {
+		"message": "Local Development",
+		"description": "The label for category Local Development in sidebar developersSidebar"
+	},
+	"sidebar.developersSidebar.category.Playground APIs": {
+		"message": "Playground APIs",
+		"description": "The label for category Playground APIs in sidebar developersSidebar"
+	},
+	"sidebar.developersSidebar.category.Javascript API": {
+		"message": "Javascript API",
+		"description": "The label for category Javascript API in sidebar developersSidebar"
+	},
+	"sidebar.developersSidebar.category.Architecture": {
+		"message": "Architecture",
+		"description": "The label for category Architecture in sidebar developersSidebar"
+	}
+}

--- a/packages/docs/site/i18n/es/docusaurus-theme-classic/footer.json
+++ b/packages/docs/site/i18n/es/docusaurus-theme-classic/footer.json
@@ -1,0 +1,42 @@
+{
+	"link.title.Docs": {
+		"message": "Docs",
+		"description": "The title of the footer links column with title=Docs in the footer"
+	},
+	"link.title.Community": {
+		"message": "Community",
+		"description": "The title of the footer links column with title=Community in the footer"
+	},
+	"link.item.label.Documentation": {
+		"message": "Documentation",
+		"description": "The label of footer link with label=Documentation linking to /"
+	},
+	"link.item.label.Blueprints": {
+		"message": "Blueprints",
+		"description": "The label of footer link with label=Blueprints linking to /blueprints"
+	},
+	"link.item.label.Developers": {
+		"message": "Developers",
+		"description": "The label of footer link with label=Developers linking to /developers"
+	},
+	"link.item.label.API Reference": {
+		"message": "API Reference",
+		"description": "The label of footer link with label=API Reference linking to /api"
+	},
+	"link.item.label.GitHub": {
+		"message": "GitHub",
+		"description": "The label of footer link with label=GitHub linking to https://github.com/WordPress/wordpress-playground"
+	},
+	"link.item.label.#meta-playground on Slack": {
+		"message": "#meta-playground on Slack",
+		"description": "The label of footer link with label=#meta-playground on Slack linking to https://make.wordpress.org/chat"
+	},
+	"copyright": {
+		"message": "Copyright © 2024 WordPress Playground, Inc. Built with Docusaurus.",
+		"description": "The footer copyright"
+	},
+	"logo.alt": {
+		"message": "Code Is Poetry",
+		"description": "The alt text of footer logo"
+	}
+}

--- a/packages/docs/site/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/packages/docs/site/i18n/es/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,26 @@
+{
+	"title": {
+		"message": "WordPress Playground",
+		"description": "The title in the navbar"
+	},
+	"logo.alt": {
+		"message": "WordPress Playground",
+		"description": "The alt text of navbar logo"
+	},
+	"item.label.Documentation": {
+		"message": "Documentation",
+		"description": "Navbar item with label Documentation"
+	},
+	"item.label.Blueprints": {
+		"message": "Blueprints",
+		"description": "Navbar item with label Blueprints"
+	},
+	"item.label.Developers": {
+		"message": "Developers",
+		"description": "Navbar item with label Developers"
+	},
+	"item.label.API Reference": {
+		"message": "API Reference",
+		"description": "Navbar item with label API Reference"
+	}
+}

--- a/packages/docs/site/i18n/fr/code.json
+++ b/packages/docs/site/i18n/fr/code.json
@@ -1,0 +1,432 @@
+{
+	"theme.ErrorPageContent.title": {
+		"message": "Cette page a planté.",
+		"description": "The title of the fallback page when the page crashed"
+	},
+	"theme.NotFound.title": {
+		"message": "Page introuvable",
+		"description": "The title of the 404 page"
+	},
+	"theme.NotFound.p1": {
+		"message": "Nous n'avons pas trouvé ce que vous recherchez.",
+		"description": "The first paragraph of the 404 page"
+	},
+	"theme.NotFound.p2": {
+		"message": "Veuillez contacter le propriétaire du site qui vous a lié à l'URL d'origine et leur faire savoir que leur lien est cassé.",
+		"description": "The 2nd paragraph of the 404 page"
+	},
+	"theme.admonition.note": {
+		"message": "remarque",
+		"description": "The default label used for the Note admonition (:::note)"
+	},
+	"theme.admonition.tip": {
+		"message": "astuce",
+		"description": "The default label used for the Tip admonition (:::tip)"
+	},
+	"theme.admonition.danger": {
+		"message": "danger",
+		"description": "The default label used for the Danger admonition (:::danger)"
+	},
+	"theme.admonition.info": {
+		"message": "info",
+		"description": "The default label used for the Info admonition (:::info)"
+	},
+	"theme.admonition.caution": {
+		"message": "attention",
+		"description": "The default label used for the Caution admonition (:::caution)"
+	},
+	"theme.BackToTopButton.buttonAriaLabel": {
+		"message": "Retour au début de la page",
+		"description": "The ARIA label for the back to top button"
+	},
+	"theme.blog.archive.title": {
+		"message": "Archive",
+		"description": "The page & hero title of the blog archive page"
+	},
+	"theme.blog.archive.description": {
+		"message": "Archive",
+		"description": "The page & hero description of the blog archive page"
+	},
+	"theme.blog.paginator.navAriaLabel": {
+		"message": "Pagination de la liste des articles du blog",
+		"description": "The ARIA label for the blog pagination"
+	},
+	"theme.blog.paginator.newerEntries": {
+		"message": "Nouvelles entrées",
+		"description": "The label used to navigate to the newer blog posts page (previous page)"
+	},
+	"theme.blog.paginator.olderEntries": {
+		"message": "Anciennes entrées",
+		"description": "The label used to navigate to the older blog posts page (next page)"
+	},
+	"theme.blog.post.paginator.navAriaLabel": {
+		"message": "Pagination des articles du blog",
+		"description": "The ARIA label for the blog posts pagination"
+	},
+	"theme.blog.post.paginator.newerPost": {
+		"message": "Article plus récent",
+		"description": "The blog post button label to navigate to the newer/previous post"
+	},
+	"theme.blog.post.paginator.olderPost": {
+		"message": "Article plus ancien",
+		"description": "The blog post button label to navigate to the older/next post"
+	},
+	"theme.blog.post.plurals": {
+		"message": "Un article|{count} articles",
+		"description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+	},
+	"theme.blog.tagTitle": {
+		"message": "{nPosts} tagués avec « {tagName} »",
+		"description": "The title of the page for a blog tag"
+	},
+	"theme.tags.tagsPageLink": {
+		"message": "Voir tous les tags",
+		"description": "The label of the link targeting the tag list page"
+	},
+	"theme.colorToggle.ariaLabel": {
+		"message": "Basculer entre le mode sombre et clair (actuellement {mode})",
+		"description": "The ARIA label for the navbar color mode toggle"
+	},
+	"theme.colorToggle.ariaLabel.mode.dark": {
+		"message": "mode sombre",
+		"description": "The name for the dark color mode"
+	},
+	"theme.colorToggle.ariaLabel.mode.light": {
+		"message": "mode clair",
+		"description": "The name for the light color mode"
+	},
+	"theme.docs.breadcrumbs.navAriaLabel": {
+		"message": "Fil d'Ariane",
+		"description": "The ARIA label for the breadcrumbs"
+	},
+	"theme.docs.DocCard.categoryDescription": {
+		"message": "{count} éléments",
+		"description": "The default description for a category card in the generated index about how many items this category includes"
+	},
+	"theme.docs.paginator.navAriaLabel": {
+		"message": "Pages de documentation",
+		"description": "The ARIA label for the docs pagination"
+	},
+	"theme.docs.paginator.previous": {
+		"message": "Précédent",
+		"description": "The label used to navigate to the previous doc"
+	},
+	"theme.docs.paginator.next": {
+		"message": "Suivant",
+		"description": "The label used to navigate to the next doc"
+	},
+	"theme.docs.tagDocListPageTitle.nDocsTagged": {
+		"message": "Un document tagué|{count} documents tagués",
+		"description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+	},
+	"theme.docs.tagDocListPageTitle": {
+		"message": "{nDocsTagged} avec \"{tagName}\"",
+		"description": "The title of the page for a docs tag"
+	},
+	"theme.docs.versionBadge.label": {
+		"message": "Version: {versionLabel}"
+	},
+	"theme.common.headingLinkTitle": {
+		"message": "Lien direct vers {heading}",
+		"description": "Title for link to heading"
+	},
+	"theme.docs.versions.unreleasedVersionLabel": {
+		"message": "Ceci est la documentation de la prochaine version {versionLabel} de {siteTitle}.",
+		"description": "The label used to tell the user that he's browsing an unreleased doc version"
+	},
+	"theme.docs.versions.unmaintainedVersionLabel": {
+		"message": "Ceci est la documentation de {siteTitle} {versionLabel}, qui n'est plus activement maintenue.",
+		"description": "The label used to tell the user that he's browsing an unmaintained doc version"
+	},
+	"theme.docs.versions.latestVersionSuggestionLabel": {
+		"message": "Pour une documentation à jour, consultez la {latestVersionLink} ({versionLabel}).",
+		"description": "The label used to tell the user to check the latest version"
+	},
+	"theme.docs.versions.latestVersionLinkLabel": {
+		"message": "dernière version",
+		"description": "The label used for the latest version suggestion link label"
+	},
+	"theme.common.editThisPage": {
+		"message": "Éditer cette page",
+		"description": "The link label to edit the current page"
+	},
+	"theme.lastUpdated.atDate": {
+		"message": " le {date}",
+		"description": "The words used to describe on which date a page has been last updated"
+	},
+	"theme.lastUpdated.byUser": {
+		"message": " par {user}",
+		"description": "The words used to describe by who the page has been last updated"
+	},
+	"theme.lastUpdated.lastUpdatedAtBy": {
+		"message": "Dernière mise à jour{atDate}{byUser}",
+		"description": "The sentence used to display when a page has been last updated, and by who"
+	},
+	"theme.navbar.mobileVersionsDropdown.label": {
+		"message": "Versions",
+		"description": "The label for the navbar versions dropdown on mobile view"
+	},
+	"theme.tags.tagsListLabel": {
+		"message": "Tags :",
+		"description": "The label alongside a tag list"
+	},
+	"theme.AnnouncementBar.closeButtonAriaLabel": {
+		"message": "Fermer",
+		"description": "The ARIA label for close button of announcement bar"
+	},
+	"theme.blog.sidebar.navAriaLabel": {
+		"message": "Navigation article de blog récent",
+		"description": "The ARIA label for recent posts in the blog sidebar"
+	},
+	"theme.CodeBlock.copied": {
+		"message": "Copié",
+		"description": "The copied button label on code blocks"
+	},
+	"theme.CodeBlock.copyButtonAriaLabel": {
+		"message": "Copier le code",
+		"description": "The ARIA label for copy code blocks button"
+	},
+	"theme.CodeBlock.copy": {
+		"message": "Copier",
+		"description": "The copy button label on code blocks"
+	},
+	"theme.CodeBlock.wordWrapToggle": {
+		"message": "Activer/désactiver le retour à la ligne",
+		"description": "The title attribute for toggle word wrapping button of code block lines"
+	},
+	"theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel": {
+		"message": "Plier/Déplier la catégorie '{label}' de la barre latérale",
+		"description": "The ARIA label to toggle the collapsible sidebar category"
+	},
+	"theme.NavBar.navAriaLabel": {
+		"message": "Main",
+		"description": "The ARIA label for the main navigation"
+	},
+	"theme.navbar.mobileLanguageDropdown.label": {
+		"message": "Langues",
+		"description": "The label for the mobile language switcher dropdown"
+	},
+	"theme.blog.post.readMore": {
+		"message": "Lire plus",
+		"description": "The label used in blog post item excerpts to link to full blog posts"
+	},
+	"theme.blog.post.readMoreLabel": {
+		"message": "En savoir plus sur {title}",
+		"description": "The ARIA label for the link to full blog posts from excerpts"
+	},
+	"theme.blog.post.readingTime.plurals": {
+		"message": "Une minute de lecture|{readingTime} minutes de lecture",
+		"description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+	},
+	"theme.docs.breadcrumbs.home": {
+		"message": "Page d'accueil",
+		"description": "The ARIA label for the home page in the breadcrumbs"
+	},
+	"theme.docs.sidebar.collapseButtonTitle": {
+		"message": "Réduire le menu latéral",
+		"description": "The title attribute for collapse button of doc sidebar"
+	},
+	"theme.docs.sidebar.collapseButtonAriaLabel": {
+		"message": "Réduire le menu latéral",
+		"description": "The title attribute for collapse button of doc sidebar"
+	},
+	"theme.docs.sidebar.navAriaLabel": {
+		"message": "Docs sidebar",
+		"description": "The ARIA label for the sidebar navigation"
+	},
+	"theme.TOCCollapsible.toggleButtonLabel": {
+		"message": "Sur cette page",
+		"description": "The label used by the button on the collapsible TOC component"
+	},
+	"theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+		"message": "Fermer la barre de navigation",
+		"description": "The ARIA label for close button of mobile sidebar"
+	},
+	"theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+		"message": "← Retour au menu principal",
+		"description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+	},
+	"theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+		"message": "Ouvrir/fermer la barre de navigation",
+		"description": "The ARIA label for hamburger menu button of mobile navigation"
+	},
+	"theme.docs.sidebar.expandButtonTitle": {
+		"message": "Déplier le menu latéral",
+		"description": "The ARIA label and title attribute for expand button of doc sidebar"
+	},
+	"theme.docs.sidebar.expandButtonAriaLabel": {
+		"message": "Déplier le menu latéral",
+		"description": "The ARIA label and title attribute for expand button of doc sidebar"
+	},
+	"theme.SearchBar.seeAll": {
+		"message": "Voir les {count} résultats"
+	},
+	"theme.SearchPage.documentsFound.plurals": {
+		"message": "Un document trouvé|{count} documents trouvés",
+		"description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+	},
+	"theme.SearchPage.existingResultsTitle": {
+		"message": "Résultats de recherche pour « {query} »",
+		"description": "The search page title for non-empty query"
+	},
+	"theme.SearchPage.emptyResultsTitle": {
+		"message": "Rechercher dans la documentation",
+		"description": "The search page title for empty query"
+	},
+	"theme.SearchPage.inputPlaceholder": {
+		"message": "Tapez votre recherche ici",
+		"description": "The placeholder for search page input"
+	},
+	"theme.SearchPage.inputLabel": {
+		"message": "Chercher",
+		"description": "The ARIA label for search page input"
+	},
+	"theme.SearchPage.algoliaLabel": {
+		"message": "Recherche par Algolia",
+		"description": "The ARIA label for Algolia mention"
+	},
+	"theme.SearchPage.noResultsText": {
+		"message": "Aucun résultat trouvé",
+		"description": "The paragraph for empty search result"
+	},
+	"theme.SearchPage.fetchingNewResults": {
+		"message": "Chargement de nouveaux résultats...",
+		"description": "The paragraph for fetching new search results"
+	},
+	"theme.SearchBar.label": {
+		"message": "Chercher",
+		"description": "The ARIA label and placeholder for search button"
+	},
+	"theme.SearchModal.searchBox.resetButtonTitle": {
+		"message": "Effacer la requête",
+		"description": "The label and ARIA label for search box reset button"
+	},
+	"theme.SearchModal.searchBox.cancelButtonText": {
+		"message": "Annuler",
+		"description": "The label and ARIA label for search box cancel button"
+	},
+	"theme.SearchModal.startScreen.recentSearchesTitle": {
+		"message": "Récemment",
+		"description": "The title for recent searches"
+	},
+	"theme.SearchModal.startScreen.noRecentSearchesText": {
+		"message": "Aucune recherche récente",
+		"description": "The text when no recent searches"
+	},
+	"theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+		"message": "Sauvegarder cette recherche",
+		"description": "The label for save recent search button"
+	},
+	"theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+		"message": "Supprimer cette recherche de l'historique",
+		"description": "The label for remove recent search button"
+	},
+	"theme.SearchModal.startScreen.favoriteSearchesTitle": {
+		"message": "Favoris",
+		"description": "The title for favorite searches"
+	},
+	"theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+		"message": "Supprimer cette recherche des favoris",
+		"description": "The label for remove favorite search button"
+	},
+	"theme.SearchModal.errorScreen.titleText": {
+		"message": "Impossible de récupérer les résultats",
+		"description": "The title for error screen of search modal"
+	},
+	"theme.SearchModal.errorScreen.helpText": {
+		"message": "Vous pouvez vérifier votre connexion réseau.",
+		"description": "The help text for error screen of search modal"
+	},
+	"theme.SearchModal.footer.selectText": {
+		"message": "sélectionner",
+		"description": "The explanatory text of the action for the enter key"
+	},
+	"theme.SearchModal.footer.selectKeyAriaLabel": {
+		"message": "Touche Entrée",
+		"description": "The ARIA label for the Enter key button that makes the selection"
+	},
+	"theme.SearchModal.footer.navigateText": {
+		"message": "naviguer",
+		"description": "The explanatory text of the action for the Arrow up and Arrow down key"
+	},
+	"theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+		"message": "Flèche vers le haut",
+		"description": "The ARIA label for the Arrow up key button that makes the navigation"
+	},
+	"theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+		"message": "Flèche vers le bas",
+		"description": "The ARIA label for the Arrow down key button that makes the navigation"
+	},
+	"theme.SearchModal.footer.closeText": {
+		"message": "fermer",
+		"description": "The explanatory text of the action for Escape key"
+	},
+	"theme.SearchModal.footer.closeKeyAriaLabel": {
+		"message": "Touche Echap",
+		"description": "The ARIA label for the Escape key button that close the modal"
+	},
+	"theme.SearchModal.footer.searchByText": {
+		"message": "Recherche via",
+		"description": "The text explain that the search is making by Algolia"
+	},
+	"theme.SearchModal.noResultsScreen.noResultsText": {
+		"message": "Aucun résultat pour",
+		"description": "The text explains that there are no results for the following search"
+	},
+	"theme.SearchModal.noResultsScreen.suggestedQueryText": {
+		"message": "Essayez de chercher",
+		"description": "The text for the suggested query when no results are found for the following search"
+	},
+	"theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+		"message": "Vous pensez que cette requête doit donner des résultats ?",
+		"description": "The text for the question where the user thinks there are missing results"
+	},
+	"theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+		"message": "Faites-le nous savoir.",
+		"description": "The text for the link to report missing results"
+	},
+	"theme.SearchModal.placeholder": {
+		"message": "Rechercher des docs",
+		"description": "The placeholder of the input of the DocSearch pop-up modal"
+	},
+	"theme.IdealImageMessage.loading": {
+		"message": "Chargement ...",
+		"description": "When the full-scale image is loading"
+	},
+	"theme.IdealImageMessage.load": {
+		"message": "Cliquez pour charger{sizeMessage}",
+		"description": "To prompt users to load the full image. sizeMessage is a parenthesized size figure."
+	},
+	"theme.IdealImageMessage.offline": {
+		"message": "Votre navigateur est hors ligne. Image non chargée",
+		"description": "When the user is viewing an offline document"
+	},
+	"theme.IdealImageMessage.404error": {
+		"message": "404. Image introuvable",
+		"description": "When the image is not found"
+	},
+	"theme.IdealImageMessage.error": {
+		"message": "Erreur. Cliquez pour recharger",
+		"description": "When the image fails to load for unknown error"
+	},
+	"theme.Playground.result": {
+		"message": "Résultat",
+		"description": "The result label of the live codeblocks"
+	},
+	"theme.Playground.liveEditor": {
+		"message": "Éditeur en direct",
+		"description": "The live editor label of the live codeblocks"
+	},
+	"theme.ErrorPageContent.tryAgain": {
+		"message": "Réessayer",
+		"description": "The label of the button to try again rendering when the React error boundary captures an error"
+	},
+	"theme.common.skipToMainContent": {
+		"message": "Aller au contenu principal",
+		"description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+	},
+	"theme.tags.tagsPageTitle": {
+		"message": "Tags",
+		"description": "The title of the tag list page"
+	}
+}

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-blog/options.json
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-blog/options.json
@@ -1,0 +1,14 @@
+{
+	"title": {
+		"message": "Blog",
+		"description": "The title for the blog used in SEO"
+	},
+	"description": {
+		"message": "Blog",
+		"description": "The description for the blog used in SEO"
+	},
+	"sidebar.title": {
+		"message": "Recent posts",
+		"description": "The label for the left sidebar"
+	}
+}

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current.json
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,54 @@
+{
+	"version.label": {
+		"message": "Next",
+		"description": "The label for version current"
+	},
+	"sidebar.mainSidebar.category.Documentation": {
+		"message": "Documentation",
+		"description": "The label for category Documentation in sidebar mainSidebar"
+	},
+	"sidebar.mainSidebar.category.About Playground": {
+		"message": "About Playground",
+		"description": "The label for category About Playground in sidebar mainSidebar"
+	},
+	"sidebar.mainSidebar.category.Guides": {
+		"message": "Guides",
+		"description": "The label for category Guides in sidebar mainSidebar"
+	},
+	"sidebar.mainSidebar.category.Contributing": {
+		"message": "Contributing",
+		"description": "The label for category Contributing in sidebar mainSidebar"
+	},
+	"sidebar.blueprintsSidebar.category.Blueprints": {
+		"message": "Blueprints",
+		"description": "The label for category Blueprints in sidebar blueprintsSidebar"
+	},
+	"sidebar.blueprintsSidebar.category.Tutorial": {
+		"message": "Tutorial",
+		"description": "The label for category Tutorial in sidebar blueprintsSidebar"
+	},
+	"sidebar.blueprintsSidebar.category.Steps": {
+		"message": "Steps",
+		"description": "The label for category Steps in sidebar blueprintsSidebar"
+	},
+	"sidebar.developersSidebar.category.Developers": {
+		"message": "Developers",
+		"description": "The label for category Developers in sidebar developersSidebar"
+	},
+	"sidebar.developersSidebar.category.Local Development": {
+		"message": "Local Development",
+		"description": "The label for category Local Development in sidebar developersSidebar"
+	},
+	"sidebar.developersSidebar.category.Playground APIs": {
+		"message": "Playground APIs",
+		"description": "The label for category Playground APIs in sidebar developersSidebar"
+	},
+	"sidebar.developersSidebar.category.Javascript API": {
+		"message": "Javascript API",
+		"description": "The label for category Javascript API in sidebar developersSidebar"
+	},
+	"sidebar.developersSidebar.category.Architecture": {
+		"message": "Architecture",
+		"description": "The label for category Architecture in sidebar developersSidebar"
+	}
+}

--- a/packages/docs/site/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/packages/docs/site/i18n/fr/docusaurus-theme-classic/footer.json
@@ -1,0 +1,42 @@
+{
+	"link.title.Docs": {
+		"message": "Docs",
+		"description": "The title of the footer links column with title=Docs in the footer"
+	},
+	"link.title.Community": {
+		"message": "Community",
+		"description": "The title of the footer links column with title=Community in the footer"
+	},
+	"link.item.label.Documentation": {
+		"message": "Documentation",
+		"description": "The label of footer link with label=Documentation linking to /"
+	},
+	"link.item.label.Blueprints": {
+		"message": "Blueprints",
+		"description": "The label of footer link with label=Blueprints linking to /blueprints"
+	},
+	"link.item.label.Developers": {
+		"message": "Developers",
+		"description": "The label of footer link with label=Developers linking to /developers"
+	},
+	"link.item.label.API Reference": {
+		"message": "API Reference",
+		"description": "The label of footer link with label=API Reference linking to /api"
+	},
+	"link.item.label.GitHub": {
+		"message": "GitHub",
+		"description": "The label of footer link with label=GitHub linking to https://github.com/WordPress/wordpress-playground"
+	},
+	"link.item.label.#meta-playground on Slack": {
+		"message": "#meta-playground on Slack",
+		"description": "The label of footer link with label=#meta-playground on Slack linking to https://make.wordpress.org/chat"
+	},
+	"copyright": {
+		"message": "Copyright © 2024 WordPress Playground, Inc. Built with Docusaurus.",
+		"description": "The footer copyright"
+	},
+	"logo.alt": {
+		"message": "Code Is Poetry",
+		"description": "The alt text of footer logo"
+	}
+}

--- a/packages/docs/site/i18n/fr/docusaurus-theme-classic/navbar.json
+++ b/packages/docs/site/i18n/fr/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,26 @@
+{
+	"title": {
+		"message": "WordPress Playground",
+		"description": "The title in the navbar"
+	},
+	"logo.alt": {
+		"message": "WordPress Playground",
+		"description": "The alt text of navbar logo"
+	},
+	"item.label.Documentation": {
+		"message": "Documentation",
+		"description": "Navbar item with label Documentation"
+	},
+	"item.label.Blueprints": {
+		"message": "Blueprints",
+		"description": "Navbar item with label Blueprints"
+	},
+	"item.label.Developers": {
+		"message": "Developers",
+		"description": "Navbar item with label Developers"
+	},
+	"item.label.API Reference": {
+		"message": "API Reference",
+		"description": "Navbar item with label API Reference"
+	}
+}


### PR DESCRIPTION
## Motivation for the change, related issues

With the merge of https://github.com/WordPress/wordpress-playground/pull/1766 translations are enabled for Playground Docs. Files can be translated but also web parts.
This PR incorporates JSON files with messages to translate for each language.

This files have been generated by running from from `packages/docs/site`:

```
npm run write-translations -- --locale fr
npm run write-translations -- --locale es
```

These files still need to be translated. This PR just adds them for the sake of simplifying the work of contributors translating Playground Docs for a specific language.

