### PR TITLE
[Web Client] Remove onBeforeBlueprint

### DIFF
--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -56,14 +56,6 @@ export interface StartPlaygroundOptions {
 	 * @private
 	 */
 	sapiName?: string;
-	/**
-	 * Called before the blueprint steps are run,
-	 * allows the caller to delay the Blueprint execution
-	 * once the Playground is booted.
-	 *
-	 * @returns
-	 */
-	onBeforeBlueprint?: () => Promise<void>;
 	mounts?: Array<MountDescriptor>;
 	shouldInstallWordPress?: boolean;
 	/**
@@ -108,7 +100,6 @@ export async function startPlaygroundWeb({
 	onBlueprintStepCompleted,
 	onClientConnected = () => {},
 	sapiName,
-	onBeforeBlueprint,
 	mounts,
 	scope,
 	corsProxy,
@@ -166,10 +157,6 @@ export async function startPlaygroundWeb({
 
 	collectPhpLogs(logger, playground);
 	onClientConnected(playground);
-
-	if (onBeforeBlueprint) {
-		await onBeforeBlueprint();
-	}
 
 	await runBlueprintSteps(compiled, playground);
 	/**

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -7,7 +7,6 @@
 
 import metadataWorkerUrl from './opfs-site-storage-worker-for-safari?worker&url';
 import type { SiteMetadata } from '../../site-metadata';
-import { createSiteMetadata } from '../../site-metadata';
 import type { SiteInfo } from '../redux/slice-sites';
 import { joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';


### PR DESCRIPTION
## Motivation for the change, related issues

The `onBeforeBlueprint` is unused in this repo and downstream dependencies that I know of. This PR removes it – it adds complexity to [Blueprints v2 integration on playground.wordpress.net](https://github.com/WordPress/wordpress-playground/pull/2586)

## Testing Instructions (or ideally a Blueprint)

CI
