### PR TITLE
[Build] Preserve optionalDependencies in built package.json

### DIFF
--- a/packages/nx-extensions/src/executors/package-json/executor.ts
+++ b/packages/nx-extensions/src/executors/package-json/executor.ts
@@ -44,6 +44,17 @@ export default async function* packageJsonExecutor(
 	}
 
 	const monorepoDependencies = getMonorepoDependencies(context);
+
+	// Read optional dependencies from the original package.json
+	let originalOptionalDependencies: Record<string, string> | undefined;
+	const originalPackageJsonPath = `${context.root}/package.json`;
+	if (fs.existsSync(originalPackageJsonPath)) {
+		const originalPackageJson = JSON.parse(
+			fs.readFileSync(originalPackageJsonPath).toString()
+		);
+		originalOptionalDependencies = originalPackageJson.optionalDependencies;
+	}
+
 	for await (const event of startBuild(options, context)) {
 		if (!event.success) {
 			throw 'There was an error with the build. See above.';
@@ -54,7 +65,8 @@ export default async function* packageJsonExecutor(
 				options,
 				context,
 				helperDependencies,
-				monorepoDependencies
+				monorepoDependencies,
+				originalOptionalDependencies
 			);
 			if (built === false) {
 				return {
@@ -87,7 +99,8 @@ async function buildPackageJson(
 	options: PackageJsonExecutorSchema,
 	context: ExecutorContext,
 	helperDependencies: ProjectGraphDependency[],
-	monorepoDependencies: MonorepoDependency[]
+	monorepoDependencies: MonorepoDependency[],
+	originalOptionalDependencies?: Record<string, string>
 ) {
 	const packageJson = createPackageJson(
 		context.projectName,
@@ -116,6 +129,21 @@ async function buildPackageJson(
 
 	for (const dep of monorepoDependencies) {
 		packageJson.dependencies[dep.name] = dep.version;
+	}
+
+	// Preserve optionalDependencies from the original package.json
+	if (originalOptionalDependencies) {
+		packageJson.optionalDependencies = originalOptionalDependencies;
+
+		// Remove optional dependencies from regular dependencies to avoid duplication
+		for (const optionalDep of Object.keys(originalOptionalDependencies)) {
+			if (
+				packageJson.dependencies &&
+				packageJson.dependencies[optionalDep]
+			) {
+				delete packageJson.dependencies[optionalDep];
+			}
+		}
 	}
 
 	// make main relative to context root


### PR DESCRIPTION
## Motivation for the change, related issues

The `fs-ext` package is listed under `"optionalDependencies"` in the top-level package.json. However, in the built packages, it becomes a regular `dependency`. This PR makes sure that all the `optionalDependencies` remain `optionalDependencies` in the final built package.

## Testing Instructions (or ideally a Blueprint)

Run `npm run build` and confirm that the built `@wp-playground/cli` and `@php-wasm/node` list `fs-ext` under `optionalDependencies` and not under `dependencies`.