### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -26,7 +26,7 @@ The editor is under development and the embedded Playground sometimes fails to l
 
 Some blueprint steps (such as [`writeFile`](/blueprints/steps#WriteFileStep)) alter the internal Filesystem structure of the Playground instance and some others (such as [`runSql`](/blueprints/steps#runSql)) alter the internal WordPress database.
 
-To check the final internal filesytem structure and database (after the blueprint steps have been applied) we can leverage some WordPress plugins that provide a SQL manager and a file explorer such as [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and [`WPide`](https://wordpress.org/plugins/wpide/) (you can see them in action from https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide)
+To check the final internal filesystem structure and database (after the blueprint steps have been applied) we can leverage some WordPress plugins that provide a SQL manager and a file explorer such as [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and [`WPide`](https://wordpress.org/plugins/wpide/) (you can see them in action from https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide)
 
 :::tip
 

--- a/packages/docs/site/docs/developers/03-build-an-app/01-index.md
+++ b/packages/docs/site/docs/developers/03-build-an-app/01-index.md
@@ -199,4 +199,4 @@ The JavaScript API provides the `run()` method which you can use to run PHP code
 </script>
 ```
 
-Combine that with a code editor like Monako or CodeMirror, and you'll get live code snippets like in [this article](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/)!
+Combine that with a code editor like Monaco or CodeMirror, and you'll get live code snippets like in [this article](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/)!

--- a/packages/docs/site/docs/main/about/build.md
+++ b/packages/docs/site/docs/main/about/build.md
@@ -29,7 +29,7 @@ Some more examples of this workflow:
 
 ## Synchronize your playground instance with a local folder and create Github Pull Requests
 
-![Storage Type Device Snaphsot](../_assets/storage-type-device.png)
+![Storage Type Device Snapshot](../_assets/storage-type-device.png)
 
 With Google Chrome you can synchronize your Playground instance with a local directory, that can be either:
 

--- a/packages/docs/site/docs/main/about/launch.md
+++ b/packages/docs/site/docs/main/about/launch.md
@@ -15,7 +15,7 @@ Read more about this at [How to use WordPress Playground for interactive demos](
 
 Get inspiration about the type of interactive demos you can create at the [Blueprints Gallery](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md)
 
-The [Blueprints builder](https://playground.wordpress.net/builder/builder.html) tool allows you edit your blueprint online and run it direclty in a Playground instance.
+The [Blueprints builder](https://playground.wordpress.net/builder/builder.html) tool allows you edit your blueprint online and run it directly in a Playground instance.
 
 <iframe width="800" src="https://www.youtube.com/embed/lQzozsoJ3aY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/packages/docs/site/docs/main/contributing/contributor-day.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day.md
@@ -107,5 +107,5 @@ You can translate supported WordPress Plugins by loading the plugin you want to 
 Have a question or an idea for a new feature? Found a bug? Something’s not working as expected? We’re here to help:
 
 -   During Contributor Day, you can reach us at the **Playground table**.
--   Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is the VS Code extension, NPM package, or the plugins, open an issue on the [Plaground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
+-   Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is the VS Code extension, NPM package, or the plugins, open an issue on the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
 -   Share your feedback on the [**#meta-playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/docs/main/contributing/index.md
+++ b/packages/docs/site/docs/main/contributing/index.md
@@ -25,7 +25,7 @@ WordPress Playground is an open-source project that welcomes all contributors—
 
 Want to help sort through open issues and resolve potential bugs? Here's how:
 
-1. Review the [list of open issues](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aopen+is%3Aissue) and find the ones that you can help with. Same goes for the [Plaground Tools repository](https://github.com/WordPress/playground-tools/issues?q=is%3Aopen+is%3Aissue).
+1. Review the [list of open issues](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aopen+is%3Aissue) and find the ones that you can help with. Same goes for the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues?q=is%3Aopen+is%3Aissue).
 2. Read through the description and comments.
 3. If it's a bug you can reproduce, add a descriptive comment or a potential fix.
 4. Otherwise, add a comment with any additional information that may be helpful.

--- a/packages/docs/site/docs/main/contributing/translations.md
+++ b/packages/docs/site/docs/main/contributing/translations.md
@@ -50,13 +50,13 @@ For example for `es` (Spanish) there's a `packages/docs/site/i18n/es/docusaurus-
 
 Under `docusaurus-plugin-content-docs/current` the same structure of files of the original docs (same structure of files than under `packages/docs/site/docs`) should be replicated.
 
-For example for `es` (Spanish) the folllowing translated files exists: `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`
+For example for `es` (Spanish) the following translated files exists: `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`
 
 If a file is not available under a language's folder the original file in the default language will be loaded
 
 When a new language is added (see PR [#1807](https://github.com/WordPress/wordpress-playground/pull/1807)) you can run `npm run write-translations -- --locale <%LANGUAGE%>` from `packages/docs/site` to generate the JSON files with messages that can be translated to a specific language.
 
-With the proper i18n `docusaurus.config.js` configuration and files under `i18n` when running `npm run build:docs` from the root of the project especific folders under `dist` for each language will be created.
+With the proper i18n `docusaurus.config.js` configuration and files under `i18n` when running `npm run build:docs` from the root of the project specific folders under `dist` for each language will be created.
 
 ## How to locally test a language
 
@@ -73,7 +73,7 @@ npm run dev -- --locale es
 
 ## Language Switcher - UI element to change language
 
-The "Language Switcher" is a UI element provided by docusuarus (the docs engine behind Playground Docs) that allows user to change the language of a specific page.
+The "Language Switcher" is a UI element provided by docusaurus (the docs engine behind Playground Docs) that allows user to change the language of a specific page.
 
 To give more visibility to a translated version the language switcher can be displayed by adding the following lines at `docusaurus.config.js`
 
@@ -109,7 +109,7 @@ These language versions of the docs should be hidden on the language switcher hi
 
 Even if the language switcher doesn't display a specific language, work on adding translated pages can still progress, as the translated pages will become publicly available once the PRs containing the translated files are merged.
 
-Asumming the `fr` language is the first language with the Documentation hub pages (Quick Start Guide, Playground web instance, About Playground, Guides,... ) completely translated to French, the `docusaurus.config.js` should look like this in that branch so `npm run build:docs` properly generate the `fr` subsite and only displays the french language in the `localeDropdown` language switcher
+Assuming the `fr` language is the first language with the Documentation hub pages (Quick Start Guide, Playground web instance, About Playground, Guides,... ) completely translated to French, the `docusaurus.config.js` should look like this in that branch so `npm run build:docs` properly generate the `fr` subsite and only displays the french language in the `localeDropdown` language switcher
 
 ```
   {

--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -83,7 +83,7 @@ The easiest way is to use the version switcher on [the official demo site](https
 
 :::info Test your plugin or theme
 
-Compatibility testing with so many WordPres and PHP versions was always a pain. WordPress Playground makes this process effortless – use it to your advantage!
+Compatibility testing with so many WordPress and PHP versions was always a pain. WordPress Playground makes this process effortless – use it to your advantage!
 
 :::
 


### PR DESCRIPTION
## Motivation for the change, related issues
It seems that the changes were reverted by merging #2226.
The changes are the same as #2199.
