### PR TITLE
Updating wp versions blueprints

### DIFF
--- a/packages/docs/site/docs/blueprints/03-data-format.md
+++ b/packages/docs/site/docs/blueprints/03-data-format.md
@@ -56,7 +56,7 @@ The `landingPage` property tells Playground which URL to navigate to after the B
 The `preferredVersions` property declares your preferred PHP and WordPress versions. It can contain the following properties:
 
 -   `php` (string): Loads the specified PHP version. Accepts `7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, or `latest`. Minor versions like `7.4.1` are not supported.
--   `wp` (string): Loads the specified WordPress version. Accepts the last six major WordPress versions. As of June 1, 2024, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7` or `6.8`. You can also use the generic values `latest`, `nightly`, or `beta`. To use a pre-release version of WordPress, `beta` will load the latest beta or release candidate versions of a release cycle (Beta or RC).
+-   `wp` (string): Loads the specified WordPress version. Accepts the last six major WordPress versions. As of September 1, 2025, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7` or `6.8`. You can also use the generic values `latest`, `nightly`, or `beta`. To use a pre-release version of WordPress, `beta` will load the latest beta or release candidate versions of a release cycle (Beta or RC).
 
 ```js
 {

--- a/packages/docs/site/docs/blueprints/03-data-format.md
+++ b/packages/docs/site/docs/blueprints/03-data-format.md
@@ -56,13 +56,13 @@ The `landingPage` property tells Playground which URL to navigate to after the B
 The `preferredVersions` property declares your preferred PHP and WordPress versions. It can contain the following properties:
 
 -   `php` (string): Loads the specified PHP version. Accepts `7.0`, `7.1`, `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, or `latest`. Minor versions like `7.4.1` are not supported.
--   `wp` (string): Loads the specified WordPress version. Accepts the last four major WordPress versions. As of June 1, 2024, that's `6.2`, `6.3`, `6.4`, or `6.5`. You can also use the generic values `latest`, `nightly`, or `beta`. To use a pre-release version of WordPress, `beta` will load the latest beta or release candidate versions of a release cycle (Beta or RC).
+-   `wp` (string): Loads the specified WordPress version. Accepts the last six major WordPress versions. As of June 1, 2024, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7` or `6.8`. You can also use the generic values `latest`, `nightly`, or `beta`. To use a pre-release version of WordPress, `beta` will load the latest beta or release candidate versions of a release cycle (Beta or RC).
 
 ```js
 {
 	"preferredVersions": {
-		"php": "8.0",
-		"wp": "6.5"
+		"php": "8.3",
+		"wp": "6.7"
 	},
 }
 ```


### PR DESCRIPTION
## Motivation for the change, related issues

This change expands the number of supported major WordPress versions for the `wp` parameter from the last four to the last six. I have looked at the folder `packages/playground/wordpress-builds/src/wordpress`, which contains those six versions.

## Testing Instructions (or ideally a Blueprint)

1. Download the Branch
2. Install the project
3. Run the command `npm run dev:docs`
4. Navigate to the page `wordpress-playground/blueprints/data-format`
5. Check the new content listing the six last WordPress versions