### PR TITLE
Increase file locking safety

### DIFF
--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library-file-locking-for-node.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library-file-locking-for-node.js
@@ -105,7 +105,12 @@ const LibraryForFileLocking = {
 
 		get_native_path_from_vfs_path(vfsPath) {
 			// TODO: Should there be a try/catch here?
-			const { node } = FS.lookupPath(vfsPath, {});
+			const { node } = FS.lookupPath(vfsPath, {
+				noent_okay: true,
+			});
+			if (!node) {
+				throw new Error(`No node found for VFS path ${vfsPath}`);
+			}
 			if (node.mount.type === NODEFS) {
 				return NODEFS.realPath(node);
 			} else if (node.mount.type === PROXYFS) {
@@ -393,10 +398,9 @@ const LibraryForFileLocking = {
 						return -ERRNO_CODES.EINVAL;
 					}
 
-					const nativeFilePath =
-						locking.get_native_path_from_vfs_path(vfsPath);
-
 					try {
+						const nativeFilePath =
+							locking.get_native_path_from_vfs_path(vfsPath);
 						const conflictingLock =
 #if ASYNCIFY == 2
 							await Promise.resolve(
@@ -536,16 +540,16 @@ const LibraryForFileLocking = {
 						pid,
 					};
 
-					const nativeFilePath =
-						locking.get_native_path_from_vfs_path(vfsPath);
-					_js_wasm_trace(
-						'fcntl(%d, F_SETLK) %s calling lockFileByteRange for range lock %s',
-						fd,
-						vfsPath,
-						rangeLock
-					);
-
 					try {
+						const nativeFilePath =
+							locking.get_native_path_from_vfs_path(vfsPath);
+						_js_wasm_trace(
+							'fcntl(%d, F_SETLK) %s calling lockFileByteRange for range lock %s',
+							fd,
+							vfsPath,
+							rangeLock
+						);
+
 						const succeeded = (
 #if ASYNCIFY == 2
 							await Promise.resolve(
@@ -702,9 +706,9 @@ const LibraryForFileLocking = {
 				return -ERRNO_CODES.EINVAL;
 			}
 
-			const nativeFilePath =
-				locking.get_native_path_from_vfs_path(vfsPath);
 			try {
+				const nativeFilePath =
+					locking.get_native_path_from_vfs_path(vfsPath);
 				const obtainedLock = (
 #if ASYNCIFY == 2
 					await Promise.resolve(
@@ -767,10 +771,10 @@ const LibraryForFileLocking = {
 				_js_wasm_trace('fd_close(%d) result %d', fd, result);
 				return result;
 			}
-			const nativeFilePath =
-				locking.get_native_path_from_vfs_path(vfsPath);
 
 			try {
+				const nativeFilePath =
+					locking.get_native_path_from_vfs_path(vfsPath);
 #if ASYNCIFY == 2
 				await
 #endif

--- a/packages/php-wasm/compile/php/phpwasm-emscripten-library-file-locking-for-node.js
+++ b/packages/php-wasm/compile/php/phpwasm-emscripten-library-file-locking-for-node.js
@@ -104,7 +104,6 @@ const LibraryForFileLocking = {
 		},
 
 		get_native_path_from_vfs_path(vfsPath) {
-			// TODO: Should there be a try/catch here?
 			const { node } = FS.lookupPath(vfsPath, {
 				noent_okay: true,
 			});
@@ -755,24 +754,34 @@ const LibraryForFileLocking = {
 #if ASYNCIFY == 2
 		return Asyncify.handleAsync(async () => {
 #endif
-			const [vfsPath, pathResolutionErrno] =
-				locking.get_vfs_path_from_fd(fd);
-			if (pathResolutionErrno !== 0) {
-				_js_wasm_trace(
-					'fd_close(%d) get_vfs_path_from_fd error %d',
-					fd,
-					pathResolutionErrno
-				);
-				return -ERRNO_CODES.EBADF;
-			}
-
-			const result = _builtin_fd_close(fd);
-			if (result !== 0 || !locking.maybeLockedFds.has(fd)) {
-				_js_wasm_trace('fd_close(%d) result %d', fd, result);
-				return result;
+			const fdCloseResult = _builtin_fd_close(fd);
+			if (fdCloseResult !== 0 || !locking.maybeLockedFds.has(fd)) {
+				_js_wasm_trace('fd_close(%d) result %d', fd, fdCloseResult);
+				return fdCloseResult;
 			}
 
 			try {
+				const [vfsPath, pathResolutionErrno] =
+				locking.get_vfs_path_from_fd(fd);
+				if (pathResolutionErrno !== 0) {
+					_js_wasm_trace(
+						'fd_close(%d) get_vfs_path_from_fd error %d',
+						fd,
+						pathResolutionErrno
+					);
+					/*
+					 * It looks like the file may have had an associated lock,
+					 * but since we cannot look up the path,
+					 * there is nothing more for us to do.
+					 *
+					 * NOTE: This seems possible for files that are locked and
+					 * then unlinked before close. It is an opportunity for a
+					 * lock to be orphaned in the lock manager.
+					 * @TODO: Explore how to ensure cleanup in this case.
+					 */
+					return fdCloseResult;
+				}
+
 				const nativeFilePath =
 					locking.get_native_path_from_vfs_path(vfsPath);
 #if ASYNCIFY == 2
@@ -793,7 +802,7 @@ const LibraryForFileLocking = {
 			} finally {
 				locking.maybeLockedFds.delete(fd);
 			}
-			return result;
+			return fdCloseResult;
 #if ASYNCIFY == 2
 		});
 #endif

--- a/packages/php-wasm/node/src/lib/use-host-filesystem.ts
+++ b/packages/php-wasm/node/src/lib/use-host-filesystem.ts
@@ -16,6 +16,10 @@ export function useHostFilesystem(php: PHP) {
 		 * Don't mount the dev directory – it's polyfilled by Emscripten.
 		 */
 		.filter((file) => file !== 'dev')
+		/*
+		 * Don't mount the proc directory – it's polyfilled by Emscripten.
+		 */
+		.filter((file) => file !== 'proc')
 		.map((file) => `/${file}`)
 		.filter((file) => {
 			try {


### PR DESCRIPTION
## Motivation for the change, related issues

This PR addresses some quality-related items under the multi-worker follow-up PR
https://github.com/WordPress/wordpress-playground/issues/2293

## Implementation details

This PR addresses the following items from https://github.com/WordPress/wordpress-playground/issues/2293:
- Make sure get_vfs_path_from_fd() doesn't abuse or mistakenly use a native /proc dir if exposed by useHostFilesystem().
- Return an error from get_native_path_from_vfs_path() if no native path is found and make sure callers handle that.

## Testing Instructions (or ideally a Blueprint)

- CI