### PR TITLE
[Website] GitHub export modal: Correctly compute the root path when exporting the entire site

### DIFF
--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -231,7 +231,7 @@ export default function GitHubExportForm({
 			} else if (formValues.contentType === 'plugin') {
 				updatedValues['toPathInRepo'] = `/${formValues.plugin}`;
 			} else {
-				updatedValues['toPathInRepo'] = '/playground';
+				updatedValues['toPathInRepo'] = '/';
 			}
 			setFormValues({
 				...formValues,
@@ -312,6 +312,10 @@ export default function GitHubExportForm({
 				);
 			}
 
+			if (relativeExportPaths.length === 0) {
+				relativeExportPaths = ['/'];
+			}
+
 			const isoDateSlug = new Date().toISOString().replace(/[:.]/g, '-');
 			const newBranchName = `playground-changes-${isoDateSlug}`;
 			let commitMessage = formValues.commitMessage;
@@ -382,7 +386,6 @@ export default function GitHubExportForm({
 					});
 				}
 			}
-
 			const changes = await changeset(
 				new Map(Object.entries(ghComparableFiles)),
 				allPlaygroundFiles


### PR DESCRIPTION
Defaults to `/` as a root path instead of `/playground` to fix an error in the full site exporting flow.

One of the previous PRs for the GitHub export modal enforced using `/playground` as the exported path when the target path in repo was missing. This effectively broke the export feature as the initial REST API requests to list the existing files under the specified repository path failed with error 404.

Furthermore, with all the data massaging done in the form, one of the steps first replaced `"/"` with `""` and then filtered it out as an empty value. This PR ensures that `"/"` remains a fallback for the relative repo path.

Really, we could use some automated tests to confirm all the different use-cases for that modal continue to work. It's complicated with the OAuth procedure required. What we could do is either mock the responses or migrate to the isomorphic-git client and ditch the REST API dependency. Git protocol is so much faster than the REST API anyway.

 ## Testing instructions

1. Go to the GitHub export modal
2. Select "custom paths" and export the `/wordpress` directory to `/` in the repo
3. Give it a new, empty repo
4. Start the export procedure
5. Confirm a lot of network requests start. There should be no errors in red text in sight.

Possible closes https://github.com/WordPress/wordpress-playground/issues/2084

cc @bgrgicak 