### PR TITLE
Expose Blueprints v2 runner in Playground CLI

### DIFF
--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -110,6 +110,17 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		return _private.get(this)!.php;
 	}
 
+	/**
+	 * @internal
+	 * @deprecated
+	 * Do not use this method directly in the code consuming
+	 * the web API. It will change or even be removed without
+	 * a warning.
+	 */
+	protected __internal_getRequestHandler() {
+		return _private.get(this)!.requestHandler;
+	}
+
 	async setPrimaryPHP(php: PHP) {
 		_private.set(this, {
 			..._private.get(this)!,

--- a/packages/playground/cli/src/load-balancer.ts
+++ b/packages/playground/cli/src/load-balancer.ts
@@ -1,5 +1,8 @@
 import type { PHPRequest, PHPResponse, RemoteAPI } from '@php-wasm/universal';
-import type { PlaygroundCliWorker } from './worker-thread';
+import type { PlaygroundCliBlueprintV1Worker as PlaygroundCliWorkerV1 } from './worker-thread';
+import type { PlaygroundCliBlueprintV2Worker as PlaygroundCliWorkerV2 } from './worker-thread-v2';
+
+type PlaygroundCliWorker = PlaygroundCliWorkerV1 | PlaygroundCliWorkerV2;
 
 // TODO: Let's merge worker management into PHPProcessManager
 // when we can have multiple workers in both CLI and web.

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -447,15 +447,18 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 				loadBalancer = new LoadBalancer(playground);
 
-				// Compile and run the blueprint
-				const compiledBlueprint = await handler.compileInputBlueprint(
-					args['additional-blueprint-steps'] || []
-				);
+				if (!args['experimental-blueprints-v2-runner']) {
+					const compiledBlueprint = await (
+						handler as BlueprintsV1Handler
+					).compileInputBlueprint(
+						args['additional-blueprint-steps'] || []
+					);
 
-				if (compiledBlueprint) {
-					logger.log(`Running the Blueprint...`);
-					await runBlueprintSteps(compiledBlueprint, playground);
-					logger.log(`Finished running the blueprint`);
+					if (compiledBlueprint) {
+						logger.log(`Running the Blueprint...`);
+						await runBlueprintSteps(compiledBlueprint, playground);
+						logger.log(`Finished running the blueprint`);
+					}
 				}
 
 				if (args.command === 'build-snapshot') {
@@ -642,12 +645,6 @@ class BlueprintsV2Handler {
 		await playground.bootAsSecondaryWorker(workerBootArgs);
 
 		return playground;
-	}
-
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	async compileInputBlueprint(..._args: any[]) {
-		// no-op for API compatibility with BlueprintV1Handler
-		return undefined;
 	}
 
 	writeProgressUpdate(

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -296,7 +296,7 @@ export interface RunCLIArgs {
 	internalCookieStore?: boolean;
 	'additional-blueprint-steps'?: any[];
 	xdebug?: boolean;
-	'experimental-blueprints-v2'?: boolean;
+	'experimental-blueprints-v2-runner'?: boolean;
 
 	// --------- Blueprint V1 args -----------
 	skipWordPressSetup?: boolean;
@@ -378,7 +378,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 			);
 
 			let handler: BlueprintsV1Handler | BlueprintsV2Handler;
-			if (args['experimental-blueprints-v2']) {
+			if (args['experimental-blueprints-v2-runner']) {
 				handler = new BlueprintsV2Handler(args, {
 					siteUrl: absoluteUrl,
 					processIdSpaceLength,

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -43,9 +43,16 @@ import {
 	parseMountWithDelimiterArguments,
 } from './mounts';
 import { startServer } from './server';
-import type { Mount, PlaygroundCliWorker } from './worker-thread';
+import type { Mount, PlaygroundCliBlueprintV1Worker } from './worker-thread';
+import type {
+	PlaygroundCliBlueprintV2Worker,
+	WorkerBootArgs,
+} from './worker-thread-v2';
 // @ts-ignore
-import importedWorkerUrlString from './worker-thread?worker&url';
+import importedWorkerV1UrlString from './worker-thread?worker&url';
+// @ts-ignore
+import importedWorkerV2UrlString from './worker-thread-v2?worker&url';
+
 // @ts-ignore
 import { FileLockManagerForNode } from '@php-wasm/node';
 import { LoadBalancer } from './load-balancer';
@@ -203,6 +210,13 @@ export async function parseOptionsAndRunCLI() {
 			type: 'number',
 			coerce: (value?: number) => value ?? cpus().length - 1,
 		})
+		.option('experimental-blueprint-v2', {
+			describe: 'Use the experimental Blueprint V2 runner.',
+			type: 'boolean',
+			default: false,
+			// Remove the "hidden" flag once Blueprint V2 is fully supported
+			hidden: true,
+		})
 		.showHelpOnFail(false)
 		.check(async (args) => {
 			if (args.wp !== undefined && !isValidWordPressSlug(args.wp)) {
@@ -274,23 +288,41 @@ export interface RunCLIArgs {
 	login?: boolean;
 	mount?: Mount[];
 	'mount-before-install'?: Mount[];
-	'blueprint-may-read-adjacent-files'?: boolean;
 	outfile?: string;
 	php?: SupportedPHPVersion;
 	port?: number;
 	quiet?: boolean;
-	skipWordPressSetup?: boolean;
-	skipSqliteSetup?: boolean;
 	wp?: string;
 	autoMount?: boolean;
-	followSymlinks?: boolean;
 	experimentalMultiWorker?: number;
 	experimentalTrace?: boolean;
 	exitOnPrimaryWorkerCrash?: boolean;
 	internalCookieStore?: boolean;
 	'additional-blueprint-steps'?: any[];
 	xdebug?: boolean;
+	'experimental-blueprints-v2'?: boolean;
+
+	// --------- Blueprint V1 args -----------
+	skipWordPressSetup?: boolean;
+	skipSqliteSetup?: boolean;
+	followSymlinks?: boolean;
+	'blueprint-may-read-adjacent-files'?: boolean;
+
+	// --------- Blueprint V2 args (not available via CLI yet) -----------
+	mode?: 'mount-only' | 'create-new-site' | 'apply-to-existing-site';
+	'db-engine'?: 'sqlite' | 'mysql';
+	'db-host'?: string;
+	'db-user'?: string;
+	'db-pass'?: string;
+	'db-name'?: string;
+	'db-path'?: string;
+	'truncate-new-site-directory'?: boolean;
+	allow?: string;
 }
+
+type PlaygroundCliWorker =
+	| PlaygroundCliBlueprintV1Worker
+	| PlaygroundCliBlueprintV2Worker;
 
 export interface RunCLIServer extends AsyncDisposable {
 	playground: RemoteAPI<PlaygroundCliWorker>;
@@ -349,10 +381,15 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 				Number.MAX_SAFE_INTEGER / totalWorkerCount
 			);
 
-			const handler = new BlueprintsV1Handler(args, {
-				siteUrl: absoluteUrl,
-				processIdSpaceLength,
-			});
+			const handler = args['experimental-blueprints-v2']
+				? new BlueprintsV2Handler(args, {
+						siteUrl: absoluteUrl,
+						processIdSpaceLength,
+				  })
+				: new BlueprintsV1Handler(args, {
+						siteUrl: absoluteUrl,
+						processIdSpaceLength,
+				  });
 
 			// Kick off worker threads now to save time later.
 			// There is no need to wait for other async processes to complete.
@@ -518,6 +555,122 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 }
 
 /**
+ * Boots Playground CLI workers using Blueprint version 2.
+ *
+ * Progress tracking, downloads, steps, and all other features are
+ * implemented in PHP and orchestrated by the worker thread.
+ */
+class BlueprintsV2Handler {
+	private phpVersion: SupportedPHPVersion;
+	private lastProgressMessage = '';
+
+	private siteUrl: string;
+	private processIdSpaceLength: number;
+	private args: RunCLIArgs;
+
+	constructor(
+		args: RunCLIArgs,
+		options: {
+			siteUrl: string;
+			processIdSpaceLength: number;
+		}
+	) {
+		this.args = args;
+		this.siteUrl = options.siteUrl;
+		this.processIdSpaceLength = options.processIdSpaceLength;
+		this.phpVersion = args.php as SupportedPHPVersion;
+	}
+
+	getWorkerUrl() {
+		return importedWorkerV2UrlString;
+	}
+
+	async bootPrimaryWorker(
+		phpPort: NodeMessagePort,
+		fileLockManagerPort: NodeMessagePort
+	) {
+		const playground: RemoteAPI<PlaygroundCliBlueprintV2Worker> =
+			consumeAPI(phpPort);
+
+		await playground.useFileLockManager(fileLockManagerPort);
+
+		const workerBootArgs = {
+			...this.args,
+			php: this.phpVersion,
+			siteUrl: this.siteUrl,
+			firstProcessId: 1,
+			processIdSpaceLength: this.processIdSpaceLength,
+			trace: this.args.debug || false,
+			blueprint: this.args.blueprint!,
+		};
+
+		await playground.bootAsPrimaryWorker(workerBootArgs);
+		return playground;
+	}
+
+	async bootSecondaryWorker({
+		worker,
+		fileLockManagerPort,
+		firstProcessId,
+	}: {
+		worker: SpawnedWorker;
+		fileLockManagerPort: NodeMessagePort;
+		firstProcessId: number;
+	}) {
+		const playground: RemoteAPI<PlaygroundCliBlueprintV2Worker> =
+			consumeAPI(worker.phpPort);
+
+		await playground.useFileLockManager(fileLockManagerPort);
+
+		const workerBootArgs: WorkerBootArgs = {
+			...this.args,
+			php: this.phpVersion!,
+			siteUrl: this.siteUrl,
+			firstProcessId,
+			processIdSpaceLength: this.processIdSpaceLength,
+			trace: this.args.debug || false,
+			blueprint: this.args.blueprint!,
+		};
+
+		await playground.bootAsSecondaryWorker(workerBootArgs);
+
+		return playground;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async compileInputBlueprint(..._args: any[]) {
+		// no-op for API compatibility with BlueprintV1Handler
+		return undefined;
+	}
+
+	writeProgressUpdate(
+		writeStream: NodeJS.WriteStream,
+		message: string,
+		finalUpdate: boolean
+	) {
+		if (message === this.lastProgressMessage) {
+			// Avoid repeating the same message
+			return;
+		}
+		this.lastProgressMessage = message;
+
+		if (writeStream.isTTY) {
+			// Overwrite previous progress updates in-place for a quieter UX.
+			writeStream.cursorTo(0);
+			writeStream.write(message);
+			writeStream.clearLine(1);
+
+			if (finalUpdate) {
+				writeStream.write('\n');
+			}
+		} else {
+			// Fall back to writing one line per progress update
+			writeStream.write(`${message}\n`);
+		}
+	}
+}
+
+/**
  * Boots Playground CLI workers using Blueprint version 1.
  *
  * Progress tracking, downloads, steps, and all other features are
@@ -544,7 +697,7 @@ class BlueprintsV1Handler {
 	}
 
 	getWorkerUrl() {
-		return importedWorkerUrlString;
+		return importedWorkerV1UrlString;
 	}
 
 	async bootPrimaryWorker(
@@ -620,7 +773,7 @@ class BlueprintsV1Handler {
 		const mountsBeforeWpInstall = this.args['mount-before-install'] || [];
 		const mountsAfterWpInstall = this.args.mount || [];
 
-		const playground = consumeAPI<PlaygroundCliWorker>(phpPort);
+		const playground = consumeAPI<PlaygroundCliBlueprintV1Worker>(phpPort);
 
 		// Comlink communication proxy
 		await playground.isConnected();
@@ -628,7 +781,7 @@ class BlueprintsV1Handler {
 		logger.log(`Booting WordPress...`);
 
 		await playground.useFileLockManager(fileLockManagerPort);
-		await playground.boot({
+		await playground.bootAsPrimaryWorker({
 			phpVersion: this.phpVersion,
 			wpVersion: compiledBlueprint.versions.wp,
 			absoluteUrl: this.siteUrl,
@@ -670,13 +823,13 @@ class BlueprintsV1Handler {
 		fileLockManagerPort: NodeMessagePort;
 		firstProcessId: number;
 	}) {
-		const additionalPlayground = consumeAPI<PlaygroundCliWorker>(
+		const additionalPlayground = consumeAPI<PlaygroundCliBlueprintV1Worker>(
 			worker.phpPort
 		);
 
 		await additionalPlayground.isConnected();
 		await additionalPlayground.useFileLockManager(fileLockManagerPort);
-		await additionalPlayground.boot({
+		await additionalPlayground.bootAsSecondaryWorker({
 			phpVersion: this.phpVersion,
 			absoluteUrl: this.siteUrl,
 			mountsBeforeWpInstall: this.args['mount-before-install'] || [],

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -267,10 +267,6 @@ export async function parseOptionsAndRunCLI() {
 	const cliArgs = {
 		...args,
 		command,
-		blueprint: await resolveBlueprint({
-			sourceString: args.blueprint,
-			blueprintMayReadAdjacentFiles: args.blueprintMayReadAdjacentFiles,
-		}),
 		mount: [...(args.mount || []), ...(args['mount-dir'] || [])],
 		'mount-before-install': [
 			...(args['mount-before-install'] || []),
@@ -381,15 +377,26 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 				Number.MAX_SAFE_INTEGER / totalWorkerCount
 			);
 
-			const handler = args['experimental-blueprints-v2']
-				? new BlueprintsV2Handler(args, {
-						siteUrl: absoluteUrl,
-						processIdSpaceLength,
-				  })
-				: new BlueprintsV1Handler(args, {
-						siteUrl: absoluteUrl,
-						processIdSpaceLength,
-				  });
+			let handler: BlueprintsV1Handler | BlueprintsV2Handler;
+			if (args['experimental-blueprints-v2']) {
+				handler = new BlueprintsV2Handler(args, {
+					siteUrl: absoluteUrl,
+					processIdSpaceLength,
+				});
+			} else {
+				handler = new BlueprintsV1Handler(args, {
+					siteUrl: absoluteUrl,
+					processIdSpaceLength,
+				});
+
+				if (typeof args.blueprint === 'string') {
+					args.blueprint = await resolveBlueprint({
+						sourceString: args.blueprint,
+						blueprintMayReadAdjacentFiles:
+							args['blueprint-may-read-adjacent-files'] === true,
+					});
+				}
+			}
 
 			// Kick off worker threads now to save time later.
 			// There is no need to wait for other async processes to complete.
@@ -856,14 +863,7 @@ class BlueprintsV1Handler {
 
 	async compileInputBlueprint(additionalBlueprintSteps: any[]) {
 		const args = this.args;
-		const resolvedBlueprint =
-			typeof args.blueprint === 'string'
-				? await resolveBlueprint({
-						sourceString: args.blueprint,
-						blueprintMayReadAdjacentFiles:
-							args['blueprint-may-read-adjacent-files'] === true,
-				  })
-				: (args.blueprint as BlueprintDeclaration);
+		const resolvedBlueprint = args.blueprint as BlueprintDeclaration;
 		/**
 		 * @TODO This looks similar to the resolveBlueprint() call in the website package:
 		 * 	     https://github.com/WordPress/wordpress-playground/blob/ce586059e5885d185376184fdd2f52335cca32b0/packages/playground/website/src/main.tsx#L41

--- a/packages/playground/cli/src/worker-thread-v2.ts
+++ b/packages/playground/cli/src/worker-thread-v2.ts
@@ -1,0 +1,431 @@
+import { errorLogPath } from '@php-wasm/logger';
+import type { FileLockManager } from '@php-wasm/node';
+import { createNodeFsMountHandler, loadNodeRuntime } from '@php-wasm/node';
+import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+import type { PHP, RemoteAPI, SupportedPHPVersion } from '@php-wasm/universal';
+import {
+	PHPExecutionFailureError,
+	PHPResponse,
+	PHPWorker,
+	consumeAPI,
+	consumeAPISync,
+	exposeAPI,
+	sandboxedSpawnHandlerFactory,
+} from '@php-wasm/universal';
+import { sprintf } from '@php-wasm/util';
+import {
+	type BlueprintMessage,
+	runBlueprintV2,
+	type ParsedBlueprintV2Declaration,
+	type BlueprintV2Declaration,
+} from './v2';
+import { bootRequestHandler } from '@wp-playground/wordpress';
+import { existsSync } from 'fs';
+import path from 'path';
+import { rootCertificates } from 'tls';
+import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
+import type { Mount } from './mounts';
+import { jspi } from 'wasm-feature-detect';
+import { type RunCLIArgs } from './run-cli';
+
+async function mountResources(php: PHP, mounts: Mount[]) {
+	for (const mount of mounts) {
+		try {
+			php.mkdir(mount.vfsPath);
+			await php.mount(
+				mount.vfsPath,
+				createNodeFsMountHandler(mount.hostPath)
+			);
+		} catch {
+			output.stderr(
+				`\x1b[31m\x1b[1mError mounting path ${mount.hostPath} at ${mount.vfsPath}\x1b[0m\n`
+			);
+			process.exit(1);
+		}
+	}
+}
+
+/**
+ * Print trace messages from PHP-WASM.
+ *
+ * @param {number} processId - The process ID.
+ * @param {string} format - The format string.
+ * @param {...any} args - The arguments.
+ */
+function tracePhpWasm(processId: number, format: string, ...args: any[]) {
+	// eslint-disable-next-line no-console
+	console.log(
+		performance.now().toFixed(6).padStart(15, '0'),
+		processId.toString().padStart(16, '0'),
+		sprintf(format, ...args)
+	);
+}
+
+/**
+ * Force TTY status to preserve ANSI control codes in the output.
+ *
+ * This script is spawned as `new Worker()` and process.stdout and process.stderr are
+ * WritableWorkerStdio objects. By default, they strip ANSI control codes from the output
+ * causing every progress bar update to be printed in a new line instead of updating the
+ * same line.
+ */
+Object.defineProperty(process.stdout, 'isTTY', { value: true });
+Object.defineProperty(process.stderr, 'isTTY', { value: true });
+
+/**
+ * Output writer that ensures that progress bars are not printed on the same line as other output.
+ */
+const output = {
+	lastWriteWasProgress: false,
+	progress(data: string) {
+		if (!process.stdout.isTTY) {
+			// eslint-disable-next-line no-console
+			console.log(data);
+		} else {
+			if (!output.lastWriteWasProgress) {
+				process.stdout.write('\n');
+			}
+			process.stdout.write('\r\x1b[K' + data);
+			output.lastWriteWasProgress = true;
+		}
+	},
+	stdout(data: string) {
+		if (output.lastWriteWasProgress) {
+			process.stdout.write('\n');
+			output.lastWriteWasProgress = false;
+		}
+		process.stdout.write(data);
+	},
+	stderr(data: string) {
+		if (output.lastWriteWasProgress) {
+			process.stdout.write('\n');
+			output.lastWriteWasProgress = false;
+		}
+		process.stderr.write(data);
+	},
+};
+
+export type WorkerBootArgs = RunCLIArgs & {
+	php: SupportedPHPVersion;
+	siteUrl: string;
+	firstProcessId: number;
+	processIdSpaceLength: number;
+	trace: boolean;
+	blueprint: BlueprintV2Declaration | ParsedBlueprintV2Declaration;
+};
+
+type WorkerRunBlueprintArgs = RunCLIArgs & {
+	siteUrl: string;
+	blueprint: BlueprintV2Declaration | ParsedBlueprintV2Declaration;
+};
+
+interface WorkerBootRequestHandlerOptions {
+	siteUrl: string;
+	php: SupportedPHPVersion;
+	allow?: string;
+	firstProcessId: number;
+	processIdSpaceLength: number;
+	trace: boolean;
+}
+
+export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
+	booted = false;
+	fileLockManager: RemoteAPI<FileLockManager> | FileLockManager | undefined;
+
+	constructor(monitor: EmscriptenDownloadMonitor) {
+		super(undefined, monitor);
+	}
+
+	/**
+	 * Call this method before boot() to use file locking.
+	 *
+	 * This method is separate from boot() to simplify the related Comlink.transferHandlers
+	 * setup – if an argument is a MessagePort, we're transferring it, not copying it.
+	 *
+	 * @see comlink-sync.ts
+	 * @see phpwasm-emscripten-library-file-locking-for-node.js
+	 */
+	async useFileLockManager(port: MessagePort) {
+		if (await jspi()) {
+			/**
+			 * If JSPI is available, php.js supports both synchronous and asynchronous locking syscalls.
+			 * Web browsers, however, only support asynchronous message passing so let's use the
+			 * asynchronous API. Every method call will return a promise.
+			 *
+			 * @see comlink-sync.ts
+			 * @see phpwasm-emscripten-library-file-locking-for-node.js
+			 */
+			this.fileLockManager = consumeAPI<FileLockManager>(port);
+		} else {
+			/**
+			 * If JSPI is not available, php.js only supports synchronous locking syscalls.
+			 * Let's use the synchronous API. Every method call will block this thread
+			 * until the result is available.
+			 *
+			 * @see comlink-sync.ts
+			 * @see phpwasm-emscripten-library-file-locking-for-node.js
+			 */
+			this.fileLockManager = await consumeAPISync<FileLockManager>(port);
+		}
+	}
+
+	async bootAsPrimaryWorker(args: WorkerBootArgs) {
+		await this.bootRequestHandler(args);
+
+		const primaryPhp = this.__internal_getPHP()!;
+		await mountResources(primaryPhp, args['mount-before-install'] || []);
+
+		if (args.mode === 'mount-only') {
+			await mountResources(primaryPhp, args.mount || []);
+			return;
+		}
+
+		await this.runBlueprintV2(args);
+	}
+
+	async bootAsSecondaryWorker(args: WorkerBootArgs) {
+		await this.bootRequestHandler(args);
+		const primaryPhp = this.__internal_getPHP()!;
+		// When secondary workers are spawned, WordPress is already installed.
+		await mountResources(primaryPhp, args['mount-before-install'] || []);
+		await mountResources(primaryPhp, args.mount || []);
+	}
+
+	async runBlueprintV2(args: WorkerRunBlueprintArgs) {
+		const requestHandler = this.__internal_getRequestHandler()!;
+		const { php, reap } =
+			await requestHandler.processManager.acquirePHPInstance({
+				considerPrimary: false,
+			});
+
+		// Mount the current working directory to the PHP runtime for the purposes of
+		// Blueprint resolution.
+		const primaryPhp = this.__internal_getPHP()!;
+		let unmountCwd = () => {};
+		if (typeof args.blueprint === 'string') {
+			const blueprintPath = path.resolve(process.cwd(), args.blueprint);
+			if (existsSync(blueprintPath)) {
+				primaryPhp.mkdir('/internal/shared/cwd');
+				unmountCwd = await primaryPhp.mount(
+					'/internal/shared/cwd',
+					createNodeFsMountHandler(path.dirname(blueprintPath))
+				);
+				args.blueprint = path.join(
+					'/internal/shared/cwd',
+					path.basename(args.blueprint)
+				);
+			}
+		}
+
+		try {
+			const cliArgsToPass: (keyof WorkerRunBlueprintArgs)[] = [
+				'mode',
+				'db-engine',
+				'db-host',
+				'db-user',
+				'db-pass',
+				'db-name',
+				'db-path',
+				'truncate-new-site-directory',
+				'allow',
+			];
+			const cliArgs = cliArgsToPass
+				.filter((arg) => arg in args)
+				.map((arg) => `--${arg}=${args[arg]}`);
+			cliArgs.push(`--site-url=${args.siteUrl}`);
+
+			let afterBlueprintTargetResolvedCalled = false;
+
+			const streamedResponse = await runBlueprintV2({
+				php,
+				blueprint: args.blueprint,
+				blueprintOverrides: {
+					additionalSteps: args['additional-blueprint-steps'],
+					wordpressVersion: args.wp,
+				},
+				cliArgs,
+				onMessage: async (message: BlueprintMessage) => {
+					switch (message.type) {
+						case 'blueprint.target_resolved': {
+							if (!afterBlueprintTargetResolvedCalled) {
+								await mountResources(
+									primaryPhp,
+									args.mount || []
+								);
+								afterBlueprintTargetResolvedCalled = true;
+							}
+							break;
+						}
+						case 'blueprint.progress': {
+							const progressMessage = `${message.caption.trim()} – ${message.progress.toFixed(
+								2
+							)}%`;
+							output.progress(progressMessage);
+							break;
+						}
+						case 'blueprint.error': {
+							const red = '\x1b[31m';
+							const bold = '\x1b[1m';
+							const reset = '\x1b[0m';
+							if (args.debug && message.details) {
+								output.stderr(
+									`${red}${bold}Fatal error:${reset} Uncaught ${message.details.exception}: ${message.details.message}\n` +
+										`  at ${message.details.file}:${message.details.line}\n` +
+										(message.details.trace
+											? message.details.trace + '\n'
+											: '')
+								);
+							} else {
+								output.stderr(
+									`${red}${bold}Error:${reset} ${message.message}\n`
+								);
+							}
+							break;
+						}
+					}
+				},
+			});
+			/**
+			 * When we're debugging, every bit of information matters – let's immediately output
+			 * everything we get from the PHP output streams.
+			 */
+			if (args.debug) {
+				streamedResponse!.stdout.pipeTo(
+					new WritableStream({
+						write(chunk) {
+							process.stdout.write(chunk);
+						},
+					})
+				);
+				streamedResponse!.stderr.pipeTo(
+					new WritableStream({
+						write(chunk) {
+							process.stderr.write(chunk);
+						},
+					})
+				);
+			}
+			await streamedResponse!.finished;
+			if ((await streamedResponse!.exitCode) !== 0) {
+				// exitCode != 1 means the blueprint execution failed. Let's throw an error.
+				// and clean up.
+				const syncResponse = await PHPResponse.fromStreamedResponse(
+					streamedResponse
+				);
+				throw new PHPExecutionFailureError(
+					`PHP.run() failed with exit code ${syncResponse.exitCode}.`,
+					syncResponse,
+					'request'
+				);
+			}
+		} catch (error) {
+			// Capture the PHP error log details to provide more context for debugging.
+			let phpLogs = '';
+			try {
+				// @TODO: Don't assume errorLogPath starts with /wordpress/
+				//        ...or maybe we can assume that in Playground CLI?
+				phpLogs = php.readFileAsText(errorLogPath);
+			} catch {
+				// Ignore errors reading the PHP error log.
+			}
+			(error as any).phpLogs = phpLogs;
+			throw error;
+		} finally {
+			reap();
+			unmountCwd();
+		}
+	}
+
+	async bootRequestHandler({
+		siteUrl,
+		allow,
+		php,
+		firstProcessId,
+		processIdSpaceLength,
+		trace,
+	}: WorkerBootRequestHandlerOptions) {
+		if (this.booted) {
+			throw new Error('Playground already booted');
+		}
+		this.booted = true;
+
+		let nextProcessId = firstProcessId;
+		const lastProcessId = firstProcessId + processIdSpaceLength - 1;
+
+		try {
+			const constants: Record<string, string | number | boolean | null> =
+				{
+					WP_DEBUG: true,
+					WP_DEBUG_LOG: true,
+					WP_DEBUG_DISPLAY: false,
+				};
+
+			const requestHandler = await bootRequestHandler({
+				siteUrl,
+				createPhpRuntime: async () => {
+					const processId = nextProcessId;
+
+					if (nextProcessId < lastProcessId) {
+						nextProcessId++;
+					} else {
+						// We've reached the end of the process ID space. Start over.
+						nextProcessId = firstProcessId;
+					}
+
+					return await loadNodeRuntime(php!, {
+						emscriptenOptions: {
+							fileLockManager: this.fileLockManager!,
+							processId,
+							trace: trace ? tracePhpWasm : undefined,
+							ENV: {
+								DOCROOT: '/wordpress',
+							},
+						},
+						followSymlinks: allow?.includes('follow-symlinks'),
+					});
+				},
+				sapiName: 'cli',
+				createFiles: {
+					'/internal/shared/ca-bundle.crt':
+						rootCertificates.join('\n'),
+				},
+				constants,
+				phpIniEntries: {
+					'openssl.cafile': '/internal/shared/ca-bundle.crt',
+				},
+				cookieStore: false,
+				spawnHandler: sandboxedSpawnHandlerFactory,
+			});
+			this.__internal_setRequestHandler(requestHandler);
+
+			const primaryPhp = await requestHandler.getPrimaryPhp();
+			await this.setPrimaryPHP(primaryPhp);
+
+			setApiReady();
+		} catch (e) {
+			setAPIError(e as Error);
+			throw e;
+		}
+	}
+
+	// Provide a named disposal method that can be invoked via comlink.
+	async dispose() {
+		await this[Symbol.asyncDispose]();
+	}
+}
+
+const phpChannel = new MessageChannel();
+
+const [setApiReady, setAPIError] = exposeAPI(
+	new PlaygroundCliBlueprintV2Worker(new EmscriptenDownloadMonitor()),
+	undefined,
+	phpChannel.port1
+);
+
+parentPort!.postMessage(
+	{
+		command: 'worker-script-initialized',
+		phpPort: phpChannel.port2,
+	},
+	[phpChannel.port2 as any]
+);

--- a/packages/playground/cli/src/worker-thread.ts
+++ b/packages/playground/cli/src/worker-thread.ts
@@ -22,7 +22,7 @@ export interface Mount {
 	vfsPath: string;
 }
 
-export type PrimaryWorkerBootOptions = {
+export type WorkerBootOptions = {
 	wpVersion?: string;
 	phpVersion?: SupportedPHPVersion;
 	absoluteUrl: string;
@@ -62,7 +62,7 @@ function tracePhpWasm(processId: number, format: string, ...args: any[]) {
 	);
 }
 
-export class PlaygroundCliWorker extends PHPWorker {
+export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 	booted = false;
 	fileLockManager: RemoteAPI<FileLockManager> | FileLockManager | undefined;
 
@@ -103,7 +103,7 @@ export class PlaygroundCliWorker extends PHPWorker {
 		}
 	}
 
-	async boot({
+	async bootAsPrimaryWorker({
 		absoluteUrl,
 		mountsBeforeWpInstall,
 		mountsAfterWpInstall,
@@ -117,7 +117,7 @@ export class PlaygroundCliWorker extends PHPWorker {
 		trace,
 		internalCookieStore,
 		withXdebug,
-	}: PrimaryWorkerBootOptions) {
+	}: WorkerBootOptions) {
 		if (this.booted) {
 			throw new Error('Playground already booted');
 		}
@@ -201,6 +201,10 @@ export class PlaygroundCliWorker extends PHPWorker {
 		}
 	}
 
+	async bootAsSecondaryWorker(args: WorkerBootOptions) {
+		return this.bootAsPrimaryWorker(args);
+	}
+
 	// Provide a named disposal method that can be invoked via comlink.
 	async dispose() {
 		await this[Symbol.asyncDispose]();
@@ -210,7 +214,7 @@ export class PlaygroundCliWorker extends PHPWorker {
 const phpChannel = new MessageChannel();
 
 const [setApiReady, setAPIError] = exposeAPI(
-	new PlaygroundCliWorker(new EmscriptenDownloadMonitor()),
+	new PlaygroundCliBlueprintV1Worker(new EmscriptenDownloadMonitor()),
 	undefined,
 	phpChannel.port1
 );

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -136,6 +136,7 @@ export default defineConfig({
 				index: 'src/index.ts',
 				cli: 'src/cli.ts',
 				'worker-thread': 'src/worker-thread.ts',
+				'worker-thread-v2': 'src/worker-thread-v2.ts',
 			},
 			name: 'playground-cli',
 			formats: ['es', 'cjs'],


### PR DESCRIPTION
## Motivation for the change, related issues

Adds Blueprints v2 support to Playground CLI via the `--experimental-blueprints-v2-runner` flag.

A part of #2223

## Implementation details

Following the structure set up in https://github.com/WordPress/wordpress-playground/pull/2392, this PR adds:

* A separate worker script `worker-thread-v2.ts` for starting workers relying on Blueprints V2
* A `BlueprintsV2Handler` class that enables using the new worker from the main CLI thread 

## Testing Instructions (or ideally a Blueprint)

Confirm the `--experimental-blueprints-v2-runner` flag yields output similar to this – it's produced by the Blueprints v2 runner:

```
$ PHP=7.4 node --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/playground/cli/src/cli.ts server --experimental-blueprints-v2-runner --blueprint=https://raw.githubusercontent.com/wordpress/blueprints/refs/heads/trunk/blueprints/custom-post/blueprint.json

Running WP-CLI command: wp post create --post_type=gbtbooks --post_title='WordPress Styling with Blocks, Patterns, Templates, and Themes' --post_content='<!-- wp:paragraph --><p>Explore WordPress styl
Complete – 100.00%
Booted!
WordPress is running on http://127.0.0.1:9400
```

Confirm the CLI still works without the `--experimental-blueprints-v2` flag:

```
$ PHP=7.4 node --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/playground/cli/src/cli.ts server  --blueprint=https://raw.githubusercontent.com/wordpress/blueprints/refs/heads/trunk/blueprints/custom-post/blueprint.json

Starting a PHP server...
Setting up WordPress latest
Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.8.2.zip
Fetching SQLite integration plugin...
Booting WordPress...
Booted!
Running the Blueprint...
Logging in – 100%
Finished running the blueprint
WordPress is running on http://127.0.0.1:9400