### PR TITLE
[i18n] Add French translation for resources.md

### DIFF
--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,5 +1,4 @@
 ---
-<!-- title: Links and Resources -->
 title: Links and Resources
 slug: /resources
 ---

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,11 +1,13 @@
 ---
+<!-- title: Links and Resources -->
 title: Links and Resources
 slug: /resources
 ---
 
-# Links and Resources
+<!-- # Links and Resources -->
+# Liens et ressources
 
-:::tip
+<!--:::tip
 
 There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
 
@@ -15,20 +17,40 @@ There's a set of redirections in place to make it easier the access to some of t
 <li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Playground Blueprints Builder</li>
 <li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Playground PR viewer for WordPress</li>
 <li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Playground PR viewer for Gutenberg</li>
-<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Playground Proxy Service <em>(see <a href="/blueprints/steps/resources#urlreference">URLReference</a> for more info)</em></li>
+<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Service Proxy Playground  <em>(see <a href="/blueprints/steps/resources#urlreference">URLReference</a> for more info)</em></li>
 </ul>
-:::
+::: -->
+:::astuce
 
-## Frequently sought links
+Un ensemble de redirections est en place pour faciliter l’accès à certains outils liés à Playground :
 
--   [Demo](https://playground.wordpress.net/)
+<ul id="list-resources-redirections">
+<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → instance Playground</li>
+<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Documentation Playground</li>
+<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Constructeur de blueprints Playground</li>
+<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Visualiseur de PR Playground pour WordPress</li>
+<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Visualiseur de PR Playground pour Gutenberg</li>
+<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Playground Proxy Service <em>(voir <a href="/blueprints/steps/resources#urlreference">URLReference</a> pour plus d’information)</em></li>
+</ul>
+::: 
+
+<!-- ## Frequently sought links -->
+## Liens fréquemment recherchés
+
+<!---   -   [Demo](https://playground.wordpress.net/)
 -   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
 -   [Documentation](https://wordpress.github.io/wordpress-playground/)
--   [Playground tools Repository](https://github.com/WordPress/playground-tools)
+-   [Playground tools Repository](https://github.com/WordPress/playground-tools) -->
+-   [Démo](https://playground.wordpress.net/)
+-   [Dépôt GitHub](https://github.com/WordPress/wordpress-playground)
+-   [Documentation](https://wordpress.github.io/wordpress-playground/)
+-   [Dépôt des outils Playground](https://github.com/WordPress/playground-tools)
 
-## Apps built with WordPress Playground
 
--   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
+<!-- ## Apps built with WordPress Playground -->
+## Apps contruites avec WordPress Playground
+
+<!---   -   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
 -   [wp-now](https://www.npmjs.com/package/%40wp-now/wp-now) – a CLI tool for instant WordPress dev envs
 -   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
 -   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
@@ -43,20 +65,48 @@ There's a set of redirections in place to make it easier the access to some of t
 -   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
 -   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
--   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+-   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)    -->
+-   [Démo officielle](https://playground.wordpress.net/) et l’app [showcase](https://developer.wordpress.org/playground) – installez un thème, essayez une extension, créez quelques pages, exportez ce que vous avez construit
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – un outil CLI pour un environnement dev WordPress intantané
+-   [WordPress Playground pour VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+-   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [annonce](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [plus de détails](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) qui alimente le [tutoriel HTML Tag Processor](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) et le [tutoriel Playground JS API](https://adamadam.blog/2023/04/12/interactive-intro-to-wordpress-playground-public-api/)
+-   [Visualiseur de pull request Gutenberg](https://playground.wordpress.net/gutenberg.html)
+-   [Démo en direct de l’extension Notifications](https://johnhooks.io/playground-experiment/)
+-   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – la toute première app iOS exécutant WordPress sur votre téléphone
+-   [Playground embedder](https://joost.blog/embedded-playground/) pour intégrer des exemples Playground dans la documentation WordPress.org à l’aide de codes courts
+-   [Démos extension sur wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – un script utilisateur qui ajoute un onglet « démo » aux pages d’extensions sur WordPress.org
+-   [Visualiseur de pull request](https://playground.wordpress.net/wordpress.html)
+-   [Synchronisation entre deux Playgrounds](https://playground.wordpress.net/demos/sync.html)
+-   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+-   [Implementation PHP de Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
 
-## Reading materials
+<!-- ## Reading materials -->
+## Documentation
 
--   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
+<!---   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
 -   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
 -   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
 -   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
--   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
+-   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)    -->
+-   [Build in-browser WordPress experiences with WordPress Playground et WebAssembly (en anglais)](https://web.dev/wordpress-playground/)
+-   [WordPress Playground sur developer.wordpress.org (en anglais)](https://developer.wordpress.org/playground)
+-   [In-Browser WordPress Tech Demos : développement WordPress avec WordPress Playground (en anglais)](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [Annonce initiale sur make.wordpress.org (en anglais)](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Discussion Hackernews (en anglais)](https://news.ycombinator.com/item?id=32960560)
 
-## Videos
+<!-- ## Videos    -->
+## Vidéos
 
--   Developer Hours Videos: [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/), [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+<!-- -   Developer Hours Videos: [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/), [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
 -   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
 -   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
 -   [Playground at WordCamp Gliwice (in polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4)
--   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
+-   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy    -->
+-   Vidéos Developer Hours (en anglais) : [zone Amériques (23 mai 2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/), [zone APAC/EMEA  (24 mai 2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+-   [Playground au « State of the Word » (en anglais)](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [Playground au WCEU 2023 (en anglais)](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   [Playground au WordCamp Gliwice (en polonais)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4)
+-   [Regarder « WordPress Playground : l’outil ultime d’apprentissage, de test et d’enseignement pour WordPress » (en anglais)](https://www.youtube.com/watch?v=dN_LaenY8bI) par Anne McCarthy


### PR DESCRIPTION
## Motivation for the change, related issues
Add French translation for resources.md

part of https://github.com/WordPress/wordpress-playground/issues/2621

cc [fellyph](https://github.com/fellyph)