### PR TITLE
Removing mentions about network disabled by default

### DIFF
--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -51,12 +51,6 @@ https://playground.wordpress.net/?plugin=coblocks&plugin=friends&theme=pendant
 
 <ThisIsQueryApi />
 
-:::info Plugin directory doesn't work in WordPress Playground
-
-Plugins must be installed manually because your WordPress site doesn't send any data to the internet. You won't be able to navigate the WordPress plugin directory inside `/wp-admin/`. The Query API method may seem to contradict that, but behind the scenes it uses the same plugin upload form as you would.
-
-:::
-
 ## Save your site
 
 To keep your WordPress Playground site for longer than a single browser session, you can export it as a zip file.

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -131,20 +131,6 @@ https://playground.wordpress.net/?plugin=coblocks&plugin=friends&theme=pendant
 
 <ThisIsQueryApi />
 
-:::info プラグインディレクトリは WordPress Playground では機能しません
-
-WordPress サイトはインターネットにデータを送信しないため、プラグインは手動でインストールする必要があります。`/wp-admin/`内の WordPress プラグインディレクトリにアクセスすることはできません。 Query API メソッドは一見矛盾しているように見えますが、実際にはプラグインのアップロードフォームと同じものを使用しています。
-
-:::
-
-<!--
-:::info Plugin directory doesn't work in WordPress Playground
-
-Plugins must be installed manually because your WordPress site doesn't send any data to the internet. You won't be able to navigate the WordPress plugin directory inside `/wp-admin/`. The Query API method may seem to contradict that, but behind the scenes it uses the same plugin upload form as you would.
-
-:::
- -->
-
 ## サイトを保存する
 
 <!--


### PR DESCRIPTION
## Motivation for the change, related issues
This pull request removes from the documentation references to the previous state of a Playground instance when the network access is disabled by default. Now, with the recent updates, network access is enabled, and this note in the documentation is no longer valid. 

## Implementation details
- Removing the references to English and Japanese translations
