### PR TITLE
[Docs] Adding fixes to broken URLs

### DIFF
--- a/packages/docs/site/docs/main/intro.md
+++ b/packages/docs/site/docs/main/intro.md
@@ -18,16 +18,16 @@ Playground is an online tool to experiment and learn about WordPress. This site 
 
 <p class="docs-hubs">The WordPress Playground documentation is distributed across four separate hubs (subsites):</p>
 
--   👉 [**Documentation**](/wordpress-playground/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
--   [**Blueprints**](/wordpress-playground/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
--   [**Developers**](/wordpress-playground/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
--   [**API Reference**](/wordpress-playground/api) – All the APIs exposed by WordPress Playground
+-   👉 [**Documentation**](/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
+-   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
+-   [**Developers**](/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
+-   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
 
 ## Navigating this documentation hub
 
 This docs hub is focused on starting with WordPress Playground and is divided into the following major sections.
 
--   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/wordpress-playground/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/wordpress-playground/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/wordpress-playground/quick-start-guide#use-a-specific-wordpress-or-php-version).
+-   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/quick-start-guide#use-a-specific-wordpress-or-php-version).
 
 -   **[Playground web instance](/web-instance)**: Learn more about the Playground instance you get at https://playground.wordpress.net/
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/intro.md
@@ -48,10 +48,10 @@ Playground is an online tool to experiment and learn about WordPress. This site 
 -   [**API リファレンス**](/api) – WordPress Playground によって公開されているすべての API
 
 <!--
--   👉 [**Documentation**](/wordpress-playground/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
--   [**Blueprints**](/wordpress-playground/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
--   [**Developers**](/wordpress-playground/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
--   [**API Reference**](/wordpress-playground/api) – All the APIs exposed by WordPress Playground
+-   👉 [**Documentation**](/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
+-   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
+-   [**Developers**](/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
+-   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
  -->
 
 ## このドキュメントハブのナビゲーション
@@ -75,7 +75,7 @@ This docs hub is focused on starting with WordPress Playground and is divided in
 -   **[リンクとリソース](/resources)**: WordPress Playground に関連する役立つリンクとリソースの素敵なまとめ。
 
 <!--
--   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/wordpress-playground/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/wordpress-playground/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/wordpress-playground/quick-start-guide#use-a-specific-wordpress-or-php-version).
+-   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/quick-start-guide#use-a-specific-wordpress-or-php-version).
 
 -   **[Playground web instance](/web-instance)**: Learn more about the Playground instance you get at https://playground.wordpress.net/
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/intro.md
@@ -40,10 +40,10 @@ WordPress Playground é uma ferramenta online onde podes testar e aprender mais 
 <p class="docs-hubs">A documentação do WordPress Playground está dividida em quatro hubs(subsites):</p>
 
 <!--
--   👉 [**Documentation**](/wordpress-playground/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
--   [**Blueprints**](/wordpress-playground/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
--   [**Developers**](/wordpress-playground/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
--   [**API Reference**](/wordpress-playground/api) – All the APIs exposed by WordPress Playground
+-   👉 [**Documentation**](/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
+-   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
+-   [**Developers**](/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
+-   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
 -->
 
 -   👉 [**Documentação**](/) _(você está aqui)_ – Introdução a WordPress Playground, guia inicial e ponto de entrada para a documentação do WordPress Playuground.
@@ -64,7 +64,7 @@ This docs hub is focused on starting with WordPress Playground and is divided in
 Este hub de documentação foca-se em ajudá-lo a começar a trabalhar com o WordPress Playground e está organizado nas seguintes seções:
 
 <!--
--   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/wordpress-playground/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/wordpress-playground/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/wordpress-playground/quick-start-guide#use-a-specific-wordpress-or-php-version).
+-   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/quick-start-guide#use-a-specific-wordpress-or-php-version).
 -   **[Playground web instance](/web-instance)**: Learn more about the Playground instance you get at https://playground.wordpress.net/
 -   **[About Playground](/about)**: To learn about WordPress Playground, how safe it is, what you can do with and some of its current limitations, visit this section.
     Discover how you can leverage WordPress Playground to [Build](./about/build), [Test](./about/test), and [Launch](./about/launch) your products.

--- a/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/intro.md
@@ -18,10 +18,10 @@ Ang Playground ay isang online na tool para subukan at pag-aralan ang WordPress.
 
 <p class="docs-hubs">Ang dokumentasyon ng WordPress Playground ay hinati sa apat na magkakahiwalay na hub (subsite):</p>
 
--   👉 [**Dokumentasyon**](/wordpress-playground/) (nandoon ka ngayon) – Panimula sa WP Playground, mga gabay para sa panimula, at iyong pasukan sa Dokumentasyon ng WP Playground.
--   [**Blueprints**](/wordpress-playground/blueprints) – Ang Blueprints ay mga JSON file para i-setup ang iyong WordPress Playground instance. Alamin ang mga ito sa Blueprint docs hub.
--   [**Para sa Developer**](/wordpress-playground/developers) – Ang WordPress Playground ay ginawa bilang isang programmable na tool. Tuklasin ang lahat ng magagawa mo gamit ang code sa Developer docs hub.
--   [**API Reference**](/wordpress-playground/api) – Lahat ng API na iniaalok ng WordPress Playground.
+-   👉 [**Dokumentasyon**](/) (nandoon ka ngayon) – Panimula sa WP Playground, mga gabay para sa panimula, at iyong pasukan sa Dokumentasyon ng WP Playground.
+-   [**Blueprints**](/blueprints) – Ang Blueprints ay mga JSON file para i-setup ang iyong WordPress Playground instance. Alamin ang mga ito sa Blueprint docs hub.
+-   [**Para sa Developer**](/developers) – Ang WordPress Playground ay ginawa bilang isang programmable na tool. Tuklasin ang lahat ng magagawa mo gamit ang code sa Developer docs hub.
+-   [**API Reference**](/api) – Lahat ng API na iniaalok ng WordPress Playground.
 
 ## Pag-navigate sa hub na ito ng dokumentasyon
 


### PR DESCRIPTION
## Motivation for the change, related issues
The internal links inside the translated version don't need to include the `/wordpress-playground/` folder at the URL; this anchor is causing a build issue on the Filipino version.  The problem is caused by the generated URL from it; for example, when a translation uses this anchor, it generates a URL `/wordpress-playground/gu/wordpress-playground/blueprints` when the correct URL would be `/wordpress-playground/gu/blueprints`. 

<img width="1505" height="649" alt="Screenshot 2025-08-04 at 10 57 08" src="https://github.com/user-attachments/assets/94964e4b-61b5-401a-ab4e-acccef878d70" />

This pull request fixes the URL and the build process for Filipino translation. 

After changes:

<img width="1116" height="198" alt="Screenshot 2025-08-04 at 11 00 48" src="https://github.com/user-attachments/assets/aace8e2a-56fa-4909-a2e5-264bdf65dc14" />
