### PR TITLE
Updated Typos in contributor-badge.md File

### DIFF
--- a/packages/docs/site/docs/main/contributing/contributor-badge.md
+++ b/packages/docs/site/docs/main/contributing/contributor-badge.md
@@ -24,13 +24,13 @@ Any contribution to the WordPress Playground project is highly valued. The Playg
 
 To get a Playground Contributor Badge, you must have made at least one eligible contribution from the list above. The team may choose to award the badge for other contributions or a combination of the above at the team’s discretion.
 
-![Playground Contributor Dadge](@site/static/img/contributing/playground-contributor-badge.webp)
+![Playground Contributor Badge](@site/static/img/contributing/playground-contributor-badge.webp)
 
 ## Playground Team Badge
 
 If you are currently a contributor and have been actively involved in the Playground project for the past **twelve months**, you are eligible for a **Playground Team Badge**.
 
-![Playground Contributor Dadge](@site/static/img/contributing/playground-team-badge.webp)
+![Playground Contributor Badge](@site/static/img/contributing/playground-team-badge.webp)
 
 ## Requesting a Profile Badge
 
@@ -41,6 +41,6 @@ If you meet the criteria, you can request a badge. Please include links to resou
 
 ### Request form
 
-![Playground Contributor Dadge](@site/static/img/contributing/request-contributor-badge.webp)
+![Playground Contributor Badge](@site/static/img/contributing/request-contributor-badge.webp)
 
 To access the request, the user should be logged in with their WordPress.org account and open the Request Membership tab, after submitting the required information. A Playground Team Representative will confirm your contribution and assign the badge. The team will perform a weekly review of contributions and award badges at that time. Updates on new badges awarded will be posted during the Playground Team meeting.


### PR DESCRIPTION
## Motivation for the change, related issues

Corrected typos in `packages/docs/site/docs/main/contributing/contributor-badge.md` file

## Implementation details
- Added `Playground Contributor Badge` instead of `Playground Contributor Dadge`

## Testing Instructions (or ideally a Blueprint)
- Open`packages/docs/site/docs/main/contributing/contributor-badge.md`.
- See Typos in Line no 27, 33 and 44
