### PR TITLE
[Data Liberation] Add blueprints-library as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "isomorphic-git"]
     path="isomorphic-git"
     url=https://github.com/adamziel/isomorphic-git.git
-[submodule "wp-html-api"]
-    path="wp-html-api"
-    url=https://github.com/WordPress/wordpress-develop
+[submodule "blueprints-library"]
+    path="packages/playground/data-liberation/blueprints-library"
+    url=https://github.com/WordPress/blueprints-library.git
     


### PR DESCRIPTION
A part of https://github.com/WordPress/wordpress-playground/issues/1894.

Adds https://github.com/WordPress/blueprints-library as a git submodule to the data-liberation package to enable easy code reuse between the projects. I'm not yet sure, but perhaps moving all the PHP libraries to the blueprints-library would make sense? TBD

No testing instructions. This is just a new submodule. No code changes are involved.
