### PR TITLE
[Web] Re-enable wp-cron

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/playground-includes/wp_http_fetch.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/playground-includes/wp_http_fetch.php
@@ -38,12 +38,6 @@ class Wp_Http_Fetch_Base
 	 */
 	public function request($url, $headers = array(), $data = array(), $options = array())
 	{
-		// Disable wp-cron requests that are extremely slow in node.js runtime environment.
-		// @TODO: Make wp-cron requests faster.
-		if (str_contains($url, '/wp-cron.php')) {
-			return false;
-		}
-
 		if (!empty($data)) {
 			$data_format = $options['data_format'];
 			if ($data_format === 'query') {

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -74,7 +74,7 @@ export async function handleRequest(data: RequestData, fetchFn = fetch) {
 		const fetchHeaders = data.headers || {};
 
 		const hasContentTypeHeader = Object.keys(fetchHeaders).some(
-			(name) => name.toLowerCase() === "content-type"
+			(name) => name.toLowerCase() === 'content-type'
 		);
 
 		if (fetchMethod == 'POST' && !hasContentTypeHeader) {
@@ -84,7 +84,7 @@ export async function handleRequest(data: RequestData, fetchFn = fetch) {
 		response = await fetchFn(fetchUrl, {
 			method: fetchMethod,
 			headers: fetchHeaders,
-			body: data.data,
+			body: fetchMethod === 'GET' ? undefined : data.data,
 			credentials: 'omit',
 		});
 	} catch (e) {


### PR DESCRIPTION
I disabled wp-cron a long time ago at a network bridge level with the following comment:

> Disable wp-cron requests that are extremely slow in node.js runtime environment.
> @TODO: Make wp-cron requests faster.

That code path wasn't running in Node.js for months now. Also, Playground changed a lot since then and these requests no longer seem slow in my testing. This PR, thus, reinstantes wp-cron.

Related to #1749

 ## Testing instructions

1. Install wp-crontrol plugin and confirm on its settings page the schedules are running as expected. Confirm there are requests to wp-cron.php in devtools and that they're not slow.
2. Try it in the web version of Playground (`npm run dev`)
3. Try it in the CLI version of Playground (`bun packages/playground/cli/src/cli.ts server`) – although that one didn't even use the Wp_Http_Fetch_Base transport so nothing should change
