### PR TITLE
[ xdebug ] Add a mock @php-wasm/xdebug-bridge package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12591,6 +12591,10 @@
 			"resolved": "packages/php-wasm/web-service-worker",
 			"link": true
 		},
+		"node_modules/@php-wasm/xdebug-bridge": {
+			"resolved": "packages/php-wasm/xdebug-bridge",
+			"link": true
+		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -52844,6 +52848,18 @@
 			"name": "@php-wasm/web-service-worker",
 			"version": "1.2.3",
 			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			}
+		},
+		"packages/php-wasm/xdebug-bridge": {
+			"name": "@php-wasm/xdebug-bridge",
+			"version": "1.2.3",
+			"license": "GPL-2.0-or-later",
+			"bin": {
+				"xdebug-bridge": "cli.js"
+			},
 			"engines": {
 				"node": ">=20.18.3",
 				"npm": ">=10.1.0"

--- a/packages/php-wasm/xdebug-bridge/.eslintrc.json
+++ b/packages/php-wasm/xdebug-bridge/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+	"extends": ["../../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.ts", "*.tsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.js", "*.jsx"],
+			"rules": {}
+		}
+	]
+} 

--- a/packages/php-wasm/xdebug-bridge/README.md
+++ b/packages/php-wasm/xdebug-bridge/README.md
@@ -1,0 +1,70 @@
+# @php-wasm/xdebug-bridge
+
+XDebug bridge server for PHP.wasm that enables debugging connections between XDebug and debugging clients.
+
+## Installation
+
+```bash
+npm install @php-wasm/xdebug-bridge
+```
+
+## Usage
+
+### Programmatic API
+
+```typescript
+import { startXDebugBridge } from '@php-wasm/xdebug-bridge';
+
+// Start with default settings
+const server = startXDebugBridge();
+await server.start();
+
+// Start with custom configuration
+const server = startXDebugBridge({
+  protocol: 'cdp',           // or 'dap'
+  xdebugServerPort: 9003,    // XDebug connection port
+  xdebugServerHost: 'localhost',
+  verbose: false,            // Silent mode
+});
+
+await server.start();
+
+// Stop the server
+await server.stop();
+```
+
+### CLI Usage
+
+```bash
+# Start with default settings
+npx xdebug-bridge
+
+# Custom port and verbose logging
+npx xdebug-bridge --port 9000 --verbose
+
+# DAP protocol, bind to all interfaces
+npx xdebug-bridge --protocol dap --host 0.0.0.0
+
+# Show help
+npx xdebug-bridge --help
+```
+
+## Configuration Options
+
+- `protocol`: Protocol to use ('cdp' or 'dap', default: 'cdp')
+- `xdebugServerPort`: Port to listen for XDebug connections (default: 9003)
+- `xdebugServerHost`: Host to bind to (default: 'localhost')
+- `verbose`: Enable verbose logging (default: false for API, true for CLI)
+- `logger`: Custom logger function
+
+## Events
+
+The server emits events for monitoring connection activity:
+
+- `started`: Server has started
+- `stopped`: Server has stopped
+- `connection`: New XDebug connection established
+- `disconnection`: XDebug connection closed
+- `xdebugData`: Raw XDebug data received
+- `error`: Server error occurred
+- `socketError`: Socket-level error occurred 

--- a/packages/php-wasm/xdebug-bridge/package.json
+++ b/packages/php-wasm/xdebug-bridge/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "@php-wasm/xdebug-bridge",
+	"version": "1.2.3",
+	"description": "XDebug bridge server for PHP.wasm",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"author": "The WordPress contributors",
+	"contributors": [
+		{
+			"name": "Adam Zielinski",
+			"email": "adam@adamziel.com",
+			"url": "https://github.com/adamziel"
+		}
+	],
+	"exports": {
+		".": {
+			"import": "./index.js",
+			"require": "./index.cjs"
+		},
+		"./package.json": "./package.json",
+		"./README.md": "./README.md"
+	},
+	"type": "module",
+	"main": "./index.cjs",
+	"module": "./index.js",
+	"bin": "cli.js",
+	"typedoc": {
+		"entryPoint": "./src/index.ts",
+		"readmeFile": "./README.md",
+		"displayName": "@php-wasm/xdebug-bridge",
+		"tsconfig": "./tsconfig.lib.json"
+	},
+	"publishConfig": {
+		"access": "public",
+		"directory": "../../../dist/packages/php-wasm/xdebug-bridge"
+	},
+	"license": "GPL-2.0-or-later",
+	"types": "index.d.ts",
+	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
+	"engines": {
+		"node": ">=20.18.3",
+		"npm": ">=10.1.0"
+	}
+} 

