### PR TITLE
[i18n] Add Japanese translations to WordPress Playground Developers Docs

### DIFF
--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/developers/intro-devs.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/developers/intro-devs.md
@@ -1,0 +1,69 @@
+---
+title: WordPress Playground 開発者向けドキュメント
+slug: /developers/
+id: intro
+---
+
+# 開発者向けドキュメント
+
+<!--
+# Developers Docs
+-->
+
+こんにちは！WordPress Playground 開発者ドキュメントへようこそ。
+
+<!--
+Hi! Welcome to WordPress Playground Developer documentation.
+-->
+
+<p class="docs-hubs">WordPress Playground のドキュメントは、4 つの個別のハブ (サブサイト) に分散されています。</p>
+
+<!--
+<p class="docs-hubs">The WordPress Playground documentation is distributed across four separate hubs (subsites):</p>
+-->
+
+-   [**ドキュメント**](/) – WP Playground の紹介、スターターガイド、そして WP Playground ドキュメントへの入り口です。
+-   [**ブループリント**](/blueprints) – ブループリントは、WordPress Playground インスタンスを設定するための JSON ファイルです。Blueprints ドキュメントハブで、その可能性について学んでください。
+-   👉 [**開発者**](/developers) (現在地) – WordPress Playground はプログラミング可能なツールとして開発されました。この開発者ドキュメントハブで、コードからできることをすべて発見してください。
+-   [**API リファレンス**](/api) – WordPress Playground で公開されているすべての API です。
+
+<!--
+-   [**Documentation**](/) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
+-   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
+-   👉 [**Developers**](/developers) (you're here)– WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in this Developers docs hub.
+-   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
+-->
+
+## 開発者向けドキュメントハブのナビゲーション
+
+<!--
+## Navigating the Developers documentation hub
+-->
+
+このドキュメント ハブは開発者情報に重点を置いており、次の主要なセクションに分かれています。
+
+<!--
+This docs hub is focused on Developers info and is divided into the following major sections:
+-->
+
+-   [開発者向けクイックスタートガイド](/developers/build-your-first-app): Playground API を使って実現できることの例をいくつか確認しながら、Playground を使った開発を始めましょう。
+
+-   [ローカル開発](/developers/local-development): WordPress サイトのセットアップと管理、そしてアプリの構築プロセスを効率化するために Playground が提供するツールについて学びましょう。
+
+-   [Playground API](/developers/apis): WordPress Playground が Playground と連携するために公開している主要な API について学びましょう。[Query API](/developers/apis/query-api/)、[Blueprints](/blueprints/)、[Javascript API](/developers/apis/javascript-api/)
+
+-   [アーキテクチャ](/developers/architecture): WordPress Playground のアーキテクチャの詳細（さまざまなコンポーネントやツールを含む）
+
+-   [制限事項](/developers/limitations/): WordPress Playground の現在の制限事項について詳しくは、ネットワーク接続の無効化、一時データ、iframe の不具合、PHP 関数の実行要件、WP-CLI の部分的なサポートなどをご覧ください。
+
+<!--
+-   [Quick Start Guide for Developers](/developers/build-your-first-app): Begin your development journey with Playground by exploring some examples of what you can achieve using Playground APIs.
+
+-   [Local Development](/developers/local-development): Discover the tools provided by Playground to streamline the process of setting up and managing WordPress sites and build your apps.
+
+-   [Playground APIs](/developers/apis): Explore the main APIs exposed by WordPress Playground to interact with the Playground: [Query API](/developers/apis/query-api/), [Blueprints](/blueprints/), [Javascript API](/developers/apis/javascript-api/)
+
+-   [Architecture](/developers/architecture): The specifics of WordPress Playground's architecture, including its various components and tools.
+
+-   [Limitations](/developers/limitations/): Learn more about the current limitations of WordPress Playground, which include disabled network connections, temporary data, iframe quirks, PHP function execution requirements, and partial WP-CLI support.
+-->


### PR DESCRIPTION
## Motivation for the change, related issues
Part of #2202

Add Japanese translations to WordPress Playground Developers Docs