### PR TITLE
[Blueprints] Preserve the first char of all filenames sourced from GitDirectoryReference

### DIFF
--- a/packages/playground/blueprints/src/lib/resources.spec.ts
+++ b/packages/playground/blueprints/src/lib/resources.spec.ts
@@ -1,4 +1,4 @@
-import { UrlResource } from './resources';
+import { UrlResource, GitDirectoryResource } from './resources';
 
 describe('UrlResource', () => {
 	it('should create a new instance of UrlResource', () => {
@@ -18,6 +18,32 @@ describe('UrlResource', () => {
 		});
 		expect(resource.getURL()).toBe(
 			'https://raw.githubusercontent.com/WordPress/wordpress-develop/trunk/src/wp-includes/version.php'
+		);
+	});
+});
+
+describe('GitDirectoryResource', () => {
+	describe('resolve', () => {
+		it.each([
+			'packages/docs/site/docs/blueprints/tutorial',
+			'/packages/docs/site/docs/blueprints/tutorial',
+		])(
+			'should return a list of files in the directory (path: %s)',
+			async (path) => {
+				const resource = new GitDirectoryResource({
+					resource: 'git:directory',
+					url: 'https://github.com/WordPress/wordpress-playground',
+					ref: '05138293dd39e25a9fa8e43a9cc775d6fb780e37',
+					path,
+				});
+				const { files } = await resource.resolve();
+				expect(Object.keys(files)).toEqual([
+					'01-what-are-blueprints-what-you-can-do-with-them.md',
+					'02-how-to-load-run-blueprints.md',
+					'03-build-your-first-blueprint.md',
+					'index.md',
+				]);
+			}
 		);
 	});
 });

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -19,7 +19,7 @@ if (should_respond_with_cors_headers($server_host, $origin)) {
     header('Access-Control-Allow-Origin: ' . $origin);
     header('Access-Control-Allow-Credentials: true');
     header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
-    header('Access-Control-Allow-Headers: Accept, Authorization, Content-Type');
+    header('Access-Control-Allow-Headers: Accept, Authorization, Content-Type, git-protocol');
 }
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     header("Allow: GET, POST, OPTIONS");

