### PR TITLE
[Playground CLI] Improve error reporting

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -1,8 +1,4 @@
 import { parseOptionsAndRunCLI } from './run-cli';
 
 // Do not await this as top-level await is not supported in all environments.
-parseOptionsAndRunCLI().catch((e: any) => {
-	// eslint-disable-next-line no-console
-	console.error(e);
-	process.exit(1);
-});
+parseOptionsAndRunCLI();

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -44,215 +44,229 @@ import { BlueprintsV2Handler } from './blueprints-v2/blueprints-v2-handler';
 import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
 
 export async function parseOptionsAndRunCLI() {
-	/**
-	 * @TODO This looks similar to Query API args https://wordpress.github.io/wordpress-playground/developers/apis/query-api/
-	 *       Perhaps the two could be handled by the same code?
-	 */
-	const yargsObject = yargs(process.argv.slice(2))
-		.usage('Usage: wp-playground <command> [options]')
-		.positional('command', {
-			describe: 'Command to run',
-			choices: ['server', 'run-blueprint', 'build-snapshot'] as const,
-			demandOption: true,
-		})
-		.option('outfile', {
-			describe: 'When building, write to this output file.',
-			type: 'string',
-			default: 'wordpress.zip',
-		})
-		.option('port', {
-			describe: 'Port to listen on when serving.',
-			type: 'number',
-			default: 9400,
-		})
-		.option('php', {
-			describe: 'PHP version to use.',
-			type: 'string',
-			default: RecommendedPHPVersion,
-			choices: SupportedPHPVersions,
-		})
-		.option('wp', {
-			describe: 'WordPress version to use.',
-			type: 'string',
-			default: 'latest',
-		})
-		// @TODO: Support read-only mounts, e.g. via WORKERFS, a custom
-		// ReadOnlyNODEFS, or by copying the files into MEMFS
-		.option('mount', {
-			describe:
-				'Mount a directory to the PHP runtime (can be used multiple times). Format: /host/path:/vfs/path',
-			type: 'array',
-			string: true,
-			coerce: parseMountWithDelimiterArguments,
-		})
-		.option('mount-before-install', {
-			describe:
-				'Mount a directory to the PHP runtime before WordPress installation (can be used multiple times). Format: /host/path:/vfs/path',
-			type: 'array',
-			string: true,
-			coerce: parseMountWithDelimiterArguments,
-		})
-		.option('mount-dir', {
-			describe:
-				'Mount a directory to the PHP runtime (can be used multiple times). Format: "/host/path" "/vfs/path"',
-			type: 'array',
-			nargs: 2,
-			array: true,
-			// coerce: parseMountDirArguments,
-		})
-		.option('mount-dir-before-install', {
-			describe:
-				'Mount a directory before WordPress installation (can be used multiple times). Format: "/host/path" "/vfs/path"',
-			type: 'string',
-			nargs: 2,
-			array: true,
-			coerce: parseMountDirArguments,
-		})
-		.option('login', {
-			describe: 'Should log the user in',
-			type: 'boolean',
-			default: false,
-		})
-		.option('blueprint', {
-			describe: 'Blueprint to execute.',
-			type: 'string',
-		})
-		.option('blueprint-may-read-adjacent-files', {
-			describe:
-				'Consent flag: Allow "bundled" resources in a local blueprint to read files in the same directory as the blueprint file.',
-			type: 'boolean',
-			default: false,
-		})
-		.option('skip-wordpress-setup', {
-			describe:
-				'Do not download, unzip, and install WordPress. Useful for mounting a pre-configured WordPress directory at /wordpress.',
-			type: 'boolean',
-			default: false,
-		})
-		.option('skip-sqlite-setup', {
-			describe:
-				'Skip the SQLite integration plugin setup to allow the WordPress site to use MySQL.',
-			type: 'boolean',
-			default: false,
-		})
-		.option('quiet', {
-			describe: 'Do not output logs and progress messages.',
-			type: 'boolean',
-			default: false,
-		})
-		.option('debug', {
-			describe:
-				'Print PHP error log content if an error occurs during Playground boot.',
-			type: 'boolean',
-			default: false,
-		})
-		.option('auto-mount', {
-			describe: `Automatically mount the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.`,
-			type: 'boolean',
-			default: false,
-		})
-		.option('follow-symlinks', {
-			describe:
-				'Allow Playground to follow symlinks by automatically mounting symlinked directories and files encountered in mounted directories. \nWarning: Following symlinks will expose files outside mounted directories to Playground and could be a security risk.',
-			type: 'boolean',
-			default: false,
-		})
-		.option('experimental-trace', {
-			describe:
-				'Print detailed messages about system behavior to the console. Useful for troubleshooting.',
-			type: 'boolean',
-			default: false,
-			// Hide this option because we want to replace with a more general log-level flag.
-			hidden: true,
-		})
-		.option('internal-cookie-store', {
-			describe:
-				'Enable internal cookie handling. When enabled, Playground will manage cookies internally using ' +
-				'an HttpCookieStore that persists cookies across requests. When disabled, cookies are handled ' +
-				'externally (e.g., by a browser in Node.js environments).',
-			type: 'boolean',
-			default: false,
-		})
-		.option('xdebug', {
-			describe: 'Enable Xdebug.',
-			type: 'boolean',
-			default: false,
-		})
-		// TODO: Should we make this a hidden flag?
-		.option('experimental-multi-worker', {
-			describe:
-				'Enable experimental multi-worker support which requires JSPI ' +
-				'and a /wordpress directory backed by a real filesystem. ' +
-				'Pass a positive number to specify the number of workers to use. ' +
-				'Otherwise, default to the number of CPUs minus 1.',
-			type: 'number',
-			coerce: (value?: number) => value ?? cpus().length - 1,
-		})
-		.option('experimental-blueprints-v2-runner', {
-			describe: 'Use the experimental Blueprint V2 runner.',
-			type: 'boolean',
-			default: false,
-			// Remove the "hidden" flag once Blueprint V2 is fully supported
-			hidden: true,
-		})
-		.showHelpOnFail(false)
-		.check(async (args) => {
-			if (args.wp !== undefined && !isValidWordPressSlug(args.wp)) {
-				try {
-					// Check if is valid URL
-					new URL(args.wp);
-				} catch {
-					throw new Error(
-						'Unrecognized WordPress version. Please use "latest", a URL, or a numeric version such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
-					);
-				}
-			}
-
-			if (args['experimental-multi-worker'] !== undefined) {
-				if (args['experimental-multi-worker'] <= 1) {
-					throw new Error(
-						'The --experimentalMultiWorker flag must be a positive integer greater than 1.'
-					);
+	try {
+		/**
+		 * @TODO This looks similar to Query API args https://wordpress.github.io/wordpress-playground/developers/apis/query-api/
+		 *       Perhaps the two could be handled by the same code?
+		 */
+		const yargsObject = yargs(process.argv.slice(2))
+			.usage('Usage: wp-playground <command> [options]')
+			.positional('command', {
+				describe: 'Command to run',
+				choices: ['server', 'run-blueprint', 'build-snapshot'] as const,
+				demandOption: true,
+			})
+			.option('outfile', {
+				describe: 'When building, write to this output file.',
+				type: 'string',
+				default: 'wordpress.zip',
+			})
+			.option('port', {
+				describe: 'Port to listen on when serving.',
+				type: 'number',
+				default: 9400,
+			})
+			.option('php', {
+				describe: 'PHP version to use.',
+				type: 'string',
+				default: RecommendedPHPVersion,
+				choices: SupportedPHPVersions,
+			})
+			.option('wp', {
+				describe: 'WordPress version to use.',
+				type: 'string',
+				default: 'latest',
+			})
+			// @TODO: Support read-only mounts, e.g. via WORKERFS, a custom
+			// ReadOnlyNODEFS, or by copying the files into MEMFS
+			.option('mount', {
+				describe:
+					'Mount a directory to the PHP runtime (can be used multiple times). Format: /host/path:/vfs/path',
+				type: 'array',
+				string: true,
+				coerce: parseMountWithDelimiterArguments,
+			})
+			.option('mount-before-install', {
+				describe:
+					'Mount a directory to the PHP runtime before WordPress installation (can be used multiple times). Format: /host/path:/vfs/path',
+				type: 'array',
+				string: true,
+				coerce: parseMountWithDelimiterArguments,
+			})
+			.option('mount-dir', {
+				describe:
+					'Mount a directory to the PHP runtime (can be used multiple times). Format: "/host/path" "/vfs/path"',
+				type: 'array',
+				nargs: 2,
+				array: true,
+				// coerce: parseMountDirArguments,
+			})
+			.option('mount-dir-before-install', {
+				describe:
+					'Mount a directory before WordPress installation (can be used multiple times). Format: "/host/path" "/vfs/path"',
+				type: 'string',
+				nargs: 2,
+				array: true,
+				coerce: parseMountDirArguments,
+			})
+			.option('login', {
+				describe: 'Should log the user in',
+				type: 'boolean',
+				default: false,
+			})
+			.option('blueprint', {
+				describe: 'Blueprint to execute.',
+				type: 'string',
+			})
+			.option('blueprint-may-read-adjacent-files', {
+				describe:
+					'Consent flag: Allow "bundled" resources in a local blueprint to read files in the same directory as the blueprint file.',
+				type: 'boolean',
+				default: false,
+			})
+			.option('skip-wordpress-setup', {
+				describe:
+					'Do not download, unzip, and install WordPress. Useful for mounting a pre-configured WordPress directory at /wordpress.',
+				type: 'boolean',
+				default: false,
+			})
+			.option('skip-sqlite-setup', {
+				describe:
+					'Skip the SQLite integration plugin setup to allow the WordPress site to use MySQL.',
+				type: 'boolean',
+				default: false,
+			})
+			.option('quiet', {
+				describe: 'Do not output logs and progress messages.',
+				type: 'boolean',
+				default: false,
+			})
+			.option('debug', {
+				describe:
+					'Print PHP error log content if an error occurs during Playground boot.',
+				type: 'boolean',
+				default: false,
+			})
+			.option('auto-mount', {
+				describe: `Automatically mount the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.`,
+				type: 'boolean',
+				default: false,
+			})
+			.option('follow-symlinks', {
+				describe:
+					'Allow Playground to follow symlinks by automatically mounting symlinked directories and files encountered in mounted directories. \nWarning: Following symlinks will expose files outside mounted directories to Playground and could be a security risk.',
+				type: 'boolean',
+				default: false,
+			})
+			.option('experimental-trace', {
+				describe:
+					'Print detailed messages about system behavior to the console. Useful for troubleshooting.',
+				type: 'boolean',
+				default: false,
+				// Hide this option because we want to replace with a more general log-level flag.
+				hidden: true,
+			})
+			.option('internal-cookie-store', {
+				describe:
+					'Enable internal cookie handling. When enabled, Playground will manage cookies internally using ' +
+					'an HttpCookieStore that persists cookies across requests. When disabled, cookies are handled ' +
+					'externally (e.g., by a browser in Node.js environments).',
+				type: 'boolean',
+				default: false,
+			})
+			.option('xdebug', {
+				describe: 'Enable Xdebug.',
+				type: 'boolean',
+				default: false,
+			})
+			// TODO: Should we make this a hidden flag?
+			.option('experimental-multi-worker', {
+				describe:
+					'Enable experimental multi-worker support which requires JSPI ' +
+					'and a /wordpress directory backed by a real filesystem. ' +
+					'Pass a positive number to specify the number of workers to use. ' +
+					'Otherwise, default to the number of CPUs minus 1.',
+				type: 'number',
+				coerce: (value?: number) => value ?? cpus().length - 1,
+			})
+			.option('experimental-blueprints-v2-runner', {
+				describe: 'Use the experimental Blueprint V2 runner.',
+				type: 'boolean',
+				default: false,
+				// Remove the "hidden" flag once Blueprint V2 is fully supported
+				hidden: true,
+			})
+			.showHelpOnFail(false)
+			.strictOptions()
+			.check(async (args) => {
+				if (args.wp !== undefined && !isValidWordPressSlug(args.wp)) {
+					try {
+						// Check if is valid URL
+						new URL(args.wp);
+					} catch {
+						throw new Error(
+							'Unrecognized WordPress version. Please use "latest", a URL, or a numeric version such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
+						);
+					}
 				}
 
-				const isMountingWordPressDir = (mount: Mount) =>
-					mount.vfsPath === '/wordpress';
-				if (
-					!args.mount?.some(isMountingWordPressDir) &&
-					!(args['mount-before-install'] as any)?.some(
-						isMountingWordPressDir
-					)
-				) {
-					throw new Error(
-						'Please mount a real filesystem directory as the /wordpress directory before using the --experimentalMultiWorker flag. For example: ' +
-							'--mount-dir-before-install ./empty-dir /wordpress'
-					);
+				if (args['experimental-multi-worker'] !== undefined) {
+					if (args['experimental-multi-worker'] <= 1) {
+						throw new Error(
+							'The --experimentalMultiWorker flag must be a positive integer greater than 1.'
+						);
+					}
+
+					const isMountingWordPressDir = (mount: Mount) =>
+						mount.vfsPath === '/wordpress';
+					if (
+						!args.mount?.some(isMountingWordPressDir) &&
+						!(args['mount-before-install'] as any)?.some(
+							isMountingWordPressDir
+						)
+					) {
+						throw new Error(
+							'Please mount a real filesystem directory as the /wordpress directory before using the --experimentalMultiWorker flag. For example: ' +
+								'--mount-dir-before-install ./empty-dir /wordpress'
+						);
+					}
 				}
-			}
-			return true;
-		});
+				return true;
+			});
 
-	yargsObject.wrap(yargsObject.terminalWidth());
-	const args = await yargsObject.argv;
+		yargsObject.wrap(yargsObject.terminalWidth());
+		const args = await yargsObject.argv;
 
-	const command = args._[0] as string;
+		const command = args._[0] as string;
 
-	if (!['run-blueprint', 'server', 'build-snapshot'].includes(command)) {
-		yargsObject.showHelp();
+		if (!['run-blueprint', 'server', 'build-snapshot'].includes(command)) {
+			yargsObject.showHelp();
+			process.exit(1);
+		}
+
+		const cliArgs = {
+			...args,
+			command,
+			mount: [...(args.mount || []), ...(args['mount-dir'] || [])],
+			'mount-before-install': [
+				...(args['mount-before-install'] || []),
+				...(args['mount-dir-before-install'] || []),
+			],
+		} as RunCLIArgs;
+
+		await runCLI(cliArgs);
+	} catch (e) {
+		if (!(e instanceof Error)) {
+			throw e;
+		}
+		const debug = process.argv.includes('--debug');
+		if (debug) {
+			console.error(e);
+		} else {
+			console.error(e.message);
+		}
 		process.exit(1);
 	}
-
-	const cliArgs = {
-		...args,
-		command,
-		mount: [...(args.mount || []), ...(args['mount-dir'] || [])],
-		'mount-before-install': [
-			...(args['mount-before-install'] || []),
-			...(args['mount-dir-before-install'] || []),
-		],
-	} as RunCLIArgs;
-
-	return runCLI(cliArgs);
 }
 
 export interface RunCLIArgs {


### PR DESCRIPTION
Improves Playground CLI error reporting in two ways:

* Stop printing the stack trace if the `--debug` flag isn't set. The typical errors are similar to "unknown option --blueprin" and displaying the stack trace makes the user experience worse.
* Rejects unrecognized options. Before this PR, a typo in one of the flags will go undetected until the user realizes the CLI doesn't do what they want it to. With this PR, the typo is immediately apparent as the process will short-circuit and report a failure. We still support both kebab-cased and camelCased CLI flags

 ## Testing instructions

Confirm this command prints a short error message:

```
node --experimental-strip-types --experimental-transform-types --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts server --php=8.4 --blueprin=./file.json
```

Add `--debug` and confirm you can see the entire stacktrace
