### PR TITLE
Suppress errors/warnings for wp_version_check.

### DIFF
--- a/packages/playground/remote/src/lib/wordpress-fetch-network-transport.ts
+++ b/packages/playground/remote/src/lib/wordpress-fetch-network-transport.ts
@@ -228,7 +228,8 @@ export class WordPressFetchNetworkTransport {
 				}
 
 				if (!$existing_transients['update_core']) {
-					wp_version_check();
+					// Silence warnings during wp_version_check() call
+					@wp_version_check();
 					delete_site_transient('update_core');
 				}
 			`,


### PR DESCRIPTION
## Motivation for the change, related issues
Closes: https://github.com/WordPress/wordpress-playground/issues/2452

## Implementation details
Suppress errors for `wp_version_check` function.

## Testing Instructions (or ideally a Blueprint)

1. Go to http://127.0.0.1:5400/website-server/website-server.
2. Click on the dashboard icon and check the logs tab. You can also verify the same in console logs.