### PR TITLE
[Docs] Adding how to contribute to the WordPress Playground

### DIFF
--- a/packages/docs/site/docs/main/contributing/contributor-day.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day.md
@@ -1,12 +1,41 @@
 ---
 slug: /contributing/contributor-day
 title: WordCamp Contributor Day
-description: A guide on using Playground tools like the VS Code extension and CLI during a WordCamp Contributor Day to get started.
+description: A guide on how to contribute to the WordPress Playground, and it can support you at Contributor Day.
 ---
 
 # WordCamp Contributor Day
 
-The [WordPress Playground VS Code extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) and [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) streamline the process of setting up a local WordPress environment. WordPress Playground powers both—no Docker, MySQL, or Apache required.
+WordCamp Contributor Day is an event where the WordPress community comes together to contribute to the WordPress project. This guide focuses on how you can contribute using the WordPress Playground project, or how the Playground can assist you in contributing to WordPress Core.
+
+## Who Can Contribute?
+
+The WordPress Playground contributor tables welcome all kinds of contributions, not just from developers. Whether you are a writer, coder, tester, plugin or theme developer, marketer, site owner, or any other type of user, you are encouraged to contribute.
+
+We value diverse contributions across various areas, including community building, testing, documentation, and design.
+
+## How to Contribute to the Playground Project
+
+This section outlines how you can contribute directly to the WordPress Playground project and its associated tools:
+
+-   **Documentation:** Enhance our documentation by improving existing content, developing new guides, or translating materials into different languages.
+-   **Blueprints:** Create plugin demos for plugins at the WordPress Plugin repository, or develop new Blueprints to enrich our project documentation.
+-   **Testing the Playground Environment:** Engage in testing the WordPress Playground project itself. You can do this by carefully crafting new issues that describe problems you encounter and suggesting actionable solutions. Test our WordPress web instance (the playground.wordpress.net site), or explore the various applications powered by Playground. Test these tools, observe their functionality, and provide detailed feedback.
+-   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
+
+All feedback, including reported issues and test results, can be submitted through our GitHub repository.
+
+### Follow-up and Continued Engagement
+
+While many tasks are completed during the event, your contribution journey doesn't have to end there. You are welcome to continue working on your issues or pull requests after Contributor Day. We anticipate ongoing activity from contributors who take on tasks beyond the event. Please note that if a pull request shows no activity for one month, it may be considered abandoned and subsequently closed.
+
+### Getting Help and Staying Engaged
+
+During Contributor Day, you can find direct assistance and interact with us at the dedicated Playground table. For continuous support and community interaction, you can connect with us on the `#playground` channel on WordPress Slack or via GitHub.
+
+## How to use Playground at Contributor Day
+
+Now we are going to cover how the Playground can assist you during the Contributor Day. The [WordPress Playground VS Code extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) and [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) streamline the process of setting up a local WordPress environment. WordPress Playground powers both—no Docker, MySQL, or Apache required.
 
 Keep reading to learn how to use these tools for [local development](/developers/local-development/wp-playground-cli) when contributing to WordPress. Please note that the extension and the NPM package are under development, and not all [Make WordPress teams](https://make.wordpress.org/) are fully supported.
 

--- a/packages/docs/site/docs/main/contributing/contributor-day.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day.md
@@ -6,11 +6,11 @@ description: A guide on how to contribute to the WordPress Playground, and it ca
 
 # WordCamp Contributor Day
 
-WordCamp Contributor Day is an event where the WordPress community comes together to contribute to the WordPress project. This guide focuses on how you can contribute using the WordPress Playground project, or how the Playground can assist you in contributing to WordPress Core.
+WordCamp Contributor Day is an event where the WordPress community comes together to contribute to the WordPress project. This guide focuses on how you can contribute to the WordPress Playground project or how the Playground can assist you in contributing to WordPress Core.
 
 ## Who Can Contribute?
 
-The WordPress Playground contributor tables welcome all kinds of contributions, not just from developers. Whether you are a writer, coder, tester, plugin or theme developer, marketer, site owner, or any other type of user, you are encouraged to contribute.
+Some events will have a dedicated table for the project. The WordPress Playground contributor tables welcome all kinds of contributions, not just from developers. Whether you are a writer, coder, tester, plugin or theme developer, marketer, site owner, or any other type of user, you are encouraged to contribute.
 
 We value diverse contributions across various areas, including community building, testing, documentation, and design.
 


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request updates the Contributor Day page in the documentation, including an intro about what Contributor Day is and how contributors can help with the project.  With this change, the page is organized into two blocks: "How you can contribute to Playground"  and "How Playground can support contributors during the Contributor Day".

The goal is to guide contributors to areas where they can collaborate with the project and to provide guidance on how to continue contributing to the project after it has been completed.

A second page will be created for Playground table leads