### PR TITLE
[Networking] Decrypt TLS 1.2 alert messages

### DIFF
--- a/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
+++ b/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
@@ -38,7 +38,6 @@ import {
 	HelloRequest,
 	ECCurveTypes,
 	ECNamedCurves,
-	AlertLevels,
 } from './types';
 
 class TLSConnectionClosed extends Error {}

--- a/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
+++ b/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
@@ -38,6 +38,7 @@ import {
 	HelloRequest,
 	ECCurveTypes,
 	ECNamedCurves,
+	AlertLevels,
 } from './types';
 
 class TLSConnectionClosed extends Error {}
@@ -507,42 +508,53 @@ export class TLS_1_2_Connection {
 			// First, check if we have a complete record of the requested type.
 			for (let i = 0; i < this.receivedTLSRecords.length; i++) {
 				const record = this.receivedTLSRecords[i];
-				if (record.type === ContentTypes.Alert) {
-					throw new Error(
-						`Alert message received: ${
-							AlertLevelNames[record.fragment[0]]
-						} ${AlertDescriptionNames[record.fragment[1]]}`
-					);
+				if (record.type !== requestedType) {
+					continue;
 				}
-				if (record.type === requestedType) {
-					this.receivedTLSRecords.splice(i, 1);
-					// Decrypt the record if needed
-					if (
-						this.sessionKeys &&
-						record.type !== ContentTypes.ChangeCipherSpec
-					) {
-						record.fragment = await this.decryptData(
-							record.type,
-							record.fragment as Uint8Array
-						);
-					}
-					return record;
-				}
+				this.receivedTLSRecords.splice(i, 1);
+				return record;
 			}
 
 			// We don't have a complete record of the requested type yet.
 			// Let's read the next TLS record, then.
 			const header = await this.pollBytes(5);
 			const length = (header[3] << 8) | header[4];
+			const type = header[0];
+			const fragment = await this.pollBytes(length);
 			const record = {
-				type: header[0],
+				type,
 				version: {
 					major: header[1],
 					minor: header[2],
 				},
 				length,
-				fragment: await this.pollBytes(length),
+				fragment:
+					this.sessionKeys && type !== ContentTypes.ChangeCipherSpec
+						? await this.decryptData(type, fragment)
+						: fragment,
 			} as TLSRecord;
+
+			if (record.type === ContentTypes.Alert) {
+				const severity = AlertLevelNames[record.fragment[0]];
+				const description = AlertDescriptionNames[record.fragment[1]];
+				/**
+				 * @TODO: Handle TLS warnings, e.g. this one:
+				 *
+				 * close_notify
+				 *     Either party may initiate a close by sending a close_notify alert.
+				 *     Any data received after a closure alert is ignored.
+				 *
+				 *     Unless some other fatal alert has been transmitted, each party is
+				 *     required to send a close_notify alert before closing the write side
+				 *     of the connection.  The other party MUST respond with a close_notify
+				 *     alert of its own and close down the connection immediately,
+				 *     discarding any pending writes.
+				 */
+				throw new Error(
+					`TLS non-warning alert received: ${severity} ${description}`
+				);
+			}
+
 			this.receivedTLSRecords.push(record);
 		}
 	}


### PR DESCRIPTION
Decrypts the incoming TLS 1.2 alert record fragments.

The TLS bridge correctly identified the alert messages sent by the client, but it did not decrypt the encrypted record fragment, which means the severity and description were missing from the logged error.

 ## Testing instructions

This one is complex to reproduce and we don't have a good automated test suite I could reference here. Until we're in a more testable spot, you'll just have to take my word for it.
