### PR TITLE
Adding blueprints docs description

### DIFF
--- a/packages/docs/site/docs/blueprints/01-index.md
+++ b/packages/docs/site/docs/blueprints/01-index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started
 slug: /blueprints/getting-started
+description: A quick-start guide to Blueprints. Understand what problems they solve and the different ways you can start using them.
 ---
 
 # Getting started with Blueprints

--- a/packages/docs/site/docs/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/docs/blueprints/02-using-blueprints.md
@@ -1,6 +1,7 @@
 ---
 title: Using Blueprints
 slug: /blueprints/using-blueprints
+description: Discover the different ways to use Blueprints, including via URL fragment, query parameter, bundles, and the JavaScript API.
 ---
 
 # Using Blueprints

--- a/packages/docs/site/docs/blueprints/03-data-format.md
+++ b/packages/docs/site/docs/blueprints/03-data-format.md
@@ -2,6 +2,7 @@
 sidebar_position: 1
 title: Blueprint data Format
 slug: /blueprints/data-format
+description: An overview of the Blueprint data format. Learn about key properties like landingPage, preferredVersions, and steps.
 ---
 
 # Blueprint data format

--- a/packages/docs/site/docs/blueprints/04-resources.md
+++ b/packages/docs/site/docs/blueprints/04-resources.md
@@ -1,5 +1,6 @@
 ---
 slug: /blueprints/steps/resources
+description: A technical reference for "Resource References." Learn how to use external files for themes, plugins, and content.
 ---
 
 # Resources References

--- a/packages/docs/site/docs/blueprints/05-steps-shorthands.md
+++ b/packages/docs/site/docs/blueprints/05-steps-shorthands.md
@@ -1,5 +1,6 @@
 ---
 slug: /blueprints/steps/shorthands
+description: A guide to the shorthand syntax for common Blueprint steps like login, plugins, and siteOptions for more concise code.
 ---
 
 # Shorthands

--- a/packages/docs/site/docs/blueprints/05-steps.md
+++ b/packages/docs/site/docs/blueprints/05-steps.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 3
 slug: /blueprints/steps
+description: The main API reference for the steps property. Discover all available step types you can use in a Blueprint.
 ---
 
 # Steps

--- a/packages/docs/site/docs/blueprints/06-bundles.md
+++ b/packages/docs/site/docs/blueprints/06-bundles.md
@@ -1,6 +1,7 @@
 ---
 title: Blueprint Bundles
 slug: /blueprints/bundles
+description: Learn about Blueprint bundles, self-contained packages that include a blueprint.json file and all its required resources.
 ---
 
 # Blueprint Bundles

--- a/packages/docs/site/docs/blueprints/07-json-api-and-function-api.md
+++ b/packages/docs/site/docs/blueprints/07-json-api-and-function-api.md
@@ -1,6 +1,7 @@
 ---
 title: API Consistency
 slug: /blueprints/steps/api-consistency
+description: Learn about the relationship between the Blueprint JSON format and the underlying JavaScript function API used to execute steps.
 ---
 
 # JSON API and Function API

--- a/packages/docs/site/docs/blueprints/08-examples.md
+++ b/packages/docs/site/docs/blueprints/08-examples.md
@@ -2,6 +2,7 @@
 sidebar_position: 8
 title: Examples
 slug: /blueprints/examples
+description: A gallery of practical Blueprint examples for various tasks, such as installing themes, running PHP, and enabling features.
 ---
 
 import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';

--- a/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshoot and debug
 slug: /blueprints/troubleshoot-and-debug
+description: A guide with tips and tools to help you troubleshoot and debug your Blueprints, from common issues to browser tools.
 ---
 
 # Troubleshoot and debug Blueprints

--- a/packages/docs/site/docs/blueprints/intro.md
+++ b/packages/docs/site/docs/blueprints/intro.md
@@ -2,6 +2,7 @@
 title: Introduction
 slug: /blueprints
 id: introduction
+description: The main introduction to the Blueprints documentation. Discover the structure of the docs and find key sections.
 ---
 
 import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';

