### PR TITLE
Replace bun with node in `local-package-repository` script

### DIFF
--- a/tools/scripts/local-package-repository.sh
+++ b/tools/scripts/local-package-repository.sh
@@ -36,7 +36,12 @@ printf "%s" "$VERSION" | pbcopy
 echo "Version number $VERSION copied to clipboard"
 echo "Use Ctrl+C to stop the server"
 
-bun ./packages/playground/cli/src/cli.ts server \
-    --port=$PORT \
-    --mount="$HOST_PATH:/wordpress/$VERSION" \
-    --quiet
+node \
+  --no-warnings \
+  --experimental-wasm-stack-switching \
+  --experimental-wasm-jspi \
+  --loader=./packages/meta/src/node-es-module-loader/loader.mts \
+  ./packages/playground/cli/src/cli.ts server \
+  --port=$PORT \
+  --mount="$HOST_PATH:/wordpress/$VERSION" \
+  --quiet


### PR DESCRIPTION
## Motivation for the change, related issues

Running `npm run local-package-repository` returns the following error when running the `cli.ts` file with `bun`  : 

```
17 | // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
18 | // USE OR OTHER DEALINGS IN THE SOFTWARE.
19 |
20 | "use strict";
21 |
22 | var binding = require('./build/Release/fs_ext.node');
         ^
error: The module 'fs_ext' was compiled against a different Node.js ABI version using NODE_MODULE_VERSION 131. This version of Bun requires NODE_MODULE_VERSION 127. Please try re-compiling or re-installing the module.
      at <anonymous> (/Users/mho/Work/Projects/Development/Web/Professional/local-package-repository/wordpress-playground/node_modules/fs-ext/fs-ext.js:22:5)## Implementation details
```

Bun's most recent version `1.2.17` requires `NODE_MODULE_VERSION` 127. This means we have to compile `fs_ext` with Node20. 

@bgrgicak What do you think of replacing `bun` with `node` instead to avoid that issue and the rebuild process?

## Testing Instructions

`npm run local-package-repository`