### PR TITLE
[PHP Playground] Add Xterm.js

### DIFF
--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -374,7 +374,12 @@ function streamToPort(stream: ReadableStream<Uint8Array>): MessagePort {
 			}
 		} catch (e: any) {
 			try {
-				port1.postMessage({ t: 'error', m: e?.message || String(e) });
+				// @TODO: Find a way to transfer the error object, including any stack trace etc.,
+				//        using the error transfer handlers.
+				port1.postMessage({
+					t: 'error',
+					m: e?.message || JSON.stringify(e),
+				});
 			} catch {
 				// Ignore error
 			}
@@ -407,10 +412,24 @@ function portToStream(port: MessagePort): ReadableStream<Uint8Array> {
 						controller.close();
 						cleanup();
 						break;
-					case 'error':
-						controller.error(new Error(data.m || 'Stream error'));
+					case 'error': {
+						let error = '';
+						try {
+							error = JSON.parse(data.m);
+						} catch {
+							// Ignore error
+						}
+						if (!error) {
+							error = data.m;
+						}
+						if (typeof error === 'string') {
+							controller.error(new Error(error));
+						} else {
+							controller.error(error);
+						}
 						cleanup();
 						break;
+					}
 				}
 			};
 			const cleanup = () => {
@@ -475,7 +494,7 @@ function promiseToPort(promise: Promise<any>): MessagePort {
 			try {
 				port1.postMessage({
 					t: 'reject',
-					m: (err as any)?.message || String(err),
+					m: (err as any)?.message || JSON.stringify(err),
 				});
 			} catch {
 				// Ignore error
@@ -504,8 +523,20 @@ function portToPromise(port: MessagePort): Promise<any> {
 				cleanup();
 				resolve(data.v);
 			} else if (data.t === 'reject') {
+				// @TODO: Find a way to transfer the error object, including any stack trace etc.,
+				//        using the error transfer handlers.
 				cleanup();
-				reject(new Error(data.m || ''));
+				let error = '';
+				try {
+					error = JSON.parse(data.m);
+				} catch {
+					// Ignore error
+				}
+				if (typeof error === 'string') {
+					reject(new Error(error));
+				} else {
+					reject(error);
+				}
 			}
 		};
 		const cleanup = () => {

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -195,11 +195,23 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		const { php, reap } = await _private
 			.get(this)!
 			.requestHandler!.processManager.acquirePHPInstance();
+		let response: StreamedPHPResponse;
 		try {
-			return await php.cli(argv, options);
-		} finally {
+			response = await php.cli(argv, options);
+		} catch (error) {
 			reap();
+			throw error;
 		}
+		/**
+		 * Register the reap() callback to run asynchronously once
+		 * the response is finished.
+		 *
+		 * We don't await for response.finished here. It is a
+		 * `StreamedPHPResponse` instance and the caller may want
+		 * to start processing the streamed data immediately.
+		 */
+		response.finished.finally(reap);
+		return response;
 	}
 
 	/** @inheritDoc @php-wasm/universal!/PHP.chdir */

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -616,6 +616,7 @@ export class PHP implements Disposable {
 		const streamedResponsePromise = this.#executeWithErrorHandling(
 			async () => {
 				if (!this.#phpWasmInitCalled) {
+					this.#phpWasmInitCalled = true;
 					await this[__private__dont__use].ccall(
 						'php_wasm_init',
 						null,
@@ -625,7 +626,6 @@ export class PHP implements Disposable {
 							isAsync: true,
 						}
 					);
-					this.#phpWasmInitCalled = true;
 				}
 				if (
 					request.scriptPath &&
@@ -1460,7 +1460,6 @@ export class PHP implements Disposable {
 					[arg]
 				);
 			}
-
 			return this[__private__dont__use].ccall('run_cli', null, [], [], {
 				async: true,
 			});

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -398,6 +398,10 @@ export class PHP implements Disposable {
 		this[__private__dont__use].FS.chdir(path);
 	}
 
+	cwd() {
+		return this[__private__dont__use].FS.cwd();
+	}
+
 	/**
 	 * Changes the permissions of a file or directory.
 	 * @param path - The path to the file or directory.

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -9,6 +9,7 @@ import { getLoadedRuntime } from './load-php-runtime';
 import type { PHPRequestHandler } from './php-request-handler';
 import { PHPResponse, StreamedPHPResponse } from './php-response';
 import type {
+	ChildProcess,
 	MessageListener,
 	PHPEvent,
 	PHPEventListener,
@@ -1437,8 +1438,12 @@ export class PHP implements Disposable {
 	 */
 	async cli(
 		argv: string[],
-		options: { env?: Record<string, string> } = {}
+		options: { env?: Record<string, string>; cwd?: string } = {}
 	): Promise<StreamedPHPResponse> {
+		if (argv[0] !== 'php' && !argv[0].endsWith('/php')) {
+			return this.subProcess(argv, options);
+		}
+
 		if (this.#phpWasmInitCalled) {
 			this.#rotationOptions.needsRotating = true;
 		}
@@ -1471,6 +1476,83 @@ export class PHP implements Disposable {
 			.finally(() => {
 				this.#rotationOptions.needsRotating = true;
 			});
+	}
+
+	/**
+	 * Runs an arbitrary CLI command using the spawn handler associated
+	 * with this PHP instance.
+	 *
+	 * @param argv
+	 * @param options
+	 * @returns StreamedPHPResponse.
+	 */
+	private async subProcess(
+		argv: string[],
+		options: { env?: Record<string, string>; cwd?: string } = {}
+	): Promise<StreamedPHPResponse> {
+		const process = this[__private__dont__use].spawnProcess(
+			argv[0],
+			argv.slice(1),
+			{
+				env: options.env,
+				cwd:
+					options.cwd ??
+					this.#rotationOptions?.cwd ??
+					this.documentRoot ??
+					'/',
+			}
+		) as ChildProcess;
+
+		const stderrStream = await createInvertedReadableStream<Uint8Array>();
+		process.on('error', (error) => {
+			stderrStream.controller.error(error);
+		});
+		process.stderr.on('data', (data) => {
+			stderrStream.controller.enqueue(data);
+		});
+
+		const stdoutStream = await createInvertedReadableStream<Uint8Array>();
+		process.stdout.on('data', (data) => {
+			stdoutStream.controller.enqueue(data);
+		});
+
+		process.on('exit', () => {
+			// Delay until next tick to ensure we don't close the streams before
+			// emitting the error event on the stderrStream.
+			setTimeout(() => {
+				/**
+				 * Ignore any close() errors, e.g. "stream already closed". We just
+				 * need to try to call close() and forget about this subprocess.
+				 */
+				try {
+					stderrStream.controller.close();
+				} catch {
+					// Ignore error
+				}
+				try {
+					stdoutStream.controller.close();
+				} catch {
+					// Ignore error
+				}
+			}, 0);
+		});
+
+		return new StreamedPHPResponse(
+			// Headers stream
+			new ReadableStream({
+				start(controller) {
+					controller.close();
+				},
+			}),
+			stdoutStream.stream,
+			stderrStream.stream,
+			// Exit code
+			new Promise((resolve) => {
+				process.on('exit', (code) => {
+					resolve(code);
+				});
+			})
+		);
 	}
 
 	setSkipShebang(shouldSkip: boolean) {

--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -40,9 +40,11 @@ export function sandboxedSpawnHandlerFactory(
 			// @TODO: Do not hardcode this
 			processApi.stdout(`18 140`);
 			processApi.exit(0);
+			return;
 		} else if (binaryName === 'tput' && args[1] === 'cols') {
 			processApi.stdout(`140`);
 			processApi.exit(0);
+			return;
 		} else if (binaryName === 'less') {
 			processApi.on('stdin', (data: Uint8Array) => {
 				processApi.stdout(data);
@@ -55,13 +57,17 @@ export function sandboxedSpawnHandlerFactory(
 			});
 			processApi.exit(0);
 			return;
-		} else if (binaryName === 'php') {
-			const { php, reap } = await processManager.acquirePHPInstance({
-				considerPrimary: false,
-			});
+		}
 
-			php.chdir(options.cwd as string);
-			try {
+		// Binaries requiring PHP to be running.
+		const { php, reap } = await processManager.acquirePHPInstance({
+			considerPrimary: false,
+		});
+
+		try {
+			php.chdir((options.cwd as string) ?? '/');
+
+			if (binaryName === 'php') {
 				// Figure out more about setting env, putenv(), etc.
 				const result = await php.cli(args, {
 					env: {
@@ -89,15 +95,23 @@ export function sandboxedSpawnHandlerFactory(
 					})
 				);
 				processApi.exit(await result.exitCode);
-			} catch (e) {
-				// An exception here means the PHP runtime has crashed.
-				processApi.exit(1);
-				throw e;
-			} finally {
-				reap();
+			} else if (binaryName === 'ls') {
+				const files = php.listFiles(args[1] || '/');
+				files.forEach((file) => {
+					processApi.stdout(file + '\n');
+				});
+				await new Promise((resolve) => setTimeout(resolve, 10));
+				processApi.exit(0);
+			} else {
+				// 127 is the exit code for command not found.
+				processApi.exit(127);
 			}
-		} else {
+		} catch (e) {
+			// An exception here means the PHP runtime has crashed.
 			processApi.exit(1);
+			throw e;
+		} finally {
+			reap();
 		}
 	});
 }

--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -65,7 +65,11 @@ export function sandboxedSpawnHandlerFactory(
 		});
 
 		try {
-			php.chdir((options.cwd as string) ?? '/');
+			if ('cwd' in options) {
+				php.chdir((options.cwd as string) ?? '/');
+			}
+
+			const cwd = php.cwd();
 
 			if (binaryName === 'php') {
 				// Figure out more about setting env, putenv(), etc.
@@ -96,7 +100,7 @@ export function sandboxedSpawnHandlerFactory(
 				);
 				processApi.exit(await result.exitCode);
 			} else if (binaryName === 'ls') {
-				const files = php.listFiles(args[1] || '/');
+				const files = php.listFiles(args[1] ?? cwd);
 				files.forEach((file) => {
 					processApi.stdout(file + '\n');
 				});

--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -7,6 +7,10 @@
 			content="width=device-width, initial-scale=1.0, user-scalable=yes"
 		/>
 		<title>WordPress PHP Playground</title>
+		<link
+			rel="stylesheet"
+			href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.css"
+		/>
 		<style>
 			html,
 			body {
@@ -153,6 +157,22 @@
 				width: 100%;
 				height: 100%;
 				border: 0;
+			}
+
+			#terminalPane {
+				height: 260px;
+				background: #111;
+				border-top: 1px solid #333;
+				color: #fff;
+				font-family: 'SF Mono', Monaco, 'Cascadia Code', 'Roboto Mono',
+					Consolas, 'Courier New', monospace;
+				padding: 8px;
+				box-sizing: border-box;
+			}
+
+			#terminal {
+				width: 100%;
+				height: calc(100% - 16px);
 			}
 
 			/* Modal styles */
@@ -315,6 +335,9 @@
 				#editor .cm-editor {
 					font-size: 13px;
 				}
+				#terminalPane {
+					height: 220px;
+				}
 			}
 
 			/* Small mobile adjustments */
@@ -342,6 +365,9 @@
 				#editor .cm-editor {
 					font-size: 12px;
 					line-height: 1.3;
+				}
+				#terminalPane {
+					height: 200px;
 				}
 			}
 
