### PR TITLE
CLI: Fix --login option and "landingPage" Blueprint property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,7 +246,9 @@ jobs:
                       --port=$PORT \
                       --mount="$HOST_PATH:/wordpress/$VERSION" \
                       --quiet& \
-                    )
+                    );
+                    # Trigger the initial request that may result in a redirect.
+                    curl -s http://127.0.0.1:$PORT/;
             - name: Wait for the package server to be ready
               run: |
                   for i in {1..60}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,23 +239,22 @@ jobs:
                   nvm install 22;
                   cd $HOST_PATH
                   RUNNER_TRACKING_ID="" && ( \
-                    nohup python3 -c "
-                    import http.server
-                    import socketserver
-                    from urllib.parse import unquote
+                    nohup python3 -c "import http.server
+                  import socketserver
+                  from urllib.parse import unquote
 
-                    class PrefixHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
-                        def do_GET(self):
-                            if self.path.startswith('/${{ env.VERSION }}/'):
-                                self.path = self.path[len('/${{ env.VERSION }}'):]
-                            elif self.path == '/${{ env.VERSION }}':
-                                self.path = '/'
-                            super().do_GET()
+                  class PrefixHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+                      def do_GET(self):
+                          if self.path.startswith('/${{ env.VERSION }}/'):
+                              self.path = self.path[len('/${{ env.VERSION }}'):]
+                          elif self.path == '/${{ env.VERSION }}':
+                              self.path = '/'
+                          super().do_GET()
 
-                    with socketserver.TCPServer(('127.0.0.1', ${{ env.PORT }}), PrefixHTTPRequestHandler) as httpd:
-                        httpd.serve_forever()
-                    "
-                    );
+                  with socketserver.TCPServer(('127.0.0.1', ${{ env.PORT }}), PrefixHTTPRequestHandler) as httpd:
+                      httpd.serve_forever()
+                  "
+                  );
             - name: Wait for the package server to be ready
               run: |
                   for i in {1..60}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,18 +237,25 @@ jobs:
               run: |
                   source ~/.nvm/nvm.sh;
                   nvm install 22;
+                  cd $HOST_PATH
                   RUNNER_TRACKING_ID="" && ( \
-                    nohup node \
-                      --experimental-strip-types \
-                      --experimental-transform-types \
-                      --import ./packages/meta/src/node-es-module-loader/register.mts \
-                      ./packages/playground/cli/src/cli.ts server \
-                      --port=$PORT \
-                      --mount="$HOST_PATH:/wordpress/$VERSION" \
-                      --quiet& \
+                    nohup python3 -c "
+                    import http.server
+                    import socketserver
+                    from urllib.parse import unquote
+
+                    class PrefixHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+                        def do_GET(self):
+                            if self.path.startswith('/${{ env.VERSION }}/'):
+                                self.path = self.path[len('/${{ env.VERSION }}'):]
+                            elif self.path == '/${{ env.VERSION }}':
+                                self.path = '/'
+                            super().do_GET()
+
+                    with socketserver.TCPServer(('127.0.0.1', ${{ env.PORT }}), PrefixHTTPRequestHandler) as httpd:
+                        httpd.serve_forever()
+                    "
                     );
-                    # Trigger the initial request that may result in a redirect.
-                    curl -s http://127.0.0.1:$PORT/ || true > /dev/null;
             - name: Wait for the package server to be ready
               run: |
                   for i in {1..60}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,7 @@ jobs:
                       --quiet& \
                     );
                     # Trigger the initial request that may result in a redirect.
-                    curl -s http://127.0.0.1:$PORT/;
+                    curl -s http://127.0.0.1:$PORT/ || true > /dev/null;
             - name: Wait for the package server to be ready
               run: |
                   for i in {1..60}; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
 
                   with socketserver.TCPServer(('127.0.0.1', ${{ env.PORT }}), PrefixHTTPRequestHandler) as httpd:
                       httpd.serve_forever()
-                  "
+                  "&
                   );
             - name: Wait for the package server to be ready
               run: |

