### PR TITLE
Re-enable and fix native file locking tests

### DIFF
--- a/packages/php-wasm/node/src/test/file-lock-manager-for-node.spec.ts
+++ b/packages/php-wasm/node/src/test/file-lock-manager-for-node.spec.ts
@@ -1292,8 +1292,7 @@ describe('FileLockManagerForNode', () => {
 		});
 	});
 
-	// TODO: Re-enable these once we can fix them.
-	describe.skip('integration with native OS file locking', () => {
+	describe('integration with native OS file locking', () => {
 		let childProcess: ChildProcess | undefined;
 
 		afterEach(async () => {

--- a/packages/php-wasm/node/src/test/file-lock-manager-for-node.spec.ts
+++ b/packages/php-wasm/node/src/test/file-lock-manager-for-node.spec.ts
@@ -17,6 +17,7 @@ import {
 import type { SupportedPHPVersion } from '@php-wasm/universal';
 import { joinPaths } from '@php-wasm/util';
 import { jspi } from 'wasm-feature-detect';
+import { flockSync as nativeFlockSync } from 'fs-ext';
 
 const TEST_FILE1 = new URL('test1.txt', import.meta.url).pathname;
 const TEST_FILE2 = new URL('test2.txt', import.meta.url).pathname;
@@ -25,7 +26,7 @@ describe('FileLockManagerForNode', () => {
 	let lockManager: FileLockManagerForNode;
 
 	beforeEach(() => {
-		lockManager = new FileLockManagerForNode();
+		lockManager = new FileLockManagerForNode(nativeFlockSync);
 		writeFileSync(TEST_FILE1, `test file 1 for ${import.meta.url}`);
 		writeFileSync(TEST_FILE2, `test file 2 for ${import.meta.url}`);
 	});


### PR DESCRIPTION
## Motivation for the change, related issues

The native file locking tests were broken and disabled. This PR re-enables and fixes them.

## Implementation details

This PR simply provides a real native file locking function that was missing from the tests' lock manager construction.

## Testing Instructions (or ideally a Blueprint)

- CI
