### PR TITLE
[XDebug Bridge] Exclude file and directory paths from devtools stack and debugging 

### DIFF
--- a/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
@@ -11,6 +11,7 @@ export type StartBridgeConfig = {
 	cdpHost?: string;
 	dbgpPort?: number;
 	phpRoot?: string;
+	excludedPaths?: string[];
 	phpInstance?: UniversalPHP;
 	getPHPFile?: (path: string) => string | Promise<string>;
 	breakOnFirstLine?: boolean;
@@ -22,6 +23,7 @@ export async function startBridge(config: StartBridgeConfig) {
 	const cdpHost = config.cdpHost ?? '127.0.0.1';
 	const phpRoot = config.phpRoot ?? process.cwd();
 	const breakOnFirstLine = config.breakOnFirstLine ?? false;
+	const excludedPaths = config.excludedPaths ?? [];
 
 	logger.log('Starting XDebug Bridge...');
 
@@ -43,8 +45,14 @@ export async function startBridge(config: StartBridgeConfig) {
 	logger.log(`XDebug receiver running on port ${dbgpPort}`);
 	logger.log('Running a PHP script with Xdebug enabled...');
 
-	// Recursively get a list of .php files in phpRoot
+	// Recursively get a list of .php files in phpRoot, skipping any directory
+	// that matches an excluded path prefix. Skipping early avoids walking into
+	// large trees like /internal/shared, node_modules, or wp-includes when the
+	// caller doesn't want them in the DevTools file tree.
 	async function getPhpFiles(dir: string): Promise<string[]> {
+		if (excludedPaths.some((prefix) => dir.startsWith(prefix))) {
+			return [];
+		}
 		const results: string[] = [];
 		const list = config.phpInstance
 			? await config.phpInstance!.listFiles(dir)
@@ -80,5 +88,6 @@ export async function startBridge(config: StartBridgeConfig) {
 		phpRoot,
 		getPHPFile,
 		breakOnFirstLine,
+		excludedPaths,
 	});
 }

--- a/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
@@ -45,9 +45,15 @@ export async function startBridge(config: StartBridgeConfig) {
 	logger.log(`XDebug receiver running on port ${dbgpPort}`);
 	logger.log('Running a PHP script with Xdebug enabled...');
 
+	function isExcluded(p: string): boolean {
+		return excludedPaths.some(
+			(prefix) => p === prefix || p.startsWith(prefix + '/')
+		);
+	}
+
 	// Recursively get a list of .php files in phpRoot
 	async function getPhpFiles(dir: string): Promise<string[]> {
-		if (excludedPaths.some((prefix) => dir.startsWith(prefix))) {
+		if (isExcluded(dir)) {
 			return [];
 		}
 		const results: string[] = [];
@@ -56,6 +62,9 @@ export async function startBridge(config: StartBridgeConfig) {
 			: readdirSync(dir);
 		for (const file of list) {
 			const filePath = path.join(dir, file);
+			if (isExcluded(filePath)) {
+				continue;
+			}
 			try {
 				// lstat avoids crashes when encountering symlinks
 				const stat = config.phpInstance

--- a/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
@@ -45,10 +45,7 @@ export async function startBridge(config: StartBridgeConfig) {
 	logger.log(`XDebug receiver running on port ${dbgpPort}`);
 	logger.log('Running a PHP script with Xdebug enabled...');
 
-	// Recursively get a list of .php files in phpRoot, skipping any directory
-	// that matches an excluded path prefix. Skipping early avoids walking into
-	// large trees like /internal/shared, node_modules, or wp-includes when the
-	// caller doesn't want them in the DevTools file tree.
+	// Recursively get a list of .php files in phpRoot
 	async function getPhpFiles(dir: string): Promise<string[]> {
 		if (excludedPaths.some((prefix) => dir.startsWith(prefix))) {
 			return [];

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -34,6 +34,7 @@ export interface XdebugCDPBridgeConfig {
 	phpRoot?: string;
 	getPHPFile(path: string): string | Promise<string>;
 	breakOnFirstLine?: boolean;
+	excludedPaths?: string[];
 }
 
 export class XdebugCDPBridge {
@@ -51,6 +52,7 @@ export class XdebugCDPBridge {
 	private phpRoot: string;
 	private readPHPFile: (path: string) => string | Promise<string>;
 	private breakOnFirstLine;
+	private excludedPaths: string[];
 
 	constructor(
 		dbgp: DbgpSession,
@@ -61,6 +63,7 @@ export class XdebugCDPBridge {
 		this.cdp = cdp;
 		this.readPHPFile = config.getPHPFile;
 		this.phpRoot = config.phpRoot || '';
+		this.excludedPaths = config.excludedPaths || [];
 		for (const url of config.knownScriptUrls) {
 			this.scriptIdByUrl.set(url, this.getOrCreateScriptId(url));
 		}
@@ -253,6 +256,12 @@ export class XdebugCDPBridge {
 			this.scriptIdByUrl.set(url, scriptId);
 		}
 		return scriptId;
+	}
+
+	private isExcludedPath(fileUri: string): boolean {
+		return this.excludedPaths.some((prefix) =>
+			fileUri.startsWith(prefix)
+		);
 	}
 
 	// Utility: escape and quote Xdebug fullname for property_get
@@ -690,10 +699,15 @@ export class XdebugCDPBridge {
 						);
 
 						if (bridgeUri && !this.scriptIdByUrl.has(bridgeUri)) {
-							await this.sendScriptToCDP(
-								bridgeUri,
-								this.getOrCreateScriptId(bridgeUri)
-							);
+							if (this.isExcludedPath(bridgeUri)) {
+								this.sendDbgpCommand('step_over');
+								break;
+							} else {
+								await this.sendScriptToCDP(
+									bridgeUri,
+									this.getOrCreateScriptId(bridgeUri)
+								);
+							}
 						}
 					}
 					if (status === 'break') {

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -197,7 +197,14 @@ export class XdebugCDPBridge {
 				.map((_value, index) => (index === 0 ? 'AAAA' : 'AACA'))
 				.join(';');
 
-			const sourceMap = {
+			const sourceMap: {
+				version: number;
+				file: string;
+				sources: string[];
+				sourcesContent: string[];
+				mappings: string;
+				x_google_ignoreList?: number[];
+			} = {
 				version: 3,
 				// File uri has to match the script parsed url
 				// While the sources url has to match the syntax
@@ -207,6 +214,10 @@ export class XdebugCDPBridge {
 				sourcesContent: [phpContent],
 				mappings,
 			};
+
+			if (this.isExcludedPath(url)) {
+				sourceMap.x_google_ignoreList = [0];
+			}
 
 			const encodedMap = Buffer.from(
 				JSON.stringify(sourceMap),
@@ -259,9 +270,7 @@ export class XdebugCDPBridge {
 	}
 
 	private isExcludedPath(fileUri: string): boolean {
-		return this.excludedPaths.some((prefix) =>
-			fileUri.startsWith(prefix)
-		);
+		return this.excludedPaths.some((prefix) => fileUri.startsWith(prefix));
 	}
 
 	// Utility: escape and quote Xdebug fullname for property_get
@@ -699,15 +708,10 @@ export class XdebugCDPBridge {
 						);
 
 						if (bridgeUri && !this.scriptIdByUrl.has(bridgeUri)) {
-							if (this.isExcludedPath(bridgeUri)) {
-								this.sendDbgpCommand('step_over');
-								break;
-							} else {
-								await this.sendScriptToCDP(
-									bridgeUri,
-									this.getOrCreateScriptId(bridgeUri)
-								);
-							}
+							await this.sendScriptToCDP(
+								bridgeUri,
+								this.getOrCreateScriptId(bridgeUri)
+							);
 						}
 					}
 					if (status === 'break') {
@@ -899,7 +903,7 @@ export class XdebugCDPBridge {
 											? this.objectHandles.get(
 													pending.params
 														.parentObjectId
-											  )?.contextId || 0
+												)?.contextId || 0
 											: 0;
 									const depth =
 										pending.cdpMethod ===
@@ -908,7 +912,7 @@ export class XdebugCDPBridge {
 											? this.objectHandles.get(
 													pending.params
 														.parentObjectId
-											  )?.depth || 0
+												)?.depth || 0
 											: 0;
 									// Use same depth/context as parent
 									this.objectHandles.set(childObjectId, {

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -270,7 +270,9 @@ export class XdebugCDPBridge {
 	}
 
 	private isExcludedPath(fileUri: string): boolean {
-		return this.excludedPaths.some((prefix) => fileUri.startsWith(prefix));
+		return this.excludedPaths.some(
+			(prefix) => fileUri === prefix || fileUri.startsWith(prefix + '/')
+		);
 	}
 
 	// Utility: escape and quote Xdebug fullname for property_get

--- a/packages/php-wasm/xdebug-bridge/src/test/start-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/test/start-bridge.spec.ts
@@ -22,7 +22,6 @@ describe('Bridge', () => {
 			if (event === 'clientConnected') {
 				setTimeout(cb, 0);
 			}
-
 			return this;
 		});
 	});
@@ -146,6 +145,46 @@ describe('Bridge', () => {
 				'/foo/baz/qux.php',
 			]);
 		});
+
+		it('forwards excludedPaths to the bridge', async () => {
+			const paths = ['/foo', '/bar'];
+
+			await startBridge({ excludedPaths: paths });
+
+			const args = (XdebugCDPBridge as any).mock.calls[0][2];
+
+			expect(args.excludedPaths).toEqual(paths);
+		});
+
+		it('skips excluded directories while walking the filesystem', async () => {
+			const filesystem: Record<string, string[]> = {
+				'/foo': ['bar.php', 'internal'],
+				'/foo/internal': ['shared'],
+				'/foo/internal/shared': ['skip-me.php'],
+			};
+
+			const php: Partial<PHP> = {
+				listFiles: vi.fn(
+					(directory: string) => filesystem[directory] || []
+				),
+				isDir: vi.fn((path: string) => path in filesystem),
+			};
+
+			await startBridge({
+				phpInstance: php as PHP,
+				phpRoot: '/foo',
+				excludedPaths: ['/foo/internal'],
+			});
+
+			const args = (XdebugCDPBridge as any).mock.calls[0][2];
+
+			// Excluded directories should be pruned from the initial enumeration
+			// so DevTools never receives them (and listFiles is never called on them).
+			expect(args.knownScriptUrls).toEqual(['/foo/bar.php']);
+			expect(php.listFiles).not.toHaveBeenCalledWith('/foo/internal');
+			expect(php.listFiles).not.toHaveBeenCalledWith(
+				'/foo/internal/shared'
+			);
 	});
 
 	describe('Log', () => {

--- a/packages/php-wasm/xdebug-bridge/src/test/start-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/test/start-bridge.spec.ts
@@ -156,6 +156,9 @@ describe('Bridge', () => {
 			expect(args.excludedPaths).toEqual(paths);
 		});
 
+		// Excluded prefixes prune the recursive walk so we never enumerate
+		// huge trees like /internal/shared, node_modules, or wp-includes
+		// that DevTools has no business listing.
 		it('skips excluded directories while walking the filesystem', async () => {
 			const filesystem: Record<string, string[]> = {
 				'/foo': ['bar.php', 'internal'],
@@ -178,13 +181,16 @@ describe('Bridge', () => {
 
 			const args = (XdebugCDPBridge as any).mock.calls[0][2];
 
-			// Excluded directories should be pruned from the initial enumeration
-			// so DevTools never receives them (and listFiles is never called on them).
+			// Only the non-excluded file is reported.
 			expect(args.knownScriptUrls).toEqual(['/foo/bar.php']);
+
+			// And we never recursed into the excluded subtree at all —
+			// no listFiles call ever hits it.
 			expect(php.listFiles).not.toHaveBeenCalledWith('/foo/internal');
 			expect(php.listFiles).not.toHaveBeenCalledWith(
 				'/foo/internal/shared'
 			);
+		});
 	});
 
 	describe('Log', () => {

--- a/packages/php-wasm/xdebug-bridge/src/test/xdebug-cdp-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/test/xdebug-cdp-bridge.spec.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import { createHash } from 'crypto';
 import { vi } from 'vitest';
+import { createHash } from 'crypto';
 import { DbgpSession } from '../lib/dbgp-session';
 import { CDPServer } from '../lib/cdp-server';
 import { XdebugCDPBridge } from '../lib/xdebug-cdp-bridge';
@@ -366,6 +366,7 @@ describe('XdebugCDPBridge', () => {
 			vi.spyOn(cdpServer, 'sendMessage').mockImplementation((message) => {
 				if (message.method === 'Debugger.scriptParsed') {
 					script = message;
+
 					resolve();
 				}
 				return originalSendMessage(message);

--- a/packages/php-wasm/xdebug-bridge/src/test/xdebug-cdp-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/test/xdebug-cdp-bridge.spec.ts
@@ -451,4 +451,61 @@ describe('XdebugCDPBridge', () => {
 			expect.objectContaining({ method: 'Debugger.scriptParsed' })
 		);
 	});
+
+	// Excluded paths are surfaced to DevTools through the source map's
+	// x_google_ignoreList field. DevTools then drives the step-over /
+	// step-into behavior (skipping ignored frames, hiding them from stack
+	// traces, etc.) — the bridge's only job is to tag the right scripts.
+	it('tags excluded scripts via x_google_ignoreList in the source map', async () => {
+		bridge.stop();
+
+		// Arrange: two scripts, one inside the excluded prefix, one outside.
+		const ignoredScript = `${fixtures}/array.php`;
+		const userScript = `${fixtures}/test.php`;
+
+		dbgpSession = new DbgpSession();
+		cdpServer = new CDPServer();
+		bridge = new XdebugCDPBridge(dbgpSession, cdpServer, {
+			knownScriptUrls: [ignoredScript, userScript],
+			getPHPFile: (file) => php.readFileAsText(file),
+			excludedPaths: [ignoredScript],
+		});
+
+		// Act: start the bridge and decode every source map it emits,
+		// keyed by the original PHP file URI inside `sources`.
+		const sourceMapsByPhpFile: Record<string, any> = {};
+
+		await new Promise<void>((resolve) => {
+			const original = cdpServer.sendMessage.bind(cdpServer);
+			vi.spyOn(cdpServer, 'sendMessage').mockImplementation((message) => {
+				if (message.method === 'Debugger.scriptParsed') {
+					const sourceMap = JSON.parse(
+						Buffer.from(
+							message.params.sourceMapURL.split(',')[1],
+							'base64'
+						).toString('utf8')
+					);
+					sourceMapsByPhpFile[sourceMap.sources[0]] = sourceMap;
+
+					if (Object.keys(sourceMapsByPhpFile).length === 2) {
+						resolve();
+					}
+				}
+				return original(message);
+			});
+
+			bridge.start();
+		});
+
+		// Assert: only the ignored script carries the ignore-list entry;
+		// the user script's source map stays untouched.
+		expect(
+			sourceMapsByPhpFile[`file://PHP.wasm/${ignoredScript}`]
+				.x_google_ignoreList
+		).toEqual([0]);
+		expect(
+			sourceMapsByPhpFile[`file://PHP.wasm/${userScript}`]
+				.x_google_ignoreList
+		).toBeUndefined();
+	});
 });

--- a/packages/php-wasm/xdebug-bridge/src/test/xdebug-cdp-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/test/xdebug-cdp-bridge.spec.ts
@@ -471,9 +471,10 @@ describe('XdebugCDPBridge', () => {
 			excludedPaths: [ignoredScript],
 		});
 
-		// Act: start the bridge and decode every source map it emits,
-		// keyed by the original PHP file URI inside `sources`.
-		const sourceMapsByPhpFile: Record<string, any> = {};
+		// Act: start the bridge and decode the source maps for the two
+		// scripts we care about, identifying each by its original path.
+		let ignoredMap: any;
+		let userMap: any;
 
 		await new Promise<void>((resolve) => {
 			const original = cdpServer.sendMessage.bind(cdpServer);
@@ -485,9 +486,13 @@ describe('XdebugCDPBridge', () => {
 							'base64'
 						).toString('utf8')
 					);
-					sourceMapsByPhpFile[sourceMap.sources[0]] = sourceMap;
-
-					if (Object.keys(sourceMapsByPhpFile).length === 2) {
+					const source = sourceMap.sources[0];
+					if (source.endsWith(ignoredScript)) {
+						ignoredMap = sourceMap;
+					} else if (source.endsWith(userScript)) {
+						userMap = sourceMap;
+					}
+					if (ignoredMap && userMap) {
 						resolve();
 					}
 				}
@@ -499,13 +504,7 @@ describe('XdebugCDPBridge', () => {
 
 		// Assert: only the ignored script carries the ignore-list entry;
 		// the user script's source map stays untouched.
-		expect(
-			sourceMapsByPhpFile[`file://PHP.wasm/${ignoredScript}`]
-				.x_google_ignoreList
-		).toEqual([0]);
-		expect(
-			sourceMapsByPhpFile[`file://PHP.wasm/${userScript}`]
-				.x_google_ignoreList
-		).toBeUndefined();
+		expect(ignoredMap.x_google_ignoreList).toEqual([0]);
+		expect(userMap.x_google_ignoreList).toBeUndefined();
 	});
 });

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1696,6 +1696,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					const bridge = await startBridge({
 						phpInstance: playgroundPool,
 						phpRoot: '/wordpress',
+						excludedPaths: ['/internal'],
 					});
 
 					bridge.start();


### PR DESCRIPTION
## Motivation for the change, related issues

Based on this [comment](https://github.com/WordPress/wordpress-playground/pull/2411#issuecomment-3115075051) and [pull request](https://github.com/WordPress/wordpress-playground/pull/2411).

In Playground CLI, the first line where Xdebug stops in DevTools is the `auto_prepend_file.php` file inside the `internal` directory, and Playground-internal files clutter the source tree. This PR lets the bridge be told which paths to exclude from the DevTools experience.

## Implementation details

`startBridge` now accepts an `excludedPaths: string[]` option. The CLI passes `['/internal']` so Playground-internal files are excluded by default.

Two pieces of behavior:

1. **Source-map ignore list** — In `XdebugCDPBridge.sendScriptToCDP`, scripts whose URI matches an excluded prefix are emitted with `x_google_ignoreList: [0]` in their source map ([Chrome DevTools docs](https://developer.chrome.com/docs/devtools/x-google-ignore-list)). DevTools then natively treats those files as third-party: stack frames are hidden, step-over/step-into walks past them automatically, and a user can still opt-in to step into them from the UI. This delegates the runtime behavior — including Adam's `a() → b() → c()` scenario where `b()` is ignored but `c()` must still be reached — to the browser instead of trying to model it in the bridge.

2. **Skip excluded directories during enumeration** — `start-bridge.ts`'s recursive `getPhpFiles` short-circuits any directory whose path matches an excluded prefix, so trees like `/internal/shared`, WordPress core, or `node_modules` are never walked when they are excluded. This avoids sending huge upfront file lists to DevTools.

The earlier `step_over` workaround in `handleDbgpMessage` has been removed; the ignore list replaces it.

## Testing Instructions

With script `cli.ts`:

```typescript
import { runCLI } from "./packages/playground/cli/src/run-cli";

const script = `<?php

$test = 42;

echo "Output!\n";

function test() {
	echo "Hello Xdebug World!\n";
}

test();
`;

const cliServer = await runCLI({command: 'server', xdebug: true, experimentalDevtools: true});

cliServer.playground.writeFile('xdebug.php', script);

const result = await cliServer.playground.run({scriptPath: `xdebug.php`});

console.log(result.text);
```

Run command:

```
node --no-warnings --experimental-wasm-stack-switching --experimental-wasm-jspi --loader=./packages/meta/src/node-es-module-loader/loader.mts cli.ts
```

### Before

<img width="1709" height="347" alt="before" src="https://github.com/user-attachments/assets/4069bf80-03cc-43e6-8116-dfd8d091d363" />

### After

<img width="1711" height="346" alt="after" src="https://github.com/user-attachments/assets/14c3b77c-178c-44c0-96de-014f96557371" />