### PR TITLE
[Website] Fix "undefined" as className

### DIFF
--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -32,11 +32,11 @@ export default function BrowserChrome({
 	const addressBarClass = classNames(css.addressBarSlot, {
 		[css.isHidden]: !showAddressBar,
 	});
-	const wrapperClass = classNames(css.wrapper, css.hasFullSizeWindow);
+	const wrapperClass = classNames(css.wrapper, css.hasFullSizeWindow, className);
 
 	return (
 		<div
-			className={`${wrapperClass} ${className}`}
+			className={wrapperClass}
 			data-cy="simulated-browser"
 		>
 			<div className={`${css.window} browser-chrome-window`}>


### PR DESCRIPTION
## Motivation for the change, related issues

I found "undefined" as a class name in the rendered DOM code.
![image](https://github.com/user-attachments/assets/34d9e109-5c1f-45ab-86e1-1d653c45b1f3)


## Implementation details

Remove potentially empty prop from string chain to classNames() method.

## Testing Instructions (or ideally a Blueprint)
Just open playground. It's on the main page as a wrapper.


Ps. Sorry for the small stuff. I'm trying to find my way around the code :)