--- a/packages/php-wasm/xdebug-bridge/project.json
+++ b/packages/php-wasm/xdebug-bridge/project.json
@@ -1,0 +1,75 @@
+{
+	"name": "php-wasm-xdebug-bridge",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/php-wasm/xdebug-bridge/src",
+	"projectType": "library",
+	"targets": {
+		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/php-wasm/xdebug-bridge/README.md dist/packages/php-wasm/xdebug-bridge"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
+			"executor": "@wp-playground/nx-extensions:package-json",
+			"options": {
+				"tsConfig": "packages/php-wasm/xdebug-bridge/tsconfig.lib.json",
+				"outputPath": "dist/packages/php-wasm/xdebug-bridge",
+				"buildTarget": "php-wasm-xdebug-bridge:build:bundle:production"
+			}
+		},
+		"build:bundle": {
+			"executor": "@nx/vite:build",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"main": "dist/packages/php-wasm/xdebug-bridge/index.js",
+				"outputPath": "dist/packages/php-wasm/xdebug-bridge"
+			},
+			"defaultConfiguration": "production",
+			"configurations": {
+				"development": {
+					"minify": false
+				},
+				"production": {
+					"minify": true
+				}
+			}
+		},
+		"dev": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "bun --watch ./packages/php-wasm/xdebug-bridge/src/cli.ts",
+				"tty": true
+			}
+		},
+		"test": {
+			"executor": "@nx/jest:jest",
+			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"options": {
+				"jestConfig": "packages/php-wasm/xdebug-bridge/jest.config.ts",
+				"passWithNoTests": true
+			},
+			"configurations": {
+				"ci": {
+					"ci": true,
+					"coverage": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"lintFilePatterns": ["packages/php-wasm/xdebug-bridge/**/*.ts"]
+			}
+		}
+	},
+	"tags": ["php-wasm"]
+} 

--- a/packages/php-wasm/xdebug-bridge/project.json
+++ b/packages/php-wasm/xdebug-bridge/project.json
@@ -50,17 +50,11 @@
 			}
 		},
 		"test": {
-			"executor": "@nx/jest:jest",
-			"outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+			"executor": "@nx/vite:test",
+			"outputs": ["{workspaceRoot}/coverage/packages/php-wasm/node"],
 			"options": {
-				"jestConfig": "packages/php-wasm/xdebug-bridge/jest.config.ts",
-				"passWithNoTests": true
-			},
-			"configurations": {
-				"ci": {
-					"ci": true,
-					"coverage": true
-				}
+				"reportsDirectory": "../../../coverage/packages/php-wasm/node",
+				"testFiles": []
 			}
 		},
 		"lint": {
@@ -72,4 +66,4 @@
 		}
 	},
 	"tags": ["php-wasm"]
-} 
+}

--- a/packages/php-wasm/xdebug-bridge/project.json
+++ b/packages/php-wasm/xdebug-bridge/project.json
@@ -56,7 +56,7 @@
 			],
 			"options": {
 				"reportsDirectory": "../../../coverage/packages/php-wasm/xdebug-bridge",
-				"testFiles": []
+				"testFiles": ["tests/mock-test.spec.ts"]
 			}
 		},
 		"lint": {

--- a/packages/php-wasm/xdebug-bridge/project.json
+++ b/packages/php-wasm/xdebug-bridge/project.json
@@ -51,9 +51,11 @@
 		},
 		"test": {
 			"executor": "@nx/vite:test",
-			"outputs": ["{workspaceRoot}/coverage/packages/php-wasm/node"],
+			"outputs": [
+				"{workspaceRoot}/coverage/packages/php-wasm/xdebug-bridge"
+			],
 			"options": {
-				"reportsDirectory": "../../../coverage/packages/php-wasm/node",
+				"reportsDirectory": "../../../coverage/packages/php-wasm/xdebug-bridge",
 				"testFiles": []
 			}
 		},

