### PR TITLE
Website: Replace 100vh with 100dvh to fix an "unscrollable" state on mobile devices

### DIFF
--- a/packages/meta/src/mindmap/v1/style.css
+++ b/packages/meta/src/mindmap/v1/style.css
@@ -6,7 +6,7 @@ body {
 
 #mindmap {
 	width: 100vw;
-	height: 100vh;
+	height: 100dvh;
 	background: white;
 }
 

--- a/packages/playground/website/demos/index.html
+++ b/packages/playground/website/demos/index.html
@@ -9,7 +9,7 @@
 		}
 		body {
 			width: 100vw;
-			height: 100vh;
+			height: 100dvh;
 			padding: 20px;
 		}
 	</style>

--- a/packages/playground/website/demos/peer.html
+++ b/packages/playground/website/demos/peer.html
@@ -10,13 +10,13 @@
 		}
 		iframe {
 			width: 100vw;
-			height: 100vh;
+			height: 100dvh;
 			border: 0;
 		}
 	</style>
 </head>
 <body>
-	<iframe id="wp" style="width: 100vw; height: 100vh"></iframe>
+	<iframe id="wp" style="width: 100vw; height: 100dvh"></iframe>
 	<script type="module">
 		const { runDemo } = await import('./peer.ts');
 		const searchParams = new URLSearchParams(document.location.search);

--- a/packages/playground/website/demos/sync.html
+++ b/packages/playground/website/demos/sync.html
@@ -9,7 +9,7 @@
 		}
 		body {
 			width: 100vw;
-			height: 100vh;
+			height: 100dvh;
 			margin: 0;
 			padding: 0;
 			display: flex;

--- a/packages/playground/website/demos/time-traveling.html
+++ b/packages/playground/website/demos/time-traveling.html
@@ -9,7 +9,7 @@
 		}
 		body {
 			width: 100vw;
-			height: 100vh;
+			height: 100dvh;
 			margin: 0;
 			padding: 0;
 			display: flex;

--- a/packages/playground/website/src/components/layout/style.module.css
+++ b/packages/playground/website/src/components/layout/style.module.css
@@ -18,7 +18,7 @@ body {
 .layout {
 	display: flex;
 	width: 100vw;
-	height: 100vh;
+	height: 100dvh;
 	overflow: hidden;
 }
 
@@ -80,7 +80,7 @@ body {
 	position: relative;
 	flex: 1 1 auto;
 	min-width: var(--site-view-min-width);
-	height: 100vh;
+	height: 100dvh;
 	border: 0px solid var(--site-manager-background-color);
 	transition: border-radius 300ms ease, border-width 300ms ease,
 		transform 300ms ease;
@@ -123,7 +123,7 @@ body {
 	content: '';
 	display: block;
 	width: 100%;
-	height: 100vh;
+	height: 100dvh;
 	background-color: transparent;
 	position: absolute;
 	top: 0;

--- a/packages/playground/website/src/components/site-manager/sidebar/style.module.css
+++ b/packages/playground/website/src/components/site-manager/sidebar/style.module.css
@@ -1,5 +1,5 @@
 .sidebar {
-	height: 100vh;
+	height: 100dvh;
 	display: flex;
 	flex-shrink: 0;
 	flex-direction: column;

--- a/packages/playground/website/src/components/site-manager/style.module.css
+++ b/packages/playground/website/src/components/site-manager/style.module.css
@@ -1,5 +1,5 @@
 .site-manager {
-	height: 100vh;
+	height: 100dvh;
 	overflow: hidden;
 	padding: var(--site-manager-border-width);
 	background-color: var(--site-manager-background-color);


### PR DESCRIPTION
On iPhones, 100vh may exceed the actual viewport size – Safari viewport height varies as you scroll the page and `vh` seems to represent the largest possible viewport.

When opening an anchor link (/`#wp-admin`), the browser wants to scroll down and align the top of the screen with the WordPress site. This causes Playground to occasionally end up in a slightly scrolled state where only the WordPress site is visible and you cannot scroll back to the Playground address bar:

![IMG_7D8D2EADEECC-1](https://github.com/user-attachments/assets/70632066-d518-437b-b28f-a88b2641086b)

Why? Because:

* `100vh` makes the page longer than it needs to be
* The difference is just enough to span the entire Playground address bar. On the screenshot above I intentionally left just a glimpse of that address bar, but it isn't normally there.
* WordPress iframe has its own scrollbar so, by scrolling, you're only moving up and down the WordPress page

## Solution: Use `dvh` unit

There's a special `dvh` unit that represents the current height of the viewport:

![plYwy](https://github.com/user-attachments/assets/76a56738-1933-4776-9529-70b0c14b48ee)

## Testing Instructions (or ideally a Blueprint)

1. Open Playground on an iPhone or a simulator (16 Pro Max in my case)
2. Create a bunch of sites, preview Blueprints etc
3. Confirm that before this PR this puts you in an unscrollable state
4. Confirm that with this PR you can always see the browser UI

cc @annziel this might interest you