### PR TITLE
Add small comment about lazy init of WXR reader

### DIFF
--- a/packages/playground/data-liberation/src/wxr/WP_WXR_Reader.php
+++ b/packages/playground/data-liberation/src/wxr/WP_WXR_Reader.php
@@ -903,6 +903,8 @@ class WP_WXR_Reader implements Iterator {
 	}
 
 	public function current(): object {
+		// Lazily initialize the iterator when it is first accessed.
+		// The alternative is eager initialization in the constructor.
 		if ( null === $this->entity_data && ! $this->is_finished() && ! $this->get_last_error() ) {
 			$this->next();
 		}


### PR DESCRIPTION
## Motivation for the change, related issues

Adds a small "why" comment to WP_WXR_Reader about lazy init. I originally had a question about this code, and the comment answers it.

## Testing Instructions (or ideally a Blueprint)

CI
