### PR TITLE
Prefer pretty permalinks like WP install does

### DIFF
--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -20,6 +20,7 @@ import {
 	wordPressRewriteRules,
 } from '.';
 import { joinPaths } from '@php-wasm/util';
+import { logger } from '@php-wasm/logger';
 
 export type PhpIniOptions = Record<string, string>;
 export type Hook = (php: PHP) => void | Promise<void>;

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -270,6 +270,29 @@ async function installWordPress(php: PHP) {
 				},
 			})
 	);
+
+	const defaultedToPrettyPermalinks = await php.run({
+		code: `<?php
+$wp_load = getenv('DOCUMENT_ROOT') . '/wp-load.php';
+if (!file_exists($wp_load)) {
+	echo '0';
+	exit;
+}
+require $wp_load;
+$option_result = update_option(
+	'permalink_structure',
+	'/%year%/%monthnum%/%day%/%postname%/'
+);
+echo $option_result ? '1' : '0';
+`,
+		env: {
+			DOCUMENT_ROOT: php.documentRoot,
+		},
+	});
+
+	if (defaultedToPrettyPermalinks.text !== '1') {
+		logger.warn('Failed to default to pretty permalinks after WP install.');
+	}
 }
 
 export function getFileNotFoundActionForWordPress(


### PR DESCRIPTION
## Motivation for the change, related issues

The WordPress installation process defaults to pretty permalinks if it can enable them and get a valid response from a loopback request. Unfortunately, at the time we run the WP installation process in Playground, the PHP request handler has not yet been put into place to handle those requests.

In addition, even if the request handler was in place in time, @adamziel [mentioned](https://github.com/WordPress/wordpress-playground/issues/1644#issuecomment-2257788681):
> I vaguely remember disabling the networking in installWordPress made for a dramatic installation speedup in web browsers

As a workaround, we can manually set the `permalink_structure` as part of WordPress installation within `bootWordPress()`.

Closes #1644

## Implementation details

Manually sets the `permalink_structure` as part of WordPress installation within `bootWordPress()`.

## Testing Instructions (or ideally a Blueprint)

Manual testing after creating nightly WP build which was pre-installed using this logic using Playground CLI. Loading the nightly build locally shows permalinks enabled.
