### PR TITLE
Rewrite clone examples to use HTTPS instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The vanilla `git clone` command will take ages. Here's a faster alternative that
 only pull the latest revision of the trunk branch:
 
 ```
-git clone -b trunk --single-branch --depth 1 --recurse-submodules git@github.com:WordPress/wordpress-playground.git
+git clone -b trunk --single-branch --depth 1 --recurse-submodules https://github.com/WordPress/wordpress-playground.git
 ```
 
 ## Running WordPress Playground locally
@@ -92,7 +92,7 @@ git clone -b trunk --single-branch --depth 1 --recurse-submodules git@github.com
 You also can run WordPress Playground locally as follows:
 
 ```bash
-git clone -b trunk --single-branch --depth 1 --recurse-submodules git@github.com:WordPress/wordpress-playground.git
+git clone -b trunk --single-branch --depth 1 --recurse-submodules https://github.com/WordPress/wordpress-playground.git
 cd wordpress-playground
 npm install
 npm run dev

--- a/packages/docs/site/docs/developers/23-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/developers/23-architecture/18-host-your-own-playground.md
@@ -58,7 +58,7 @@ The most flexible and customizable method is to build the site locally.
 Create a shallow clone of the Playground repository, or your own fork.
 
 ```sh
-git clone -b trunk --single-branch --depth 1 --recurse-submodules git@github.com:WordPress/wordpress-playground.git
+git clone -b trunk --single-branch --depth 1 --recurse-submodules https://github.com/WordPress/wordpress-playground.git
 ```
 
 Enter the `wordpress-playground` directory.


### PR DESCRIPTION
Let's use `https` instead of `ssh` in our cloning instructions because some people might not have GitHub `ssh` configured on their machines, while `https` works for everyone. 

A user reported that they [have issues with cloning Playground ](https://github.com/WordPress/wordpress-playground/issues/1961). I'm not sure what the root cause of the issue is, but it prompted me to rewrite the cloning instructions to remove friction from the setup process.

## Testing Instructions (or ideally a Blueprint)

- review readmes
- try using the cloning command 