### PR TITLE
[PHP] Do not rotate PHP instances that were explicitly exited

### DIFF
--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1422,6 +1422,10 @@ export class PHP implements Disposable {
 		}
 	}
 
+	isInitialized() {
+		return this.#webSapiInitialized;
+	}
+
 	[Symbol.dispose]() {
 		if (this.#webSapiInitialized) {
 			this.exit(0);

--- a/packages/php-wasm/universal/src/lib/rotate-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/rotate-php-runtime.ts
@@ -40,6 +40,9 @@ export function rotatePHPRuntime({
 }: RotateOptions) {
 	let runtimeRequestCount = 0;
 	async function rotateRuntime() {
+		if (!php.isInitialized()) {
+			return;
+		}
 		const release = await php.semaphore.acquire();
 		try {
 			await php.hotSwapPHPRuntime(await recreateRuntime(), cwd);


### PR DESCRIPTION
## Motivation for the change, related issues

Prevents calling `hotSwapPHPRuntime` on a PHP instance that is not initialized to avoid the following failures in Playground CLI:

```
{
  type: 'request.error',
  error: Error: PHP.run() failed with exit code 255.
      at runExecutionFunction.then.dispatchEvent.type (/Users/cloudnik/www/Automattic/core/plugins/wordpress-playground/packages/php-wasm/universal/src/lib/php.ts:1052:14),
  source: 'php-wasm'
}
Trace: hotSwapPHPRuntime called on a disposed PHP instance
    at PHP.hotSwapPHPRuntime (/Users/cloudnik/www/Automattic/core/plugins/wordpress-playground/packages/php-wasm/universal/src/lib/php.ts:1272:13)
    at rotateRuntime (/Users/cloudnik/www/Automattic/core/plugins/wordpress-playground/packages/php-wasm/universal/src/lib/rotate-php-runtime.ts:45:14)
    at async rotateRuntimeForPhpWasmError (/Users/cloudnik/www/Automattic/core/plugins/wordpress-playground/packages/php-wasm/universal/src/lib/rotate-php-runtime.ts:64:4)
```

## Implementation details

Checks for `php.#webSapiInitialized` before calling `php.hotSwapPHPRuntime()` to avoid the following execution path:

* PHP request fails with exit code 255
* PHP instance is killed to create a new one in its place
* `rotateRuntimeForPhpWasmError()` event listener is called one last time before it is disposed

## Testing Instructions (or ideally a Blueprint)

TBD
