### PR TITLE
[XDebug Bridge] List additional ASYNCIFY_ONLY functions to prevent  `unreachable` crashes when using Devtools

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -681,6 +681,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "zend_stream_stdio_closer",\
 "zend_destroy_file_handle",\
 "php_init_config",\
+"zend_register_constant",\
 "zend_register_ini_entries_ex",\
 "php_module_startup",\
 "wasm_sapi_module_startup",\
@@ -951,7 +952,6 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "ZEND_UNSET_DIM_SPEC_CV_CONST_HANDLER",\
 "zend_std_read_dimension",\
 "zend_fetch_dimension_address_read_R_slow",\
-"ZEND_FETCH_DIM_R_SPEC_CV_CONST_HANDLER",\
 "zend_call_method",\
 "zend_assign_to_object_dim",\
 "ZEND_ASSIGN_DIM_SPEC_CV_CONST_OP_DATA_CONST_HANDLER",\
@@ -1019,7 +1019,6 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "do_cli_server",\
 "execute_ex",\
 "EVP_PKEY_encrypt",\
-"execute_ex",\
 "exif_error_docref",\
 "fclose",\
 "fcntl",\
@@ -1160,6 +1159,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "param_dtor",\
 "parentWrite",\
 "pcacheUnpin",\
+"persistent_stream_open_function",\
 "pdo_dbh_attribute_set",\
 "pdo_dbh_free_storage",\
 "pdo_dbstmt_free_storage",\
@@ -1205,6 +1205,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "php_exec",\
 "php_execute_script_ex",\
 "php_execute_script",\
+"php_fopen_primary_script",\
 "php_fsockopen_stream",\
 "php_getimagesize_from_any",\
 "php_if_fopen",\
@@ -1275,6 +1276,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "php_stream_flush",\
 "php_stream_notification_free",\
 "php_stream_notification_notify",\
+"php_stream_open_for_zend",\
 "php_stream_read_to_str",\
 "php_stream_temp_cast",\
 "php_stream_temp_flush",\
@@ -1670,6 +1672,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "zend_error_va_list",\
 "zend_error_va",\
 "zend_error_zstr_at",\
+"zend_error_zstr",\
 "zend_error",\
 "zend_eval_const_expr",\
 "zend_eval_string_ex",\
@@ -1830,6 +1833,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "zend_try_ct_eval_binary_op",\
 "zend_try_ct_eval_unary_op",\
 "zend_type_error",\
+"zend_undefined_index",\
 "ZEND_UNSET_CV_SPEC_CV_UNUSED_HANDLER",\
 "ZEND_UNSET_DIM_SPEC_CV_CONST_HANDLER",\
 "ZEND_UNSET_DIM_SPEC_CV_CV_HANDLER",\
@@ -1893,6 +1897,7 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "zif_curl_multi_select",\
 "zif_current",\
 "zif_debug_print_backtrace",\
+"zif_define",\
 "zif_end",\
 "zif_exec",\
 "zif_exif_imagetype",\

--- a/packages/php-wasm/node/asyncify/php_7_2.js
+++ b/packages/php-wasm/node/asyncify/php_7_2.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_2_34', 'php_7_2.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 29379142;
+export const dependenciesTotalSize = 29381880;
 const phpVersionString = '7.2.34';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_7_3.js
+++ b/packages/php-wasm/node/asyncify/php_7_3.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_3_33', 'php_7_3.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 29695998;
+export const dependenciesTotalSize = 29698903;
 const phpVersionString = '7.3.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_7_4.js
+++ b/packages/php-wasm/node/asyncify/php_7_4.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_4_33', 'php_7_4.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 30107713;
+export const dependenciesTotalSize = 30110863;
 const phpVersionString = '7.4.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_8_0.js
+++ b/packages/php-wasm/node/asyncify/php_8_0.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_0_30', 'php_8_0.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 31315360;
+export const dependenciesTotalSize = 31318489;
 const phpVersionString = '8.0.30';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_8_1.js
+++ b/packages/php-wasm/node/asyncify/php_8_1.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_1_33', 'php_8_1.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 31648487;
+export const dependenciesTotalSize = 31651651;
 const phpVersionString = '8.1.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_8_2.js
+++ b/packages/php-wasm/node/asyncify/php_8_2.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_2_29', 'php_8_2.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 32040568;
+export const dependenciesTotalSize = 32043737;
 const phpVersionString = '8.2.29';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_8_3.js
+++ b/packages/php-wasm/node/asyncify/php_8_3.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_3_24', 'php_8_3.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 33144925;
+export const dependenciesTotalSize = 33148094;
 const phpVersionString = '8.3.24';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_8_4.js
+++ b/packages/php-wasm/node/asyncify/php_8_4.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_4_11', 'php_8_4.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 36942530;
+export const dependenciesTotalSize = 36945699;
 const phpVersionString = '8.4.11';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/supported-php-versions.mjs
+++ b/packages/php-wasm/supported-php-versions.mjs
@@ -6,7 +6,7 @@
  * @property {string} lastRelease
  */
 
-export const lastRefreshed = '2025-07-30T06:35:47.306Z';
+export const lastRefreshed = '2025-08-04T12:45:56.385Z';
 
 /**
  * @type {PhpVersion[]}

--- a/packages/playground/cli/project.json
+++ b/packages/playground/cli/project.json
@@ -45,7 +45,7 @@
 		"dev": {
 			"executor": "nx:run-commands",
 			"options": {
-				"command": "bun --watch ./packages/playground/cli/src/cli.ts",
+				"command": "node --no-warnings --experimental-wasm-stack-switching --experimental-wasm-jspi --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/playground/cli/src/cli.ts",
 				"tty": true
 			}
 		},


### PR DESCRIPTION
## Motivation for the change, related issues

I listed the two crashes I encountered  while using Devtools in the comments.

I am currently recompiling `php-wasm-node:asyncify`. 

## Implementation details

Added the following functions in `ASYNCIFY_ONLY_PREFIXED` :

```diff
// NEEDED TO PREVENT THE FIRST CRASH
+ php_fopen_primary_script
+ persistent_stream_open_function
+ php_stream_open_for_zend
+ zend_error_zstr
+ zend_register_constant
+ zif_define

// NEEDED TO PREVENT THE SECOND CRASH
+ zend_undefined_index
```

## Testing Instructions

Based on the instructions from #2442

One test is to step into the running files 68 times until breaking on `define( 'WP_DEBUG', false );`. The next step would crash previously. Not anymore.

The second test is to quit the Devtools tab while it is running. It crashed previously. Not anymore.