### PR TITLE
Ensure all NPM packages have readmes included in their builds

### DIFF
--- a/packages/php-wasm/cli/project.json
+++ b/packages/php-wasm/cli/project.json
@@ -5,6 +5,19 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/php-wasm/cli/README.md dist/packages/php-wasm/cli"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",
 			"options": {
 				"tsConfig": "packages/php-wasm/cli/tsconfig.lib.json",

--- a/packages/php-wasm/progress/project.json
+++ b/packages/php-wasm/progress/project.json
@@ -5,6 +5,19 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/php-wasm/progress/README.md dist/packages/php-wasm/progress"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",
 			"options": {
 				"tsConfig": "packages/php-wasm/progress/tsconfig.lib.json",

--- a/packages/php-wasm/scopes/project.json
+++ b/packages/php-wasm/scopes/project.json
@@ -5,6 +5,19 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/php-wasm/scopes/README.md dist/packages/php-wasm/scopes"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",
 			"options": {
 				"tsConfig": "packages/php-wasm/scopes/tsconfig.lib.json",

--- a/packages/php-wasm/web-service-worker/project.json
+++ b/packages/php-wasm/web-service-worker/project.json
@@ -5,12 +5,17 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
-			"executor": "@wp-playground/nx-extensions:package-json",
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
 			"options": {
-				"tsConfig": "packages/php-wasm/web-service-worker/tsconfig.lib.json",
-				"outputPath": "dist/packages/php-wasm/web-service-worker",
-				"buildTarget": "php-wasm-web-service-worker:build:bundle:production"
-			}
+				"commands": [
+					"cp packages/php-wasm/web-service-worker/README.md dist/packages/php-wasm/web-service-worker"
+				]
+			},
+			"dependsOn": ["build:package-json"]
 		},
 		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",

--- a/packages/playground/blueprints/project.json
+++ b/packages/playground/blueprints/project.json
@@ -5,6 +5,19 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/playground/blueprints/README.md dist/packages/playground/blueprints"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",
 			"options": {
 				"tsConfig": "packages/playground/blueprints/tsconfig.lib.json",

--- a/packages/playground/cli/project.json
+++ b/packages/playground/cli/project.json
@@ -5,6 +5,19 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/playground/cli/README.md dist/packages/playground/cli"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",
 			"options": {
 				"tsConfig": "packages/playground/cli/tsconfig.lib.json",

--- a/packages/playground/client/project.json
+++ b/packages/playground/client/project.json
@@ -5,13 +5,26 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/playground/client/README.md dist/packages/playground/client"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@wp-playground/nx-extensions:package-json",
 			"options": {
 				"tsConfig": "packages/playground/client/tsconfig.lib.json",
 				"outputPath": "dist/packages/playground/client",
 				"buildTarget": "playground-client:build:bundle:production"
 			},
-			"dependsOn": ["build:README", "build:rollup-declarations"]
+			"dependsOn": ["build:rollup-declarations"]
 		},
 		"build:rollup-declarations": {
 			"executor": "nx:run-commands",
@@ -23,15 +36,6 @@
 					"cp packages/playground/client/src/rollup.d.ts dist/packages/playground/client/index.d.ts"
 				],
 				"parallel": false
-			},
-			"dependsOn": ["build:bundle"]
-		},
-		"build:README": {
-			"executor": "nx:run-commands",
-			"options": {
-				"commands": [
-					"cp packages/playground/client/README.md dist/packages/playground/client"
-				]
 			},
 			"dependsOn": ["build:bundle"]
 		},

--- a/packages/playground/components/project.json
+++ b/packages/playground/components/project.json
@@ -5,6 +5,19 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/playground/components/README.md dist/packages/playground/components"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"defaultConfiguration": "production",

--- a/packages/playground/components/project.json
+++ b/packages/playground/components/project.json
@@ -15,9 +15,9 @@
 					"cp packages/playground/components/README.md dist/packages/playground/components"
 				]
 			},
-			"dependsOn": ["build:package-json"]
+			"dependsOn": ["build:vite"]
 		},
-		"build:package-json": {
+		"build:vite": {
 			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"defaultConfiguration": "production",

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -15,9 +15,9 @@
 					"cp packages/playground/remote/README.md dist/packages/playground/remote"
 				]
 			},
-			"dependsOn": ["build:package-json"]
+			"dependsOn": ["build:vite"]
 		},
-		"build:package-json": {
+		"build:vite": {
 			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"options": {

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -5,6 +5,19 @@
 	"projectType": "library",
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/playground/remote/README.md dist/packages/playground/remote"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"options": {

--- a/packages/playground/sync/project.json
+++ b/packages/playground/sync/project.json
@@ -6,6 +6,19 @@
 	"tags": ["scope:web-client"],
 	"targets": {
 		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/playground/sync/README.md dist/packages/playground/sync"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
 			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"defaultConfiguration": "production",

--- a/packages/playground/sync/project.json
+++ b/packages/playground/sync/project.json
@@ -16,9 +16,9 @@
 					"cp packages/playground/sync/README.md dist/packages/playground/sync"
 				]
 			},
-			"dependsOn": ["build:package-json"]
+			"dependsOn": ["build:vite"]
 		},
-		"build:package-json": {
+		"build:vite": {
 			"executor": "@nx/vite:build",
 			"outputs": ["{options.outputPath}"],
 			"defaultConfiguration": "production",


### PR DESCRIPTION
## Motivation for the change, related issues

This PR ensures all public package builds include a  README.md file,
because some of our NPM packages don't include a readme on the npmjs.com package page.

The readmes exist in project folders, but before this PR they were not added to the built version of the package.

## Implementation details

Add `build:README` step to these public packages:

- @php-wasm/cli
- @php-wasm/progress
- @php-wasm/scopes
- @php-wasm/web-service-worker
- @wp-playground/blueprints
- @wp-playground/cli
- @wp-playground/client
- @wp-playground/components
- @wp-playground/remote
- @wp-playground/sync

## Testing Instructions (or ideally a Blueprint)

- Remove the `dist` folder if it exists
- Run `npm run build`
- Check that all PHP-wasm builds have a README.md
```
find dist/packages/php-wasm -mindepth 1 -maxdepth 1 -type d '!' -exec test -e '{}/README.md' \; -print
```
- The above command should only return `dist/packages/php-wasm/out-tsc-phpwasm-node` which isn't a package
- Check that all Playground builds have a README.md
```
find dist/packages/playground -mindepth 1 -maxdepth 1 -type d '!' -exec test -e '{}/README.md' \; -print
```
- The above command should only return `dist/packages/playground/website` which isn't a published package

