### PR TITLE
Playground CLI: Log unhandled rejections and stop them from crashing workers

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -19,6 +19,7 @@ import { rootCertificates } from 'tls';
 import { jspi } from 'wasm-feature-detect';
 import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
 import { mountResources } from '../mounts';
+import { logger } from '@php-wasm/logger';
 
 export interface Mount {
 	hostPath: string;
@@ -303,6 +304,10 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 		await this[Symbol.asyncDispose]();
 	}
 }
+
+process.on('unhandledRejection', (e: any) => {
+	logger.error('Unhandled rejection:', e);
+});
 
 const phpChannel = new MessageChannel();
 

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -1,4 +1,4 @@
-import { errorLogPath } from '@php-wasm/logger';
+import { errorLogPath, logger } from '@php-wasm/logger';
 import type { FileLockManager } from '@php-wasm/node';
 import { createNodeFsMountHandler, loadNodeRuntime } from '@php-wasm/node';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
@@ -484,6 +484,10 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 		await this[Symbol.asyncDispose]();
 	}
 }
+
+process.on('unhandledRejection', (e: any) => {
+	logger.error('Unhandled rejection:', e);
+});
 
 const phpChannel = new MessageChannel();
 


### PR DESCRIPTION
## Motivation for the change, related issues

As discussed with @bph and @adamziel, we are seeing some workers crashing due to unhandled Promise rejections. Let's log them and stop them from crashing the workers until we understand more.

## Implementation details

This PR adds a simple unhandledRejections handler for each worker process that relays the error via logger.error().

## Testing Instructions (or ideally a Blueprint)

- CI
- Manually add a Promise.reject() call to the end of each Playground CLI worker script, run the CLI, and confirm the unhandled rejection is logged and does not crash the worker.
