### PR TITLE
[XDebug Bridge] Load Plugin file in Devtools if `--auto-mount` option enabled

### DIFF
--- a/packages/php-wasm/xdebug-bridge/src/lib/index.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/index.ts
@@ -2,4 +2,5 @@ export * from './cdp-server';
 export * from './dbgp-session';
 export * from './run-cli';
 export * from './start-bridge';
+export * from './utils';
 export * from './xdebug-cdp-bridge';

--- a/packages/php-wasm/xdebug-bridge/src/lib/utils.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/utils.ts
@@ -1,0 +1,58 @@
+export function findFirstDebuggableLine(content: string) {
+	const lines = content.split('\n');
+	let inBlockComment = false;
+	let inFunctionOrClass = false;
+	let braceDepth = 0;
+
+	for (let i = 0; i < lines.length; i++) {
+		const lineRaw = lines[i];
+		const line = lineRaw.trim();
+
+		if (line === '') continue;
+
+		if (line.startsWith('/*')) {
+			inBlockComment = true;
+			continue;
+		}
+
+		if (inBlockComment) {
+			if (line.includes('*/')) inBlockComment = false;
+			continue;
+		}
+
+		if (line.match(/^\s*(function|class)\b/)) {
+			inFunctionOrClass = true;
+		}
+
+		braceDepth += (line.match(/{/g) || []).length;
+		braceDepth -= (line.match(/}/g) || []).length;
+
+		if (inFunctionOrClass && braceDepth === 0) {
+			inFunctionOrClass = false;
+			continue;
+		}
+
+		if (inFunctionOrClass || braceDepth > 0) {
+			continue;
+		}
+
+		if (
+			line.startsWith('//') ||
+			line.startsWith('#') ||
+			line === '<?php' ||
+			line === '?>'
+		) {
+			continue;
+		}
+
+		if (
+			line.match(
+				/^\s*(var_dump|print|echo|exit|die|return|require|include|define|[$]\w+|\w+\s*\()/
+			)
+		) {
+			return i + 1;
+		}
+	}
+
+	return 0;
+}

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -48,6 +48,7 @@ export class XdebugCDPBridge {
 	private readPHPFile: (path: string) => string | Promise<string>;
 	private remoteRoot: string;
 	private localRoot: string;
+	private xdebugBreakpoints: Record<string, number[]> = {};
 
 	constructor(
 		dbgp: DbgpSession,
@@ -62,6 +63,15 @@ export class XdebugCDPBridge {
 		for (const url of config.knownScriptUrls) {
 			this.scriptIdByUrl.set(url, this.getOrCreateScriptId(url));
 		}
+	}
+
+	setXdebugBreakpoint(uri: string, line: number) {
+		if (
+			!this.xdebugBreakpoints[uri] ||
+			this.xdebugBreakpoints[uri].length == 0
+		)
+			this.xdebugBreakpoints[uri] = [];
+		this.xdebugBreakpoints[uri].push(line);
 	}
 
 	start() {
@@ -457,12 +467,26 @@ export class XdebugCDPBridge {
 		return p;
 	}
 
+	private formatXdebugBreakpointCommand(uri: string, line: number) {
+		return `breakpoint_set -t line -f ${this.formatPropertyFullName(
+			uri
+		)} -n ${line}`;
+	}
+
 	private async handleDbgpMessage(msgObj: any) {
 		if (msgObj.init) {
 			// Xdebug initial handshake
 			const initAttr = msgObj.init.$;
 			this.initFileUri = initAttr.fileuri || initAttr.fileuri;
 			this.xdebugStatus = 'starting';
+
+			Object.entries(this.xdebugBreakpoints).forEach(([uri, lines]) => {
+				lines.forEach((line) =>
+					this.sendDbgpCommand(
+						this.formatXdebugBreakpointCommand(uri, line)
+					)
+				);
+			});
 
 			const firstBreakTxn = this.sendDbgpCommand('step_into');
 			this.pendingCommands.set(firstBreakTxn, {

--- a/packages/playground/cli/src/mounts.ts
+++ b/packages/playground/cli/src/mounts.ts
@@ -123,7 +123,7 @@ export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
 		],
 	};
 
-	if (isPluginFilename(path)) {
+	if (isPluginDirectory(path)) {
 		const pluginName = basename(path);
 		mount.push({
 			hostPath: path,
@@ -131,7 +131,7 @@ export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
 		});
 		newArgs['additional-blueprint-steps'].push({
 			step: 'activatePlugin',
-			pluginPath: `/wordpress/wp-content/plugins/${basename(path)}`,
+			pluginPath: `/wordpress/wp-content/plugins/${pluginName}`,
 		});
 	} else if (isThemeDirectory(path)) {
 		const themeName = basename(path);
@@ -210,14 +210,17 @@ export function isThemeDirectory(path: string): boolean {
 	return !!themeNameRegex.exec(styleCssContent);
 }
 
-export function isPluginFilename(path: string): boolean {
+export function isPluginDirectory(path: string): boolean {
+	return !!findPluginFilename(path);
+}
+
+export function findPluginFilename(path: string): string | undefined {
 	const files = fs.readdirSync(path);
 	const pluginNameRegex = /^(?:[ \t]*<\?php)?[ \t/*#@]*Plugin Name:(.*)$/im;
-	const pluginNameMatch = files
+	return files
 		.filter((file) => file.endsWith('.php'))
 		.find((file) => {
 			const fileContent = fs.readFileSync(join(path, file), 'utf8');
 			return !!pluginNameRegex.exec(fileContent);
 		});
-	return !!pluginNameMatch;
 }

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -49,7 +49,7 @@ import { isValidWordPressSlug } from './is-valid-wordpress-slug';
 import { resolveBlueprint } from './resolve-blueprint';
 import { BlueprintsV2Handler } from './blueprints-v2/blueprints-v2-handler';
 import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
-import { startBridge } from '@php-wasm/xdebug-bridge';
+import { findFirstDebuggableLine, startBridge } from '@php-wasm/xdebug-bridge';
 import { basename } from 'path';
 
 export async function parseOptionsAndRunCLI() {
@@ -564,6 +564,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 							const line = findFirstDebuggableLine(
 								await playground!.readFileAsText(filePath)
 							);
+
 							bridge.setXdebugBreakpoint(filePath, line);
 
 							await playground!.run({
@@ -743,63 +744,4 @@ async function zipSite(
 	});
 	const zip = await playground.readFileAsBuffer('/tmp/build.zip');
 	fs.writeFileSync(outfile, zip);
-}
-
-function findFirstDebuggableLine(content: string) {
-	const lines = content.split('\n');
-	let inBlockComment = false;
-	let inFunctionOrClass = false;
-	let braceDepth = 0;
-
-	for (let i = 0; i < lines.length; i++) {
-		const lineRaw = lines[i];
-		const line = lineRaw.trim();
-
-		if (line === '') continue;
-
-		if (line.startsWith('/*')) {
-			inBlockComment = true;
-			continue;
-		}
-
-		if (inBlockComment) {
-			if (line.includes('*/')) inBlockComment = false;
-			continue;
-		}
-
-		if (line.match(/^\s*(function|class)\b/)) {
-			inFunctionOrClass = true;
-		}
-
-		braceDepth += (line.match(/{/g) || []).length;
-		braceDepth -= (line.match(/}/g) || []).length;
-
-		if (inFunctionOrClass && braceDepth === 0) {
-			inFunctionOrClass = false;
-			continue;
-		}
-
-		if (inFunctionOrClass || braceDepth > 0) {
-			continue;
-		}
-
-		if (
-			line.startsWith('//') ||
-			line.startsWith('#') ||
-			line === '<?php' ||
-			line === '?>'
-		) {
-			continue;
-		}
-
-		if (
-			line.match(
-				/^\s*(var_dump|print|echo|exit|die|return|require|include|define|[$]\w+|\w+\s*\()/
-			)
-		) {
-			return i + 1;
-		}
-	}
-
-	return 0;
 }

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -559,8 +559,15 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 						if (isPluginDirectory(path)) {
 							const pluginName = basename(path);
 							const pluginFilename = findPluginFilename(path);
-							playground!.run({
-								scriptPath: `/wordpress/wp-content/plugins/${pluginName}/${pluginFilename}`,
+
+							const filePath = `/wordpress/wp-content/plugins/${pluginName}/${pluginFilename}`;
+							const line = findFirstDebuggableLine(
+								await playground!.readFileAsText(filePath)
+							);
+							bridge.setXdebugBreakpoint(filePath, line);
+
+							await playground!.run({
+								scriptPath: '/wordpress/index.php',
 							});
 						}
 					}
@@ -736,4 +743,63 @@ async function zipSite(
 	});
 	const zip = await playground.readFileAsBuffer('/tmp/build.zip');
 	fs.writeFileSync(outfile, zip);
+}
+
+function findFirstDebuggableLine(content: string) {
+	const lines = content.split('\n');
+	let inBlockComment = false;
+	let inFunctionOrClass = false;
+	let braceDepth = 0;
+
+	for (let i = 0; i < lines.length; i++) {
+		const lineRaw = lines[i];
+		const line = lineRaw.trim();
+
+		if (line === '') continue;
+
+		if (line.startsWith('/*')) {
+			inBlockComment = true;
+			continue;
+		}
+
+		if (inBlockComment) {
+			if (line.includes('*/')) inBlockComment = false;
+			continue;
+		}
+
+		if (line.match(/^\s*(function|class)\b/)) {
+			inFunctionOrClass = true;
+		}
+
+		braceDepth += (line.match(/{/g) || []).length;
+		braceDepth -= (line.match(/}/g) || []).length;
+
+		if (inFunctionOrClass && braceDepth === 0) {
+			inFunctionOrClass = false;
+			continue;
+		}
+
+		if (inFunctionOrClass || braceDepth > 0) {
+			continue;
+		}
+
+		if (
+			line.startsWith('//') ||
+			line.startsWith('#') ||
+			line === '<?php' ||
+			line === '?>'
+		) {
+			continue;
+		}
+
+		if (
+			line.match(
+				/^\s*(var_dump|print|echo|exit|die|return|require|include|define|[$]\w+|\w+\s*\()/
+			)
+		) {
+			return i + 1;
+		}
+	}
+
+	return 0;
 }

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -26,6 +26,8 @@ import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
 // @ts-ignore
 import {
 	expandAutoMounts,
+	findPluginFilename,
+	isPluginDirectory,
 	parseMountDirArguments,
 	parseMountWithDelimiterArguments,
 } from './mounts';
@@ -48,6 +50,7 @@ import { resolveBlueprint } from './resolve-blueprint';
 import { BlueprintsV2Handler } from './blueprints-v2/blueprints-v2-handler';
 import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
 import { startBridge } from '@php-wasm/xdebug-bridge';
+import { basename } from 'path';
 
 export async function parseOptionsAndRunCLI() {
 	try {
@@ -549,6 +552,18 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 					});
 
 					bridge.start();
+
+					if (args.autoMount) {
+						const path = process.cwd();
+
+						if (isPluginDirectory(path)) {
+							const pluginName = basename(path);
+							const pluginFilename = findPluginFilename(path);
+							playground!.run({
+								scriptPath: `/wordpress/wp-content/plugins/${pluginName}/${pluginFilename}`,
+							});
+						}
+					}
 				}
 
 				return {


### PR DESCRIPTION
## Motivation for the change, related issues

🚧 This draft is an experimental work in progress since I am not sure this should be the correct behavior. 🚧 

When running `node node_modules/@wp-playground/cli/cli.js server --xdebug --experimental-devtools --auto-mount` it returns : 

```
Starting a PHP server...
Setting up WordPress latest
Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.8.2.zip
Fetching SQLite integration plugin...
Booting WordPress...
Booted!
Running the Blueprint...
Running the Blueprint – 100%
Finished running the blueprint
WordPress is running on http://127.0.0.1:9400
Connect Chrome DevTools to CDP at:
devtools://devtools/bundled/inspector.html?ws=localhost:9229

Chrome connected! Initializing Xdebug receiver...
XDebug receiver running on port 9003
Running a PHP script with Xdebug enabled...
```

But nothing next. It doesn't run a php script with Xdebug enabled since no `playground.run()` is called.

This pull request aims to run a chosen script when using `--auto-mount`. Since `auto-mount` will smartly recognize a Plugin or a Theme, it should also debug the given Plugin script.

## Implementation details

if `--experimental-devtools`, `--xdebug` and `--auto-mount`, the script will check if a Plugin is available in `process.cwd()` and debug it.

## Testing Instructions

In a empty directory named `recolor-wp-admin-plugin`, add file : 

`index.php`
```php
<?php
/**
 * Plugin Name: Recolor wp-admin
 * Description: A simple plugin to recolor the wp-admin interface
 * Version: 1.0
 * Author: Adam Zielinski
 */

function blue_admin_nav_enqueue()
{
    wp_enqueue_style( 'blue-admin', plugin_dir_url( __FILE__ ) . 'style.css' );
}

add_action( 'admin_enqueue_scripts', 'blue_admin_nav_enqueue' );
```

`style.css` 
```css
#wpadminbar,
#adminmenu,
#adminmenuback,
#adminmenuwrap,
#adminmenu .wp-submenu,
#adminmenu li.menu-top:hover
{
	background-color: blue !important;
}
```

Now run : 

```
> cd recolor-wp-admin-plugin

> node ../node_modules/@wp-playground/cli/cli.js server --login --xdebug --experimental-devtools --auto-mount
```

<img width="1920" height="618" alt="screenshot_001" src="https://github.com/user-attachments/assets/6bc09b3b-2453-43c4-934d-53a6400ade07" />

<img width="1920" height="361" alt="screenshot_005" src="https://github.com/user-attachments/assets/66c015b2-10b2-4f11-b459-167c90a29989" />

<img width="1920" height="352" alt="screenshot_007" src="https://github.com/user-attachments/assets/4aca3960-1829-4d19-8b43-1524d32a88a2" />

