### PR TITLE
[i18n] Add Japanese docs meta description to the main folder

### DIFF
--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/build.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/build.md
@@ -1,7 +1,7 @@
 ---
-title: 構築
+title: 構築 - WordPress Playground
 slug: /about/build
-description: WP Playground で構築する
+description: ローカル環境の設定からテーマや新しいツールの作成まで、WordPress Playground が製品の構築にどのように役立つかを学びます。
 sidebar_class_name: navbar-build-item
 ---
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/index.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/index.md
@@ -1,6 +1,7 @@
 ---
-title: プレイグラウンドについて
+title: WordPress プレイグラウンドについて
 slug: /about
+description: WordPress Playground の概要、それが何であるか、なぜ便利なのか、そしてブラウザで WordPress を実行する方法について説明します。
 ---
 
 # WordPress プレイグラウンドについて

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/launch.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/launch.md
@@ -1,6 +1,7 @@
 ---
-title: ローンチ
+title: ローンチ - WordPress Playground
 slug: /about/launch
+description: ウェブサイトへのインタラクティブなデモの埋め込みからネイティブ モバイル アプリの作成まで、Playground を使用して製品を起動する方法を学びます。
 ---
 
 # ローンチ

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/test.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/test.md
@@ -1,6 +1,7 @@
 ---
-title: テスト
+title: テスト - WordPress Playground
 slug: /about/test
+description: Playground を使用してテーマ、プラグイン、プルリクエスト、WordPress と PHP のさまざまなバージョンをテストする方法を説明します。
 ---
 
 # テスト

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/code.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/code.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/code
+title: コードの貢献 - WordPress Playground
+description: リポジトリをフォークする方法、ローカル環境をセットアップする方法、プルリクエストを送信する方法などを説明した、コード貢献のガイドです。
 ---
 
 # コードの貢献

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/coding-standards
+title: コーディング原則 - WordPress Playground
+description: 役立つエラー メッセージ、最小限のパブリック API、ブループリントを中心に、Playground のコーディング原則について詳しく説明します。
 ---
 
 # コーディング原則

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/contributor-day
+title: WordCamp コントリビューターデー - WordPress Playground
+description: WordCamp コントリビューターデー 中に VS Code 拡張機能や CLI などの Playground ツールを使用するためのガイドです。
 ---
 
 # WordCamp コントリビューター デイ

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/documentation
+title: ドキュメントの貢献 - WordPress Playground
+description: 問題のオープンからプル リクエストの送信まで、Playground ドキュメントに貢献する方法に関するガイド。
 ---
 
 # ドキュメントの貢献

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/index.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/index.md
@@ -1,13 +1,14 @@
 ---
-title: イントロダクション
+title: WordPress Playgroundプロジェクトへの貢献
 slug: /contributing
 id: introduction
+description: WordPress Playground への貢献の出発点です。コード、ドキュメント、バグ報告に関するガイドラインをご覧ください。
 ---
 
-# WP Playground プロジェクトへの貢献
+# WordPress Playground プロジェクトへの貢献
 
 <!--
-# Contributing to WP Playground project
+# Contributing to WordPress Playground project
 -->
 
 WordPress Playground は、コードからデザイン、ドキュメントからトリアージまで、あらゆる種類の貢献者を歓迎するオープンソース プロジェクトです。

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/translations
+title: 翻訳への貢献 - WordPress Playground
+description: ファイル構造、ローカルテスト、レビュープロセスなど、Playground ドキュメントを翻訳する方法を学びます。
 ---
 
 # 翻訳への貢献

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/for-plugin-developers.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/for-plugin-developers.md
@@ -1,7 +1,7 @@
 ---
-title: プラグイン開発者のための Playground
+title: プラグイン開発者のためのWordPressプレイグラウンド
 slug: /guides/for-plugin-developers
-description: プラグイン開発者のための WordPress Playground
+description: Playground を使用してプラグインの魅力的なライブ デモを構築、テスト、作成するためのプラグイン開発者向けガイドです。
 ---
 
 WordPress Playground は、プラグイン開発者がブラウザ環境で直接プラグインを構築、テスト、紹介できる革新的なツールです。

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/for-theme-developers.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/for-theme-developers.md
@@ -1,7 +1,7 @@
 ---
