### PR TITLE
Statically analyzable build

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -18,10 +18,13 @@ import {
 	readAsFile,
 } from './download';
 import type { PlaygroundCliBlueprintV1Worker } from './worker-thread-v1';
-// @ts-ignore
-import importedWorkerV1UrlString from './worker-thread-v1?worker&url';
 import type { MessagePort as NodeMessagePort } from 'worker_threads';
-import { LogVerbosity, type RunCLIArgs, type SpawnedWorker } from '../run-cli';
+import {
+	LogVerbosity,
+	type RunCLIArgs,
+	type SpawnedWorker,
+	type WorkerType,
+} from '../run-cli';
 
 /**
  * Boots Playground CLI workers using Blueprint version 1.
@@ -49,20 +52,8 @@ export class BlueprintsV1Handler {
 		this.processIdSpaceLength = options.processIdSpaceLength;
 	}
 
-	getWorkerUrl() {
-		if (
-			process.env['VITEST'] &&
-			importedWorkerV1UrlString.startsWith('/src/')
-		) {
-			// Work around issue where Vitest cannot find the worker script.
-			return path.join(
-				import.meta.dirname,
-				'..',
-				'..',
-				importedWorkerV1UrlString
-			);
-		}
-		return importedWorkerV1UrlString;
+	getWorkerType(): WorkerType {
+		return 'v1';
 	}
 
 	async bootPrimaryWorker(

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -4,11 +4,8 @@ import type {
 	PlaygroundCliBlueprintV2Worker,
 	WorkerBootArgs,
 } from './worker-thread-v2';
-// @ts-ignore
-import importedWorkerV2UrlString from './worker-thread-v2?worker&url';
 import type { MessagePort as NodeMessagePort } from 'worker_threads';
-import type { RunCLIArgs, SpawnedWorker } from '../run-cli';
-import path from 'path';
+import type { RunCLIArgs, SpawnedWorker, WorkerType } from '../run-cli';
 
 /**
  * Boots Playground CLI workers using Blueprint version 2.
@@ -37,20 +34,8 @@ export class BlueprintsV2Handler {
 		this.phpVersion = args.php as SupportedPHPVersion;
 	}
 
-	getWorkerUrl() {
-		if (
-			process.env['VITEST'] &&
-			importedWorkerV2UrlString.startsWith('/src/')
-		) {
-			// Work around issue where Vitest cannot find the worker script.
-			return path.join(
-				import.meta.dirname,
-				'..',
-				'..',
-				importedWorkerV2UrlString
-			);
-		}
-		return importedWorkerV2UrlString;
+	getWorkerType(): WorkerType {
+		return 'v2';
 	}
 
 	async bootPrimaryWorker(

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -50,11 +50,6 @@ import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
 import { startBridge } from '@php-wasm/xdebug-bridge';
 import path from 'path';
 
-// Inlined worker URLs for static analysis by downstream bundlers
-// These are replaced at build time by the Vite plugin in vite.config.ts
-declare const __WORKER_V1_URL__: string;
-declare const __WORKER_V2_URL__: string;
-
 export const LogVerbosity = {
 	Quiet: { name: 'quiet', severity: LogSeverity.Fatal },
 	Normal: { name: 'normal', severity: LogSeverity.Info },
@@ -823,55 +818,16 @@ async function spawnWorkerThreads(
  * @returns
  */
 async function spawnWorkerThread(workerType: 'v1' | 'v2') {
-	/**
-	 * When running the CLI from source via `node cli.ts`, the Vite-provided
-	 * __WORKER_V1_URL__ and __WORKER_V2_URL__ are undefined. Let's set them to
-	 * the correct paths.
-	 */
-	if (typeof __WORKER_V1_URL__ === 'undefined') {
-		// Need to split the __WORKER_V1_URL__ string in two parts to avoid Vite replacing
-		// it with a string literal.
-		// @ts-expect-error
-		globalThis['__WORKER_V1_URL__'] = './blueprints-v1/worker-thread-v1.ts';
-	}
-	if (typeof __WORKER_V2_URL__ === 'undefined') {
-		// Need to split the __WORKER_V2_URL__ string in two parts to avoid Vite replacing
-		// it with a string literal.
-		// @ts-expect-error
-		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
-	}
 	if (workerType === 'v1') {
-		if (process.env['VITEST'] && __WORKER_V1_URL__.startsWith('/src/')) {
-			// Work around issue where Vitest cannot find the worker script.
-			return new Worker(
-				new URL(
-					path.join(
-						import.meta.dirname,
-						'..',
-						'..',
-						__WORKER_V1_URL__
-					),
-					import.meta.url
-				)
-			);
-		}
-		return new Worker(new URL(__WORKER_V1_URL__, import.meta.url));
+		return new Worker(
+			new URL('./blueprints-v1/worker-thread-v1.ts', import.meta.url)
+		);
+	} else if (workerType === 'v2') {
+		return new Worker(
+			new URL('./blueprints-v2/worker-thread-v2.ts', import.meta.url)
+		);
 	} else {
-		if (process.env['VITEST'] && __WORKER_V2_URL__.startsWith('/src/')) {
-			// Work around issue where Vitest cannot find the worker script.
-			return new Worker(
-				new URL(
-					path.join(
-						import.meta.dirname,
-						'..',
-						'..',
-						__WORKER_V2_URL__
-					),
-					import.meta.url
-				)
-			);
-		}
-		return new Worker(new URL(__WORKER_V2_URL__, import.meta.url));
+		throw new Error(`Invalid worker type: ${workerType}`);
 	}
 }
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -49,6 +49,11 @@ import { BlueprintsV2Handler } from './blueprints-v2/blueprints-v2-handler';
 import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
 import { startBridge } from '@php-wasm/xdebug-bridge';
 
