### PR TITLE
Translate 'localhost' to 127.0.0.1 in MySQL connections

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -352,8 +352,11 @@ RUN if [ "$WITH_MBREGEX" = "yes" ] && [ "${PHP_VERSION:0:3}" != "7.0" ]; \
 
 # Get and patch PHP
 COPY ./php/php*.patch /root/
+COPY ./php/apply-mysqlnd-patch.sh /root/
 RUN cd /root && \
 	git apply --no-index /root/php${PHP_VERSION:0:3}*.patch -v && \
+	chmod +x /root/apply-mysqlnd-patch.sh && \
+	/root/apply-mysqlnd-patch.sh && \
 	( [[ "${PHP_VERSION:0:3}" == '8.3' ]] && \
 		git apply --no-index /root/php-chunk-alloc-zend-assert-8.3.patch -v || \
 		( [[ "${PHP_VERSION:0:3}" == '8.4' ]] && \
@@ -366,6 +369,7 @@ RUN cd /root && \
 # Install Mysql support if needed
 RUN if [ "$WITH_MYSQL" = "yes" ]; then \
 		echo -n ' --enable-mysql --enable-pdo --with-mysql=mysqlnd --with-mysqli=mysqlnd --with-pdo-mysql=mysqlnd ' >> /root/.php-configure-flags; \
+		echo -n ' -DMYSQLND_FORCE_TCP_LOCALHOST ' >> /root/.emcc-php-wasm-flags; \
 	fi
 
 # Build the patched PHP

--- a/packages/php-wasm/compile/php/apply-mysqlnd-patch.sh
+++ b/packages/php-wasm/compile/php/apply-mysqlnd-patch.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# Script to robustly apply the mysqlnd localhost->127.0.0.1 patch
-# This script finds the hostname assignment and modifies it to use 127.0.0.1 instead of localhost
+# This script finds the hostname assignment in mysqlnd driver
+# and modifies it to use 127.0.0.1 instead of localhost.
+# 
+# We don't use a .patch file because the line numbers differ between
+# PHP versions.
 
 TARGET_FILE="php-src/ext/mysqlnd/mysqlnd_connection.c"
 
@@ -10,7 +13,6 @@ if [ ! -f "$TARGET_FILE" ]; then
     exit 1
 fi
 
-# Check if the patch has already been applied
 if grep -q "effective_host" "$TARGET_FILE"; then
     echo "Patch already applied to $TARGET_FILE"
     exit 0

--- a/packages/php-wasm/compile/php/apply-mysqlnd-patch.sh
+++ b/packages/php-wasm/compile/php/apply-mysqlnd-patch.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Script to robustly apply the mysqlnd localhost->127.0.0.1 patch
+# This script finds the hostname assignment and modifies it to use 127.0.0.1 instead of localhost
+
+TARGET_FILE="php-src/ext/mysqlnd/mysqlnd_connection.c"
+
+if [ ! -f "$TARGET_FILE" ]; then
+    echo "Error: $TARGET_FILE not found"
+    exit 1
+fi
+
+# Check if the patch has already been applied
+if grep -q "effective_host" "$TARGET_FILE"; then
+    echo "Patch already applied to $TARGET_FILE"
+    exit 0
+fi
+
+# Replace the hostname assignment line with our patched version
+sed -i.bak 's/MYSQLND_CSTRING hostname = { host, host? strlen(host) : 0 };/\tconst char * effective_host = (host \&\& strcmp(host, "localhost") == 0) ? "127.0.0.1" : host;\
+\tMYSQLND_CSTRING hostname = { effective_host, effective_host ? strlen(effective_host) : 0 };/' "$TARGET_FILE"
+
+# Check if the replacement was successful
+if grep -q "effective_host" "$TARGET_FILE"; then
+    rm -f "$TARGET_FILE.bak"
+    echo "Successfully applied mysqlnd patch to $TARGET_FILE"
+else
+    # Restore backup if replacement failed
+    if [ -f "$TARGET_FILE.bak" ]; then
+        mv "$TARGET_FILE.bak" "$TARGET_FILE"
+    fi
+    echo "Failed to apply mysqlnd patch to $TARGET_FILE"
+    exit 1
+fi

--- a/packages/php-wasm/node/asyncify/php_7_2.js
+++ b/packages/php-wasm/node/asyncify/php_7_2.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_2_34', 'php_7_2.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 22894584;
+export const dependenciesTotalSize = 22894943;
 const phpVersionString = '7.2.34';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -32115,13 +32115,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		9805437: ($0) => {
+		9805453: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		9805485: ($0) => {
+		9805501: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/asyncify/php_7_3.js
+++ b/packages/php-wasm/node/asyncify/php_7_3.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_3_33', 'php_7_3.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 23218224;
+export const dependenciesTotalSize = 23218265;
 const phpVersionString = '7.3.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -32115,13 +32115,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		10210573: ($0) => {
+		10210589: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		10210621: ($0) => {
+		10210637: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/asyncify/php_7_4.js
+++ b/packages/php-wasm/node/asyncify/php_7_4.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_4_33', 'php_7_4.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 23626844;
+export const dependenciesTotalSize = 23626901;
 const phpVersionString = '7.4.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -831,7 +831,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 	};
 
-	var ___heap_base = 11742080;
+	var ___heap_base = 11742144;
 
 	var alignMemory = (size, alignment) => {
 		return Math.ceil(size / alignment) * alignment;
@@ -1786,13 +1786,13 @@ export function init(RuntimeName, PHPLoader) {
 		1024
 	);
 
-	var ___stack_high = 11742080;
+	var ___stack_high = 11742144;
 
-	var ___stack_low = 10693504;
+	var ___stack_low = 10693568;
 
 	var ___stack_pointer = new WebAssembly.Global(
 		{ value: 'i32', mutable: true },
-		11742080
+		11742144
 	);
 
 	var PATH = {
@@ -32115,13 +32115,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		10534365: ($0) => {
+		10534397: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		10534413: ($0) => {
+		10534445: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/asyncify/php_8_0.js
+++ b/packages/php-wasm/node/asyncify/php_8_0.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_0_30', 'php_8_0.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 24845908;
+export const dependenciesTotalSize = 24845949;
 const phpVersionString = '8.0.30';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -32115,13 +32115,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		11563965: ($0) => {
+		11563981: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		11564013: ($0) => {
+		11564029: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/asyncify/php_8_1.js
+++ b/packages/php-wasm/node/asyncify/php_8_1.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_1_33', 'php_8_1.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 25172830;
+export const dependenciesTotalSize = 25172855;
 const phpVersionString = '8.1.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_8_2.js
+++ b/packages/php-wasm/node/asyncify/php_8_2.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_2_29', 'php_8_2.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 25477308;
+export const dependenciesTotalSize = 25477333;
 const phpVersionString = '8.2.29';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/asyncify/php_8_3.js
+++ b/packages/php-wasm/node/asyncify/php_8_3.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_3_25', 'php_8_3.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 26575785;
+export const dependenciesTotalSize = 26575874;
 const phpVersionString = '8.3.25';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -831,7 +831,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 	};
 
-	var ___heap_base = 13876672;
+	var ___heap_base = 13876736;
 
 	var alignMemory = (size, alignment) => {
 		return Math.ceil(size / alignment) * alignment;
@@ -1786,13 +1786,13 @@ export function init(RuntimeName, PHPLoader) {
 		1024
 	);
 
-	var ___stack_high = 13876672;
+	var ___stack_high = 13876736;
 
-	var ___stack_low = 12828096;
+	var ___stack_low = 12828160;
 
 	var ___stack_pointer = new WebAssembly.Global(
 		{ value: 'i32', mutable: true },
-		13876672
+		13876736
 	);
 
 	var PATH = {
@@ -32115,13 +32115,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		12632621: ($0) => {
+		12632685: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		12632669: ($0) => {
+		12632733: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/asyncify/php_8_4.js
+++ b/packages/php-wasm/node/asyncify/php_8_4.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_4_12', 'php_8_4.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 30326874;
+export const dependenciesTotalSize = 30326899;
 const phpVersionString = '8.4.12';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/jspi/php_7_2.js
+++ b/packages/php-wasm/node/jspi/php_7_2.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_2_34', 'php_7_2.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 22384535;
+export const dependenciesTotalSize = 22384612;
 const phpVersionString = '7.2.34';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -848,7 +848,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 	};
 
-	var ___heap_base = 11083488;
+	var ___heap_base = 11083552;
 
 	var alignMemory = (size, alignment) => {
 		return Math.ceil(size / alignment) * alignment;
@@ -1743,13 +1743,13 @@ export function init(RuntimeName, PHPLoader) {
 		1024
 	);
 
-	var ___stack_high = 11083488;
+	var ___stack_high = 11083552;
 
-	var ___stack_low = 10034912;
+	var ___stack_low = 10034976;
 
 	var ___stack_pointer = new WebAssembly.Global(
 		{ value: 'i32', mutable: true },
-		11083488
+		11083552
 	);
 
 	var PATH = {
@@ -18258,7 +18258,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 		instrumentWasmExports(exports) {
 			var exportPattern =
-				/^(php_wasm_init|fd_close|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|main|__main_argc_argv)$/;
+				/^(php_wasm_init|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|fd_close|main|__main_argc_argv)$/;
 			Asyncify.asyncExports = new Set();
 			var ret = {};
 			for (let [x, original] of Object.entries(exports)) {
@@ -31275,13 +31275,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		9805998: ($0) => {
+		9806030: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		9806046: ($0) => {
+		9806078: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/jspi/php_7_3.js
+++ b/packages/php-wasm/node/jspi/php_7_3.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_3_33', 'php_7_3.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 22719972;
+export const dependenciesTotalSize = 22720049;
 const phpVersionString = '7.3.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -18258,7 +18258,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 		instrumentWasmExports(exports) {
 			var exportPattern =
-				/^(php_wasm_init|fd_close|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|main|__main_argc_argv)$/;
+				/^(php_wasm_init|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|fd_close|main|__main_argc_argv)$/;
 			Asyncify.asyncExports = new Set();
 			var ret = {};
 			for (let [x, original] of Object.entries(exports)) {
@@ -31275,13 +31275,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		10211134: ($0) => {
+		10211166: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		10211182: ($0) => {
+		10211214: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/jspi/php_7_4.js
+++ b/packages/php-wasm/node/jspi/php_7_4.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '7_4_33', 'php_7_4.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 23088361;
+export const dependenciesTotalSize = 23088438;
 const phpVersionString = '7.4.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -18262,7 +18262,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 		instrumentWasmExports(exports) {
 			var exportPattern =
-				/^(php_wasm_init|fd_close|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|main|__main_argc_argv)$/;
+				/^(php_wasm_init|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|fd_close|main|__main_argc_argv)$/;
 			Asyncify.asyncExports = new Set();
 			var ret = {};
 			for (let [x, original] of Object.entries(exports)) {
@@ -31275,13 +31275,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		10534926: ($0) => {
+		10534958: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		10534974: ($0) => {
+		10535006: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/jspi/php_8_0.js
+++ b/packages/php-wasm/node/jspi/php_8_0.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_0_30', 'php_8_0.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 24293495;
+export const dependenciesTotalSize = 24293572;
 const phpVersionString = '8.0.30';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -848,7 +848,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 	};
 
-	var ___heap_base = 12843488;
+	var ___heap_base = 12843552;
 
 	var alignMemory = (size, alignment) => {
 		return Math.ceil(size / alignment) * alignment;
@@ -1743,13 +1743,13 @@ export function init(RuntimeName, PHPLoader) {
 		1024
 	);
 
-	var ___stack_high = 12843488;
+	var ___stack_high = 12843552;
 
-	var ___stack_low = 11794912;
+	var ___stack_low = 11794976;
 
 	var ___stack_pointer = new WebAssembly.Global(
 		{ value: 'i32', mutable: true },
-		12843488
+		12843552
 	);
 
 	var PATH = {
@@ -18262,7 +18262,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 		instrumentWasmExports(exports) {
 			var exportPattern =
-				/^(php_wasm_init|fd_close|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|main|__main_argc_argv)$/;
+				/^(php_wasm_init|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|fd_close|main|__main_argc_argv)$/;
 			Asyncify.asyncExports = new Set();
 			var ret = {};
 			for (let [x, original] of Object.entries(exports)) {
@@ -31275,13 +31275,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		11564526: ($0) => {
+		11564558: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		11564574: ($0) => {
+		11564606: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/jspi/php_8_1.js
+++ b/packages/php-wasm/node/jspi/php_8_1.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_1_33', 'php_8_1.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 24628760;
+export const dependenciesTotalSize = 24628805;
 const phpVersionString = '8.1.33';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -18268,7 +18268,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 		instrumentWasmExports(exports) {
 			var exportPattern =
-				/^(php_wasm_init|fd_close|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|main|__main_argc_argv)$/;
+				/^(php_wasm_init|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|fd_close|main|__main_argc_argv)$/;
 			Asyncify.asyncExports = new Set();
 			var ret = {};
 			for (let [x, original] of Object.entries(exports)) {

--- a/packages/php-wasm/node/jspi/php_8_2.js
+++ b/packages/php-wasm/node/jspi/php_8_2.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_2_29', 'php_8_2.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 24915437;
+export const dependenciesTotalSize = 24915546;
 const phpVersionString = '8.2.29';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -848,7 +848,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 	};
 
-	var ___heap_base = 12959392;
+	var ___heap_base = 12959456;
 
 	var alignMemory = (size, alignment) => {
 		return Math.ceil(size / alignment) * alignment;
@@ -1743,13 +1743,13 @@ export function init(RuntimeName, PHPLoader) {
 		1024
 	);
 
-	var ___stack_high = 12959392;
+	var ___stack_high = 12959456;
 
-	var ___stack_low = 11910816;
+	var ___stack_low = 11910880;
 
 	var ___stack_pointer = new WebAssembly.Global(
 		{ value: 'i32', mutable: true },
-		12959392
+		12959456
 	);
 
 	var PATH = {
@@ -18270,7 +18270,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 		instrumentWasmExports(exports) {
 			var exportPattern =
-				/^(php_wasm_init|fd_close|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|main|__main_argc_argv)$/;
+				/^(php_wasm_init|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|fd_close|main|__main_argc_argv)$/;
 			Asyncify.asyncExports = new Set();
 			var ret = {};
 			for (let [x, original] of Object.entries(exports)) {
@@ -31275,13 +31275,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		11682270: ($0) => {
+		11682334: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		11682318: ($0) => {
+		11682382: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/jspi/php_8_3.js
+++ b/packages/php-wasm/node/jspi/php_8_3.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_3_25', 'php_8_3.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 26008119;
+export const dependenciesTotalSize = 26008183;
 const phpVersionString = '8.3.25';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -848,7 +848,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 	};
 
-	var ___heap_base = 13877792;
+	var ___heap_base = 13877856;
 
 	var alignMemory = (size, alignment) => {
 		return Math.ceil(size / alignment) * alignment;
@@ -1743,13 +1743,13 @@ export function init(RuntimeName, PHPLoader) {
 		1024
 	);
 
-	var ___stack_high = 13877792;
+	var ___stack_high = 13877856;
 
-	var ___stack_low = 12829216;
+	var ___stack_low = 12829280;
 
 	var ___stack_pointer = new WebAssembly.Global(
 		{ value: 'i32', mutable: true },
-		13877792
+		13877856
 	);
 
 	var PATH = {
@@ -18270,7 +18270,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 		instrumentWasmExports(exports) {
 			var exportPattern =
-				/^(php_wasm_init|fd_close|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|main|__main_argc_argv)$/;
+				/^(php_wasm_init|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|fd_close|main|__main_argc_argv)$/;
 			Asyncify.asyncExports = new Set();
 			var ret = {};
 			for (let [x, original] of Object.entries(exports)) {
@@ -31275,13 +31275,13 @@ export function init(RuntimeName, PHPLoader) {
 	// End JS library code
 
 	var ASM_CONSTS = {
-		12633182: ($0) => {
+		12633246: ($0) => {
 			if (!$0) {
 				AL.alcErr = 0xa004;
 				return 1;
 			}
 		},
-		12633230: ($0) => {
+		12633294: ($0) => {
 			if (!AL.currentCtx) {
 				err('alGetProcAddress() called without a valid context');
 				return 1;

--- a/packages/php-wasm/node/jspi/php_8_3.js
+++ b/packages/php-wasm/node/jspi/php_8_3.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_3_25', 'php_8_3.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 26008183;
+export const dependenciesTotalSize = 26008228;
 const phpVersionString = '8.3.25';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js

--- a/packages/php-wasm/node/jspi/php_8_4.js
+++ b/packages/php-wasm/node/jspi/php_8_4.js
@@ -8,7 +8,7 @@ import path from 'path';
 
 const dependencyFilename = path.join(__dirname, '8_4_12', 'php_8_4.wasm');
 export { dependencyFilename };
-export const dependenciesTotalSize = 29761007;
+export const dependenciesTotalSize = 29761052;
 const phpVersionString = '8.4.12';
 export function init(RuntimeName, PHPLoader) {
 	// The rest of the code comes from the built php.js file and esm-suffix.js
@@ -18270,7 +18270,7 @@ export function init(RuntimeName, PHPLoader) {
 		},
 		instrumentWasmExports(exports) {
 			var exportPattern =
-				/^(php_wasm_init|fd_close|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|main|__main_argc_argv)$/;
+				/^(php_wasm_init|wasm_sleep|wasm_read|emscripten_sleep|wasm_sapi_handle_request|wasm_sapi_request_shutdown|wasm_poll_socket|wrap_select|__wrap_select|select|php_pollfd_for|fflush|wasm_popen|wasm_read|wasm_php_exec|run_cli|wasm_recv|fd_close|main|__main_argc_argv)$/;
 			Asyncify.asyncExports = new Set();
 			var ret = {};
 			for (let [x, original] of Object.entries(exports)) {

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -6,7 +6,6 @@ export async function getPHPLoaderModule(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion
 ): Promise<PHPLoaderModule> {
 	if (await jspi()) {
-		console.log('jspi');
 		switch (version) {
 			case '8.4':
 				// @ts-ignore

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -6,6 +6,7 @@ export async function getPHPLoaderModule(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion
 ): Promise<PHPLoaderModule> {
 	if (await jspi()) {
+		console.log('jspi');
 		switch (version) {
 			case '8.4':
 				// @ts-ignore

--- a/packages/php-wasm/node/src/test/php-mysqli.spec.ts
+++ b/packages/php-wasm/node/src/test/php-mysqli.spec.ts
@@ -1,5 +1,3 @@
-import http from 'http';
-import https from 'https';
 import fs from 'fs';
 import path from 'path';
 import {
@@ -14,80 +12,56 @@ import { jspi } from 'wasm-feature-detect';
 
 const runtimeMode = (await jspi()) ? 'jspi' : 'asyncify';
 
-const requestHandler = (
-	req: http.IncomingMessage,
-	res: http.ServerResponse
-) => {
-	if (req.url === '/image.jpg') {
-		const image = fs.readFileSync(
-			path.join(__dirname, 'test-data', 'image.jpg')
+const phpVersions =
+	'PHP' in process.env ? [process.env['PHP']] : SupportedPHPVersions;
+
+// Run MySQL functions if credentials are provided
+const mysqlCredentials = {
+	host: process.env['MYSQL_HOST'] ?? '127.0.0.1',
+	user: process.env['MYSQL_USER'],
+	password: process.env['MYSQL_PASSWORD'],
+	database: process.env['MYSQL_DATABASE'],
+	port: process.env['MYSQL_PORT'] ?? '3306',
+};
+
+describe('MySQL network functions', () => {
+	if (
+		!mysqlCredentials.host ||
+		!mysqlCredentials.user ||
+		!mysqlCredentials.password ||
+		!mysqlCredentials.database
+	) {
+		test.skip(
+			'Skipping MySQL network functions because no credentials were provided.'
 		);
-		res.writeHead(200, { 'Content-Type': 'image/jpeg' });
-		res.write(image);
-		res.end();
-	} else {
-		res.writeHead(200, { 'Content-Type': 'text/plain' });
-		res.end('Hello World\n');
+		console.log(`
+			Skipping MySQL network functions because no credentials were provided.
+
+			To run MySQL network function tests, set the following environment variables:
+			- MYSQL_HOST
+			- MYSQL_USER
+			- MYSQL_PASSWORD
+			- MYSQL_DATABASE
+
+			Use 127.0.0.1 instead of localhost to ensure MySQL uses
+			TCP instead of socket, because MySQL in Playground
+			still doesn't support sockets.
+		`);
+		return;
 	}
-};
+	describe.each(phpVersions)(`PHP %s – ${runtimeMode}`, (phpVersion) => {
+		let php: PHP;
+		beforeEach(async () => {
+			php = new PHP(await loadNodeRuntime(phpVersion as any));
+			await setPhpIniEntries(php, { allow_url_fopen: 1 });
+		});
 
-const httpServer = http.createServer(requestHandler);
-const selfSignedCert = {
-	key: fs.readFileSync(path.join(__dirname, 'test-data', 'key.pem')),
-	cert: fs.readFileSync(path.join(__dirname, 'test-data', 'cert.pem')),
-};
-const httpsServer = https.createServer(
-	{
-		key: selfSignedCert.key,
-		cert: selfSignedCert.cert,
-	},
-	requestHandler
-);
+		afterEach(async () => {
+			php.exit();
+		});
 
-[
-	{
-		protocol: 'http',
-		port: new Promise((resolve) => {
-			httpServer.listen(0, function () {
-				resolve((httpServer.address() as any).port);
-			});
-		}),
-	},
-	{
-		protocol: 'https',
-		port: new Promise((resolve) => {
-			httpsServer.listen(0, function () {
-				resolve((httpsServer.address() as any).port);
-			});
-		}),
-	},
-].forEach(({ protocol, port }) => {
-	const host = '127.0.0.1';
-
-	const httpUrl = `${protocol}://${host}:${port}`;
-
-	describe(`${protocol} protocol – ${runtimeMode}`, () => {
-		const phpVersions =
-			'PHP' in process.env ? [process.env['PHP']] : SupportedPHPVersions;
-
-		const topOfTheStack: Record<string, string> = {};
-
-		// Run MySQL functions if credentials are provided
-		const mysqlCredentials = {
-			host: process.env['MYSQL_HOST'] ?? '127.0.0.1',
-			user: process.env['MYSQL_USER'],
-			password: process.env['MYSQL_PASSWORD'],
-			database: process.env['MYSQL_DATABASE'],
-			port: process.env['MYSQL_PORT'] ?? '3306',
-		};
-
-		if (
-			mysqlCredentials.host &&
-			mysqlCredentials.user &&
-			mysqlCredentials.password &&
-			mysqlCredentials.database
-		) {
-			topOfTheStack['mysqli'] = `
+		test('MySQL network functions', () => {
+			assertNoCrash(`
 				$mysqli = new mysqli(
 					"${mysqlCredentials.host}",
 					"${mysqlCredentials.user}",
@@ -105,277 +79,79 @@ const httpsServer = https.createServer(
 				mysqli_get_server_info($mysqli);
 				mysqli_get_server_version($mysqli);
 				mysqli_get_proto_info($mysqli);
-				mysqli_close($mysqli);`;
-		} else {
-			console.log(`
-				Skipping MySQL network functions because no credentials were provided.
-
-				To run MySQL network function tests, set the following environment variables:
-				- MYSQL_HOST
-				- MYSQL_USER
-				- MYSQL_PASSWORD
-				- MYSQL_DATABASE
-
-				Use 127.0.0.1 instead of localhost to ensure MySQL uses
-				TCP instead of socket, because MySQL in Playground
-				still doesn't support sockets.
+				mysqli_close($mysqli);
 			`);
-		}
-		describe.each(phpVersions)(`PHP %s – ${runtimeMode}`, (phpVersion) => {
-			let php: PHP;
-			beforeEach(async () => {
-				php = new PHP(await loadNodeRuntime(phpVersion as any));
-				await setPhpIniEntries(php, { allow_url_fopen: 1 });
-			});
+		});
 
-			afterEach(async () => {
-				php.exit();
-			});
-
-			describe.each(Object.keys(topOfTheStack))(
-				'%s',
-				(networkCallKey) => {
-					const networkCall = topOfTheStack[networkCallKey];
-					test('Direct call', () => assertNoCrash(networkCall));
-					describe('Function calls', () => {
-						test('Simple call', () =>
-							assertNoCrash(`${networkCall};`));
-						test('Simple call', () =>
-							assertNoCrash(
-								`function top() { ${networkCall} } top();`
-							));
-						test('Via call_user_func', () =>
-							assertNoCrash(
-								`function top() { ${networkCall} } call_user_func('top'); `
-							));
-						test('Via call_user_func_array', () =>
-							assertNoCrash(
-								`function top() { ${networkCall} } call_user_func_array('top', array());`
-							));
-					});
-
-					describe('Array functions', () => {
-						test('array_filter', () =>
-							assertNoCrash(`
-							function top() { ${networkCall} }
-							array_filter(array('top'), 'top');
-						`));
-
-						test('array_map', () =>
-							assertNoCrash(`
-								function top() { ${networkCall} }
-								array_map(array('top'), 'top');
-							`));
-
-						// Network calls in sort() would be silly so let's skip those for now.
-					});
-
-					describe('Class method calls', () => {
-						test('Regular method', () =>
-							assertNoCrash(`
-						class Top {
-							function my_method() { ${networkCall} }
-						}
-						$x = new Top();
-						$x->my_method();
-					`));
-						test('Via ReflectionMethod->invoke()', () =>
-							assertNoCrash(`
-						class Top {
-							function my_method() { ${networkCall} }
-						}
-						$reflectionMethod = new ReflectionMethod('Top', 'my_method');
-						$reflectionMethod->invoke(new Top());
-					`));
-						test('Via ReflectionMethod->invokeArgs()', () =>
-							assertNoCrash(`
-						class Top {
-							function my_method() { ${networkCall} }
-						}
-						$reflectionMethod = new ReflectionMethod('Top', 'my_method');
-						$reflectionMethod->invokeArgs(new Top(), array());
-					`));
-						test('Via call_user_func', () =>
-							assertNoCrash(`
-						class Top {
-							function my_method() { ${networkCall} }
-						}
-						call_user_func([new Top(), 'my_method']);
-						`));
-						test('Via call_user_func_array', () =>
-							assertNoCrash(`
-						class Top {
-							function my_method() { ${networkCall} }
-						}
-						call_user_func_array([new Top(), 'my_method'], []);
-						`));
-						test('Constructor', () =>
-							assertNoCrash(`
-						class Top {
-							function __construct() { ${networkCall} }
-						}
-						new Top();
-					`));
-						test('Destructor', () =>
-							assertNoCrash(`
-						class Top {
-							function __destruct() { ${networkCall} }
-						}
-						$x = new Top();
-						unset($x);
-					`));
-						test('__call', () =>
-							assertNoCrash(`
-						class Top {
-							function __call($method, $args) { ${networkCall} }
-						}
-						$x = new Top();
-						$x->test();
-					`));
-						test('__get', () =>
-							assertNoCrash(`
-						class Top {
-							function __get($prop) { ${networkCall} }
-						}
-						$x = new Top();
-						$x->test;
-					`));
-						test('__set', () =>
-							assertNoCrash(`
-						class Top {
-							function __set($prop, $value) { ${networkCall} }
-						}
-						$x = new Top();
-						$x->test = 1;
-					`));
-						test('__isset', () =>
-							assertNoCrash(`
-						class Top {
-							function __isset($prop) { ${networkCall} }
-						}
-						$x = new Top();
-						isset($x->test);
-					`));
-						test('ArrayAccess', () => {
-							assertNoCrash(`
-							class Top implements ArrayAccess {
-								function offsetExists($offset) { ${networkCall} }
-								function offsetGet($offset) { ${networkCall} }
-								function offsetSet($offset, $value) { ${networkCall} }
-								function offsetUnset($offset) { ${networkCall} }
-							}
-							$x = new Top();
-							isset($x['test']);
-							$a = $x['test'];
-							$x['test'] = 123;
-							unset($x['test']);
-						`);
-						});
-						test('Iterator', () =>
-							assertNoCrash(`
-						$data = new class() implements IteratorAggregate {
-							public function getIterator(): Traversable {
-								${networkCall};
-								return new ArrayIterator( [] );
-							}
-						};
-						echo json_encode( [
-							...$data
-						] );
-					`));
-
-						test('Countable', () =>
-							assertNoCrash(`
-						$data = new class() implements Countable {
-							public function count() {
-								${networkCall}
-								return 0;
-							}
-						};
-						count($data);
-					`));
-
-						test('yield', () =>
-							assertNoCrash(`
-						function countTo2() {
-							${networkCall};
-							yield '1';
-							${networkCall};
-							yield '2';
-						}
-						foreach(countTo2() as $number) {
-							echo $number;
-						}
-					`));
-					});
-
-					describe('exif extension support', () => {
-						it('exif_read_data', async () => {
-							assertNoCrash(
-								`var_dump(exif_read_data('${httpUrl}/image.jpg'));`
-							);
-						});
-						it('exif_imagetype', async () => {
-							assertNoCrash(
-								`var_dump(exif_imagetype('${httpUrl}/image.jpg'));`
-							);
-						});
-						it('exif_thumbnail', async () => {
-							assertNoCrash(
-								`var_dump(exif_thumbnail('${httpUrl}/image.jpg'));`
-							);
-						});
-					});
+		test('Can connect to "localhost"', () => {
+			assertNoCrash(`
+				$mysqli = new mysqli(
+					"localhost",
+					"${mysqlCredentials.user}",
+					"${mysqlCredentials.password}",
+					"${mysqlCredentials.database}",
+					${mysqlCredentials.port}
+				);
+				if (mysqli_connect_errno()) {
+					// This should crash the process I hope
+					klfhjkljfkdjfd();
 				}
-			);
+				mysqli_ping($mysqli);
+				mysqli_query($mysqli, "SELECT 1");
+				mysqli_multi_query($mysqli, "SELECT 1; SELECT 2;");
+				mysqli_get_server_info($mysqli);
+				mysqli_get_server_version($mysqli);
+				mysqli_get_proto_info($mysqli);
+				mysqli_close($mysqli);
+			`);
+		});
 
-			async function assertNoCrash(code: string) {
-				try {
-					const result = await php.run({
-						code: `<?php ${code}`,
-					});
-					expect(result).toBeTruthy();
-					expect(result.text).toBe('');
-					expect(result.errors).toBeFalsy();
-				} catch (e) {
-					if (
-						'FIX_DOCKERFILE' in process.env &&
-						process.env['FIX_DOCKERFILE'] === 'true' &&
-						runtimeMode == 'asyncify' &&
-						'functionsMaybeMissingFromAsyncify' in php
-					) {
-						const missingCandidates = (
-							php.functionsMaybeMissingFromAsyncify as string[]
+		async function assertNoCrash(code: string) {
+			try {
+				const result = await php.run({
+					code: `<?php ${code}`,
+				});
+				expect(result).toBeTruthy();
+				expect(result.text).toBe('');
+				expect(result.errors).toBeFalsy();
+			} catch (e) {
+				if (
+					'FIX_DOCKERFILE' in process.env &&
+					process.env['FIX_DOCKERFILE'] === 'true' &&
+					runtimeMode == 'asyncify' &&
+					'functionsMaybeMissingFromAsyncify' in php
+				) {
+					const missingCandidates = (
+						php.functionsMaybeMissingFromAsyncify as string[]
+					)
+						.map((candidate) =>
+							candidate.replace('byn$fpcast-emu$', '')
 						)
-							.map((candidate) =>
-								candidate.replace('byn$fpcast-emu$', '')
-							)
-							.filter(
-								(candidate) =>
-									!Dockerfile.includes(`"${candidate}"`)
-							);
-						if (missingCandidates.length) {
-							addAsyncifyFunctionsToDockerfile(missingCandidates);
-							throw new Error(
-								`Asyncify crash! The following missing functions were just auto-added to the ASYNCIFY_ONLY list in the Dockerfile: \n ` +
-									missingCandidates.join(', ') +
-									`\nYou now need to rebuild PHP and re-run this test: \n` +
-									`  npm run recompile:php:node:asyncify:8.0\n` +
-									`  node --stack-trace-limit=100 ./node_modules/.bin/nx test php-wasm-node --test-name-pattern='asyncify'\n`
-							);
-						}
-
-						const err = new Error(
-							`Asyncify crash! No C functions present in the stack trace were missing ` +
-								`from the Dockerfile. This could mean the stack trace is too short – try increasing the stack trace limit ` +
-								`with --stack-trace-limit=100. If you already did that, fixing this problem will likely take more digging.`
+						.filter(
+							(candidate) =>
+								!Dockerfile.includes(`"${candidate}"`)
 						);
-						err.cause = e;
-						throw err;
+					if (missingCandidates.length) {
+						addAsyncifyFunctionsToDockerfile(missingCandidates);
+						throw new Error(
+							`Asyncify crash! The following missing functions were just auto-added to the ASYNCIFY_ONLY list in the Dockerfile: \n ` +
+								missingCandidates.join(', ') +
+								`\nYou now need to rebuild PHP and re-run this test: \n` +
+								`  npm run recompile:php:node:asyncify:8.0\n` +
+								`  node --stack-trace-limit=100 ./node_modules/.bin/nx test php-wasm-node --test-name-pattern='asyncify'\n`
+						);
 					}
+
+					const err = new Error(
+						`Asyncify crash! No C functions present in the stack trace were missing ` +
+							`from the Dockerfile. This could mean the stack trace is too short – try increasing the stack trace limit ` +
+							`with --stack-trace-limit=100. If you already did that, fixing this problem will likely take more digging.`
+					);
+					err.cause = e;
+					throw err;
 				}
 			}
-		});
+		}
 	});
 });
 

--- a/packages/php-wasm/supported-php-versions.mjs
+++ b/packages/php-wasm/supported-php-versions.mjs
@@ -6,7 +6,7 @@
  * @property {string} lastRelease
  */
 
-export const lastRefreshed = '2025-09-11T22:46:03.434Z';
+export const lastRefreshed = '2025-09-13T10:45:12.627Z';
 
 /**
  * @type {PhpVersion[]}


### PR DESCRIPTION
## Motivation for the change, related issues

Allows connecting to a MySQL server when `$host` is set to `"localhost"` and not `"127.0.0.1"`.

Mysqlnd driver used by all PHP connectors (mysqli_connect, new PDO, ...) has a hardcoded behavior: when `$host` is `"localhost"`, it connects via a unix socket and not a TCP socket. Supporting unix sockets from an Emscripten app is not trivial. 

Fixes #370
Fixes https://github.com/WordPress/playground-tools/issues/18

## Implementation

This PR patches the mysqlnd driver to replace `"localhost"` with `"127.0.0.1"` and use a TCP connection.
Technically, this changes the semantics compared to what a native PHP build would do. However, the vast majority of MySQL users don't care about this distinction. All they see is a failed connection to localhost. If a use-case emerges for connecting over a unix socket specifically and not over TCP, we'll need to revisit this approach and explore adding support for unix sockets.

## Testing Instructions (or ideally a Blueprint)

CI – there's a new test