### PR TITLE
[Data Liberation] Add WXR import CLI script

### DIFF
--- a/packages/playground/data-liberation/bin/import/blueprint-import-wxr.json
+++ b/packages/playground/data-liberation/bin/import/blueprint-import-wxr.json
@@ -1,0 +1,18 @@
+{
+	"$schema": "../../../blueprints/public/blueprint-schema.json",
+	"constants": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true
+	},
+	"login": true,
+	"steps": [
+		{
+			"step": "activatePlugin",
+			"pluginPath": "data-liberation/plugin.php"
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require_once 'wordpress/wp-load.php';\n$upload_dir = wp_upload_dir();\nforeach ( wp_visit_file_tree( $upload_dir['basedir'] . '/import-wxr' ) as $event ) {\nforeach ( $event->files as $file ) {\nif ( $file->isFile() && pathinfo( $file->getPathname(), PATHINFO_EXTENSION ) === 'xml' ) {\ndata_liberation_import( $file->getPathname() );\n}\n}\n};"
+		}
+	]
+}

--- a/packages/playground/data-liberation/bin/import/import-wxr.sh
+++ b/packages/playground/data-liberation/bin/import/import-wxr.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 #
-# A script that accepts a WXR XML file and imports it into a WordPress site
+# A script that accepts a folder and imports all WXR files into a WordPress site
 #
 # Usage:
-#    ./import-wxr.sh <filename>
+#    ./import-wxr.sh <folder-name>
 #
 
 # Display help message
 show_help() {
-	echo "Usage: $0 [-h|--help] <filename>"
+	echo "Usage: $0 [-h|--help] <folder-name>"
 	echo "Options:"
 	echo "  -h, --help Show this help message"
 }
@@ -43,6 +43,6 @@ if [ -d "$1" ]; then
 		--mount=$1:/wordpress/wp-content/uploads/import-wxr \
 		--blueprint=./blueprint-import-wxr.json
 else
-	echo "Error: File '$1' does not exist"
+	echo "Error: Folder '$1' does not exist"
 	exit 1
 fi

--- a/packages/playground/data-liberation/bin/import/import-wxr.sh
+++ b/packages/playground/data-liberation/bin/import/import-wxr.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# A script that accepts a WXR XML file and imports it into a WordPress site
+#
+# Usage:
+#    ./import-wxr.sh <filename>
+#
+
+# Display help message
+show_help() {
+	echo "Usage: $0 [-h|--help] <filename>"
+	echo "Options:"
+	echo "  -h, --help Show this help message"
+}
+
+# Check if no arguments were provided. If so, display help message
+if [ $# -eq 0 ]; then
+	show_help
+	exit 1
+fi
+
+# Parse command line arguments. If an invalid argument is provided, display help message
+while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do case $1 in
+  -h | --help )
+	show_help
+	exit 0
+	;;
+esac; shift; done
+if [[ "$1" == '--' ]]; then shift; fi
+
+# Check if filename is provided. If not, display error message.
+if [ -z "$1" ]; then
+	echo "Error: No folder provided"
+	show_help
+	exit 1
+fi
+
+# Check if the file exists
+if [ -d "$1" ]; then
+	bun ../../../cli/src/cli.ts \
+		server \
+		--mount=../../:/wordpress/wp-content/plugins/data-liberation \
+		--mount=$1:/wordpress/wp-content/uploads/import-wxr \
+		--blueprint=./blueprint-import-wxr.json
+else
+	echo "Error: File '$1' does not exist"
+	exit 1
+fi

--- a/packages/playground/data-liberation/bootstrap.php
+++ b/packages/playground/data-liberation/bootstrap.php
@@ -52,6 +52,7 @@ require_once __DIR__ . '/src/import/WP_File_Visitor.php';
 require_once __DIR__ . '/src/import/WP_File_Visitor_Event.php';
 require_once __DIR__ . '/src/import/WP_Imported_Entity.php';
 require_once __DIR__ . '/src/import/WP_Attachment_Downloader.php';
+require_once __DIR__ . '/src/import/WP_Attachment_Downloader_Event.php';
 require_once __DIR__ . '/src/import/WP_Stream_Importer.php';
 require_once __DIR__ . '/src/import/WP_Markdown_Importer.php';
 

--- a/packages/playground/data-liberation/phpunit.xml
+++ b/packages/playground/data-liberation/phpunit.xml
@@ -10,6 +10,7 @@
       <file>tests/URLParserWHATWGComplianceTests.php</file>
       <file>tests/WPXMLProcessorTests.php</file>
       <file>tests/UrldecodeNTests.php</file>
+      <file>tests/WPStreamImporterTests.php</file>
     </testsuite>
   </testsuites>
 </phpunit>

