### PR TITLE
Make fs-ext dependency optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
 				"diff3": "0.0.4",
 				"express": "4.21.2",
 				"file-saver": "^2.0.5",
-				"fs-ext": "2.1.1",
+				"fs-ext": "*",
 				"fs-extra": "11.1.1",
 				"ini": "4.1.2",
 				"octokit": "3.1.2",
@@ -127,6 +127,9 @@
 			"engines": {
 				"node": ">=20.18.3",
 				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -27037,6 +27040,7 @@
 			"resolved": "https://registry.npmjs.org/fs-ext/-/fs-ext-2.1.1.tgz",
 			"integrity": "sha512-/TrISPOFhCkbgIRWK9lzscRzwPCu0PqtCcvMc9jsHKBgZGoqA0VzhspVht5Zu8lxaXjIYIBWILHpRotYkCCcQA==",
 			"hasInstallScript": true,
+			"optional": true,
 			"dependencies": {
 				"nan": "^2.21.0"
 			},
@@ -38054,7 +38058,8 @@
 			"version": "2.22.2",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
 			"integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
 		"diff3": "0.0.4",
 		"express": "4.21.2",
 		"file-saver": "^2.0.5",
-		"fs-ext": "2.1.1",
 		"fs-extra": "11.1.1",
 		"ini": "4.1.2",
 		"octokit": "3.1.2",
@@ -190,5 +189,8 @@
 	"engines": {
 		"node": ">=20.18.3",
 		"npm": ">=10.1.0"
+	},
+	"optionalDependencies": {
+		"fs-ext": "2.1.1"
 	}
 }

--- a/packages/php-wasm/node/build.js
+++ b/packages/php-wasm/node/build.js
@@ -73,54 +73,6 @@ const dirnamePlugin = {
 	},
 };
 
-// Create a require function that can be used in the nativeNodeModulesPlugin.
-const require = createRequire(import.meta.url);
-
-/**
- * This is a plugin for handling native Node.js modules.
- *
- * Taken from:
- * https://github.com/evanw/esbuild/issues/1051#issuecomment-806325487
- */
-const nativeNodeModulesPlugin = {
-	name: 'native-node-modules',
-	setup(build) {
-		// If a ".node" file is imported within a module in the "file" namespace, resolve
-		// it to an absolute path and put it into the "node-file" virtual namespace.
-		build.onResolve({ filter: /\.node$/, namespace: 'file' }, (args) => ({
-			path: require.resolve(args.path, { paths: [args.resolveDir] }),
-			namespace: 'node-file',
-		}));
-
-		// Files in the "node-file" virtual namespace call "require()" on the
-		// path from esbuild of the ".node" file in the output directory.
-		build.onLoad({ filter: /.*/, namespace: 'node-file' }, (args) => ({
-			contents: `
-				import path from ${JSON.stringify(args.path)}
-				try { module.exports = require(path) }
-				catch {}
-			`,
-		}));
-
-		// If a ".node" file is imported within a module in the "node-file" namespace, put
-		// it in the "file" namespace where esbuild's default loading behavior will handle
-		// it. It is already an absolute path since we resolved it to one above.
-		build.onResolve(
-			{ filter: /\.node$/, namespace: 'node-file' },
-			(args) => ({
-				path: args.path,
-				namespace: 'file',
-			})
-		);
-
-		// Tell esbuild's default loading behavior to use the "file" loader for
-		// these ".node" files.
-		let opts = build.initialOptions;
-		opts.loader = opts.loader || {};
-		opts.loader['.node'] = 'file';
-	},
-};
-
 /**
  * This is a plugin for handling imports ending with ?url.
  */