--- a/packages/playground/storage/src/lib/git-sparse-checkout.spec.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.spec.ts
@@ -2,6 +2,7 @@ import {
 	listGitRefs,
 	sparseCheckout,
 	listGitFiles,
+	resolveCommitHash,
 } from './git-sparse-checkout';
 
 describe('listRefs', () => {
@@ -18,9 +19,16 @@ describe('listRefs', () => {
 
 describe('sparseCheckout', () => {
 	it('should retrieve the requested files from a git repo', async () => {
+		const commitHash = await resolveCommitHash(
+			'https://github.com/WordPress/wordpress-playground.git',
+			{
+				value: 'trunk',
+				type: 'branch',
+			}
+		);
 		const files = await sparseCheckout(
 			'https://github.com/WordPress/wordpress-playground.git',
-			'refs/heads/trunk',
+			commitHash,
 			['README.md']
 		);
 		expect(files).toEqual({
@@ -32,9 +40,16 @@ describe('sparseCheckout', () => {
 
 describe('listGitFiles', () => {
 	it('should list the files in a git repo', async () => {
+		const commitHash = await resolveCommitHash(
+			'https://github.com/WordPress/wordpress-playground.git',
+			{
+				value: 'trunk',
+				type: 'branch',
+			}
+		);
 		const files = await listGitFiles(
 			'https://github.com/WordPress/wordpress-playground.git',
-			'refs/heads/trunk'
+			commitHash
 		);
 		expect(files).toEqual(
 			expect.arrayContaining([

--- a/packages/playground/storage/src/lib/git-sparse-checkout.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.ts
@@ -39,11 +39,9 @@ if (typeof window !== 'undefined') {
  */
 export async function sparseCheckout(
 	repoUrl: string,
-	fullyQualifiedBranchName: string,
+	commitHash: string,
 	filesPaths: string[]
 ) {
-	const refs = await listGitRefs(repoUrl, fullyQualifiedBranchName);
-	const commitHash = refs[fullyQualifiedBranchName];
 	const treesIdx = await fetchWithoutBlobs(repoUrl, commitHash);
 	const objects = await resolveObjects(treesIdx, commitHash, filesPaths);
 
@@ -75,24 +73,24 @@ export type FileTreeFolder = {
 };
 export type FileTree = FileTreeFile | FileTreeFolder;
 
+export type GitRef = {
+	value: string;
+	type?: 'branch' | 'commit' | 'infer';
+};
+
 /**
  * Lists all files in a git repository.
  *
  * See https://git-scm.com/book/en/v2/Git-Internals-Git-Objects for more information.
  *
  * @param repoUrl The URL of the git repository.
- * @param fullyQualifiedBranchName The full name of the branch to fetch from (e.g., 'refs/heads/main').
+ * @param commitHash The commit hash to fetch from.
  * @returns A list of all files in the repository.
  */
 export async function listGitFiles(
 	repoUrl: string,
-	fullyQualifiedBranchName: string
+	commitHash: string
 ): Promise<FileTree[]> {
-	const refs = await listGitRefs(repoUrl, fullyQualifiedBranchName);
-	if (!(fullyQualifiedBranchName in refs)) {
-		throw new Error(`Branch ${fullyQualifiedBranchName} not found`);
-	}
-	const commitHash = refs[fullyQualifiedBranchName];
 	const treesIdx = await fetchWithoutBlobs(repoUrl, commitHash);
 	const rootTree = await resolveAllObjects(treesIdx, commitHash);
 	if (!rootTree?.object) {
@@ -100,6 +98,42 @@ export async function listGitFiles(
 	}
 
 	return gitTreeToFileTree(rootTree);
+}
+
+/**
+ * Resolves a ref description, e.g. a branch name, to a commit hash.
+ *
+ * @param repoUrl The URL of the git repository.
+ * @param ref The branch name or commit hash.
+ * @returns The commit hash.
+ */
+export async function resolveCommitHash(repoUrl: string, ref: GitRef) {
+	if (ref.type === 'infer' || ref.type === undefined) {
+		if (['', 'HEAD'].includes(ref.value)) {
+			ref = {
+				value: ref.value,
+				type: 'branch',
+			};
+		} else if (typeof ref.value === 'string' && ref.value.length === 40) {
+			ref = {
+				value: ref.value,
+				type: 'commit',
+			};
+		} else {
+			ref = {
+				value: `refs/heads/${ref.value}`,
+				type: 'branch',
+			};
+		}
+	}
+	if (ref.type === 'commit') {
+		return ref.value;
+	}
+	const refs = await listGitRefs(repoUrl, ref.value);
+	if (!(ref.value in refs)) {
+		throw new Error(`Branch ${ref.value} not found`);
+	}
+	return refs[ref.value];
 }
 
 function gitTreeToFileTree(tree: GitTree): FileTree[] {

--- a/packages/playground/storage/src/lib/paths.ts
+++ b/packages/playground/storage/src/lib/paths.ts
@@ -46,3 +46,10 @@ export function listDescendantFiles(files: FileTree[], selectedPath: string) {
 	}
 	return descendants;
 }
+
+export function removePathPrefix(path: string, prefix: string) {
+	if (path.startsWith(prefix)) {
+		return path.substring(prefix.length);
+	}
+	return path;
+}


### PR DESCRIPTION
Adjust GitDirectoryReference to stop cutting off the first character from each filename when the repository path starts with a slash.

Closes https://github.com/WordPress/wordpress-playground/issues/2061
Closes #1999

 ## Implementation

The problem was passing the wring prefix length to `fileName.substring()` (user input vs path without the leading slash). This PR adjusts that.

In addition, it updates git-sparse-checkout.ts to use `commitHash` and not ref name for fetching files. This way you can checkout a specific commit, and that's convenient for testing and developers consuming the API.

It also modified the CORS proxy to allow 'git-protocol' in headers.

## Testing 

Go to http://127.0.0.1:5400/website-server/#{%22landingPage%22:%22/wp-admin/%22,%22preferredVersions%22:{%22php%22:%227.4%22,%22wp%22:%225.9%22},%22steps%22:[{%22step%22:%22login%22,%22username%22:%22admin%22},{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22git:directory%22,%22url%22:%22https://wordpress-playground-cors-proxy.net/cors-proxy.php?https://github.com/Automattic/page-optimize.git%22,%22ref%22:%22master%22,%22path%22:%22/%22},%22options%22:{%22activate%22:true,%22targetFolderName%22:%22page-optimize-from-git%22}}]} and confirm you see wp-admin (without CSS).
