### PR TITLE
[PHP Process Manager] Support acquiring a non-primary PHP instance

### DIFF
--- a/packages/php-wasm/node/src/test/php-process-manager.spec.ts
+++ b/packages/php-wasm/node/src/test/php-process-manager.spec.ts
@@ -3,6 +3,17 @@ import { loadNodeRuntime } from '..';
 import { PHP, PHPProcessManager } from '@php-wasm/universal';
 
 describe('PHPProcessManager', () => {
+	it('should return the primary PHP instance', async () => {
+		const mgr = new PHPProcessManager({
+			phpFactory: async () =>
+				new PHP(await loadNodeRuntime(RecommendedPHPVersion)),
+			maxPhpInstances: 4,
+		});
+
+		const php = await mgr.getPrimaryPhp();
+		expect(php).toBeInstanceOf(PHP);
+	});
+
 	it('should spawn new PHP instances', async () => {
 		const mgr = new PHPProcessManager({
 			phpFactory: async () =>
@@ -92,12 +103,17 @@ describe('PHPProcessManager', () => {
 			maxPhpInstances: 5,
 		});
 
+		// A synchronous call. Do not await this promise on purpose.
 		mgr.getPrimaryPhp();
+
 		// No await here, because we want to check if a second,
 		// synchronous call throws an error if issued before
 		// the first call completes asynchronously.
-		await expect(() => mgr.getPrimaryPhp()).rejects.toThrowError(
-			/Requested spawning a primary PHP instance/
-		);
+		try {
+			mgr.getPrimaryPhp();
+		} catch (e) {
+			expect(e).toBeInstanceOf(Error);
+			expect((e as Error).message).toContain('Requested spawning a primary PHP instance');
+		}
 	});
 });

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -1852,7 +1852,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			expect(response.exitCode).toEqual(0);
 		});
 
