### PR TITLE
Fix resolving mounted symlinks in secondary PHP instances

### DIFF
--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -95,7 +95,7 @@ export async function loadNodeRuntime(
 			 * in the Emscripten's filesystem and mount the OS directory
 			 * to the Emscripten filesystem.
 			 *
-			 * The directory is mounted to the `/internals/symlinks` directory to avoid
+			 * The directory is mounted to the `/internal/symlinks` directory to avoid
 			 * conflicts with existing VFS directories.
 			 * We can set a arbitrary mount path because readlink is the source of truth
 			 * for the path and Emscripten will accept it as if it was the real link path.
@@ -111,7 +111,7 @@ export async function loadNodeRuntime(
 							)
 						);
 					const symlinkPath = joinPaths(
-						`/internals/symlinks`,
+						`/internal/symlinks`,
 						absoluteSourcePath
 					);
 					if (

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -336,6 +336,8 @@ export interface RunCLIServer extends AsyncDisposable {
 	playground: RemoteAPI<PlaygroundCliWorker>;
 	server: Server;
 	[Symbol.asyncDispose](): Promise<void>;
+	// Expose the number of worker threads to the test runner.
+	workerThreadCount: number;
 }
 
 export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
@@ -565,6 +567,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 						);
 						await new Promise((resolve) => server.close(resolve));
 					},
+					workerThreadCount: totalWorkerCount,
 				};
 			} catch (error) {
 				if (!args.debug) {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -7,7 +7,13 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { promisify } from 'node:util';
 import { exec } from 'node:child_process';
-import { readdirSync } from 'node:fs';
+import {
+	readdirSync,
+	writeFileSync,
+	symlinkSync,
+	unlinkSync,
+	existsSync,
+} from 'node:fs';
 import { createHash } from 'node:crypto';
 import { MinifiedWordPressVersionsList } from '@wp-playground/wordpress-builds';
 
@@ -234,6 +240,67 @@ describe('run-cli', () => {
 			 * Playground should not modify the mounted directory.
 			 */
 			expect(await getDirectoryChecksum(tmpDir)).toBe(checksum);
+		});
+
+		test('should be able to follow external symlinks in primary and secondary PHP instances', async () => {
+			// TODO: Make sure test always uses a single worker.
+			// TODO: Is there a way to confirm we are testing use of a non-primary PHP instance?
+			const tmpDir = await mkdtemp(
+				path.join(tmpdir(), 'playground-test-')
+			);
+			writeFileSync(
+				path.join(tmpDir, 'sleep.php'),
+				'<?php sleep(1); echo "Slept"; '
+			);
+			const symlinkPath = path.join(
+				import.meta.dirname,
+				'mount-examples',
+				'symlinking',
+				'symlinked-script'
+			);
+
+			try {
+				if (existsSync(symlinkPath)) {
+					unlinkSync(symlinkPath);
+				}
+				// TODO: Confirm that symlink target is outside of current working dir tree.
+				symlinkSync(tmpDir, symlinkPath);
+				cliServer = await runCLI({
+					debug: true,
+					command: 'server',
+					followSymlinks: true,
+					'mount-before-install': [
+						{
+							hostPath: symlinkPath,
+							vfsPath: '/wordpress/wp-content/test-script',
+						},
+					],
+				});
+				expect(cliServer.workerThreadCount).toBe(1);
+				// Make multiple simultaneous requests to force the use of a secondary PHP instance.
+				// TODO: Find way to confirm this.
+				const responses = await Promise.all([
+					cliServer.playground.request({
+						url: '/wp-content/test-script/sleep.php',
+						method: 'GET',
+					}),
+					cliServer.playground.request({
+						url: '/wp-content/test-script/sleep.php',
+						method: 'GET',
+					}),
+					// Test a third request to hopefully test more than one secondary instance.
+					cliServer.playground.request({
+						url: '/wp-content/test-script/sleep.php',
+						method: 'GET',
+					}),
+				]);
+				responses.forEach((response) => {
+					expect(response.httpStatusCode).toBe(200);
+					expect(response.text).toContain('Slept');
+				});
+			} finally {
+				unlinkSync(symlinkPath);
+			}
 		});
 	});
 });

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -259,6 +259,8 @@ describe('run-cli', () => {
 				'symlinked-script'
 			);
 
+			fs.mkdirSync( path.dirname( symlinkPath ), { recursive: true } );
+
 			try {
 				if (existsSync(symlinkPath)) {
 					unlinkSync(symlinkPath);

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -299,7 +299,9 @@ describe('run-cli', () => {
 					expect(response.text).toContain('Slept');
 				});
 			} finally {
-				unlinkSync(symlinkPath);
+				if (existsSync(symlinkPath)) {
+					unlinkSync(symlinkPath);
+				}
 			}
 		});
 	});

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -8,6 +8,7 @@ import { tmpdir } from 'node:os';
 import { promisify } from 'node:util';
 import { exec } from 'node:child_process';
 import {
+	mkdirSync,
 	readdirSync,
 	writeFileSync,
 	symlinkSync,
@@ -259,7 +260,7 @@ describe('run-cli', () => {
 				'symlinked-script'
 			);
 
-			fs.mkdirSync( path.dirname( symlinkPath ), { recursive: true } );
+			mkdirSync( path.dirname( symlinkPath ), { recursive: true } );
 
 			try {
 				if (existsSync(symlinkPath)) {

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -266,6 +266,7 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 				'/tmp',
 				requestHandler.documentRoot,
 				'/internal/shared',
+				'/internal/symlinks',
 			]);
 		}
 


### PR DESCRIPTION
## Motivation for the change, related issues

It appears that plugin symlinks are resolved by the primary PHP instance but then fail to be resolved within a secondary PHP instance.

Fixes #2405

## Implementation details

Mounts /internal/symlinks in secondary PHP instances.

## Testing Instructions (or ideally a Blueprint)

- CI, including new unit test(s)