### PR TITLE
Website: Stop responding with default MIME type

### DIFF
--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -548,6 +548,7 @@ export class PHPRequestHandler {
  */
 function inferMimeType(path: string): string {
 	const extension = path.split('.').pop() as keyof typeof mimeTypes;
+	// @TODO: Consider not sending a default mime type to let the browser guess
 	return mimeTypes[extension] || mimeTypes['_default'];
 }
 

--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -133,9 +133,11 @@ function playground_handle_request() {
 		: false;
 
 	require_once __DIR__ . '/mime-types.php';
-	$content_type = $mime_types[ $extension ] ?? $mime_types['_default'];
-	$log( "Setting Content-Type to '$content_type'" );
-	header( "Content-Type: $content_type" );
+	if ( isset( $mime_types[ $extension ] ) ) {
+		$content_type = $mime_types[ $extension ];
+		$log( "Setting Content-Type to '$content_type'" );
+		header( "Content-Type: $content_type" );
+	}
 
 	$custom_response_headers = playground_get_custom_response_headers( $requested_path );
 	if ( ! empty( $custom_response_headers ) ) {


### PR DESCRIPTION
## Motivation for the change, related issues

Responding with a default MIME type can interfere with more intelligent default handling by web browsers.

## Implementation details

Update `custom-redirects-lib.php` to no longer respond with default MIME type when the type is not known.

## Testing Instructions (or ideally a Blueprint)

Tested manually on a stale Playground staging site.