@@ -171,13 +123,13 @@ async function build() {
 		format: 'cjs',
 		bundle: true,
 		tsconfig: 'packages/php-wasm/node/tsconfig.json',
-		external: ['@php-wasm/*', '@wp-playground/*', 'ws'],
+		external: ['@php-wasm/*', '@wp-playground/*', 'ws', 'fs-ext'],
 		loader: {
 			'.php': 'text',
 			'.ini': 'file',
 			'.wasm': 'file',
 		},
-		plugins: [dirnamePlugin, nativeNodeModulesPlugin, importUrlPlugin],
+		plugins: [dirnamePlugin, importUrlPlugin],
 	});
 
 	await esbuild.build({
@@ -203,7 +155,14 @@ const __dirname = import.meta.dirname;
 		packages: 'external',
 		bundle: true,
 		tsconfig: 'packages/php-wasm/node/tsconfig.json',
-		external: ['@php-wasm/*', '@wp-playground/*', 'ws', 'fs', 'path'],
+		external: [
+			'@php-wasm/*',
+			'@wp-playground/*',
+			'ws',
+			'fs',
+			'path',
+			'fs-ext',
+		],
 		supported: {
 			'dynamic-import': true,
 			'top-level-await': true,
@@ -214,7 +173,7 @@ const __dirname = import.meta.dirname;
 			'.ini': 'file',
 			'.wasm': 'file',
 		},
-		plugins: [dirnamePlugin, nativeNodeModulesPlugin, importUrlPlugin],
+		plugins: [dirnamePlugin, importUrlPlugin],
 	});
 
 	fs.copyFileSync(

--- a/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
+++ b/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
@@ -1,6 +1,17 @@
 import { logger } from '@php-wasm/logger';
 import { openSync, closeSync } from 'fs';
-import { flockSync as nativeFlockSync } from 'fs-ext';
+
+type NativeFlockSync = (
+	fd: number,
+	flags: 'sh' | 'ex' | 'shnb' | 'exnb' | 'un'
+) => void;
+const nativeFlockSync: NativeFlockSync = await import('fs-ext').then(
+	(m) => m.flockSync,
+	() =>
+		function flockSyncNoOp() {
+			/* do nothing */
+		}
+);
 
 import type {
 	FileLockManager,

--- a/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
+++ b/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
@@ -1,17 +1,21 @@
 import { logger } from '@php-wasm/logger';
 import { openSync, closeSync } from 'fs';
+import { createRequire } from 'module';
 
 type NativeFlockSync = (
 	fd: number,
 	flags: 'sh' | 'ex' | 'shnb' | 'exnb' | 'un'
 ) => void;
-const nativeFlockSync: NativeFlockSync = await import('fs-ext').then(
-	(m) => m.flockSync,
-	() =>
-		function flockSyncNoOp() {
+const nativeFlockSync: NativeFlockSync = (() => {
+	const require = createRequire(import.meta.url);
+	try {
+		return require('fs-ext').flockSync;
+	} catch {
+		return function flockSyncNoOp() {
 			/* do nothing */
-		}
-);
+		};
+	}
+})();
 
 import type {
 	FileLockManager,

--- a/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
+++ b/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
@@ -7,7 +7,7 @@ type NativeFlockSync = (
 	flags: 'sh' | 'ex' | 'shnb' | 'exnb' | 'un'
 ) => void;
 const nativeFlockSync: NativeFlockSync = (() => {
-	const require = createRequire(import.meta.url);
+	const require = createRequire(import.meta.filename);
 	try {
 		return require('fs-ext').flockSync;
 	} catch {

--- a/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
+++ b/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
@@ -1,6 +1,5 @@
 import { logger } from '@php-wasm/logger';
 import { openSync, closeSync } from 'fs';
-import { createRequire } from 'module';
 
 type NativeFlockSync = (
 	fd: number,

--- a/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
+++ b/packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts
@@ -6,16 +6,6 @@ type NativeFlockSync = (
 	fd: number,
 	flags: 'sh' | 'ex' | 'shnb' | 'exnb' | 'un'
 ) => void;
-const nativeFlockSync: NativeFlockSync = (() => {
-	const require = createRequire(import.meta.filename);
-	try {
-		return require('fs-ext').flockSync;
-	} catch {
-		return function flockSyncNoOp() {
-			/* do nothing */
-		};
-	}
-})();
 
 import type {
 	FileLockManager,
@@ -31,6 +21,7 @@ type LockMode = 'exclusive' | 'shared' | 'unlock';
 type NativeLock = {
 	fd: number;
 	mode: LockMode;
+	nativeFlockSync: NativeFlockSync;
 };
 
 type LockedRange = RequestedRangeLock & {
@@ -46,9 +37,20 @@ const MAX_64BIT_OFFSET = BigInt(2n ** 64n - 1n);
  * It provides methods for locking and unlocking files, as well as finding conflicting locks.
  */
 export class FileLockManagerForNode implements FileLockManager {
+	nativeFlockSync: NativeFlockSync;
 	locks: Map<string, FileLock>;
 
-	constructor() {
+	/**
+	 * Create a new FileLockManagerForNode instance.
+	 *
+	 * @param nativeFlockSync A synchronous flock() function to lock files via the host OS.
+	 */
+	constructor(
+		nativeFlockSync: NativeFlockSync = function flockSyncNoOp() {
+			/* do nothing */
+		}
+	) {
+		this.nativeFlockSync = nativeFlockSync;
 		this.locks = new Map();
 	}
 
@@ -66,7 +68,11 @@ export class FileLockManagerForNode implements FileLockManager {
 				return true;
 			}
 
-			const maybeLock = FileLock.maybeCreate(path, op.type);
+			const maybeLock = FileLock.maybeCreate(
+				path,
+				op.type,
+				this.nativeFlockSync
+			);
 			if (maybeLock === undefined) {
 				return false;
 			}
@@ -97,7 +103,11 @@ export class FileLockManagerForNode implements FileLockManager {
 				return true;
 			}
 
-			const maybeLock = FileLock.maybeCreate(path, requestedLock.type);
+			const maybeLock = FileLock.maybeCreate(
+				path,
+				requestedLock.type,
+				this.nativeFlockSync
+			);
 			if (maybeLock === undefined) {
 				return false;
 			}
@@ -192,7 +202,8 @@ export class FileLock {
 	 */
 	static maybeCreate(
 		path: string,
-		mode: Exclude<WholeFileLock['type'], 'unlocked'>
+		mode: Exclude<WholeFileLock['type'], 'unlocked'>,
+		nativeFlockSync: NativeFlockSync
 	): FileLock | undefined {
 		let fd;
 		try {
@@ -201,7 +212,7 @@ export class FileLock {
 			const flockFlags = mode === 'exclusive' ? 'exnb' : 'shnb';
 			nativeFlockSync(fd, flockFlags);
 
-			const nativeLock: NativeLock = { fd, mode };
+			const nativeLock: NativeLock = { fd, mode, nativeFlockSync };
 			return new FileLock(nativeLock);
 		} catch {
 			if (fd !== undefined) {
@@ -601,7 +612,7 @@ export class FileLock {
 			'un';
 
 		try {
-			nativeFlockSync(this.nativeLock.fd, flockFlags);
+			this.nativeLock.nativeFlockSync(this.nativeLock.fd, flockFlags);
 			this.nativeLock.mode = requiredNativeLockType;
 			return true;
 		} catch {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -480,7 +480,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 		.catch(() => {
 			logger.warn(
 				'The fs-ext package is not installed. ' +
-					'File locking will not be integrated with ' +
+					'Internal file locking will not be integrated with ' +
 					'host OS file locking.'
 			);
 			return undefined;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -475,7 +475,17 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 	// Declare file lock manager outside scope of startServer
 	// so we can look at it when debugging request handling.
-	const fileLockManager = new FileLockManagerForNode();
+	const nativeFlockSync = await import('fs-ext')
+		.then((m) => m.flockSync)
+		.catch(() => {
+			logger.warn(
+				'The fs-ext package is not installed. ' +
+					'File locking will not be integrated with ' +
+					'host OS file locking.'
+			);
+			return undefined;
+		});
+	const fileLockManager = new FileLockManagerForNode(nativeFlockSync);
 
 	let wordPressReady = false;
 

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -82,6 +82,7 @@ export default defineConfig({
 				'readline',
 				'worker_threads',
 				'url',
+				'fs-ext',
 			],
 		},
 		lib: {


### PR DESCRIPTION
## Motivation for the change, related issues

Some folks are encountering issues with building the fs-ext module containing a native Node.js add-on. 

Fixes #2308

## Implementation details

This PR makes the fs-ext dependency optional. This means that the dependency will be proactively installed by `npm`, but if an optional dependency fails to install, it does not fail the entire npm install.

## Testing Instructions (or ideally a Blueprint)

- Run `npm ci`
- Confirm that `fs-ext` is installed under node_modules
- Edit packages/php-wasm/node/src/lib/file-lock-manager-for-node.ts and add a console.log() statement to `flockSyncNoOp()`
- Make local dir test dir
- Run `npx nx unbuilt-jspi playground-cli server --mountBeforeInstall=<local-test-dir-path>:/wordpress`
- Confirm it starts with no errors and no `flockSyncNoOp` messages.
- Delete `node_modules/fs-ext`
- Run `npx nx unbuilt-jspi playground-cli server --mountBeforeInstall=<local-test-dir-path>:/wordpress`
- Confirm it starts successfully and prints `flockSyncNoP` console messages.