### PR TITLE
Blueprints: Use `?` instead of `/` to CORS Proxy URLs

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -67,7 +67,7 @@ export interface CompileBlueprintOptions {
 	 *
 	 * For example, if corsProxy is set to "https://cors.wordpress.net/proxy.php",
 	 * then the CORS requests to https://github.com/WordPress/gutenberg.git would actually
-	 * be made to https://cors.wordpress.net/proxy.php/https://github.com/WordPress/gutenberg.git.
+	 * be made to https://cors.wordpress.net/proxy.php?https://github.com/WordPress/gutenberg.git.
 	 */
 	corsProxy?: string;
 }

--- a/packages/playground/blueprints/src/lib/resources.ts
+++ b/packages/playground/blueprints/src/lib/resources.ts
@@ -459,7 +459,7 @@ export class GitDirectoryResource extends Resource<Directory> {
 
 	async resolve() {
 		const repoUrl = this.options?.corsProxy
-			? `${this.options.corsProxy}/${this.reference.url}`
+			? `${this.options.corsProxy}?${this.reference.url}`
 			: this.reference.url;
 		const ref = ['', 'HEAD'].includes(this.reference.ref)
 			? 'HEAD'

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -80,7 +80,7 @@ export interface StartPlaygroundOptions {
 	 *
 	 * For example, if corsProxy is set to "https://cors.wordpress.net/proxy.php",
 	 * then the CORS requests to https://github.com/WordPress/wordpress-playground.git would actually
-	 * be made to https://cors.wordpress.net/proxy.php/https://github.com/WordPress/wordpress-playground.git.
+	 * be made to https://cors.wordpress.net/proxy.php?https://github.com/WordPress/wordpress-playground.git.
 	 *
 	 * The Blueprints library will arbitrarily choose which requests to proxy. If you need
 	 * to proxy every single request, do not use this option. Instead, you should preprocess


### PR DESCRIPTION
Makes GitDirectoryResource (introduced in #1858) relay the requests through `/cors-proxy.php?{url}` instead of `/cors-proxy.php/{url}`. This makes it compatible with the actual `cors-proxy.php` script Playground ended up shipping.

 ## Testing instructions

None, this only works in production. Maybe you could run the Blueprint from https://github.com/WordPress/wordpress-playground/pull/1858 and confirm in the network tools that it's actually using the `?` instead of `/`.