### PR TITLE
Allow Authorization header pass-through with X-Cors-Proxy-Allowed-Request-Headers

### DIFF
--- a/packages/playground/php-cors-proxy/README.md
+++ b/packages/playground/php-cors-proxy/README.md
@@ -25,6 +25,7 @@ Request http://127.0.0.1:5263/proxy.php/https://w.org/?test=1 to get the respons
 
 -   Stream data both ways, don't buffer.
 -   Don't pass auth headers in either direction.
+    - Opt-in for request headers possible using `X-Cors-Proxy-Allowed-Request-Headers`.
 -   Refuse to request private IPs.
 -   Refuse to process non-GET non-POST non-OPTIONS requests.
 -   Refuse to process POST request body larger than, say, 100KB.

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -301,6 +301,36 @@ class IpUtils
 
 
 function filter_headers_strings($php_headers, $remove_headers) {
+    // Default allowed headers to be extended by X-Cors-Proxy-Allowed-Request-Headers
+    $allowed_headers = [
+        'accept',
+        'accept-language',
+        'content-language',
+        'content-type',
+        'dnt',
+        'origin',
+        'range',
+        'user-agent'
+    ];
+    $allowed_request_headers_header = strtolower('X-Cors-Proxy-Allowed-Request-Headers');
+
+    // Add any additional allowed headers from X-Cors-Proxy-Allowed-Request-Headers
+    if (isset($php_headers[$allowed_request_headers_header])) {
+        $allowed_request_headers = $php_headers[$allowed_request_headers_header];
+
+        $additional_headers = array_map(
+            'trim',
+            explode(',', $allowed_request_headers)
+        );
+        $allowed_headers = array_merge($allowed_headers, $additional_headers);
+    }
+
+    // Only keep headers that are in the allowed list
+    $php_headers = array_filter($php_headers, function($header) use ($allowed_headers) {
+        $header_name = strtolower(explode(':', $header)[0]);
+        return in_array($header_name, $allowed_headers);
+    });
+
     $remove_headers = array_map('strtolower', $remove_headers);
     $headers = [];
     foreach ($php_headers as $header) {

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -299,11 +299,29 @@ class IpUtils
 
 }
 
-
-function filter_headers_by_name($php_headers, $headers_requiring_opt_in, $disallowed_headers) {
+/**
+ * Filters headers by name, removing disallowed headers and enforcing opt-in requirements.
+ * 
+ * @param array $php_headers {
+ *  An associative array of headers.
+ *  @type string $key Header name.
+ * }
+ * @param array $disallowed_headers       List of header names that are disallowed.
+ * @param array $headers_requiring_opt_in List of header names that require opt-in
+ *                                        via the X-Cors-Proxy-Allowed-Request-Headers header.
+ * 
+ * @return array {
+ *  Filtered headers.
+ *  @type string $key Header name.
+ */
+function filter_headers_by_name(
+    $php_headers,
+    $disallowed_headers,
+    $headers_requiring_opt_in = [],
+) {
     $lowercased_php_headers = array_change_key_case($php_headers, CASE_LOWER);
-    $headers_requiring_opt_in = array_map('strtolower', $headers_requiring_opt_in);
     $disallowed_headers = array_map('strtolower', $disallowed_headers);
+    $headers_requiring_opt_in = array_map('strtolower', $headers_requiring_opt_in);
 
     // Get explicitly allowed headers from X-Cors-Proxy-Allowed-Request-Headers
     $headers_opt_in_str =

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -300,7 +300,7 @@ class IpUtils
 }
 
 
-function filter_headers_strings($php_headers, $headers_requiring_opt_in, $disallowed_headers) {
+function filter_headers_by_name($php_headers, $headers_requiring_opt_in, $disallowed_headers) {
     $lowercased_php_headers = array_change_key_case($php_headers, CASE_LOWER);
     $headers_requiring_opt_in = array_map('strtolower', $headers_requiring_opt_in);
     $disallowed_headers = array_map('strtolower', $disallowed_headers);

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -300,38 +300,41 @@ class IpUtils
 }
 
 
-function filter_headers_strings($php_headers, $allowed_headers, $remove_headers) {
-    $allowed_headers = $allowed_headers ?? [];
+function filter_headers_strings($php_headers, $headers_requiring_opt_in, $remove_headers) {
+    $headers_requiring_opt_in = $headers_requiring_opt_in ?? [];
     $remove_headers = $remove_headers ?? [];
 
     $allowed_request_headers_header = strtolower('X-Cors-Proxy-Allowed-Request-Headers');
 
-    // Add any additional allowed headers from X-Cors-Proxy-Allowed-Request-Headers
-    if (isset($php_headers[$allowed_request_headers_header])) {
-        $allowed_request_headers = $php_headers[$allowed_request_headers_header];
+    $lowercased_php_headers = array_change_key_case($php_headers, CASE_LOWER);
 
-        $additional_headers = array_map(
+    // Get explicitly allowed headers from X-Cors-Proxy-Allowed-Request-Headers
+    $explicitly_allowed_headers = [];
+    if (isset($lowercased_php_headers[$allowed_request_headers_header])) {
+        $explicitly_allowed_headers = array_map(
             'trim',
-            explode(',', $allowed_request_headers)
+            explode(',', $lowercased_php_headers[$allowed_request_headers_header])
         );
-        $allowed_headers = array_merge($allowed_headers, $additional_headers);
     }
+    $explicitly_allowed_headers = array_map('strtolower', $explicitly_allowed_headers);
 
-    $allowed_headers = array_map('strtolower', $allowed_headers);
-
-    // Only keep headers that are in the allowed list
-    $php_headers = array_filter($php_headers, function($header) use ($allowed_headers) {
-        $header_name = strtolower(explode(':', $header)[0]);
-        return in_array($header_name, $allowed_headers);
-    });
-
+    $headers_requiring_opt_in = array_map('strtolower', $headers_requiring_opt_in);
     $remove_headers = array_map('strtolower', $remove_headers);
 
-    // Remove strictly disallowed headers
+    // Filter headers
     return array_filter(
         $php_headers,
-        function($key) use ($remove_headers) {
-            return !in_array(strtolower($key), $remove_headers);
+        function ($key) use ($headers_requiring_opt_in, $remove_headers, $explicitly_allowed_headers) {
+            $lower_key = strtolower($key);
+            // Remove if in remove_headers list
+            if (in_array($lower_key, $remove_headers)) {
+                return false;
+            }
+            // Remove if requires opt-in but not explicitly allowed
+            if (in_array($lower_key, $headers_requiring_opt_in) && !in_array($lower_key, $explicitly_allowed_headers)) {
+                return false;
+            }
+            return true;
         },
         ARRAY_FILTER_USE_KEY
     );

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -300,18 +300,7 @@ class IpUtils
 }
 
 
-function filter_headers_strings($php_headers, $remove_headers) {
-    // Default allowed headers to be extended by X-Cors-Proxy-Allowed-Request-Headers
-    $allowed_headers = [
-        'accept',
-        'accept-language',
-        'content-language',
-        'content-type',
-        'dnt',
-        'origin',
-        'range',
-        'user-agent'
-    ];
+function filter_headers_strings($php_headers, $allowed_headers, $remove_headers) {
     $allowed_request_headers_header = strtolower('X-Cors-Proxy-Allowed-Request-Headers');
 
     // Add any additional allowed headers from X-Cors-Proxy-Allowed-Request-Headers
@@ -324,6 +313,8 @@ function filter_headers_strings($php_headers, $remove_headers) {
         );
         $allowed_headers = array_merge($allowed_headers, $additional_headers);
     }
+
+    $allowed_headers = array_map('strtolower', $allowed_headers);
 
     // Only keep headers that are in the allowed list
     $php_headers = array_filter($php_headers, function($header) use ($allowed_headers) {

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -301,6 +301,9 @@ class IpUtils
 
 
 function filter_headers_strings($php_headers, $allowed_headers, $remove_headers) {
+    $allowed_headers = $allowed_headers ?? [];
+    $remove_headers = $remove_headers ?? [];
+
     $allowed_request_headers_header = strtolower('X-Cors-Proxy-Allowed-Request-Headers');
 
     // Add any additional allowed headers from X-Cors-Proxy-Allowed-Request-Headers
@@ -323,17 +326,15 @@ function filter_headers_strings($php_headers, $allowed_headers, $remove_headers)
     });
 
     $remove_headers = array_map('strtolower', $remove_headers);
-    $headers = [];
-    foreach ($php_headers as $header) {
-        $lower_header = strtolower($header);
-        foreach($remove_headers as $remove_header) {
-            if (strpos($lower_header, $remove_header) === 0) {
-                continue 2;
-            }
-        }
-        $headers[] = $header;
-    }
-    return $headers;
+
+    // Remove strictly disallowed headers
+    return array_filter(
+        $php_headers,
+        function($key) use ($remove_headers) {
+            return !in_array(strtolower($key), $remove_headers);
+        },
+        ARRAY_FILTER_USE_KEY
+    );
 }
 
 function kv_headers_to_curl_format($headers) {

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -101,7 +101,7 @@ curl_setopt($ch, CURLOPT_RESOLVE, [
     "$host:443:$resolvedIp"
 ]);
 
-// Pass all incoming headers except cookies and host
+// Explicitly remove 'Cookie' and 'Host' headers even if they are present in X-Cors-Proxy-Allowed-Request-Headers
 $curlHeaders = filter_headers_strings(
     kv_headers_to_curl_format(getallheaders()),
     [

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -101,13 +101,12 @@ curl_setopt($ch, CURLOPT_RESOLVE, [
     "$host:443:$resolvedIp"
 ]);
 
-// Pass all incoming headers except cookies and authorization
+// Pass all incoming headers except cookies and host
 $curlHeaders = filter_headers_strings(
     kv_headers_to_curl_format(getallheaders()),
     [
         'Cookie',
-        'Authorization',
-        'Host',
+        'Host'
     ]
 );
 curl_setopt(

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -101,13 +101,24 @@ curl_setopt($ch, CURLOPT_RESOLVE, [
     "$host:443:$resolvedIp"
 ]);
 
-// Explicitly remove 'Cookie' and 'Host' headers even if they are present in X-Cors-Proxy-Allowed-Request-Headers
+$default_allowed_headers = [
+    'Accept',
+    'Accept-Language',
+    'Content-Language',
+    'Content-Type',
+    'DNT',
+    'Origin',
+    'Range',
+    'User-Agent'
+];
+$strictly_disallowed_headers = [
+    'Cookie',
+    'Host'
+];
 $curlHeaders = filter_headers_strings(
     kv_headers_to_curl_format(getallheaders()),
-    [
-        'Cookie',
-        'Host'
-    ]
+    $default_allowed_headers,
+    $strictly_disallowed_headers
 );
 curl_setopt(
     $ch,

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -186,6 +186,11 @@ curl_setopt(
             stripos($header, 'HTTP/') !== 0 &&
             stripos($header, 'Set-Cookie:') !== 0 &&
             stripos($header, 'Authorization:') !== 0 &&
+            // The proxy server does not support relaying auth challenges.
+            // Specifically, we want to avoid browsers prompting for basic auth
+            // credentials which they will send to the proxy server for the
+            // remainder of the session.
+            stripos($header, 'WWW-Authenticate:') !== 0 &&
             stripos($header, 'Cache-Control:') !== 0 &&
             // The browser won't accept multiple values for these headers.
             stripos($header, 'Access-Control-Allow-Origin:') !== 0 &&

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -101,15 +101,9 @@ curl_setopt($ch, CURLOPT_RESOLVE, [
     "$host:443:$resolvedIp"
 ]);
 
-$default_allowed_headers = [
-    'Accept',
-    'Accept-Language',
-    'Content-Language',
-    'Content-Type',
-    'DNT',
-    'Origin',
-    'Range',
-    'User-Agent'
+// Pass all incoming headers except cookies and authorization
+$headers_requiring_opt_in = [
+    'Authorization'
 ];
 $strictly_disallowed_headers = [
     'Cookie',
@@ -118,7 +112,7 @@ $strictly_disallowed_headers = [
 $curlHeaders = kv_headers_to_curl_format(
     filter_headers_strings(
         getallheaders(),
-        $default_allowed_headers,
+        $headers_requiring_opt_in,
         $strictly_disallowed_headers
     )
 );

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -110,7 +110,7 @@ $strictly_disallowed_headers = [
     'Host'
 ];
 $curlHeaders = kv_headers_to_curl_format(
-    filter_headers_strings(
+    filter_headers_by_name(
         getallheaders(),
         $headers_requiring_opt_in,
         $strictly_disallowed_headers

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -115,10 +115,12 @@ $strictly_disallowed_headers = [
     'Cookie',
     'Host'
 ];
-$curlHeaders = filter_headers_strings(
-    kv_headers_to_curl_format(getallheaders()),
-    $default_allowed_headers,
-    $strictly_disallowed_headers
+$curlHeaders = kv_headers_to_curl_format(
+    filter_headers_strings(
+        getallheaders(),
+        $default_allowed_headers,
+        $strictly_disallowed_headers
+    )
 );
 curl_setopt(
     $ch,

--- a/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
+++ b/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
@@ -147,4 +147,58 @@ class ProxyFunctionsTests extends TestCase
             'http://cors.playground.wordpress.net/cors-proxy.php?http://cors.playground.wordpress.net'
         );
     }
+
+    public function testFilterHeadersStrings()
+    {
+        $original_headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'Cookie' => 'test=1',
+            'Host' => 'example.com',
+        ];
+
+        $headers_requiring_opt_in = [
+            'Authorization',
+        ];
+
+        $strictly_disallowed_headers = [
+            'Cookie',
+            'Host',
+        ];
+
+        $this->assertEquals([
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+        ], filter_headers_strings($original_headers, $headers_requiring_opt_in, $strictly_disallowed_headers));
+    }
+
+    public function testFilterHeaderStringsWithAdditionalAllowedHeaders()
+    {
+        $original_headers = [
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'Cookie' => 'test=1',
+            'Host' => 'example.com',
+            'Authorization' => 'Bearer 1234567890',
+            'X-Authorization' => 'Bearer 1234567890',
+            'X-Cors-Proxy-Allowed-Request-Headers' => 'Authorization',
+        ];
+
+        $headers_requiring_opt_in = [
+            'Authorization',
+        ];
+
+        $strictly_disallowed_headers = [
+            'Cookie',
+            'Host',
+        ];
+
+        $this->assertEquals([
+            'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer 1234567890',
+            'X-Authorization' => 'Bearer 1234567890',
+            'X-Cors-Proxy-Allowed-Request-Headers' => 'Authorization',
+        ], filter_headers_strings($original_headers, $headers_requiring_opt_in, $strictly_disallowed_headers));
+    }
 }

--- a/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
+++ b/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
@@ -175,7 +175,8 @@ class ProxyFunctionsTests extends TestCase
                 $original_headers,
                 $strictly_disallowed_headers,
                 $headers_requiring_opt_in,
-            ));
+            )
+        );
     }
 
     public function testFilterHeaderStringsWithAdditionalAllowedHeaders()
@@ -211,6 +212,7 @@ class ProxyFunctionsTests extends TestCase
                 $original_headers,
                 $strictly_disallowed_headers,
                 $headers_requiring_opt_in,
-            ));
+            )
+        );
     }
 }

--- a/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
+++ b/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
@@ -169,7 +169,7 @@ class ProxyFunctionsTests extends TestCase
         $this->assertEquals([
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
-        ], filter_headers_strings($original_headers, $headers_requiring_opt_in, $strictly_disallowed_headers));
+        ], filter_headers_by_name($original_headers, $headers_requiring_opt_in, $strictly_disallowed_headers));
     }
 
     public function testFilterHeaderStringsWithAdditionalAllowedHeaders()
@@ -199,6 +199,6 @@ class ProxyFunctionsTests extends TestCase
             'Authorization' => 'Bearer 1234567890',
             'X-Authorization' => 'Bearer 1234567890',
             'X-Cors-Proxy-Allowed-Request-Headers' => 'Authorization',
-        ], filter_headers_strings($original_headers, $headers_requiring_opt_in, $strictly_disallowed_headers));
+        ], filter_headers_by_name($original_headers, $headers_requiring_opt_in, $strictly_disallowed_headers));
     }
 }

