### PR TITLE
Divider Missing in Mobile View - set defult color for the divider.

### DIFF
--- a/packages/playground/wordpress-builds/public/wp-6.4/wp-admin/css/list-tables.css
+++ b/packages/playground/wordpress-builds/public/wp-6.4/wp-admin/css/list-tables.css
@@ -1989,7 +1989,7 @@ div.action-links,
 		display: flex;
 		flex-wrap: wrap;
 		gap: 8px;
-		color: transparent;
+		/* color: transparent; */
 	}
 
 	.row-actions span a,


### PR DESCRIPTION
## Motivation for the change, related issues
https://github.com/WordPress/wordpress-playground/issues/2276

## Implementation details
Update CSS and set the default color for the divider instead of the transparent color. 

