### PR TITLE
E2E: Disable a flaky deployment test

### DIFF
--- a/packages/playground/website/playwright/e2e/deployment.spec.ts
+++ b/packages/playground/website/playwright/e2e/deployment.spec.ts
@@ -58,7 +58,13 @@ for (const cachingEnabled of [true, false]) {
 	});
 }
 
-test(
+/**
+ * This test is flaky and often fails on CI even after multiple retries. It
+ * lowers the confidence in the test suite so it's being skipped. It is still
+ * useful for manual testing when updating the service worker and may get
+ * improved the next time we change something in the service worker.
+ */
+test.skip(
 	'When a new website version is deployed while the old version is still loaded, ' +
 		'creating a new site should still work.',
 	async ({ website, page, wordpress }) => {


### PR DESCRIPTION
Disables an E2E test that notoriously fails:

> When a new website version is deployed while the old version is still loaded, creating a new site should still work.

I would love to improve this test, but this particular one is tedious and the process could take a few days I am not willing to put in right now. At the same time, keeping a failing test around lowers our confidence in the E2E test overall. Skipping it and keeping the code around for the next time we adjust the service worker seems like a good compromise, especially since the deployments seem to be in a good place now without many reports of the stale Playground version sticking around for too long.