--- a/packages/php-wasm/node/src/lib/networking/outbound-ws-to-tcp-proxy.ts
+++ b/packages/php-wasm/node/src/lib/networking/outbound-ws-to-tcp-proxy.ts
@@ -206,10 +206,8 @@ async function onWsConnect(client: any, request: http.IncomingMessage) {
 			clientLog("can't resolve " + reqTargetHost + ' due to:', e);
 			// Send empty binary data to notify requester that connection was
 			// initiated
-			setTimeout(() => {
-				client.send([]);
-				client.close(3000);
-			});
+			client.send([]);
+			client.close(3000);
 			return;
 		}
 	} else {
@@ -240,12 +238,7 @@ async function onWsConnect(client: any, request: http.IncomingMessage) {
 	});
 	target.on('error', function (e: any) {
 		clientLog('target connection error', e);
-		setTimeout(() => {
-			client.send([]);
-			client.close(3000);
-			if (target) {
-				target.end();
-			}
-		});
+		target.end();
+		client.close(3000);
 	});
 }

--- a/packages/php-wasm/node/src/lib/networking/outbound-ws-to-tcp-proxy.ts
+++ b/packages/php-wasm/node/src/lib/networking/outbound-ws-to-tcp-proxy.ts
@@ -206,8 +206,10 @@ async function onWsConnect(client: any, request: http.IncomingMessage) {
 			clientLog("can't resolve " + reqTargetHost + ' due to:', e);
 			// Send empty binary data to notify requester that connection was
 			// initiated
-			client.send([]);
-			client.close(3000);
+			setTimeout(() => {
+				client.send([]);
+				client.close(3000);
+			});
 			return;
 		}
 	} else {
@@ -238,7 +240,12 @@ async function onWsConnect(client: any, request: http.IncomingMessage) {
 	});
 	target.on('error', function (e: any) {
 		clientLog('target connection error', e);
-		target.end();
-		client.close(3000);
+		setTimeout(() => {
+			client.send([]);
+			client.close(3000);
+			if (target) {
+				target.end();
+			}
+		});
 	});
 }

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -56,7 +56,6 @@ export interface CompiledBlueprint {
 		networking: boolean;
 	};
 	extraLibraries: ExtraLibrary[];
-	landingPage: string;
 	/** The compiled steps for the blueprint */
 	run: (playground: UniversalPHP) => Promise<void>;
 }
@@ -330,7 +329,6 @@ function compileBlueprintJson(
 			),
 			wp: blueprint.preferredVersions?.wp || 'latest',
 		},
-		landingPage: blueprint.landingPage || '/',
 		features: {
 			// Disable intl by default to reduce the transfer size
 			intl: blueprint.features?.intl ?? false,
@@ -374,6 +372,22 @@ function compileBlueprintJson(
 					}
 				}
 			} finally {
+				try {
+					await (playground as any).goTo(
+						blueprint.landingPage || '/'
+					);
+				} catch {
+					/**
+					 * Redirecting to the landing page is a browser-only feature for now.
+					 *
+					 * The playground object only exposes the `goTo` method when
+					 * it's a Comlink proxy object running in the browser.
+					 *
+					 * Let's tolerate any errors thrown in other runtimes.
+					 *
+					 * @TODO: Handle "landingPage" in a PHP plugin to make it work in all environments.
+					 */
+				}
 				progress.finish();
 			}
 		},

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -56,6 +56,7 @@ export interface CompiledBlueprint {
 		networking: boolean;
 	};
 	extraLibraries: ExtraLibrary[];
+	landingPage: string;
 	/** The compiled steps for the blueprint */
 	run: (playground: UniversalPHP) => Promise<void>;
 }
@@ -329,6 +330,7 @@ function compileBlueprintJson(
 			),
 			wp: blueprint.preferredVersions?.wp || 'latest',
 		},
