### PR TITLE
Give user alert to confirm browser refresh

### DIFF
--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -222,3 +222,12 @@ function setQueryParams(url: string, params: Record<string, unknown>) {
 	urlObject.search = qs.toString();
 	return urlObject.toString();
 }
+
+// Add beforeunload event listener to warn about unsaved changes
+window.addEventListener('beforeunload', (event) => {
+    // You might want to add conditions here to only show when there are actual changes
+    // For now, we'll show it for all page exits
+    event.preventDefault();
+    event.returnValue = ''; // Required for Chrome
+    return ''; // Required for some other browsers
+});


### PR DESCRIPTION
Fixes https://github.com/WordPress/wordpress-playground/issues/81

This PR addresses #81 – Give user alert to confirm browser refresh by adding a browser-level confirmation dialog that triggers when a user attempts to refresh or close the Playground window/tab. This helps prevent accidental data loss or session interruption due to unintended refreshes.

✅ **Changes Introduced**

- Added a beforeunload event listener to the Playground UI.
- The event prompts a native browser confirmation dialog, asking the user to confirm if they really want to refresh or navigate away from the page.
- Ensures smoother UX by reducing unintentional disruptions during usage.

🧪 **Testing Instructions**

- Start the Playground.
- Interact with any UI component to simulate an active session.
- Try refreshing the page or closing the browser tab.
- A browser-native alert will now ask for confirmation.

**Sceenshot**

![confirm_alert](https://github.com/user-attachments/assets/61308a05-fc35-42ea-bc90-59a6f08d730e)
