### PR TITLE
Make isomorphic-git submodule use https, not ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "isomorphic-git"]
     path="isomorphic-git"
-    url=git@github.com:adamziel/isomorphic-git.git
+    url=https://github.com/adamziel/isomorphic-git.git


### PR DESCRIPTION
Quick change hoping to get this workflow to pass:

https://github.com/WordPress/wordpress-playground/actions/runs/11239658990/job/31247221277

The current error is

```
Prepare all required actions
Getting action download info
Download action repository 'actions/setup-node@v4' (SHA:0a44ba7841725637a19e28fa30b79a866c81b0a6)
Download action repository 'actions/cache@v2' (SHA:8492260343ad570701412c2f464a5877dc76bace)
Run ./.github/actions/prepare-playground
Run git fetch origin trunk --depth=1 --recurse-submodules
From https://github.com/WordPress/wordpress-playground
 * branch            trunk      -> FETCH_HEAD
Fetching submodule isomorphic-git
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Errors during submodule fetch:
	isomorphic-git
```

I suspect it's something related to SSH keys so I'm baling out on that and switching to HTTPS. It's a public repo anyway.
