### PR TITLE
[Website] Prevent the initial flash of "You have no Playgrounds" message

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -3,7 +3,7 @@ import { resolveBlueprintFromURL } from '../../lib/state/url/resolve-blueprint-f
 import { useCurrentUrl } from '../../lib/state/url/router-hooks';
 import { opfsSiteStorage } from '../../lib/state/opfs/opfs-site-storage';
 import {
-	siteListingLoaded,
+	OPFSSitesLoaded,
 	selectSiteBySlug,
 	setTemporarySiteSpec,
 	deriveSiteNameFromSlug,
@@ -36,7 +36,7 @@ export function EnsurePlaygroundSiteIsSelected({
 	children: React.ReactNode;
 }) {
 	const siteListingStatus = useAppSelector(
-		(state) => state.sites.loadingState
+		(state) => state.sites.opfsSitesLoadingState
 	);
 	const activeSite = useAppSelector((state) => selectActiveSite(state));
 	const dispatch = useAppDispatch();
@@ -60,14 +60,14 @@ export function EnsurePlaygroundSiteIsSelected({
 	useEffect(() => {
 		if (!opfsSiteStorage) {
 			logger.error('Error loading sites: OPFS not available');
-			dispatch(siteListingLoaded([]));
+			dispatch(OPFSSitesLoaded([]));
 			return;
 		}
 		opfsSiteStorage.list().then(
-			(sites) => dispatch(siteListingLoaded(sites)),
+			(sites) => dispatch(OPFSSitesLoaded(sites)),
 			(error) => {
 				logger.error('Error loading sites:', error);
-				dispatch(siteListingLoaded([]));
+				dispatch(OPFSSitesLoaded([]));
 			}
 		);
 	}, [dispatch]);

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -14,12 +14,11 @@ import { SiteError } from '../../lib/state/redux/slice-ui';
 import { Button, Spinner } from '@wordpress/components';
 import {
 	removeSite,
-	selectAllSites,
 	selectSiteBySlug,
+	selectSitesLoaded,
 	selectTemporarySites,
 } from '../../lib/state/redux/slice-sites';
 import classNames from 'classnames';
-import { PlaygroundRoute, redirectTo } from '../../lib/state/url/router';
 
 export const supportedDisplayModes = [
 	'browser-full-screen',
@@ -59,8 +58,6 @@ export const PlaygroundViewport = ({
  * as there's no risk of data loss
  */
 export const KeepAliveTemporarySitesViewport = () => {
-	const allSites = useAppSelector(selectAllSites);
-
 	const temporarySites = useAppSelector(selectTemporarySites);
 	const activeSite = useActiveSite();
 	const siteSlugsToRender = useMemo(() => {
@@ -120,9 +117,7 @@ export const KeepAliveTemporarySitesViewport = () => {
 		]);
 	}, [siteSlugsToRender]);
 
-	const sitesFinishedLoading = useAppSelector((state) =>
-		['error', 'loaded'].includes(state.sites.loadingState)
-	);
+	const sitesFinishedLoading = useAppSelector(selectSitesLoaded);
 	if (!sitesFinishedLoading) {
 		return (
 			<div
@@ -134,31 +129,6 @@ export const KeepAliveTemporarySitesViewport = () => {
 				}}
 			>
 				<Spinner style={{ width: '60px', height: '60px' }} />
-			</div>
-		);
-	}
-
-	if (!allSites.length) {
-		// @TODO: Use the dedicated design for this
-		// (the one in Figma with white background and pretty fonts.)
-		return (
-			<div className={css.fullSize}>
-				<div className={css.siteError}>
-					<div
-						className={css.siteErrorContent}
-						style={{ textAlign: 'center' }}
-					>
-						<h2>You don't have any Playgrounds right now</h2>
-						<Button
-							variant="primary"
-							onClick={() => {
-								redirectTo(PlaygroundRoute.newTemporarySite());
-							}}
-						>
-							Create a temporary Playground
-						</Button>
-					</div>
-				</div>
 			</div>
 		);
 	}


### PR DESCRIPTION
Sometimes when Playground is loaded, the user sees a brief flash of the "You don't have any Playgrounds yet" message. This PR fixes that. The user will see the spinner until their Playground loads.

 ## Implementation

Before this PR, the message is displayed when:

 * The OPFS sites are already loaded
 * The temporary site was not created yet in the redux store

With this PR, the message will never be displayed again. It's removed entirely. There should never be a situation where a fully loaded Playground has no sites. The temporary site is always there.

Furthermore, this PR keeps track of the temporary site initialization state and flips a boolean flag called `setFirstTemporarySiteCreated` once the first temp site is ready.

 ## Testing instructions

This one is tricky to test as the bug relies on a specific race condition. You might add `await new Promise(resolve=>setTimeout(resolve, 10000));` to setTemporarySiteSpec to delay that part and confirm you only see the spinner for 10 seconds.
