### PR TITLE
Blueprints: Use the major WordPress version to download RC/beta translations

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/set-site-language.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/set-site-language.spec.ts
@@ -1,47 +1,73 @@
-import { MinifiedWordPressVersions } from '@wp-playground/wordpress-builds';
 import { getWordPressTranslationUrl } from './set-site-language';
 
 describe('getTranslationUrl()', () => {
-	it('should return a major.minor translation URL for a major.minor version', () => {
-		expect(getWordPressTranslationUrl('6.6', 'en_US')).toBe(
-			'https://downloads.wordpress.org/translation/core/6.6/en_US.zip'
-		);
-	});
-
-	it('should return a major.minor.patch translation URL for a major.minor.patch version', () => {
-		expect(getWordPressTranslationUrl('6.5.1', 'es_ES')).toBe(
-			'https://downloads.wordpress.org/translation/core/6.5.1/es_ES.zip'
-		);
-	});
-
 	[
 		{
-			version: '6.6-RC1',
+			versionString: '6.2',
+			latestBetaVersion: '6.6-RC',
+			latestMinifiedVersion: '6.5.2',
+			expectedUrl: `https://downloads.wordpress.org/translation/core/6.2/en_US.zip`,
+			description:
+				'should return a major.minor translation URL when the input version string is in a major.minor format',
+		},
+		{
+			versionString: '6.2.1',
+			latestBetaVersion: '6.3.1-RC',
+			latestMinifiedVersion: '6.4.2',
+			expectedUrl: `https://downloads.wordpress.org/translation/core/6.2.1/en_US.zip`,
+			description:
+				'should return a major.minor.patch translation URL when the input version string is in a major.minor.patch format',
+		},
+		{
+			versionString: '6.6-RC1',
+			latestBetaVersion: '6.6-RC',
+			latestMinifiedVersion: '6.5.2',
+			expectedUrl: `https://downloads.wordpress.org/translation/core/6.6-RC/en_US.zip`,
 			description:
 				'should return the latest RC translation URL for a RC version',
 		},
 		{
-			version: '6.6-beta2',
+			versionString: '6.6-beta2',
+			latestBetaVersion: '6.6-RC',
+			latestMinifiedVersion: '6.5.2',
+			expectedUrl: `https://downloads.wordpress.org/translation/core/6.6-RC/en_US.zip`,
 			description:
 				'should return the latest RC translation URL for a beta version',
 		},
 		{
-			version: '6.6-nightly',
+			versionString: '6.6-nightly',
+			latestBetaVersion: '6.6-RC',
+			latestMinifiedVersion: '6.5.2',
+			expectedUrl: `https://downloads.wordpress.org/translation/core/6.6-RC/en_US.zip`,
 			description:
 				'should return the latest RC translation URL for a nightly version',
 		},
 		{
-			version: '6.8-alpha-59408',
+			versionString: '6.8-alpha-59408',
+			latestBetaVersion: '6.8-RC',
+			latestMinifiedVersion: '6.7.2',
+			expectedUrl: `https://downloads.wordpress.org/translation/core/6.8-RC/en_US.zip`,
 			description:
 				'should return the latest RC translation URL for an alpha version',
 		},
-	].forEach(({ version, description }) => {
-		it(description, () => {
-			const latestBetaVersion =
-				MinifiedWordPressVersions['beta'].split('-')[0];
-			expect(getWordPressTranslationUrl(version, 'en_US')).toBe(
-				`https://downloads.wordpress.org/translation/core/${latestBetaVersion}-RC/en_US.zip`
-			);
-		});
-	});
+	].forEach(
+		({
+			versionString,
+			latestBetaVersion,
+			latestMinifiedVersion,
+			expectedUrl,
+			description,
+		}) => {
+			it(description, () => {
+				expect(
+					getWordPressTranslationUrl(
+						versionString,
+						'en_US',
+						latestBetaVersion,
+						latestMinifiedVersion
+					)
+				).toBe(expectedUrl);
+			});
+		}
+	);
 });

--- a/packages/playground/blueprints/src/lib/steps/set-site-language.ts
+++ b/packages/playground/blueprints/src/lib/steps/set-site-language.ts
@@ -32,7 +32,9 @@ export interface SetSiteLanguageStep {
  */
 export const getWordPressTranslationUrl = (
 	wpVersion: string,
-	language: string
+	language: string,
+	latestBetaVersion: string = MinifiedWordPressVersions['beta'],
+	latestMinifiedVersion: string = LatestMinifiedWordPressVersion
 ) => {
 	/**
 	 * The translation API provides translations for all WordPress releases
@@ -51,17 +53,18 @@ export const getWordPressTranslationUrl = (
 	 * For example translations for WordPress 6.6-BETA1 or 6.6-RC1 are found under
 	 * https://downloads.wordpress.org/translation/core/6.6-RC/en_GB.zip
 	 */
-	if (wpVersion.match(/(\d.\d(.\d)?)-(alpha|beta|nightly|rc).*$/i)) {
-		wpVersion = MinifiedWordPressVersions['beta'].replace(
-			/(rc|beta).*$/i,
-			'RC'
-		);
+	if (wpVersion.match(/^(\d.\d(.\d)?)-(alpha|beta|nightly|rc).*$/i)) {
+		wpVersion = latestBetaVersion
+			// Remove the patch version, e.g. 6.6.1-RC1 -> 6.6-RC1
+			.replace(/^(\d.\d)(.\d+)/i, '$1')
+			// Replace "rc" and "beta" with "RC", e.g. 6.6-nightly -> 6.6-RC
+			.replace(/(rc|beta).*$/i, 'RC');
 	} else if (!wpVersion.match(/^(\d+\.\d+)(?:\.\d+)?$/)) {
 		/**
 		 * If the WordPress version string isn't a major.minor or major.minor.patch,
 		 * the latest available WordPress build version will be used instead.
 		 */
-		wpVersion = LatestMinifiedWordPressVersion;
+		wpVersion = latestMinifiedVersion;
 	}
 	return `https://downloads.wordpress.org/translation/core/${wpVersion}/${language}.zip`;
 };


### PR DESCRIPTION
Uses a major WordPress version to fetch the translations, e.g. `https://downloads.wordpress.org/translation/core/6.6-RC/en_US.zip` instead of `https://downloads.wordpress.org/translation/core/6.6.1-RC/en_US.zip`

This fixes an issue introduced in #1987 that caused the E2E tests to fail on trunk:

```
  ✘  77 [chromium] › blueprints.spec.ts:438:6 › should translate WP-admin to Spanish for the beta WordPress build (retry #3) (30.2s)
```

The setSiteLanguage step would try to download the translations from

https://downloads.wordpress.org/translation/core/6.7.1-RC/es_ES.zip

which responded with a 404, instead of

https://downloads.wordpress.org/translation/core/6.7-RC/es_ES.zip

where the translations are actually available.

 ## Testing instructions

* Confirm the E2E tests pass
* Go here and confirm you can see a Spanish version of wp admin: http://localhost:5400/website-server/?language=es_ES&url=%2Fwp-admin%2F&wp=beta&modal=error-report
