### PR TITLE
Fix CORS proxy deploy workflow

### DIFF
--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -40,7 +40,6 @@ jobs:
               run: |
                   pwd
                   ls -laR
-                  exit 1
 
             - name: Deploy to CORS proxy server
               shell: bash

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -35,6 +35,13 @@ jobs:
                       packages/playground/php-cors-proxy-deployment
                   sparse-checkout-cone-mode: false
 
+            - name: Observe working directory contents
+              shell: bash
+              run: |
+                  pwd
+                  ls -laR
+                  exit 1
+
             - name: Deploy to CORS proxy server
               shell: bash
               # TODO: Use completely separate environments for website and CORS proxy deployments

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -10,8 +10,9 @@ jobs:
     build_and_deploy:
         # Only run this workflow from the trunk branch and when it's triggered by a maintainer listed below
         # TODO: Can we check for group membership?
+        # TODO: Restore trunk branch check before merge
         if: >
-            github.ref == 'refs/heads/trunk' && (
+            github.ref == 'refs/heads/fix-cors-proxy-deploy-workflow' && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||
@@ -29,8 +30,10 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  sparse-checkout: packages/playground/php-cors-proxy
+                  sparse-checkout: |
+                      packages/playground/php-cors-proxy
                       packages/playground/php-cors-proxy-deployment
+                  sparse-checkout-cone-mode: false
 
             - name: Deploy to CORS proxy server
               shell: bash

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -10,9 +10,8 @@ jobs:
     build_and_deploy:
         # Only run this workflow from the trunk branch and when it's triggered by a maintainer listed below
         # TODO: Can we check for group membership?
-        # TODO: Restore trunk branch check before merge
         if: >
-            github.ref == 'refs/heads/fix-cors-proxy-deploy-workflow' && (
+            github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -52,7 +52,7 @@ jobs:
 
                   # CORS proxy files
                   rsync --verbose --archive --compress -e "ssh -i ~/.ssh/id_ed25519" \
-                    --include '*/' --include '*.php' --exclude '*' \
+                    --include '*/' --exclude 'tests/' --include '*.php' --exclude '*' \
                     --delete --prune-empty-dirs \
                     packages/playground/php-cors-proxy/ \
                     ${{ secrets.DEPLOY_CORS_PROXY_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:'~/updated-proxy-files'

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -52,8 +52,8 @@ jobs:
 
                   # CORS proxy files
                   rsync --verbose --archive --compress -e "ssh -i ~/.ssh/id_ed25519" \
-                    --include '*/' --exclude 'tests/' --include '*.php' --exclude '*' \
-                    --delete --prune-empty-dirs \
+                    --exclude 'tests/' --include '*/' --include '*.php' --exclude '*' \
+                    --delete --delete-excluded --prune-empty-dirs \
                     packages/playground/php-cors-proxy/ \
                     ${{ secrets.DEPLOY_CORS_PROXY_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:'~/updated-proxy-files'
 

--- a/packages/playground/php-cors-proxy-deployment/apply-update.sh
+++ b/packages/playground/php-cors-proxy-deployment/apply-update.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+SITE_API_BASE="$( "$SITE_PHP" -r 'require "/scripts/env.php"; echo SITE_API_BASE;')"
+
 echo Syncing staged files to production
 rsync -av --delete --no-perms --omit-dir-times ~/updated-proxy-files/ /srv/htdocs/
 

--- a/packages/playground/php-cors-proxy-deployment/apply-update.sh
+++ b/packages/playground/php-cors-proxy-deployment/apply-update.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+# Explicitly use the site's declared PHP version.
+# Otherwise, we've seen this defaulting to older versions which can break our scripts.
+SITE_PHP="/usr/local/php${PHP_VERSION}/bin/php"
 SITE_API_BASE="$( "$SITE_PHP" -r 'require "/scripts/env.php"; echo SITE_API_BASE;')"
 
 echo Syncing staged files to production

--- a/packages/playground/php-cors-proxy-deployment/apply-update.sh
+++ b/packages/playground/php-cors-proxy-deployment/apply-update.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 SITE_PHP="/usr/local/php${PHP_VERSION}/bin/php"
 SITE_API_BASE="$( "$SITE_PHP" -r 'require "/scripts/env.php"; echo SITE_API_BASE;')"
 
+echo Adding config file to updated proxy files
+cp ~/cors-proxy-deployment/cors-proxy-config.php ~/updated-proxy-files/
+
 echo Syncing staged files to production
 rsync -av --delete --no-perms --omit-dir-times ~/updated-proxy-files/ /srv/htdocs/
 

--- a/packages/playground/php-cors-proxy-deployment/apply-update.sh
+++ b/packages/playground/php-cors-proxy-deployment/apply-update.sh
@@ -19,6 +19,6 @@ curl -sS -X POST -H "Auth: $ATOMIC_SITE_API_KEY" "$SITE_API_BASE/edge-cache/$ATO
 echo Applying latest CORS proxy rate-limiting schema
 # NOTE: This will reset rate-limiting token buckets, but that should be tolerable
 # as long as we're generally discouraging abuse of the proxy.
-cat ~/website-deployment/cors-proxy-rate-limiting-table.sql | mysql --database="$DB_NAME"
+cat ~/cors-proxy-deployment/cors-proxy-rate-limiting-table.sql | mysql --database="$DB_NAME"
 
 echo Done!


### PR DESCRIPTION
## Motivation for the change, related issues

The CORS proxy deploy workflow isn't able to find the files it checked out in order to sync them to the dedicated proxy site.

## Implementation details

This PR fixes multiple incorrect paths, tightens command line params, and restores some missing bash var declarations in order to fix deployment of the dedicated CORS proxy.

## Testing Instructions (or ideally a Blueprint)

Allow dispatching this branch's version of the workflow and trigger the workflow manually to test.