### PR TITLE
[PHP] Allow removing CWD during runtime rotation

### DIFF
--- a/packages/php-wasm/node/src/lib/node-fs-mount.ts
+++ b/packages/php-wasm/node/src/lib/node-fs-mount.ts
@@ -3,6 +3,7 @@ import {
 	FSHelpers,
 	type MountHandler,
 } from '@php-wasm/universal';
+import { isParentOf } from '@php-wasm/util';
 import { lstatSync } from 'fs';
 import { dirname } from 'path';
 
@@ -53,6 +54,12 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 			FS!.unmount(vfsMountPoint);
 			if (removeVfsNode) {
 				if (FS.isDir(lookup.node.mode)) {
+					if (isParentOf(vfsMountPoint, FS.cwd())) {
+						throw new Error(
+							`Cannot remove the VFS directory "${vfsMountPoint}" on umount cleanup – it is a parent of the CWD "${FS.cwd()}". Change CWD before ` +
+								`unmounting or explicitly disable post-unmount node cleanup with createNodeFsMountHandler(path, {cleanupNodesOnUnmount: false}).`
+						);
+					}
 					FS.rmdir(vfsMountPoint);
 				} else {
 					FS.unlink(vfsMountPoint);

--- a/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
+++ b/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
@@ -51,7 +51,6 @@ describe.each([true, false])(
 
 			const php = new PHP(await recreateRuntime());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime: recreateRuntimeSpy,
 				maxRequests: 10,
 			});
@@ -88,7 +87,6 @@ describe.each([true, false])(
 
 			const php = new PHP(await recreateRuntime());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime: recreateRuntimeSpy,
 				maxRequests: 10,
 			});
@@ -121,7 +119,6 @@ describe.each([true, false])(
 
 			const php = new PHP(await recreateRuntime());
 			php.enableRuntimeRotation({
-				cwd: '/wordpress',
 				recreateRuntime: recreateRuntimeSpy,
 				maxRequests: 10,
 			});
@@ -228,7 +225,6 @@ describe.each([true, false])(
 			// Rotate the PHP runtime
 			const php = new PHP(await recreateRuntime());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime: recreateRuntimeSpy,
 				maxRequests: 1000,
 			});
@@ -257,7 +253,6 @@ describe.each([true, false])(
 			const recreateRuntimeSpy = vitest.fn(recreateRuntime);
 			const php = new PHP(await recreateRuntimeSpy());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime: recreateRuntimeSpy,
 				maxRequests: 1,
 			});
@@ -271,7 +266,6 @@ describe.each([true, false])(
 			const recreateRuntimeSpy = vitest.fn(recreateRuntime);
 			const php = new PHP(await recreateRuntimeSpy());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime: recreateRuntimeSpy,
 				maxRequests: 1234,
 			});
@@ -289,7 +283,6 @@ describe.each([true, false])(
 			const recreateRuntimeSpy = vitest.fn(recreateRuntime);
 			const php = new PHP(await recreateRuntimeSpy());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime: recreateRuntimeSpy,
 				maxRequests: 1234,
 			});
@@ -318,7 +311,6 @@ describe.each([true, false])(
 			});
 			const php = new PHP(await recreateRuntimeSpy());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime: recreateRuntimeSpy,
 				maxRequests: 1,
 			});
