### PR TITLE
Revert "Remove old PR preview HTML files and add redirects to new preview modals"

### DIFF
--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -57,10 +57,29 @@ function playground_handle_request() {
 		// Note: Using the header `Vary: Referer` does not seem to affect cacheability.
 		$may_edge_cache = false;
 
-		$log( "Redirecting to '{$redirect['location']}' with status '{$redirect['status']}'" );
-		header( "Location: {$redirect['location']}" );
-		http_response_code( $redirect['status'] );
-		die();
+		if ( isset( $redirect['internal' ] ) && $redirect['internal'] ) {
+			$requested_path = $redirect['location'];
+		} else {
+			$should_redirect = true;
+			if ( isset( $redirect['condition']['referers'] ) ) {
+				$should_redirect = false;
+				if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
+					foreach ( $redirect['condition']['referers'] as $referer ) {
+						if ( str_starts_with( $_SERVER['HTTP_REFERER'], $referer ) ) {
+							$should_redirect = true;
+							break;
+						}
+					}
+				}
+			}
+
+			if ( $should_redirect ) {
+				$log( "Redirecting to '{$redirect['location']}' with status '{$redirect['status']}'" );
+				header( "Location: {$redirect['location']}" );
+				http_response_code( $redirect['status'] );
+				die();
+			}
+		}
 	}
 
 	//
@@ -188,6 +207,20 @@ function playground_maybe_redirect( $requested_path ) {
 		);
 	}
 
