### PR TITLE
[Web] Use null Response body when Playground responde with a null body status code

### DIFF
--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -87,8 +87,19 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 			phpResponse.httpStatusCode
 		);
 	}
-
-	return new Response(phpResponse.bytes, {
+	/**
+	 * Make sure we don't pass an actual body string to new Response()
+	 * if the status is a null body status (101, 103, 204, 205, or 304).
+	 * new Response() throws a TypeError in that case, as the fetch() spec
+	 * requires.
+	 *
+	 * @see https://fetch.spec.whatwg.org/#statuses
+	 */
+	const isNullBodyCode = [101, 103, 204, 205, 304].includes(
+		phpResponse.httpStatusCode
+	);
+	const responseBody = isNullBodyCode ? null : phpResponse.bytes;
+	return new Response(responseBody, {
 		headers: phpResponse.headers,
 		status: phpResponse.httpStatusCode,
 	});


### PR DESCRIPTION
# Description

Ensures the service worker uses a null body when constructing a `new Response()` with one of the [null body status codes](https://fetch.spec.whatwg.org/#statuses).

## Rationale

[WooCommerce failed in Playground](https://github.com/woocommerce/woocommerce/issues/58718) after skipping the setup wizard with this error:

> utils.ts:91 Uncaught (in promise) TypeError: Failed to construct 'Response': Response with null body status cannot have body

Turns out, the [fetch() spec defines](https://fetch.spec.whatwg.org/#statuses) something called a "null body status" which are status codes 101, 103, 204, 205, and 304. When `new Response()` is created with one of these codes, the body must be null.

The offending request was:

/wp-json/wc-admin/onboarding/profile/update-store-currency-and-measurement-units?_locale=user Request Method:  POST
Status Code: 204 No Content (from service worker)

 # Testing instructions

* Go to http://127.0.0.1:5400/website-server/?plugin=woocommerce
* Go to wp-admin
* Skip the onboarding wizard
* Click the CTA to launch the store
* Confirm the flow doesn't get stuck on the "turning on the lights" screen but actually finishes

cc @nerrad
