### PR TITLE
[Documentation] Adding pt-br About and Launch Page

### DIFF
--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/about/index.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/about/index.md
@@ -1,0 +1,156 @@
+---
+title: Sobre o Playground
+slug: /about
+---
+
+<!--
+# About WordPress Playground
+-->
+
+# Sobre o WordPress Playground
+
+<!--
+## What is WordPress Playground?
+-->
+
+## O que é o WordPress Playground?
+
+<!--
+**WordPress Playground is the platform that lets you run WordPress instantly on any device without a host**. It allows you to experiment and learn about WordPress without affecting your live website. It's a virtual sandbox where you can play around with different features, designs, and settings in a safe and controlled environment.
+-->
+
+**WordPress Playground é uma plataforma que permite executar WordPress instataneamente em qualquer dispositivo sem precisar de um servidor**. Isto permite usuários experimentar e aprender WordPress em um ambiente isoloado sem risco de afetar um site em produção. Playground é um sandbox virtual onde você pode experimentar diferentes recursos, design e configurações num ambiente seguro.
+
+<!--
+WordPress Playground is your place to build, test, and launch:
+
+-   [Build](/about/build): WordPress Playground can help you to build products with WordPress. Use it from where you work best, whether that's in the browser, Node.js, mobile apps, VS Code, or elsewhere.
+-   [Test](/about/test): Upgrade your QA process with WordPress Playground. Quickly test your plugins or themes, experiment in a private sandbox, and create PRs from your WP Playground instance to any repo.
+-   [Launch](/about/launch): Use WordPress Playground to showcase your product, let users try it live, or launch it in the App Store with zero lead time.
+-->
+
+WordPress Playground é um local para construir, testar e Lançamento:
+
+-   [Construir](/about/build): WordPress Playground pode ajudar você a construir produtos com WordPress. Utilize isto onde funcionar melhor, seja no naevgador, Node.js, aplicações móveis, VS Code, ou em qualquer outro lugar.
+-   [Test](/about/test): Atualize o seu processo de QA com o WordPress Playground. Rapidamente teste seus plugins ou temas, teste num sandbox privado e crie pull requests da sua instância Playground WordPress para qualquer repositório.
+-   [Lançamento](/about/launch): Use o Playgroud WordPress para demostrar o seu produto, permitir que os usuários o experimentem ao vivo ou lançá-lo na App Store com zero tempo de espera.
+
+<!--
+## Why WordPress Playground?
+-->
+
+## Por que o WordPress Playground?
+
+<!--
+### Try themes and plugins on the fly
+-->
+
+### Experimente temas e plugins dinamicamente
+
+<!--
+With the WordPress Playground, you can explore any [theme](https://developer.wordpress.org/themes/getting-started/what-is-a-theme/). You can choose from a wide range of themes and see how they look on your site. You can also modify the colors, fonts, layouts, and other visual elements to create a unique design. \
+In addition to themes, you can experiment with plugins too. With WordPress Playground, you can install and test different plugins to see how they work and what they can do for your site. This allows you to explore and understand the capabilities of WordPress without worrying about breaking anything.
+-->
+
+Com o WordPress Playground, você pode explorar qualquer [tema](https://developer.wordpress.org/themes/getting-started/what-is-a-theme/). Você pode escolher entre uma vasta gama de temas e ver como eles ficam no seu site. Você também pode modificar as cores, fontes, layouts e outros elementos visuais para criar um design único. \
+Além dos temas, você também pode experimentar com plugins. Com o WordPress Playground, você pode instalar e testar diferentes plugins para ver como eles funcionam e o que eles podem fazer pelo seu site. Isso permite que você explore e entenda as capacidades do WordPress sem se preocupar em quebrar nada.
+
+<!--
+### Create content on the go
+-->
+
+### Crie conteúdo em qualquer lugar
+
+<!--
+Another great feature of WordPress Playground is the ability to create and edit content. You can write blog posts, create pages, and add media like images and videos to your site. This helps you understand how to organize and structure your content effectively.
+-->
+
+Outra ótima característica do WordPress Playground é a capacidade de criar e editar conteúdo. Você pode escrever posts de blog, criar páginas e adicionar mídias como imagens e vídeos ao seu site. Isso ajuda você a entender como organizar e estruturar seu conteúdo de forma eficaz.
+
+<!--
+The content you create is limited to the Playground on your device and disappears once you leave it, so you are free to explore and play without risking breaking any actual site.
+-->
+
+O conteúdo que você cria é limitado ao Playground no seu dispositivo e desaparece assim que você o fecha, então você está livre para explorar e brincar sem arriscar quebrar qualquer site real.
+
+<!--
+But hey! You can also connect your Playground instance to a GitHub repo and create a PR to persist those changes.
+-->
+
+Mas ei! Você também pode conectar sua instância do Playground a um repositório do GitHub e criar um PR para persistir essas mudanças.
+
+<!--
+### It's super safe
+-->
+
+### É super seguro
+
+<!--
+Overall, WordPress Playground provides a risk-free environment for beginners to learn and get hands-on experience with WordPress. It helps you to gain confidence and knowledge before making changes to your live website.
+-->
+
+No geral, o WordPress Playground oferece um ambiente livre de riscos para iniciantes aprenderem e terem experiência prática com o WordPress. Ele ajuda você a ganhar confiança e conhecimento antes de fazer alterações no seu site ao vivo.
+
+<!--
+:::tip
+Check the [guides section](/guides) to learn more about how to leverage WordPress Playground to test your themes and plugins and create content on the fly.
+:::
+-->
+
+:::tip
+Confira a [seção de guias](/guides) para aprender mais sobre como aproveitar o WordPress Playground para testar seus temas e plugins e criar conteúdo dinamicamente.
+:::
+
+<!--
+## How does WordPress Playground work?
+-->
+
+## Como o WordPress Playground funciona?
+
+<!--
+When you first start using WordPress Playground, you'll be provided with a separate space where you can create and customise your own WordPress website. This space is completely isolated from your actual website.
+-->
+
+Quando você começa a usar o WordPress Playground, você recebe um espaço separado onde pode criar e personalizar seu próprio site WordPress. Este espaço é completamente isolado do seu site real.
+
+<!--
+### Streamed, not served.
+-->
+
+### Transmitido, não servido.
+
+<!--
+The WordPress you see when you open Playground in your browser is a WordPress that should function like any WordPress, with [a few limitations](/developers/limitations) and the important exception that it's not a permanent server with an internet address which will limit connections to some third-party services (automation, sharing, analysis, email, backups, etc.) in a persistent way.
+-->
+
+O WordPress que você vê ao abrir o Playground no seu navegador é um WordPress que deve funcionar como qualquer outro WordPress, com [algumas limitações](/developers/limitations) e a importante exceção de que não é um servidor permanente com um endereço de internet, o que limitará as conexões a alguns serviços de terceiros (automação, compartilhamento, análise, e-mail, backups, etc.) de forma persistente.
+
+<!--
+The loading screen and progress bar you see on Playground includes both the streaming of those foundational technologies to your browser and configuration steps from [WordPress Blueprints](/blueprints) (see [examples](/blueprints/examples)), so that a full server, WordPress software, Theme & Plugin solutions and configuration instructions can be streamed over-the-wire.
+-->
+
+A tela de carregamento e a barra de progresso que você vê no Playground incluem tanto a transmissão dessas tecnologias fundamentais para o seu navegador quanto as etapas de configuração dos [WordPress Blueprints](/blueprints) (veja [exemplos](/blueprints/examples)), de modo que um servidor completo, o software WordPress, soluções de Temas e Plugins e instruções de configuração possam ser transmitidos pela rede.
+
+<!--
+## What makes Playground different from running WordPress on a web server or local desktop app?
+-->
+
+## O que torna o Playground diferente de executar o WordPress em um servidor web ou aplicativo de desktop local?
+
+<!--
+Web applications like WordPress have long relied on server technologies [to run logic](/developers/architecture/wasm-php-overview) and [store data](/developers/architecture/wordpress#sqlite).
+-->
+
+Aplicações web como o WordPress há muito tempo dependem de tecnologias de servidor [para executar a lógica](/developers/architecture/wasm-php-overview) e [armazenar dados](/developers/architecture/wordpress#sqlite).
+
+<!--
+Using those technologies has meant either running a web server connected to the internet or using those technologies in a desktop service or app (sometimes called a "WordPress local environment") that either leans on a virtual server with the technologies installed or the underlying technologies on the current device.
+-->
+
+Usar essas tecnologias significava executar um servidor web conectado à internet ou usar essas tecnologias em um serviço ou aplicativo de desktop (às vezes chamado de "ambiente local do WordPress") que se apoia em um servidor virtual com as tecnologias instaladas ou nas tecnologias subjacentes no dispositivo atual.
+
+<!--
+Playground is a novel way to stream server technologies—including WordPress (and WP-CLI)—as files that can then run in the browser.
+-->
+
+O Playground é uma maneira inovadora de transmitir tecnologias de servidor — incluindo WordPress (e WP-CLI) — como arquivos que podem ser executados no navegador.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/about/launch.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/about/launch.md
@@ -1,0 +1,96 @@
+---
+title: Lançamento
+slug: /about/launch
+---
+
+<!--
+# Launch
+-->
+
+# Lançamento
+
+<!--
+Reach your clients or customers faster. Showcase your product, let users try it live, or launch it in the App Store with zero lead time.
+-->
+
+Alcance seus clientes mais rápido. Apresente seu produto, permita que os usuários o experimentem ao vivo ou lance-o na App Store sem tempo de espera.
+
+<!--
+## Embed interactive product demos on websites.
+-->
+
+## Incorpore demos interativas de produtos em sites.
+
+<!--
+Leverage [blueprints'](/blueprints) potential to create interactive demos of your plugins or themes. For example, you can provide a link to your users/clients to showcase how your custom plugin integrates with an adapted theme, demonstrating their combined functionality and appearance.
+-->
+
+Aproveite o potencial dos [blueprints](/blueprints) para criar demos interativas de seus plugins ou temas. Por exemplo, você pode fornecer um link para seus usuários/clientes para mostrar como seu plugin personalizado se integra a um tema adaptado, demonstrando sua funcionalidade e aparência combinadas.
+
+<!--
+Read more about this at [How to use WordPress Playground for interactive demos](https://developer.wordpress.org/news/2024/04/25/how-to-use-wordpress-playground-for-interactive-demos/)
+-->
+
+Leia mais sobre isso em [Como usar o WordPress Playground para demos interativas](https://developer.wordpress.org/news/2024/04/25/how-to-use-wordpress-playground-for-interactive-demos/)
+
+<!--
+Get inspiration about the type of interactive demos you can create at the [Blueprints Gallery](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md)
+-->
+
+Inspire-se sobre o tipo de demos interativas que você pode criar na [Galeria de Blueprints](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md)
+
+<!--
+The [Blueprints builder](https://playground.wordpress.net/builder/builder.html) tool allows you edit your blueprint online and run it directly in a Playground instance.
+-->
+
+A ferramenta [Construtor de Blueprints](https://playground.wordpress.net/builder/builder.html) permite que você edite seu blueprint online e o execute diretamente em uma instância do Playground.
+
+<iframe width="800" src="https://www.youtube.com/embed/lQzozsoJ3aY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<p></p>
+
+<!--
+Another handy tool to create a blueprint is the [WordPress Playground Step Library](https://akirk.github.io/playground-step-library/#) tool that provides a visual interface to drag or click the steps to create a blueprint for WordPress Playground. You can also [create your own steps](https://github.com/akirk/playground-step-library/#contributing)!
+-->
+
+Outra ferramenta útil para criar um blueprint é a [Biblioteca de Passos do WordPress Playground](https://akirk.github.io/playground-step-library/#), que fornece uma interface visual para arrastar ou clicar nos passos para criar um blueprint para o WordPress Playground. Você também pode [criar seus próprios passos](https://github.com/akirk/playground-step-library/#contributing)!
+
+<!--
+## Embed demos in posts and pages with the WordPress Playground block
+-->
+
+## Incorpore demos em posts e páginas com o bloco WordPress Playground
+
+<!--
+This [WordPress Playground block](https://wordpress.org/plugins/interactive-code-block/) allows you to embed WordPress Playground in your posts and pages. You can also include an interactive code editor to demonstrate and teach your readers how WordPress plugins are built.
+-->
+
+Este [bloco do WordPress Playground](https://wordpress.org/plugins/interactive-code-block/) permite que você incorpore o WordPress Playground em seus posts e páginas. Você também pode incluir um editor de código interativo para demonstrar e ensinar seus leitores como os plugins do WordPress são construídos.
+
+<!--
+With this block you have a straightforward and effective way to create live WordPress environments that can be embedded within your blog posts.
+-->
+
+Com este bloco, você tem uma maneira direta e eficaz de criar ambientes WordPress ao vivo que podem ser incorporados em seus posts de blog.
+
+<!--
+:::info
+For any issues or questions about the WordPress Playground Block, please open a GitHub issue in the [playground-tools](https://github.com/WordPress/playground-tools) repository.
+:::
+-->
+
+:::info
+Para quaisquer problemas ou perguntas sobre o Bloco WordPress Playground, por favor, abra uma issue no GitHub no repositório [playground-tools](https://github.com/WordPress/playground-tools).
+:::
+
+<!--
+## Put a native app running WordPress in the App Store.
+-->
+
+## Coloque um aplicativo nativo rodando WordPress na App Store.
+
+<!--
+Check the [How to ship a real WordPress site in a native iOS app via Playground?](../guides/wordpress-native-ios-app) guide for info on this use case
+-->
+
+Confira o guia [Como enviar um site WordPress real em um aplicativo iOS nativo via Playground?](../guides/wordpress-native-ios-app) para informações sobre este caso de uso.


### PR DESCRIPTION
## Motivation for the change, related issues

Adding Brazilian Portuguese translation for the pages About and Launch, it will help Portuguese speakers have a better understanding of the Playgroung and how to launch a new instance of the playground. This pull request is part of issue #2306.