### PR TITLE
[Remote] Enable releasing @wp-playground/remote by making it public

### DIFF
--- a/packages/playground/remote/package.json
+++ b/packages/playground/remote/package.json
@@ -20,5 +20,8 @@
 	"files": [
 		"/lib",
 		"/index.d.ts"
-	]
+	],
+	"publishConfig": {
+		"access": "public"
+	}
 }


### PR DESCRIPTION
We want to start releasing the `@wp-playground/remote` package, so we need to make it public in the Package configuration.

In https://github.com/WordPress/wordpress-playground/pull/1924 we implemented the releasing of types from `@wp-playground/remote`, but it's [failing in CI ](https://github.com/WordPress/wordpress-playground/actions/runs/11522776140/job/32079350654) because it's not configured as public.

This PR sets `publishConfig.access` to `public` and enables releasing.

**Note** While testing this I [manually released the package](https://www.npmjs.com/package/@wp-playground/remote) to ensure it's working.


cc @psrpinto @adamziel 
