### PR TITLE
[Website] Add PHP Playground

### DIFF
--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -329,6 +329,28 @@ $html_processor = WP_HTML_Processor::create_fragment('&lt;p>&lt;span>Hey!&lt;/sp
 $html_processor->next_tag();
 var_dump($html_processor->get_tag());</code></pre>
 						</li>
+						<li>
+							<strong>🔗 Embed in your app:</strong> You can embed
+							this playground in an iframe to provide interactive
+							PHP code snippets. Simply encode your code and PHP
+							version in the URL fragment. For example:
+							<pre
+								style="
+									background: #f5f5f5;
+									padding: 8px;
+									margin: 8px 0;
+									border-radius: 4px;
+									font-size: 13px;
+									overflow-x: auto;
+								"
+							><code>&lt;iframe 
+  src="https://playground.wordpress.net/php-playground.html#eyJjb2RlIjoiPD9waHBcblxuZWNobyBcIkkgYW0gYSBjb2RlIHNuaXBwZXQhXCI7XG4iLCJwaHAiOiI4LjQifQ=="
+  width="100%" 
+  height="600"&gt;
+&lt;/iframe&gt;</code></pre>
+							The above example loads:
+							<code>&lt;?php echo "I am a code snippet!"; </code>
+						</li>
 					</ul>
 
 					<p>

--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -307,6 +307,30 @@
 						</li>
 					</ul>
 
+					<h2>💡 Tips</h2>
+					<ul>
+						<li>
+							<strong>🌟 WordPress is available!</strong> Run
+							<code>require '/wordpress/wp-load.php';</code> to
+							load the latest WordPress release. For example:
+							<pre
+								style="
+									background: #f5f5f5;
+									padding: 8px;
+									margin: 8px 0;
+									border-radius: 4px;
+									font-size: 13px;
+									overflow-x: auto;
+								"
+							><code>&lt;?php
+require '/wordpress/wp-load.php';
+
+$html_processor = WP_HTML_Processor::create_fragment('&lt;p>&lt;span>Hey!&lt;/span>&lt;/p>');
+$html_processor->next_tag();
+var_dump($html_processor->get_tag());</code></pre>
+						</li>
+					</ul>
+
 					<p>
 						<strong
 							><a

--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -332,8 +332,8 @@ var_dump($html_processor->get_tag());</code></pre>
 						<li>
 							<strong>🔗 Embed in your app:</strong> You can embed
 							this playground in an iframe to provide interactive
-							PHP code snippets. Simply encode your code and PHP
-							version in the URL fragment. For example:
+							PHP code snippets. Provide your base64-encoded code
+							snippet and your PHP version in the URL fragment:
 							<pre
 								style="
 									background: #f5f5f5;

--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -1,0 +1,704 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>WordPress PHP Playground</title>
+		<style>
+			html,
+			body {
+				margin: 0;
+				height: 100%;
+				display: flex;
+				flex-direction: column;
+				font-family: system-ui, sans-serif;
+			}
+
+			#app {
+				flex: 1;
+				display: flex;
+				min-height: 0;
+			}
+
+			/* Editor (left) */
+			#editorPane {
+				flex: 1;
+				display: flex;
+				flex-direction: column;
+				min-width: 280px;
+			}
+
+			.controls {
+				padding: 8px 12px;
+				background: #f5f5f5;
+				border-bottom: 1px solid #ddd;
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				gap: 8px;
+				&,
+				* {
+					font-size: 16px;
+				}
+			}
+
+			.controls h1 {
+				margin: 0;
+				font-size: 18px;
+				font-weight: 600;
+				color: #333;
+			}
+
+			.controls-right {
+				display: flex;
+				align-items: center;
+				gap: 8px;
+			}
+
+			#helpBtn {
+				color: #0073aa;
+				text-decoration: none;
+				font-size: 14px;
+				margin-left: 8px;
+			}
+
+			#helpBtn:hover {
+				text-decoration: underline;
+			}
+
+			#editor {
+				flex: 1;
+				font-size: 14px;
+			}
+
+			/* CodeMirror font size */
+			#editor .cm-editor {
+				font-size: 14px;
+				line-height: 1.4;
+			}
+
+			#editor .cm-content {
+				font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono',
+					Consolas, 'Courier New', monospace;
+			}
+
+			/* Enhanced PHP syntax highlighting */
+			#editor .cm-editor .tok-keyword {
+				color: #0969da;
+				font-weight: 600;
+			}
+			#editor .cm-editor .tok-string {
+				color: #032f62;
+			}
+			#editor .cm-editor .tok-comment {
+				color: #6a737d;
+				font-style: italic;
+			}
+			#editor .cm-editor .tok-variableName {
+				color: #d73a49;
+			}
+			#editor .cm-editor .tok-number {
+				color: #005cc5;
+			}
+			#editor .cm-editor .tok-operator {
+				color: #d73a49;
+			}
+			#editor .cm-editor .tok-punctuation {
+				color: #24292e;
+			}
+			#editor .cm-editor .tok-typeName {
+				color: #6f42c1;
+			}
+			#editor .cm-editor .tok-propertyName {
+				color: #005cc5;
+			}
+			#editor .cm-editor .tok-function {
+				color: #6f42c1;
+				font-weight: 600;
+			}
+
+			/* Preview (right) */
+			#previewPane {
+				flex: 1;
+				position: relative;
+				min-width: 320px;
+			}
+
+			#preview {
+				position: absolute;
+				inset: 0;
+				width: 100%;
+				height: 100%;
+				border: 0;
+			}
+
+			/* Modal styles */
+			.modal {
+				display: none;
+				position: fixed;
+				z-index: 1000;
+				left: 0;
+				top: 0;
+				width: 100%;
+				height: 100%;
+				background-color: rgba(0, 0, 0, 0.5);
+			}
+
+			.modal.show {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+
+			.modal-content {
+				background: white;
+				border-radius: 8px;
+				padding: 24px;
+				max-width: 600px;
+				max-height: 80vh;
+				overflow-y: auto;
+				position: relative;
+				margin: 20px;
+				box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+			}
+
+			.modal-header {
+				display: flex;
+				justify-content: space-between;
+				align-items: center;
+				margin-bottom: 16px;
+				padding-bottom: 16px;
+				border-bottom: 1px solid #ddd;
+			}
+
+			.modal-header h2 {
+				margin: 0;
+				color: #333;
+				font-size: 20px;
+			}
+
+			.close {
+				background: none;
+				border: none;
+				font-size: 24px;
+				cursor: pointer;
+				color: #666;
+				padding: 0;
+				width: 30px;
+				height: 30px;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			}
+
+			.close:hover {
+				color: #333;
+			}
+
+			.modal-body {
+				line-height: 1.6;
+				color: #555;
+			}
+
+			.modal-body h3 {
+				color: #333;
+				margin-top: 20px;
+				margin-bottom: 8px;
+			}
+
+			.modal-body ul {
+				padding-left: 20px;
+			}
+
+			.modal-body a {
+				color: #0073aa;
+				text-decoration: none;
+			}
+
+			.modal-body a:hover {
+				text-decoration: underline;
+			}
+
+			.modal-body code {
+				background: #f5f5f5;
+				padding: 2px 4px;
+				border-radius: 3px;
+				font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono',
+					Consolas, 'Courier New', monospace;
+				font-size: 14px;
+			}
+
+			/* Responsive layout: stack panes on small screens */
+			@media (max-width: 900px) {
+				#app {
+					flex-direction: column;
+				}
+				#previewPane {
+					height: 50vh;
+					min-width: 0;
+				}
+				.modal-content {
+					margin: 10px;
+					max-width: calc(100% - 20px);
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<div id="app">
+			<div id="editorPane">
+				<div class="controls">
+					<h1>WordPress PHP Playground</h1>
+					<div class="controls-right">
+						<label for="phpVersion">PHP</label>
+						<select id="phpVersion">
+							<option value="8.4" selected>8.4</option>
+							<option value="8.3">8.3</option>
+							<option value="8.2">8.2</option>
+							<option value="8.1">8.1</option>
+							<option value="8.0">8.0</option>
+							<option value="7.4">7.4</option>
+							<option value="7.3">7.3</option>
+							<option value="7.2">7.2</option>
+						</select>
+						<button id="runBtn">Run</button>
+						<a href="#" id="helpBtn">How does this work?</a>
+					</div>
+				</div>
+				<div id="editor"></div>
+			</div>
+			<div id="previewPane">
+				<iframe id="preview" title="WordPress Playground"></iframe>
+			</div>
+		</div>
+
+		<!-- Help Modal -->
+		<div id="helpModal" class="modal">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h2>✨ WordPress PHP Playground ✨</h2>
+					<button class="close" id="closeModal">&times;</button>
+				</div>
+				<div class="modal-body">
+					<p>
+						This app runs PHP code directly inside your browser via
+						<a href="https://wordpress.org/playground/"
+							>WordPress Playground</a
+						>.
+					</p>
+
+					<p><strong>Here's how:</strong></p>
+
+					<ul>
+						<li>
+							<strong>🚀 WebAssembly Binary:</strong> The entire
+							PHP runtime is compiled with plenty of extensions to
+							run natively in your browser
+						</li>
+						<li>
+							<strong>🔌 JavaScript syscall handlers:</strong>
+							Network requests, subprocesses, file locks, and
+							other system calls are supported via JavaScript
+							handlers.
+						</li>
+						<li>
+							<strong>🔗 Shareable URLs:</strong> Code and
+							settings are encoded in the URL fragment, copy,
+							paste, and enjoy it together!
+						</li>
+					</ul>
+
+					<p>
+						<strong
+							><a
+								href="https://wordpress.org/playground/"
+								target="_blank"
+								>Learn more about WordPress Playground!</a
+							></strong
+						>
+					</p>
+				</div>
+			</div>
+		</div>
+
+		<script>
+			// Function to restore code and PHP version from URL fragment
+			function loadStateFromURL() {
+				const fragment = window.location.hash.slice(1); // Remove #
+				if (fragment) {
+					const decoded = decodeBase64UTF8(fragment);
+					if (decoded !== null) {
+						try {
+							const state = JSON.parse(decoded);
+							return {
+								code: state.code || null,
+								phpVersion: state.php || null,
+							};
+						} catch (e) {
+							// Try legacy format (just code)
+							return {
+								code: decoded,
+								phpVersion: null,
+							};
+						}
+					}
+				}
+				return { code: null, phpVersion: null };
+			}
+
+			/**
+			 * URL Fragment State Storage
+			 *
+			 * This implementation stores and restores PHP code and PHP version from the URL fragment using base64 encoding.
+			 * Features:
+			 * - UTF-8 safe encoding/decoding
+			 * - Stores both code and PHP version
+			 * - Automatic saving on code changes (debounced to 500ms)
+			 * - Automatic saving when PHP version changes
+			 * - Immediate saving when running code (Cmd+S)
+			 * - Browser navigation support (back/forward buttons)
+			 * - Shareable URLs with embedded code and PHP version
+			 * - Backward compatibility with legacy code-only URLs
+			 */
+
+			// Utility functions for UTF-8 safe base64 encoding/decoding
+			function encodeBase64UTF8(str) {
+				// Convert string to UTF-8 bytes, then to base64
+				return btoa(
+					encodeURIComponent(str).replace(
+						/%([0-9A-F]{2})/g,
+						(match, p1) => {
+							return String.fromCharCode('0x' + p1);
+						}
+					)
+				);
+			}
+
+			function decodeBase64UTF8(base64) {
+				try {
+					// Decode base64 to bytes, then interpret as UTF-8
+					return decodeURIComponent(
+						atob(base64)
+							.split('')
+							.map((c) => {
+								return (
+									'%' +
+									('00' + c.charCodeAt(0).toString(16)).slice(
+										-2
+									)
+								);
+							})
+							.join('')
+					);
+				} catch (e) {
+					console.warn(
+						'Failed to decode base64 from URL fragment:',
+						e
+					);
+					return null;
+				}
+			}
+
+			// Function to save code and PHP version to URL fragment
+			function saveStateToURL(code, phpVersion) {
+				const state = JSON.stringify({
+					code: code,
+					php: phpVersion,
+				});
+				const encoded = encodeBase64UTF8(state);
+				// Use replaceState to avoid adding to browser history
+				window.history.replaceState(null, null, '#' + encoded);
+			}
+
+			var versionSelect = document.getElementById('phpVersion');
+
+			function restorePHPVersionFromURL() {
+				var defaultPhpVersion = '8.4';
+				const { phpVersion: initialPhpVersion } = loadStateFromURL();
+				versionSelect.value = initialPhpVersion || defaultPhpVersion;
+			}
+			restorePHPVersionFromURL();
+
+			// Modal functionality
+			const helpBtn = document.getElementById('helpBtn');
+			const helpModal = document.getElementById('helpModal');
+			const closeModal = document.getElementById('closeModal');
+
+			function openModal() {
+				helpModal.classList.add('show');
+				document.body.style.overflow = 'hidden';
+			}
+
+			function closeModalFn() {
+				helpModal.classList.remove('show');
+				document.body.style.overflow = '';
+			}
+
+			helpBtn.addEventListener('click', (e) => {
+				e.preventDefault();
+				openModal();
+			});
+
+			closeModal.addEventListener('click', closeModalFn);
+
+			// Close modal when clicking outside
+			helpModal.addEventListener('click', (e) => {
+				if (e.target === helpModal) {
+					closeModalFn();
+				}
+			});
+
+			// Close modal with Escape key
+			document.addEventListener('keydown', (e) => {
+				if (
+					e.key === 'Escape' &&
+					helpModal.classList.contains('show')
+				) {
+					closeModalFn();
+				}
+			});
+		</script>
+
+		<script type="module">
+			import {
+				EditorState,
+				Compartment,
+			} from 'https://esm.sh/@codemirror/state';
+			import {
+				EditorView,
+				keymap,
+				lineNumbers,
+				highlightActiveLine,
+				highlightActiveLineGutter,
+				dropCursor,
+				rectangularSelection,
+				crosshairCursor,
+			} from 'https://esm.sh/@codemirror/view';
+			import {
+				defaultKeymap,
+				history,
+				historyKeymap,
+				indentWithTab,
+			} from 'https://esm.sh/@codemirror/commands';
+			import {
+				searchKeymap,
+				highlightSelectionMatches,
+			} from 'https://esm.sh/@codemirror/search';
+			import {
+				autocompletion,
+				completionKeymap,
+				closeBrackets,
+				closeBracketsKeymap,
+			} from 'https://esm.sh/@codemirror/autocomplete';
+			import {
+				foldGutter,
+				indentOnInput,
+				bracketMatching,
+				foldKeymap,
+				syntaxHighlighting,
+				defaultHighlightStyle,
+			} from 'https://esm.sh/@codemirror/language';
+			import { php } from 'https://esm.sh/@codemirror/lang-php';
+			import {
+				startPlaygroundWeb,
+				SupportedPHPVersionsList,
+			} from 'https://esm.sh/@wp-playground/client';
+
+			const editorEl = document.getElementById('editor');
+			const phpCompartment = new Compartment();
+
+			const defaultPhpVersion = '8.4';
+			const { phpVersion: initialPhpVersion } = loadStateFromURL();
+			const startingPhpVersion = initialPhpVersion || defaultPhpVersion;
+			// Populate PHP version select options from SupportedPHPVersionsList
+			versionSelect.innerHTML = ''; // Clear existing options
+
+			SupportedPHPVersionsList.forEach((version) => {
+				const option = document.createElement('option');
+				option.value = version;
+				option.textContent = version;
+				versionSelect.appendChild(option);
+			});
+
+			// Set the first version as selected by default
+			restorePHPVersionFromURL();
+
+			const defaultCode = `<?php
+// Welcome to PHP Playground!
+$message = "Hello from PHP " . phpversion();
+echo $message;
+
+function greet($name) {
+    return "Hello, " . $name . "!";
+}
+
+echo greet("World");
+?>`;
+
+			// Load initial state from URL
+			const { code: initialCode } = loadStateFromURL();
+			const startingCode = initialCode || defaultCode;
+
+			const state = EditorState.create({
+				doc: startingCode,
+				extensions: [
+					// Basic editor features
+					lineNumbers(),
+					highlightActiveLineGutter(),
+					highlightActiveLine(),
+					foldGutter(),
+					dropCursor(),
+					rectangularSelection(),
+					crosshairCursor(),
+
+					// Language and syntax
+					phpCompartment.of(php()),
+					syntaxHighlighting(defaultHighlightStyle),
+					indentOnInput(),
+					bracketMatching(),
+					closeBrackets(),
+
+					// History and undo/redo
+					history(),
+
+					// Search
+					highlightSelectionMatches(),
+
+					// Autocompletion
+					autocompletion(),
+
+					// Update listener to save code to URL fragment
+					EditorView.updateListener.of((update) => {
+						if (update.docChanged) {
+							const code = update.state.doc.toString();
+							const phpVersion =
+								document.getElementById('phpVersion').value;
+							// Debounce URL updates to avoid excessive history updates
+							clearTimeout(window.saveCodeTimeout);
+							window.saveCodeTimeout = setTimeout(() => {
+								saveStateToURL(code, phpVersion);
+							}, 500);
+						}
+					}),
+
+					// Keymaps (order matters - custom keymaps should come first)
+					keymap.of([
+						{
+							key: 'Mod-s',
+							preventDefault: true,
+							run() {
+								executeCode();
+								return true;
+							},
+						},
+						...closeBracketsKeymap,
+						...completionKeymap,
+						...foldKeymap,
+						...searchKeymap,
+						...historyKeymap,
+						...defaultKeymap,
+						indentWithTab,
+					]),
+				],
+			});
+
+			const view = new EditorView({ state, parent: editorEl });
+
+			const runBtn = document.getElementById('runBtn');
+			const previewIframe = document.getElementById('preview');
+
+			// Set initial PHP version from URL
+			if (startingPhpVersion) {
+				versionSelect.value = startingPhpVersion;
+			}
+
+			let client = null;
+			let currentPhpVersion = versionSelect.value;
+
+			// Detect platform for keyboard shortcut display
+			const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+			const shortcutText = isMac ? 'Cmd+S' : 'Ctrl+S';
+			runBtn.textContent = `Run (${shortcutText})`;
+
+			// Save to URL when PHP version changes
+			versionSelect.addEventListener('change', () => {
+				const code = view.state.doc.toString();
+				const phpVersion = versionSelect.value;
+				saveStateToURL(code, phpVersion);
+			});
+
+			async function bootPlayground(version) {
+				// Point the iframe at the appropriate PHP version using the Query API
+				previewIframe.src = `https://playground.wordpress.net/remote.html?php=${encodeURIComponent(
+					version
+				)}`;
+				client = await startPlaygroundWeb({
+					iframe: previewIframe,
+					remoteUrl: previewIframe.src,
+					blueprint: {
+						preferredVersions: {
+							wp: 'latest',
+							php: version,
+						},
+					},
+				});
+				await client.isReady;
+				await client.writeFile('/wordpress/code.php', startingCode);
+				await client.goTo('/code.php'); // Blank document
+			}
+
+			async function executeCode() {
+				const code = view.state.doc.toString();
+				const phpVersion = versionSelect.value;
+
+				// Save code and PHP version to URL fragment immediately when running
+				saveStateToURL(code, phpVersion);
+
+				if (phpVersion !== currentPhpVersion) {
+					currentPhpVersion = phpVersion;
+					await bootPlayground(currentPhpVersion);
+				}
+				await client.writeFile('/wordpress/code.php', code);
+				const uuid = crypto.randomUUID();
+				await client.goTo('/code.php?' + uuid);
+			}
+
+			runBtn.addEventListener('click', executeCode);
+
+			// Handle browser navigation (back/forward) to restore code from URL
+			window.addEventListener('hashchange', () => {
+				const { code: codeFromURL, phpVersion: phpVersionFromURL } =
+					loadStateFromURL();
+
+				if (codeFromURL !== null) {
+					const currentCode = view.state.doc.toString();
+					if (codeFromURL !== currentCode) {
+						// Update editor content
+						view.dispatch({
+							changes: {
+								from: 0,
+								to: view.state.doc.length,
+								insert: codeFromURL,
+							},
+						});
+					}
+				}
+
+				if (
+					phpVersionFromURL !== null &&
+					phpVersionFromURL !== versionSelect.value
+				) {
+					// Update PHP version selector
+					versionSelect.value = phpVersionFromURL;
+				}
+			});
+
+			// Save initial state to URL if not already present
+			if (!window.location.hash) {
+				saveStateToURL(startingCode, startingPhpVersion);
+			}
+
+			// Initial boot
+			bootPlayground(currentPhpVersion);
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Adds a CodeMirror editor with a Playground iframe to run any PHP code snippet directly in your browser.


https://github.com/user-attachments/assets/b7aaa59d-171c-4604-9955-0819371afe49


Once deployed, it will be available at https://playground.wordpress.net/php-playground.html.

## Tips

Here's an excerpt from the "how does it work" modal:

- **🌟 WordPress is available!**  
  Run `require '/wordpress/wp-load.php';` to load the latest WordPress release.  For example:

```php
  <?php
  require '/wordpress/wp-load.php';

  $html_processor = WP_HTML_Processor::create_fragment('<p><span>Hey!</span></p>');
  $html_processor->next_tag();
  var_dump($html_processor->get_tag());
```

- **🔗 Embed in your app:**

You can embed this playground in an iframe to provide interactive PHP code snippets. Provide your base64-encoded code, and the PHP version in the URL fragment. For example:

```html
<iframe 
  src="https://playground.wordpress.net/php-playground.html#eyJjb2RlIjoiPD9waHBcblxuZWNobyBcIkkgYW0gYSBjb2RlIHNuaXBwZXQhXCI7XG4iLCJwaHAiOiI4LjQifQ=="
  width="100%" 
  height="600">
</iframe>
```

Loads:

```
<?php echo "I am a code snippet!";
```

## Testing instructions

* Go to http://127.0.0.1:5400/website-server/php-playground.html
* Play with it, confirm it seems to work as intended

cc @fellyph @akirk @JanJakes @zaerl @dmsnell @brandonpayton 