### PR TITLE
Replace nightly version with trunk

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
@@ -113,10 +113,19 @@ export function UnconnectedSiteSettingsForm({
 										},
 										...Object.keys(
 											supportedWPVersions || {}
-										).map((version) => ({
-											label: `${supportedWPVersions[version]}`,
-											value: version,
-										})),
+										).map((version) => {
+											const label =
+												version === 'nightly'
+													? 'trunk'
+													: supportedWPVersions[
+															version
+													  ];
+											const value =
+												version === 'nightly'
+													? 'trunk'
+													: version;
+											return { label, value };
+										}),
 									]
 								}
 								onChange={(value, extra) => {

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -614,12 +614,12 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 			version: 'custom-' + sha1.substring(0, 8),
 			source: 'inferred',
 		};
-	} else if (versionQuery === 'trunk' || versionQuery === 'nightly') {
+	} else if (versionQuery === 'trunk') {
 		return {
 			releaseUrl:
-				'https://wordpress.org/nightly-builds/wordpress-latest.zip',
-			version: 'nightly-' + new Date().toISOString().split('T')[0],
-			source: 'inferred',
+				'https://github.com/WordPress/wordpress-develop/archive/refs/heads/trunk.zip',
+			version: 'trunk-' + new Date().toISOString().split('T')[0],
+			source: 'github',
 		};
 	}
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordpress-playground/issues/1763

This PR replaces the existing Nightly WordPress version option in the Playground UI with Trunk, which downloads directly from the wordpress/wordpress trunk branch.

**What’s Changed**

- Removed the nightly option from the version selector.
- Updated the version dropdown to include a Trunk option that uses:

`wp: "https://github.com/WordPress/WordPress/archive/refs/heads/trunk.zip"`

**Why Replace Nightly with Trunk?**

- The current "Nightly" builds are committed daily to the repo as .zip files, which causes **significant repository bloat over time.**
- Using Trunk avoids this issue by **downloading directly from GitHub,** eliminating the need to store the zip file in the repo.
- Trunk offers essentially the same latest development build as Nightly.
- This change helps reduce maintenance overhead while continuing to support up-to-date WordPress testing.

**Testing Instructions**

1. Run the Playground locally.
2. In the “WordPress version” dropdown, select Trunk.
3. Ensure the Playground loads WordPress from the [trunk ZIP](https://github.com/WordPress/WordPress/archive/refs/heads/trunk.zip).
4. Verify general site behavior to confirm successful WP load.

**Video:**


https://github.com/user-attachments/assets/d2ed077d-edee-40a4-96d9-a0a5c4eafe64


