### PR TITLE
[WordPress] Support auto-login with customize.php as a landing page

### DIFF
--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -286,7 +286,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * @returns The relative path.
 	 */
 	internalUrlToPath(internalUrl: string): string {
-		const url = new URL(internalUrl);
+		const url = new URL(internalUrl, 'https://playground.internal');
 		if (url.pathname.startsWith(this.#PATHNAME)) {
 			url.pathname = url.pathname.slice(this.#PATHNAME.length);
 		}

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -275,6 +275,9 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * @returns The absolute URL.
 	 */
 	pathToInternalUrl(path: string): string {
+		if (!path.startsWith('/')) {
+			path = `/${path}`;
+		}
 		return `${this.absoluteUrl}${path}`;
 	}
 

--- a/packages/php-wasm/universal/src/lib/urls.ts
+++ b/packages/php-wasm/universal/src/lib/urls.ts
@@ -17,6 +17,13 @@ export const DEFAULT_BASE_URL = 'http://example.com';
  * @returns The path, query, and fragment.
  */
 export function toRelativeUrl(url: URL): string {
+	/**
+	 * The origin of an about:blank URL is a string "null". The URL is not
+	 * relative, but there's also nothing we can do to make it "more relative"
+	 * so let's just bale out and return the URL as is.
+	 *
+	 * @see https://html.spec.whatwg.org/multipage/browsers.html#concept-origin (Opaque origins)
+	 */
 	if (url.origin === 'null') {
 		return url.toString();
 	}

--- a/packages/php-wasm/universal/src/lib/urls.ts
+++ b/packages/php-wasm/universal/src/lib/urls.ts
@@ -17,6 +17,9 @@ export const DEFAULT_BASE_URL = 'http://example.com';
  * @returns The path, query, and fragment.
  */
 export function toRelativeUrl(url: URL): string {
+	if (url.origin === 'null') {
+		return url.toString();
+	}
 	return url.toString().substring(url.origin.length);
 }
 

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -381,7 +381,7 @@ function compileBlueprintJson(
 					 */
 					const targetUrl = await (
 						playground as any
-					).internalUrlToPath(blueprint.landingPage || '/');
+					).pathToInternalUrl(blueprint.landingPage || '/');
 					await (playground as any).goTo(
 						'/index.php?playground-redirection-handler&next=' +
 							encodeURIComponent(targetUrl)

--- a/packages/playground/blueprints/src/lib/compile.ts
+++ b/packages/playground/blueprints/src/lib/compile.ts
@@ -373,8 +373,18 @@ function compileBlueprintJson(
 				}
 			} finally {
 				try {
+					/**
+					 * Use an intermediate redirection step to ensure the login cookies
+					 * are set before we redirecting to the landing page.
+					 *
+					 * @see playground_auto_login_redirect_target in the @wp-playground/wordpress package.
+					 */
+					const targetUrl = await (
+						playground as any
+					).internalUrlToPath(blueprint.landingPage || '/');
 					await (playground as any).goTo(
-						blueprint.landingPage || '/'
+						'/index.php?playground-redirection-handler&next=' +
+							encodeURIComponent(targetUrl)
 					);
 				} catch {
 					/**

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -643,7 +643,4 @@ test('WordPress homepage loads when mu-plugin prints a notice', async ({
 	await expect(wordpress.locator('body')).toContainText(
 		'Welcome to WordPress. This is your first post.'
 	);
-
-	// Verify there's no admin bar
-	await expect(wordpress.locator('body')).not.toContainText('Dashboard');
 });

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -628,7 +628,9 @@ test('WordPress homepage loads when mu-plugin prints a notice', async ({
 				step: 'writeFile',
 				path: '/wordpress/wp-content/mu-plugins/000-print-notice.php',
 				data: `<?php
+				add_action('init', function() {
 					echo 'This is a notice printed by an mu-plugin.';
+			    });
 				`,
 			},
 		],

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -178,6 +178,28 @@ test('Landing page without the initial slash should work', async ({
 	await expect(wordpress.locator('body')).toContainText('Plugins');
 });
 
+/**
+ * /wp-admin/customize.php, and potentially other pages in WordPress,
+ * run authorization checks before running the init hook. If they're
+ * set as the landing page of the Blueprint, the user will be redirected
+ * to wp-login.php?reauth=1 before we have a chance to set the
+ * authorization cookie.
+ *
+ * To avoid this, we redirect to an intermediate page that will
+ * redirect the user to the landing page.
+ */
+test('/wp-admin/customize.php should work as a landing page', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		landingPage: 'wp-admin/customize.php',
+		login: true,
+	};
+	await website.goto(`/#${JSON.stringify(blueprint)}`);
+	await expect(wordpress.locator('body')).toContainText('Customize');
+});
+
 test('wp-cli step should create a post', async ({ website, wordpress }) => {
 	const blueprint: Blueprint = {
 		landingPage: '/wp-admin/post.php',

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -234,7 +234,7 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 		 * redirect the user to the landing page.
 		 */
 		function playground_auto_login_redirect_target() {
-			if(str_starts_with($_SERVER['REQUEST_URI'], '/index.php?playground-redirection-handler')) {
+			if(strpos($_SERVER['REQUEST_URI'], '?playground-redirection-handler') !== false) {
 				$next = $_GET['next'];
 				header('Location: ' . $next, true, 302);
 				exit;

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -171,6 +171,9 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 			 */
 			if (headers_sent()) {
 				_doing_it_wrong('playground_auto_login', 'Headers already sent, the Playground runtime will not auto-login the user', '1.0.0');
+			if(str_contains($_SERVER['REQUEST_URI'], 'customize.php')) {
+				die("A");
+			}
 				return;
 			}
 
@@ -199,6 +202,7 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 			 * so we need to reload the page to ensure the cookies are set.
 			 */
 			$redirect_url = $_SERVER['REQUEST_URI'];
+
 			/**
 			 * Intentionally do not use wp_redirect() here. It removes
 			 * %0A and %0D sequences from the URL, which we don't want.
@@ -215,6 +219,28 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 		 * The wp hook isn't triggered on
 		 **/
 		add_action('init', 'playground_auto_login', 1);
+
+		/**
+		 * Use an intermediate redirection step to ensure the login cookies
+		 * are set before we redirecting to the landing page.
+		 *
+		 * /wp-admin/customize.php, and potentially other pages in WordPress,
+		 * run authorization checks before running the init hook. If they're
+		 * set as the landing page of the Blueprint, the user will be redirected
+		 * to wp-login.php?reauth=1 before we have a chance to set the
+		 * authorization cookie.
+		 *
+		 * To avoid this, we redirect to an intermediate page that will
+		 * redirect the user to the landing page.
+		 */
+		function playground_auto_login_redirect_target() {
+			if(str_starts_with($_SERVER['REQUEST_URI'], '/index.php?playground-redirection-handler')) {
+				$next = $_GET['next'];
+				header('Location: ' . $next, true, 302);
+				exit;
+			}
+		}
+		add_action('init', 'playground_auto_login_redirect_target', 1);
 
 		/**
 		 * Disable the Site Admin Email Verification Screen for any session started

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -171,9 +171,6 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 			 */
 			if (headers_sent()) {
 				_doing_it_wrong('playground_auto_login', 'Headers already sent, the Playground runtime will not auto-login the user', '1.0.0');
-			if(str_contains($_SERVER['REQUEST_URI'], 'customize.php')) {
-				die("A");
-			}
 				return;
 			}
 


### PR DESCRIPTION
## Motivation for the change, related issues

Introduces an additional redirection step – `/index.php?playground-redirection-handler` – to make sure the autologin step works with every possible landingPage in WordPress.

`/wp-admin/customize.php` (and potentially other pages in WordPress) run authorization checks before running the init hook. If the landingPage of a Blueprint is the customizer, the user will be redirected to:

* `/wp-admin/customize.php` ->
* `/wp-login.php?reauth=1&redirect_to=/wp-admin/customize.php` (we'll only set the auth cookies here) ->
* `/wp-login.php?reauth=1&redirect_to=/wp-admin/customize.php` (auth cookies have been immediately invalidated by reauth=1)

## Testing Instructions (or ideally a Blueprint)

Go to http://127.0.0.1:5400/website-server/?login=yes&url=/wp-admin/customize.php and confirm you're redirected to customizer without seeing the login form on the way there.

cc @fellyph @akirk @JanJakes 