### PR TITLE
[PHP Playground] Attach client to https://playground.wordpress.net/remote.html

### DIFF
--- a/packages/playground/website-extras/src/php-playground/components/PlaygroundManager.tsx
+++ b/packages/playground/website-extras/src/php-playground/components/PlaygroundManager.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from 'react';
 import { startPlaygroundWeb } from '@wp-playground/client';
-import { DEFAULT_URL_PREFIX, DEFAULT_WORKSPACE_DIR } from '../constants';
+import {
+	DEFAULT_URL_PREFIX,
+	DEFAULT_WORKSPACE_DIR,
+	getRemoteUrl,
+} from '../constants';
 import { useAppDispatch, useAppSelector } from '../hooks';
 import {
 	applyUrlState,
@@ -15,8 +19,6 @@ import { setCurrentPath } from '../store';
 import { loadStateFromURL, saveStateToURL } from '../url-state';
 import { playgroundRuntime } from '../runtime';
 import { logger } from '@php-wasm/logger';
-// @ts-expect-error
-import { getRemoteUrl } from 'virtual:website-config';
 
 export const PlaygroundManager = () => {
 	const dispatch = useAppDispatch();
@@ -118,7 +120,7 @@ export const PlaygroundManager = () => {
 			try {
 				const clientInstance = await startPlaygroundWeb({
 					iframe: previewIframe,
-					remoteUrl: getRemoteUrl(),
+					remoteUrl: getRemoteUrl().toString(),
 					// blueprint: {
 					// 	preferredVersions: {
 					// 		wp: wpVersionRef.current,

--- a/packages/playground/website-extras/src/php-playground/components/PlaygroundManager.tsx
+++ b/packages/playground/website-extras/src/php-playground/components/PlaygroundManager.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { startPlaygroundWeb } from '@wp-playground/client';
-import {
-	DEFAULT_URL_PREFIX,
-	DEFAULT_WORKSPACE_DIR,
-	DEFAULT_WP_REMOTE,
-} from '../constants';
+import { DEFAULT_URL_PREFIX, DEFAULT_WORKSPACE_DIR } from '../constants';
 import { useAppDispatch, useAppSelector } from '../hooks';
 import {
 	applyUrlState,
@@ -19,6 +15,8 @@ import { setCurrentPath } from '../store';
 import { loadStateFromURL, saveStateToURL } from '../url-state';
 import { playgroundRuntime } from '../runtime';
 import { logger } from '@php-wasm/logger';
+// @ts-expect-error
+import { getRemoteUrl } from 'virtual:website-config';
 
 export const PlaygroundManager = () => {
 	const dispatch = useAppDispatch();
@@ -120,7 +118,7 @@ export const PlaygroundManager = () => {
 			try {
 				const clientInstance = await startPlaygroundWeb({
 					iframe: previewIframe,
-					remoteUrl: DEFAULT_WP_REMOTE,
+					remoteUrl: getRemoteUrl(),
 					// blueprint: {
 					// 	preferredVersions: {
 					// 		wp: wpVersionRef.current,

--- a/packages/playground/website-extras/src/php-playground/constants.ts
+++ b/packages/playground/website-extras/src/php-playground/constants.ts
@@ -1,9 +1,3 @@
-export const DEFAULT_PHP_VERSION = '8.4';
-export const DEFAULT_WP_VERSION = '6.8';
-// @TODO: Use URL imported from vite build-time config
-export const DEFAULT_WP_REMOTE = 'http://127.0.0.1:5400/remote.html';
-// export const DEFAULT_WP_REMOTE = 'https://playground.wordpress.net/remote.html';
-
 // @TODO: Get rid of the hardcoded initial path, always source cwd from the client.
 export const DEFAULT_WORKSPACE_DIR = '/wordpress/workspace';
 export const DEFAULT_URL_PREFIX = '/workspace';

--- a/packages/playground/website-extras/src/php-playground/constants.ts
+++ b/packages/playground/website-extras/src/php-playground/constants.ts
@@ -1,3 +1,6 @@
+// @ts-expect-error
+import { buildVersion } from 'virtual:website-config';
+
 // @TODO: Get rid of the hardcoded initial path, always source cwd from the client.
 export const DEFAULT_WORKSPACE_DIR = '/wordpress/workspace';
 export const DEFAULT_URL_PREFIX = '/workspace';
@@ -15,3 +18,10 @@ $html_processor = WP_HTML_Processor::create_fragment('<p><span>Hey!</span></p>')
 $html_processor->next_tag();
 var_dump($html_processor->get_tag());
 ?>`;
+
+export function getRemoteUrl() {
+	const remoteUrl = new URL(window.location.origin);
+	remoteUrl.pathname = '/remote.html';
+	remoteUrl.searchParams.set('v', buildVersion);
+	return remoteUrl;
+}

--- a/packages/playground/website-extras/src/php-playground/store.ts
+++ b/packages/playground/website-extras/src/php-playground/store.ts
@@ -6,7 +6,8 @@ import {
 import type { PlaygroundClient } from '@wp-playground/client';
 import { SupportedPHPVersionsList } from '@wp-playground/client';
 
-import { DEFAULT_CODE, DEFAULT_PHP_VERSION } from './constants';
+import { DEFAULT_CODE } from './constants';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
 export type BootStatus = 'idle' | 'booting' | 'ready' | 'error';
 
@@ -28,7 +29,7 @@ export interface PlaygroundState {
 const initialState: PlaygroundState = {
 	code: DEFAULT_CODE,
 	currentPath: null,
-	phpVersion: DEFAULT_PHP_VERSION,
+	phpVersion: RecommendedPHPVersion,
 	wpVersion: 'latest',
 	phpVersions: SupportedPHPVersionsList,
 	wpVersions: [],

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -597,7 +597,7 @@ export async function unzipWordPress(php: PHP, wpZip: File) {
 					'/'
 				);
 				logger.warn(
-					`Skipping ${wpPath} because something exists at the target path.`
+					`Cannot unzip WordPress files at ${target}: ${wpPath} already exists.`
 				);
 				return;
 			}


### PR DESCRIPTION
## Motivation for the change, related issues

#2694 is trying to attach to a local remote (127.0.0.1) instead of https://playground.wordpress.net/remote.html. This PR makes it use a remote appropriate for a given environment by leveraging the same `website-config` virtual vite module as the `@wp-playground/website` package