--- a/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
+++ b/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
@@ -157,19 +157,25 @@ class ProxyFunctionsTests extends TestCase
             'Host' => 'example.com',
         ];
 
-        $headers_requiring_opt_in = [
-            'Authorization',
-        ];
-
         $strictly_disallowed_headers = [
             'Cookie',
             'Host',
         ];
 
-        $this->assertEquals([
-            'Accept' => 'application/json',
-            'Content-Type' => 'application/json',
-        ], filter_headers_by_name($original_headers, $headers_requiring_opt_in, $strictly_disallowed_headers));
+        $headers_requiring_opt_in = [
+            'Authorization',
+        ];
+
+        $this->assertEquals(
+            [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+            ],
+            filter_headers_by_name(
+                $original_headers,
+                $strictly_disallowed_headers,
+                $headers_requiring_opt_in,
+            ));
     }
 
     public function testFilterHeaderStringsWithAdditionalAllowedHeaders()
@@ -184,21 +190,27 @@ class ProxyFunctionsTests extends TestCase
             'X-Cors-Proxy-Allowed-Request-Headers' => 'Authorization',
         ];
 
-        $headers_requiring_opt_in = [
-            'Authorization',
-        ];
-
         $strictly_disallowed_headers = [
             'Cookie',
             'Host',
         ];
 
