### PR TITLE
Add Dependabot configuration for npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    exclude-paths:
+      - packages


### PR DESCRIPTION
## Motivation for the change, related issues

Let's try using Dependabot alerts for simple dependency updates. We may not always follow its advice, as the npm ecosystem really likes breaking BC in the large dependency trees, but it will at least provide more visibility around the current state of things.

cc @wojtekn @brandonpayton 
