### PR TITLE
[XDebug Bridge] Highlight syntax of php scripts from mime type in Devtools

### DIFF
--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import crypto from 'crypto';
 import { parseStringPromise } from 'xml2js';
 import type { DbgpSession } from './dbgp-session';
 import type { CDPServer } from './cdp-server';
@@ -65,7 +66,7 @@ export class XdebugCDPBridge {
 		this.breakOnFirstLine = config.breakOnFirstLine || false;
 	}
 
-	start() {
+	start(): void {
 		// Xdebug connected
 		this.dbgp.on('connected', () => {
 			this.xdebugConnected = true;
@@ -111,29 +112,33 @@ export class XdebugCDPBridge {
 		this.sendInitialScripts().then(() => {
 			if (!this.breakOnFirstLine) {
 				// Opens Sources tab instead of Console by pausing the process
-				this.cdp.sendMessage({
-					method: 'Debugger.paused',
-					params: {
-						callFrames: [
-							{
-								location: {
-									scriptId: '1',
-									lineNumber: 0,
-								},
-								scopeChain: [],
-								this: { type: 'undefined' },
-							},
-						],
-						reason: 'other',
-					},
-				});
+				const entry = this.scriptIdByUrl.entries().next().value;
 
-				// Resume the process after 50ms to maintain focus on the first file.
-				// 50ms is an arbitrary choice: 0ms won’t display the code at this delay,
-				// while 100ms would be too long and cause a visible break on the first line.
-				setTimeout(() => {
-					this.cdp.sendMessage({ method: 'Debugger.resumed' });
-				}, 200);
+				if (entry) {
+					this.cdp.sendMessage({
+						method: 'Debugger.paused',
+						params: {
+							callFrames: [
+								{
+									location: {
+										scriptId: entry[1],
+										lineNumber: 0,
+									},
+									scopeChain: [],
+									this: { type: 'undefined' },
+								},
+							],
+							reason: 'other',
+						},
+					});
+
+					// Resume the process after 50ms to maintain focus on the first file.
+					// 50ms is an arbitrary choice: 0ms won’t display the code at this delay,
+					// while 100ms would be too long and cause a visible break on the first line.
+					setTimeout(() => {
+						this.cdp.sendMessage({ method: 'Debugger.resumed' });
+					}, 50);
+				}
 			}
 
 			// Send a nice welcome message with instructions
@@ -162,12 +167,12 @@ export class XdebugCDPBridge {
 		});
 	}
 
-	stop() {
+	stop(): void {
 		this.dbgp.close();
 		this.cdp.close();
 	}
 
-	private async sendInitialScripts() {
+	private async sendInitialScripts(): Promise<void> {
 		for (const [bridgeUri, scriptId] of this.scriptIdByUrl.entries()) {
 			await this.sendScriptToCDP(bridgeUri, scriptId);
 		}
@@ -175,10 +180,7 @@ export class XdebugCDPBridge {
 
 	private async sendScriptToCDP(url: string, id: string): Promise<void> {
 		const highlightUri = this.uriFromBridgeToCDPSyntaxHighlight(url);
-		const placeholder = [...Array(16)]
-			.map(() => Math.floor(Math.random() * 16).toString(16))
-			.join('');
-		const cdpUri = this.uriFromBridgeToCDP(placeholder);
+		const cdpUri = this.uriFromBridgeToCDP(url);
 
 		const phpContent = await this.readPHPFile(url);
 		const phpLines = phpContent.split('\n');
@@ -225,7 +227,14 @@ export class XdebugCDPBridge {
 	private getOrCreateScriptId(url: string): string {
 		let scriptId = this.scriptIdByUrl.get(url);
 		if (!scriptId) {
-			scriptId = String(this.nextScriptId++);
+			// IDs are used as references in the source directory.
+			// To prevent exposing raw IDs, we hash them with SHA-256
+			// and keep only the first 16 characters.
+			scriptId = crypto
+				.createHash('sha256')
+				.update(String(this.nextScriptId++))
+				.digest('hex')
+				.slice(0, 16);
 			this.scriptIdByUrl.set(url, scriptId);
 		}
 		return scriptId;
@@ -265,7 +274,7 @@ export class XdebugCDPBridge {
 		return txnIdStr;
 	}
 
-	private async handleCdpMessage(message: any) {
+	private async handleCdpMessage(message: any): Promise<void> {
 		const { id, method, params } = message;
 		let result: any = {};
 		let sendResponse = true;
@@ -528,25 +537,31 @@ export class XdebugCDPBridge {
 
 	/* ---------- uri mapping ---------- */
 
-	private uriFromBridgeToCDPSyntaxHighlight(uri: string) {
+	private uriFromBridgeToCDPSyntaxHighlight(uri: string): string {
 		return `file://PHP.wasm/${uri}`;
 	}
 
-	private uriFromBridgeToCDP(uri: string) {
+	private uriFromBridgeToCDP(uri: string): string {
+		uri = this.scriptIdByUrl.get(uri) ?? '';
+
 		return `file://placeholders/${uri}`;
 	}
 
-	private uriFromCDPToBridge(uri: string) {
+	private uriFromCDPToBridge(uri: string): string {
 		const prefix = 'file://placeholders/';
 
-		return uri.slice(prefix.length);
+		return (
+			[...this.scriptIdByUrl.entries()].find(
+				([, v]) => v === uri.slice(prefix.length)
+			)?.[0] ?? ''
+		);
 	}
 
-	private uriFromBridgeToDBGP(uri: string) {
+	private uriFromBridgeToDBGP(uri: string): string {
 		return path.resolve(process.cwd(), uri);
 	}
 
-	private uriFromDBGPToBridge(uri: string) {
+	private uriFromDBGPToBridge(uri: string): string {
 		uri = uri.startsWith('file://') ? uri.slice(7) : uri;
 
 		const index = uri.indexOf(this.phpRoot);
@@ -554,7 +569,7 @@ export class XdebugCDPBridge {
 		return index !== -1 ? uri.slice(index) : uri;
 	}
 
-	private async handleDbgpMessage(msgObj: any) {
+	private async handleDbgpMessage(msgObj: any): Promise<void> {
 		if (msgObj.init) {
 			this.breakpoints.forEach((breakpoint) => {
 				this.handleCdpMessage({

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -175,7 +175,10 @@ export class XdebugCDPBridge {
 
 	private async sendScriptToCDP(url: string, id: string): Promise<void> {
 		const highlightUri = this.uriFromBridgeToCDPSyntaxHighlight(url);
-		const cdpUri = this.uriFromBridgeToCDP(url);
+		const placeholder = [...Array(16)]
+			.map(() => Math.floor(Math.random() * 16).toString(16))
+			.join('');
+		const cdpUri = this.uriFromBridgeToCDP(placeholder);
 
 		const phpContent = await this.readPHPFile(url);
 		const phpLines = phpContent.split('\n');
@@ -477,15 +480,38 @@ export class XdebugCDPBridge {
 				break;
 			}
 			case 'Debugger.getScriptSource': {
+				const sid = params.scriptId;
+				const bridgeUri = [...this.scriptIdByUrl.entries()].find(
+					([, v]) => v === sid
+				)?.[0];
+
+				const fullPath = [];
+
+				if (bridgeUri) {
+					fullPath.push(
+						...[
+							"Here's the full path for your convenience:\n",
+							`${this.uriFromBridgeToCDPSyntaxHighlight(
+								bridgeUri
+							).replace('file://', '')}\n`,
+						]
+					);
+				}
+
 				// getScriptSource usually fills the source file.
 				// With scripts now using source maps, the source map
 				// now handles displaying the file content.
 				// Therefore, we return a redirect message instead.
 				result = {
 					scriptSource: [
-						'`This is not the file you’re looking for.',
-						'It exists solely as a technical placeholder due to limitations in the dev tools.',
-						'Please disregard this file and locate your intended file in the PHP.wasm directory.`',
+						'`Are you looking for your source code?',
+						'Go to PHP.wasm group in the navigator and find it there.',
+						...fullPath,
+						"What is this file, then? It's a placeholder required due to the dev tools limitations.",
+						'The XDebug <-> Devtools bridge implement PHP syntax highlighting using source maps,',
+						'and the unfortunate side effect is having a "source" file and a "target" file.',
+						'This is the "source". If you\'re interested in even more details, see the discussion at:\n',
+						'https://github.com/WordPress/wordpress-playground/pull/2566`',
 					].join('\n'),
 				};
 				break;
@@ -507,11 +533,11 @@ export class XdebugCDPBridge {
 	}
 
 	private uriFromBridgeToCDP(uri: string) {
-		return `file://source/${uri}`;
+		return `file://placeholders/${uri}`;
 	}
 
 	private uriFromCDPToBridge(uri: string) {
-		const prefix = 'file://source/';
+		const prefix = 'file://placeholders/';
 
 		return uri.slice(prefix.length);
 	}

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -483,7 +483,9 @@ export class XdebugCDPBridge {
 				)?.[0];
 				let scriptSource = '';
 				if (bridgeUri) {
-					scriptSource = await this.readPHPFile(bridgeUri);
+					const raw = await this.readPHPFile(bridgeUri);
+
+					scriptSource = raw.replace(/\s+/g, ' ');
 				}
 				result = { scriptSource };
 				break;

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -501,24 +501,21 @@ export class XdebugCDPBridge {
 	/* ---------- uri mapping ---------- */
 
 	private uriFromBridgeToCDPSyntaxHighlight(uri: string) {
-		const prefix = path.isAbsolute(uri) ? '' : '/';
-
-		return `file://PHP.wasm${prefix}${uri}`;
+		return `file://PHP.wasm/${uri}`;
 	}
 
 	private uriFromBridgeToCDP(uri: string) {
-		const prefix = path.isAbsolute(uri) ? '' : '/';
-
-		return `file://source${prefix}${uri}`;
+		return `file://source/${uri}`;
 	}
-	private uriFromCDPToBridge(uri: string) {
-		const prefix = 'file://source';
 
-		return uri.startsWith(prefix) ? uri.slice(prefix.length) : uri;
+	private uriFromCDPToBridge(uri: string) {
+		const prefix = 'file://source/';
+
+		return uri.slice(prefix.length);
 	}
 
 	private uriFromBridgeToDBGP(uri: string) {
-		return path.isAbsolute(uri) ? uri : path.resolve(uri);
+		return path.resolve(process.cwd(), uri);
 	}
 
 	private uriFromDBGPToBridge(uri: string) {

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -477,6 +477,10 @@ export class XdebugCDPBridge {
 				break;
 			}
 			case 'Debugger.getScriptSource': {
+				// getScriptSource usually fills the source file.
+				// With scripts now using source maps, the source map
+				// now handles displaying the file content.
+				// Therefore, we return an empty script source.
 				result = { scriptSource: '' };
 				break;
 			}

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -108,57 +108,57 @@ export class XdebugCDPBridge {
 		});
 
 		// Load known scripts
-		this.sendInitialScripts();
-
-		if (!this.breakOnFirstLine) {
-			// Opens Sources tab instead of Console by pausing the process
-			this.cdp.sendMessage({
-				method: 'Debugger.paused',
-				params: {
-					callFrames: [
-						{
-							location: {
-								scriptId: '1',
-								lineNumber: 0,
+		this.sendInitialScripts().then(() => {
+			if (!this.breakOnFirstLine) {
+				// Opens Sources tab instead of Console by pausing the process
+				this.cdp.sendMessage({
+					method: 'Debugger.paused',
+					params: {
+						callFrames: [
+							{
+								location: {
+									scriptId: '1',
+									lineNumber: 0,
+								},
+								scopeChain: [],
+								this: { type: 'undefined' },
 							},
-							scopeChain: [],
-							this: { type: 'undefined' },
-						},
-					],
-					reason: 'other',
+						],
+						reason: 'other',
+					},
+				});
+
+				// Resume the process after 50ms to maintain focus on the first file.
+				// 50ms is an arbitrary choice: 0ms won’t display the code at this delay,
+				// while 100ms would be too long and cause a visible break on the first line.
+				setTimeout(() => {
+					this.cdp.sendMessage({ method: 'Debugger.resumed' });
+				}, 200);
+			}
+
+			// Send a nice welcome message with instructions
+			this.cdp.sendMessage({
+				method: 'Log.entryAdded',
+				params: {
+					entry: {
+						source: 'other',
+						level: 'info',
+						text: '🎉 Welcome to WordPress Playground DevTools! 🎉\n   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾\n\n1. Add breakpoints in your files to start step debugging.\n\n2. Run your php file, project, plugin or theme using PHP.wasm or Playground CLI.\n\n3. Witness the magic break.',
+						timestamp: Date.now(),
+					},
 				},
 			});
-
-			// Resume the process after 50ms to maintain focus on the first file.
-			// 50ms is an arbitrary choice: 0ms won’t display the code at this delay,
-			// while 100ms would be too long and cause a visible break on the first line.
-			setTimeout(() => {
-				this.cdp.sendMessage({ method: 'Debugger.resumed' });
-			}, 50);
-		}
-
-		// Send a nice welcome message with instructions
-		this.cdp.sendMessage({
-			method: 'Log.entryAdded',
-			params: {
-				entry: {
-					source: 'other',
-					level: 'info',
-					text: '🎉 Welcome to WordPress Playground DevTools! 🎉\n   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾\n\n1. Add breakpoints in your files to start step debugging.\n\n2. Run your php file, project, plugin or theme using PHP.wasm or Playground CLI.\n\n3. Witness the magic break.',
-					timestamp: Date.now(),
+			this.cdp.sendMessage({
+				method: 'Log.entryAdded',
+				params: {
+					entry: {
+						source: 'other',
+						level: 'info',
+						text: ' ',
+						timestamp: Date.now(),
+					},
 				},
-			},
-		});
-		this.cdp.sendMessage({
-			method: 'Log.entryAdded',
-			params: {
-				entry: {
-					source: 'other',
-					level: 'info',
-					text: ' ',
-					timestamp: Date.now(),
-				},
-			},
+			});
 		});
 	}
 
@@ -167,19 +167,56 @@ export class XdebugCDPBridge {
 		this.cdp.close();
 	}
 
-	private sendInitialScripts() {
+	private async sendInitialScripts() {
 		for (const [bridgeUri, scriptId] of this.scriptIdByUrl.entries()) {
-			this.cdp.sendMessage({
-				method: 'Debugger.scriptParsed',
-				params: {
-					scriptId,
-					url: this.uriFromBridgeToCDP(bridgeUri),
-					startLine: 0,
-					startColumn: 0,
-					executionContextId: 1,
-				},
-			});
+			await this.sendScriptToCDP(bridgeUri, scriptId);
 		}
+	}
+
+	private async sendScriptToCDP(url: string, id: string): Promise<void> {
+		const highlightUri = this.uriFromBridgeToCDPSyntaxHighlight(url);
+		const cdpUri = this.uriFromBridgeToCDP(url);
+
+		const phpContent = await this.readPHPFile(url);
+		const phpLines = phpContent.split('\n');
+
+		// The first line is AAAA while the others are AACA.
+		// This is enough to set breakpoints with CDP and
+		// communicate with the DBGp protocol.
+		const mappings = phpLines
+			.map((_value, index) => (index === 0 ? 'AAAA' : 'AACA'))
+			.join(';');
+
+		const sourceMap = {
+			version: 3,
+			// File uri has to match the script parsed url
+			// While the sources url has to match the syntax
+			// highlighted file displayed in Devtools.
+			file: cdpUri,
+			sources: [highlightUri],
+			sourcesContent: [phpContent],
+			mappings,
+		};
+
+		const encodedMap = Buffer.from(
+			JSON.stringify(sourceMap),
+			'utf-8'
+		).toString('base64');
+		const sourceMapDataUri = `data:application/json;base64,${encodedMap}`;
+
+		this.cdp.sendMessage({
+			method: 'Debugger.scriptParsed',
+			params: {
+				scriptId: id,
+				url: cdpUri,
+				startLine: 0,
+				startColumn: 0,
+				endLine: phpLines.length,
+				endColumn: 0,
+				executionContextId: 1,
+				sourceMapURL: sourceMapDataUri,
+			},
+		});
 	}
 
 	private getOrCreateScriptId(url: string): string {
@@ -463,22 +500,25 @@ export class XdebugCDPBridge {
 
 	/* ---------- uri mapping ---------- */
 
-	private setPrefixForCDP() {
-		return path.isAbsolute(this.phpRoot) ? 'file://' : 'file:///';
+	private uriFromBridgeToCDPSyntaxHighlight(uri: string) {
+		const prefix = path.isAbsolute(uri) ? '' : '/';
+
+		return `file://PHP.wasm${prefix}${uri}`;
 	}
 
 	private uriFromBridgeToCDP(uri: string) {
-		return `${this.setPrefixForCDP()}${uri}`;
-	}
+		const prefix = path.isAbsolute(uri) ? '' : '/';
 
+		return `file://source${prefix}${uri}`;
+	}
 	private uriFromCDPToBridge(uri: string) {
-		const prefix = this.setPrefixForCDP();
+		const prefix = 'file://source';
 
 		return uri.startsWith(prefix) ? uri.slice(prefix.length) : uri;
 	}
 
 	private uriFromBridgeToDBGP(uri: string) {
-		return path.resolve(uri);
+		return path.isAbsolute(uri) ? uri : path.resolve(uri);
 	}
 
 	private uriFromDBGPToBridge(uri: string) {
@@ -582,17 +622,10 @@ export class XdebugCDPBridge {
 						);
 
 						if (bridgeUri && !this.scriptIdByUrl.has(bridgeUri)) {
-							this.cdp.sendMessage({
-								method: 'Debugger.scriptParsed',
-								params: {
-									scriptId:
-										this.getOrCreateScriptId(bridgeUri),
-									url: this.uriFromBridgeToCDP(bridgeUri),
-									startLine: 0,
-									startColumn: 0,
-									executionContextId: 1,
-								},
-							});
+							await this.sendScriptToCDP(
+								bridgeUri,
+								this.getOrCreateScriptId(bridgeUri)
+							);
 						}
 					}
 					if (status === 'break') {
@@ -950,16 +983,7 @@ export class XdebugCDPBridge {
 							if (!this.scriptIdByUrl.has(bridgeUri)) {
 								// Mark it known and send scriptParsed
 								this.scriptIdByUrl.set(bridgeUri, scriptId);
-								this.cdp.sendMessage({
-									method: 'Debugger.scriptParsed',
-									params: {
-										scriptId: scriptId,
-										url: this.uriFromBridgeToCDP(bridgeUri),
-										startLine: 0,
-										startColumn: 0,
-										executionContextId: 1,
-									},
-								});
+								await this.sendScriptToCDP(bridgeUri, scriptId);
 							}
 						}
 						// Build callFrames array

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -480,8 +480,14 @@ export class XdebugCDPBridge {
 				// getScriptSource usually fills the source file.
 				// With scripts now using source maps, the source map
 				// now handles displaying the file content.
-				// Therefore, we return an empty script source.
-				result = { scriptSource: '' };
+				// Therefore, we return a redirect message instead.
+				result = {
+					scriptSource: [
+						'`This is not the file you’re looking for.',
+						'It exists solely as a technical placeholder due to limitations in the dev tools.',
+						'Please disregard this file and locate your intended file in the PHP.wasm directory.`',
+					].join('\n'),
+				};
 				break;
 			}
 			default:

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -477,17 +477,7 @@ export class XdebugCDPBridge {
 				break;
 			}
 			case 'Debugger.getScriptSource': {
-				const sid = params.scriptId;
-				const bridgeUri = [...this.scriptIdByUrl.entries()].find(
-					([, v]) => v === sid
-				)?.[0];
-				let scriptSource = '';
-				if (bridgeUri) {
-					const raw = await this.readPHPFile(bridgeUri);
-
-					scriptSource = raw.replace(/\s+/g, ' ');
-				}
-				result = { scriptSource };
+				result = { scriptSource: '' };
 				break;
 			}
 			default:

--- a/packages/php-wasm/xdebug-bridge/src/tests/xdebug-cdp-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/tests/xdebug-cdp-bridge.spec.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import crypto from 'crypto';
 import { vi } from 'vitest';
 import { DbgpSession } from '../lib/dbgp-session';
 import { CDPServer } from '../lib/cdp-server';
@@ -13,6 +14,14 @@ describe('XdebugCDPBridge', () => {
 	let cdpServer: CDPServer;
 	let bridge: XdebugCDPBridge;
 	let fixtures: string;
+
+	function hash(id: number): string {
+		return crypto
+			.createHash('sha256')
+			.update(String(id))
+			.digest('hex')
+			.slice(0, 16);
+	}
 
 	beforeEach(async () => {
 		php = new PHP(
@@ -45,8 +54,12 @@ describe('XdebugCDPBridge', () => {
 	});
 
 	it('initializes with correct script IDs', () => {
-		expect(bridge['scriptIdByUrl'].get(`${fixtures}/array.php`)).toBe('1');
-		expect(bridge['scriptIdByUrl'].get(`${fixtures}/test.php`)).toBe('2');
+		expect(bridge['scriptIdByUrl'].get(`${fixtures}/array.php`)).toBe(
+			hash(1)
+		);
+		expect(bridge['scriptIdByUrl'].get(`${fixtures}/test.php`)).toBe(
+			hash(2)
+		);
 	});
 
 	it('registers event handlers in start function', () => {
@@ -113,7 +126,7 @@ describe('XdebugCDPBridge', () => {
 			id: 202,
 			method: 'Debugger.setBreakpointByUrl',
 			params: {
-				url: 'file:///test.php',
+				url: `file://placeholders/${hash(2)}`,
 				lineNumber: 4,
 			},
 		});
@@ -124,7 +137,7 @@ describe('XdebugCDPBridge', () => {
 				breakpointId: '1',
 				locations: [
 					{
-						scriptId: '3',
+						scriptId: hash(2),
 						lineNumber: 4,
 						columnNumber: 0,
 					},
@@ -137,7 +150,7 @@ describe('XdebugCDPBridge', () => {
 		bridge['breakpoints'].set('1', {
 			cdpId: '1',
 			xdebugId: null,
-			fileUri: 'file:///test.php',
+			fileUri: `file://placeholders/${hash(2)}`,
 			lineNumber: 5,
 		});
 
@@ -161,7 +174,7 @@ describe('XdebugCDPBridge', () => {
 			id: 3,
 			method: 'Debugger.setBreakpointByUrl',
 			params: {
-				url: `file://placeholders/${fixtures}/test.php`,
+				url: `file://placeholders/${hash(2)}`,
 				lineNumber: 2,
 			},
 		});
@@ -180,7 +193,7 @@ describe('XdebugCDPBridge', () => {
 
 		expect(
 			[...bridge['scriptIdByUrl'].entries()].find(
-				([, v]) => v === '2'
+				([, v]) => v === hash(2)
 			)?.[0]
 		).toBe(`${fixtures}/test.php`);
 
@@ -191,7 +204,7 @@ describe('XdebugCDPBridge', () => {
 					callFrames: expect.arrayContaining([
 						expect.objectContaining({
 							location: expect.objectContaining({
-								scriptId: '2',
+								scriptId: hash(2),
 								lineNumber: 2,
 							}),
 						}),
@@ -208,7 +221,7 @@ describe('XdebugCDPBridge', () => {
 			id: 3,
 			method: 'Debugger.setBreakpointByUrl',
 			params: {
-				url: `file://placeholders/${fixtures}/array.php`,
+				url: `file://placeholders/${hash(1)}`,
 				lineNumber: 15,
 			},
 		});
@@ -321,7 +334,7 @@ describe('XdebugCDPBridge', () => {
 
 		expect(
 			[...bridge['scriptIdByUrl'].entries()].find(
-				([, v]) => v === '3'
+				([, v]) => v === hash(3)
 			)?.[0]
 		).toBe('/internal/shared/auto_prepend_file.php');
 
@@ -332,7 +345,7 @@ describe('XdebugCDPBridge', () => {
 					callFrames: expect.arrayContaining([
 						expect.objectContaining({
 							location: expect.objectContaining({
-								scriptId: '3',
+								scriptId: hash(3),
 								lineNumber: 2,
 							}),
 						}),
@@ -370,7 +383,7 @@ describe('XdebugCDPBridge', () => {
 			'executionContextId',
 			'sourceMapURL',
 		]);
-		expect(script!.params.scriptId).toEqual('1');
+		expect(script!.params.scriptId).toEqual(hash(1));
 		expect(script!.params.url).toEqual(
 			expect.stringContaining('file://placeholders/')
 		);

--- a/packages/php-wasm/xdebug-bridge/src/tests/xdebug-cdp-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/tests/xdebug-cdp-bridge.spec.ts
@@ -341,4 +341,63 @@ describe('XdebugCDPBridge', () => {
 			})
 		);
 	});
+
+	it('sends a script with its correct data, source map and mappings to CDP', async () => {
+		bridge.start();
+
+		let script;
+
+		await new Promise<void>((resolve) => {
+			const original = cdpServer.sendMessage.bind(cdpServer);
+			vi.spyOn(cdpServer, 'sendMessage').mockImplementation((message) => {
+				if (
+					message.method === 'Debugger.scriptParsed' &&
+					message.params.url.includes('test.php')
+				) {
+					script = message;
+					resolve();
+				}
+				return original(message);
+			});
+		});
+
+		const url = script!.params.url;
+
+		expect(Object.keys(script!.params)).toEqual([
+			'scriptId',
+			'url',
+			'startLine',
+			'startColumn',
+			'endLine',
+			'endColumn',
+			'executionContextId',
+			'sourceMapURL',
+		]);
+		expect(script!.params.scriptId).toEqual('2');
+		expect(script!.params.url).toEqual(
+			expect.stringContaining('file://source/')
+		);
+		expect(script!.params.endLine).toEqual(12);
+
+		const sourceMap = JSON.parse(
+			Buffer.from(
+				script!.params.sourceMapURL.split(',')[1],
+				'base64'
+			).toString('utf8')
+		);
+		const phpContent = fs.readFileSync(`${fixtures}/test.php`).toString();
+
+		expect(sourceMap.file).toEqual(url);
+		expect(sourceMap.sources).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining('file://PHP.wasm/'),
+			])
+		);
+		expect(sourceMap.sourcesContent).toEqual(
+			expect.arrayContaining([phpContent])
+		);
+		expect(sourceMap.mappings).toEqual(
+			'AAAA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA'
+		);
+	});
 });

--- a/packages/php-wasm/xdebug-bridge/src/tests/xdebug-cdp-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/tests/xdebug-cdp-bridge.spec.ts
@@ -161,8 +161,8 @@ describe('XdebugCDPBridge', () => {
 			id: 3,
 			method: 'Debugger.setBreakpointByUrl',
 			params: {
-				url: `${fixtures}/test.php`,
-				lineNumber: 7,
+				url: `file://source/${fixtures}/test.php`,
+				lineNumber: 2,
 			},
 		});
 
@@ -192,7 +192,7 @@ describe('XdebugCDPBridge', () => {
 						expect.objectContaining({
 							location: expect.objectContaining({
 								scriptId: '2',
-								lineNumber: 7,
+								lineNumber: 2,
 							}),
 						}),
 					]),
@@ -208,7 +208,7 @@ describe('XdebugCDPBridge', () => {
 			id: 3,
 			method: 'Debugger.setBreakpointByUrl',
 			params: {
-				url: `${fixtures}/array.php`,
+				url: `file://source/${fixtures}/array.php`,
 				lineNumber: 15,
 			},
 		});

--- a/packages/php-wasm/xdebug-bridge/src/tests/xdebug-cdp-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/tests/xdebug-cdp-bridge.spec.ts
@@ -161,7 +161,7 @@ describe('XdebugCDPBridge', () => {
 			id: 3,
 			method: 'Debugger.setBreakpointByUrl',
 			params: {
-				url: `file://source/${fixtures}/test.php`,
+				url: `file://placeholders/${fixtures}/test.php`,
 				lineNumber: 2,
 			},
 		});
@@ -208,7 +208,7 @@ describe('XdebugCDPBridge', () => {
 			id: 3,
 			method: 'Debugger.setBreakpointByUrl',
 			params: {
-				url: `file://source/${fixtures}/array.php`,
+				url: `file://placeholders/${fixtures}/array.php`,
 				lineNumber: 15,
 			},
 		});
@@ -350,10 +350,7 @@ describe('XdebugCDPBridge', () => {
 		await new Promise<void>((resolve) => {
 			const original = cdpServer.sendMessage.bind(cdpServer);
 			vi.spyOn(cdpServer, 'sendMessage').mockImplementation((message) => {
-				if (
-					message.method === 'Debugger.scriptParsed' &&
-					message.params.url.includes('test.php')
-				) {
+				if (message.method === 'Debugger.scriptParsed') {
 					script = message;
 					resolve();
 				}
@@ -373,11 +370,11 @@ describe('XdebugCDPBridge', () => {
 			'executionContextId',
 			'sourceMapURL',
 		]);
-		expect(script!.params.scriptId).toEqual('2');
+		expect(script!.params.scriptId).toEqual('1');
 		expect(script!.params.url).toEqual(
-			expect.stringContaining('file://source/')
+			expect.stringContaining('file://placeholders/')
 		);
-		expect(script!.params.endLine).toEqual(12);
+		expect(script!.params.endLine).toEqual(17);
 
 		const sourceMap = JSON.parse(
 			Buffer.from(
@@ -385,7 +382,7 @@ describe('XdebugCDPBridge', () => {
 				'base64'
 			).toString('utf8')
 		);
-		const phpContent = fs.readFileSync(`${fixtures}/test.php`).toString();
+		const phpContent = fs.readFileSync(`${fixtures}/array.php`).toString();
 
 		expect(sourceMap.file).toEqual(url);
 		expect(sourceMap.sources).toEqual(
@@ -397,7 +394,7 @@ describe('XdebugCDPBridge', () => {
 			expect.arrayContaining([phpContent])
 		);
 		expect(sourceMap.mappings).toEqual(
-			'AAAA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA'
+			'AAAA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA;AACA'
 		);
 	});
 });


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request aims to apply syntax highlighting to debuggable PHP code using the Xdebug Bridge and Chrome Devtools.

This comes with a downside. To enable syntax highlighting to Debugger's parsed scripts, we also import a copy of that file that will act as the given script. Adding two identical files in the Source panel File tree.

## Testing Instructions

First, run the Bridge

```
nx reset && nx run php-wasm-xdebug-bridge:dev --php-root packages/php-wasm/xdebug-bridge --verbosity debug
```

Go to Devtools and add a breakpoint.

<img width="1190" height="715" alt="screenshot-001" src="https://github.com/user-attachments/assets/898e3fd6-d516-481b-87ab-6db54e1c2743" />


Then, run the CLI command

```
nx reset && nx run php-wasm-cli:dev packages/php-wasm/xdebug-bridge/src/tests/fixtures/test.php --xdebug
```

It will break in the script, not the resource.

<img width="1122" height="639" alt="screenshot-002" src="https://github.com/user-attachments/assets/dc6ec8a5-9781-4ff5-98c0-29ce671d5a45" />

