### PR TITLE
Preserve chroot across all worker-managed PHP instances

### DIFF
--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -165,7 +165,8 @@
 					"php-dynamic-loading.spec.ts",
 					"php-request-handler.spec.ts",
 					"php.spec.ts",
-					"file-lock-manager-for-node.spec.ts"
+					"file-lock-manager-for-node.spec.ts",
+					"php-worker.spec.ts"
 				]
 			}
 		},
@@ -189,7 +190,8 @@
 					"php-dynamic-loading.spec.ts",
 					"php-request-handler.spec.ts",
 					"php.spec.ts",
-					"file-lock-manager-for-node.spec.ts"
+					"file-lock-manager-for-node.spec.ts",
+					"php-worker.spec.ts"
 				]
 			}
 		},

--- a/packages/php-wasm/node/src/test/php-worker.spec.ts
+++ b/packages/php-wasm/node/src/test/php-worker.spec.ts
@@ -1,0 +1,53 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries -- ignore test-related interdependencies so we can test.
+import { PHP, PHPRequestHandler, PHPWorker } from '@php-wasm/universal';
+import { loadNodeRuntime } from '..';
+import { RecommendedPHPVersion } from '@wp-playground/common';
+
+describe('PHP Worker', () => {
+	let handler: PHPRequestHandler;
+	let worker: PHPWorker;
+	beforeEach(async () => {
+		handler = new PHPRequestHandler({
+			documentRoot: '/wordpress',
+			absoluteUrl: 'http://127.0.0.1:2398',
+			phpFactory: async () =>
+				new PHP(await loadNodeRuntime(RecommendedPHPVersion)),
+			maxPhpInstances: 3,
+		});
+		worker = new PHPWorker(handler);
+		await worker.setPrimaryPHP(await handler.getPrimaryPhp());
+	});
+
+	afterEach(async () => {
+		await handler[Symbol.asyncDispose]();
+		await worker[Symbol.asyncDispose]();
+	});
+
+	it('chdir() should change cwd for the worker', async () => {
+		worker.chdir('/tmp');
+		expect(worker.cwd()).toBe('/tmp');
+	});
+
+	it.each(['primary', 'non-primary'])(
+		'chdir() should change cwd for the %s PHP instances',
+		async (instanceType) => {
+			worker.chdir('/tmp');
+
+			/**
+			 * Block the primary PHP instance to ensure run()
+			 * creates a fresh PHP instance.
+			 */
+			const { reap } = await handler.processManager.acquirePHPInstance({
+				considerPrimary: instanceType === 'primary',
+			});
+			try {
+				const response = await worker.run({
+					code: `<?php echo getcwd();`,
+				});
+				expect(response.text).toBe('/tmp');
+			} finally {
+				reap();
+			}
+		}
+	);
+});

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -59,6 +59,8 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 	/** @inheritDoc @php-wasm/universal!RequestHandler.documentRoot  */
 	documentRoot = '';
 
+	private chroot: string | null = null;
+
 	#eventListeners: Map<string, Set<PHPWorkerEventListener>> = new Map();
 
 	onMessageListeners: MessageListener[] = [];
@@ -101,6 +103,7 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 	public __internal_setRequestHandler(requestHandler: PHPRequestHandler) {
 		this.absoluteUrl = requestHandler.absoluteUrl;
 		this.documentRoot = requestHandler.documentRoot;
+		this.chroot = this.documentRoot;
 		_private.set(this, {
 			..._private.get(this),
 			requestHandler,
@@ -177,9 +180,7 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 
 	/** @inheritDoc @php-wasm/universal!/PHP.run */
 	async run(request: PHPRunOptions): Promise<PHPResponse> {
-		const { php, reap } = await _private
-			.get(this)!
-			.requestHandler!.processManager.acquirePHPInstance();
+		const { php, reap } = await this.acquirePHPInstance();
 		try {
 			return await php.run(request);
 		} finally {
@@ -192,9 +193,7 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 		argv: string[],
 		options?: { env?: Record<string, string> }
 	): Promise<StreamedPHPResponse> {
-		const { php, reap } = await _private
-			.get(this)!
-			.requestHandler!.processManager.acquirePHPInstance();
+		const { php, reap } = await this.acquirePHPInstance();
 		try {
 			return await php.cli(argv, options);
 		} finally {
@@ -204,7 +203,27 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 
 	/** @inheritDoc @php-wasm/universal!/PHP.chdir */
 	chdir(path: string): void {
+		// Remember the new chroot for all PHP instances yet to be acquired.
+		this.chroot = path;
 		return _private.get(this)!.php!.chdir(path);
+	}
+
+	/** @inheritDoc @php-wasm/universal!/PHP.chdir */
+	cwd(): string {
+		return _private.get(this)!.php!.cwd();
+	}
+
+	/**
+	 * @returns A PHP instance with a consistent chroot.
+	 */
+	private async acquirePHPInstance() {
+		const { php, reap } = await _private
+			.get(this)!
+			.requestHandler!.processManager.acquirePHPInstance();
+		if (this.chroot !== null) {
+			php.chdir(this.chroot);
+		}
+		return { php, reap };
 	}
 
 	/** @inheritDoc @php-wasm/universal!/PHP.setSapiName */


### PR DESCRIPTION
## Motivation for the change, related issues

After this PR, `phpWorker.chdir("/tmp")` remains in effect for all subsequently spawned PHP instances. Before this PR, it spawns a single PHP instance, sets the chdir there, and immediately reaps it, leaving the chdir unused by all future PHP instances.

## Implementation details

Ensures `PHPWorker` calls `php.chdir()` on all newly spawned PHP instances. The underlying logic may also make sense at the `PHPProcessManager` level. However, since I need `playgroundClient.chdir()` to work correctly, we'll need a little something at the worker level as well – therefore I feel confident merging this change and revisiting it later if needed.

## Testing Instructions (or ideally a Blueprint)

CI, this PR comes with a test.
