### PR TITLE
[WordPress][CLI] Allow requesting internal URLs via http_request_host_is_external

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -188,11 +188,6 @@ if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 	add_filter('wp_signature_hosts', function ($hosts) {
 		return [];
 	});
-
-	// add_filter('http_request_host_is_external', function ($arg) {
-	// 	return true;
-	// });
-	add_filter('http_request_host_is_external', '__return_true');
 } else {
 	require(__DIR__ . '/playground-includes/wp_http_dummy.php');
 	$__requests_class::add_transport('Wp_Http_Dummy');

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -265,6 +265,26 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
             );
         } );
 
+		/**
+		 * Prevents wp_http_validate_url() from universally failing.
+		 *
+		 * wp_http_validate_url() calls gethostbyname() to verify whether the host
+		 * is external. If it is internal, the URL validation fails and WordPress
+		 * refuses to make a request.
+		 *
+		 * However, in EMscripten, gethostbyname() returns a private network IP address.
+		 * This causes wp_http_validate_url() to return false for all URLs.
+		 *
+		 * This filter ensures that all URLs are considered external. In production
+		 * environments, this would be considered a security risk. However, Playground
+		 * already provides multiple code execution vectors as features (e.g. Blueprints).
+		 *
+		 * If someone wants to poke around local IP addresses, they already have multiple
+		 * tools at their disposal. Therefore, this is not a real security risk in context
+		 * of WordPress Playground or Playground CLI.
+		 */
+		add_filter('http_request_host_is_external', '__return_true');
+
 		// Support pretty permalinks
         add_filter( 'got_url_rewrite', '__return_true' );
 

--- a/packages/playground/wordpress/src/test/http-request-host-is-external.spec.ts
+++ b/packages/playground/wordpress/src/test/http-request-host-is-external.spec.ts
@@ -1,0 +1,36 @@
+import { RecommendedPHPVersion } from '@wp-playground/common';
+import { loadNodeRuntime } from '@php-wasm/node';
+import { bootWordPress } from '../boot';
+import {
+	getSqliteDriverModule,
+	getWordPressModule,
+} from '@wp-playground/wordpress-builds';
+
+describe('http_request_host_is_external filter', () => {
+	it('returns true after WordPress boot', async () => {
+		const handler = await bootWordPress({
+			createPhpRuntime: async () =>
+				await loadNodeRuntime(RecommendedPHPVersion),
+			siteUrl: 'http://playground-domain/',
+			wordPressZip: await getWordPressModule(),
+			sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+		});
+
+		const php = await handler.getPrimaryPhp();
+		const result = await php.run({
+			code: `<?php
+				ob_start();
+				require getenv('DOCUMENT_ROOT') . '/wp-load.php';
+				$val = apply_filters('http_request_host_is_external', false, 'https://resplendent-curlew-7b82c2.instawp.xyz/wp-content/uploads/2025/08/portland2.jpeg');
+				ob_clean();
+				echo $val ? '1' : '0';
+				ob_end_flush();
+			`,
+			env: {
+				DOCUMENT_ROOT: php.documentRoot,
+			},
+		});
+
+		expect(result.text).toBe('1');
+	});
+});


### PR DESCRIPTION
## Motivation for the change, related issues

WordPress uses gethostbyname() inside wp_http_validate_url() to decide if a host is external.
In Emscripten, this resolves to a private network IP, which causes WordPress to reject all outgoing requests.

This change adds the http_request_host_is_external filter returning true to bypass the check. While unsafe in production, it’s acceptable in Playground because the environment already allows arbitrary code execution (e.g. Blueprints, CLI).

Also added a test to confirm the filter is applied after WordPress boots.

## Future work

Ideally, `gethostbyname()` would just work. While it's possible to shim it in Node.js, the only solution in the browser seems to be issuing `fetch()` to a PHP script to would perform the DNS resolution. That would be super slow.

Realistically, we can either:

* Implement gethostbyname in Node.js and not implement it in the web version of Playground
* Apply the same filter in Node.js as we already do on the web – which is at least consistent

This PR does the latter.

Related to #400 

## Testing Instructions (or ideally a Blueprint)

CI
