### PR TITLE
[i18n] Translating fragments docs and adding Contributor badge page

### DIFF
--- a/packages/docs/site/i18n/pt-BR/_fragments/_api_list.mdx
+++ b/packages/docs/site/i18n/pt-BR/_fragments/_api_list.mdx
@@ -1,0 +1,9 @@
+<!-- Original English content:
+-   [Query API](/developers/apis/query-api) enable basic operations using only query parameters
+-   [Blueprints API](/blueprints) give you a great degree of control with a simple JSON file
+-   [JavaScript API](/developers/apis/javascript-api) give you full control via a JavaScript client from an npm package
+-->
+
+-   [Query API](/developers/apis/query-api) permite operações básicas usando apenas parâmetros de consulta
+-   [Blueprints API](/blueprints) oferece um alto grau de controle com um arquivo JSON simples
+-   [JavaScript API](/developers/apis/javascript-api) oferece controle total através de um cliente JavaScript de um pacote npm

--- a/packages/docs/site/i18n/pt-BR/_fragments/_playground_wp_net_may_stop_working.md
+++ b/packages/docs/site/i18n/pt-BR/_fragments/_playground_wp_net_may_stop_working.md
@@ -1,0 +1,13 @@
+<!-- Original English content:
+:::caution Careful with the demo site
+
+The site at https://playground.wordpress.net is there to support the community, but there are no guarantees it will continue to work if the traffic grows significantly.
+
+If you need certain availability, you should [host your own WordPress Playground](/developers/architecture/host-your-own-playground).
+-->
+
+:::caution Cuidado com o site de demonstração
+
+O site em https://playground.wordpress.net está lá para apoiar a comunidade, mas não há garantias de que continuará funcionando se o tráfego crescer significativamente.
+
+Se você precisa de certa disponibilidade, você deve [hospedar seu próprio WordPress Playground](/developers/architecture/host-your-own-playground).

--- a/packages/docs/site/i18n/pt-BR/_fragments/_this_is_query_api.md
+++ b/packages/docs/site/i18n/pt-BR/_fragments/_this_is_query_api.md
@@ -1,0 +1,5 @@
+<!-- Original English content:
+This is called [Query API](/developers/apis/query-api/) and you can learn more about it [here](/developers/apis/query-api/).
+-->
+
+Isso é chamado de [Query API](/developers/apis/query-api/) e você pode aprender mais sobre isso [aqui](/developers/apis/query-api/).

