### PR TITLE
[php-wasm/universal] Try require() before dynamic imprt in comlink-sync.ts

### DIFF
--- a/packages/php-wasm/universal/src/lib/comlink-sync.ts
+++ b/packages/php-wasm/universal/src/lib/comlink-sync.ts
@@ -147,10 +147,15 @@ export class NodeSABSyncReceiveMessageTransport {
 
 	static async create() {
 		if (!NodeSABSyncReceiveMessageTransport.receiveMessageOnPort) {
-			NodeSABSyncReceiveMessageTransport.receiveMessageOnPort =
-				await import('worker_threads').then(
-					(m) => m.receiveMessageOnPort
-				);
+			try {
+				NodeSABSyncReceiveMessageTransport.receiveMessageOnPort =
+					require('worker_threads').receiveMessageOnPort;
+			} catch {
+				NodeSABSyncReceiveMessageTransport.receiveMessageOnPort =
+					await import('worker_threads').then(
+						(m) => m.receiveMessageOnPort
+					);
+			}
 		}
 		return new NodeSABSyncReceiveMessageTransport();
 	}


### PR DESCRIPTION
## Motivation for the change, related issues

https://github.com/WordPress/wordpress-playground/pull/2317 introduced a dynamic import in a CJS code path (`comlink-sync.ts`). Node 20 requires a `--experimental-vm-modules` flag to run dynamic imports in such a context. This PR tries calling `require()` first to make it all work again.

## Testing Instructions (or ideally a Blueprint)

Confirm the `test-built-npm-packages` test passed.