### PR TITLE
Fix Playground CLI boot from native dirs on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,12 @@ jobs:
     test-playground-cli:
         strategy:
             matrix:
-                os: [ubuntu-latest, windows-latest, macos-latest]
+                # NOTE: macOS is currently skipped because tests were running into
+                # "EMFILE: too many open files" errors when running within the GH runner.
+                # It would be great to fix the issue and add macOS testing here.
+                # In the meantime, many of the current developers test locally on macOS.
+                # @TODO: Fix issues and re-enable macOS testing.
+                os: [ubuntu-latest, windows-latest]
         continue-on-error: true
         runs-on: ${{ matrix.os }}
         name: 'test-playground-cli (${{ matrix.os }})'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,8 @@ jobs:
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
-            - run: node node_modules/nx/bin/nx affected --target=test-for-node-22-and-above
+            # TODO: Before merge: Only pass --allowOnly for Windows.
+            - run: node node_modules/nx/bin/nx affected --target=test-for-node-22-and-above -- --allowOnly
     test-e2e:
         runs-on: ubuntu-latest
         # Run as root to allow node to bind to port 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,15 @@ jobs:
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
-            # TODO: Before merge: Only pass --allowOnly for Windows.
-            - run: node node_modules/nx/bin/nx affected --target=test-for-node-22-and-above -- --allowOnly
+            - name: Run full test suite
+              if: runner.os != 'windows-latest'
+              run: node node_modules/nx/bin/nx affected --target=test-for-node-22-and-above
+            # NOTE: We currently have to reduce the number of tests we run on Windows,
+            # and we do so by using Vitest's test.only() function. In order to use this
+            # within the `nx affected` command, we need to pass the Vitest arg --allowOnly.
+            - name: Run limited test suite on Windows
+              if: runner.os == 'windows-latest'
+              run: node node_modules/nx/bin/nx affected --target=test-for-node-22-and-above -- --allowOnly
     test-e2e:
         runs-on: ubuntu-latest
         # Run as root to allow node to bind to port 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
+        continue-on-error: true
         runs-on: ${{ matrix.os }}
         name: 'test-playground-cli (${{ matrix.os }})'
         steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,13 +141,13 @@ jobs:
               with:
                   node-version: 22
             - name: Run full test suite
-              if: runner.os != 'windows-latest'
+              if: runner.os != 'Windows'
               run: node node_modules/nx/bin/nx affected --target=test-for-node-22-and-above
             # NOTE: We currently have to reduce the number of tests we run on Windows,
             # and we do so by using Vitest's test.only() function. In order to use this
             # within the `nx affected` command, we need to pass the Vitest arg --allowOnly.
             - name: Run limited test suite on Windows
-              if: runner.os == 'windows-latest'
+              if: runner.os == 'Windows'
               run: node node_modules/nx/bin/nx affected --target=test-for-node-22-and-above -- --allowOnly
     test-e2e:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,11 @@ jobs:
                   MYSQL_USER: user
                   MYSQL_PASSWORD: password
     test-playground-cli:
-        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest, macos-latest]
+        runs-on: ${{ matrix.os }}
+        name: 'test-playground-cli (${{ matrix.os }})'
         steps:
             - uses: actions/checkout@v4
               with:

--- a/package.json
+++ b/package.json
@@ -194,7 +194,5 @@
 		"node": ">=20.18.3",
 		"npm": ">=10.1.0"
 	},
-	"optionalDependencies": {
-		"fs-ext": "2.1.1"
-	}
+	"optionalDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -194,5 +194,7 @@
 		"node": ">=20.18.3",
 		"npm": ">=10.1.0"
 	},
-	"optionalDependencies": {}
+	"optionalDependencies": {
+		"fs-ext": "2.1.1"
+	}
 }

--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -16,11 +16,9 @@ const tsconfig: TsConfig = JSON.parse(readFileSync(tsconfigPath, 'utf-8'));
 const pathAliases = tsconfig.compilerOptions.paths;
 const baseUrl = tsconfig.compilerOptions.baseUrl || '.';
 
