### PR TITLE
CORS Proxy: Reject targeting self

### DIFF
--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -50,7 +50,14 @@ function url_validate_and_resolve($url, $resolve_function='gethostbynamel') {
 
     $host = $parsedUrl['host'];
 
-    // @TODO: Reject requests to this host.
+    if (
+        ( isset( $_SERVER['HTTP_HOST'] ) &&
+            strcasecmp($_SERVER['HTTP_HOST'], $host) === 0) ||
+        ( isset( $_SERVER['SERVER_ADDR'] ) &&
+            strcasecmp($_SERVER['SERVER_ADDR'], $host) === 0)
+    ) {
+        throw new CorsProxyException("URL cannot target the CORS proxy host.");
+    }
 
     // Ensure the hostname does not resolve to a private IP
     $resolved_ips = $resolve_function($host);

--- a/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
+++ b/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
@@ -110,5 +110,13 @@ class ProxyFunctionsTests extends TestCase
         $this->expectException(CorsProxyException::class);
         url_validate_and_resolve('ftp://example.com');
     }
-    
+
+    public function testUrlValidateAndResolveWithTargetSelf()
+    {
+        $this->expectException(CorsProxyException::class);
+        $_SERVER['HTTP_HOST'] = 'cors.playground.wordpress.net';
+        url_validate_and_resolve(
+            'http://cors.playground.wordpress.net/cors-proxy.php?http://cors.playground.wordpress.net'
+        );
+    }
 }


### PR DESCRIPTION
## Motivation for the change, related issues

The CORS proxy shouldn't be able to target itself, so this PR rejects requests that attempt to do so.

Closes #1919

## Implementation details

This PR checks the `$_SERVER['HTTP_HOST'` and `$_SERVER['SERVER_ADDR']` and rejects the request if the target host matches either.

## Testing Instructions (or ideally a Blueprint)

- CI