@@ -438,6 +464,9 @@
 			<div id="previewPane">
 				<iframe id="preview" title="WordPress Playground"></iframe>
 			</div>
+		</div>
+		<div id="terminalPane">
+			<div id="terminal"></div>
 		</div>
 
 		<!-- Help Modal -->
@@ -708,6 +737,8 @@
 				startPlaygroundWeb,
 				SupportedPHPVersionsList,
 			} from 'https://playground.wordpress.net/client/index.js';
+			import { Terminal } from 'https://cdn.jsdelivr.net/npm/xterm@5.3.0/+esm';
+			import { FitAddon } from 'https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/+esm';
 
 			const editorEl = document.getElementById('editor');
 			const phpCompartment = new Compartment();
@@ -834,6 +865,428 @@ var_dump($html_processor->get_tag());
 			let bootPromise = Promise.resolve();
 			let runCounter = 0;
 
+			const terminalContainer = document.getElementById('terminal');
+			const term = new Terminal({
+				convertEol: true,
+				fontSize: 14,
+				theme: {
+					background: '#111111',
+					foreground: '#f1f5f9',
+				},
+				cursorBlink: true,
+			});
+			const fitAddon = new FitAddon();
+			term.loadAddon(fitAddon);
+			term.open(terminalContainer);
+			fitAddon.fit();
+
+			function debounce(fn, delay) {
+				let timeoutId = null;
+				return (...args) => {
+					if (timeoutId) {
+						clearTimeout(timeoutId);
+					}
+					timeoutId = setTimeout(() => {
+						fn(...args);
+					}, delay);
+				};
+			}
+
+			window.addEventListener(
+				'resize',
+				debounce(() => fitAddon.fit(), 150)
+			);
+
+			const commandHistory = [];
+			let historyIndex = -1;
+			let currentLine = '';
+			let isRunningCommand = false;
+			let currentProcess = null;
+			const WP_CLI_PATH = '/tmp/wp-cli.phar';
+			const COMPOSER_PATH = '/tmp/composer.phar';
+
+			term.writeln(
+				'WordPress Playground CLI ready. Type `help` to see available commands.'
+			);
+			prompt(false);
+
+			function prompt(newLine = true) {
+				const prefix = newLine ? '\r\n$ ' : '$ ';
+				term.write(prefix);
+			}
+
+			function refreshInputLine() {
+				term.write(`\r\x1b[2K$ ${currentLine}`);
+			}
+
+			function writeStdout(text) {
+				if (!text) {
+					return;
+				}
+				const normalised = text.replace(/\r?\n/g, '\r\n');
+				term.write(normalised);
+			}
+
+			function writeStderr(text) {
+				if (!text) {
+					return;
+				}
+				const normalised = text.replace(/\r?\n/g, '\r\n');
+				term.write(`\u001b[31m${normalised}\u001b[0m`);
+			}
+
+			function splitShellCommand(command) {
+				const MODE_NORMAL = 0;
+				const MODE_IN_QUOTE = 1;
+				let mode = MODE_NORMAL;
+				let quote = '';
+				const parts = [];
+				let currentPart = '';
+				for (let i = 0; i < command.length; i++) {
+					const char = command[i];
+					if (mode === MODE_NORMAL) {
+						if (char === '"' || char === "'") {
+							mode = MODE_IN_QUOTE;
+							quote = char;
+						} else if (/\s/.test(char)) {
+							if (currentPart) {
+								parts.push(currentPart);
+								currentPart = '';
+							}
+						} else {
+							currentPart += char;
+						}
+					} else if (mode === MODE_IN_QUOTE) {
+						if (char === '\\') {
+							i += 1;
+							currentPart += command[i] ?? '';
+						} else if (char === quote) {
+							mode = MODE_NORMAL;
+							quote = '';
+						} else {
+							currentPart += char;
+						}
+					}
+				}
+				if (currentPart) {
+					parts.push(currentPart);
+				}
+				return parts;
+			}
+
+			async function ensureWpCliBinary() {
+				await bootPromise;
+				if (!client) {
+					throw new Error('Playground client is not ready yet.');
+				}
+				if (await client.fileExists(WP_CLI_PATH)) {
+					return;
+				}
+				term.writeln('\r\nDownloading WP-CLI...');
+				const response = await fetch(
+					'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar'
+				);
+				if (!response.ok) {
+					throw new Error('Failed to download WP-CLI');
+				}
+				const buffer = await response.arrayBuffer();
+				await client.writeFile(WP_CLI_PATH, new Uint8Array(buffer));
+				term.writeln('Download complete.');
+			}
+
+			async function ensureComposerBinary() {
+				await bootPromise;
+				if (!client) {
+					throw new Error('Playground client is not ready yet.');
+				}
+				if (await client.fileExists(COMPOSER_PATH)) {
+					return;
+				}
+				term.writeln('\r\nDownloading Composer...');
+				const response = await fetch(
+					'https://wordpress-playground-cors-proxy.net/?https://getcomposer.org/composer-stable.phar'
+				);
+				if (!response.ok) {
+					throw new Error('Failed to download Composer');
+				}
+				const buffer = await response.arrayBuffer();
+				await client.writeFile(COMPOSER_PATH, new Uint8Array(buffer));
+				term.writeln('Download complete.');
+			}
+
+			async function runCli(argv, options = {}) {
+				await bootPromise;
+				if (!client) {
+					throw new Error('Playground client is not ready yet.');
+				}
+				const requestHandler = client.__internal_getRequestHandler?.();
+				if (!requestHandler?.processManager) {
+					throw new Error('Unable to access PHP runtime.');
+				}
+				const { php, reap } =
+					await requestHandler.processManager.acquirePHPInstance();
+				let response;
+				try {
+					response = await php.cli(argv, options);
+				} catch (error) {
+					reap();
+					throw error;
+				}
+				response.exitCode.finally(() => {
+					reap();
+				});
+
+				const process = {
+					response,
+					php,
+					aborted: false,
+					async terminate() {
+						if (process.aborted) {
+							return;
+						}
+						process.aborted = true;
+						try {
+							await response.stdout.cancel();
+						} catch {}
+						try {
+							await response.stderr.cancel();
+						} catch {}
+						try {
+							php.exit(130);
+						} catch {}
+					},
+				};
+				const callbackSink = (callback) =>
+					new WritableStream({
+						write(chunk) {
+							if (process.aborted) {
+								return;
+							}
+							if (chunk) {
+								callback(chunk);
+							}
+						},
+					});
+
+				currentProcess = process;
+
+				const streamStdout = response.stdout
+					.pipeThrough(new TextDecoderStream())
+					.pipeTo(callbackSink(writeStdout))
+					.catch((error) => {
+						if (!process.aborted) {
+							throw error;
+						}
+					});
+
+				const streamStderr = response.stderr
+					.pipeThrough(new TextDecoderStream())
+					.pipeTo(callbackSink(writeStderr))
+					.catch((error) => {
+						if (!process.aborted) {
+							throw error;
+						}
+					});
+
+				const exitCodePromise = response.exitCode.catch((error) => {
+					if (!process.aborted) {
+						throw error;
+					}
+					return 130;
+				});
+
+				const [, , exitCode] = await Promise.all([
+					streamStdout,
+					streamStderr,
+					exitCodePromise,
+				]);
+
+				const wasAborted = process.aborted;
+				currentProcess = null;
+				if (wasAborted) {
+					term.writeln('\r\nProcess interrupted.');
+				}
+				return { exitCode, aborted: wasAborted };
+			}
+
+			async function runTerminalCommand(rawInput) {
+				const trimmed = rawInput.trim();
+				if (!trimmed) {
+					isRunningCommand = false;
+					prompt();
+					return;
+				}
+				const parts = splitShellCommand(trimmed);
+				if (parts.length === 0) {
+					isRunningCommand = false;
+					prompt();
+					return;
+				}
+				const [command, ...args] = parts;
+				try {
+					switch (command) {
+						case 'help': {
+							term.writeln(
+								'\r\nAvailable commands:\r\n  help        Show this message\r\n  php <...>  Run PHP CLI arguments\r\n  wp <...>   Run WP-CLI (auto-downloads if needed)\r\n  composer <...>  Run Composer (auto-downloads if needed)'
+							);
+							break;
+						}
+						case 'php': {
+							if (!args.length) {
+								term.writeln('\r\nUsage: php <arguments>');
+								break;
+							}
+							const result = await runCli(['php', ...args]);
+							if (!result.aborted && result.exitCode !== 0) {
+								term.writeln(
+									`\r\nProcess exited with code ${result.exitCode}`
+								);
+							}
+							break;
+						}
+						case 'wp': {
+							await ensureWpCliBinary();
+							const result = await runCli([
+								'php',
+								WP_CLI_PATH,
+								'--path=/wordpress',
+								...args,
+							]);
+							if (!result.aborted && result.exitCode !== 0) {
+								term.writeln(
+									`\r\nProcess exited with code ${result.exitCode}`
+								);
+							}
+							break;
+						}
+						case 'composer': {
+							await ensureComposerBinary();
+							const result = await runCli([
+								'php',
+								COMPOSER_PATH,
+								...args,
+							]);
+							if (!result.aborted && result.exitCode !== 0) {
+								term.writeln(
+									`\r\nProcess exited with code ${result.exitCode}`
+								);
+							}
+							break;
+						}
+						default:
+							term.writeln(`\r\n${command}: command not found`);
+					}
+				} catch (error) {
+					const message = error?.message || String(error);
+					term.writeln(`\r\nError: ${message}`);
+				} finally {
+					isRunningCommand = false;
+					if (!currentProcess) {
+						prompt();
+					}
+				}
+			}
+
+			async function abortActiveProcess() {
+				if (!currentProcess) {
+					isRunningCommand = false;
+					prompt();
+					return;
+				}
+				try {
+					await currentProcess.terminate();
+				} finally {
+					isRunningCommand = false;
+				}
+			}
+
+			term.onData((data) => {
+				if (data === '\u0003') {
+					term.write('^C');
+					void abortActiveProcess();
+					currentLine = '';
+					return;
+				}
+				if (isRunningCommand) {
+					return;
+				}
+				switch (data) {
+					case '\r': {
+						term.write('\r\n');
+						const submitted = currentLine;
+						if (submitted.trim()) {
+							commandHistory.unshift(submitted);
+						}
+						historyIndex = -1;
+						currentLine = '';
+						isRunningCommand = true;
+						void runTerminalCommand(submitted);
+						break;
+					}
+					case '\u007F': {
+						if (currentLine.length > 0) {
+							currentLine = currentLine.slice(0, -1);
+							term.write('\b \b');
+						}
+						break;
+					}
+					default: {
+						if ((data >= ' ' && data <= '~') || data >= '\u00a0') {
+							currentLine += data;
+							term.write(data);
+						}
+						break;
+					}
+				}
+			});
+
+			term.attachCustomKeyEventHandler((event) => {
+				if (event.type !== 'keydown') {
+					return true;
+				}
+				if ((event.metaKey || event.ctrlKey) && event.code === 'KeyV') {
+					navigator.clipboard
+						.readText()
+						.then((text) => {
+							if (!isRunningCommand && text) {
+								currentLine += text;
+								refreshInputLine();
+							}
+						})
+						.catch(() => {});
+					return false;
+				}
+				if (event.metaKey || event.ctrlKey) {
+					return true;
+				}
+				if (event.code === 'ArrowUp') {
+					event.preventDefault();
+					if (commandHistory.length === 0) {
+						return false;
+					}
+					const nextIndex = historyIndex + 1;
+					if (nextIndex < commandHistory.length) {
+						historyIndex = nextIndex;
+						currentLine = commandHistory[historyIndex];
+						refreshInputLine();
+					}
+					return false;
+				}
+				if (event.code === 'ArrowDown') {
+					event.preventDefault();
+					if (historyIndex > 0) {
+						historyIndex -= 1;
+						currentLine = commandHistory[historyIndex];
+					} else {
+						historyIndex = -1;
+						currentLine = '';
+					}
+					refreshInputLine();
+					return false;
+				}
+				return true;
+			});
+
 			// Detect platform for keyboard shortcut display
 			const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 			const shortcutText = isMac ? 'Cmd+S' : 'Ctrl+S';
