### PR TITLE
[Website] Resolve the Blueprint declaration for the 'View Blueprint' button

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -32,6 +32,7 @@ import { getRelativeDate } from '../../../lib/get-relative-date';
 import { setActiveModal } from '../../../lib/state/redux/slice-ui';
 import { modalSlugs } from '../../layout';
 import { removeSite } from '../../../lib/state/redux/slice-sites';
+import { BlueprintReflection } from '@wp-playground/blueprints';
 
 export function SiteInfoPanel({
 	className,
@@ -264,15 +265,27 @@ export function SiteInfoPanel({
 										</MenuGroup>
 										<MenuGroup>
 											<MenuItem
-												// @ts-ignore
-												href={`/builder/builder.html#${encodeStringAsBase64(
-													JSON.stringify(
-														site.metadata
-															.originalBlueprint as any
-													) as string
-												)}`}
-												target="_blank"
-												rel="noopener noreferrer"
+												onClick={async () => {
+													const reflection =
+														await BlueprintReflection.create(
+															site.metadata
+																.originalBlueprint as any
+														);
+													const declaration =
+														reflection.getDeclaration() as any;
+													const encoded =
+														encodeStringAsBase64(
+															JSON.stringify(
+																declaration
+															) as string
+														);
+													window.open(
+														`/builder/builder.html#${encoded}`,
+														'_blank',
+														'noopener,noreferrer'
+													);
+													onClose();
+												}}
 												icon={external}
 												iconPosition="right"
 												aria-label="View Blueprint"


### PR DESCRIPTION
## Motivation for the change, related issues

Improves the #2562 situation in that it brings over the Blueprint to the JSON editor when you click "View Blueprint". It's still not a full solution as the editor doesn't seem to support the "bundled" resources at the moment, e.g.

```ts
    {
      "step": "writeFile",
      "path": "/wordpress/wp-content/mu-plugins/rewrite.php",
      "data": {
        "resource": "bundled",
        "path": "./scripts/setup.php"
      }
    },
```

Still, it improves the user experience so we might land it and keep thinking.

cc @bph @brandonpayton 

## Testing Instructions (or ideally a Blueprint)

Follow the steps in #2562 and confirm the Blueprint editor shows the correct JSON file.