### PR TITLE
[PHP] Rotate the spawn handler in hotSwapPHPRuntime()

### DIFF
--- a/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
+++ b/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
@@ -6,6 +6,7 @@ import {
 	PHP,
 	__private__dont__use,
 } from '@php-wasm/universal';
+import { createSpawnHandler } from '@php-wasm/util';
 import { loadNodeRuntime } from '../lib';
 import { createNodeFsMountHandler } from '../lib/node-fs-mount';
 
@@ -378,5 +379,50 @@ describe('php.enableRuntimeRotation()', () => {
 			fs.rmdirSync(tempDir);
 			php.exit();
 		}
+	}, 30_000);
+
+	it('Should preserve the spawn handler through PHP runtime recreation', async () => {
+		const php = new PHP(await recreateRuntime());
+		php.enableRuntimeRotation({
+			cwd: '/test-root',
+			recreateRuntime,
+			maxRequests: 1,
+		});
+
+		// Set up a custom spawn handler that tracks calls
+		let spawnHandlerCallCount = 0;
+		const customSpawnHandler = createSpawnHandler(
+			async (command: string[], processApi: any) => {
+				spawnHandlerCallCount++;
+				// Simple echo command handler
+				if (command[0] === 'echo') {
+					processApi.stdout(
+						new TextEncoder().encode(
+							command.slice(1).join(' ') + '\n'
+						)
+					);
+				}
+				processApi.exit(0);
+			}
+		);
+
+		php.setSpawnHandler(customSpawnHandler);
+
+		// Test the spawn handler works before rotation
+		const result1 = await php.run({
+			code: `<?php echo exec("echo Hello World");`,
+		});
+		expect(result1.text).toBe('Hello World');
+		expect(spawnHandlerCallCount).toBe(1);
+
+		// Rotate the PHP runtime
+		await php.run({ code: `` });
+
+		// Test the spawn handler still works after rotation
+		const result2 = await php.run({
+			code: `<?php echo exec("echo Hello Again");`,
+		});
+		expect(result2.text).toBe('Hello Again');
+		expect(spawnHandlerCallCount).toBe(2);
 	}, 30_000);
 });

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1336,6 +1336,7 @@ export class PHP implements Disposable {
 		// runtime.
 
 		const oldFS = this[__private__dont__use].FS;
+		const oldSpawnProcess = this[__private__dont__use].spawnProcess;
 
 		// Unmount all the mount handlers
 		const mountHandlers: { mountHandler: MountHandler; vfsPath: string }[] =
@@ -1354,6 +1355,10 @@ export class PHP implements Disposable {
 
 		// Initialize the new runtime
 		this.initializeRuntime(runtime);
+
+		if (oldSpawnProcess) {
+			this[__private__dont__use].spawnProcess = oldSpawnProcess;
+		}
 
 		if (this.#sapiName) {
 			this.setSapiName(this.#sapiName);


### PR DESCRIPTION
This PR ensures setting the spawn handler once is effective for the entire lifetime of a given PHP instance. Before this PR, the spawn handler would not be re-bound to the new PHP runtime in the hotSwapPHPRuntime() call.

Follows up on #2559. The spawn handler was not preserved even before more prominent.

 ## Testing instructions

CI – there's a new test to ensure the spawn handler is preserved after the runtime rotation / swapping
