### PR TITLE
Add Install instructions to the Playwright README

### DIFF
--- a/packages/playground/website/playwright/README.md
+++ b/packages/playground/website/playwright/README.md
@@ -2,6 +2,14 @@
 
 **Note:** We are currently migrating the e2e tests to [Playwright](https://playwright.dev/) from Cypress.
 
+## Install Playwright
+
+You first need to install Playwright to run the tests below:
+
+```bash
+npx playwright install --with-deps
+```
+
 ## Run tests
 
 Runs the end-to-end tests.


### PR DESCRIPTION
When running the instructions on https://github.com/WordPress/wordpress-playground/blob/421c9fae4740a76d7cdf8a1d270550489a721750/packages/playground/website/playwright/README.md, I'd get this error:
```
Error: browserType.launch: Executable doesn't exist at /Users/alex/Library/Caches/ms-playwright/chromium-1134/chrome-mac/Chromium.app/Contents/MacOS/Chromium
```

This adds the necessary install command to the README.