-title: テーマ開発者のための Playground
+title: テーマ開発者のためのWordPressプレイグラウンド
 slug: /guides/for-theme-developers
-description: テーマ開発者のための WordPress プレイグラウンド
+description: Playground を使用して、Blueprints でテーマのライブ デモを構築、テスト、作成するためのテーマ開発者向けガイドです。
 ---
 
 WordPress Playground は、テーマ開発者がブラウザ環境で直接テーマを構築、テスト、紹介できる革新的なツールです。

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/index.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/index.md
@@ -1,7 +1,7 @@
 ---
-title: 📖 ガイド
+title: 📖 ガイド - WordPress Playground
 slug: /guides
-description: WordPress Playground ガイド
+description: さまざまなトピックと関連するユースケースを理解して操作するのに役立つ WordPress プレイグラウンド ガイド。
 sidebar_class_name: navbar-build-item
 ---
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/providing-content-for-your-demo.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/providing-content-for-your-demo.md
@@ -1,7 +1,7 @@
 ---
 title: Playground でデモ用のコンテンツを提供する
 slug: /guides/providing-content-for-your-demo
-description: WordPress Playground でデモ用のコンテンツを提供する
+description: Blueprints、WP-CLI、または PHP を使用して Playground デモにコンテンツを追加し、テーマやプラグインを紹介する方法を学びます。
 ---
 
 WordPress Playground で優れたデモを提供するために、プラグインやテーマの機能をわかりやすく示すために、デフォルトのコンテンツを読み込むことをお勧めします。このデフォルトコンテンツには、画像やその他のアセットが含まれる場合があります。

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/wordpress-native-ios-app.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/wordpress-native-ios-app.md
@@ -1,7 +1,7 @@
 ---
-title: ネイティブ iOS アプリのプレイグラウンド
+title: ネイティブiOSアプリのWordPress Playground
 slug: /guides/wordpress-native-ios-app
-description: ネイティブ iOS アプリの WordPress Playground
+description: Playground を使用した「Blocknotes」のケース スタディに基づいて、ネイティブ iOS アプリ内で WordPress サイトを実行する方法を学びます。
 ---
 
 ## Playground 経由でネイティブ iOS アプリで実際の WordPress サイトを配布するにはどうすればよいでしょうか?

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/intro.md
@@ -1,7 +1,8 @@
 ---
-title: はじめに
+title: はじめに - WordPress Playground
 slug: /
 id: introduction
+description: WordPress Playground ドキュメントへようこそ！このページではドキュメントの構造を紹介し、ドキュメントの使い方を説明します。
 ---
 
 # WordPress Playground ドキュメント

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -1,6 +1,7 @@
 ---
-title: クイックスタート ガイド
+title: クイックスタート ガイド - WordPress Playground
 slug: /quick-start-guide
+description: Playground を使い始めるための5分ガイド。プラグインのテスト、テーマの試用、そして様々なバージョンのWP/PHPの使い方を学びましょう。
 ---
 
 import ThisIsQueryApi from '@site/docs/\_fragments/\_this_is_query_api.md';
@@ -232,7 +233,7 @@ You can also use the `wp` and `php` query parameters to open Playground with the
  -->
 
 -   https://playground.wordpress.net/?wp=6.5
--   https://playground.wordpress.net/?php=7.4
+-   https://playground.wordpress.net/?php=8.3
 -   https://playground.wordpress.net/?php=8.2&wp=6.2
 
 <ThisIsQueryApi />

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,6 +1,7 @@
 ---
-title: リンクとリソース
+title: リンクとリソース - WordPress Playground
 slug: /resources
+description: WordPress Playground について詳しく知るためのアプリ、ツール、記事、ビデオへの役立つリンクを厳選したリストです。
 ---
 
 # リンクとリソース

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -1,6 +1,7 @@
 ---
-title: Playground ウェブ インスタンス
+title: ウェブ インスタンス - WordPress Playground
 slug: /web-instance
+description: ツールバー、設定、インスタンス マネージャーを網羅した、playground.wordpress.net の Web インターフェイスの詳細なガイドです。
 ---
 
 # WordPress Playground ウェブ インスタンス


### PR DESCRIPTION
## Motivation for the change, related issues

Add Japanese docs meta description to the main folder

## Implementation details

This will add the meta description added in pull request #2504 to the Japanese documentation.
