### PR TITLE
[PHP utils] Export splitShellCommand

### DIFF
--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -12,6 +12,7 @@ export {
 export { createSpawnHandler } from './create-spawn-handler';
 export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
+export { splitShellCommand } from './split-shell-command';
 export { WritablePolyfill, type WritableOptions } from './writable-polyfill';
 export { EventEmitterPolyfill } from './event-emitter-polyfill';
 export * from './php-vars';


### PR DESCRIPTION
## Motivation for the change, related issues

Pre-requisite for https://github.com/WordPress/wordpress-playground/pull/2699. Empowers developers to create terminal-enabled apps by exporting the `splitShellCommand()` utility that was internal before.

```ts
import { splitShellCommand } from "@php-wasm/util";
splitShellCommand('wp create post --title="Great post title!"');
['wp', 'create', 'post', '--title=Great post title!']
```