--- a/packages/php-wasm/xdebug-bridge/src/cli.ts
+++ b/packages/php-wasm/xdebug-bridge/src/cli.ts
@@ -12,6 +12,7 @@ interface CLIArgs {
 }
 
 function printHelp(): void {
+	// eslint-ignore-next-line
 	console.log(`
 XDebug Bridge Server CLI
 
@@ -63,7 +64,9 @@ function parseCliArgs(): CLIArgs {
 
 		if (values.protocol) {
 			if (values.protocol !== 'cdp' && values.protocol !== 'dap') {
-				throw new Error(`Invalid protocol: ${values.protocol}. Must be 'cdp' or 'dap'.`);
+				throw new Error(
+					`Invalid protocol: ${values.protocol}. Must be 'cdp' or 'dap'.`
+				);
 			}
 			args.protocol = values.protocol as 'cdp' | 'dap';
 		}
@@ -71,7 +74,9 @@ function parseCliArgs(): CLIArgs {
 		if (values.port) {
 			const port = parseInt(values.port, 10);
 			if (isNaN(port) || port < 1 || port > 65535) {
-				throw new Error(`Invalid port: ${values.port}. Must be a number between 1 and 65535.`);
+				throw new Error(
+					`Invalid port: ${values.port}. Must be a number between 1 and 65535.`
+				);
 			}
 			args.port = port;
 		}
@@ -90,7 +95,11 @@ function parseCliArgs(): CLIArgs {
 
 		return args;
 	} catch (error) {
-		console.error(`Error parsing arguments: ${error instanceof Error ? error.message : String(error)}`);
+		console.error(
+			`Error parsing arguments: ${
+				error instanceof Error ? error.message : String(error)
+			}`
+		);
 		process.exit(1);
 	}
 }
@@ -110,19 +119,26 @@ async function main(): Promise<void> {
 		verbose: args.verbose ?? true, // CLI defaults to verbose
 	};
 
+	// eslint-ignore-next-line
 	console.log('Starting XDebug Bridge Server...');
-	
+
 	const server = startXDebugBridge(config);
 
 	// Handle graceful shutdown
 	const shutdown = async (signal: string) => {
+		// eslint-ignore-next-line
 		console.log(`\nReceived ${signal}, shutting down gracefully...`);
 		try {
 			await server.stop();
+			// eslint-ignore-next-line
 			console.log('XDebug Bridge Server stopped.');
 			process.exit(0);
 		} catch (error) {
-			console.error(`Error during shutdown: ${error instanceof Error ? error.message : String(error)}`);
+			console.error(
+				`Error during shutdown: ${
+					error instanceof Error ? error.message : String(error)
+				}`
+			);
 			process.exit(1);
 		}
 	};
@@ -133,22 +149,32 @@ async function main(): Promise<void> {
 	// Start the server
 	try {
 		await server.start();
-		
+
 		const port = server.getPort();
 		const host = server.getHost();
-		
+
+		// eslint-ignore-next-line
 		console.log(`✅ XDebug Bridge Server is running on ${host}:${port}`);
+		// eslint-ignore-next-line
 		console.log(`📡 Protocol: ${config.protocol || 'cdp'}`);
+		// eslint-ignore-next-line
 		console.log('🔍 Waiting for XDebug connections...');
+		// eslint-ignore-next-line
 		console.log('Press Ctrl+C to stop the server');
 
 		// Set up event listeners for connection activity
 		server.on('connection', (socket) => {
-			console.log(`🔗 New XDebug connection established from ${socket.remoteAddress}:${socket.remotePort}`);
+			// eslint-ignore-next-line
+			console.log(
+				`🔗 New XDebug connection established from ${socket.remoteAddress}:${socket.remotePort}`
+			);
 		});
 
 		server.on('disconnection', (socket) => {
-			console.log(`❌ XDebug connection closed from ${socket.remoteAddress}:${socket.remotePort}`);
+			// eslint-ignore-next-line
+			console.log(
+				`❌ XDebug connection closed from ${socket.remoteAddress}:${socket.remotePort}`
+			);
 		});
 
 		server.on('error', (error) => {
@@ -156,11 +182,16 @@ async function main(): Promise<void> {
 		});
 
 		server.on('socketError', ({ socket, error }) => {
-			console.error(`❌ Socket error from ${socket.remoteAddress}:${socket.remotePort}: ${error.message}`);
+			console.error(
+				`❌ Socket error from ${socket.remoteAddress}:${socket.remotePort}: ${error.message}`
+			);
 		});
-
 	} catch (error) {
-		console.error(`❌ Failed to start XDebug Bridge Server: ${error instanceof Error ? error.message : String(error)}`);
+		console.error(
+			`❌ Failed to start XDebug Bridge Server: ${
+				error instanceof Error ? error.message : String(error)
+			}`
+		);
 		process.exit(1);
 	}
 }
@@ -168,7 +199,11 @@ async function main(): Promise<void> {
 // Only run if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
 	main().catch((error) => {
-		console.error(`❌ Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+		console.error(
+			`❌ Unexpected error: ${
+				error instanceof Error ? error.message : String(error)
+			}`
+		);
 		process.exit(1);
 	});
-} 
+}

