### PR TITLE
Add ESLint rule to avoid unintentional dependency on @wp-playgrounds/wordpress-builds

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
 	"root": true,
 	"ignorePatterns": ["**/*"],
-	"plugins": ["@nx"],
+	"plugins": ["@nx", "playground-dev"],
 	"overrides": [
 		{
 			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
@@ -73,7 +73,8 @@
 				"@typescript-eslint/no-empty-interface": 0,
 				"@typescript-eslint/no-empty-function": 0,
 				"@typescript-eslint/no-unused-vars": "error",
-				"no-constant-condition": 0
+				"no-constant-condition": 0,
+				"playground-dev/avoid-wordpress-builds-dependency": "error"
 			}
 		},
 		{

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -90,7 +90,8 @@
 		{
 			"files": "*.spec.ts",
 			"rules": {
-				"no-console": 0
+				"no-console": 0,
+				"playground-dev/avoid-wordpress-builds-dependency": 0
 			}
 		},
 		{

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,7 @@
 				"eslint-plugin-cypress": "^2.13.4",
 				"eslint-plugin-import": "2.27.5",
 				"eslint-plugin-jsx-a11y": "6.7.1",
+				"eslint-plugin-playground-dev": "file:packages/meta/src/eslint-plugin-playground-dev",
 				"eslint-plugin-react": "7.32.2",
 				"eslint-plugin-react-hooks": "4.6.0",
 				"gh-pages": "5.0.0",
@@ -25928,6 +25929,10 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/eslint-plugin-playground-dev": {
+			"resolved": "packages/meta/src/eslint-plugin-playground-dev",
+			"link": true
+		},
 		"node_modules/eslint-plugin-react": {
 			"version": "7.32.2",
 			"dev": true,
@@ -47498,6 +47503,11 @@
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
 			}
+		},
+		"packages/meta/src/eslint-plugin-playground-dev": {
+			"version": "0.0.1",
+			"dev": true,
+			"license": "GPL-2.0-or-later"
 		},
 		"packages/nx-extensions": {
 			"name": "@wp-playground/nx-extensions",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
 		"eslint-plugin-cypress": "^2.13.4",
 		"eslint-plugin-import": "2.27.5",
 		"eslint-plugin-jsx-a11y": "6.7.1",
+		"eslint-plugin-playground-dev": "file:packages/meta/src/eslint-plugin-playground-dev",
 		"eslint-plugin-react": "7.32.2",
 		"eslint-plugin-react-hooks": "4.6.0",
 		"gh-pages": "5.0.0",

--- a/packages/meta/src/eslint-plugin-playground-dev/avoid-wordpress-builds-dependency.js
+++ b/packages/meta/src/eslint-plugin-playground-dev/avoid-wordpress-builds-dependency.js
@@ -1,10 +1,12 @@
+const description =
+	'Avoid dependency on @wp-playground/wordpress-builds ' +
+	'because it is a private, unpublished package. Public, ' +
+	'published packages will be broken if they have a runtime ' +
+	'dependency on an unpublished package.';
 module.exports = {
 	meta: {
 		type: 'problem',
-		docs: {
-			description:
-				'Avoid using @wp-playground/wordpress-builds dependency',
-		},
+		docs: { description },
 	},
 	create(context) {
 		return {
@@ -13,7 +15,11 @@ module.exports = {
 					context.report({
 						loc: node.loc,
 						message:
-							'Avoid using @wp-playground/wordpress-builds dependency',
+							description +
+							' ' +
+							'If you need this dependency and deem it safe, ' +
+							'please disable the rule for this line and leave ' +
+							'a comment explaining why.',
 					});
 				}
 			},

--- a/packages/meta/src/eslint-plugin-playground-dev/avoid-wordpress-builds-dependency.js
+++ b/packages/meta/src/eslint-plugin-playground-dev/avoid-wordpress-builds-dependency.js
@@ -1,0 +1,22 @@
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Avoid using @wp-playground/wordpress-builds dependency',
+		},
+	},
+	create(context) {
+		return {
+			ImportDeclaration: (node) => {
+				if (node.source.value === '@wp-playground/wordpress-builds') {
+					context.report({
+						loc: node.source,
+						message:
+							'Avoid using @wp-playground/wordpress-builds dependency',
+					});
+				}
+			},
+		};
+	},
+};

--- a/packages/meta/src/eslint-plugin-playground-dev/avoid-wordpress-builds-dependency.js
+++ b/packages/meta/src/eslint-plugin-playground-dev/avoid-wordpress-builds-dependency.js
@@ -11,7 +11,7 @@ module.exports = {
 			ImportDeclaration: (node) => {
 				if (node.source.value === '@wp-playground/wordpress-builds') {
 					context.report({
-						loc: node.source,
+						loc: node.loc,
 						message:
 							'Avoid using @wp-playground/wordpress-builds dependency',
 					});

--- a/packages/meta/src/eslint-plugin-playground-dev/index.js
+++ b/packages/meta/src/eslint-plugin-playground-dev/index.js
@@ -1,0 +1,7 @@
+const wpBuildsDepRule = require('./avoid-wordpress-builds-dependency');
+const plugin = {
+	rules: {
+		'avoid-wordpress-builds-dependency': wpBuildsDepRule,
+	},
+};
+module.exports = plugin;

--- a/packages/meta/src/eslint-plugin-playground-dev/package.json
+++ b/packages/meta/src/eslint-plugin-playground-dev/package.json
@@ -1,0 +1,11 @@
+{
+	"private": true,
+	"name": "eslint-plugin-playground-dev",
+	"version": "0.0.1",
+	"description": "ESLint rules for developing WordPress Playground packages",
+	"main": "index.js",
+	"scripts": {
+		"test": "echo \"TODO: Use ESLint rule tester if tests are needed.\" && exit 1"
+	},
+	"license": "GPL-2.0-or-later"
+}

--- a/packages/playground/remote/.eslintrc.json
+++ b/packages/playground/remote/.eslintrc.json
@@ -8,7 +8,11 @@
 		},
 		{
 			"files": ["*.ts", "*.tsx"],
-			"rules": {}
+			"rules": {
+				// The remote package uses wordpress-builds in a way that does
+				// not create a runtime dependency to an unpublished package.
+				"playground-dev/avoid-wordpress-builds-dependency": 0
+			}
 		},
 		{
 			"files": ["*.js", "*.jsx"],


### PR DESCRIPTION
## Motivation for the change, related issues

We've encountered issues like https://github.com/WordPress/wordpress-playground/issues/2026 where an undesired dependency on `@wp-playground/wordpress-builds` (which is an unpublished, private package) caused problems.

## Implementation details

This PR adds an ESLint rule that considers dependency on `@wp-playground/wordpress-builds` to be an error. If a module wants a dependency on that package, it can disable the ESLint rule for the import line.

We should improve the rule message to better communicate the above.

Please feel free to take this and finish if you are interested. Otherwise, I can wrap later.

## Testing Instructions (or ideally a Blueprint)

- Add an ESLint rule tester test for this and ensure it is run as part of CI
- CI
