### PR TITLE
CORS proxy: Fix custom origin validation during deployment

### DIFF
--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -73,7 +73,6 @@ jobs:
                   if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
-                    $origin_pattern = ''
                     for origin in $CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED; do
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -73,9 +73,8 @@ jobs:
                   if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
-                    readarray -t CUSTOM_ORIGINS <<<"${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}"
+                    readarray -t\n CUSTOM_ORIGINS <<<"${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}"
                     for origin in "${CUSTOM_ORIGINS[@]}"; do
-
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
                       ]]; then

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -73,7 +73,7 @@ jobs:
                   if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
-                    readarray -t CUSTOM_ORIGINS <<< "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}"
+                    readarray -t CUSTOM_ORIGINS <<<"${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}"
                     for origin in "${CUSTOM_ORIGINS[@]}"; do
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -44,7 +44,7 @@ jobs:
             - name: Deploy to CORS proxy server
               shell: bash
               env:
-                  CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED: ${{ secrets.CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED }}
+                  CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED: ${{ vars.CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED }}
               run: |
                   mkdir -p ~/.ssh
                   echo "${{ secrets.DEPLOY_CORS_PROXY_TARGET_HOST_KEY }}" >> ~/.ssh/known_hosts
@@ -72,12 +72,11 @@ jobs:
                   if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
+                    $origin_pattern = ''
                     for origin in $CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED; do
-                      if ! (
-                        [[ $origin =~ ^https?://([a-zA-Z0-9-]+\.)*[a-zA-Z]{2,}$ ]] ||
-                        [[ $origin =~ ^https?://([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] ||
-                        [[ $origin =~ ^https?://^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}$ ]]
-                      ); then
+                      if ! [[
+                        $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
+                      ]];; then
                         echo "Unable to use CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED"
                         echo "Invalid origin: '$origin'"
                         exit -1;

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -73,7 +73,7 @@ jobs:
                   if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
-                    for origin in $CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED; do
+                    echo "$CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED" | while read -r origin; do
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
                       ]]; then

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -74,11 +74,11 @@ jobs:
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
                     readarray -t CUSTOM_ORIGINS <<< "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}"
-                    for origin in $CUSTOM_ORIGINS; do
+                    for origin in "${CUSTOM_ORIGINS[@]}"; do
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
                       ]]; then
-                        echo "Unable to use CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED"
+                        echo "Unable to use CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED"
                         echo "Invalid origin: '$origin'"
                         exit -1;
                       fi

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -10,18 +10,19 @@ jobs:
     build_and_deploy:
         # Only run this workflow from the trunk branch and when it's triggered by a maintainer listed below
         # TODO: Can we check for group membership?
-        if: >
-            github.ref == 'refs/heads/trunk' && (
-                github.event_name == 'workflow_run' ||
-                github.event_name == 'workflow_dispatch' ||
-                github.actor == 'adamziel' ||
-                github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak' ||
-                github.actor == 'brandonpayton' ||
-                github.actor == 'zaerl' ||
-                github.actor == 'akirk' ||
-                github.actor == 'janjakes'
-            )
+        # TODO: Re-enable this guard before merging.
+        # if: >
+        #     github.ref == 'refs/heads/trunk' && (
+        #         github.event_name == 'workflow_run' ||
+        #         github.event_name == 'workflow_dispatch' ||
+        #         github.actor == 'adamziel' ||
+        #         github.actor == 'dmsnell' ||
+        #         github.actor == 'bgrgicak' ||
+        #         github.actor == 'brandonpayton' ||
+        #         github.actor == 'zaerl' ||
+        #         github.actor == 'akirk' ||
+        #         github.actor == 'janjakes'
+        #     )
 
         # Specify runner + deployment step
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -73,8 +73,7 @@ jobs:
                   if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
-                    readarray -t\n CUSTOM_ORIGINS <<<"${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}"
-                    for origin in "${CUSTOM_ORIGINS[@]}"; do
+                    for origin in $CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED; do
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
                       ]]; then

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -10,19 +10,18 @@ jobs:
     build_and_deploy:
         # Only run this workflow from the trunk branch and when it's triggered by a maintainer listed below
         # TODO: Can we check for group membership?
-        # TODO: Re-enable this guard before merging.
-        # if: >
-        #     github.ref == 'refs/heads/trunk' && (
-        #         github.event_name == 'workflow_run' ||
-        #         github.event_name == 'workflow_dispatch' ||
-        #         github.actor == 'adamziel' ||
-        #         github.actor == 'dmsnell' ||
-        #         github.actor == 'bgrgicak' ||
-        #         github.actor == 'brandonpayton' ||
-        #         github.actor == 'zaerl' ||
-        #         github.actor == 'akirk' ||
-        #         github.actor == 'janjakes'
-        #     )
+        if: >
+            github.ref == 'refs/heads/trunk' && (
+                github.event_name == 'workflow_run' ||
+                github.event_name == 'workflow_dispatch' ||
+                github.actor == 'adamziel' ||
+                github.actor == 'dmsnell' ||
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton' ||
+                github.actor == 'zaerl' ||
+                github.actor == 'akirk' ||
+                github.actor == 'janjakes'
+            )
 
         # Specify runner + deployment step
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -73,7 +73,13 @@ jobs:
                   if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
