### PR TITLE
[Website] Flatten the stored runtime configuration format

### DIFF
--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	BlueprintV1,
 	BlueprintV1Declaration,
 	PHPConstants,
+	ExtraLibrary,
 } from './lib/v1/types';
 export type {
 	Blueprint,

--- a/packages/playground/website/src/components/site-manager/site-settings-form/stored-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/stored-site-settings-form.tsx
@@ -33,15 +33,8 @@ export function StoredSiteSettingsForm({
 				changes: {
 					runtimeConfiguration: {
 						...siteInfo.metadata.runtimeConfiguration,
-						features: {
-							...siteInfo.metadata.runtimeConfiguration.features,
-							networking: data.withNetworking,
-						},
-						preferredVersions: {
-							...siteInfo.metadata.runtimeConfiguration
-								.preferredVersions,
-							php: data.phpVersion,
-						},
+						phpVersion: data.phpVersion,
+						networking: data.withNetworking,
 					},
 				},
 			})
@@ -54,10 +47,9 @@ export function StoredSiteSettingsForm({
 		() => ({
 			name: siteInfo.metadata.name,
 			// @TODO: Handle an unsupported PHP version coming up here
-			phpVersion: siteInfo.metadata.runtimeConfiguration.preferredVersions
-				.php as any,
-			withNetworking:
-				!!siteInfo.metadata.runtimeConfiguration.features.networking,
+			phpVersion: siteInfo.metadata.runtimeConfiguration
+				.phpVersion as any,
+			withNetworking: !!siteInfo.metadata.runtimeConfiguration.networking,
 		}),
 		[siteInfo]
 	);

--- a/packages/playground/website/src/components/site-manager/site-settings-form/temporary-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/temporary-site-settings-form.tsx
@@ -38,9 +38,9 @@ export function TemporarySiteSettingsForm({
 		const searchParams = siteInfo.originalUrlParams?.searchParams || {};
 		const runtimeConf = siteInfo.metadata?.runtimeConfiguration || {};
 		return {
-			phpVersion: runtimeConf?.preferredVersions?.php as any,
-			wpVersion: runtimeConf?.preferredVersions?.wp as any,
-			withNetworking: runtimeConf?.features?.networking,
+			phpVersion: runtimeConf?.phpVersion as any,
+			wpVersion: runtimeConf?.wpVersion as any,
+			withNetworking: runtimeConf?.networking,
 			language: 'language' in searchParams ? searchParams.language : '',
 			multisite:
 				'multisite' in searchParams

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -10,7 +10,13 @@ import type { SiteMetadata } from '../redux/slice-sites';
 import type { SiteInfo } from '../redux/slice-sites';
 import { joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
-import { getBlueprintDeclaration } from '@wp-playground/blueprints';
+import {
+	type ExtraLibrary,
+	type PHPConstants,
+	getBlueprintDeclaration,
+} from '@wp-playground/blueprints';
+import type { SupportedPHPVersion } from '@php-wasm/universal';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
 const ROOT_PATH = '/sites';
 // TODO: Decide on metadata filename
@@ -165,6 +171,53 @@ async function metadataToStoredFormat(
 
 function storedFormatToMetadata(data: string) {
 	const { slug, ...metadata } = JSON.parse(data) as StoredSiteMetadata;
+
+	/**
+	 * Migrate the legacy runtimeConfiguration data format to the new, flat one.
+	 */
+	if ('preferredVersions' in metadata.runtimeConfiguration) {
+		const legacyConfig = metadata.runtimeConfiguration as {
+			/**
+			 * The preferred PHP and WordPress versions to use.
+			 */
+			preferredVersions?: {
+				/**
+				 * The preferred PHP version to use.
+				 * If not specified, the latest supported version will be used
+				 */
+				php: SupportedPHPVersion | 'latest';
+				/**
+				 * The preferred WordPress version to use.
+				 * If not specified, the latest supported version will be used
+				 */
+				wp: string | 'latest';
+			};
+			features?: {
+				intl?: boolean;
+				/** Should boot with support for network request via wp_safe_remote_get? */
+				networking?: boolean;
+			};
+			/**
+			 * Extra libraries to preload into the Playground instance.
+			 */
+			extraLibraries?: ExtraLibrary[];
+			/**
+			 * PHP Constants to define on every request
+			 */
+			constants?: PHPConstants;
+		};
+
+		metadata.runtimeConfiguration = {
+			phpVersion:
+				(legacyConfig.preferredVersions?.php as SupportedPHPVersion) ??
+				RecommendedPHPVersion,
+			wpVersion: legacyConfig.preferredVersions?.wp ?? 'latest',
+			intl: legacyConfig.features?.intl ?? false,
+			networking: legacyConfig.features?.networking ?? true,
+			extraLibraries: legacyConfig.extraLibraries as any[],
+			constants: legacyConfig.constants ?? {},
+		};
+	}
 
 	return {
 		slug,

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -97,7 +97,19 @@ export function bootSiteClient(
 
 		let blueprint: Blueprint;
 		if (isWordPressInstalled) {
-			blueprint = site.metadata.runtimeConfiguration!;
+			blueprint = {
+				preferredVersions: {
+					php: site.metadata.runtimeConfiguration.phpVersion,
+					wp: site.metadata.runtimeConfiguration.wpVersion,
+				},
+				features: {
+					intl: site.metadata.runtimeConfiguration.intl,
+					networking: site.metadata.runtimeConfiguration.networking,
+				},
+				extraLibraries: site.metadata.runtimeConfiguration
+					.extraLibraries as any[],
+				constants: site.metadata.runtimeConfiguration.constants,
+			};
 		} else {
 			blueprint = site.metadata.originalBlueprint;
 		}

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -9,9 +9,9 @@ import { selectActiveSite, setActiveSite } from './store';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
 import {
 	type BlueprintV1,
-	type BlueprintV1Declaration,
-	type PHPConstants,
 	compileBlueprintV1,
+	type PHPConstants,
+	type ExtraLibrary,
 } from '@wp-playground/blueprints';
 import {
 	type BlueprintSource,
@@ -20,6 +20,7 @@ import {
 	applyQueryOverrides,
 } from '../url/resolve-blueprint-from-url';
 import { logger } from '@php-wasm/logger';
+import type { SupportedPHPVersion } from '@php-wasm/universal';
 
 /**
  * The Site model used to represent a site within Playground.
@@ -316,11 +317,10 @@ export function setTemporarySiteSpec(
 				originalBlueprintSource: resolvedBlueprint.source!,
 
 				runtimeConfiguration: {
-					preferredVersions: {
-						wp: compiledBlueprint.versions.wp,
-						php: compiledBlueprint.versions.php,
-					},
-					features: compiledBlueprint.features,
+					wpVersion: compiledBlueprint.versions.wp,
+					phpVersion: compiledBlueprint.versions.php,
+					intl: compiledBlueprint.features.intl,
+					networking: compiledBlueprint.features.networking,
 					extraLibraries: compiledBlueprint.extraLibraries,
 					/*
 					 * Constants don't matter so much for temporary sites so let's
@@ -388,14 +388,18 @@ export interface SiteMetadata {
 	//whenLastLoaded: number;
 
 	// @TODO: Accept any string as a php version?
-	runtimeConfiguration: Pick<
-		Required<BlueprintV1Declaration>,
-		'features' | 'extraLibraries' | 'preferredVersions'
-	> & {
-		constants?: PHPConstants;
-	};
+	runtimeConfiguration: RuntimeConfiguration;
 	originalBlueprint: BlueprintV1;
 	originalBlueprintSource: BlueprintSource;
+}
+
+export interface RuntimeConfiguration {
+	phpVersion: SupportedPHPVersion;
+	wpVersion: string;
+	intl: boolean;
+	networking: boolean;
+	extraLibraries: ExtraLibrary[];
+	constants: PHPConstants;
 }
 
 export const { setOPFSSitesLoadingState } = sitesSlice.actions;


### PR DESCRIPTION
## What does this PR change?

Flattens the `RuntimeConfiguration` type used by the Playground website from the previous, nested shape:

```ts
{
	preferredVersions?: {
		php: SupportedPHPVersion | 'latest';
		wp: string | 'latest';
	};
	features?: {
		intl?: boolean;
		networking?: boolean;
	};
	extraLibraries?: ExtraLibrary[];
	constants?: PHPConstants;
}
```

to

```ts
export interface RuntimeConfiguration {
	phpVersion: SupportedPHPVersion;
	wpVersion: string;
	intl: boolean;
	networking: boolean;
	extraLibraries: ExtraLibrary[];
	constants: PHPConstants;
}
```

## Why?

The old configuration format is a subset of Blueprint v1 type. Since we're adding support for Blueprints v2, we need a format that will be convenient regardless of the underlying Blueprint version. The nesting made interop more difficult, hence I've flattened the data structure. 

A part of https://github.com/WordPress/wordpress-playground/pull/2586.

## Testing Instructions (or ideally a Blueprint)

CI