### PR TITLE
[Meta] Fix package-lock.json after dependabot

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,0 +1,39 @@
+name: Rehydrate lockfile on Dependabot PRs
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    fix-lock:
+        if: github.actor == 'dependabot[bot]'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.head_ref }}
+                  fetch-depth: 0
+
+            - uses: actions/setup-node@v4
+              with:
+                  # Honor the version pinned in package.json -> packageManager
+                  node-version-file: '.nvmrc'
+                  cache: 'npm'
+
+            - name: Show npm version
+              run: npm --version
+
+            - name: Rehydrate workspace links in lockfile
+              run: |
+                  # Update only the lockfile, but with workspaces awareness
+                  npm install --package-lock-only --workspaces --include-workspace-root
+
+            - name: Commit lockfile fix
+              uses: stefanzweifel/git-auto-commit-action@v5
+              with:
+                  commit_message: 'chore: rehydrate workspace links in package-lock for workspaces'
+                  branch: ${{ github.head_ref }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "wp-playground",
 	"version": "0.0.0",
 	"license": "GPL-2.0-or-later",
+	"packageManager": "npm@10.9.2",
 	"scripts": {
 		"build": "nx run-many --all --target=build",
 		"rebuild:wordpress-builds": "nx run playground-wordpress-builds:bundle-wordpress:all -- --force",


### PR DESCRIPTION
## Motivation for the change, related issues

Dependabot removes links from package-lock.json, making all CI jobs fail. This PR adds a CI job that re-adds them.

```
		"node_modules/@php-wasm/xdebug-bridge": {
			"resolved": "packages/php-wasm/xdebug-bridge",
			"link": true
		},
```
