### PR TITLE
[PHP Worker] listen to all PHP instances events via worker.addEventListener()

### DIFF
--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -10,7 +10,7 @@ interface TsConfig {
 }
 
 // Read and parse tsconfig.base.json
-const workspaceRoot = join(import.meta.dirname, '..', '..', '..');
+const workspaceRoot = join(import.meta.dirname, '..', '..', '..', '..')
 const tsconfigPath = join(workspaceRoot, 'tsconfig.base.json');
 const tsconfig: TsConfig = JSON.parse(readFileSync(tsconfigPath, 'utf-8'));
 const pathAliases = tsconfig.compilerOptions.paths;

--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -10,7 +10,7 @@ interface TsConfig {
 }
 
 // Read and parse tsconfig.base.json
-const workspaceRoot = process.cwd();
+const workspaceRoot = new URL('../../../../', import.meta.url).pathname;
 const tsconfigPath = join(workspaceRoot, 'tsconfig.base.json');
 const tsconfig: TsConfig = JSON.parse(readFileSync(tsconfigPath, 'utf-8'));
 const pathAliases = tsconfig.compilerOptions.paths;

--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -10,7 +10,7 @@ interface TsConfig {
 }
 
 // Read and parse tsconfig.base.json
-const workspaceRoot = import.meta.dirname;
+const workspaceRoot = join(import.meta.dirname, '..', '..', '..');
 const tsconfigPath = join(workspaceRoot, 'tsconfig.base.json');
 const tsconfig: TsConfig = JSON.parse(readFileSync(tsconfigPath, 'utf-8'));
 const pathAliases = tsconfig.compilerOptions.paths;

--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -10,7 +10,7 @@ interface TsConfig {
 }
 
 // Read and parse tsconfig.base.json
-const workspaceRoot = new URL('../../../../', import.meta.url).pathname;
+const workspaceRoot = import.meta.dirname;
 const tsconfigPath = join(workspaceRoot, 'tsconfig.base.json');
 const tsconfig: TsConfig = JSON.parse(readFileSync(tsconfigPath, 'utf-8'));
 const pathAliases = tsconfig.compilerOptions.paths;

--- a/packages/php-wasm/universal/src/lib/php-worker.spec.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.spec.ts
@@ -1,17 +1,10 @@
-import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
-import type { PHP } from '@php-wasm/universal';
+import { PHPWorker } from './php-worker';
 import { describe, expect, test, vi } from 'vitest';
-
-import { PlaygroundWorkerEndpoint } from './playground-worker-endpoint';
+import type { PHP } from './php';
 
 type PhpEvent = { type: string; [key: string]: unknown };
 type PhpEventListener = (event: PhpEvent) => void | Promise<void>;
 type PhpMessageListener = (message: unknown) => unknown | Promise<unknown>;
-
-const createMonitor = () =>
-	({
-		addEventListener: vi.fn(),
-	} as unknown as EmscriptenDownloadMonitor);
 
 const createMockPHP = () => {
 	const eventListeners = new Map<string, Set<PhpEventListener>>();
@@ -49,11 +42,7 @@ const createMockPHP = () => {
 	};
 };
 
