### PR TITLE
[Website] A specific error when a GitHub artifact is not found

### DIFF
--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -71,6 +71,13 @@ const monitoredFetch = (input: RequestInfo | URL, init?: RequestInit) =>
 	downloadMonitor.monitorFetch(fetch(input, init));
 const memoizedFetch = createMemoizedFetch(monitoredFetch);
 
+class ArtifactExpiredError extends Error {
+	constructor(message: string = 'GitHub artifact expired') {
+		super(message);
+		this.name = 'ArtifactExpiredError';
+	}
+}
+
 export interface MountDescriptor {
 	mountpoint: string;
 	device: MountDevice;
@@ -222,7 +229,30 @@ export class PlaygroundWorkerEndpoint extends PHPWorker {
 					// monitorFetch will read the content-length response header when available.
 					wordPressRequest = monitoredFetch(
 						this.requestedWordPressVersion
-					);
+					).then((response) => {
+						if (response.ok) {
+							return response;
+						}
+						// Try to detect a GitHub artifact expiration coming from plugin-proxy.php
+						let json: any = null;
+						return response.json().then(
+							(parsedJson) => {
+								json = parsedJson;
+								if (json && json.error === 'artifact_expired') {
+									throw new ArtifactExpiredError();
+								}
+								throw new Error(
+									`Failed to download WordPress ZIP (HTTP ${response.status})`
+								);
+							},
+							() => {
+								// Not JSON or different error shape – fall through to generic error
+								throw new Error(
+									`Failed to download WordPress ZIP (HTTP ${response.status})`
+								);
+							}
+						);
+					});
 				} else {
 					const wpDetails = getWordPressModuleDetails(wpVersion);
 					downloadMonitor.expectAssets({

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -72,7 +72,7 @@ const monitoredFetch = (input: RequestInfo | URL, init?: RequestInit) =>
 const memoizedFetch = createMemoizedFetch(monitoredFetch);
 
 class ArtifactExpiredError extends Error {
-	constructor(message: string = 'GitHub artifact expired') {
+	constructor(message = 'GitHub artifact expired') {
 		super(message);
 		this.name = 'ArtifactExpiredError';
 	}

--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -80,6 +80,9 @@ class PluginDownloader
 					if ($artifact->size_in_bytes < 3000) {
 						throw new ApiException('artifact_invalid');
 					}
+					if ($artifact->expired) {
+						throw new ApiException('artifact_expired');
+					}
 					$zip_download_api_endpoint = $artifact->archive_download_url;
 					break;
 				}

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -297,13 +297,13 @@ function SiteErrorMessage({
 			<>
 				<h1>This artifact has expired</h1>
 				<p>
-					The GitHub CI artifact referenced by this Blueprint is no
-					longer available. GitHub only keeps PR build artifacts for a
-					limited time.
+					The requested GitHub artifactis no longer available. GitHub
+					only serves PR build artifacts for a limited time.
 				</p>
 				<p>
-					Update the Blueprint to point at a fresh build or re-run the
-					PR workflow to produce a new artifact, then try again.
+					If you want to preview that PR, you will need to re-run
+					GitHub workflows in that PR. One way to do that is by
+					pushing an empty commit.
 				</p>
 				<Button
 					className={css.actionButton}

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -277,14 +277,45 @@ function SiteErrorMessage({
 					It seems like you deleted the local directory you previously
 					selected.
 				</p>
-				<p>Unforunately, this site won't work anymore.</p>
+				<p>Unfortunately, this site won't work anymore.</p>
 				<Button
+					className={css.actionButton}
+					variant="primary"
 					onClick={() => {
 						dispatch(removeSite(siteSlug));
 						dispatch(removeClientInfo(siteSlug));
 					}}
 				>
-					Delete this site
+					Delete this site and try again
+				</Button>
+			</>
+		);
+	}
+
+	if (error === 'github-artifact-expired') {
+		return (
+			<>
+				<h1>This artifact has expired</h1>
+				<p>
+					The GitHub CI artifact referenced by this Blueprint is no
+					longer available. GitHub only keeps PR build artifacts for a
+					limited time.
+				</p>
+				<p>
+					Update the Blueprint to point at a fresh build or re-run the
+					PR workflow to produce a new artifact, then try again.
+				</p>
+				<Button
+					className={css.actionButton}
+					variant="primary"
+					onClick={() => {
+						// Remove core-pr parameter and reload
+						const url = new URL(window.location.href);
+						url.searchParams.delete('core-pr');
+						window.location.href = url.toString();
+					}}
+				>
+					Restart Playground without that PR
 				</Button>
 			</>
 		);
@@ -295,6 +326,8 @@ function SiteErrorMessage({
 			<h1>Something went wrong</h1>
 			<p>An error occurred while loading your site. Please try again.</p>
 			<Button
+				className={css.actionButton}
+				variant="primary"
 				onClick={() => {
 					window.location.reload();
 				}}

--- a/packages/playground/website/src/components/playground-viewport/style.module.css
+++ b/packages/playground/website/src/components/playground-viewport/style.module.css
@@ -25,6 +25,16 @@
 	h1 {
 		text-align: center;
 	}
+
+	h1,
+	p {
+		margin-bottom: 15px;
+	}
+
+	.actionButton {
+		display: block;
+		margin: 0 auto;
+	}
 }
 
 .hidden {

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -181,8 +181,15 @@ export function bootSiteClient(
 			}
 		} catch (e) {
 			logger.error(e);
-			dispatch(setActiveSiteError('site-boot-failed'));
-			dispatch(setActiveModal(modalSlugs.ERROR_REPORT));
+			if (
+				(e as any).name === 'ArtifactExpiredError' ||
+				(e as any).originalErrorClassName === 'ArtifactExpiredError'
+			) {
+				dispatch(setActiveSiteError('github-artifact-expired'));
+			} else {
+				dispatch(setActiveSiteError('site-boot-failed'));
+				dispatch(setActiveModal(modalSlugs.ERROR_REPORT));
+			}
 			return;
 		}
 

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -7,7 +7,8 @@ export type SiteError =
 	| 'directory-handle-directory-does-not-exist'
 	| 'directory-handle-unknown-error'
 	// @TODO: Improve name?
-	| 'site-boot-failed';
+	| 'site-boot-failed'
+	| 'github-artifact-expired';
 
 export type SiteManagerSection = 'sidebar' | 'site-details' | 'blueprints';
 export interface UIState {


### PR DESCRIPTION
## Motivation for the change, related issues

Previewing a stale WordPress-develop PR triggers a general error message. This PR turns it into a friendly error message that explains what happens and what can be done about it:

<img width="2560" height="2296" alt="CleanShot 2025-09-04 at 16 55 54@2x" src="https://github.com/user-attachments/assets/52e003cb-b820-4418-8cbc-1fc8d765b192" />

Fixes #2570

## Testing Instructions (or ideally a Blueprint)

Go to http://127.0.0.1:5400/website-server/?core-pr=8729 and confirm you can see that screen

cc @dd32 @fellyph 