--- a/packages/playground/data-liberation/plugin.php
+++ b/packages/playground/data-liberation/plugin.php
@@ -25,39 +25,23 @@ add_filter('wp_kses_uri_attributes', function() {
     return [];
 });
 
-/**
- * Development debug code to run the import manually.
- * @TODO: Remove this in favor of a CLI command.
- */
 add_action('init', function() {
-    return;
-    $wxr_path = __DIR__ . '/tests/fixtures/wxr-simple.xml';
-    $importer = WP_Stream_Importer::create_for_wxr_file(
-        $wxr_path
-    );
-    while($importer->next_step()) {
-        // ...
+    if ( defined( 'WP_CLI' ) && WP_CLI ) {
+        /**
+         * Import a WXR file.
+         *
+         * <file>
+         * : The WXR file to import.
+         */
+        $command = function ( $args, $assoc_args ) {
+            $file = $args[0];
+            data_liberation_import( $file );
+        };
+
+        // Register the WP-CLI import command.
+		// Example usage: wp data-liberation /path/to/file.xml
+        WP_CLI::add_command( 'data-liberation', $command );
     }
-    return;
-    $importer->next_step();
-    $paused_importer_state = $importer->get_reentrancy_cursor();
-
-    echo "\n\n";
-    echo "moving to importer2\n";
-    echo "\n\n";
-
-    $importer2 = WP_Stream_Importer::create_for_wxr_file(
-        $wxr_path,
-        array(),
-        $paused_importer_state
-    );
-    $importer2->next_step();
-    $importer2->next_step();
-    $importer2->next_step();
-    // $importer2->next_step();
-    // var_dump($importer2);
-
-    die("YAY");
 });
 
 // Register admin menu

--- a/packages/playground/data-liberation/project.json
+++ b/packages/playground/data-liberation/project.json
@@ -50,6 +50,16 @@
 				],
 				"parallel": false
 			}
+		},
+		"test:wp-phpunit": {
+			"executor": "nx:run-commands",
+			"options": {
+				"cwd": "packages/playground/data-liberation",
+				"commands": [
+					"bun ../cli/src/cli.ts run-blueprint --quiet --mount=./:/wordpress/wp-content/plugins/data-liberation --blueprint=./tests/import/blueprint-import.json"
+				],
+				"parallel": false
+			}
 		}
 	}
 }

