### PR TITLE
Stop address bar from adding trailing slash to query params

### DIFF
--- a/packages/playground/website/src/components/address-bar/index.tsx
+++ b/packages/playground/website/src/components/address-bar/index.tsx
@@ -19,12 +19,7 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 	const handleSubmit = useCallback(
 		function (e: React.FormEvent<HTMLFormElement>) {
 			e.preventDefault();
-			let requestedPath = input.current!.value;
-			// Ensure a trailing slash when requesting directory paths
-			const isDirectory = !requestedPath.split('/').pop()!.includes('.');
-			if (isDirectory && !requestedPath.endsWith('/')) {
-				requestedPath += '/';
-			}
+			const requestedPath = input.current!.value;
 			onUpdate?.(requestedPath);
 			input.current!.blur();
 		},


### PR DESCRIPTION
## Motivation for the change, related issues

Before this change, adding query params to a dir URI in the address bar would lead to the address bar adding a trailing slash after the query params.

For example, entering `/?query=param` would become `/?query=param/`, which is undesired and incorrect.

Thanks to @bgrgicak for pointing this out in #1789.

## Implementation details

Since the PHP request handler already redirects dir URIs to include a trailing slash, we can remove this code and stop the bug from happening.

## Testing Instructions (or ideally a Blueprint)

- Run a dev server
- Enter `/?test=query` in the Playground web app address bar
- Confirm that no trailing slash is added in the address bar