+		landingPage: blueprint.landingPage || '/',
 		features: {
 			// Disable intl by default to reduce the transfer size
 			intl: blueprint.features?.intl ?? false,
@@ -372,22 +374,6 @@ function compileBlueprintJson(
 					}
 				}
 			} finally {
-				try {
-					await (playground as any).goTo(
-						blueprint.landingPage || '/'
-					);
-				} catch {
-					/**
-					 * Redirecting to the landing page is a browser-only feature for now.
-					 *
-					 * The playground object only exposes the `goTo` method when
-					 * it's a Comlink proxy object running in the browser.
-					 *
-					 * Let's tolerate any errors thrown in other runtimes.
-					 *
-					 * @TODO: Handle "landingPage" in a PHP plugin to make it work in all environments.
-					 */
-				}
 				progress.finish();
 			}
 		},

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -341,7 +341,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 	const fileLockManager = new FileLockManagerForNode(nativeFlockSync);
 
 	let wordPressReady = false;
-	let isFirstRequest = true;
+	let isFirstRequest = false; // Set to true after booting WordPress
 
 	logger.log('Starting a PHP server...');
 
@@ -422,6 +422,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 				await playground.isReady();
 				wordPressReady = true;
+				isFirstRequest = true;
 				logger.log(`Booted!`);
 
 				loadBalancer = new LoadBalancer(playground);

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -341,6 +341,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 	const fileLockManager = new FileLockManagerForNode(nativeFlockSync);
 
 	let wordPressReady = false;
+	let isFirstRequest = true;
 
 	logger.log('Starting a PHP server...');
 
@@ -535,6 +536,35 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 				return PHPResponse.forHttpCode(
 					502,
 					'WordPress is not ready yet'
+				);
+			}
+			// Clear the playground_auto_login_already_happened cookie on the first request.
+			// Otherwise the first Playground CLI server started on the machine will set it,
+			// all the subsequent runs will get the stale cookie, and the auto-login will
+			// assume they don't have to auto-login again.
+			if (isFirstRequest) {
+				isFirstRequest = false;
+				const headers: Record<string, string[]> = {
+					'Content-Type': ['text/plain'],
+					'Content-Length': ['0'],
+					Location: [compiledBlueprint.landingPage],
+				};
+				if (
+					request.headers?.['cookie']?.includes(
+						'playground_auto_login_already_happened'
+					)
+				) {
+					headers['Set-Cookie'] = [
+						'playground_auto_login_already_happened=1; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/',
+					];
+				}
+				return new PHPResponse(
+					302,
+					{
+						'Content-Length': ['0'],
+						Location: [compiledBlueprint.landingPage],
+					},
+					new Uint8Array()
 				);
 			}
 			return await loadBalancer.handleRequest(request);

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -342,7 +342,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 	let wordPressReady = false;
 	let isFirstRequest = true;
-	let isSecondRequest = false;
 
 	logger.log('Starting a PHP server...');
 
