### PR TITLE
Follow up allow full screen

### DIFF
--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -15,7 +15,7 @@ import TOCInline from '@theme/TOCInline';
 
 This page will guide you through each of these. Oh, and if you're a visual learner – here's a video:
 
-<iframe width="752" height="423.2" title="Getting started with WordPress Playground" src="https://video.wordpress.com/v/3UBIXJ9S?autoPlay=false&amp;height=1080&amp;width=1920&amp;fill=true" class="editor-media-modal-detail__preview is-video" allowfullscreen></iframe>
+<iframe width="752" height="423.2" title="Getting started with WordPress Playground" src="https://video.wordpress.com/v/3UBIXJ9S?autoPlay=false&amp;height=1080&amp;width=1920&amp;fill=true" class="editor-media-modal-detail__preview is-video" allowFullScreen></iframe>
 
 ## Start a new WordPress site
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -27,7 +27,7 @@ import TOCInline from '@theme/TOCInline';
 This page will guide you through each of these. Oh, and if you're a visual learner – here's a video:
  -->
 
-<iframe width="752" height="423.2" title="Getting started with WordPress Playground" src="https://video.wordpress.com/v/3UBIXJ9S?autoPlay=false&amp;height=1080&amp;width=1920&amp;fill=true" class="editor-media-modal-detail__preview is-video"></iframe>
+<iframe width="752" height="423.2" title="Getting started with WordPress Playground" src="https://video.wordpress.com/v/3UBIXJ9S?autoPlay=false&amp;height=1080&amp;width=1920&amp;fill=true" class="editor-media-modal-detail__preview is-video" allowFullScreen></iframe>
 
 ## 新しい WordPress サイトを始める
 


### PR DESCRIPTION
## Motivation for the change, related issues

related #2244 #2237

allowfullscreen was added in this PR, but the allowfullscreen button is not enabled in the documentation.
https://wordpress.github.io/wordpress-playground/quick-start-guide/

Docusaurus markdown requires the use of JSX notation, so we will change it to camelCase so that allowfullscreen works properly.

We will make the same change to the Japanese version

https://github.com/user-attachments/assets/8493f6e7-4fcd-49ae-82d5-cde69577f474

