### PR TITLE
[Web][Networking] Call setupFetchNetworkTransport() in the web worker, not in remote.html

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -2,7 +2,6 @@ import { errorLogPath, logger } from '@php-wasm/logger';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { EmscriptenDownloadMonitor, ProgressTracker } from '@php-wasm/progress';
 import type {
-	PHP,
 	PHPRequest,
 	PHPRequestHandler,
 	SupportedPHPVersion,

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -2,6 +2,7 @@ import { errorLogPath, logger } from '@php-wasm/logger';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { EmscriptenDownloadMonitor, ProgressTracker } from '@php-wasm/progress';
 import type {
+	PHP,
 	PHPRequest,
 	PHPRequestHandler,
 	SupportedPHPVersion,

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -30,7 +30,6 @@ export const workerUrl: string = new URL(moduleWorkerUrl, origin) + '';
 // @ts-ignore
 import serviceWorkerPath from '../../service-worker.ts?worker&url';
 import type { FilesystemOperation } from '@php-wasm/fs-journal';
-import { setupFetchNetworkTransport } from './setup-fetch-network-transport';
 import { logger } from '@php-wasm/logger';
 import { PhpWasmError } from '@php-wasm/util';
 import { responseTo } from '@php-wasm/web-service-worker';
@@ -319,12 +318,6 @@ export async function bootPlaygroundRemote() {
 					wpFrame,
 					getOrigin((await playground.absoluteUrl)!)
 				);
-
-				if (options.withNetworking) {
-					await setupFetchNetworkTransport(phpWorkerApi, {
-						corsProxyUrl: options.corsProxyUrl,
-					});
-				}
 
 				setAPIReady();
 			} catch (e) {

--- a/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/setup-fetch-network-transport.ts
@@ -56,16 +56,6 @@ export async function setupFetchNetworkTransport(
 			data.headers = Object.fromEntries(data.headers);
 		}
 
-		// Let the Playground request handler know that this request is
-		// coming from PHP. We can't just add this header to all external
-		// requests because of CORS. The browser will refuse to process
-		// cross-origin requests with custom headers unless the server
-		// explicitly allows them in Access-Control-Allow-Headers.
-		const parsedUrl = new URL(data.url);
-		if (parsedUrl.hostname === window.location.hostname) {
-			data.headers['x-request-issuer'] = 'php';
-		}
-
 		const corsProxyUrl = options?.corsProxyUrl;
 		return handleRequest(data, (url: any, options: any) =>
 			fetchWithCorsProxy(url, options, corsProxyUrl)

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -37,7 +37,7 @@ import transportFetch from './playground-mu-plugin/playground-includes/wp_http_f
 import transportDummy from './playground-mu-plugin/playground-includes/wp_http_dummy.php?raw';
 /* @ts-ignore */
 import playgroundWebMuPlugin from './playground-mu-plugin/0-playground.php?raw';
-import type { SupportedPHPVersion } from '@php-wasm/universal';
+import type { PHP, SupportedPHPVersion } from '@php-wasm/universal';
 import {
 	PHPResponse,
 	PHPWorker,
@@ -55,6 +55,7 @@ import {
 	intlDisabledFunctions,
 	networkingDisabledFunctions,
 } from './disabled-functions';
+import { setupFetchNetworkTransport } from './setup-fetch-network-transport';
 
 // post message to parent
 self.postMessage('worker-script-started');
@@ -334,6 +335,13 @@ export class PlaygroundWorkerEndpoint extends PHPWorker {
 							});
 						},
 					});
+				},
+				onPHPInstanceCreated: async (php: PHP) => {
+					if (withNetworking) {
+						await setupFetchNetworkTransport(php, {
+							corsProxyUrl: corsProxyUrl,
+						});
+					}
 				},
 				// Do not await the WordPress download or the sqlite integration download.
 				// Let bootWordPress start the PHP runtime download first, and then await

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -337,6 +337,14 @@ export class PlaygroundWorkerEndpoint extends PHPWorker {
 					});
 				},
 				onPHPInstanceCreated: async (php: PHP) => {
+					/**
+	 				 * Setup WP_HTTP_Fetch network transport. It must be done per PHP instance because
+	   				 * it binds a php.onMessage() handler which is scoped to PHP class instance. Calling
+		 			 * setupFetchNetworkRequest() only for `primaryPHP` would leave all the non-primary
+	   				 * instances without a network call handler.
+		 			 *
+					 * @see https://github.com/WordPress/wordpress-playground/pull/2286
+	   				 */ 
 					if (withNetworking) {
 						await setupFetchNetworkTransport(php, {
 							corsProxyUrl: corsProxyUrl,

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -37,6 +37,7 @@ export type DatabaseType = 'sqlite' | 'mysql' | 'custom';
 
 export interface BootOptions {
 	createPhpRuntime: () => Promise<number>;
+	onPHPInstanceCreated?: (php: PHP) => Promise<void>;
 	/**
 	 * Mounting and Copying is handled via hooks for starters.
 	 *
@@ -240,6 +241,10 @@ export async function bootRequestHandler(options: BootOptions) {
 			recreateRuntime: options.createPhpRuntime,
 			maxRequests: 400,
 		});
+
+		if (options.onPHPInstanceCreated) {
+			await options.onPHPInstanceCreated(php);
+		}
 
 		return php;
 	}


### PR DESCRIPTION
This PR enables running simultaneous network calls asynchronously handled by multiple co-existing PHP instances within the same worker.

The gist of the problem can be seen here:

```ts
const mgr = new PHPProcessManager({
	phpFactory: async () =>
		new PHP(await loadNodeRuntime(RecommendedPHPVersion)),
	maxPhpInstances: 3,
});

const primaryPhp = await mgr.getPrimaryPhp();

// We setup a JavaScript handler for WP_HTTP_Fetch by listening
// to its post_message_to_js() call via primaryPHP.onMessage()...
setupFetchNetworkTransport(primaryPhp);

// ...but that does nothing for the next spawned PHP instance. When
//    it calls post_message_to_js(), there's no message handler to
//    translate that into fetch(). As a result, the response comes
//    back empty.
const { php } = await mgr.acquirePHPInstance({ considerPrimary: false });
php.run({ code: "<?php wp_safe_remote_get('https://w.org'); " })
```

## Solution

We bind the `.onMessage` handler to every PHP instance created by the `PHPProcessManager`. As a side-effect, we also:

* Added `onPHPInstanceCreated` callback to `bootWordPress()`
* Moved the `setupFetchNetworkTransport` call from `boot-playground-remote.ts` to the web worker where PHP is spawned. This should make it marginally faster. Before this PR, the handler was one worker away.

 ## Testing instructions

1. Run this Blueprint: http://127.0.0.1:5400/website-server/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2Fautomattic%2Fremote-data-blocks-demo%2Ftrunk%2Fshopify%2Fshopify-blueprint.json
2. Click "Edit page"
3. Confirm the four requests to /wp-json/remote-data-blocks/v1/remote-data have actual data in their response body. Specifically, they should NOT have a JSON-encoded error message.
