### PR TITLE
[CLI] Restore the "login" argument handler

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -104,7 +104,7 @@ async function run() {
 		})
 		.option('debug', {
 			describe:
-				'Return PHP error log content if an error occurs while building the site.',
+				'Print PHP error log content if an error occurs during Playground boot.',
 			type: 'boolean',
 			default: false,
 		})

--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -215,6 +215,7 @@ async function run() {
 					php: args.php as SupportedPHPVersion,
 					wp: args.wp,
 				},
+				login: args.login,
 			};
 		}
 


### PR DESCRIPTION
This PR restores support for login in the CLI using a `login` argument. 

The support was previously removed in #1811.

## Testing Instructions (or ideally a Blueprint)

- Run `bun ./packages/playground/cli/src/cli.ts server --login`
- Open Playground and see that you are logged in