--- a/packages/playground/data-liberation/src/functions.php
+++ b/packages/playground/data-liberation/src/functions.php
@@ -198,8 +198,13 @@ function wp_visit_file_tree( $dir ) {
  * @param string $path The path to the WXR file.
  * @return void
  */
-function data_liberation_import( $path ) {
-	$importer  = WP_Stream_Importer::create_for_wxr_file( $path );
+function data_liberation_import( $path ): bool {
+	$importer = WP_Stream_Importer::create_for_wxr_file( $path );
+
+	if ( ! $importer ) {
+		return false;
+	}
+
 	$is_wp_cli = defined( 'WP_CLI' ) && WP_CLI;
 
 	if ( $is_wp_cli ) {
@@ -217,4 +222,6 @@ function data_liberation_import( $path ) {
 	if ( $is_wp_cli ) {
 		WP_CLI::success( 'Import ended' );
 	}
+
+	return true;
 }

--- a/packages/playground/data-liberation/src/functions.php
+++ b/packages/playground/data-liberation/src/functions.php
@@ -191,3 +191,23 @@ function wp_visit_file_tree( $dir ) {
 		new SplFileInfo( $dir )
 	);
 }
+
+/**
+ * Import a WXR file. Used in the CLI.
+ *
+ * @param string $file The path to the WXR file.
+ * @return void
+ */
+function data_liberation_import( $file ) {
+	$entity_iterator_factory = function () use ( $file ) {
+		$wxr = new WP_WXR_Reader();
+		$wxr->connect_upstream( new WP_File_Reader( $file ) );
+
+		return $wxr;
+	};
+
+	$importer = WP_Stream_Importer::create( $entity_iterator_factory );
+
+	$importer->frontload_assets();
+	$importer->import_entities();
+}

--- a/packages/playground/data-liberation/src/import/WP_Stream_Importer.php
+++ b/packages/playground/data-liberation/src/import/WP_Stream_Importer.php
@@ -409,7 +409,7 @@ class WP_Stream_Importer {
 
 		$enqueued = $this->downloader->enqueue_if_not_exists( $url, $output_path );
 		if ( $enqueued ) {
-			$resource_id   = $this->downloader->get_last_enqueued_resource_id();
+			$resource_id   = $this->downloader->get_enqueued_resource_id();
 			$entity_cursor = $this->entity_iterator->get_reentrancy_cursor();
 			$this->active_downloads[ $entity_cursor ][ $resource_id ] = true;
 		}

--- a/packages/playground/data-liberation/src/import/WP_Stream_Importer.php
+++ b/packages/playground/data-liberation/src/import/WP_Stream_Importer.php
@@ -186,6 +186,15 @@ class WP_Stream_Importer {
 	}
 
 	/**
+	 * Get the current stage.
+	 *
+	 * @return string
+	 */
+	public function get_current_stage() {
+		return $this->stage;
+	}
+
+	/**
 	 * Advance the cursor to the oldest finished download. For example:
 	 *
 	 * * We've started downloading files A, B, C, and D in this order.

--- a/packages/playground/data-liberation/tests/WPStreamImporterTests.php
+++ b/packages/playground/data-liberation/tests/WPStreamImporterTests.php
@@ -1,0 +1,29 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the WPStreamImporter class.
+ */
+class WPStreamImporterTests extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( ! isset( $_SERVER['SERVER_SOFTWARE'] ) || $_SERVER['SERVER_SOFTWARE'] !== 'PHP.wasm' ) {
+			$this->markTestSkipped( 'Test only runs in Playground' );
+		}
+	}
+
+	public function test_import_wxr_is_missing() {
+		$import = data_liberation_import( __DIR__ . '/wxr/not-a-valid-file.xml' );
+
+		$this->assertFalse( $import );
+	}
+
+	public function test_import_simple_wxr() {
+		$import = data_liberation_import( __DIR__ . '/wxr/small-export.xml' );
+
+		$this->assertTrue( $import );
+	}
+}

--- a/packages/playground/data-liberation/tests/WPStreamImporterTests.php
+++ b/packages/playground/data-liberation/tests/WPStreamImporterTests.php
@@ -15,12 +15,6 @@ class WPStreamImporterTests extends TestCase {
 		}
 	}
 
-	public function test_import_wxr_is_missing() {
-		$import = data_liberation_import( __DIR__ . '/wxr/not-a-valid-file.xml' );
-
-		$this->assertFalse( $import );
-	}
-
 	public function test_import_simple_wxr() {
 		$import = data_liberation_import( __DIR__ . '/wxr/small-export.xml' );
 

--- a/packages/playground/data-liberation/tests/import/blueprint-import.json
+++ b/packages/playground/data-liberation/tests/import/blueprint-import.json
@@ -8,7 +8,7 @@
 		},
 		{
 			"step": "runPHP",
-			"code": "<?php require_once 'wordpress/wp-load.php'; $base = '/wordpress/wp-content/plugins/data-liberation/';\nrequire $base . 'vendor/autoload.php';\ntry {\n$arguments = [\n'--stderr',\n'--configuration', $base . 'phpunit.xml'\n];\n$res = (new PHPUnit\\TextUI\\Application())->run($arguments);\nif ( $res !== 0 ) {\n// throw new Exception( 'PHPUnit failed' );\ntrigger_error('ciao', E_USER_ERROR);\n}\n} catch (Throwable $e) {\necho \"Error running PHPUnit: \" . $e->getMessage();\nthrow $e;\n};"
+			"code": "<?php require_once 'wordpress/wp-load.php'; $base = '/wordpress/wp-content/plugins/data-liberation/';\nrequire $base . 'vendor/autoload.php';\ntry {\n$arguments = [\n'--stderr',\n'--configuration', $base . 'phpunit.xml'\n];\n$res = (new PHPUnit\\TextUI\\Application())->run($arguments);\nif ( $res !== 0 ) {\ntrigger_error('PHPUnit failed', E_USER_ERROR);\n}\n} catch (Throwable $e) {\ntrigger_error('PHPUnit failed: ' . $e->getMessage(), E_USER_ERROR);\n};"
 		}
 	]
 }

--- a/packages/playground/data-liberation/tests/import/blueprint-import.json
+++ b/packages/playground/data-liberation/tests/import/blueprint-import.json
@@ -1,15 +1,14 @@
 {
 	"$schema": "../../../blueprints/public/blueprint-schema.json",
-	"constants": {
-		"WP_DEBUG": true,
-		"WP_DEBUG_DISPLAY": true,
-		"WP_DEBUG_LOG": true
-	},
 	"login": true,
 	"steps": [
 		{
 			"step": "activatePlugin",
 			"pluginPath": "data-liberation/plugin.php"
+		},
+		{
+			"step": "runPHP",
+			"code": "<?php require_once 'wordpress/wp-load.php'; $base = '/wordpress/wp-content/plugins/data-liberation/';\nrequire $base . 'vendor/autoload.php';\ntry {\n$arguments = [\n'--stderr',\n'--configuration', $base . 'phpunit.xml'\n];\n$res = (new PHPUnit\\TextUI\\Application())->run($arguments);\nif ( $res !== 0 ) {\n// throw new Exception( 'PHPUnit failed' );\ntrigger_error('ciao', E_USER_ERROR);\n}\n} catch (Throwable $e) {\necho \"Error running PHPUnit: \" . $e->getMessage();\nthrow $e;\n};"
 		}
 	]
 }

