### PR TITLE
Translations: Fix command typo in docs.

### DIFF
--- a/packages/docs/site/docs/main/contributing/translations.md
+++ b/packages/docs/site/docs/main/contributing/translations.md
@@ -67,7 +67,7 @@ To locally test an existing language, you can do:
 
 ```
 
-npm run dev:docs -- --locale es
+npm run dev -- --locale es
 
 ```
 


### PR DESCRIPTION
## Motivation for the change, related issues
Closes: https://github.com/WordPress/wordpress-playground/issues/2447

## Implementation details
- Updated the command to test the translations in local.