-		it('Frees up the heap memory after handling a request body with a size of ~512MB', async () => {
+		it('Frees up the heap memory after handling a request body with a size of ~400MB', async () => {
 			const estimateFreeMemory = () =>
 				php[__private__dont__use].HEAPU32.reduce(
 					(count: number, byte: number) =>
@@ -1872,7 +1872,7 @@ describe.each(SupportedPHPVersions)('PHP %s', (phpVersion) => {
 			//   body pointer.
 			// This will allow us to estimate the amount of the memory that
 			// was not freed after the request.
-			const body = '#'.repeat(1024 * 1024 * 512 - 24);
+			const body = '#'.repeat(1024 * 1024 * 400 - 24);
 
 			let contentLength = 0;
 			const _lengthBytesUTF8 = php[__private__dont__use].lengthBytesUTF8;

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -51,8 +51,7 @@ export default defineConfig(function () {
 				// forked test process.
 				forks: {
 					execArgv: [
-						'--expose-gc',
-						'--async-stack-traces',
+						'--expose-gc'
 					],
 				},
 			},

--- a/packages/php-wasm/universal/src/lib/php-process-manager.ts
+++ b/packages/php-wasm/universal/src/lib/php-process-manager.ts
@@ -144,17 +144,16 @@ export class PHPProcessManager implements AsyncDisposable {
 	 *                                and the waiting timeout is exceeded.
 	 */
 	async acquirePHPInstance({
-		considerPrimary = false,
+		considerPrimary = true,
 	}: {
 		considerPrimary?: boolean;
 	} = {}): Promise<SpawnedPHP> {
 		/**
 		 * First and foremost, make sure we have the primary PHP instance in place.
-		 * We may not actually acquire it. We just need it to exist.
+		 * We don't acquire it yet. We just make sure it exists.
 		 *
-		 * @TODO: Re-evaluate why we need it to exist. Should spawn() be just more
-		 *        lenient with its "another primary instance already started spawning"
-		 *        check?
+		 * @TODO: Decouple Filesystem from PHP to get rid of the notion of a primary PHP instance.
+		 * @see https://github.com/WordPress/wordpress-playground/issues/2269
 		 */
 		if (!this.primaryPhp) {
 			await this.getPrimaryPhp();

--- a/packages/php-wasm/universal/src/lib/php-process-manager.ts
+++ b/packages/php-wasm/universal/src/lib/php-process-manager.ts
@@ -147,7 +147,7 @@ export class PHPProcessManager implements AsyncDisposable {
 		considerPrimary = true,
 	}: {
 		considerPrimary?: boolean;
-	} = {}): Promise<SpawnedPHP> {
+		} = {}): Promise<SpawnedPHP> {
 		/**
 		 * First and foremost, make sure we have the primary PHP instance in place.
 		 * We don't acquire it yet. We just make sure it exists.
@@ -200,10 +200,12 @@ export class PHPProcessManager implements AsyncDisposable {
 	 * for PHP to spawn.
 	 */
 	private spawn(factoryArgs: PHPFactoryOptions): Promise<SpawnedPHP> {
-		if (factoryArgs.isPrimary && this.allInstances.length > 0) {
-			throw new Error(
-				'Requested spawning a primary PHP instance when another primary instance already started spawning.'
-			);
+		if (factoryArgs.isPrimary) {
+			if (this.primaryPhpPromise && !this.primaryPhp) {
+				throw new Error(
+					'Requested spawning a primary PHP instance when another primary instance already started spawning.'
+				);
+			}
 		}
 		const spawned = this.doSpawn(factoryArgs);
 		this.allInstances.push(spawned);

--- a/packages/php-wasm/universal/src/lib/php-process-manager.ts
+++ b/packages/php-wasm/universal/src/lib/php-process-manager.ts
@@ -73,6 +73,7 @@ export class MaxPhpInstancesError extends Error {
  */
 export class PHPProcessManager implements AsyncDisposable {
 	private primaryPhp?: PHP;
+	private primaryPhpPromise?: Promise<SpawnedPHP>;
 	private primaryIdle = true;
 	private nextInstance: Promise<SpawnedPHP> | null = null;
 	/**
@@ -112,8 +113,11 @@ export class PHPProcessManager implements AsyncDisposable {
 				'phpFactory or primaryPhp must be set before calling getPrimaryPhp().'
 			);
 		} else if (!this.primaryPhp) {
-			const spawned = await this.spawn!({ isPrimary: true });
-			this.primaryPhp = spawned.php;
+			if (!this.primaryPhpPromise) {
+				this.primaryPhpPromise = this.spawn({ isPrimary: true });
+			}
+			this.primaryPhp = (await this.primaryPhpPromise).php;
+			this.primaryPhpPromise = undefined;
 		}
 		return this.primaryPhp!;
 	}
@@ -125,15 +129,44 @@ export class PHPProcessManager implements AsyncDisposable {
 	 * instance, or a newly spawned PHP instance – depending on the resource
 	 * availability.
 	 *
+	 * @param considerPrimary - Whether to consider the primary PHP instance.
+	 *                          It matters because PHP.cli() sets the SAPI to CLI and
+	 *                          kills the entire process after it finishes running,
+	 *                          making the primary PHP instance non-reusable for
+	 *                          subsequent .run() calls. This is fine for one-off
+	 *                          child PHP instances, but not for the primary PHP
+	 *                          that's meant to continue working for the entire duration
+	 *                          of the ProcessManager lifetime. Therefore, we don't
+	 *                          consider the primary PHP instance by default unless
+	 *                          the caller explicitly requests it.
+	 *
 	 * @throws {MaxPhpInstancesError} when the maximum number of PHP instances is reached
 	 *                                and the waiting timeout is exceeded.
 	 */
-	async acquirePHPInstance(): Promise<SpawnedPHP> {
-		if (this.primaryIdle) {
+	async acquirePHPInstance({
+		considerPrimary = false,
+	}: {
+		considerPrimary?: boolean;
+	} = {}): Promise<SpawnedPHP> {
+		/**
+		 * First and foremost, make sure we have the primary PHP instance in place.
+		 * We may not actually acquire it. We just need it to exist.
+		 *
+		 * @TODO: Re-evaluate why we need it to exist. Should spawn() be just more
+		 *        lenient with its "another primary instance already started spawning"
+		 *        check?
+		 */
+		if (!this.primaryPhp) {
+			await this.getPrimaryPhp();
+		}
+
+		if (this.primaryIdle && considerPrimary) {
 			this.primaryIdle = false;
 			return {
 				php: await this.getPrimaryPhp(),
-				reap: () => (this.primaryIdle = true),
+				reap: () => {
+					this.primaryIdle = true;
+				},
 			};
 		}
 

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -493,7 +493,9 @@ export class PHPRequestHandler {
 	): Promise<PHPResponse> {
 		let spawnedPHP: SpawnedPHP | undefined = undefined;
 		try {
-			spawnedPHP = await this.processManager!.acquirePHPInstance();
+			spawnedPHP = await this.processManager!.acquirePHPInstance({
+				considerPrimary: true,
+			});
 		} catch (e) {
 			if (e instanceof MaxPhpInstancesError) {
 				return PHPResponse.forHttpCode(502);

--- a/packages/playground/blueprints/src/lib/steps/login.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/login.spec.ts
@@ -43,7 +43,7 @@ describe('Blueprint step login', () => {
 		});
 		expect(response.httpStatusCode).toBe(200);
 		expect(response.text).toContain('Edit Site');
-	});
+	}, 10000);
 
 	it('should log the user into wp-admin', async () => {
 		await login(php, {});
@@ -52,7 +52,7 @@ describe('Blueprint step login', () => {
 		});
 		expect(response.httpStatusCode).toBe(200);
 		expect(response.text).toContain('Dashboard');
-	});
+	}, 10000);
 
 	it('should log the user in if the playground_force_auto_login_as_user query parameter is set', async () => {
 		await defineWpConfigConsts(php, {

--- a/packages/playground/blueprints/vite.config.ts
+++ b/packages/playground/blueprints/vite.config.ts
@@ -79,6 +79,7 @@ export default defineConfig({
 		cache: {
 			dir: '../../../node_modules/.vitest',
 		},
+		testTimeout: 10000,
 		environment: 'node',
 		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 		reporters: ['default'],

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -255,6 +255,59 @@ export async function bootRequestHandler(options: BootOptions) {
 		cookieStore: options.cookieStore,
 	});
 
+	const { php, reap } = await requestHandler.processManager.acquirePHPInstance({
+		considerPrimary: false,
+	});
+	try {
+		if (options.hooks?.beforeWordPressFiles) {
+			await options.hooks.beforeWordPressFiles(php);
+		}
+
+		if (options.wordPressZip) {
+			await unzipWordPress(php, await options.wordPressZip);
+		}
+
+		if (options.constants) {
+			for (const key in options.constants) {
+				php.defineConstant(key, options.constants[key] as string);
+			}
+		}
+
+		php.defineConstant('WP_HOME', options.siteUrl);
+		php.defineConstant('WP_SITEURL', options.siteUrl);
+
+		/*
+		 * Add required constants to "wp-config.php" if they are not already defined.
+		 * This is needed, because some WordPress backups and exports may not include
+		 * definitions for some of the necessary constants.
+		 */
+		await ensureWpConfig(php, requestHandler.documentRoot);
+
+		// Run "before database" hooks to mount/copy more files in
+		if (options.hooks?.beforeDatabaseSetup) {
+			await options.hooks.beforeDatabaseSetup(php);
+		}
+
+		// @TODO Assert WordPress core files are in place
+
+		if (options.sqliteIntegrationPluginZip) {
+			await preloadSqliteIntegration(
+				php,
+				await options.sqliteIntegrationPluginZip
+			);
+		}
+
+		if (!(await isWordPressInstalled(php))) {
+			await installWordPress(php);
+		}
+
+		if (!(await isWordPressInstalled(php))) {
+			throw new Error('WordPress installation has failed.');
+		}
+	} finally {
+		reap();
+	}
+
 	return requestHandler;
 }
 

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -255,59 +255,6 @@ export async function bootRequestHandler(options: BootOptions) {
 		cookieStore: options.cookieStore,
 	});
 
-	const { php, reap } = await requestHandler.processManager.acquirePHPInstance({
-		considerPrimary: false,
-	});
-	try {
-		if (options.hooks?.beforeWordPressFiles) {
-			await options.hooks.beforeWordPressFiles(php);
-		}
-
-		if (options.wordPressZip) {
-			await unzipWordPress(php, await options.wordPressZip);
-		}
-
-		if (options.constants) {
-			for (const key in options.constants) {
-				php.defineConstant(key, options.constants[key] as string);
-			}
-		}
-
-		php.defineConstant('WP_HOME', options.siteUrl);
-		php.defineConstant('WP_SITEURL', options.siteUrl);
-
-		/*
-		 * Add required constants to "wp-config.php" if they are not already defined.
-		 * This is needed, because some WordPress backups and exports may not include
-		 * definitions for some of the necessary constants.
-		 */
-		await ensureWpConfig(php, requestHandler.documentRoot);
-
-		// Run "before database" hooks to mount/copy more files in
-		if (options.hooks?.beforeDatabaseSetup) {
-			await options.hooks.beforeDatabaseSetup(php);
-		}
-
-		// @TODO Assert WordPress core files are in place
-
-		if (options.sqliteIntegrationPluginZip) {
-			await preloadSqliteIntegration(
-				php,
-				await options.sqliteIntegrationPluginZip
-			);
-		}
-
-		if (!(await isWordPressInstalled(php))) {
-			await installWordPress(php);
-		}
-
-		if (!(await isWordPressInstalled(php))) {
-			throw new Error('WordPress installation has failed.');
-		}
-	} finally {
-		reap();
-	}
-
 	return requestHandler;
 }
 

--- a/packages/playground/wordpress/src/version-detect.ts
+++ b/packages/playground/wordpress/src/version-detect.ts
@@ -3,19 +3,26 @@ import type { PHPRequestHandler } from '@php-wasm/universal';
 export async function getLoadedWordPressVersion(
 	requestHandler: PHPRequestHandler
 ): Promise<string> {
-	const php = await requestHandler.getPrimaryPhp();
-	const result = await php.run({
-		code: `<?php
-			require '${requestHandler.documentRoot}/wp-includes/version.php';
-			echo $wp_version;
-		`,
-	});
+	const { php, reap } =
+		await requestHandler.processManager.acquirePHPInstance({
+			considerPrimary: true,
+		});
+	try {
+		const result = await php.run({
+			code: `<?php
+				require '${requestHandler.documentRoot}/wp-includes/version.php';
+				echo $wp_version;
+			`,
+		});
 
-	const versionString = result.text;
-	if (!versionString) {
-		throw new Error('Unable to read loaded WordPress version.');
+		const versionString = result.text;
+		if (!versionString) {
+			throw new Error('Unable to read loaded WordPress version.');
+		}
+		return versionStringToLoadedWordPressVersion(versionString);
+	} finally {
+		reap();
 	}
-	return versionStringToLoadedWordPressVersion(versionString);
 }
 
 /**

--- a/packages/playground/wordpress/vite.config.ts
+++ b/packages/playground/wordpress/vite.config.ts
@@ -63,6 +63,7 @@ export default defineConfig({
 		cache: {
 			dir: '../../../node_modules/.vitest',
 		},
+		testTimeout: 10000,
 		environment: 'node',
 		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
 		reporters: ['default'],


### PR DESCRIPTION
Adds a `considerPrimary` option to `processManager.acquirePHPInstance`.

PHP’s CLI SAPI always exits the process at the end of a run, so using the primary instance for ad-hoc runs breaks its long-lived reuse. By default, `acquirePHPInstance()` will now ignore the primary slot unless you explicitly opt in. This lets us safely use one-off children by default and tap into the primary only when you really need a persistent session.

`considerPrimary` defaults to `true` so we must be very careful about how we acquire a PHP instance before running `.cli()`. Ideally it would default to `false`, making `.cli()` calls safe by default. Unfortunately, that brakes a bunch of tests, especially around `maxPhpInstance` and memory limits. Two possible solutions are:

* Address each failure, which I don't think is worth the time investment
* #2269 – I think that's the way to go. We could then remove the entire concept of a "primary PHP instance".

In addition, this PR fixes a race condition in `spawn()`. Spawning the primary PHP instance was racing when called multiple times. By introducing a `primaryPhpPromise` cache, we ensure that only one spawn happens at a time and any concurrent callers await the same promise. Once resolved, we clear the promise so future calls will still retrieve the already-spawned instance.

## Testing instructions

Rely on CI checks.