### PR TITLE
Fix: Set an explicit path for docsaurus.config.js

### DIFF
--- a/packages/docs/site/docs/main/contributing/translations.md
+++ b/packages/docs/site/docs/main/contributing/translations.md
@@ -20,7 +20,7 @@ Check the [How can I contribute?](/contributing/documentation#how-can-i-contribu
 Check the [Internationalization section](https://docusaurus.io/docs/i18n/introduction) of Docusaurus Docs to learn more about translations management in a Docusaurus website (the engine behind Playground Docs).
 :::
 
-Languages available for the Docs site are defined on `docusaurus.config.js`. For example:
+Languages available for the Docs site are defined on `packages/docs/site/docusaurus.config.js`. For example:
 
 ```
 i18n: {


### PR DESCRIPTION
## Motivation for the change, related issues
By default, the system assumes a single, fixed location on the root for docusaurus.config.js. This can lead to confusion when projects organize their documentation folder in a custom structure.

This is my experience when trying to translate into Tagalog, which could save bit time and avoid confusion if we explicitly detailed the path for the config file..

## Implementation details
Documentation update

Update the “Getting Started” guide in README.md to explain the new docsConfigPath option and list examples for typical project layouts.

## Testing Instructions (or ideally a Blueprint)
- Pull the PR
- Run `npm run dev:docs`
- Navigate to [Translations implementation details](http://localhost:3000/wordpress-playground/contributing/translations#translations-implementation-details)

## Issue: 
https://github.com/WordPress/wordpress-playground/issues/2334

## Result:
Before(Prod):
![2025-07-07_19-08](https://github.com/user-attachments/assets/a2a6222b-2cd4-414c-bf0c-530d29deec5d)

After:
![2025-07-07_19-07](https://github.com/user-attachments/assets/a17ad3b2-46af-4dac-9725-b285c5a26924)