### PR TITLE
Enable separate source maps for all package builds

### DIFF
--- a/packages/php-wasm/cli/vite.config.ts
+++ b/packages/php-wasm/cli/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(() => {
 		build: {
 			assetsInlineLimit: 0,
 			target: 'es2020',
+			sourcemap: true,
 			rollupOptions: {
 				external: [
 					'@php-wasm/node',

--- a/packages/php-wasm/fs-journal/vite.config.ts
+++ b/packages/php-wasm/fs-journal/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
 			fileName: 'index',
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/php-wasm/logger/vite.config.ts
+++ b/packages/php-wasm/logger/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
 			fileName: 'index',
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/php-wasm/node-polyfills/vite.config.ts
+++ b/packages/php-wasm/node-polyfills/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
 			// Don't forget to update your package.json as well.
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig(function () {
 				fileName: 'index',
 				formats: ['es'],
 			},
+			sourcemap: true,
 			rollupOptions: {
 				// Don't bundle the PHP loaders in the final build. See
 				// the preserve-php-loaders-imports plugin above.

--- a/packages/php-wasm/progress/vite.config.ts
+++ b/packages/php-wasm/progress/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
 			// Don't forgot to update your package.json as well.
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/php-wasm/scopes/vite.config.ts
+++ b/packages/php-wasm/scopes/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
 			fileName: 'index',
 			formats: ['es'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/php-wasm/stream-compression/vite.config.ts
+++ b/packages/php-wasm/stream-compression/vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig({
 			// Don't forget to update your package.json as well.
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/php-wasm/universal/vite.config.ts
+++ b/packages/php-wasm/universal/vite.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
 			fileName: 'index',
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/php-wasm/util/vite.config.ts
+++ b/packages/php-wasm/util/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
 			fileName: 'index',
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -80,6 +80,7 @@ export default defineConfig(({ command }) => {
 				fileName: 'index',
 				formats: ['es'],
 			},
+			sourcemap: true,
 			rollupOptions: {
 				// Don't bundle the PHP loaders in the final build. See
 				// the preserve-php-loaders-imports plugin above.

--- a/packages/playground/blueprints/vite.config.ts
+++ b/packages/playground/blueprints/vite.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
 			// Don't forgot to update your package.json as well.
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			external: getExternalModules(),
 		},

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 	build: {
 		assetsInlineLimit: 0,
 		target: 'es2020',
+		sourcemap: true,
 		rollupOptions: {
 			external: [
 				'@php-wasm/node',

--- a/packages/playground/common/vite.config.ts
+++ b/packages/playground/common/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
 		//            in the app mode.
 		// @see https://github.com/vitejs/vite/issues/3295
 		assetsInlineLimit: 0,
+		sourcemap: true,
 		rollupOptions: {
 			input: path('src/index.ts'),
 			// These additional options are required to preserve

--- a/packages/playground/components/vite.config.ts
+++ b/packages/playground/components/vite.config.ts
@@ -41,6 +41,7 @@ export default defineConfig({
 			// Don't forgot to update your package.json as well.
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			external: getExternalModules(),
 		},

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -72,6 +72,7 @@ export default defineConfig({
 	worker: {
 		format: 'es',
 		plugins,
+		sourcemap: true,
 		rollupOptions: {
 			output: {
 				// Ensure the service worker always has the same name
@@ -92,6 +93,7 @@ export default defineConfig({
 		//            in the app mode.
 		// @see https://github.com/vitejs/vite/issues/3295
 		assetsInlineLimit: 0,
+		sourcemap: true,
 		rollupOptions: {
 			input: {
 				wordpress: path('/remote.html'),

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -72,7 +72,6 @@ export default defineConfig({
 	worker: {
 		format: 'es',
 		plugins,
-		sourcemap: true,
 		rollupOptions: {
 			output: {
 				// Ensure the service worker always has the same name

--- a/packages/playground/storage/vite.config.ts
+++ b/packages/playground/storage/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
 			// Don't forgot to update your package.json as well.
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/playground/sync/vite.config.ts
+++ b/packages/playground/sync/vite.config.ts
@@ -37,6 +37,7 @@ export default {
 			// Don't forgot to update your package.json as well.
 			formats: ['es', 'cjs'],
 		},
+		sourcemap: true,
 		rollupOptions: {
 			// External packages that should not be bundled into your library.
 			external: getExternalModules(),

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -170,6 +170,7 @@ export default defineConfig(({ command, mode }) => {
 		// See: https://vitejs.dev/guide/build.html#library-mode
 		build: {
 			target: 'esnext',
+			sourcemap: true,
 			rollupOptions: {
 				input: {
 					index: fileURLToPath(

--- a/packages/playground/wordpress-builds/vite.config.ts
+++ b/packages/playground/wordpress-builds/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
 		//            in the app mode.
 		// @see https://github.com/vitejs/vite/issues/3295
 		assetsInlineLimit: 0,
+		sourcemap: true,
 		rollupOptions: {
 			external: getExternalModules(),
 			input: path('src/index.ts'),

--- a/packages/playground/wordpress/vite.config.ts
+++ b/packages/playground/wordpress/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
 		//            in the app mode.
 		// @see https://github.com/vitejs/vite/issues/3295
 		assetsInlineLimit: 0,
+		sourcemap: true,
 		rollupOptions: {
 			input: path('src/index.ts'),
 			external: getExternalModules(),


### PR DESCRIPTION
## Motivation for the change, related issues

Enabling source map generation for production builds would make it easier to debug Playground in production.

## Implementation details

I edited all vite.config.js files and added `sourcemap: true` to generate separate source maps files for all package builds. Keeping separate source maps should allow us to only pay the cost for downloading them when actively debugging.

## Testing Instructions (or ideally a Blueprint)

- Create a production build, serve it via a local web server, open dev tools, and confirm it is possible to view the original source code.
- CI
