### PR TITLE
[Website] Switch the CORS Proxy URL to wordpress-playground-cors-proxy.net

### DIFF
--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig(({ command, mode }) => {
 		'CORS_PROXY_URL' in process.env
 			? process.env.CORS_PROXY_URL
 			: mode === 'production'
-			? '/cors-proxy.php?'
+			? 'https://wordpress-playground-cors-proxy.net/?'
 			: 'http://127.0.0.1:5263/cors-proxy.php?';
 
 	return {


### PR DESCRIPTION
Updates playground.wordpress.net to use the new CORS Proxy URL. This makes sure the requests are not routed through
https://playground.wordpress.net/cors-proxy.php anymore.

As a next step, we should restrict the access from playground.wordpress.net

 ## Testing instructions

None, this is a production-only change. Merge, deploy, confirm it worked.

cc @brandonpayton 
