### PR TITLE
Support submitting PR preview modal with ENTER key

### DIFF
--- a/packages/playground/website/src/github/preview-pr/form.tsx
+++ b/packages/playground/website/src/github/preview-pr/form.tsx
@@ -42,7 +42,7 @@ export default function PreviewPRForm({
 		}
 	}, []);
 
-	async function handleSubmit(e: React.MouseEvent<HTMLButtonElement>) {
+	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
 
 		if (!value) {
@@ -209,7 +209,7 @@ export default function PreviewPRForm({
 	}
 
 	return (
-		<div>
+		<form onSubmit={handleSubmit}>
 			<div className={css.content}>
 				{submitting && (
 					<div className={css.overlay}>
@@ -233,6 +233,6 @@ export default function PreviewPRForm({
 				onSubmit={handleSubmit}
 				submitText="Preview"
 			/>
-		</div>
+		</form>
 	);
 }


### PR DESCRIPTION
## Motivation for the change, related issues

My intuition expected to be able to submit the PR preview modal with an Enter key, but we did not yet support that. This PR adds that support.

## Testing Instructions (or ideally a Blueprint)

- Run `npm run dev` and manually confirm that you can submit PR preview modals with both the Enter key from the input box and by clicking the "Submit" button.