### PR TITLE
Ensure that Site Editor templates are associated with the correct taxonomy

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -59,6 +59,25 @@ export const importWxr: StepHandler<ImportWxrStep<File>> = async (
 			return wp_slash($data);
 		});
 
+		// Ensure that Site Editor templates are associated with the correct taxonomy.
+		add_filter( 'wp_import_post_terms', function ( $terms, $post_id ) {
+			foreach ( $terms as $post_term ) {
+				if ( 'wp_theme' !== $term['taxonomy'] ) continue;
+				$post_term = get_term_by('slug', $term['slug'], $term['taxonomy'] );
+				if ( ! $post_term ) {
+					$post_term = wp_insert_term(
+						$term['slug'],
+						$term['taxonomy']
+					);
+					$term_id = $post_term['term_id'];
+				} else {
+					$term_id = $post_term->term_id;
+				}
+				wp_set_object_terms( $post_id, $term_id, $term['taxonomy']) ;
+			}
+			return $terms;
+		}, 10, 2 );
+
 		$result = $importer->import( '/tmp/import.wxr' );
 		`,
 	});


### PR DESCRIPTION
Fixes #1996 

While the bug might be in the WordPress-Importer itself, we can fix it by adding a filter that just ensures that the term will be created. I vote for adding this small intermediate fix even as in #1888 there is the plan to import WXRs differently in future. This is confusing behavior right now and we can fix it