### PR TITLE
Normalize filesystem operations when syncing from memory fs to OPFS

### DIFF
--- a/packages/php-wasm/fs-journal/src/lib/fs-journal.ts
+++ b/packages/php-wasm/fs-journal/src/lib/fs-journal.ts
@@ -455,7 +455,7 @@ export function normalizeFilesystemOperations(
 				}
 			}
 		}
-		// Any substiturions? Apply them and and start over.
+		// Any substitutions? Apply them and start over.
 		// We can't just continue as the current operation may
 		// have been replaced.
 		if (Object.entries(substitutions).length > 0) {

--- a/packages/php-wasm/fs-journal/src/lib/fs-journal.ts
+++ b/packages/php-wasm/fs-journal/src/lib/fs-journal.ts
@@ -448,10 +448,15 @@ export function normalizeFilesystemOperations(
 					latter.operation === 'DELETE' &&
 					formerType === 'same_node'
 				) {
-					// Creating a node and then deleting it is equivalent to doing
-					// nothing.
+					// A CREATE/WRITE followed by a DELETE on the same node.
+					// The CREATE/WRITE is redundant.
 					substitutions[j] = [];
-					substitutions[i] = [];
+
+					// The DELETE is redundant only if the node was created
+					// in this journal.
+					if (former.operation === 'CREATE') {
+						substitutions[i] = [];
+					}
 				}
 			}
 		}

--- a/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
+++ b/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
@@ -344,6 +344,31 @@ describe('normalizeFilesystemOperations()', () => {
 				},
 			])
 		).toEqual([]);
