### PR TITLE
Use unique tmp.zip filename in unzipFile() to avoid conflicts in async calls

### DIFF
--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -152,6 +152,7 @@
 			"options": {
 				"reportsDirectory": "../../../coverage/packages/php-wasm/node",
 				"testFiles": [
+					"unzip-file.spec.ts",
 					"php-crash.spec.ts",
 					"php-ini.spec.ts",
 					"php-memory.spec.ts",
@@ -175,6 +176,7 @@
 				"configFile": "packages/php-wasm/node/vite.jspi.config.ts",
 				"reportsDirectory": "../../../coverage/packages/php-wasm/node",
 				"testFiles": [
+					"unzip-file.spec.ts",
 					"php-crash.spec.ts",
 					"php-ini.spec.ts",
 					"php-memory.spec.ts",

--- a/packages/php-wasm/node/src/test/unzip-file.spec.ts
+++ b/packages/php-wasm/node/src/test/unzip-file.spec.ts
@@ -1,0 +1,52 @@
+import {
+	unzipFile,
+	zipDirectory,
+	RecommendedPHPVersion,
+} from '@wp-playground/common';
+import { PHP } from '@php-wasm/universal';
+import { loadNodeRuntime } from '../lib';
+
+describe('unzipFile – concurrent calls avoid conflicts', () => {
+	let php: PHP;
+
+	beforeEach(async () => {
+		php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
+	});
+
+	afterEach(async () => {
+		php.exit();
+	});
+
+	it('handles two parallel unzips with File inputs without conflicts', async () => {
+		// Prepare two distinct source directories
+		php.mkdir('/src1');
+		php.writeFile('/src1/a.txt', 'one');
+		php.mkdir('/src2');
+		php.writeFile('/src2/b.txt', 'two');
+
+		// Create two zip archives using the same PHP instance
+		const zip1 = await zipDirectory(php, '/src1');
+		const zip2 = await zipDirectory(php, '/src2');
+
+		// Wrap buffers as Files to exercise the random tmp zip path code path
+		const file1 = new File([zip1 as any], 'src1.zip');
+		const file2 = new File([zip2 as any], 'src2.zip');
+
+		// Run two unzips in parallel – should not conflict
+		await Promise.all([
+			unzipFile(php, file1, '/dst1'),
+			unzipFile(php, file2, '/dst2'),
+		]);
+
+		// Verify extraction results are correct and isolated
+		expect(await php.readFileAsText('/dst1/a.txt')).toBe('one');
+		expect(php.isFile('/dst1/b.txt')).toBe(false);
+		expect(await php.readFileAsText('/dst2/b.txt')).toBe('two');
+		expect(php.isFile('/dst2/a.txt')).toBe(false);
+
+		// Ensure there are no leftover temporary zip files in /tmp
+		const tmpFiles = php.listFiles('/tmp');
+		const leftoverZips = tmpFiles.filter((f) => f.endsWith('.zip'));
+		expect(leftoverZips).toHaveLength(0);
+	});
+});

--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -19,13 +19,17 @@ export const RecommendedPHPVersion = '8.3';
 /**
  * Unzip a zip file inside Playground.
  */
-const tmpPath = '/tmp/file.zip';
 export const unzipFile = async (
 	php: UniversalPHP,
 	zipPath: string | File,
 	extractToPath: string,
 	overwriteFiles = true
 ) => {
+	/**
+	 * Use a random file name to avoid conflicts across concurrent unzipFile()
+	 * calls.
+	 */
+	const tmpPath = `/tmp/file-${Math.random()}.zip`;
 	if (zipPath instanceof File) {
 		const zipFile = zipPath;
 		zipPath = tmpPath;


### PR DESCRIPTION
## Motivation for the change, related issues

Makes sure `unzipFile` uses a unique filename for the temporary zip artifact, instead of always using `tmp.zip`. This enables calling it multiple times before the first call finishes.

Fixes https://github.com/WordPress/wordpress-playground/issues/2560

## Testing Instructions (or ideally a Blueprint)

* CI
* Confirm this code no longer fails:

```
	cliServer = await runCLI({
		command: 'server',
		wp: 'latest',
		blueprint: {
			steps: [
				{
					"step": "setSiteLanguage",
					"language": "pt_BR"
				},
			],
		},
	});
```

cc @fellyph 