### PR TITLE
Make PHP 8.3 the default version

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/run-php.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-php.spec.ts
@@ -3,8 +3,9 @@ import { runPHP } from './run-php';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { logger } from '@php-wasm/logger';
 import { vi } from 'vitest';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
-const phpVersion = '8.0';
+const phpVersion = RecommendedPHPVersion;
 describe('Blueprint step runPHP', () => {
 	let php: PHP;
 	let loggerErrorSpy: any;

--- a/packages/playground/blueprints/src/lib/steps/run-sql.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-sql.spec.ts
@@ -3,8 +3,9 @@ import { phpVars } from '@php-wasm/util';
 import { runSql } from './run-sql';
 import { PHPRequestHandler } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
-const phpVersion = '8.0';
+const phpVersion = RecommendedPHPVersion;
 describe('Blueprint step runSql', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
@@ -8,8 +8,9 @@ import {
 } from '@wp-playground/wordpress-builds';
 import { bootWordPress } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
-const phpVersion = '8.0';
+const phpVersion = RecommendedPHPVersion;
 describe('Blueprint step wpCLI', () => {
 	let php: PHP;
 

--- a/packages/playground/blueprints/src/lib/steps/write-files.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/write-files.spec.ts
@@ -2,8 +2,9 @@ import { PHP } from '@php-wasm/universal';
 import { writeFiles } from './write-files';
 import { PHPRequestHandler } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
-const phpVersion = '8.0';
+const phpVersion = RecommendedPHPVersion;
 describe('writeFiles', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;

--- a/packages/playground/cli/src/worker-thread.ts
+++ b/packages/playground/cli/src/worker-thread.ts
@@ -10,6 +10,7 @@ import {
 	sandboxedSpawnHandlerFactory,
 } from '@php-wasm/universal';
 import { sprintf } from '@php-wasm/util';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 import { bootWordPress } from '@wp-playground/wordpress';
 import { rootCertificates } from 'tls';
 import { jspi } from 'wasm-feature-detect';
@@ -111,7 +112,7 @@ export class PlaygroundCliWorker extends PHPWorker {
 		absoluteUrl,
 		mountsBeforeWpInstall,
 		mountsAfterWpInstall,
-		phpVersion = '8.0',
+		phpVersion = RecommendedPHPVersion,
 		wordPressZip,
 		sqliteIntegrationPluginZip,
 		firstProcessId,

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -14,7 +14,7 @@ import { phpVars } from '@php-wasm/util';
 
 export { createMemoizedFetch } from './create-memoized-fetch';
 
-export const RecommendedPHPVersion = '8.0';
+export const RecommendedPHPVersion = '8.3';
 
 /**
  * Unzip a zip file inside Playground.

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -28,7 +28,10 @@ import {
 	hasCachedStaticFilesRemovedFromMinifiedBuild,
 } from './worker-utils';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
-import { createMemoizedFetch } from '@wp-playground/common';
+import {
+	createMemoizedFetch,
+	RecommendedPHPVersion,
+} from '@wp-playground/common';
 import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { journalFSEvents, replayFSJournal } from '@php-wasm/fs-journal';
 /* @ts-ignore */
@@ -175,7 +178,7 @@ export class PlaygroundWorkerEndpoint extends PHPWorker {
 		mounts = [],
 		wpVersion = LatestMinifiedWordPressVersion,
 		sqliteDriverVersion = LatestSqliteDriverVersion,
-		phpVersion = '8.0',
+		phpVersion = RecommendedPHPVersion,
 		sapiName = 'cli',
 		withICU = false,
 		withNetworking = true,

--- a/packages/playground/website/cypress/e2e/query-api.cy.ts
+++ b/packages/playground/website/cypress/e2e/query-api.cy.ts
@@ -10,11 +10,11 @@ const LatestSupportedWordPressVersion = Object.keys(
 
 describe('Query API', () => {
 	describe('option `php`', () => {
-		it('should load PHP 8.0 by default', () => {
+		it('should load PHP 8.3 by default', () => {
 			cy.visit('/?url=/phpinfo.php');
 			cy.wordPressDocument()
 				.find('h1')
-				.should('contain', 'PHP Version 8.0');
+				.should('contain', 'PHP Version 8.3');
 		});
 
 		it('should load PHP 7.4 when requested', () => {

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -10,11 +10,11 @@ const LatestSupportedWordPressVersion = Object.keys(
 	MinifiedWordPressVersions
 ).filter((x) => !['nightly', 'beta'].includes(x))[0];
 
-test('should load PHP 8.0 by default', async ({ website, wordpress }) => {
+test('should load PHP 8.3 by default', async ({ website, wordpress }) => {
 	// Navigate to the website
 	await website.goto('./?url=/phpinfo.php');
 	await expect(wordpress.locator('h1.p').first()).toContainText(
-		'PHP Version 8.0'
+		'PHP Version 8.3'
 	);
 });
 
@@ -127,8 +127,8 @@ test('should retain encoded control characters in the URL', async ({
 	test.skip(
 		browserName === 'firefox' || browserName === 'webkit',
 		`It's unclear why this test fails in Firefox and Safari. The actual feature seems to be working in manual testing. ` +
-		`Let's figure this out and re-enable the test at one point. The upsides of merging the original PR sill ` +
-		`outweighted the downsides of disabling the test on FF.`
+			`Let's figure this out and re-enable the test at one point. The upsides of merging the original PR sill ` +
+			`outweighted the downsides of disabling the test on FF.`
 	);
 	const path =
 		'/wp-admin/admin.php?page=html-api-debugger&html=%3Cdiv%3E%0A1%0A2%0A3%0A%3C%2Fdiv%3E';

--- a/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/unconnected-site-settings-form.tsx
@@ -7,6 +7,7 @@ import { Controller, useForm } from 'react-hook-form';
 import classNames from 'classnames';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useSupportedWordPressVersions } from './use-supported-wordpress-versions';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
 type ConfigurableFields = Record<
 	keyof SiteFormData & ('wpVersion' | 'language' | 'multisite'),
@@ -43,7 +44,7 @@ export function UnconnectedSiteSettingsForm({
 	},
 }: SiteSettingsFormProps) {
 	defaultValues = {
-		phpVersion: '8.0',
+		phpVersion: RecommendedPHPVersion,
 		wpVersion: 'latest',
 		language: '',
 		withNetworking: true,

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -11,6 +11,7 @@ import {
 } from '@wp-playground/client';
 import { parseBlueprint } from './router';
 import { OverlayFilesystem, InMemoryFilesystem } from '@wp-playground/storage';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
 export type BlueprintSource =
 	| {
@@ -129,7 +130,9 @@ function applyQueryOverrides(
 		blueprint.preferredVersions = {} as any;
 	}
 	blueprint.preferredVersions!.php =
-		(query.get('php') as any) || blueprint.preferredVersions!.php || '8.0';
+		(query.get('php') as any) ||
+		blueprint.preferredVersions!.php ||
+		RecommendedPHPVersion;
 	blueprint.preferredVersions!.wp =
 		query.get('wp') || blueprint.preferredVersions!.wp || 'latest';
 


### PR DESCRIPTION
## Motivation for the change, related issues

Makes PHP 8.3 the default version used by playground.wordpress.net and Playground CLI.

## Implementation details

WordPress reports this warning on PHP 8.0:

<img width="720" height="323" alt="screenshot_2025-07-15_at_11 02 26_720" src="https://github.com/user-attachments/assets/ce2ca5c8-0220-4e37-8911-2beefe542b22" />

Furthermore, [PHP 8.3 was the most popular release in January 2025](https://stitcher.io/blog/php-version-stats-january-2025) so there's no real reason not to make it the default. 

## Testing Instructions (or ideally a Blueprint)

CI
