### PR TITLE
Attempt to fix docs site deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - run: npm run build:docs
-            - uses: actions/upload-pages-artifact@v1
+            - uses: actions/upload-pages-artifact@v3
               with: { path: dist/docs/build }
             - name: Deploy to GitHub Pages
               id: deployment


### PR DESCRIPTION
## Motivation for the change, related issues

This PR attempts to fix the following error:

Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Implementation details

- We update actions/upload-pages-artifact from v1 to v3.
- The v1 version uses actions/upload-artifact@v3.
- The v3 version uses actions/upload-artifact@v4, which is the latest major version.

## Testing Instructions (or ideally a Blueprint)

- CI

Docs site deployment is already broken. Let's go ahead and merge this and see how doc site deployment runs on trunk.
