### PR TITLE
Respect '?url' in Node.js module loader for getting modules paths

### DIFF
--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -149,6 +149,14 @@ export async function load(
 		};
 	}
 
+	if (urlObj.searchParams.has('url')) {
+		return {
+			format: 'module',
+			shortCircuit: true,
+			source: `export default ${JSON.stringify(urlObj.pathname)};`,
+		};
+	}
+
 	if (urlObj.pathname.endsWith('.json')) {
 		const source = readFileSync(urlObj.pathname, 'utf8');
 		return {


### PR DESCRIPTION
## Motivation for the change, related issues

Vite supports imports such as that yield either a URL or a filesystem path of the imported file. This is useful for shipping static files with the repository. This PR adds a support for the same ?url syntax to plain Node.js to enable testing the code using these paths.

## Testing Instructions (or ideally a Blueprint)

CC @brandonpayton – I'd love to add a test case for this once we're testing the loader