### PR TITLE
Add browser refresh confirmation for temporary sites

### DIFF
--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -128,21 +128,61 @@ export const listenToOnlineOfflineEventsMiddleware: Middleware =
 	};
 
 let browserConfirmationRanOnce = false;
+let hasUserInteracted = false;
+
 export const browserConfirmationMiddleware: Middleware =
 	(store) => (next) => (action) => {
 		if (!browserConfirmationRanOnce) {
 			browserConfirmationRanOnce = true;
 			if (typeof window !== 'undefined') {
-				window.addEventListener('beforeunload', (e) => {
-					const state = store.getState() as any;
-					// Access the active site directly from state structure
-					const activeSiteSlug = state.ui?.activeSite?.slug;
-					const activeSite = activeSiteSlug
-						? state.sites?.entities?.[activeSiteSlug]
-						: undefined;
+				// Track user interactions to avoid warning on quick open/close
+				const interactionEvents = [
+					'click',
+					'keypress',
+					'input',
+					'change',
+				];
+				interactionEvents.forEach((event) => {
+					window.addEventListener(
+						event,
+						() => {
+							hasUserInteracted = true;
+						},
+						{ once: true, capture: true }
+					);
+				});
 
-					// Only show confirmation for temporary sites (storage === 'none')
-					if (activeSite && activeSite.metadata?.storage === 'none') {
+				window.addEventListener('beforeunload', (e) => {
+					// Don't warn if user hasn't interacted with the site
+					if (!hasUserInteracted) {
+						return;
+					}
+
+					// Check if WordPress editor already has unsaved changes
+					// If it does, let WordPress handle the confirmation
+					try {
+						const wpWindow = window as any;
+						if (
+							wpWindow.wp?.data
+								?.select?.('core/editor')
+								?.isEditedPostDirty?.()
+						) {
+							// WordPress will show its own dialog
+							return;
+						}
+					} catch {
+						// WordPress editor not available, continue with our check
+					}
+
+					const state = store.getState() as any;
+
+					// Check ALL temporary sites, not just the active one
+					const temporarySites = Object.values(
+						state.sites?.entities || {}
+					).filter((site: any) => site?.metadata?.storage === 'none');
+
+					// Only show confirmation if there are temporary sites
+					if (temporarySites.length > 0) {
 						e.preventDefault();
 						e.returnValue = '';
 						return '';

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -127,6 +127,33 @@ export const listenToOnlineOfflineEventsMiddleware: Middleware =
 		return next(action);
 	};
 
+let browserConfirmationRanOnce = false;
+export const browserConfirmationMiddleware: Middleware =
+	(store) => (next) => (action) => {
+		if (!browserConfirmationRanOnce) {
+			browserConfirmationRanOnce = true;
+			if (typeof window !== 'undefined') {
+				window.addEventListener('beforeunload', (e) => {
+					const state = store.getState() as any;
+					// Access the active site directly from state structure
+					const activeSiteSlug = state.ui?.activeSite?.slug;
+					const activeSite = activeSiteSlug ? state.sites?.entities?.[activeSiteSlug] : undefined;
+					
+					// Only show confirmation for temporary sites (storage === 'none')
+					if (activeSite && activeSite.metadata?.storage === 'none') {
+						const message = 'Your changes will be lost. This is a temporary Playground site. Are you sure you want to leave?';
+						e.preventDefault();
+						// Modern browsers require setting returnValue
+						e.returnValue = message;
+						// Some older browsers use the return value
+						return message;
+					}
+				});
+			}
+		}
+		return next(action);
+	};
+
 export const {
 	setActiveModal,
 	setActiveSiteError,

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -137,16 +137,15 @@ export const browserConfirmationMiddleware: Middleware =
 					const state = store.getState() as any;
 					// Access the active site directly from state structure
 					const activeSiteSlug = state.ui?.activeSite?.slug;
-					const activeSite = activeSiteSlug ? state.sites?.entities?.[activeSiteSlug] : undefined;
-					
+					const activeSite = activeSiteSlug
+						? state.sites?.entities?.[activeSiteSlug]
+						: undefined;
+
 					// Only show confirmation for temporary sites (storage === 'none')
 					if (activeSite && activeSite.metadata?.storage === 'none') {
-						const message = 'Your changes will be lost. This is a temporary Playground site. Are you sure you want to leave?';
 						e.preventDefault();
-						// Modern browsers require setting returnValue
-						e.returnValue = message;
-						// Some older browsers use the return value
-						return message;
+						e.returnValue = '';
+						return '';
 					}
 				});
 			}

--- a/packages/playground/website/src/lib/state/redux/store.ts
+++ b/packages/playground/website/src/lib/state/redux/store.ts
@@ -3,6 +3,7 @@ import type { SiteError } from './slice-ui';
 import uiReducer, {
 	__internal_uiSlice,
 	listenToOnlineOfflineEventsMiddleware,
+	browserConfirmationMiddleware,
 } from './slice-ui';
 import type { SiteInfo } from './slice-sites';
 import sitesReducer, {
@@ -61,7 +62,8 @@ const store = configureStore({
 	},
 	middleware: (getDefaultMiddleware) =>
 		ignoreSerializableCheck(getDefaultMiddleware).concat(
-			listenToOnlineOfflineEventsMiddleware
+			listenToOnlineOfflineEventsMiddleware,
+			browserConfirmationMiddleware
 		),
 });
 


### PR DESCRIPTION
## Summary

Fixes #81 

This PR implements a browser confirmation dialog that warns users before they refresh or leave the page when using a temporary Playground site, preventing accidental data loss.

## Changes

- Added `browserConfirmationMiddleware` in `slice-ui.ts` that listens for the `beforeunload` event
- The middleware checks if the active site is temporary (storage type is `'none'`)
- Shows a browser-native confirmation dialog only for temporary sites
- Registered the new middleware in the Redux store

## Test Plan

1. Open WordPress Playground and create a temporary site
2. Make some changes in the WordPress admin or editor
3. Try to refresh the page or navigate away - you should see a confirmation dialog
4. Click "Cancel" to stay on the page, or "Leave" to proceed with the refresh/navigation
5. Save the site to make it permanent
6. Try to refresh again - no confirmation should appear for saved sites

## Screenshots

<img width="1508" height="768" alt="Screenshot 2025-08-26 at 2 36 02 PM" src="https://github.com/user-attachments/assets/d73018a0-b53d-4cd6-a0ef-184982438d19" />
