### PR TITLE
[Website] Prevent creation of two temporary sites

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -57,9 +57,11 @@ export function EnsurePlaygroundSiteIsSelected({
 		async function ensureSiteIsSelected() {
 			// If the site slug is provided, try to load the site.
 			if (requestedSiteSlug) {
+				// Wait until the site listing is loaded
 				if (siteListingStatus !== 'loaded') {
 					return;
 				}
+
 				// If the site does not exist, redirect to a new temporary site.
 				if (!requestedSiteObject) {
 					// @TODO: Notification: 'The requested site was not found. Redirecting to a new temporary site.'

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -57,11 +57,9 @@ export function EnsurePlaygroundSiteIsSelected({
 		async function ensureSiteIsSelected() {
 			// If the site slug is provided, try to load the site.
 			if (requestedSiteSlug) {
-				// Wait until the site listing is loaded
 				if (siteListingStatus !== 'loaded') {
 					return;
 				}
-
 				// If the site does not exist, redirect to a new temporary site.
 				if (!requestedSiteObject) {
 					// @TODO: Notification: 'The requested site was not found. Redirecting to a new temporary site.'
@@ -72,6 +70,14 @@ export function EnsurePlaygroundSiteIsSelected({
 					return;
 				}
 				dispatch(setActiveSite(requestedSiteSlug));
+				return;
+			}
+
+			// Don't create a new temporary site until the site listing settles.
+			// Otherwise, the status change from "loading" to "loaded" would
+			// re-run this entire effect, potentially leading to multiple
+			// sites being created since we couldn't look for duplicates yet.
+			if (!['loaded', 'error'].includes(siteListingStatus)) {
 				return;
 			}
 


### PR DESCRIPTION
## Motivation for the change, related issues

#1731 introduced multiple Playground management. However, visiting a URL containing a Blueprint sometimes led to a creation of multiple temporary sites due to a React effect running twice. This PR prevents that error by delaying the new site creation until the effect settles down. In particular, we're waiting for the site list to either get loaded or error out.

## Testing Instructions (or ideally a Blueprint)

Go to http://localhost:5400/website-server/?plugin=classic-editor&blueprint-url=https%3A%2F%2Fwordpress.org%2Fplugins%2Fwp-json%2Fplugins%2Fv1%2Fplugin%2Fclassic-editor%2Fblueprint.json%3Frev%3D3158978%26lang%3Den_US and confirm you only got a single temporary site
