### PR TITLE
[Blueprints] Rewrite paths in the wp-cli step. Improve error reporting.

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -2,6 +2,7 @@ import type { PHPResponse, UniversalPHP } from '@php-wasm/universal';
 import type { StepHandler } from '.';
 import { joinPaths, phpVar } from '@php-wasm/util';
 import type { FileReference } from '../resources';
+import { logger } from '@php-wasm/logger';
 
 export const defaultWpCliPath = '/tmp/wp-cli.phar';
 export const defaultWpCliResource: FileReference = {
@@ -77,6 +78,46 @@ export const wpCLI: StepHandler<WPCLIStep, Promise<PHPResponse>> = async (
 		throw new Error(`The first argument must be "wp".`);
 	}
 
+	let rewrotePaths = false;
+	const wordpressArgs = args.map((arg) => {
+		if (arg.startsWith('wordpress/')) {
+			rewrotePaths = true;
+			// return `/${arg}`;
+		}
+		return arg;
+	});
+
+	if (rewrotePaths) {
+		logger.error(
+			`
+The wp-cli step in your Blueprint refers to a relative path.
+
+Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
+how real web servers work. This means relative paths that used to work may no longer 
+point to the correct location.
+
+Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
+update your code to use an absolute path instead:
+
+Instead of:
+
+        {
+            "step": "wp-cli",
+            "command": "wp media import wordpress/wp-content/Select-storage-method.png --post_id=4 --title='Select your storage method' --featured_image"
+        }
+
+Use:
+
+        {
+            "step": "wp-cli",
+            "command": "wp media import /wordpress/wp-content/Select-storage-method.png --post_id=4 --title='Select your storage method' --featured_image"
+        }
+
+This will ensure your code works reliably regardless of the current working directory.
+        `.trim()
+		);
+	}
+
 	const documentRoot = await playground.documentRoot;
 
 	await playground.writeFile('/tmp/stdout', '');
@@ -96,7 +137,7 @@ export const wpCLI: StepHandler<WPCLIStep, Promise<PHPResponse>> = async (
 		$GLOBALS['argv'] = array_merge([
 		  "/tmp/wp-cli.phar",
 		  "--path=${documentRoot}"
-		], ${phpVar(args)});
+		], ${phpVar(wordpressArgs)});
 
 		// Provide stdin, stdout, stderr streams outside of
 		// the CLI SAPI.

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -79,10 +79,10 @@ export const wpCLI: StepHandler<WPCLIStep, Promise<PHPResponse>> = async (
 	}
 
 	let rewrotePaths = false;
-	const wordpressArgs = args.map((arg) => {
+	const argsWithRewrittenPaths = args.map((arg) => {
 		if (arg.startsWith('wordpress/')) {
 			rewrotePaths = true;
-			// return `/${arg}`;
+			return `/${arg}`;
 		}
 		return arg;
 	});
@@ -137,7 +137,7 @@ This will ensure your code works reliably regardless of the current working dire
 		$GLOBALS['argv'] = array_merge([
 		  "/tmp/wp-cli.phar",
 		  "--path=${documentRoot}"
-		], ${phpVar(wordpressArgs)});
+		], ${phpVar(argsWithRewrittenPaths)});
 
 		// Provide stdin, stdout, stderr streams outside of
 		// the CLI SAPI.

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -4,7 +4,12 @@ import type {
 	RemoteAPI,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
-import { PHPResponse, exposeAPI, exposeSyncAPI } from '@php-wasm/universal';
+import {
+	PHPResponse,
+	exposeAPI,
+	exposeSyncAPI,
+	printDebugDetails,
+} from '@php-wasm/universal';
 import type {
 	BlueprintBundle,
 	BlueprintDeclaration,
@@ -261,9 +266,16 @@ export async function parseOptionsAndRunCLI() {
 		}
 		const debug = process.argv.includes('--debug');
 		if (debug) {
-			console.error(e);
+			printDebugDetails(e);
 		} else {
-			console.error(e.message);
+			const messageChain = [];
+			do {
+				messageChain.push(e.message);
+				e = e.cause;
+			} while (e instanceof Error);
+			console.error(
+				'\x1b[1m' + messageChain.join(' caused by ') + '\x1b[0m'
+			);
 		}
 		process.exit(1);
 	}
@@ -541,7 +553,10 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 				if (!args.debug) {
 					throw error;
 				}
-				const phpLogs = await playground.readFileAsText(errorLogPath);
+				let phpLogs = '';
+				if (await playground.fileExists(errorLogPath)) {
+					phpLogs = await playground.readFileAsText(errorLogPath);
+				}
 				throw new Error(phpLogs, { cause: error });
 			}
 		},

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -269,10 +269,11 @@ export async function parseOptionsAndRunCLI() {
 			printDebugDetails(e);
 		} else {
 			const messageChain = [];
+			let currentError = e;
 			do {
-				messageChain.push(e.message);
-				e = e.cause;
-			} while (e instanceof Error);
+				messageChain.push(currentError.message);
+				currentError = currentError.cause as Error;
+			} while (currentError instanceof Error);
 			console.error(
 				'\x1b[1m' + messageChain.join(' caused by ') + '\x1b[0m'
 			);


