### PR TITLE
Stop adding source maps to offline assets list (#68)

### DIFF
--- a/packages/vite-extensions/vite-list-assets-required-for-offline-mode.ts
+++ b/packages/vite-extensions/vite-list-assets-required-for-offline-mode.ts
@@ -17,6 +17,10 @@ const patternsToNotCache = [
 	/\/test-fixtures\/.*/, // Test fixtures
 	'/index.js',
 	/**
+	 * Source maps are not required to run the site and can be quite large.
+	 */
+	/\.js\.map$/,
+	/**
 	 * WordPress assets removed from the minified builds, for example:
 	 *
 	 *      /wp-6.2/wp-content/themes/twentytwentyone/style.css


### PR DESCRIPTION
## Motivation for the change, related issues

When I enabled source maps for the website build in [bba856f](https://github.com/WordPress/wordpress-playground/commit/bba856fcadb1c3e6d3bdea3387cb8c382553b480), the source maps were inadvertently added to the list of assets required for working offline.

Source maps are not needed to run Playground offline, and they can be quite large. So we need to remove them from the list.

## Implementation details

This PR adds a new exclusion pattern so source maps are no longer included in `assets-required-for-offline-mode.json`.

## Testing Instructions (or ideally a Blueprint)

- On trunk, build the website and save a copy of `dist/packages/playground/wasm-wordpress-net/assets-required-for-offline-mode.json`
- Switch to this branch, rebuild the website, and save another copy of the above JSON file.
- Confirm that there are no .js.map files referenced in the second JSON file.
- On the command line run `diff <(cat old.json | sort) <(cat new.json | sort)` and confirm that the only differences are .js.map files missing from the second JSON file.
