### PR TITLE
Restore CORS support to CORS proxy

### DIFF
--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -10,8 +10,9 @@ jobs:
     build_and_deploy:
         # Only run this workflow from the trunk branch and when it's triggered by a maintainer listed below
         # TODO: Can we check for group membership?
+        # TODO: Restore trunk branch check before merging
         if: >
-            github.ref == 'refs/heads/trunk' && (
+            github.ref == 'refs/heads/restore-cors-support-to-cors-proxy' && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -10,9 +10,8 @@ jobs:
     build_and_deploy:
         # Only run this workflow from the trunk branch and when it's triggered by a maintainer listed below
         # TODO: Can we check for group membership?
-        # TODO: Restore trunk branch check before merging
         if: >
-            github.ref == 'refs/heads/restore-cors-support-to-cors-proxy' && (
+            github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -354,3 +354,24 @@ function rewrite_relative_redirect(
     }
     return $proxy_absolute_url . $redirect_location;
 }
+
+/**
+ * Answers whether CORS is allowed for the specified origin.
+ */
+function should_respond_with_cors_headers($host, $origin) {
+    if (
+        $host !== 'playground.wordpress.net' &&
+        $origin === 'https://playground.wordpress.net'
+    ) {
+        return true;
+    }
+
+    $origin_host = parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST);
+    $is_local_origin = in_array(
+        $origin_host,
+        array('localhost', '127.0.0.1'),
+        true
+    );
+
+    return $is_local_origin;
+}

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -359,6 +359,10 @@ function rewrite_relative_redirect(
  * Answers whether CORS is allowed for the specified origin.
  */
 function should_respond_with_cors_headers($host, $origin) {
+    if (empty($origin)) {
+        return false;
+    }
+
     $is_request_from_playground_web_app = $origin === 'https://playground.wordpress.net';
     $not_hosted_with_playground_web_app = $host !== 'playground.wordpress.net';
     if (
@@ -368,7 +372,7 @@ function should_respond_with_cors_headers($host, $origin) {
         return true;
     }
 
-    $origin_host = parse_url($_SERVER['HTTP_ORIGIN'], PHP_URL_HOST);
+    $origin_host = parse_url($origin, PHP_URL_HOST);
     $is_local_origin = in_array(
         $origin_host,
         array('localhost', '127.0.0.1'),

--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -359,9 +359,11 @@ function rewrite_relative_redirect(
  * Answers whether CORS is allowed for the specified origin.
  */
 function should_respond_with_cors_headers($host, $origin) {
+    $is_request_from_playground_web_app = $origin === 'https://playground.wordpress.net';
+    $not_hosted_with_playground_web_app = $host !== 'playground.wordpress.net';
     if (
-        $host !== 'playground.wordpress.net' &&
-        $origin === 'https://playground.wordpress.net'
+        $is_request_from_playground_web_app &&
+        $not_hosted_with_playground_web_app
     ) {
         return true;
     }

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -13,6 +13,16 @@ if (file_exists($config_file)) {
     require_once $config_file;
 }
 
+$server_host = $_SERVER['HTTP_HOST'] ?? '';
+$origin = $_SERVER['HTTP_ORIGIN'] ?? '';
+
+if (should_respond_with_cors_headers($server_host, $origin)) {
+    header('Access-Control-Allow-Origin: ' . $origin);
+    header('Access-Control-Allow-Credentials: true');
+    header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+    header('Access-Control-Allow-Headers: Authorization, Content-Type');
+}
+
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     header("Allow: GET, POST, OPTIONS");
     exit;


### PR DESCRIPTION
## Motivation for the change, related issues

We want to move the CORS proxy to a separate host from playground.wordpress.net. In order to continue using the proxy from playground.wordpress.net, the CORS proxy needs to support cross-origin requests to itself.

## Implementation details

This PR updates the CORS proxy to again respond with CORS-related headers for supported origins. Currently, supported origins are "https://playground.wordpress.net" and local origins based on "127.0.0.1" and "localhost".

## Testing Instructions (or ideally a Blueprint)

- Once #2022 is merged, deploy this branch to the dedicated CORS proxy host.
- Create a Blueprint that uses the dedicated CORS proxy host.
- Confirm the Blueprint works with playground.wordpress.net.
- Confirm the Blueprint works with the local dev server.