### PR TITLE
Add the possibility for users to close the sidebar on mobile view

### DIFF
--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -32,6 +32,7 @@ export const SiteManager = forwardRef<
 	const sidebar = (
 		<Sidebar
 			className={css.sidebar}
+			mobileUi={fullScreenSections}
 			afterSiteClick={() => {
 				if (fullScreenSiteManager) {
 					// Close the site manager so the site view is visible.

--- a/packages/playground/website/src/components/site-manager/sidebar/index.tsx
+++ b/packages/playground/website/src/components/site-manager/sidebar/index.tsx
@@ -12,8 +12,9 @@ import {
 	__experimentalItem as Item,
 	Flex,
 	DropdownMenu,
+	Button,
 } from '@wordpress/components';
-import { moreVertical, page } from '@wordpress/icons';
+import { moreVertical, page, close } from '@wordpress/icons';
 import { ClockIcon, WordPressIcon } from '@wp-playground/components';
 import {
 	setActiveSite,
@@ -36,8 +37,10 @@ import { GithubImportMenuItem } from '../../toolbar-buttons/github-import-menu-i
 export function Sidebar({
 	className,
 	afterSiteClick,
+	mobileUi,
 }: {
 	className?: string;
+	mobileUi?: boolean;
 	afterSiteClick?: (slug: string) => void;
 }) {
 	const offline = useAppSelector((state) => state.ui.offline);
@@ -100,8 +103,21 @@ export function Sidebar({
 			>
 				<h1 className="sr-only">WordPress Playground</h1>
 				<div className={css.sidebarHeader}>
-					{/* Remove Playground logo because branding isn't finalized. */}
-					{/* <Logo className={css.sidebarLogoButton} /> */}
+					{mobileUi && (
+						<Button
+							className={css.closeButton}
+							onClick={() => {
+								if (temporarySite) {
+									onSiteClick(temporarySite.slug);
+									return;
+								}
+								redirectTo(PlaygroundRoute.newTemporarySite());
+							}}
+							icon={close}
+							label="Close sidebar"
+							showTooltip={true}
+						/>
+					)}
 				</div>
 				<DropdownMenu
 					className={css.componentsDropdown}

--- a/packages/playground/website/src/components/site-manager/sidebar/style.module.css
+++ b/packages/playground/website/src/components/site-manager/sidebar/style.module.css
@@ -10,12 +10,11 @@
 
 .sidebar-header {
 	display: flex;
-	padding: 16px 24px;
+	padding: 8px;
 	flex: 0 1 auto;
 	position: sticky;
 	top: 0;
 	left: 0;
-	background-color: var(--site-manager-background-color);
 }
 
 .sidebar-section {
@@ -108,6 +107,10 @@
 
 .components-dropdown {
 	button {
-		color: white;
+		color: var(--site-manager-text-color);
 	}
+}
+
+.closeButton {
+	color: var(--site-manager-text-color);
 }


### PR DESCRIPTION
## Motivation for the change, related issues 

I created this pull request to resolve the issue raised in #2212, where the user is unable to close the sidebar in mobile view. Mobile users can get stuck if they open the sidebar. There is an option to leave the sidebar if the user opens a temporary blueprint, but some users want to close the sidebar without taking any action.  

## Implementation details

I have included a close button only for mobile users when they are at the sidebar:
<img width="525" alt="Screenshot 2025-06-12 at 14 09 21" src="https://github.com/user-attachments/assets/777e925a-498c-440c-9c90-ac16645983ac" />

When the users are on Desktop view, the close button is not displayed:
<img width="191" alt="Screenshot 2025-06-12 at 14 09 55" src="https://github.com/user-attachments/assets/5f86135e-2e85-4a27-a279-33114f61aa8b" />

The decision to display the button is based on a property called `mobileUI`, which is already used by other components. 

## Testing Instructions (or ideally a Blueprint)

1. Run the playground
2. Set the browser to a mobile view
3. Open the site manager on the top left of the view
4. Close the settings page in the top left corner
5. Check the close button at the top left corner, as shown in the previous screenshot
6. Set the view to desktop and open the site manager. 
7. The close button should not be displayed