### PR TITLE
Explore Data Liberation exporter

### DIFF
--- a/packages/playground/data-liberation/bootstrap.php
+++ b/packages/playground/data-liberation/bootstrap.php
@@ -10,6 +10,10 @@ require_once __DIR__ . '/blueprints-library/src/WordPress/AsyncHttp/Response.php
 require_once __DIR__ . '/blueprints-library/src/WordPress/AsyncHttp/HttpError.php';
 require_once __DIR__ . '/blueprints-library/src/WordPress/AsyncHttp/Connection.php';
 require_once __DIR__ . '/blueprints-library/src/WordPress/AsyncHttp/Client.php';
+require_once __DIR__ . '/blueprints-library/src/WordPress/Zip/ZipStreamWriter.php';
+require_once __DIR__ . '/blueprints-library/src/WordPress/Zip/ZipFileEntry.php';
+require_once __DIR__ . '/blueprints-library/src/WordPress/Zip/ZipCentralDirectoryEntry.php';
+require_once __DIR__ . '/blueprints-library/src/WordPress/Zip/ZipEndCentralDirectoryEntry.php';
 
 require_once __DIR__ . '/src/byte-readers/WP_Byte_Reader.php';
 require_once __DIR__ . '/src/byte-readers/WP_File_Reader.php';
@@ -64,6 +68,7 @@ require_once __DIR__ . '/src/import/WP_Stream_Importer.php';
 require_once __DIR__ . '/src/import/WP_Entity_Iterator_Chain.php';
 require_once __DIR__ . '/src/import/WP_Retry_Frontloading_Iterator.php';
 require_once __DIR__ . '/src/import/WP_Markdown_Importer.php';
+require_once __DIR__ . '/src/export/WP_Exporter.php';
 
 require_once __DIR__ . '/src/utf8_decoder.php';
 

--- a/packages/playground/data-liberation/plugin.php
+++ b/packages/playground/data-liberation/plugin.php
@@ -657,3 +657,15 @@ add_action(
 		);
 	}
 );
+
+add_action('wp_loaded', 'data_liberation_maybe_test_export');
+function data_liberation_maybe_test_export() {
+	$request_path = parse_url($_SERVER["REQUEST_URI"], PHP_URL_PATH);
+	if( $request_path !== '/_data_liberation_test_export' ) {
+		return;
+	}
+
+	$exporter = new WP_Exporter();
+	$exporter->stream_export();
+	die();
+}