--- a/packages/php-wasm/xdebug-bridge/src/cli.ts
+++ b/packages/php-wasm/xdebug-bridge/src/cli.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import { parseArgs } from 'util';
+import { startXDebugBridge, type XDebugBridgeConfig } from './xdebug-bridge';
+
+interface CLIArgs {
+	protocol?: 'cdp' | 'dap';
+	port?: number;
+	host?: string;
+	verbose?: boolean;
+	help?: boolean;
+}
+
+function printHelp(): void {
+	console.log(`
+XDebug Bridge Server CLI
+
+Usage: xdebug-bridge [options]
+
+Options:
+  --protocol <protocol>    Protocol to use: cdp, dap (default: cdp)
+  --port <port>           Port to listen on (default: 9003)
+  --host <host>           Host to bind to (default: localhost)
+  --verbose               Enable verbose logging
+  --help                  Show this help message
+
+Examples:
+  xdebug-bridge                                    # Start with default settings
+  xdebug-bridge --port 9000 --verbose            # Custom port with verbose logging
+  xdebug-bridge --protocol dap --host 0.0.0.0    # DAP protocol, bind to all interfaces
+`);
+}
+
+function parseCliArgs(): CLIArgs {
+	try {
+		const { values } = parseArgs({
+			args: process.argv.slice(2),
+			options: {
+				protocol: {
+					type: 'string',
+					short: 'p',
+				},
+				port: {
+					type: 'string',
+					short: 'P',
+				},
+				host: {
+					type: 'string',
+					short: 'h',
+				},
+				verbose: {
+					type: 'boolean',
+					short: 'v',
+				},
+				help: {
+					type: 'boolean',
+				},
+			},
+			allowPositionals: false,
+		});
+
+		const args: CLIArgs = {};
+
+		if (values.protocol) {
+			if (values.protocol !== 'cdp' && values.protocol !== 'dap') {
+				throw new Error(`Invalid protocol: ${values.protocol}. Must be 'cdp' or 'dap'.`);
+			}
+			args.protocol = values.protocol as 'cdp' | 'dap';
+		}
+
+		if (values.port) {
+			const port = parseInt(values.port, 10);
+			if (isNaN(port) || port < 1 || port > 65535) {
+				throw new Error(`Invalid port: ${values.port}. Must be a number between 1 and 65535.`);
+			}
+			args.port = port;
+		}
+
+		if (values.host) {
+			args.host = values.host;
+		}
+
+		if (values.verbose) {
+			args.verbose = true;
+		}
+
+		if (values.help) {
+			args.help = true;
+		}
+
+		return args;
+	} catch (error) {
+		console.error(`Error parsing arguments: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	}
+}
+
+async function main(): Promise<void> {
+	const args = parseCliArgs();
+
+	if (args.help) {
+		printHelp();
+		return;
+	}
+
+	const config: XDebugBridgeConfig = {
+		protocol: args.protocol,
+		xdebugServerPort: args.port,
+		xdebugServerHost: args.host,
+		verbose: args.verbose ?? true, // CLI defaults to verbose
+	};
+
+	console.log('Starting XDebug Bridge Server...');
+	
+	const server = startXDebugBridge(config);
+
+	// Handle graceful shutdown
+	const shutdown = async (signal: string) => {
+		console.log(`\nReceived ${signal}, shutting down gracefully...`);
+		try {
+			await server.stop();
+			console.log('XDebug Bridge Server stopped.');
+			process.exit(0);
+		} catch (error) {
+			console.error(`Error during shutdown: ${error instanceof Error ? error.message : String(error)}`);
+			process.exit(1);
+		}
+	};
+
+	process.on('SIGINT', () => shutdown('SIGINT'));
+	process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+	// Start the server
+	try {
+		await server.start();
+		
+		const port = server.getPort();
+		const host = server.getHost();
+		
+		console.log(`✅ XDebug Bridge Server is running on ${host}:${port}`);
+		console.log(`📡 Protocol: ${config.protocol || 'cdp'}`);
+		console.log('🔍 Waiting for XDebug connections...');
+		console.log('Press Ctrl+C to stop the server');
+
+		// Set up event listeners for connection activity
+		server.on('connection', (socket) => {
+			console.log(`🔗 New XDebug connection established from ${socket.remoteAddress}:${socket.remotePort}`);
+		});
+
+		server.on('disconnection', (socket) => {
+			console.log(`❌ XDebug connection closed from ${socket.remoteAddress}:${socket.remotePort}`);
+		});
+
+		server.on('error', (error) => {
+			console.error(`❌ Server error: ${error.message}`);
+		});
+
+		server.on('socketError', ({ socket, error }) => {
+			console.error(`❌ Socket error from ${socket.remoteAddress}:${socket.remotePort}: ${error.message}`);
+		});
+
+	} catch (error) {
+		console.error(`❌ Failed to start XDebug Bridge Server: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	}
+}
+
+// Only run if this file is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+	main().catch((error) => {
+		console.error(`❌ Unexpected error: ${error instanceof Error ? error.message : String(error)}`);
+		process.exit(1);
+	});
+} 

