### PR TITLE
[Docs] Adding table lead guide documentation

### DIFF
--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -1,7 +1,7 @@
 ---
 slug: /contributing/table-lead-guide
 title: Table Lead Guide for Contributor Day
-description: A concise guide for leading a WordPress Playground table at WordCamp Contributor Day.
+description: How to lead a WordPress Playground table at Contributor Day of a WordCamp.
 ---
 
 # Table Lead Guide for Contributor Day

--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -43,7 +43,7 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 
 **Encourage Different Contribution Types**:
 
-Check the contributors' level, try to understand based on their level how they can contribute to the project in a short window during the contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing
+Check the contributors' levels, try to understand based on their level how they can contribute to the project in the short window of a contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing:
 
 -   Documentation improvements and translations.
 -   Carefully crafted issues describing problems with actionable solutions.

--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -12,9 +12,10 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 
 ### Pre-Work Checklist
 
--   **Curate "Good First Issues"**: Review and update the [good first issues list](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) on GitHub. These should be straightforward tasks that new contributors can complete independently.
--   **Coordinate with the Team**: Confirm if team members are available online to provide remote support during the event, especially for flagship WordCamps.
--   **Connect with Local Contributors**: Identify regular contributors in the region attending the event. This is an opportunity to gather feedback and strengthen community connections.
+-   **Curate "Good First Issues"**: Review and update the [good first issues list](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) on GitHub. These should be straightforward tasks that new contributors can complete independently. If you find a bug that is not on the list but could be part of it, contact the playground team at the Slack channel.
+-   **Coordinate with the Playground Team**: Confirm if Playground team members are available online to provide remote support during the event, especially for flagship WordCamps. Due to timezone differences, align in advance at the #playground channel to check their availability.
+-   **Connect with Local Contributors**: Identify regular contributors in the region attending the event. Check on the #playground Slack Channel if an active community member is participating in the contributor day. This is an opportunity to gather feedback and strengthen community connections.
+-   **Check the Playground Repository**: If you never contribute with the WordPress Playground Repository, you should get familiar with this a good section at the documentation that can guide you to understand the project is [Developers > Architecture](/developers/architecture) it will contain information how the project is organized. If you have any questions, please get in touch with the team at the Playground Slack channel.
 
 ## Starting the Day
 
