### PR TITLE
[Docs] Add docs-description blueprints tutorial and What are Blueprints?

### DIFF
--- a/packages/docs/site/docs/blueprints/tutorial/01-what-are-blueprints-what-you-can-do-with-them.md
+++ b/packages/docs/site/docs/blueprints/tutorial/01-what-are-blueprints-what-you-can-do-with-them.md
@@ -1,7 +1,7 @@
 ---
 title: What are Blueprints?
 slug: /blueprints/tutorial/what-are-blueprints-what-you-can-do-with-them
-description: Getting started with Blueprints
+description: Learn what Blueprints are and how they configure WordPress Playground. Discover the benefits of using JSON for instant site setup.
 ---
 
 # What are Blueprints, and what can you do with them?

--- a/packages/docs/site/docs/blueprints/tutorial/index.md
+++ b/packages/docs/site/docs/blueprints/tutorial/index.md
@@ -1,6 +1,6 @@
 ---
 title: Blueprints 101
-description: Entrance to a short course on Blueprints
+description: The landing page for the "Blueprints 101" crash course. This short tutorial covers everything you need to get started.
 hide_table_of_contents: false
 slug: /blueprints/tutorial
 ---


### PR DESCRIPTION
## Motivation for the change, related issues
Add docs-description blueprints tutorial and What are Blueprints?

related 
https://github.com/WordPress/wordpress-playground/pull/2511#discussion_r2277780392
https://github.com/WordPress/wordpress-playground/pull/2511#discussion_r2277784103