### PR TITLE
Query API: Preserve multiple ?plugin= query params

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -99,9 +99,7 @@ export function EnsurePlaygroundSiteIsSelected({
 						originalBlueprint: blueprint,
 					},
 					originalUrlParams: {
-						searchParams: Object.fromEntries(
-							url.searchParams.entries()
-						),
+						searchParams: parseSearchParams(url.searchParams),
 						hash: url.hash,
 					},
 				})
@@ -114,4 +112,13 @@ export function EnsurePlaygroundSiteIsSelected({
 	}, [url.href, requestedSiteSlug, siteListingStatus]);
 
 	return children;
+}
+
+function parseSearchParams(searchParams: URLSearchParams) {
+	const params: Record<string, any> = {};
+	for (const key of searchParams.keys()) {
+		const value = searchParams.getAll(key);
+		params[key] = value.length > 1 ? value : value[0];
+	}
+	return params;
 }

--- a/packages/playground/website/src/lib/state/url/router-hooks.ts
+++ b/packages/playground/website/src/lib/state/url/router-hooks.ts
@@ -38,6 +38,10 @@ export function updateUrl(
 				([key, value]) => {
 					if (value === undefined) {
 						currentUrl.searchParams.delete(key);
+					} else if (Array.isArray(value)) {
+						value.forEach((v) => {
+							currentUrl.searchParams.append(key, v);
+						});
 					} else {
 						currentUrl.searchParams.set(key, value);
 					}


### PR DESCRIPTION
Ensures that URLs with multiple parameter values, such as `?plugin=friends&plugin=hello-dolly`, are preserved after the initial page load.

As seen in #1941, Playground started redirecting from `?plugin=friends&plugin=hello-dolly` to just `?plugin=hello-dolly`. This is caused by storing only the last key=>value pair in the redux store instead of all the key=>value pairs for all query parameters.

## Testing Instructions (or ideally a Blueprint)

Go to the Input URL and confirm it behaves as follows:

**Before this PR**

```
Input URL:  /?plugin=classic-editor&plugin=hello-dolly&plugin=plugin-check
Result URL: /?plugin=plugin-check
```

**After this PR**

```
Input URL:  /?plugin=classic-editor&plugin=hello-dolly&plugin=plugin-check
Result URL: /?plugin=classic-editor&plugin=hello-dolly&plugin=plugin-check
```
