### PR TITLE
[Client] Add noop experimentalBlueprintsV2Runner option

### DIFF
--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -43,6 +43,10 @@ export interface StartPlaygroundOptions {
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
 	blueprint?: BlueprintV1;
+	/**
+	 * Prefer experimental Blueprints v2 PHP runner instead of TypeScript steps
+	 */
+	experimentalBlueprintsV2Runner?: boolean;
 	onBlueprintStepCompleted?: OnStepCompleted;
 	onBlueprintValidated?: (blueprint: BlueprintV1Declaration) => void;
 	/**

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -17,22 +17,18 @@ import type { WebClientMixin } from './playground-client';
 import type { ProgressBarOptions } from './progress-bar';
 import ProgressBar from './progress-bar';
 
-// Avoid literal "import.meta.url" on purpose as vite would attempt
-// to resolve it during build time. This should specifically be
-// resolved by the browser at runtime to reflect the current origin.
-const origin = new URL('/', (import.meta || {}).url).origin;
-
-// @ts-ignore
-import workerV1Url from './playground-worker-endpoint-blueprints-v1.ts?worker&url';
-
-export const workerUrl: string = new URL(workerV1Url, origin) + '';
-
 // @ts-ignore
 import serviceWorkerPath from '../../service-worker.ts?worker&url';
 import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { logger } from '@php-wasm/logger';
 import { PhpWasmError } from '@php-wasm/util';
 import { responseTo } from '@php-wasm/web-service-worker';
+
+// Avoid literal "import.meta.url" on purpose as vite would attempt
+// to resolve it during build time. This should specifically be
+// resolved by the browser at runtime to reflect the current origin.
+const origin = new URL('/', (import.meta || {}).url).origin;
+
 export const serviceWorkerUrl = new URL(serviceWorkerPath, origin);
 
 // Prevent Vite from hot-reloading this file – it would
@@ -91,6 +87,12 @@ export async function bootPlaygroundRemote() {
 		// functional service worker at this point because sw.register() succeeded.
 		logger.error('Failed to update service worker.', e);
 	}
+
+	const workerV1Url = await import(
+		// @ts-ignore
+		'./playground-worker-endpoint-blueprints-v1.ts?worker&url'
+	);
+	const workerUrl = new URL(workerV1Url, origin) + '';
 
 	const phpWorkerApi = consumeAPI<PlaygroundWorkerEndpoint>(
 		await spawnPHPWorkerThread(workerUrl)

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -88,11 +88,12 @@ export async function bootPlaygroundRemote() {
 		logger.error('Failed to update service worker.', e);
 	}
 
+	// @ts-ignore
 	const workerV1Url = await import(
 		// @ts-ignore
 		'./playground-worker-endpoint-blueprints-v1.ts?worker&url'
 	);
-	const workerUrl = new URL(workerV1Url, origin) + '';
+	const workerUrl = new URL(workerV1Url as any, origin) + '';
 
 	const phpWorkerApi = consumeAPI<PlaygroundWorkerEndpoint>(
 		await spawnPHPWorkerThread(workerUrl)

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -109,6 +109,11 @@ export function bootSiteClient(
 				remoteUrl: getRemoteUrl().toString(),
 				scope: site.slug,
 				blueprint,
+				experimentalBlueprintsV2Runner:
+					!isWordPressInstalled &&
+					new URLSearchParams(window.location.search).get(
+						'experimental-blueprints-v2-runner'
+					) === 'yes',
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playground) => {


### PR DESCRIPTION
## Motivation for the change, related issues

A part of #2586. This PR adds an option called `experimentalBlueprintsV2Runner` to `startPlaygroundWeb()`. The option does nothing at the moment. A follow-up PR will make use of it to choose the relevant worker implementation.

## Testing Instructions (or ideally a Blueprint)

CI