### PR TITLE
Blueprints: Tolerate relative paths

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/cp.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/cp.spec.ts
@@ -2,13 +2,22 @@ import { PHP } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { cp } from './cp';
 import { loadNodeRuntime } from '@php-wasm/node';
+import { logger } from '@php-wasm/logger';
+import { vi } from 'vitest';
 
 const docroot = '/php';
 describe('Blueprint step cp()', () => {
 	let php: PHP;
+	let loggerErrorSpy: any;
+	
 	beforeEach(async () => {
 		php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
 		php.mkdir(docroot);
+		loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		loggerErrorSpy.mockRestore();
 	});
 
 	it('should copy a file', async () => {
@@ -52,5 +61,59 @@ describe('Blueprint step cp()', () => {
 		expect(php.readFileAsText(`${docroot}/index2.php`)).toBe(
 			`<?php echo 'Hello World';`
 		);
+	});
+
+	it('should log error and normalize relative fromPath', async () => {
+		php.writeFile(`${docroot}/source.php`, `<?php echo 'Test';`);
+		
+		await cp(php, {
+			fromPath: 'php/source.php',
+			toPath: `${docroot}/dest.php`,
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The cp() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.fileExists(`${docroot}/dest.php`)).toBe(true);
+	});
+
+	it('should log error and normalize relative toPath', async () => {
+		php.writeFile(`${docroot}/source.php`, `<?php echo 'Test';`);
+		
+		await cp(php, {
+			fromPath: `${docroot}/source.php`,
+			toPath: 'php/dest.php',
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The cp() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.fileExists(`${docroot}/dest.php`)).toBe(true);
+	});
+
+	it('should log error and normalize both relative paths', async () => {
+		php.writeFile(`${docroot}/source.php`, `<?php echo 'Test';`);
+		
+		await cp(php, {
+			fromPath: 'php/source.php',
+			toPath: 'php/dest.php',
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The cp() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.fileExists(`${docroot}/dest.php`)).toBe(true);
+	});
+
+	it('should not log error for absolute paths', async () => {
+		php.writeFile(`${docroot}/source.php`, `<?php echo 'Test';`);
+		
+		await cp(php, {
+			fromPath: `${docroot}/source.php`,
+			toPath: `${docroot}/dest.php`,
+		});
+
+		expect(loggerErrorSpy).not.toHaveBeenCalled();
+		expect(php.fileExists(`${docroot}/dest.php`)).toBe(true);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/cp.ts
+++ b/packages/playground/blueprints/src/lib/steps/cp.ts
@@ -1,3 +1,4 @@
+import { logger } from '@php-wasm/logger';
 import type { StepHandler } from '.';
 
 /**
@@ -29,6 +30,31 @@ export const cp: StepHandler<CpStep> = async (
 	playground,
 	{ fromPath, toPath }
 ) => {
+	if (!fromPath.startsWith('/') || !toPath.startsWith('/')) {
+		logger.error(
+			`
+The cp() step in your Blueprint refers to a relative path.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer 
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:  cp({ fromPath: 'wordpress/wp-load.php', toPath: 'wordpress/wp-load.php' });
+Use:         cp({ fromPath: '/wordpress/wp-load.php', toPath: '/wordpress/wp-load.php' });
+
+This will ensure your code works reliably regardless of the current working directory.
+		`.trim()
+		);
+	}
+	if (!fromPath.startsWith('/')) {
+		fromPath = `/${fromPath}`;
+	}
+	if (!toPath.startsWith('/')) {
+		toPath = `/${toPath}`;
+	}
 	await playground.writeFile(
 		toPath,
 		await playground.readFileAsBuffer(fromPath)

--- a/packages/playground/blueprints/src/lib/steps/mkdir.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/mkdir.spec.ts
@@ -2,11 +2,20 @@ import { PHP } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { mkdir } from './mkdir';
 import { loadNodeRuntime } from '@php-wasm/node';
+import { logger } from '@php-wasm/logger';
+import { vi } from 'vitest';
 
 describe('Blueprint step mkdir', () => {
 	let php: PHP;
+	let loggerErrorSpy: any;
+	
 	beforeEach(async () => {
 		php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
+		loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		loggerErrorSpy.mockRestore();
 	});
 
 	it('should create a directory', async () => {
@@ -39,5 +48,29 @@ describe('Blueprint step mkdir', () => {
 		expect(php.readFileAsText(existingFile)).toBe(
 			`<?php echo 'Hello World';`
 		);
+	});
+
+	it('should log error when using relative path', async () => {
+		const relativePath = 'php/newdir';
+		
+		await mkdir(php, {
+			path: relativePath,
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The mkdir() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.isDir('/php/newdir')).toBe(true);
+	});
+
+	it('should not log error for absolute paths', async () => {
+		const absolutePath = '/php/newdir';
+		
+		await mkdir(php, {
+			path: absolutePath,
+		});
+
+		expect(loggerErrorSpy).not.toHaveBeenCalled();
+		expect(php.isDir(absolutePath)).toBe(true);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/mkdir.ts
+++ b/packages/playground/blueprints/src/lib/steps/mkdir.ts
@@ -1,3 +1,4 @@
+import { logger } from '@php-wasm/logger';
 import type { StepHandler } from '.';
 
 /**
@@ -22,5 +23,24 @@ export interface MkdirStep {
  * Creates a directory at the specified path.
  */
 export const mkdir: StepHandler<MkdirStep> = async (playground, { path }) => {
+	if (!path.startsWith('/')) {
+		logger.error(
+			`
+The mkdir() step in your Blueprint refers to a relative path.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer 
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:  mkdir({ path: 'wordpress/my-new-folder' });
+Use:         mkdir({ path: '/wordpress/my-new-folder' });
+
+This will ensure your code works reliably regardless of the current working directory.
+		`.trim()
+		);
+	}
 	await playground.mkdir(path);
 };

--- a/packages/playground/blueprints/src/lib/steps/mv.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/mv.spec.ts
@@ -2,13 +2,22 @@ import { PHP } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { mv } from './mv';
 import { loadNodeRuntime } from '@php-wasm/node';
+import { logger } from '@php-wasm/logger';
+import { vi } from 'vitest';
 
 const docroot = '/php';
 describe('Blueprint step mv()', () => {
 	let php: PHP;
+	let loggerErrorSpy: any;
+	
 	beforeEach(async () => {
 		php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
 		php.mkdir(docroot);
+		loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		loggerErrorSpy.mockRestore();
 	});
 
 	it('should move a file', async () => {
@@ -52,5 +61,63 @@ describe('Blueprint step mv()', () => {
 		expect(php.readFileAsText(`${docroot}/index2.php`)).toBe(
 			`<?php echo 'Hello World';`
 		);
+	});
+
+	it('should log error and normalize relative fromPath', async () => {
+		php.writeFile(`${docroot}/source.php`, `<?php echo 'Test';`);
+		
+		await mv(php, {
+			fromPath: 'php/source.php',
+			toPath: `${docroot}/dest.php`,
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The mv() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.fileExists(`${docroot}/source.php`)).toBe(false);
+		expect(php.fileExists(`${docroot}/dest.php`)).toBe(true);
+	});
+
+	it('should log error and normalize relative toPath', async () => {
+		php.writeFile(`${docroot}/source.php`, `<?php echo 'Test';`);
+		
+		await mv(php, {
+			fromPath: `${docroot}/source.php`,
+			toPath: 'php/dest.php',
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The mv() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.fileExists(`${docroot}/source.php`)).toBe(false);
+		expect(php.fileExists(`${docroot}/dest.php`)).toBe(true);
+	});
+
+	it('should log error and normalize both relative paths', async () => {
+		php.writeFile(`${docroot}/source.php`, `<?php echo 'Test';`);
+		
+		await mv(php, {
+			fromPath: 'php/source.php',
+			toPath: 'php/dest.php',
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The mv() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.fileExists(`${docroot}/source.php`)).toBe(false);
+		expect(php.fileExists(`${docroot}/dest.php`)).toBe(true);
+	});
+
+	it('should not log error for absolute paths', async () => {
+		php.writeFile(`${docroot}/source.php`, `<?php echo 'Test';`);
+		
+		await mv(php, {
+			fromPath: `${docroot}/source.php`,
+			toPath: `${docroot}/dest.php`,
+		});
+
+		expect(loggerErrorSpy).not.toHaveBeenCalled();
+		expect(php.fileExists(`${docroot}/source.php`)).toBe(false);
+		expect(php.fileExists(`${docroot}/dest.php`)).toBe(true);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/mv.ts
+++ b/packages/playground/blueprints/src/lib/steps/mv.ts
@@ -1,3 +1,4 @@
+import { logger } from '@php-wasm/logger';
 import type { StepHandler } from '.';
 
 /**
@@ -29,5 +30,30 @@ export const mv: StepHandler<MvStep> = async (
 	playground,
 	{ fromPath, toPath }
 ) => {
+	if (!fromPath.startsWith('/') || !toPath.startsWith('/')) {
+		logger.error(
+			`
+The mv() step in your Blueprint refers to a relative path.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer 
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:  mv({ fromPath: 'wordpress/wp-load.php', toPath: 'wordpress/wp-load.php' });
+Use:         mv({ fromPath: '/wordpress/wp-load.php', toPath: '/wordpress/wp-load.php' });
+
+This will ensure your code works reliably regardless of the current working directory.
+		`.trim()
+		);
+	}
+	if (!fromPath.startsWith('/')) {
+		fromPath = `/${fromPath}`;
+	}
+	if (!toPath.startsWith('/')) {
+		toPath = `/${toPath}`;
+	}
 	await playground.mv(fromPath, toPath);
 };

--- a/packages/playground/blueprints/src/lib/steps/rm.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/rm.spec.ts
@@ -2,13 +2,22 @@ import { PHP } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { rm } from './rm';
 import { loadNodeRuntime } from '@php-wasm/node';
+import { logger } from '@php-wasm/logger';
+import { vi } from 'vitest';
 
 const docroot = '/php';
 describe('Blueprint step rm()', () => {
 	let php: PHP;
+	let loggerErrorSpy: any;
+	
 	beforeEach(async () => {
 		php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
 		php.mkdir(docroot);
+		loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		loggerErrorSpy.mockRestore();
 	});
 
 	it('should remove a file', async () => {
@@ -34,5 +43,29 @@ describe('Blueprint step rm()', () => {
 				path: `${docroot}/dir`,
 			})
 		).rejects.toThrow(/There is a directory under that path./);
+	});
+
+	it('should log error and normalize relative path', async () => {
+		php.writeFile(`${docroot}/test.php`, `<?php echo 'Test';`);
+		
+		await rm(php, {
+			path: 'php/test.php',
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The rm() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.fileExists(`${docroot}/test.php`)).toBe(false);
+	});
+
+	it('should not log error for absolute paths', async () => {
+		php.writeFile(`${docroot}/test.php`, `<?php echo 'Test';`);
+		
+		await rm(php, {
+			path: `${docroot}/test.php`,
+		});
+
+		expect(loggerErrorSpy).not.toHaveBeenCalled();
+		expect(php.fileExists(`${docroot}/test.php`)).toBe(false);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/rm.ts
+++ b/packages/playground/blueprints/src/lib/steps/rm.ts
@@ -1,3 +1,4 @@
+import { logger } from '@php-wasm/logger';
 import type { StepHandler } from '.';
 
 /**
@@ -23,5 +24,23 @@ export interface RmStep {
  * Removes a file at the specified path.
  */
 export const rm: StepHandler<RmStep> = async (playground, { path }) => {
+	if (!path.startsWith("/")) {
+		logger.error(`
+The rm() step in your Blueprint refers to a relative path.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer 
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:  rm({ path: 'wordpress/wp-load.php' });
+Use:         rm({ path: '/wordpress/wp-load.php' });
+
+This will ensure your code works reliably regardless of the current working directory.
+		`.trim());
+		path = `/${path}`;
+	}
 	await playground.unlink(path);
 };

--- a/packages/playground/blueprints/src/lib/steps/rmdir.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/rmdir.spec.ts
@@ -1,0 +1,65 @@
+import { PHP } from '@php-wasm/universal';
+import { RecommendedPHPVersion } from '@wp-playground/common';
+import { rmdir } from './rmdir';
+import { loadNodeRuntime } from '@php-wasm/node';
+import { logger } from '@php-wasm/logger';
+import { vi } from 'vitest';
+
+const docroot = '/php';
+describe('Blueprint step rmdir()', () => {
+	let php: PHP;
+	let loggerErrorSpy: any;
+	
+	beforeEach(async () => {
+		php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
+		php.mkdir(docroot);
+		loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		loggerErrorSpy.mockRestore();
+	});
+
+	it('should remove a directory', async () => {
+		php.mkdir(`${docroot}/testdir`);
+		expect(php.isDir(`${docroot}/testdir`)).toBe(true);
+		
+		await rmdir(php, {
+			path: `${docroot}/testdir`,
+		});
+		
+		expect(php.isDir(`${docroot}/testdir`)).toBe(false);
+	});
+
+	it('should fail when the directory does not exist', async () => {
+		await expect(
+			rmdir(php, {
+				path: `${docroot}/nonexistent`,
+			})
+		).rejects.toThrow();
+	});
+
+	it('should log error and normalize relative path', async () => {
+		php.mkdir(`${docroot}/testdir`);
+		
+		await rmdir(php, {
+			path: 'php/testdir',
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The rmdir() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.isDir(`${docroot}/testdir`)).toBe(false);
+	});
+
+	it('should not log error for absolute paths', async () => {
+		php.mkdir(`${docroot}/testdir`);
+		
+		await rmdir(php, {
+			path: `${docroot}/testdir`,
+		});
+
+		expect(loggerErrorSpy).not.toHaveBeenCalled();
+		expect(php.isDir(`${docroot}/testdir`)).toBe(false);
+	});
+}); 

--- a/packages/playground/blueprints/src/lib/steps/rmdir.ts
+++ b/packages/playground/blueprints/src/lib/steps/rmdir.ts
@@ -1,3 +1,4 @@
+import { logger } from '@php-wasm/logger';
 import type { StepHandler } from '.';
 
 /**
@@ -23,5 +24,23 @@ export interface RmdirStep {
  * Removes a directory at the specified path.
  */
 export const rmdir: StepHandler<RmdirStep> = async (playground, { path }) => {
+	if (!path.startsWith("/")) {
+		logger.error(`
+The rmdir() step in your Blueprint refers to a relative path.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer 
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:  rmdir({ path: 'wordpress/wp-load.php' });
+Use:         rmdir({ path: '/wordpress/wp-load.php' });
+
+This will ensure your code works reliably regardless of the current working directory.
+		`.trim());
+		path = `/${path}`;
+	}
 	await playground.rmdir(path);
 };

--- a/packages/playground/blueprints/src/lib/steps/run-php.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-php.spec.ts
@@ -1,13 +1,21 @@
 import { PHP } from '@php-wasm/universal';
 import { runPHP } from './run-php';
 import { loadNodeRuntime } from '@php-wasm/node';
+import { logger } from '@php-wasm/logger';
+import { vi } from 'vitest';
 
 const phpVersion = '8.0';
 describe('Blueprint step runPHP', () => {
 	let php: PHP;
+	let loggerErrorSpy: any;
 
 	beforeEach(async () => {
 		php = new PHP(await loadNodeRuntime(phpVersion));
+		loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		loggerErrorSpy.mockRestore();
 	});
 
 	it('should run PHP code', async () => {
@@ -17,5 +25,78 @@ describe('Blueprint step runPHP', () => {
 
 	it('should throw on PHP error', async () => {
 		await expect(runPHP(php, { code: '<?php $%^;' })).rejects.toThrow();
+	});
+
+	it('should log error and normalize relative path with single quotes', async () => {
+		const originalCode = "<?php require_once 'wordpress/wp-load.php'; echo 'loaded';";
+		
+		// Call runPHP with the original code to trigger the path replacement
+		// We expect this to fail because wp-load.php doesn't exist, but we want to test the logger
+		try {
+			await runPHP(php, { code: originalCode });
+		} catch {
+			// Expected to fail, but logger should have been called
+		}
+		
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining("It looks like you're trying to load WordPress using a relative path")
+		);
+	});
+
+	it('should log error and normalize relative path with double quotes', async () => {
+		const originalCode = '<?php require_once "wordpress/wp-load.php"; echo "loaded";';
+		
+		// Call runPHP with the original code to trigger the path replacement
+		// We expect this to fail because wp-load.php doesn't exist, but we want to test the logger
+		try {
+			await runPHP(php, { code: originalCode });
+		} catch {
+			// Expected to fail, but logger should have been called
+		}
+		
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining("It looks like you're trying to load WordPress using a relative path")
+		);
+	});
+
+	it('should handle both single and double quoted paths in same code', async () => {
+		const originalCode = '<?php echo "wordpress/wp-load.php"; echo \'wordpress/wp-load.php\';';
+		
+		// Call runPHP with the original code to trigger the path replacement
+		const result = await runPHP(php, { code: originalCode });
+		
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining("It looks like you're trying to load WordPress using a relative path")
+		);
+		// Verify the paths were replaced
+		expect(result.text).toContain('/wordpress/wp-load.php');
+	});
+
+	it('should not log error for absolute paths', async () => {
+		const codeWithAbsolutePath = "<?php echo '/wordpress/wp-load.php is absolute';";
+		
+		const result = await runPHP(php, { code: codeWithAbsolutePath });
+		
+		expect(loggerErrorSpy).not.toHaveBeenCalled();
+		expect(result.text).toContain('/wordpress/wp-load.php');
+	});
+
+	it('should not trigger on unrelated wordpress strings', async () => {
+		const codeWithUnrelatedWordpress = '<?php echo "This is about wordpress/wp-load.php but not a require";';
+		
+		const result = await runPHP(php, { code: codeWithUnrelatedWordpress });
+		
+		expect(loggerErrorSpy).not.toHaveBeenCalled();
+		expect(result.text).toContain('wordpress/wp-load.php');
+	});
+
+	it('should replace relative paths in code', async () => {
+		const codeWithRelativePath = '<?php echo "wordpress/wp-load.php"; echo \'wordpress/wp-load.php\';';
+		
+		const result = await runPHP(php, { code: codeWithRelativePath });
+		
+		// Verify the paths were replaced in the output
+		expect(result.text).toContain('/wordpress/wp-load.php');
+		expect(loggerErrorSpy).toHaveBeenCalled();
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/run-php.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-php.ts
@@ -1,5 +1,6 @@
 import type { PHPResponse } from '@php-wasm/universal';
 import type { StepHandler } from '.';
+import { logger } from '@php-wasm/logger';
 
 /**
  * @inheritDoc runPHP
@@ -30,5 +31,35 @@ export const runPHP: StepHandler<RunPHPStep, Promise<PHPResponse>> = async (
 	playground,
 	{ code }
 ) => {
+	if (
+		code.includes('"wordpress/wp-load.php"') ||
+		code.includes("'wordpress/wp-load.php'")
+	) {
+		logger.error(
+			`
+It looks like you're trying to load WordPress using a relative path 'wordpress/wp-load.php'.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer 
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:  require_once 'wordpress/wp-load.php';
+Use:         require_once '/wordpress/wp-load.php';
+
+This will ensure your code works reliably regardless of the current working directory.
+		`.trim()
+		);
+		code = code.replace(
+			"'wordpress/wp-load.php'",
+			"'/wordpress/wp-load.php'"
+		);
+		code = code.replace(
+			'"wordpress/wp-load.php"',
+			'"/wordpress/wp-load.php"'
+		);
+	}
 	return await playground.run({ code });
 };

--- a/packages/playground/blueprints/src/lib/steps/write-file.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/write-file.spec.ts
@@ -1,0 +1,105 @@
+import { PHP } from '@php-wasm/universal';
+import { RecommendedPHPVersion } from '@wp-playground/common';
+import { writeFile } from './write-file';
+import { loadNodeRuntime } from '@php-wasm/node';
+import { logger } from '@php-wasm/logger';
+import { vi } from 'vitest';
+
+const docroot = '/php';
+describe('Blueprint step writeFile()', () => {
+	let php: PHP;
+	let loggerErrorSpy: any;
+	
+	beforeEach(async () => {
+		php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
+		php.mkdir(docroot);
+		loggerErrorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		loggerErrorSpy.mockRestore();
+	});
+
+	it('should write a file with string data', async () => {
+		const content = '<?php echo "Hello World";';
+		
+		await writeFile(php, {
+			path: `${docroot}/test.php`,
+			data: content,
+		});
+		
+		expect(php.fileExists(`${docroot}/test.php`)).toBe(true);
+		expect(php.readFileAsText(`${docroot}/test.php`)).toBe(content);
+	});
+
+	it('should write a file with Uint8Array data', async () => {
+		const content = new TextEncoder().encode('Test content');
+		
+		await writeFile(php, {
+			path: `${docroot}/test.txt`,
+			data: content,
+		});
+		
+		expect(php.fileExists(`${docroot}/test.txt`)).toBe(true);
+		expect(php.readFileAsText(`${docroot}/test.txt`)).toBe('Test content');
+	});
+
+	it('should write a file with File data', async () => {
+		const content = new File(['Test file content'], 'test.txt');
+		
+		await writeFile(php, {
+			path: `${docroot}/test.txt`,
+			data: content,
+		});
+		
+		expect(php.fileExists(`${docroot}/test.txt`)).toBe(true);
+		expect(php.readFileAsText(`${docroot}/test.txt`)).toBe('Test file content');
+	});
+
+	it('should log error and normalize relative path', async () => {
+		const content = '<?php echo "Test";';
+		
+		await writeFile(php, {
+			path: 'php/test.php',
+			data: content,
+		});
+
+		expect(loggerErrorSpy).toHaveBeenCalledWith(
+			expect.stringContaining('The writeFile() step in your Blueprint refers to a relative path.')
+		);
+		expect(php.fileExists(`${docroot}/test.php`)).toBe(true);
+		expect(php.readFileAsText(`${docroot}/test.php`)).toBe(content);
+	});
+
+	it('should not log error for absolute paths', async () => {
+		const content = '<?php echo "Test";';
+		
+		await writeFile(php, {
+			path: `${docroot}/test.php`,
+			data: content,
+		});
+
+		expect(loggerErrorSpy).not.toHaveBeenCalled();
+		expect(php.fileExists(`${docroot}/test.php`)).toBe(true);
+		expect(php.readFileAsText(`${docroot}/test.php`)).toBe(content);
+	});
+
+	it('should overwrite existing files', async () => {
+		const originalContent = 'Original content';
+		const newContent = 'New content';
+		
+		// Write initial file
+		await writeFile(php, {
+			path: `${docroot}/test.txt`,
+			data: originalContent,
+		});
+		
+		// Overwrite with new content
+		await writeFile(php, {
+			path: `${docroot}/test.txt`,
+			data: newContent,
+		});
+		
+		expect(php.readFileAsText(`${docroot}/test.txt`)).toBe(newContent);
+	});
+}); 

--- a/packages/playground/blueprints/src/lib/steps/write-file.ts
+++ b/packages/playground/blueprints/src/lib/steps/write-file.ts
@@ -1,3 +1,4 @@
+import { logger } from '@php-wasm/logger';
 import type { StepHandler } from '.';
 
 /**
@@ -31,6 +32,24 @@ export const writeFile: StepHandler<WriteFileStep<File>> = async (
 ) => {
 	if (data instanceof File) {
 		data = new Uint8Array(await data.arrayBuffer());
+	}
+	if (!path.startsWith("/")) {
+		logger.error(`
+The writeFile() step in your Blueprint refers to a relative path.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer 
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:  writeFile({ path: 'wordpress/wp-load.php', data: '<?php echo "Hello World!"; ?>' });
+Use:         writeFile({ path: '/wordpress/wp-load.php', data: '<?php echo "Hello World!"; ?>' });
+
+This will ensure your code works reliably regardless of the current working directory.
+		`.trim());
+		path = `/${path}`;
 	}
 	/**
 	 * PR #1426 removed the mu-plugins directory from the default

--- a/packages/playground/blueprints/src/lib/steps/write-files.ts
+++ b/packages/playground/blueprints/src/lib/steps/write-files.ts
@@ -1,6 +1,7 @@
 import { writeFiles as writeFilesToPhpWasm } from '@php-wasm/universal';
 import type { StepHandler } from '.';
 import type { Directory } from '../resources';
+import { logger } from '@php-wasm/logger';
 
 /**
  * @inheritDoc writeFiles
@@ -51,5 +52,25 @@ export const writeFiles: StepHandler<WriteFilesStep<Directory>> = async (
 	playground,
 	{ writeToPath, filesTree }
 ) => {
+	if (!writeToPath.startsWith('/')) {
+		logger.error(
+			`
+The writeFiles() step in your Blueprint refers to a relative path.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:  writeFiles({ writeToPath: 'wordpress/wp-content/plugins/my-plugin', filesTree: { name: 'style.css': 'a { color: red; }' });
+Use:         writeFiles({ writeToPath: '/wordpress/wp-content/plugins/my-plugin', filesTree: { name: 'style.css': 'a { color: red; }' });
+
+This will ensure your code works reliably regardless of the current working directory.
+		`.trim()
+		);
+		writeToPath = `/${writeToPath}`;
+	}
 	await writeFilesToPhpWasm(playground, writeToPath, filesTree.files);
 };


### PR DESCRIPTION
## Motivation for the change, related issues

Playground have recently changed `cwd` from `/` to `/wordpress` to mimic what nginx, apache, and other webservers do. Unfortunately, many Blueprints use root-based relative paths. This PR detects them, rewrites them as absolute paths, and explains the problem in an error message.

## Testing instructions

Confirm this Blueprint runs locally:

https://raw.githubusercontent.com/WordPress/blueprints/2e206b8dbe03cebd90f2955aaca3d8334cf3754b/blueprints/friends-cors/blueprint.json