### PR TITLE
[Website] Apply base URLs to relative redirection URLs

### DIFF
--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -83,7 +83,7 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 		phpResponse.headers['location']
 	) {
 		return Response.redirect(
-			phpResponse.headers['location'][0],
+			new URL(phpResponse.headers['location'][0], url.toString()),
 			phpResponse.httpStatusCode
 		);
 	}


### PR DESCRIPTION
Fixes relative redirects support in wp-admin.

Technically, this PR ensures that redirection URLs handled in `convertFetchEventToPHPRequest` are combined with a base URL before passing them on to the browser.

Fixes #2578

## Testing Instructions (or ideally a Blueprint)

Go to wp-admin and create a new user. Confirm you are redirected back to wp-admin in the end and not to a 404 page