--- a/packages/playground/data-liberation/src/export/WP_Exporter.php
+++ b/packages/playground/data-liberation/src/export/WP_Exporter.php
@@ -38,12 +38,11 @@ class WP_Exporter {
 		$uploads_path = $uploads['basedir'];
 
 		$flags = \FilesystemIterator::SKIP_DOTS;
-		$recursive_dir_iterator = new \RecursiveDirectoryIterator(
-			$uploads_path,
-			$flags
-		);
 		$uploads_iterator = new \RecursiveIteratorIterator(
-			$recursive_dir_iterator
+			new \RecursiveDirectoryIterator(
+				$uploads_path,
+				$flags
+			)	
 		);
 
 		foreach ( $uploads_iterator as $file ) {
@@ -52,7 +51,11 @@ class WP_Exporter {
 			}
 			$absolute_path = $file->getPathname();
 			$relative_path = substr( $absolute_path, strlen($uploads_path) + 1 );
-			$zip_writer->writeFileFromPath( $relative_path, $absolute_path );
+			$zip_writer->writeFileFromPath(
+				// TODO: How to handle unconventional upload locations?
+				"wp-content/uploads/$relative_path",
+				$absolute_path
+			);
 
 			// TODO: Is this necessary to make sure per-file output is flushed?
 			fflush( $output_stream );

--- a/packages/playground/data-liberation/src/export/WP_Exporter.php
+++ b/packages/playground/data-liberation/src/export/WP_Exporter.php
@@ -21,6 +21,14 @@ class WP_Exporter {
 
 		// @TODO: Replace upload URLs with relative file URLs.
 
+		$uploads = wp_upload_dir();
+		// @TODO: This is a hack and kind of broken. Replace attachment URLs using proper XML and URL parsing libraries.
+		$wxr_content = str_replace(
+			trailingslashit( $uploads['baseurl'] ),
+			'file://./wp-content/uploads/',
+			$wxr_content
+		);
+
 		header('Content-Type: application/zip');
 
 		// @TODO: Can we get rid of this open-stdout-on-demand workaround?
@@ -33,7 +41,6 @@ class WP_Exporter {
 		$zip_writer = new ZipStreamWriter( $output_stream );
 		$zip_writer->writeFileFromString( 'META-INF/export.wxr', $wxr_content );
 
-		$uploads = wp_upload_dir();
 		$uploads_path = $uploads['basedir'];
 
 		$flags = \FilesystemIterator::SKIP_DOTS;

--- a/packages/playground/data-liberation/src/export/WP_Exporter.php
+++ b/packages/playground/data-liberation/src/export/WP_Exporter.php
@@ -53,10 +53,11 @@ class WP_Exporter {
 			$absolute_path = $file->getPathname();
 			$relative_path = substr( $absolute_path, strlen($uploads_path) + 1 );
 			$zip_writer->writeFileFromPath( $relative_path, $absolute_path );
+
+			// TODO: Is this necessary to make sure per-file output is flushed?
+			fflush( $output_stream );
 		}
 
 		$zip_writer->finish();
-		// TODO: Is this necessary?
-		fflush( $output_stream );
 	}
 }

--- a/packages/playground/data-liberation/src/export/WP_Exporter.php
+++ b/packages/playground/data-liberation/src/export/WP_Exporter.php
@@ -1,6 +1,5 @@
 <?php
 
-use WordPress\Zip\ZipStreamReader;
 use WordPress\Zip\ZipStreamWriter;
 
 class WP_Exporter {

--- a/packages/playground/data-liberation/src/export/WP_Exporter.php
+++ b/packages/playground/data-liberation/src/export/WP_Exporter.php
@@ -1,0 +1,62 @@
+<?php
+
+use WordPress\Zip\ZipStreamReader;
+use WordPress\Zip\ZipStreamWriter;
+
+class WP_Exporter {
+	public static function stream_export( $output_stream = false ) {
+		// @TODO: This is a hack. Maybe we should have a way to export without setting headers.
+		$preexisting_response_headers = headers_list();
+
+		require_once ABSPATH . 'wp-admin/includes/export.php';
+		ob_start();
+		export_wp();
+
+		// @TODO: This is a hack to avoid headers set by export_wp(). Maybe we should have a way to export without setting headers.
+		header_remove();
+		foreach ( $preexisting_response_headers as $header ) {
+			header( $header, false );
+		}
+
+		$wxr_content = ob_get_clean();
+
+		// @TODO: Replace upload URLs with relative file URLs.
+
+		header('Content-Type: application/zip');
+
+		// @TODO: Can we get rid of this open-stdout-on-demand workaround?
+		// NOTE: Opening stdout on demand after output buffering the export
+		// because output buffering seemed to interfere with a preexisting stdout stream.
+		// By opening stdout after output buffering, streaming the zip to stdout appears to work.
+		if ( !$output_stream ) {
+			$output_stream = fopen('php://output', 'wb');
+		}
+		$zip_writer = new ZipStreamWriter( $output_stream );
+		$zip_writer->writeFileFromString( 'META-INF/export.wxr', $wxr_content );
+
+		$uploads = wp_upload_dir();
+		$uploads_path = $uploads['basedir'];
+
+		$flags = \FilesystemIterator::SKIP_DOTS;
+		$recursive_dir_iterator = new \RecursiveDirectoryIterator(
+			$uploads_path,
+			$flags
+		);
+		$uploads_iterator = new \RecursiveIteratorIterator(
+			$recursive_dir_iterator
+		);
+
+		foreach ( $uploads_iterator as $file ) {
+			if ( $file->isDir() ) {
+				continue;
+			}
+			$absolute_path = $file->getPathname();
+			$relative_path = substr( $absolute_path, strlen($uploads_path) + 1 );
+			$zip_writer->writeFileFromPath( $relative_path, $absolute_path );
+		}
+
+		$zip_writer->finish();
+		// TODO: Is this necessary?
+		fflush( $output_stream );
+	}
+}


### PR DESCRIPTION
## Motivation for the change, related issues

This PR explores a basic export that creates a zip containing a full WXR and all uploads.

Related to #2055

cc @adamziel 

## Implementation details

- [x] Uses the WordPress core WXR exporter
- [x] Puts the output in a zip
- [ ] Rewrite URLs to reference local files (e.g. file://./wp-content/uploads)
- [x] Put the uploads in that same zip, nested under `wp-content/uploads`
- [x] Don't buffer the ZIP in memory, stream-output the files straight to the client

## Testing Instructions (or ideally a Blueprint)

TBD

For manual testing, this PR adds a temporary endpoint for downloading a site's full export zip. GET `/_data_liberation_test_export` to receive an export zip.