### PR TITLE
Publish @wp-playground/remote (types only)

### DIFF
--- a/packages/playground/client/project.json
+++ b/packages/playground/client/project.json
@@ -42,7 +42,6 @@
 				"outputPath": "dist/packages/playground/client",
 				"main": "packages/playground/client/index.html",
 				"tsConfig": "packages/playground/client/tsconfig.lib.json",
-				"assets": ["packages/playground/client/*.md"],
 				"minify": true
 			},
 			"defaultConfiguration": "production",
@@ -60,8 +59,7 @@
 			"defaultConfiguration": "development",
 			"options": {
 				"buildTarget": "playground-client:build",
-				"tsConfig": "packages/playground/client/tsconfig.lib.json",
-				"assets": ["packages/playground/client/*.md"]
+				"tsConfig": "packages/playground/client/tsconfig.lib.json"
 			}
 		},
 		"publish": {

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -22,9 +22,8 @@ export {
 	SupportedPHPVersionsList,
 	LatestSupportedPHPVersion,
 } from '@php-wasm/universal';
-export type { PlaygroundClient, MountDescriptor } from '@wp-playground/remote';
-
 export { phpVar, phpVars } from '@php-wasm/util';
+export type { PlaygroundClient, MountDescriptor };
 
 import {
 	Blueprint,

--- a/packages/playground/remote/README-npm.md
+++ b/packages/playground/remote/README-npm.md
@@ -1,0 +1,3 @@
+# playground-remote
+
+This package contains only type definitions that are required by other packages (e.g. `@wp-playground/client`). You normally do not need to directly reference this package in your `package.json`.

--- a/packages/playground/remote/README-npm.md
+++ b/packages/playground/remote/README-npm.md
@@ -1,3 +1,0 @@
-# playground-remote
-
-This package contains only type definitions that are required by other packages (e.g. `@wp-playground/client`). You normally do not need to directly reference this package in your `package.json`.

--- a/packages/playground/remote/package.json
+++ b/packages/playground/remote/package.json
@@ -17,5 +17,10 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"type": "module",
-	"private": true
+	"private": true,
+	"files": [
+		"/lib",
+		"/index.d.ts",
+		"/README.md"
+	]
 }

--- a/packages/playground/remote/package.json
+++ b/packages/playground/remote/package.json
@@ -17,7 +17,6 @@
 	],
 	"license": "GPL-2.0-or-later",
 	"type": "module",
-	"private": true,
 	"files": [
 		"/lib",
 		"/index.d.ts",

--- a/packages/playground/remote/package.json
+++ b/packages/playground/remote/package.json
@@ -19,7 +19,6 @@
 	"type": "module",
 	"files": [
 		"/lib",
-		"/index.d.ts",
-		"/README.md"
+		"/index.d.ts"
 	]
 }

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -55,6 +55,15 @@
 				"command": "node tools/scripts/publish.mjs playground {args.ver} {args.tag}",
 				"parallel": false
 			},
+			"dependsOn": ["build", "build:README-npm"]
+		},
+		"build:README-npm": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/playground/remote/README-npm.md dist/packages/playground/remote/README.md"
+				]
+			},
 			"dependsOn": ["build"]
 		},
 		"lint": {

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -52,7 +52,7 @@
 		"publish": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "node tools/scripts/publish.mjs playground {args.ver} {args.tag}",
+				"command": "node tools/scripts/publish.mjs playground-remote {args.ver} {args.tag}",
 				"parallel": false
 			},
 			"dependsOn": ["build", "build:README-npm"]

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -10,8 +10,7 @@
 			"options": {
 				"outputPath": "dist/packages/playground/remote",
 				"main": "packages/playground/remote/remote.html",
-				"tsConfig": "packages/playground/remote/tsconfig.lib.json",
-				"assets": ["packages/playground/remote/*.md"]
+				"tsConfig": "packages/playground/remote/tsconfig.lib.json"
 			}
 		},
 		"dev": {

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -55,15 +55,6 @@
 				"command": "node tools/scripts/publish.mjs playground-remote {args.ver} {args.tag}",
 				"parallel": false
 			},
-			"dependsOn": ["build", "build:README-npm"]
-		},
-		"build:README-npm": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"cp packages/playground/remote/README-npm.md dist/packages/playground/remote/README.md"
-				]
-			},
 			"dependsOn": ["build"]
 		},
 		"lint": {


### PR DESCRIPTION
Fixes #1725

This PR publishes the `@wp-playground/remote` package with only type definitions, as per discussion in #1725.

I've tested the changes introduced here locally, using [verdaccio](https://verdaccio.org/), and can confirm that the issues with missing types (namely `PlaygroundClient`) are fixed.

I took the liberty to fix some small things I noticed, and made sure to add context in commit messages, when necessary.

## Package contents
```
.
├── lib
│   ├── progress-bar
│   │   └── index.d.ts
│   ├── boot-playground-remote.d.ts
│   ├── config.d.ts
│   ├── create-memoized-fetch.d.ts
│   ├── index.d.ts
│   ├── offline-mode-cache.d.ts
│   ├── playground-client.d.ts
│   ├── setup-fetch-network-transport.d.ts
│   ├── worker-thread.d.ts
│   └── worker-utils.d.ts
├── index.d.ts
└── package.json
```

## Testing instructions
Install [verdaccio](https://verdaccio.org/):

```shell
npm install -g verdaccio
```

Run it:

```shell
verdaccio
```

> There would probably be a smarter way to test this without modifying the files below, but this got the job done for me.

Edit `tools/scripts/publish.mjs` so that the `spawnSync` call takes an extra `--registry` argument:

```js
spawnSync('npm', ['publish', '--access', 'public', tag ? `--tag ${tag}` : '', '--registry', 'http://localhost:4873/'], {
```

Edit the `publish` command in `packages/playground/client/project.json` so that it looks something like:

```json
"command": "node tools/scripts/publish.mjs playground-client 2.0.0 test",
```

Edit the `publish` command in `packages/playground/remote/project.json` so that it looks something like:

```json
"command": "node tools/scripts/publish.mjs playground-remote 0.0.1 test",
```

Publish both packages to verdaccio:

```shell
npx nx publish playground-remote
npx nx publish playground-client
```

Clone the test repo and configure it to use the verdaccio registry:

```shell
cd some-dir
git clone git@github.com:psrpinto/playground-ts-test.git
cd playground-ts-test

# Will create a .npmrc file in the current directory. 
npm set registry http://localhost:4873/ --location project
```

Edit `package.json` of the test repo so that it references the version of `@wp-playground/client` you published above:

```json
"@wp-playground/client": "^2.0.0",
```

Then `npm install`.

Open the test repo in your IDE, navigate to `src/playground/Playground.tsx` and make sure the `PlaygroundClient` has correct completion, and that you can navigate to its file.