@@ -858,6 +1311,7 @@ var_dump($html_processor->get_tag());
 			async function bootPlayground(phpVersion, wpVersion) {
 				// Point the iframe at the appropriate PHP and WordPress versions using the Query API
 				previewIframe.src = `https://playground.wordpress.net/remote.html`;
+				// previewIframe.src = `http://127.0.0.1:5400/remote.html`;
 				client = await startPlaygroundWeb({
 					iframe: previewIframe,
 					remoteUrl: previewIframe.src,

--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -1048,6 +1048,9 @@ var_dump($html_processor->get_tag());
 						if (process.aborted) {
 							return;
 						}
+						await new Promise((resolve) =>
+							setTimeout(resolve, 1000)
+						);
 						process.aborted = true;
 						abortedPromise.resolve();
 
@@ -1063,7 +1066,6 @@ var_dump($html_processor->get_tag());
 				const callbackSink = (callback) =>
 					new WritableStream({
 						write(chunk) {
-							console.log({ chunk });
 							if (process.aborted) {
 								return;
 							}
@@ -1081,11 +1083,14 @@ var_dump($html_processor->get_tag());
 
 				response.stderr
 					.pipeThrough(new TextDecoderStream())
-					.pipeTo(callbackSink(writeStderr));
+					.pipeTo(callbackSink(writeStderr))
+					.catch((error) => {
+						console.log('catch', error);
+					});
 
 				const exitCode = await Promise.race([
 					response.exitCode,
-					abortedPromise.promise.then(() => 130),
+					// abortedPromise.promise.then(() => 130),
 				]);
 
 				currentProcess = null;
@@ -1113,27 +1118,6 @@ var_dump($html_processor->get_tag());
 							term.writeln(
 								'\r\nAvailable commands:\r\n  help        Show this message\r\n  php <...>  Run PHP CLI arguments\r\n  wp <...>   Run WP-CLI (auto-downloads if needed)\r\n  composer <...>  Run Composer (auto-downloads if needed)'
 							);
-							break;
-						}
-						case 'ls': {
-							(
-								(await client.listFiles(args[0] || '/')) || []
-							).forEach((line) => {
-								term.writeln(line);
-							});
-							break;
-						}
-						case 'php': {
-							if (!args.length) {
-								term.writeln('\r\nUsage: php <arguments>');
-								break;
-							}
-							const result = await runCli(['php', ...args]);
-							if (!result.aborted && result.exitCode !== 0) {
-								term.writeln(
-									`\r\nProcess exited with code ${result.exitCode}`
-								);
-							}
 							break;
 						}
 						case 'wp': {
@@ -1165,8 +1149,26 @@ var_dump($html_processor->get_tag());
 							}
 							break;
 						}
-						default:
-							term.writeln(`\r\n${command}: command not found`);
+						default: {
+							if (!args.length) {
+								term.writeln('\r\nUsage: php <arguments>');
+								break;
+							}
+							const result = await runCli(parts);
+							if (result.exitCode === 127) {
+								term.writeln(
+									`\r\n${command}: command not found`
+								);
+							} else if (
+								!result.aborted &&
+								result.exitCode !== 0
+							) {
+								term.writeln(
+									`\r\nProcess exited with code ${result.exitCode}`
+								);
+							}
+							break;
+						}
 					}
 				} catch (error) {
 					const message = error?.message || String(error);

--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -1151,7 +1151,9 @@ var_dump($html_processor->get_tag());
 						}
 						default: {
 							if (!args.length) {
-								term.writeln('\r\nUsage: php <arguments>');
+								term.writeln(
+									`\r\nUsage: ${command} <arguments>`
+								);
 								break;
 							}
 							const result = await runCli(parts);

--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -1004,13 +1004,28 @@ var_dump($html_processor->get_tag());
 				}
 				term.writeln('\r\nDownloading Composer...');
 				const response = await fetch(
-					'https://wordpress-playground-cors-proxy.net/?https://getcomposer.org/composer-stable.phar'
+					'https://wordpress-playground-cors-proxy.net/?https://getcomposer.org/download/2.8.12/composer.phar'
 				);
 				if (!response.ok) {
 					throw new Error('Failed to download Composer');
 				}
 				const buffer = await response.arrayBuffer();
-				await client.writeFile(COMPOSER_PATH, new Uint8Array(buffer));
+				await client.writeFile(
+					COMPOSER_PATH + '.bin',
+					new Uint8Array(buffer)
+				);
+				await client.writeFile(
+					COMPOSER_PATH,
+					`<?php
+					// Composer assumes the grapheme_strlen function is available
+					// and will crash if it's not. Symfony Polyfills somehow do
+					// not kick in in this case.
+					function grapheme_strlen($string) {
+						return strlen($string);
+					}
+					require_once __FILE__ . '.bin';
+				`
+				);
 				term.writeln('Download complete.');
 			}
 

--- a/packages/playground/website/public/php-playground.html
+++ b/packages/playground/website/public/php-playground.html
@@ -1014,28 +1014,32 @@ var_dump($html_processor->get_tag());
 				term.writeln('Download complete.');
 			}
 
