### PR TITLE
Distribute @wp-playground/client without any package.json dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,22 @@ jobs:
                     exit 1
                   fi
                   npx nx affected --target=build --parallel=3 --verbose
+            - name: Confirm the built Playground client package.json file has no dependencies listed
+              run: |
+                  if [ ! -f dist/packages/playground/client/package.json ]; then
+                    echo "Error: dist/packages/playground/client/package.json not found"
+                    echo "This is a regression from https://github.com/WordPress/playground/pull/1000"
+                    exit 1
+                  fi
+
+                  DEPENDENCIES=$(jq '.dependencies // {}' dist/packages/playground/client/package.json)
+                  if [ "$DEPENDENCIES" != "{}" ]; then
+                    echo "Error: @wp-playground/client package.json has dependencies listed:"
+                    echo "$DEPENDENCIES"
+                    exit 1
+                  else
+                    echo "✓ @wp-playground/client package.json has no dependencies listed"
+                  fi
 
     # Deploy documentation job
     deploy_docs:

--- a/packages/nx-extensions/src/executors/package-json/executor.ts
+++ b/packages/nx-extensions/src/executors/package-json/executor.ts
@@ -156,6 +156,15 @@ async function buildPackageJson(
 	}
 	packageJson.main = main;
 
+	// Playground-client is a dependency-less package. Let's make sure it can be installed
+	// without bringing in any other packages.
+	if ('playground-client' === context.projectName) {
+		delete packageJson.overrides;
+		delete packageJson.dependencies;
+		delete packageJson.devDependencies;
+		delete packageJson.optionalDependencies;
+	}
+
 	fs.writeFileSync(
 		options.outputPath + '/package.json',
 		serializeJson(packageJson)

--- a/packages/playground/client/package.json
+++ b/packages/playground/client/package.json
@@ -41,5 +41,6 @@
 	"engines": {
 		"node": ">=20.18.3",
 		"npm": ">=10.1.0"
-	}
+	},
+	"dependencies": {}
 }


### PR DESCRIPTION
## Motivation for the change, related issues

`@wp-playground/client` doesn't make a single import, but its `package.json` [lists 27 dependencies](https://www.npmjs.com/package/@wp-playground/client?activeTab=dependencies) coming from the NX package-json executor. This PR ensures it has zero dependencies.

## Testing Instructions (or ideally a Blueprint)

Run `nx reset; nx build playground-client` and confirm the `dist/packages/playground/client/package.json` file has no dependencies.