### PR TITLE
Fix doc deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,8 +296,8 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - run: npm run build:docs
-            - uses: actions/upload-pages-artifact@v1
+            - uses: actions/upload-pages-artifact@v3
               with: { path: dist/docs/build }
             - name: Deploy to GitHub Pages
               id: deployment
-              uses: actions/deploy-pages@v2
+              uses: actions/deploy-pages@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,9 +270,10 @@ jobs:
     # Deploy documentation job
     deploy_docs:
         # Only deploy docs when pushing to the WordPress/wordpress-playground repository
+        # TODO: Remove PR branch from condition
         if: >
             github.repository == 'WordPress/wordpress-playground' &&
-            github.ref == 'refs/heads/trunk' &&
+            (github.ref == 'refs/heads/trunk' || github.ref == 'refs/heads/fix-doc-deployment') &&
             github.event_name == 'push'
         # Add a dependency to the build job
         needs: [test-unit-asyncify, test-e2e, build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,11 +270,10 @@ jobs:
     # Deploy documentation job
     deploy_docs:
         # Only deploy docs when pushing to the WordPress/wordpress-playground repository
-        # TODO: Re-enable branch protections
-        # if: >
-        #     github.repository == 'WordPress/wordpress-playground' &&
-        #     github.ref == 'refs/heads/trunk' &&
-        #     github.event_name == 'push'
+        if: >
+            github.repository == 'WordPress/wordpress-playground' &&
+            github.ref == 'refs/heads/trunk' &&
+            github.event_name == 'push'
         # Add a dependency to the build job
         needs: [test-unit-asyncify, test-e2e, build]
         name: 'Deploy doc site'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,10 +270,11 @@ jobs:
     # Deploy documentation job
     deploy_docs:
         # Only deploy docs when pushing to the WordPress/wordpress-playground repository
-        # TODO: Remove PR branch from condition
-        if: >
-            github.repository == 'WordPress/wordpress-playground' &&
-            ((github.ref == 'refs/heads/trunk' && github.event_name == 'push') || github.ref == 'refs/heads/fix-doc-deployment')
+        # TODO: Re-enable branch protections
+        # if: >
+        #     github.repository == 'WordPress/wordpress-playground' &&
+        #     github.ref == 'refs/heads/trunk' &&
+        #     github.event_name == 'push'
         # Add a dependency to the build job
         needs: [test-unit-asyncify, test-e2e, build]
         name: 'Deploy doc site'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,8 +273,7 @@ jobs:
         # TODO: Remove PR branch from condition
         if: >
             github.repository == 'WordPress/wordpress-playground' &&
-            (github.ref == 'refs/heads/trunk' || github.ref == 'refs/heads/fix-doc-deployment') &&
-            github.event_name == 'push'
+            ((github.ref == 'refs/heads/trunk' && github.event_name == 'push') || github.ref == 'refs/heads/fix-doc-deployment')
         # Add a dependency to the build job
         needs: [test-unit-asyncify, test-e2e, build]
         name: 'Deploy doc site'


### PR DESCRIPTION
## Motivation for the change, related issues

Doc deployment is failing after PRs are merged. Example [here](https://github.com/WordPress/wordpress-playground/actions/runs/15415560458/job/43413520891#step:1:60).

## Implementation details

This PR updates the versions of the GH actions used for doc deployment.

## Testing Instructions (or ideally a Blueprint)

- CI
