### PR TITLE
CORS Proxy: Index update_at column because it is used for lookup

### DIFF
--- a/packages/playground/website-deployment/cors-proxy-rate-limiting-table.sql
+++ b/packages/playground/website-deployment/cors-proxy-rate-limiting-table.sql
@@ -6,5 +6,6 @@ CREATE TABLE cors_proxy_rate_limiting (
 	tokens SMALLINT UNSIGNED NOT NULL,
 	updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	-- @TODO: Make this per-domain
-	CHECK (capacity > 0 AND tokens < capacity)
+	CHECK (capacity > 0 AND tokens < capacity),
+	INDEX (updated_at)
 );


### PR DESCRIPTION
## Motivation for the change, related issues

The CORS proxy regularly deletes rate-limiting records over a day old, and the `updated_at` column is not indexed even though it is used for looking up entries that can be deleted.

Closes #1921.

## Implementation details

This PR updates the table creation SQL to add an index for the `updated_at` column.

## Testing Instructions (or ideally a Blueprint)

- CI
- Tested the SQL by running against a local DB
