### PR TITLE
[Website] Allow remote.html from same origin as Playground client script

### DIFF
--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -164,6 +164,8 @@ const validRemoteOrigins = [
 	'https://wasm.wordpress.net',
 	// Allow hosting remote from same origin
 	location.origin,
+	// Allow hosting remote from the same origin as the client library.
+	new URL(import.meta.url).origin,
 	'http://localhost',
 	'http://localhost:5400',
 	'https://localhost',


### PR DESCRIPTION
## Motivation for the change, related issues

I tested Telex using a self-hosted Playground client and remote from https://playground.automattic.ai. The client/remote compatibility check in https://playground.automattic.ai/client/index.js is rejecting the remote URL of https://playground.automattic.ai/remote.html even though they are hosted together and should be compatible.

This PR fixes the check to allow a remote from the same origin as the client script.

## Implementation details

This PR adds the following to the list of compatible origins within the client script:
```
	// Allow hosting remote from the same origin as the client library.
	new URL(import.meta.url).origin,
```

## Testing Instructions (or ideally a Blueprint)

I tested this change with a manual edit to `https://playground.automattic.ai/client/index.js`, and it resolved the issue.

- CI