--- a/packages/docs/site/i18n/pt-BR/_fragments/_work_in_progress.md
+++ b/packages/docs/site/i18n/pt-BR/_fragments/_work_in_progress.md
@@ -1,0 +1,11 @@
+<!-- Original English content:
+:::danger Work in Progress
+
+WordPress Playground is under active development and the features described in this document
+may break or change without a warning.
+-->
+
+:::danger Trabalho em Andamento
+
+O WordPress Playground está em desenvolvimento ativo e os recursos descritos neste documento
+podem quebrar ou mudar sem aviso prévio.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/about/build.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/about/build.md
@@ -1,0 +1,174 @@
+---
+title: Build
+slug: /about/build
+description: Build with WP Playground
+sidebar_class_name: navbar-build-item
+---
+
+<!--
+# Build
+-->
+
+# Construir
+
+<!--
+WordPress Playground can help you to create and learn WordPress quickly, even on mobile with no signal. You can use Playground where you work best, whether that's in the browser, Node.js, mobile apps, VS Code, or elsewhere.
+-->
+
+O WordPress Playground pode ajudá-lo a criar e aprender WordPress rapidamente, mesmo no celular sem sinal. Você pode usar o Playground onde trabalha melhor, seja no navegador, Node.js, aplicativos móveis, VS Code ou em outros lugares.
+
+<!--
+## Setting quickly a local WordPress environment
+-->
+
+## Configurando rapidamente um ambiente WordPress local
+
+<!--
+You can seamlessly integrate Playground into your development workflow to launch a local WordPress environment quickly for testing your code. You can do this directly [from the terminal](/developers/local-development/wp-playground-cli) or [your preferred IDE.](/developers/local-development/vscode-extension)
+-->
+
+Você pode integrar perfeitamente o Playground ao seu fluxo de trabalho de desenvolvimento para lançar rapidamente um ambiente WordPress local para testar seu código. Você pode fazer isso diretamente [do terminal](/developers/local-development/wp-playground-cli) ou [da sua IDE preferida](/developers/local-development/vscode-extension).
+
+<!--
+## Save changes done on a Block Theme and create Github Pull Requests
+-->
+
+## Salvar alterações feitas em um Tema de Blocos e criar Pull Requests no GitHub
+
+<!--
+You can connect your Playground instance to a GitHub repository and create a Pull Request with the changes you've done through the WordPress UI, leveraging the [Create Block Theme](https://wordpress.org/plugins/create-block-theme/) plugin.
+
+With this workflow, you could build a block theme completely in your browser and save your change to GitHub, or you could improve/fix an existing one.
+-->
+
+Você pode conectar sua instância do Playground a um repositório GitHub e criar um Pull Request com as alterações que fez através da interface do WordPress, aproveitando o plugin [Create Block Theme](https://wordpress.org/plugins/create-block-theme/).
+
+Com este fluxo de trabalho, você pode construir um tema de blocos completamente no seu navegador e salvar suas alterações no GitHub, ou pode melhorar/corrigir um existente.
+
+<iframe width="800" src="https://www.youtube.com/embed/94KnoFhQg1g" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<p></p>
+
+<!--
+Some more examples of this workflow:
+
+-   [Developer Hours: Creating WordPress Playground Blueprints for Testing and Demos](https://www.youtube.com/watch?v=gKrij8V3nK0&t=2488s)
+-   [Recap Hallway Hangout: Theme Building with Playground, Create-block-theme plugin, and GitHub](https://make.wordpress.org/core/2024/06/25/recap-hallway-hangout-theme-building-with-playground-create-block-theme-plugin-and-github/)
+-->
+
+Mais alguns exemplos deste fluxo de trabalho:
+
+-   [Developer Hours: Creating WordPress Playground Blueprints for Testing and Demos](https://www.youtube.com/watch?v=gKrij8V3nK0&t=2488s)
+-   [Recap Hallway Hangout: Theme Building with Playground, Create-block-theme plugin, and GitHub](https://make.wordpress.org/core/2024/06/25/recap-hallway-hangout-theme-building-with-playground-create-block-theme-plugin-and-github/)
+
+<!--
+## Synchronize your playground instance with a local folder and create Github Pull Requests
+-->
+
+## Sincronizar sua instância do playground com uma pasta local e criar Pull Requests no GitHub
+
+![Captura do Tipo de Armazenamento do Dispositivo](../_assets/storage-type-device.png)
+
+<!--
+With Google Chrome you can synchronize your Playground instance with a local directory, that can be either:
+
+-   And empty directory – to save this Playground and start syncing
+-   An existing directory – to load it here and start syncing
+-->
+
+Com o Google Chrome você pode sincronizar sua instância do Playground com um diretório local, que pode ser:
+
+-   Um diretório vazio – para salvar este Playground e começar a sincronizar
+-   Um diretório existente – para carregá-lo aqui e começar a sincronizar
+
+<!--
+:::info
+
+This feature is only available for Google Chrome for now. It won't work with other browsers, yet.
+
+:::
+-->
+
+:::info
+
+Este recurso está disponível apenas para o Google Chrome por enquanto. Não funcionará com outros navegadores ainda.
+
+:::
+
+<!--
+Regarding changes done on both sides of the connection:
+
+-   Files changed in Playground will be synchronized to your computer.
+-   Files changed on your computer will not be synchronized to Playground. You'll need to click the "Sync local files" button.
+
+With this workflow you can create directly GitHub PRs from your changes done on your local directory.
+-->
+
+Quanto às alterações feitas em ambos os lados da conexão:
+
+-   Arquivos alterados no Playground serão sincronizados para o seu computador.
+-   Arquivos alterados no seu computador não serão sincronizados para o Playground. Você precisará clicar no botão "Sync local files".
+
+Com este fluxo de trabalho você pode criar diretamente PRs do GitHub a partir das suas alterações feitas no seu diretório local.
+
+<!--
+See here a little demo of this workflow in action:
+-->
+
+Veja aqui uma pequena demonstração deste fluxo de trabalho em ação:
+
+<iframe width="800" src="https://www.youtube.com/embed/UYK88eZqrjo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<p></p>
+
+<!--
+## Integrate with other APIs to create new tools.
+-->
+
+## Integrar com outras APIs para criar novas ferramentas.
+
+<!--
+Playground can be combined with different APIs to create amazing tools. The possibilities are endless.
+
+You can [use WordPress Playground in Node.js](/developers/local-development/php-wasm-node) to create new tools. The [@php-wasm/node package](https://npmjs.org/@php-wasm/node), which ships the PHP WebAssembly runtime, is the package used for [https://playground.wordpress.net/](https://playground.wordpress.net/), for example.
+
+Another interesting app built on top of Playground is **Translate Live** (see [example](https://translate.wordpress.org/projects/wp-plugins/friends/dev/de/default/playground/)) which, in combination with Open AI provides a WordPress translations tool "in place" where translations can be seen and modified in their real context (see example). Read more about this tool at [Translate Live: Updates to the Translation Playground](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-->
+
+O Playground pode ser combinado com diferentes APIs para criar ferramentas incríveis. As possibilidades são infinitas.
+
+Você pode [usar o WordPress Playground no Node.js](/developers/local-development/php-wasm-node) para criar novas ferramentas. O pacote [@php-wasm/node](https://npmjs.org/@php-wasm/node), que envia o runtime PHP WebAssembly, é o pacote usado para [https://playground.wordpress.net/](https://playground.wordpress.net/), por exemplo.
+
+Outro aplicativo interessante construído sobre o Playground é o **Translate Live** (veja [exemplo](https://translate.wordpress.org/projects/wp-plugins/friends/dev/de/default/playground/)) que, em combinação com a Open AI, fornece uma ferramenta de traduções WordPress "no local" onde as traduções podem ser vistas e modificadas em seu contexto real (veja exemplo). Leia mais sobre esta ferramenta em [Translate Live: Updates to the Translation Playground](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+
+<!--
+## Work offline and as a native app
+-->
+
+## Trabalhar offline e como um aplicativo nativo
+
+<!--
+When you first visit [playground.wordpress.net](https://playground.wordpress.net/), your browser automatically caches all the necessary files to use Playground. From that point on, you can access [playground.wordpress.net](https://playground.wordpress.net/), even without internet connection, ensuring you can continue working on your projects without interruptions.
+
+You can also install Playground on your device as a Progressive Web App (PWA) to launch the Playground directly from your home screen—just like a native app.
+
+Read [Introducing Offline Mode and PWA Support for WordPress Playground](https://make.wordpress.org/playground/2024/08/05/offline-mode-and-pwa-support/) for more info.
+-->
+
+Quando você visita pela primeira vez [playground.wordpress.net](https://playground.wordpress.net/), seu navegador automaticamente armazena em cache todos os arquivos necessários para usar o Playground. A partir desse momento, você pode acessar [playground.wordpress.net](https://playground.wordpress.net/), mesmo sem conexão com a internet, garantindo que você pode continuar trabalhando em seus projetos sem interrupções.
+
+Você também pode instalar o Playground no seu dispositivo como um Progressive Web App (PWA) para lançar o Playground diretamente da sua tela inicial—exatamente como um aplicativo nativo.
+
+Leia [Introducing Offline Mode and PWA Support for WordPress Playground](https://make.wordpress.org/playground/2024/08/05/offline-mode-and-pwa-support/) para mais informações.
+
+<!--
+## Embed a WordPress site in non-web environments
+-->
+
+## Incorporar um site WordPress em ambientes não-web
+
+<!--
+The [How to ship a real WordPress site in a native iOS app via Playground?](../guides/wordpress-native-ios-app) guide shows how we can leverage Playground to wrap a WordPress site into an IOS app.
+-->
+
+O guia [How to ship a real WordPress site in a native iOS app via Playground?](../guides/wordpress-native-ios-app) mostra como podemos aproveitar o Playground para envolver um site WordPress em um aplicativo iOS.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/about/test.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/about/test.md
@@ -1,0 +1,100 @@
+---
+title: Test
+slug: /about/test
+---
+
+<!--
+# Test
+-->
+
+# Testar
+
+<!--
+Upgrade your QA process with the ability to review progress in your browser in a single click. When you're ready, push updates instantly.
+-->
+
+Aprimore seu processo de QA com a capacidade de revisar o progresso no seu navegador com um único clique. Quando estiver pronto, envie atualizações instantaneamente.
+
+<!--
+## Test any theme or plugin
+-->
+
+## Testar qualquer tema ou plugin
+
+<!--
+With Playground, you can test any plugin or theme. Use the [Query API](/developers/apis/query-api) to quickly load any plugin or theme published in wordpress.org [plugins](https://wordpress.org/plugins) and [themes](https://wordpress.org/themes/) directories.
+
+For example, the following link will load the ["pendant" theme](https://wordpress.org/themes/pendant/) and the[ "gutenberg" plugin](https://wordpress.org/plugins/gutenberg/) on a Playground instance:
+
+[https://playground.wordpress.net/?theme=pendant&plugin=gutenberg](https://playground.wordpress.net/?theme=pendant&plugin=gutenberg)
+
+But you can also test [more elaborate configurations using blueprints](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md), for example testing a plugin's code from a gist (see [blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/install-plugin-from-gist/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/install-plugin-from-gist/blueprint.json))
+-->
+
+Com o Playground, você pode testar qualquer plugin ou tema. Use a [Query API](/developers/apis/query-api) para carregar rapidamente qualquer plugin ou tema publicado nos diretórios de [plugins](https://wordpress.org/plugins) e [temas](https://wordpress.org/themes/) do wordpress.org.
+
+Por exemplo, o seguinte link carregará o tema ["pendant"](https://wordpress.org/themes/pendant/) e o plugin ["gutenberg"](https://wordpress.org/plugins/gutenberg/) em uma instância do Playground:
+
+[https://playground.wordpress.net/?theme=pendant&plugin=gutenberg](https://playground.wordpress.net/?theme=pendant&plugin=gutenberg)
+
+Mas você também pode testar [configurações mais elaboradas usando blueprints](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md), por exemplo testando o código de um plugin de um gist (veja [blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/install-plugin-from-gist/blueprint.json) e [demonstração ao vivo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/install-plugin-from-gist/blueprint.json))
+
+<!--
+## Live preview pull requests
+-->
+
+## Visualização ao vivo de pull requests
+
+<!--
+Testing pull requests is one of the most exciting use cases for the Playground project. With Playground, you can enable a Live preview link on each Pull Request of a WordPress-related project in GitHub so that developers can see in action the effects of code in that Pull Request. Read more about this at [Preview WordPress Core Pull Requests with Playground](https://wptavern.com/preview-wordpress-core-pull-requests-with-playground#:~:text=Previewing%20WordPress%20Pull%20Requests%20requires,testing%20and%20team%20workflows%20difficult.).
+
+There are some public implementations of this use case such as [WordPress Core PR previewer](https://playground.wordpress.net/wordpress.html) and [Gutenberg PR previewer](https://playground.wordpress.net/gutenberg.html). Users can input the PR number or URL to be redirected to a WordPress instance, powered by Playground, where the changes from the PR are applied.
+
+GitHub actions such as [WP Playground PR Preview](https://github.com/vcanales/action-wp-playground-pr-preview) allows you to add PR previews powered by WP Playground on any repository. For example, this feature [was enabled](https://github.com/WordPress/twentytwentyfive/pull/359) in the [WordPress/twentytwentyfive](https://github.com/WordPress/twentytwentyfive) repository.
+-->
+
+Testar pull requests é um dos casos de uso mais emocionantes do projeto Playground. Com o Playground, você pode habilitar um link de visualização ao vivo em cada Pull Request de um projeto relacionado ao WordPress no GitHub para que os desenvolvedores possam ver em ação os efeitos do código nesse Pull Request. Leia mais sobre isso em [Preview WordPress Core Pull Requests with Playground](https://wptavern.com/preview-wordpress-core-pull-requests-with-playground#:~:text=Previewing%20WordPress%20Pull%20Requests%20requires,testing%20and%20team%20workflows%20difficult.).
+
+Existem algumas implementações públicas deste caso de uso, como o [WordPress Core PR previewer](https://playground.wordpress.net/wordpress.html) e o [Gutenberg PR previewer](https://playground.wordpress.net/gutenberg.html). Os usuários podem inserir o número do PR ou URL para ser redirecionados para uma instância WordPress, alimentada pelo Playground, onde as alterações do PR são aplicadas.
+
+GitHub actions como [WP Playground PR Preview](https://github.com/vcanales/action-wp-playground-pr-preview) permitem adicionar visualizações de PR alimentadas pelo WP Playground em qualquer repositório. Por exemplo, este recurso [foi habilitado](https://github.com/WordPress/twentytwentyfive/pull/359) no repositório [WordPress/twentytwentyfive](https://github.com/WordPress/twentytwentyfive).
+
+<!--
+## Clone your site and experiment in a private sandbox.
+-->
+
+## Clone seu site e experimente em uma sandbox privada.
+
+<!--
+With the [Sandbox Site powered by Playground](https://wordpress.org/plugins/playground/) plugin you can create a private WordPress Playground copy of your site to test plugins safely or do any other experiments on your site's replica without uploading any data to the cloud and without affecting the original site.
+-->
+
+Com o plugin [Sandbox Site powered by Playground](https://wordpress.org/plugins/playground/) você pode criar uma cópia privada do WordPress Playground do seu site para testar plugins com segurança ou fazer qualquer outro experimento na réplica do seu site sem fazer upload de dados para a nuvem e sem afetar o site original.
+
+<!--
+## Test different WordPress and PHP versions.
+-->
+
+## Testar diferentes versões do WordPress e PHP.
+
+<!--
+With Playground, you can quickly test any major WordPress or PHP version by _customizing its settings_ or using a custom blueprint with the `preferredVersions` property.
+
+For example, you can always test the latest development version of WordPress, also called [Beta Nightly](https://wordpress.org/download/beta-nightly/), from this link: [https://playground.wordpress.net/?wp=nightly](https://playground.wordpress.net/?wp=nightly)
+
+During the Beta period of any WordPress release, you can also test the latest WordPress Beta or RC release with theme test data and debugging plugins (see [blueprint](https://github.com/WordPress/blueprints/blob/trunk/blueprints/beta-rc/blueprint.json) and [live demo). ](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/beta-rc/blueprint.json)
+
+You can also load any [theme, plugin](/developers/apis/query-api), or [configuration](/blueprints) in any of the available WordPress and PHP versions to check how they work in that environment.
+
+The [WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress](https://www.youtube.com/watch?v=dN_LaenY8bI) provides a great overview of the testing possibilities with Playground.
+-->
+
+Com o Playground, você pode testar rapidamente qualquer versão principal do WordPress ou PHP _personalizando suas configurações_ ou usando um blueprint personalizado com a propriedade `preferredVersions`.
+
+Por exemplo, você pode sempre testar a versão mais recente de desenvolvimento do WordPress, também chamada de [Beta Nightly](https://wordpress.org/download/beta-nightly/), a partir deste link: [https://playground.wordpress.net/?wp=nightly](https://playground.wordpress.net/?wp=nightly)
+
+Durante o período Beta de qualquer lançamento do WordPress, você também pode testar o último lançamento Beta ou RC do WordPress com dados de teste de tema e plugins de depuração (veja [blueprint](https://github.com/WordPress/blueprints/blob/trunk/blueprints/beta-rc/blueprint.json) e [demonstração ao vivo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/beta-rc/blueprint.json))
+
+Você também pode carregar qualquer [tema, plugin](/developers/apis/query-api) ou [configuração](/blueprints) em qualquer uma das versões disponíveis do WordPress e PHP para verificar como eles funcionam nesse ambiente.
+
+O [WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress](https://www.youtube.com/watch?v=dN_LaenY8bI) fornece uma excelente visão geral das possibilidades de teste com o Playground.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
@@ -1,0 +1,103 @@
+---
+title: Playground Contributor Badge
+slug: /contributing/contributor-badge
+description: Find out the criteria for the WordPress Playground Contributor Badge and how to request it for your WordPress.org profile.
+---
+
+<!--
+# Playground Contributor Badge
+-->
+
+# Playground Contributor Badge
+
+<!--
+This page provides detailed information on the Playground Contributor Badge and the process of requesting it on your [WordPress.org](https://wordpress.org) profile.
+-->
+
+Esta página fornece informações detalhadas sobre o Playground Contributor Badge e o processo de solicitação no seu perfil [WordPress.org](https://wordpress.org).
+
+---
+
+<!--
+## Getting Started
+-->
+
+## Começando
+
+<!--
+Any contribution to the WordPress Playground project is highly valued. The Playground team recognizes contributions across several key areas:
+
+-   **Playground Code:** Making code changes and reviewing the core project.
+-   **Playground UI:** Improving the user interface of the web experience.
+-   **Documentation:** Writing, updating, and reviewing documentation.
+-   **Translation:** Translating any part of the project.
+-   **Blueprints Gallery:** Creating new blueprints or improving existing ones.
+-->
+
+Qualquer contribuição para o projeto WordPress Playground é altamente valorizada. A equipe do Playground reconhece contribuições em várias áreas principais:
+
+-   **Código do Playground:** Fazendo alterações de código e revisando o projeto principal.
+-   **Interface do Playground:** Melhorando a interface do usuário da experiência web.
+-   **Documentação:** Escrevendo, atualizando e revisando documentação.
+-   **Tradução:** Traduzindo qualquer parte do projeto.
+-   **Galeria de Blueprints:** Criando novos blueprints ou melhorando os existentes.
+
+<!--
+## Playground Contributor Badge
+-->
+
+## Playground Contributor Badge
+
+<!--
+To get a Playground Contributor Badge, you must have made at least one eligible contribution from the list above. The team may choose to award the badge for other contributions or a combination of the above at the team's discretion.
+-->
+
+Para obter um Playground Contributor Badge, você deve ter feito pelo menos uma contribuição elegível da lista acima. A equipe pode optar por conceder o badge para outras contribuições ou uma combinação das acima, a critério da equipe.
+
+![Playground Contributor Badge](@site/static/img/contributing/playground-contributor-badge.webp)
+
+<!--
+## Playground Team Badge
+-->
+
+## Playground Team Badge
+
+<!--
+If you are currently a contributor and have been actively involved in the Playground project for the past **twelve months**, you are eligible for a **Playground Team Badge**.
+-->
+
+Se você é atualmente um contribuidor e tem estado ativamente envolvido no projeto Playground nos últimos **doze meses**, você é elegível para um **Playground Team Badge**.
+
+![Playground Contributor Badge](@site/static/img/contributing/playground-team-badge.webp)
+
+<!--
+## Requesting a Profile Badge
+-->
+
+## Solicitando um Badge de Perfil
+
+<!--
+If you meet the criteria, you can request a badge. Please include links to resources (such as GitHub pull requests, issues, or translated strings) that show you have met the criteria. Send a request at the links bellow:
+
+-   [Contributor Badge](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [Team Badge](https://profiles.wordpress.org/associations/playground-team/)
+-->
+
+Se você atende aos critérios, pode solicitar um badge. Por favor, inclua links para recursos (como pull requests do GitHub, issues ou strings traduzidas) que mostrem que você atendeu aos critérios. Envie uma solicitação nos links abaixo:
+
+-   [Contributor Badge](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [Team Badge](https://profiles.wordpress.org/associations/playground-team/)
+
+<!--
+### Request form
+-->
+
+### Formulário de solicitação
+
+![Playground Contributor Badge](@site/static/img/contributing/request-contributor-badge.webp)
+
+<!--
+To access the request, the user should be logged in with their WordPress.org account and open the Request Membership tab, after submitting the required information. A Playground Team Representative will confirm your contribution and assign the badge. The team will perform a weekly review of contributions and award badges at that time. Updates on new badges awarded will be posted during the Playground Team meeting.
+-->
+
+Para acessar a solicitação, o usuário deve estar logado com sua conta WordPress.org e abrir a aba Request Membership, após enviar as informações necessárias. Um Representante da Equipe do Playground confirmará sua contribuição e atribuirá o badge. A equipe realizará uma revisão semanal das contribuições e concederá os badges nesse momento. Atualizações sobre novos badges concedidos serão publicadas durante a reunião da Equipe do Playground.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -16,12 +16,12 @@ Você pode ajudar a traduzir a documentação do Playground para qualquer idioma
 <!--
 ## How can I contribute to translations?
 
-By using the same workflow than contributing to any other docs page. You could fork [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) and make PRs with your changes or edit pages directly using the GitHub UI
+By using the same workflow than contributing to any other docs page. You could fork [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) and make PRs with your changes, or edit pages directly using the GitHub UI
 -->
 
 ## Como posso contribuir para as traduções?
 
-Usando o mesmo fluxo de trabalho que contribuir para qualquer outra página de documentação. Você pode fazer um fork do [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) e criar PRs com suas alterações ou editar páginas diretamente usando a interface do GitHub.
+Usando o mesmo fluxo de trabalho que contribuir para qualquer outra página de documentação. Você pode fazer um fork do [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) e criar PRs com suas alterações, ou editar páginas diretamente usando a interface do GitHub.
 
 <!--
 :::info
@@ -37,7 +37,7 @@ Consulte [Como posso contribuir?](/contributing/documentation#how-can-i-contribu
 ## Translations implementation details
 
 :::info
-Check the [Internationalization section](https://docusaurus.io/docs/i18n/introduction) of Docusaurus Docs to learn more about translations management in a Docusaurus website (the engine behind Playground Docs).
+Check the [Internationalization section](https://docusaurus.io/docs/i18n/introduction) of Docusaurus Docs to learn more about translation management in a Docusaurus website (the engine behind Playground Docs).
 :::
 -->
 
@@ -48,10 +48,10 @@ Consulte a [seção de Internacionalização](https://docusaurus.io/docs/i18n/in
 :::
 
 <!--
-Languages available for the Docs site are defined on `docusaurus.config.js`. For example:
+Languages available for the Docs site are defined on `packages/docs/site/docusaurus.config.js`. For example:
 -->
 
-Os idiomas disponíveis para o site de Documentação são definidos no `docusaurus.config.js`. Por exemplo:ff
+Os idiomas disponíveis para o site de Documentação são definidos no `packages/docs/site/docusaurus.config.js`. Por exemplo:
 
 ```
 i18n: {
@@ -73,60 +73,46 @@ i18n: {
 
 <!--
 Translated docs pages are located in the [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) repository.
+
+Under `packages/docs/site/i18n/`, there's a folder for each language.
+For example, for `es` (Spanish), there's a `packages/docs/site/i18n/es` folder.
+
+Under each language folder, there should be a `docusaurus-plugin-content-docs/current` folder.
+For example, for `es` (Spanish), there's a `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current` folder.
+
+Under `docusaurus-plugin-content-docs/current`, the same structure of files of the original docs (same structure of files as) under `packages/docs/site/docs`) should be replicated.
+
+For example, for `es` (Spanish), the following translated files exist: `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`
+
+If a file is not available under a language's folder, the original file in the default language will be loaded.
+
+When a new language is added (see PR [#1807](https://github.com/WordPress/wordpress-playground/pull/1807)), you can run `npm run write-translations -- --locale <%LANGUAGE%>` from `packages/docs/site` to generate the JSON files containing messages that can be translated into a specific language.
+
+With the proper i18n `docusaurus.config.js` configuration and files under `i18n` when running `npm run build:docs` from the root of the project, specific folders under `dist` for each language will be created.
 -->
 
 As páginas de documentação traduzidas estão localizadas no repositório [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground).
 
-<!--
-Under `packages/docs/site/i18n/` there's a folder for each language.
-For example for `es` (Spanish) there's a `packages/docs/site/i18n/es` folder
--->
-
-Sob `packages/docs/site/i18n/` há uma pasta para cada idioma.
-Por exemplo, para `es` (Espanhol) há uma pasta `packages/docs/site/i18n/es`.
-
-<!--
-Under each language folder there should be a `docusaurus-plugin-content-docs/current` folder.
-For example for `es` (Spanish) there's a `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current` folder.
--->
+Sob `packages/docs/site/i18n/`, há uma pasta para cada idioma.
+Por exemplo, para `es` (Espanhol), há uma pasta `packages/docs/site/i18n/es`.
 
 Sob cada pasta de idioma deve haver uma pasta `docusaurus-plugin-content-docs/current`.
-Por exemplo, para `es` (Espanhol) há uma pasta `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current`.
+Por exemplo, para `es` (Espanhol), há uma pasta `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current`.
 
-<!--
-Under `docusaurus-plugin-content-docs/current` the same structure of files of the original docs (same structure of files than under `packages/docs/site/docs`) should be replicated.
--->
+Sob `docusaurus-plugin-content-docs/current`, a mesma estrutura de arquivos da documentação original (mesma estrutura de arquivos que sob `packages/docs/site/docs`) deve ser replicada.
 
-Sob `docusaurus-plugin-content-docs/current` a mesma estrutura de arquivos da documentação original (mesma estrutura de arquivos que sob `packages/docs/site/docs`) deve ser replicada.
-
-<!--
-For example, for `es` (Spanish), the following translated files exist: `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`
--->
-
-Por exemplo, para `es` (Espanhol) existem os seguintes arquivos traduzidos: `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`.
-
-<!--
-If a file is not available under a language's folder, the original file in the default language will be loaded
--->
+Por exemplo, para `es` (Espanhol), existem os seguintes arquivos traduzidos: `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`.
 
 Se um arquivo não estiver disponível sob a pasta de um idioma, o arquivo original no idioma padrão será carregado.
 
-<!--
-When a new language is added (see PR [#1807](https://github.com/WordPress/wordpress-playground/pull/1807)) you can run `npm run write-translations -- --locale <%LANGUAGE%>` from `packages/docs/site` to generate the JSON files with messages that can be translated to a specific language.
--->
-
-Quando um novo idioma é adicionado (veja PR [#1807](https://github.com/WordPress/wordpress-playground/pull/1807)) você pode executar `npm run write-translations -- --locale <%LANGUAGE%>` de `packages/docs/site` para gerar os arquivos JSON com mensagens que podem ser traduzidas para um idioma específico.
-
-<!--
-With the proper i18n `docusaurus.config.js` configuration and files under `i18n` when running `npm run build:docs` from the root of the project, specific folders under `dist` for each language will be created.
--->
+Quando um novo idioma é adicionado (veja PR [#1807](https://github.com/WordPress/wordpress-playground/pull/1807)), você pode executar `npm run write-translations -- --locale <%LANGUAGE%>` de `packages/docs/site` para gerar os arquivos JSON contendo mensagens que podem ser traduzidas para um idioma específico.
 
 Com a configuração adequada do i18n no `docusaurus.config.js` e arquivos sob `i18n`, ao executar `npm run build:docs` da raiz do projeto, pastas específicas sob `dist` para cada idioma serão criadas.
 
 <!--
 ## How to locally test a language
 
-To locally test an existing language you can do:
+To locally test an existing language, you can do:
 
 -   Modify (translate) any file under one of the available languages: `packages/docs/site/i18n/{%LANGUAGE%}/docusaurus-plugin-content-docs/current`
 -   From `/packages/docs/site` run the version for the language you'd like to test. For example, to test `es`:
@@ -134,13 +120,13 @@ To locally test an existing language you can do:
 
 ## Como testar um idioma localmente
 
-Para testar localmente um idioma existente você pode fazer:
+Para testar localmente um idioma existente, você pode fazer:
 
 -   Modificar (traduzir) qualquer arquivo sob um dos idiomas disponíveis: `packages/docs/site/i18n/{%LANGUAGE%}/docusaurus-plugin-content-docs/current`
 -   De `/packages/docs/site` execute a versão para o idioma que você gostaria de testar. Por exemplo, para testar `es`:
 
 ```
-npm run dev:docs -- --locale es
+npm run dev -- --locale es
 ```
 
 <!--
@@ -148,14 +134,14 @@ npm run dev:docs -- --locale es
 
 The "Language Switcher" is a UI element provided by Docusaurus (the docs engine behind Playground Docs) that allows users to change the language of a specific page.
 
-To give more visibility to a translated version the language switcher can be displayed by adding the following lines at `docusaurus.config.js`
+To give more visibility to a translated version, the language switcher can be displayed by adding the following lines to `packages/docs/site/docusaurus.config.js`
 -->
 
 ## Seletor de Idioma - Elemento de interface para alterar o idioma
 
-O "Seletor de Idioma" é um elemento de interface fornecido pelo Docusaurus (o motor de documentação por trás da Documentação do Playground) que permite ao usuário alterar o idioma de uma página específica.
+O "Seletor de Idioma" é um elemento de interface fornecido pelo Docusaurus (o motor de documentação por trás da Documentação do Playground) que permite aos usuários alterar o idioma de uma página específica.
 
-Para dar mais visibilidade a uma versão traduzida, o seletor de idioma pode ser exibido adicionando as seguintes linhas no `docusaurus.config.js`:
+Para dar mais visibilidade a uma versão traduzida, o seletor de idioma pode ser exibido adicionando as seguintes linhas ao `packages/docs/site/docusaurus.config.js`:
 
 ```
 {
@@ -178,19 +164,30 @@ Isso gerará um menu suspenso no cabeçalho para acessar diretamente uma versão
 ### Making a language publicly available on the Language Switcher
 
 All languages are available once the i18n setup for a language is complete and the correct file structure is in place under `i18n`.
--->
-
-### Tornando um idioma publicamente disponível no Seletor de Idioma
-
-Todos os idiomas estão disponíveis quando a configuração i18n para um idioma é feita e a estrutura correta de arquivos está disponível sob `i18n`.
 
 -   https://wordpress.github.io/wordpress-playground/
 -   https://wordpress.github.io/wordpress-playground/es/
 -   https://wordpress.github.io/wordpress-playground/fr/
 
-<!--
-These language versions of the docs should be hidden on the language switcher hidden until there's a fair amount of pages translated for that language. To be more precise, the recommendation is to only make a language publicly available on the Language Switcher when at least the [Documentation](https://wordpress.github.io/wordpress-playground/) section is completely translated for a specific language, including the following sections:
+These language versions of the docs should be hidden on the language switcher hidden until there's a fair amount of pages translated for that language. To be more precise, the recommendation is only to make a language publicly available on the Language Switcher when at least the [Documentation](https://wordpress.github.io/wordpress-playground/) section is completely translated for a specific language, including the following sections:
+
+-   [Quick Start Guide](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+-   [Playground web instance](https://wordpress.github.io/wordpress-playground/web-instance)
+-   [About Playground](https://wordpress.github.io/wordpress-playground/about)
+-   [Guides](https://wordpress.github.io/wordpress-playground/guides)
+-   [Contributing](https://wordpress.github.io/wordpress-playground/contributing)
+-   [Links and Resources](https://wordpress.github.io/wordpress-playground/resources)
+
+Even if the language switcher doesn't display a specific language, work on adding translated pages can still progress, as the translated pages will become publicly available once the PRs containing the translated files are merged.
 -->
+
+### Tornando um idioma publicamente disponível no Seletor de Idioma
+
+Todos os idiomas estão disponíveis quando a configuração i18n para um idioma é completa e a estrutura correta de arquivos está em vigor sob `i18n`.
+
+-   https://wordpress.github.io/wordpress-playground/
+-   https://wordpress.github.io/wordpress-playground/es/
+-   https://wordpress.github.io/wordpress-playground/fr/
 
 Essas versões de idioma da documentação devem ser ocultadas no seletor de idioma até que haja uma quantidade razoável de páginas traduzidas para esse idioma. Para ser mais preciso, a recomendação é tornar um idioma publicamente disponível no Seletor de Idioma apenas quando pelo menos a seção [Documentação](https://wordpress.github.io/wordpress-playground/) estiver completamente traduzida para um idioma específico, incluindo as seguintes seções:
 
@@ -200,10 +197,6 @@ Essas versões de idioma da documentação devem ser ocultadas no seletor de idi
 -   [Guias](https://wordpress.github.io/wordpress-playground/guides)
 -   [Contribuindo](https://wordpress.github.io/wordpress-playground/contributing)
 -   [Links e Recursos](https://wordpress.github.io/wordpress-playground/resources)
-
-<!--
-Even if the language switcher doesn't display a specific language, work on adding translated pages can still progress, as the translated pages will become publicly available once the PRs containing the translated files are merged.
--->
 
 Mesmo que o seletor de idioma não exiba um idioma específico, o trabalho de adicionar páginas traduzidas ainda pode progredir, pois as páginas traduzidas se tornarão publicamente disponíveis uma vez que os PRs contendo os arquivos traduzidos sejam mesclados.
 
@@ -243,9 +236,9 @@ Assumindo que o idioma `fr` seja o primeiro idioma com as páginas do hub de Doc
 <!--
 ### Testing the Language Switcher locally
 
-Regarding testing the `localeDropdown` locally, I have found that although it is displayed locally, it doesn't really work locally as expected, as the translated pages are not found. But it seems to work well in production.
+Regarding testing the `localeDropdown` locally, I have found that although it is displayed locally, it doesn't work locally as expected, as the translated pages are not found. But it seems to work well in production.
 
-You can test the `localeDropdown` from any fork and doing from the root of the project:
+You can test the `localeDropdown` from any fork and do so from the root of the project:
 -->
 
 ### Testando o Seletor de Idioma localmente
@@ -261,6 +254,14 @@ npm run deploy:docs
 
 <!--
 This generates three versions of the docs in the GitHub Pages of my forked repo:
+
+```
+https://<%GH-USER-WITH-FORK%>.github.io/wordpress-playground/
+https://<%GH-USER-WITH-FORK%>.github.io/wordpress-playground/es/
+https://<%GH-USER-WITH-FORK%>.github.io/wordpress-playground/fr/
+```
+
+A possible approach to testing the `localeDropdown` feature is to deploy it to the GitHub Pages of a forked repository.
 -->
 
 Isso gera três versões da documentação nas GitHub Pages do meu repositório forkado:
@@ -271,19 +272,16 @@ https://<%GH-USER-WITH-FORK%>.github.io/wordpress-playground/es/
 https://<%GH-USER-WITH-FORK%>.github.io/wordpress-playground/fr/
 ```
 
-<!--
-So, a possible approach to testing the `localeDropdown` feature is by deploying it to the GitHub Pages of a forked repository.
-
--->
-
-Então, uma abordagem possível para testar o recurso `localeDropdown` é implantá-lo nas GitHub Pages de um repositório forkado.
+Uma abordagem possível para testar o recurso `localeDropdown` é implantá-lo nas GitHub Pages de um repositório forkado.
 
 <!--
 ## Process to translate one page into a language
 
 The recommended process is to copy and paste the `.md` file from the original path (`packages/docs/site/docs`) into the desired language path ( `packages/docs/site/i18n/{%LANGUAGE%}/docusaurus-plugin-content-docs/current`). It is important to replicate the structure of files at `packages/docs/site/docs`
 
-The file under `packages/docs/site/i18n/{%LANGUAGE%}/docusaurus-plugin-content-docs/current` can be translated and a PR can be created with the new changes.
+The file under `packages/docs/site/i18n/{%LANGUAGE%}/docusaurus-plugin-content-docs/current` can be translated, and a PR can be created with the new changes.
+
+When the PR is merged, the translated version of that page should appear under https://wordpress.github.io/wordpress-playground/{%LANGUAGE%}
 -->
 
 ## Processo para traduzir uma página em um idioma
@@ -292,8 +290,52 @@ O processo recomendado é copiar e colar o arquivo `.md` do caminho original (`p
 
 O arquivo sob `packages/docs/site/i18n/{%LANGUAGE%}/docusaurus-plugin-content-docs/current` pode ser traduzido e um PR pode ser criado com as novas alterações.
 
+Quando o PR for mesclado, a versão traduzida dessa página deve aparecer sob https://wordpress.github.io/wordpress-playground/{%LANGUAGE%}
+
 <!--
-When the PR is merged, the translated version of that page should appear under https://wordpress.github.io/wordpress-playground/{%LANGUAGE%}
+## Review process
+
+To facilitate the reviewing process, we do recommend keeping the original content commented close to the translated content, for example:
+
+```
+<!--
+👋 Hi! Welcome to WordPress Playground documentation.
+
+Playground is an online tool to experiment and learn about WordPress. This site (Documentation) is where you will find all the information you need to start using Playground.
 -->
 
-Quando o PR for mesclado, a versão traduzida dessa página deve aparecer sob https://wordpress.github.io/wordpress-playground/{%LANGUAGE%}
+👋 Olá! Bem vindo a documentação oficial do WordPress Playground.
+
+WordPress Playground é uma ferramenta online onde podes testar e aprender mais sobre o WordPress. Nesta página(Documentação) irá encontrar todas as informações necessárias para começar a trabalhar com o Playground.
+
+<!--
+<p class="docs-hubs">The WordPress Playground documentation is distributed across four separate hubs (subsites):</p>
+-->
+<p class="docs-hubs">A documentação do WordPress Playground está dividida em quatro hubs(subsites):</p>
+```
+
+For an improved review process, find reviewers matching the PR's language. Request a reviewer by posting on https://make.wordpress.org/polyglots/ and include the locale tag (e.g., #ja for Japanese). This will notify the Japanese GTEs.
+-->
+
+## Processo de revisão
+
+Para facilitar o processo de revisão, recomendamos manter o conteúdo original comentado próximo ao conteúdo traduzido, por exemplo:
+
+```
+<!--
+👋 Hi! Welcome to WordPress Playground documentation.
+
+Playground is an online tool to experiment and learn about WordPress. This site (Documentation) is where you will find all the information you need to start using Playground.
+-->
+
+👋 Olá! Bem vindo a documentação oficial do WordPress Playground.
+
+WordPress Playground é uma ferramenta online onde podes testar e aprender mais sobre o WordPress. Nesta página(Documentação) irá encontrar todas as informações necessárias para começar a trabalhar com o Playground.
+
+<!--
+<p class="docs-hubs">The WordPress Playground documentation is distributed across four separate hubs (subsites):</p>
+-->
+<p class="docs-hubs">A documentação do WordPress Playground está dividida em quatro hubs(subsites):</p>
+```
+
+Para um processo de revisão melhorado, encontre revisores que correspondam ao idioma do PR. Solicite um revisor postando em https://make.wordpress.org/polyglots/ e inclua a tag de localização (ex: #pt-BR para Português Brasileiro). Isso notificará os GTEs brasileiros.


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request translates the fragments from the documentation, together with the following pages:
- Contributor Badge
- Build
- Test

And updates the Translation Page.