### PR TITLE
Fix local package repository command running issue

### DIFF
--- a/packages/playground/blueprints/src/lib/reflection.ts
+++ b/packages/playground/blueprints/src/lib/reflection.ts
@@ -20,6 +20,12 @@ export async function getBlueprintDeclaration(
 export type BlueprintType = 'bundle' | 'declaration';
 
 export class BlueprintReflection {
+	private readonly declaration:
+		| BlueprintV1Declaration
+		| BlueprintV2Declaration;
+	private readonly bundle: BlueprintBundle | undefined;
+	private readonly version: number;
+
 	static async create(blueprint: Blueprint) {
 		const declaration = await getBlueprintDeclaration(blueprint);
 		const bundle = isBlueprintBundle(blueprint) ? blueprint : undefined;
@@ -38,12 +44,14 @@ export class BlueprintReflection {
 	}
 
 	protected constructor(
-		private readonly declaration:
-			| BlueprintV1Declaration
-			| BlueprintV2Declaration,
-		private readonly bundle: BlueprintBundle | undefined,
-		private readonly version: number
-	) {}
+		declaration: BlueprintV1Declaration | BlueprintV2Declaration,
+		bundle: BlueprintBundle | undefined,
+		version: number
+	) {
+		this.declaration = declaration;
+		this.bundle = bundle;
+		this.version = version;
+	}
 
 	getVersion() {
 		return this.version;


### PR DESCRIPTION
## Motivation for the change, related issues

Running `npm run local-package-repository` crashes with the following error : 

```
node:internal/modules/typescript:67
        throw new ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX(error.message);
              ^

SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]:   x TypeScript parameter property is not supported in strip-only mode
    ,-[41:1]
 38 |         }
 39 |
 40 |         protected constructor(
 41 | ,->         private readonly declaration:
 42 | |               | BlueprintV1Declaration
 43 | `->             | BlueprintV2Declaration,
 44 |             private readonly bundle: BlueprintBundle | undefined,
 45 |             private readonly version: number
 46 |         ) {}
    `----
  x TypeScript parameter property is not supported in strip-only mode
    ,-[44:1]
 41 |         private readonly declaration:
 42 |             | BlueprintV1Declaration
 43 |             | BlueprintV2Declaration,
 44 |         private readonly bundle: BlueprintBundle | undefined,
    :                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 45 |         private readonly version: number
 46 |     ) {}
    `----
  x TypeScript parameter property is not supported in strip-only mode
    ,-[45:1]
 42 |             | BlueprintV1Declaration
 43 |             | BlueprintV2Declaration,
 44 |         private readonly bundle: BlueprintBundle | undefined,
 45 |         private readonly version: number
    :                          ^^^^^^^^^^^^^^^
 46 |     ) {}
 47 |
 48 |     getVersion() {
    `----

    at parseTypeScript (node:internal/modules/typescript:67:15)
    at processTypeScriptCode (node:internal/modules/typescript:129:42)
    at stripTypeScriptModuleTypes (node:internal/modules/typescript:196:22)
    at ModuleLoader.<anonymous> (node:internal/modules/esm/translators:551:16)
    at #translate (node:internal/modules/esm/loader:534:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:581:27) {
  code: 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX'
}
```

## Implementation details

Rewriting the constructor without parameter properties.

## Testing Instructions (or ideally a Blueprint)

Run `npm run local-package-repository`