### PR TITLE
Add /release redirect to WP beta/RC blueprint

### DIFF
--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -226,6 +226,20 @@ function playground_maybe_redirect( $requested_path ) {
 		);
 	}
 
+	if ( $requested_path === '/release' ) {
+		// Make this redirect relative to `release` in case we implement
+		// subdir staging for the Playground website.
+		$redirect_base_path = substr($requested_path, 0, - strlen('release'));
+		$redirect_location = 
+			$redirect_base_path .
+			'?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/beta-rc/blueprint.json';
+
+		return array(          
+			'location' => $redirect_location,                    
+			'status' => 301
+		);                     
+	} 
+
 	if ( str_ends_with( $requested_path, '/wordpress-browser.html' ) ) {
 		return array(
 			'location' => '/',


### PR DESCRIPTION
## Motivation for the change, related issues

[When sharing blueprint URLs, particularly in chat platforms, the current long link tends to break due to its length, which affects its usability.](https://github.com/WordPress/wordpress-playground/issues/1864#issue-2573717150)

Closes #1864

## Implementation details

This PR adds a simple redirect to `custom-redirects-lib.php`.

## Testing Instructions (or ideally a Blueprint)

Tested via a stale WP Cloud staging site. It had a `custom-redirects-lib.php` file that was up-to-date-enough for this.
