### PR TITLE
Adding the docs meta description to the main folder

### DIFF
--- a/packages/docs/site/docs/main/about/build.md
+++ b/packages/docs/site/docs/main/about/build.md
@@ -1,7 +1,7 @@
 ---
-title: Build
+title: Build - WordPress Playground
 slug: /about/build
-description: Build with WP Playground
+description: Learn how WordPress Playground helps you build products, from setting up local environments to creating themes and new tools.
 sidebar_class_name: navbar-build-item
 ---
 

--- a/packages/docs/site/docs/main/about/index.md
+++ b/packages/docs/site/docs/main/about/index.md
@@ -1,6 +1,7 @@
 ---
-title: About Playground
+title: About WordPress Playground
 slug: /about
+description: An overview of WordPress Playground, explaining what it is, why it's useful, and how it runs WordPress in your browser.
 ---
 
 # About WordPress Playground

--- a/packages/docs/site/docs/main/about/launch.md
+++ b/packages/docs/site/docs/main/about/launch.md
@@ -1,6 +1,7 @@
 ---
-title: Launch
+title: Launch - WordPress Playground
 slug: /about/launch
+description: Learn how to use Playground to launch products, from embedding interactive demos on websites to creating native mobile apps.
 ---
 
 # Launch

--- a/packages/docs/site/docs/main/about/test.md
+++ b/packages/docs/site/docs/main/about/test.md
@@ -1,6 +1,7 @@
 ---
-title: Test
+title: Test - WordPress Playground
 slug: /about/test
+description: Discover how to use Playground for testing themes, plugins, pull requests, and different versions of WordPress and PHP.
 ---
 
 # Test

--- a/packages/docs/site/docs/main/contributing/code.md
+++ b/packages/docs/site/docs/main/contributing/code.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/code
+title: Code contributions - WordPress Playground
+description: A guide for code contributions, covering how to fork the repo, set up a local environment, and submit a pull request.
 ---
 
 # Code contributions

--- a/packages/docs/site/docs/main/contributing/coding-standards.md
+++ b/packages/docs/site/docs/main/contributing/coding-standards.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/coding-standards
+title: Coding principles - WordPress Playground
+description: Details the coding principles for Playground, focusing on helpful error messages, a minimal public API, and Blueprints.
 ---
 
 # Coding principles

--- a/packages/docs/site/docs/main/contributing/contributor-badge.md
+++ b/packages/docs/site/docs/main/contributing/contributor-badge.md
@@ -1,5 +1,5 @@
 ---
-title: Playground Contributor Badge
+title: WordPress Playground Contributor Badge
 slug: /contributing/contributor-badge
 description: Find out the criteria for the WordPress Playground Contributor Badge and how to request it for your WordPress.org profile.
 ---

--- a/packages/docs/site/docs/main/contributing/contributor-day.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/contributor-day
+title: WordCamp Contributor Day - WordPress Playground
+description: A guide on using Playground tools like the VS Code extension and CLI during a WordCamp Contributor Day to get started.
 ---
 
 # WordCamp Contributor Day

--- a/packages/docs/site/docs/main/contributing/documentation.md
+++ b/packages/docs/site/docs/main/contributing/documentation.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/documentation
+title: Documentation Contributions - WordPress Playground
+description: A guide on how to contribute to the Playground documentation, from opening issues to submitting pull requests.
 ---
 
 # Documentation contributions

--- a/packages/docs/site/docs/main/contributing/index.md
+++ b/packages/docs/site/docs/main/contributing/index.md
@@ -1,10 +1,11 @@
 ---
-title: Introduction
+title: Contributing to WordPress Playground project
 slug: /contributing
 id: introduction
+description: Your starting point for contributing to WordPress Playground. Find guidelines for code, documentation, and reporting bugs.
 ---
 
-# Contributing to WP Playground project
+# Contributing to WordPress Playground project
 
 WordPress Playground is an open-source project that welcomes contributors of all kinds, from code to design, documentation to triage.
 

--- a/packages/docs/site/docs/main/contributing/translations.md
+++ b/packages/docs/site/docs/main/contributing/translations.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/translations
+title: Contributions to translations - WordPress Playground
+description: Learn how to translate the Playground documentation, including file structure, local testing, and the review process.
 ---
 
 # Contributions to translations

--- a/packages/docs/site/docs/main/guides/for-plugin-developers.md
+++ b/packages/docs/site/docs/main/guides/for-plugin-developers.md
@@ -1,7 +1,7 @@
 ---
-title: Playground for Plugin Developers
+title: WordPress Playground for Plugin Developers
 slug: /guides/for-plugin-developers
