### PR TITLE
[CLI] Build worker thread with stable filenames

### DIFF
--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -117,7 +117,14 @@ export default defineConfig({
 		rollupOptions: {
 			external,
 			output: {
-				entryFileNames: (/* chunkInfo: any */) => {
+				entryFileNames: (chunkInfo: any) => {
+					// Keep stable filenames for worker threads without hash
+					if (
+						chunkInfo.name === 'worker-thread-v1' ||
+						chunkInfo.name === 'worker-thread-v2'
+					) {
+						return '[name].js';
+					}
 					return '[name]-[hash].js';
 				},
 			},

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -1,5 +1,6 @@
 const { SupportedPHPVersions } = require('@php-wasm/universal');
 const { runCLI } = require('@wp-playground/cli');
+const path = require('path');
 
 // Exclude PHP 7.2 – it often times out on CI.
 SupportedPHPVersions.filter(
@@ -34,8 +35,9 @@ SupportedPHPVersions.filter(
 
 		for (const file of requiredFiles) {
 			// Try to resolve the file from the CLI package
-			const resolvedPath = require.resolve(`@wp-playground/cli/${file}`);
-			expect(resolvedPath).toBeTruthy();
+			const resolvedBasePath = require.resolve(`@wp-playground/cli`);
+			const filePath = path.join(resolvedBasePath, file);
+			expect(filePath).toBeTruthy();
 		}
 	});
 });

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -27,4 +27,15 @@ SupportedPHPVersions.filter(
 			}
 		}, 30000);
 	});
+
+	it('Should include required worker thread files in CLI package', () => {
+		// Verify that the Playground CLI package ships with the required worker thread files
+		const requiredFiles = ['worker-thread-v1.cjs', 'worker-thread-v2.cjs'];
+
+		for (const file of requiredFiles) {
+			// Try to resolve the file from the CLI package
+			const resolvedPath = require.resolve(`@wp-playground/cli/${file}`);
+			expect(resolvedPath).toBeTruthy();
+		}
+	});
 });

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -37,4 +37,26 @@ describe(`PHP ${phpVersion}`, () => {
 			}
 		}
 	});
+
+	it('Should include required worker thread files in CLI package', () => {
+		// Verify that the Playground CLI package ships with the required worker thread files
+		const requiredFiles = ['worker-thread-v1.js', 'worker-thread-v2.js'];
+
+		for (const file of requiredFiles) {
+			try {
+				// Try to resolve the file from the CLI package
+				const resolvedPath = require.resolve(
+					`@wp-playground/cli/${file}`
+				);
+				assert.ok(
+					resolvedPath,
+					`${file} should be resolvable from CLI package`
+				);
+			} catch (error) {
+				assert.fail(
+					`Required file ${file} is missing from CLI package: ${error.message}`
+				);
+			}
+		}
+	});
 });

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -1,5 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { runCLI } from '@wp-playground/cli';
 import type { SupportedPHPVersion } from '@php-wasm/universal';
 import { SupportedPHPVersions } from '@php-wasm/universal';
@@ -17,8 +19,7 @@ describe(`PHP ${phpVersion}`, () => {
 		const cli = await runCLI({
 			command: 'server',
 			php: phpVersion,
-			verbosity: 'quiet',
-			exitOnPrimaryWorkerCrash: false,
+			quiet: true,
 		});
 		try {
 			const response = await cli.playground.request({
@@ -38,20 +39,17 @@ describe(`PHP ${phpVersion}`, () => {
 		}
 	});
 
-	it('Should include required worker thread files in CLI package', () => {
+	it('Should include required worker thread files in CLI package', async () => {
 		// Verify that the Playground CLI package ships with the required worker thread files
 		const requiredFiles = ['worker-thread-v1.js', 'worker-thread-v2.js'];
 
 		for (const file of requiredFiles) {
 			try {
-				// Try to resolve the file from the CLI package
-				const resolvedPath = require.resolve(
-					`@wp-playground/cli/${file}`
-				);
-				assert.ok(
-					resolvedPath,
-					`${file} should be resolvable from CLI package`
-				);
+				// Resolve the file from the CLI package without importing it
+				const url = import.meta.resolve(`@wp-playground/cli/${file}`);
+				const path = fileURLToPath(url);
+				// Verify that the resolved file actually exists on disk
+				await access(path);
 			} catch (error) {
 				assert.fail(
 					`Required file ${file} is missing from CLI package: ${error.message}`

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -46,7 +46,8 @@ describe(`PHP ${phpVersion}`, () => {
 		for (const file of requiredFiles) {
 			try {
 				// Resolve the file from the CLI package without importing it
-				const url = import.meta.resolve(`@wp-playground/cli/${file}`);
+				const baseUrl = import.meta.resolve(`@wp-playground/cli`);
+				const url = new URL(file, baseUrl);
 				const path = fileURLToPath(url);
 				// Verify that the resolved file actually exists on disk
 				await access(path);


### PR DESCRIPTION
## Motivation for the change, related issues

Playground CLI consumers struggle with the changing name of the `worker-thread-*` files – they need to configure them as separate entrypoints. This PR ensures they're always distributed with the following stable names:

* `worker-thread-v1.js`
* `worker-thread-v1.cjs`
* `worker-thread-v2.js`
* `worker-thread-v2.cjs`

## Testing Instructions (or ideally a Blueprint)

TODO: Add a CI test to ensure the built packages always contain these four files