### PR TITLE
[CLI] Polyfill the Buffer class without making it an empty object in CLI

### DIFF
--- a/packages/playground/storage/src/lib/git-sparse-checkout.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.ts
@@ -15,15 +15,17 @@ import { GitPackIndex } from 'isomorphic-git/src/models/GitPackIndex.js';
 import { collect } from 'isomorphic-git/src/internal-apis.js';
 import { parseUploadPackResponse } from 'isomorphic-git/src/wire/parseUploadPackResponse.js';
 import { ObjectTypeError } from 'isomorphic-git/src/errors/ObjectTypeError.js';
-import { Buffer } from 'buffer';
+import { Buffer as BufferPolyfill } from 'buffer';
 
 /**
- * A polyfill for the Buffer class. We need it because isomorphic-git uses it internally.
- * The isomorphic-git version released via npm shipes a Buffer implementation, but we're
- * using a version cloned from the git repository which assumes a global Buffer is available.
+ * Polyfills the Buffer class in the browser.
+ *
+ * We need it because isomorphic-git uses Buffer internally. The isomorphic-git version
+ * released via npm shipes a Buffer implementation, but we're using a version cloned from
+ * the git repository which assumes a global Buffer is available.
  */
-if (typeof window !== 'undefined') {
-	window.Buffer = Buffer;
+if (typeof globalThis.Buffer === 'undefined') {
+	globalThis.Buffer = BufferPolyfill;
 }
 
 /**

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -107,4 +107,58 @@ describe(`PHP ${phpVersion}`, () => {
 			}
 		}
 	});
+
+	/**
+	 * This broke at one point in the built package. It bundler tried really hard to create an isomorphic
+	 * package, but ended shipping the following code which always returned false:
+	 *
+	 *    var z = {};
+	 *    if (i.object instanceof z.Buffer)
+	 *
+	 * This test confirms the git client still works after bundling.
+	 */
+	it(
+		'Should support git:directory resources',
+		{ timeout: 30000 },
+		async () => {
+			const cli = await runCLI({
+				command: 'server',
+				php: phpVersion,
+				quiet: true,
+				blueprint: {
+					steps: [
+						{
+							step: 'installPlugin',
+							options: {
+								activate: true,
+								targetFolderName: 'blocky-formats',
+							},
+							pluginData: {
+								resource: 'git:directory',
+								url: 'https://github.com/dmsnell/blocky-formats.git',
+								ref: 'HEAD',
+								path: '/',
+							},
+						},
+					],
+				},
+			});
+			try {
+				const response = await cli.playground.request({
+					method: 'GET',
+					url: '/',
+				});
+				assert.equal(response.httpStatusCode, 200);
+				const expectedText = 'My WordPress Website';
+				assert.ok(
+					response.text.includes(expectedText),
+					`Response text does not include '${expectedText}'`
+				);
+			} finally {
+				if (cli) {
+					await cli[Symbol.asyncDispose]();
+				}
+			}
+		}
+	);
 });


### PR DESCRIPTION
## Motivation for the change, related issues

The distributed version of Playground CLI errored out with the following message when cloning the git repository:

```
Error when executing the blueprint step #0 ({"step":"installPlugin","options":{"activate":true,"targetFolderName":"blocky-formats"},"pluginData":{"resource":"git:directory","url":"https://github.com/dmsnell/blocky-formats.git","ref":"HEAD","path":"/"}}) : An internal error caused this command to fail. Please file a bug report at https://github.com/isomorphic-git/isomorphic-git/issues with this error message: Could not read object undefined from packfile caused by An internal error caused this command to fail. Please file a bug report at https://github.com/isomorphic-git/isomorphic-git/issues with this error message: Could not read object undefined from packfile
```

At the same time, running Playground CLI from the source worked well.

The problem was with the bundling process. The built packages contained the following code due to the `Buffer` polyfilling technique used:

```ts
var z = {};
if (i.object instanceof z.Buffer)
```

## Implementation details

This PR:

* Only polyfills the `Buffer` class when it's missing
* Avoids a name collision between the imported polyfill and the global `Buffer` class.

## Testing Instructions (or ideally a Blueprint)

CI – there's a new test that confirms `git:directory` resources may be used in the built package.