@@ -339,7 +331,6 @@ describe.each([true, false])(
 		it('Should preserve the custom SAPI name', async () => {
 			const php = new PHP(await recreateRuntime());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime,
 				maxRequests: 1,
 			});
@@ -356,7 +347,6 @@ describe.each([true, false])(
 		it('Should preserve the MEMFS files', async () => {
 			const php = new PHP(await recreateRuntime());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime,
 				maxRequests: 1,
 			});
@@ -379,7 +369,6 @@ describe.each([true, false])(
 		it('Should not overwrite the NODEFS files', async () => {
 			const php = new PHP(await recreateRuntime());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime,
 				maxRequests: 1,
 			});
@@ -424,7 +413,6 @@ describe.each([true, false])(
 		it('Should preserve the spawn handler through PHP runtime recreation', async () => {
 			const php = new PHP(await recreateRuntime());
 			php.enableRuntimeRotation({
-				cwd: '/test-root',
 				recreateRuntime,
 				maxRequests: 1,
 			});
@@ -464,6 +452,64 @@ describe.each([true, false])(
 			});
 			expect(result2.text).toBe('Hello Again');
 			expect(spawnHandlerCallCount).toBe(2);
+		}, 30_000);
+
+		it('Should preserve NODEFS mount when CWD is the same as mount point', async () => {
+			const php = new PHP(await recreateRuntime());
+			php.enableRuntimeRotation({
+				recreateRuntime,
+				maxRequests: 1,
+			});
+
+			// Create a temporary directory to mount
+			const tempDir = fs.mkdtempSync(
+				path.join(os.tmpdir(), 'nodefs-mount-')
+			);
+			const testFile = path.join(tempDir, 'test.txt');
+			fs.writeFileSync(testFile, 'Hello from NODEFS');
+
+			try {
+				// Mount the temp directory at /wordpress
+				await php.mount(
+					'/wordpress',
+					createNodeFsMountHandler(tempDir)
+				);
+
+				// Set CWD to the mount point
+				php.chdir('/wordpress');
+				expect(php.cwd()).toBe('/wordpress');
+
+				// Verify the mounted file is accessible
+				expect(php.fileExists('/wordpress/test.txt')).toBe(true);
+				expect(php.readFileAsText('/wordpress/test.txt')).toBe(
+					'Hello from NODEFS'
+				);
+
+				// Trigger runtime rotation by making a request
+				await php.run({ code: `<?php echo "Triggering rotation";` });
+				await php.run({ code: `<?php echo "Triggering rotation";` });
+
+				// Verify CWD is preserved after rotation
+				expect(php.cwd()).toBe('/wordpress');
+
+				// Verify the mount is still accessible after rotation
+				expect(php.fileExists('/wordpress/test.txt')).toBe(true);
+				expect(php.readFileAsText('/wordpress/test.txt')).toBe(
+					'Hello from NODEFS'
+				);
+
+				// Test that we can still write to the mounted directory
+				php.writeFile(
+					'/wordpress/new-file.txt',
+					'Created after rotation'
+				);
+				expect(
+					fs.readFileSync(path.join(tempDir, 'new-file.txt'), 'utf8')
+				).toBe('Created after rotation');
+			} finally {
+				fs.rmSync(tempDir, { recursive: true });
+				php.exit();
+			}
 		}, 30_000);
 	}
 );

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -89,7 +89,6 @@ export class PHP implements Disposable {
 		needsRotating: boolean;
 		maxRequests: number;
 		requestsMade: number;
-		cwd?: string;
 	} = {
 		enabled: false,
 		recreateRuntime: () => 0,
@@ -1315,14 +1314,12 @@ export class PHP implements Disposable {
 	enableRuntimeRotation(options: {
 		recreateRuntime: () => Promise<number> | number;
 		maxRequests?: number;
-		cwd?: string;
 	}) {
 		this.#rotationOptions = {
 			...this.#rotationOptions,
 			enabled: true,
 			recreateRuntime: options.recreateRuntime,
 			maxRequests: options.maxRequests ?? 400,
-			cwd: options.cwd,
 		};
 	}
 
@@ -1357,6 +1354,27 @@ export class PHP implements Disposable {
 		const oldFS = this[__private__dont__use].FS;
 		const oldRootLevelPaths = this.listFiles('/').map((file) => `/${file}`);
 		const oldSpawnProcess = this[__private__dont__use].spawnProcess;
+
+		// Temporarily set CWD to / and restore it at the end of this method.
+		//
+		// There's a chance cleaning up old mounts via mount.unmount()
+		// will attempt removing the CWD. Normally, this would throw
+		// FS.ErrnoError(10) EBUSY and interrupt the PHP runtime rotation,
+		// leaving us in a broken state.
+		//
+		// Even though removing the CWD directory is not allowed by the
+		// filesystem, we don't care that much here – we're merely freeing
+		// all the resources allocated by the old filesystem before it's
+		// garbage collected. We are about to recreate the same filesystem
+		// structure and mounts in another PHP runtime.
+		//
+		// Therefore, let's suspend the strict EBUSY check by setting the CWD
+		// to / for the cleanup purposes. We'll attempt to restore the original
+		// CWD on the new runtime once we re-apply all the mounts there. We'll
+		// only have a real reason to throw an error if the CWD path does not
+		// exist in the new filesystem after the rotation.
+		const oldCWD = oldFS.cwd();
+		oldFS.chdir('/');
 
 		// Unmount all the mount handlers
 		const mountHandlers: { mountHandler: MountHandler; vfsPath: string }[] =
@@ -1405,6 +1423,16 @@ export class PHP implements Disposable {
 		for (const { mountHandler, vfsPath } of mountHandlers) {
 			this.mkdir(vfsPath);
 			await this.mount(vfsPath, mountHandler);
+		}
+		try {
+			newFs.chdir(oldCWD);
+		} catch (e) {
+			throw new Error(
+				`Failed to restore CWD to ${oldCWD} after PHP runtime rotation.`,
+				{
+					cause: e,
+				}
+			);
 		}
 	}
 

--- a/packages/php-wasm/universal/src/lib/rotate-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/rotate-php-runtime.ts
@@ -15,13 +15,11 @@ export interface RotateOptions {
  */
 export function rotatePHPRuntime({
 	php,
-	cwd,
 	recreateRuntime,
 	maxRequests = 400,
 }: RotateOptions) {
 	return php.enableRuntimeRotation({
 		recreateRuntime,
 		maxRequests,
-		cwd,
 	});
 }

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -319,7 +319,6 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 			recreateRuntime: options.createPhpRuntime,
 			maxRequests: 400,
 		});
-		php.chdir(requestHandler.documentRoot);
 
 		if (options.onPHPInstanceCreated) {
 			await options.onPHPInstanceCreated(php, { isPrimary });

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -316,10 +316,10 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 		// Rotate the PHP runtime periodically to avoid memory leak-related crashes.
 		// @see https://github.com/WordPress/wordpress-playground/pull/990 for more context
 		php.enableRuntimeRotation({
-			cwd: requestHandler.documentRoot,
 			recreateRuntime: options.createPhpRuntime,
 			maxRequests: 400,
 		});
+		php.chdir(requestHandler.documentRoot);
 
 		if (options.onPHPInstanceCreated) {
 			await options.onPHPInstanceCreated(php, { isPrimary });


### PR DESCRIPTION
## Motivation for the change, related issues

Temporarily sets CWD to `/` at the beginning of PHP runtime rotation
and restores it at the end of the rotation.

This resolves a Playground CLI issue that left the runtime in an undefined
state when rotating the runtime with a local mount at `/wordpress`

## Implementation details

There's a chance cleaning up old mounts via mount.unmount()
will attempt removing the CWD. Normally, this would throw
FS.ErrnoError(10) EBUSY and interrupt the PHP runtime rotation,
leaving us in a broken state.

Even though removing the CWD directory is not allowed by the
filesystem, we don't care that much here – we're merely freeing
all the resources allocated by the old filesystem before it's
garbage collected. We are about to recreate the same filesystem
structure and mounts in another PHP runtime.

Therefore, let's suspend the strict EBUSY check by setting the CWD
to / for the cleanup purposes. We'll attempt to restore the original
CWD on the new runtime once we re-apply all the mounts there. We'll
only have a real reason to throw an error if the CWD path does not
exist in the new filesystem after the rotation.

## Testing Instructions (or ideally a Blueprint)

CI unit tests.

For manual testing, do this:

```
cli.ts server --mount-before-install=./test-site/:/wordpress
```

Then:

1. Let it do the setup.
7. Modify wp-content/themes/twentytwentyfour/functions.php to call `non_existent_function()`. This will nudge the PHP class to rotate the runtime and call `unmount()` for all the mounts,
8. Run the following command:

```
cli.ts server --mount-before-install=./test-site/:/wordpress  --skip-wordpress-setup
```

Finally, visit the local site. You should see an error screen. Refresh it three times, confirm you still see the same WordPress error screen.