### PR TITLE
[Fix] Zip spec compliance for exported backup file

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/zip-wp-content.ts
+++ b/packages/playground/blueprints/src/lib/steps/zip-wp-content.ts
@@ -106,7 +106,8 @@ function zipDir($root, $output, $options = array())
                         $directory_path = $entry . '/';
                         array_push($directories, $directory_path);
                     } else if (is_file($entry)) {
-                        $zip->addFile($entry, substr($entry, strlen($zip_root)));
+                        // ensure compliance with zip spec by only using relative paths for files
+                        $zip->addFile($entry, ltrim(substr($entry, strlen($zip_root)), '/'));
                     }
                 }
                 closedir($handle);


### PR DESCRIPTION
## Motivation for the change, related issues
Files in a zip file should only have relative urls as per spec. Right now, when exporting the backup for the site, we create a zip file with a leading slash in the files inside it.

This got surfaced in Studio app when we switched to a diff zip library that strictly adheres to zip spec and PG exported zip files fail to process.

Related to: https://github.com/Automattic/dotcom-forge/issues/10369

Note: There are other places where `ZipArchive` is used but this PR only modifies the location that impacts the site export. <img width="531" alt="Screenshot 2025-01-30 at 11 44 32" src="https://github.com/user-attachments/assets/561896ee-0fe9-40c1-b413-d226c68fc0be" />
Probably other places can use the same change, and I can follow that up in a separate PR, if you like.

## Testing Instructions (or ideally a Blueprint)
Export zip of a site and examine the file paths inside it using the following script:

```php
<?php
$zip = new ZipArchive();
$zip->open('/Users/ashfame/Downloads/wordpress-playground-16.zip');
echo "=== ZIP Contents ===".PHP_EOL;
for($i = 0; $i < $zip->numFiles; $i++) {
	echo $zip->getNameIndex($i) . PHP_EOL;
}
echo "=== End ZIP Contents ===".PHP_EOL;
$zip->close();
```

Prior to this PR, you would see file paths like:
```
/wp-content/themes/twentytwentyfive/patterns/more-posts.php
```
and with this PR you will see file paths without the leading slash:
```
wp-content/themes/twentytwentyfive/patterns/more-posts.php
```