-const playgroundPackageRoot = resolvePath(
-	import.meta.dirname,
-	'..',
-	'..',
-	'..'
+// Use a URL so we can compare more easily with file:// URLs during load.
+const playgroundPackageRootUrl = pathToFileURL(
+	resolvePath(import.meta.dirname, '..', '..', '..')
 );
 
 const aliasMap = new Map<string, URL>();
@@ -120,7 +118,9 @@ export async function resolve(
 		const resolvedImportPathUrl = pathToFileURL(resolvedImportPath);
 
 		// Restore any search params used for customizing module resolution.
-		resolvedImportPathUrl.search = specifierSearchParams;
+		if (specifierSearchParams !== undefined) {
+			resolvedImportPathUrl.search = specifierSearchParams;
+		}
 
 		specifier = resolvedImportPathUrl.href;
 	}
@@ -178,11 +178,11 @@ export async function load(
 	context: LoadContext,
 	nextLoad: LoaderNext
 ): Promise<LoadResult> {
-	const urlObj = new URL(url);
-
-	if (urlObj.protocol !== 'file:') {
+	if (!url.startsWith('file:/')) {
 		return nextLoad(url, context);
 	}
+
+	const urlObj = new URL(url);
 
 	if (context.format === 'url') {
 		urlObj.search = '';
@@ -198,7 +198,7 @@ export async function load(
 
 	if (context.format === 'raw') {
 		// Load raw file content
-		const content = readFileSync(urlObj.pathname, 'utf8');
+		const content = readFileSync(urlObj, 'utf8');
 		return {
 			format: 'module',
 			shortCircuit: true,
@@ -208,7 +208,7 @@ export async function load(
 
 	if (context.format === 'base64' || urlObj.searchParams.has('base64')) {
 		// Load binary file content and export as base64 string
-		const content = readFileSync(urlObj.pathname);
+		const content = readFileSync(urlObj);
 		const base64 = content.toString('base64');
 		return {
 			format: 'module',
@@ -220,7 +220,7 @@ export async function load(
 	}
 
 	if (context.format === 'json' || urlObj.pathname.endsWith('.json')) {
-		const source = readFileSync(urlObj.pathname, 'utf8');
+		const source = readFileSync(urlObj, 'utf8');
 		return {
 			format: 'json',
 			source,
@@ -230,7 +230,7 @@ export async function load(
 
 	const supportedModuleFormats = ['module', 'module-typescript'];
 	if (
-		urlObj.pathname.startsWith(playgroundPackageRoot) &&
+		urlObj.pathname.startsWith(playgroundPackageRootUrl.pathname) &&
 		supportedModuleFormats.includes(context.format!)
 	) {
 		const loadResult = await nextLoad(url, context);
@@ -246,7 +246,7 @@ export async function load(
 				/(?<!(?:const|var|let)\s*)\b__(dirname|filename)/g,
 				'import.meta.$1'
 			);
-			loadResult.source = Buffer.from(updatedSource, 'utf8');
+			loadResult.source = updatedSource;
 		}
 		return loadResult;
 	}

--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, lstatSync } from 'fs';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 import { join, resolve as resolvePath, dirname } from 'path';
 
 interface TsConfig {
@@ -23,12 +23,13 @@ const playgroundPackageRoot = resolvePath(
 	'..'
 );
 
-const aliasMap = new Map<string, string>();
+const aliasMap = new Map<string, URL>();
 for (const [alias, paths] of Object.entries(pathAliases)) {
 	// Our config is simple and doesn't use wildcards,
 	// so we can just use the first path
 	const resolvedPath = resolvePath(baseUrl, paths[0]);
-	aliasMap.set(alias, resolvedPath);
+	const resolvedPathUrl = pathToFileURL(resolvedPath);
+	aliasMap.set(alias, resolvedPathUrl);
 }
 
 interface ResolveContext {
@@ -52,17 +53,19 @@ export async function resolve(
 	) => Promise<ResolveResult>
 ): Promise<ResolveResult> {
 	// Resolve aliases to paths
-	for (const [alias, resolvedPath] of aliasMap.entries()) {
-		if (specifier === alias && resolvedPath.endsWith('.ts')) {
-			return nextResolve(resolvedPath, context);
+	for (const [alias, aliasTargetUrl] of aliasMap.entries()) {
+		if (specifier === alias && aliasTargetUrl.pathname.endsWith('.ts')) {
+			return nextResolve(aliasTargetUrl.href, context);
 		}
 
 		const aliasSubpathPrefix = `${alias}/`;
 		if (specifier.startsWith(aliasSubpathPrefix)) {
-			specifier = resolvePath(
-				resolvedPath,
+			const aliasTargetPath = fileURLToPath(aliasTargetUrl);
+			const resolvedPath = resolvePath(
+				aliasTargetPath,
 				`${specifier.slice(aliasSubpathPrefix.length)}`
 			);
+			specifier = pathToFileURL(resolvedPath).href;
 			break;
 		}
 	}

--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -103,20 +103,32 @@ export async function resolve(
 		context.parentURL &&
 		context.parentURL.startsWith('file://')
 	) {
+		const [specifierPath, specifierSearchParams] = specifier.split('?');
+
 		const moduleDoingRelativeImport = fileURLToPath(context.parentURL!);
 		const relativeImportBase = dirname(moduleDoingRelativeImport);
 
-		let resolvedImportPath = resolvePath(relativeImportBase, specifier);
-
+		let resolvedImportPath = resolvePath(relativeImportBase, specifierPath);
 		if (
 			existsSync(resolvedImportPath) &&
 			lstatSync(resolvedImportPath).isDirectory()
 		) {
 			// This is a directory. Let's try the index file.
-			specifier = join(resolvedImportPath, 'index');
-		} else {
-			specifier = resolvedImportPath;
+			resolvedImportPath = join(resolvedImportPath, 'index');
 		}
+
+		const resolvedImportPathUrl = pathToFileURL(resolvedImportPath);
+
+		// Restore any search params used for customizing module resolution.
+		resolvedImportPathUrl.search = specifierSearchParams;
+
+		specifier = resolvedImportPathUrl.href;
+	}
+
+	if (!specifier.startsWith('file://')) {
+		// We've resolved aliases and relative paths, so let's assume anything that is not a
+		// file:// URL is outside our codebase and should be handled by the default resolver.
+		return nextResolve(specifier, context);
 	}
 
 	const specifierUrl = new URL(specifier, 'file://');
@@ -132,13 +144,15 @@ export async function resolve(
 	}
 
 	for (const extension of possibleModuleExtensions) {
-		const candidateFilePath = `${specifier}${extension}`;
+		const specifierPath = fileURLToPath(specifier);
+		const candidateFilePath = `${specifierPath}${extension}`;
 
 		if (
 			existsSync(candidateFilePath) &&
 			lstatSync(candidateFilePath).isFile()
 		) {
-			return nextResolve(candidateFilePath, context);
+			specifier = pathToFileURL(candidateFilePath).href;
+			return nextResolve(specifier, context);
 		}
 	}
 

--- a/packages/php-wasm/node/src/test/file-lock-manager-for-node.spec.ts
+++ b/packages/php-wasm/node/src/test/file-lock-manager-for-node.spec.ts
@@ -3,6 +3,7 @@ import { FileLockManagerForNode } from '../lib/file-lock-manager-for-node';
 import { fork } from 'child_process';
 import type { ChildProcess } from 'child_process';
 import { join } from 'path';
+import os from 'os';
 import type {
 	FileLockManager,
 	WholeFileLockOp,
@@ -21,6 +22,9 @@ import { flockSync as nativeFlockSync } from 'fs-ext';
 
 const TEST_FILE1 = new URL('test1.txt', import.meta.url).pathname;
 const TEST_FILE2 = new URL('test2.txt', import.meta.url).pathname;
+
+// @TODO: Remove this condition once native file locking works with Windows.
+const shouldTestNativeLocking = os.platform() !== 'win32';
 
 describe('FileLockManagerForNode', () => {
 	let lockManager: FileLockManagerForNode;
@@ -1293,208 +1297,221 @@ describe('FileLockManagerForNode', () => {
 		});
 	});
 
-	describe('integration with native OS file locking', () => {
-		let childProcess: ChildProcess | undefined;
+	describe.runIf(shouldTestNativeLocking)(
+		'integration with native OS file locking',
+		() => {
+			let childProcess: ChildProcess | undefined;
 
-		afterEach(async () => {
-			if (childProcess) {
-				await killProcess(childProcess);
-				childProcess = undefined;
-			}
-		});
-
-		it('cannot acquire exclusive lock when native exclusive lock exists', async () => {
-			// Child process gets native exclusive lock
-			const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
-			expect(result1).toEqual({
-				success: true,
-				child: expect.any(Object),
+			afterEach(async () => {
+				if (childProcess) {
+					await killProcess(childProcess);
+					childProcess = undefined;
+				}
 			});
-			childProcess = result1.child;
 
-			// Try to get exclusive lock through lock manager
-			const result2 = lockManager.lockWholeFile(TEST_FILE1, {
-				type: 'exclusive',
-				pid: 1,
-				fd: 1,
-			});
-			expect(result2).toBe(false);
-		});
-
-		it('cannot acquire shared lock when native exclusive lock exists', async () => {
-			// Child process gets native exclusive lock
-			const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
-			expect(result1).toEqual({
-				success: true,
-				child: expect.any(Object),
-			});
-			childProcess = result1.child;
-
-			// Try to get shared lock through lock manager
-			const result2 = lockManager.lockWholeFile(TEST_FILE1, {
-				type: 'shared',
-				pid: 1,
-				fd: 1,
-			});
-			expect(result2).toBe(false);
-		});
-
-		it('can acquire shared lock when native shared lock exists', async () => {
-			// Child process gets native shared lock
-			const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
-			expect(result1).toEqual({
-				success: true,
-				child: expect.any(Object),
-			});
-			childProcess = result1.child;
-
-			// Try to get shared lock through lock manager
-			const result2 = lockManager.lockWholeFile(TEST_FILE1, {
-				type: 'shared',
-				pid: 1,
-				fd: 1,
-			});
-			expect(result2).toBe(true);
-		});
-
-		it('cannot acquire exclusive lock when native shared lock exists', async () => {
-			// Child process gets native shared lock
-			const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
-			expect(result1).toEqual({
-				success: true,
-				child: expect.any(Object),
-			});
-			childProcess = result1.child;
-
-			// Try to get exclusive lock through lock manager
-			const result2 = lockManager.lockWholeFile(TEST_FILE1, {
-				type: 'exclusive',
-				pid: 1,
-				fd: 1,
-			});
-			expect(result2).toBe(false);
-		});
-
-		it('cannot acquire exclusive range lock when native exclusive lock exists', async () => {
-			// Child process gets native exclusive lock
-			const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
-			expect(result1).toEqual({
-				success: true,
-				child: expect.any(Object),
-			});
-			childProcess = result1.child;
-
-			// Try to get exclusive range lock through lock manager
-			const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
-				type: 'exclusive',
-				start: 0n,
-				end: 100n,
-				pid: 1,
-			});
-			expect(result2).toBe(false);
-		});
-
-		it('cannot acquire shared range lock when native exclusive lock exists', async () => {
-			// Child process gets native exclusive lock
-			const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
-			expect(result1).toEqual({
-				success: true,
-				child: expect.any(Object),
-			});
-			childProcess = result1.child;
-
-			// Try to get shared range lock through lock manager
-			const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
-				type: 'shared',
-				start: 0n,
-				end: 100n,
-				pid: 1,
-			});
-			expect(result2).toBe(false);
-		});
-
-		it('can acquire shared range lock when native shared lock exists', async () => {
-			// Child process gets native shared lock
-			const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
-			expect(result1).toEqual({
-				success: true,
-				child: expect.any(Object),
-			});
-			childProcess = result1.child;
-
-			// Try to get shared range lock through lock manager
-			const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
-				type: 'shared',
-				start: 0n,
-				end: 100n,
-				pid: 1,
-			});
-			expect(result2).toBe(true);
-		});
-
-		it('cannot acquire exclusive range lock when native shared lock exists', async () => {
-			// Child process gets native shared lock
-			const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
-			expect(result1).toEqual({
-				success: true,
-				child: expect.any(Object),
-			});
-			childProcess = result1.child;
-
-			// Try to get exclusive range lock through lock manager
-			const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
-				type: 'exclusive',
-				start: 0n,
-				end: 100n,
-				pid: 1,
-			});
-			expect(result2).toBe(false);
-		});
-
-		// Helper function to spawn a child process that will attempt to acquire a lock
-		function spawnLockProcess(
-			filePath: string,
-			lockType: 'exclusive' | 'shared'
-		): Promise<{ success: boolean; error?: string; child?: ChildProcess }> {
-			return new Promise((resolve) => {
-				const child = fork(join(__dirname, 'file-lock-test-worker.js'));
-
-				child.on(
-					'message',
-					(message: {
-						type: 'success' | 'error';
-						fd?: number;
-						error?: string;
-					}) => {
-						if (message.type === 'success') {
-							resolve({ success: true, child });
-						} else {
-							resolve({
-								success: false,
-								error: message.error,
-								child,
-							});
-						}
-					}
-				);
-
-				child.on('error', (error) => {
-					resolve({ success: false, error: error.message, child });
+			it('cannot acquire exclusive lock when native exclusive lock exists', async () => {
+				// Child process gets native exclusive lock
+				const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
+				expect(result1).toEqual({
+					success: true,
+					child: expect.any(Object),
 				});
+				childProcess = result1.child;
 
-				child.send({ type: 'acquire', filePath, lockType });
+				// Try to get exclusive lock through lock manager
+				const result2 = lockManager.lockWholeFile(TEST_FILE1, {
+					type: 'exclusive',
+					pid: 1,
+					fd: 1,
+				});
+				expect(result2).toBe(false);
 			});
-		}
 
-		// Helper function to kill a process
-		async function killProcess(child: ChildProcess): Promise<void> {
-			return new Promise((resolve) => {
-				child.send({ type: 'release' });
-				// Give the process a moment to clean up
-				child.on('exit', resolve);
+			it('cannot acquire shared lock when native exclusive lock exists', async () => {
+				// Child process gets native exclusive lock
+				const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
+				expect(result1).toEqual({
+					success: true,
+					child: expect.any(Object),
+				});
+				childProcess = result1.child;
+
+				// Try to get shared lock through lock manager
+				const result2 = lockManager.lockWholeFile(TEST_FILE1, {
+					type: 'shared',
+					pid: 1,
+					fd: 1,
+				});
+				expect(result2).toBe(false);
 			});
+
+			it('can acquire shared lock when native shared lock exists', async () => {
+				// Child process gets native shared lock
+				const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
+				expect(result1).toEqual({
+					success: true,
+					child: expect.any(Object),
+				});
+				childProcess = result1.child;
+
+				// Try to get shared lock through lock manager
+				const result2 = lockManager.lockWholeFile(TEST_FILE1, {
+					type: 'shared',
+					pid: 1,
+					fd: 1,
+				});
+				expect(result2).toBe(true);
+			});
+
+			it('cannot acquire exclusive lock when native shared lock exists', async () => {
+				// Child process gets native shared lock
+				const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
+				expect(result1).toEqual({
+					success: true,
+					child: expect.any(Object),
+				});
+				childProcess = result1.child;
+
+				// Try to get exclusive lock through lock manager
+				const result2 = lockManager.lockWholeFile(TEST_FILE1, {
+					type: 'exclusive',
+					pid: 1,
+					fd: 1,
+				});
+				expect(result2).toBe(false);
+			});
+
+			it('cannot acquire exclusive range lock when native exclusive lock exists', async () => {
+				// Child process gets native exclusive lock
+				const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
+				expect(result1).toEqual({
+					success: true,
+					child: expect.any(Object),
+				});
+				childProcess = result1.child;
+
+				// Try to get exclusive range lock through lock manager
+				const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
+					type: 'exclusive',
+					start: 0n,
+					end: 100n,
+					pid: 1,
+				});
+				expect(result2).toBe(false);
+			});
+
+			it('cannot acquire shared range lock when native exclusive lock exists', async () => {
+				// Child process gets native exclusive lock
+				const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
+				expect(result1).toEqual({
+					success: true,
+					child: expect.any(Object),
+				});
+				childProcess = result1.child;
+
+				// Try to get shared range lock through lock manager
+				const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
+					type: 'shared',
+					start: 0n,
+					end: 100n,
+					pid: 1,
+				});
+				expect(result2).toBe(false);
+			});
+
+			it('can acquire shared range lock when native shared lock exists', async () => {
+				// Child process gets native shared lock
+				const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
+				expect(result1).toEqual({
+					success: true,
+					child: expect.any(Object),
+				});
+				childProcess = result1.child;
+
+				// Try to get shared range lock through lock manager
+				const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
+					type: 'shared',
+					start: 0n,
+					end: 100n,
+					pid: 1,
+				});
+				expect(result2).toBe(true);
+			});
+
+			it('cannot acquire exclusive range lock when native shared lock exists', async () => {
+				// Child process gets native shared lock
+				const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
+				expect(result1).toEqual({
+					success: true,
+					child: expect.any(Object),
+				});
+				childProcess = result1.child;
+
+				// Try to get exclusive range lock through lock manager
+				const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
+					type: 'exclusive',
+					start: 0n,
+					end: 100n,
+					pid: 1,
+				});
+				expect(result2).toBe(false);
+			});
+
+			// Helper function to spawn a child process that will attempt to acquire a lock
+			function spawnLockProcess(
+				filePath: string,
+				lockType: 'exclusive' | 'shared'
+			): Promise<{
+				success: boolean;
+				error?: string;
+				child?: ChildProcess;
+			}> {
+				return new Promise((resolve) => {
+					const child = fork(
+						join(__dirname, 'file-lock-test-worker.js')
+					);
+
+					child.on(
+						'message',
+						(message: {
+							type: 'success' | 'error';
+							fd?: number;
+							error?: string;
+						}) => {
+							if (message.type === 'success') {
+								resolve({ success: true, child });
+							} else {
+								resolve({
+									success: false,
+									error: message.error,
+									child,
+								});
+							}
+						}
+					);
+
+					child.on('error', (error) => {
+						resolve({
+							success: false,
+							error: error.message,
+							child,
+						});
+					});
+
+					child.send({ type: 'acquire', filePath, lockType });
+				});
+			}
+
+			// Helper function to kill a process
+			async function killProcess(child: ChildProcess): Promise<void> {
+				return new Promise((resolve) => {
+					child.send({ type: 'release' });
+					// Give the process a moment to clean up
+					child.on('exit', resolve);
+				});
+			}
 		}
-	});
+	);
 
 	const phpVersionsToTest =
 		'PHP' in process.env

--- a/packages/php-wasm/node/src/test/file-lock-manager-for-node.spec.ts
+++ b/packages/php-wasm/node/src/test/file-lock-manager-for-node.spec.ts
@@ -3,7 +3,6 @@ import { FileLockManagerForNode } from '../lib/file-lock-manager-for-node';
 import { fork } from 'child_process';
 import type { ChildProcess } from 'child_process';
 import { join } from 'path';
-import os from 'os';
 import type {
 	FileLockManager,
 	WholeFileLockOp,
@@ -22,9 +21,6 @@ import { flockSync as nativeFlockSync } from 'fs-ext';
 
 const TEST_FILE1 = new URL('test1.txt', import.meta.url).pathname;
 const TEST_FILE2 = new URL('test2.txt', import.meta.url).pathname;
-
-// @TODO: Remove this condition once native file locking works with Windows.
-const shouldTestNativeLocking = os.platform() !== 'win32';
 
 describe('FileLockManagerForNode', () => {
 	let lockManager: FileLockManagerForNode;
@@ -1297,221 +1293,208 @@ describe('FileLockManagerForNode', () => {
 		});
 	});
 
-	describe.runIf(shouldTestNativeLocking)(
-		'integration with native OS file locking',
-		() => {
-			let childProcess: ChildProcess | undefined;
+	describe('integration with native OS file locking', () => {
+		let childProcess: ChildProcess | undefined;
 
-			afterEach(async () => {
-				if (childProcess) {
-					await killProcess(childProcess);
-					childProcess = undefined;
-				}
+		afterEach(async () => {
+			if (childProcess) {
+				await killProcess(childProcess);
+				childProcess = undefined;
+			}
+		});
+
+		it('cannot acquire exclusive lock when native exclusive lock exists', async () => {
+			// Child process gets native exclusive lock
+			const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
+			expect(result1).toEqual({
+				success: true,
+				child: expect.any(Object),
 			});
+			childProcess = result1.child;
 
-			it('cannot acquire exclusive lock when native exclusive lock exists', async () => {
-				// Child process gets native exclusive lock
-				const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
-				expect(result1).toEqual({
-					success: true,
-					child: expect.any(Object),
-				});
-				childProcess = result1.child;
-
-				// Try to get exclusive lock through lock manager
-				const result2 = lockManager.lockWholeFile(TEST_FILE1, {
-					type: 'exclusive',
-					pid: 1,
-					fd: 1,
-				});
-				expect(result2).toBe(false);
+			// Try to get exclusive lock through lock manager
+			const result2 = lockManager.lockWholeFile(TEST_FILE1, {
+				type: 'exclusive',
+				pid: 1,
+				fd: 1,
 			});
+			expect(result2).toBe(false);
+		});
 
-			it('cannot acquire shared lock when native exclusive lock exists', async () => {
-				// Child process gets native exclusive lock
-				const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
-				expect(result1).toEqual({
-					success: true,
-					child: expect.any(Object),
-				});
-				childProcess = result1.child;
-
-				// Try to get shared lock through lock manager
-				const result2 = lockManager.lockWholeFile(TEST_FILE1, {
-					type: 'shared',
-					pid: 1,
-					fd: 1,
-				});
-				expect(result2).toBe(false);
+		it('cannot acquire shared lock when native exclusive lock exists', async () => {
+			// Child process gets native exclusive lock
+			const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
+			expect(result1).toEqual({
+				success: true,
+				child: expect.any(Object),
 			});
+			childProcess = result1.child;
 
-			it('can acquire shared lock when native shared lock exists', async () => {
-				// Child process gets native shared lock
-				const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
-				expect(result1).toEqual({
-					success: true,
-					child: expect.any(Object),
-				});
-				childProcess = result1.child;
-
-				// Try to get shared lock through lock manager
-				const result2 = lockManager.lockWholeFile(TEST_FILE1, {
-					type: 'shared',
-					pid: 1,
-					fd: 1,
-				});
-				expect(result2).toBe(true);
+			// Try to get shared lock through lock manager
+			const result2 = lockManager.lockWholeFile(TEST_FILE1, {
+				type: 'shared',
+				pid: 1,
+				fd: 1,
 			});
+			expect(result2).toBe(false);
+		});
 
-			it('cannot acquire exclusive lock when native shared lock exists', async () => {
-				// Child process gets native shared lock
-				const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
-				expect(result1).toEqual({
-					success: true,
-					child: expect.any(Object),
-				});
-				childProcess = result1.child;
-
-				// Try to get exclusive lock through lock manager
-				const result2 = lockManager.lockWholeFile(TEST_FILE1, {
-					type: 'exclusive',
-					pid: 1,
-					fd: 1,
-				});
-				expect(result2).toBe(false);
+		it('can acquire shared lock when native shared lock exists', async () => {
+			// Child process gets native shared lock
+			const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
+			expect(result1).toEqual({
+				success: true,
+				child: expect.any(Object),
 			});
+			childProcess = result1.child;
 
-			it('cannot acquire exclusive range lock when native exclusive lock exists', async () => {
-				// Child process gets native exclusive lock
-				const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
-				expect(result1).toEqual({
-					success: true,
-					child: expect.any(Object),
-				});
-				childProcess = result1.child;
-
-				// Try to get exclusive range lock through lock manager
-				const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
-					type: 'exclusive',
-					start: 0n,
-					end: 100n,
-					pid: 1,
-				});
-				expect(result2).toBe(false);
+			// Try to get shared lock through lock manager
+			const result2 = lockManager.lockWholeFile(TEST_FILE1, {
+				type: 'shared',
+				pid: 1,
+				fd: 1,
 			});
+			expect(result2).toBe(true);
+		});
 
-			it('cannot acquire shared range lock when native exclusive lock exists', async () => {
-				// Child process gets native exclusive lock
-				const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
-				expect(result1).toEqual({
-					success: true,
-					child: expect.any(Object),
-				});
-				childProcess = result1.child;
-
-				// Try to get shared range lock through lock manager
-				const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
-					type: 'shared',
-					start: 0n,
-					end: 100n,
-					pid: 1,
-				});
-				expect(result2).toBe(false);
+		it('cannot acquire exclusive lock when native shared lock exists', async () => {
+			// Child process gets native shared lock
+			const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
+			expect(result1).toEqual({
+				success: true,
+				child: expect.any(Object),
 			});
+			childProcess = result1.child;
 
-			it('can acquire shared range lock when native shared lock exists', async () => {
-				// Child process gets native shared lock
-				const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
-				expect(result1).toEqual({
-					success: true,
-					child: expect.any(Object),
-				});
-				childProcess = result1.child;
-
-				// Try to get shared range lock through lock manager
-				const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
-					type: 'shared',
-					start: 0n,
-					end: 100n,
-					pid: 1,
-				});
-				expect(result2).toBe(true);
+			// Try to get exclusive lock through lock manager
+			const result2 = lockManager.lockWholeFile(TEST_FILE1, {
+				type: 'exclusive',
+				pid: 1,
+				fd: 1,
 			});
+			expect(result2).toBe(false);
+		});
 
-			it('cannot acquire exclusive range lock when native shared lock exists', async () => {
-				// Child process gets native shared lock
-				const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
-				expect(result1).toEqual({
-					success: true,
-					child: expect.any(Object),
-				});
-				childProcess = result1.child;
-
-				// Try to get exclusive range lock through lock manager
-				const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
-					type: 'exclusive',
-					start: 0n,
-					end: 100n,
-					pid: 1,
-				});
-				expect(result2).toBe(false);
+		it('cannot acquire exclusive range lock when native exclusive lock exists', async () => {
+			// Child process gets native exclusive lock
+			const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
+			expect(result1).toEqual({
+				success: true,
+				child: expect.any(Object),
 			});
+			childProcess = result1.child;
 
-			// Helper function to spawn a child process that will attempt to acquire a lock
-			function spawnLockProcess(
-				filePath: string,
-				lockType: 'exclusive' | 'shared'
-			): Promise<{
-				success: boolean;
-				error?: string;
-				child?: ChildProcess;
-			}> {
-				return new Promise((resolve) => {
-					const child = fork(
-						join(__dirname, 'file-lock-test-worker.js')
-					);
+			// Try to get exclusive range lock through lock manager
+			const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
+				type: 'exclusive',
+				start: 0n,
+				end: 100n,
+				pid: 1,
+			});
+			expect(result2).toBe(false);
+		});
 
-					child.on(
-						'message',
-						(message: {
-							type: 'success' | 'error';
-							fd?: number;
-							error?: string;
-						}) => {
-							if (message.type === 'success') {
-								resolve({ success: true, child });
-							} else {
-								resolve({
-									success: false,
-									error: message.error,
-									child,
-								});
-							}
+		it('cannot acquire shared range lock when native exclusive lock exists', async () => {
+			// Child process gets native exclusive lock
+			const result1 = await spawnLockProcess(TEST_FILE1, 'exclusive');
+			expect(result1).toEqual({
+				success: true,
+				child: expect.any(Object),
+			});
+			childProcess = result1.child;
+
+			// Try to get shared range lock through lock manager
+			const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
+				type: 'shared',
+				start: 0n,
+				end: 100n,
+				pid: 1,
+			});
+			expect(result2).toBe(false);
+		});
+
+		it('can acquire shared range lock when native shared lock exists', async () => {
+			// Child process gets native shared lock
+			const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
+			expect(result1).toEqual({
+				success: true,
+				child: expect.any(Object),
+			});
+			childProcess = result1.child;
+
+			// Try to get shared range lock through lock manager
+			const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
+				type: 'shared',
+				start: 0n,
+				end: 100n,
+				pid: 1,
+			});
+			expect(result2).toBe(true);
+		});
+
+		it('cannot acquire exclusive range lock when native shared lock exists', async () => {
+			// Child process gets native shared lock
+			const result1 = await spawnLockProcess(TEST_FILE1, 'shared');
+			expect(result1).toEqual({
+				success: true,
+				child: expect.any(Object),
+			});
+			childProcess = result1.child;
+
+			// Try to get exclusive range lock through lock manager
+			const result2 = lockManager.lockFileByteRange(TEST_FILE1, {
+				type: 'exclusive',
+				start: 0n,
+				end: 100n,
+				pid: 1,
+			});
+			expect(result2).toBe(false);
+		});
+
+		// Helper function to spawn a child process that will attempt to acquire a lock
+		function spawnLockProcess(
+			filePath: string,
+			lockType: 'exclusive' | 'shared'
+		): Promise<{ success: boolean; error?: string; child?: ChildProcess }> {
+			return new Promise((resolve) => {
+				const child = fork(join(__dirname, 'file-lock-test-worker.js'));
+
+				child.on(
+					'message',
+					(message: {
+						type: 'success' | 'error';
+						fd?: number;
+						error?: string;
+					}) => {
+						if (message.type === 'success') {
+							resolve({ success: true, child });
+						} else {
+							resolve({
+								success: false,
+								error: message.error,
+								child,
+							});
 						}
-					);
+					}
+				);
 
-					child.on('error', (error) => {
-						resolve({
-							success: false,
-							error: error.message,
-							child,
-						});
-					});
-
-					child.send({ type: 'acquire', filePath, lockType });
+				child.on('error', (error) => {
+					resolve({ success: false, error: error.message, child });
 				});
-			}
 
-			// Helper function to kill a process
-			async function killProcess(child: ChildProcess): Promise<void> {
-				return new Promise((resolve) => {
-					child.send({ type: 'release' });
-					// Give the process a moment to clean up
-					child.on('exit', resolve);
-				});
-			}
+				child.send({ type: 'acquire', filePath, lockType });
+			});
 		}
-	);
+
+		// Helper function to kill a process
+		async function killProcess(child: ChildProcess): Promise<void> {
+			return new Promise((resolve) => {
+				child.send({ type: 'release' });
+				// Give the process a moment to clean up
+				child.on('exit', resolve);
+			});
+		}
+	});
 
 	const phpVersionsToTest =
 		'PHP' in process.env

--- a/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
+++ b/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
@@ -111,7 +111,7 @@ describe.each([true, false])(
 
 			expect(recreateRuntimeSpy).toHaveBeenCalledTimes(1);
 
-			// Confirm the local NODEFS mount is lost
+			// Confirm the local NODEFS mount is not lost
 			expect(php.readFileAsText('/test-root/file')).toBe('playground');
 		});
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -45,6 +45,7 @@ import { BlueprintsV2Handler } from './blueprints-v2/blueprints-v2-handler';
 import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
 import { startBridge } from '@php-wasm/xdebug-bridge';
 import path from 'path';
+import os from 'os';
 import {
 	cleanupStalePlaygroundTempDirs,
 	createPlaygroundCliTempDir,
@@ -495,16 +496,20 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 	// Declare file lock manager outside scope of startServer
 	// so we can look at it when debugging request handling.
-	const nativeFlockSync = await import('fs-ext')
-		.then((m) => m.flockSync)
-		.catch(() => {
-			logger.warn(
-				'The fs-ext package is not installed. ' +
-					'Internal file locking will not be integrated with ' +
-					'host OS file locking.'
-			);
-			return undefined;
-		});
+	const nativeFlockSync =
+		os.platform() === 'win32'
+			? // @TODO: Enable fs-ext here when it works with Windows.
+			  undefined
+			: await import('fs-ext')
+					.then((m) => m.flockSync)
+					.catch(() => {
+						logger.warn(
+							'The fs-ext package is not installed. ' +
+								'Internal file locking will not be integrated with ' +
+								'host OS file locking.'
+						);
+						return undefined;
+					});
 	const fileLockManager = new FileLockManagerForNode(nativeFlockSync);
 
 	let wordPressReady = false;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -495,9 +495,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 	// Declare file lock manager outside scope of startServer
 	// so we can look at it when debugging request handling.
-	// @TODO: Restore fs-ext npm dependency or equivalent when we can
-	// get it to work with Windows. In the meantime,
-	// the dependency has been removed from package.json.
 	const nativeFlockSync = await import('fs-ext')
 		.then((m) => m.flockSync)
 		.catch(() => {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -495,6 +495,9 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 	// Declare file lock manager outside scope of startServer
 	// so we can look at it when debugging request handling.
+	// @TODO: Restore fs-ext npm dependency or equivalent when we can
+	// get it to work with Windows. In the meantime,
+	// the dependency has been removed from package.json.
 	const nativeFlockSync = await import('fs-ext')
 		.then((m) => m.flockSync)
 		.catch(() => {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import os from 'node:os';
 import { runCLI } from '../src/run-cli';
 import type { RunCLIArgs, RunCLIServer } from '../src/run-cli';
 import type { MockInstance } from 'vitest';
@@ -483,51 +484,56 @@ describe.each(blueprintVersions)(
 				expect(response.text).toContain('Hello world');
 			});
 
-			test('should run a wordpress project using --auto-mount', async ({
-				skip,
-			}) => {
-				if (version === 2) {
-					// @TODO: Fix this test for Blueprints v2.
-					// It makes a valid complaint that the unzipped WP is not yet installed.
-					skip();
+			// NOTE: We have had trouble running the full test set on Windows
+			// due to Out of Memory errors. Until we debug and fix this,
+			// Let's pick this as the single test to run for Blueprints v1 and v2 on Windows
+			// because it integrates a good number of Playground CLI features.
+			(os.platform() === 'win32' ? test.only : test)(
+				'should run a wordpress project using --auto-mount',
+				async ({ skip }) => {
+					if (version === 2) {
+						// @TODO: Fix this test for Blueprints v2.
+						// It makes a valid complaint that the unzipped WP is not yet installed.
+						skip();
+					}
+
+					const tmpDir = await mkdtemp(
+						path.join(tmpdir(), 'playground-test-')
+					);
+					vi.spyOn(process, 'cwd').mockReturnValue(
+						path.join(tmpDir, 'wordpress')
+					);
+
+					const zip = await fetch('https://wordpress.org/latest.zip');
+					const zipPath = path.join(tmpDir, 'wp.zip');
+					await writeFile(
+						zipPath,
+						new Uint8Array(await zip.arrayBuffer())
+					);
+					await promisify(exec)(`unzip "${zipPath}" -d "${tmpDir}"`);
+
+					const checksum = await getDirectoryChecksum(tmpDir);
+
+					cliServer = await runCLI({
+						...suiteCliArgs,
+						command: 'server',
+						autoMount: '',
+					});
+					const response = await cliServer.playground.request({
+						url: '/',
+						method: 'GET',
+					});
+					expect(response.httpStatusCode).toBe(200);
+					expect(response.text).toContain(
+						`<title>${expectedHomePageTitle}</title>`
+					);
+
+					/**
+					 * Playground should not modify the mounted directory.
+					 */
+					expect(await getDirectoryChecksum(tmpDir)).toBe(checksum);
 				}
-
-				const tmpDir = await mkdtemp(
-					path.join(tmpdir(), 'playground-test-')
-				);
-				vi.spyOn(process, 'cwd').mockReturnValue(
-					path.join(tmpDir, 'wordpress')
-				);
-
-				const zip = await fetch('https://wordpress.org/latest.zip');
-				const zipPath = path.join(tmpDir, 'wp.zip');
-				await writeFile(
-					zipPath,
-					new Uint8Array(await zip.arrayBuffer())
-				);
-				await promisify(exec)(`unzip "${zipPath}" -d "${tmpDir}"`);
-
-				const checksum = await getDirectoryChecksum(tmpDir);
-
-				cliServer = await runCLI({
-					...suiteCliArgs,
-					command: 'server',
-					autoMount: '',
-				});
-				const response = await cliServer.playground.request({
-					url: '/',
-					method: 'GET',
-				});
-				expect(response.httpStatusCode).toBe(200);
-				expect(response.text).toContain(
-					`<title>${expectedHomePageTitle}</title>`
-				);
-
-				/**
-				 * Playground should not modify the mounted directory.
-				 */
-				expect(await getDirectoryChecksum(tmpDir)).toBe(checksum);
-			});
+			);
 		});
 
 		describe('verbosity', () => {

--- a/packages/playground/cli/vite.config.ts
+++ b/packages/playground/cli/vite.config.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest" />
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 import { type PluginOption, defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
@@ -219,10 +220,13 @@ export default defineConfig({
 					'--disable-warning=ExperimentalWarning',
 					// Use our own ESM loader to help resolve modules within the Worker script.
 					'--import',
-					join(
-						import.meta.dirname,
-						'../../meta/src/node-es-module-loader/register.mts'
-					),
+					// Convert path to file:// URL because it is required for running in Windows.
+					pathToFileURL(
+						join(
+							import.meta.dirname,
+							'../../meta/src/node-es-module-loader/register.mts'
+						)
+					).href,
 				],
 			},
 		},


### PR DESCRIPTION
## Motivation for the change, related issues

I began this PR to run the Playground CLI tests on Windows:
> It may be too much to run 100% of our unit tests on Windows in CI, but maybe we can run some integration tests for those supported platforms.

But once we started running those tests, we found a bug that prevented Playground CLI boot in Windows when mount a native `/wordpress` directory. Since #2446 landed, every Playground CLI instance mounts a native directory to `/wordress`. This is an important fix.

So this PR became a bug-fixing PR that also enables some Playground CLI tests for Windows.

## Implementation details

- Add an OS matrix to the test-playground-cli section of CI.yml
- Adjust our custom Node.js module loader to produce module specifiers that also work in Windows. This means preserving paths as file:// URLs. Our run-cli tests currently rely upon this loader, and it is good to make sure contributors on Windows can use the same commands to run unbuilt Playground CLI.
- Disabling use of `fs-ext` package for file locking in Windows because related "RESOURCE BUSY" errors were interfering with boot.

## Testing Instructions (or ideally a Blueprint)

- CI