--- a/packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md
+++ b/packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md
@@ -1,7 +1,7 @@
 ---
 title: How to run Blueprints
 slug: /blueprints/tutorial/how-to-load-run-blueprints
-description: Learn about the multiple ways to use blueprints
+description: Learn the various methods for loading and running Blueprints, including using a URL fragment or the blueprint-url parameter.
 ---
 
 # How to load and run Blueprints

--- a/packages/docs/site/docs/blueprints/tutorial/03-build-your-first-blueprint.md
+++ b/packages/docs/site/docs/blueprints/tutorial/03-build-your-first-blueprint.md
@@ -1,7 +1,7 @@
 ---
 title: Build your first Blueprint
 slug: /blueprints/tutorial/build-your-first-blueprint
-description: Six steps to your first blueprint
+description: A step-by-step tutorial to build your first Blueprint. Learn to install themes, plugins, and import site content.
 ---
 
 Let's build an elementary Blueprint that

--- a/packages/docs/site/docs/main/about/build.md
+++ b/packages/docs/site/docs/main/about/build.md
@@ -1,5 +1,5 @@
 ---
-title: Build - WordPress Playground
+title: Build
 slug: /about/build
 description: Learn how WordPress Playground helps you build products, from setting up local environments to creating themes and new tools.
 sidebar_class_name: navbar-build-item

--- a/packages/docs/site/docs/main/about/launch.md
+++ b/packages/docs/site/docs/main/about/launch.md
@@ -1,5 +1,5 @@
 ---
-title: Launch - WordPress Playground
+title: Launch
 slug: /about/launch
 description: Learn how to use Playground to launch products, from embedding interactive demos on websites to creating native mobile apps.
 ---

--- a/packages/docs/site/docs/main/about/test.md
+++ b/packages/docs/site/docs/main/about/test.md
@@ -1,5 +1,5 @@
 ---
-title: Test - WordPress Playground
+title: Test
 slug: /about/test
 description: Discover how to use Playground for testing themes, plugins, pull requests, and different versions of WordPress and PHP.
 ---

--- a/packages/docs/site/docs/main/contributing/code.md
+++ b/packages/docs/site/docs/main/contributing/code.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/code
-title: Code contributions - WordPress Playground
+title: Code contributions
 description: A guide for code contributions, covering how to fork the repo, set up a local environment, and submit a pull request.
 ---
 

--- a/packages/docs/site/docs/main/contributing/coding-standards.md
+++ b/packages/docs/site/docs/main/contributing/coding-standards.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/coding-standards
-title: Coding principles - WordPress Playground
+title: Coding principles
 description: Details the coding principles for Playground, focusing on helpful error messages, a minimal public API, and Blueprints.
 ---
 

--- a/packages/docs/site/docs/main/contributing/contributor-day.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/contributor-day
-title: WordCamp Contributor Day - WordPress Playground
+title: WordCamp Contributor Day
 description: A guide on using Playground tools like the VS Code extension and CLI during a WordCamp Contributor Day to get started.
 ---
 

--- a/packages/docs/site/docs/main/contributing/documentation.md
+++ b/packages/docs/site/docs/main/contributing/documentation.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/documentation
-title: Documentation Contributions - WordPress Playground
+title: Documentation Contributions
 description: A guide on how to contribute to the Playground documentation, from opening issues to submitting pull requests.
 ---
 

--- a/packages/docs/site/docs/main/contributing/translations.md
+++ b/packages/docs/site/docs/main/contributing/translations.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/translations
-title: Contributions to translations - WordPress Playground
+title: Contributions to translations
 description: Learn how to translate the Playground documentation, including file structure, local testing, and the review process.
 ---
 

--- a/packages/docs/site/docs/main/guides/index.md
+++ b/packages/docs/site/docs/main/guides/index.md
@@ -1,5 +1,5 @@
 ---
-title: 📖 Guides - WordPress Playground
+title: 📖 Guides
 slug: /guides
 description: A WordPress Playground Guide to help you understand and work with various topics and related use cases.
 sidebar_class_name: navbar-build-item

