### PR TITLE
Add test to verify mount() correctly handles files (closes #503)

### DIFF
--- a/packages/php-wasm/node/src/test/mount.spec.ts
+++ b/packages/php-wasm/node/src/test/mount.spec.ts
@@ -138,6 +138,21 @@ describe('Mounting', () => {
 				}
 			});
 
+			it('Should create a file node, not a directory, when mounting a file', async () => {
+				// This test addresses issue #503
+				// Ensure the mount point doesn't exist yet
+				expect(php.fileExists(fileMountPoint)).toBe(false);
+
+				await php.mount(
+					fileMountPoint,
+					createNodeFsMountHandler(filePath)
+				);
+
+				// The mount point should be a file, not a directory
+				expect(php.isFile(fileMountPoint)).toBe(true);
+				expect(php.isDir(fileMountPoint)).toBe(false);
+			});
+
 			it('Should unmount mounted file and remove created node from VFS', async () => {
 				const unmount = await php.mount(
 					fileMountPoint,


### PR DESCRIPTION
## Summary

Closes #503

This PR adds a test to verify that the `mount()` method correctly creates file nodes (not directories) when mounting files. 

## Investigation Results

After investigating issue #503, it appears the bug described has already been resolved. The current implementation in `node-fs-mount.ts` correctly:
- Creates parent directories for files: `FS.mkdirTree(dirname(vfsMountPoint))`  
- Creates directory trees for directories: `FS.mkdirTree(vfsMountPoint)`

This fix was likely implemented as part of PR #2338 ("File mounting in NODEFS").

## Changes

- Added explicit test case to `mount.spec.ts` that verifies:
  - Mount point doesn't exist before mounting
  - After mounting a file, `isFile()` returns `true`
  - After mounting a file, `isDir()` returns `false`

## Test Plan

The new test case ensures this behavior remains correct and prevents regression. The test explicitly addresses the concern raised in issue #503.

Since the bug appears to be already fixed, this PR primarily serves to:
1. Document that the issue is resolved
2. Add test coverage to prevent regression
3. Allow issue #503 to be closed