### PR TITLE
[Blueprints] Replace randomString() with randomFilename() in installAsset()

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/install-asset.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-asset.ts
@@ -1,5 +1,5 @@
 import type { UniversalPHP } from '@php-wasm/universal';
-import { joinPaths, randomString } from '@php-wasm/util';
+import { joinPaths, randomFilename } from '@php-wasm/util';
 import { unzip } from './unzip';
 
 export interface InstallAssetOptions {
@@ -35,7 +35,7 @@ export async function installAsset(
 		targetPath,
 		zipFile,
 		ifAlreadyInstalled = 'overwrite',
-		targetFolderName = ''
+		targetFolderName = '',
 	}: InstallAssetOptions
 ): Promise<{
 	assetFolderPath: string;
@@ -46,7 +46,7 @@ export async function installAsset(
 	const assetNameGuess = zipFileName.replace(/\.zip$/, '');
 
 	const wpContent = joinPaths(await playground.documentRoot, 'wp-content');
-	const tmpDir = joinPaths(wpContent, randomString());
+	const tmpDir = joinPaths(wpContent, randomFilename());
 	const tmpUnzippedFilesPath = joinPaths(tmpDir, 'assets', assetNameGuess);
 
 	if (await playground.fileExists(tmpUnzippedFilesPath)) {
@@ -88,7 +88,7 @@ export async function installAsset(
 		}
 
 		// If a specific slug was requested be used, use that.
-		if ( targetFolderName && targetFolderName.length ) {
+		if (targetFolderName && targetFolderName.length) {
 			assetFolderName = targetFolderName;
 		}
 


### PR DESCRIPTION
## Motivation for the change, related issues

@bcotrim reported a problem with random empty folders showing up in wp-content when creating sites from a specific Blueprint: 

<img width="1370" height="904" alt="image" src="https://github.com/user-attachments/assets/f619ad4b-9980-4ab6-9aef-3b5f989f9283" />

The problem was with the `installAsset()` function calling `randomString()` to generate filenames. Sometimes the resulting string would contain a slash, which would create a subdirectory structure. After the asset is processed, only the subdirectory would be cleaned up, leaving the parent directory unchanged.

## Implementation details

This PR replaces the `randomString()` call with a `randomFilename()` call. It uses the same randomizer, but it restrict the set of special characters to just `-` and `_`.

## Testing Instructions (or ideally a Blueprint)

Run [this Blueprint](https://gist.github.com/adamziel/aed5588cf6721f1b662e6fe8ac0ecc0d) with a local Playground CLI or Playground web and confirm that, after it's finished, there are no random-looking directories inside `wp-content`. Repeat this test a few times for a good measure.

cc @bcotrim @brandonpayton @wojtekn @JanJakes @akirk 