### PR TITLE
Updating slack channel from #meta-playground to #playground

### DIFF
--- a/packages/docs/site/docs/blueprints/07-json-api-and-function-api.md
+++ b/packages/docs/site/docs/blueprints/07-json-api-and-function-api.md
@@ -15,7 +15,7 @@ You can use Blueprints both with the web and the node.js versions of WordPress P
 
 The team is exploring ways to transition Blueprints from a TypeScript library to a PHP library. This would allow people to run Blueprints in any WordPress environments: Playground, a hosted site, or a local setup.
 
-The proposed [new specification](https://github.com/WordPress/blueprints-library/issues/6) is discussed on a separate [GitHub repository](https://github.com/WordPress/blueprints-library/), and you’re more than welcome to join (there or on the [#meta-playground](https://wordpress.slack.com/archives/C04EWKGDJ0K) Slack channel) and help shape the next generation of Playground.
+The proposed [new specification](https://github.com/WordPress/blueprints-library/issues/6) is discussed on a separate [GitHub repository](https://github.com/WordPress/blueprints-library/), and you’re more than welcome to join (there or on the [#playground](https://wordpress.slack.com/archives/C04EWKGDJ0K) Slack channel) and help shape the next generation of Playground.
 :::
 
 ## Differences between JSON and Function APIs

--- a/packages/docs/site/docs/main/contributing/contributor-day.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day.md
@@ -108,4 +108,4 @@ Have a question or an idea for a new feature? Found a bug? Something’s not wor
 
 -   During Contributor Day, you can reach us at the **Playground table**.
 -   Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is the VS Code extension, NPM package, or the plugins, open an issue on the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
--   Share your feedback on the [**#meta-playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/docs/main/intro.md
+++ b/packages/docs/site/docs/main/intro.md
@@ -71,7 +71,7 @@ import APIList from '@site/docs/\_fragments/\_api_list.mdx';
 WordPress Playground is an open-source project and welcomes all contributors from code to design, and from documentation to triage. Don't worry, _you don't need to know WebAssembly_ to contribute!
 
 -   See the [Contributors Handbook](/contributing) for all the details on how you can contribute.
--   Join us in the `#meta-playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
+-   Join us in the `#playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
 
 As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).
 

--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -213,7 +213,7 @@ const config = {
 								href: 'https://github.com/WordPress/wordpress-playground',
 							},
 							{
-								label: '#meta-playground on Slack',
+								label: '#playground on Slack',
 								href: 'https://make.wordpress.org/chat',
 							},
 						],

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md
@@ -71,7 +71,7 @@ import APIList from '@site/docs/\_fragments/\_api_list.mdx';
 WordPress Playground es un proyecto open-source y todas las aportaciones al mismo son bienvenidas, desde código hasta diseño, desde documentación hasta organización de tareas del proyecto. No te preocupes, ¡_no necesitas saber de WebAssembly_ para contribuir al proyecto!
 
 -   Echa un vistazo al [Contributors Handbook](/contributing/) para todo lo que necesitas saber para contribuir al proyecto.
--   Únete al canal de Slack `#meta-playground` (en la página [WordPress Slack](https://make.wordpress.org/chat/) encontrarás la información sobre como acceder al Slack de WordPress)
+-   Únete al canal de Slack `#playground` (en la página [WordPress Slack](https://make.wordpress.org/chat/) encontrarás la información sobre como acceder al Slack de WordPress)
 
 Como con todos los proyectos de WordPress, queremos asegurar en entorno seguro y acogedor para todos. Con esto en mente, se espera de todos los contribuidores que cumplan con nuestro [código de conducta](https://make.wordpress.org/handbook/community-code-of-conduct/).
 

--- a/packages/docs/site/i18n/es/docusaurus-theme-classic/footer.json
+++ b/packages/docs/site/i18n/es/docusaurus-theme-classic/footer.json
@@ -27,9 +27,9 @@
 		"message": "GitHub",
 		"description": "The label of footer link with label=GitHub linking to https://github.com/WordPress/wordpress-playground"
 	},
-	"link.item.label.#meta-playground on Slack": {
-		"message": "#meta-playground on Slack",
-		"description": "The label of footer link with label=#meta-playground on Slack linking to https://make.wordpress.org/chat"
+	"link.item.label.#playground on Slack": {
+		"message": "#playground on Slack",
+		"description": "The label of footer link with label=#playground on Slack linking to https://make.wordpress.org/chat"
 	},
 	"copyright": {
 		"message": "Copyright © 2024 WordPress Playground, Inc. Built with Docusaurus.",

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/intro.md
@@ -71,7 +71,7 @@ import APIList from '@site/docs/\_fragments/\_api_list.mdx';
 WordPress Playground is an open-source project and welcomes all contributors from code to design, and from documentation to triage. Don't worry, _you don't need to know WebAssembly_ to contribute!
 
 -   See the [Contributors Handbook](/contributing) for all the details on how you can contribute.
--   Join us in the `#meta-playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
+-   Join us in the `#playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
 
 As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).
 

--- a/packages/docs/site/i18n/fr/docusaurus-theme-classic/footer.json
+++ b/packages/docs/site/i18n/fr/docusaurus-theme-classic/footer.json
@@ -27,9 +27,9 @@
 		"message": "GitHub",
 		"description": "The label of footer link with label=GitHub linking to https://github.com/WordPress/wordpress-playground"
 	},
-	"link.item.label.#meta-playground on Slack": {
-		"message": "#meta-playground on Slack",
-		"description": "The label of footer link with label=#meta-playground on Slack linking to https://make.wordpress.org/chat"
+	"link.item.label.#playground on Slack": {
+		"message": "#playground on Slack",
+		"description": "The label of footer link with label=#playground on Slack linking to https://make.wordpress.org/chat"
 	},
 	"copyright": {
 		"message": "Copyright © 2024 WordPress Playground, Inc. Built with Docusaurus.",

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -242,10 +242,10 @@ Have a question or an idea for a new feature? Found a bug? Something’s not wor
 
 -   コントリビューター デイ 中は、**Playground テーブル** でご連絡ください。
 -   [WordPress Playground GitHub リポジトリ](https://github.com/WordPress/wordpress-playground/issues/new) で Issue を開いてください。VS Code 拡張機能、NPM パッケージ、またはプラグインに関する問題の場合は、[Playground Tools リポジトリ](https://github.com/WordPress/playground-tools/issues/new) で Issue を開いてください。
--   [**#meta-playground** Slack チャンネル](https://wordpress.slack.com/archives/C04EWKGDJ0K) でフィードバックを共有してください。
+-   [**#playground** Slack チャンネル](https://wordpress.slack.com/archives/C04EWKGDJ0K) でフィードバックを共有してください。
 
 <!--
 -   During Contributor Day, you can reach us at the **Playground table**.
 -   Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is the VS Code extension, NPM package, or the plugins, open an issue on the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
--   Share your feedback on the [**#meta-playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
 -->

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/intro.md
@@ -165,11 +165,11 @@ WordPress Playground is an open-source project and welcomes all contributors fro
  -->
 
 -   貢献方法の詳細については、[貢献者ハンドブック](/contributing) をご覧ください。
--   Slack の `#meta-playground` チャンネルにご参加ください（サインアップ情報については、[WordPress Slack ページ](https://make.wordpress.org/chat/) をご覧ください）。
+-   Slack の `#playground` チャンネルにご参加ください（サインアップ情報については、[WordPress Slack ページ](https://make.wordpress.org/chat/) をご覧ください）。
 
 <!--
 -   See the [Contributors Handbook](/contributing) for all the details on how you can contribute.
--   Join us in the `#meta-playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
+-   Join us in the `#playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
  -->
 
 すべての WordPress プロジェクトと同様に、私たちはすべての人にとって歓迎される環境を確保したいと考えています。そのため、すべての貢献者は私たちの [行動規範](https://make.wordpress.org/handbook/community-code-of-conduct/) に従うことが期待されます。

--- a/packages/docs/site/i18n/ja/docusaurus-theme-classic/footer.json
+++ b/packages/docs/site/i18n/ja/docusaurus-theme-classic/footer.json
@@ -27,9 +27,9 @@
 		"message": "GitHub",
 		"description": "The label of footer link with label=GitHub linking to https://github.com/WordPress/wordpress-playground"
 	},
-	"link.item.label.#meta-playground on Slack": {
-		"message": "#meta-playground on Slack",
-		"description": "The label of footer link with label=#meta-playground on Slack linking to https://make.wordpress.org/chat"
+	"link.item.label.#playground on Slack": {
+		"message": "#playground on Slack",
+		"description": "The label of footer link with label=#playground on Slack linking to https://make.wordpress.org/chat"
 	},
 	"copyright": {
 		"message": "Copyright © 2025 WordPress Playground, Inc. Built with Docusaurus.",

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/intro.md
@@ -150,13 +150,13 @@ O WordPress Playground é um projeto de código aberto (open-source) e todas as 
 
 <!--
 -   See the [Contributors Handbook](/contributing) for all the details on how you can contribute.
--   Join us in the `#meta-playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
+-   Join us in the `#playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
 
 As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).
 -->
 
 -   Dê uma olhada no [Manual do Colaborador (Contributors Handbook)](/contributing/) para tudo o que você precisa saber para contribuir com o projeto.
--   Junte-se ao canal `#meta-playground` no Slack (na página do [Slack do WordPress](https://make.wordpress.org/chat/) você encontrará as informações sobre como acessar o Slack do WordPress)
+-   Junte-se ao canal `#playground` no Slack (na página do [Slack do WordPress](https://make.wordpress.org/chat/) você encontrará as informações sobre como acessar o Slack do WordPress)
 
 Como em todos os projetos do WordPress, queremos garantir um ambiente seguro e acolhedor para todos. Com isso em mente, espera-se que todos os contribuidores cumpram o nosso [código de conduta](https://make.wordpress.org/handbook/community-code-of-conduct/).
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-theme-classic/footer.json
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-theme-classic/footer.json
@@ -27,9 +27,9 @@
 		"message": "GitHub",
 		"description": "O rótulo do link do rodapé com rótulo=GitHub linkando para https://github.com/WordPress/wordpress-playground"
 	},
-	"link.item.label.#meta-playground on Slack": {
-		"message": "#meta-playground no Slack",
-		"description": "O rótulo do link do rodapé com rótulo=#meta-playground on Slack linkando para https://make.wordpress.org/chat"
+	"link.item.label.#playground on Slack": {
+		"message": "#playground no Slack",
+		"description": "O rótulo do link do rodapé com rótulo=#playground on Slack linkando para https://make.wordpress.org/chat"
 	},
 	"copyright": {
 		"message": "Copyright © 2025 WordPress Playground, Inc. Built with Docusaurus.",


### PR DESCRIPTION
## Motivation for the change, related issues
The playground channel has changed over the past year from ´#meta-playground´ to ´#playground´. This pull request updates all the references on the documentation to the new channel name.


## Implementation details
- Replacing the references in 13 files


## Testing Instructions (or ideally a Blueprint)
- Download the branch ´updating-playground-slack-channel´
- Install the dependencies
- Run the command ´npm run dev:docs´
- search for ´#meta-playground´