### PR TITLE
Correct inline docs for isExitCode return type

### DIFF
--- a/packages/php-wasm/universal/src/lib/is-exit-code.ts
+++ b/packages/php-wasm/universal/src/lib/is-exit-code.ts
@@ -2,7 +2,7 @@
  * Check if the Emscripten-thrown error is an exit code 0 error.
  *
  * @param e The error to check
- * @returns True if the error is an exit code 0 error
+ * @returns True if the error appears to represent an exit code or status
  */
 export function isExitCode(e: any): e is { exitCode: number } {
 	if (!(e instanceof Error)) {


### PR DESCRIPTION
After #2266, the inline docs for the isExitCode() return type were not quite correct because the function now returns true for non-zero return values. This is a tiny PR from editing that line via the GH web UI.
