### PR TITLE
docs: add browser support information to limitations documentation

### DIFF
--- a/packages/docs/site/docs/developers/24-limitations/01-index.md
+++ b/packages/docs/site/docs/developers/24-limitations/01-index.md
@@ -30,6 +30,19 @@ As Playground [streams rather than serves](/about#streamed-not-served) WordPress
 </figure>
 </blockquote>
 
+### Browser support
+
+WordPress Playground is designed to work across all major desktop and mobile browsers. This includes:
+
+- **Desktop browsers**: Chrome, Firefox, Safari, Edge, and other Chromium-based browsers
+- **Mobile browsers**: Safari (iOS), Chrome (Android), and other mobile browser variants
+
+Playground leverages modern web technologies and should function consistently across these browser environments. However, some advanced features may have varying levels of support depending on the specific browser and its version.
+
+<blockquote>
+<strong>Note:</strong> Opera Mini support is not currently confirmed.
+</blockquote>
+
 ## When developing with Playground
 
 ### Iframe quirks


### PR DESCRIPTION
## What

Adds browser support information to the limitations documentation page.

## Why

Users need clear information about which browsers are supported by WordPress Playground to make informed decisions about compatibility and usage.

## How

- Added new 'Browser support' section under 'In the browser' 
- Documented support for major desktop and mobile browsers (Chrome, Firefox, Safari, Edge, and Chromium-based browsers)
- Included note about Opera Mini support uncertainty
- Maintained consistent documentation formatting and style

## Testing

- [ ] Verify the new section displays correctly in the documentation
- [ ] Check that the formatting matches the existing documentation style
- [ ] Confirm the information is accurate and helpful for users

## Screenshots

[Screenshots to be added]