### PR DESCRIPTION
## Motivation for the change, related issues

Playground have recently changed cwd from / to /wordpress to mimic what nginx, apache, and other webservers do. Unfortunately, many Blueprints use root-based relative paths in the `wp-cli` step. This PR detects them, rewrites them as absolute paths, and explains the problem in an error message. This PR follows up on https://github.com/WordPress/wordpress-playground/pull/2268


## Testing Instructions (or ideally a Blueprint)

Confirm the following behavior:

**Before this PR:**

```
$ node --experimental-wasm-jspi --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/playground/cli/src/cli.ts server -blueprint=https://raw.githubusercontent.com/wordpress/blueprints/refs/heads/trunk/blueprints/wpcli-post-with-image/blueprint.json
Starting a PHP server...
Setting up WordPress latest
Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.8.2.zip
Fetching SQLite integration plugin...
Booting WordPress...
Booted!
Running the Blueprint...
Downloading wp-cli.phar – 83%PHP.run() output was: #!/usr/bin/env php

PHPExecutionFailureError: PHP.run() failed with exit code 1 and the following output: Warning: Unable to import file 'wordpress/wp-content/Select-storage-method.png'. Reason: File doesn't exist.
```

**After this PR:**

```
$ Starting a PHP server...
Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.8.2.zip
Fetching SQLite integration plugin...
Booting WordPress...
Booted!
Running the Blueprint...
Downloading wp-cli.phar – 66%The wp-cli step in your Blueprint refers to a relative path.

Playground recently changed the working directory from '/' to '/wordpress' to better mimic 
how real web servers work. This means relative paths that used to work may no longer 
point to the correct location.

Playground automatically updated the path for you, but at one point path rewriting will be removed. Please
update your code to use an absolute path instead:

Instead of:

        {
            "step": "wp-cli",
            "command": "wp media import wordpress/wp-content/Select-storage-method.png --post_id=4 --title='Select your storage method' --featured_image"
        }

Use:

        {
            "step": "wp-cli",
            "command": "wp media import /wordpress/wp-content/Select-storage-method.png --post_id=4 --title='Select your storage method' --featured_image"
        }

This will ensure your code works reliably regardless of the current working directory.
Downloading wp-cli.phar – 100%
Logging in – 100%
Finished running the blueprint
WordPress is running on http://127.0.0.1:9400
```


Also, the error reporting was improved so, without the path rewriting, the error message would now be:

```
Error when executing the blueprint step #4 ({"step":"wp-cli","command":"wp media import wordpress/wp-content/Select-storage-method.png --post_id=4 --title='Select your storage method' --featured_image"}) : Comlink method call failed > caused by > Comlink method call failed > caused by > PHP.run() failed with exit code 1. 

=== Stdout ===
 #!/usr/bin/env php


=== Stderr ===
 Warning: Unable to import file 'wordpress/wp-content/Select-storage-method.png'. Reason: File doesn't exist.
Error: No images imported.
```