### PR TITLE
Fix go-to-site menu items to reveal site view

### DIFF
--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -28,6 +28,7 @@ export const SiteManager = forwardRef<
 		setActiveSection('sites');
 	};
 
+	const fullScreenSiteManager = useMediaQuery('(max-width: 1126px)');
 	const fullScreenSections = useMediaQuery('(max-width: 875px)');
 	const sitesList = (
 		<Sidebar
@@ -42,6 +43,7 @@ export const SiteManager = forwardRef<
 			site={activeSite}
 			removeSite={onRemoveSite}
 			mobileUi={fullScreenSections}
+			siteViewHidden={fullScreenSiteManager}
 			onBackButtonClick={() => {
 				setActiveSection('sites');
 			}}

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -54,12 +54,14 @@ export function SiteInfoPanel({
 	site,
 	removeSite,
 	mobileUi,
+	siteViewHidden,
 	onBackButtonClick,
 }: {
 	className: string;
 	site: SiteInfo;
 	removeSite: (site: SiteInfo) => Promise<void>;
 	mobileUi?: boolean;
+	siteViewHidden?: boolean;
 	onBackButtonClick?: () => void;
 }) {
 	const offline = useAppSelector((state) => state.ui.offline);
@@ -85,10 +87,8 @@ export function SiteInfoPanel({
 		? 'footer'
 		: 'menu';
 	function navigateTo(path: string) {
-		if (mobileUi) {
-			// Collapse the sidebar when opening a site
-			// because otherwise the site view will remain
-			// hidden by the sidebar on small screens.
+		if (siteViewHidden) {
+			// Close the site manager so the site view is visible.
 			dispatch(setSiteManagerOpen(false));
 		}
 
@@ -218,9 +218,10 @@ export function SiteInfoPanel({
 														icon={external}
 														iconPosition="right"
 														aria-label="Go to homepage"
-														onClick={() =>
-															navigateTo('/')
-														}
+														onClick={() => {
+															navigateTo('/');
+															onClose();
+														}}
 													>
 														Homepage
 													</MenuItem>
@@ -228,11 +229,12 @@ export function SiteInfoPanel({
 														icon={external}
 														iconPosition="right"
 														aria-label="Go to WP Admin"
-														onClick={() =>
+														onClick={() => {
 															navigateTo(
 																'/wp-admin/'
-															)
-														}
+															);
+															onClose();
+														}}
 													>
 														WP Admin
 													</MenuItem>


### PR DESCRIPTION
## Motivation for the change, related issues

There is a dead zone where the Playground view is hidden by the Playground Manager yet the "Homepage" and "WP Admin" links do not review the Playground view when navigating to those pages. This page fixes that.

Thanks for @chriszarate for reporting!

## Implementation details

We use `useMediaQuery()` in a parent component to inform the site info child component that the Playground view is expected to be hidden. Then, we hide the Playground Manager when navigating if the Playground view is not already shown.

## Testing Instructions (or ideally a Blueprint)

- `npm run dev`
- Navigate to the local dev site
- Open Playground Manager
- Resize the window to look like the following
   ![Screenshot 2024-09-30 at 5 32 56 PM](https://github.com/user-attachments/assets/1d7b1898-ad43-4438-ac29-419835b62cb5)
- Click "Homepage" in the hamburger menu and confirm that the Playground view is shown and the homepage displayed.
- Reopen the Playground Manager, click "WP Admin" in the hamburger menu, and confirm that the Playground view is shown and the WP Admin Dashboard displayed.