-class TestEndpoint extends PlaygroundWorkerEndpoint {
-	constructor() {
-		super(createMonitor());
-	}
-
+class TestEndpoint extends PHPWorker {
 	attachPhp(php: PHP) {
 		this.registerWorkerListeners(php);
 	}

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -6,7 +6,6 @@ import type { PHPResponse, StreamedPHPResponse } from './php-response';
 import type {
 	MessageListener,
 	PHPEvent,
-	PHPEventListener,
 	PHPRequest,
 	PHPRunOptions,
 } from './universal-php';
@@ -24,8 +23,6 @@ export type LimitedPHPApi = Pick<
 	PHP,
 	| 'request'
 	| 'defineConstant'
-	| 'addEventListener'
-	| 'removeEventListener'
 	| 'mkdir'
 	| 'mkdirTree'
 	| 'readFileAsText'
@@ -43,8 +40,16 @@ export type LimitedPHPApi = Pick<
 > & {
 	documentRoot: PHP['documentRoot'];
 	absoluteUrl: PHP['absoluteUrl'];
+	addEventListener:
+		| PHP['addEventListener']
+		| ((event: string, listener: (event: any) => any) => void);
+	removeEventListener:
+		| PHP['removeEventListener']
+		| ((event: string, listener: (event: any) => any) => void);
 };
 
+export type PHPWorkerEvent = PHPEvent | { type: string };
+export type PHPWorkerEventListener = (event: PHPWorkerEvent) => void;
 /**
  * A PHP client that can be used to run PHP code in the browser.
  */
@@ -54,6 +59,9 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 	/** @inheritDoc @php-wasm/universal!RequestHandler.documentRoot  */
 	documentRoot = '';
 
+	#eventListeners: Map<string, Set<PHPWorkerEventListener>> = new Map();
+
+	onMessageListeners: MessageListener[] = [];
 	/** @inheritDoc */
 	constructor(
 		requestHandler?: PHPRequestHandler,
@@ -256,7 +264,12 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 
 	/** @inheritDoc @php-wasm/universal!/PHP.onMessage */
 	onMessage(listener: MessageListener) {
-		return _private.get(this)!.php!.onMessage(listener);
+		this.onMessageListeners.push(listener);
+		return async () => {
+			this.onMessageListeners = this.onMessageListeners.filter(
+				(l) => l !== listener
+			);
+		};
 	}
 
 	/** @inheritDoc @php-wasm/universal!/PHP.defineConstant */
@@ -266,18 +279,50 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 
 	/** @inheritDoc @php-wasm/universal!/PHP.addEventListener */
 	addEventListener(
-		eventType: PHPEvent['type'],
-		listener: PHPEventListener
+		eventType: PHPWorkerEvent['type'],
+		listener: PHPWorkerEventListener
 	): void {
-		_private.get(this)!.php!.addEventListener(eventType, listener);
+		if (!this.#eventListeners.has(eventType)) {
+			this.#eventListeners.set(eventType, new Set());
+		}
+		this.#eventListeners.get(eventType)!.add(listener);
 	}
 
-	/** @inheritDoc @php-wasm/universal!/PHP.removeEventListener */
+	/**
+	 * Removes an event listener for a PHP event.
+	 * @param eventType - The type of event to remove the listener from.
+	 * @param listener - The listener function to be removed.
+	 */
 	removeEventListener(
-		eventType: PHPEvent['type'],
-		listener: PHPEventListener
-	): void {
-		_private.get(this)!.php!.removeEventListener(eventType, listener);
+		eventType: PHPWorkerEvent['type'],
+		listener: PHPWorkerEventListener
+	) {
+		this.#eventListeners.get(eventType)?.delete(listener);
+	}
+
+	protected dispatchEvent<Event extends PHPWorkerEvent>(event: Event) {
+		const listeners = this.#eventListeners.get(event.type);
+		if (!listeners) {
+			return;
+		}
+		for (const listener of listeners) {
+			listener(event);
+		}
+	}
+
+	protected registerWorkerListeners(php: PHP) {
+		php.addEventListener('*', async (event) => {
+			this.dispatchEvent(event);
+		});
+		php.onMessage(async (message) => {
+			for (const listener of this.onMessageListeners) {
+				const returnData = await listener(message);
+				if (returnData) {
+					return returnData;
+				}
+			}
+			return '';
+		});
 	}
 
 	async [Symbol.asyncDispose]() {

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -71,7 +71,10 @@ export class PHP implements Disposable {
 	#sapiName?: string;
 	#phpWasmInitCalled = false;
 	#wasmErrorsTarget: UnhandledRejectionsTarget | null = null;
-	#eventListeners: Map<string, Set<PHPEventListener>> = new Map();
+	#eventListeners: Map<string, Set<PHPEventListener>> = new Map([
+		// Listen to all events
+		['*', new Set()],
+	]);
 	#messageListeners: MessageListener[] = [];
 	#mounts: Record<string, MountObject> = {};
 	#rotationOptions: {
@@ -127,7 +130,10 @@ export class PHP implements Disposable {
 	 * @param eventType - The type of event to listen for.
 	 * @param listener - The listener function to be called when the event is triggered.
 	 */
-	addEventListener(eventType: PHPEvent['type'], listener: PHPEventListener) {
+	addEventListener(
+		eventType: PHPEvent['type'] | '*',
+		listener: PHPEventListener
+	) {
 		if (!this.#eventListeners.has(eventType)) {
 			this.#eventListeners.set(eventType, new Set());
 		}
@@ -140,14 +146,17 @@ export class PHP implements Disposable {
 	 * @param listener - The listener function to be removed.
 	 */
 	removeEventListener(
-		eventType: PHPEvent['type'],
+		eventType: PHPEvent['type'] | '*',
 		listener: PHPEventListener
 	) {
 		this.#eventListeners.get(eventType)?.delete(listener);
 	}
 
 	dispatchEvent<Event extends PHPEvent>(event: Event) {
-		const listeners = this.#eventListeners.get(event.type);
+		const listeners = [
+			...(this.#eventListeners.get(event.type) || []),
+			...(this.#eventListeners.get('*') || []),
+		];
 		if (!listeners) {
 			return;
 		}

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -312,7 +312,7 @@ const [setApiReady, setAPIError] = exposeAPI(
 	phpChannel.port1
 );
 
-parentPort!.postMessage(
+parentPort?.postMessage(
 	{
 		command: 'worker-script-initialized',
 		phpPort: phpChannel.port2,

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -277,7 +277,8 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 						followSymlinks: allow?.includes('follow-symlinks'),
 					});
 				},
-				async onPHPInstanceCreated(php) {
+				onPHPInstanceCreated: async (php) => {
+					this.registerWorkerListeners(php);
 					await mountResources(php, mountsBeforeWpInstall);
 					await mountResources(php, mountsAfterWpInstall);
 				},

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -493,7 +493,7 @@ const [setApiReady, setAPIError] = exposeAPI(
 	phpChannel.port1
 );
 
-parentPort!.postMessage(
+parentPort?.postMessage(
 	{
 		command: 'worker-script-initialized',
 		phpPort: phpChannel.port2,

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -220,6 +220,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 				'openssl.cafile': '/internal/shared/ca-bundle.crt',
 			},
 			onPHPInstanceCreated: async (php: PHP) => {
+				this.registerWorkerListeners(php);
 				await mountResources(php, args['mount-before-install'] || []);
 				if (this.blueprintTargetResolved) {
 					await mountResources(php, args.mount || []);

--- a/packages/playground/cli/tests/worker-thread-events.spec.ts
+++ b/packages/playground/cli/tests/worker-thread-events.spec.ts
@@ -1,0 +1,135 @@
+import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+import type { PHP } from '@php-wasm/universal';
+import { describe, expect, test, vi } from 'vitest';
+
+import { PlaygroundCliBlueprintV1Worker } from '../src/blueprints-v1/worker-thread-v1';
+import { PlaygroundCliBlueprintV2Worker } from '../src/blueprints-v2/worker-thread-v2';
+
+type PhpEvent = { type: string; [key: string]: unknown };
+type PhpEventListener = (event: PhpEvent) => void | Promise<void>;
+type PhpMessageListener = (message: unknown) => unknown | Promise<unknown>;
+
+const createMonitor = () =>
+	({
+		addEventListener: vi.fn(),
+	} as unknown as EmscriptenDownloadMonitor);
+
+const createMockPHP = () => {
+	const eventListeners = new Map<string, Set<PhpEventListener>>();
+	const messageListeners = new Set<PhpMessageListener>();
+
+	return {
+		addEventListener: vi.fn(
+			(eventType: string, listener: PhpEventListener) => {
+				if (!eventListeners.has(eventType)) {
+					eventListeners.set(eventType, new Set());
+				}
+				eventListeners.get(eventType)!.add(listener);
+			}
+		),
+		onMessage: vi.fn((listener: PhpMessageListener) => {
+			messageListeners.add(listener);
+			return Promise.resolve(() => {
+				messageListeners.delete(listener);
+			});
+		}),
+		emitEvent: async (event: PhpEvent) => {
+			const listeners = eventListeners.get('*');
+			if (!listeners) {
+				return;
+			}
+			await Promise.all([...listeners].map((listener) => listener(event)));
+		},
+		emitMessage: async (message: unknown) => {
+			await Promise.all([...messageListeners].map((listener) => listener(message)));
+		},
+	};
+};
+
+class TestableV2Worker extends PlaygroundCliBlueprintV2Worker {
+	constructor() {
+		super(createMonitor());
+	}
+
+	attachPhp(php: PHP) {
+		this.registerWorkerListeners(php);
+	}
+}
+
+class TestableV1Worker extends PlaygroundCliBlueprintV1Worker {
+	constructor() {
+		super(createMonitor());
+	}
+
+	attachPhp(php: PHP) {
+		this.registerWorkerListeners(php);
+	}
+}
+
+describe('Playground CLI blueprint workers', () => {
+	test('V2 worker listeners receive events from every PHP instance', async () => {
+		const worker = new TestableV2Worker();
+		const phpA = createMockPHP();
+		const phpB = createMockPHP();
+		const received: any[] = [];
+
+		worker.addEventListener('blueprint.progress', (event) => {
+			received.push(event);
+		});
+
+		worker.attachPhp(phpA as unknown as PHP);
+		worker.attachPhp(phpB as unknown as PHP);
+
+		await phpA.emitEvent({
+			type: 'blueprint.progress',
+			source: 'A',
+		});
+		await phpB.emitEvent({
+			type: 'blueprint.progress',
+			source: 'B',
+		});
+
+		expect(received).toEqual([
+			expect.objectContaining({ type: 'blueprint.progress', source: 'A' }),
+			expect.objectContaining({ type: 'blueprint.progress', source: 'B' }),
+		]);
+		expect(phpA.addEventListener).toHaveBeenCalledWith(
+			'*',
+			expect.any(Function)
+		);
+		expect(phpB.addEventListener).toHaveBeenCalledWith(
+			'*',
+			expect.any(Function)
+		);
+	});
+
+	test('V1 worker listeners receive events from every PHP instance', async () => {
+		const worker = new TestableV1Worker();
+		const phpA = createMockPHP();
+		const phpB = createMockPHP();
+		const received: any[] = [];
+
+		worker.addEventListener('runtime.exit', (event) => {
+			received.push(event);
+		});
+
+		worker.attachPhp(phpA as unknown as PHP);
+		worker.attachPhp(phpB as unknown as PHP);
+
+		await phpA.emitEvent({ type: 'runtime.exit', source: 'A' });
+		await phpB.emitEvent({ type: 'runtime.exit', source: 'B' });
+
+		expect(received).toEqual([
+			expect.objectContaining({ type: 'runtime.exit', source: 'A' }),
+			expect.objectContaining({ type: 'runtime.exit', source: 'B' }),
+		]);
+		expect(phpA.addEventListener).toHaveBeenCalledWith(
+			'*',
+			expect.any(Function)
+		);
+		expect(phpB.addEventListener).toHaveBeenCalledWith(
+			'*',
+			expect.any(Function)
+		);
+	});
+});

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
@@ -1,0 +1,91 @@
+import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
+import type { PHP } from '@php-wasm/universal';
+import { describe, expect, test, vi } from 'vitest';
+
+import { PlaygroundWorkerEndpoint } from './playground-worker-endpoint';
+
+type PhpEvent = { type: string; [key: string]: unknown };
+type PhpEventListener = (event: PhpEvent) => void | Promise<void>;
+type PhpMessageListener = (message: unknown) => unknown | Promise<unknown>;
+
+const createMonitor = () =>
+	({
+		addEventListener: vi.fn(),
+	} as unknown as EmscriptenDownloadMonitor);
+
+const createMockPHP = () => {
+	const eventListeners = new Map<string, Set<PhpEventListener>>();
+	const messageListeners = new Set<PhpMessageListener>();
+
+	return {
+		addEventListener: vi.fn(
+			(eventType: string, listener: PhpEventListener) => {
+				if (!eventListeners.has(eventType)) {
+					eventListeners.set(eventType, new Set());
+				}
+				eventListeners.get(eventType)!.add(listener);
+			}
+		),
+		onMessage: vi.fn((listener: PhpMessageListener) => {
+			messageListeners.add(listener);
+			return Promise.resolve(() => {
+				messageListeners.delete(listener);
+			});
+		}),
+		emitEvent: async (event: PhpEvent) => {
+			const listeners = eventListeners.get('*');
+			if (!listeners) {
+				return;
+			}
+			await Promise.all([...listeners].map((listener) => listener(event)));
+		},
+		emitMessage: async (message: unknown) => {
+			await Promise.all([...messageListeners].map((listener) => listener(message)));
+		},
+	};
+};
+
+class TestEndpoint extends PlaygroundWorkerEndpoint {
+	constructor() {
+		super(createMonitor());
+	}
+
+	attachPhp(php: PHP) {
+		this.registerWorkerListeners(php);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async boot(_: unknown = undefined) {}
+}
+
+describe('PlaygroundWorkerEndpoint', () => {
+	test('listeners receive events from each PHP instance', async () => {
+		const endpoint = new TestEndpoint();
+		const phpA = createMockPHP();
+		const phpB = createMockPHP();
+		const received: PhpEvent[] = [];
+
+		endpoint.addEventListener('worker.ready', (event) => {
+			received.push(event);
+		});
+
+		endpoint.attachPhp(phpA as unknown as PHP);
+		endpoint.attachPhp(phpB as unknown as PHP);
+
+		await phpA.emitEvent({ type: 'worker.ready', source: 'A' });
+		await phpB.emitEvent({ type: 'worker.ready', source: 'B' });
+
+		expect(received).toEqual([
+			expect.objectContaining({ type: 'worker.ready', source: 'A' }),
+			expect.objectContaining({ type: 'worker.ready', source: 'B' }),
+		]);
+		expect(phpA.addEventListener).toHaveBeenCalledWith(
+			'*',
+			expect.any(Function)
+		);
+		expect(phpB.addEventListener).toHaveBeenCalledWith(
+			'*',
+			expect.any(Function)
+		);
+	});
+});

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
@@ -37,10 +37,14 @@ const createMockPHP = () => {
 			if (!listeners) {
 				return;
 			}
-			await Promise.all([...listeners].map((listener) => listener(event)));
+			await Promise.all(
+				[...listeners].map((listener) => listener(event))
+			);
 		},
 		emitMessage: async (message: unknown) => {
-			await Promise.all([...messageListeners].map((listener) => listener(message)));
+			await Promise.all(
+				[...messageListeners].map((listener) => listener(message))
+			);
 		},
 	};
 };
@@ -63,7 +67,7 @@ describe('PlaygroundWorkerEndpoint', () => {
 		const endpoint = new TestEndpoint();
 		const phpA = createMockPHP();
 		const phpB = createMockPHP();
-		const received: PhpEvent[] = [];
+		const received: any[] = [];
 
 		endpoint.addEventListener('worker.ready', (event) => {
 			received.push(event);

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -28,11 +28,7 @@ import transportFetch from './playground-mu-plugin/playground-includes/wp_http_f
 /* @ts-ignore */
 import transportDummy from './playground-mu-plugin/playground-includes/wp_http_dummy.php?raw';
 import { logger } from '@php-wasm/logger';
-import type {
-	MessageListener,
-	PHP,
-	SupportedPHPVersion,
-} from '@php-wasm/universal';
+import type { PHP, SupportedPHPVersion } from '@php-wasm/universal';
 import {
 	PHPResponse,
 	PHPWorker,
@@ -98,7 +94,6 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 	 */
 	loadedWordPressVersion: string | undefined;
 
-	onMessageListeners: MessageListener[] = [];
 	blueprintMessageListeners: Array<(message: any) => void | Promise<void>> =
 		[];
 
@@ -242,15 +237,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				if (withNetworking) {
 					await this.networkTransport!.setupMessageHandler(php);
 				}
-				php.onMessage(async (message) => {
-					for (const listener of this.onMessageListeners) {
-						const returnData = await listener(message);
-						if (returnData) {
-							return returnData;
-						}
-					}
-					return '';
-				});
+				this.registerWorkerListeners(php);
 			},
 			spawnHandler: sandboxedSpawnHandlerFactory,
 			sapiName,
@@ -420,15 +407,6 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		return await hasCachedStaticFilesRemovedFromMinifiedBuild(
 			this.__internal_getPHP()!
 		);
-	}
-
-	override onMessage(listener: MessageListener) {
-		this.onMessageListeners.push(listener);
-		return async () => {
-			this.onMessageListeners = this.onMessageListeners.filter(
-				(l) => l !== listener
-			);
-		};
 	}
 
 	// @TODO: Recycle addEventListener/removeEventListener instead of introducing another


### PR DESCRIPTION
Before this PR, worker.addEventListener() only listens to the events emitted by the primary PHP instance. After this PR, it listens to events emitted by all the PHP instances created by a given worker.

 ## Implementation details

Instead of passing through the `worker.addEventListener()` call to the primary PHP instance, the PHPWorker class:

* Registers a wildcard event listener for all PHP events.
* Maintains its own list of event listeners.

Whenever any PHP instance emits an event that has worker-wide listeners registered, the worker class notifies them.

This PR refactors all the worker implementations: web and node, v1 and v2.

 ## Testing instructions

CI (TODO: Add test coverage)
