### PR TITLE
Fix use of secrets on WP Cloud site

### DIFF
--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -271,6 +271,8 @@ function playground_maybe_set_environment( $requested_path ) {
 	}
 
 	if ( str_ends_with( $requested_path, 'logger.php' ) ) {
+		// Define DB_PASSWORD early so Atomic_Persistent_Data can work.
+		__atomic_env_define( 'DB_PASSWORD' );
 		$secrets = new Atomic_Persistent_Data;
 		if ( isset(
 			$secrets->LOGGER_SLACK_CHANNEL,
@@ -286,6 +288,8 @@ function playground_maybe_set_environment( $requested_path ) {
 	}
 
 	if ( str_ends_with( $requested_path, 'plugin-proxy.php' ) ) {
+		// Define DB_PASSWORD early so Atomic_Persistent_Data can work.
+		__atomic_env_define( 'DB_PASSWORD' );
 		$secrets = new Atomic_Persistent_Data;
 		if ( isset( $secrets->GITHUB_TOKEN ) ) {
 			putenv( "GITHUB_TOKEN={$secrets->GITHUB_TOKEN}" );
@@ -297,6 +301,8 @@ function playground_maybe_set_environment( $requested_path ) {
 	}
 
 	if ( str_ends_with( $requested_path, 'oauth.php' ) ) {
+		// Define DB_PASSWORD early so Atomic_Persistent_Data can work.
+		__atomic_env_define( 'DB_PASSWORD' );
 		$secrets = new Atomic_Persistent_Data;
 		if ( isset(
 			$secrets->GITHUB_APP_CLIENT_ID,


### PR DESCRIPTION
## Motivation for the change, related issues

A previous change to how we serve PHP files on the website broke use of secrets stored with WP Cloud. This PR fixes that.

## Implementation details

Because we are using WP cloud persistent data storage early in the request lifecycle (when custom-redirects.php is executed), certain environmental dependencies of persistent storage are not yet defined. This PR forces the definition of those dependencies to give us access to secrets from persistent storage.

## Testing Instructions (or ideally a Blueprint)

Manually tested on Playground website.
