### PR TITLE
[CLI] Include site URL in the "WordPress is available on" message

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -672,7 +672,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 					logger.log(`Ready!`);
 				}
 
-				let message = `WordPress is running on ${serverUrl}`;
+				let message = `WordPress server is listening on ${serverUrl}`;
 				if (siteUrl !== serverUrl) {
 					message += ` (WP site URL: ${siteUrl})`;
 				}

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -672,7 +672,11 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 					logger.log(`Ready!`);
 				}
 
-				logger.log(`WordPress is running on ${serverUrl}`);
+				let message = `WordPress is running on ${serverUrl}`;
+				if (siteUrl !== serverUrl) {
+					message += ` (WP site URL: ${siteUrl})`;
+				}
+				logger.log(message);
 
 				if (args.experimentalDevtools && args.xdebug) {
 					const bridge = await startBridge({

--- a/packages/playground/cli/tests/test-running-unbuilt-cli.sh
+++ b/packages/playground/cli/tests/test-running-unbuilt-cli.sh
@@ -16,7 +16,7 @@ function test_playground_cli() {
 	echo "Running Playground CLI with Nx target: $TARGET $@"
 	timeout -s TERM 30s npx nx "$TARGET" playground-cli server --php=8.3 $@ 2>&1 > playground-cli-test-output &
 	PID=$!
-	CLI_STARTUP_STRING='WordPress is running on http://127.0.0.1:9400'
+	CLI_STARTUP_STRING='WordPress server is listening on http://127.0.0.1:9400'
 
 	# Sleep until Playground CLI starts or the process times out.
 	while ps -p "$PID" > /dev/null && ! grep -q "$CLI_STARTUP_STRING" playground-cli-test-output; do


### PR DESCRIPTION
## Motivation for the change, related issues

Makes the CLI server startup message clearer – it now outputs both the server URL and the WordPress site URL:

<img width="1660" height="268" alt="CleanShot 2025-08-29 at 14 31 21@2x" src="https://github.com/user-attachments/assets/06be2a92-7c4d-4837-868c-4aa51bf8ca1c" />