@@ -545,7 +544,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 			// assume they don't have to auto-login again.
 			if (isFirstRequest) {
 				isFirstRequest = false;
-				isSecondRequest = true;
 				const headers: Record<string, string[]> = {
 					'Content-Type': ['text/plain'],
 					'Content-Length': ['0'],

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -341,7 +341,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 	const fileLockManager = new FileLockManagerForNode(nativeFlockSync);
 
 	let wordPressReady = false;
-	let isFirstRequest = false; // Set to true after booting WordPress
+	let isFirstRequest = true;
+	let isSecondRequest = false;
 
 	logger.log('Starting a PHP server...');
 
@@ -422,7 +423,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 				await playground.isReady();
 				wordPressReady = true;
-				isFirstRequest = true;
 				logger.log(`Booted!`);
 
 				loadBalancer = new LoadBalancer(playground);
@@ -545,10 +545,11 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 			// assume they don't have to auto-login again.
 			if (isFirstRequest) {
 				isFirstRequest = false;
+				isSecondRequest = true;
 				const headers: Record<string, string[]> = {
 					'Content-Type': ['text/plain'],
 					'Content-Length': ['0'],
-					Location: [compiledBlueprint.landingPage],
+					Location: ['/'],
 				};
 				if (
 					request.headers?.['cookie']?.includes(
@@ -559,14 +560,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 						'playground_auto_login_already_happened=1; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/',
 					];
 				}
-				return new PHPResponse(
-					302,
-					{
-						'Content-Length': ['0'],
-						Location: [compiledBlueprint.landingPage],
-					},
-					new Uint8Array()
-				);
+				return new PHPResponse(302, headers, new Uint8Array());
 			}
 			return await loadBalancer.handleRequest(request);
 		},

--- a/packages/playground/cli/tests/test-running-unbuilt-cli.sh
+++ b/packages/playground/cli/tests/test-running-unbuilt-cli.sh
@@ -30,7 +30,7 @@ function test_playground_cli() {
 		echo "Playground CLI started successfully"
 		echo "Checking WordPress home page..."
 
-		HOME_PAGE_OUTPUT="$(curl -s http://127.0.0.1:9400 || echo 'No output')"
+		HOME_PAGE_OUTPUT="$(curl -sL http://127.0.0.1:9400 || echo 'No output')"
 		if [[ $HOME_PAGE_OUTPUT != *"My WordPress Website"* ]]; then
 			echo "Home page output: $HOME_PAGE_OUTPUT"
 			echo "Error: Home page did not contain 'My WordPress Website'"

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -171,6 +171,11 @@ export async function startPlaygroundWeb({
 
 	await runBlueprintSteps(compiled, playground);
 	/**
+	 * @TODO: Handle "landingPage" in a PHP plugin to make it work in all environments.
+	 */
+	await (playground as any).goTo(compiled.landingPage || '/');
+
+	/**
 	 * Pre-fetch WordPress update checks to speed up the initial wp-admin load.
 	 *
 	 * @see https://github.com/WordPress/wordpress-playground/pull/2295

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -171,11 +171,6 @@ export async function startPlaygroundWeb({
 
 	await runBlueprintSteps(compiled, playground);
 	/**
-	 * @TODO: Handle "landingPage" in a PHP plugin to make it work in all environments.
-	 */
-	await (playground as any).goTo(compiled.landingPage || '/');
-
-	/**
 	 * Pre-fetch WordPress update checks to speed up the initial wp-admin load.
 	 *
 	 * @see https://github.com/WordPress/wordpress-playground/pull/2295

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -22,6 +22,6 @@ SupportedPHPVersions.forEach((phpVersion: string) => {
 			} finally {
 				await cli[Symbol.asyncDispose]();
 			}
-		}, 10000);
+		}, 22000);
 	});
 });

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -13,7 +13,7 @@ if (!SupportedPHPVersions.includes(phpVersion)) {
 }
 
 describe(`PHP ${phpVersion}`, () => {
-	it('Should load WordPress', { timeout: 12000 }, async () => {
+	it('Should load WordPress', { timeout: 22000 }, async () => {
 		const cli = await runCLI({
 			command: 'server',
 			php: phpVersion,


### PR DESCRIPTION
Makes the --login flag work in Playground CLI.

When you start the CLI server for the second time on the same machine it shows the login screen instead of auto-logging you in. The culprit is the  `playground_auto_login_already_happened` cookie, which the first run sets and later runs inherit. Because the cookie survives process restarts, the auto-login plugin silently skips its job.  ￼

### Solution

run-cli.ts now tracks whether a request is the very first one served by the process. On that first hit it:
	•	clears the stale cookie by returning a Set-Cookie header that expires it immediately, and
	•	responds with a 302 pointing to /, guaranteeing the request that follows will hit WordPress after the login routine runs.

The logic is guarded by a boolean isFirstRequest flag initialised at boot and flipped after the first response. 

As a follow up, we'll need to also adjust how the landingPage property is handled (it collides with the hardcoded redirection to /)

### CI adjustments

Because the very first HTTP call now yields a redirect, the workflow had to be taught to trigger—and then ignore—the 301/302 chain. The fix:
	•	primes the server with an initial curl so the redirect is consumed before the readiness probe starts
	•	replaces the Playground-CLI-based package host with a Python http.server to avoid using tool that's being tested in the test

## How to verify

Run wp-playground server twice in a row. Each session should open directly in wp-admin without showing the login form. The CI matrix stays green.
