### PR TITLE
[PHP] Refresh the latest PHP versions before recompiling

### DIFF
--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -3,7 +3,32 @@ import util from 'util';
 import fs from 'fs';
 const rmAsync = util.promisify(fs.rm);
 import { spawn } from 'child_process';
-import { phpVersions } from '../supported-php-versions.mjs';
+import { phpVersions, lastRefreshed } from '../supported-php-versions.mjs';
+
+// Refresh PHP versions if they need updating (if last refreshed more than 24 hours ago)
+const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+const lastRefreshedDate = new Date(lastRefreshed);
+
+if (lastRefreshedDate < twentyFourHoursAgo) {
+	console.log(
+		'📅 PHP versions data is older than 24 hours, checking for updates...'
+	);
+	try {
+		const { updatePHPVersions } = await import('./update-php-versions.mjs');
+		await updatePHPVersions();
+
+		// Reload the supported-php-versions.mjs module to get the updated versions
+		const { phpVersions: updatedPhpVersions } = await import(
+			'../supported-php-versions.mjs?' + Date.now()
+		);
+		// Replace the original phpVersions with the updated ones
+		phpVersions.length = 0;
+		phpVersions.push(...updatedPhpVersions);
+	} catch (error) {
+		console.warn('⚠️  Failed to update PHP versions:', error.message);
+		process.exit(1);
+	}
+}
 
 // yargs parse
 import yargs from 'yargs';