--- a/packages/docs/site/docs/main/intro.md
+++ b/packages/docs/site/docs/main/intro.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction - WordPress Playground
+title: Introduction
 slug: /
 id: introduction
 description: Welcome to the WordPress Playground docs! This page introduces the documentation structure and helps you find your way around.

--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Quick Start Guide - WordPress Playground
+title: Quick Start Guide
 slug: /quick-start-guide
 description: A 5-minute guide to get started with Playground. Learn how to test plugins, try themes, and use different WP/PHP versions.
 ---

--- a/packages/docs/site/docs/main/resources.md
+++ b/packages/docs/site/docs/main/resources.md
@@ -1,5 +1,5 @@
 ---
-title: Links and Resources - WordPress Playground
+title: Links and Resources
 slug: /resources
 description: A curated list of helpful links to apps, tools, articles, and videos for learning more about WordPress Playground.
 ---

--- a/packages/docs/site/docs/main/web-instance.md
+++ b/packages/docs/site/docs/main/web-instance.md
@@ -1,5 +1,5 @@
 ---
-title: Web Instance - WordPress Playground
+title: Web Instance
 slug: /web-instance
 description: A detailed guide to the web interface at playground.wordpress.net, covering the toolbar, settings, and instance manager.
 ---

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/build.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/build.md
@@ -1,5 +1,5 @@
 ---
-title: 構築 - WordPress Playground
+title: 構築
 slug: /about/build
 description: ローカル環境の設定からテーマや新しいツールの作成まで、WordPress Playground が製品の構築にどのように役立つかを学びます。
 sidebar_class_name: navbar-build-item

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/launch.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/launch.md
@@ -1,5 +1,5 @@
 ---
-title: ローンチ - WordPress Playground
+title: ローンチ
 slug: /about/launch
 description: ウェブサイトへのインタラクティブなデモの埋め込みからネイティブ モバイル アプリの作成まで、Playground を使用して製品を起動する方法を学びます。
 ---

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/test.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/about/test.md
@@ -1,5 +1,5 @@
 ---
-title: テスト - WordPress Playground
+title: テスト
 slug: /about/test
 description: Playground を使用してテーマ、プラグイン、プルリクエスト、WordPress と PHP のさまざまなバージョンをテストする方法を説明します。
 ---

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/code.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/code.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/code
-title: コードの貢献 - WordPress Playground
+title: コードの貢献
 description: リポジトリをフォークする方法、ローカル環境をセットアップする方法、プルリクエストを送信する方法などを説明した、コード貢献のガイドです。
 ---
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/coding-standards
-title: コーディング原則 - WordPress Playground
+title: コーディング原則
 description: 役立つエラー メッセージ、最小限のパブリック API、ブループリントを中心に、Playground のコーディング原則について詳しく説明します。
 ---
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/contributor-day
-title: WordCamp コントリビューターデー - WordPress Playground
+title: WordCamp コントリビューターデー
 description: WordCamp コントリビューターデー 中に VS Code 拡張機能や CLI などの Playground ツールを使用するためのガイドです。
 ---
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/documentation
-title: ドキュメントの貢献 - WordPress Playground
+title: ドキュメントの貢献
 description: 問題のオープンからプル リクエストの送信まで、Playground ドキュメントに貢献する方法に関するガイド。
 ---
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/translations
-title: 翻訳への貢献 - WordPress Playground
+title: 翻訳への貢献
 description: ファイル構造、ローカルテスト、レビュープロセスなど、Playground ドキュメントを翻訳する方法を学びます。
 ---
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/index.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/guides/index.md
@@ -1,5 +1,5 @@
 ---
-title: 📖 ガイド - WordPress Playground
+title: 📖 ガイド
 slug: /guides
 description: さまざまなトピックと関連するユースケースを理解して操作するのに役立つ WordPress プレイグラウンド ガイド。
 sidebar_class_name: navbar-build-item

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/intro.md
@@ -1,5 +1,5 @@
 ---
-title: はじめに - WordPress Playground
+title: はじめに
 slug: /
 id: introduction
 description: WordPress Playground ドキュメントへようこそ！このページではドキュメントの構造を紹介し、ドキュメントの使い方を説明します。

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -1,5 +1,5 @@
 ---
