### PR TITLE
Fix error from adding blank target to external links

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -147,11 +147,13 @@ export async function parseOptionsAndRunCLI() {
 				describe:
 					'Do not download, unzip, and install WordPress. Useful for mounting a pre-configured WordPress directory at /wordpress.',
 				type: 'boolean',
+				default: false,
 			})
 			.option('skip-sqlite-setup', {
 				describe:
 					'Skip the SQLite integration plugin setup to allow the WordPress site to use MySQL.',
 				type: 'boolean',
+				default: false,
 			})
 			// Hidden - Deprecated in favor of verbosity
 			.option('quiet', {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -147,13 +147,11 @@ export async function parseOptionsAndRunCLI() {
 				describe:
 					'Do not download, unzip, and install WordPress. Useful for mounting a pre-configured WordPress directory at /wordpress.',
 				type: 'boolean',
-				default: false,
 			})
 			.option('skip-sqlite-setup', {
 				describe:
 					'Skip the SQLite integration plugin setup to allow the WordPress site to use MySQL.',
 				type: 'boolean',
-				default: false,
 			})
 			// Hidden - Deprecated in favor of verbosity
 			.option('quiet', {

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -120,11 +120,11 @@ function playground_add_target_blank_to_external_links() {
 			// Set target="_blank" for external links when clicked.
 			// This covers links that are added after the page has loaded.
 			document.addEventListener('click', e => {
+				// window, document, SVG Text nodes etc. don't have the `closest` method
 				if ( !e.target?.closest ) {
-					console.log( `Unexpected click event: ${e}` )
 					return;
 				}
-				const a = e.target?.closest('a[href]');
+				const a = e.target.closest('a[href]');
 				if (!a) return;
 				addTargetBlank(a);
 			});
@@ -132,8 +132,8 @@ function playground_add_target_blank_to_external_links() {
 			// Also handle focus events to cover keyboard navigation on
 			// links that are added after the page has loaded.
 			document.addEventListener('focus', e => {
+				// window, document, SVG Text nodes etc. don't have the `closest` method
 				if ( !e.target?.closest ) {
-					console.log( `Unexpected click event: ${e}` )
 					return;
 				}
 				const a = e.target?.closest('a[href]');

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -132,6 +132,10 @@ function playground_add_target_blank_to_external_links() {
 			// Also handle focus events to cover keyboard navigation on
 			// links that are added after the page has loaded.
 			document.addEventListener('focus', e => {
+				if ( !e.target?.closest ) {
+					console.log( `Unexpected click event: ${e}` )
+					return;
+				}
 				const a = e.target?.closest('a[href]');
 				if (!a) return;
 				addTargetBlank(a);

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -100,7 +100,7 @@ function playground_add_target_blank_to_external_links() {
 	if (empty($_SERVER['REQUEST_URI']) || wp_doing_ajax() || wp_doing_cron()) {
 		return;
 	}
-	
+
 	?>
 	<script>
 		function addTargetBlankToExternalLinks() {
@@ -116,10 +116,14 @@ function playground_add_target_blank_to_external_links() {
 			document.querySelectorAll('a[href]').forEach(a => {
 				addTargetBlank(a);
 			});
-			
+
 			// Set target="_blank" for external links when clicked.
 			// This covers links that are added after the page has loaded.
 			document.addEventListener('click', e => {
+				if ( !e.target?.closest ) {
+					console.log( `Unexpected click event: ${e}` )
+					return;
+				}
 				const a = e.target?.closest('a[href]');
 				if (!a) return;
 				addTargetBlank(a);


### PR DESCRIPTION
## Motivation for the change, related issues

We use playground as a preview tool inside an app that generates WordPress blocks via AI assistant. We encounter `JavaScript Error: TypeError: e.target.closest is not a function` coming from Playground and it encumbers our assisted error recovery because it comes from outside of the generated code.

## Implementation details

We don't attempt to update the link if the element surprisingly doesn't have a closest method (which is why we also log the element to see why this happens)

## Testing Instructions (or ideally a Blueprint)

Hard to figure out, sometimes it occurs.