### PR TITLE
[Playground CLI] Kebab-case yargs options declarations

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -157,7 +157,7 @@ export async function parseOptionsAndRunCLI() {
 			type: 'boolean',
 			default: false,
 		})
-		.option('experimentalTrace', {
+		.option('experimental-trace', {
 			describe:
 				'Print detailed messages about system behavior to the console. Useful for troubleshooting.',
 			type: 'boolean',
@@ -179,7 +179,7 @@ export async function parseOptionsAndRunCLI() {
 			default: false,
 		})
 		// TODO: Should we make this a hidden flag?
-		.option('experimentalMultiWorker', {
+		.option('experimental-multi-worker', {
 			describe:
 				'Enable experimental multi-worker support which requires JSPI ' +
 				'and a /wordpress directory backed by a real filesystem. ' +
@@ -208,8 +208,8 @@ export async function parseOptionsAndRunCLI() {
 				}
 			}
 
-			if (args.experimentalMultiWorker !== undefined) {
-				if (args.experimentalMultiWorker <= 1) {
+			if (args['experimental-multi-worker'] !== undefined) {
+				if (args['experimental-multi-worker'] <= 1) {
 					throw new Error(
 						'The --experimentalMultiWorker flag must be a positive integer greater than 1.'
 					);


### PR DESCRIPTION
## Motivation for the change, related issues

Short and sweet consistency change in Playground CLI. All yargs options are now declared using kebab-case.

## Testing Instructions (or ideally a Blueprint)

Confirm we're not breaking CI checks.
