### PR TITLE
[Web] tolerate empty e.target in addTargetBlankToExternalLinks

### DIFF
--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -47,6 +47,7 @@ async function run() {
 	const hasDevtoolsOption = args.some((arg) =>
 		arg.startsWith('--experimental-devtools')
 	);
+	console.log('hasDevtoolsOption', args);
 	if (hasDevtoolsOption) {
 		args = args.filter((arg) => arg !== '--experimental-devtools');
 	}

--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -47,7 +47,6 @@ async function run() {
 	const hasDevtoolsOption = args.some((arg) =>
 		arg.startsWith('--experimental-devtools')
 	);
-	console.log('hasDevtoolsOption', args);
 	if (hasDevtoolsOption) {
 		args = args.filter((arg) => arg !== '--experimental-devtools');
 	}

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -120,7 +120,7 @@ function playground_add_target_blank_to_external_links() {
 			// Set target="_blank" for external links when clicked.
 			// This covers links that are added after the page has loaded.
 			document.addEventListener('click', e => {
-				const a = e.target.closest('a[href]');
+				const a = e.target?.closest('a[href]');
 				if (!a) return;
 				addTargetBlank(a);
 			});
@@ -128,7 +128,7 @@ function playground_add_target_blank_to_external_links() {
 			// Also handle focus events to cover keyboard navigation on
 			// links that are added after the page has loaded.
 			document.addEventListener('focus', e => {
-				const a = e.target.closest('a[href]');
+				const a = e.target?.closest('a[href]');
 				if (!a) return;
 				addTargetBlank(a);
 			}, true);


### PR DESCRIPTION
## Motivation for the change, related issues

A user reported the following error coming from the `addTargetBlankToExternalLinks` function:

```
JavaScript Error: TypeError: e.target.closest is not a function https://playground.wordpress.net/scope:0.7531680412299814/wp-admin/post.php?post=5&action=edit:570:24
```

It could happen when another event listener removes the `e.target` node before the event bubbles up to the `document` node.

This PR makes sure an empty `e.target` is tolerated and short-circuits without an error.

cc @draganescu