### PR TITLE
Tagalog: Translations of Blueprints docs page

### DIFF
--- a/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/blueprints/intro.md
+++ b/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/blueprints/intro.md
@@ -1,0 +1,44 @@
+---
+title: Introduction
+slug: /blueprints
+id: introduction
+---
+
+import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
+
+# Blueprints Docs
+
+:::tip
+Tingnan ang [Blueprints Gallery](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md) upang tuklasin ang mga totoong halimbawa ng code ng paggamit ng WordPress Playground para maglunsad ng isang WordPress site na may iba't ibang setup.
+:::
+
+Hi! Maligayang pagdating sa dokumentasyon ng WordPress Playground Blueprints.
+
+Ang Blueprints ay mga JSON file para sa pag-set up ng iyong sariling WordPress Playground instance. Sa subsite na ito (Blueprints Docs) mo makikita ang lahat ng impormasyong kailangan mo para gamitin ang Blueprints.
+
+<p class="docs-hubs">Ang dokumentasyon ng WordPress Playground ay hinati sa apat na magkakahiwalay na hub (subsite):</p>
+
+-   [**Dokumentasyon**](/) – Panimula sa WP Playground, mga gabay sa pagsisimula, at iyong entry point sa WP Playground Docs.
+-   👉 [**Blueprints**](/blueprints) (nandito ka) – Ang Blueprints ay mga JSON file para i-setup ang iyong WordPress Playground instance. Alamin ang mga posibilidad nito sa hub na ito.
+-   [**Mga Developer**](/developers) – Ang WordPress Playground ay ginawa bilang programmable na tool. Tuklasin lahat ng magagawa mo rito gamit ang iyong code sa Developers hub.
+-   [**Sanggunian ng API**](/api) – Lahat ng API na inaalok ng WordPress Playground
+
+## Paglilibot sa hub ng dokumentasyon ng Blueprints
+
+Nakatuon ang hub na ito sa impormasyon tungkol sa Blueprints at hinati sa mga sumusunod na pangunahing seksyon:
+
+-   [Pagsisimula sa Blueprints](/blueprints/getting-started): Mabilis na gabay sa pag-set up ng WordPress Playground instance gamit ang Blueprint JSON file.
+
+-   [Tutorial – Blueprints 101](/blueprints/tutorial): Crash course sa Blueprints API. Gabay sa buong proseso ng paggawa ng blueprint na naglo-load ng tema at plugin (at iba pa).
+
+-   [Format ng Blueprint data](/blueprints/data-format): Ang Blueprint JSON file ay naglalarawan ng iyong Playground instance gamit ang iba't ibang property. Itong seksyon ay tumutuon sa mga pangunahing property na dapat mong malaman.
+
+-   [Paggamit ng mga Blueprints](/blueprints/using-blueprints): Alamin dito ang iba't ibang paraan ng paggamit ng Blueprints.
+
+-   [Mga Hakbang](/blueprints/steps): Sanggunian ng API para sa lahat ng available na hakbang na maaaring ilagay sa blueprint para magpatakbo ng tasks tulad ng pag-login, pag-activate ng plugin/tema, file operations, at iba pa.
+
+-   [Mga Bundle ng Blueprint](/blueprints/bundles): Alamin kung paano gumawa at gumamit ng mga Blueprint bundle – self-contained na package na may kasamang Blueprint at lahat ng kinakailangang resources.
+
+-   [Mga Halimbawa](/blueprints/examples): Koleksyon ng mga halimbawa ng Blueprint para sa iba't ibang setup ng WordPress Playground, kasama ang pag-install ng tema/plugin, pagpapatakbo ng PHP code, pag-enable ng features, at pag-load ng partikular na bersyon ng WordPress.
+
+-   [Pag-troubleshoot at pag-debug ng Blueprints](/blueprints/troubleshoot-and-debug): Mga tip at tools para sa pag-troubleshoot at pag-debug ng Blueprints.


### PR DESCRIPTION
## Motivation for the change, related issues
This PR adds Tagalog (Filipino) translation for the WordPress Playground Blueprints introduction page. This translation improves accessibility for Filipino developers and users who prefer to read documentation in their native language, making WordPress Playground more inclusive and accessible to the global WordPress community.

## Implementation details

- File added: packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/blueprints/intro.md
- Translation: Complete Tagalog translation of the Blueprints introduction page
- Content preserved: All original structure, links, and formatting maintained
