### PR TITLE
[WordPress] Split bootWordPress and bootRequestHandler

### DIFF
--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -129,8 +129,60 @@ export interface BootOptions {
  * @param options Boot configuration options
  * @return PHPRequestHandler instance with WordPress installed.
  */
-
 export async function bootWordPress(options: BootOptions) {
+	const requestHandler = await bootRequestHandler(options);
+
+	const php = await requestHandler.getPrimaryPhp();
+	if (options.hooks?.beforeWordPressFiles) {
+		await options.hooks.beforeWordPressFiles(php);
+	}
+
+	if (options.wordPressZip) {
+		await unzipWordPress(php, await options.wordPressZip);
+	}
+
+	if (options.constants) {
+		for (const key in options.constants) {
+			php.defineConstant(key, options.constants[key] as string);
+		}
+	}
+
+	php.defineConstant('WP_HOME', options.siteUrl);
+	php.defineConstant('WP_SITEURL', options.siteUrl);
+
+	/*
+	 * Add required constants to "wp-config.php" if they are not already defined.
+	 * This is needed, because some WordPress backups and exports may not include
+	 * definitions for some of the necessary constants.
+	 */
+	await ensureWpConfig(php, requestHandler.documentRoot);
+
+	// Run "before database" hooks to mount/copy more files in
+	if (options.hooks?.beforeDatabaseSetup) {
+		await options.hooks.beforeDatabaseSetup(php);
+	}
+
+	// @TODO Assert WordPress core files are in place
+
+	if (options.sqliteIntegrationPluginZip) {
+		await preloadSqliteIntegration(
+			php,
+			await options.sqliteIntegrationPluginZip
+		);
+	}
+
+	if (!(await isWordPressInstalled(php))) {
+		await installWordPress(php);
+	}
+
+	if (!(await isWordPressInstalled(php))) {
+		throw new Error('WordPress installation has failed.');
+	}
+
+	return requestHandler;
+}
+
+export async function bootRequestHandler(options: BootOptions) {
 	async function createPhp(
 		requestHandler: PHPRequestHandler,
 		isPrimary: boolean
@@ -202,53 +254,6 @@ export async function bootWordPress(options: BootOptions) {
 			options.getFileNotFoundAction ?? getFileNotFoundActionForWordPress,
 		cookieStore: options.cookieStore,
 	});
-
-	const php = await requestHandler.getPrimaryPhp();
-	if (options.hooks?.beforeWordPressFiles) {
-		await options.hooks.beforeWordPressFiles(php);
-	}
-
-	if (options.wordPressZip) {
-		await unzipWordPress(php, await options.wordPressZip);
-	}
-
-	if (options.constants) {
-		for (const key in options.constants) {
-			php.defineConstant(key, options.constants[key] as string);
-		}
-	}
-
-	php.defineConstant('WP_HOME', options.siteUrl);
-	php.defineConstant('WP_SITEURL', options.siteUrl);
-
-	/*
-	 * Add required constants to "wp-config.php" if they are not already defined.
-	 * This is needed, because some WordPress backups and exports may not include
-	 * definitions for some of the necessary constants.
-	 */
-	await ensureWpConfig(php, requestHandler.documentRoot);
-
-	// Run "before database" hooks to mount/copy more files in
-	if (options.hooks?.beforeDatabaseSetup) {
-		await options.hooks.beforeDatabaseSetup(php);
-	}
-
-	// @TODO Assert WordPress core files are in place
-
-	if (options.sqliteIntegrationPluginZip) {
-		await preloadSqliteIntegration(
-			php,
-			await options.sqliteIntegrationPluginZip
-		);
-	}
-
-	if (!(await isWordPressInstalled(php))) {
-		await installWordPress(php);
-	}
-
-	if (!(await isWordPressInstalled(php))) {
-		throw new Error('WordPress installation has failed.');
-	}
 
 	return requestHandler;
 }

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -1,7 +1,11 @@
 import type { PHP, UniversalPHP } from '@php-wasm/universal';
 import { joinPaths, phpVar } from '@php-wasm/util';
 import { unzipFile, createMemoizedFetch } from '@wp-playground/common';
-export { bootWordPress, getFileNotFoundActionForWordPress } from './boot';
+export {
+	bootWordPress,
+	bootRequestHandler,
+	getFileNotFoundActionForWordPress,
+} from './boot';
 export { defineWpConfigConstants, ensureWpConfig } from './rewrite-wp-config';
 export { getLoadedWordPressVersion } from './version-detect';
 
@@ -318,7 +322,7 @@ export async function preloadPhpInfoRoute(
 		'/internal/shared/preload/phpinfo.php',
 		`<?php
     // Render PHPInfo if the requested page is /phpinfo.php
-    if ( ${phpVar(requestPath)} === $_SERVER['REQUEST_URI'] ) {
+    if ( isset($_SERVER['REQUEST_URI']) && ${phpVar(requestPath)} === $_SERVER['REQUEST_URI'] ) {
         phpinfo();
         exit;
     }


### PR DESCRIPTION
Extracts out the part of `bootWordPress` that initializes the Playground request handler, calls it`bootRequestHandler`, and exports it from the `@wp-playground/wordpress` module.

## Motivation

Blueprints v2 handle WordPress installation via PHP code. However, the existing `bootWordPress` function also installs WordPress. The two operations conflict. Since we only want to run the installation steps once, this PR allows the new runner to skip the WordPress installation procedure that's shipped with Playground.

## Testing instructions

Confirm the tests still pass.