--- a/packages/php-wasm/compile/update-php-versions.mjs
+++ b/packages/php-wasm/compile/update-php-versions.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+
+/**
+ * Script to automatically update PHP version numbers in supported-php-versions.mjs
+ *
+ * This script fetches the latest release information from multiple sources:
+ * - PHP.watch API for comprehensive version data
+ * - phpreleases.com API as fallback
+ * - Direct GitHub API for php/php-src releases
+ *
+ * Usage: node tools/update-php-versions.mjs
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Path to the supported PHP versions file
+const SUPPORTED_VERSIONS_FILE = path.resolve(
+	__dirname,
+	'../supported-php-versions.mjs'
+);
+
+/**
+ * Fetch data from a URL with error handling
+ */
+async function fetchJSON(url, description = '') {
+	try {
+		console.log(`Fetching ${description || url}...`);
+		const response = await fetch(url);
+		if (!response.ok) {
+			throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+		}
+		return await response.json();
+	} catch (error) {
+		console.warn(`Failed to fetch from ${url}: ${error.message}`);
+		return null;
+	}
+}
+
+/**
+ * Fetch latest version data from GitHub API
+ */
+async function fetchFromGitHub() {
+	let data = [];
+	try {
+		console.log('Fetching GitHub API for php/php-src tags (8 pages)...');
+
+		// Fetch 8 pages in parallel to get more comprehensive tag data
+		const pagePromises = [];
+		for (let page = 1; page <= 8; page++) {
+			pagePromises.push(
+				fetch(
+					`https://api.github.com/repos/php/php-src/tags?per_page=100&page=${page}`
+				).then((response) => {
+					if (!response.ok) {
+						throw new Error(
+							`HTTP ${response.status}: ${response.statusText}`
+						);
+					}
+					return response.json();
+				})
+			);
+		}
+
+		const pageResults = await Promise.allSettled(pagePromises);
+
+		// Combine successful results
+		for (const result of pageResults) {
+			if (result.status === 'fulfilled' && Array.isArray(result.value)) {
+				data = data.concat(result.value);
+			}
+		}
+
+		if (data.length === 0) {
+			throw new Error('No tag data retrieved from any page');
+		}
+	} catch (error) {
+		console.warn(`Failed to fetch from GitHub API: ${error.message}`);
+		data = null;
+	}
+	if (!Array.isArray(data)) return null;
+
+	const versions = {};
+
+	// Process tags to extract version numbers
+	for (const tag of data) {
+		const tagName = tag.name;
+		// Match patterns like "php-8.3.15", "php-8.2.26", etc.
+		const match = tagName.match(/^php-(\d+)\.(\d+)\.(\d+)$/);
+		if (match) {
+			const [, major, minor, patch] = match;
+			const version = `${major}.${minor}`;
+			const fullVersion = `${major}.${minor}.${patch}`;
+
+			// Keep the latest (highest) version for each major.minor
+			if (
+				!versions[version] ||
+				compareVersions(fullVersion, versions[version]) > 0
+			) {
+				versions[version] = fullVersion;
+			}
+		}
+	}
+
+	return versions;
+}
+
+/**
+ * Compare two semantic version strings
+ * Returns: 1 if a > b, -1 if a < b, 0 if equal
+ */
+function compareVersions(a, b) {
+	const aParts = a.split('.').map(Number);
+	const bParts = b.split('.').map(Number);
+
+	for (let i = 0; i < Math.max(aParts.length, bParts.length); i++) {
+		const aVal = aParts[i] || 0;
+		const bVal = bParts[i] || 0;
+
+		if (aVal > bVal) return 1;
+		if (aVal < bVal) return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * Merge version data from multiple sources, preferring more recent/reliable sources
+ */
+function mergeVersionData(...sources) {
+	const merged = {};
+
+	// Merge all sources, later sources take precedence
+	for (const source of sources) {
+		if (source) {
+			Object.assign(merged, source);
+		}
+	}
+
+	return merged;
+}
+
+/**
+ * Read the current supported-php-versions.mjs file
+ */
+function readCurrentVersions() {
+	try {
+		const content = fs.readFileSync(SUPPORTED_VERSIONS_FILE, 'utf8');
+
+		// Extract the phpVersions array using regex
+		const arrayMatch = content.match(
+			/export const phpVersions = (\[[\s\S]*?\]);/
+		);
+		if (!arrayMatch) {
+			throw new Error('Could not find phpVersions array in file');
+		}
+
+		// Parse the array (this is a bit hacky but works for our specific format)
+		const arrayString = arrayMatch[1];
+
+		// Extract version objects using regex
+		const versionMatches = arrayString.matchAll(
+			/\{[\s\S]*?version:\s*['"`]([^'"`]+)['"`][\s\S]*?lastRelease:\s*['"`]([^'"`]+)['"`][\s\S]*?\}/g
+		);
+
+		const versions = [];
+		for (const match of versionMatches) {
+			const [fullMatch, version, lastRelease] = match;
+
+			// Extract other properties
+			const loaderMatch = fullMatch.match(
+				/loaderFilename:\s*['"`]([^'"`]+)['"`]/
+			);
+			const wasmMatch = fullMatch.match(
+				/wasmFilename:\s*['"`]([^'"`]+)['"`]/
+			);
+
+			versions.push({
+				version,
+				loaderFilename: loaderMatch
+					? loaderMatch[1]
+					: `php_${version.replace('.', '_')}.js`,
+				wasmFilename: wasmMatch
+					? wasmMatch[1]
+					: `php_${version.replace('.', '_')}.wasm`,
+				lastRelease,
+			});
+		}
+
+		return versions;
+	} catch (error) {
+		console.error(`Error reading current versions: ${error.message}`);
+		return [];
+	}
+}
+
+/**
+ * Update the supported-php-versions.mjs file with new version data
+ */
+function updateVersionsFile(currentVersions, latestVersions) {
+	let updatedCount = 0;
+
+	// Update last release versions
+	const updatedVersions = currentVersions.map((versionObj) => {
+		const version = versionObj.version;
+		const newVersion = latestVersions[version];
+
+		if (newVersion && newVersion !== versionObj.lastRelease) {
+			console.log(
+				`Updating ${version}: ${versionObj.lastRelease} → ${newVersion}`
+			);
+			updatedCount++;
+			return {
+				...versionObj,
+				lastRelease: newVersion,
+			};
+		}
+
+		return versionObj;
+	});
+
+	// Generate the new file content
+	const fileContent = generateFileContent(updatedVersions);
+
+	// Write the updated file
+	fs.writeFileSync(SUPPORTED_VERSIONS_FILE, fileContent, 'utf8');
+
+	console.log(
+		`\nUpdated ${updatedCount} PHP versions in ${SUPPORTED_VERSIONS_FILE}`
+	);
+	return updatedCount;
+}
+
+/**
+ * Generate the complete file content for supported-php-versions.mjs
+ */
+function generateFileContent(versions) {
+	const header = `/**
+ * @typedef {Object} PhpVersion
+ * @property {string} version
+ * @property {string} loaderFilename
+ * @property {string} wasmFilename
+ * @property {string} lastRelease
+ */
+
+export const lastRefreshed = ${JSON.stringify(new Date().toISOString())};
+
+/**
+ * @type {PhpVersion[]}
+ * @see https://www.php.net/releases/index.php
+ */
+export const phpVersions = [`;
+
+	const footer = `];
+`;
+
+	const versionEntries = versions
+		.map((version) => {
+			return `\t{
+\t\tversion: '${version.version}',
+\t\tloaderFilename: '${version.loaderFilename}',
+\t\twasmFilename: '${version.wasmFilename}',
+\t\tlastRelease: '${version.lastRelease}',
+\t}`;
+		})
+		.join(',\n');
+
+	return header + '\n' + versionEntries + '\n' + footer;
+}
+
+/**
+ * Main function
+ */
+export async function updatePHPVersions() {
+	console.log('🔄 Updating PHP versions...\n');
+
+	// Fetch version data from multiple sources
+	console.log('📡 Fetching version data from APIs...');
+	const latestVersions = await fetchFromGitHub();
+
+	if (Object.keys(latestVersions).length === 0) {
+		console.error('❌ Failed to fetch version data from any source');
+		process.exit(1);
+	}
+
+	console.log('\n📋 Latest versions found:');
+	for (const [version, release] of Object.entries(latestVersions)) {
+		console.log(`  ${version}: ${release}`);
+	}
+
+	// Read current versions
+	console.log('\n📖 Reading current supported-php-versions.mjs...');
+	const currentVersions = readCurrentVersions();
+
+	if (currentVersions.length === 0) {
+		console.error('❌ Failed to read current versions');
+		process.exit(1);
+	}
+
+	// Update the file
+	console.log('\n✏️  Updating versions...');
+	const updatedCount = updateVersionsFile(currentVersions, latestVersions);
+
+	if (updatedCount > 0) {
+		console.log('\n✅ Successfully updated PHP versions!');
+	} else {
+		console.log('\n✨ All PHP versions are already up to date!');
+	}
+}

--- a/packages/php-wasm/supported-php-versions.mjs
+++ b/packages/php-wasm/supported-php-versions.mjs
@@ -6,6 +6,8 @@
  * @property {string} lastRelease
  */
 
+export const lastRefreshed = '2025-07-15T12:04:38.826Z';
+
 /**
  * @type {PhpVersion[]}
  * @see https://www.php.net/releases/index.php
@@ -15,25 +17,25 @@ export const phpVersions = [
 		version: '8.4',
 		loaderFilename: 'php_8_4.js',
 		wasmFilename: 'php_8_4.wasm',
-		lastRelease: '8.4.0',
+		lastRelease: '8.4.10',
 	},
 	{
 		version: '8.3',
 		loaderFilename: 'php_8_3.js',
 		wasmFilename: 'php_8_3.wasm',
-		lastRelease: '8.3.0',
+		lastRelease: '8.3.23',
 	},
 	{
 		version: '8.2',
 		loaderFilename: 'php_8_2.js',
 		wasmFilename: 'php_8_2.wasm',
-		lastRelease: '8.2.10',
+		lastRelease: '8.2.29',
 	},
 	{
 		version: '8.1',
 		loaderFilename: 'php_8_1.js',
 		wasmFilename: 'php_8_1.wasm',
-		lastRelease: '8.1.23',
+		lastRelease: '8.1.33',
 	},
 	{
 		version: '8.0',


### PR DESCRIPTION
This PR refreshes the supported-php-versions.mjs file with the latest PHP versions when you attempt to rebuild any PHP version (but only if the list is older than 24 hours).

This will help Playground stay up to date with latest PHP point releases. Right now it's a few point versions behind.

 ## Testing instructions

* Manually set `lastRefreshed` to a past date in `supported-php-versions`
* Run npm run recompile:php:node:asyncify:8.4
* Confirm the versions were refreshed before the build and that it builds 8.4.10 instead of 8.4.0

cc @zaerl 