### PR TITLE
[Blueprints] Ensure plugins and themes are installed in subfolders when using url references in the installPlugin/Theme step

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -67,6 +67,9 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 				die( $response->get_error_message() );
 			} else if ( false === $response ) {
 				die( "The activatePlugin step wasn't able to find the plugin $plugin_path." );
+			} else if ( $response === null ) {
+			 	// When the response is null, the plugin was successfully activated
+				die( 'true' );
 			}
 		`,
 		env: {
@@ -75,6 +78,12 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 		},
 	});
 	if (activatePluginResult.text) {
+		/**
+		 * If the plugin was successfully activated, we can return early.
+		 */
+		if (activatePluginResult.text === 'true') {
+			return;
+		}
 		logger.warn(
 			`Plugin ${pluginPath} activation printed the following bytes: ${activatePluginResult.text}`
 		);

--- a/packages/playground/blueprints/src/lib/steps/install-asset.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-asset.ts
@@ -35,7 +35,7 @@ export async function installAsset(
 		targetPath,
 		zipFile,
 		ifAlreadyInstalled = 'overwrite',
-		targetFolderName = ''
+		targetFolderName = '',
 	}: InstallAssetOptions
 ): Promise<{
 	assetFolderPath: string;
@@ -43,7 +43,15 @@ export async function installAsset(
 }> {
 	// Extract to temporary folder so we can find asset folder name
 	const zipFileName = zipFile.name;
-	const assetNameGuess = zipFileName.replace(/\.zip$/, '');
+	let assetNameGuess = zipFileName.replace(/\.zip$/, '');
+	/**
+	 * Some resource types like GitDirectoryReference and UrlReference
+	 * don't have a name, so we need to generate a random name to ensure
+	 * the asset folder name exists.
+	 */
+	if (!zipFileName) {
+		assetNameGuess = `${randomString(32, '')}`;
+	}
 
 	const wpContent = joinPaths(await playground.documentRoot, 'wp-content');
 	const tmpDir = joinPaths(wpContent, randomString());
@@ -88,7 +96,7 @@ export async function installAsset(
 		}
 
 		// If a specific slug was requested be used, use that.
-		if ( targetFolderName && targetFolderName.length ) {
+		if (targetFolderName && targetFolderName.length) {
 			assetFolderName = targetFolderName;
 		}
 


### PR DESCRIPTION
## Motivation for the change, related issues

Before this PR, a plugin or theme could be installed to the `wp-content/plugins` and `wp-content/themes` folder without a subfolder.
This would happen when the plugin/theme resource was installed using references without a name attribute, [for example using a URL reference.](https://github.com/WordPress/wordpress-playground/blob/41bb913d1a347809bfaee7154e926ce68b0d6e73/packages/playground/blueprints/src/lib/steps/install-asset.ts#L45)

This was caused by the [install asset code assuming there will always be a name](https://github.com/WordPress/wordpress-playground/pull/2128/files#diff-0fe76e82e969a1cae5a9aed6d4976a180ca4946567925907b24b92d28a4c99a5R46) but the name isn't a required attribute in some reference types, so it can be empty.

To fix this we now generate a random asset name in case it doesn't already exist. 

There is a chance that a plugin doesn't use a subfolder (for example Hello Dolly), but because we can't assume this it's safer to install it into a subfolder. Otherwise, multiple plugins installed in the `wp-content/plugins` or `wp-content/themes` directory could override each other's files. 
Also today the [activate plugin script assumes there is only one plugin in the provided folder](https://github.com/WordPress/wordpress-playground/blob/65c1dce308aaf8eb4d8f6e08578bc76870640de0/packages/playground/blueprints/src/lib/steps/activate-plugin.ts#L61).

### Potential improvements

~~This approach isn't ideal because it means the plugin/theme will be installed into a randomly generated folder which isn't expected. We should consider other ways of extracting the name.~~ [Exploration conclusion](https://github.com/WordPress/wordpress-playground/pull/2128#issuecomment-2589678036)

Also, we could add support for names to other resource types, but this wouldn't fix existing Blueprints. 


## Testing Instructions (or ideally a Blueprint)

- Open this [Playground URL](http://127.0.0.1:5400/website-server/#{%22landingPage%22:%22/wp-admin/plugins.php%22,%22features%22:{%22networking%22:true},%22preferredVersions%22:{%22wp%22:%22latest%22,%22php%22:%228.3%22},%22login%22:true,%22steps%22:[{%22step%22:%22installPlugin%22,%22pluginData%22:{%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy/?repo=ryanwelcher/interactivity-api-todomvc&release=v0.1.3&asset=to-do-mvc.zip%22},%22options%22:{%22activate%22:true}}]})
- Confirm that the _To Do Mvc_ plugin is active and that there are no errors in the browser console
