### PR TITLE
[Website] Enable CORS proxy for all fetches

### DIFF
--- a/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.ts
@@ -1,0 +1,29 @@
+import { cloneRequest } from '@php-wasm/web-service-worker';
+
+export async function fetchWithCorsProxy(
+	input: RequestInfo,
+	init?: RequestInit,
+	corsProxyUrl?: string
+): Promise<Response> {
+	const directFetch = fetch(input, init);
+	if (!corsProxyUrl) {
+		return directFetch;
+	}
+
+	try {
+		return await directFetch;
+	} catch {
+		let newInput: string | Request;
+		if (typeof input === 'string' || input instanceof URL) {
+			newInput = `${corsProxyUrl}${input}`;
+		} else if (input instanceof Request) {
+			newInput = await cloneRequest(input, {
+				url: `${corsProxyUrl}${input.url}`,
+			});
+		} else {
+			throw new Error('Invalid input type for fetch');
+		}
+
+		return fetch(newInput, init);
+	}
+}

--- a/packages/php-wasm/web/src/lib/index.ts
+++ b/packages/php-wasm/web/src/lib/index.ts
@@ -17,3 +17,4 @@ export type {
 
 export * from './tls/certificates';
 export type { TCPOverFetchOptions } from './tcp-over-fetch-websocket';
+export { fetchWithCorsProxy } from './fetch-with-cors-proxy';

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -42,6 +42,7 @@ import { TLS_1_2_Connection } from './tls/1_2/connection';
 import { generateCertificate, GeneratedCertificate } from './tls/certificates';
 import { concatUint8Arrays } from './tls/utils';
 import { ContentTypes } from './tls/1_2/types';
+import { fetchWithCorsProxy } from './fetch-with-cors-proxy';
 
 export type TCPOverFetchOptions = {
 	CAroot: GeneratedCertificate;
@@ -421,10 +422,6 @@ class RawBytesFetch {
 	 * Streams a HTTP response including the status line and headers.
 	 */
 	static fetchRawResponseBytes(request: Request, corsProxyUrl?: string) {
-		const targetRequest = corsProxyUrl
-			? new Request(`${corsProxyUrl}${request.url}`, request)
-			: request;
-
 		// This initially used a TransformStream and piped the response
 		// body to the writable side of the TransformStream.
 		//
@@ -434,7 +431,11 @@ class RawBytesFetch {
 			async start(controller) {
 				let response: Response;
 				try {
-					response = await fetch(targetRequest);
+					response = await fetchWithCorsProxy(
+						request,
+						undefined,
+						corsProxyUrl
+					);
 				} catch (error) {
 					/**
 					 * Pretend we've got a 400 Bad Request response whenever

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -319,7 +319,13 @@ export async function bootPlaygroundRemote() {
 				);
 
 				if (options.withNetworking) {
-					await setupFetchNetworkTransport(phpWorkerApi);
+					console.log(
+						'Setting up fetch network transport',
+						options.corsProxyUrl
+					);
+					await setupFetchNetworkTransport(phpWorkerApi, {
+						corsProxyUrl: options.corsProxyUrl,
+					});
 				}
 
 				setAPIReady();

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -319,10 +319,6 @@ export async function bootPlaygroundRemote() {
 				);
 
 				if (options.withNetworking) {
-					console.log(
-						'Setting up fetch network transport',
-						options.corsProxyUrl
-					);
 					await setupFetchNetworkTransport(phpWorkerApi, {
 						corsProxyUrl: options.corsProxyUrl,
 					});

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -1,4 +1,5 @@
 import { UniversalPHP } from '@php-wasm/universal';
+import { fetchWithCorsProxy } from '@php-wasm/web';
 import { defineWpConfigConsts } from '@wp-playground/blueprints';
 
 export interface RequestData {
@@ -13,13 +14,20 @@ export interface RequestMessage {
 	data: RequestData;
 }
 
+export interface SetupFetchNetworkTransportOptions {
+	corsProxyUrl?: string;
+}
+
 /**
  * Allow WordPress to make network requests via the fetch API.
  * On the WordPress side, this is handled by Requests_Transport_Fetch
  *
  * @param playground the Playground instance to set up with network support.
  */
-export async function setupFetchNetworkTransport(playground: UniversalPHP) {
+export async function setupFetchNetworkTransport(
+	playground: UniversalPHP,
+	options?: SetupFetchNetworkTransportOptions
+) {
 	await defineWpConfigConsts(playground, {
 		consts: {
 			USE_FETCH_FOR_REQUESTS: true,
@@ -58,16 +66,14 @@ export async function setupFetchNetworkTransport(playground: UniversalPHP) {
 			data.headers['x-request-issuer'] = 'php';
 		}
 
-		return handleRequest(data);
+		const corsProxyUrl = options?.corsProxyUrl;
+		return handleRequest(data, (url: any, options: any) =>
+			fetchWithCorsProxy(url, options, corsProxyUrl)
+		);
 	});
 }
 
 export async function handleRequest(data: RequestData, fetchFn = fetch) {
-	const hostname = new URL(data.url).hostname;
-	const fetchUrl = ['w.org', 's.w.org'].includes(hostname)
-		? `/plugin-proxy.php?url=${encodeURIComponent(data.url)}`
-		: data.url;
-
 	let response;
 	try {
 		const fetchMethod = data.method || 'GET';
@@ -81,7 +87,7 @@ export async function handleRequest(data: RequestData, fetchFn = fetch) {
 			fetchHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
 		}
 
-		response = await fetchFn(fetchUrl, {
+		response = await fetchFn(data.url, {
 			method: fetchMethod,
 			headers: fetchHeaders,
 			body: fetchMethod === 'GET' ? undefined : data.data,


### PR DESCRIPTION
Enables CORS proxy for all WordPress and Playground requests by replacing the regular `fetch()` call with a custom `fetchWithCorsProxy()` in:

* TLS network bridge
* URL Blueprint resources
* fetch network transport

This gives WordPress running inside Playground more access to cross origin resources. It is still limited by the proxy itself,  in particular around the supported headers, content types, and allowed transfer sizes.

 ## Implementation

`fetchWithCorsProxy(url, requestOptions, corsProxyUrl)` starts with a regular `fetch(url)`. If it succeeds, we're good. If it fails, it retries, but this time it goes through the CORS proxy: `fetch(\`${corsProxyUrl}${url}\`)`. This applies to all the requests initiated either by WordPress or by the provided Blueprint.

 ## Testing

Go to the URL below. Confirm the output is `int(<large number>)` and the network tools ran two requests:

```
http://127.0.0.1:5400/website-server/#{%22landingPage%22:%22/curl-test.php%22,%22features%22:{%22networking%22:true},%22steps%22:[{%22step%22:%22writeFile%22,%22path%22:%22/wordpress/curl-test.php%22,%22data%22:%22%3C?php\n\t\t\t\t\t$ch%20=%20curl_init();\n\t\t\t\t\tcurl_setopt($ch,%20CURLOPT_URL,%20\%22https://adamadam.blog\%22);\n\t\t\t\t\tcurl_setopt($ch,%20CURLOPT_TCP_NODELAY,%200);\n\t\t\t\t\tcurl_setopt($ch,%20CURLOPT_RETURNTRANSFER,%201);\n\t\t\t\t\t$result%20=%20curl_exec($ch);\n\t\t\t\t\tcurl_close($ch);\n\t\t\t\t\tvar_dump(\n\t\t\t\t\t\tstrlen(\n\t\t\t\t\t\t\t$result\n\t\t\t\t\t\t)\n\t\t\t\t\t);\n\t\t\t\t%22}]}
```

Go to the URL below, confirm it opens the homepage of my blog https://adamadam.blog:

```
http://127.0.0.1:5400/website-server/#{%20%22landingPage%22:%20%22/test.html%22,%20%22steps%22:%20[%20{%20%22step%22:%20%22writeFile%22,%20%22path%22:%20%22/wordpress/test.html%22,%20%22data%22:%20{%20%22resource%22:%20%22url%22,%20%22url%22:%20%22https://adamadam.blog%22%20}%20}%20]%20}
```

Go to the URL below, confirm it opens the homepage of my blog:

```
http://127.0.0.1:5400/website-server/#{%20%22landingPage%22:%20%22/test.html%22,%20%22features%22:%20{%20%22networking%22:%20true%20},%20%22constants%22:%20{%20%22WP_DEBUG%22:%20true,%20%22WP_SCRIPT_DEBUG%22:%20true,%20%22WP_DEBUG_DISPLAY%22:%20true%20},%20%22steps%22:%20[%20{%20%22step%22:%20%22runPHP%22,%20%22code%22:%20%22%3C?php%20require%20'/wordpress/wp-load.php';%20file_put_contents('/wordpress/test.html',%20wp_remote_retrieve_body(wp_safe_remote_get('https://adamadam.blog')));%22%20}%20]%20}
```