-                    echo "$CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED" | while read -r origin; do
+                    for origin in $CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED; do
+                      # Remove leading and trailing whitespace
+                      # NOTE: IIUC, this should already be happening as part of
+                      # string splitting, but it does not appear to be.
+                      origin="${origin##*([[:space:]])}"
+                      origin="${origin%%*([[:space:]])}"
+
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
                       ]]; then

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -74,9 +74,12 @@ jobs:
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
                     for origin in $CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED; do
-                      if ! [[
-                        $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
-                      ]]; then
+                      # NOTE: These patterns are not perfect but should be sufficient here.
+                      if ! (
+                        [[ $origin =~ ^https?:\/\/([a-zA-Z0-9-]+\.)*[a-zA-Z]{2,}(:[[:digit:]]{1,5})?$ ]] ||
+                        [[ $origin =~ ^https?://([0-9]{1,3}\.){3}[0-9]{1,3}(:[[:digit:]]{1,5})?$ ]] ||
+                        [[ $origin =~ ^https?://^([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}(:[[:digit:]]{1,5})?$ ]]
+                      ); then
                         echo "Unable to use CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED"
                         echo "Invalid origin: '$origin'"
                         echo "Full contents: '${CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED}'"

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -77,7 +77,7 @@ jobs:
                     for origin in $CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED; do
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
-                      ]];; then
+                      ]]; then
                         echo "Unable to use CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED"
                         echo "Invalid origin: '$origin'"
                         exit -1;

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -75,11 +75,13 @@ jobs:
 
                     readarray -t CUSTOM_ORIGINS <<<"${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}"
                     for origin in "${CUSTOM_ORIGINS[@]}"; do
+
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
                       ]]; then
                         echo "Unable to use CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED"
                         echo "Invalid origin: '$origin'"
+                        echo "Full contents: '${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}'"
                         exit -1;
                       fi
 

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Deploy to CORS proxy server
               shell: bash
               env:
-                  CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED: ${{ vars.CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED }}
+                  CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED: ${{ vars.CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED }}
               run: |
                   mkdir -p ~/.ssh
                   echo "${{ secrets.DEPLOY_CORS_PROXY_TARGET_HOST_KEY }}" >> ~/.ssh/known_hosts
@@ -70,10 +70,11 @@ jobs:
                     -tt -C '~/cors-proxy-deployment/apply-update.sh'
 
                   # If configured, support CORS responses for a custom list of origins
-                  if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED}" ]]; then
+                  if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
-                    for origin in $CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED; do
+                    readarray -t CUSTOM_ORIGINS <<< "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}"
+                    for origin in $CUSTOM_ORIGINS; do
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
                       ]]; then

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -45,7 +45,7 @@ jobs:
             - name: Deploy to CORS proxy server
               shell: bash
               env:
-                  CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED: ${{ vars.CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED }}
+                  CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED: ${{ vars.CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED }}
               run: |
                   mkdir -p ~/.ssh
                   echo "${{ secrets.DEPLOY_CORS_PROXY_TARGET_HOST_KEY }}" >> ~/.ssh/known_hosts
@@ -70,22 +70,16 @@ jobs:
                     -tt -C '~/cors-proxy-deployment/apply-update.sh'
 
                   # If configured, support CORS responses for a custom list of origins
-                  if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}" ]]; then
+                  if [[ -n "${CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED}" ]]; then
                     CUSTOM_ORIGINS_PHP="<?php define('PLAYGROUND_CORS_PROXY_SUPPORTED_ORIGINS', array("
 
-                    for origin in $CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED; do
-                      # Remove leading and trailing whitespace
-                      # NOTE: IIUC, this should already be happening as part of
-                      # string splitting, but it does not appear to be.
-                      origin="${origin##*([[:space:]])}"
-                      origin="${origin%%*([[:space:]])}"
-
+                    for origin in $CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED; do
                       if ! [[
                         $origin =~ ^https?:\/\/(?:[a-zA-Z0-9-]+\.)*[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?::\d{1,5})?$
                       ]]; then
-                        echo "Unable to use CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED"
+                        echo "Unable to use CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED"
                         echo "Invalid origin: '$origin'"
-                        echo "Full contents: '${CUSTOM_SUPPORTED_ORIGINS_NEWLINE_SEPARATED}'"
+                        echo "Full contents: '${CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED}'"
                         exit -1;
                       fi
 


### PR DESCRIPTION
## Motivation for the change, related issues

We allow customizing the list of origins supported by the CORS proxy, but there is a bug in the deployment script that rejects valid origins within the custom origin list.

## Implementation details

This PR:
- Fixes the validation regex to accept port numbers.
- Fixes the validation regex to accept arbitrary TLDs.
- Makes the CUSTOM_SUPPORTED_ORIGINS_SPACE_SEPARATED list a variable instead of a secret so maintainers can edit the list directly. With a secret, the only way items can be added and removed is to know the current value of the secret, but GitHub does not expose the current value.

## Testing Instructions (or ideally a Blueprint)

- CI
- Manually trigger CORS proxy deployment from this PR branch
