### PR TITLE
Deploy web app less often to reduce cache invalidation

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
     # Deploy the website every day at 9am and 6pm UTC
     schedule:
-        - cron: '0 9,18 * * *'
+        - cron: '0 11 * * 2'
 
 concurrency:
     group: website-deployment

--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -2,7 +2,7 @@ name: Deploy to playground.wordpress.net
 
 on:
     workflow_dispatch:
-    # Deploy the website every day at 9am and 6pm UTC
+    # Deploy the website every Tuesday at 11am UTC
     schedule:
         - cron: '0 11 * * 2'
 


### PR DESCRIPTION
## Motivation for the change, related issues

@adamziel mentioned:
> I’ve heard PHP Playground takes too long time to load every day – that’s because we use network-first caching strategy. I don’t see an easy way to switch to local-first caching, but we could invalidate the cache less frequently.

This seems like a good idea to me. The workflow for updating major and beta WP versions already triggers a deploy if there are changes. And if we need a deploy for any other reason, we can start one manually.

## Implementation details

This changes the web app deployment schedule to 1100 UTC on Tuesday. This way, we avoid creating sudden changes at the beginning of everyone's week but have plenty of time to address any issues before the end of the week.

## Testing Instructions (or ideally a Blueprint)

- CI
- After merge, confirm that the web app is deployed as expected on the following Tuesday and that no other scheduled runs occur.