### PR TITLE
[PHP.wasm for Node] Fix php.js import path in the published npm package

### DIFF
--- a/packages/php-wasm/web/project.json
+++ b/packages/php-wasm/web/project.json
@@ -1,6 +1,6 @@
 {
 	"name": "php-wasm-web",
-	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
 	"sourceRoot": "packages/php-wasm/web/src",
 	"projectType": "library",
 	"implicitDependencies": ["php-wasm-compile"],

--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -57,14 +57,14 @@ export default defineConfig(({ command }) => {
 					) {
 						/**
 						 * The ../ is weird but necessary to make the final build say
-						 * import("./php_8_2.js")
+						 * import("./php/jspi/php_8_2.js")
 						 * and not
-						 * import("php_8_2.js")
+						 * import("php/jspi/php_8_2.js")
 						 *
-						 * The slice(-2) will ensure the 'php/`
+						 * The slice(-3) will ensure the 'php/jspi/`
 						 * portion of the path is preserved.
 						 */
-						return '../' + specifier.split('/').slice(-2).join('/');
+						return '../' + specifier.split('/').slice(-3).join('/');
 					}
 				},
 			},


### PR DESCRIPTION
@sejas has [brought to our attention](https://github.com/WordPress/playground-tools/pull/359#issuecomment-2418639404) that the imports of the wasm assets are using incorrect paths, since https://github.com/WordPress/wordpress-playground/commit/3bebb247c75b4938fb6addc36abd1f19fe54cf1f.

The [source](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/web/src/lib/get-php-loader-module.ts#L22) says something like:

```ts
return await import('../../public/php/jspi/php_8_3.js');
```

Which currently results in the built file saying:

```js
return await import("./jspi/php_8_3.js");
```


However, since the tree of the published package is as follows, the path in the built file is missing a leading `/php`.

```
php
├── asyncify
│   └── php_8_3.js
└── jspi
    └── php_8_3.js
```

This PR fixes the issue by making it so that the imports have a leading `/php`, which results in the import being:

```js
return await import("./php/jspi/php_8_3.js");
```

## Testing instructions

Build the package:

```shell
npx nx run php-wasm-web:build
```

Then make sure that the paths in `dist/packages/php-wasm/web/index.js` (around line 95) are correct, i.e. `./php/jspi/php_8_3.js`.