@@ -32,6 +33,7 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
     - [Playground Documentation](https://wordpress.github.io/wordpress-playground/)
     - [Playground Step Library](https://akirk.github.io/playground-step-library/)
     - [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+    - [Contributor Day guide](/contributing/contributor-day/)
 
 5. **Introduce the GitHub Repository**: Provide a brief walkthrough of the repository structure, highlighting different packages and their purposes for first-time contributors.
 
@@ -41,9 +43,11 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 
 **Encourage Different Contribution Types**:
 
+Check the contributors' level, try to understand based on their level how they can contribute to the project in a short window during the contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing
+
 -   Documentation improvements and translations
 -   Carefully crafted issues describing problems with actionable solutions
--   Blueprint creation and plugin demos
+-   Blueprint creation and plugin demos at the WordPress plugin repository
 -   Testing and product feedback
 
 **Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the [Polyglots/Translation table](https://make.wordpress.org/polyglots/) might translate Playground documentation, or the [Core Test team](https://make.wordpress.org/test/) could provide valuable Playground feedback.

--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -1,0 +1,74 @@
+---
+slug: /contributing/table-lead-guide
+title: Table Lead Guide for Contributor Day
+description: A concise guide for leading a WordPress Playground table at WordCamp Contributor Day.
+---
+
+# Table Lead Guide for Contributor Day
+
+This guide helps table leads prepare for and manage a WordPress Playground contributor table at WordCamp events.
+
+## Before Contributor Day
+
+### Pre-Work Checklist
+
+-   **Curate "Good First Issues"**: Review and update the [good first issues list](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) on GitHub. These should be straightforward tasks that new contributors can complete independently.
+-   **Coordinate with the Team**: Confirm if team members are available online to provide remote support during the event, especially for flagship WordCamps.
+-   **Connect with Local Contributors**: Identify regular contributors in the region attending the event. This is an opportunity to gather feedback and strengthen community connections.
+
+## Starting the Day
+
+### Setup and Onboarding
+
+1. **Create Your Agenda**: Prepare a flexible checklist of key activities while allowing for organic collaboration. Share it in the project documentation if helpful.
+
+2. **Guide Contributors to Slack**: Direct everyone to the `#playground` channel on WordPress Slack. This centralizes communication and enables asynchronous collaboration with late arrivals.
+
+3. **Post a Welcome Message**: Share an initial message in the Slack channel announcing your presence (in-person or online) and welcoming contributions from everyone.
+
+4. **Share Essential Links**: Post these resources in the `#playground` channel:
+
+    - [WordPress Playground Web Instance](https://playground.wordpress.net/)
+    - [Playground Documentation](https://wordpress.github.io/wordpress-playground/)
+    - [Playground Step Library](https://akirk.github.io/playground-step-library/)
+    - [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+
+5. **Introduce the GitHub Repository**: Provide a brief walkthrough of the repository structure, highlighting different packages and their purposes for first-time contributors.
+
+## During the Day
+
+### Managing Contributions
+
+**Encourage Different Contribution Types**:
+
+-   Documentation improvements and translations
+-   Carefully crafted issues describing problems with actionable solutions
+-   Blueprint creation and plugin demos
+-   Testing and product feedback
+
+**Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the Translation(#polyglots) table might translate Playground documentation, or the #test-core team could provide valuable Playground feedback.
+
+**Collect Feedback**: Ask contributors about their experience and note improvement suggestions. Document this feedback in a P2 post when possible.
+
+## After the Event
+
+### Follow-Up and Support
+
+1. **Review Pull Requests**: List PRs created during the day and assess their completion likelihood. Most contributions have a short momentum window—engagement within the first two weeks is critical.
+
+2. **Set Clear Expectations**: For incomplete PRs, follow this approach:
+
+    - After one month of inactivity, leave a comment asking if the author plans to complete the work
+    - If no response after two more weeks, inform them that the PR may be taken over by another contributor or closed
+
+3. **Stay Active on Slack**: Continue supporting new contributors through the `#playground` channel, answering questions and helping them become regular contributors.
+
+4. **Reflect and Improve**: Review collected feedback and your experience to refine this guide for future events.
+
+## Getting Help
+
+-   **During the Event**: Connect with contributors at the Playground table
+-   **Ongoing Support**: Use the [`#playground` Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K)
+-   **Report Issues**: Submit to the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new)
+
+For more information on contributing to WordPress Playground, see the [Contributor Day guide](/contributing/contributor-day).

--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -63,7 +63,7 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 
 3. **Stay Active on Slack**: Continue supporting new contributors through the `#playground` channel, answering questions and helping them become regular contributors.
 
-4. **Reflect and Improve**: Review collected feedback and your experience to refine this guide for future events.
+4. **Reflect and Improve**: Review collected feedback and your experience to refine this guide for future events. Feel free to submit a Pull Request to this guide!
 
 ## Getting Help
 

--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -45,14 +45,14 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 
 Check the contributors' level, try to understand based on their level how they can contribute to the project in a short window during the contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing
 
--   Documentation improvements and translations
--   Carefully crafted issues describing problems with actionable solutions
--   Blueprint creation and plugin demos at the WordPress plugin repository
--   Testing and product feedback
+-   Documentation improvements and translations.
+-   Carefully crafted issues describing problems with actionable solutions.
+-   Blueprint creation and plugin demos at the WordPress plugin repository.
+-   Testing and product feedback.
 
 **Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the [Polyglots/Translation table](https://make.wordpress.org/polyglots/) might translate Playground documentation, or the [Core Test team](https://make.wordpress.org/test/) could provide valuable Playground feedback.
 
-**Collect Feedback**: Ask contributors about their experience and note improvement suggestions. Document this feedback in a P2 post when possible.
+**Collect Feedback**: Ask contributors about their experience and note improvement suggestions. Report this in the [#playground Slack Channel](https://wordpress.slack.com/archives/C04EWKGDJ0K) if possible.
 
 ## After the Event
 
@@ -62,8 +62,8 @@ Check the contributors' level, try to understand based on their level how they c
 
 2. **Set Clear Expectations**: For incomplete PRs, follow this approach:
 
-    - After one month of inactivity, leave a comment asking if the author plans to complete the work
-    - If no response after two more weeks, inform them that the PR may be taken over by another contributor or closed
+    - After one month of inactivity, leave a comment asking if the author plans to complete the work.
+    - If no response after two more weeks, inform them that the PR may be taken over by another contributor or closed.
 
 3. **Stay Active on Slack**: Continue supporting new contributors through the `#playground` channel, answering questions and helping them become regular contributors.
 
@@ -71,8 +71,8 @@ Check the contributors' level, try to understand based on their level how they c
 
 ## Getting Help
 
--   **During the Event**: Connect with contributors at the Playground table
--   **Ongoing Support**: Use the [`#playground` Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K)
--   **Report Issues**: Submit to the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new)
+-   **During the Event**: Connect with contributors at the Playground table.
+-   **Ongoing Support**: Use the [`#playground` Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   **Report Issues**: Submit to the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new).
 
 For more information on contributing to WordPress Playground, see the [Contributor Day guide](/contributing/contributor-day).

--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -46,7 +46,7 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 -   Blueprint creation and plugin demos
 -   Testing and product feedback
 
-**Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the Translation(#polyglots) table might translate Playground documentation, or the #test-core team could provide valuable Playground feedback.
+**Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the [Polyglots/Translation table](https://make.wordpress.org/polyglots/) might translate Playground documentation, or the [Core Test team](https://make.wordpress.org/test/) could provide valuable Playground feedback.
 
 **Collect Feedback**: Ask contributors about their experience and note improvement suggestions. Document this feedback in a P2 post when possible.
 

--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -22,7 +22,7 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 
 1. **Create Your Agenda**: Prepare a flexible checklist of key activities while allowing for organic collaboration. Share it in the project documentation if helpful.
 
-2. **Guide Contributors to Slack**: Direct everyone to the `#playground` channel on WordPress Slack. This centralizes communication and enables asynchronous collaboration with late arrivals.
+2. **Guide Contributors to Slack**: Direct everyone to the [`#playground` channel on WordPress Slack](https://wordpress.slack.com/archives/C04EWKGDJ0K). This centralizes communication and enables asynchronous collaboration with late arrivals.
 
 3. **Post a Welcome Message**: Share an initial message in the Slack channel announcing your presence (in-person or online) and welcoming contributions from everyone.
 


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request adds a new documentation page that serves as a guide for table leads at WordCamp Contributor Day events, specifically focusing on managing a WordPress Playground contributor table. The guide covers preparation, onboarding, contribution management, and post-event follow-up.