+			function invertPromise() {
+				let resolve, reject;
+				const promise = new Promise((_resolve, _reject) => {
+					resolve = _resolve;
+					reject = _reject;
+				});
+				return {
+					resolve,
+					reject,
+					promise,
+				};
+			}
+
 			async function runCli(argv, options = {}) {
 				await bootPromise;
 				if (!client) {
 					throw new Error('Playground client is not ready yet.');
 				}
-				const requestHandler = client.__internal_getRequestHandler?.();
-				if (!requestHandler?.processManager) {
-					throw new Error('Unable to access PHP runtime.');
-				}
-				const { php, reap } =
-					await requestHandler.processManager.acquirePHPInstance();
-				let response;
-				try {
-					response = await php.cli(argv, options);
-				} catch (error) {
-					reap();
-					throw error;
-				}
-				response.exitCode.finally(() => {
-					reap();
-				});
+				console.log({ argv, options });
+				await client.writeFile(
+					'/tmp/test.php',
+					'<?php echo "hi!"; flush(); sleep(60); echo "\nnewline"; ?>'
+				);
+				const response = await client.cli(argv, options);
 
+				const abortedPromise = invertPromise();
 				const process = {
 					response,
 					php,
@@ -1045,20 +1049,21 @@ var_dump($html_processor->get_tag());
 							return;
 						}
 						process.aborted = true;
-						try {
-							await response.stdout.cancel();
-						} catch {}
-						try {
-							await response.stderr.cancel();
-						} catch {}
-						try {
-							php.exit(130);
-						} catch {}
+						abortedPromise.resolve();
+
+						// Ignore cancelation errors and also don't
+						// await these promises. The cancel() calls
+						// go to the remote worker which may be busy
+						// for some more time before it's able to
+						// respond to the cancel() call.
+						response.stdout.cancel().catch(() => {});
+						response.stderr.cancel().catch(() => {});
 					},
 				};
 				const callbackSink = (callback) =>
 					new WritableStream({
 						write(chunk) {
+							console.log({ chunk });
 							if (process.aborted) {
 								return;
 							}
@@ -1070,43 +1075,22 @@ var_dump($html_processor->get_tag());
 
 				currentProcess = process;
 
-				const streamStdout = response.stdout
+				response.stdout
 					.pipeThrough(new TextDecoderStream())
-					.pipeTo(callbackSink(writeStdout))
-					.catch((error) => {
-						if (!process.aborted) {
-							throw error;
-						}
-					});
+					.pipeTo(callbackSink(writeStdout));
 
-				const streamStderr = response.stderr
+				response.stderr
 					.pipeThrough(new TextDecoderStream())
-					.pipeTo(callbackSink(writeStderr))
-					.catch((error) => {
-						if (!process.aborted) {
-							throw error;
-						}
-					});
+					.pipeTo(callbackSink(writeStderr));
 
-				const exitCodePromise = response.exitCode.catch((error) => {
-					if (!process.aborted) {
-						throw error;
-					}
-					return 130;
-				});
-
-				const [, , exitCode] = await Promise.all([
-					streamStdout,
-					streamStderr,
-					exitCodePromise,
+				const exitCode = await Promise.race([
+					response.exitCode,
+					abortedPromise.promise.then(() => 130),
 				]);
 
-				const wasAborted = process.aborted;
 				currentProcess = null;
-				if (wasAborted) {
-					term.writeln('\r\nProcess interrupted.');
-				}
-				return { exitCode, aborted: wasAborted };
+
+				return { exitCode, aborted: process.aborted };
 			}
 
 			async function runTerminalCommand(rawInput) {
@@ -1129,6 +1113,14 @@ var_dump($html_processor->get_tag());
 							term.writeln(
 								'\r\nAvailable commands:\r\n  help        Show this message\r\n  php <...>  Run PHP CLI arguments\r\n  wp <...>   Run WP-CLI (auto-downloads if needed)\r\n  composer <...>  Run Composer (auto-downloads if needed)'
 							);
+							break;
+						}
+						case 'ls': {
+							(
+								(await client.listFiles(args[0] || '/')) || []
+							).forEach((line) => {
+								term.writeln(line);
+							});
 							break;
 						}
 						case 'php': {
@@ -1198,6 +1190,8 @@ var_dump($html_processor->get_tag());
 				} finally {
 					isRunningCommand = false;
 				}
+
+				currentProcess = null;
 			}
 
 			term.onData((data) => {
@@ -1310,8 +1304,8 @@ var_dump($html_processor->get_tag());
 
 			async function bootPlayground(phpVersion, wpVersion) {
 				// Point the iframe at the appropriate PHP and WordPress versions using the Query API
-				previewIframe.src = `https://playground.wordpress.net/remote.html`;
-				// previewIframe.src = `http://127.0.0.1:5400/remote.html`;
+				// previewIframe.src = `https://playground.wordpress.net/remote.html`;
+				previewIframe.src = `http://127.0.0.1:5400/remote.html`;
 				client = await startPlaygroundWeb({
 					iframe: previewIframe,
 					remoteUrl: previewIframe.src,


### PR DESCRIPTION
## Motivation for the change, related issues

Work in progress to add XTerm.js to the PHP Playground to enable easy running wp-cli commands and installing Composer packages.

<img width="4112" height="2392" alt="CleanShot 2025-09-27 at 00 27 36@2x" src="https://github.com/user-attachments/assets/f15d1b33-81cc-4e93-920b-d43abb118859" />

I'd like to integrate this with WordPress Playground, too. TBD on how to reuse this code.

cc @akirk @mho22 @sirreal @dmsnell @brandonpayton @JanJakes @zaerl @ashfame @fellyph 