### PR TITLE
[PHP-wasm Node] Remove unused node creation code from createNodeFsMountHandler

### DIFF
--- a/packages/php-wasm/node/src/lib/node-fs-mount.ts
+++ b/packages/php-wasm/node/src/lib/node-fs-mount.ts
@@ -39,9 +39,14 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 		let lookup: Emscripten.FS.Lookup | undefined;
 		try {
 			lookup = FS.lookupPath(vfsMountPoint);
-		} catch {}
-		if (!lookup?.node) {
-			throw new Error('Unable to access the mount point in VFS.');
+		} catch (e) {
+			const error = e as Emscripten.FS.ErrnoError;
+			if (error.errno === 44) {
+				throw new Error(
+					`Unable to access the mount point ${vfsMountPoint} in VFS after attempting to create it.`
+				);
+			}
+			throw e;
 		}
 		FS.mount(FS.filesystems['NODEFS'], { root: localPath }, vfsMountPoint);
 		return () => {

--- a/packages/php-wasm/node/src/lib/node-fs-mount.ts
+++ b/packages/php-wasm/node/src/lib/node-fs-mount.ts
@@ -3,8 +3,8 @@ import {
 	FSHelpers,
 	type MountHandler,
 } from '@php-wasm/universal';
-import { lstatSync, readlinkSync, statSync } from 'fs';
-import { basename, dirname } from 'path';
+import { lstatSync } from 'fs';
+import { dirname } from 'path';
 
 export function createNodeFsMountHandler(localPath: string): MountHandler {
 	return function (php, FS, vfsMountPoint) {

--- a/packages/php-wasm/node/src/lib/node-fs-mount.ts
+++ b/packages/php-wasm/node/src/lib/node-fs-mount.ts
@@ -1,4 +1,8 @@
-import { FSHelpers, type MountHandler } from '@php-wasm/universal';
+import {
+	type Emscripten,
+	FSHelpers,
+	type MountHandler,
+} from '@php-wasm/universal';
 import { lstatSync, readlinkSync, statSync } from 'fs';
 import { basename, dirname } from 'path';
 
@@ -20,14 +24,7 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 		let removeVfsNode = false;
 		if (!FSHelpers.fileExists(FS, vfsMountPoint)) {
 			const lstat = lstatSync(localPath);
-			if (lstat.isSymbolicLink()) {
-				FS.mkdirTree(dirname(vfsMountPoint));
-				(FS as any).createNode(
-					FS.lookupPath(vfsMountPoint, { parent: true }).node,
-					basename(localPath),
-					110000
-				);
-			} else if (lstat.isFile()) {
+			if (lstat.isFile() || lstat.isSymbolicLink()) {
 				FS.mkdirTree(dirname(vfsMountPoint));
 				FS.writeFile(vfsMountPoint, '');
 			} else if (lstat.isDirectory()) {
@@ -39,8 +36,11 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 			}
 			removeVfsNode = true;
 		}
-		const lookup = FS.lookupPath(vfsMountPoint);
-		if (!lookup.node) {
+		let lookup: Emscripten.FS.Lookup | undefined;
+		try {
+			lookup = FS.lookupPath(vfsMountPoint);
+		} catch {}
+		if (!lookup?.node) {
 			throw new Error('Unable to access the mount point in VFS.');
 		}
 		FS.mount(FS.filesystems['NODEFS'], { root: localPath }, vfsMountPoint);

--- a/packages/php-wasm/node/src/lib/node-fs-mount.ts
+++ b/packages/php-wasm/node/src/lib/node-fs-mount.ts
@@ -1,5 +1,5 @@
 import { FSHelpers, type MountHandler } from '@php-wasm/universal';
-import { statSync } from 'fs';
+import { lstatSync, readlinkSync, statSync } from 'fs';
 import { basename, dirname } from 'path';
 
 export function createNodeFsMountHandler(localPath: string): MountHandler {
@@ -19,17 +19,18 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 		 */
 		let removeVfsNode = false;
 		if (!FSHelpers.fileExists(FS, vfsMountPoint)) {
-			if (statSync(localPath).isSymbolicLink()) {
+			const lstat = lstatSync(localPath);
+			if (lstat.isSymbolicLink()) {
 				FS.mkdirTree(dirname(vfsMountPoint));
 				(FS as any).createNode(
 					FS.lookupPath(vfsMountPoint, { parent: true }).node,
 					basename(localPath),
 					110000
 				);
-			} else if (statSync(localPath).isFile()) {
+			} else if (lstat.isFile()) {
 				FS.mkdirTree(dirname(vfsMountPoint));
 				FS.writeFile(vfsMountPoint, '');
-			} else if (statSync(localPath).isDirectory()) {
+			} else if (lstat.isDirectory()) {
 				FS.mkdirTree(vfsMountPoint);
 			} else {
 				throw new Error(


### PR DESCRIPTION
## Motivation for the change, related issues

While testing symlink issues in the Playground CLI, I realized that `statSync(localPath).isSymbolicLink()` will always be false because `statSync` follows symlinks. When I fixed that issue, I realized that symlinks must be mounted as either files or directories, otherwise the `FS.lookupPath` will always [throw errno 44 for the symlinked path.](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/php-wasm/node/asyncify/php_8_0.js#L3572)

This PR doesn't change any PHP-wasm behavior; it only removes unused code.

## Testing Instructions (or ideally a Blueprint)

- CI
