### PR TITLE
Update form-data npm dependency via package.json overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27462,15 +27462,16 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-			"integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -200,7 +200,8 @@
 		"typescript": "5.4.5",
 		"@playwright/test": "1.47.1",
 		"ws": "^8.18.0",
-		"tmp": "0.2.5"
+		"tmp": "0.2.5",
+		"form-data": "^4.0.4"
 	},
 	"workspaces": [
 		"packages/nx-extensions",


### PR DESCRIPTION
## Motivation for the change, related issues

Updates the form-data dependency, [like dependabot](https://github.com/WordPress/wordpress-playground/pull/2759), but in a way that won't regress on the next npm install.