### PR TITLE
[Website] Rename Create a similar Playground to Edit Playground settings

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -57,11 +57,12 @@ SupportedPHPVersions.forEach(async (version) => {
 		}
 		await website.goto(`./`);
 
-		await website.openForkPlaygroundSettings();
+		await website.openPlaygroundSettings();
 
 		await website.selectPHPVersion(version);
 
-		await website.clickSaveInForkPlaygroundSettings();
+		await website.clickSaveInPlaygroundSettings();
+		await website.confirmPlaygroundSettingsUpdate();
 
 		await expect(
 			await website.getSiteInfoRowLocator('PHP version')
@@ -72,7 +73,7 @@ SupportedPHPVersions.forEach(async (version) => {
 		website,
 	}) => {
 		await website.goto('./');
-		await website.openForkPlaygroundSettings();
+		await website.openPlaygroundSettings();
 		await website.selectPHPVersion(version);
 
 		// Uncheck the "with extensions" checkbox
@@ -81,7 +82,8 @@ SupportedPHPVersions.forEach(async (version) => {
 		);
 		await phpExtensionCheckbox.uncheck();
 
-		await website.clickSaveInForkPlaygroundSettings();
+		await website.clickSaveInPlaygroundSettings();
+		await website.confirmPlaygroundSettingsUpdate();
 
 		await expect(
 			await website.getSiteInfoRowLocator('PHP version')
@@ -97,9 +99,10 @@ Object.keys(MinifiedWordPressVersions)
 			website,
 		}) => {
 			await website.goto('./');
-			await website.openForkPlaygroundSettings();
+			await website.openPlaygroundSettings();
 			await website.selectWordPressVersion(version);
-			await website.clickSaveInForkPlaygroundSettings();
+			await website.clickSaveInPlaygroundSettings();
+			await website.confirmPlaygroundSettingsUpdate();
 
 			await expect(
 				await website.getSiteInfoRowLocator('WordPress version')
@@ -128,9 +131,10 @@ test('should display networking as active when networking is enabled', async ({
 test('should enable networking when requested', async ({ website }) => {
 	await website.goto('./');
 
-	await website.openForkPlaygroundSettings();
+	await website.openPlaygroundSettings();
 	await website.setNetworkingEnabled(true);
-	await website.clickSaveInForkPlaygroundSettings();
+	await website.clickSaveInPlaygroundSettings();
+	await website.confirmPlaygroundSettingsUpdate();
 
 	await expect(await website.hasNetworkingEnabled()).toBeTruthy();
 });
@@ -138,9 +142,10 @@ test('should enable networking when requested', async ({ website }) => {
 test('should disable networking when requested', async ({ website }) => {
 	await website.goto('./?networking=yes');
 
-	await website.openForkPlaygroundSettings();
+	await website.openPlaygroundSettings();
 	await website.setNetworkingEnabled(false);
-	await website.clickSaveInForkPlaygroundSettings();
+	await website.clickSaveInPlaygroundSettings();
+	await website.confirmPlaygroundSettingsUpdate();
 
 	await expect(await website.hasNetworkingEnabled()).toBeFalsy();
 });

--- a/packages/playground/website/playwright/website-page.ts
+++ b/packages/playground/website/playwright/website-page.ts
@@ -70,7 +70,7 @@ export class WebsitePage {
 		const editSettingsButton = this.page.locator(
 			'button.components-button',
 			{
-				hasText: 'Create a similar Playground',
+				hasText: 'Edit Playground settings',
 			}
 		);
 		await editSettingsButton.click({ timeout: 5000 });

--- a/packages/playground/website/playwright/website-page.ts
+++ b/packages/playground/website/playwright/website-page.ts
@@ -65,7 +65,7 @@ export class WebsitePage {
 			.innerText();
 	}
 
-	async openForkPlaygroundSettings() {
+	async openPlaygroundSettings() {
 		await this.ensureSiteManagerIsOpen();
 		const editSettingsButton = this.page.locator(
 			'button.components-button',
@@ -81,14 +81,24 @@ export class WebsitePage {
 		await phpVersionSelect.selectOption(version);
 	}
 
-	async clickSaveInForkPlaygroundSettings() {
+	async clickSaveInPlaygroundSettings() {
 		const saveSettingsButton = this.page.locator(
 			'button.components-button.is-primary',
 			{
-				hasText: 'Create',
+				hasText: 'Update',
 			}
 		);
 		await saveSettingsButton.click();
+	}
+
+	async confirmPlaygroundSettingsUpdate() {
+		const confirmSettingsUpdateButton = this.page.locator(
+			'button.components-button.is-primary',
+			{
+				hasText: 'Reset and update',
+			}
+		);
+		await confirmSettingsUpdateButton.click();
 	}
 
 	async selectWordPressVersion(version: string) {

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -548,7 +548,7 @@ function SiteSettingsTab({ site }: { site: SiteInfo }) {
 											className={css.buttonNoPadding}
 											onClick={onClick}
 										>
-											Create a similar Playground
+											Edit Playground settings
 										</Button>
 									)}
 								</StartSimilarSiteButton>

--- a/packages/playground/website/src/components/site-manager/start-similar-site-button/index.tsx
+++ b/packages/playground/website/src/components/site-manager/start-similar-site-button/index.tsx
@@ -1,4 +1,7 @@
-import { Modal } from '@wordpress/components';
+import {
+	Modal,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
 import { useMemo, useState } from 'react';
 import { useAppSelector } from '../../../lib/state/redux/store';
 import SiteSettingsForm, { SiteFormData } from '../site-settings-form';
@@ -13,6 +16,9 @@ export function StartSimilarSiteButton({
 	siteSlug: string;
 	children: (onClick: () => void) => React.ReactNode;
 }) {
+	const [confirmDialogSiteFormData, setConfirmDialogSiteFormData] = useState<
+		SiteFormData | false
+	>(false);
 	const siteInfo = useAppSelector((state) =>
 		selectSiteBySlug(state, siteSlug)
 	)!;
@@ -63,16 +69,39 @@ export function StartSimilarSiteButton({
 	return (
 		<div>
 			{children(() => setModalOpen(true))}
-
+			<ConfirmDialog
+				isOpen={!!confirmDialogSiteFormData}
+				onConfirm={() =>
+					updateSite(confirmDialogSiteFormData as SiteFormData)
+				}
+				onCancel={() => setConfirmDialogSiteFormData(false)}
+				title="Confirm Playground settings update"
+				confirmButtonText="Reset and update"
+			>
+				<p>
+					By updating Playground settings on a temporary site, <br />
+					you will reset the Playground and lose all changes you made
+					<br />
+					previously.
+				</p>
+				<p>
+					If you want to keep the changes you made previously, <br />
+					you can cancel this dialog, Click Save in Playground details{' '}
+					<br />
+					and update settings after the site is saved.
+				</p>
+			</ConfirmDialog>
 			{isModalOpen && (
 				<Modal
-					title="Create a similar Playground"
+					title="Edit Playground setting"
 					onRequestClose={() => setModalOpen(false)}
 				>
 					<SiteSettingsForm
-						onSubmit={updateSite}
+						onSubmit={(data: SiteFormData) =>
+							setConfirmDialogSiteFormData(data)
+						}
 						onCancel={() => setModalOpen(false)}
-						submitButtonText="Create"
+						submitButtonText="Update"
 						defaultValues={defaultValues}
 					/>
 				</Modal>

--- a/packages/playground/website/src/components/site-manager/start-similar-site-button/index.tsx
+++ b/packages/playground/website/src/components/site-manager/start-similar-site-button/index.tsx
@@ -93,7 +93,7 @@ export function StartSimilarSiteButton({
 			</ConfirmDialog>
 			{isModalOpen && (
 				<Modal
-					title="Edit Playground setting"
+					title="Edit Playground settings"
 					onRequestClose={() => setModalOpen(false)}
 				>
 					<SiteSettingsForm

--- a/packages/playground/website/src/components/site-manager/start-similar-site-button/index.tsx
+++ b/packages/playground/website/src/components/site-manager/start-similar-site-button/index.tsx
@@ -83,21 +83,17 @@ export function StartSimilarSiteButton({
 				<Modal
 					onRequestClose={() => setConfirmDialogSiteFormData(false)}
 					title="Confirm Playground settings update"
+					size="medium"
 				>
 					<p>
-						By updating Playground settings on a temporary site,{' '}
-						<br />
-						you will reset the Playground and lose all changes you
-						made
-						<br />
+						Clone will create a new temporary Playground with
+						updated settings and keep the changes you made
 						previously.
 					</p>
 					<p>
-						If you want to keep the changes you made previously,{' '}
-						<br />
-						you can cancel this dialog, Click Save in Playground
-						details <br />
-						and update settings after the site is saved.
+						Resetting will remove the Playground and all changes you
+						made previously and create a new Playground with the
+						updated settings.
 					</p>
 					<Flex direction="column">
 						<FlexItem>
@@ -110,7 +106,7 @@ export function StartSimilarSiteButton({
 									)
 								}
 							>
-								Update settings and reset content
+								Reset site and update settings
 							</Button>
 						</FlexItem>
 						<FlexItem>
@@ -123,7 +119,7 @@ export function StartSimilarSiteButton({
 									)
 								}
 							>
-								Update settings and clone site
+								Clone site with new settings
 							</Button>
 						</FlexItem>
 						<FlexItem>

--- a/packages/playground/website/src/components/site-manager/start-similar-site-button/style.module.css
+++ b/packages/playground/website/src/components/site-manager/start-similar-site-button/style.module.css
@@ -1,0 +1,5 @@
+.confirm-dialog-button {
+	width: 100%;
+	text-align: center;
+	display: block;
+}


### PR DESCRIPTION
## Motivation for the change, related issues

@annezazu asked why we don't support changing settings on temporary Playgrounds after the redesign. 
We do, but the label is called _Create a similar Playground_ which is technically correct but might not be clear to users. 
We concluded that the label should be _Edit Playground settings_ even if it's not 100% technically correct.

### Suggested improvement

For users it might not be fully expected that the site will be cloned, so I added a modal that clarifies what clone does and added support for resetting the site with new settings.

Ideally, we would only change the settings and keep the same site, but we can't do it until we implement site cloning. 

## Implementation details

TBD

## Testing Instructions (or ideally a Blueprint)

- CI
