### PR TITLE
Add --internal-cookie-store option for Playground CLI

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -602,7 +602,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 					processIdSpaceLength,
 					followSymlinks,
 					trace,
-					disableCookieStore: !args.internalCookieStore,
+					internalCookieStore: args.internalCookieStore,
 				});
 
 				if (
@@ -689,7 +689,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 								processIdSpaceLength,
 								followSymlinks,
 								trace,
-								disableCookieStore: !args.internalCookieStore,
+								internalCookieStore: args.internalCookieStore,
 							});
 							await additionalPlayground.isReady();
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -175,6 +175,14 @@ export async function parseOptionsAndRunCLI() {
 			// Hide this option because we want to replace with a more general log-level flag.
 			hidden: true,
 		})
+		.option('internal-cookie-store', {
+			describe:
+				'Enable internal cookie handling. When enabled, Playground will manage cookies internally using ' +
+				'an HttpCookieStore that persists cookies across requests. When disabled, cookies are handled ' +
+				'externally (e.g., by a browser in Node.js environments).',
+			type: 'boolean',
+			default: false,
+		})
 		// TODO: Should we make this a hidden flag?
 		.option('experimentalMultiWorker', {
 			describe:
@@ -283,6 +291,7 @@ export interface RunCLIArgs {
 	followSymlinks?: boolean;
 	experimentalMultiWorker?: number;
 	experimentalTrace?: boolean;
+	internalCookieStore?: boolean;
 }
 
 export interface RunCLIServer extends AsyncDisposable {
@@ -593,6 +602,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 					processIdSpaceLength,
 					followSymlinks,
 					trace,
+					disableCookieStore: !args.internalCookieStore,
 				});
 
 				if (
@@ -679,6 +689,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 								processIdSpaceLength,
 								followSymlinks,
 								trace,
+								disableCookieStore: !args.internalCookieStore,
 							});
 							await additionalPlayground.isReady();
 

--- a/packages/playground/cli/src/worker-thread.ts
+++ b/packages/playground/cli/src/worker-thread.ts
@@ -27,9 +27,10 @@ export type PrimaryWorkerBootOptions = {
 	followSymlinks: boolean;
 	trace: boolean;
 	/**
-	 * Disable internal cookie handling. When true, Playground will not manage cookies internally,
-	 * which can be useful when cookies are handled externally (e.g., by a browser in Node.js environments).
-	 * By default, Playground uses an internal HttpCookieStore that persists cookies across requests.
+	 * Disable internal cookie handling. When true, Playground will not manage
+	 * cookies internally, which can be useful when cookies are handled externally
+	 * (e.g., by a browser in Node.js environments). By default, Playground uses
+	 * an internal HttpCookieStore that persists cookies across requests.
 	 */
 	disableCookieStore?: boolean;
 };

--- a/packages/playground/cli/src/worker-thread.ts
+++ b/packages/playground/cli/src/worker-thread.ts
@@ -26,6 +26,12 @@ export type PrimaryWorkerBootOptions = {
 	dataSqlPath?: string;
 	followSymlinks: boolean;
 	trace: boolean;
+	/**
+	 * Disable internal cookie handling. When true, Playground will not manage cookies internally,
+	 * which can be useful when cookies are handled externally (e.g., by a browser in Node.js environments).
+	 * By default, Playground uses an internal HttpCookieStore that persists cookies across requests.
+	 */
+	disableCookieStore?: boolean;
 };
 
 function mountResources(php: PHP, mounts: Mount[]) {
@@ -70,6 +76,7 @@ export class PlaygroundCliWorker extends PHPWorker {
 		dataSqlPath,
 		followSymlinks,
 		trace,
+		disableCookieStore,
 	}: PrimaryWorkerBootOptions) {
 		if (this.booted) {
 			throw new Error('Playground already booted');
@@ -137,7 +144,7 @@ export class PlaygroundCliWorker extends PHPWorker {
 						mountResources(php, mountsBeforeWpInstall);
 					},
 				},
-				cookieStore: false,
+				cookieStore: disableCookieStore ? false : undefined,
 				dataSqlPath,
 			});
 			this.__internal_setRequestHandler(requestHandler);

--- a/packages/playground/cli/src/worker-thread.ts
+++ b/packages/playground/cli/src/worker-thread.ts
@@ -27,12 +27,13 @@ export type PrimaryWorkerBootOptions = {
 	followSymlinks: boolean;
 	trace: boolean;
 	/**
-	 * Disable internal cookie handling. When true, Playground will not manage
-	 * cookies internally, which can be useful when cookies are handled externally
-	 * (e.g., by a browser in Node.js environments). By default, Playground uses
-	 * an internal HttpCookieStore that persists cookies across requests.
+	 * When true, Playground will not send cookies to the client but will manage
+	 * them internally. This can be useful in environments that can't store cookies,
+	 * e.g. VS Code WebView.
+	 *
+	 * Default: false.
 	 */
-	disableCookieStore?: boolean;
+	internalCookieStore?: boolean;
 };
 
 function mountResources(php: PHP, mounts: Mount[]) {
@@ -77,7 +78,7 @@ export class PlaygroundCliWorker extends PHPWorker {
 		dataSqlPath,
 		followSymlinks,
 		trace,
-		disableCookieStore,
+		internalCookieStore,
 	}: PrimaryWorkerBootOptions) {
 		if (this.booted) {
 			throw new Error('Playground already booted');
@@ -145,7 +146,7 @@ export class PlaygroundCliWorker extends PHPWorker {
 						mountResources(php, mountsBeforeWpInstall);
 					},
 				},
-				cookieStore: disableCookieStore ? false : undefined,
+				cookieStore: internalCookieStore ? undefined : false,
 				dataSqlPath,
 			});
 			this.__internal_setRequestHandler(requestHandler);


### PR DESCRIPTION
## Description

Adds a new `--internal-cookie-store` flag in the Playground CLI and a corresponding `internalCookieStore` argument in `RunCLIArgs`. When enabled, all the cookies are stored and served from an internal cookie jar. By default, that option is disabled and the user agent is responsible for handling cookies.

## Motivation

Some workflows need Playground to own cookie persistence, e.g. VS Code webview does not store cookies so any Blueprint with autologin enabled results in an infinite redirection loop.

## Testing steps

* Start Playground CLI without the flag and confirm that WordPress sends a `set-cookie` header both on the homepage and when logging in.
* Restart it with `--internal-cookie-store` and verify no cookies are sent to the browser. Confirm the admin login form still works.

cc @bgrgicak @ryanwelcher 