### PR TITLE
[Docs] Bump PHP version to avoid WordPress PHP version Warning

### DIFF
--- a/packages/docs/site/docs/blueprints/01-index.md
+++ b/packages/docs/site/docs/blueprints/01-index.md
@@ -12,7 +12,7 @@ Blueprints are JSON files for setting up your very own WordPress Playground inst
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"landingPage": "/wp-admin/",
 	"preferredVersions": {
-		"php": "8.0",
+		"php": "8.3",
 		"wp": "latest"
 	},
 	"steps": [
@@ -45,13 +45,13 @@ Blueprints fetch any resources you declare for you. You don't have to worry abou
 
 ### You can link to a Blueprint-preconfigured Playground
 
-Because Blueprints can be pasted in the URL, you can embed or link to a Playground with a specific configuration. For example, clicking this button will open a Playground with PHP 7.4 and a pendant theme installed:
+Because Blueprints can be pasted in the URL, you can embed or link to a Playground with a specific configuration. For example, clicking this button will open a Playground with PHP 8.3 and a pendant theme installed:
 
 import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
 
 <BlueprintExample justButton={true} blueprint={{
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
   		"wp": "latest"
 	},
 	"steps": [

--- a/packages/docs/site/docs/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/docs/blueprints/02-using-blueprints.md
@@ -22,14 +22,14 @@ For example, to create a Playground with specific versions of WordPress and PHP 
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }
 ```
 
 And then you would go to
-`https://playground.wordpress.net/#{"preferredVersions":{"php":"7.4","wp":"6.5"}}`.
+`https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
 
 :::tip
 In Javascript, you can get a compact version of any blueprint JSON with [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) and [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
@@ -39,11 +39,11 @@ Example:
 const blueprintJson = `{
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }`;
-const minifiedBlueprintJson = JSON.stringify(JSON.parse(blueprintJson)); // {"preferredVersions":{"php":"7.4","wp":"6.5"}}
+const minifiedBlueprintJson = JSON.stringify(JSON.parse(blueprintJson)); // {"preferredVersions":{"php":"8.3","wp":"6.5"}}
 ```
 
 :::
@@ -54,7 +54,7 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 
 <BlueprintExample justButton={true} blueprint={{
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }} />
@@ -74,7 +74,7 @@ Example:
 const blueprintJson = `{
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }`;
@@ -138,7 +138,7 @@ You can also use Blueprints with the JavaScript API using the `startPlaygroundWe
 		blueprint: {
 			landingPage: '/wp-admin/',
 			preferredVersions: {
-				php: '8.0',
+				php: '8.3',
 				wp: 'latest',
 			},
 			steps: [

--- a/packages/docs/site/docs/blueprints/03-data-format.md
+++ b/packages/docs/site/docs/blueprints/03-data-format.md
@@ -15,7 +15,7 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 <BlueprintExample blueprint={{
 	"landingPage": "/wp-admin/",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	},
 	"features": {

--- a/packages/docs/site/docs/blueprints/08-examples.md
+++ b/packages/docs/site/docs/blueprints/08-examples.md
@@ -237,7 +237,7 @@ To specify the latest commit of a particular branch, you can change the referenc
     "landingPage": "/wp-admin",
 	"login" : true,
 	"preferredVersions" : {
-		"php": "8.0",
+		"php": "8.3",
 		"wp": "https://playground.wordpress.net/plugin-proxy.php?build-ref=trunk"
 	}
 }} />
@@ -250,7 +250,7 @@ Here's an example of a Blueprint that uses bundled resources from a Blueprint bu
 {
 	"landingPage": "/",
 	"preferredVersions": {
-		"php": "8.0",
+		"php": "8.3",
 		"wp": "latest"
 	},
 	"steps": [

--- a/packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md
+++ b/packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md
@@ -16,15 +16,15 @@ Let's say you want to create a Playground with specific versions of WordPress an
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "5.9"
 	}
 }
 ```
 
-To run it, go to `https://playground.wordpress.net/#{"preferredVersions": {"php":"7.4", "wp":"5.9"}}`. You can also use the button below:
+To run it, go to `https://playground.wordpress.net/#{"preferredVersions": {"php":"8.3", "wp":"5.9"}}`. You can also use the button below:
 
-[<kbd> &nbsp; Run Blueprint &nbsp; </kbd>](https://playground.wordpress.net/#{"preferredVersions":{"php":"7.4","wp":"5.9"}})
+[<kbd> &nbsp; Run Blueprint &nbsp; </kbd>](https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"5.9"}})
 
 Use this method to run the example code in the next chapter, [**Build your first Blueprint**](/blueprints/tutorial/build-your-first-blueprint).
 

--- a/packages/docs/site/docs/developers/03-build-an-app/01-index.md
+++ b/packages/docs/site/docs/developers/03-build-an-app/01-index.md
@@ -161,7 +161,7 @@ A live plugin demo with a configurable PHP and WordPress makes an excellent comp
 With the Query API, you'd simply add the `php` and `wp` query parameters to the URL:
 
 ```html
-<iframe src="https://playground.wordpress.net/?php=7.4&wp=6.1"></iframe>
+<iframe src="https://playground.wordpress.net/?php=8.3&wp=6.1"></iframe>
 ```
 
 With JSON Blueprints, you'd use the `preferredVersions` property:
@@ -169,7 +169,7 @@ With JSON Blueprints, you'd use the `preferredVersions` property:
 ```json
 {
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.1"
 	}
 }

--- a/packages/docs/site/docs/developers/05-local-development/01-wp-now.md
+++ b/packages/docs/site/docs/developers/05-local-development/01-wp-now.md
@@ -40,7 +40,7 @@ You can also start `wp-now` from any `wp-content` folder. The following example 
 
 ```bash
 cd my-wordpress-folder/wp-content
-npx @wp-now/wp-now start --wp=6.4 --php=8.0 --blueprint=path/to/blueprint.json
+npx @wp-now/wp-now start --wp=6.4 --php=8.3 --blueprint=path/to/blueprint.json
 ```
 
 ## Install wp-now globally

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -37,7 +37,7 @@ npx @wp-playground/cli@latest server --auto-mount
 
 ### Choosing a WordPress and PHP Version
 
-By default, the CLI loads the latest stable version of WordPress and PHP 8.0 due to its improved performance. To specify your preferred versions, you can use the flag `--wp=<version>` and `--php=<version>`:
+By default, the CLI loads the latest stable version of WordPress and PHP 8.3 due to its improved performance. To specify your preferred versions, you can use the flag `--wp=<version>` and `--php=<version>`:
 
 ```bash
 npx @wp-playground/cli@latest server --wp=6.8 --php=8.4

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/04-blueprint-json-in-api-client.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/04-blueprint-json-in-api-client.md
@@ -15,7 +15,7 @@ const client = await startPlaygroundWeb({
 	blueprint: {
 		preferredVersions: {
 			wp: '6.3',
-			php: '8.0',
+			php: '8.3',
 		},
 		steps: [
 			{ step: 'login' },

--- a/packages/docs/site/docs/developers/23-architecture/09-browser-tab-orchestrates-execution.md
+++ b/packages/docs/site/docs/developers/23-architecture/09-browser-tab-orchestrates-execution.md
@@ -38,7 +38,7 @@ export async function startApp() {
 			workerUrl, // Valid Worker script URL
 			{
 				wpVersion: 'latest',
-				phpVersion: '7.4', // Startup options
+				phpVersion: '8.3', // Startup options
 			}
 		)
 	);

--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -88,7 +88,7 @@ Compatibility testing with so many WordPress and PHP versions was always a pain.
 You can also use the `wp` and `php` query parameters to open Playground with the right versions already loaded:
 
 -   https://playground.wordpress.net/?wp=6.5
--   https://playground.wordpress.net/?php=7.4
+-   https://playground.wordpress.net/?php=8.3
 -   https://playground.wordpress.net/?php=8.2&wp=6.2
 
 <ThisIsQueryApi />

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/blueprints/01-index.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/blueprints/01-index.md
@@ -91,17 +91,17 @@ Blueprints fetch any resources you declare for you. You don't have to worry abou
 ### You can link to a Blueprint-preconfigured Playground
 -->
 
-ブループリントは URL に貼り付けることができるため、特定の設定の Playground を埋め込んだり、リンクしたりできます。例えば、このボタンをクリックすると、PHP 7.4 とペンダントテーマがインストールされた Playground が開きます。
+ブループリントは URL に貼り付けることができるため、特定の設定の Playground を埋め込んだり、リンクしたりできます。例えば、このボタンをクリックすると、PHP 8.3 とペンダントテーマがインストールされた Playground が開きます。
 
 <!--
-Because Blueprints can be pasted in the URL, you can embed or link to a Playground with a specific configuration. For example, clicking this button will open a Playground with PHP 7.4 and a pendant theme installed:
+Because Blueprints can be pasted in the URL, you can embed or link to a Playground with a specific configuration. For example, clicking this button will open a Playground with PHP 8.3 and a pendant theme installed:
 -->
 
 import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
 
 <BlueprintExample justButton={true} blueprint={{
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
   		"wp": "latest"
 	},
 	"steps": [

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
@@ -49,7 +49,7 @@ For example, to create a Playground with specific versions of WordPress and PHP 
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }
@@ -70,7 +70,7 @@ JavaScript では、[`JSON.stringify`](https://developer.mozilla.org/en-US/docs/
 const blueprintJson = `{
 "$schema": "https://playground.wordpress.net/blueprint-schema.json",
 "preferredVersions": {
-"php": "7.4",
+"php": "8.3",
 "wp": "6.5"
 }
 }`;
@@ -88,7 +88,7 @@ Example:
 const blueprintJson = `{
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }`;
@@ -108,7 +108,7 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 
 <BlueprintExample justButton={true} blueprint={{
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }} />
@@ -140,7 +140,7 @@ JavaScript では、グローバル関数 `btoa()` を使用して、任意の�
 const blueprintJson = `{
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }`;
@@ -159,7 +159,7 @@ Example:
 const blueprintJson = `{
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	}
 }`;

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/blueprints/03-data-format.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/blueprints/03-data-format.md
@@ -27,7 +27,7 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 <BlueprintExample blueprint={{
 	"landingPage": "/wp-admin/",
 	"preferredVersions": {
-		"php": "7.4",
+		"php": "8.3",
 		"wp": "6.5"
 	},
 	"features": {


### PR DESCRIPTION
## Motivation for the change, related issues

Running a few demos inside the WordPress Documentation is triggering the not-recommended PHP version warning:

<img width="873" height="662" alt="Screenshot 2025-07-30 at 14 55 28" src="https://github.com/user-attachments/assets/c586c21f-7858-47a0-93b6-7b5268e58d1b" />

This pull request bumps the demos using a version lower than 8.3 to the recommended version.

