### PR TITLE
PHP Node: Only consider NODEFS to be a shared filesystem

### DIFF
--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library-file-locking-for-node.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library-file-locking-for-node.js
@@ -40,13 +40,21 @@ const LibraryForFileLocking = {
 			}
 
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (!node?.mount?.opts?.fs?.lookupPath || !node?.mount?.type?.realPath) {
 				return false;
 			}
 
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);

--- a/packages/php-wasm/node/jspi/php_7_2.js
+++ b/packages/php-wasm/node/jspi/php_7_2.js
@@ -5659,13 +5659,27 @@ export function init(RuntimeName, PHPLoader) {
 			if (node?.isSharedFS) {
 				return true;
 			}
+
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (
+				!node?.mount?.opts?.fs?.lookupPath ||
+				!node?.mount?.type?.realPath
+			) {
 				return false;
 			}
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode =
+					node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);

--- a/packages/php-wasm/node/jspi/php_7_3.js
+++ b/packages/php-wasm/node/jspi/php_7_3.js
@@ -5659,13 +5659,27 @@ export function init(RuntimeName, PHPLoader) {
 			if (node?.isSharedFS) {
 				return true;
 			}
+
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (
+				!node?.mount?.opts?.fs?.lookupPath ||
+				!node?.mount?.type?.realPath
+			) {
 				return false;
 			}
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode =
+					node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);

--- a/packages/php-wasm/node/jspi/php_7_4.js
+++ b/packages/php-wasm/node/jspi/php_7_4.js
@@ -5659,13 +5659,27 @@ export function init(RuntimeName, PHPLoader) {
 			if (node?.isSharedFS) {
 				return true;
 			}
+
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (
+				!node?.mount?.opts?.fs?.lookupPath ||
+				!node?.mount?.type?.realPath
+			) {
 				return false;
 			}
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode =
+					node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);

--- a/packages/php-wasm/node/jspi/php_8_0.js
+++ b/packages/php-wasm/node/jspi/php_8_0.js
@@ -5677,13 +5677,27 @@ export function init(RuntimeName, PHPLoader) {
 			if (node?.isSharedFS) {
 				return true;
 			}
+
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (
+				!node?.mount?.opts?.fs?.lookupPath ||
+				!node?.mount?.type?.realPath
+			) {
 				return false;
 			}
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode =
+					node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);

--- a/packages/php-wasm/node/jspi/php_8_1.js
+++ b/packages/php-wasm/node/jspi/php_8_1.js
@@ -5677,13 +5677,27 @@ export function init(RuntimeName, PHPLoader) {
 			if (node?.isSharedFS) {
 				return true;
 			}
+
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (
+				!node?.mount?.opts?.fs?.lookupPath ||
+				!node?.mount?.type?.realPath
+			) {
 				return false;
 			}
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode =
+					node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);

--- a/packages/php-wasm/node/jspi/php_8_2.js
+++ b/packages/php-wasm/node/jspi/php_8_2.js
@@ -5677,13 +5677,27 @@ export function init(RuntimeName, PHPLoader) {
 			if (node?.isSharedFS) {
 				return true;
 			}
+
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (
+				!node?.mount?.opts?.fs?.lookupPath ||
+				!node?.mount?.type?.realPath
+			) {
 				return false;
 			}
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode =
+					node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);

--- a/packages/php-wasm/node/jspi/php_8_3.js
+++ b/packages/php-wasm/node/jspi/php_8_3.js
@@ -5677,13 +5677,27 @@ export function init(RuntimeName, PHPLoader) {
 			if (node?.isSharedFS) {
 				return true;
 			}
+
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (
+				!node?.mount?.opts?.fs?.lookupPath ||
+				!node?.mount?.type?.realPath
+			) {
 				return false;
 			}
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode =
+					node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);

--- a/packages/php-wasm/node/jspi/php_8_4.js
+++ b/packages/php-wasm/node/jspi/php_8_4.js
@@ -5677,13 +5677,27 @@ export function init(RuntimeName, PHPLoader) {
 			if (node?.isSharedFS) {
 				return true;
 			}
+
 			// Handle PROXYFS nodes which wrap other nodes.
-			if (!node?.mount?.opts?.fs?.lookupPath) {
+			if (
+				!node?.mount?.opts?.fs?.lookupPath ||
+				!node?.mount?.type?.realPath
+			) {
 				return false;
 			}
-			const vfsPath = NODEFS.realPath(node);
-			const underlyingNode = node.mount.opts.fs.lookupPath(vfsPath)?.node;
-			return !!underlyingNode?.isSharedFS;
+
+			// Only NODEFS can be shared between workers at the moment.
+			if (node.mount.type !== NODEFS) {
+				return false;
+			}
+			const vfsPath = node.mount.type.realPath(node);
+			try {
+				const underlyingNode =
+					node.mount.opts.fs.lookupPath(vfsPath)?.node;
+				return !!underlyingNode?.isSharedFS;
+			} catch (e) {
+				return false;
+			}
 		},
 		is_path_to_shared_fs(path) {
 			const { node } = FS.lookupPath(path);


### PR DESCRIPTION
## Motivation for the change, related issues

https://github.com/WordPress/wordpress-playground/pull/2231 overrides `FS.hashAddNode` with `function hashAddNodeIfNotSharedFS(node)` where additional logic applies if `is_shared_fs_node(node)` is true. Only NODEFS nodes were supposed to be considered as coming from a shared fs. Unfortunately, the internal logic of `is_shared_fs_node()` also returned true for MEMFS nodes. This caused a FS error 44 for the following operation where `runtime2` attempts to create a directory in a `/wordpress` directory mounted from `runtime1`:

```ts
import { loadNodeRuntime } from "@php-wasm/node";
import { getLoadedRuntime } from "@php-wasm/universal";

const opts = {
	emscriptenOptions: { ENV: { DOCROOT: '/wordpress' } }
};
const runtime1 = getLoadedRuntime(await loadNodeRuntime('8.3', opts));
runtime1.FS.mkdir("/wordpress");

const runtime2 = getLoadedRuntime(await loadNodeRuntime('8.3', opts));
runtime2.FS.mkdir("/wordpress");

runtime2.FS.mount(
	runtime2.PROXYFS,
	{ root: '/wordpress', fs: runtime1.FS },
	'/wordpress'
);

// This works:
// runtime1.FS.mkdir("/wordpress/wp-content");

// This doesn't:
runtime2.FS.mkdir("/wordpress/wp-content");
```

Specifically, the FS error 44 was triggered inside `is_shared_fs_node()` when calling NODEFS operations on these non-NODEFS nodes.

## Implementation details

Adds a check confirming the shared node comes from NODEFS.

## Testing Instructions (or ideally a Blueprint)

* Confirm the reproduction above works without errors.
* Once #2285 lands, we'll be able to add a unit test

cc @brandonpayton 
