### PR TITLE
Allow the WP update and changelog workflows to commit to trunk again

### DIFF
--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -34,7 +34,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
-                  persist-credentials: true
+                  persist-credentials: false
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
@@ -63,6 +63,7 @@ jobs:
                   sudo chown -R "$(whoami):$(id -gn)" packages/playground/wordpress-builds/public
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
+                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   git add -A
                   git commit -a -m "Recompile WordPress major and beta versions"
                   git pull --rebase

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -27,7 +27,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
-                  persist-credentials: true
+                  persist-credentials: false
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
@@ -39,6 +39,7 @@ jobs:
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
+                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   git add -A
                   git commit -a -m "Refresh WordPress Nightly"
                   git pull --rebase

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -43,7 +43,7 @@ jobs:
                   submodules: recursive
                   ref: trunk
                   clean: true
-                  persist-credentials: true
+                  persist-credentials: false
             - name: 'Install bun (for the changelog)'
               run: |
                   curl -fsSL https://bun.sh/install | bash
@@ -61,6 +61,7 @@ jobs:
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
+                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   if [[ -n $(git status --porcelain CHANGELOG.md) ]]; then
                       git commit -m "chore: update changelog" \
                           CHANGELOG.md \


### PR DESCRIPTION
## Motivation for the change, related issues

The WP build and changelog update workflows are currently blocked from committing to trunk because it is a protected branch. 

## Implementation details
This PR fixes that by restoring use of GH_ACTOR and GH_TOKEN in those workflows.

I previously removed use of the occasionally-expiring Personal Access Token (PAT), not understanding that it was required for pushing to protected branches. At the time we were not protecting trunk in the that repo, and using the default token provided in the GH workflow context worked just fine.

Once we switched back to using branch protection, these workflows started breaking.

For a GitHub Actions workflow to push to a protected branch we need to do one of the following:
- Use a PAT and update it before it expires
- Use a Deploy Key (doesn't expire but has a lot of power if it falls into the wrong hands)
- Create a GitHub app at the organization level, add it to the repo, create an app token during workflow execution, and use that. This is a bit annoying since we don't (or at least I don't) have access to create an app within the WordPress GH org, so we'd have to request the app and then jump through hoops to use it in each workflow.
- Create a PR within the workflow and use the GH REST API (even via GH CLI) to merge it

Right now, we have a PAT that is working for the sqlite-database-integration update, so I'm just restoring that for the other workflows.

## Testing Instructions (or ideally a Blueprint)

Merge and run workflows on trunk.
