### PR TITLE
Fix to ensure that Site Editor templates are associated with the correct taxonomy upon import

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/fixtures/import-wxr-site-editor-template.xml
+++ b/packages/playground/blueprints/src/lib/steps/fixtures/import-wxr-site-editor-template.xml
@@ -1,0 +1,65 @@
+<rss version="2.0"
+	xmlns:excerpt="http://wordpress.org/export/1.2/excerpt/"
+	xmlns:content="http://purl.org/rss/1.0/modules/content/"
+	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
+	xmlns:dc="http://purl.org/dc/elements/1.1/"
+	xmlns:wp="http://wordpress.org/export/1.2/"
+>
+
+<channel>
+	<title>Site Editor Template Issue Test</title>
+	<link>https://example.com</link>
+	<description>Testing the specific GitHub issue with Site Editor template taxonomy association</description>
+	<pubDate>Mon, 01 Jan 2024 12:00:00 +0000</pubDate>
+	<language>en-US</language>
+	<wp:wxr_version>1.2</wp:wxr_version>
+	<wp:base_site_url>https://example.com</wp:base_site_url>
+	<wp:base_blog_url>https://example.com</wp:base_blog_url>
+
+	<wp:author><wp:author_id>1</wp:author_id><wp:author_login><![CDATA[admin]]></wp:author_login><wp:author_email><![CDATA[admin@localhost.com]]></wp:author_email><wp:author_display_name><![CDATA[admin]]></wp:author_display_name><wp:author_first_name><![CDATA[]]></wp:author_first_name><wp:author_last_name><![CDATA[]]></wp:author_last_name></wp:author>
+
+	<!-- Note: Deliberately NOT including the wp:term definition to reproduce the issue -->
+
+	<generator>https://wordpress.org/?v=6.5</generator>
+
+	<item>
+		<title><![CDATA[Index]]></title>
+		<link>https://example.com/wp_template/index</link>
+		<pubDate>Mon, 01 Jan 2024 12:00:00 +0000</pubDate>
+		<dc:creator><![CDATA[admin]]></dc:creator>
+		<guid isPermaLink="false">https://example.com/wp_template/index</guid>
+		<description></description>
+		<content:encoded><![CDATA[<!-- wp:template-part {"slug":"header","theme":"adonay"} /-->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+<!-- wp:heading -->
+<h2 class="wp-block-heading">Welcome to the Adonay theme site</h2>
+<!-- /wp:heading -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"adonay"} /-->]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:post_id>10</wp:post_id>
+		<wp:post_date><![CDATA[2024-01-01 12:00:00]]></wp:post_date>
+		<wp:post_date_gmt><![CDATA[2024-01-01 12:00:00]]></wp:post_date_gmt>
+		<wp:post_modified><![CDATA[2024-01-01 12:00:00]]></wp:post_modified>
+		<wp:post_modified_gmt><![CDATA[2024-01-01 12:00:00]]></wp:post_modified_gmt>
+		<wp:comment_status><![CDATA[closed]]></wp:comment_status>
+		<wp:ping_status><![CDATA[closed]]></wp:ping_status>
+		<wp:post_name><![CDATA[index]]></wp:post_name>
+		<wp:status><![CDATA[publish]]></wp:status>
+		<wp:post_parent>0</wp:post_parent>
+		<wp:menu_order>0</wp:menu_order>
+		<wp:post_type><![CDATA[wp_template]]></wp:post_type>
+		<wp:post_password><![CDATA[]]></wp:post_password>
+		<wp:is_sticky>0</wp:is_sticky>
+		<category domain="wp_theme" nicename="adonay"><![CDATA[adonay]]></category>
+		<wp:postmeta>
+			<wp:meta_key><![CDATA[_wp_file_path]]></wp:meta_key>
+			<wp:meta_value><![CDATA[index]]></wp:meta_value>
+		</wp:postmeta>
+	</item>
+</channel>
+</rss>

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
@@ -14,6 +14,40 @@ import { loadNodeRuntime } from '@php-wasm/node';
 describe('Blueprint step importWxr', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;
+
+	const checkTemplateImportResults = async () => {
+		return await php.run({
+			code: `<?php
+			require getenv('DOCROOT') . '/wp-load.php';
+
+			// Get the imported template
+			$templates = get_posts([
+				'post_type' => 'wp_template',
+				'post_status' => 'publish',
+				'numberposts' => -1,
+				'post_title' => 'Index'
+			]);
+
+			$template = $templates ? $templates[0] : null;
+			$terms = $template ? wp_get_object_terms($template->ID, 'wp_theme') : [];
+			$adonay_term = get_term_by('slug', 'adonay', 'wp_theme');
+
+			echo json_encode([
+				'template_found' => !empty($template),
+				'template_title' => $template ? $template->post_title : null,
+				'terms_associated_count' => count($terms),
+				'adonay_term_exists' => !empty($adonay_term),
+				'associated_term_slugs' => array_map(function($term) {
+					return $term->slug;
+				}, $terms)
+			]);
+			`,
+			env: {
+				DOCROOT: await php.documentRoot,
+			},
+		});
+	};
+
 	beforeEach(async () => {
 		handler = await bootWordPress({
 			createPhpRuntime: async () =>
@@ -75,5 +109,59 @@ describe('Blueprint step importWxr', () => {
 
 		expect(json.post_content).toEqual(expectedPostContent);
 		expect(json.post_title).toEqual(`"Issue\\Issue"`);
+	});
+
+	it('Should fail to associate wp_theme taxonomy when fix is disabled', async () => {
+		// Create mu-plugins directory and write a plugin that disables the fix during import_start
+		await php.mkdir('/wordpress/wp-content/mu-plugins');
+		await php.writeFile(
+			'/wordpress/wp-content/mu-plugins/disable-wp-theme-fix.php',
+			`<?php
+add_action( 'import_start', function() {
+	remove_filter( 'wp_import_post_terms', 'wp_playground_import_post_terms_handler', 10 );
+} );
+`
+		);
+
+		const fileData = await readFile(
+			__dirname + '/fixtures/import-wxr-site-editor-template.xml'
+		);
+		const file = new File([fileData], 'import.wxr');
+
+		await importWxr(php, { file });
+
+		const result = await checkTemplateImportResults();
+		const json = result.json;
+
+		// Verify the template was imported but taxonomy association failed
+		expect(json.template_found).toBe(true);
+		expect(json.template_title).toEqual('Index');
+		expect(json.terms_associated_count).toBe(0);
+		expect(json.adonay_term_exists).toBe(false);
+		expect(json.associated_term_slugs).toEqual([]);
+
+		// Clean up the mu-plugin
+		await php.unlink(
+			'/wordpress/wp-content/mu-plugins/disable-wp-theme-fix.php'
+		);
+	});
+
+	it('Should create and associate wp_theme taxonomy terms for Site Editor templates', async () => {
+		const fileData = await readFile(
+			__dirname + '/fixtures/import-wxr-site-editor-template.xml'
+		);
+		const file = new File([fileData], 'import.wxr');
+
+		await importWxr(php, { file });
+
+		const result = await checkTemplateImportResults();
+		const json = result.json;
+
+		// Verify the template was imported and taxonomy association worked
+		expect(json.template_found).toBe(true);
+		expect(json.template_title).toEqual('Index');
+		expect(json.terms_associated_count).toBe(1);
+		expect(json.adonay_term_exists).toBe(true);
+		expect(json.associated_term_slugs).toEqual(['adonay']);
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -80,25 +80,28 @@ async function importWithDefaultImporter(
 	add_action( 'wp_insert_post_data', function( $data ) {
 		return wp_slash($data);
 	});
-  
-  // Ensure that Site Editor templates are associated with the correct taxonomy.
-  add_filter( 'wp_import_post_terms', function ( $terms, $post_id ) {
-    foreach ( $terms as $post_term ) {
-      if ( 'wp_theme' !== $term['taxonomy'] ) continue;
-      $post_term = get_term_by('slug', $term['slug'], $term['taxonomy'] );
-      if ( ! $post_term ) {
-        $post_term = wp_insert_term(
-          $term['slug'],
-          $term['taxonomy']
-        );
-        $term_id = $post_term['term_id'];
-      } else {
-        $term_id = $post_term->term_id;
-      }
-      wp_set_object_terms( $post_id, $term_id, $term['taxonomy']) ;
-    }
-    return $terms;
-  }, 10, 2 );
+
+	// Ensure that Site Editor templates are associated with the correct taxonomy.
+	function wp_playground_import_post_terms_handler( $terms, $post_id ) {
+		foreach ( $terms as $term ) {
+			if ( 'wp_theme' !== $term['taxonomy'] ) continue;
+			$post_term = get_term_by('slug', $term['slug'], $term['taxonomy'] );
+			if ( ! $post_term ) {
+				$post_term = wp_insert_term(
+					$term['slug'],
+					$term['taxonomy']
+				);
+				$term_id = $post_term['term_id'];
+			} else {
+				$term_id = $post_term->term_id;
+			}
+			wp_set_object_terms( $post_id, $term_id, $term['taxonomy']) ;
+		}
+		return $terms;
+	}
+
+	add_filter( 'wp_import_post_terms', 'wp_playground_import_post_terms_handler', 10, 2 );
+
 	$result = $importer->import( '/tmp/import.wxr' );
 	`,
 	});


### PR DESCRIPTION
Fixes #1996, #2579

This fixes the wrong use of the variable and introduces two tests that ensure that the proposed fix actually helps.