### PR TITLE
[Comlink] Throw the original error in the error handler

### DIFF
--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -278,11 +278,22 @@ const throwTransferHandlerCustom: Comlink.TransferHandler<
 		if (serialized.isError) {
 			const error = ErrorSerializer.deserializeError(serialized.value);
 			/**
-			 * Rethrow to capture the stack trace of the original Comlink call.
+			 * The original error from the web worker does not include any call
+			 * stack from the Playground web app. Let's include that information
+			 * in the error chain.
+			 *
+			 * We'll place it at the bottom of the error chain. This way the API
+			 * consumer gets the original error object and not an opaque
+			 * "Comlink method call failed" error, but they can still inspect
+			 * it further to see the full call stack.
 			 */
-			throw new Error('Comlink method call failed', {
-				cause: error,
-			});
+			const additionalCallStack = new Error('Comlink method call failed');
+			let deepestError = error;
+			while (deepestError.cause) {
+				deepestError = deepestError.cause;
+			}
+			deepestError.cause = additionalCallStack;
+			throw error;
 		}
 		throw serialized.value;
 	},


### PR DESCRIPTION
## Motivation for the change, related issues

The [new Comlink error handler](https://github.com/WordPress/wordpress-playground/pull/2357) rewired the logic around passing errors from web workers to the Playground web app. Specifically, it enriched the error with additional stack trace before rethrowing it:

```js
throw new Error('Comlink method call failed', {
	cause: originalError
});
```

Unfortunately, this also put the original error at the bottom of the `error.cause` chain, making error handling confusing for the API consumers.

This PR ensures the thrown error the original one. This way a simple `try {} catch(e) {}` is enough to log the error details without having to reason about `e.cause.cause` etc. The additional stack trace information is now attached at the bottom of the cause chain for when the developer needs to inspect it.

## Testing Instructions (or ideally a Blueprint)

Run Playground with this Blueprint and confirm the top-level error message speaks about PHP failure. Specifically, it should not say "Comlink method call failed":

```json
{
  "steps": [
    {
      "step": "mkdir",
      "path": "/wordpress/wp-content/mu-plugins"
    },
    {
      "step": "writeFile",
      "path": "/wordpress/wp-content/mu-plugins/test.php",
      "data": "<?php undefined_function();"
    }
  ]
}
```