### PR TITLE
Stop adding all CORS proxy files to website build

### DIFF
--- a/packages/playground/website/project.json
+++ b/packages/playground/website/project.json
@@ -19,7 +19,7 @@
 					"cp -r ./client ./wasm-wordpress-net/",
 					"cp -r ./remote/* ./wasm-wordpress-net/",
 					"cp -r ./website/* ./wasm-wordpress-net/",
-					"cp -r ../../../packages/playground/php-cors-proxy/* ./wasm-wordpress-net/",
+					"cp -r ../../../packages/playground/php-cors-proxy/{cors-proxy.php,cors-proxy-functions.php} ./wasm-wordpress-net/",
 					"cat ./remote/.htaccess ./website/.htaccess > ./wasm-wordpress-net/.htaccess",
 					"curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > wasm-wordpress-net/wp-cli.phar",
 					"cat wasm-wordpress-net/wp-cli.phar | gzip -c -9 > wasm-wordpress-net/wp-cli.phar.gz"


### PR DESCRIPTION
This fixes a build issue where undesired cruft from the PHP CORS proxy was added to the website build.