--- a/packages/php-wasm/xdebug-bridge/src/index.ts
+++ b/packages/php-wasm/xdebug-bridge/src/index.ts
@@ -1,0 +1,1 @@
+export * from './xdebug-bridge'; 

--- a/packages/php-wasm/xdebug-bridge/src/xdebug-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/xdebug-bridge.ts
@@ -1,0 +1,227 @@
+import { createServer, Server, Socket } from 'net';
+import { EventEmitter } from 'events';
+
+export interface XDebugBridgeConfig {
+	/**
+	 * The protocol to use for the bridge communication.
+	 * @default "cdp"
+	 */
+	protocol?: 'cdp' | 'dap';
+	
+	/**
+	 * The port where XDebug server will listen for connections.
+	 * @default 9003
+	 */
+	xdebugServerPort?: number;
+	
+	/**
+	 * The host where XDebug server will bind to.
+	 * @default "localhost"
+	 */
+	xdebugServerHost?: string;
+	
+	/**
+	 * Whether to enable verbose logging.
+	 * @default false
+	 */
+	verbose?: boolean;
+	
+	/**
+	 * Custom logger function. If not provided and verbose is true, console.log will be used.
+	 */
+	logger?: (message: string) => void;
+}
+
+export interface XDebugBridgeServer extends EventEmitter {
+	/**
+	 * Start the XDebug bridge server.
+	 */
+	start(): Promise<void>;
+	
+	/**
+	 * Stop the XDebug bridge server.
+	 */
+	stop(): Promise<void>;
+	
+	/**
+	 * Get the actual port the server is listening on.
+	 */
+	getPort(): number | null;
+	
+	/**
+	 * Get the host the server is listening on.
+	 */
+	getHost(): string;
+	
+	/**
+	 * Check if the server is currently running.
+	 */
+	isRunning(): boolean;
+}
+
+class XDebugBridgeServerImpl extends EventEmitter implements XDebugBridgeServer {
+	private server: Server | null = null;
+	private config: Required<XDebugBridgeConfig>;
+	private connectedClients = new Set<Socket>();
+
+	constructor(config: XDebugBridgeConfig = {}) {
+		super();
+		
+		this.config = {
+			protocol: config.protocol ?? 'cdp',
+			xdebugServerPort: config.xdebugServerPort ?? 9003,
+			xdebugServerHost: config.xdebugServerHost ?? 'localhost',
+			verbose: config.verbose ?? false,
+			logger: config.logger ?? ((message: string) => {
+				if (this.config.verbose) {
+					console.log(`[XDebug Bridge] ${message}`);
+				}
+			}),
+		};
+	}
+
+	private log(message: string): void {
+		this.config.logger(message);
+	}
+
+	async start(): Promise<void> {
+		if (this.server) {
+			throw new Error('XDebug bridge server is already running');
+		}
+
+		return new Promise((resolve, reject) => {
+			this.server = createServer();
+			
+			this.server.on('connection', (socket: Socket) => {
+				this.handleConnection(socket);
+			});
+
+			this.server.on('error', (error: Error) => {
+				this.log(`Server error: ${error.message}`);
+				this.emit('error', error);
+				reject(error);
+			});
+
+			this.server.listen(this.config.xdebugServerPort, this.config.xdebugServerHost, () => {
+				const address = this.server?.address();
+				const port = typeof address === 'object' && address ? address.port : this.config.xdebugServerPort;
+				
+				this.log(`XDebug bridge server started on ${this.config.xdebugServerHost}:${port}`);
+				this.log(`Protocol: ${this.config.protocol}`);
+				this.emit('started', { host: this.config.xdebugServerHost, port });
+				resolve();
+			});
+		});
+	}
+
+	async stop(): Promise<void> {
+		if (!this.server) {
+			return;
+		}
+
+		return new Promise((resolve) => {
+			// Close all client connections
+			for (const client of this.connectedClients) {
+				client.destroy();
+			}
+			this.connectedClients.clear();
+
+			this.server!.close(() => {
+				this.log('XDebug bridge server stopped');
+				this.emit('stopped');
+				this.server = null;
+				resolve();
+			});
+		});
+	}
+
+	getPort(): number | null {
+		if (!this.server) return null;
+		const address = this.server.address();
+		return typeof address === 'object' && address ? address.port : null;
+	}
+
+	getHost(): string {
+		return this.config.xdebugServerHost;
+	}
+
+	isRunning(): boolean {
+		return this.server !== null && this.server.listening;
+	}
+
+	private handleConnection(socket: Socket): void {
+		const clientAddress = `${socket.remoteAddress}:${socket.remotePort}`;
+		this.log(`New XDebug connection from ${clientAddress}`);
+		
+		this.connectedClients.add(socket);
+		this.emit('connection', socket);
+
+		socket.on('data', (data: Buffer) => {
+			this.handleXDebugData(socket, data);
+		});
+
+		socket.on('close', () => {
+			this.log(`XDebug connection closed from ${clientAddress}`);
+			this.connectedClients.delete(socket);
+			this.emit('disconnection', socket);
+		});
+
+		socket.on('error', (error: Error) => {
+			this.log(`Socket error from ${clientAddress}: ${error.message}`);
+			this.connectedClients.delete(socket);
+			this.emit('socketError', { socket, error });
+		});
+	}
+
+	private handleXDebugData(socket: Socket, data: Buffer): void {
+		const message = data.toString('utf8');
+		this.log(`Received XDebug data: ${message.substring(0, 100)}${message.length > 100 ? '...' : ''}`);
+		
+		// Emit the raw data for external processing
+		this.emit('xdebugData', { socket, data, message });
+		
+		// Basic protocol handling based on configured protocol
+		if (this.config.protocol === 'cdp') {
+			this.handleCDPMessage(socket, message);
+		} else if (this.config.protocol === 'dap') {
+			this.handleDAPMessage(socket, message);
+		}
+	}
+
+	private handleCDPMessage(socket: Socket, message: string): void {
+		// Basic CDP message handling - this is a placeholder for actual CDP protocol implementation
+		try {
+			// XDebug typically sends XML, but we might need to convert it to CDP format
+			this.log('Processing message for CDP protocol');
+			
+			// For now, just echo back a simple response to keep the connection alive
+			// In a real implementation, this would convert XDebug XML to CDP JSON
+		} catch (error) {
+			this.log(`Error processing CDP message: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	private handleDAPMessage(socket: Socket, message: string): void {
+		// Basic DAP message handling - this is a placeholder for actual DAP protocol implementation
+		try {
+			// XDebug typically sends XML, but we might need to convert it to DAP format
+			this.log('Processing message for DAP protocol');
+			
+			// For now, just echo back a simple response to keep the connection alive
+			// In a real implementation, this would convert XDebug XML to DAP JSON
+		} catch (error) {
+			this.log(`Error processing DAP message: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+}
+
+/**
+ * Starts an XDebug bridge server that can relay debugging sessions.
+ * 
+ * @param config Configuration options for the XDebug bridge
+ * @returns A promise that resolves to an XDebugBridgeServer instance
+ */
+export function startXDebugBridge(config: XDebugBridgeConfig = {}): XDebugBridgeServer {
+	const bridge = new XDebugBridgeServerImpl(config);
+	return bridge;
+} 

--- a/packages/php-wasm/xdebug-bridge/src/xdebug-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/xdebug-bridge.ts
@@ -1,4 +1,4 @@
-import { createServer, Server, Socket } from 'net';
+import { createServer, type Server, type Socket } from 'net';
 import { EventEmitter } from 'events';
 
 export interface XDebugBridgeConfig {
@@ -7,25 +7,25 @@ export interface XDebugBridgeConfig {
 	 * @default "cdp"
 	 */
 	protocol?: 'cdp' | 'dap';
-	
+
 	/**
 	 * The port where XDebug server will listen for connections.
 	 * @default 9003
 	 */
 	xdebugServerPort?: number;
-	
+
 	/**
 	 * The host where XDebug server will bind to.
 	 * @default "localhost"
 	 */
 	xdebugServerHost?: string;
-	
+
 	/**
 	 * Whether to enable verbose logging.
 	 * @default false
 	 */
 	verbose?: boolean;
-	
+
 	/**
 	 * Custom logger function. If not provided and verbose is true, console.log will be used.
 	 */
@@ -37,46 +37,52 @@ export interface XDebugBridgeServer extends EventEmitter {
 	 * Start the XDebug bridge server.
 	 */
 	start(): Promise<void>;
-	
+
 	/**
 	 * Stop the XDebug bridge server.
 	 */
 	stop(): Promise<void>;
-	
+
 	/**
 	 * Get the actual port the server is listening on.
 	 */
 	getPort(): number | null;
-	
+
 	/**
 	 * Get the host the server is listening on.
 	 */
 	getHost(): string;
-	
+
 	/**
 	 * Check if the server is currently running.
 	 */
 	isRunning(): boolean;
 }
 
-class XDebugBridgeServerImpl extends EventEmitter implements XDebugBridgeServer {
+class XDebugBridgeServerImpl
+	extends EventEmitter
+	implements XDebugBridgeServer
+{
 	private server: Server | null = null;
 	private config: Required<XDebugBridgeConfig>;
 	private connectedClients = new Set<Socket>();
 
 	constructor(config: XDebugBridgeConfig = {}) {
 		super();
-		
+
 		this.config = {
 			protocol: config.protocol ?? 'cdp',
 			xdebugServerPort: config.xdebugServerPort ?? 9003,
 			xdebugServerHost: config.xdebugServerHost ?? 'localhost',
 			verbose: config.verbose ?? false,
-			logger: config.logger ?? ((message: string) => {
-				if (this.config.verbose) {
-					console.log(`[XDebug Bridge] ${message}`);
-				}
-			}),
+			logger:
+				config.logger ??
+				((message: string) => {
+					if (this.config.verbose) {
+						// @ts-ignore
+						console.log(`[XDebug Bridge] ${message}`);
+					}
+				}),
 		};
 	}
 
@@ -91,7 +97,7 @@ class XDebugBridgeServerImpl extends EventEmitter implements XDebugBridgeServer 
 
 		return new Promise((resolve, reject) => {
 			this.server = createServer();
-			
+
 			this.server.on('connection', (socket: Socket) => {
 				this.handleConnection(socket);
 			});
@@ -102,15 +108,27 @@ class XDebugBridgeServerImpl extends EventEmitter implements XDebugBridgeServer 
 				reject(error);
 			});
 
-			this.server.listen(this.config.xdebugServerPort, this.config.xdebugServerHost, () => {
-				const address = this.server?.address();
-				const port = typeof address === 'object' && address ? address.port : this.config.xdebugServerPort;
-				
-				this.log(`XDebug bridge server started on ${this.config.xdebugServerHost}:${port}`);
-				this.log(`Protocol: ${this.config.protocol}`);
-				this.emit('started', { host: this.config.xdebugServerHost, port });
-				resolve();
-			});
+			this.server.listen(
+				this.config.xdebugServerPort,
+				this.config.xdebugServerHost,
+				() => {
+					const address = this.server?.address();
+					const port =
+						typeof address === 'object' && address
+							? address.port
+							: this.config.xdebugServerPort;
+
+					this.log(
+						`XDebug bridge server started on ${this.config.xdebugServerHost}:${port}`
+					);
+					this.log(`Protocol: ${this.config.protocol}`);
+					this.emit('started', {
+						host: this.config.xdebugServerHost,
+						port,
+					});
+					resolve();
+				}
+			);
 		});
 	}
 
@@ -152,12 +170,12 @@ class XDebugBridgeServerImpl extends EventEmitter implements XDebugBridgeServer 
 	private handleConnection(socket: Socket): void {
 		const clientAddress = `${socket.remoteAddress}:${socket.remotePort}`;
 		this.log(`New XDebug connection from ${clientAddress}`);
-		
+
 		this.connectedClients.add(socket);
 		this.emit('connection', socket);
 
-		socket.on('data', (data: Buffer) => {
-			this.handleXDebugData(socket, data);
+		socket.on('data', () => {
+			// TODO: Handle XDebug data
 		});
 
 		socket.on('close', () => {
@@ -172,56 +190,17 @@ class XDebugBridgeServerImpl extends EventEmitter implements XDebugBridgeServer 
 			this.emit('socketError', { socket, error });
 		});
 	}
-
-	private handleXDebugData(socket: Socket, data: Buffer): void {
-		const message = data.toString('utf8');
-		this.log(`Received XDebug data: ${message.substring(0, 100)}${message.length > 100 ? '...' : ''}`);
-		
-		// Emit the raw data for external processing
-		this.emit('xdebugData', { socket, data, message });
-		
-		// Basic protocol handling based on configured protocol
-		if (this.config.protocol === 'cdp') {
-			this.handleCDPMessage(socket, message);
-		} else if (this.config.protocol === 'dap') {
-			this.handleDAPMessage(socket, message);
-		}
-	}
-
-	private handleCDPMessage(socket: Socket, message: string): void {
-		// Basic CDP message handling - this is a placeholder for actual CDP protocol implementation
-		try {
-			// XDebug typically sends XML, but we might need to convert it to CDP format
-			this.log('Processing message for CDP protocol');
-			
-			// For now, just echo back a simple response to keep the connection alive
-			// In a real implementation, this would convert XDebug XML to CDP JSON
-		} catch (error) {
-			this.log(`Error processing CDP message: ${error instanceof Error ? error.message : String(error)}`);
-		}
-	}
-
-	private handleDAPMessage(socket: Socket, message: string): void {
-		// Basic DAP message handling - this is a placeholder for actual DAP protocol implementation
-		try {
-			// XDebug typically sends XML, but we might need to convert it to DAP format
-			this.log('Processing message for DAP protocol');
-			
-			// For now, just echo back a simple response to keep the connection alive
-			// In a real implementation, this would convert XDebug XML to DAP JSON
-		} catch (error) {
-			this.log(`Error processing DAP message: ${error instanceof Error ? error.message : String(error)}`);
-		}
-	}
 }
 
 /**
  * Starts an XDebug bridge server that can relay debugging sessions.
- * 
+ *
  * @param config Configuration options for the XDebug bridge
  * @returns A promise that resolves to an XDebugBridgeServer instance
  */
-export function startXDebugBridge(config: XDebugBridgeConfig = {}): XDebugBridgeServer {
+export function startXDebugBridge(
+	config: XDebugBridgeConfig = {}
+): XDebugBridgeServer {
 	const bridge = new XDebugBridgeServerImpl(config);
 	return bridge;
-} 
+}

--- a/packages/php-wasm/xdebug-bridge/tests/mock-test.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/tests/mock-test.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from 'vitest';
+
+test('mock test to prevent vitest from failing', () => {
+	// This is a placeholder test to ensure vitest doesn't fail due to no tests
+	// TODO: Add actual tests for the xdebug-bridge functionality
+	expect(true).toBe(true);
+});

--- a/packages/php-wasm/xdebug-bridge/tsconfig.json
+++ b/packages/php-wasm/xdebug-bridge/tsconfig.json
@@ -1,0 +1,21 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+} 

--- a/packages/php-wasm/xdebug-bridge/tsconfig.lib.json
+++ b/packages/php-wasm/xdebug-bridge/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+} 

--- a/packages/php-wasm/xdebug-bridge/tsconfig.spec.json
+++ b/packages/php-wasm/xdebug-bridge/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"module": "commonjs",
+		"types": ["jest", "node"]
+	},
+	"include": [
+		"jest.config.ts",
+		"src/**/*.test.ts",
+		"src/**/*.spec.ts",
+		"src/**/*.d.ts"
+	]
+} 

--- a/packages/php-wasm/xdebug-bridge/vite.config.ts
+++ b/packages/php-wasm/xdebug-bridge/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
 
@@ -26,7 +27,15 @@ export default defineConfig({
 		sourcemap: true,
 		target: 'node20',
 	},
+	test: {
+		globals: true,
+		cache: {
+			dir: '../../../node_modules/.vitest',
+		},
+		environment: 'node',
+		reporters: ['default'],
+	},
 	define: {
 		'import.meta.vitest': undefined,
 	},
-}); 
+});

