### PR TITLE
[Client] Accept wasm.wordpress.net as an official origin

### DIFF
--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -207,6 +207,8 @@ function allowStorageAccessByUserActivation(iframe: HTMLIFrameElement) {
 const officialRemoteOrigin = 'https://playground.wordpress.net';
 const validRemoteOrigins = [
 	officialRemoteOrigin,
+	// An older origin that's still used by some plugins.
+	'https://wasm.wordpress.net',
 	// Allow hosting remote from same origin
 	location.origin,
 	'http://localhost',


### PR DESCRIPTION
## Motivation for the change, related issues

This PR accepts `https://wasm.wordpress.net` as a valid origin for the Playground client served from playground.wordpress.net.

The [WordPress Playground plugin](https://wordpress.org/plugins/interactive-code-block/) embeds Playground from `https://wasm.wordpress.net` due [to a historical nuance](https://github.com/WordPress/playground-tools/blob/88ed4924eff6d758015ac028b885d284e4711216/packages/wordpress-playground-block/src/components/playground-preview/index.tsx#L215). This [breaks the rendering of the block](https://github.com/WordPress/playground-tools/issues/380) with the following error:

```
index.js:25317 Uncaught (in promise) Error: Invalid remote URL: https://wasm.wordpress.net/remote.html. Expected remote URL to have a path of "/remote.html" based on one of the following origins:
 https://playground.wordpress.net/
```

While this PR resolves the immediate issue on WordPress.org, we should also update the plugin to use playground.wordpress.net.

**Before**

<img width="2312" height="1548" alt="CleanShot 2025-07-14 at 22 26 59@2x" src="https://github.com/user-attachments/assets/b5fe0b0e-44ec-408e-b330-5c33a2591ffd" />

**After**

<img width="2332" height="1564" alt="CleanShot 2025-07-14 at 22 26 11@2x" src="https://github.com/user-attachments/assets/068a9fb4-f549-4022-9c02-6f1a7041e90c" />

## Testing Instructions (or ideally a Blueprint)

There's no easy way to test this PR :(