### PR TITLE
[Website] Bugfix: Delist data-liberation-core.phar from the preloaded offline mode assets

### DIFF
--- a/packages/vite-extensions/vite-list-assets-required-for-offline-mode.ts
+++ b/packages/vite-extensions/vite-list-assets-required-for-offline-mode.ts
@@ -57,6 +57,7 @@ const patternsToNotCache = [
 	/^\/assets\/php_.*\.js$/, // PHP JS files
 	/^\/assets\/wp-.*\.zip$/, // Minified WordPress builds and static assets bundles
 	/^\/assets\/sqlite-database-integration-[\w]+\.zip/, // SQLite plugin
+	/^\/assets\/data-liberation-core\.phar-[\w]+\.gz$/, // Data Liberation library for WXR imports
 ];
 
 function listFiles(dirPath: string, fileList: string[] = []) {


### PR DESCRIPTION
Removes data-liberation-core.phar from the list of assets preloaded to support offline mode. It was implicitly added to that list in #2058.

The preloading triggers the following error:

```
Failed to execute 'addAll' on 'Cache': Cache.addAll(): duplicate requests
```

The error stops the initialization of the offline mode cache on the first page load. It still work on subsequent page loads. Still, this behavior breaks an E2E test in trunk.

Playground doesn't need to preload that asset. It is only required for a psecific flavor of the importWxr step and there's already an established pattern of not preloading plugins, e.g. the SQLite database integration plugin is not preloaded.

 ## Testing instructions

Confirm the Chromium E2E tests pass
 