+	if ( str_ends_with( $requested_path, '/wordpress' ) ) {
+		return array(
+			'location' => 'wordpress.html',
+			'status' => 301
+		);
+	}
+
+	if ( str_ends_with( $requested_path, '/gutenberg' ) ) {
+		return array(
+			'location' => 'gutenberg.html',
+			'status' => 301
+		);
+	}
+
 	if ( str_ends_with( $requested_path, '/proxy' ) ) {
 		return array(
 			'location' => 'https://github-proxy.com/',
@@ -216,38 +249,16 @@ function playground_maybe_redirect( $requested_path ) {
 		);
 	}
 
-	if (
-		str_ends_with( $requested_path, '/wordpress.html' ) &&
-		isset( $_SERVER['HTTP_REFERER'] ) &&
-		(
-			str_starts_with( $_SERVER['HTTP_REFERER'], 'https://developer.wordpress.org/') ||
-			str_starts_with( $_SERVER['HTTP_REFERER'], 'https://wordpress.org/')
-		)
-	) {
+	if ( str_ends_with( $requested_path, '/wordpress.html' ) ) {
 		return array(
+			'condition' => array(
+				'referers' => array(
+					'https://developer.wordpress.org/',
+					'https://wordpress.org/',
+				),
+			),
 			'location' => '/index.html',
 			'status' => 302,
-		);
-	}
-
-	if (
-		str_ends_with( $requested_path, '/wordpress' ) ||
-		str_ends_with( $requested_path, '/wordpress.html' )
-	) {
-		error_log( 'redir wp' );
-		return array(
-			'location' => '/?modal=preview-pr-wordpress',
-			'status' => 301
-		);
-	}
-
-	if (
-		str_ends_with( $requested_path, '/gutenberg' ) ||
-		str_ends_with( $requested_path, '/gutenberg.html' )
-	) {
-		return array(
-			'location' => '/?modal=preview-pr-gutenberg',
-			'status' => 301
 		);
 	}
 

--- a/packages/playground/website/demos/index.html
+++ b/packages/playground/website/demos/index.html
@@ -67,7 +67,7 @@
 			<a href="time-traveling.html" target="_blank">Time Travel</a>
 		</li>
 		<li>
-			<a href="../?modal=preview-pr-wordpress" target="_blank"
+			<a href="../wordpress.html" target="_blank"
 				>WordPress Pull Request Previewer</a
 			>
 		</li>

--- a/packages/playground/website/public/gutenberg.css
+++ b/packages/playground/website/public/gutenberg.css
@@ -1,0 +1,190 @@
+body,
+html {
+	height: 100%;
+}
+html {
+	font-size: 16px;
+}
+body {
+	margin: 0;
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+		Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	line-height: 1.8;
+	color: #191e23;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+svg {
+	fill: currentColor;
+}
+label {
+	margin-bottom: 4px;
+	font-size: 16px;
+}
+input[type='text'] {
+	appearance: none;
+	-webkit-appearance: none;
+	-moz-appearance: textfield;
+	border: 1px solid #8d96a0;
+	border-radius: 4px;
+	padding: 5px 8px;
+	outline: 0;
+	font-size: 26px;
+}
+input[type='text']::-webkit-inner-spin-button,
+input[type='text']::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+input[type='text']:focus {
+	border-color: #00a0d2;
+	box-shadow: 0 0 0 1px #00a0d2;
+	color: #191e23;
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+}
+button {
+	border-radius: 3px;
+	vertical-align: top;
+	height: 40px;
+	line-height: 38px;
+	padding: 0 12px;
+	webkit-appearance: none;
+	border: 0;
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 30px;
+	margin: 0;
+	background: #0085ba;
+	border-color: #006a95 #00648c #00648c;
+	box-shadow: inset 0 -1px 0 #00648c;
+	color: #fff;
+	text-shadow: 0 -1px 1px #005d82, 1px 0 1px #005d82, 0 1px 1px #005d82,
+		-1px 0 1px #005d82;
+}
+button:hover {
+	box-shadow: inset 0 -1px 0 #00435d;
+	background: #007eb1;
+	border-color: #00435d;
+}
+button:active {
+	background: #006a95;
+	border-color: #00435d;
+	box-shadow: inset 0 1px 0 #00435d;
+	vertical-align: top;
+}
+button:focus {
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+	box-shadow: inset 0 -1px 0 #00435d, 0 0 0 2px #bfe7f3;
+	background: #007eb1;
+	border-color: #00435d;
+}
+#main {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	height: 50vh;
+	width: 100%;
+	margin: 0 auto;
+}
+#logo {
+	flex-shrink: 1;
+	flex-grow: 0;
+	flex-basis: 100%;
+}
+#create,
+#run {
+	height: 60px;
+	margin: 5vh 0;
+	flex-shrink: 0;
+}
+#createFields {
+	display: flex;
+	align-items: center;
+}
+#gutenberg-pr {
+	width: 280px;
+	margin-right: 4px;
+}
+#run {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+#status {
+	display: block;
+	font-weight: 400;
+	font-size: 1.4rem;
+	text-align: center;
+	font-family: 'Noto Serif', serif;
+}
+#progress {
+	max-width: 360px;
+	width: 90%;
+	margin: 0 auto;
+	height: 5px;
+	background: #eaeaea;
+	padding: 3px;
+}
+#progressFill {
+	height: 5px;
+	background: #191e23;
+	transition: width 0.6s ease-in-out;
+}
+#links {
+	text-align: center;
+	padding: 0 10px;
+}
+#error {
+	text-align: center;
+	padding: 0 10px;
+	margin-bottom: 5vh;
+	color: #8b0000;
+	font-weight: bold;
+	font-size: 1.5em;
+}
+
+#submit {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+#submit:not(.loading) .verifying {
+	display: none;
+}
+#submit.loading .go {
+	display: none;
+}
+
+#submit.loading {
+	position: relative;
+	background: #00435d;
+	border-color: #00435d;
+	cursor: default;
+}
+
+#submit.loading:before {
+	content: '';
+	/* position: absolute;
+    top: 0;
+    left: 0; */
+	margin-right: 5px;
+	margin-left: -5px;
+	width: 15px;
+	height: 15px;
+	border-radius: 50%;
+	border: 2px solid #fff;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+
+<head>
+	<title>Gutenberg PR Previewer</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta
+		property="og:image"
+		content="https://playground.wordpress.net/ogimage.png"
+	/>
+	<meta property="og:title" content="Gutenberg Pull Request preview" />
+	<meta
+		property="og:description"
+		content="Try any gutenberg Pull Request live via WordPress Playground!"
+	/>
+	<meta
+		name="description"
+		content="Try any gutenberg Pull Request live via WordPress Playground!"
+	/>
+	<link
+		rel="stylesheet"
+		href="https://fonts.googleapis.com/css?family=Noto+Serif:400,700"
+	/>
+	<link rel="stylesheet" href="./previewer.css" />
+	<script
+		async
+		src="https://www.googletagmanager.com/gtag/js?id=G-SVTNFCP8T7"
+	></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() {
+			dataLayer.push(arguments);
+		}
+		gtag('js', new Date());
+		gtag('config', 'G-SVTNFCP8T7');
+	</script>
+</head>
+
+<body>
+	<div id="main">
+		<!--
+			Credit for the logo and site design goes to Andrew Duthy
+			who originally built and hosted http://gutenberg.run/
+		-->
+		<svg id="logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 150 150">
+			<g transform="translate(-311.9 -353.7)">
+				<path
+					d="M458.6 407c-2.5-1.7-5.9-1-7.6 1.5-9.9 14.9-30.9 15.7-32 15.7h-.5c-25.9 0-35.8 22.1-36.2 23-1.2 2.8.1 6 2.8 7.2.7.3 1.5.5 2.2.5 2.1 0 4.1-1.2 5-3.3.1-.2 6.9-15.4 24.4-16.4v28.3c-.7 6.1-3.6 10.9-8.7 14.5-5.3 3.7-12.4 5.6-21.1 5.6-10.4 0-18.9-3.6-25.2-10.7-6.4-7.1-9.6-17.2-9.6-30.2l.1-31.2c.5-11.5 3.6-20.6 9.5-27.1 6.4-7.1 14.8-10.7 25.2-10.7 8.7 0 15.8 1.9 21.1 5.6 5.3 3.7 8.3 8.8 8.8 15.4v.7c0 3.8 3.1 6.9 6.9 6.9 3.8 0 6.9-3.1 6.9-6.9v-.7c-1-9.9-5.5-17.7-13.6-23.6-8.1-5.9-18.2-8.8-30.4-8.8-14.5 0-26.2 4.8-35.1 14.3-8.4 8.9-12.8 20.6-13.3 35 0 1-.1 2-.1 3l.1 28.1h-.1c0 15.9 4.5 28.6 13.4 38.1s20.6 14.3 35.1 14.3c12.2 0 22.3-2.9 30.4-8.8 7.4-5.4 11.8-12.5 13.3-21.3l.3-31.4c9.1-2.2 21.5-7.2 29.3-19 2-2.5 1.3-5.9-1.3-7.6z"
+				/>
+			</g>
+		</svg>
+		<form
+			id="create"
+			action="https://playground.wordpress.net"
+			method="GET"
+		>
+			<label for="pr-number">Pull request number or URL:</label>
+			<div id="createFields">
+				<input
+					id="pr-number"
+					type="text"
+					name="pr-number"
+					value=""
+					required
+					autofocus
+				/>
+				<button id="submit">
+					<span class="go">Go</span>
+					<span class="verifying">Verifying</span>
+				</button>
+			</div>
+		</form>
+		<div id="error"></div>
+	</div>
+
+	<div id="links">
+		Powered by
+		<a href="https://developer.wordpress.org/playground">
+			WordPress Playground
+		</a>
+		. To build a previewer like this for your repository, check the
+		<a
+			target="_blank"
+			href="https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/gutenberg.html"
+			>code on GitHub</a
+		>
+		and the
+		<a
+			href="https://wordpress.github.io/wordpress-playground/developers/build-your-first-app/#preview-pull-requests-from-your-repository"
+		>
+			documentation page</a
+		>.
+	</div>
+	<script>
+		/*
+		 * This function uses a Playground Blueprint to apply a PR to a WordPress Playground site.
+		 *
+		 * You could build a similar tool to preview Pull Requests from your own repository!
+		 *
+		 * Learn more at:
+		 *
+		 * * https://wordpress.github.io/wordpress-playground/
+		 * * https://wordpress.github.io/wordpress-playground/developers/build-your-first-app/#preview-pull-requests-from-your-repository
+		 */
+
+		let submitting = false;
+		const submitButton = document.getElementById('submit');
+		const form = document.getElementById('create');
+		const errorDiv = document.getElementById('error');
+
+		// If there's a PR query parameter, call previewPr with its value
+		const urlParams = new URLSearchParams(window.location.search);
+		const prNumber = urlParams.get('pr');
+		if (prNumber) {
+			document.getElementById('pr-number').value = prNumber;
+			previewPr(prNumber);
+		}
+
+		form.addEventListener('submit', async function onSubmit(e) {
+			e.preventDefault();
+			if (submitting) {
+				return;
+			}
+			let prNumber = document.getElementById('pr-number').value;
+
+			// Extract number from a GitHub URL
+			if (
+				prNumber
+					.toLowerCase()
+					.includes('github.com/wordpress/gutenberg/pull')
+			) {
+				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
+			}
+
+			previewPr(prNumber);
+		});
+
+		async function previewPr(prNumber) {
+			submitting = true;
+			errorDiv.innerText = '';
+			submitButton.classList.add('loading');
+			submitButton.disabled = true;
+
+			// Verify that the PR exists and that GitHub CI finished building it
+			const zipArtifactUrl = `/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
+			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
+			const response = await fetch(zipArtifactUrl + '&verify_only=true');
+			if (response.status !== 200) {
+				errorDiv.innerText = `The PR ${prNumber} does not exist or GitHub CI did not finish building it yet.`;
+				submitting = false;
+				submitButton.classList.remove('loading');
+				submitButton.disabled = false;
+				return;
+			}
+
+			// Redirect to the Playground site with the Blueprint to download and apply the PR
+			const blueprint = {
+				landingPage: '/wp-admin/',
+				features: {
+					networking: true,
+				},
+				steps: [
+					{
+						step: 'login',
+						username: 'admin',
+						password: 'password',
+					}
+				],
+			};
+			// If there's a import-site query parameter, pass that to the blueprint
+			const urlParams = new URLSearchParams(window.location.search);
+			try {
+				const importSite = new URL(urlParams.get('import-site'));
+				if (importSite) {
+					// Add it as the first step in the blueprint
+					blueprint.steps.unshift({
+						step: 'importWordPressFiles',
+						wordPressFilesZip: {
+							resource: 'url',
+							url: importSite.origin + importSite.pathname,
+						},
+					});
+				}
+			} catch {
+				console.error('Invalid import-site URL');
+			}
+
+			const encoded = JSON.stringify(blueprint);
+			window.location =
+				'./?gutenberg-pr=' + prNumber + '#' + encodeURI(encoded);
+		}
+	</script>
+</body>

--- a/packages/playground/website/public/previewer.css
+++ b/packages/playground/website/public/previewer.css
@@ -1,0 +1,195 @@
+body,
+html {
+	height: 100%;
+}
+html {
+	font-size: 16px;
+}
+body {
+	margin: 0;
+	font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
+		Oxygen-Sans, Ubuntu, Cantarell, Helvetica Neue, sans-serif;
+	line-height: 1.8;
+	color: #191e23;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+svg {
+	fill: currentColor;
+}
+label {
+	margin-bottom: 4px;
+	font-size: 22px;
+}
+input[type='text'] {
+	appearance: none;
+	-webkit-appearance: none;
+	-moz-appearance: textfield;
+	border: 1px solid #8d96a0;
+	border-radius: 4px;
+	padding: 5px 8px;
+	outline: 0;
+	font-size: 26px;
+}
+input[type='text']::-webkit-inner-spin-button,
+input[type='text']::-webkit-outer-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+input[type='text']:focus {
+	border-color: #00a0d2;
+	box-shadow: 0 0 0 1px #00a0d2;
+	color: #191e23;
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+}
+button {
+	border-radius: 3px;
+	vertical-align: top;
+	height: 40px;
+	line-height: 38px;
+	padding: 0 12px;
+	webkit-appearance: none;
+	border: 0;
+	cursor: pointer;
+	display: inline-flex;
+	font-size: 30px;
+	margin: 0;
+	background: #0085ba;
+	border-color: #006a95 #00648c #00648c;
+	box-shadow: inset 0 -1px 0 #00648c;
+	color: #fff;
+	text-shadow: 0 -1px 1px #005d82, 1px 0 1px #005d82, 0 1px 1px #005d82,
+		-1px 0 1px #005d82;
+}
+button:hover {
+	box-shadow: inset 0 -1px 0 #00435d;
+	background: #007eb1;
+	border-color: #00435d;
+}
+button:active {
+	background: #006a95;
+	border-color: #00435d;
+	box-shadow: inset 0 1px 0 #00435d;
+	vertical-align: top;
+}
+button:focus {
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+	box-shadow: inset 0 -1px 0 #00435d, 0 0 0 2px #bfe7f3;
+	background: #007eb1;
+	border-color: #00435d;
+}
+#main {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	height: 50vh;
+	width: 100%;
+	margin: 0 auto;
+}
+#logo {
+	flex-shrink: 1;
+	flex-grow: 0;
+	flex-basis: 100%;
+}
+#create,
+#run {
+	height: 60px;
+	margin: 5vh 0;
+	flex-shrink: 0;
+}
+#createFields {
+	display: flex;
+	align-items: center;
+}
+#pr-number {
+	width: 280px;
+	margin-right: 4px;
+}
+#run {
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+#status {
+	display: block;
+	font-weight: 400;
+	font-size: 1.4rem;
+	text-align: center;
+	font-family: 'Noto Serif', serif;
+}
+#progress {
+	max-width: 360px;
+	width: 90%;
+	margin: 0 auto;
+	height: 5px;
+	background: #eaeaea;
+	padding: 3px;
+}
+#progressFill {
+	height: 5px;
+	background: #191e23;
+	transition: width 0.6s ease-in-out;
+}
+#links {
+	text-align: center;
+	padding: 0 10px;
+}
+#error {
+	max-width: 600px;
+	text-align: center;
+	padding: 20px;
+	margin-top: 5vh;
+	margin-bottom: 5vh;
+	background: #8b0000;
+	color: #fff;
+	font-size: 1.2em;
+}
+#error:empty {
+	display: none;
+}
+
+#submit {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+#submit:not(.loading) .verifying {
+	display: none;
+}
+#submit.loading .go {
+	display: none;
+}
+
+#submit.loading {
+	position: relative;
+	background: #00435d;
+	border-color: #00435d;
+	cursor: default;
+}
+
+#submit.loading:before {
+	content: '';
+	/* position: absolute;
+    top: 0;
+    left: 0; */
+	margin-right: 5px;
+	margin-left: -5px;
+	width: 15px;
+	height: 15px;
+	border-radius: 50%;
+	border: 2px solid #fff;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
+}

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<head>
+	<title>WordPress PR Previewer</title>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta
+		property="og:image"
+		content="https://playground.wordpress.net/ogimage.png"
+	/>
+	<meta property="og:title" content="WordPress Pull Request preview" />
+	<meta
+		property="og:description"
+		content="Try any wordpress-develop Pull Request live via WordPress Playground!"
+	/>
+	<meta
+		name="description"
+		content="Try any wordpress-develop Pull Request live via WordPress Playground!"
+	/>
+	<link
+		rel="stylesheet"
+		href="https://fonts.googleapis.com/css?family=Noto+Serif:400,700"
+	/>
+	<link rel="stylesheet" href="./previewer.css" />
+	<script
+		async
+		src="https://www.googletagmanager.com/gtag/js?id=G-SVTNFCP8T7"
+	></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag() {
+			dataLayer.push(arguments);
+		}
+		gtag('js', new Date());
+		gtag('config', 'G-SVTNFCP8T7');
+	</script>
+</head>
+<body>
+	<div id="main">
+		<svg
+			id="logo"
+			viewBox="0 0 122.52 122.523"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<g fill="#1e1e1e">
+				<path
+					d="m8.708 61.26c0 20.802 12.089 38.779 29.619 47.298l-25.069-68.686c-2.916 6.536-4.55 13.769-4.55 21.388z"
+				/>
+				<path
+					d="m96.74 58.608c0-6.495-2.333-10.993-4.334-14.494-2.664-4.329-5.161-7.995-5.161-12.324 0-4.831 3.664-9.328 8.825-9.328.233 0 .454.029.681.042-9.35-8.566-21.807-13.796-35.489-13.796-18.36 0-34.513 9.42-43.91 23.688 1.233.037 2.395.063 3.382.063 5.497 0 14.006-.667 14.006-.667 2.833-.167 3.167 3.994.337 4.329 0 0-2.847.335-6.015.501l19.138 56.925 11.501-34.493-8.188-22.434c-2.83-.166-5.511-.501-5.511-.501-2.832-.166-2.5-4.496.332-4.329 0 0 8.679.667 13.843.667 5.496 0 14.006-.667 14.006-.667 2.835-.167 3.168 3.994.337 4.329 0 0-2.853.335-6.015.501l18.992 56.494 5.242-17.517c2.272-7.269 4.001-12.49 4.001-16.989z"
+				/>
+				<path
+					d="m62.184 65.857-15.768 45.819c4.708 1.384 9.687 2.141 14.846 2.141 6.12 0 11.989-1.058 17.452-2.979-.141-.225-.269-.464-.374-.724z"
+				/>
+				<path
+					d="m107.376 36.046c.226 1.674.354 3.471.354 5.404 0 5.333-.996 11.328-3.996 18.824l-16.053 46.413c15.624-9.111 26.133-26.038 26.133-45.426.001-9.137-2.333-17.729-6.438-25.215z"
+				/>
+				<path
+					d="m61.262 0c-33.779 0-61.262 27.481-61.262 61.26 0 33.783 27.483 61.263 61.262 61.263 33.778 0 61.265-27.48 61.265-61.263-.001-33.779-27.487-61.26-61.265-61.26zm0 119.715c-32.23 0-58.453-26.223-58.453-58.455 0-32.23 26.222-58.451 58.453-58.451 32.229 0 58.45 26.221 58.45 58.451 0 32.232-26.221 58.455-58.45 58.455z"
+				/>
+			</g>
+		</svg>
+		<form
+			id="create"
+			action="https://playground.wordpress.net"
+			method="GET"
+		>
+			<label for="pr-number">Pull request number or URL:</label>
+			<div id="createFields">
+				<input
+					id="pr-number"
+					type="text"
+					name="pr-number"
+					value=""
+					required
+					autofocus
+				/>
+				<button id="submit">
+					<span class="go">Go</span>
+					<span class="verifying">Verifying</span>
+				</button>
+			</div>
+		</form>
+		<div id="error"></div>
+	</div>
+
+	<div id="links">
+		Powered by
+		<a href="https://developer.wordpress.org/playground">
+			WordPress Playground
+		</a>
+		. To build a previewer like this for your repository, check the
+		<a
+			target="_blank"
+			href="https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/gutenberg.html"
+			>code on GitHub</a
+		>
+		and the
+		<a
+			href="https://wordpress.github.io/wordpress-playground/developers/build-your-first-app/#preview-pull-requests-from-your-repository"
+		>
+			documentation page</a
+		>.
+	</div>
+	<script>
+		/*
+		 * This function uses a Playground Blueprint to apply a PR to a WordPress Playground site.
+		 *
+		 * You could build a similar tool to preview Pull Requests from your own repository!
+		 *
+		 * Learn more at:
+		 *
+		 * * https://wordpress.github.io/wordpress-playground/
+		 * * https://wordpress.github.io/wordpress-playground/developers/build-your-first-app/#preview-pull-requests-from-your-repository
+		 */
+
+		let submitting = false;
+		const submitButton = document.getElementById('submit');
+		const form = document.getElementById('create');
+		const errorDiv = document.getElementById('error');
+
+		form.addEventListener('submit', async function onSubmit(e) {
+			e.preventDefault();
+			if (submitting) {
+				return;
+			}
+
+			previewPr(document.getElementById('pr-number').value);
+		});
+
+		// If there's a PR query parameter, call previewPr with its value
+		let cleanupRetry = null;
+		const urlParams = new URLSearchParams(window.location.search);
+		const prNumber = urlParams.get('pr');
+		if (prNumber) {
+			document.getElementById('pr-number').value = prNumber;
+			previewPr(prNumber);
+		}
+
+		async function previewPr(prNumber) {
+			if (cleanupRetry) {
+				cleanupRetry();
+			}
+
+			submitting = true;
+			errorDiv.innerText = '';
+			submitButton.classList.add('loading');
+			submitButton.disabled = true;
+
+			// Extract number from a GitHub URL
+			if (
+				prNumber
+					.toLowerCase()
+					.includes('github.com/wordpress/wordpress-develop/pull')
+			) {
+				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
+			}
+
+			// Verify that the PR exists and that GitHub CI finished building it
+			const zipArtifactUrl = `https://playground.wordpress.net/plugin-proxy.php?org=WordPress&repo=wordpress-develop&workflow=Test%20Build%20Processes&artifact=wordpress-build-${prNumber}&pr=${prNumber}`;
+			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist
+			const response = await fetch(zipArtifactUrl + '&verify_only=true');
+			if (response.status !== 200) {
+				let error = 'invalid_pr_number';
+				try {
+					const json = await response.json();
+					if (json.error) {
+						error = json.error;
+					}
+				} catch (e) {}
+
+				if (error === 'invalid_pr_number') {
+					errorDiv.innerText = `The PR ${prNumber} does not exist.`;
+				} else if (
+					error === 'artifact_not_found' ||
+					error === 'artifact_not_available'
+				) {
+					if (parseInt(prNumber) < 5749) {
+						errorDiv.innerText = `The PR ${prNumber} predates the Pull Request previewer and requires a rebase before it can be previewed.`;
+					} else {
+						let retryIn = 30000;
+						function renderRetryIn() {
+							errorDiv.innerText = `Waiting for GitHub to finish building PR ${prNumber}. This might take 15 minutes or more! Retrying in ${
+								retryIn / 1000
+							}...`;
+						}
+						renderRetryIn();
+						const timerInterval = setInterval(() => {
+							retryIn -= 1000;
+							if (retryIn <= 0) {
+								retryIn = 0;
+							}
+							renderRetryIn();
+						}, 1000);
+						const scheduledRetry = setTimeout(() => {
+							previewPr(prNumber);
+						}, retryIn);
+						cleanupRetry = () => {
+							clearInterval(timerInterval);
+							clearTimeout(scheduledRetry);
+							cleanupRetry = null;
+						};
+					}
+				} else if (error === 'artifact_invalid') {
+					errorDiv.innerText = `The PR ${prNumber} requires a rebase before it can be previewed.`;
+				} else {
+					errorDiv.innerText = `The PR ${prNumber} couldn't be previewed due to an unexpected error. Please try again later or fill an issue in the WordPress Playground repository.`;
+					// https://github.com/WordPress/wordpress-playground/issues/new
+				}
+				submitting = false;
+				submitButton.classList.remove('loading');
+				submitButton.disabled = false;
+				return;
+			}
+
+			// Redirect to the Playground site with the Blueprint to download and apply the PR
+			const blueprint = {
+				$schema:
+					'https://playground.wordpress.net/blueprint-schema.json',
+				landingPage: urlParams.get('url') || '/wp-admin',
+				login: true,
+				preferredVersions: {
+					php: '7.4',
+				},
+				features: {
+					networking: true,
+				},
+			};
+			const encoded = JSON.stringify(blueprint);
+
+			// Passthrough the mode query parameter if it exists
+			const targetParams = new URLSearchParams();
+			if (urlParams.has('mode')) {
+				targetParams.set('mode', urlParams.get('mode'));
+			}
+			targetParams.set('core-pr', prNumber);
+			window.location =
+				'./?' + targetParams.toString() + '#' + encodeURI(encoded);
+		}
+	</script>
+</body>

--- a/packages/playground/website/src/components/site-manager/sidebar/index.tsx
+++ b/packages/playground/website/src/components/site-manager/sidebar/index.tsx
@@ -59,7 +59,7 @@ export function Sidebar({
 	const resources = [
 		{
 			label: 'Preview WordPress PR',
-			href: '/?modal=preview-pr-wordpress',
+			href: '/wordpress.html',
 		},
 		{
 			label: 'More demos',


### PR DESCRIPTION
Reverts WordPress/wordpress-playground#2081

The change broke PR preview links. The modal does not yet have feature parity with the separate HTML pages. It needs to support all the same user flows and query params before it can  replace the existing previewers. Cc @brandonpayton @ajotka 