+		expect(
+			normalizeFilesystemOperations([
+				{
+					operation: 'CREATE',
+					path: '/test/file1.txt',
+					nodeType: 'file',
+				},
+				{
+					operation: 'WRITE',
+					path: '/test/file1.txt',
+					nodeType: 'file',
+				},
+				{
+					operation: 'RENAME',
+					path: '/test/file1.txt',
+					toPath: '/test/file2.txt',
+					nodeType: 'file',
+				},
+				{
+					operation: 'DELETE',
+					path: '/test/file2.txt',
+					nodeType: 'file',
+				},
+			])
+		).toEqual([]);
 	});
 	it('Normalizes a more complex scenario', () => {
 		expect(

--- a/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
+++ b/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
@@ -182,6 +182,30 @@ describe('Journal MemFS', () => {
 });
 
 describe('normalizeFilesystemOperations()', () => {
+	it('Normalizes CREATE and WRITE + multiple WRITE file ops to a single WRITE', () => {
+		const expected = [
+			{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+		];
+		expect(
+			normalizeFilesystemOperations([
+				{ operation: 'CREATE', path: '/test', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+			])
+		).toEqual(expected);
+		expect(
+			normalizeFilesystemOperations([
+				{ operation: 'CREATE', path: '/test', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+			])
+		).toEqual(expected);
+		expect(
+			normalizeFilesystemOperations([
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+			])
+		).toEqual(expected);
+	});
 	it('Normalizes CREATE and RENAME to a single CREATE (file)', () => {
 		expect(
 			normalizeFilesystemOperations([

--- a/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
+++ b/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
@@ -219,6 +219,34 @@ describe('normalizeFilesystemOperations()', () => {
 			])
 		).toEqual([{ operation: 'CREATE', path: '/test2', nodeType: 'file' }]);
 	});
+	it('Normalizes CREATE and RENAME with WRITEs to a single WRITE (file)', () => {
+		expect(
+			normalizeFilesystemOperations([
+				{ operation: 'CREATE', path: '/test', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+				{
+					operation: 'RENAME',
+					path: '/test',
+					toPath: '/test2',
+					nodeType: 'file',
+				},
+			])
+		).toEqual([{ operation: 'WRITE', path: '/test2', nodeType: 'file' }]);
+		expect(
+			normalizeFilesystemOperations([
+				{ operation: 'CREATE', path: '/test', nodeType: 'file' },
+				{
+					operation: 'RENAME',
+					path: '/test',
+					toPath: '/test2',
+					nodeType: 'file',
+				},
+				{ operation: 'WRITE', path: '/test2', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test2', nodeType: 'file' },
+			])
+		).toEqual([{ operation: 'WRITE', path: '/test2', nodeType: 'file' }]);
+	});
 	it('Normalizes CREATE and RENAME to a single CREATE (directory)', () => {
 		expect(
 			normalizeFilesystemOperations([

--- a/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
+++ b/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
@@ -369,6 +369,31 @@ describe('normalizeFilesystemOperations()', () => {
 				},
 			])
 		).toEqual([]);
+		expect(
+			normalizeFilesystemOperations([
+				{
+					operation: 'CREATE',
+					path: '/test/file1.txt',
+					nodeType: 'file',
+				},
+				{
+					operation: 'RENAME',
+					path: '/test/file1.txt',
+					toPath: '/test/file2.txt',
+					nodeType: 'file',
+				},
+				{
+					operation: 'WRITE',
+					path: '/test/file2.txt',
+					nodeType: 'file',
+				},
+				{
+					operation: 'DELETE',
+					path: '/test/file2.txt',
+					nodeType: 'file',
+				},
+			])
+		).toEqual([]);
 	});
 	it('Normalizes a more complex scenario', () => {
 		expect(

--- a/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
+++ b/packages/php-wasm/fs-journal/src/test/fs-journal.spec.ts
@@ -246,6 +246,21 @@ describe('normalizeFilesystemOperations()', () => {
 				{ operation: 'WRITE', path: '/test2', nodeType: 'file' },
 			])
 		).toEqual([{ operation: 'WRITE', path: '/test2', nodeType: 'file' }]);
+		expect(
+			normalizeFilesystemOperations([
+				{ operation: 'CREATE', path: '/test', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test', nodeType: 'file' },
+				{
+					operation: 'RENAME',
+					path: '/test',
+					toPath: '/test2',
+					nodeType: 'file',
+				},
+				{ operation: 'WRITE', path: '/test2', nodeType: 'file' },
+				{ operation: 'WRITE', path: '/test2', nodeType: 'file' },
+			])
+		).toEqual([{ operation: 'WRITE', path: '/test2', nodeType: 'file' }]);
 	});
 	it('Normalizes CREATE and RENAME to a single CREATE (directory)', () => {
 		expect(

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -3,6 +3,7 @@ import { FSHelpers, __private__dont__use } from '@php-wasm/universal';
 import { Semaphore, basename, joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
 import type { FilesystemOperation } from '@php-wasm/fs-journal';
+import { normalizeFilesystemOperations } from '@php-wasm/fs-journal';
 import { journalFSEvents } from '@php-wasm/fs-journal';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type * as pleaseLoadTypes from 'wicg-file-system-access';
@@ -282,12 +283,30 @@ export function journalFSEventsToOpfs(
 	const rewriter = new OpfsRewriter(php, opfsRoot, memfsRoot);
 
 	async function flushJournal() {
+		if (journal.length === 0) {
+			return;
+		}
+
 		const release = await php.semaphore.acquire();
+
+		// Concurrency safety note
+		// As I understand it, journal is specific to a PHP instance,
+		// so it's not possible to have concurrency push of entries to journal
+		// But this can change in future so it doesn't hurt to read from journal
+		// in a concurrent safe way, which is what we are doing here.
+
+		// We first copy it to a new array
+		const journalEntries = [...journal];
+		// and then only delete however many entries we were able to grab
+		// since with concurrent writes there could have been more insertions
+		journal.splice(0, journalEntries.length);
+
+		const compressedJournal = normalizeFilesystemOperations(journalEntries);
 		try {
 			// @TODO This is way too slow in practice, we need to batch the
 			// changes into groups of parallelizable operations.
-			while (journal.length) {
-				await rewriter.processEntry(journal.shift()!);
+			while (compressedJournal.length) {
+				await rewriter.processEntry(compressedJournal.shift()!);
 			}
 		} finally {
 			release();

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -305,8 +305,8 @@ export function journalFSEventsToOpfs(
 		try {
 			// @TODO This is way too slow in practice, we need to batch the
 			// changes into groups of parallelizable operations.
-			while (compressedJournal.length) {
-				await rewriter.processEntry(compressedJournal.shift()!);
+			for (const entry of compressedJournal) {
+				await rewriter.processEntry(entry);
 			}
 		} finally {
 			release();


### PR DESCRIPTION
This PR supersedes https://github.com/Automattic/wordpress-playground-private/pull/126

## Motivation for the change, related issues
When using OPFS, the memory fs sync to OPFS doesn't normalize filesystem operations, even though there is a normalizing file system operations function already available. In a previous attempt, a new journal compression function was added that followed the following rules but partitioned around RENAME operations:

- Multiple WRITE operations of the same file (at end of request, writing once is enough)
- CREATE operation before WRITE operation (no need to CREATE separately)
- DELETE operation after CREATE/WRITE operation (no need to handle CREATE/WRITE in these cases)

While reconciling the logic of both functions, I discovered the already existing function handles pretty much all rules that were implemented (and some more), so in this PR, I have extended the tests to ensure the expected behavior out of [normalizeFilesystemOperations()](https://github.com/WordPress/wordpress-playground/blob/de3d42f95c3697e28a87b4d73bc767994f12aa4e/packages/php-wasm/fs-journal/src/lib/fs-journal.ts#L364)

A [test case](https://github.com/WordPress/wordpress-playground/pull/2252/commits/5441b7110e6334744a9e83a79797b828f3bae5c6) was found which was failing and the [fix](https://github.com/WordPress/wordpress-playground/pull/2252/commits/94d5fe3519320223672bf39cac747506f01d32ed) for that in the logic was implemented.
And now OPFSRewriter normalizes fs operations before executing them to keep OPFS in sync.

Improvements in journal size that's processed (screenshot from earlier PR):

<img width="267" alt="438687809-b4c6c627-7742-41c1-8e82-d9f2d06c9248" src="https://github.com/user-attachments/assets/96425a36-3fb2-4a57-8f58-ee9cf4e4b706" />