### PR TITLE
[Blueprints] Make landingPage handling runtime-specific and move it to PlaygroundViewport

### DIFF
--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -305,18 +305,6 @@ export function compileBlueprint(
 					}
 				}
 			} finally {
-				try {
-					await (playground as any).goTo(
-						blueprint.landingPage || '/'
-					);
-				} catch (e) {
-					/*
-					 * PHP exposes no goTo method.
-					 * We can't use `goto` in playground here,
-					 * because it may be a Comlink proxy object
-					 * with no such method.
-					 */
-				}
 				progress.finish();
 			}
 		},

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -78,7 +78,7 @@ export function EnsurePlaygroundSiteIsSelected({
 					return;
 				}
 
-				dispatch(setActiveSite(requestedSiteSlug));
+				dispatch(setActiveSite(requestedSiteSlug, { redirect: false }));
 				return;
 			}
 

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -8,7 +8,10 @@ import {
 	useAppDispatch,
 	useAppSelector,
 } from '../../lib/state/redux/store';
-import { removeClientInfo } from '../../lib/state/redux/slice-clients';
+import {
+	removeClientInfo,
+	selectClientBySiteSlug,
+} from '../../lib/state/redux/slice-clients';
 import { bootSiteClient } from '../../lib/state/redux/boot-site-client';
 import { SiteError } from '../../lib/state/redux/slice-ui';
 import { Button, Spinner } from '@wordpress/components';
@@ -230,6 +233,31 @@ export const JustViewport = function JustViewport({
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [siteSlug, iframeRef, runtimeConfigString]);
+
+	const client = useAppSelector((state) =>
+		selectClientBySiteSlug(state, siteSlug)
+	);
+	useEffect(() => {
+		if (!client) {
+			return;
+		}
+		const url = new URL(window.location.href);
+		const landingPage = url.searchParams.get('url') || '/';
+		client.goTo(landingPage).catch((e) => {
+			/*
+			 * PHP exposes no goTo method.
+			 * We can't use `goto` in playground here,
+			 * because it may be a Comlink proxy object
+			 * with no such method.
+			 */
+			console.error(e);
+		});
+		if (site.metadata.storage !== 'none') {
+			console.log({ client }, url.searchParams.get('url') || '/');
+			url.searchParams.delete('url');
+			redirectTo(url.toString());
+		}
+	}, [!client]);
 
 	const error = useAppSelector(selectActiveSiteError);
 

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -242,7 +242,10 @@ export const JustViewport = function JustViewport({
 			return;
 		}
 		const url = new URL(window.location.href);
-		const landingPage = url.searchParams.get('url') || '/';
+		const landingPage =
+			url.searchParams.get('url') ||
+			site.metadata?.originalBlueprint?.landingPage ||
+			'/';
 		client.goTo(landingPage).catch((e) => {
 			/*
 			 * PHP exposes no goTo method.
@@ -250,13 +253,13 @@ export const JustViewport = function JustViewport({
 			 * because it may be a Comlink proxy object
 			 * with no such method.
 			 */
-			console.error(e);
 		});
 		if (site.metadata.storage !== 'none') {
-			console.log({ client }, url.searchParams.get('url') || '/');
 			url.searchParams.delete('url');
 			redirectTo(url.toString());
 		}
+		// Only ever re-run this effect once – when the client becomes available.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [!client]);
 
 	const error = useAppSelector(selectActiveSiteError);

--- a/packages/playground/website/src/lib/state/redux/store.ts
+++ b/packages/playground/website/src/lib/state/redux/store.ts
@@ -76,7 +76,14 @@ export const selectActiveSiteError = (
 
 export const useActiveSite = () => useAppSelector(selectActiveSite);
 
-export const setActiveSite = (slug: string | undefined) => {
+export const setActiveSite = (
+	slug: string | undefined,
+	{
+		redirect = true,
+	}: {
+		redirect?: boolean;
+	} = {}
+) => {
 	return (
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
@@ -87,7 +94,7 @@ export const setActiveSite = (slug: string | undefined) => {
 			return;
 		}
 		dispatch(__internal_uiSlice.actions.setActiveSite(slug));
-		if (slug) {
+		if (slug && redirect) {
 			const site = selectSiteBySlug(getState(), slug);
 			redirectTo(PlaygroundRoute.site(site));
 		}


### PR DESCRIPTION
Moves the `playground.goTo(blueprint.landingPage)` call from the `compile()` method to the `PlaygroundViewport` component to:

* Support `?url=/wp-admin/` on OPFS sites, not just on the temporary sites
* Stop using that browser-specific `goTo` method in all Blueprints. It sets `iframe.src` which is browser-specific. `.goTo()` is not available in, say, Playground CLI or Studio. Those runtimes would need their own handlers to support the landing page.

 ## Remaining work

* Add E2E tests
* Explain more context and why this cannot be easily supported in `compile()`

 ## Testing instructions

For temporary sites:

* Go to http://localhost:5400/website-server/?url=/wp-admin/
* Confirm you're redirected to WP admin adn the `url` parameter is still present in the address bar

For stored sites:

* Create a local Playground site
* Store it in OPFS
* Add `?url=/wp-admin/` and visit it
* Confirm you're redirected to WP Admin and the `url` parameter is removed from the address bar

cc @akirk @brandonpayton @bgrgicak 