--- a/packages/playground/data-liberation/tests/import/run.sh
+++ b/packages/playground/data-liberation/tests/import/run.sh
@@ -4,4 +4,4 @@ bun ../../../cli/src/cli.ts \
     server \
     --mount=../../:/wordpress/wp-content/plugins/data-liberation \
     --mount=../../../../docs:/wordpress/wp-content/docs \
-    --blueprint=/Users/cloudnik/www/Automattic/core/plugins/playground/packages/playground/data-liberation/tests/import/blueprint-import.json
+    --blueprint=./blueprint-import.json


### PR DESCRIPTION
Add Data Liberation import script. The script lets you import a folder with WXRs inside WordPress. Add the possibility to run PHPUnit inside Playground.

```bash
cd packages/playground/data-liberation/bin/import
bash import-wxr.sh /a-folder/with-the/wxr-files-to-import-inside
```

```bash
cd packages/playground/data-liberation
nx run test:wp-phpunit
```

The import CLI is also registered as a WP-CLI command in the `init` action if WP-CLI is included. So it can also be run as `wp data-liberation your-wrx-file-you-want-to-import.xml`.

## Motivation for the change, related issues
There's no good entry point to running that import right now; we use an ad-hoc code snippet inside the Data Liberation WordPress plugin. This new CLI command will make testing the import easy.

There must be also be the possibility of running the PHPUnit test in the context of WordPress.

1. New CLI script
2. Added PHPUnit run inside Playground
3. Fix: missing `require_once`
4. Fix: wrong method name
5. Fix: endless loop

## Implementation details
This script consists of six major parts.

### The bin/import/import-wxr.sh bash script
This script accepts a folder path. You can create one and put all the WXR you want to import inside it. It starts the `cli.ts` server, mounts the folder specified in `/wordpress/wp-content/uploads/import-wxr`.

### The bin/import/blueprint-import-wxr.json blueprint
The bluescript enables the Data Liberation plugin. Enumerate all the files with .xml extension inside the mounted folder and import them all using a new function created.

The PHP snippet run in the `runPHP` step uses the `wp_visit_file_tree` provided by the plugin:
```php
<?PHP

require_once 'wordpress/wp-load.php';

$upload_dir = wp_upload_dir();

foreach ( wp_visit_file_tree( $upload_dir['basedir'] . '/import-wxr' ) as $event ) {
  foreach ( $event->files as $file ) {
    if ( $file->isFile() && pathinfo( $file->getPathname(), PATHINFO_EXTENSION ) === 'xml' ) {
      data_liberation_import( $file->getPathname() ); // Import the WXR.
    }
  }
};
```

### A new `data_liberation_import` function
The new simple import function in the plugin runs `WP_Stream_Importer` and not much more.

### The new tests/import/run.sh script
This script runs PHPUnit inside Playground. It generates an error if PHPUnit generates an error.

### The new tests/import/blueprint-import.json blueprint
This blueprint runs all PHPUnit tests found in `tests` inside Playground. It returns success if everything goes well. It returns an error if one or more tests fail.

```php
$base = '/wordpress/wp-content/plugins/data-liberation/';
require $base . 'vendor/autoload.php';

try {
    $arguments = [
        '--stderr',
        '--configuration', $base . 'phpunit.xml'
    ];

    $res = (new PHPUnit\TextUI\Application())->run($arguments);

    if ( $res !== 0 ) {
        trigger_error('PHPUnit failed', E_USER_ERROR);
    }
} catch (Throwable $e) {
    trigger_error('PHPUnit failed: ' . $e->getMessage(), E_USER_ERROR);
}
```

### New unit test
The new `WPStreamImporterTests` class runs the first test using `WP_Stream_Importer::create_for_wxr_file`. It is only runnable inside WordPress, so there is a check in `setUp()` if it's the right environment. Otherwise, it is not run.

## Testing Instructions (or ideally a Blueprint)

### Import script
Example with one of the preexisting XML files:
```
cd packages/playground/data-liberation/bin/import
mkdir tmp
cp ../../tests/wxr/small-export.xml tmp
bash import-wxr.sh ./tmp
```
Then check `http://127.0.0.1:9400/wp-admin/edit.php`. All the WXR posts should be there.

### PHPUnit run inside Playground
Run test on local:
```
cd packages/playground/data-liberation
nx run test:phpunit
```
1188 tests should succeed.

Run PHPUnit on Playground:
```
cd packages/playground/data-liberation
nx run test:wp-phpunit
```
All tests should succeed and output "Successfully ran target test:wp-phpunit for project playground-data-liberation".