-description: WordPress Playground for Plugin Developers
+description: A guide for plugin developers on using Playground to build, test, and create compelling live demos for their plugins.
 ---
 
 The WordPress Playground is an innovative tool that allows plugin developers to build, test and showcase their plugins directly in a browser environment.

--- a/packages/docs/site/docs/main/guides/for-theme-developers.md
+++ b/packages/docs/site/docs/main/guides/for-theme-developers.md
@@ -1,7 +1,7 @@
 ---
-title: Playground for Theme Developers
+title: WordPress Playground for Theme Developers
 slug: /guides/for-theme-developers
-description: WordPress Playground for Theme Developers
+description: A guide for theme developers on using Playground to build, test, and create live demos for their themes with Blueprints.
 ---
 
 The WordPress Playground is an innovative tool that allows theme developers to build, test, and showcase their themes directly in a browser environment.

--- a/packages/docs/site/docs/main/guides/index.md
+++ b/packages/docs/site/docs/main/guides/index.md
@@ -1,7 +1,7 @@
 ---
-title: 📖 Guides
+title: 📖 Guides - WordPress Playground
 slug: /guides
-description: WordPress Playground Guides
+description: A WordPress Playground Guide to help you understand and work with various topics and related use cases.
 sidebar_class_name: navbar-build-item
 ---
 

--- a/packages/docs/site/docs/main/guides/providing-content-for-your-demo.md
+++ b/packages/docs/site/docs/main/guides/providing-content-for-your-demo.md
@@ -1,7 +1,7 @@
 ---
 title: Providing content for your demo with Playground
 slug: /guides/providing-content-for-your-demo
-description: Providing content for your demo with WordPress Playground
+description: Learn how to populate your Playground demo with content using Blueprints, WP-CLI, or PHP to showcase themes and plugins.
 ---
 
 One of the things you may want to do to provide a good demo with WordPress Playground is to load default content to better highlight the features of your plugin or theme. This default content may include images or other assets.

--- a/packages/docs/site/docs/main/guides/wordpress-native-ios-app.md
+++ b/packages/docs/site/docs/main/guides/wordpress-native-ios-app.md
@@ -1,7 +1,7 @@
 ---
-title: Playground in native iOS apps
+title: WordPress Playground in native iOS apps
 slug: /guides/wordpress-native-ios-app
-description: WordPress Playground in native iOS apps
+description: Discover how to run a WordPress site within a native iOS app, based on the "Blocknotes" case study using Playground.
 ---
 
 ## How to ship a real WordPress site in a native iOS app via Playground?

--- a/packages/docs/site/docs/main/intro.md
+++ b/packages/docs/site/docs/main/intro.md
@@ -1,7 +1,8 @@
 ---
-title: Introduction
+title: Introduction - WordPress Playground
 slug: /
 id: introduction
+description: Welcome to the WordPress Playground docs! This page introduces the documentation structure and helps you find your way around.
 ---
 
 # WordPress Playground Docs

--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -1,6 +1,7 @@
 ---
-title: Quick Start Guide
+title: Quick Start Guide - WordPress Playground
 slug: /quick-start-guide
+description: A 5-minute guide to get started with Playground. Learn how to test plugins, try themes, and use different WP/PHP versions.
 ---
 
 import ThisIsQueryApi from '@site/docs/\_fragments/\_this_is_query_api.md';

--- a/packages/docs/site/docs/main/resources.md
+++ b/packages/docs/site/docs/main/resources.md
@@ -1,6 +1,7 @@
 ---
-title: Links and Resources
+title: Links and Resources - WordPress Playground
 slug: /resources
+description: A curated list of helpful links to apps, tools, articles, and videos for learning more about WordPress Playground.
 ---
 
 # Links and Resources

--- a/packages/docs/site/docs/main/web-instance.md
+++ b/packages/docs/site/docs/main/web-instance.md
@@ -1,6 +1,7 @@
 ---
-title: Playground web instance
+title: Web Instance - WordPress Playground
 slug: /web-instance
+description: A detailed guide to the web interface at playground.wordpress.net, covering the toolbar, settings, and instance manager.
 ---
 
 # WordPress Playground web instance

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/code.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/code.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/code
+title: Contribuições de código - WordPress Playground
+description: Um guia para contribuições de código, cobrindo como fazer um fork do repositório, configurar um ambiente local e enviar um pull request.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/coding-standards
+title: Princípios de codificação - WordPress Playground
+description: Detalha os princípios de codificação do Playground, com foco em mensagens de erro úteis, uma API pública mínima e Blueprints.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/documentation
+title: Contribuições para a documentação - WordPress Playground
+description: Um guia sobre como contribuir para a documentação do Playground, desde abrir issues até enviar pull requests.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/index.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/index.md
@@ -1,7 +1,8 @@
 ---
