### PR TITLE
Build `@php-wasm` packages as dual ESM + CJS

### DIFF
--- a/packages/php-wasm/scopes/package.json
+++ b/packages/php-wasm/scopes/package.json
@@ -20,8 +20,17 @@
 		"directory": "../../../dist/packages/php-wasm/scopes"
 	},
 	"license": "GPL-2.0-or-later",
+	"exports": {
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./package.json": "./package.json",
+		"./README.md": "./README.md"
+	},
 	"type": "module",
-	"main": "index.js",
+	"main": "./index.cjs",
+	"module": "./index.js",
 	"types": "index.d.ts",
 	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
 	"engines": {

--- a/packages/php-wasm/scopes/vite.config.ts
+++ b/packages/php-wasm/scopes/vite.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
 			entry: 'src/index.ts',
 			name: 'php-wasm-scope',
 			fileName: 'index',
-			formats: ['es'],
+			formats: ['es', 'cjs'],
 		},
 		rollupOptions: {
 			// External packages that should not be bundled into your library.

--- a/packages/php-wasm/util/package.json
+++ b/packages/php-wasm/util/package.json
@@ -13,6 +13,17 @@
 		"access": "public",
 		"directory": "../../../dist/packages/php-wasm/util"
 	},
+	"exports": {
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./package.json": "./package.json",
+		"./README.md": "./README.md"
+	},
+	"type": "module",
+	"main": "./index.cjs",
+	"module": "./index.js",
 	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
 	"engines": {
 		"node": ">=18.18.0",

--- a/packages/php-wasm/web-service-worker/package.json
+++ b/packages/php-wasm/web-service-worker/package.json
@@ -19,10 +19,18 @@
 		"access": "public",
 		"directory": "../../../dist/packages/php-wasm/web-service-worker"
 	},
-	"license": "GPL-2.0-or-later",
+	"exports": {
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./package.json": "./package.json",
+		"./README.md": "./README.md"
+	},
 	"type": "module",
-	"main": "src/index.js",
-	"types": "src/index.d.ts",
+	"main": "./index.cjs",
+	"module": "./index.js",
+	"license": "GPL-2.0-or-later",
 	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
 	"engines": {
 		"node": ">=18.18.0",

--- a/packages/php-wasm/web-service-worker/project.json
+++ b/packages/php-wasm/web-service-worker/project.json
@@ -12,15 +12,20 @@
 				"buildTarget": "php-wasm-web-service-worker:build:bundle:production"
 			}
 		},
+		"build:package-json": {
+			"executor": "@wp-playground/nx-extensions:package-json",
+			"options": {
+				"tsConfig": "packages/php-wasm/web-service-worker/tsconfig.lib.json",
+				"outputPath": "dist/packages/php-wasm/web-service-worker",
+				"buildTarget": "php-wasm-web-service-worker:build:bundle:production"
+			}
+		},
 		"build:bundle": {
-			"executor": "@nx/js:tsc",
+			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"options": {
-				"outputPath": "dist/packages/php-wasm/web-service-worker",
-				"main": "packages/php-wasm/web-service-worker/src/index.ts",
-				"tsConfig": "packages/php-wasm/web-service-worker/tsconfig.lib.json",
-				"assets": ["packages/php-wasm/web-service-worker/*.md"],
-				"updateBuildableProjectDepsInPackageJson": true
+				"emptyOutDir": false,
+				"outputPath": "dist/packages/php-wasm/web-service-worker"
 			}
 		},
 		"lint": {

--- a/packages/php-wasm/web-service-worker/vite.config.ts
+++ b/packages/php-wasm/web-service-worker/vite.config.ts
@@ -6,6 +6,8 @@ import { join } from 'path';
 
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { getExternalModules } from '../../vite-extensions/vite-external-modules';
 
 export default defineConfig({
 	cacheDir: '../../../node_modules/.vite/php-wasm-web-service-worker',
@@ -21,6 +23,20 @@ export default defineConfig({
 			root: '../../../',
 		}),
 	],
+
+	build: {
+		lib: {
+			// Could also be a dictionary or array of multiple entry points.
+			entry: 'src/index.ts',
+			name: 'php-wasm-web-service-worker',
+			fileName: 'index',
+			formats: ['es', 'cjs'],
+		},
+		rollupOptions: {
+			// External packages that should not be bundled into your library.
+			external: getExternalModules(),
+		},
+	},
 
 	test: {
 		globals: true,


### PR DESCRIPTION
## Motivation for the change, related issues

Ships CommonJS files alongside ES Modules files for the following packages:

* `@php-wasm/web-service-worker`
* `@php-wasm/util`
* `@php-wasm/scopes`

This resolves Node.js import errors reported in https://github.com/WordPress/wordpress-playground/issues/2086.

Closes https://github.com/WordPress/wordpress-playground/issues/2086

## Implementation details

I broke those imports in https://github.com/WordPress/wordpress-playground/commit/c6b4f4a071f208827bffd8024b03119d0ff1ad6b by creating a dependency between @wp-playground/blueprints and @php-wasm/web-service-worker. The latter package is only built as ESModules and doesn't ship any commonjs files expected by Node.js.

## Testing Instructions (or ideally a Blueprint)

1. Follow https://github.com/WordPress/wordpress-playground/pull/2053 to test-publish the packages locally
2. Import `@php-wasm/web-service-worker` in Node.js to confirm the fix worked