### PR TITLE
[CORS Proxy] Support chunked encoding when running in Apache/Nginx/etc

### DIFF
--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -97,8 +97,7 @@ $relay_http_code_and_initial_headers_if_not_already_sent = function () use ($ch,
 };
 
 function send_response_chunk($data) {
-    global $is_chunked_response;
-    if ($is_chunked_response && php_sapi_name() === 'cli-server') {
+    if (should_send_as_chunked_response()) {
         // We need to manually chunk the response when running in the PHP
         // built-in server. It won't handle that for us.
         echo sprintf("%s\r\n%s\r\n", dechex(strlen($data)), $data);
@@ -112,6 +111,17 @@ function send_response_chunk($data) {
     }
     @ob_flush();
     @flush();
+}
+
+/**
+ * We need to manually chunk the response when running the PHP
+ * dev server AND the transfer-encoding header is set to chunked.
+ * 
+ * Apache, Nginx, etc. will handle the chunking for us.
+ */
+function should_send_as_chunked_response() {
+    global $is_chunked_response;
+    return $is_chunked_response && php_sapi_name() === 'cli-server';
 }
 
 // Pin the hostname resolution to an IP we've resolved earlier
@@ -265,6 +275,6 @@ curl_close($ch);
 // Only send chunked transfer encoding footer if we're using chunked encoding.
 // We need to manually send the footer when running in the PHP built-in server
 // because, unlike apache or nginx, it won't handle that for us.
-if ($is_chunked_response && php_sapi_name() === 'cli-server') {
+if (should_send_as_chunked_response()) {
     echo "0\r\n\r\n";
 }


### PR DESCRIPTION
Adds support for `transfer-encoding: chunked` on Apache, Nginx, and other web servers.

#2077 added support for `transfer-encoding: chunked` in a way that works on a local PHP dev server. The proxy manually chunks the output bytes and outputs each chunk's header, separator, body, and trailer.

However, it doesn't work on playground.wordpress.net because the web server there handles the chunked encoding on its own. The bytes echoed by cors-proxy.php are treated as body bytes, which messes up the response body.

This PR restricts the manual chunking to a local CLI dev server.

## Testing instructions

Run cors-proxy.php in Apache or so and confirm that requesting resources served with chunked encoding works with this patch but not without it. One such URL is https://adamadam.blog/feed/.
