### PR TITLE
[PHP.wasm CLI] Support PHP subprocesses

### DIFF
--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -1,7 +1,14 @@
 /**
  * A CLI script that runs PHP CLI via the WebAssembly build.
  */
-import { writeFileSync, existsSync, mkdtempSync, rmSync, rmdirSync } from 'fs';
+import {
+	writeFileSync,
+	existsSync,
+	mkdtempSync,
+	rmSync,
+	rmdirSync,
+	chmodSync,
+} from 'fs';
 import { rootCertificates } from 'tls';
 
 import {
@@ -45,12 +52,39 @@ async function run() {
 	// @see https://github.com/npm/npm/issues/4531
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { TMPDIR, ...envVariables } = process.env;
+
+	/**
+	 * Ensure the PHP_BINARY constant is set to the PHP-WASM binary.
+	 *
+	 * ## Rationale
+	 *
+	 * We want any `proc_open()` calls to use the PHP-WASM binary and
+	 * not the system PHP binary.
+	 *
+	 * ## How it works
+	 *
+	 * The code below creates a temporary `php` executable in PATH,
+	 * which covers `proc_open( "php", ... )` calls.
+	 *
+	 * Furthermore, when PHP detects the `php` executable in PATH, it
+	 * sets the PHP_BINARY constant to it.
+	 */
+	const tempDir = mkdtempSync('php-wasm-bin');
+	writeFileSync(
+		`${tempDir}/php`,
+		`#!/bin/sh
+${process.argv[0]} ${process.execArgv.join(' ')} ${process.argv[1]}
+	`
+	);
+	chmodSync(`${tempDir}/php`, 0o755);
+
 	const php = new PHP(
 		await loadNodeRuntime(phpVersion, {
 			emscriptenOptions: {
 				ENV: {
 					...envVariables,
 					TERM: 'xterm',
+					PATH: `${tempDir}:${envVariables['PATH']}`,
 				},
 			},
 		})
@@ -58,38 +92,18 @@ async function run() {
 
 	useHostFilesystem(php);
 	php.setSpawnHandler((command: string) => {
-		const phpWasmCommand = `${process.argv[0]} ${process.execArgv.join(
-			' '
-		)} ${process.argv[1]}`;
-		// Naively replace the PHP binary with the PHP-WASM command
-		// @TODO: Don't process the command. Lean on the shell to do it, e.g.
-		// through a PATH or an alias.
-		const updatedCommand = command.replace(
-			/^(?:\\ |[^ ])*php\d?(\s|$)/,
-			phpWasmCommand + '$1'
-		);
-
-		// Create a shell script in a temporary directory
-		const tempDir = mkdtempSync('php-wasm-');
-		const tempScriptPath = `${tempDir}/script.sh`;
-		writeFileSync(
-			tempScriptPath,
-			`#!/bin/sh
-	${updatedCommand} < /dev/stdin
-	`
-		);
-
-		try {
-			return spawn(updatedCommand, [], {
-				shell: true,
-				stdio: ['pipe', 'pipe', 'pipe'],
-				timeout: 5000,
-			});
-		} finally {
-			// Remove the temporary directory
-			rmSync(tempScriptPath);
-			rmdirSync(tempDir);
+		/**
+		 * @TODO: What if php <path> targets a VFS file? this seems to be happening despite
+		 *        the .useHostFilesystem() call.
+		 */
+		if (command.startsWith('exec ')) {
+			command = command.slice(5);
 		}
+		return spawn(command, [], {
+			shell: true,
+			stdio: ['pipe', 'pipe', 'pipe'],
+			timeout: 5000,
+		});
 	});
 
 	const hasMinusCOption = args.some((arg) => arg.startsWith('-c'));

--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -88,16 +88,6 @@ ${process.argv[0]} ${process.execArgv.join(' ')} ${process.argv[1]}
 	);
 
 	useHostFilesystem(php);
-	php.setSpawnHandler(
-		(command: string, args: string[], options: Record<string, any>) => {
-			return spawn(command, args, {
-				...options,
-				shell: true,
-				stdio: ['pipe', 'pipe', 'pipe'],
-				timeout: 5000,
-			});
-		}
-	);
 
 	const hasMinusCOption = args.some((arg) => arg.startsWith('-c'));
 	if (!hasMinusCOption) {

--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -88,20 +88,16 @@ ${process.argv[0]} ${process.execArgv.join(' ')} ${process.argv[1]}
 	);
 
 	useHostFilesystem(php);
-	php.setSpawnHandler((command: string) => {
-		/**
-		 * @TODO: What if php <path> targets a VFS file? this seems to be happening despite
-		 *        the .useHostFilesystem() call.
-		 */
-		if (command.startsWith('exec ')) {
-			command = command.slice(5);
+	php.setSpawnHandler(
+		(command: string, args: string[], options: Record<string, any>) => {
+			return spawn(command, args, {
+				...options,
+				shell: true,
+				stdio: ['pipe', 'pipe', 'pipe'],
+				timeout: 5000,
+			});
 		}
-		return spawn(command, [], {
-			shell: true,
-			stdio: ['pipe', 'pipe', 'pipe'],
-			timeout: 5000,
-		});
-	});
+	);
 
 	const hasMinusCOption = args.some((arg) => arg.startsWith('-c'));
 	if (!hasMinusCOption) {

--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -1,14 +1,8 @@
 /**
  * A CLI script that runs PHP CLI via the WebAssembly build.
  */
-import {
-	writeFileSync,
-	existsSync,
-	mkdtempSync,
-	rmSync,
-	rmdirSync,
-	chmodSync,
-} from 'fs';
+import os from 'os';
+import { writeFileSync, existsSync, mkdtempSync, chmodSync } from 'fs';
 import { rootCertificates } from 'tls';
 
 import {
@@ -20,6 +14,7 @@ import type { SupportedPHPVersion } from '@php-wasm/universal';
 import { PHP } from '@php-wasm/universal';
 import { spawn } from 'child_process';
 import { loadNodeRuntime, useHostFilesystem } from '@php-wasm/node';
+import path from 'path';
 
 let args = process.argv.slice(2);
 if (!args.length) {
@@ -69,7 +64,7 @@ async function run() {
 	 * Furthermore, when PHP detects the `php` executable in PATH, it
 	 * sets the PHP_BINARY constant to it.
 	 */
-	const tempDir = mkdtempSync('php-wasm-bin');
+	const tempDir = mkdtempSync(path.join(os.tmpdir(), 'php-wasm-bin'));
 	writeFileSync(
 		`${tempDir}/php`,
 		`#!/bin/sh
@@ -78,11 +73,13 @@ ${process.argv[0]} ${process.execArgv.join(' ')} ${process.argv[1]}
 	);
 	chmodSync(`${tempDir}/php`, 0o755);
 
+	const sysTempDir = mkdtempSync(path.join(os.tmpdir(), 'php-wasm-sys-tmp'));
 	const php = new PHP(
 		await loadNodeRuntime(phpVersion, {
 			emscriptenOptions: {
 				ENV: {
 					...envVariables,
+					TMPDIR: sysTempDir,
 					TERM: 'xterm',
 					PATH: `${tempDir}:${envVariables['PATH']}`,
 				},

--- a/packages/php-wasm/cli/src/php.ini
+++ b/packages/php-wasm/cli/src/php.ini
@@ -6,7 +6,6 @@ log_errors=1
 always_populate_raw_post_data=-1
 upload_max_filesize=2000M
 post_max_size=2000M
-disable_functions=proc_open,popen,curl_exec,curl_multi_exec
 allow_url_fopen=On
 session.save_path=/home/web_user
 implicit_flush=1

--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
@@ -471,12 +471,52 @@ const LibraryExample = {
 			 */
 			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 * 
+					 * Good.
+					 * 
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(new Error(`Process exited with code ${code}`));
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 

--- a/packages/php-wasm/node/asyncify/php_7_2.js
+++ b/packages/php-wasm/node/asyncify/php_7_2.js
@@ -7361,14 +7361,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/asyncify/php_7_3.js
+++ b/packages/php-wasm/node/asyncify/php_7_3.js
@@ -7361,14 +7361,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/asyncify/php_7_4.js
+++ b/packages/php-wasm/node/asyncify/php_7_4.js
@@ -7361,14 +7361,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/asyncify/php_8_0.js
+++ b/packages/php-wasm/node/asyncify/php_8_0.js
@@ -7361,14 +7361,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/asyncify/php_8_1.js
+++ b/packages/php-wasm/node/asyncify/php_8_1.js
@@ -7389,14 +7389,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/asyncify/php_8_2.js
+++ b/packages/php-wasm/node/asyncify/php_8_2.js
@@ -7391,14 +7391,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/asyncify/php_8_3.js
+++ b/packages/php-wasm/node/asyncify/php_8_3.js
@@ -7391,14 +7391,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/asyncify/php_8_4.js
+++ b/packages/php-wasm/node/asyncify/php_8_4.js
@@ -7391,14 +7391,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/jspi/php_7_2.js
+++ b/packages/php-wasm/node/jspi/php_7_2.js
@@ -7309,14 +7309,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/jspi/php_7_3.js
+++ b/packages/php-wasm/node/jspi/php_7_3.js
@@ -7309,14 +7309,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/jspi/php_7_4.js
+++ b/packages/php-wasm/node/jspi/php_7_4.js
@@ -7309,14 +7309,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/jspi/php_8_0.js
+++ b/packages/php-wasm/node/jspi/php_8_0.js
@@ -7327,14 +7327,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/jspi/php_8_1.js
+++ b/packages/php-wasm/node/jspi/php_8_1.js
@@ -7355,14 +7355,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/jspi/php_8_2.js
+++ b/packages/php-wasm/node/jspi/php_8_2.js
@@ -7357,14 +7357,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/jspi/php_8_3.js
+++ b/packages/php-wasm/node/jspi/php_8_3.js
@@ -7357,14 +7357,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/jspi/php_8_4.js
+++ b/packages/php-wasm/node/jspi/php_8_4.js
@@ -7357,14 +7357,57 @@ export function init(RuntimeName, PHPLoader) {
 			 * the process has already been spawned. We can only listen
 			 * to the 'spawn' event and if it has already been spawned,
 			 * listen to the 'exit' event.
-			 */ try {
+			 */
+			try {
 				await new Promise((resolve, reject) => {
-					cp.on('spawn', resolve);
-					cp.on('error', reject);
+					/**
+					 * There was no `await` between the `spawnProcess` call
+					 * and the `await` below so the process haven't had a chance
+					 * to run any of the exit-related callbacks yet.
+					 *
+					 * Good.
+					 *
+					 * Let's listen to all the lifecycle events and resolve
+					 * the promise when the process starts or immediately crashes.
+					 */
+					let resolved = false;
+					cp.on('spawn', () => {
+						if (resolved) return;
+						resolved = true;
+						resolve();
+					});
+					cp.on('error', (e) => {
+						if (resolved) return;
+						resolved = true;
+						reject(e);
+					});
+					cp.on('exit', function (code) {
+						if (resolved) return;
+						resolved = true;
+						if (code === 0) {
+							resolve();
+						} else {
+							reject(
+								new Error(`Process exited with code ${code}`)
+							);
+						}
+					});
+					/**
+					 * If the process haven't even started after 5 seconds, something
+					 * is wrong. Perhaps we're missing an event listener, or perhaps
+					 * the `spawnProcess` implementation failed to dispatch the relevant
+					 * event. Either way, let's crash to avoid blocking the proc_open()
+					 * call indefinitely.
+					 */
+					setTimeout(() => {
+						if (resolved) return;
+						resolved = true;
+						reject(new Error('Process timed out'));
+					}, 5000);
 				});
 			} catch (e) {
 				console.error(e);
-				wakeUp(1);
+				wakeUp(ProcInfo.pid);
 				return;
 			}
 			// Now we want to pass data from the STDIN source supplied by PHP

--- a/packages/php-wasm/node/src/lib/use-host-filesystem.ts
+++ b/packages/php-wasm/node/src/lib/use-host-filesystem.ts
@@ -33,7 +33,7 @@ export function useHostFilesystem(php: PHP) {
 				 * * PHP.wasm calls proc_open() to execute the script in the host filesystem.
 				 */
 				return statPathFollowSymlinks(file).isDirectory();
-			} catch (e) {
+			} catch {
 				return false;
 			}
 		});

--- a/packages/php-wasm/node/src/lib/use-host-filesystem.ts
+++ b/packages/php-wasm/node/src/lib/use-host-filesystem.ts
@@ -1,4 +1,5 @@
 import type { PHP } from '@php-wasm/universal';
+import type { Stats } from 'node:fs';
 import { lstatSync, readdirSync } from 'node:fs';
 import { createNodeFsMountHandler } from './node-fs-mount';
 
@@ -16,7 +17,26 @@ export function useHostFilesystem(php: PHP) {
 		 */
 		.filter((file) => file !== 'dev')
 		.map((file) => `/${file}`)
-		.filter((file) => lstatSync(file).isDirectory());
+		.filter((file) => {
+			try {
+				/**
+				 * We need to follow the symlink before deciding whether a
+				 * path is a directory.
+				 *
+				 * For example, on Mac, the top level /var directory is a symlink
+				 * to /private/var. If we don't follow the symlink, we won't mount
+				 * it and PHP will use a separate, VFS-scoped /var directory. This,
+				 * in turn, will break the following use-case:
+				 *
+				 * * PHP.wasm writes a PHP script to a temporary directory in
+				 *   /private/var/folders/.../T/ in the host filesystem.
+				 * * PHP.wasm calls proc_open() to execute the script in the host filesystem.
+				 */
+				return statPathFollowSymlinks(file).isDirectory();
+			} catch (e) {
+				return false;
+			}
+		});
 	for (const dir of dirs) {
 		if (!php.fileExists(dir)) {
 			php.mkdirTree(dir);
@@ -24,4 +44,33 @@ export function useHostFilesystem(php: PHP) {
 		php.mount(dir, createNodeFsMountHandler(dir));
 	}
 	php.chdir(process.cwd());
+}
+
+/**
+ * @param path The path to the file or symlink to stat.
+ * @returns The stats of the file or symlink target.
+ */
+function statPathFollowSymlinks(path: string): Stats {
+	let stat = lstatSync(path);
+	if (stat.isSymbolicLink()) {
+		// Follow symlinks recursively to check if the target is a directory
+		const fs = require('fs');
+		let target = path;
+		const seen = new Set();
+		while (true) {
+			if (seen.has(target)) {
+				// Detected a symlink loop
+				throw new Error(`Symlink loop detected: ${path}`);
+			}
+			seen.add(target);
+			const linkStat = lstatSync(target);
+			if (linkStat.isSymbolicLink()) {
+				target = fs.realpathSync(target);
+				continue;
+			}
+			stat = linkStat;
+			break;
+		}
+	}
+	return stat;
 }

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -60,7 +60,11 @@ type ChildProcess = EventEmitter & {
 	stdout: EventEmitter;
 	stderr: EventEmitter;
 };
-export type SpawnHandler = (command: string, args: string[]) => ChildProcess;
+export type SpawnHandler = (
+	command: string,
+	args: string[],
+	options: Record<string, any>
+) => ChildProcess;
 
 export type HTTPMethod =
 	| 'GET'


### PR DESCRIPTION
## Description

Improves `proc_open()` support enough for the [Blueprints v2 runner](https://github.com/WordPress/php-toolkit/releases/tag/v0.0.2-alpha) to work with `@php-wasm/cli` (`@wp-playground/cli` integration is still pending):

* Ensures `@php-wasm/cli` has a `php` executable in its PATH that represents `@php-wasm/cli`.
* Removes `proc_open,popen,curl_exec,curl_multi_exec` functions from the disable_functions list.
* Propagates the system TMP_DIR to the PHP runtime
* Bugfix: Don't block indefinitely when the `proc_open()`-ed child process exits prematurely. Take note of the `exit` event an treat it as a failure.
* Mount top-level symlinks, such as /var, in the useHostFilesystem
* Remove a custom spawn handler in `php-wasm/main.ts` in favor of the generic one in php.js which correctly propagates `cwd` to the child process.

With this PR:

```
> PHP=8.0 bun ../playground/packages/php-wasm/cli/src/main.ts components/Blueprints/bin/blueprint.php exec ./u
ntracked/content-import.json --site-path=./untracked/new-site --site-url=http://127.0.0.1:2456 --db-engine=sqlite --truncate-new-site-directory
Creating a new site
  Site URL:  http://127.0.0.1:2456
  Site path: /Users/cloudnik/www/Automattic/core/plugins/wordpress-components/untracked/new-site
  Blueprint: /Users/cloudnik/www/Automattic/core/plugins/wordpress-components/untracked/content-import.json


[info] Loading importer libraries from /Users/cloudnik/www/Automattic/core/plugins/wordpress-components/components/Blueprints/../../dist/php-toolkit.phar

✔ Blueprint successfully executed.
[100%] Complete        
```

### Remaining work

- [ ] Add a unit test harness for all the resolved issues

### Follow-up work

* Displaying a live progress bar in the CLI doesn't work yet. Only full lines of text are displayed at the moment. It's not a blocker for this work, but it would be a nice next step as it indicates there's something missing in PHP.wasm's stdout support.
* Wire `@wp-playground/cli run-blueprint` command to use the Blueprints v2 runner.

cc @bgrgicak @akirk 