### PR TITLE
Relay correct source paths in DWARF debug info

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -64,6 +64,24 @@
         "cwd": "${workspaceFolder}",
         "autoAttachChildProcesses": true
       },
+            {
+        "name": "Debug Playground CLI with DWARF Symbols",
+        "request": "launch",
+        "type": "node",
+        "runtimeVersion": "23",
+        "runtimeExecutable": "npx",
+        "runtimeArgs": [
+          "nx",
+          "debug",
+          "playground-cli",
+          "server",
+          "--php=8.3",
+        ],
+        "args": "${input:playgroundCliCommand}",
+        "cwd": "${workspaceFolder}",
+        "autoAttachChildProcesses": true,
+        "enableDWARF": true
+      },
       {
         "name": "Launch Chrome",
         "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -64,7 +64,7 @@
         "cwd": "${workspaceFolder}",
         "autoAttachChildProcesses": true
       },
-            {
+      {
         "name": "Debug Playground CLI with DWARF Symbols",
         "request": "launch",
         "type": "node",
@@ -75,7 +75,6 @@
           "debug",
           "playground-cli",
           "server",
-          "--php=8.3",
         ],
         "args": "${input:playgroundCliCommand}",
         "cwd": "${workspaceFolder}",

--- a/packages/php-wasm/compile/Makefile
+++ b/packages/php-wasm/compile/Makefile
@@ -1,3 +1,9 @@
+MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+MAKEFILE_DIR := $(dir $(MAKEFILE_PATH))
+
+# Remove trailing slash if present
+MAKEFILE_DIR := $(patsubst %/,%,$(MAKEFILE_DIR))
+
 base-image: base-image/.ready
 base-image/.ready:
 	cd base-image; docker build -f ./Dockerfile -t playground-php-wasm:base .
@@ -142,19 +148,34 @@ libopenssl/jspi/dist/1.1.1/root/lib/lib/libssl.a: base-image libz_jspi
 	docker cp $$(docker create playground-php-wasm:libopenssl-1.1.1):/root/install/lib ./libopenssl/jspi/dist/1.1.1/root/lib
 	docker cp $$(docker create playground-php-wasm:libopenssl-1.1.1):/root/install/include ./libopenssl/jspi/dist/1.1.1/root/lib
 
+WITH_DEBUG ?= no
+
 libsqlite3_asyncify: libsqlite3/asyncify/dist/root/lib/lib/libsqlite3.a
 libsqlite3/asyncify/dist/root/lib/lib/libsqlite3.a: base-image libz_asyncify
 	mkdir -p ./libsqlite3/asyncify/dist/root/lib
-	docker build -f ./libsqlite3/Dockerfile -t playground-php-wasm:libsqlite3 .
+	docker build -f ./libsqlite3/Dockerfile -t playground-php-wasm:libsqlite3 . \
+		--build-arg WITH_DEBUG=${WITH_DEBUG} \
+		--build-arg DEBUG_DWARF_COMPILATION_DIR=${MAKEFILE_DIR}/libsqlite3
+		--progress=plain
 	docker cp $$(docker create playground-php-wasm:libsqlite3):/root/lib/lib ./libsqlite3/asyncify/dist/root/lib
 	docker cp $$(docker create playground-php-wasm:libsqlite3):/root/lib/include ./libsqlite3/asyncify/dist/root/lib
+	@if [ "${WITH_DEBUG}" = "yes" ]; then \
+		docker cp $$(docker create playground-php-wasm:libsqlite3):/root/sqlite-src ./libsqlite3/; \
+	fi
 
 libsqlite3_jspi: libsqlite3/jspi/dist/root/lib/lib/libsqlite3.a
 libsqlite3/jspi/dist/root/lib/lib/libsqlite3.a: base-image libz_jspi
 	mkdir -p ./libsqlite3/jspi/dist/root/lib
-	docker build -f ./libsqlite3/Dockerfile -t playground-php-wasm:libsqlite3 . --build-arg JSPI=1
+	docker build -f ./libsqlite3/Dockerfile -t playground-php-wasm:libsqlite3 . \
+		--build-arg JSPI=1 \
+		--build-arg WITH_DEBUG=${WITH_DEBUG} \
+		--build-arg DEBUG_DWARF_COMPILATION_DIR=${MAKEFILE_DIR}/libsqlite3
+		--progress=plain
 	docker cp $$(docker create playground-php-wasm:libsqlite3):/root/lib/lib ./libsqlite3/jspi/dist/root/lib
 	docker cp $$(docker create playground-php-wasm:libsqlite3):/root/lib/include ./libsqlite3/jspi/dist/root/lib
+	@if [ "${WITH_DEBUG}" = "yes" ]; then \
+		docker cp $$(docker create playground-php-wasm:libsqlite3):/root/sqlite-src ./libsqlite3/; \
+	fi
 
 libiconv_asyncify: libiconv/asyncify/dist/root/lib/lib/libiconv.a
 libiconv/asyncify/dist/root/lib/lib/libiconv.a: base-image libz_asyncify

--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -242,6 +242,12 @@ await asyncSpawn(
 		`OUTPUT_DIR_FOR_SOURCE_MAP_BASE=${outputDir}`,
 		'--build-arg',
 		getArg('WITH_DEBUG'),
+		// This directory path offset allows us to reconcile paths for source
+		// source files in DWARF debug info.
+		'--build-arg',
+		`DEBUG_OFFSET_TO_PHP_WASM_PACKAGE=${
+			platform === 'web' ? '../../../../..' : '../../..'
+		}`,
 		'--build-arg',
 		getArg('WITH_ICONV'),
 		'--build-arg',

--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -239,15 +239,18 @@ await asyncSpawn(
 		'--build-arg',
 		getArg('WITH_SOURCEMAPS'),
 		'--build-arg',
-		`OUTPUT_DIR_FOR_SOURCE_MAP_BASE=${outputDir}`,
+		// Relay output directory so we can create source maps and DWARF debug
+		// info containing correct paths.
+		`OUTPUT_DIR_ON_HOST=${outputDir}`,
 		'--build-arg',
 		getArg('WITH_DEBUG'),
-		// This directory path offset allows us to reconcile paths for source
-		// source files in DWARF debug info.
+		// This directory path allows us to set what the DWARF file references
+		// are relative to so step debugging source files works correctly.
 		'--build-arg',
-		`DEBUG_OFFSET_TO_PHP_WASM_PACKAGE=${
-			platform === 'web' ? '../../../../..' : '../../..'
-		}`,
+		`DEBUG_DWARF_COMPILATION_DIR=${path.resolve(
+			import.meta.dirname,
+			'..'
+		)}`,
 		'--build-arg',
 		getArg('WITH_ICONV'),
 		'--build-arg',

--- a/packages/php-wasm/compile/libsqlite3/Dockerfile
+++ b/packages/php-wasm/compile/libsqlite3/Dockerfile
@@ -1,6 +1,8 @@
 FROM playground-php-wasm:base
 
 ARG JSPI
+ARG WITH_DEBUG
+ARG DEBUG_DWARF_COMPILATION_DIR
 
 RUN mkdir -p /root/lib/include /root/lib/lib
 COPY ./libz/ /root/libz
@@ -15,13 +17,26 @@ RUN if [ "$JSPI" = "1" ]; then \
 RUN set -euxo pipefail &&\
     wget --no-check-certificate https://www.sqlite.org/2022/sqlite-autoconf-3400100.tar.gz && \
     tar -xzvf sqlite-autoconf-3400100.tar.gz && \
-    cd sqlite-autoconf-3400100 && \
+    mv sqlite-autoconf-3400100 sqlite-src && \
+    cd sqlite-src && \
     source /root/emsdk/emsdk_env.sh && \
     emconfigure ./configure \
         --build i386-pc-linux-gnu \
         --target wasm32-unknown-emscripten \
         --prefix=/root/lib/ && \
     export JSPI_FLAGS=$(if [ "$JSPI" = "1" ]; then echo "-sSUPPORT_LONGJMP=wasm -fwasm-exceptions"; else echo ""; fi) && \
-    EMCC_SKIP="-lc" EMCC_FLAGS=" -D__x86_64__  -sSIDE_MODULE $JSPI_FLAGS" emmake make && \
+    export EMCC_SKIP="-lc"; \
+    export EMCC_FLAGS=" \
+        -D__x86_64__  -sSIDE_MODULE \
+        $JSPI_FLAGS \
+        $(\
+            if [ "$WITH_DEBUG" = "yes" ]; then \
+                echo "-g3 -fdebug-compilation-dir=${DEBUG_DWARF_COMPILATION_DIR}/sqlite-src "; \
+            else \
+                echo ''; \
+            fi \
+        )\
+    "; \
+    emmake make && \
     emmake make install
 

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -88,9 +88,9 @@ ARG WITH_MYSQL
 ARG WITH_OPENSSL
 ARG WITH_ICONV
 ARG WITH_SOURCEMAPS
-ARG OUTPUT_DIR_FOR_SOURCE_MAP_BASE
+ARG OUTPUT_DIR_ON_HOST
 ARG WITH_DEBUG
-ARG DEBUG_OFFSET_TO_PHP_WASM_PACKAGE
+ARG DEBUG_DWARF_COMPILATION_DIR
 ARG WITH_WS_NETWORKING_PROXY
 ARG WITH_INTL
 
@@ -162,6 +162,7 @@ RUN if [ "$WITH_CLI_SAPI" = "yes" ]; \
 		# Configure build flags
 		echo -n ' --enable-phar --enable-cli=static ' >> /root/.php-configure-flags && \
 		echo -n ' /root/php-src/sapi/cli/php_cli_process_title.c /root/php-src/sapi/cli/ps_title.c ' \
+			# Use absolute paths to help path mapping for DWARF debug info
 			'/root/php-src/sapi/cli/php_http_parser.c /root/php-src/sapi/cli/php_cli_server.c ' \
 			'/root/php-src/sapi/cli/php_cli.c ' \
 			>> /root/.emcc-php-wasm-sources && \
@@ -474,11 +475,16 @@ EOF
 RUN echo '' > /root/php-src/ext/standard/proc_open.h;
 RUN echo '' > /root/php-src/ext/standard/proc_open.c;
 
+ARG OUTPUT_DIR_ON_HOST
+ARG DEBUG_DWARF_COMPILATION_DIR
 RUN source /root/emsdk/emsdk_env.sh && \
 	# We're compiling PHP as emscripten's side module...
 	export JSPI_FLAGS=$(if [ "$WITH_JSPI" = "yes" ]; then echo "-sSUPPORT_LONGJMP=wasm -fwasm-exceptions"; else echo ""; fi) && \
 	export PHP_VERSION_ESCAPED="${PHP_VERSION//./_}" && \
-	EMCC_FLAGS=" -D__x86_64__ -sSIDE_MODULE -Dsetsockopt=wasm_setsockopt -Dphp_exec=wasm_php_exec $JSPI_FLAGS -fdebug-compilation-dir=${OUTPUT_DIR_FOR_SOURCE_MAP_BASE}/${PHP_VERSION_ESCAPED}/ -fdebug-prefix-map=/root/php-src/=php-src/ " \
+	EMCC_FLAGS=" -D__x86_64__ -sSIDE_MODULE -Dsetsockopt=wasm_setsockopt -Dphp_exec=wasm_php_exec \
+		$JSPI_FLAGS \
+		-fdebug-compilation-dir=${DEBUG_DWARF_COMPILATION_DIR}/ \
+		-fdebug-prefix-map=/root/php-src/=${OUTPUT_DIR_ON_HOST}/${PHP_VERSION_ESCAPED}/php-src/ " \
 	# ...which means we must skip all the libraries - they will be provided in the final linking step.
 	EMCC_SKIP="-lz -ledit -ldl -lncurses -lzip -lpng16 -lssl -lcrypto -licuuc -licudata -licui18n -licuio -lxml2 -lc -lm -lsqlite3 /root/lib/lib/libxml2.a /root/lib/lib/libsqlite3.so /root/lib/lib/libsqlite3.a /root/lib/lib/libsqlite3.a /root/lib/lib/libpng16.so /root/lib/lib/libwebp.a /root/lib/lib/libsharpyuv.a /root/lib/lib/libjpeg.a" \
 	emmake make -j1
@@ -498,8 +504,8 @@ RUN if [[ "${PHP_VERSION:0:1}" -le "7" && "${PHP_VERSION:2:1}" -le "3" ]]; then 
 	fi
 
 ARG WITH_SOURCEMAPS
-ARG OUTPUT_DIR_FOR_SOURCE_MAP_BASE
-ARG DEBUG_OFFSET_TO_PHP_WASM_PACKAGE
+ARG OUTPUT_DIR_ON_HOST
+ARG DEBUG_DWARF_COMPILATION_DIR
 ARG WITH_DEBUG
 RUN set -euxo pipefail; \
 	if [ "$EMSCRIPTEN_ENVIRONMENT" = "node" ]; then \
@@ -511,16 +517,17 @@ RUN set -euxo pipefail; \
 		# Make source file paths relative to the location of the .wasm file
 		# so we can debug without additional config in host OS.
 		export PHP_VERSION_ESCAPED="${PHP_VERSION//./_}"; \
-		echo -n " -fdebug-compilation-dir=${OUTPUT_DIR_FOR_SOURCE_MAP_BASE}/${PHP_VERSION_ESCAPED}/ " \
-			"-fdebug-prefix-map=/root/php_wasm.c=${DEBUG_OFFSET_TO_PHP_WASM_PACKAGE}/compile/php/php_wasm.c " \
-			"-fdebug-prefix-map=/root/php-src/=php-src/  " \
+		echo -n " -fdebug-compilation-dir=${DEBUG_DWARF_COMPILATION_DIR}/ " \
+			"-fdebug-prefix-map=/root/php_wasm.c=${DEBUG_DWARF_COMPILATION_DIR}/compile/php/php_wasm.c " \
+			"-fdebug-prefix-map=/root/php-src/=${OUTPUT_DIR_ON_HOST}/${PHP_VERSION_ESCAPED}/php-src/  " \
+			"-fdebug-prefix-map=./=${OUTPUT_DIR_ON_HOST}/${PHP_VERSION_ESCAPED}/php-src/  " \
 			>> /root/.emcc-php-wasm-flags; \
 		if [ "${WITH_SOURCEMAPS}" = "yes" ]; then \
 			echo -n ' -gsource-map' >> /root/.emcc-php-wasm-flags; \
 			# Ensure source maps are loaded from the correct URL on the web.
 			# Without this, browsers will try the wasm:// protocol and never load the source map.
 			if [ "$EMSCRIPTEN_ENVIRONMENT" = "web" ]; then \
-				echo -n " --source-map-base http://127.0.0.1:5400/@fs${OUTPUT_DIR_FOR_SOURCE_MAP_BASE}/${PHP_VERSION_ESCAPED}/" >> /root/.emcc-php-wasm-flags; \
+				echo -n " --source-map-base http://127.0.0.1:5400/@fs${OUTPUT_DIR_ON_HOST}/${PHP_VERSION_ESCAPED}/" >> /root/.emcc-php-wasm-flags; \
 			fi; \
 		fi; \
 	else \
@@ -2080,6 +2087,7 @@ RUN set -euxo pipefail; \
 	-s MIN_NODE_VERSION=200900 \
 	-s INITIAL_MEMORY=1024MB \
 	-s ALLOW_MEMORY_GROWTH=1 \
+	-s ASSERTIONS=0 \
 	-s ERROR_ON_UNDEFINED_SYMBOLS=1 \
 	-s NODEJS_CATCH_EXIT=0 \
 	-s NODEJS_CATCH_REJECTION=0 \

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -510,7 +510,6 @@ RUN set -euxo pipefail; \
 		echo -n ' -g3 ' >> /root/.emcc-php-wasm-flags; \
 		# Make source file paths relative to the location of the .wasm file
 		# so we can debug without additional config in host OS.
-		#echo -n ' -fdebug-prefix-map=/root/php-src/=./php-src/ ' >> /root/.emcc-php-wasm-flags; \
 		export PHP_VERSION_ESCAPED="${PHP_VERSION//./_}"; \
 		echo -n " -fdebug-compilation-dir=${OUTPUT_DIR_FOR_SOURCE_MAP_BASE}/${PHP_VERSION_ESCAPED}/ " \
 			"-fdebug-prefix-map=/root/php_wasm.c=${DEBUG_OFFSET_TO_PHP_WASM_PACKAGE}/compile/php/php_wasm.c " \

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -90,6 +90,7 @@ ARG WITH_ICONV
 ARG WITH_SOURCEMAPS
 ARG OUTPUT_DIR_FOR_SOURCE_MAP_BASE
 ARG WITH_DEBUG
+ARG DEBUG_OFFSET_TO_PHP_WASM_PACKAGE
 ARG WITH_WS_NETWORKING_PROXY
 ARG WITH_INTL
 
@@ -160,7 +161,9 @@ RUN if [ "$WITH_CLI_SAPI" = "yes" ]; \
 	then \
 		# Configure build flags
 		echo -n ' --enable-phar --enable-cli=static ' >> /root/.php-configure-flags && \
-		echo -n ' sapi/cli/php_cli_process_title.c sapi/cli/ps_title.c sapi/cli/php_http_parser.c sapi/cli/php_cli_server.c sapi/cli/php_cli.c ' \
+		echo -n ' /root/php-src/sapi/cli/php_cli_process_title.c /root/php-src/sapi/cli/ps_title.c ' \
+			'/root/php-src/sapi/cli/php_http_parser.c /root/php-src/sapi/cli/php_cli_server.c ' \
+			'/root/php-src/sapi/cli/php_cli.c ' \
 			>> /root/.emcc-php-wasm-sources && \
 		echo -n ', "_run_cli", "_wasm_add_cli_arg"' >> /root/.EXPORTED_FUNCTIONS && \
 		echo -n ' -DWITH_CLI_SAPI=1 ' >> /root/.emcc-php-wasm-flags && \
@@ -474,7 +477,8 @@ RUN echo '' > /root/php-src/ext/standard/proc_open.c;
 RUN source /root/emsdk/emsdk_env.sh && \
 	# We're compiling PHP as emscripten's side module...
 	export JSPI_FLAGS=$(if [ "$WITH_JSPI" = "yes" ]; then echo "-sSUPPORT_LONGJMP=wasm -fwasm-exceptions"; else echo ""; fi) && \
-	EMCC_FLAGS=" -D__x86_64__ -sSIDE_MODULE -Dsetsockopt=wasm_setsockopt -Dphp_exec=wasm_php_exec $JSPI_FLAGS " \
+	export PHP_VERSION_ESCAPED="${PHP_VERSION//./_}" && \
+	EMCC_FLAGS=" -D__x86_64__ -sSIDE_MODULE -Dsetsockopt=wasm_setsockopt -Dphp_exec=wasm_php_exec $JSPI_FLAGS -fdebug-compilation-dir=${OUTPUT_DIR_FOR_SOURCE_MAP_BASE}/${PHP_VERSION_ESCAPED}/ -fdebug-prefix-map=/root/php-src/=php-src/ " \
 	# ...which means we must skip all the libraries - they will be provided in the final linking step.
 	EMCC_SKIP="-lz -ledit -ldl -lncurses -lzip -lpng16 -lssl -lcrypto -licuuc -licudata -licui18n -licuio -lxml2 -lc -lm -lsqlite3 /root/lib/lib/libxml2.a /root/lib/lib/libsqlite3.so /root/lib/lib/libsqlite3.a /root/lib/lib/libsqlite3.a /root/lib/lib/libpng16.so /root/lib/lib/libwebp.a /root/lib/lib/libsharpyuv.a /root/lib/lib/libjpeg.a" \
 	emmake make -j1
@@ -495,6 +499,7 @@ RUN if [[ "${PHP_VERSION:0:1}" -le "7" && "${PHP_VERSION:2:1}" -le "3" ]]; then 
 
 ARG WITH_SOURCEMAPS
 ARG OUTPUT_DIR_FOR_SOURCE_MAP_BASE
+ARG DEBUG_OFFSET_TO_PHP_WASM_PACKAGE
 ARG WITH_DEBUG
 RUN set -euxo pipefail; \
 	if [ "$EMSCRIPTEN_ENVIRONMENT" = "node" ]; then \
@@ -503,12 +508,19 @@ RUN set -euxo pipefail; \
 	fi; \
 	if [ "${WITH_SOURCEMAPS}" = "yes" ] || [ "${WITH_DEBUG}" = "yes" ]; then \
 		echo -n ' -g3 ' >> /root/.emcc-php-wasm-flags; \
+		# Make source file paths relative to the location of the .wasm file
+		# so we can debug without additional config in host OS.
+		#echo -n ' -fdebug-prefix-map=/root/php-src/=./php-src/ ' >> /root/.emcc-php-wasm-flags; \
+		export PHP_VERSION_ESCAPED="${PHP_VERSION//./_}"; \
+		echo -n " -fdebug-compilation-dir=${OUTPUT_DIR_FOR_SOURCE_MAP_BASE}/${PHP_VERSION_ESCAPED}/ " \
+			"-fdebug-prefix-map=/root/php_wasm.c=${DEBUG_OFFSET_TO_PHP_WASM_PACKAGE}/compile/php/php_wasm.c " \
+			"-fdebug-prefix-map=/root/php-src/=php-src/  " \
+			>> /root/.emcc-php-wasm-flags; \
 		if [ "${WITH_SOURCEMAPS}" = "yes" ]; then \
 			echo -n ' -gsource-map' >> /root/.emcc-php-wasm-flags; \
 			# Ensure source maps are loaded from the correct URL on the web.
 			# Without this, browsers will try the wasm:// protocol and never load the source map.
 			if [ "$EMSCRIPTEN_ENVIRONMENT" = "web" ]; then \
-				export PHP_VERSION_ESCAPED="${PHP_VERSION//./_}"; \
 				echo -n " --source-map-base http://127.0.0.1:5400/@fs${OUTPUT_DIR_FOR_SOURCE_MAP_BASE}/${PHP_VERSION_ESCAPED}/" >> /root/.emcc-php-wasm-flags; \
 			fi; \
 		fi; \


### PR DESCRIPTION
## Motivation for the change, related issues

It is possible to build php-wasm with DWARF debug info today, but actually using the debugger to step through source lines requires additional configuration to map original source file paths (from Docker) to actual source file paths in the host OS.

The purpose of this PR is to set the correct source paths at build time so folks can debug php-wasm without additional configuration.

This is not just a matter of convenience. Some debuggers (VSCode) only allow a single path mapping, so we cannot step into source files from different directory subtrees at the same time (for example, php-src and php_wasm.c). It would be simpler, faster, and more complete for debugging with DWARF to work out of the box.

## Implementation details

This PR adds compilation flags like the following to establish compilation dir and source file paths relative to that:
- `-fdebug-compilation-dir=${OUTPUT_DIR_FOR_SOURCE_MAP_BASE}/${PHP_VERSION_ESCAPED}/`
- `-fdebug-prefix-map=/root/php_wasm.c=${DEBUG_OFFSET_TO_PHP_WASM_PACKAGE}/compile/php/php_wasm.c`

## Testing Instructions (or ideally a Blueprint)

### For php-wasm/node

- Build a version of PHP for php-wasm/node
- Set a breakpoint at the beginning of `run_cli()` in `php_wasm.c`
- Run the "Debug PHP-WASM CLI with DWARF Symbols" target in VSCode
- Select the version of PHP built with debug info
- Observe you hit the breakpoint
- Step through execution and into a php-src file to demonstrate that mapping works

### For php-wasm/web

- Build a version of PHP for php-wasm/web
- Run `npm run dev`
- Launch Chrome Canary
- Install the [C/C++ DevTools Support (DWARF) extension](https://chromewebstore.google.com/detail/cc++-devtools-support-dwa/pdcpmagijalfljmkmjngeonclgbbannb) if you don't already have it
- Navigate to http://127.0.0.1:5400/website-server/
- Select the version of PHP built with debug info
- Open the devtools Sources tab
- Try to open `php_wasm.c`. If the file shows up, it indicates there are DWARF mappings to that file.
- Try to open `zend_alloc.c`. If the file shows up, it indicates the DWARF mappings to PHP source files are working.
- Set a breakpoint at an interesting place and try to hit it.