### PR TITLE
[i18n] Fixing typos in French translation of quick-start-guide.md

### DIFF
--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -74,7 +74,7 @@ https://playground.wordpress.net/?plugin=coblocks&plugin=friends&theme=pendant
 <ThisIsQueryApi />
 
 <!-- ## Save your site -->
-## Sauvegardez votre site
+## Sauvegarder votre site
 
 <!-- To keep your WordPress Playground site for longer than a single browser session, you can export it as a `.zip` file. -->
 Pour conserver votre site WordPress Playground au delà d’une seule session de navigateur, vous pouvez l’exporter sous la forme d’un fichier `.zip`.


### PR DESCRIPTION
## Implementation details
Fixing typos in French translation of quick-start-guide.md

part of #2621

cc [fellyph](@github.com/fellyph) 
