### PR TITLE
[CLI] Playground CLI supports --auto-mount=path option

### DIFF
--- a/packages/playground/cli/src/mounts.ts
+++ b/packages/playground/cli/src/mounts.ts
@@ -110,7 +110,9 @@ const ACTIVATE_FIRST_THEME_STEP = {
 /**
  * Auto-mounts resolution logic:
  */
-export function expandAutoMounts(path: string, args: RunCLIArgs): RunCLIArgs {
+export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
+	const path = args.autoMount!;
+
 	const mount = [...(args.mount || [])];
 	const mountBeforeInstall = [...(args['mount-before-install'] || [])];
 

--- a/packages/playground/cli/src/mounts.ts
+++ b/packages/playground/cli/src/mounts.ts
@@ -110,9 +110,7 @@ const ACTIVATE_FIRST_THEME_STEP = {
 /**
  * Auto-mounts resolution logic:
  */
-export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
-	const path = process.cwd();
-
+export function expandAutoMounts(path: string, args: RunCLIArgs): RunCLIArgs {
 	const mount = [...(args.mount || [])];
 	const mountBeforeInstall = [...(args['mount-before-install'] || [])];
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -157,15 +157,6 @@ export async function parseOptionsAndRunCLI() {
 				// TODO: Update docs
 				describe: `Automatically mount the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.`,
 				type: 'string',
-				coerce(arg) {
-					if (arg === 'false') {
-						return '';
-					}
-					if (arg === '' || arg === 'true') {
-						return process.cwd();
-					}
-					return arg;
-				},
 			})
 			.option('follow-symlinks', {
 				describe:
@@ -362,8 +353,14 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 	 * Expand auto-mounts to include the necessary mounts and steps
 	 * when running in auto-mount mode.
 	 */
-	if (args.autoMount) {
-		args = expandAutoMounts(args.autoMount, args);
+	if (args.autoMount !== undefined) {
+		if (args.autoMount === '') {
+			// No auto-mount path was provided, so use the current working directory.
+			// Note: We default here instead of in the yargs declaration
+			// because it allows us to test the default as part of the runCLI unit tests.
+			args = { ...args, autoMount: process.cwd() };
+		}
+		args = expandAutoMounts(args);
 	}
 
 	if (args.quiet) {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -154,9 +154,18 @@ export async function parseOptionsAndRunCLI() {
 				default: false,
 			})
 			.option('auto-mount', {
+				// TODO: Update docs
 				describe: `Automatically mount the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.`,
-				type: 'boolean',
-				default: false,
+				type: 'string',
+				coerce(arg) {
+					if (arg === 'false') {
+						return '';
+					}
+					if (arg === '' || arg === 'true') {
+						return process.cwd();
+					}
+					return arg;
+				},
 			})
 			.option('follow-symlinks', {
 				describe:
@@ -300,7 +309,7 @@ export interface RunCLIArgs {
 	port?: number;
 	quiet?: boolean;
 	wp?: string;
-	autoMount?: boolean;
+	autoMount?: string;
 	experimentalMultiWorker?: number;
 	experimentalTrace?: boolean;
 	exitOnPrimaryWorkerCrash?: boolean;
@@ -354,7 +363,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 	 * when running in auto-mount mode.
 	 */
 	if (args.autoMount) {
-		args = expandAutoMounts(args);
+		args = expandAutoMounts(args.autoMount, args);
 	}
 
 	if (args.quiet) {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -356,8 +356,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 	if (args.autoMount !== undefined) {
 		if (args.autoMount === '') {
 			// No auto-mount path was provided, so use the current working directory.
-			// Note: We default here instead of in the yargs declaration
-			// because it allows us to test the default as part of the runCLI unit tests.
+			// Note: We default here instead of in the yargs declaration because
+			// it allows us to test the default as part of the runCLI() unit tests.
 			args = { ...args, autoMount: process.cwd() };
 		}
 		args = expandAutoMounts(args);

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -220,10 +220,26 @@ export async function parseOptionsAndRunCLI() {
 					}
 				}
 
+				if (args['auto-mount']) {
+					let autoMountIsDir = false;
+					try {
+						const autoMountStats = fs.statSync(args['auto-mount']);
+						autoMountIsDir = autoMountStats.isDirectory();
+					} catch {
+						autoMountIsDir = false;
+					}
+
+					if (!autoMountIsDir) {
+						throw new Error(
+							`The specified --auto-mount path is not a directory: '${args['auto-mount']}'.`
+						);
+					}
+				}
+
 				if (args['experimental-multi-worker'] !== undefined) {
 					if (args['experimental-multi-worker'] <= 1) {
 						throw new Error(
-							'The --experimentalMultiWorker flag must be a positive integer greater than 1.'
+							'The --experimental-multi-worker flag must be a positive integer greater than 1.'
 						);
 					}
 
@@ -236,7 +252,7 @@ export async function parseOptionsAndRunCLI() {
 						)
 					) {
 						throw new Error(
-							'Please mount a real filesystem directory as the /wordpress directory before using the --experimentalMultiWorker flag. For example: ' +
+							'Please mount a real filesystem directory as the /wordpress directory before using the --experimental-multi-worker flag. For example: ' +
 								'--mount-dir-before-install ./empty-dir /wordpress'
 						);
 					}

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -154,8 +154,7 @@ export async function parseOptionsAndRunCLI() {
 				default: false,
 			})
 			.option('auto-mount', {
-				// TODO: Update docs
-				describe: `Automatically mount the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.`,
+				describe: `Automatically mount the specified directory. If no path is provided, mount the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.`,
 				type: 'string',
 			})
 			.option('follow-symlinks', {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -90,6 +90,69 @@ describe('run-cli', () => {
 		expect(response.text).toContain('<title>My Blog Name</title>');
 	});
 
+	test('should be able to follow external symlinks in primary and secondary PHP instances', async () => {
+		// TODO: Make sure test always uses a single worker.
+		// TODO: Is there a way to confirm we are testing use of a non-primary PHP instance?
+		const tmpDir = await mkdtemp(path.join(tmpdir(), 'playground-test-'));
+		writeFileSync(
+			path.join(tmpDir, 'sleep.php'),
+			'<?php sleep(1); echo "Slept"; '
+		);
+		const symlinkPath = path.join(
+			import.meta.dirname,
+			'mount-examples',
+			'symlinking',
+			'symlinked-script'
+		);
+
+		mkdirSync(path.dirname(symlinkPath), { recursive: true });
+
+		try {
+			if (existsSync(symlinkPath)) {
+				unlinkSync(symlinkPath);
+			}
+			// TODO: Confirm that symlink target is outside of current working dir tree.
+			symlinkSync(tmpDir, symlinkPath);
+			cliServer = await runCLI({
+				debug: true,
+				command: 'server',
+				followSymlinks: true,
+				'mount-before-install': [
+					{
+						hostPath: symlinkPath,
+						vfsPath: '/wordpress/wp-content/test-script',
+					},
+				],
+			});
+			expect(cliServer.workerThreadCount).toBe(1);
+			// Make multiple simultaneous requests to force the use of a secondary PHP instance.
+			// TODO: Find way to confirm this.
+			const responses = await Promise.all([
+				cliServer.playground.request({
+					url: '/wp-content/test-script/sleep.php',
+					method: 'GET',
+				}),
+				cliServer.playground.request({
+					url: '/wp-content/test-script/sleep.php',
+					method: 'GET',
+				}),
+				// Test a third request to hopefully test more than one secondary instance.
+				cliServer.playground.request({
+					url: '/wp-content/test-script/sleep.php',
+					method: 'GET',
+				}),
+			]);
+			responses.forEach((response) => {
+				expect(response.httpStatusCode).toBe(200);
+				expect(response.text).toContain('Slept');
+			});
+		} finally {
+			if (existsSync(symlinkPath)) {
+				unlinkSync(symlinkPath);
+			}
+		}
+	});
+
 	// @TODO: Also test with Blueprints v2.
 	describe('auto-mount', () => {
 		const getDirectoryChecksum = async (dir: string) => {
@@ -241,71 +304,6 @@ describe('run-cli', () => {
 			 * Playground should not modify the mounted directory.
 			 */
 			expect(await getDirectoryChecksum(tmpDir)).toBe(checksum);
-		});
-
-		test('should be able to follow external symlinks in primary and secondary PHP instances', async () => {
-			// TODO: Make sure test always uses a single worker.
-			// TODO: Is there a way to confirm we are testing use of a non-primary PHP instance?
-			const tmpDir = await mkdtemp(
-				path.join(tmpdir(), 'playground-test-')
-			);
-			writeFileSync(
-				path.join(tmpDir, 'sleep.php'),
-				'<?php sleep(1); echo "Slept"; '
-			);
-			const symlinkPath = path.join(
-				import.meta.dirname,
-				'mount-examples',
-				'symlinking',
-				'symlinked-script'
-			);
-
-			mkdirSync(path.dirname(symlinkPath), { recursive: true });
-
-			try {
-				if (existsSync(symlinkPath)) {
-					unlinkSync(symlinkPath);
-				}
-				// TODO: Confirm that symlink target is outside of current working dir tree.
-				symlinkSync(tmpDir, symlinkPath);
-				cliServer = await runCLI({
-					debug: true,
-					command: 'server',
-					followSymlinks: true,
-					'mount-before-install': [
-						{
-							hostPath: symlinkPath,
-							vfsPath: '/wordpress/wp-content/test-script',
-						},
-					],
-				});
-				expect(cliServer.workerThreadCount).toBe(1);
-				// Make multiple simultaneous requests to force the use of a secondary PHP instance.
-				// TODO: Find way to confirm this.
-				const responses = await Promise.all([
-					cliServer.playground.request({
-						url: '/wp-content/test-script/sleep.php',
-						method: 'GET',
-					}),
-					cliServer.playground.request({
-						url: '/wp-content/test-script/sleep.php',
-						method: 'GET',
-					}),
-					// Test a third request to hopefully test more than one secondary instance.
-					cliServer.playground.request({
-						url: '/wp-content/test-script/sleep.php',
-						method: 'GET',
-					}),
-				]);
-				responses.forEach((response) => {
-					expect(response.httpStatusCode).toBe(200);
-					expect(response.text).toContain('Slept');
-				});
-			} finally {
-				if (existsSync(symlinkPath)) {
-					unlinkSync(symlinkPath);
-				}
-			}
 		});
 	});
 });

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -204,6 +204,36 @@ describe('run-cli', () => {
 				'<title>My WordPress Website</title>'
 			);
 		});
+
+		test('should run a plugin project using --auto-mount=<specific-path>', async () => {
+			const autoMountPath = path.join(
+				import.meta.dirname,
+				'mount-examples',
+				'plugin'
+			);
+			cliServer = await runCLI({
+				command: 'server',
+				autoMount: autoMountPath,
+			});
+			const phpResponse = await cliServer.playground.run({
+				code: `<?php
+					require_once '/wordpress/wp-load.php';
+					require_once '/wordpress/wp-admin/includes/plugin.php';
+					echo is_plugin_active('plugin/sample-plugin.php') ? '1' : '0';
+				?>`,
+			});
+			expect(phpResponse.text).toBe('1');
+
+			const response = await cliServer.playground.request({
+				url: '/',
+				method: 'GET',
+			});
+			expect(response.httpStatusCode).toBe(200);
+			expect(response.text).toContain(
+				'<title>My WordPress Website</title>'
+			);
+		});
+
 		test(`should run a theme project using --auto-mount`, async () => {
 			vi.spyOn(process, 'cwd').mockReturnValue(
 				path.join(import.meta.dirname, 'mount-examples', 'theme')
@@ -211,6 +241,29 @@ describe('run-cli', () => {
 			cliServer = await runCLI({
 				command: 'server',
 				autoMount: '',
+			});
+
+			expect(await getActiveTheme()).toBe('Yolo Theme');
+
+			const response = await cliServer.playground.request({
+				url: '/',
+				method: 'GET',
+			});
+			expect(response.httpStatusCode).toBe(200);
+			expect(response.text).toContain(
+				'<title>My WordPress Website</title>'
+			);
+		});
+
+		test('should run a theme project using --auto-mount=<specific-path>', async () => {
+			const autoMountPath = path.join(
+				import.meta.dirname,
+				'mount-examples',
+				'theme'
+			);
+			cliServer = await runCLI({
+				command: 'server',
+				autoMount: autoMountPath,
 			});
 
 			expect(await getActiveTheme()).toBe('Yolo Theme');
@@ -240,6 +293,23 @@ describe('run-cli', () => {
 			expect(response.httpStatusCode).toBe(200);
 		});
 
+		test('should run a wp-content project using --auto-mount=<specific-path>', async () => {
+			const autoMountPath = path.join(
+				import.meta.dirname,
+				'mount-examples',
+				'wp-content'
+			);
+			cliServer = await runCLI({
+				command: 'server',
+				autoMount: autoMountPath,
+			});
+			const response = await cliServer.playground.request({
+				url: '/wp-login.php',
+				method: 'GET',
+			});
+			expect(response.httpStatusCode).toBe(200);
+		});
+
 		test('should run a static html project using --auto-mount', async () => {
 			vi.spyOn(process, 'cwd').mockReturnValue(
 				path.join(import.meta.dirname, 'mount-examples', 'static-html')
@@ -256,6 +326,24 @@ describe('run-cli', () => {
 			expect(response.text).toContain('<title>Static HTML</title>');
 		});
 
+		test('should run a static html project using --auto-mount=<specific-path>', async () => {
+			const autoMountPath = path.join(
+				import.meta.dirname,
+				'mount-examples',
+				'static-html'
+			);
+			cliServer = await runCLI({
+				command: 'server',
+				autoMount: autoMountPath,
+			});
+			const response = await cliServer.playground.request({
+				url: '/',
+				method: 'GET',
+			});
+			expect(response.httpStatusCode).toBe(200);
+			expect(response.text).toContain('<title>Static HTML</title>');
+		});
+
 		test('should run a php project using --auto-mount', async () => {
 			vi.spyOn(process, 'cwd').mockReturnValue(
 				path.join(import.meta.dirname, 'mount-examples', 'php')
@@ -263,6 +351,24 @@ describe('run-cli', () => {
 			cliServer = await runCLI({
 				command: 'server',
 				autoMount: '',
+			});
+			const response = await cliServer.playground.request({
+				url: '/',
+				method: 'GET',
+			});
+			expect(response.httpStatusCode).toBe(200);
+			expect(response.text).toContain('Hello world');
+		});
+
+		test('should run a php project using --auto-mount=<specific-path>', async () => {
+			const autoMountPath = path.join(
+				import.meta.dirname,
+				'mount-examples',
+				'php'
+			);
+			cliServer = await runCLI({
+				command: 'server',
+				autoMount: autoMountPath,
 			});
 			const response = await cliServer.playground.request({
 				url: '/',
@@ -290,6 +396,38 @@ describe('run-cli', () => {
 			cliServer = await runCLI({
 				command: 'server',
 				autoMount: '',
+			});
+			const response = await cliServer.playground.request({
+				url: '/',
+				method: 'GET',
+			});
+			expect(response.httpStatusCode).toBe(200);
+			expect(response.text).toContain(
+				'<title>My WordPress Website</title>'
+			);
+
+			/**
+			 * Playground should not modify the mounted directory.
+			 */
+			expect(await getDirectoryChecksum(tmpDir)).toBe(checksum);
+		});
+
+		test('should run a wordpress project using --auto-mount=<specific-path>', async () => {
+			const tmpDir = await mkdtemp(
+				path.join(tmpdir(), 'playground-test-')
+			);
+			const autoMountPath = path.join(tmpDir, 'wordpress');
+
+			const zip = await fetch('https://wordpress.org/latest.zip');
+			const zipPath = path.join(tmpDir, 'wp.zip');
+			await writeFile(zipPath, new Uint8Array(await zip.arrayBuffer()));
+			await promisify(exec)(`unzip "${zipPath}" -d "${tmpDir}"`);
+
+			const checksum = await getDirectoryChecksum(tmpDir);
+
+			cliServer = await runCLI({
+				command: 'server',
+				autoMount: autoMountPath,
 			});
 			const response = await cliServer.playground.request({
 				url: '/',

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -121,7 +121,7 @@ describe('run-cli', () => {
 			);
 			cliServer = await runCLI({
 				command: 'server',
-				autoMount: true,
+				autoMount: '',
 			});
 			const phpResponse = await cliServer.playground.run({
 				code: `<?php
@@ -147,7 +147,7 @@ describe('run-cli', () => {
 			);
 			cliServer = await runCLI({
 				command: 'server',
-				autoMount: true,
+				autoMount: '',
 			});
 
 			expect(await getActiveTheme()).toBe('Yolo Theme');
@@ -168,7 +168,7 @@ describe('run-cli', () => {
 			);
 			cliServer = await runCLI({
 				command: 'server',
-				autoMount: true,
+				autoMount: '',
 			});
 			const response = await cliServer.playground.request({
 				url: '/wp-login.php',
@@ -183,7 +183,7 @@ describe('run-cli', () => {
 			);
 			cliServer = await runCLI({
 				command: 'server',
-				autoMount: true,
+				autoMount: '',
 			});
 			const response = await cliServer.playground.request({
 				url: '/',
@@ -199,7 +199,7 @@ describe('run-cli', () => {
 			);
 			cliServer = await runCLI({
 				command: 'server',
-				autoMount: true,
+				autoMount: '',
 			});
 			const response = await cliServer.playground.request({
 				url: '/',
@@ -226,7 +226,7 @@ describe('run-cli', () => {
 
 			cliServer = await runCLI({
 				command: 'server',
-				autoMount: true,
+				autoMount: '',
 			});
 			const response = await cliServer.playground.request({
 				url: '/',
@@ -260,7 +260,7 @@ describe('run-cli', () => {
 				'symlinked-script'
 			);
 
-			mkdirSync( path.dirname( symlinkPath ), { recursive: true } );
+			mkdirSync(path.dirname(symlinkPath), { recursive: true });
 
 			try {
 				if (existsSync(symlinkPath)) {


### PR DESCRIPTION
## Motivation for the change, related issues

It is impossible (or at least awkward) to test the Playground CLI `--auto-mount` option locally using the `npx nx unbuilt-jspi playground-cli` family of commands. The reason is that `--auto-mount` tries to auto mount the current working directory, but those commands must be executed with the Playground source directory.

For this case, it would be useful to be able to pass a path to the `--auto-mount` option.

In addition, it is more powerful and flexible for to regular users to be able to pass an explicit `--auto-mount=path`.

## Implementation details

This PR:
- Changes the type of the `--auto-mount` option to a string.
- Updates the `--auto-mount` yargs description.
- Updates `runCLI()` to default auto-mount to the current working directory if `--auto-mount` is specific but no path is provided.
- Adds tests passing an explicit path to auto-mount.

## Testing Instructions (or ideally a Blueprint)

- CI
