### PR TITLE
[i18n] Add Japanese translations to WordPress Playground badge

### DIFF
--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
@@ -1,0 +1,107 @@
+---
+title: WordPress Playground 貢献者バッジ
+slug: /contributing/contributor-badge
+description: WordPress Playground 貢献者バッジの基準と、WordPress.org プロフィールにバッジをリクエストする方法を確認してください。
+---
+
+# プレイグラウンド貢献者バッジ
+
+<!--
+# Playground Contributor Badge
+-->
+
+このページでは、プレイグラウンド貢献者バッジに関する詳細情報と、[WordPress.org](https://wordpress.org) プロフィールでそれをリクエストするプロセスについて説明します。
+
+<!--
+This page provides detailed information on the Playground Contributor Badge and the process of requesting it on your [WordPress.org](https://wordpress.org) profile.
+-->
+
+---
+
+## はじめる
+
+<!--
+## Getting Started
+-->
+
+WordPress Playground プロジェクトへのあらゆる貢献は高く評価されます。Playground チームは、以下の主要分野における貢献を高く評価しています。
+
+<!--
+Any contribution to the WordPress Playground project is highly valued. The Playground team recognizes contributions across several key areas:
+-->
+
+-   **プレイグラウンド コード:** コード変更とコアプロジェクトのレビュー。
+-   **プレイグラウンド UI:** Web エクスペリエンスのユーザーインターフェースの改善。
+-   **ドキュメント:** ドキュメントの作成、更新、レビュー。
+-   **翻訳:** プロジェクトのあらゆる部分の翻訳。
+-   **ブループリント ギャラリー:** 新しいブループリントの作成、または既存のブループリントの改善。
+
+<!--
+-   **Playground Code:** Making code changes and reviewing the core project.
+-   **Playground UI:** Improving the user interface of the web experience.
+-   **Documentation:** Writing, updating, and reviewing documentation.
+-   **Translation:** Translating any part of the project.
+-   **Blueprints Gallery:** Creating new blueprints or improving existing ones.
+-->
+
+## プレイグラウンド貢献者バッジ
+
+<!--
+## Playground Contributor Badge
+-->
+
+プレイグラウンド貢献者バッジを取得するには、上記のリストにある対象となる貢献を少なくとも 1 つ行う必要があります。チームの裁量により、他の貢献、または上記の組み合わせに対してバッジを授与する場合があります。
+
+<!--
+To get a Playground Contributor Badge, you must have made at least one eligible contribution from the list above. The team may choose to award the badge for other contributions or a combination of the above at the team’s discretion.
+-->
+
+![Playground Contributor Badge](@site/static/img/contributing/playground-contributor-badge.webp)
+
+## プレイグラウンドチームバッジ
+
+<!--
+## Playground Team Badge
+-->
+
+現在貢献者であり、過去 **12 か月間** プレイグラウンドプロジェクトに積極的に参加している場合は、**プレイグラウンド チーム バッジ** を受け取る資格があります。
+
+<!--
+If you are currently a contributor and have been actively involved in the Playground project for the past **twelve months**, you are eligible for a **Playground Team Badge**.
+-->
+
+![Playground Contributor Badge](@site/static/img/contributing/playground-team-badge.webp)
+
+## プロフィールバッジのリクエスト
+
+<!--
+## Requesting a Profile Badge
+-->
+
+基準を満たしている場合は、バッジをリクエストできます。基準を満たしていることを示すリソース（ GitHub のプルリクエスト、Issue、翻訳された文字列など）へのリンクを必ず含めてください。以下のリンクからリクエストを送信してください。
+
+<!--
+If you meet the criteria, you can request a badge. Please include links to resources (such as GitHub pull requests, issues, or translated strings) that show you have met the criteria. Send a request at the links bellow:
+-->
+
+-   [貢献者 バッジ](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [チーム バッジ](https://profiles.wordpress.org/associations/playground-team/)
+
+<!--
+-   [Contributor Badge](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [Team Badge](https://profiles.wordpress.org/associations/playground-team/)
+-->
+
+### リクエストフォーム
+
+<!--
+### Request form
+-->
+
+![Playground Contributor Badge](@site/static/img/contributing/request-contributor-badge.webp)
+
+リクエストにアクセスするには、WordPress.org アカウントでログインし、「メンバーシップをリクエスト」タブを開いて必要な情報を送信してください。プレイグラウンド チームの担当者があなたの貢献を確認し、バッジを付与します。チームは毎週貢献度をレビューし、その時点でバッジを授与します。新しいバッジの授与に関する最新情報は、プレイグラウンド チームミーティング中に投稿されます。
+
+<!--
+To access the request, the user should be logged in with their WordPress.org account and open the Request Membership tab, after submitting the required information. A Playground Team Representative will confirm your contribution and assign the badge. The team will perform a weekly review of contributions and award badges at that time. Updates on new badges awarded will be posted during the Playground Team meeting.
+-->


### PR DESCRIPTION
## Motivation for the change, related issues
Part of #2202

Add Japanese translations to WordPress Playground badge