### PR TITLE
Add name to Playground Website and Website extras cli packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19760,6 +19760,14 @@
 			"resolved": "packages/playground/sync",
 			"link": true
 		},
+		"node_modules/@wp-playground/website": {
+			"resolved": "packages/playground/website",
+			"link": true
+		},
+		"node_modules/@wp-playground/website-extras": {
+			"resolved": "packages/playground/website-extras",
+			"link": true
+		},
 		"node_modules/@wp-playground/wordpress": {
 			"resolved": "packages/playground/wordpress",
 			"link": true
@@ -51902,14 +51910,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/website": {
-			"resolved": "packages/playground/website",
-			"link": true
-		},
-		"node_modules/website-extras": {
-			"resolved": "packages/playground/website-extras",
-			"link": true
-		},
 		"node_modules/websocket-driver": {
 			"version": "0.7.4",
 			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -52957,9 +52957,11 @@
 			"license": "GPL-2.0-or-later"
 		},
 		"packages/playground/website": {
+			"name": "@wp-playground/website",
 			"version": "0.0.1"
 		},
 		"packages/playground/website-extras": {
+			"name": "@wp-playground/website-extras",
 			"version": "0.0.1"
 		},
 		"packages/playground/wordpress": {

--- a/packages/playground/website-extras/package.json
+++ b/packages/playground/website-extras/package.json
@@ -1,5 +1,6 @@
 {
 	"version": "0.0.1",
 	"type": "commonjs",
-	"private": true
+	"private": true,
+	"name": "@wp-playground/website-extras"
 }

--- a/packages/playground/website/package.json
+++ b/packages/playground/website/package.json
@@ -1,5 +1,6 @@
 {
 	"version": "0.0.1",
 	"type": "commonjs",
-	"private": true
+	"private": true,
+	"name": "@wp-playground/website"
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -70,6 +70,9 @@
 			"@wp-playground/website": [
 				"packages/playground/website/src/index.ts"
 			],
+			"@wp-playground/website-extras": [
+				"packages/playground/website-extras/src/php-playground/main.tsx"
+			],
 			"@wp-playground/wordpress": [
 				"packages/playground/wordpress/src/index.ts"
 			],


### PR DESCRIPTION
## Motivation for the change, related issues

After creating the website-extras package, npm release [started complaining](https://github.com/WordPress/wordpress-playground/actions/runs/18165904240/job/51707950355) about the missing "name" prioerties in package.json. This PR adds them to the website and website-extras packages. It also piggybacks a tsconfig.json reference to website-extras main.tsx file.

## Testing Instructions (or ideally a Blueprint)

CI works