-title: クイックスタート ガイド - WordPress Playground
+title: クイックスタート ガイド
 slug: /quick-start-guide
 description: Playground を使い始めるための5分ガイド。プラグインのテスト、テーマの試用、そして様々なバージョンのWP/PHPの使い方を学びましょう。
 ---

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,5 +1,5 @@
 ---
-title: リンクとリソース - WordPress Playground
+title: リンクとリソース
 slug: /resources
 description: WordPress Playground について詳しく知るためのアプリ、ツール、記事、ビデオへの役立つリンクを厳選したリストです。
 ---

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -1,5 +1,5 @@
 ---
-title: ウェブ インスタンス - WordPress Playground
+title: ウェブ インスタンス
 slug: /web-instance
 description: ツールバー、設定、インスタンス マネージャーを網羅した、playground.wordpress.net の Web インターフェイスの詳細なガイドです。
 ---

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/code.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/code.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/code
-title: Contribuições de código - WordPress Playground
+title: Contribuições de código
 description: Um guia para contribuições de código, cobrindo como fazer um fork do repositório, configurar um ambiente local e enviar um pull request.
 ---
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/coding-standards
-title: Princípios de codificação - WordPress Playground
+title: Princípios de codificação
 description: Detalha os princípios de codificação do Playground, com foco em mensagens de erro úteis, uma API pública mínima e Blueprints.
 ---
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
@@ -1,6 +1,6 @@
 ---
 slug: /contributing/documentation
-title: Contribuições para a documentação - WordPress Playground
+title: Contribuições para a documentação
 description: Um guia sobre como contribuir para a documentação do Playground, desde abrir issues até enviar pull requests.
 ---
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -1,5 +1,5 @@
 ---
-title: Contribuições para traduções - WordPress Playground
+title: Contribuições para traduções
 slug: /contributing/translations
 description: Aprenda a traduzir a documentação do Playground, incluindo a estrutura de arquivos, testes locais e o processo de revisão.
 ---

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/index.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/index.md
@@ -1,5 +1,5 @@
 ---
-title: 📖 Guias - WordPress Playground
+title: 📖 Guias
 slug: /guides
 description: Guia do WordPress Playground para ajudar você a entender e trabalhar com vários tópicos e casos de uso.
 sidebar_class_name: navbar-build-item

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/intro.md
@@ -1,5 +1,5 @@
 ---
-title: Introdução - WordPress Playground
+title: Introdução
 slug: /
 id: introduction
 description: Boas-vindas à documentação do WordPress Playground! Esta página apresenta a estrutura da documentação e ajuda você a se orientar.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -1,5 +1,5 @@
 ---
-title: Primeiros passos - WordPress Playground
+title: Primeiros passos
 slug: /quick-start-guide
 description: Um guia de 5 minutos para começar a usar o Playground. Aprenda a testar plugins, temas e usar diferentes versões de WP/PHP.
 ---

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,5 +1,5 @@
 ---
-title: Links e Recursos - WordPress Playground
+title: Links e Recursos
 slug: /resources
 description: Uma lista de links úteis para aplicativos, ferramentas, artigos e vídeos para aprender mais sobre o WordPress Playground.
 ---

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -1,5 +1,5 @@
 ---
-title: Web Instance - WordPress Playground
+title: Web Instance
 slug: /web-instance
 description: Um guia detalhado da interface web em playground.wordpress.net, cobrindo a barra de ferramentas, configurações e o gerenciador de instâncias.
 ---


### PR DESCRIPTION
## Motivation for the change, related issues

This PR addresses issue #2500 by adding descriptions to the Blueprints pages and the Playground Documentation. It also fixes a recent change to page titles for SEO, which unintentionally broke the Documentation sidebar.

The previous SEO title changes will be reverted. A new approach will be used to implement SEO-friendly titles without affecting the sidebar navigation.

<img width="562" height="392" alt="Screenshot 2025-08-18 at 17 42 11" src="https://github.com/user-attachments/assets/3466129d-0c36-4431-a647-4ac5e5730b2b" />
