### PR TITLE
Improve self-host docs

### DIFF
--- a/packages/docs/site/docs/developers/23-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/developers/23-architecture/18-host-your-own-playground.md
@@ -113,7 +113,6 @@ The combined Apache `.htaccess` file looks like this.
 
 ```htaccess
 AddType application/wasm .wasm
-AddType	application/octet-stream .data
 ```
 
 An equivalent in NGINX.
@@ -124,19 +123,11 @@ location ~* .wasm$ {
     application/wasm wasm;
   }
 }
-
-location ~* .data$ {
-  types {
-    application/octet-stream data;
-  }
-}
-
-location /scope:.* {
-  rewrite ^scope:.*?/(.*)$ $1 last;
-}
 ```
 
 You may need to adjust the above according to server specifics, particularly how to invoke PHP for the path `/plugin-proxy`.
+
+[Caddy web server](https://caddyserver.com) doesn't require any special config to work.
 
 ## Customize bundled data
 

--- a/packages/playground/remote/.htaccess
+++ b/packages/playground/remote/.htaccess
@@ -1,2 +1,1 @@
 AddType application/wasm .wasm
-AddType	application/octet-stream .data


### PR DESCRIPTION
Found some outdated instructions for self-hosting playground instance. (Thanks @bgrgicak for answering my questions)

Additionally, I don't know if the following line is still relevant:

```
You may need to adjust the above according to server specifics, particularly how to invoke PHP for the path `/plugin-proxy`.
```

If not, I can remove it too.



