### PR TITLE
Use SQLite AST driver also with Blueprints v2

### DIFF
--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -242,6 +242,12 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 		if (options.phpIniEntries) {
 			setPhpIniEntries(php, options.phpIniEntries);
 		}
+
+		// Use the new AST-based SQLite driver.
+		// TODO: Remove this once the new driver is the default; when this is closed:
+		//         https://github.com/WordPress/sqlite-database-integration/issues/195
+		php.defineConstant('WP_SQLITE_AST_DRIVER', true);
+
 		/**
 		 * Set up mu-plugins in /internal/shared/mu-plugins
 		 * using auto_prepend_file to provide platform-level

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -377,11 +377,6 @@ export async function preloadSqliteIntegration(
 	}`;
 	await php.mv(temporarySqlitePluginFolder, SQLITE_PLUGIN_FOLDER);
 
-	// Use the new AST-based SQLite driver.
-	// TODO: Remove this once the new driver is the default; when this is closed:
-	//         https://github.com/WordPress/sqlite-database-integration/issues/195
-	php.defineConstant('WP_SQLITE_AST_DRIVER', true);
-
 	// Prevents the SQLite integration from trying to call activate_plugin()
 	await php.defineConstant('SQLITE_MAIN_FILE', '1');
 	const dbCopy = await php.readFileAsText(


### PR DESCRIPTION
## Motivation for the change, related issues
The new SQLite driver is not used by Playground CLI when running with Blueprints v2. This PR makes sure the `WP_SQLITE_AST_DRIVER` feature flag is always defined.

## Implementation details
I moved the feature flag from `preloadSqliteIntegration` (used only with Blueprints v1) to `bootRequest handler` (which is always used).

## Testing Instructions (or ideally a Blueprint)
**To test on the CLI:**
1. Create the following Blueprint:
```json
{
  "steps": [
    {
      "step": "mkdir",
      "path": "wordpress/wp-content/mu-plugins"
    },
    {
      "step": "writeFile",
      "path": "wordpress/wp-content/mu-plugins/load.php",
      "data": "<?php var_dump( get_class($GLOBALS['wpdb']->dbh));"
    }
  ],
  "login": true,
  "preferredVersions": {
    "php": "8.3",
    "wp": "latest"
  },
  "features": {}
}
```
2. Run `npx nx unbuilt-jspi playground-cli server --blueprint blueprint.json`.
3. Go to http://127.0.0.1:9400/.
4. You should see `string(16) "WP_SQLite_Driver"` — the new driver instance (not `string(20) "WP_SQLite_Translator"` — the old driver).

For Blueprints v2 runner, you can use the same steps while adding the `--experimental-blueprints-v2-runner` flag:
```bash
npx nx unbuilt-jspi playground-cli --experimental-blueprints-v2-runner server --blueprint blueprint.json
```

**To test that it still works on Playground web:**
1. Run `npx nx bundle-sqlite-database playground-wordpress-builds`.
6. Run `npm run dev`.
7. Go to [http://127.0.0.1:5400/website-server/#{%22steps%22:[{%22step%22:%22mkdir%22,%22path%22:%22wordpress/wp-content/mu-plugins%22},{%22step%22:%22writeFile%22,%22path%22:%22wordpress/wp-content/mu-plugins/load.php%22,%22data%22:%22%3C?php%20var_dump(%20get_class($GLOBALS['wpdb']-%3Edbh));%22}],%22login%22:true}](http://127.0.0.1:5400/website-server/#%7B%22steps%22:%5B%7B%22step%22:%22mkdir%22,%22path%22:%22wordpress/wp-content/mu-plugins%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22wordpress/wp-content/mu-plugins/load.php%22,%22data%22:%22%3C?php%20var_dump(%20get_class($GLOBALS%5B'wpdb'%5D-%3Edbh));%22%7D%5D,%22login%22:true%7D)
8. You should see `string(16) "WP_SQLite_Driver"` — the new driver instance (not `string(20) "WP_SQLite_Translator"` — the old driver).