### PR TITLE
Restrict CORS proxy to requests from Playground website origin

### DIFF
--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -8,16 +8,8 @@ define('MAX_RESPONSE_SIZE', 100 * 1024 * 1024); // 100MB
 
 require_once __DIR__ . '/proxy-functions.php';
 
-// Set CORS headers
-function set_cors_headers() {
-    header("Access-Control-Allow-Origin: *");
-    header("Access-Control-Allow-Methods: GET, POST, HEAD, OPTIONS");
-    header("Access-Control-Allow-Headers: *");
-}
-
-// Handle preflight request
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
-    set_cors_headers();
+    header("Allow: GET, POST, OPTIONS");
     exit;
 }
 
@@ -129,7 +121,6 @@ if ($requestMethod !== 'GET' && $requestMethod !== 'HEAD' && $requestMethod !== 
 }
 
 // Execute cURL session
-set_cors_headers();
 if (!curl_exec($ch)) {
     http_response_code(502);
     echo "Bad Gateway – curl_exec error: " . curl_error($ch);


### PR DESCRIPTION
## Motivation for the change, related issues

We are preparing to deploy a CORS proxy for Playground use, and we want to limit the proxy to use by Playground.

After this PR, let's also add rate-limiting to prevent abuse.

## Implementation details

Stop responding with headers to permit CORS. If the proxy is hosted on the same origin, Playground client requests to the proxy do not need CORS.

## Testing Instructions (or ideally a Blueprint)

- cd to parent dir of `cors-proxy.php` 
- Run `php -S localhost:7788 -t .`
- Request `http://localhost:7788/cors-proxy.php?https%3A%2F%2Fwordpress.org%2Flatest.zip` and make sure it responds with a WordPress zip.
