### PR TITLE
Fix failing WP update workflows

### DIFF
--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -36,9 +36,6 @@ jobs:
                   clean: true
                   persist-credentials: true
                   submodules: true
-            - name: 'Install bun'
-              run: |
-                  curl -fsSL https://bun.sh/install | bash
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 23

--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -44,7 +44,7 @@ jobs:
               shell: bash
               env:
                   FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
-              run: PATH="${PATH}:${HOME}/.bun/bin" npx nx bundle-wordpress:major-and-beta playground-wordpress-builds
+              run: npx nx bundle-wordpress:major-and-beta playground-wordpress-builds
             - name: Check for uncommitted changes
               id: changes
               run: |

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -32,12 +32,9 @@ jobs:
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 23
-            - name: 'Install bun'
-              run: |
-                  curl -fsSL https://bun.sh/install | bash
             - name: 'Recompile WordPress'
               shell: bash
-              run: PATH="${PATH}:${HOME}/.bun/bin" npx nx bundle-wordpress:nightly playground-wordpress-builds
+              run: npx nx bundle-wordpress:nightly playground-wordpress-builds
             - name: Config git user
               run: |
                   git config --global user.name "deployment_bot"

--- a/packages/playground/cli/project.json
+++ b/packages/playground/cli/project.json
@@ -92,7 +92,7 @@
 						"command": "node -e \"if (parseInt(process.versions.node) < 22) { console.error('Node.js version 22 or greater is required'); process.exit(1); }\"",
 						"forwardAllArgs": false
 					},
-					"node --experimental-strip-types --experimental-transform-types --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts --watch ./packages/playground/cli/src/cli.ts"
+					"node --experimental-strip-types --experimental-transform-types --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts"
 				],
 				"tty": true,
 				"parallel": false
@@ -106,7 +106,7 @@
 						"command": "node -e \"if (parseInt(process.versions.node) < 23) { console.error('Node.js version 23 or greater is required for JSPI support'); process.exit(1); }\"",
 						"forwardAllArgs": false
 					},
-					"node --experimental-wasm-jspi --experimental-strip-types --experimental-transform-types  --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts --watch ./packages/playground/cli/src/cli.ts"
+					"node --experimental-wasm-jspi --experimental-strip-types --experimental-transform-types  --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts"
 				],
 				"tty": true,
 				"parallel": false

--- a/packages/playground/wordpress-builds/build/build.js
+++ b/packages/playground/wordpress-builds/build/build.js
@@ -111,6 +111,11 @@ if (args.wpVersion === 'nightly') {
 }
 
 if (!versionInfo.url) {
+	if (args.wpVersion === 'beta') {
+		process.stdout.write('Skipping. We did not find a WP beta version.\n');
+		process.exit(0);
+	}
+
 	process.stdout.write(`WP version ${args.wpVersion} is not supported\n`);
 	process.stdout.write(await parser.getHelp());
 	process.exit(1);
@@ -154,9 +159,12 @@ try {
 	await fs.mkdir(wordpressDir);
 	// Install WordPress in a local directory
 	await asyncSpawn(
-		'bun',
+		'npx',
 		[
-			'../../cli/src/cli.ts',
+			'nx',
+			'unbuilt-jspi',
+			'playground-cli',
+			'--',
 			'run-blueprint',
 			`--wp=${versionInfo.url}`,
 			`--mount-before-install=${wordpressDir}:/wordpress`,


### PR DESCRIPTION
## Motivation for the change, related issues

Our automation that updates WordPress builds is currently broken. The workflows try to run Playground CLI with bun, and that is not currently working (due to broken worker URL resolution at runtime).

## Implementation details

This PR adjusts the build script and the workflows to use Node.js instead of Bun.

It also fixes a couple other small bugs:
1. The Playground CLI Nx targets `unbuilt-asyncify` and `unbuilt-jspi` were mistakenly passing the `--watch` argument to node. My intent with those targets was for them to be easy ways to run Playground CLI once.
2.  The WP build script were exiting with an error if the beta version was specified but a beta version wasn't available. Sometimes beta versions aren't available, so now we exit normally in that case.

## Testing Instructions (or ideally a Blueprint)

- CI
- Deploy
- Test workflows on trunk

These workflows are already broken, so I'm just going merge and see if they work in production. If there are further issues, I'll open another PR and do the slower kind of testing that involves commenting out only-on-main-branch guards and temporarily adding exceptions to branch protections.