### PR TITLE
[CI] Do not block CI tests on linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
             - run: npx nx affected --target=typecheck
     test-unit-asyncify:
         runs-on: ubuntu-latest
-        needs: [lint-and-typecheck]
         strategy:
             fail-fast: false
             matrix:
@@ -76,7 +75,6 @@ jobs:
                   MYSQL_PASSWORD: password
     test-unit-jspi:
         runs-on: ubuntu-latest
-        needs: [lint-and-typecheck]
         strategy:
             fail-fast: false
             matrix:
@@ -125,7 +123,6 @@ jobs:
                   MYSQL_PASSWORD: password
     test-playground-cli:
         runs-on: ubuntu-latest
-        needs: [lint-and-typecheck]
         steps:
             - uses: actions/checkout@v4
               with:
@@ -136,7 +133,6 @@ jobs:
             - run: node node_modules/nx/bin/nx affected --target=test-for-node-22-and-above
     test-e2e:
         runs-on: ubuntu-latest
-        needs: [lint-and-typecheck]
         # Run as root to allow node to bind to port 80
         steps:
             - uses: actions/checkout@v4
@@ -154,7 +150,6 @@ jobs:
 
     test-e2e-playwright-prepare:
         runs-on: ubuntu-latest
-        needs: [lint-and-typecheck]
         steps:
             - uses: actions/checkout@v4
               with:
@@ -225,7 +220,6 @@ jobs:
 
     test-built-npm-packages:
         runs-on: ubuntu-latest
-        needs: [lint-and-typecheck]
         steps:
             - uses: actions/checkout@v4
               with:
@@ -315,7 +309,6 @@ jobs:
 
     test-running-unbuilt-playground-cli:
         runs-on: ubuntu-latest
-        needs: [lint-and-typecheck]
         steps:
             - uses: actions/checkout@v4
               with:
@@ -325,7 +318,6 @@ jobs:
 
     build:
         runs-on: ubuntu-latest
-        needs: [lint-and-typecheck]
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
## Motivation for the change, related issues

I often run into linting issues that prevent me from knowing whether all the tests pass on my PR. With this PR, tests will run without waiting for the linter. If all the tests puss but the linting doesn't, it's a good signal we can solve the formatting issues and merge.
