### PR TITLE
Webapp: Design improvements

### DIFF
--- a/packages/playground/website/src/components/modal/modal-buttons.tsx
+++ b/packages/playground/website/src/components/modal/modal-buttons.tsx
@@ -9,12 +9,15 @@ interface ModalButtonsProps {
 	onCancel?: () => void;
 	onSubmit?: (e: any) => void;
 }
-export default function ModalButtons({ submitText = 'Submit', areDisabled = false, areBusy, onCancel, onSubmit }: ModalButtonsProps) {
+export default function ModalButtons({
+	submitText = 'Submit',
+	areDisabled = false,
+	areBusy,
+	onCancel,
+	onSubmit,
+}: ModalButtonsProps) {
 	return (
-		<Flex
-			justify="end"
-			className={css.modalButtons}
-		>
+		<Flex justify="end" className={css.modalButtons} gap={4}>
 			<Button
 				isBusy={areBusy}
 				disabled={areDisabled}
@@ -32,5 +35,5 @@ export default function ModalButtons({ submitText = 'Submit', areDisabled = fals
 				{submitText}
 			</Button>
 		</Flex>
-	)
+	);
 }

--- a/packages/playground/website/src/components/site-manager/sidebar/index.tsx
+++ b/packages/playground/website/src/components/site-manager/sidebar/index.tsx
@@ -93,7 +93,11 @@ export function Sidebar({
 			aria-orientation={undefined}
 		>
 			{/* Padding 3px is because of focus on dropdown button */}
-			<Flex justify="space-between" direction="row" style={{ padding: '3px'}}>
+			<Flex
+				justify="space-between"
+				direction="row"
+				style={{ padding: '3px' }}
+			>
 				<h1 className="sr-only">WordPress Playground</h1>
 				<div className={css.sidebarHeader}>
 					{/* Remove Playground logo because branding isn't finalized. */}
@@ -111,21 +115,15 @@ export function Sidebar({
 						<>
 							<WordPressPRMenuItem
 								onClose={onClose}
-								disabled={
-									offline
-								}
+								disabled={offline}
 							/>
 							<GutenbergPRMenuItem
 								onClose={onClose}
-								disabled={
-									offline
-								}
+								disabled={offline}
 							/>
 							<GithubImportMenuItem
 								onClose={onClose}
-								disabled={
-									offline
-								}
+								disabled={offline}
 							/>
 							<RestoreFromZipMenuItem
 								text="Import from .zip"
@@ -214,10 +212,7 @@ export function Sidebar({
 						>
 							Saved Playgrounds
 						</Heading>
-						<MenuGroup
-							className={css.sidebarList}
-							label="Saved Playgrounds"
-						>
+						<MenuGroup className={css.sidebarList}>
 							{storedSites.map((site) => {
 								/**
 								 * The `wordpress` site is selected when no site slug is provided.

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -429,7 +429,11 @@ export default function GitHubExportForm({
 
 	if (pushResult) {
 		return (
-			<form id="export-playground-form" onSubmit={handleSubmit}>
+			<form
+				id="export-playground-form"
+				onSubmit={handleSubmit}
+				className="typography"
+			>
 				<h2>
 					Pull Request{' '}
 					{formValues.prAction === 'create' ? 'created' : 'updated'}!

--- a/packages/playground/website/src/github/github-import-form/form.tsx
+++ b/packages/playground/website/src/github/github-import-form/form.tsx
@@ -175,7 +175,11 @@ export default function GitHubImportForm({
 
 	return (
 		<GitHubOAuthGuard>
-			<form id="import-playground-form" onSubmit={handleSubmit}>
+			<form
+				id="import-playground-form"
+				onSubmit={handleSubmit}
+				className="typography"
+			>
 				<p>
 					You may import WordPress plugins, themes, and entire
 					wp-content directories from any public GitHub repository.

--- a/packages/playground/website/src/github/github-oauth-guard/index.tsx
+++ b/packages/playground/website/src/github/github-oauth-guard/index.tsx
@@ -87,7 +87,7 @@ function Authenticate({
 		[css.disabled]: mayLoseProgress && !exported,
 	});
 	return (
-		<div>
+		<div className="typography">
 			<p>
 				Importing plugins, themes, and wp-content directories directly
 				from your public GitHub repositories.

--- a/packages/playground/website/src/github/preview-pr/form.tsx
+++ b/packages/playground/website/src/github/preview-pr/form.tsx
@@ -220,12 +220,13 @@ export default function PreviewPRForm({
 					disabled={submitting}
 					label="Pull request number or URL"
 					value={value}
+					autoFocus
 					onChange={(e) => {
 						setError('');
 						setValue(e);
 					}}
 				/>
-				{errorMsg && <div>{errorMsg}</div>}
+				{errorMsg && <div className={css.error}>{errorMsg}</div>}
 			</div>
 			<ModalButtons
 				areDisabled={submitting}

--- a/packages/playground/website/src/github/preview-pr/style.module.css
+++ b/packages/playground/website/src/github/preview-pr/style.module.css
@@ -25,3 +25,7 @@
 		margin: 0;
 	}
 }
+
+.error {
+	color: #f00;
+}


### PR DESCRIPTION
* Adds "autofocus" to the PR import modal
* Makes the PR import error message red
* Adds a horizontal gap between PR import modal buttons
* Restores vertical margin between GitHub modal text paragraphs
* Removes the double "Playground sites" header in the sidebar

![CleanShot 2024-11-22 at 13 33 23@2x](https://github.com/user-attachments/assets/0ed36e16-0083-4d29-83b5-9d9f498a4e77)

![CleanShot 2024-11-22 at 13 27 36@2x](https://github.com/user-attachments/assets/7270558a-3dc2-4d1a-81a8-c7fc6bef333c)

![CleanShot 2024-11-22 at 13 27 25@2x](https://github.com/user-attachments/assets/de03c3fb-02f9-4cb9-8283-a62600f25d50)

## Testing Instructions (or ideally a Blueprint)

Confirm the webapp complies with the above description.

