### PR TITLE
[XDebug Bridge] Read files from VFS when a PHP instance is provided

### DIFF
--- a/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
@@ -1,5 +1,5 @@
 import { logger } from '@php-wasm/logger';
-import type { PHP } from '@php-wasm/universal';
+import type { PHP, PHPWorker, RemoteAPI } from '@php-wasm/universal';
 import { readdirSync, readFileSync, lstatSync } from 'fs';
 import path from 'path';
 import { CDPServer } from './cdp-server';
@@ -11,7 +11,7 @@ export type StartBridgeConfig = {
 	cdpHost?: string;
 	dbgpPort?: number;
 	phpRoot?: string;
-	phpInstance?: PHP;
+	phpInstance?: PHP | RemoteAPI<PHPWorker>;
 	getPHPFile?: (path: string) => string | Promise<string>;
 	breakOnFirstLine?: boolean;
 };
@@ -44,17 +44,25 @@ export async function startBridge(config: StartBridgeConfig) {
 	logger.log('Running a PHP script with Xdebug enabled...');
 
 	// Recursively get a list of .php files in phpRoot
-	function getPhpFiles(dir: string): string[] {
+	async function getPhpFiles(dir: string): Promise<string[]> {
 		const results: string[] = [];
-		const list = readdirSync(dir);
+		const list = config.phpInstance
+			? await config.phpInstance!.listFiles(dir)
+			: readdirSync(dir);
 		for (const file of list) {
 			const filePath = path.join(dir, file);
-			// lstat avoids crashes when encountering symlinks
-			const stat = lstatSync(filePath);
-			if (stat && stat.isDirectory()) {
-				results.push(...getPhpFiles(filePath));
-			} else if (file.endsWith('.php')) {
-				results.push(filePath);
+			try {
+				// lstat avoids crashes when encountering symlinks
+				const stat = config.phpInstance
+					? await config.phpInstance!.isDir(filePath)
+					: lstatSync(filePath).isDirectory();
+				if (stat) {
+					results.push(...(await getPhpFiles(filePath)));
+				} else if (file.endsWith('.php')) {
+					results.push(filePath);
+				}
+			} catch {
+				// Skip this entry if we can't read it
 			}
 		}
 		return results;
@@ -66,7 +74,7 @@ export async function startBridge(config: StartBridgeConfig) {
 		? config.getPHPFile
 		: (path: string) => readFileSync(path, 'utf-8');
 
-	const phpFiles = getPhpFiles(phpRoot);
+	const phpFiles = await getPhpFiles(phpRoot);
 	return new XdebugCDPBridge(dbgpSession, cdpServer, {
 		knownScriptUrls: phpFiles,
 		phpRoot,

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -71,8 +71,8 @@ export class XdebugCDPBridge {
 		// Xdebug connected
 		this.dbgp.on('connected', () => {
 			this.xdebugConnected = true;
-			this.sendDbgpCommand('stdout', '-c 1'); // copies PHP stdout to IDE
-			this.sendDbgpCommand('stderr', '-c 1'); // copies PHP stderr to IDE
+			this.sendDbgpCommand('stdout', '-c 1'); // copies PHP stdout to console
+			this.sendDbgpCommand('stderr', '-c 1'); // copies PHP stderr to console
 		});
 		// Xdebug messages
 		this.dbgp.on('message', async (xml: string) => {

--- a/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/xdebug-cdp-bridge.ts
@@ -301,6 +301,19 @@ export class XdebugCDPBridge {
 				break;
 			case 'Debugger.setBreakpointByUrl': {
 				const { url: cdpUri, lineNumber: line } = params;
+				/**
+				 * `url` is an optional parameter. If it's not set, we don't
+				 * have enough information to set a breakpoint so let's just
+				 * ignore the message.
+				 *
+				 * Why would `url` be not set? We don't know that yet.
+				 *
+				 * https://chromedevtools.github.io/devtools-protocol/tot/Debugger/#method-setBreakpointByUrl
+				 */
+				if (!cdpUri) {
+					sendResponse = false;
+					break;
+				}
 				const bridgeUri = this.uriFromCDPToBridge(cdpUri);
 				const dbgpUri = this.uriFromBridgeToDBGP(bridgeUri);
 				const lineNumber = (typeof line === 'number' ? line : 0) + 1; // CDP lineNumber is 0-based, Xdebug expects 1-based

--- a/packages/php-wasm/xdebug-bridge/src/tests/start-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/tests/start-bridge.spec.ts
@@ -1,7 +1,7 @@
 import './mocker';
 import { type MockInstance, vi } from 'vitest';
 import { WebSocket } from 'ws';
-import type { PHP } from '@php-wasm/universal';
+import { type PHP } from '@php-wasm/universal';
 import { EventEmitter } from 'events';
 import { CDPServer } from '../lib/cdp-server';
 import { DbgpSession } from '../lib/dbgp-session';
@@ -89,6 +89,7 @@ describe('Bridge', () => {
 
 		it('uses phpInstance readFileAsText when provided', async () => {
 			const php = {
+				listFiles: vi.fn(() => []),
 				readFileAsText: vi
 					.fn()
 					.mockResolvedValue('<?php echo "Hello World";'),
@@ -113,6 +114,37 @@ describe('Bridge', () => {
 			const result = await args.getPHPFile('file:///custom.php');
 			expect(getPHPFile).toHaveBeenCalledWith('file:///custom.php');
 			expect(result).toBe('<?php echo "Hello World";');
+		});
+
+		it('reads PHP files from the filesystem when no phpInstance is provided', async () => {
+			await startBridge({ phpRoot: '/foo/bar' });
+
+			const args = (XdebugCDPBridge as any).mock.calls[0][2];
+
+			expect(args.knownScriptUrls).toEqual(['/foo/bar/baz.php']);
+		});
+
+		it('reads files from the virtual filesystem when a PHP instance is provided', async () => {
+			const filesystem: Record<string, string[]> = {
+				'/foo': ['bar.php', 'baz'],
+				'/foo/baz': ['qux.php', 'quux.txt'],
+			};
+
+			const php: Partial<PHP> = {
+				listFiles: vi.fn(
+					(directory: string) => filesystem[directory] || []
+				),
+				isDir: vi.fn((path: string) => path in filesystem),
+			};
+
+			await startBridge({ phpInstance: php as PHP, phpRoot: '/foo' });
+
+			const args = (XdebugCDPBridge as any).mock.calls[0][2];
+
+			expect(args.knownScriptUrls).toEqual([
+				'/foo/bar.php',
+				'/foo/baz/qux.php',
+			]);
 		});
 	});
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -745,8 +745,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 
 				if (args.experimentalDevtools && args.xdebug) {
 					const bridge = await startBridge({
-						getPHPFile: async (path: string) =>
-							await playground!.readFileAsText(path),
+						phpInstance: playground,
+						phpRoot: '/wordpress',
 					});
 
 					bridge.start();


### PR DESCRIPTION
## Motivation for the change, related issues

Based on [this comment](https://github.com/WordPress/wordpress-playground/issues/2601#issuecomment-3291816566) in issue #2601 

This enables the playground to open the bridge in the virtual filesystem `/wordpress` directory instead of the Node filesystem. 

This pull request will allow step debugging with Xdebug and Chrome Devtools by using the following command :

```
node_modules/.bin/wp-playground-cli server --login --xdebug --experimental-devtools --mount=./plugin:/wordpress/wp-content/plugins/plugin
```

Before this pull request, we do not have access to the virtual filesystem.

## Implementation details

If `phpInstance` is provided during `startBridge`, it will `listFiles` from the php instance instead of Node. Giving access to `/wordpress` directory.

## Testing Instructions (or ideally a Blueprint)

Two new tests in CI