### PR TITLE
Extract Blueprint v1-specific parts of Playground CLI

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -1,8 +1,7 @@
 import { parseOptionsAndRunCLI } from './run-cli';
 
 // Do not await this as top-level await is not supported in all environments.
-parseOptionsAndRunCLI().catch(() => {
-	// process.exit(1); is here and not in parseOptionsAndRunCLI()
-	// so that we can unit test the failure modes with try/catch.
+parseOptionsAndRunCLI().catch((e: any) => {
+	console.error(e);
 	process.exit(1);
 });

--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -2,6 +2,7 @@ import { parseOptionsAndRunCLI } from './run-cli';
 
 // Do not await this as top-level await is not supported in all environments.
 parseOptionsAndRunCLI().catch((e: any) => {
+	// eslint-disable-next-line no-console
 	console.error(e);
 	process.exit(1);
 });

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -265,18 +265,7 @@ export async function parseOptionsAndRunCLI() {
 		],
 	} as RunCLIArgs;
 
-	try {
-		return runCLI(cliArgs);
-	} catch (e) {
-		const reportableCause = ReportableError.getReportableCause(e);
-		if (reportableCause) {
-			console.log('');
-			console.log(reportableCause.message);
-			process.exit(1);
-		} else {
-			throw e;
-		}
-	}
+	return runCLI(cliArgs);
 }
 
 export interface RunCLIArgs {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -28,20 +28,20 @@ import {
 import fs from 'fs';
 import type { Server } from 'http';
 import path from 'path';
-import { Worker, MessageChannel as NodeMessageChannel } from 'worker_threads';
+import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
 // @ts-ignore
 import { resolveWordPressRelease } from '@wp-playground/wordpress';
-import {
-	expandAutoMounts,
-	parseMountDirArguments,
-	parseMountWithDelimiterArguments,
-} from './mounts';
 import {
 	CACHE_FOLDER,
 	cachedDownload,
 	fetchSqliteIntegration,
 	readAsFile,
 } from './download';
+import {
+	expandAutoMounts,
+	parseMountDirArguments,
+	parseMountWithDelimiterArguments,
+} from './mounts';
 import { startServer } from './server';
 import type { Mount, PlaygroundCliWorker } from './worker-thread';
 // @ts-ignore
@@ -56,7 +56,6 @@ import { jspi } from 'wasm-feature-detect';
 import type { MessagePort as NodeMessagePort } from 'worker_threads';
 import yargs from 'yargs';
 import { isValidWordPressSlug } from './is-valid-wordpress-slug';
-import { ReportableError } from './reportable-error';
 import { resolveBlueprint } from './resolve-blueprint';
 
 export async function parseOptionsAndRunCLI() {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -28,7 +28,7 @@ import {
 import fs from 'fs';
 import type { Server } from 'http';
 import path from 'path';
-import { Worker, MessageChannel } from 'worker_threads';
+import { Worker, MessageChannel as NodeMessageChannel } from 'worker_threads';
 // @ts-ignore
 import { resolveWordPressRelease } from '@wp-playground/wordpress';
 import {
@@ -285,6 +285,7 @@ export interface RunCLIArgs {
 	login?: boolean;
 	mount?: Mount[];
 	'mount-before-install'?: Mount[];
+	'blueprint-may-read-adjacent-files'?: boolean;
 	outfile?: string;
 	php?: SupportedPHPVersion;
 	port?: number;
@@ -322,36 +323,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 	 */
 	if (args.autoMount) {
 		args = expandAutoMounts(args);
-	}
-
-	/**
-	 * TODO: This exact feature will be provided in the PHP Blueprints library.
-	 *       Let's use it when it ships. Let's also use it in the web Playground
-	 *       app.
-	 */
-	async function zipSite(outfile: string) {
-		await playground.run({
-			code: `<?php
-			$zip = new ZipArchive();
-			if(false === $zip->open('/tmp/build.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
-				throw new Exception('Failed to create ZIP');
-			}
-			$files = new RecursiveIteratorIterator(
-				new RecursiveDirectoryIterator('/wordpress')
-			);
-			foreach ($files as $file) {
-				echo $file . PHP_EOL;
-				if (!$file->isFile()) {
-					continue;
-				}
-				$zip->addFile($file->getPathname(), $file->getPathname());
-			}
-			$zip->close();
-
-		`,
-		});
-		const zip = await playground.readFileAsBuffer('/tmp/build.zip');
-		fs.writeFileSync(outfile, zip);
 	}
 
 	async function compileInputBlueprint(additionalBlueprintSteps: any[]) {
@@ -436,54 +407,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 		}
 	}
 
-	/**
-	 * Spawns a new Worker Thread.
-	 *
-	 * @param  workerUrl The absolute URL of the worker script.
-	 * @returns The spawned Worker Thread.
-	 */
-	async function spawnPHPWorkerThread(workerUrl: URL) {
-		const worker = new Worker(workerUrl);
-
-		return new Promise<{ worker: Worker; phpPort: NodeMessagePort }>(
-			(resolve, reject) => {
-				worker.once('message', function (message: any) {
-					// Let the worker confirm it has initialized.
-					// We could use the 'online' event to detect start of JS execution,
-					// but that would miss initialization errors.
-					if (message.command === 'worker-script-initialized') {
-						resolve({ worker, phpPort: message.phpPort });
-					}
-				});
-				worker.once('error', function (e: Error) {
-					console.error(e);
-					const error = new Error(
-						`Worker failed to load at ${workerUrl}. ${
-							e.message ? `Original error: ${e.message}` : ''
-						}`
-					);
-					(error as any).filename = workerUrl;
-					reject(error);
-				});
-			}
-		);
-	}
-
-	function spawnWorkerThreads(
-		count: number
-	): Promise<{ worker: Worker; phpPort: NodeMessagePort }[]> {
-		const moduleWorkerUrl = new URL(
-			importedWorkerUrlString,
-			import.meta.url
-		);
-
-		const promises = [];
-		for (let i = 0; i < count; i++) {
-			promises.push(spawnPHPWorkerThread(moduleWorkerUrl));
-		}
-		return Promise.all(promises);
-	}
-
 	if (args.quiet) {
 		// @ts-ignore
 		logger.handlers = [];
@@ -507,36 +430,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 		});
 	const fileLockManager = new FileLockManagerForNode(nativeFlockSync);
 
-	/**
-	 * Expose the file lock manager API on a MessagePort and return it.
-	 *
-	 * @see comlink-sync.ts
-	 * @see phpwasm-emscripten-library-file-locking-for-node.js
-	 */
-	async function exposeFileLockManager() {
-		const { port1, port2 } = new MessageChannel();
-		if (await jspi()) {
-			/**
-			 * When JSPI is available, the worker thread expects an asynchronous API.
-			 *
-			 * @see worker-thread.ts
-			 * @see comlink-sync.ts
-			 * @see phpwasm-emscripten-library-file-locking-for-node.js
-			 */
-			exposeAPI(fileLockManager, null, port1);
-		} else {
-			/**
-			 * When JSPI is not available, the worker thread expects a synchronous API.
-			 *
-			 * @see worker-thread.ts
-			 * @see comlink-sync.ts
-			 * @see phpwasm-emscripten-library-file-locking-for-node.js
-			 */
-			await exposeSyncAPI(fileLockManager, port1);
-		}
-		return port2;
-	}
-
 	let wordPressReady = false;
 
 	logger.log('Starting a PHP server...');
@@ -549,7 +442,10 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 			// Kick off worker threads now to save time later.
 			// There is no need to wait for other async processes to complete.
 			const totalWorkerCount = args.experimentalMultiWorker ?? 1;
-			const promisedWorkers = spawnWorkerThreads(totalWorkerCount);
+			const promisedWorkers = spawnWorkerThreads(
+				importedWorkerUrlString,
+				totalWorkerCount
+			);
 
 			logger.log(`Setting up WordPress ${args.wp}`);
 			let wpDetails: any = undefined;
@@ -631,7 +527,9 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 				// Comlink communication proxy
 				await playground.isConnected();
 
-				const fileLockManagerPort = await exposeFileLockManager();
+				const fileLockManagerPort = await exposeFileLockManager(
+					fileLockManager
+				);
 
 				logger.log(`Booting WordPress...`);
 
@@ -690,7 +588,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 				}
 
 				if (args.command === 'build-snapshot') {
-					await zipSite(args.outfile as string);
+					await zipSite(playground, args.outfile as string);
 					logger.log(`WordPress exported to ${args.outfile}`);
 					process.exit(0);
 				} else if (args.command === 'run-blueprint') {
@@ -729,7 +627,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 								index * processIdSpaceLength;
 
 							const fileLockManagerPort =
-								await exposeFileLockManager();
+								await exposeFileLockManager(fileLockManager);
 							await additionalPlayground.useFileLockManager(
 								fileLockManagerPort
 							);
@@ -811,4 +709,387 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 			return await loadBalancer.handleRequest(request);
 		},
 	});
+}
+
+/**
+ * Boots Playground CLI workers using Blueprint version 1.
+ *
+ * Progress tracking, downloads, steps, and all other features are
+ * implemented in TypeScript and orchestrated by this class.
+ */
+class BlueprintsV1Handler {
+	private phpVersion: SupportedPHPVersion | undefined;
+	private lastProgressMessage = '';
+
+	private siteUrl: string;
+	private processIdSpaceLength: number;
+	private args: RunCLIArgs;
+
+	constructor(
+		args: RunCLIArgs,
+		options: {
+			siteUrl: string;
+			processIdSpaceLength: number;
+		}
+	) {
+		this.args = args;
+		this.siteUrl = options.siteUrl;
+		this.processIdSpaceLength = options.processIdSpaceLength;
+	}
+
+	getWorkerUrl() {
+		return importedWorkerUrlString;
+	}
+
+	async bootPrimaryWorker(
+		phpPort: NodeMessagePort,
+		fileLockManagerPort: NodeMessagePort
+	) {
+		const compiledBlueprint = await this.compileInputBlueprint(
+			this.args['additional-blueprint-steps'] || []
+		);
+		this.phpVersion = compiledBlueprint.versions.php;
+
+		let wpDetails: any = undefined;
+		// @TODO: Rename to FetchProgressMonitor. There's nothing Emscripten
+		// about that class anymore.
+		const monitor = new EmscriptenDownloadMonitor();
+		if (!this.args.skipWordPressSetup) {
+			let progressReached100 = false;
+			monitor.addEventListener('progress', ((
+				e: CustomEvent<ProgressEvent & { finished: boolean }>
+			) => {
+				if (progressReached100) {
+					return;
+				}
+
+				// @TODO Every progress bar will want percentages. The
+				//       download monitor should just provide that.
+				const { loaded, total } = e.detail;
+				// Use floor() so we don't report 100% until truly there.
+				const percentProgress = Math.floor(
+					Math.min(100, (100 * loaded) / total)
+				);
+				progressReached100 = percentProgress === 100;
+
+				if (!this.args.quiet) {
+					this.writeProgressUpdate(
+						process.stdout,
+						`Downloading WordPress ${percentProgress}%...`,
+						progressReached100
+					);
+				}
+			}) as any);
+
+			wpDetails = await resolveWordPressRelease(this.args.wp);
+			logger.log(
+				`Resolved WordPress release URL: ${wpDetails?.releaseUrl}`
+			);
+		}
+
+		const preinstalledWpContentPath =
+			wpDetails &&
+			path.join(
+				CACHE_FOLDER,
+				`prebuilt-wp-content-for-wp-${wpDetails.version}.zip`
+			);
+		const wordPressZip = !wpDetails
+			? undefined
+			: fs.existsSync(preinstalledWpContentPath)
+			? readAsFile(preinstalledWpContentPath)
+			: await cachedDownload(
+					wpDetails.releaseUrl,
+					`${wpDetails.version}.zip`,
+					monitor
+			  );
+
+		logger.log(`Fetching SQLite integration plugin...`);
+		const sqliteIntegrationPluginZip = this.args.skipSqliteSetup
+			? undefined
+			: await fetchSqliteIntegration(monitor);
+
+		const followSymlinks = this.args.followSymlinks === true;
+		const trace = this.args.experimentalTrace === true;
+
+		const mountsBeforeWpInstall = this.args['mount-before-install'] || [];
+		const mountsAfterWpInstall = this.args.mount || [];
+
+		const playground = consumeAPI<PlaygroundCliWorker>(phpPort);
+
+		// Comlink communication proxy
+		await playground.isConnected();
+
+		logger.log(`Booting WordPress...`);
+
+		await playground.useFileLockManager(fileLockManagerPort);
+		await playground.boot({
+			phpVersion: this.phpVersion,
+			wpVersion: compiledBlueprint.versions.wp,
+			absoluteUrl: this.siteUrl,
+			mountsBeforeWpInstall,
+			mountsAfterWpInstall,
+			wordPressZip: wordPressZip && (await wordPressZip!.arrayBuffer()),
+			sqliteIntegrationPluginZip:
+				await sqliteIntegrationPluginZip!.arrayBuffer(),
+			firstProcessId: 0,
+			processIdSpaceLength: this.processIdSpaceLength,
+			followSymlinks,
+			trace,
+			internalCookieStore: this.args.internalCookieStore,
+		});
+
+		if (
+			wpDetails &&
+			!this.args['mount-before-install'] &&
+			!fs.existsSync(preinstalledWpContentPath)
+		) {
+			logger.log(`Caching preinstalled WordPress for the next boot...`);
+			fs.writeFileSync(
+				preinstalledWpContentPath,
+				(await zipDirectory(playground, '/wordpress'))!
+			);
+			logger.log(`Cached!`);
+		}
+
+		return playground;
+	}
+
+	async bootSecondaryWorker({
+		worker,
+		fileLockManagerPort,
+		firstProcessId,
+	}: {
+		worker: SpawnedWorker;
+		fileLockManagerPort: NodeMessagePort;
+		firstProcessId: number;
+	}) {
+		const additionalPlayground = consumeAPI<PlaygroundCliWorker>(
+			worker.phpPort
+		);
+
+		await additionalPlayground.isConnected();
+		await additionalPlayground.useFileLockManager(fileLockManagerPort);
+		await additionalPlayground.boot({
+			phpVersion: this.phpVersion,
+			absoluteUrl: this.siteUrl,
+			mountsBeforeWpInstall: this.args['mount-before-install'] || [],
+			mountsAfterWpInstall: this.args['mount'] || [],
+			// Skip WordPress zip because we share the /wordpress directory
+			// populated by the initial worker.
+			wordPressZip: undefined,
+			// Skip SQLite integration plugin for now because we
+			// will copy it from primary's `/internal` directory.
+			sqliteIntegrationPluginZip: undefined,
+			dataSqlPath: '/wordpress/wp-content/database/.ht.sqlite',
+			firstProcessId,
+			processIdSpaceLength: this.processIdSpaceLength,
+			followSymlinks: this.args.followSymlinks === true,
+			trace: this.args.experimentalTrace === true,
+			// @TODO: Move this to the request handler or else every worker
+			//        will have a separate cookie store.
+			internalCookieStore: this.args.internalCookieStore,
+		});
+		await additionalPlayground.isReady();
+		return additionalPlayground;
+	}
+
+	async compileInputBlueprint(additionalBlueprintSteps: any[]) {
+		const args = this.args;
+		const resolvedBlueprint =
+			typeof args.blueprint === 'string'
+				? await resolveBlueprint({
+						sourceString: args.blueprint,
+						blueprintMayReadAdjacentFiles:
+							args['blueprint-may-read-adjacent-files'] === true,
+				  })
+				: (args.blueprint as BlueprintDeclaration);
+		/**
+		 * @TODO This looks similar to the resolveBlueprint() call in the website package:
+		 * 	     https://github.com/WordPress/wordpress-playground/blob/ce586059e5885d185376184fdd2f52335cca32b0/packages/playground/website/src/main.tsx#L41
+		 *
+		 * 		 Also the Blueprint Builder tool does something similar.
+		 *       Perhaps all these cases could be handled by the same function?
+		 */
+		const blueprint: BlueprintDeclaration | BlueprintBundle =
+			isBlueprintBundle(resolvedBlueprint)
+				? resolvedBlueprint
+				: {
+						login: args.login,
+						...(resolvedBlueprint || {}),
+						preferredVersions: {
+							php:
+								args.php ??
+								resolvedBlueprint?.preferredVersions?.php ??
+								RecommendedPHPVersion,
+							wp:
+								args.wp ??
+								resolvedBlueprint?.preferredVersions?.wp ??
+								'latest',
+							...(resolvedBlueprint?.preferredVersions || {}),
+						},
+				  };
+
+		const tracker = new ProgressTracker();
+		let lastCaption = '';
+		let progressReached100 = false;
+		tracker.addEventListener('progress', (e: any) => {
+			if (progressReached100) {
+				return;
+			}
+			progressReached100 = e.detail.progress === 100;
+
+			// Use floor() so we don't report 100% until truly there.
+			const progressInteger = Math.floor(e.detail.progress);
+			lastCaption =
+				e.detail.caption || lastCaption || 'Running the Blueprint';
+			const message = `${lastCaption.trim()} – ${progressInteger}%`;
+			if (!args.quiet) {
+				this.writeProgressUpdate(
+					process.stdout,
+					message,
+					progressReached100
+				);
+			}
+		});
+		return await compileBlueprint(blueprint as BlueprintDeclaration, {
+			progress: tracker,
+			additionalSteps: additionalBlueprintSteps,
+		});
+	}
+
+	writeProgressUpdate(
+		writeStream: NodeJS.WriteStream,
+		message: string,
+		finalUpdate: boolean
+	) {
+		if (message === this.lastProgressMessage) {
+			// Avoid repeating the same message
+			return;
+		}
+		this.lastProgressMessage = message;
+
+		if (writeStream.isTTY) {
+			// Overwrite previous progress updates in-place for a quieter UX.
+			writeStream.cursorTo(0);
+			writeStream.write(message);
+			writeStream.clearLine(1);
+
+			if (finalUpdate) {
+				writeStream.write('\n');
+			}
+		} else {
+			// Fall back to writing one line per progress update
+			writeStream.write(`${message}\n`);
+		}
+	}
+}
+
+type SpawnedWorker = {
+	worker: Worker;
+	phpPort: NodeMessagePort;
+};
+function spawnWorkerThreads(
+	workerUrlString: string,
+	count: number
+): Promise<SpawnedWorker[]> {
+	const moduleWorkerUrl = new URL(workerUrlString, import.meta.url);
+
+	const promises = [];
+	for (let i = 0; i < count; i++) {
+		const worker = new Worker(moduleWorkerUrl);
+		const onExit: (code: number) => void = (code: number) => {
+			if (code === 0) {
+				return;
+			}
+			process.stderr.write(`Worker ${i} exited with code ${code}\n`);
+			// If the primary worker crashes, exit the entire process.
+			if (i === 0) {
+				process.exit(1);
+			}
+		};
+		promises.push(
+			new Promise<{ worker: Worker; phpPort: NodeMessagePort }>(
+				(resolve, reject) => {
+					worker.once('message', function (message: any) {
+						// Let the worker confirm it has initialized.
+						// We could use the 'online' event to detect start of JS execution,
+						// but that would miss initialization errors.
+						if (message.command === 'worker-script-initialized') {
+							resolve({ worker, phpPort: message.phpPort });
+						}
+					});
+					worker.once('error', function (e: Error) {
+						console.error(e);
+						const error = new Error(
+							`Worker failed to load at ${moduleWorkerUrl}. ${
+								e.message ? `Original error: ${e.message}` : ''
+							}`
+						);
+						(error as any).filename = moduleWorkerUrl;
+						reject(error);
+					});
+					worker.once('exit', onExit);
+				}
+			)
+		);
+	}
+	return Promise.all(promises);
+}
+
+/**
+ * Expose the file lock manager API on a MessagePort and return it.
+ *
+ * @see comlink-sync.ts
+ * @see phpwasm-emscripten-library-file-locking-for-node.js
+ */
+async function exposeFileLockManager(fileLockManager: FileLockManagerForNode) {
+	const { port1, port2 } = new NodeMessageChannel();
+	if (await jspi()) {
+		/**
+		 * When JSPI is available, the worker thread expects an asynchronous API.
+		 *
+		 * @see worker-thread.ts
+		 * @see comlink-sync.ts
+		 * @see phpwasm-emscripten-library-file-locking-for-node.js
+		 */
+		exposeAPI(fileLockManager, null, port1);
+	} else {
+		/**
+		 * When JSPI is not available, the worker thread expects a synchronous API.
+		 *
+		 * @see worker-thread.ts
+		 * @see comlink-sync.ts
+		 * @see phpwasm-emscripten-library-file-locking-for-node.js
+		 */
+		await exposeSyncAPI(fileLockManager, port1);
+	}
+	return port2;
+}
+
+async function zipSite(
+	playground: RemoteAPI<PlaygroundCliWorker>,
+	outfile: string
+) {
+	await playground.run({
+		code: `<?php
+		$zip = new ZipArchive();
+		if(false === $zip->open('/tmp/build.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
+			throw new Exception('Failed to create ZIP');
+		}
+		$files = new RecursiveIteratorIterator(
+			new RecursiveDirectoryIterator('/wordpress')
+		);
+		foreach ($files as $file) {
+			echo $file . PHP_EOL;
+			if (!$file->isFile()) {
+				continue;
+			}
+			$zip->addFile($file->getPathname(), $file->getPathname());
+		}
+		$zip->close();
+
+	`,
+	});
+	const zip = await playground.readFileAsBuffer('/tmp/build.zip');
+	fs.writeFileSync(outfile, zip);
 }

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -286,6 +286,7 @@ export interface RunCLIArgs {
 	followSymlinks?: boolean;
 	experimentalMultiWorker?: number;
 	experimentalTrace?: boolean;
+	exitOnPrimaryWorkerCrash?: boolean;
 	internalCookieStore?: boolean;
 	'additional-blueprint-steps'?: any[];
 	xdebug?: boolean;
@@ -357,7 +358,23 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 			// There is no need to wait for other async processes to complete.
 			const promisedWorkers = spawnWorkerThreads(
 				handler.getWorkerUrl(),
-				totalWorkerCount
+				totalWorkerCount,
+				({ exitCode, isMain, workerIndex }) => {
+					if (exitCode === 0) {
+						return;
+					}
+					logger.error(
+						`Worker ${workerIndex} exited with code ${exitCode}\n`
+					);
+					// If the primary worker crashes, exit the entire process.
+					if (!isMain) {
+						return;
+					}
+					if (!args.exitOnPrimaryWorkerCrash) {
+						return;
+					}
+					process.exit(1);
+				}
 			);
 
 			logger.log(`Setting up WordPress ${args.wp}`);
@@ -781,7 +798,12 @@ type SpawnedWorker = {
 };
 function spawnWorkerThreads(
 	workerUrlString: string,
-	count: number
+	count: number,
+	onWorkerExit: (options: {
+		exitCode: number;
+		isMain: boolean;
+		workerIndex: number;
+	}) => void
 ): Promise<SpawnedWorker[]> {
 	const moduleWorkerUrl = new URL(workerUrlString, import.meta.url);
 
@@ -789,14 +811,11 @@ function spawnWorkerThreads(
 	for (let i = 0; i < count; i++) {
 		const worker = new Worker(moduleWorkerUrl);
 		const onExit: (code: number) => void = (code: number) => {
-			if (code === 0) {
-				return;
-			}
-			process.stderr.write(`Worker ${i} exited with code ${code}\n`);
-			// If the primary worker crashes, exit the entire process.
-			if (i === 0) {
-				process.exit(1);
-			}
+			onWorkerExit({
+				exitCode: code,
+				isMain: i === 0,
+				workerIndex: i,
+			});
 		};
 		promises.push(
 			new Promise<{ worker: Worker; phpPort: NodeMessagePort }>(

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -233,7 +233,8 @@ export async function parseOptionsAndRunCLI() {
 					)
 				) {
 					throw new Error(
-						'Please mount a real filesystem directory as the /wordpress directory before using the --experimentalMultiWorker flag.'
+						'Please mount a real filesystem directory as the /wordpress directory before using the --experimentalMultiWorker flag. For example: ' +
+							'--mount-dir-before-install ./empty-dir /wordpress'
 					);
 				}
 			}
@@ -325,96 +326,10 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 		args = expandAutoMounts(args);
 	}
 
-	async function compileInputBlueprint(additionalBlueprintSteps: any[]) {
-		/**
-		 * @TODO This looks similar to the resolveBlueprint() call in the website package:
-		 * 	     https://github.com/WordPress/wordpress-playground/blob/ce586059e5885d185376184fdd2f52335cca32b0/packages/playground/website/src/main.tsx#L41
-		 *
-		 * 		 Also the Blueprint Builder tool does something similar.
-		 *       Perhaps all these cases could be handled by the same function?
-		 */
-		const blueprint: BlueprintDeclaration | BlueprintBundle =
-			isBlueprintBundle(args.blueprint)
-				? args.blueprint
-				: {
-						login: args.login,
-						...args.blueprint,
-						preferredVersions: {
-							php:
-								args.php ??
-								args?.blueprint?.preferredVersions?.php ??
-								RecommendedPHPVersion,
-							wp:
-								args.wp ??
-								args?.blueprint?.preferredVersions?.wp ??
-								'latest',
-							...(args.blueprint?.preferredVersions || {}),
-						},
-				  };
-
-		const tracker = new ProgressTracker();
-		let lastCaption = '';
-		let progressReached100 = false;
-		tracker.addEventListener('progress', (e: any) => {
-			if (progressReached100) {
-				return;
-			}
-			progressReached100 = e.detail.progress === 100;
-
-			// Use floor() so we don't report 100% until truly there.
-			const progressInteger = Math.floor(e.detail.progress);
-			lastCaption =
-				e.detail.caption || lastCaption || 'Running the Blueprint';
-			const message = `${lastCaption.trim()} – ${progressInteger}%`;
-			if (!args.quiet) {
-				writeProgressUpdate(
-					process.stdout,
-					message,
-					progressReached100
-				);
-			}
-		});
-		return await compileBlueprint(blueprint as BlueprintDeclaration, {
-			progress: tracker,
-			additionalSteps: additionalBlueprintSteps,
-		});
-	}
-
-	let lastProgressMessage = '';
-	function writeProgressUpdate(
-		writeStream: NodeJS.WriteStream,
-		message: string,
-		finalUpdate: boolean
-	) {
-		if (message === lastProgressMessage) {
-			// Avoid repeating the same message
-			return;
-		}
-		lastProgressMessage = message;
-
-		if (writeStream.isTTY) {
-			// Overwrite previous progress updates in-place for a quieter UX.
-			writeStream.cursorTo(0);
-			writeStream.write(message);
-			writeStream.clearLine(1);
-
-			if (finalUpdate) {
-				writeStream.write('\n');
-			}
-		} else {
-			// Fall back to writing one line per progress update
-			writeStream.write(`${message}\n`);
-		}
-	}
-
 	if (args.quiet) {
 		// @ts-ignore
 		logger.handlers = [];
 	}
-
-	const compiledBlueprint = await compileInputBlueprint(
-		args['additional-blueprint-steps'] || []
-	);
 
 	// Declare file lock manager outside scope of startServer
 	// so we can look at it when debugging request handling.
@@ -439,147 +354,54 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 		onBind: async (server: Server, port: number): Promise<RunCLIServer> => {
 			const absoluteUrl = `http://127.0.0.1:${port}`;
 
+			// Create the blueprints handler
+			const totalWorkerCount = args.experimentalMultiWorker ?? 1;
+			const processIdSpaceLength = Math.floor(
+				Number.MAX_SAFE_INTEGER / totalWorkerCount
+			);
+
+			const handler = new BlueprintsV1Handler(args, {
+				siteUrl: absoluteUrl,
+				processIdSpaceLength,
+			});
+
 			// Kick off worker threads now to save time later.
 			// There is no need to wait for other async processes to complete.
-			const totalWorkerCount = args.experimentalMultiWorker ?? 1;
 			const promisedWorkers = spawnWorkerThreads(
-				importedWorkerUrlString,
+				handler.getWorkerUrl(),
 				totalWorkerCount
 			);
 
 			logger.log(`Setting up WordPress ${args.wp}`);
-			let wpDetails: any = undefined;
-			// @TODO: Rename to FetchProgressMonitor. There's nothing Emscripten
-			// about that class anymore.
-			const monitor = new EmscriptenDownloadMonitor();
-			if (!args.skipWordPressSetup) {
-				let progressReached100 = false;
-				monitor.addEventListener('progress', ((
-					e: CustomEvent<ProgressEvent & { finished: boolean }>
-				) => {
-					if (progressReached100) {
-						return;
-					}
 
-					// @TODO Every progress bar will want percentages. The
-					//       download monitor should just provide that.
-					const { loaded, total } = e.detail;
-					// Use floor() so we don't report 100% until truly there.
-					const percentProgress = Math.floor(
-						Math.min(100, (100 * loaded) / total)
-					);
-					progressReached100 = percentProgress === 100;
-
-					if (!args.quiet) {
-						writeProgressUpdate(
-							process.stdout,
-							`Downloading WordPress ${percentProgress}%...`,
-							progressReached100
-						);
-					}
-				}) as any);
-
-				wpDetails = await resolveWordPressRelease(args.wp);
-				logger.log(
-					`Resolved WordPress release URL: ${wpDetails?.releaseUrl}`
-				);
-			}
-
-			const preinstalledWpContentPath =
-				wpDetails &&
-				path.join(
-					CACHE_FOLDER,
-					`prebuilt-wp-content-for-wp-${wpDetails.version}.zip`
-				);
-			const wordPressZip = !wpDetails
-				? undefined
-				: fs.existsSync(preinstalledWpContentPath)
-				? readAsFile(preinstalledWpContentPath)
-				: await cachedDownload(
-						wpDetails.releaseUrl,
-						`${wpDetails.version}.zip`,
-						monitor
-				  );
-
-			logger.log(`Fetching SQLite integration plugin...`);
-			const sqliteIntegrationPluginZip = args.skipSqliteSetup
-				? undefined
-				: await fetchSqliteIntegration(monitor);
-
-			const followSymlinks = args.followSymlinks === true;
-			const trace = args.experimentalTrace === true;
 			try {
-				const mountsBeforeWpInstall =
-					args['mount-before-install'] || [];
-				const mountsAfterWpInstall = args.mount || [];
-
 				const [initialWorker, ...additionalWorkers] =
 					await promisedWorkers;
 
-				playground = consumeAPI<PlaygroundCliWorker>(
-					initialWorker.phpPort
+				const fileLockManagerPort = await exposeFileLockManager(
+					fileLockManager
+				);
+
+				// Boot the primary worker using the handler
+				playground = await handler.bootPrimaryWorker(
+					initialWorker.phpPort,
+					fileLockManagerPort
 				);
 				playgroundsToCleanUp.push({
 					playground,
 					worker: initialWorker.worker,
 				});
 
-				// Comlink communication proxy
-				await playground.isConnected();
-
-				const fileLockManagerPort = await exposeFileLockManager(
-					fileLockManager
-				);
-
-				logger.log(`Booting WordPress...`);
-
-				// Each additional worker needs a separate process ID space
-				// for file locking to work properly because locks are associated
-				// with individual processes. To accommodate this, we split the safe
-				// integers into a range for each worker.
-				const processIdSpaceLength = Math.floor(
-					Number.MAX_SAFE_INTEGER / totalWorkerCount
-				);
-
-				await playground.useFileLockManager(fileLockManagerPort);
-				await playground.boot({
-					phpVersion: compiledBlueprint.versions.php,
-					wpVersion: compiledBlueprint.versions.wp,
-					absoluteUrl,
-					mountsBeforeWpInstall,
-					mountsAfterWpInstall,
-					wordPressZip:
-						wordPressZip && (await wordPressZip!.arrayBuffer()),
-					sqliteIntegrationPluginZip:
-						await sqliteIntegrationPluginZip!.arrayBuffer(),
-					firstProcessId: 0,
-					processIdSpaceLength,
-					followSymlinks,
-					trace,
-					internalCookieStore: args.internalCookieStore,
-					withXdebug: args.xdebug,
-				});
-
-				if (
-					wpDetails &&
-					!args['mount-before-install'] &&
-					!fs.existsSync(preinstalledWpContentPath)
-				) {
-					logger.log(
-						`Caching preinstalled WordPress for the next boot...`
-					);
-					fs.writeFileSync(
-						preinstalledWpContentPath,
-						await zipDirectory(playground, '/wordpress')
-					);
-					logger.log(`Cached!`);
-				}
-
-				loadBalancer = new LoadBalancer(playground);
-
 				await playground.isReady();
 				wordPressReady = true;
 				logger.log(`Booted!`);
+
+				loadBalancer = new LoadBalancer(playground);
+
+				// Compile and run the blueprint
+				const compiledBlueprint = await handler.compileInputBlueprint(
+					args['additional-blueprint-steps'] || []
+				);
 
 				if (compiledBlueprint) {
 					logger.log(`Running the Blueprint...`);
@@ -609,49 +431,28 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 						'/internal'
 					);
 
-					// Boot additional workers
+					// Boot additional workers using the handler
 					const initialWorkerProcessIdSpace = processIdSpaceLength;
 					await Promise.all(
 						additionalWorkers.map(async (worker, index) => {
-							const additionalPlayground =
-								consumeAPI<PlaygroundCliWorker>(worker.phpPort);
-							playgroundsToCleanUp.push({
-								playground: additionalPlayground,
-								worker: worker.worker,
-							});
-
-							await additionalPlayground.isConnected();
-
 							const firstProcessId =
 								initialWorkerProcessIdSpace +
 								index * processIdSpaceLength;
 
 							const fileLockManagerPort =
 								await exposeFileLockManager(fileLockManager);
-							await additionalPlayground.useFileLockManager(
-								fileLockManagerPort
-							);
-							await additionalPlayground.boot({
-								phpVersion: compiledBlueprint.versions.php,
-								absoluteUrl,
-								mountsBeforeWpInstall,
-								mountsAfterWpInstall,
-								// Skip WordPress zip because we share the /wordpress directory
-								// populated by the initial worker.
-								wordPressZip: undefined,
-								// Skip SQLite integration plugin for now because we
-								// will copy it from primary's `/internal` directory.
-								sqliteIntegrationPluginZip: undefined,
-								dataSqlPath:
-									'/wordpress/wp-content/database/.ht.sqlite',
-								firstProcessId,
-								processIdSpaceLength,
-								followSymlinks,
-								trace,
-								internalCookieStore: args.internalCookieStore,
-								withXdebug: args.xdebug,
+
+							const additionalPlayground =
+								await handler.bootSecondaryWorker({
+									worker,
+									fileLockManagerPort,
+									firstProcessId,
+								});
+
+							playgroundsToCleanUp.push({
+								playground: additionalPlayground,
+								worker: worker.worker,
 							});
-							await additionalPlayground.isReady();
 
 							// Replicate the Blueprint-initialized /internal directory
 							await additionalPlayground.writeFile(
@@ -836,6 +637,7 @@ class BlueprintsV1Handler {
 			followSymlinks,
 			trace,
 			internalCookieStore: this.args.internalCookieStore,
+			withXdebug: this.args.xdebug,
 		});
 
 		if (
@@ -888,6 +690,7 @@ class BlueprintsV1Handler {
 			// @TODO: Move this to the request handler or else every worker
 			//        will have a separate cookie store.
 			internalCookieStore: this.args.internalCookieStore,
+			withXdebug: this.args.xdebug,
 		});
 		await additionalPlayground.isReady();
 		return additionalPlayground;

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -4,11 +4,12 @@ const { runCLI } = require('@wp-playground/cli');
 SupportedPHPVersions.forEach((phpVersion: string) => {
 	describe(`PHP ${phpVersion}`, () => {
 		it('WordPress should load', async () => {
-			const cli = await runCLI({
-				command: 'server',
-				php: phpVersion as any,
-			});
+			let cli: any;
 			try {
+				cli = await runCLI({
+					command: 'server',
+					php: phpVersion as any,
+				});
 				// Make a request
 				const response = await cli.playground.request({
 					method: 'GET',
@@ -18,6 +19,9 @@ SupportedPHPVersions.forEach((phpVersion: string) => {
 				// Verify response
 				expect(response.httpStatusCode).toBe(200);
 				expect(response.text).toContain('My WordPress Website');
+			} catch (e) {
+				console.error(e);
+				throw e;
 			} finally {
 				await cli[Symbol.asyncDispose]();
 			}

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -4,13 +4,12 @@ const { runCLI } = require('@wp-playground/cli');
 SupportedPHPVersions.forEach((phpVersion: string) => {
 	describe(`PHP ${phpVersion}`, () => {
 		it('WordPress should load', async () => {
-			let cli: any;
+			const cli = await runCLI({
+				command: 'server',
+				php: phpVersion as any,
+				exitOnPrimaryWorkerCrash: false,
+			});
 			try {
-				cli = await runCLI({
-					command: 'server',
-					php: phpVersion as any,
-					exitOnPrimaryWorkerCrash: false,
-				});
 				// Make a request
 				const response = await cli.playground.request({
 					method: 'GET',
@@ -20,9 +19,6 @@ SupportedPHPVersions.forEach((phpVersion: string) => {
 				// Verify response
 				expect(response.httpStatusCode).toBe(200);
 				expect(response.text).toContain('My WordPress Website');
-			} catch (e) {
-				console.error(e);
-				throw e;
 			} finally {
 				await cli[Symbol.asyncDispose]();
 			}

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -9,6 +9,7 @@ SupportedPHPVersions.forEach((phpVersion: string) => {
 				cli = await runCLI({
 					command: 'server',
 					php: phpVersion as any,
+					exitOnPrimaryWorkerCrash: false,
 				});
 				// Make a request
 				const response = await cli.playground.request({

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -20,6 +20,7 @@ describe(`PHP ${phpVersion}`, () => {
 				command: 'server',
 				php: phpVersion,
 				quiet: true,
+				exitOnPrimaryWorkerCrash: false,
 			});
 			const response = await cli.playground.request({
 				method: 'GET',
@@ -31,9 +32,6 @@ describe(`PHP ${phpVersion}`, () => {
 				response.text.includes(expectedText),
 				`Response text does not include '${expectedText}'`
 			);
-		} catch (e) {
-			console.error(e);
-			throw e;
 		} finally {
 			if (cli) {
 				await cli[Symbol.asyncDispose]();

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -14,7 +14,7 @@ if (!SupportedPHPVersions.includes(phpVersion)) {
 
 describe(`PHP ${phpVersion}`, () => {
 	it('Should load WordPress', { timeout: 12000 }, async () => {
-		let cli;
+		let cli: any;
 		try {
 			cli = await runCLI({
 				command: 'server',
@@ -31,6 +31,9 @@ describe(`PHP ${phpVersion}`, () => {
 				response.text.includes(expectedText),
 				`Response text does not include '${expectedText}'`
 			);
+		} catch (e) {
+			console.error(e);
+			throw e;
 		} finally {
 			if (cli) {
 				await cli[Symbol.asyncDispose]();

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -14,14 +14,13 @@ if (!SupportedPHPVersions.includes(phpVersion)) {
 
 describe(`PHP ${phpVersion}`, () => {
 	it('Should load WordPress', { timeout: 12000 }, async () => {
-		let cli: any;
+		const cli = await runCLI({
+			command: 'server',
+			php: phpVersion,
+			quiet: true,
+			exitOnPrimaryWorkerCrash: false,
+		});
 		try {
-			cli = await runCLI({
-				command: 'server',
-				php: phpVersion,
-				quiet: true,
-				exitOnPrimaryWorkerCrash: false,
-			});
 			const response = await cli.playground.request({
 				method: 'GET',
 				url: '/',


### PR DESCRIPTION
## Motivation for the change, related issues

This PR sets the stage for integrating Blueprints v2. All the Blueprints v1-specific parts are moved to a new class called `BlueprintsV1Handler`. This opens the door to implementing `BlueprintsV2Handler`.

A part of #2223 

## Testing Instructions (or ideally a Blueprint)

This PR mostly moves code around without changing the logic. Just run a smoke test:

* Confirm CI is green
* Run a few CLI commands and confirm they still work, e.g. 

```
PHP=7.4 node --experimental-wasm-jspi --stack-trace-limit=100 --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/playground/cli/src/cli.ts server --wp=6.8 --php=8.4

PHP=7.4 node --experimental-wasm-jspi --stack-trace-limit=100 --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/playground/cli/src/cli.ts server --mount=.:/wordpress/wp-content/plugins/MY-PLUGIN-DIRECTORY

PHP=7.4 node --experimental-wasm-jspi --stack-trace-limit=100 --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/playground/cli/src/cli.ts server --blueprint=my-blueprint.json
```

And a few others from https://wordpress.github.io/wordpress-playground/developers/local-development/wp-playground-cli