### PR TITLE
[Website] Open external links in a new tab/window

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -101,15 +101,35 @@ function playground_add_target_blank_to_external_links() {
 		return;
 	}
 	?>
-	<script>
-		document.addEventListener('click', e => {
-			const a = e.target.closest('a[href]');
-			if (!a) return;                                 // not a link
-			if (new URL(a.href, location).origin !== location.origin) {
-				a.target = '_blank';                        // open in new tab/window
-				a.rel ||= 'noopener';                       // cuts the opener reference
+	<script type="module">
+		
+		function addTargetBlankToExternalLinks() {
+			function handleClick(a) {
+				const url = new URL(a.href, location);
+				if (url.origin !== location.origin) {
+					a.target = '_blank';
+				}
 			}
-		});
+
+			// Set target="_blank" for existing external links
+			document.querySelectorAll('a[href]').forEach(a => {
+				handleClick(a);
+			});
+			
+			// Set target="_blank" for external links when clicked.
+			// This covers links that are added after the page has loaded.
+			document.addEventListener('click', e => {
+				const a = e.target.closest('a[href]');
+				if (!a) return;
+				handleClick(a);
+			});
+		}
+		
+		if (document.readyState === 'loading') {
+			document.addEventListener('DOMContentLoaded', addTargetBlankToExternalLinks);
+		} else {
+			addTargetBlankToExternalLinks();
+		}
 	</script>
 
 	<?php

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -111,7 +111,8 @@ function playground_add_target_blank_to_external_links() {
 				}
 			}
 
-			// Set target="_blank" for existing external links
+			// Set target="_blank" for existing external links – this
+			// covers keyboard navigation.
 			document.querySelectorAll('a[href]').forEach(a => {
 				handleClick(a);
 			});
@@ -123,6 +124,14 @@ function playground_add_target_blank_to_external_links() {
 				if (!a) return;
 				handleClick(a);
 			});
+
+			// Also handle focus events to cover keyboard navigation on
+			// links that are added after the page has loaded.
+			document.addEventListener('focus', e => {
+				const a = e.target.closest('a[href]');
+				if (!a) return;
+				handleClick(a);
+			}, true);
 		}
 		
 		if (document.readyState === 'loading') {

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -104,7 +104,7 @@ function playground_add_target_blank_to_external_links() {
 	<script type="module">
 		
 		function addTargetBlankToExternalLinks() {
-			function handleClick(a) {
+			function addTargetBlank(a) {
 				const url = new URL(a.href, location);
 				if (url.origin !== location.origin) {
 					a.target = '_blank';
@@ -114,7 +114,7 @@ function playground_add_target_blank_to_external_links() {
 			// Set target="_blank" for existing external links – this
 			// covers keyboard navigation.
 			document.querySelectorAll('a[href]').forEach(a => {
-				handleClick(a);
+				addTargetBlank(a);
 			});
 			
 			// Set target="_blank" for external links when clicked.
@@ -122,7 +122,7 @@ function playground_add_target_blank_to_external_links() {
 			document.addEventListener('click', e => {
 				const a = e.target.closest('a[href]');
 				if (!a) return;
-				handleClick(a);
+				addTargetBlank(a);
 			});
 
 			// Also handle focus events to cover keyboard navigation on
@@ -130,7 +130,7 @@ function playground_add_target_blank_to_external_links() {
 			document.addEventListener('focus', e => {
 				const a = e.target.closest('a[href]');
 				if (!a) return;
-				handleClick(a);
+				addTargetBlank(a);
 			}, true);
 		}
 		

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -100,9 +100,9 @@ function playground_add_target_blank_to_external_links() {
 	if (empty($_SERVER['REQUEST_URI']) || wp_doing_ajax() || wp_doing_cron()) {
 		return;
 	}
+	
 	?>
-	<script type="module">
-		
+	<script>
 		function addTargetBlankToExternalLinks() {
 			function addTargetBlank(a) {
 				const url = new URL(a.href, location);
@@ -133,7 +133,7 @@ function playground_add_target_blank_to_external_links() {
 				addTargetBlank(a);
 			}, true);
 		}
-		
+
 		if (document.readyState === 'loading') {
 			document.addEventListener('DOMContentLoaded', addTargetBlankToExternalLinks);
 		} else {

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -92,6 +92,32 @@ add_action('admin_print_scripts', function () {
 });
 
 /**
+ * Adds target="_blank" to external links when clicked to open them in a new tab.
+ * This prevents users from loading non-Playground pages inside the Playground iframe.
+ */
+function playground_add_target_blank_to_external_links() {
+	// Only run on frontend and admin pages, not during AJAX requests or CLI
+	if (empty($_SERVER['REQUEST_URI']) || wp_doing_ajax() || wp_doing_cron()) {
+		return;
+	}
+	?>
+	<script>
+		document.addEventListener('click', e => {
+			const a = e.target.closest('a[href]');
+			if (!a) return;                                 // not a link
+			if (new URL(a.href, location).origin !== location.origin) {
+				a.target = '_blank';                        // open in new tab/window
+				a.rel ||= 'noopener';                       // cuts the opener reference
+			}
+		});
+	</script>
+
+	<?php
+}
+add_action('wp_head', 'playground_add_target_blank_to_external_links');
+add_action('admin_head', 'playground_add_target_blank_to_external_links');
+
+/**
  * The default WordPress requests transports have been disabled
  * at this point. However, the Requests class requires at least
  * one working transport or else it throws warnings and acts up.


### PR DESCRIPTION
## Motivation for the change, related issues

Adds `target="_blank"` to external links in Playground web (not CLI). This ensures external links are loaded in a new tab and not inside the Playground iframe.

## Implementation details

Adds `a.target = '_blank';` via a `<script>` echoed by an mu-plugin.

## Testing Instructions (or ideally a Blueprint)

Go to wp-admin and click the `WordPress` link in this part of the footer:

> Thank you for creating with [WordPress](https://wordpress.org/).Version 6.8.2

cc @fellyph – While looking at your Blueprint I realized this is something we should solve at the platform level. 

cc @JanJakes for reviews