+// Inlined worker URLs for static analysis by downstream bundlers
+// These are replaced at build time by the Vite plugin in vite.config.ts
+declare const __WORKER_V1_URL__: string;
+declare const __WORKER_V2_URL__: string;
+
 export const LogVerbosity = {
 	Quiet: { name: 'quiet', severity: LogSeverity.Fatal },
 	Normal: { name: 'normal', severity: LogSeverity.Info },
@@ -817,16 +822,27 @@ async function spawnWorkerThreads(
  * @returns
  */
 async function spawnWorkerThread(workerType: 'v1' | 'v2') {
+	/**
+	 * When running the CLI from source via `node cli.ts`, the Vite-provided
+	 * __WORKER_V1_URL__ and __WORKER_V2_URL__ are undefined. Let's set them to
+	 * the correct paths.
+	 */
+	if (typeof __WORKER_V1_URL__ === 'undefined') {
+		// Need to split the __WORKER_V1_URL__ string in two parts to avoid Vite replacing
+		// it with a string literal.
+		// @ts-expect-error
+		globalThis['__WORKER_V1_URL__'] = './blueprints-v1/worker-thread-v1.ts';
+	}
+	if (typeof __WORKER_V2_URL__ === 'undefined') {
+		// Need to split the __WORKER_V2_URL__ string in two parts to avoid Vite replacing
+		// it with a string literal.
+		// @ts-expect-error
+		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
+	}
 	if (workerType === 'v1') {
-		return new Worker(
-			new URL('./blueprints-v1/worker-thread-v1.ts', import.meta.url)
-		);
-	} else if (workerType === 'v2') {
-		return new Worker(
-			new URL('./blueprints-v2/worker-thread-v2.ts', import.meta.url)
-		);
+		return new Worker(new URL(__WORKER_V1_URL__, import.meta.url));
 	} else {
-		throw new Error(`Invalid worker type: ${workerType}`);
+		return new Worker(new URL(__WORKER_V2_URL__, import.meta.url));
 	}
 }
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -832,15 +832,13 @@ async function spawnWorkerThread(workerType: 'v1' | 'v2') {
 		// Need to split the __WORKER_V1_URL__ string in two parts to avoid Vite replacing
 		// it with a string literal.
 		// @ts-expect-error
-		globalThis['__WORKER_' + 'V1_URL__'] =
-			'./blueprints-v1/worker-thread-v1.ts';
+		globalThis['__WORKER_V1_URL__'] = './blueprints-v1/worker-thread-v1.ts';
 	}
 	if (typeof __WORKER_V2_URL__ === 'undefined') {
 		// Need to split the __WORKER_V2_URL__ string in two parts to avoid Vite replacing
 		// it with a string literal.
 		// @ts-expect-error
-		globalThis['__WORKER_' + 'V2_URL__'] =
-			'./blueprints-v2/worker-thread-v2.ts';
+		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
 	}
 	if (workerType === 'v1') {
 		if (process.env['VITEST'] && __WORKER_V1_URL__.startsWith('/src/')) {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -48,6 +48,12 @@ import { resolveBlueprint } from './resolve-blueprint';
 import { BlueprintsV2Handler } from './blueprints-v2/blueprints-v2-handler';
 import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
 import { startBridge } from '@php-wasm/xdebug-bridge';
+import path from 'path';
+
+// Inlined worker URLs for static analysis by downstream bundlers
+// These are replaced at build time by the Vite plugin in vite.config.ts
+declare const __WORKER_V1_URL__: string;
+declare const __WORKER_V2_URL__: string;
 
 export const LogVerbosity = {
 	Quiet: { name: 'quiet', severity: LogSeverity.Fatal },
@@ -56,6 +62,8 @@ export const LogVerbosity = {
 } as const;
 
 type LogVerbosity = (typeof LogVerbosity)[keyof typeof LogVerbosity]['name'];
+
+export type WorkerType = 'v1' | 'v2';
 
 export async function parseOptionsAndRunCLI() {
 	try {
@@ -554,8 +562,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 			// Kick off worker threads now to save time later.
 			// There is no need to wait for other async processes to complete.
 			const promisedWorkers = spawnWorkerThreads(
-				handler.getWorkerUrl(),
 				totalWorkerCount,
+				handler.getWorkerType(),
 				({ exitCode, isMain, workerIndex }) => {
 					if (exitCode === 0) {
 						return;
@@ -756,20 +764,18 @@ export type SpawnedWorker = {
 	worker: Worker;
 	phpPort: NodeMessagePort;
 };
-function spawnWorkerThreads(
-	workerUrlString: string,
+async function spawnWorkerThreads(
 	count: number,
+	workerType: WorkerType,
 	onWorkerExit: (options: {
 		exitCode: number;
 		isMain: boolean;
 		workerIndex: number;
 	}) => void
 ): Promise<SpawnedWorker[]> {
-	const moduleWorkerUrl = new URL(workerUrlString, import.meta.url);
-
 	const promises = [];
 	for (let i = 0; i < count; i++) {
-		const worker = new Worker(moduleWorkerUrl);
+		const worker = await spawnWorkerThread(workerType);
 		const onExit: (code: number) => void = (code: number) => {
 			onWorkerExit({
 				exitCode: code,
@@ -791,11 +797,10 @@ function spawnWorkerThreads(
 					worker.once('error', function (e: Error) {
 						console.error(e);
 						const error = new Error(
-							`Worker failed to load at ${moduleWorkerUrl}. ${
+							`Worker failed to load worker. ${
 								e.message ? `Original error: ${e.message}` : ''
 							}`
 						);
-						(error as any).filename = moduleWorkerUrl;
 						reject(error);
 					});
 					worker.once('exit', onExit);
@@ -804,6 +809,53 @@ function spawnWorkerThreads(
 		);
 	}
 	return Promise.all(promises);
+}
+
+/**
+ * A statically analyzable function that spawns a worker thread of a given type.
+ *
+ * **Important:** This function builds to code that has the worker URL hardcoded
+ * inline, e.g. `new Worker(new URL('./worker-thread-v1.js', import.meta.url))`.
+ * This allows the downstream consumers to statically analyze the code, recognize
+ * it uses workers, create new entrypoints, and rewrite the new Worker() calls.
+ *
+ * @param workerType
+ * @returns
+ */
+async function spawnWorkerThread(workerType: 'v1' | 'v2') {
+	if (workerType === 'v1') {
+		if (process.env['VITEST'] && __WORKER_V1_URL__.startsWith('/src/')) {
+			// Work around issue where Vitest cannot find the worker script.
+			return new Worker(
+				new URL(
+					path.join(
+						import.meta.dirname,
+						'..',
+						'..',
+						__WORKER_V1_URL__
+					),
+					import.meta.url
+				)
+			);
+		}
+		return new Worker(new URL(__WORKER_V1_URL__, import.meta.url));
+	} else {
+		if (process.env['VITEST'] && __WORKER_V2_URL__.startsWith('/src/')) {
+			// Work around issue where Vitest cannot find the worker script.
+			return new Worker(
+				new URL(
+					path.join(
+						import.meta.dirname,
+						'..',
+						'..',
+						__WORKER_V2_URL__
+					),
+					import.meta.url
+				)
+			);
+		}
+		return new Worker(new URL(__WORKER_V2_URL__, import.meta.url));
+	}
 }
 
 /**

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -829,12 +829,18 @@ async function spawnWorkerThread(workerType: 'v1' | 'v2') {
 	 * the correct paths.
 	 */
 	if (typeof __WORKER_V1_URL__ === 'undefined') {
+		// Need to split the __WORKER_V1_URL__ string in two parts to avoid Vite replacing
+		// it with a string literal.
 		// @ts-expect-error
-		globalThis['__WORKER_V1_URL__'] = './blueprints-v1/worker-thread-v1.ts';
+		globalThis['__WORKER_' + 'V1_URL__'] =
+			'./blueprints-v1/worker-thread-v1.ts';
 	}
 	if (typeof __WORKER_V2_URL__ === 'undefined') {
+		// Need to split the __WORKER_V2_URL__ string in two parts to avoid Vite replacing
+		// it with a string literal.
 		// @ts-expect-error
-		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
+		globalThis['__WORKER_' + 'V2_URL__'] =
+			'./blueprints-v2/worker-thread-v2.ts';
 	}
 	if (workerType === 'v1') {
 		if (process.env['VITEST'] && __WORKER_V1_URL__.startsWith('/src/')) {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -828,14 +828,10 @@ async function spawnWorkerThread(workerType: 'v1' | 'v2') {
 	 * the correct paths.
 	 */
 	if (typeof __WORKER_V1_URL__ === 'undefined') {
-		// Need to split the __WORKER_V1_URL__ string in two parts to avoid Vite replacing
-		// it with a string literal.
 		// @ts-expect-error
 		globalThis['__WORKER_V1_URL__'] = './blueprints-v1/worker-thread-v1.ts';
 	}
 	if (typeof __WORKER_V2_URL__ === 'undefined') {
-		// Need to split the __WORKER_V2_URL__ string in two parts to avoid Vite replacing
-		// it with a string literal.
 		// @ts-expect-error
 		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
 	}

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -48,7 +48,6 @@ import { resolveBlueprint } from './resolve-blueprint';
 import { BlueprintsV2Handler } from './blueprints-v2/blueprints-v2-handler';
 import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
 import { startBridge } from '@php-wasm/xdebug-bridge';
-import path from 'path';
 
 export const LogVerbosity = {
 	Quiet: { name: 'quiet', severity: LogSeverity.Fatal },

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -823,6 +823,19 @@ async function spawnWorkerThreads(
  * @returns
  */
 async function spawnWorkerThread(workerType: 'v1' | 'v2') {
+	/**
+	 * When running the CLI from source via `node cli.ts`, the Vite-provided
+	 * __WORKER_V1_URL__ and __WORKER_V2_URL__ are undefined. Let's set them to
+	 * the correct paths.
+	 */
+	if (typeof __WORKER_V1_URL__ === 'undefined') {
+		// @ts-expect-error
+		globalThis['__WORKER_V1_URL__'] = './blueprints-v1/worker-thread-v1.ts';
+	}
+	if (typeof __WORKER_V2_URL__ === 'undefined') {
+		// @ts-expect-error
+		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
+	}
 	if (workerType === 'v1') {
 		if (process.env['VITEST'] && __WORKER_V1_URL__.startsWith('/src/')) {
 			// Work around issue where Vitest cannot find the worker script.

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -51,7 +51,52 @@ const plugins = [
 	viteTsConfigPaths({
 		root: '../../../',
 	}),
-
+	/**
+	 * Inline worker URLs as string literals so downstream bundlers (e.g., webpack)
+	 * can statically analyze `new Worker(new URL('...'))`.
+	 *
+	 * We emit different extensions per output format:
+	 * - ES modules: .js
+	 * - CommonJS: .cjs
+	 */
+	{
+		name: 'inline-worker-url-literals',
+		renderChunk(code, _chunk, outputOptions) {
+			const format = (outputOptions as any).format as string | undefined;
+			const isCjs = format === 'cjs';
+			const v1 = isCjs
+				? './worker-thread-v1.cjs'
+				: './worker-thread-v1.js';
+			const v2 = isCjs
+				? './worker-thread-v2.cjs'
+				: './worker-thread-v2.js';
+			let transformed = code;
+			// Replace macro tokens if used
+			transformed = transformed
+				.split(/(?<!["'])__WORKER_V1_URL__(?!["'])/g)
+				.join(JSON.stringify(v1));
+			transformed = transformed
+				.split(/(?<!["'])__WORKER_V2_URL__(?!["'])/g)
+				.join(JSON.stringify(v2));
+			// Replace usages of imported worker URL strings inside new URL(...)
+			const patternV1 =
+				/new\s+URL\(\s*importedWorkerV1UrlString\s*,\s*import\.meta\.url\s*\)/g;
+			const patternV2 =
+				/new\s+URL\(\s*importedWorkerV2UrlString\s*,\s*import\.meta\.url\s*\)/g;
+			transformed = transformed.replace(
+				patternV1,
+				`new URL(${JSON.stringify(v1)}, import.meta.url)`
+			);
+			transformed = transformed.replace(
+				patternV2,
+				`new URL(${JSON.stringify(v2)}, import.meta.url)`
+			);
+			if (transformed !== code) {
+				return { code: transformed, map: null };
+			}
+			return null;
+		},
+	},
 	/**
 	 * In library mode, Vite bundles all `?url` imports as JS modules with a single,
 	 * base64 export. blueprints.phar is too large for that. We need to preserve it

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -51,52 +51,7 @@ const plugins = [
 	viteTsConfigPaths({
 		root: '../../../',
 	}),
-	/**
-	 * Inline worker URLs as string literals so downstream bundlers (e.g., webpack)
-	 * can statically analyze `new Worker(new URL('...'))`.
-	 *
-	 * We emit different extensions per output format:
-	 * - ES modules: .js
-	 * - CommonJS: .cjs
-	 */
-	{
-		name: 'inline-worker-url-literals',
-		renderChunk(code, _chunk, outputOptions) {
-			const format = (outputOptions as any).format as string | undefined;
-			const isCjs = format === 'cjs';
-			const v1 = isCjs
-				? './worker-thread-v1.cjs'
-				: './worker-thread-v1.js';
-			const v2 = isCjs
-				? './worker-thread-v2.cjs'
-				: './worker-thread-v2.js';
-			let transformed = code;
-			// Replace macro tokens if used
-			transformed = transformed
-				.split(/(?<!["'])__WORKER_V1_URL__(?!["'])/g)
-				.join(JSON.stringify(v1));
-			transformed = transformed
-				.split(/(?<!["'])__WORKER_V2_URL__(?!["'])/g)
-				.join(JSON.stringify(v2));
-			// Replace usages of imported worker URL strings inside new URL(...)
-			const patternV1 =
-				/new\s+URL\(\s*importedWorkerV1UrlString\s*,\s*import\.meta\.url\s*\)/g;
-			const patternV2 =
-				/new\s+URL\(\s*importedWorkerV2UrlString\s*,\s*import\.meta\.url\s*\)/g;
-			transformed = transformed.replace(
-				patternV1,
-				`new URL(${JSON.stringify(v1)}, import.meta.url)`
-			);
-			transformed = transformed.replace(
-				patternV2,
-				`new URL(${JSON.stringify(v2)}, import.meta.url)`
-			);
-			if (transformed !== code) {
-				return { code: transformed, map: null };
-			}
-			return null;
-		},
-	},
+
 	/**
 	 * In library mode, Vite bundles all `?url` imports as JS modules with a single,
 	 * base64 export. blueprints.phar is too large for that. We need to preserve it

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -52,6 +52,52 @@ const plugins = [
 		root: '../../../',
 	}),
 	/**
+	 * Inline worker URLs as string literals so downstream bundlers (e.g., webpack)
+	 * can statically analyze `new Worker(new URL('...'))`.
+	 *
+	 * We emit different extensions per output format:
+	 * - ES modules: .js
+	 * - CommonJS: .cjs
+	 */
+	{
+		name: 'inline-worker-url-literals',
+		renderChunk(code, _chunk, outputOptions) {
+			const format = (outputOptions as any).format as string | undefined;
+			const isCjs = format === 'cjs';
+			const v1 = isCjs
+				? './worker-thread-v1.cjs'
+				: './worker-thread-v1.js';
+			const v2 = isCjs
+				? './worker-thread-v2.cjs'
+				: './worker-thread-v2.js';
+			let transformed = code;
+			// Replace macro tokens if used
+			transformed = transformed
+				.split('__WORKER_V1_URL__')
+				.join(JSON.stringify(v1));
+			transformed = transformed
+				.split('__WORKER_V2_URL__')
+				.join(JSON.stringify(v2));
+			// Replace usages of imported worker URL strings inside new URL(...)
+			const patternV1 =
+				/new\s+URL\(\s*importedWorkerV1UrlString\s*,\s*import\.meta\.url\s*\)/g;
+			const patternV2 =
+				/new\s+URL\(\s*importedWorkerV2UrlString\s*,\s*import\.meta\.url\s*\)/g;
+			transformed = transformed.replace(
+				patternV1,
+				`new URL(${JSON.stringify(v1)}, import.meta.url)`
+			);
+			transformed = transformed.replace(
+				patternV2,
+				`new URL(${JSON.stringify(v2)}, import.meta.url)`
+			);
+			if (transformed !== code) {
+				return { code: transformed, map: null };
+			}
+			return null;
+		},
+	},
+	/**
 	 * In library mode, Vite bundles all `?url` imports as JS modules with a single,
 	 * base64 export. blueprints.phar is too large for that. We need to preserve it
 	 * as an actual file.

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -73,10 +73,10 @@ const plugins = [
 			let transformed = code;
 			// Replace macro tokens if used
 			transformed = transformed
-				.split('__WORKER_V1_URL__')
+				.split(/(?<!["'])__WORKER_V1_URL__(?!["'])/g)
 				.join(JSON.stringify(v1));
 			transformed = transformed
-				.split('__WORKER_V2_URL__')
+				.split(/(?<!["'])__WORKER_V2_URL__(?!["'])/g)
 				.join(JSON.stringify(v2));
 			// Replace usages of imported worker URL strings inside new URL(...)
 			const patternV1 =

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -29,8 +29,14 @@ SupportedPHPVersions.filter(
 		}, 30000);
 	});
 
+	/**
+	 * Very the built Playground packages ship worker files that have stable names.
+	 * This is important for downstream consumers that may need to statically declare
+	 * a separate entrypoint for each worker file. Including a hash in the filename,
+	 * e.g. `worker-thread-v1-af872f.cjs`, would break their build config on every
+	 * @wp-playground/cli release.
+	 */
 	it('Should include required worker thread files in CLI package', () => {
-		// Verify that the Playground CLI package ships with the required worker thread files
 		const requiredFiles = ['worker-thread-v1.cjs', 'worker-thread-v2.cjs'];
 
 		for (const file of requiredFiles) {

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { access } from 'node:fs/promises';
+import { access, readdir, readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
 import { runCLI } from '@wp-playground/cli';
 import type { SupportedPHPVersion } from '@php-wasm/universal';
 import { SupportedPHPVersions } from '@php-wasm/universal';
@@ -75,18 +76,28 @@ describe(`PHP ${phpVersion}`, () => {
 		// @TODO: Also verify this is wrapped in a new Worker() call.
 		const staticStrings = {
 			'worker-thread-v1.js':
-				'new URL("./worker-thread-v1.js", import.meta.url)',
+				'new URL("worker-thread-v1.js", import.meta.url)',
 			'worker-thread-v2.js':
-				'new URL("./worker-thread-v2.js", import.meta.url)',
+				'new URL("worker-thread-v2.js", import.meta.url)',
 		};
 		for (const file of Object.keys(staticStrings)) {
 			try {
 				// Resolve the file from the CLI package without importing it
 				const baseUrl = import.meta.resolve(`@wp-playground/cli`);
 				const url = new URL(file, baseUrl);
-				const path = fileURLToPath(url);
+				const moduleDir = dirname(fileURLToPath(url));
+				const runCliModuleNames = (await readdir(moduleDir)).filter(
+					(name) => /^run-cli-[^.]+\.js$/.test(name)
+				);
+				assert.equal(
+					runCliModuleNames.length,
+					1,
+					`Only one run-cli .js file should be found in ${moduleDir}`
+				);
+				const runCliPath = join(moduleDir, runCliModuleNames[0]);
+				const runCliModuleText = await readFile(runCliPath, 'utf8');
 				assert.ok(
-					staticStrings[file].includes(path),
+					runCliModuleText.includes(staticStrings[file]),
 					`Workers are not loaded in a statically analyzable way for ${file}`
 				);
 			} catch (error) {

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -39,8 +39,14 @@ describe(`PHP ${phpVersion}`, () => {
 		}
 	});
 
+	/**
+	 * Very the built Playground packages ship worker files that have stable names.
+	 * This is important for downstream consumers that may need to statically declare
+	 * a separate entrypoint for each worker file. Including a hash in the filename,
+	 * e.g. `worker-thread-v1-af872f.cjs`, would break their build config on every
+	 * @wp-playground/cli release.
+	 */
 	it('Should include required worker thread files in CLI package', async () => {
-		// Verify that the Playground CLI package ships with the required worker thread files
 		const requiredFiles = ['worker-thread-v1.js', 'worker-thread-v2.js'];
 
 		for (const file of requiredFiles) {
@@ -54,6 +60,31 @@ describe(`PHP ${phpVersion}`, () => {
 			} catch (error) {
 				assert.fail(
 					`Required file ${file} is missing from CLI package: ${error.message}`
+				);
+			}
+		}
+	});
+
+	it('Should have a new URL("./worker-thread-v1.js", import.meta.url) string', async () => {
+		const staticStrings = {
+			'worker-thread-v1.js':
+				'new URL("./worker-thread-v1.js", import.meta.url)',
+			'worker-thread-v2.js':
+				'new URL("./worker-thread-v2.js", import.meta.url)',
+		};
+		for (const file of Object.keys(staticStrings)) {
+			try {
+				// Resolve the file from the CLI package without importing it
+				const baseUrl = import.meta.resolve(`@wp-playground/cli`);
+				const url = new URL(file, baseUrl);
+				const path = fileURLToPath(url);
+				assert.ok(
+					staticStrings[file].includes(path),
+					`Static string for ${file} is not correct`
+				);
+			} catch (error) {
+				assert.fail(
+					`Static string for ${file} is not correct: ${error.message}`
 				);
 			}
 		}

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -76,9 +76,9 @@ describe(`PHP ${phpVersion}`, () => {
 		// @TODO: Also verify this is wrapped in a new Worker() call.
 		const staticStrings = {
 			'worker-thread-v1.js':
-				'new URL("worker-thread-v1.js", import.meta.url)',
+				'new URL("./worker-thread-v1.js", import.meta.url)',
 			'worker-thread-v2.js':
-				'new URL("worker-thread-v2.js", import.meta.url)',
+				'new URL("./worker-thread-v2.js", import.meta.url)',
 		};
 		for (const file of Object.keys(staticStrings)) {
 			try {

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -40,7 +40,7 @@ describe(`PHP ${phpVersion}`, () => {
 	});
 
 	/**
-	 * Very the built Playground packages ship worker files that have stable names.
+	 * Verify the built Playground packages ship worker files that have stable names.
 	 * This is important for downstream consumers that may need to statically declare
 	 * a separate entrypoint for each worker file. Including a hash in the filename,
 	 * e.g. `worker-thread-v1-af872f.cjs`, would break their build config on every
@@ -65,7 +65,14 @@ describe(`PHP ${phpVersion}`, () => {
 		}
 	});
 
-	it('Should have a new URL("./worker-thread-v1.js", import.meta.url) string', async () => {
+	/**
+	 * Verify the workers are loaded in a way that can be statically analyzed by
+	 * downstream bundlers. Without this, bundling an app relying on Playground CLI
+	 * is challenging as the consumer must handle detecting and chunking workers and
+	 * also rewrite their target URL.
+	 */
+	it('Should load workers using a new URL("./worker-thread-v1.js", import.meta.url) string', async () => {
+		// @TODO: Also verify this is wrapped in a new Worker() call.
 		const staticStrings = {
 			'worker-thread-v1.js':
 				'new URL("./worker-thread-v1.js", import.meta.url)',
@@ -80,11 +87,11 @@ describe(`PHP ${phpVersion}`, () => {
 				const path = fileURLToPath(url);
 				assert.ok(
 					staticStrings[file].includes(path),
-					`Static string for ${file} is not correct`
+					`Workers are not loaded in a statically analyzable way for ${file}`
 				);
 			} catch (error) {
 				assert.fail(
-					`Static string for ${file} is not correct: ${error.message}`
+					`Workers are not loaded in a statically analyzable way for ${file}: ${error.message}`
 				);
 			}
 		}


### PR DESCRIPTION
Refactors how worker threads are loaded in the Playground CLI to make worker URLs statically analyzable by downstream bundlers (such as webpack and Vite). This makes the `@wp-playground/cli` package easies to consume.

## Implementation details

### Worker thread loading and static analysis improvements:

* Replaces dynamic URL imports for worker threads in `blueprints-v1-handler.ts` and `blueprints-v2-handler.ts` with a new `getWorkerType()` method that returns just `"v1" | "v2"`;
* Refactors `run-cli.ts` to spawn workers with an inline `new Worker(new URL('./blueprints-v1-handler.ts', meta.import.url)); so that downstream bundlers can statically analyze it. The URL is injected with a vite plugin to avoid mangling the declaration during minification and other transforms.

## Testing Instructions (or ideally a Blueprint)

CI tests both built and unbuilt packages

cc @brandonpayton @akirk @wojtekn @bcotrim