### PR TITLE
Suppress PHP warnings when pre-fetching WordPress updates

### DIFF
--- a/packages/playground/remote/src/lib/wordpress-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/wordpress-fetch-network-transport.ts
@@ -217,6 +217,13 @@ export class WordPressFetchNetworkTransport {
 					delete_site_transient($php_transient_key);
 				}
 
+				// Suppress errors to avoid noise in the console. Otherwise, WordPress will
+				// log the following errors:
+				// * wp_update_plugins(): An unexpected error occurred. Something may be wrong with WordPress.org or this server
+				// * wp_update_themes(): An unexpected error occurred. Something may be wrong with WordPress.org or this server
+				// * wp_version_check(): An unexpected error occurred. Something may be wrong with WordPress.org or this server
+				$previous_error_reporting = error_reporting(0);
+
 				if (!$existing_transients['update_plugins']) {
 					wp_update_plugins();
 					delete_site_transient('update_plugins');

--- a/packages/playground/remote/src/lib/wordpress-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/wordpress-fetch-network-transport.ts
@@ -217,12 +217,23 @@ export class WordPressFetchNetworkTransport {
 					delete_site_transient($php_transient_key);
 				}
 
-				// Suppress errors to avoid noise in the console. Otherwise, WordPress will
-				// log the following errors:
-				// * wp_update_plugins(): An unexpected error occurred. Something may be wrong with WordPress.org or this server
-				// * wp_update_themes(): An unexpected error occurred. Something may be wrong with WordPress.org or this server
-				// * wp_version_check(): An unexpected error occurred. Something may be wrong with WordPress.org or this server
-				$previous_error_reporting = error_reporting(0);
+				// Set up custom error handler to suppress specific WordPress.org connection warnings:
+				// * wp_update_plugins(): An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.) in /wordpress/wp-includes/functions.php on line 135
+				// * wp_update_themes(): An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.) in /wordpress/wp-includes/functions.php on line 135
+				// * wp_version_check(): An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.) in /wordpress/wp-includes/functions.php on line 135
+				$previous_error_handler = set_error_handler(function($errno, $errstr, $errfile, $errline) {
+					if (
+						strpos($errstr, 'WordPress could not establish a secure connection to WordPress.org') !== false ||
+						strpos($errstr, 'An unexpected error occurred. Something may be wrong with WordPress.org') !== fals
+					) {
+						return true;
+					}
+					// For all other errors, use the previous error handler or default behavior
+					if ($previous_error_handler) {
+						return call_user_func($previous_error_handler, $errno, $errstr, $errfile, $errline);
+					}
+					return false; // Use default error handling
+				});
 
 				if (!$existing_transients['update_plugins']) {
 					wp_update_plugins();

--- a/packages/playground/remote/src/lib/wordpress-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/wordpress-fetch-network-transport.ts
@@ -222,9 +222,10 @@ export class WordPressFetchNetworkTransport {
 				// * wp_update_themes(): An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.) in /wordpress/wp-includes/functions.php on line 135
 				// * wp_version_check(): An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.) in /wordpress/wp-includes/functions.php on line 135
 				$previous_error_handler = set_error_handler(function($errno, $errstr, $errfile, $errline) {
+					global $previous_error_handler;
 					if (
 						strpos($errstr, 'WordPress could not establish a secure connection to WordPress.org') !== false ||
-						strpos($errstr, 'An unexpected error occurred. Something may be wrong with WordPress.org') !== fals
+						strpos($errstr, 'An unexpected error occurred. Something may be wrong with WordPress.org') !== false
 					) {
 						return true;
 					}


### PR DESCRIPTION
https://github.com/WordPress/wordpress-playground/pull/2295 added pre-fetching of all the api.wp.org/update-check requests in Playground Web. Unfortunately, it also generates some noise in the output:

```
[04-Aug-2025 17:10:25 UTC] PHP Warning:  wp_update_plugins(): An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.) in /wordpress/wp-includes/functions.php on line 135
[04-Aug-2025 17:10:25 UTC] PHP Warning:  wp_update_themes(): An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.) in /wordpress/wp-includes/functions.php on line 135
[04-Aug-2025 17:10:25 UTC] PHP Warning:  wp_version_check(): An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="https://wordpress.org/support/forums/">support forums</a>. (WordPress could not establish a secure connection to WordPress.org. Please contact your server administrator.) in /wordpress/wp-includes/functions.php on line 135
```

This PR suppresses those warnings without suppressing other errors.

cc @draganescu

## Testing instructions

1. Go to http://127.0.0.1:5400/website-server/?php=8.0
2. Confirm the warnings mentioned above are not present in the browser devtools