-        $this->assertEquals([
-            'Accept' => 'application/json',
-            'Content-Type' => 'application/json',
-            'Authorization' => 'Bearer 1234567890',
-            'X-Authorization' => 'Bearer 1234567890',
-            'X-Cors-Proxy-Allowed-Request-Headers' => 'Authorization',
-        ], filter_headers_by_name($original_headers, $headers_requiring_opt_in, $strictly_disallowed_headers));
+        $headers_requiring_opt_in = [
+            'Authorization',
+        ];
+
+        $this->assertEquals(
+            [
+                'Accept' => 'application/json',
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer 1234567890',
+                'X-Authorization' => 'Bearer 1234567890',
+                'X-Cors-Proxy-Allowed-Request-Headers' => 'Authorization',
+            ],
+            filter_headers_by_name(
+                $original_headers,
+                $strictly_disallowed_headers,
+                $headers_requiring_opt_in,
+            ));
     }
 }


### PR DESCRIPTION
## Motivation for the change, related issues

This change comes out of our need to make authenticated external API requests from the WordPress backend in [Remote Data Blocks](https://github.com/Automattic/remote-data-blocks).

Prior to this pull request, the CORS proxy would always strip out the `Cookie`, `Authorization`, and `Host` request headers for security / privacy reasons. However, that makes it impossible to authenticate WordPress backend requests through the proxy to APIs that require `Authorization` headers.

This change adds a `X-Cors-Proxy-Allowed-Request-Headers` and functionality to allow the `Authorization` header through when it is included in the new special header. This is a compromise that enables the authorization use case while preventing accidental or malicious exposure of credentials since the developer has to explicitly opt-in for the request.

## Implementation details

The code updates `filter_headers_by_name` to accept an array of headers that are *always* removed and an array of headers that are removed unless the header name is present in `X-Cors-Proxy-Allowed-Request-Headers`. We only add `Authorization` to the latter array for now.

## Testing Instructions (or ideally a Blueprint)

* Make a proxied remote request with an `Authorization` header and see that the header is removed.
* Make the same request but include `X-Cors-Proxy-Allowed-Request-Headers=Authorization` and see that the header makes it through.