### PR TITLE
[Website] Remove duplicate "Saved Playgrounds" label 

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -106,9 +106,12 @@ test('should preserve PHP constants when saving a temporary site to OPFS', async
 		// Saving the site takes a while on CI
 		timeout: 90000,
 	});
-	await expect(website.page.getByLabel('Playground title')).not.toContainText(
-		'Temporary Playground'
-	);
+
+	const storedPlaygroundTitleText = await website.page
+		.getByLabel('Playground title')
+		.textContent();
+	await expect(storedPlaygroundTitleText).not.toBeNull();
+	await expect(storedPlaygroundTitleText).not.toMatch('Temporary Playground');
 
 	await website.page
 		.locator('button')
@@ -117,9 +120,8 @@ test('should preserve PHP constants when saving a temporary site to OPFS', async
 
 	// Switch back to the stored site and confirm the PHP constant is still present.
 	await website.page
-		.getByLabel('Saved Playgrounds')
 		.locator('button')
-		.last()
+		.filter({ hasText: storedPlaygroundTitleText! })
 		.click();
 
 	await expect(wordpress.locator('body')).toContainText('E2E_TEST_VALUE');

--- a/packages/playground/website/src/components/site-manager/sidebar/index.tsx
+++ b/packages/playground/website/src/components/site-manager/sidebar/index.tsx
@@ -93,7 +93,11 @@ export function Sidebar({
 			aria-orientation={undefined}
 		>
 			{/* Padding 3px is because of focus on dropdown button */}
-			<Flex justify="space-between" direction="row" style={{ padding: '3px'}}>
+			<Flex
+				justify="space-between"
+				direction="row"
+				style={{ padding: '3px' }}
+			>
 				<h1 className="sr-only">WordPress Playground</h1>
 				<div className={css.sidebarHeader}>
 					{/* Remove Playground logo because branding isn't finalized. */}
@@ -111,21 +115,15 @@ export function Sidebar({
 						<>
 							<WordPressPRMenuItem
 								onClose={onClose}
-								disabled={
-									offline
-								}
+								disabled={offline}
 							/>
 							<GutenbergPRMenuItem
 								onClose={onClose}
-								disabled={
-									offline
-								}
+								disabled={offline}
 							/>
 							<GithubImportMenuItem
 								onClose={onClose}
-								disabled={
-									offline
-								}
+								disabled={offline}
 							/>
 							<RestoreFromZipMenuItem
 								text="Import from .zip"
@@ -214,10 +212,7 @@ export function Sidebar({
 						>
 							Saved Playgrounds
 						</Heading>
-						<MenuGroup
-							className={css.sidebarList}
-							label="Saved Playgrounds"
-						>
+						<MenuGroup className={css.sidebarList}>
 							{storedSites.map((site) => {
 								/**
 								 * The `wordpress` site is selected when no site slug is provided.


### PR DESCRIPTION
This PR removes a duplicate "Saved Playgrounds" label introduced in https://github.com/WordPress/wordpress-playground/pull/1911/files#diff-c6c2e0c567fcdad3afb3e836bf7b0e4376155ea723e62aab2df07b7d04a1932aR174.

The Playground Website uses custom section labels that match our design so I removed the label added by `MenuGroup` and left the custom label.

Fixes #2036

## Testing Instructions (or ideally a Blueprint)

- Start Playground
- Open Playground manager
- Ensure that you have saved sites (if not save a temporary site)
- Confirm that the sidebar has only one Saved Playgrounds" label


![Screenshot 2024-12-03 at 08 56 05](https://github.com/user-attachments/assets/347855aa-3afe-46f4-998b-a3865809e2b2)
