### PR TITLE
Restore .d.ts files missing from the published @wp-playground/remote npm package

### DIFF
--- a/packages/playground/remote/package.json
+++ b/packages/playground/remote/package.json
@@ -22,6 +22,7 @@
 		"/index.d.ts"
 	],
 	"publishConfig": {
-		"access": "public"
+		"access": "public",
+		"directory": "../../../dist/packages/playground/remote"
 	}
 }


### PR DESCRIPTION
Fixes #1951 

The reason why type definitions were not being published was that `lerna` was using `./packages/playground/remote/` as the source directory, instead of `./dist/packages/playground/remote/`. Since the type definitions are only present in `dist/`, they were not being published.

In #1924 I did test that the published package contained the type definitions, but I did not test it using `lerna`. Instead, I tested using `npm publish` directly from the `dist/` directory. Now I have tested this PR using `lerna` and can confirm that the published package will contain the type definitions.

I learned my lesson, from now on I'll always test publishing packages with `lerna` instead of `npm publish` :)

Here's the relevant `lerna` logs that show the type definitions will now be included in the published package:

```
lerna notice 📦  @wp-playground/remote@1.0.8
lerna notice === Tarball Contents ===
lerna notice 696B  package.json
lerna notice 465B  lib/boot-playground-remote.d.ts
lerna notice 92B   lib/config.d.ts
lerna notice 567B  lib/create-memoized-fetch.d.ts
lerna notice 23B   index.d.ts
lerna notice 220B  lib/index.d.ts
lerna notice 587B  lib/progress-bar/index.d.ts
lerna notice 1.4kB lib/offline-mode-cache.d.ts
lerna notice 2.4kB lib/playground-client.d.ts
lerna notice 677B  lib/setup-fetch-network-transport.d.ts
lerna notice 2.4kB lib/worker-thread.d.ts
lerna notice 3.6kB lib/worker-utils.d.ts
lerna notice === Tarball Details ===
```