--- a/packages/php-wasm/xdebug-bridge/vite.config.ts
+++ b/packages/php-wasm/xdebug-bridge/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+	plugins: [],
+	build: {
+		lib: {
+			entry: {
+				index: resolve(__dirname, 'src/index.ts'),
+				cli: resolve(__dirname, 'src/cli.ts'),
+			},
+			formats: ['es', 'cjs'],
+			fileName: (format, entryName) => {
+				if (format === 'es') {
+					return `${entryName}.js`;
+				}
+				return `${entryName}.cjs`;
+			},
+		},
+		rollupOptions: {
+			external: ['net', 'events', 'util'],
+			output: {
+				exports: 'named',
+			},
+		},
+		sourcemap: true,
+		target: 'node20',
+	},
+	define: {
+		'import.meta.vitest': undefined,
+	},
+}); 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -38,6 +38,9 @@
 			"@php-wasm/web-service-worker": [
 				"packages/php-wasm/web-service-worker/src/index.ts"
 			],
+			"@php-wasm/xdebug-bridge": [
+				"packages/php-wasm/xdebug-bridge/src/index.ts"
+			],
 			"@wp-playground/blueprints": [
 				"packages/playground/blueprints/src/index.ts"
 			],


### PR DESCRIPTION
## Motivation for the change, related issues

Adds a mock, AI-generated `@php-wasm/xdebug-bridge` package to jumpstart the work on [XDebug in browser devtools](https://github.com/WordPress/wordpress-playground/pull/2288).

Cursor prompt:

> Create a new package `@php-wasm/xdebug-bridge` with a startXDebugBridge() function that starts a plain network server, It should accept a few config params via an object, e.g. protocol ("cdp"), xdebugServerPort (number, default to xdebug default port).
> 
> It should also ship a CLI script that can be used to run that function from CLI. Accept CLI args, print useful information, but make sure startXDebugBridge() can still be executed without printing anything to console.

## Testing Instructions (or ideally a Blueprint)

Confirm it doesn't break the CI.

cc @mho22 