### PR TITLE
[CLI] Set debug constants during boot

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -297,8 +297,8 @@ async function run() {
 
 			const constants: Record<string, string | number | boolean | null> =
 				{
-					WP_DEBUG: args.debug,
-					WP_DEBUG_LOG: args.debug,
+					WP_DEBUG: true,
+					WP_DEBUG_LOG: true,
 					WP_DEBUG_DISPLAY: false,
 				};
 

--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -215,7 +215,6 @@ async function run() {
 					php: args.php as SupportedPHPVersion,
 					wp: args.wp,
 				},
-				login: args.login,
 			};
 		}
 
@@ -296,6 +295,13 @@ async function run() {
 				? readAsFile(preinstalledWpContentPath)
 				: fetchWordPress(wpDetails.url, monitor);
 
+			const constants: Record<string, string | number | boolean | null> =
+				{
+					WP_DEBUG: args.debug,
+					WP_DEBUG_LOG: args.debug,
+					WP_DEBUG_DISPLAY: false,
+				};
+
 			requestHandler = await bootWordPress({
 				siteUrl: absoluteUrl,
 				createPhpRuntime: async () =>
@@ -307,6 +313,7 @@ async function run() {
 					'/internal/shared/ca-bundle.crt':
 						rootCertificates.join('\n'),
 				},
+				constants,
 				phpIniEntries: {
 					'openssl.cafile': '/internal/shared/ca-bundle.crt',
 					allow_url_fopen: '1',


### PR DESCRIPTION
This PR sets the WordPress debug constants during the CLI boot. 

Depending on the `--debug` flag, `WP_DEBUG`, and `WP_DEBUG_LOG` will be set to true or false during boot. 
The `WP_DEBUG_DISPLAY` constant will always be set to `false` to match the [Website behavior. ](https://github.com/WordPress/wordpress-playground/blob/b25c7a4373fde99a58f950cf6effe72a0d92de39/packages/playground/remote/src/lib/worker-thread.ts#L225) 

Disabling `WP_DEBUG_DISPLAY` will also avoid [crashing the CLI during boot if a plugin activation fails](https://github.com/WordPress/wordpress-playground/issues/1979). Long-term https://github.com/WordPress/wordpress-playground/issues/1979 shouldn't crash Playground anymore, but we still want these constant defaults in the CLI.

## Testing Instructions (or ideally a Blueprint)

- Store this blueprint on your machine
```
{
  "steps": [
    {
      "step": "installPlugin",
      "pluginData": {
        "resource": "wordpress.org/plugins",
        "slug": "002-ps-custom-post-type"
      },
      "options": {
        "activate": true
      }
    }
  ]
}
```
- Start the CLI with the blueprint (change the `BLUEPRINT_PATH` to match your path)
```
bun ./packages/playground/cli/src/cli.ts server --debug --blueprint BLUEPRINT_PATH
```
