### PR TITLE
Update deploy-pages action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,4 +194,4 @@ jobs:
               with: { path: dist/docs/build }
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v2
+              uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Motivation for the change, related issues

The current docs deploy workflow cannot find the docs artifact after updating to upload-pages-artifact@v3. The [example](https://github.com/actions/upload-pages-artifact/blob/2d163be3ddce01512f3eea7ac5b7023b5d643ce1/README.md#usage) for upload-pages-artifact@v3 shows use of deploy-pages@v4.

## Implementation details

Let's try updating to `deploy-pages@v4`.

## Testing Instructions (or ideally a Blueprint)

- CI
- Observe whether this fixes the broken the doc deployment workflow