### PR TITLE
Declare the correct Blueprints v2 types

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -49,8 +49,10 @@ export type {
 export * from './lib/steps';
 export * from './lib/steps/handlers';
 export type {
+	BlueprintV2,
+	BlueprintV2Declaration,
 	RawBlueprintV2Data,
-	ParsedBlueprintV2String,
+	ParsedBlueprintV1orV2String as ParsedBlueprintV2String,
 } from './lib/v2/blueprint-v2-declaration';
 export { getV2Runner } from './lib/v2/get-v2-runner';
 export { runBlueprintV2 } from './lib/v2/run-blueprint-v2';

--- a/packages/playground/blueprints/src/lib/types.ts
+++ b/packages/playground/blueprints/src/lib/types.ts
@@ -1,7 +1,9 @@
 import type { Filesystem } from '@wp-playground/storage';
-import type { V2Schema } from './v2/wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema';
 import type { BlueprintV1, BlueprintV1Declaration } from './v1/types';
-import type { RawBlueprintV2Data } from './v2/blueprint-v2-declaration';
+import type {
+	BlueprintV2,
+	BlueprintV2Declaration,
+} from './v2/blueprint-v2-declaration';
 
 /**
  * A filesystem structure containing a /blueprint.json file and any
@@ -9,5 +11,7 @@ import type { RawBlueprintV2Data } from './v2/blueprint-v2-declaration';
  */
 export type BlueprintBundle = Filesystem;
 
-export type BlueprintDeclaration = BlueprintV1Declaration | RawBlueprintV2Data;
-export type Blueprint = BlueprintV1 | V2Schema.BlueprintV2;
+export type BlueprintDeclaration =
+	| BlueprintV1Declaration
+	| BlueprintV2Declaration;
+export type Blueprint = BlueprintV1 | BlueprintV2;

--- a/packages/playground/blueprints/src/lib/v2/blueprint-v2-declaration.ts
+++ b/packages/playground/blueprints/src/lib/v2/blueprint-v2-declaration.ts
@@ -1,13 +1,23 @@
+import type { BlueprintBundle } from '../types';
 import type { BlueprintV1Declaration } from '../v1/types';
+import type { V2Schema } from './wep-1-blueprint-v2-schema/appendix-A-blueprint-v2-schema';
 
-export type RawBlueprintV2Data = string | BlueprintV1Declaration | undefined;
-export type ParsedBlueprintV2String =
+type BlueprintV2Declaration = V2Schema.BlueprintV2;
+export type BlueprintV2 = BlueprintV2Declaration | BlueprintBundle;
+
+export type { BlueprintV2Declaration };
+export type RawBlueprintV2Data = string | BlueprintV2Declaration | undefined;
+
+export type ParsedBlueprintV1orV2String =
 	| { type: 'inline-file'; contents: string }
 	| { type: 'file-reference'; reference: string };
 
 export function parseBlueprintDeclaration(
-	source: RawBlueprintV2Data | ParsedBlueprintV2String
-): ParsedBlueprintV2String {
+	source:
+		| RawBlueprintV2Data
+		| ParsedBlueprintV1orV2String
+		| BlueprintV1Declaration
+): ParsedBlueprintV1orV2String {
 	if (
 		typeof source === 'object' &&
 		'type' in source &&

--- a/packages/playground/blueprints/src/lib/v2/run-blueprint-v2.ts
+++ b/packages/playground/blueprints/src/lib/v2/run-blueprint-v2.ts
@@ -7,9 +7,10 @@ import { phpVar } from '@php-wasm/util';
 import { getV2Runner } from './get-v2-runner';
 import {
 	type RawBlueprintV2Data,
-	type ParsedBlueprintV2String,
+	type ParsedBlueprintV1orV2String,
 	parseBlueprintDeclaration,
 } from './blueprint-v2-declaration';
+import type { BlueprintV1Declaration } from '../v1/types';
 
 export type PHPExceptionDetails = {
 	exception: string;
@@ -32,7 +33,10 @@ export type BlueprintMessage =
 interface RunV2Options {
 	php: UniversalPHP;
 	cliArgs?: string[];
-	blueprint: RawBlueprintV2Data | ParsedBlueprintV2String;
+	blueprint:
+		| RawBlueprintV2Data
+		| ParsedBlueprintV1orV2String
+		| BlueprintV1Declaration;
 	blueprintOverrides?: {
 		wordpressVersion?: string;
 		additionalSteps?: any[];

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -21,6 +21,7 @@ import { sprintf } from '@php-wasm/util';
 import {
 	type BlueprintMessage,
 	runBlueprintV2,
+	type BlueprintV1Declaration,
 } from '@wp-playground/blueprints';
 import {
 	type ParsedBlueprintV2String,
@@ -122,13 +123,19 @@ export type PrimaryWorkerBootArgs = RunCLIArgs & {
 	firstProcessId: number;
 	processIdSpaceLength: number;
 	trace: boolean;
-	blueprint: RawBlueprintV2Data | ParsedBlueprintV2String;
+	blueprint:
+		| RawBlueprintV2Data
+		| ParsedBlueprintV2String
+		| BlueprintV1Declaration;
 	nativeInternalDirPath: string;
 };
 
 type WorkerRunBlueprintArgs = RunCLIArgs & {
 	siteUrl: string;
-	blueprint: RawBlueprintV2Data | ParsedBlueprintV2String;
+	blueprint:
+		| RawBlueprintV2Data
+		| ParsedBlueprintV2String
+		| BlueprintV1Declaration;
 };
 
 export type SecondaryWorkerBootArgs = {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -13,6 +13,7 @@ import {
 import type {
 	BlueprintBundle,
 	BlueprintV1Declaration,
+	BlueprintV2Declaration,
 } from '@wp-playground/blueprints';
 import { runBlueprintV1Steps } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
@@ -394,7 +395,10 @@ export async function parseOptionsAndRunCLI() {
 }
 
 export interface RunCLIArgs {
-	blueprint?: BlueprintV1Declaration | BlueprintBundle;
+	blueprint?:
+		| BlueprintV1Declaration
+		| BlueprintV2Declaration
+		| BlueprintBundle;
 	command: 'server' | 'run-blueprint' | 'build-snapshot';
 	debug?: boolean;
 	login?: boolean;


### PR DESCRIPTION
## Motivation for the change, related issues

Uses the actual Blueprint v2 type declarations from https://github.com/Automattic/WordPress-extension-proposals/blob/trunk/wep-1-blueprint-v2-schema/proposal.md instead of saying V2 schema is the same as V1 schema.

A part of #2586.

## Testing Instructions (or ideally a Blueprint)

CI.