### PR TITLE
[PHP] Tolerate pre-existing /internal directory when initializing the PHP module

### DIFF
--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library.js
@@ -38,19 +38,28 @@ const LibraryExample = {
 				.filter(Boolean)
 				.join(':');
 
+			// In multi-worker setups, some of the directories may already exist.
+			// Let's handle that gracefully.
+			function mkdirIfMissing(path) {
+				try {
+					FS.mkdir(path);
+				} catch (e) {
+					if (e.errno != ERRNO_CODES.EEXIST) throw e;
+				}
+			}
 			// The /internal directory is required by the C module. It's where the
 			// stdout, stderr, and headers information are written for the JavaScript
 			// code to read later on.
-			FS.mkdir('/internal');
+			mkdirIfMissing('/internal');
 			// The files from the shared directory are shared between all the
 			// PHP processes managed by PHPProcessManager.
-			FS.mkdir('/internal/shared');
+			mkdirIfMissing('/internal/shared');
 			// The files from the preload directory are preloaded using the
 			// auto_prepend_file php.ini directive.
-			FS.mkdir('/internal/shared/preload');
+			mkdirIfMissing('/internal/shared/preload');
 			// Platform-level bin directory for a fallback `php` binary. Without it,
 			// PHP may not populate the PHP_BINARY constant.
-			FS.mkdir('/internal/shared/bin');
+			mkdirIfMissing('/internal/shared/bin');
 			const originalOnRuntimeInitialized = Module['onRuntimeInitialized'];
 			Module['onRuntimeInitialized'] = () => {
 				// Dummy PHP binary for PHP to populate the PHP_BINARY constant.

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -159,9 +159,6 @@ export async function loadPHPRuntime(
 
 	const id = ++lastRuntimeId;
 
-	// TODO: Ask @adamziel why this is here.
-	// eslint-disable-next-line @typescript-eslint/no-unused-expressions -- why is this here?
-	PHPRuntime.FS;
 	PHPRuntime.id = id;
 	PHPRuntime.originalExit = PHPRuntime._exit;
 


### PR DESCRIPTION
## Motivation for the change, related issues

PHP creates a series of `/internal` directories when it's first created – via PHPWASM.init() inside php.js. There are scenarios where those directories may already exist – for example (TBD a list of such scenarios. I forgot why I had to do it in the first place)

## Implementation details

## Testing Instructions (or ideally a Blueprint)
