### PR TITLE
[Blueprints] Allow multisites to load wp-admin pages with the landingPage attribute

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -58,6 +58,6 @@ export const enableMultisite: StepHandler<EnableMultisiteStep> = async (
 	});
 
 	await wpCLI(playground, {
-		command: `wp core multisite-convert --base="${sitePath}"`,
+		command: 'wp core multisite-convert',
 	});
 };

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -192,3 +192,25 @@ test('should login the user in if a login step is provided', async ({
 		).toContain(path);
 	});
 });
+
+test('should correctly redirect to a multisite wp-admin url', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		landingPage: '/example/wp-admin/options-general.php',
+		steps: [
+			{
+				step: 'enableMultisite',
+			},
+			{
+				step: 'wp-cli',
+				command: 'wp site create --slug=example',
+			},
+		],
+	};
+
+	const encodedBlueprint = JSON.stringify(blueprint);
+	await website.goto(`./#${encodedBlueprint}`);
+	await expect(wordpress.locator('body')).toContainText('General Settings');
+});


### PR DESCRIPTION
This PR allows multisite Blueprints to load `/wp-admin/` URLs using the `landingPage` attribute.

Before this PR multisites were configured with an incorrect base path that broke WordPress rewrites.
WordPress couldn't resolve `/SITE-SLUG/wp-login.php` as `/wp-login.php`, instead it returned the WordPress 404 page.

When a Blueprint attempts to load `/wp-admin/` using the `landingPage` attribute, it first needs to open `/wp-login.php` to log in the user. But, because WordPress couldn't access `/wp-login.php`, logins were failing, and as a result `/wp-admin/` pages couldn't be loaded.

The fix was to remove a custom `base` URL and let the `wp core multisite-convert` CLI command create automatically.
This PR also adds a test to cover this scenario, so we can make sure it doesn't happen again. 

Fixes #1907 

## Testing Instructions (or ideally a Blueprint)

- CI