### PR TITLE
Playground CLI: Skip WP install when using existing WP files

### DIFF
--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -179,7 +179,7 @@ export async function bootWordPress(options: BootOptions) {
 		);
 	}
 
-	if (!options.dataSqlPath) {
+	if (options.wordPressZip && !options.dataSqlPath) {
 		if (!(await isWordPressInstalled(php))) {
 			// Install WordPress if it's not installed.
 			await installWordPress(php);


### PR DESCRIPTION
## Motivation for the change, related issues

Playground CLI will refuse to boot for an existing WP site due to a WP install failure even when `--skip-wordpress-setup` is enabled.

This is a PR to fix that.

## Implementation details

In the bootWordPress() function, do not perform WP installation if no `wordpressZip` is provided.

## Testing Instructions (or ideally a Blueprint)

- CI