### PR TITLE
[Data Liberation] wp-admin importer page

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -815,7 +815,9 @@ export ASYNCIFY_ONLY=$'"rc_dtor_func",\
 "stream_resource_regular_dtor",\
 "stream_array_from_fd_set",\
 "zend_call_function",\
+"zend_call_method_if_exists",\
 "zend_call_known_function",\
+"php_userstreamop_set_option",\
 "zend_close_rsrc_list",\
 "zend_deactivate",\
 "zend_destroy_rsrc_list",\
@@ -826,6 +828,7 @@ export ASYNCIFY_ONLY=$'"rc_dtor_func",\
 "zend_execute",\
 "zend_execute_scripts",\
 "zend_error",\
+"zend_deprecated_function",\
 "zend_error_va_list",\
 "zend_hash_apply",\
 "zend_hash_graceful_reverse_destroy",\
@@ -842,6 +845,7 @@ export ASYNCIFY_ONLY=$'"rc_dtor_func",\
 "zif_call_user_func",\
 "zif_json_encode",\
 "zif_call_user_func_array",\
+"zend_user_it_get_current_data",\
 "zif_fclose",\
 "zif_feof",\
 "zif_file_get_contents",\

--- a/packages/playground/data-liberation/import-screen.js
+++ b/packages/playground/data-liberation/import-screen.js
@@ -1,0 +1,14 @@
+import { store, getContext } from '@wordpress/interactivity';
+const { state } = store('dataLiberation', {
+	state: {
+		selectedImportType: 'wxr_file',
+		get isImportTypeSelected() {
+			return getContext().importType === state.selectedImportType;
+		},
+	},
+	actions: {
+		setImportType: () => {
+			state.selectedImportType = getContext().importType;
+		},
+	},
+});

--- a/packages/playground/data-liberation/plugin.php
+++ b/packages/playground/data-liberation/plugin.php
@@ -25,57 +25,412 @@ add_filter('wp_kses_uri_attributes', function() {
     return [];
 });
 
