### PR TITLE
Fix scp error in web app deployment

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -57,15 +57,14 @@ jobs:
                     dist/packages/playground/wasm-wordpress-net/ \
                     ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:'~/updated-playground-files'
 
+                  # Include MIME types for use with PHP-served files
+                  cp packages/php-wasm/universal/src/lib/mime-types.json \
+                    packages/playground/website-deployment/
+
                   # Host-specific deployment scripts and server config
                   rsync -avz -e "ssh -i ~/.ssh/id_ed25519" --delete \
                     packages/playground/website-deployment/ \
                     ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:'~/website-deployment'
-
-                  # Copy MIME types for use with PHP-served files
-                  scp -i ~/.ssh/id_ed25519 \
-                    packages/php-wasm/universal/src/lib/mime-types.json \
-                    ${{ secrets.DEPLOY_WEBSITE_TARGET_USER }}@${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}:'~/website-deployment/'
 
                   # Apply update
                   ssh -i ~/.ssh/id_ed25519 \


### PR DESCRIPTION
## Motivation for the change, related issues

We're currently experiencing an scp error when attempting to transfer `mime-types.json` as a single file to a the destination `'~/website-deployment/'`.
https://github.com/WordPress/wordpress-playground/actions/runs/13481525026/job/37667340559#step:7:16325

It seems like the home dir resolution is failing altogether or inconsistent between scp and regular ssh login. This was working before. There may have been a change in the hosting environment that inadvertently affected this script.

The previous step copies a directory to the same destination, and that is working fine.

## Implementation details

As a workaround, this PR just copies `mime-types.json` into the local directory that is successfully copied to the server. This way, the file is transferred to the same location, and we avoid this single-file weirdness with scp.

## Testing Instructions (or ideally a Blueprint)

- CI
- Try workflow after merging. The workflow is already currently broken, and it is faster to test this way.