### PR TITLE
[CLI] Respond with HTTP 500 response when the request handler throws an error

### DIFF
--- a/packages/meta/src/node-es-module-loader/loader.mts
+++ b/packages/meta/src/node-es-module-loader/loader.mts
@@ -14,7 +14,10 @@ const workspaceRoot = join(import.meta.dirname, '..', '..', '..', '..');
 const tsconfigPath = join(workspaceRoot, 'tsconfig.base.json');
 const tsconfig: TsConfig = JSON.parse(readFileSync(tsconfigPath, 'utf-8'));
 const pathAliases = tsconfig.compilerOptions.paths;
-const baseUrl = tsconfig.compilerOptions.baseUrl || '.';
+const baseUrl = resolvePath(
+	tsconfig.compilerOptions.baseUrl || '.',
+	dirname(tsconfigPath)
+);
 
 // Use a URL so we can compare more easily with file:// URLs during load.
 const playgroundPackageRootUrl = pathToFileURL(

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -448,6 +448,7 @@ type PlaygroundCliWorker =
 export interface RunCLIServer extends AsyncDisposable {
 	playground: RemoteAPI<PlaygroundCliWorker>;
 	server: Server;
+	serverUrl: string;
 	[Symbol.asyncDispose](): Promise<void>;
 	// Expose the number of worker threads to the test runner.
 	workerThreadCount: number;
@@ -755,6 +756,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 				return {
 					playground,
 					server,
+					serverUrl,
 					[Symbol.asyncDispose]: async function disposeCLI() {
 						await Promise.all(
 							playgroundsToCleanUp.map(

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -797,7 +797,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 				const headers: Record<string, string[]> = {
 					'Content-Type': ['text/plain'],
 					'Content-Length': ['0'],
-					Location: ['/'],
+					Location: [request.url],
 				};
 				if (
 					request.headers?.['cookie']?.includes(

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -1,9 +1,10 @@
-import type { PHPRequest, PHPResponse } from '@php-wasm/universal';
+import { type PHPRequest, PHPResponse } from '@php-wasm/universal';
 import type { Request } from 'express';
 import express from 'express';
 import type { IncomingMessage, Server, ServerResponse } from 'http';
 import type { AddressInfo } from 'net';
 import type { RunCLIServer } from './run-cli';
+import { logger } from '@php-wasm/logger';
 
 export interface ServerOptions {
 	port: number;
@@ -30,12 +31,18 @@ export async function startServer(
 	});
 
 	app.use('/', async (req, res) => {
-		const phpResponse = await options.handleRequest({
-			url: req.url,
-			headers: parseHeaders(req),
-			method: req.method as any,
-			body: await bufferRequestBody(req),
-		});
+		let phpResponse: PHPResponse;
+		try {
+			phpResponse = await options.handleRequest({
+				url: req.url,
+				headers: parseHeaders(req),
+				method: req.method as any,
+				body: await bufferRequestBody(req),
+			});
+		} catch (error) {
+			logger.error(error);
+			phpResponse = PHPResponse.forHttpCode(500);
+		}
 
 		res.statusCode = phpResponse.httpStatusCode;
 		for (const key in phpResponse.headers) {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -649,21 +649,23 @@ describe('other run-cli behaviors', () => {
 			});
 			cliServer.playground.writeFile('/wordpress/dummy.txt', '');
 			const dummyUrl = new URL('/dummy.txt', cliServer.serverUrl);
-			const res = await new Promise<http.Response>((resolve, reject) => {
-				// We use http.get() instead of fetch() because fetch() will not
-				// expose the contents of redirection responses.
-				const req = http.get(
-					dummyUrl,
-					{
-						headers: {
-							cookie: 'playground_auto_login_already_happened=1',
+			const res = await new Promise<http.IncomingMessage>(
+				(resolve, reject) => {
+					// We use http.get() instead of fetch() because fetch() will not
+					// expose the contents of redirection responses.
+					const req = http.get(
+						dummyUrl,
+						{
+							headers: {
+								cookie: 'playground_auto_login_already_happened=1',
+							},
 						},
-					},
-					resolve
-				);
-				req.on('error', reject);
-				req.end();
-			});
+						resolve
+					);
+					req.on('error', reject);
+					req.end();
+				}
+			);
 			expect(res.statusCode).toBe(302);
 			expect(res.headers['set-cookie']).toContain(
 				'playground_auto_login_already_happened=1; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/'

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import os from 'node:os';
+import http from 'node:http';
 import { runCLI } from '../src/run-cli';
 import type { RunCLIArgs, RunCLIServer } from '../src/run-cli';
 import type { MockInstance } from 'vitest';
@@ -60,6 +61,7 @@ describe.each(blueprintVersions)(
 				// irrelevant for this test.
 				skipWordPressSetup: true,
 				skipSqliteSetup: true,
+				blueprint: undefined,
 			});
 			await cliServer.playground.writeFile(
 				'/wordpress/version.php',
@@ -624,20 +626,66 @@ describe.each(blueprintVersions)(
 	60_000 * 5
 );
 
-describe('error handling', () => {
-	test('should return 500 when the request handler throws an error', async () => {
-		const cliServer = await runCLI({
-			command: 'server',
-			skipWordPressSetup: true,
-			blueprint: undefined,
+describe('other run-cli behaviors', () => {
+	let cliServer: RunCLIServer;
+
+	afterEach(async () => {
+		if (cliServer) {
+			try {
+				await cliServer[Symbol.asyncDispose]();
+			} catch {
+				// Ignore any dispose-related errors
+			}
+		}
+	});
+
+	describe('auto-login', () => {
+		test('should clear old auto-login cookie', async () => {
+			cliServer = await runCLI({
+				command: 'server',
+				skipWordPressSetup: true,
+				skipSqliteSetup: true,
+				blueprint: undefined,
+			});
+			cliServer.playground.writeFile('/wordpress/dummy.txt', '');
+			const dummyUrl = new URL('/dummy.txt', cliServer.serverUrl);
+			const res = await new Promise<http.Response>((resolve, reject) => {
+				// We use http.get() instead of fetch() because fetch() will not
+				// expose the contents of redirection responses.
+				const req = http.get(
+					dummyUrl,
+					{
+						headers: {
+							cookie: 'playground_auto_login_already_happened=1',
+						},
+					},
+					resolve
+				);
+				req.on('error', reject);
+				req.end();
+			});
+			expect(res.statusCode).toBe(302);
+			expect(res.headers['set-cookie']).toContain(
+				'playground_auto_login_already_happened=1; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Path=/'
+			);
 		});
+	});
 
-		const throwAnError = (() => {
-			throw new Error('test error');
-		}) as any;
-		cliServer.playground.request = throwAnError;
+	describe('error handling', () => {
+		test('should return 500 when the request handler throws an error', async () => {
+			cliServer = await runCLI({
+				command: 'server',
+				skipWordPressSetup: true,
+				blueprint: undefined,
+			});
 
-		const response = await fetch(new URL('/', cliServer.serverUrl));
-		expect(response.status).toBe(500);
+			const throwAnError = (() => {
+				throw new Error('test error');
+			}) as any;
+			cliServer.playground.request = throwAnError;
+
+			const response = await fetch(new URL('/', cliServer.serverUrl));
+			expect(response.status).toBe(500);
+		});
 	});
 });

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -56,17 +56,20 @@ describe.each(blueprintVersions)(
 				...suiteCliArgs,
 				command: 'server',
 				php: '8.0',
+				// Let's skip the cost of WordPress setup because it is
+				// irrelevant for this test.
+				skipWordPressSetup: true,
+				skipSqliteSetup: true,
 			});
 			await cliServer.playground.writeFile(
 				'/wordpress/version.php',
 				'<?php echo phpversion(); ?>'
 			);
-			const response = await cliServer.playground.request({
-				url: '/version.php',
-				method: 'GET',
-			});
-			expect(response.httpStatusCode).toBe(200);
-			expect(response.text).toContain('8.0');
+			const versionUrl = new URL('/version.php', cliServer.serverUrl);
+			const response = await fetch(versionUrl);
+			expect(response.status).toBe(200);
+			const text = await response.text();
+			expect(text).toContain('8.0');
 		});
 
 		test('should use custom site-url when provided', async () => {
@@ -80,12 +83,14 @@ describe.each(blueprintVersions)(
 				'/wordpress/site-url.php',
 				'<?php require_once "/wordpress/wp-load.php"; echo get_option("siteurl"); ?>'
 			);
-			const response = await cliServer.playground.request({
-				url: '/site-url.php',
-				method: 'GET',
-			});
-			expect(response.httpStatusCode).toBe(200);
-			expect(response.text).toContain(customSiteUrl);
+			const siteUrlTestUrl = new URL(
+				'/site-url.php',
+				cliServer.serverUrl
+			);
+			const response = await fetch(siteUrlTestUrl);
+			expect(response.status).toBe(200);
+			const text = await response.text();
+			expect(text).toContain(customSiteUrl);
 		});
 
 		test('should use default site-url when not provided', async () => {
@@ -98,12 +103,14 @@ describe.each(blueprintVersions)(
 				'/wordpress/site-url.php',
 				'<?php require_once "/wordpress/wp-load.php"; echo get_option("siteurl"); ?>'
 			);
-			const response = await cliServer.playground.request({
-				url: '/site-url.php',
-				method: 'GET',
-			});
-			expect(response.httpStatusCode).toBe(200);
-			expect(response.text).toContain('http://127.0.0.1:9500');
+			const siteUrlTestUrl = new URL(
+				'/site-url.php',
+				cliServer.serverUrl
+			);
+			const response = await fetch(siteUrlTestUrl);
+			expect(response.status).toBe(200);
+			const text = await response.text();
+			expect(text).toContain('http://127.0.0.1:9500');
 		});
 
 		test('should set WordPress version', async () => {
@@ -123,12 +130,11 @@ describe.each(blueprintVersions)(
             echo get_bloginfo("version");
             ?>`
 			);
-			const response = await cliServer.playground.request({
-				url: '/version.php',
-				method: 'GET',
-			});
-			expect(response.httpStatusCode).toBe(200);
-			expect(response.text).toContain(oldestSupportedVersion);
+			const versionUrl = new URL('/version.php', cliServer.serverUrl);
+			const response = await fetch(versionUrl);
+			expect(response.status).toBe(200);
+			const text = await response.text();
+			expect(text).toContain(oldestSupportedVersion);
 		});
 
 		test('should run blueprint', async () => {
@@ -146,12 +152,11 @@ describe.each(blueprintVersions)(
 					],
 				},
 			});
-			const response = await cliServer.playground.request({
-				url: '/',
-				method: 'GET',
-			});
-			expect(response.httpStatusCode).toBe(200);
-			expect(response.text).toContain('<title>My Blog Name</title>');
+			const homeUrl = new URL('/', cliServer.serverUrl);
+			const response = await fetch(homeUrl);
+			expect(response.status).toBe(200);
+			const text = await response.text();
+			expect(text).toContain('<title>My Blog Name</title>');
 		});
 
 		test('should be able to follow external symlinks in primary and secondary PHP instances', async ({
@@ -206,25 +211,21 @@ describe.each(blueprintVersions)(
 				expect(cliServer.workerThreadCount).toBe(1);
 				// Make multiple simultaneous requests to force the use of a secondary PHP instance.
 				// TODO: Find way to confirm this.
+				const sleepUrl = new URL(
+					'/wp-content/test-script/sleep.php',
+					cliServer.serverUrl
+				);
 				const responses = await Promise.all([
-					cliServer.playground.request({
-						url: '/wp-content/test-script/sleep.php',
-						method: 'GET',
-					}),
-					cliServer.playground.request({
-						url: '/wp-content/test-script/sleep.php',
-						method: 'GET',
-					}),
+					fetch(sleepUrl),
+					fetch(sleepUrl),
 					// Test a third request to hopefully test more than one secondary instance.
-					cliServer.playground.request({
-						url: '/wp-content/test-script/sleep.php',
-						method: 'GET',
-					}),
+					fetch(sleepUrl),
 				]);
-				responses.forEach((response) => {
-					expect(response.httpStatusCode).toBe(200);
-					expect(response.text).toContain('Slept');
-				});
+				for (const response of responses) {
+					expect(response.status).toBe(200);
+					const text = await response.text();
+					expect(text).toContain('Slept');
+				}
 			} finally {
 				if (existsSync(symlinkPath)) {
 					unlinkSync(symlinkPath);
@@ -252,12 +253,11 @@ describe.each(blueprintVersions)(
 						},
 					],
 				});
-				const response = await cliServer.playground.request({
-					url: '/',
-					method: 'GET',
-				});
-				expect(response.httpStatusCode).toBe(200);
-				expect(response.text).toContain(
+				const homeUrl = new URL('/', cliServer.serverUrl);
+				const response = await fetch(homeUrl);
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain(
 					`<title>${expectedHomePageTitle}</title>`
 				);
 			});
@@ -284,12 +284,11 @@ describe.each(blueprintVersions)(
 					],
 				});
 				// Confirm the new site looks intact with its WP installed.
-				const setupResponse = await cliServer.playground.request({
-					url: '/',
-					method: 'GET',
-				});
-				expect(setupResponse.httpStatusCode).toBe(200);
-				expect(setupResponse.text).toContain(
+				const homeUrl = new URL('/', cliServer.serverUrl);
+				const setupResponse = await fetch(homeUrl);
+				expect(setupResponse.status).toBe(200);
+				const setupText = await setupResponse.text();
+				expect(setupText).toContain(
 					`<title>${expectedHomePageTitle}</title>`
 				);
 				await cliServer.server.close();
@@ -307,12 +306,10 @@ describe.each(blueprintVersions)(
 						},
 					],
 				});
-				const redirectResponse = await cliServer.playground.request({
-					url: '/',
-					method: 'GET',
-				});
-				expect(redirectResponse.httpStatusCode).toBe(200);
-				expect(redirectResponse.text).toContain(
+				const redirectResponse = await fetch(homeUrl);
+				expect(redirectResponse.status).toBe(200);
+				const redirectText = await redirectResponse.text();
+				expect(redirectText).toContain(
 					`<title>${expectedHomePageTitle}</title>`
 				);
 			});
@@ -388,12 +385,11 @@ describe.each(blueprintVersions)(
 				});
 				expect(phpResponse.text).toBe('1');
 
-				const response = await cliServer.playground.request({
-					url: '/',
-					method: 'GET',
-				});
-				expect(response.httpStatusCode).toBe(200);
-				expect(response.text).toContain(
+				const homeUrl = new URL('/', cliServer.serverUrl);
+				const response = await fetch(homeUrl);
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain(
 					`<title>${expectedHomePageTitle}</title>`
 				);
 			});
@@ -409,12 +405,11 @@ describe.each(blueprintVersions)(
 
 				expect(await getActiveTheme()).toBe('Yolo Theme');
 
-				const response = await cliServer.playground.request({
-					url: '/',
-					method: 'GET',
-				});
-				expect(response.httpStatusCode).toBe(200);
-				expect(response.text).toContain(
+				const homeUrl = new URL('/', cliServer.serverUrl);
+				const response = await fetch(homeUrl);
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain(
 					`<title>${expectedHomePageTitle}</title>`
 				);
 			});
@@ -439,11 +434,9 @@ describe.each(blueprintVersions)(
 					command: 'server',
 					autoMount: '',
 				});
-				const response = await cliServer.playground.request({
-					url: '/wp-login.php',
-					method: 'GET',
-				});
-				expect(response.httpStatusCode).toBe(200);
+				const loginUrl = new URL('/wp-login.php', cliServer.serverUrl);
+				const response = await fetch(loginUrl);
+				expect(response.status).toBe(200);
 			});
 
 			test('should run a static html project using --auto-mount', async () => {
@@ -459,12 +452,11 @@ describe.each(blueprintVersions)(
 					command: 'server',
 					autoMount: '',
 				});
-				const response = await cliServer.playground.request({
-					url: '/',
-					method: 'GET',
-				});
-				expect(response.httpStatusCode).toBe(200);
-				expect(response.text).toContain('<title>Static HTML</title>');
+				const homeUrl = new URL('/', cliServer.serverUrl);
+				const response = await fetch(homeUrl);
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain('<title>Static HTML</title>');
 			});
 
 			test('should run a php project using --auto-mount', async () => {
@@ -476,12 +468,11 @@ describe.each(blueprintVersions)(
 					command: 'server',
 					autoMount: '',
 				});
-				const response = await cliServer.playground.request({
-					url: '/',
-					method: 'GET',
-				});
-				expect(response.httpStatusCode).toBe(200);
-				expect(response.text).toContain('Hello world');
+				const homeUrl = new URL('/', cliServer.serverUrl);
+				const response = await fetch(homeUrl);
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain('Hello world');
 			});
 
 			// NOTE: We have had trouble running the full test set on Windows
@@ -519,12 +510,11 @@ describe.each(blueprintVersions)(
 						command: 'server',
 						autoMount: '',
 					});
-					const response = await cliServer.playground.request({
-						url: '/',
-						method: 'GET',
-					});
-					expect(response.httpStatusCode).toBe(200);
-					expect(response.text).toContain(
+					const homeUrl = new URL('/', cliServer.serverUrl);
+					const response = await fetch(homeUrl);
+					expect(response.status).toBe(200);
+					const text = await response.text();
+					expect(text).toContain(
 						`<title>${expectedHomePageTitle}</title>`
 					);
 
@@ -642,14 +632,12 @@ describe('error handling', () => {
 			blueprint: undefined,
 		});
 
-		await cliServer.playground.addEventListener('request.end', () => {
+		const throwAnError = (() => {
 			throw new Error('test error');
-		});
+		}) as any;
+		cliServer.playground.request = throwAnError;
 
-		const response = await cliServer.playground.request({
-			url: '/',
-			method: 'GET',
-		});
-		expect(response.httpStatusCode).toBe(500);
+		const response = await fetch(new URL('/', cliServer.serverUrl));
+		expect(response.status).toBe(500);
 	});
 });

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -633,3 +633,23 @@ describe.each(blueprintVersions)(
 	},
 	60_000 * 5
 );
+
+describe('error handling', () => {
+	test('should return 500 when the request handler throws an error', async () => {
+		const cliServer = await runCLI({
+			command: 'server',
+			skipWordPressSetup: true,
+			blueprint: undefined,
+		});
+
+		await cliServer.playground.addEventListener('request.end', () => {
+			throw new Error('test error');
+		});
+
+		const response = await cliServer.playground.request({
+			url: '/',
+			method: 'GET',
+		});
+		expect(response.httpStatusCode).toBe(500);
+	});
+});


### PR DESCRIPTION
## Motivation for the change, related issues

Without this PR, an exception thrown by `PHP.run()` would cause the CLI thread to exit with error code 1 due to an UnhandledPromiseRejection error. With this PR, the exception will be logged and the user will see a basic page communicating HTTP error 500 (internal server error).

## Testing Instructions (or ideally a Blueprint)

This is challenging. I've added a test, hoping it would pass, but something in the setup makes it fail (because PHP.run() refuses to throw an exception). I wonder how could we add a unit test for this @brandonpayton 