### PR TITLE
[Client] Expose Blueprints v2 runner via a feature flag

### DIFF
--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -36,6 +36,7 @@ import { additionalRemoteOrigins } from './additional-remote-origins';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { remoteDevServerHost, remoteDevServerPort } from '../../build-config';
 import { BlueprintsV1Handler } from './blueprints-v1-handler';
+import { BlueprintsV2Handler } from './blueprints-v2-handler';
 
 export interface StartPlaygroundOptions {
 	iframe: HTMLIFrameElement;
@@ -112,6 +113,9 @@ export async function startPlaygroundWeb(
 
 	remoteUrl = setQueryParams(remoteUrl, {
 		progressbar: !disableProgressBar,
+		'blueprints-runner': options.experimentalBlueprintsV2Runner
+			? 'v2'
+			: 'v1',
 	});
 	progressTracker.setCaption('Preparing WordPress');
 
@@ -120,7 +124,9 @@ export async function startPlaygroundWeb(
 		iframe.addEventListener('load', resolve, false);
 	});
 
-	const handler = new BlueprintsV1Handler(options);
+	const handler = options.experimentalBlueprintsV2Runner
+		? new BlueprintsV2Handler(options)
+		: new BlueprintsV1Handler(options);
 	const playground = await handler.bootPlayground(iframe, progressTracker);
 
 	progressTracker.finish();

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -43,6 +43,10 @@ export interface StartPlaygroundOptions {
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
 	blueprint?: BlueprintV1;
+	/**
+	 * Prefer experimental Blueprints v2 PHP runner instead of TypeScript steps
+	 */
+	experimentalBlueprintsV2Runner?: boolean;
 	onBlueprintStepCompleted?: OnStepCompleted;
 	onBlueprintValidated?: (blueprint: BlueprintV1Declaration) => void;
 	/**

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -17,22 +17,18 @@ import type { WebClientMixin } from './playground-client';
 import type { ProgressBarOptions } from './progress-bar';
 import ProgressBar from './progress-bar';
 
-// Avoid literal "import.meta.url" on purpose as vite would attempt
-// to resolve it during build time. This should specifically be
-// resolved by the browser at runtime to reflect the current origin.
-const origin = new URL('/', (import.meta || {}).url).origin;
-
-// @ts-ignore
-import workerV1Url from './playground-worker-endpoint-blueprints-v1.ts?worker&url';
-
-export const workerUrl: string = new URL(workerV1Url, origin) + '';
-
 // @ts-ignore
 import serviceWorkerPath from '../../service-worker.ts?worker&url';
 import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { logger } from '@php-wasm/logger';
 import { PhpWasmError } from '@php-wasm/util';
 import { responseTo } from '@php-wasm/web-service-worker';
+
+// Avoid literal "import.meta.url" on purpose as vite would attempt
+// to resolve it during build time. This should specifically be
+// resolved by the browser at runtime to reflect the current origin.
+const origin = new URL('/', (import.meta || {}).url).origin;
+
 export const serviceWorkerUrl = new URL(serviceWorkerPath, origin);
 
 // Prevent Vite from hot-reloading this file – it would
@@ -91,6 +87,12 @@ export async function bootPlaygroundRemote() {
 		// functional service worker at this point because sw.register() succeeded.
 		logger.error('Failed to update service worker.', e);
 	}
+
+	const workerV1Url = await import(
+		// @ts-ignore
+		'./playground-worker-endpoint-blueprints-v1.ts?worker&url'
+	);
+	const workerUrl = new URL(workerV1Url, origin) + '';
 
 	const phpWorkerApi = consumeAPI<PlaygroundWorkerEndpoint>(
 		await spawnPHPWorkerThread(workerUrl)

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -24,10 +24,23 @@ import { logger } from '@php-wasm/logger';
 import { PhpWasmError } from '@php-wasm/util';
 import { responseTo } from '@php-wasm/web-service-worker';
 
+// Select worker runtime (v1 or v2) based on query parameter
+// @ts-ignore
+import workerV1Url from './playground-worker-endpoint-blueprints-v1.ts?worker&url';
+// @ts-ignore
+import workerV2Url from './playground-worker-endpoint-blueprints-v2.ts?worker&url';
+
 // Avoid literal "import.meta.url" on purpose as vite would attempt
 // to resolve it during build time. This should specifically be
 // resolved by the browser at runtime to reflect the current origin.
 const origin = new URL('/', (import.meta || {}).url).origin;
+
+function getWorkerUrl(): string {
+	const runner = new URL(document.location.href).searchParams.get('blueprints-runner');
+	const isV2 = runner === 'v2';
+	const selected = isV2 ? workerV2Url : workerV1Url;
+	return new URL(selected, origin) + '';
+}
 
 export const serviceWorkerUrl = new URL(serviceWorkerPath, origin);
 
@@ -88,12 +101,7 @@ export async function bootPlaygroundRemote() {
 		logger.error('Failed to update service worker.', e);
 	}
 
-	// @ts-ignore
-	const workerV1Url = await import(
-		// @ts-ignore
-		'./playground-worker-endpoint-blueprints-v1.ts?worker&url'
-	);
-	const workerUrl = new URL(workerV1Url as any, origin) + '';
+	const workerUrl = new URL(getWorkerUrl(), origin) + '';
 
 	const phpWorkerApi = consumeAPI<PlaygroundWorkerEndpoint>(
 		await spawnPHPWorkerThread(workerUrl)

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -88,11 +88,12 @@ export async function bootPlaygroundRemote() {
 		logger.error('Failed to update service worker.', e);
 	}
 
+	// @ts-ignore
 	const workerV1Url = await import(
 		// @ts-ignore
 		'./playground-worker-endpoint-blueprints-v1.ts?worker&url'
 	);
-	const workerUrl = new URL(workerV1Url, origin) + '';
+	const workerUrl = new URL(workerV1Url as any, origin) + '';
 
 	const phpWorkerApi = consumeAPI<PlaygroundWorkerEndpoint>(
 		await spawnPHPWorkerThread(workerUrl)

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -109,6 +109,11 @@ export function bootSiteClient(
 				remoteUrl: getRemoteUrl().toString(),
 				scope: site.slug,
 				blueprint,
+				experimentalBlueprintsV2Runner:
+					!isWordPressInstalled &&
+					new URLSearchParams(window.location.search).get(
+						'experimental-blueprints-v2-runner'
+					) === 'yes',
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playground) => {


### PR DESCRIPTION
## Motivation for the change, related issues

Exposes the Blueprints v2 data flows via a `?experimental-blueprints-v2-runner=yes` query API arg. Blueprints v2 won't actually execute yet. This PR only allows triggering the boot flow. For a functional Blueprint v2 execution, we'll need a few more PRs.

## Testing Instructions (or ideally a Blueprint)

Go to this URL and confirm you're getting an error "Invalid blueprint: must NOT have additional properties at ":

```
http://127.0.0.1:5400/website-server/?experimental-blueprints-v2-runner=yes&php=8.3#{%22version%22:2}
```
