### PR TITLE
[Blueprints] Stop escaping landingPage URLs when loading WP Admin

### DIFF
--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -176,3 +176,17 @@ test('should login the user in if a login step is provided', async ({
 	await website.goto(`./#${encodedBlueprint}`);
 	await expect(wordpress.locator('body')).toContainText('Dashboard');
 });
+
+['/wp-admin/', '/wp-admin/post.php?post=1&action=edit'].forEach((path) => {
+	test(`should correctly redirect encoded wp-admin url to ${path}`, async ({
+		website,
+		wordpress,
+	}) => {
+		const blueprint: Blueprint = {
+			landingPage: path,
+		};
+		const encodedBlueprint = JSON.stringify(blueprint);
+		await website.goto(`./#${encodedBlueprint}`);
+		await expect(wordpress.locator('body')).toContainText('Dashboard');
+	});
+});

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -187,6 +187,8 @@ test('should login the user in if a login step is provided', async ({
 		};
 		const encodedBlueprint = JSON.stringify(blueprint);
 		await website.goto(`./#${encodedBlueprint}`);
-		await expect(wordpress.locator('body')).toContainText('Dashboard');
+		expect(
+			await wordpress.locator('body').evaluate((body) => body.baseURI)
+		).toContain(path);
 	});
 });

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -95,29 +95,11 @@ test('should not login the user in if the login query parameter is set to no', a
 ['/wp-admin/', '/wp-admin/post.php?post=1&action=edit'].forEach((path) => {
 	test(`should correctly redirect encoded wp-admin url to ${path}`, async ({
 		website,
+		wordpress,
 	}) => {
 		await website.goto(`./?url=${encodeURIComponent(path)}`);
-		await expect(
-			website.page.locator(`input[value="${path}"]`)
-		).toHaveValue(path);
+		expect(
+			await wordpress.locator('body').evaluate((body) => body.baseURI)
+		).toContain(path);
 	});
-});
-
-/**
- * When the Playground website reads a url from the query string, it
- * picks up the "url" query argument.
- * If the "url" argument has unencoded query arguments starting with "&", they are
- * considered to be query arguments of the Playground website itself and not part
- * of the "url" argument.
- */
-test(`should strip any query arguments starting with "&" from a unencoded url after login`, async ({
-	website,
-}) => {
-	await website.goto(
-		`./?url=/wp-admin/edit.php?post_status=publish&post_type=post`
-	);
-	const expectedUrl = '/wp-admin/edit.php?post_status=publish';
-	await expect(
-		website.page.locator(`input[value="${expectedUrl}"]`)
-	).toHaveValue(expectedUrl);
 });

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -91,3 +91,33 @@ test('should not login the user in if the login query parameter is set to no', a
 		'Log In'
 	);
 });
+
+['/wp-admin/', '/wp-admin/post.php?post=1&action=edit'].forEach((path) => {
+	test(`should correctly redirect encoded wp-admin url to ${path}`, async ({
+		website,
+	}) => {
+		await website.goto(`./?url=${encodeURIComponent(path)}`);
+		await expect(
+			website.page.locator(`input[value="${path}"]`)
+		).toHaveValue(path);
+	});
+});
+
+/**
+ * When the Playground website reads a url from the query string, it
+ * picks up the "url" query argument.
+ * If the "url" argument has unencoded query arguments starting with "&", they are
+ * considered to be query arguments of the Playground website itself and not part
+ * of the "url" argument.
+ */
+test(`should strip any query arguments starting with "&" from a unencoded url after login`, async ({
+	website,
+}) => {
+	await website.goto(
+		`./?url=/wp-admin/edit.php?post_status=publish&post_type=post`
+	);
+	const expectedUrl = '/wp-admin/edit.php?post_status=publish';
+	await expect(
+		website.page.locator(`input[value="${expectedUrl}"]`)
+	).toHaveValue(expectedUrl);
+});

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -121,6 +121,14 @@ export async function resolveBlueprintFromURL(url: URL) {
 
 	// Landing page
 	if (query.get('url')) {
+		/**
+		 * If the provided url has multiple query arguments, only the first one
+		 * is picked up as the url argument of the Playground website.
+		 *
+		 * @TODO This is standard browser behavior, but we should consider changing it
+		 * in the future to pick up all query arguments of the url if
+		 * they aren't valid Playground website query arguments.
+		 */
 		blueprint.landingPage = query.get('url')!;
 	}
 

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -121,14 +121,6 @@ export async function resolveBlueprintFromURL(url: URL) {
 
 	// Landing page
 	if (query.get('url')) {
-		/**
-		 * If the provided url has multiple query arguments, only the first one
-		 * is picked up as the url argument of the Playground website.
-		 *
-		 * @TODO This is standard browser behavior, but we should consider changing it
-		 * in the future to pick up all query arguments of the url if
-		 * they aren't valid Playground website query arguments.
-		 */
 		blueprint.landingPage = query.get('url')!;
 	}
 

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -147,7 +147,7 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 			/**
 			 * Check if the request is for the login page.
 			 */
-			if (is_login() && is_user_logged_in() && isset($_GET['redirect_to'])) {
+			if (is_login() && is_user_logged_in() && !empty($_GET['redirect_to'])) {
 				wp_redirect($_GET['redirect_to']);
 				exit;
 			}

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -109,7 +109,7 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 			 * playground_force_auto_login_as_user GET parameter.
 			 */
 			if ( defined('PLAYGROUND_FORCE_AUTO_LOGIN_ENABLED') && isset($_GET['playground_force_auto_login_as_user']) ) {
-				return esc_attr($_GET['playground_force_auto_login_as_user']);
+				return $_GET['playground_force_auto_login_as_user'];
 			}
 			return false;
 		}
@@ -148,7 +148,7 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 			 * Check if the request is for the login page.
 			 */
 			if (is_login() && is_user_logged_in() && isset($_GET['redirect_to'])) {
-				wp_redirect(esc_url($_GET['redirect_to']));
+				wp_redirect($_GET['redirect_to']);
 				exit;
 			}
 		}, 1);


### PR DESCRIPTION
This PR removes URL escaping from the [autologin plugin](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/wordpress/src/index.ts#L151) which escapes the URL provided by the `redirect_to` query string on the wp-login.php` page and adds more tests to cover different login scenarios.

When a user requests to open a page in Playground via the Blueprint `landingPage` property or the `url` query string they must be redirected to that page during boot. 
If the page is restricted like WP admin, users must be logged in first to ensure they can view the page.

### Landing page redirect flow during Playground boot

If a user requests to open a page that isn't in WP Admin, Playground will log in [during the `init` action. ](https://github.com/WordPress/wordpress-playground/blob/ad10aca689ba9dba958ba578e5a939ff490dd8b5/packages/playground/wordpress/src/index.ts#L145)

When the requested URL is inside WP admin, WordPress will check if the user is logged in before running the `init` action, which prevents Playground from logging in automatically.
If the user isn't logged in WordPress will redirect the page to `wp-login.php` and store the original landing page URL in a `redirect_to` query argument. 

During the `wp-login.php` load, Playground can automatically log in using the `init` action, but the loaded page will be `wp-login.php`  instead of the requested landing page.
To get to the requested landing page, [Playground will pick up the `redirect_to` URL provided by WordPress and redirect to the requested landing page during the `init` action.](https://github.com/WordPress/wordpress-playground/blob/ad10aca689ba9dba958ba578e5a939ff490dd8b5/packages/playground/wordpress/src/index.ts#L151)

Fixes #1886
Bug introduced in #1856

## Testing Instructions (or ideally a Blueprint)

- CI