-// echo '<plaintext>';
-// var_dump(glob('/wordpress/wp-content/uploads/*'));
-// var_dump(glob('/wordpress/wp-content/plugins/data-liberation/../../docs/site/static/img/*'));
-// die("X");
-add_action('init', function() {
-    // echo '<plaintext>';
-    // $wxr_path = __DIR__ . '/tests/fixtures/wxr-simple.xml';
-    // $wxr_path = __DIR__ . '/tests/wxr/woocommerce-demo-products.xml';
-    $wxr_path = __DIR__ . '/tests/wxr/a11y-unit-test-data.xml';
-    $hash = md5($wxr_path);
-    if(file_exists('./.imported-' . $hash)) {
+// Register admin menu
+add_action('admin_menu', function() {
+    add_menu_page(
+        'Data Liberation',
+        'Data Liberation',
+        'manage_options',
+        'data-liberation',
+        'data_liberation_admin_page',
+        'dashicons-database-import'
+    );
+});
+
+add_action('admin_enqueue_scripts', 'enqueue_data_liberation_scripts');
+
+function enqueue_data_liberation_scripts() {
+    wp_register_script_module(
+        '@data-liberation/import-screen',
+        plugin_dir_url( __FILE__ ) . 'import-screen.js',
+        array( '@wordpress/interactivity' )
+    );
+    wp_enqueue_script_module(
+        '@data-liberation/import-screen',
+        plugin_dir_url( __FILE__ ) . 'import-screen.js',
+        array( '@wordpress/interactivity' )
+    );
+}
+function data_liberation_add_minute_schedule( $schedules ) {
+    // add a 'weekly' schedule to the existing set
+    $schedules['data_liberation_minute'] = array(
+        'interval' => 60,
+        'display' => __('Once a Minute')
+    );
+    return $schedules;
+}
+add_filter( 'cron_schedules', 'data_liberation_add_minute_schedule' );
+
+// Render admin page
+function data_liberation_admin_page() {
+
+    // Populates the initial global state values.
+    wp_interactivity_state( 'dataLiberation', array(
+        'selectedImportType' => 'wxr_file',
+        'isImportTypeSelected' => function() {
+            // @TODO Figure out why this function is not hiding the form rows
+            $state   = wp_interactivity_state();
+            $context = wp_interactivity_get_context();
+            return $context['importType'] === $state['selectedImportType'];
+        },
+    ));
+    ?>
+    <div class="wrap">
+        <h1>Data Liberation</h1>
+    <?php
+
+    $current_import = get_option('data_liberation_active_import');
+    if(isset($_GET['run-step']) && $current_import) {
+        echo '<h2>Next import step stdout output:</h2>';
+        echo '<pre>';
+        data_liberation_process_import();
+        echo '</pre>';
+    }
+    
+    ?>
+        <h2>Active import</h2>
+        <?php
+        // Show import status if one is active
+        $active_import = get_option('data_liberation_active_import');
+        if ($active_import) {
+            $progress = get_option('data_liberation_import_progress');
+            ?>
+            <div class="notice notice-info">
+                <p>
+                    <pre><?php echo json_encode($active_import, JSON_PRETTY_PRINT); ?></pre>
+                    <strong>$progress array:</strong>
+                    <pre><?php echo json_encode($progress, JSON_PRETTY_PRINT); ?></pre>
+                    <br/>
+                    <a href="<?php echo esc_url(add_query_arg('run-step', 'true', admin_url('admin.php?page=data-liberation'))); ?>">
+                        Process the next import chunk
+                    </a>
+                </p>
+                <h4>Decisions required</h4>
+                <ul>
+                    <li>
+                        Image waterfall.png could not be download after 3 attempts.
+                        <a href="#">Retry download</a>
+                        <a href="#">Upload manually</a>
+                        <a href="#">Fetch from another URL</a>
+                        <a href="#">Delete attachment and remove its references from the imported posts</a>
+                    </li>
+                </ul>
+                <h4>Progress details</h4>
+                <p>
+                    TODO: Provide actual progress details.
+                </p>
+                <table>
+                    <tr>
+                        <th scope="row">Images downloaded</th>
+                        <td>0 / 48 </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Posts imported</th>
+                        <td>0 / 48 </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">Current status</th>
+                        <td>Preparing import...</td>
+                    </tr>
+                </table>
+            </div>
+            <?php
+        } else {
+            echo '<p>No import is currently in progress.</p>';
+        }
+        ?>
+
+        <form
+            method="post"
+            enctype="multipart/form-data"
+            action="<?php echo esc_url(admin_url('admin-post.php')); ?>"
+            data-wp-interactive="dataLiberation"
+        >
+            <?php wp_nonce_field('data_liberation_import'); ?>
+            <input type="hidden" name="action" value="data_liberation_import">
+            
+            <h2>Import Content</h2>
+            
+            <table class="form-table">
+                <tr>
+                    <th scope="row">Import Type</th>
+                    <td>
+                        <label data-wp-context='{ "importType": "wxr_file" }'>
+                            <input type="radio" name="import_type" value="wxr_file" checked
+                                data-wp-bind--checked="state.isImportTypeSelected"
+                                data-wp-on--change="actions.setImportType">
+                            Upload WXR File
+                        </label><br>
+                        <label data-wp-context='{ "importType": "wxr_url" }'>
+                            <input type="radio" name="import_type" value="wxr_url"
+                                data-wp-bind--checked="state.isImportTypeSelected"
+                                data-wp-on--change="actions.setImportType">
+                            WXR File URL
+                        </label><br>
+                        <label data-wp-context='{ "importType": "markdown_zip" }'>
+                            <input type="radio" name="import_type" value="markdown_zip"
+                                data-wp-bind--checked="state.isImportTypeSelected"
+                                data-wp-on--change="actions.setImportType">
+                            Markdown ZIP Archive
+                        </label>
+                    </td>
+                </tr>
+                
+                <tr data-wp-context='{ "importType": "wxr_file" }'
+                    data-wp-class--hidden="!state.isImportTypeSelected">
+                    <th scope="row">WXR File</th>
+                    <td>
+                        <input type="file" name="wxr_file" accept=".xml">
+                        <p class="description">Upload a WordPress eXtended RSS (WXR) file</p>
+                    </td>
+                </tr>
+                
+                <tr data-wp-context='{ "importType": "wxr_url" }'
+                data-wp-class--hidden="!state.isImportTypeSelected">
+                    <th scope="row">WXR URL</th>
+                    <td>
+                        <input type="url" name="wxr_url" class="regular-text">
+                        <p class="description">Enter the URL of a WXR file</p>
+                    </td>
+                </tr>
+                
+                <tr data-wp-context='{ "importType": "markdown_zip" }'
+                    data-wp-class--hidden="!state.isImportTypeSelected">
+                    <th scope="row">Markdown ZIP</th>
+                    <td>
+                        <input type="file" name="markdown_zip" accept=".zip">
+                        <p class="description">Upload a ZIP file containing markdown files</p>
+                    </td>
+                </tr>
+            </table>
+
+            <?php submit_button('Start Import'); ?>
+        </form>
+
+        <h2>Previous Imports</h2>
+
+        <p>TODO: Show a table of previous imports.</p>
+            
+        <table class="form-table">
+            <tr>
+                <th scope="row">Date</th>
+                <th scope="row">Data source</th>
+                <th scope="row">Time taken</th>
+                <th scope="row">Entities imported</th>
+                <th scope="row">Result</th>
+            </tr>
+            <tr>
+                <td>2024-01-01</td>
+                <td>WXR file</td>
+                <td>10 minutes</td>
+                <td>1000</td>
+                <td>Success</td>
+            </tr>
+        </table>
+    </div>
+    <?php
+}
+
+// Handle form submission
+add_action('admin_post_data_liberation_import', function() {
+    if (!current_user_can('manage_options')) {
+        wp_die('Unauthorized');
+    }
+
+    // @TODO: check nonce
+    // check_admin_nonce('data_liberation_import');
+    $import_type = $_POST['import_type'];
+    $attachment_id = null;
+    $file_name = '';
+
+    switch ($import_type) {
+        case 'wxr_file':
+            if (empty($_FILES['wxr_file']['tmp_name'])) {
+                wp_die('Please select a file to upload');
+            }
+            if (!in_array($_FILES['wxr_file']['type'], ['text/xml', 'application/xml'])) {
+                wp_die('Invalid file type');
+            }
+            /**
+             * @TODO: Reconsider storing the file in the media library where everyone
+             *        can access it via a public URL.
+             */
+            $attachment_id = media_handle_upload(
+                'wxr_file',
+                0,
+                array(),
+                array(
+                    'mimes' => array(
+                        'xml' => 'text/xml',
+                        'xml-application' => 'application/xml',
+                    ),
+                    // test_form checks:
+                    // Whether to test that the $_POST['action'] parameter is as expected.
+                    // It seems useless here and it causes cryptic error "Invalid form submission".
+                    // Let's just disable it.
+                    'test_form' => false,
+
+                    // @TODO: Find a way to make this type check work.
+                    'test_type' => false,
+                )
+            );
+            if (is_wp_error($attachment_id)) {
+                wp_die($attachment_id->get_error_message());
+            }
+            $file_name = $_FILES['wxr_file']['name'];
+            break;
+
+        case 'wxr_url':
+            if (empty($_POST['wxr_url']) || !filter_var($_POST['wxr_url'], FILTER_VALIDATE_URL)) {
+                wp_die('Please enter a valid URL');
+            }
+            // Don't download the file, it could be 300GB or so. The
+            // import callback will stream it as needed.
+            break;
+
+        case 'markdown_zip':
+            if (empty($_FILES['markdown_zip']['tmp_name'])) {
+                wp_die('Please select a file to upload');
+            }
+            if ($_FILES['markdown_zip']['type'] !== 'application/zip') {
+                wp_die('Invalid file type');
+            }
+            $attachment_id = media_handle_upload('markdown_zip', 0);
+            if (is_wp_error($attachment_id)) {
+                wp_die($attachment_id->get_error_message());
+            }
+            $file_name = $_FILES['markdown_zip']['name'];
+            break;
+
+        default:
+            wp_die('Invalid import type');
+    }
+
+    // Store import info
+    // @TODO: consider storing a history of imports instead of just the current one
+    update_option('data_liberation_active_import', array(
+        'type' => $import_type,
+        'wxr_url' => $_POST['wxr_url'] ?? null,
+        'attachment_id' => $attachment_id,
+        'file_name' => $file_name,
+        'started_at' => current_time('mysql')
+    ));
+
+    update_option('data_liberation_import_progress', array(
+        'status' => 'Preparing import...',
+        'current' => 0,
+        'total' => 0
+    ));
+
+    // Schedule the next import step every minute, so 30 seconds more than the
+    // default PHP max_execution_time.
+    /**
+     * @TODO: The schedule doesn't seem to be actually running.
+     */
+    // if(is_wp_error(wp_schedule_event(time(), 'data_liberation_minute', 'data_liberation_process_import'))) {
+    //     wp_delete_attachment($attachment_id, true);
+    //     // @TODO: More user friendly error message – maybe redirect back to the import screen and 
+    //     //        show the error there.
+    //     wp_die('Failed to schedule import – the "data_liberation_minute" schedule may not be registered.');
+    // }
+
+    wp_redirect(add_query_arg(
+        'message', 'import-scheduled',
+        admin_url('admin.php?page=data-liberation')
+    ));
+    exit;
+});
+
+// Process import in the background
+function data_liberation_process_import() {
+    $import = get_option('data_liberation_active_import');
+    if (!$import) {
         return;
     }
-    touch('./.imported-' . $hash);
+    return data_liberation_import_step($import);
+}
+add_action('data_liberation_process_import', 'data_liberation_process_import');
 
-    $all_posts = get_posts(array('numberposts' => -1, 'post_type' => 'any', 'post_status' => 'any'));
-    foreach ($all_posts as $post) {
-        wp_delete_post($post->ID, true);
-    }
+function data_liberation_import_step($import) {
+    $importer = data_liberation_create_importer($import);
+    // @TODO: Save the last importer state so we can resume it later if interrupted.
+    update_option('data_liberation_import_progress', [
+        'status' => 'Downloading static assets...',
+        'current' => 0,
+        'total' => 0
+    ]);
+    $importer->frontload_assets();
+    // @TODO: Keep track of multiple progress dimensions – posts, assets, categories, etc.
+    update_option('data_liberation_import_progress', [
+        'status' => 'Importing posts...',
+        'current' => 0,
+        'total' => 0
+    ]);
+    $importer->import_entities();
+    delete_option('data_liberation_active_import');
+    // @TODO: Do not echo things. Append to an import log where we can retrace the steps.
+    //        Also, store specific import events in the database so the user can react and
+    //        make decisions.
+    echo '<br/>Import finished. TODO: Summary: Time taken, number of entities imported, etc. Also, preserve something tabular for the user to review the historical results.';
+}
 
-    $mode = 'wxr';
-    // $mode = 'markdown';
+function data_liberation_create_importer($import) {
+    switch($import['type']) {
+        case 'wxr_file':
+            $wxr_path = get_attached_file($import['attachment_id']);
+            if(false === $wxr_path) {
+                // @TODO: Save the error, report it to the user.
+                return;
+            }
+            $entity_iterator_factory = function() use ($wxr_path) {
+                $wxr = new WP_WXR_Reader();
+                $wxr->connect_upstream(new WP_File_Reader($wxr_path));
 
-    if('markdown' === $mode) {
-        $docs_root = __DIR__ . '/../../docs/site';
-        $docs_content_root = $docs_root . '/docs';
-        $entity_iterator_factory = function() use ($docs_content_root) {
-            return new WP_Markdown_Directory_Tree_Reader(
-                $docs_content_root,
-                1000
+                return $wxr;
+            };
+            return WP_Stream_Importer::create(
+                $entity_iterator_factory
             );
-        };
-        $markdown_importer = WP_Markdown_Importer::create(
-            $entity_iterator_factory, [
-                'source_site_url' => 'file://' . $docs_content_root,
-                'local_markdown_assets_root' => $docs_root,
-                'local_markdown_assets_url_prefix' => '@site/',
-            ]
-        );
-        $markdown_importer->frontload_assets();
-        $markdown_importer->import_posts();
-    } else {
-        $entity_iterator_factory = function() use ($wxr_path) {
-            $wxr = new WP_WXR_Reader();
-            $wxr->connect_upstream(new WP_File_Reader($wxr_path));
-            return $wxr;
-        };
-        $wxr_importer = WP_Stream_Importer::create(
-            $entity_iterator_factory
-        );
-        $wxr_importer->frontload_assets();
-        $wxr_importer->import_posts();
+
+        case 'wxr_url':
+            $wxr_url = $import['wxr_url'];
+            $entity_iterator_factory = function() use ($wxr_url) {
+                $wxr = new WP_WXR_Reader();
+                $wxr->connect_upstream(new WP_Remote_File_Reader($wxr_url));
+                return $wxr;
+            };
+            return WP_Stream_Importer::create(
+                $entity_iterator_factory
+            );
+
+        case 'markdown_zip':
+            // @TODO: Don't unzip. Stream data directly from the ZIP file.
+            $zip_path = get_attached_file($import['attachment_id']);
+            $temp_dir = sys_get_temp_dir() . '/data-liberation-markdown-' . $import['attachment_id'];
+            if (!file_exists($temp_dir)) {
+                mkdir($temp_dir, 0777, true);
+                $zip = new ZipArchive();
+                if ($zip->open($zip_path) === TRUE) {
+                    $zip->extractTo($temp_dir);
+                    $zip->close();
+                } else {
+                    // @TODO: Save the error, report it to the user
+                    return;
+                }
+            }
+            $markdown_root = $temp_dir;
+            $entity_iterator_factory = function() use ($markdown_root) {
+                return new WP_Markdown_Directory_Tree_Reader(
+                    $markdown_root,
+                    1000
+                );
+            };
+            return WP_Markdown_Importer::create(
+                $entity_iterator_factory, [
+                    'source_site_url' => 'file://' . $markdown_root,
+                    'local_markdown_assets_root' => $markdown_root,
+                    'local_markdown_assets_url_prefix' => '@site/',
+                ]
+            );
     }
-});
+}

--- a/packages/playground/data-liberation/src/import/WP_Stream_Importer.php
+++ b/packages/playground/data-liberation/src/import/WP_Stream_Importer.php
@@ -84,7 +84,7 @@ class WP_Stream_Importer {
 	 * Downloads all the assets referenced in the imported entities.
 	 *
 	 * This method is idempotent, re-entrant, and should be called
-	 * before import_posts() so that every inserted post already has
+	 * before import_entities() so that every inserted post already has
 	 * all its attachments downloaded.
 	 */
 	public function frontload_assets() {
@@ -136,7 +136,7 @@ class WP_Stream_Importer {
 	 *        large datasets, but maybe it could be a choice for
 	 *        the API consumer?
 	 */
-	public function import_posts() {
+	public function import_entities() {
 		$importer = new WP_Entity_Importer();
 		$factory  = $this->entity_iterator_factory;
 		$entities = $factory();

--- a/packages/playground/data-liberation/src/wxr/WP_WXR_Reader.php
+++ b/packages/playground/data-liberation/src/wxr/WP_WXR_Reader.php
@@ -866,6 +866,9 @@ class WP_WXR_Reader implements Iterator {
 	}
 
 	public function current(): object {
+		if ( null === $this->entity_data && ! $this->is_finished() && ! $this->get_last_error() ) {
+			$this->next();
+		}
 		return $this->get_entity();
 	}
 

--- a/packages/playground/data-liberation/tests/import/blueprint-import.json
+++ b/packages/playground/data-liberation/tests/import/blueprint-import.json
@@ -4,6 +4,7 @@
 		"WP_DEBUG": true,
 		"WP_DEBUG_LOG": true
 	},
+	"login": true,
 	"steps": [
 		{
 			"step": "activatePlugin",


### PR DESCRIPTION
## Motivation for the change, related issues

A rough mockup of a wp-admin page for data liberation imports:

![CleanShot 2024-11-18 at 19 23 52@2x](https://github.com/user-attachments/assets/0b0990cb-d4f8-476b-8df4-78475816b5fc)

It actually allows you to import a WXR file, but almost nothing else works. This PR is only meant to provide a starting point to expand.

## Testing Instructions (or ideally a Blueprint)

* Run Playground with the data-liberation plugin installed:

```bash
cd packages/playground/data-liberation/tests/import
bash run.sh
```

* Go to http://127.0.0.1:9400/wp-admin/admin.php?page=data-liberation
* Confirm you can see the screen from the picture above

cc @brandonpayton @zaerl