### PR TITLE
Deploy public web app after WP major/beta update

### DIFF
--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -75,7 +75,5 @@ jobs:
               if: steps.changes.outputs.COMMIT_CHANGES == '1'
               uses: benc-uk/workflow-dispatch@v1
               with:
-                  # TODO: Switch back to build-website.yml before merging to public repo
-                  #workflow: build-website.yml
-                  workflow: deploy-private-website.yml
+                  workflow: build-website.yml
                   token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation for the change, related issues

The WP major/beta update workflow was left trying to deploy the private web app.

## Implementation details

This PR fixes the workflow to deploy the public web app.

## Testing Instructions (or ideally a Blueprint)

Deploy and run on trunk