### PR TITLE
[WordPress] Separate bootWordPress() from bootRequestHandler()

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
@@ -8,13 +8,13 @@ import { activatePlugin } from './activate-plugin';
 import { phpVar } from '@php-wasm/util';
 import type { PHPRequestHandler } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 
 describe('Blueprint step activatePlugin()', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;
 	beforeEach(async () => {
-		handler = await bootWordPress({
+		handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',

--- a/packages/playground/blueprints/src/lib/steps/activate-theme.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.spec.ts
@@ -8,13 +8,13 @@ import {
 import { activateTheme } from './activate-theme';
 import { phpVar } from '@php-wasm/util';
 import type { PHPRequestHandler } from '@php-wasm/universal';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 
 describe('Blueprint step activateTheme()', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;
 	beforeEach(async () => {
-		handler = await bootWordPress({
+		handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.spec.ts
@@ -4,7 +4,7 @@ import {
 	getWordPressModule,
 } from '@wp-playground/wordpress-builds';
 import { enableMultisite } from './enable-multisite';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -14,7 +14,7 @@ import type { PHPRequest, PHPRequestHandler } from '@php-wasm/universal';
 describe('Blueprint step enableMultisite', () => {
 	let handler: PHPRequestHandler;
 	async function doBootWordPress(options: { absoluteUrl: string }) {
-		handler = await bootWordPress({
+		handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: options.absoluteUrl,

--- a/packages/playground/blueprints/src/lib/steps/import-theme-starter-content.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-theme-starter-content.spec.ts
@@ -6,14 +6,14 @@ import {
 } from '@wp-playground/wordpress-builds';
 import { importThemeStarterContent } from './import-theme-starter-content';
 import type { PHPRequestHandler } from '@php-wasm/universal';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
 
 describe('Blueprint step importThemeStarterContent', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;
 	beforeEach(async () => {
-		handler = await bootWordPress({
+		handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
@@ -8,7 +8,7 @@ import { importWxr } from './import-wxr';
 import { readFile } from 'fs/promises';
 import { installPlugin } from './install-plugin';
 import type { PHPRequestHandler } from '@php-wasm/universal';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { CorePluginResource } from '../v1/resources';
 import { resetData } from './reset-data';
@@ -60,7 +60,7 @@ describe('Blueprint step importWxr', () => {
 	});
 
 	beforeEach(async () => {
-		handler = await bootWordPress({
+		handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			// Simulate playground.wordpress.net URL scheme:

--- a/packages/playground/blueprints/src/lib/steps/login.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/login.spec.ts
@@ -6,7 +6,7 @@ import {
 } from '@wp-playground/wordpress-builds';
 import { login } from './login';
 import type { PHPRequestHandler } from '@php-wasm/universal';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { defineWpConfigConsts } from './define-wp-config-consts';
 import { joinPaths, phpVar } from '@php-wasm/util';
@@ -15,7 +15,7 @@ describe('Blueprint step login', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;
 	beforeEach(async () => {
-		handler = await bootWordPress({
+		handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',

--- a/packages/playground/blueprints/src/lib/steps/reset-data.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/reset-data.spec.ts
@@ -5,14 +5,14 @@ import {
 	getSqliteDriverModule,
 	getWordPressModule,
 } from '@wp-playground/wordpress-builds';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
 
 const docroot = '/php';
 describe('Blueprint step resetData()', () => {
 	let php: PHP;
 	beforeEach(async () => {
-		const handler = await bootWordPress({
+		const handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',

--- a/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
@@ -6,14 +6,14 @@ import {
 } from '@wp-playground/wordpress-builds';
 import { setSiteOptions } from './site-data';
 import type { PHPRequestHandler } from '@php-wasm/universal';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
 
 describe('Blueprint step setSiteOptions()', () => {
 	let php: PHP;
 	let handler: PHPRequestHandler;
 	beforeEach(async () => {
-		handler = await bootWordPress({
+		handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
@@ -6,7 +6,7 @@ import {
 	getSqliteDriverModule,
 	getWordPressModule,
 } from '@wp-playground/wordpress-builds';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 
@@ -15,7 +15,7 @@ describe('Blueprint step wpCLI', () => {
 	let php: PHP;
 
 	beforeEach(async () => {
-		const handler = await bootWordPress({
+		const handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () => await loadNodeRuntime(phpVersion),
 			siteUrl: 'http://playground-domain/',
 			sapiName: 'cli',

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -11,7 +11,10 @@ import {
 } from '@php-wasm/universal';
 import { sprintf } from '@php-wasm/util';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import { bootWordPress, bootRequestHandler } from '@wp-playground/wordpress';
+import {
+	bootRequestHandler,
+	bootWordPressAndRequestHandler,
+} from '@wp-playground/wordpress';
 import { rootCertificates } from 'tls';
 import { jspi } from 'wasm-feature-detect';
 import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
@@ -151,7 +154,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 					WP_DEBUG_DISPLAY: false,
 				};
 			let wordpressBooted = false;
-			const requestHandler = await bootWordPress({
+			const requestHandler = await bootWordPressAndRequestHandler({
 				siteUrl,
 				createPhpRuntime: async () => {
 					const processId = nextProcessId;

--- a/packages/playground/remote/src/lib/worker-thread.ts
+++ b/packages/playground/remote/src/lib/worker-thread.ts
@@ -49,7 +49,7 @@ import {
 	SupportedPHPVersionsList,
 } from '@php-wasm/universal';
 import {
-	bootWordPress,
+	bootWordPressAndRequestHandler,
 	getFileNotFoundActionForWordPress,
 	getLoadedWordPressVersion,
 } from '@wp-playground/wordpress';
@@ -346,7 +346,7 @@ export class PlaygroundWorkerEndpoint extends PHPWorker {
 				corsProxyUrl: corsProxyUrl,
 			});
 
-			const requestHandlerPromise = bootWordPress({
+			const requestHandlerPromise = bootWordPressAndRequestHandler({
 				siteUrl: setURLScope(wordPressSiteUrl, scope).toString(),
 				createPhpRuntime: async () => {
 					let wasmUrl = '';

--- a/packages/playground/sync/src/test/sql.spec.ts
+++ b/packages/playground/sync/src/test/sql.spec.ts
@@ -6,13 +6,13 @@ import {
 	getWordPressModule,
 } from '@wp-playground/wordpress-builds';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import { bootWordPress } from '@wp-playground/wordpress';
+import { bootWordPressAndRequestHandler } from '@wp-playground/wordpress';
 import { loadNodeRuntime } from '@php-wasm/node';
 
 describe('Sync tests', () => {
 	let php: PHP;
 	beforeEach(async () => {
-		const handler = await bootWordPress({
+		const handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -39,6 +39,14 @@ export type PHPInstanceCreatedHook = (
 
 export type DatabaseType = 'sqlite' | 'mysql' | 'custom';
 
+export async function bootWordPressAndRequestHandler(
+	options: BootRequestHandlerOptions & BootWordPressOptions
+) {
+	const requestHandler = await bootRequestHandler(options);
+	await bootWordPress(requestHandler, options);
+	return requestHandler;
+}
+
 export interface BootRequestHandlerOptions {
 	createPhpRuntime: (isPrimary?: boolean) => Promise<number>;
 	onPHPInstanceCreated?: PHPInstanceCreatedHook;
@@ -105,7 +113,7 @@ export interface BootRequestHandlerOptions {
 	cookieStore?: CookieStore | false;
 }
 
-export interface BootOptions extends BootRequestHandlerOptions {
+export interface BootWordPressOptions {
 	/**
 	 * Mounting and Copying is handled via hooks for starters.
 	 *
@@ -120,6 +128,15 @@ export interface BootOptions extends BootRequestHandlerOptions {
 	wordPressZip?: File | Promise<File> | undefined;
 	/** Preloaded SQLite integration plugin. */
 	sqliteIntegrationPluginZip?: File | Promise<File>;
+	/**
+	 * PHP constants to define for every request.
+	 */
+	constants?: Record<string, string | number | boolean | null>;
+	/**
+	 * URL to use as the site URL. This is used to set the WP_HOME
+	 * and WP_SITEURL constants in WordPress.
+	 */
+	siteUrl: string;
 }
 
 /**
@@ -137,9 +154,10 @@ export interface BootOptions extends BootRequestHandlerOptions {
  * @param options Boot configuration options
  * @return PHPRequestHandler instance with WordPress installed.
  */
-export async function bootWordPress(options: BootOptions) {
-	const requestHandler = await bootRequestHandler(options);
-
+export async function bootWordPress(
+	requestHandler: PHPRequestHandler,
+	options: BootWordPressOptions
+) {
 	const php = await requestHandler.getPrimaryPhp();
 	if (options.hooks?.beforeWordPressFiles) {
 		await options.hooks.beforeWordPressFiles(php);

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -5,6 +5,7 @@ import { logger } from '@php-wasm/logger';
 
 export {
 	bootWordPress,
+	bootWordPressAndRequestHandler,
 	bootRequestHandler,
 	getFileNotFoundActionForWordPress,
 } from './boot';

--- a/packages/playground/wordpress/src/test/database.spec.ts
+++ b/packages/playground/wordpress/src/test/database.spec.ts
@@ -7,7 +7,7 @@ import {
 import { mkdirSync, rmdirSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { bootWordPress } from '../boot';
+import { bootWordPressAndRequestHandler } from '../boot';
 import { getLoadedWordPressVersion } from '../version-detect';
 
 describe('Test database', () => {
@@ -37,7 +37,7 @@ describe('Test database', () => {
 
 	it("should not start WordPress when SQLite ZIP not specified, the SQLite driver directory doesn't exist and MySQL can't be used", async () => {
 		await expect(async () => {
-			await bootWordPress({
+			await bootWordPressAndRequestHandler({
 				createPhpRuntime: async () =>
 					await loadNodeRuntime(RecommendedPHPVersion),
 				siteUrl: 'http://playground-domain/',
@@ -48,7 +48,7 @@ describe('Test database', () => {
 	});
 
 	it('hould install WordPress when SQL data path specified, even without SQLite ZIP path or SQLite driver directory', async () => {
-		const handler = await bootWordPress({
+		const handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',
@@ -66,7 +66,7 @@ describe('Test database', () => {
 
 	it("should fail when the SQLite driver directory exists, but doesn't contain a valid driver", async () => {
 		await expect(async () => {
-			await bootWordPress({
+			await bootWordPressAndRequestHandler({
 				createPhpRuntime: async () =>
 					await loadNodeRuntime(RecommendedPHPVersion),
 				siteUrl: 'http://playground-domain/',

--- a/packages/playground/wordpress/src/test/http-request-host-is-external.spec.ts
+++ b/packages/playground/wordpress/src/test/http-request-host-is-external.spec.ts
@@ -1,6 +1,6 @@
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { loadNodeRuntime } from '@php-wasm/node';
-import { bootWordPress } from '../boot';
+import { bootWordPressAndRequestHandler } from '../boot';
 import {
 	getSqliteDriverModule,
 	getWordPressModule,
@@ -8,7 +8,7 @@ import {
 
 describe('http_request_host_is_external filter', () => {
 	it('returns true after WordPress boot', async () => {
-		const handler = await bootWordPress({
+		const handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',

--- a/packages/playground/wordpress/src/test/version-detect.spec.ts
+++ b/packages/playground/wordpress/src/test/version-detect.spec.ts
@@ -6,7 +6,7 @@ import {
 import { RecommendedPHPVersion } from '@wp-playground/common';
 // eslint-disable-next-line @nx/enforce-module-boundaries -- ignore circular package dep so @php-wasm/node can test with the WP file-not-found callback
 import { loadNodeRuntime } from '@php-wasm/node';
-import { bootWordPress } from '../boot';
+import { bootWordPressAndRequestHandler } from '../boot';
 import {
 	getLoadedWordPressVersion,
 	versionStringToLoadedWordPressVersion,
@@ -17,7 +17,7 @@ describe('Test WP version detection', async () => {
 		MinifiedWordPressVersions
 	)) {
 		it(`detects WP ${expectedWordPressVersion} at runtime`, async () => {
-			const handler = await bootWordPress({
+			const handler = await bootWordPressAndRequestHandler({
 				createPhpRuntime: async () =>
 					await loadNodeRuntime(RecommendedPHPVersion),
 				siteUrl: 'http://playground-domain/',
@@ -34,7 +34,7 @@ describe('Test WP version detection', async () => {
 	}
 
 	it('errors when unable to read version at runtime', async () => {
-		const handler = await bootWordPress({
+		const handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',
@@ -52,7 +52,7 @@ describe('Test WP version detection', async () => {
 	});
 
 	it('errors on reading empty version at runtime', async () => {
-		const handler = await bootWordPress({
+		const handler = await bootWordPressAndRequestHandler({
 			createPhpRuntime: async () =>
 				await loadNodeRuntime(RecommendedPHPVersion),
 			siteUrl: 'http://playground-domain/',


### PR DESCRIPTION
Adds the `requestHandler` argument to `bootWordPress()` to separate booting the request handler from booting WordPress. Exports a new `bootWordPressAndRequestHandler` function from the `@wp-playground/wordpress` package.

Sets the stage for #2586

 ## Testing instructions

CI
