### PR TITLE
Skip flaky e2e tests in Firefox and Webkit

### DIFF
--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -251,7 +251,14 @@ test('Intl functions should work when intl is enabled', async ({
 test('HTTPS requests via curl_exec() should work', async ({
 	website,
 	wordpress,
+	browserName,
 }) => {
+	test.skip(
+		browserName === 'firefox' || browserName === 'webkit',
+		`The curl_exec() tests often fail in CI on Firefox and WebKit. The root cause is unknown, ` +
+			'but the issue does not occur in local testing or on https://playground.wordpress.net/. ' +
+			'Perhaps it is something highly specific to the CI runtime.'
+	);
 	const blueprint: Blueprint = {
 		landingPage: '/curl-test.php',
 		features: { networking: true },
@@ -553,7 +560,15 @@ test('should correctly redirect to a multisite wp-admin url', async ({
 	test(`should translate WP-admin to Spanish for the ${wpVersion} WordPress build`, async ({
 		website,
 		wordpress,
+		browserName,
 	}) => {
+		test.skip(
+			(wpVersion === 'nightly' || wpVersion === 'beta') &&
+				(browserName === 'firefox' || browserName === 'webkit'),
+			`The translation tests often fail in CI on Firefox and WebKit. The root cause is unknown, ` +
+				'but the issue does not occur in local testing or on https://playground.wordpress.net/. ' +
+				'Perhaps it is something highly specific to the CI runtime.'
+		);
 		const blueprint: Blueprint = {
 			landingPage: '/wp-admin/',
 			preferredVersions: {


### PR DESCRIPTION
## Motivation for the change, related issues

Skips the two tests responsible for most failed CI runs:

* `HTTPS requests via curl_exec() should work` in Firefox and Webkit
* `Should translate WP-admin to Spanish for the nightly/beta WordPress build` in Firefox and Webkit

The scenarios pass in Chrome and also work in manual testing on localhost and playground.wordpress.net. While finding the root cause will be highly useful, accepting a red X as the norm is highly unuseful and makes us miss actual failures.

## Testing instructions

Confirm the CI checks pass.

FYI @brandonpayton @zaerl @JanJakes @fellyph 