### PR TITLE
Fix corrupt zip download from Site Editor export

### DIFF
--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -112,6 +112,14 @@ phpLoaderOptions.forEach((options) => {
 				expect(streamed.headers).toBeInstanceOf(Promise);
 			});
 
+			it('should provide stdout bytes through stdoutBytes property', async () => {
+				const streamed = await php.runStream({
+					code: '<?php echo "Hello World";',
+				});
+				const bytes = await streamed.stdoutBytes;
+				expect(bytes).toBe(new TextEncoder().encode('Hello World'));
+			});
+
 			it('should provide stdout text through stdoutText property', async () => {
 				const streamed = await php.runStream({
 					code: '<?php echo "Hello World";',

--- a/packages/php-wasm/node/src/test/php.spec.ts
+++ b/packages/php-wasm/node/src/test/php.spec.ts
@@ -117,7 +117,9 @@ phpLoaderOptions.forEach((options) => {
 					code: '<?php echo "Hello World";',
 				});
 				const bytes = await streamed.stdoutBytes;
-				expect(bytes).toBe(new TextEncoder().encode('Hello World'));
+				expect(bytes).toStrictEqual(
+					new TextEncoder().encode('Hello World')
+				);
 			});
 
 			it('should provide stdout text through stdoutText property', async () => {

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -147,6 +147,9 @@ export class StreamedPHPResponse {
 		);
 	}
 
+	/**
+	 * Exposes the stdout bytes as they're produced by the PHP instance
+	 */
 	get stdoutBytes(): Promise<Uint8Array> {
 		if (!this.cachedStdoutBytes) {
 			this.cachedStdoutBytes = streamToBytes(this.stdout);
@@ -228,8 +231,9 @@ async function streamToText(
 async function streamToBytes(
 	stream: ReadableStream<Uint8Array>
 ): Promise<Uint8Array> {
-	const reader = (stream as ReadableStream<BufferSource>).getReader();
-	const chunks: BufferSource[] = [];
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+
 	while (true) {
 		const { done, value } = await reader.read();
 		if (done) {
@@ -240,7 +244,7 @@ async function streamToBytes(
 			const result = new Uint8Array(totalLength);
 			let offset = 0;
 			for (const chunk of chunks) {
-				result.set(chunk as Uint8Array, offset);
+				result.set(chunk, offset);
 				offset += chunk.byteLength;
 			}
 			return result;

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -319,9 +319,7 @@ export class PHPResponse implements PHPResponseData {
 		return new PHPResponse(
 			await streamedResponse.httpStatusCode,
 			await streamedResponse.headers,
-			// new TextEncoder().encode(
 			await streamedResponse.stdoutBytes,
-			// )
 			await streamedResponse.stderrText,
 			await streamedResponse.exitCode
 		);

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -75,7 +75,7 @@ export class StreamedPHPResponse {
 		httpStatusCode: number;
 	}> | null = null;
 
-	private cachedStdoutText: Promise<string> | null = null;
+	private cachedStdoutBytes: Promise<Uint8Array> | null = null;
 	private cachedStderrText: Promise<string> | null = null;
 
 	constructor(
@@ -142,10 +142,16 @@ export class StreamedPHPResponse {
 	 * Exposes the stdout bytes as they're produced by the PHP instance
 	 */
 	get stdoutText(): Promise<string> {
-		if (!this.cachedStdoutText) {
-			this.cachedStdoutText = streamToText(this.stdout);
+		return this.stdoutBytes.then((bytes) =>
+			new TextDecoder().decode(bytes)
+		);
+	}
+
+	get stdoutBytes(): Promise<Uint8Array> {
+		if (!this.cachedStdoutBytes) {
+			this.cachedStdoutBytes = streamToBytes(this.stdout);
 		}
-		return this.cachedStdoutText;
+		return this.cachedStdoutBytes;
 	}
 
 	/**
@@ -219,6 +225,32 @@ async function streamToText(
 	}
 }
 
+async function streamToBytes(
+	stream: ReadableStream<Uint8Array>
+): Promise<Uint8Array> {
+	const reader = (stream as ReadableStream<BufferSource>).getReader();
+	const chunks: BufferSource[] = [];
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) {
+			const totalLength = chunks.reduce(
+				(acc, chunk) => acc + chunk.byteLength,
+				0
+			);
+			const result = new Uint8Array(totalLength);
+			let offset = 0;
+			for (const chunk of chunks) {
+				result.set(chunk as Uint8Array, offset);
+				offset += chunk.byteLength;
+			}
+			return result;
+		}
+		if (value) {
+			chunks.push(value);
+		}
+	}
+}
+
 /**
  * PHP response. Body is an `ArrayBuffer` because it can
  * contain binary data.
@@ -283,7 +315,9 @@ export class PHPResponse implements PHPResponseData {
 		return new PHPResponse(
 			await streamedResponse.httpStatusCode,
 			await streamedResponse.headers,
-			new TextEncoder().encode(await streamedResponse.stdoutText),
+			// new TextEncoder().encode(
+			await streamedResponse.stdoutBytes,
+			// )
 			await streamedResponse.stderrText,
 			await streamedResponse.exitCode
 		);


### PR DESCRIPTION
## Motivation for the change, related issues

The purpose of this PR is to fix the corrupt zip download from the Site Editor "Export" feature.

Fixes #2528

## Implementation details

This PR adds a `stdoutBytes` property to StreamedPHPResponse and updates `PHPResponse.fromStreamedResponse()` to use that.

Prior to this change, `fromStreamedResponse()` used the `stdoutText` property which took a byte stream that was decoded on the fly to text and then re-encoded by the accessor to bytes. The bytes of a zip file going through that transform were being corrupted. Without that transform, the zip file bytes are not corrupted.

## Testing Instructions (or ideally a Blueprint)

- Automated: CI
- Manual
  - Run `npx nx unbuilt-asyncify playground-cli -- server`
  - Open the site in a browser
  - Navigate to the Site Editor
  - Open the upper-right hamburger menu and click the "Export" menu item to download a theme export zip.
  - Confirm that the downloaded zip can be extracted and that the contents do not look obviously broken.