### PR TITLE
[CORS Proxy] Rate-limits IPv6 requests based on /64 subnets, not specific addresses

### DIFF
--- a/packages/playground/website-deployment/cors-proxy-config.php
+++ b/packages/playground/website-deployment/cors-proxy-config.php
@@ -256,7 +256,7 @@ function playground_get_ipv6_block(string $ipv6_remote_ip, int $block_size=64): 
 	if($block_size % 8 !== 0) {
 		// We're using a naive substr-based approach that reasons about
 		// groups of 8 bits (characters) and not separately about each bit.
-		// This approach can only support block sizes that are multiplies
+		// This approach can only support block sizes that are multiples
 		// of 8.
 		throw new Exception('Block size must be a multiple of 8.');
 	}

--- a/packages/playground/website-deployment/cors-proxy-config.php
+++ b/packages/playground/website-deployment/cors-proxy-config.php
@@ -253,12 +253,17 @@ function playground_get_ipv6_block(string $ipv6_remote_ip, int $block_size=64): 
 		return null;
 	}
 
-	if($block_size % 8 !== 0) {
+	if ($block_size % 8 !== 0) {
 		// We're using a naive substr-based approach that reasons about
 		// groups of 8 bits (characters) and not separately about each bit.
 		// This approach can only support block sizes that are multiples
 		// of 8.
 		throw new Exception('Block size must be a multiple of 8.');
+	}
+
+	$max_block_size = 128;
+	if ($block_size > $max_block_size) {
+		throw new Exception('Block size must be less than or equal to 128.');
 	}
 
 	$subnet_length = $block_size / 8;

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -1,0 +1,35 @@
+<?php
+
+require __DIR__ . '/cors-proxy-config.php';
+
+function assert_equal($expected, $actual, $message='') {
+	if ($expected !== $actual) {
+        $message = $message ?: "Test failed.";
+		echo "$message.\nExpected: $expected\nActual:   $actual\n";
+        die();
+	}
+}
+
+assert_equal(
+    '2607:B4C0:0000:0000:0000:0000:0000:0000',
+    playground_ip_to_a_64_subnet(
+        '2607:B4C0:0000:0000:0000:0000:0000:0001'
+    ),
+    'IPv6 was not correctly transformed into a subnet'
+);
+
+assert_equal(
+    '2607:B4C0:AAAA:BBBB:0000:0000:0000:0000',
+    playground_ip_to_a_64_subnet(
+        '2607:B4C0:AAAA:BBBB:CCCC:DDDD:EEEE:FFFF'
+    ),
+    'IPv6 was not correctly transformed into a subnet'
+);
+
+assert_equal(
+    '::ffff:127.0.0.1', 
+    playground_ip_to_a_64_subnet('127.0.0.1', 64),
+    'A part of the IPv4 range was lost'
+);
+
+echo 'All tests passed';

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -10,6 +10,20 @@ function assert_equal($expected, $actual, $message='') {
 	}
 }
 
+function assert_throws($expected_message, $callback) {
+    try {
+        $callback();
+    } catch (Exception $e) {
+        if ($e->getMessage() !== $expected_message) {
+            echo "Test failed.\nExpected: $expected_message\nActual:   {$e->getMessage()}\n";
+            die();
+        }
+        return;
+    }
+    echo "Test failed.\nExpected: $expected_message\nActual:   No exception was thrown\n";
+    die();
+}
+
 assert_equal(
     '2607:B4C0:0000:0000:0000:0000:0000:0000',
     playground_ip_to_a_64_subnet(
@@ -30,6 +44,26 @@ assert_equal(
     '::ffff:127.0.0.1', 
     playground_ip_to_a_64_subnet('127.0.0.1', 64),
     'A part of the IPv4 range was lost'
+);
+
+assert_throws(
+    'Block size must be a multiple of 8.',
+    function () {
+        playground_get_ipv6_block(
+            '2607:B4C0:AAAA:BBBB:CCCC:DDDD:EEEE:FFFF',
+            8 - 1
+        );
+    }
+);
+
+assert_throws(
+    'Block size must be less than or equal to 128.',
+    function () {
+        playground_get_ipv6_block(
+            '2607:B4C0:AAAA:BBBB:CCCC:DDDD:EEEE:FFFF',
+            128 + 8
+        );
+    }
 );
 
 echo 'All tests passed';


### PR DESCRIPTION
Rate-limits the CORS proxy requests based on the first 64 bits of an IPv6 address, not all 128 bits. This prevents a person with an entire /64 subnet from exhausting the storage or getting more than their fair share of the tokens.  This only applies to IPv6. For IPv4 addresses, all 64 bits are still considered.

 ## Implementation

Converts a string-based IP address into a binary string, then zeros the first 64 bits in that string and re-encodes it as a human-readable IP string.

 ## Testing instructions

* Deploy and attack the proxy :-)
* Run the unit tests

```php
php ./packages/playground/website-deployment/tests.php
```

cc @brandonpayton for reviews
