### PR TITLE
Add links to WordPress plugin and theme directories for easier discovery

### DIFF
--- a/packages/docs/site/docs/developers/03-build-an-app/01-index.md
+++ b/packages/docs/site/docs/developers/03-build-an-app/01-index.md
@@ -49,6 +49,13 @@ You can install plugins and themes from the WordPress directory with only URL pa
 
 ## Showcase any plugin or theme
 
+Looking for plugins or themes to try?
+
+Browse the official directories to discover plugin and theme slugs:
+
+-   [WordPress Plugin Directory](https://wordpress.org/plugins/)
+-   [WordPress Theme Directory](https://wordpress.org/themes/)
+
 What if your plugin is not in the WordPress directory?
 
 You can still showcase it on Playground by using [JSON Blueprints](/blueprints). For example, this Blueprint would download and install a plugin and a theme from your website and also import some starter content:

--- a/packages/docs/site/docs/developers/03-build-an-app/01-index.md
+++ b/packages/docs/site/docs/developers/03-build-an-app/01-index.md
@@ -51,7 +51,7 @@ You can install plugins and themes from the WordPress directory with only URL pa
 
 Looking for plugins or themes to try?
 
-Browse the official directories to discover plugin and theme slugs:
+Browse the official directories to discover plugin and theme and their slugs.
 
 -   [WordPress Plugin Directory](https://wordpress.org/plugins/)
 -   [WordPress Theme Directory](https://wordpress.org/themes/)

--- a/packages/docs/site/docs/developers/24-limitations/01-index.md
+++ b/packages/docs/site/docs/developers/24-limitations/01-index.md
@@ -14,7 +14,7 @@ You can track the status of these issues on the [Playground Project board](https
 
 Playground [disables network connections](/blueprints/data-format#features) by default, blocking access to wp.org assets (themes, plugins, blocks, or patterns) in `wp-admin`. You can still upload zipped plugin and theme files from your device or enable the option via the [Query API](/developers/apis/query-api#available-options) or [Blueprints API](/blueprints/troubleshoot-and-debug#review-common-gotchas).
 
-To find plugin and theme slugs, you can browse the official WordPress directories outside Playground:
+To find plugins and themes and their slugs, browse the official WordPress directories outside of Playground.
 
 -   [WordPress Plugin Directory](https://wordpress.org/plugins/)
 -   [WordPress Theme Directory](https://wordpress.org/themes/)

--- a/packages/docs/site/docs/developers/24-limitations/01-index.md
+++ b/packages/docs/site/docs/developers/24-limitations/01-index.md
@@ -14,6 +14,11 @@ You can track the status of these issues on the [Playground Project board](https
 
 Playground [disables network connections](/blueprints/data-format#features) by default, blocking access to wp.org assets (themes, plugins, blocks, or patterns) in `wp-admin`. You can still upload zipped plugin and theme files from your device or enable the option via the [Query API](/developers/apis/query-api#available-options) or [Blueprints API](/blueprints/troubleshoot-and-debug#review-common-gotchas).
 
+To find plugin and theme slugs, you can browse the official WordPress directories outside Playground:
+
+-   [WordPress Plugin Directory](https://wordpress.org/plugins/)
+-   [WordPress Theme Directory](https://wordpress.org/themes/)
+
 ### Temporary by design
 
 As Playground [streams rather than serves](/about#streamed-not-served) WordPress, all database changes and uploads will be gone when you refresh the page. To avoid losing your work, either [export your work](/quick-start-guide#save-your-site) before or enable storage in the browser/device via the "Save" button found in the "Open Playground Manager" menu on the top left of the site.

--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -37,6 +37,13 @@ Everything you build stays in your browser and is **not** sent anywhere. Once yo
 
 You can upload any plugin or theme you want in [/wp-admin/](https://playground.wordpress.net/?url=/wp-admin/).
 
+If you're not sure which plugin or theme to use, you can explore the official directories here:
+
+-   [WordPress Plugin Directory](https://wordpress.org/plugins/)
+-   [WordPress Theme Directory](https://wordpress.org/themes/)
+
+Use the plugin or theme slug from the URL to preinstall them via Playground.
+
 To save a few clicks, you can preinstall plugins or themes from the WordPress plugin directory by adding a `plugin` or `theme` parameter to the URL. For example, to install the coblocks plugin, you can use this URL:
 
 https://playground.wordpress.net/?plugin=coblocks


### PR DESCRIPTION
Fixes #1548

This PR improves the user experience for new or first-time Playground users by adding helpful links to the official WordPress Plugin and Theme directories. These additions make it easier for users to discover plugin and theme slugs they can use with the Playground Query API.

### What’s Changed

Added the following links:
- [WordPress Plugin Directory](https://wordpress.org/plugins/)
- [WordPress Theme Directory](https://wordpress.org/themes/)

### Updated Docs

- `start-using.md`: Added directory links to the "Try a block, a theme, or a plugin" section.
- `build-your-first-app.md`: Added helpful links after plugin/theme slug usage examples.
- `limitations.md`: Added directory links where access limitations to `/wp-admin/` are discussed.

These updates help users easily explore and find correct slugs to use in the URL query parameters like `?plugin=` and `?theme=`.