-title: Introdução
+title: Contribuindo para o projeto WordPress Playground
 slug: /contributing
 id: introduction
+description: Seu ponto de partida para contribuir com o WordPress Playground. Encontre diretrizes para código, documentação e reporte de bugs.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -1,6 +1,7 @@
 ---
-title: Contribuições para traduções
+title: Contribuições para traduções - WordPress Playground
 slug: /contributing/translations
+description: Aprenda a traduzir a documentação do Playground, incluindo a estrutura de arquivos, testes locais e o processo de revisão.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/for-plugin-developers.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/for-plugin-developers.md
@@ -1,9 +1,8 @@
 ---
-title: Playground for Plugin Developers
+title: WordPress Playground for Plugin Developers
 slug: /guides/for-plugin-developers
-description: WordPress Playground for Plugin Developers
+description: Um guia para desenvolvedores de plugins sobre como usar o Playground para construir, testar e criar demos de seus plugins.
 ---
-
 <!--
 The WordPress Playground is an innovative tool that allows plugin developers to build, test and showcase their plugins directly in a browser environment.
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/for-theme-developers.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/for-theme-developers.md
@@ -1,7 +1,7 @@
 ---
-title: Playground for Theme Developers
+title: WordPress Playground for Theme Developers
 slug: /guides/for-theme-developers
-description: WordPress Playground for Theme Developers
+description: Um guia para desenvolvedores de temas sobre como usar o Playground para construir, testar e criar demos de seus temas com Blueprints.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/index.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/index.md
@@ -1,7 +1,7 @@
 ---
-title: 📖 Guides
+title: 📖 Guias - WordPress Playground
 slug: /guides
-description: WordPress Playground Guides
+description: Guia do WordPress Playground para ajudar você a entender e trabalhar com vários tópicos e casos de uso.
 sidebar_class_name: navbar-build-item
 ---
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/providing-content-for-your-demo.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/providing-content-for-your-demo.md
@@ -1,7 +1,7 @@
 ---
-title: Providing content for your demo with Playground
+title: Aprenda criar conteudo de demonstração com o Playground
 slug: /guides/providing-content-for-your-demo
-description: Providing content for your demo with WordPress Playground
+description: Aprenda a popular sua demonstração do Playground com conteúdo usando Blueprints, WP-CLI ou PHP para exibir temas e plugins.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/wordpress-native-ios-app.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/wordpress-native-ios-app.md
@@ -1,7 +1,7 @@
 ---
-title: Playground in native iOS apps
+title: WordPress Playground em aplicações iOS nativas
 slug: /guides/wordpress-native-ios-app
-description: WordPress Playground in native iOS apps
+description: Descubra como executar um site WordPress em um aplicativo iOS nativo, com base no estudo de caso "Blocknotes" usando o Playground.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/intro.md
@@ -1,7 +1,8 @@
 ---
-title: Introdução
+title: Introdução - WordPress Playground
 slug: /
 id: introduction
+description: Boas-vindas à documentação do WordPress Playground! Esta página apresenta a estrutura da documentação e ajuda você a se orientar.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -1,6 +1,7 @@
 ---
-title: Primeiros passos
+title: Primeiros passos - WordPress Playground
 slug: /quick-start-guide
+description: Um guia de 5 minutos para começar a usar o Playground. Aprenda a testar plugins, temas e usar diferentes versões de WP/PHP.
 ---
 
 import ThisIsQueryApi from '@site/docs/\_fragments/\_this_is_query_api.md';

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,6 +1,7 @@
 ---
-title: Links e Recursos
+title: Links e Recursos - WordPress Playground
 slug: /resources
+description: Uma lista de links úteis para aplicativos, ferramentas, artigos e vídeos para aprender mais sobre o WordPress Playground.
 ---
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -1,6 +1,7 @@
 ---
-title: Playground web instance
+title: Web Instance - WordPress Playground
 slug: /web-instance
+description: Um guia detalhado da interface web em playground.wordpress.net, cobrindo a barra de ferramentas, configurações e o gerenciador de instâncias.
 ---
 
 <!--


### PR DESCRIPTION
## Motivation for the change, related issues
This pull request includes a meta description for the pages present in the `main` folder. The goal of this change is to include a meaningful description about the content present on the page to help search engines and improve the click rate on content shared on social media. 

This pull request also includes the meta description for Brazilian Portuguese pages

This task is related to issue #2500 

Adding the docs meta description to the main folder
