### PR TITLE
Adding Kapa AI script tag

### DIFF
--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -66,6 +66,26 @@ const config = {
 		},
 	},
 	themes: ['@docusaurus/theme-live-codeblock'],
+	scripts: [
+		{
+			src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
+			'data-website-id': '50db26d1-afa4-4a5c-992d-695fa98588d2',
+			'data-project-name': 'WordPress Playground',
+			'data-project-color': '#FFFFFF',
+			'data-project-logo':
+				'https://wordpress.github.io/wordpress-playground/img/playground-logo.svg',
+			'data-bot-protection-mechanism': 'hcaptcha',
+			'data-modal-title': 'WordPress Playground AI Assistant',
+			'data-modal-example-questions-title': 'Try asking me...',
+			'data-modal-disclaimer':
+				'This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year',
+			'data-modal-example-questions':
+				'How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?',
+			'data-button-text-color': '#000000',
+			'data-hyperlink-color': '#3996e3',
+			async: true,
+		},
+	],
 	plugins: [
 		getDocusaurusPluginTypedocApiConfig(),
 		[

--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -66,26 +66,6 @@ const config = {
 		},
 	},
 	themes: ['@docusaurus/theme-live-codeblock'],
-	scripts: [
-		{
-			src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
-			'data-website-id': '50db26d1-afa4-4a5c-992d-695fa98588d2',
-			'data-project-name': 'WordPress Playground',
-			'data-project-color': '#FFFFFF',
-			'data-project-logo':
-				'https://wordpress.github.io/wordpress-playground/img/playground-logo.svg',
-			'data-bot-protection-mechanism': 'hcaptcha',
-			'data-modal-title': 'WordPress Playground AI Assistant',
-			'data-modal-example-questions-title': 'Try asking me...',
-			'data-modal-disclaimer':
-				'This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year',
-			'data-modal-example-questions':
-				'How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?',
-			'data-button-text-color': '#000000',
-			'data-hyperlink-color': '#3996e3',
-			async: true,
-		},
-	],
 	plugins: [
 		getDocusaurusPluginTypedocApiConfig(),
 		[
@@ -115,6 +95,7 @@ const config = {
 				},
 			},
 		],
+		'./plugins/kapa-ai-plugin.js',
 	],
 
 	presets: [
@@ -186,6 +167,11 @@ const config = {
 						to: 'api',
 						label: 'API Reference',
 						position: 'left',
+					},
+					{
+						type: 'html',
+						position: 'right',
+						value: '<a href="#" class="navbar__link" onclick="window.Kapa?.open?.()" aria-label="Ask AI">Ask AI</a>',
 					},
 					{
 						href: 'https://github.com/WordPress/wordpress-playground',

--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -169,11 +169,6 @@ const config = {
 						position: 'left',
 					},
 					{
-						type: 'html',
-						position: 'right',
-						value: '<a href="#" class="navbar__link" onclick="window.Kapa?.open?.()" aria-label="Ask AI">Ask AI</a>',
-					},
-					{
 						href: 'https://github.com/WordPress/wordpress-playground',
 						position: 'right',
 						className: 'header-github-link',

--- a/packages/docs/site/i18n/en/kapa-ai-plugin/kapa-ai.json
+++ b/packages/docs/site/i18n/en/kapa-ai-plugin/kapa-ai.json
@@ -1,0 +1,18 @@
+{
+	"kapaAi.modalTitle": {
+		"message": "WordPress Playground AI Assistant",
+		"description": "Title for Kapa AI modal"
+	},
+	"kapaAi.exampleQuestionsTitle": {
+		"message": "Try asking me...",
+		"description": "Title for example questions section"
+	},
+	"kapaAi.disclaimer": {
+		"message": "This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year",
+		"description": "Disclaimer text for Kapa AI"
+	},
+	"kapaAi.exampleQuestions": {
+		"message": "How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?",
+		"description": "Example questions for Kapa AI"
+	}
+}

--- a/packages/docs/site/i18n/es/kapa-ai-plugin/kapa-ai.json
+++ b/packages/docs/site/i18n/es/kapa-ai-plugin/kapa-ai.json
@@ -1,0 +1,18 @@
+{
+	"kapaAi.modalTitle": {
+		"message": "Asistente de IA de WordPress Playground",
+		"description": "Title for Kapa AI modal"
+	},
+	"kapaAi.exampleQuestionsTitle": {
+		"message": "Intenta preguntarme...",
+		"description": "Title for example questions section"
+	},
+	"kapaAi.disclaimer": {
+		"message": "Este **asistente de IA contesta preguntas sobre WordPress Playground** usando la [documentación](https://wordpress.github.io/wordpress-playground/) y los issues de GitHub(https://github.com/WordPress/wordpress-playground/issues) del año pasado",
+		"description": "Disclaimer text for Kapa AI"
+	},
+	"kapaAi.exampleQuestions": {
+		"message": "¿Cómo usar la API de Blueprints?,¿Cómo cambiar la versión de PHP?,¿Cómo importar un archivo WXR?,¿Cómo montar archivos locales?",
+		"description": "Example questions for Kapa AI"
+	}
+}

--- a/packages/docs/site/i18n/fr/kapa-ai-plugin/kapa-ai.json
+++ b/packages/docs/site/i18n/fr/kapa-ai-plugin/kapa-ai.json
@@ -1,0 +1,18 @@
+{
+	"kapaAi.modalTitle": {
+		"message": "WordPress Playground AI Assistant",
+		"description": "Title for Kapa AI modal"
+	},
+	"kapaAi.exampleQuestionsTitle": {
+		"message": "Try asking me...",
+		"description": "Title for example questions section"
+	},
+	"kapaAi.disclaimer": {
+		"message": "This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year",
+		"description": "Disclaimer text for Kapa AI"
+	},
+	"kapaAi.exampleQuestions": {
+		"message": "How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?",
+		"description": "Example questions for Kapa AI"
+	}
+}

--- a/packages/docs/site/i18n/ja/kapa-ai-plugin/kapa-ai.json
+++ b/packages/docs/site/i18n/ja/kapa-ai-plugin/kapa-ai.json
@@ -1,0 +1,18 @@
+{
+	"kapaAi.modalTitle": {
+		"message": "WordPress Playground AI Assistant",
+		"description": "Title for Kapa AI modal"
+	},
+	"kapaAi.exampleQuestionsTitle": {
+		"message": "Try asking me...",
+		"description": "Title for example questions section"
+	},
+	"kapaAi.disclaimer": {
+		"message": "This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year",
+		"description": "Disclaimer text for Kapa AI"
+	},
+	"kapaAi.exampleQuestions": {
+		"message": "How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?",
+		"description": "Example questions for Kapa AI"
+	}
+}

--- a/packages/docs/site/i18n/pt-BR/kapa-ai-plugin/kapa-ai.json
+++ b/packages/docs/site/i18n/pt-BR/kapa-ai-plugin/kapa-ai.json
@@ -1,0 +1,18 @@
+{
+	"kapaAi.modalTitle": {
+		"message": "WordPress Playground AI Assistant",
+		"description": "Title for Kapa AI modal"
+	},
+	"kapaAi.exampleQuestionsTitle": {
+		"message": "Try asking me...",
+		"description": "Title for example questions section"
+	},
+	"kapaAi.disclaimer": {
+		"message": "This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year",
+		"description": "Disclaimer text for Kapa AI"
+	},
+	"kapaAi.exampleQuestions": {
+		"message": "How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?",
+		"description": "Example questions for Kapa AI"
+	}
+}

--- a/packages/docs/site/plugins/kapa-ai-plugin.js
+++ b/packages/docs/site/plugins/kapa-ai-plugin.js
@@ -1,0 +1,55 @@
+export default function kapaAiPlugin(context, options) {
+	return {
+		name: 'kapa-ai-plugin',
+		injectHtmlTags({ content }) {
+			// Get the current locale from the content metadata
+			const locale =
+				content?.metadata?.locale ||
+				context.i18n.currentLocale ||
+				context.i18n.defaultLocale;
+
+			// Map Docusaurus locales to Kapa AI language codes
+			// See https://docs.kapa.ai/integrations/website-widget/configuration#supported-languages
+			const localeMap = {
+				en: 'en',
+				es: 'es',
+				fr: 'fr',
+				ja: 'ja',
+				'pt-br': 'pt',
+				tl: 'en',
+				gu: 'en',
+			};
+
+			const language = localeMap[locale] || 'en';
+			const kapaAiConfig = {
+				src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
+				'data-website-id': '50db26d1-afa4-4a5c-992d-695fa98588d2',
+				'data-project-name': 'WordPress Playground',
+				'data-project-color': '#FFFFFF',
+				'data-project-logo':
+					'https://wordpress.github.io/wordpress-playground/img/playground-logo.svg',
+				'data-bot-protection-mechanism': 'hcaptcha',
+				'data-modal-title': 'WordPress Playground AI Assistant',
+				'data-modal-example-questions-title': 'Try asking me...',
+				'data-modal-disclaimer':
+					'This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year',
+				'data-modal-example-questions':
+					'How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?',
+				'data-button-text-color': '#000000',
+				'data-hyperlink-color': '#3996e3',
+				'data-button-hide': 'true', // Hide the default bottom right button
+				'data-language': language,
+				async: true,
+			};
+
+			return {
+				headTags: [
+					{
+						tagName: 'script',
+						attributes: kapaAiConfig,
+					},
+				],
+			};
+		},
+	};
+}

--- a/packages/docs/site/plugins/kapa-ai-plugin.js
+++ b/packages/docs/site/plugins/kapa-ai-plugin.js
@@ -134,7 +134,7 @@ export default function kapaAiPlugin(context, options) {
 					translatedConfig.exampleQuestions,
 				'data-button-text-color': '#000000',
 				'data-hyperlink-color': '#3996e3',
-				// 'data-button-hide': 'true', // Hide the default bottom right button
+				'data-button-hide': 'true', // Hide the default bottom right button
 				'data-language': language,
 				async: true,
 			};

--- a/packages/docs/site/plugins/kapa-ai-plugin.js
+++ b/packages/docs/site/plugins/kapa-ai-plugin.js
@@ -1,12 +1,105 @@
+// Default translation messages
+const defaultMessages = {
+	'kapaAi.modalTitle': {
+		message: 'WordPress Playground AI Assistant',
+		description: 'Title for Kapa AI modal',
+	},
+	'kapaAi.exampleQuestionsTitle': {
+		message: 'Try asking me...',
+		description: 'Title for example questions section',
+	},
+	'kapaAi.disclaimer': {
+		message:
+			'This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year',
+		description: 'Disclaimer text for Kapa AI',
+	},
+	'kapaAi.exampleQuestions': {
+		message:
+			'How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?',
+		description: 'Example questions for Kapa AI',
+	},
+};
+
 export default function kapaAiPlugin(context, options) {
+	const { i18n } = context;
+
+	// Store translated content per locale
+	const translationsCache = {};
+
+	/**
+	 * Get translated messages for a locale
+	 */
+	function getTranslatedMessages(locale) {
+		// Return cached if available
+		if (translationsCache[locale]) {
+			return translationsCache[locale];
+		}
+
+		// Return defaults if not in cache
+		return {
+			modalTitle: defaultMessages['kapaAi.modalTitle'].message,
+			exampleQuestionsTitle:
+				defaultMessages['kapaAi.exampleQuestionsTitle'].message,
+			disclaimer: defaultMessages['kapaAi.disclaimer'].message,
+			exampleQuestions:
+				defaultMessages['kapaAi.exampleQuestions'].message,
+		};
+	}
+
 	return {
 		name: 'kapa-ai-plugin',
+
+		getDefaultCodeTranslationMessages() {
+			return defaultMessages;
+		},
+
+		getTranslationFiles() {
+			return [
+				{
+					path: 'kapa-ai',
+					content: defaultMessages,
+				},
+			];
+		},
+
+		translateContent({ content, translationFiles }) {
+			// Extract translations from the translation files
+			const kapaTranslations = translationFiles.find(
+				(f) => f.path === 'kapa-ai'
+			)?.content;
+
+			if (kapaTranslations) {
+				// Determine the current locale being processed
+				const currentLocale =
+					content?.metadata?.locale || i18n.currentLocale;
+
+				// Store translations for this locale
+				translationsCache[currentLocale] = {
+					modalTitle:
+						kapaTranslations['kapaAi.modalTitle']?.message ||
+						defaultMessages['kapaAi.modalTitle'].message,
+					exampleQuestionsTitle:
+						kapaTranslations['kapaAi.exampleQuestionsTitle']
+							?.message ||
+						defaultMessages['kapaAi.exampleQuestionsTitle'].message,
+					disclaimer:
+						kapaTranslations['kapaAi.disclaimer']?.message ||
+						defaultMessages['kapaAi.disclaimer'].message,
+					exampleQuestions:
+						kapaTranslations['kapaAi.exampleQuestions']?.message ||
+						defaultMessages['kapaAi.exampleQuestions'].message,
+				};
+			}
+
+			return content;
+		},
+
 		injectHtmlTags({ content }) {
 			// Get the current locale from the content metadata
 			const locale =
 				content?.metadata?.locale ||
-				context.i18n.currentLocale ||
-				context.i18n.defaultLocale;
+				i18n.currentLocale ||
+				i18n.defaultLocale;
 
 			// Map Docusaurus locales to Kapa AI language codes
 			// See https://docs.kapa.ai/integrations/website-widget/configuration#supported-languages
@@ -21,6 +114,10 @@ export default function kapaAiPlugin(context, options) {
 			};
 
 			const language = localeMap[locale] || 'en';
+
+			// Get translated messages for this locale
+			const translatedConfig = getTranslatedMessages(locale);
+
 			const kapaAiConfig = {
 				src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
 				'data-website-id': '50db26d1-afa4-4a5c-992d-695fa98588d2',
@@ -29,15 +126,15 @@ export default function kapaAiPlugin(context, options) {
 				'data-project-logo':
 					'https://wordpress.github.io/wordpress-playground/img/playground-logo.svg',
 				'data-bot-protection-mechanism': 'hcaptcha',
-				'data-modal-title': 'WordPress Playground AI Assistant',
-				'data-modal-example-questions-title': 'Try asking me...',
-				'data-modal-disclaimer':
-					'This **AI assistant answers WordPress Playground questions** using the [documentation](https://wordpress.github.io/wordpress-playground/) and [github issues](https://github.com/WordPress/wordpress-playground/issues) from last year',
+				'data-modal-title': translatedConfig.modalTitle,
+				'data-modal-example-questions-title':
+					translatedConfig.exampleQuestionsTitle,
+				'data-modal-disclaimer': translatedConfig.disclaimer,
 				'data-modal-example-questions':
-					'How to use Blueprints API?,How to change PHP version?,How to import a WXR file?,How to mount local files?',
+					translatedConfig.exampleQuestions,
 				'data-button-text-color': '#000000',
 				'data-hyperlink-color': '#3996e3',
-				'data-button-hide': 'true', // Hide the default bottom right button
+				// 'data-button-hide': 'true', // Hide the default bottom right button
 				'data-language': language,
 				async: true,
 			};

--- a/packages/docs/site/src/css/custom.css
+++ b/packages/docs/site/src/css/custom.css
@@ -165,28 +165,28 @@ a.navbar__link--active:hover {
 	font-weight: normal;
 }
 
-.ask-ai-button {
+.kapa-ai-button {
 	background-color: var(--ifm-color-primary);
+	font-weight: var(--ifm-font-weight-semibold);
 	color: white;
-	border: none;
-	border-radius: 0.25rem;
-	padding: 0.5rem 1rem;
-	font-size: 0.9rem;
-	font-weight: 500;
+	padding: var(--ifm-navbar-item-padding-vertical)
+		var(--ifm-navbar-item-padding-horizontal);
+	display: none;
+	text-decoration: none;
 	cursor: pointer;
-	transition: all 0.2s ease-in-out;
-	margin: 0 0.5rem;
 }
 
-.ask-ai-button:hover {
-	opacity: 0.9;
-	transform: translateY(-1px);
+.kapa-ai-button:hover {
+	color: white;
+	text-decoration: none;
 }
 
-[data-theme='dark'] .ask-ai-button {
+[data-theme='dark'] .kapa-ai-button {
 	color: black;
 }
 
-[data-theme='dark'] .ask-ai-button:hover {
-	opacity: 0.9;
+@media (min-width: 997px) {
+	.kapa-ai-button {
+		display: inline-block;
+	}
 }

--- a/packages/docs/site/src/css/custom.css
+++ b/packages/docs/site/src/css/custom.css
@@ -164,3 +164,29 @@ a.navbar__link--active:hover {
 #list-resources-redirections a {
 	font-weight: normal;
 }
+
+.ask-ai-button {
+	background-color: var(--ifm-color-primary);
+	color: white;
+	border: none;
+	border-radius: 0.25rem;
+	padding: 0.5rem 1rem;
+	font-size: 0.9rem;
+	font-weight: 500;
+	cursor: pointer;
+	transition: all 0.2s ease-in-out;
+	margin: 0 0.5rem;
+}
+
+.ask-ai-button:hover {
+	opacity: 0.9;
+	transform: translateY(-1px);
+}
+
+[data-theme='dark'] .ask-ai-button {
+	color: black;
+}
+
+[data-theme='dark'] .ask-ai-button:hover {
+	opacity: 0.9;
+}

--- a/packages/docs/site/src/theme/Navbar/Search/index.js
+++ b/packages/docs/site/src/theme/Navbar/Search/index.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import Search from '@theme-original/Navbar/Search';
+
+export default function SearchWrapper(props) {
+	const handleClick = (e) => {
+		e.preventDefault();
+		window.Kapa?.open?.();
+	};
+
+	/*
+	 * This add the Kapa AI button to the end of the navbar. It is impossible to add it
+	 * by using themeConfig.navbar.items because the Search component it hardcoded.
+	 * See https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/Navbar/Content/index.tsx#L100
+	 *
+	 * By swizzling the Search component, we can add the Kapa AI button to the right of it.
+	 */
+	return (
+		<>
+			<Search {...props} />
+			<div>
+				<a
+					className="kapa-ai-button"
+					onClick={handleClick}
+					aria-label="Ask AI"
+				>
+					Ask AI
+				</a>
+			</div>
+		</>
+	);
+}


### PR DESCRIPTION
This pull request adds a new AI assistant widget to the WordPress Playground documentation site by updating the Docusaurus configuration. The widget is integrated via a script and includes custom branding, bot protection, and messaging.

Integration of the AI assistant widget:

* ~~Added a new entry to the `scripts` array in `docusaurus.config.js` to load the Kapa AI widget, including configuration options for project branding, modal titles, and example questions.~~
* Added the Kapa script to a custom plugin to make it possible to load the current locale
* Map Playground locales to Kapa locales
* Added i18n
* Translated in ES

<img width="499" height="93" alt="immagine" src="https://github.com/user-attachments/assets/45b5d1fd-49af-4c3c-b63a-55cd82cc5545" />

<img width="497" height="77" alt="immagine" src="https://github.com/user-attachments/assets/b8e90f32-710f-4aef-81fa-18f18f4facb7" />

### How to test it?

- From top folder, run the command `npm run build:docs`, then `npm run dev:docs`
- Check the button on top right

Switching to different locales by using the locale dropdown is not possible [on localhost.](https://docusaurus.io/docs/i18n/tutorial#start-your-site) To test another locale, do this:
```bash
cd packages/docs/site
npm run start -- --locale es # es, for example
```
And be sure the Kapa UI is in Spanish:
<img width="272" height="145" alt="immagine" src="https://github.com/user-attachments/assets/6ad6695a-4e14-4653-ade8-5e28fda0d84a" />
