### PR TITLE
Allow installing multiple themes via URL, as required by parent/child themes.

### DIFF
--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -102,15 +102,14 @@ export async function resolveBlueprintFromURL(
 							url: query.get('import-site')!,
 						},
 					} as StepDefinition),
-				query.get('theme') &&
-					({
+				... query.getAll('theme').map((theme) => ({
 						step: 'installTheme',
 						themeData: {
 							resource: 'wordpress.org/themes',
-							slug: query.get('theme')!,
+							slug: theme,
 						},
 						progress: { weight: 2 },
-					} as StepDefinition),
+					} as StepDefinition )),
 			].filter(Boolean),
 		};
 		source = {

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -102,14 +102,18 @@ export async function resolveBlueprintFromURL(
 							url: query.get('import-site')!,
 						},
 					} as StepDefinition),
-				... query.getAll('theme').map((theme) => ({
+				... query.getAll('theme').map((theme, index, themes) => ({
 						step: 'installTheme',
 						themeData: {
 							resource: 'wordpress.org/themes',
 							slug: theme,
 						},
+						options: {
+							// Activate only the last theme in the list.
+							activate: index === themes.length - 1,
+						},
 						progress: { weight: 2 },
-					} as StepDefinition )),
+					} as StepDefinition)),
 			].filter(Boolean),
 		};
 		source = {

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -102,18 +102,21 @@ export async function resolveBlueprintFromURL(
 							url: query.get('import-site')!,
 						},
 					} as StepDefinition),
-				... query.getAll('theme').map((theme, index, themes) => ({
-						step: 'installTheme',
-						themeData: {
-							resource: 'wordpress.org/themes',
-							slug: theme,
-						},
-						options: {
-							// Activate only the last theme in the list.
-							activate: index === themes.length - 1,
-						},
-						progress: { weight: 2 },
-					} as StepDefinition)),
+				...query.getAll('theme').map(
+					(theme, index, themes) =>
+						({
+							step: 'installTheme',
+							themeData: {
+								resource: 'wordpress.org/themes',
+								slug: theme,
+							},
+							options: {
+								// Activate only the last theme in the list.
+								activate: index === themes.length - 1,
+							},
+							progress: { weight: 2 },
+						} as StepDefinition)
+				),
 			].filter(Boolean),
 		};
 		source = {


### PR DESCRIPTION
## Motivation for the change, related issues

At present it isn't possible to install Child themes via the playground through the URL without using a blueprint.

## Implementation details

Iterate over the theme parameter.

## Testing Instructions (or ideally a Blueprint)

Compare http://127.0.0.1:5400/website-server/?theme=acai&theme=skincare-brand&url=wp-admin/themes.php to http://playground.wordpress.net/?theme=acai&theme=skincare-brand&url=wp-admin/themes.php