### PR TITLE
[Blueprints] Accept branch names and tags in git:directory resource

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -1089,16 +1089,26 @@ const schema11 = {
 				},
 				ref: {
 					type: 'string',
-					description: 'The branch of the git repository',
+					description:
+						'The ref (branch, tag, or commit) of the git repository',
+				},
+				refType: {
+					$ref: '#/definitions/GitDirectoryRefType',
+					description:
+						'Explicit hint about the ref type (branch, tag, commit, refname)',
 				},
 				path: {
 					type: 'string',
 					description:
-						'The path to the directory in the git repository',
+						'The path to the directory in the git repository. Defaults to the repo root.',
 				},
 			},
-			required: ['resource', 'url', 'ref', 'path'],
+			required: ['resource', 'url', 'ref'],
 			additionalProperties: false,
+		},
+		GitDirectoryRefType: {
+			type: 'string',
+			enum: ['branch', 'tag', 'commit', 'refname'],
 		},
 		DirectoryLiteralReference: {
 			type: 'object',
@@ -3945,7 +3955,7 @@ const schema23 = {
 		},
 	],
 };
-const schema28 = {
+const schema29 = {
 	type: 'object',
 	properties: {
 		activate: {
@@ -3960,7 +3970,7 @@ const schema28 = {
 	},
 	additionalProperties: false,
 };
-const schema29 = {
+const schema30 = {
 	type: 'object',
 	properties: {
 		activate: {
@@ -3980,7 +3990,7 @@ const schema29 = {
 	},
 	additionalProperties: false,
 };
-const schema36 = {
+const schema37 = {
 	type: 'object',
 	properties: {
 		adminUsername: { type: 'string' },
@@ -4005,17 +4015,238 @@ const schema25 = {
 		url: { type: 'string', description: 'The URL of the git repository' },
 		ref: {
 			type: 'string',
-			description: 'The branch of the git repository',
+			description:
+				'The ref (branch, tag, or commit) of the git repository',
+		},
+		refType: {
+			$ref: '#/definitions/GitDirectoryRefType',
+			description:
+				'Explicit hint about the ref type (branch, tag, commit, refname)',
 		},
 		path: {
 			type: 'string',
-			description: 'The path to the directory in the git repository',
+			description:
+				'The path to the directory in the git repository. Defaults to the repo root.',
 		},
 	},
-	required: ['resource', 'url', 'ref', 'path'],
+	required: ['resource', 'url', 'ref'],
 	additionalProperties: false,
 };
 const schema26 = {
+	type: 'string',
+	enum: ['branch', 'tag', 'commit', 'refname'],
+};
+function validate19(
+	data,
+	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
+) {
+	let vErrors = null;
+	let errors = 0;
+	if (errors === 0) {
+		if (data && typeof data == 'object' && !Array.isArray(data)) {
+			let missing0;
+			if (
+				(data.resource === undefined && (missing0 = 'resource')) ||
+				(data.url === undefined && (missing0 = 'url')) ||
+				(data.ref === undefined && (missing0 = 'ref'))
+			) {
+				validate19.errors = [
+					{
+						instancePath,
+						schemaPath: '#/required',
+						keyword: 'required',
+						params: { missingProperty: missing0 },
+						message:
+							"must have required property '" + missing0 + "'",
+					},
+				];
+				return false;
+			} else {
+				const _errs1 = errors;
+				for (const key0 in data) {
+					if (
+						!(
+							key0 === 'resource' ||
+							key0 === 'url' ||
+							key0 === 'ref' ||
+							key0 === 'refType' ||
+							key0 === 'path'
+						)
+					) {
+						validate19.errors = [
+							{
+								instancePath,
+								schemaPath: '#/additionalProperties',
+								keyword: 'additionalProperties',
+								params: { additionalProperty: key0 },
+								message: 'must NOT have additional properties',
+							},
+						];
+						return false;
+						break;
+					}
+				}
+				if (_errs1 === errors) {
+					if (data.resource !== undefined) {
+						let data0 = data.resource;
+						const _errs2 = errors;
+						if (typeof data0 !== 'string') {
+							validate19.errors = [
+								{
+									instancePath: instancePath + '/resource',
+									schemaPath: '#/properties/resource/type',
+									keyword: 'type',
+									params: { type: 'string' },
+									message: 'must be string',
+								},
+							];
+							return false;
+						}
+						if ('git:directory' !== data0) {
+							validate19.errors = [
+								{
+									instancePath: instancePath + '/resource',
+									schemaPath: '#/properties/resource/const',
+									keyword: 'const',
+									params: { allowedValue: 'git:directory' },
+									message: 'must be equal to constant',
+								},
+							];
+							return false;
+						}
+						var valid0 = _errs2 === errors;
+					} else {
+						var valid0 = true;
+					}
+					if (valid0) {
+						if (data.url !== undefined) {
+							const _errs4 = errors;
+							if (typeof data.url !== 'string') {
+								validate19.errors = [
+									{
+										instancePath: instancePath + '/url',
+										schemaPath: '#/properties/url/type',
+										keyword: 'type',
+										params: { type: 'string' },
+										message: 'must be string',
+									},
+								];
+								return false;
+							}
+							var valid0 = _errs4 === errors;
+						} else {
+							var valid0 = true;
+						}
+						if (valid0) {
+							if (data.ref !== undefined) {
+								const _errs6 = errors;
+								if (typeof data.ref !== 'string') {
+									validate19.errors = [
+										{
+											instancePath: instancePath + '/ref',
+											schemaPath: '#/properties/ref/type',
+											keyword: 'type',
+											params: { type: 'string' },
+											message: 'must be string',
+										},
+									];
+									return false;
+								}
+								var valid0 = _errs6 === errors;
+							} else {
+								var valid0 = true;
+							}
+							if (valid0) {
+								if (data.refType !== undefined) {
+									let data3 = data.refType;
+									const _errs8 = errors;
+									if (typeof data3 !== 'string') {
+										validate19.errors = [
+											{
+												instancePath:
+													instancePath + '/refType',
+												schemaPath:
+													'#/definitions/GitDirectoryRefType/type',
+												keyword: 'type',
+												params: { type: 'string' },
+												message: 'must be string',
+											},
+										];
+										return false;
+									}
+									if (
+										!(
+											data3 === 'branch' ||
+											data3 === 'tag' ||
+											data3 === 'commit' ||
+											data3 === 'refname'
+										)
+									) {
+										validate19.errors = [
+											{
+												instancePath:
+													instancePath + '/refType',
+												schemaPath:
+													'#/definitions/GitDirectoryRefType/enum',
+												keyword: 'enum',
+												params: {
+													allowedValues:
+														schema26.enum,
+												},
+												message:
+													'must be equal to one of the allowed values',
+											},
+										];
+										return false;
+									}
+									var valid0 = _errs8 === errors;
+								} else {
+									var valid0 = true;
+								}
+								if (valid0) {
+									if (data.path !== undefined) {
+										const _errs11 = errors;
+										if (typeof data.path !== 'string') {
+											validate19.errors = [
+												{
+													instancePath:
+														instancePath + '/path',
+													schemaPath:
+														'#/properties/path/type',
+													keyword: 'type',
+													params: { type: 'string' },
+													message: 'must be string',
+												},
+											];
+											return false;
+										}
+										var valid0 = _errs11 === errors;
+									} else {
+										var valid0 = true;
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		} else {
+			validate19.errors = [
+				{
+					instancePath,
+					schemaPath: '#/type',
+					keyword: 'type',
+					params: { type: 'object' },
+					message: 'must be object',
+				},
+			];
+			return false;
+		}
+	}
+	validate19.errors = vErrors;
+	return errors === 0;
+}
+const schema27 = {
 	type: 'object',
 	additionalProperties: false,
 	properties: {
@@ -4029,7 +4260,7 @@ const schema26 = {
 	},
 	required: ['files', 'name', 'resource'],
 };
-const schema27 = {
+const schema28 = {
 	type: 'object',
 	additionalProperties: {
 		anyOf: [
@@ -4039,8 +4270,8 @@ const schema27 = {
 	},
 	properties: {},
 };
-const wrapper0 = { validate: validate20 };
-function validate20(
+const wrapper0 = { validate: validate22 };
+function validate22(
 	data,
 	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
 ) {
@@ -4091,7 +4322,7 @@ function validate20(
 							schemaPath: '#/additionalProperties/anyOf/1/type',
 							keyword: 'type',
 							params: {
-								type: schema27.additionalProperties.anyOf[1]
+								type: schema28.additionalProperties.anyOf[1]
 									.type,
 							},
 							message: 'must be object,string',
@@ -4123,7 +4354,7 @@ function validate20(
 						vErrors.push(err1);
 					}
 					errors++;
-					validate20.errors = vErrors;
+					validate22.errors = vErrors;
 					return false;
 				} else {
 					errors = _errs3;
@@ -4141,7 +4372,7 @@ function validate20(
 				}
 			}
 		} else {
-			validate20.errors = [
+			validate22.errors = [
 				{
 					instancePath,
 					schemaPath: '#/type',
@@ -4153,10 +4384,10 @@ function validate20(
 			return false;
 		}
 	}
-	validate20.errors = vErrors;
+	validate22.errors = vErrors;
 	return errors === 0;
 }
-function validate19(
+function validate21(
 	data,
 	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
 ) {
@@ -4170,7 +4401,7 @@ function validate19(
 				(data.name === undefined && (missing0 = 'name')) ||
 				(data.resource === undefined && (missing0 = 'resource'))
 			) {
-				validate19.errors = [
+				validate21.errors = [
 					{
 						instancePath,
 						schemaPath: '#/required',
@@ -4191,7 +4422,7 @@ function validate19(
 							key0 === 'name'
 						)
 					) {
-						validate19.errors = [
+						validate21.errors = [
 							{
 								instancePath,
 								schemaPath: '#/additionalProperties',
@@ -4209,7 +4440,7 @@ function validate19(
 						let data0 = data.resource;
 						const _errs2 = errors;
 						if (typeof data0 !== 'string') {
-							validate19.errors = [
+							validate21.errors = [
 								{
 									instancePath: instancePath + '/resource',
 									schemaPath: '#/properties/resource/type',
@@ -4221,7 +4452,7 @@ function validate19(
 							return false;
 						}
 						if ('literal:directory' !== data0) {
-							validate19.errors = [
+							validate21.errors = [
 								{
 									instancePath: instancePath + '/resource',
 									schemaPath: '#/properties/resource/const',
@@ -4242,7 +4473,7 @@ function validate19(
 						if (data.files !== undefined) {
 							const _errs4 = errors;
 							if (
-								!validate20(data.files, {
+								!validate22(data.files, {
 									instancePath: instancePath + '/files',
 									parentData: data,
 									parentDataProperty: 'files',
@@ -4251,8 +4482,8 @@ function validate19(
 							) {
 								vErrors =
 									vErrors === null
-										? validate20.errors
-										: vErrors.concat(validate20.errors);
+										? validate22.errors
+										: vErrors.concat(validate22.errors);
 								errors = vErrors.length;
 							}
 							var valid0 = _errs4 === errors;
@@ -4263,7 +4494,7 @@ function validate19(
 							if (data.name !== undefined) {
 								const _errs5 = errors;
 								if (typeof data.name !== 'string') {
-									validate19.errors = [
+									validate21.errors = [
 										{
 											instancePath:
 												instancePath + '/name',
@@ -4285,7 +4516,7 @@ function validate19(
 				}
 			}
 		} else {
-			validate19.errors = [
+			validate21.errors = [
 				{
 					instancePath,
 					schemaPath: '#/type',
@@ -4297,7 +4528,7 @@ function validate19(
 			return false;
 		}
 	}
-	validate19.errors = vErrors;
+	validate21.errors = vErrors;
 	return errors === 0;
 }
 function validate18(
@@ -4309,194 +4540,26 @@ function validate18(
 	const _errs0 = errors;
 	let valid0 = false;
 	const _errs1 = errors;
-	const _errs2 = errors;
-	if (errors === _errs2) {
-		if (data && typeof data == 'object' && !Array.isArray(data)) {
-			let missing0;
-			if (
-				(data.resource === undefined && (missing0 = 'resource')) ||
-				(data.url === undefined && (missing0 = 'url')) ||
-				(data.ref === undefined && (missing0 = 'ref')) ||
-				(data.path === undefined && (missing0 = 'path'))
-			) {
-				const err0 = {
-					instancePath,
-					schemaPath: '#/definitions/GitDirectoryReference/required',
-					keyword: 'required',
-					params: { missingProperty: missing0 },
-					message: "must have required property '" + missing0 + "'",
-				};
-				if (vErrors === null) {
-					vErrors = [err0];
-				} else {
-					vErrors.push(err0);
-				}
-				errors++;
-			} else {
-				const _errs4 = errors;
-				for (const key0 in data) {
-					if (
-						!(
-							key0 === 'resource' ||
-							key0 === 'url' ||
-							key0 === 'ref' ||
-							key0 === 'path'
-						)
-					) {
-						const err1 = {
-							instancePath,
-							schemaPath:
-								'#/definitions/GitDirectoryReference/additionalProperties',
-							keyword: 'additionalProperties',
-							params: { additionalProperty: key0 },
-							message: 'must NOT have additional properties',
-						};
-						if (vErrors === null) {
-							vErrors = [err1];
-						} else {
-							vErrors.push(err1);
-						}
-						errors++;
-						break;
-					}
-				}
-				if (_errs4 === errors) {
-					if (data.resource !== undefined) {
-						let data0 = data.resource;
-						const _errs5 = errors;
-						if (typeof data0 !== 'string') {
-							const err2 = {
-								instancePath: instancePath + '/resource',
-								schemaPath:
-									'#/definitions/GitDirectoryReference/properties/resource/type',
-								keyword: 'type',
-								params: { type: 'string' },
-								message: 'must be string',
-							};
-							if (vErrors === null) {
-								vErrors = [err2];
-							} else {
-								vErrors.push(err2);
-							}
-							errors++;
-						}
-						if ('git:directory' !== data0) {
-							const err3 = {
-								instancePath: instancePath + '/resource',
-								schemaPath:
-									'#/definitions/GitDirectoryReference/properties/resource/const',
-								keyword: 'const',
-								params: { allowedValue: 'git:directory' },
-								message: 'must be equal to constant',
-							};
-							if (vErrors === null) {
-								vErrors = [err3];
-							} else {
-								vErrors.push(err3);
-							}
-							errors++;
-						}
-						var valid2 = _errs5 === errors;
-					} else {
-						var valid2 = true;
-					}
-					if (valid2) {
-						if (data.url !== undefined) {
-							const _errs7 = errors;
-							if (typeof data.url !== 'string') {
-								const err4 = {
-									instancePath: instancePath + '/url',
-									schemaPath:
-										'#/definitions/GitDirectoryReference/properties/url/type',
-									keyword: 'type',
-									params: { type: 'string' },
-									message: 'must be string',
-								};
-								if (vErrors === null) {
-									vErrors = [err4];
-								} else {
-									vErrors.push(err4);
-								}
-								errors++;
-							}
-							var valid2 = _errs7 === errors;
-						} else {
-							var valid2 = true;
-						}
-						if (valid2) {
-							if (data.ref !== undefined) {
-								const _errs9 = errors;
-								if (typeof data.ref !== 'string') {
-									const err5 = {
-										instancePath: instancePath + '/ref',
-										schemaPath:
-											'#/definitions/GitDirectoryReference/properties/ref/type',
-										keyword: 'type',
-										params: { type: 'string' },
-										message: 'must be string',
-									};
-									if (vErrors === null) {
-										vErrors = [err5];
-									} else {
-										vErrors.push(err5);
-									}
-									errors++;
-								}
-								var valid2 = _errs9 === errors;
-							} else {
-								var valid2 = true;
-							}
-							if (valid2) {
-								if (data.path !== undefined) {
-									const _errs11 = errors;
-									if (typeof data.path !== 'string') {
-										const err6 = {
-											instancePath:
-												instancePath + '/path',
-											schemaPath:
-												'#/definitions/GitDirectoryReference/properties/path/type',
-											keyword: 'type',
-											params: { type: 'string' },
-											message: 'must be string',
-										};
-										if (vErrors === null) {
-											vErrors = [err6];
-										} else {
-											vErrors.push(err6);
-										}
-										errors++;
-									}
-									var valid2 = _errs11 === errors;
-								} else {
-									var valid2 = true;
-								}
-							}
-						}
-					}
-				}
-			}
-		} else {
-			const err7 = {
-				instancePath,
-				schemaPath: '#/definitions/GitDirectoryReference/type',
-				keyword: 'type',
-				params: { type: 'object' },
-				message: 'must be object',
-			};
-			if (vErrors === null) {
-				vErrors = [err7];
-			} else {
-				vErrors.push(err7);
-			}
-			errors++;
-		}
+	if (
+		!validate19(data, {
+			instancePath,
+			parentData,
+			parentDataProperty,
+			rootData,
+		})
+	) {
+		vErrors =
+			vErrors === null
+				? validate19.errors
+				: vErrors.concat(validate19.errors);
+		errors = vErrors.length;
 	}
 	var _valid0 = _errs1 === errors;
 	valid0 = valid0 || _valid0;
 	if (!valid0) {
-		const _errs13 = errors;
+		const _errs2 = errors;
 		if (
-			!validate19(data, {
+			!validate21(data, {
 				instancePath,
 				parentData,
 				parentDataProperty,
@@ -4505,15 +4568,15 @@ function validate18(
 		) {
 			vErrors =
 				vErrors === null
-					? validate19.errors
-					: vErrors.concat(validate19.errors);
+					? validate21.errors
+					: vErrors.concat(validate21.errors);
 			errors = vErrors.length;
 		}
-		var _valid0 = _errs13 === errors;
+		var _valid0 = _errs2 === errors;
 		valid0 = valid0 || _valid0;
 	}
 	if (!valid0) {
-		const err8 = {
+		const err0 = {
 			instancePath,
 			schemaPath: '#/anyOf',
 			keyword: 'anyOf',
@@ -4521,9 +4584,9 @@ function validate18(
 			message: 'must match a schema in anyOf',
 		};
 		if (vErrors === null) {
-			vErrors = [err8];
+			vErrors = [err0];
 		} else {
-			vErrors.push(err8);
+			vErrors.push(err0);
 		}
 		errors++;
 		validate18.errors = vErrors;
@@ -4541,7 +4604,7 @@ function validate18(
 	validate18.errors = vErrors;
 	return errors === 0;
 }
-const schema30 = {
+const schema31 = {
 	type: 'object',
 	properties: {
 		method: {
@@ -4638,12 +4701,12 @@ const schema30 = {
 	required: ['url'],
 	additionalProperties: false,
 };
-const schema31 = {
+const schema32 = {
 	type: 'string',
 	enum: ['GET', 'POST', 'HEAD', 'OPTIONS', 'PATCH', 'PUT', 'DELETE'],
 };
-const schema32 = { type: 'object', additionalProperties: { type: 'string' } };
-function validate28(
+const schema33 = { type: 'object', additionalProperties: { type: 'string' } };
+function validate30(
 	data,
 	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
 ) {
@@ -4653,7 +4716,7 @@ function validate28(
 		if (data && typeof data == 'object' && !Array.isArray(data)) {
 			let missing0;
 			if (data.url === undefined && (missing0 = 'url')) {
-				validate28.errors = [
+				validate30.errors = [
 					{
 						instancePath,
 						schemaPath: '#/required',
@@ -4675,7 +4738,7 @@ function validate28(
 							key0 === 'body'
 						)
 					) {
-						validate28.errors = [
+						validate30.errors = [
 							{
 								instancePath,
 								schemaPath: '#/additionalProperties',
@@ -4693,7 +4756,7 @@ function validate28(
 						let data0 = data.method;
 						const _errs2 = errors;
 						if (typeof data0 !== 'string') {
-							validate28.errors = [
+							validate30.errors = [
 								{
 									instancePath: instancePath + '/method',
 									schemaPath: '#/definitions/HTTPMethod/type',
@@ -4715,12 +4778,12 @@ function validate28(
 								data0 === 'DELETE'
 							)
 						) {
-							validate28.errors = [
+							validate30.errors = [
 								{
 									instancePath: instancePath + '/method',
 									schemaPath: '#/definitions/HTTPMethod/enum',
 									keyword: 'enum',
-									params: { allowedValues: schema31.enum },
+									params: { allowedValues: schema32.enum },
 									message:
 										'must be equal to one of the allowed values',
 								},
@@ -4735,7 +4798,7 @@ function validate28(
 						if (data.url !== undefined) {
 							const _errs5 = errors;
 							if (typeof data.url !== 'string') {
-								validate28.errors = [
+								validate30.errors = [
 									{
 										instancePath: instancePath + '/url',
 										schemaPath: '#/properties/url/type',
@@ -4766,7 +4829,7 @@ function validate28(
 											if (
 												typeof data2[key1] !== 'string'
 											) {
-												validate28.errors = [
+												validate30.errors = [
 													{
 														instancePath:
 															instancePath +
@@ -4798,7 +4861,7 @@ function validate28(
 											}
 										}
 									} else {
-										validate28.errors = [
+										validate30.errors = [
 											{
 												instancePath:
 													instancePath + '/headers',
@@ -6787,7 +6850,7 @@ function validate28(
 											vErrors.push(err34);
 										}
 										errors++;
-										validate28.errors = vErrors;
+										validate30.errors = vErrors;
 										return false;
 									} else {
 										errors = _errs14;
@@ -6809,7 +6872,7 @@ function validate28(
 				}
 			}
 		} else {
-			validate28.errors = [
+			validate30.errors = [
 				{
 					instancePath,
 					schemaPath: '#/type',
@@ -6821,10 +6884,10 @@ function validate28(
 			return false;
 		}
 	}
-	validate28.errors = vErrors;
+	validate30.errors = vErrors;
 	return errors === 0;
 }
-const schema33 = {
+const schema34 = {
 	type: 'object',
 	properties: {
 		relativeUri: {
@@ -6890,7 +6953,7 @@ const schema33 = {
 	},
 	additionalProperties: false,
 };
-function validate30(
+function validate32(
 	data,
 	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
 ) {
@@ -6900,8 +6963,8 @@ function validate30(
 		if (data && typeof data == 'object' && !Array.isArray(data)) {
 			const _errs1 = errors;
 			for (const key0 in data) {
-				if (!func2.call(schema33.properties, key0)) {
-					validate30.errors = [
+				if (!func2.call(schema34.properties, key0)) {
+					validate32.errors = [
 						{
 							instancePath,
 							schemaPath: '#/additionalProperties',
@@ -6918,7 +6981,7 @@ function validate30(
 				if (data.relativeUri !== undefined) {
 					const _errs2 = errors;
 					if (typeof data.relativeUri !== 'string') {
-						validate30.errors = [
+						validate32.errors = [
 							{
 								instancePath: instancePath + '/relativeUri',
 								schemaPath: '#/properties/relativeUri/type',
@@ -6937,7 +7000,7 @@ function validate30(
 					if (data.scriptPath !== undefined) {
 						const _errs4 = errors;
 						if (typeof data.scriptPath !== 'string') {
-							validate30.errors = [
+							validate32.errors = [
 								{
 									instancePath: instancePath + '/scriptPath',
 									schemaPath: '#/properties/scriptPath/type',
@@ -6956,7 +7019,7 @@ function validate30(
 						if (data.protocol !== undefined) {
 							const _errs6 = errors;
 							if (typeof data.protocol !== 'string') {
-								validate30.errors = [
+								validate32.errors = [
 									{
 										instancePath:
 											instancePath + '/protocol',
@@ -6978,7 +7041,7 @@ function validate30(
 								let data3 = data.method;
 								const _errs8 = errors;
 								if (typeof data3 !== 'string') {
-									validate30.errors = [
+									validate32.errors = [
 										{
 											instancePath:
 												instancePath + '/method',
@@ -7002,7 +7065,7 @@ function validate30(
 										data3 === 'DELETE'
 									)
 								) {
-									validate30.errors = [
+									validate32.errors = [
 										{
 											instancePath:
 												instancePath + '/method',
@@ -7010,7 +7073,7 @@ function validate30(
 												'#/definitions/HTTPMethod/enum',
 											keyword: 'enum',
 											params: {
-												allowedValues: schema31.enum,
+												allowedValues: schema32.enum,
 											},
 											message:
 												'must be equal to one of the allowed values',
@@ -7039,7 +7102,7 @@ function validate30(
 													typeof data4[key1] !==
 													'string'
 												) {
-													validate30.errors = [
+													validate32.errors = [
 														{
 															instancePath:
 																instancePath +
@@ -7071,7 +7134,7 @@ function validate30(
 												}
 											}
 										} else {
-											validate30.errors = [
+											validate32.errors = [
 												{
 													instancePath:
 														instancePath +
@@ -7709,7 +7772,7 @@ function validate30(
 												vErrors.push(err12);
 											}
 											errors++;
-											validate30.errors = vErrors;
+											validate32.errors = vErrors;
 											return false;
 										} else {
 											errors = _errs18;
@@ -7742,7 +7805,7 @@ function validate30(
 																key4
 															] !== 'string'
 														) {
-															validate30.errors =
+															validate32.errors =
 																[
 																	{
 																		instancePath:
@@ -7777,7 +7840,7 @@ function validate30(
 														}
 													}
 												} else {
-													validate30.errors = [
+													validate32.errors = [
 														{
 															instancePath:
 																instancePath +
@@ -7818,7 +7881,7 @@ function validate30(
 																	key5
 																] !== 'string'
 															) {
-																validate30.errors =
+																validate32.errors =
 																	[
 																		{
 																			instancePath:
@@ -7854,7 +7917,7 @@ function validate30(
 															}
 														}
 													} else {
-														validate30.errors = [
+														validate32.errors = [
 															{
 																instancePath:
 																	instancePath +
@@ -7883,7 +7946,7 @@ function validate30(
 														typeof data.code !==
 														'string'
 													) {
-														validate30.errors = [
+														validate32.errors = [
 															{
 																instancePath:
 																	instancePath +
@@ -7915,7 +7978,7 @@ function validate30(
 				}
 			}
 		} else {
-			validate30.errors = [
+			validate32.errors = [
 				{
 					instancePath,
 					schemaPath: '#/type',
@@ -7927,7 +7990,7 @@ function validate30(
 			return false;
 		}
 	}
-	validate30.errors = vErrors;
+	validate32.errors = vErrors;
 	return errors === 0;
 }
 function validate14(
@@ -13845,7 +13908,7 @@ function validate14(
 												) {
 													const _errs266 = errors;
 													if (
-														!validate28(
+														!validate30(
 															data.request,
 															{
 																instancePath:
@@ -13861,9 +13924,9 @@ function validate14(
 													) {
 														vErrors =
 															vErrors === null
-																? validate28.errors
+																? validate30.errors
 																: vErrors.concat(
-																		validate28.errors
+																		validate30.errors
 																  );
 														errors = vErrors.length;
 													}
@@ -15332,7 +15395,7 @@ function validate14(
 												) {
 													const _errs330 = errors;
 													if (
-														!validate30(
+														!validate32(
 															data.options,
 															{
 																instancePath:
@@ -15348,9 +15411,9 @@ function validate14(
 													) {
 														vErrors =
 															vErrors === null
-																? validate30.errors
+																? validate32.errors
 																: vErrors.concat(
-																		validate30.errors
+																		validate32.errors
 																  );
 														errors = vErrors.length;
 													}

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -1345,15 +1345,23 @@
 				},
 				"ref": {
 					"type": "string",
-					"description": "The branch of the git repository"
+					"description": "The ref (branch, tag, or commit) of the git repository"
+				},
+				"refType": {
+					"$ref": "#/definitions/GitDirectoryRefType",
+					"description": "Explicit hint about the ref type (branch, tag, commit, refname)"
 				},
 				"path": {
 					"type": "string",
-					"description": "The path to the directory in the git repository"
+					"description": "The path to the directory in the git repository. Defaults to the repo root."
 				}
 			},
-			"required": ["resource", "url", "ref", "path"],
+			"required": ["resource", "url", "ref"],
 			"additionalProperties": false
+		},
+		"GitDirectoryRefType": {
+			"type": "string",
+			"enum": ["branch", "tag", "commit", "refname"]
 		},
 		"DirectoryLiteralReference": {
 			"type": "object",

--- a/packages/playground/blueprints/src/lib/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.spec.ts
@@ -61,14 +61,15 @@ describe('GitDirectoryResource', () => {
 			const resource = new GitDirectoryResource({
 				resource: 'git:directory',
 				url,
-				ref: '05138293dd39e25a9fa8e43a9cc775d6fb780e37',
-				refType: 'commit',
+				ref: 'trunk',
+				// A path with only a few files to avoid timing out.
+				path: '.github',
 			});
 			const { files, name } = await resource.resolve();
 
 			expect(name).toBe(fallbackName);
-			expect(resource.name).toBe(fallbackName);
-			expect(files['README.md']).toBeInstanceOf(Uint8Array);
+			expect(resource.name).toBe('.github');
+			expect(files['dependabot.yml']).toBeInstanceOf(Uint8Array);
 		});
 	});
 });

--- a/packages/playground/blueprints/src/lib/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.spec.ts
@@ -40,6 +40,7 @@ describe('GitDirectoryResource', () => {
 					resource: 'git:directory',
 					url: 'https://github.com/WordPress/wordpress-playground',
 					ref: '05138293dd39e25a9fa8e43a9cc775d6fb780e37',
+					refType: 'commit',
 					path,
 				});
 				const { files } = await resource.resolve();
@@ -51,6 +52,24 @@ describe('GitDirectoryResource', () => {
 				]);
 			}
 		);
+
+		it('defaults to the repo root when path is omitted', async () => {
+			const url = 'https://github.com/WordPress/wordpress-playground';
+			const fallbackName = url
+				.replaceAll(/[^a-zA-Z0-9-.]/g, '-')
+				.replaceAll(/-+/g, '-');
+			const resource = new GitDirectoryResource({
+				resource: 'git:directory',
+				url,
+				ref: '05138293dd39e25a9fa8e43a9cc775d6fb780e37',
+				refType: 'commit',
+			});
+			const { files, name } = await resource.resolve();
+
+			expect(name).toBe(fallbackName);
+			expect(resource.name).toBe(fallbackName);
+			expect(files['README.md']).toBeInstanceOf(Uint8Array);
+		});
 	});
 });
 

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -62,15 +62,18 @@ export type UrlReference = {
 	/** Optional caption for displaying a progress message */
 	caption?: string;
 };
+type GitDirectoryRefType = 'branch' | 'tag' | 'commit' | 'refname';
 export type GitDirectoryReference = {
 	/** Identifies the file resource as a git directory */
 	resource: 'git:directory';
 	/** The URL of the git repository */
 	url: string;
-	/** The branch of the git repository */
+	/** The ref (branch, tag, or commit) of the git repository */
 	ref: string;
-	/** The path to the directory in the git repository */
-	path: string;
+	/** Explicit hint about the ref type (branch, tag, commit, refname) */
+	refType?: GitDirectoryRefType;
+	/** The path to the directory in the git repository. Defaults to the repo root. */
+	path?: string;
 };
 export interface Directory {
 	files: FileTree;
@@ -570,11 +573,11 @@ export class GitDirectoryResource extends Resource<Directory> {
 
 		const commitHash = await resolveCommitHash(repoUrl, {
 			value: this.reference.ref,
-			type: 'infer',
+			type: this.reference.refType ?? 'infer',
 		});
 		const allFiles = await listGitFiles(repoUrl, commitHash);
 
-		const requestedPath = this.reference.path.replace(/^\/+/, '');
+		const requestedPath = (this.reference.path ?? '').replace(/^\/+/, '');
 		const filesToClone = listDescendantFiles(allFiles, requestedPath);
 		let files = await sparseCheckout(repoUrl, commitHash, filesToClone);
 
@@ -584,7 +587,7 @@ export class GitDirectoryResource extends Resource<Directory> {
 		);
 		return {
 			name:
-				dirname(this.reference.path) ||
+				dirname(this.reference.path || '') ||
 				this.reference.url
 					.replaceAll(/[^a-zA-Z0-9-.]/g, '-')
 					.replaceAll(/-+/g, '-'),
@@ -594,7 +597,13 @@ export class GitDirectoryResource extends Resource<Directory> {
 
 	/** @inheritDoc */
 	get name() {
-		return this.reference.path.split('/').pop()!;
+		const path = this.reference.path ?? '';
+		if (!path) {
+			return this.reference.url
+				.replaceAll(/[^a-zA-Z0-9-.]/g, '-')
+				.replaceAll(/-+/g, '-');
+		}
+		return path.split('/').pop() || '';
 	}
 }
 

--- a/packages/playground/storage/src/lib/git-sparse-checkout.spec.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.spec.ts
@@ -41,6 +41,59 @@ describe('resolveCommitHash', () => {
 		});
 		expect(commitHash).toMatch(/^[a-f0-9]{40}$/);
 	});
+
+	it('returns the commit hash unchanged when type is commit', async () => {
+		const commit = '1234567890abcdef1234567890abcdef12345678';
+		const resolved = await resolveCommitHash(repoUrl, {
+			value: commit,
+			type: 'commit',
+		});
+
+		expect(resolved).toBe(commit);
+	});
+
+	it('resolves branch refs when type is branch', async () => {
+		const resolved = await resolveCommitHash(repoUrl, {
+			value: 'trunk',
+			type: 'branch',
+		});
+		expect(resolved).toMatch(/^[a-f0-9]{40}$/);
+	});
+
+	it('falls back to tags when branches do not match', async () => {
+		const resolved = await resolveCommitHash(repoUrl, {
+			value: 'trunk',
+		});
+		expect(resolved).toMatch(/^[a-f0-9]{40}$/);
+	});
+
+	it('throws when the requested branch cannot be found', async () => {
+		await expect(
+			resolveCommitHash(repoUrl, {
+				value: 'missing-branch',
+				type: 'branch',
+			})
+		).rejects.toThrow(
+			`Git ref "refs/heads/missing-branch" not found at ${repoUrl}`
+		);
+	});
+
+	it('throws when neither branch nor tag can be inferred', async () => {
+		await expect(
+			resolveCommitHash(repoUrl, {
+				value: 'missing-ref',
+			})
+		).rejects.toThrow(`Git ref "missing-ref" not found at ${repoUrl}`);
+	});
+
+	it('throws for unsupported ref types', async () => {
+		await expect(
+			resolveCommitHash(repoUrl, {
+				value: 'whatever',
+				type: 'unsupported' as any,
+			})
+		).rejects.toThrow('Invalid ref type: unsupported');
+	});
 });
 
 describe('sparseCheckout', () => {

--- a/packages/playground/storage/src/lib/git-sparse-checkout.spec.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.spec.ts
@@ -17,6 +17,32 @@ describe('listRefs', () => {
 	});
 });
 
+describe('resolveCommitHash', () => {
+	const repoUrl = 'https://github.com/WordPress/wordpress-playground.git';
+
+	it('infers branch refs when type is omitted', async () => {
+		const commitHash = await resolveCommitHash(repoUrl, {
+			value: 'trunk',
+		});
+		expect(commitHash).toMatch(/^[a-f0-9]{40}$/);
+	});
+
+	it('infers tag refs without an explicit type', async () => {
+		const commitHash = await resolveCommitHash(repoUrl, {
+			value: 'v0.1.28',
+		});
+		expect(commitHash).toMatch(/^[a-f0-9]{40}$/);
+	});
+
+	it('resolves explicit tag refs', async () => {
+		const commitHash = await resolveCommitHash(repoUrl, {
+			value: 'v0.1.28',
+			type: 'tag',
+		});
+		expect(commitHash).toMatch(/^[a-f0-9]{40}$/);
+	});
+});
+
 describe('sparseCheckout', () => {
 	it('should retrieve the requested files from a git repo', async () => {
 		const commitHash = await resolveCommitHash(

--- a/packages/playground/storage/src/lib/git-sparse-checkout.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.ts
@@ -1,3 +1,5 @@
+/* eslint-disable comment-length/limit-multi-line-comments */
+
 /*
  * Import internal data parsers and structures from isomorphic-git. These
  * exports are not available in the npm version of isomorphic-git, which is why
@@ -80,16 +82,11 @@ export type GitRef = {
 	type?: 'branch' | 'commit' | 'refname' | 'tag' | 'infer';
 };
 
-type NormalizedGitRef =
-	| {
-			kind: 'commit';
-			oid: string;
-	  }
-	| {
-			kind: 'refname';
-			refname: string;
-			resolvedOid?: string;
-	  };
+type ParsedGitRef = {
+	kind: 'refname' | 'commit';
+	refname: string;
+	resolvedOid?: string;
+};
 
 const FULL_SHA_REGEX = /^[0-9a-f]{40}$/i;
 
@@ -123,15 +120,15 @@ export async function listGitFiles(
  * @returns The commit hash.
  */
 export async function resolveCommitHash(repoUrl: string, ref: GitRef) {
-	const normalized = await normalizeGitRef(repoUrl, ref);
-	if (normalized.kind === 'commit') {
-		return normalized.oid;
+	const parsed = await parseGitRef(repoUrl, ref);
+	if (parsed.resolvedOid) {
+		return parsed.resolvedOid;
 	}
 
-	const oid =
-		normalized.resolvedOid ??
-		(await fetchRefOidOrThrow(repoUrl, normalized.refname));
-
+	const oid = await fetchRefOid(repoUrl, parsed.refname);
+	if (!oid) {
+		throw new Error(`Git ref "${parsed.refname}" not found at ${repoUrl}`);
+	}
 	return oid;
 }
 
@@ -195,22 +192,50 @@ export async function listGitRefs(
 	for await (const line of parseGitResponseLines(response)) {
 		const spaceAt = line.indexOf(' ');
 		const ref = line.slice(0, spaceAt);
-		const name = line.slice(spaceAt + 1, line.length - 1);
+		/**
+		 * Git protocol may return a line such as:
+		 *
+		 * 41d27ca5d6df1e7826c7fa297398159857ea2d60 refs/tags/v0.1.28 peeled:883860eacc7c37377f772a26919e700749020e4c
+		 *
+		 * This means:
+		 *
+		 * * A tag with a name `v0.1.28`
+		 * * The tag is an object with an oid `883860eacc7c37377f772a26919e700749020e4c`
+		 * * The tag points to a commit with an oid `41d27ca5d6df1e7826c7fa297398159857ea2d60`
+		 *
+		 * nameBuffer is everything after the first space. Let's extract the ref name
+		 * itself, that is refs/tags/v0.1.28.
+		 */
+		const nameBuffer = line.slice(spaceAt + 1, line.length - 1);
+		const name = nameBuffer.split(' ')[0];
 		refs[name] = ref;
 	}
 	return refs;
 }
 
-async function normalizeGitRef(
+/**
+ * Turns a user-provided ref in a convenient format, such as 'main' or
+ * '1234567890abcdef1234567890abcdef12345678' into a more structured
+ * format that tells us about the nature of the ref, e.g.
+ *
+ * * { kind: 'refname', refname: 'refs/heads/main' }
+ * * { kind: 'commit', refname: '1234567890abcdef1234567890abcdef12345678' }.
+ *
+ * @param repoUrl
+ * @param ref
+ * @returns
+ */
+async function parseGitRef(
 	repoUrl: string,
 	ref: GitRef
-): Promise<NormalizedGitRef> {
+): Promise<ParsedGitRef> {
 	const type = ref.type ?? 'infer';
 	switch (type) {
 		case 'commit':
 			return {
 				kind: 'commit',
-				oid: ref.value,
+				refname: ref.value,
+				resolvedOid: ref.value,
 			};
 		case 'branch':
 			return {
@@ -227,66 +252,52 @@ async function normalizeGitRef(
 				kind: 'refname',
 				refname: ref.value.trim(),
 			};
-		case 'infer':
-			return inferGitRef(repoUrl, ref.value);
+		case 'infer': {
+			const trimmed = ref.value.trim();
+			if (trimmed === '' || trimmed === 'HEAD') {
+				return {
+					kind: 'refname',
+					refname: 'HEAD',
+				};
+			}
+			if (trimmed.startsWith('refs/')) {
+				return {
+					kind: 'refname',
+					refname: trimmed,
+				};
+			}
+			if (FULL_SHA_REGEX.test(trimmed)) {
+				return {
+					kind: 'commit',
+					refname: trimmed,
+					resolvedOid: trimmed,
+				};
+			}
+
+			const branchRef = `refs/heads/${trimmed}`;
+			const branchOid = await fetchRefOid(repoUrl, branchRef);
+			if (branchOid) {
+				return {
+					kind: 'refname',
+					refname: branchRef,
+					resolvedOid: branchOid,
+				};
+			}
+
+			const tagRef = `refs/tags/${trimmed}`;
+			const tagOid = await fetchRefOid(repoUrl, tagRef);
+			if (tagOid) {
+				return {
+					kind: 'refname',
+					refname: tagRef,
+					resolvedOid: tagOid,
+				};
+			}
+			throw new Error(`Git ref "${ref.value}" not found at ${repoUrl}`);
+		}
 		default:
 			throw new Error(`Invalid ref type: ${ref.type}`);
 	}
-}
-
-async function inferGitRef(
-	repoUrl: string,
-	value: string
-): Promise<NormalizedGitRef> {
-	const trimmed = value.trim();
-	if (trimmed === '' || trimmed === 'HEAD') {
-		return {
-			kind: 'refname',
-			refname: trimmed || 'HEAD',
-		};
-	}
-	if (trimmed.startsWith('refs/')) {
-		return {
-			kind: 'refname',
-			refname: trimmed,
-		};
-	}
-	if (FULL_SHA_REGEX.test(trimmed)) {
-		return {
-			kind: 'commit',
-			oid: trimmed,
-		};
-	}
-
-	const branchRef = `refs/heads/${trimmed}`;
-	const branchOid = await fetchRefOid(repoUrl, branchRef);
-	if (branchOid) {
-		return {
-			kind: 'refname',
-			refname: branchRef,
-			resolvedOid: branchOid,
-		};
-	}
-
-	const tagRef = `refs/tags/${trimmed}`;
-	const tagOid = await fetchRefOid(repoUrl, tagRef);
-	if (tagOid) {
-		return {
-			kind: 'refname',
-			refname: tagRef,
-			resolvedOid: tagOid,
-		};
-	}
-
-	throw new Error(`Git ref "${value}" not found at ${repoUrl}`);
-}
-
-async function fetchRefOidOrThrow(repoUrl: string, refname: string) {
-	const oid = await fetchRefOid(repoUrl, refname);
-	if (!oid) {
-		throw new Error(`Git ref "${refname}" not found at ${repoUrl}`);
-	}
-	return oid;
 }
 
 async function fetchRefOid(repoUrl: string, refname: string) {

--- a/packages/playground/storage/src/lib/git-sparse-checkout.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.ts
@@ -77,8 +77,21 @@ export type GitFileTree = GitFileTreeFile | GitFileTreeFolder;
 
 export type GitRef = {
 	value: string;
-	type?: 'branch' | 'commit' | 'refname' | 'infer';
+	type?: 'branch' | 'commit' | 'refname' | 'tag' | 'infer';
 };
+
+type NormalizedGitRef =
+	| {
+			kind: 'commit';
+			oid: string;
+	  }
+	| {
+			kind: 'refname';
+			refname: string;
+			resolvedOid?: string;
+	  };
+
+const FULL_SHA_REGEX = /^[0-9a-f]{40}$/i;
 
 /**
  * Lists all files in a git repository.
@@ -110,38 +123,16 @@ export async function listGitFiles(
  * @returns The commit hash.
  */
 export async function resolveCommitHash(repoUrl: string, ref: GitRef) {
-	if (ref.type === 'infer' || ref.type === undefined) {
-		if (['', 'HEAD'].includes(ref.value)) {
-			ref = {
-				value: ref.value,
-				type: 'refname',
-			};
-		} else if (typeof ref.value === 'string' && ref.value.length === 40) {
-			ref = {
-				value: ref.value,
-				type: 'commit',
-			};
-		}
+	const normalized = await normalizeGitRef(repoUrl, ref);
+	if (normalized.kind === 'commit') {
+		return normalized.oid;
 	}
-	if (ref.type === 'branch') {
-		ref = {
-			value: `refs/heads/${ref.value}`,
-			type: 'refname',
-		};
-	}
-	switch (ref.type) {
-		case 'commit':
-			return ref.value;
-		case 'refname': {
-			const refs = await listGitRefs(repoUrl, ref.value);
-			if (!(ref.value in refs)) {
-				throw new Error(`Branch ${ref.value} not found`);
-			}
-			return refs[ref.value];
-		}
-		default:
-			throw new Error(`Invalid ref type: ${ref.type}`);
-	}
+
+	const oid =
+		normalized.resolvedOid ??
+		(await fetchRefOidOrThrow(repoUrl, normalized.refname));
+
+	return oid;
 }
 
 function gitTreeToFileTree(tree: GitTree): GitFileTree[] {
@@ -208,6 +199,106 @@ export async function listGitRefs(
 		refs[name] = ref;
 	}
 	return refs;
+}
+
+async function normalizeGitRef(
+	repoUrl: string,
+	ref: GitRef
+): Promise<NormalizedGitRef> {
+	const type = ref.type ?? 'infer';
+	switch (type) {
+		case 'commit':
+			return {
+				kind: 'commit',
+				oid: ref.value,
+			};
+		case 'branch':
+			return {
+				kind: 'refname',
+				refname: `refs/heads/${ref.value.trim()}`,
+			};
+		case 'tag':
+			return {
+				kind: 'refname',
+				refname: `refs/tags/${ref.value.trim()}`,
+			};
+		case 'refname':
+			return {
+				kind: 'refname',
+				refname: ref.value.trim(),
+			};
+		case 'infer':
+			return inferGitRef(repoUrl, ref.value);
+		default:
+			throw new Error(`Invalid ref type: ${ref.type}`);
+	}
+}
+
+async function inferGitRef(
+	repoUrl: string,
+	value: string
+): Promise<NormalizedGitRef> {
+	const trimmed = value.trim();
+	if (trimmed === '' || trimmed === 'HEAD') {
+		return {
+			kind: 'refname',
+			refname: trimmed || 'HEAD',
+		};
+	}
+	if (trimmed.startsWith('refs/')) {
+		return {
+			kind: 'refname',
+			refname: trimmed,
+		};
+	}
+	if (FULL_SHA_REGEX.test(trimmed)) {
+		return {
+			kind: 'commit',
+			oid: trimmed,
+		};
+	}
+
+	const branchRef = `refs/heads/${trimmed}`;
+	const branchOid = await fetchRefOid(repoUrl, branchRef);
+	if (branchOid) {
+		return {
+			kind: 'refname',
+			refname: branchRef,
+			resolvedOid: branchOid,
+		};
+	}
+
+	const tagRef = `refs/tags/${trimmed}`;
+	const tagOid = await fetchRefOid(repoUrl, tagRef);
+	if (tagOid) {
+		return {
+			kind: 'refname',
+			refname: tagRef,
+			resolvedOid: tagOid,
+		};
+	}
+
+	throw new Error(`Git ref "${value}" not found at ${repoUrl}`);
+}
+
+async function fetchRefOidOrThrow(repoUrl: string, refname: string) {
+	const oid = await fetchRefOid(repoUrl, refname);
+	if (!oid) {
+		throw new Error(`Git ref "${refname}" not found at ${repoUrl}`);
+	}
+	return oid;
+}
+
+async function fetchRefOid(repoUrl: string, refname: string) {
+	const refs = await listGitRefs(repoUrl, refname);
+	const candidates = [refname, `${refname}^{}`];
+	for (const candidate of candidates) {
+		const sanitized = candidate.trim();
+		if (sanitized in refs) {
+			return refs[sanitized];
+		}
+	}
+	return null;
 }
 
 async function fetchWithoutBlobs(repoUrl: string, commitHash: string) {

--- a/packages/playground/storage/src/lib/git-sparse-checkout.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.ts
@@ -77,11 +77,21 @@ export type GitFileTreeFolder = {
 };
 export type GitFileTree = GitFileTreeFile | GitFileTreeFolder;
 
+/**
+ * A Git ref in a human-readable format. Could be a single string,
+ * e.g. 'main', 'v0.1.28', '1234567890abcdef1234567890abcdef12345678',
+ * could be a string and an explicit type, e.g. { value: 'main', type: 'branch' },
+ */
 export type GitRef = {
 	value: string;
 	type?: 'branch' | 'commit' | 'refname' | 'tag' | 'infer';
 };
 
+/**
+ * A Git ref in a machine-friendly format.
+ * Contains all the information needed to resolve the ref to its oid,
+ * and, optionally, the oid itself.
+ */
 type ParsedGitRef = {
 	kind: 'refname' | 'commit';
 	refname: string;


### PR DESCRIPTION
## Motivation for the change, related issues

Enables sourcing data from arbitrary branches and tags via Blueprints.

Before this PR, you had to use a ref name that's either `HEAD` or a commit hash. With this PR, you can also reference branches by their names and tags. Also, the `path` property is no longer required and defaults to `/`.

## Testing Instructions (or ideally a Blueprint)

Run this Blueprint and confirm it installs and activates the Blocky formats plugin from its Git repo:

```json
{
  "login": true,
  "landingPage": "/wp-admin/post-new.php",
  "steps": [
    {
      "step": "installPlugin",
      "options": {
        "activate": true,
        "targetFolderName": "blocky-formats"
      },
      "pluginData": {
        "resource": "git:directory",
        "url": "https://github.com/dmsnell/blocky-formats.git",
        "ref": "trunk"
      }
    }
  ],
  "preferredVersions": {
    "php": "8.3",
    "wp": "latest"
  },
  "features": {}
}

```
