### PR TITLE
[Docs] Updating resources page

### DIFF
--- a/packages/docs/site/docs/main/resources.md
+++ b/packages/docs/site/docs/main/resources.md
@@ -82,3 +82,6 @@ There's a set of redirections in place to make it easier the access to some of t
 -   [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) by Álvaro Gómez Velasco
 -   [Use WordPress with just a browser! WordPress Playground Tutorial: Basic usage of Playground (in Japanese)](https://www.youtube.com/watch?v=6s_B0WvJauU) by Shimomura Tomoki
 -   [WordPress Playground: How to use Blueprints](https://www.youtube.com/watch?v=Vcao6uXguWg) by Shimomura Tomoki
+-   [Streamlined Block Theme Development: Using WordPress Playground and GitHub for No-Code Version Control of Site Editor Changes](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) by Birgit Pauli-Haack
+-   [Playground, la mejor herramienta jamás inventada para enseñar WordPress (in Spanish)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) by Nilo Vélez
+-   [Testing Faster Than a Red Bull Pit Stop: WordPress Playground and WooCommerce Blueprints](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) by Daniel Dudzic

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,0 +1,87 @@
+---
+title: Enlaces y Recursos
+slug: /resources
+description: Una lista curada de enlaces útiles a aplicaciones, herramientas, artículos y videos para aprender más sobre WordPress Playground.
+---
+
+# Enlaces y Recursos
+
+:::tip
+
+Hay un conjunto de redirecciones para facilitar el acceso a algunas de las herramientas relacionadas con Playground:
+
+<ul id="list-resources-redirections">
+<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → Instancia de Playground</li>
+<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Documentación de Playground</li>
+<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Constructor de Blueprints de Playground</li>
+<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Visor de PR de Playground para WordPress</li>
+<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Visor de PR de Playground para Gutenberg</li>
+<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Servicio Proxy de Playground <em>(ver <a href="/blueprints/steps/resources#urlreference">URLReference</a> para más información)</em></li>
+</ul>
+:::
+
+## Enlaces frecuentemente buscados
+
+-   [Demo](https://playground.wordpress.net/)
+-   [Repositorio de GitHub](https://github.com/WordPress/wordpress-playground)
+-   [Documentación](https://wordpress.github.io/wordpress-playground/)
+-   [Repositorio de herramientas de Playground](https://github.com/WordPress/playground-tools)
+
+## Aplicaciones construidas con WordPress Playground
+
+-   [Demo oficial](https://playground.wordpress.net/) y la aplicación [showcase](https://developer.wordpress.org/playground) – instala un tema, prueba un plugin, crea algunas páginas, exporta lo que has construido
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – una herramienta CLI para entorno de desarrollo WordPress instantáneo
+-   [WordPress Playground para VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+-   Traducciones en vivo: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [anuncio](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [más detalles](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Bloque de código interactivo](https://wordpress.org/plugins/interactive-code-block/) que potencia el [tutorial del Procesador de Etiquetas HTML](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) y el [tutorial de la API JS de Playground](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
+-   [Visor de Pull Request de Gutenberg](https://playground.wordpress.net/gutenberg.html)
+-   [Demo en vivo del plugin de notificaciones](https://johnhooks.io/playground-experiment/)
+-   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – la primera aplicación iOS que ejecuta WordPress en tu teléfono
+-   [Incrustador de Playground](https://joost.blog/embedded-playground/) para incrustar ejemplos de Playground en la documentación de WordPress.org usando shortcodes
+-   [Demos de plugins en wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – un script de usuario que agrega una pestaña "demo" a las páginas de plugins en WordPress.org
+-   [Visor de Pull Request de WordPress](https://playground.wordpress.net/wordpress.html)
+-   [Sincronización entre dos Playgrounds](https://playground.wordpress.net/demos/sync.html)
+-   [Viaje en el tiempo](https://playground.wordpress.net/demos/time-traveling.html)
+-   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+-   [Implementación PHP de Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+
+## Material de lectura
+
+-   [Construye experiencias WordPress en el navegador con WordPress Playground y WebAssembly (en inglés)](https://web.dev/wordpress-playground/)
+-   [WordPress Playground en developer.wordpress.org (en inglés)](https://developer.wordpress.org/playground)
+-   [Demos técnicas de WordPress en el navegador: Desarrollo de WordPress con WordPress Playground (en inglés)](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [Anuncio inicial en make.wordpress.org (en inglés)](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Discusión de Hackernews (en inglés)](https://news.ycombinator.com/item?id=32960560)
+
+## Videos
+
+-   Videos de Developer Hours:
+    -   [Región Américas (23 de mayo de 2023) (en inglés)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [Región APAC/EMEA (24 de mayo de 2023) (en inglés)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [Creando Blueprints de WordPress Playground para pruebas y demos (28 de mayo de 2024) (en inglés)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) por Birgit Pauli-Haack & Nick Diego
+    -   [Developer Hours: Todo lo que necesitas saber sobre WordPress Playground (17 de diciembre de 2024) (en inglés)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) por Nick Diego & Ryan Welcher
+-   [Playground en State of the Word (en inglés)](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [Playground en WCEU 2023 (en inglés)](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   [Ver "WordPress Playground: la herramienta definitiva de aprendizaje, pruebas y enseñanza para WordPress" (en inglés)](https://www.youtube.com/watch?v=dN_LaenY8bI) por Anne McCarthy
+-   [WordPress Playground para desarrolladores (en inglés)](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) por Berislav Grgicak y Jonathan Bossenger
+-   [Soporte de temas del editor de código del bloque WordPress Playground (en inglés)](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) por Jonathan Bossenger
+-   [WordPress Playground – usa WordPress sin servidor en WCEU 2024 (en inglés)](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) por Adam Zielinski
+-   [Codifica, Prueba, Repite: Acelerando el desarrollo con WordPress Playground en WordCamp Larissa 2024 (en inglés)](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) por Uros Tasic
+-   [Liberando datos con WordPress Playground en una extensión de navegador en WordCamp Países Bajos 2024 (en inglés)](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) por Alex Kirk
+-   [Más allá de Playground: WordPress como herramienta y constructor de productos en WCUS 2024 (en inglés)](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) por Dennis Snell
+-   [Crea una demo con Playground en WC Asia 2025 (en inglés)](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) por Birgit Pauli-Haack
+-   [Diseccionando WordPress Playground en WordCamp Nepal 2025 (en inglés)](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) por Sakar Upadhyaya Khatiwada
+-   [Construyendo pruebas automatizadas con WordPress Playground en WCEU 2025 (en inglés)](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/) por Berislav Grgicak
+-   [De cero a demo: Dominando los Blueprints de WordPress Playground en WCEU 2025 (en inglés)](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) por Birgit Pauli-Haack
+-   [Playground en WordCamp Gliwice (en polaco)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) por Adam Zielinski
+-   [WordPress Playground en WordCamp Wrocław 2024 (en polaco)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) por Adam Zielinski
+-   [WordPress Playground en WordCamp Gdynia 2025 (en polaco)](https://wordpress.tv/2025/04/21/wordpress-playground/) por Magdalena Paciorek
+-   [Descubriendo Playground, la herramienta para hacer demos](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) por Alex Cuadra
+-   [WordPress Playground: Instalación completa y funcional de WordPress](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) por Fernando García Rebolledo
+-   [Playground: Un WordPress de usar y tirar dentro de tu navegador en WordCamp Madrid 2025](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) por Álvaro Gómez Velasco
+-   [¡Usa WordPress con solo un navegador! Tutorial de WordPress Playground: Uso básico de Playground (en japonés)](https://www.youtube.com/watch?v=6s_B0WvJauU) por Shimomura Tomoki
+-   [WordPress Playground: Cómo usar Blueprints (en japonés)](https://www.youtube.com/watch?v=Vcao6uXguWg) por Shimomura Tomoki
+-   [Desarrollo simplificado de temas de bloques: Usando WordPress Playground y GitHub para control de versiones sin código de cambios del editor de sitios (en inglés)](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) por Birgit Pauli-Haack
+-   [Playground, la mejor herramienta jamás inventada para enseñar WordPress](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) por Nilo Vélez
+-   [Probando más rápido que un pit stop de Red Bull: WordPress Playground y Blueprints de WooCommerce (en inglés)](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) por Daniel Dudzic

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/resources.md
@@ -6,7 +6,15 @@ description: Una lista curada de enlaces útiles a aplicaciones, herramientas, a
 
 # Enlaces y Recursos
 
+<!--
+# Links and Resources
+-->
+
 :::tip
+
+<!--
+There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
+-->
 
 Hay un conjunto de redirecciones para facilitar el acceso a algunas de las herramientas relacionadas con Playground:
 
@@ -20,14 +28,48 @@ Hay un conjunto de redirecciones para facilitar el acceso a algunas de las herra
 </ul>
 :::
 
+<!--
+## Frequently sought links
+-->
+
 ## Enlaces frecuentemente buscados
+
+<!--
+-   [Demo](https://playground.wordpress.net/)
+-   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+-   [Documentation](https://wordpress.github.io/wordpress-playground/)
+-   [Playground tools Repository](https://github.com/WordPress/playground-tools)
+-->
 
 -   [Demo](https://playground.wordpress.net/)
 -   [Repositorio de GitHub](https://github.com/WordPress/wordpress-playground)
 -   [Documentación](https://wordpress.github.io/wordpress-playground/)
 -   [Repositorio de herramientas de Playground](https://github.com/WordPress/playground-tools)
 
+<!--
+## Apps built with WordPress Playground
+-->
+
 ## Aplicaciones construidas con WordPress Playground
+
+<!--
+-   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – a CLI tool for instant WordPress dev enviroment
+-   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+-   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
+-   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
+-   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
+-   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
+-   [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
+-   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
+-   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
+-   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
+-   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+-   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+-->
 
 -   [Demo oficial](https://playground.wordpress.net/) y la aplicación [showcase](https://developer.wordpress.org/playground) – instala un tema, prueba un plugin, crea algunas páginas, exporta lo que has construido
 -   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – una herramienta CLI para entorno de desarrollo WordPress instantáneo
@@ -46,7 +88,19 @@ Hay un conjunto de redirecciones para facilitar el acceso a algunas de las herra
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
 -   [Implementación PHP de Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
 
+<!--
+## Reading materials
+-->
+
 ## Material de lectura
+
+<!--
+-   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
+-   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
+-   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
+-->
 
 -   [Construye experiencias WordPress en el navegador con WordPress Playground y WebAssembly (en inglés)](https://web.dev/wordpress-playground/)
 -   [WordPress Playground en developer.wordpress.org (en inglés)](https://developer.wordpress.org/playground)
@@ -54,7 +108,43 @@ Hay un conjunto de redirecciones para facilitar el acceso a algunas de las herra
 -   [Anuncio inicial en make.wordpress.org (en inglés)](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
 -   [Discusión de Hackernews (en inglés)](https://news.ycombinator.com/item?id=32960560)
 
+<!--
 ## Videos
+-->
+
+## Videos
+
+<!--
+-   Developer Hours Videos:
+    -   [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [Creating WordPress Playground Blueprints for Testing and Demos (May 28, 2024)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) by Birgit Pauli-Haack & Nick Diego
+    -   [Developer Hours: Everything you need to know about WordPress Playground (Dec 17, 2024)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) by Nick Diego & Ryan Welcher
+-   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
+-   [WordPress Playground for developers](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) by Berislav Grgicak and Jonathan Bossenger
+-   [WordPress Playground Block code editor theme support](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) by Jonathan Bossenger
+-   [WordPress Playground – use WordPress without a server at WCEU 2024](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) by Adam Zielinski
+-   [Code, Test, Repeat: Accelerating Development with WordPress Playground at WordCamp Larissa 2024](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) by Uros Tasic
+-   [Liberating data with WordPress Playground in a Browser Extension at WordCamp Netherlands 2024](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) by Alex Kirk
+-   [Beyond the Playground: WordPress as a Tool and Product Builder at WCUS 2024](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) by Dennis Snell
+-   [Create a demo with Playground at WC Asia 2025](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) by Birgit Pauli-Haack
+-   [Disssecting WordPress Playground at WordCamp Nepal 2025](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) by Sakar Upadhyaya Khatiwada
+-   [Building Automated Test with WordPress Playground at WCEU 2025](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/)by Berislav Grgicak
+-   [From Zero to Demo: Mastering WordPress Playground Blueprints at WCEU 2025](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) by Birgit Pauli-Haack
+-   [Playground at WordCamp Gliwice (in Polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) by Adam Zielinski
+-   [WordPress Playground at WordCamp Wrocław 2024 (in Polish)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) by Adam Zielinski
+-   [WordPress Playground at WordCamp Gdynia 2025 (in Polish)](https://wordpress.tv/2025/04/21/wordpress-playground/) by Magdalena Paciorek
+-   [Discovering Playground, the demo tool(in Spanish)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) by Alex Cuadra
+-   [WordPress Playground: Complete and functional WordPress installation(in Spanish)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) by Fernando García Rebolledo
+-   [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) by Álvaro Gómez Velasco
+-   [Use WordPress with just a browser! WordPress Playground Tutorial: Basic usage of Playground (in Japanese)](https://www.youtube.com/watch?v=6s_B0WvJauU) by Shimomura Tomoki
+-   [WordPress Playground: How to use Blueprints](https://www.youtube.com/watch?v=Vcao6uXguWg) by Shimomura Tomoki
+-   [Streamlined Block Theme Development: Using WordPress Playground and GitHub for No-Code Version Control of Site Editor Changes](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) by Birgit Pauli-Haack
+-   [Playground, la mejor herramienta jamás inventada para enseñar WordPress (in Spanish)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) by Nilo Vélez
+-   [Testing Faster Than a Red Bull Pit Stop: WordPress Playground and WooCommerce Blueprints](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) by Daniel Dudzic
+-->
 
 -   Videos de Developer Hours:
     -   [Región Américas (23 de mayo de 2023) (en inglés)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,27 +1,14 @@
 ---
 title: Liens et ressources
 slug: /resources
+description: Une liste organisée de liens utiles vers des applications, des outils, des articles et des vidéos pour en savoir plus sur WordPress Playground.
 ---
 
-<!-- # Links and Resources -->
 # Liens et ressources
 
-<!--:::tip
+:::tip
 
-There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
-
-<ul id="list-resources-redirections">
-<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → Playground instance</li>
-<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Playground Docs</li>
-<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Playground Blueprints Builder</li>
-<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Playground PR viewer for WordPress</li>
-<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Playground PR viewer for Gutenberg</li>
-<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Service Proxy Playground  <em>(see <a href="/blueprints/steps/resources#urlreference">URLReference</a> for more info)</em></li>
-</ul>
-::: -->
-:::astuce
-
-Un ensemble de redirections est en place pour faciliter l’accès à certains outils liés à Playground :
+Un ensemble de redirections est en place pour faciliter l'accès à certains outils liés à Playground :
 
 <ul id="list-resources-redirections">
 <li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → instance Playground</li>
@@ -29,83 +16,72 @@ Un ensemble de redirections est en place pour faciliter l’accès à certains o
 <li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Constructeur de blueprints Playground</li>
 <li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Visualiseur de PR Playground pour WordPress</li>
 <li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Visualiseur de PR Playground pour Gutenberg</li>
-<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Playground Proxy Service <em>(voir <a href="/blueprints/steps/resources#urlreference">URLReference</a> pour plus d’information)</em></li>
+<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Service Proxy Playground <em>(voir <a href="/blueprints/steps/resources#urlreference">URLReference</a> pour plus d'information)</em></li>
 </ul>
-::: 
+:::
 
-<!-- ## Frequently sought links -->
 ## Liens fréquemment recherchés
 
-<!---   -   [Demo](https://playground.wordpress.net/)
--   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
--   [Documentation](https://wordpress.github.io/wordpress-playground/)
--   [Playground tools Repository](https://github.com/WordPress/playground-tools) -->
 -   [Démo](https://playground.wordpress.net/)
 -   [Dépôt GitHub](https://github.com/WordPress/wordpress-playground)
 -   [Documentation](https://wordpress.github.io/wordpress-playground/)
 -   [Dépôt des outils Playground](https://github.com/WordPress/playground-tools)
 
+## Applications créées avec WordPress Playground
 
-<!-- ## Apps built with WordPress Playground -->
-## Apps contruites avec WordPress Playground
-
-<!---   -   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
--   [wp-now](https://www.npmjs.com/package/%40wp-now/wp-now) – a CLI tool for instant WordPress dev envs
--   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
--   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
--   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://adamadam.blog/2023/04/12/interactive-intro-to-wordpress-playground-public-api/)
--   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
--   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
--   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
--   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
--   [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
--   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
--   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
--   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
--   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
--   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
--   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)    -->
--   [Démo officielle](https://playground.wordpress.net/) et l’app [showcase](https://developer.wordpress.org/playground) – installez un thème, essayez une extension, créez quelques pages, exportez ce que vous avez construit
--   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – un outil CLI pour un environnement dev WordPress intantané
+-   [Démo officielle](https://playground.wordpress.net/) et l'application [vitrine](https://developer.wordpress.org/playground) – installez un thème, essayez une extension, créez quelques pages, exportez ce que vous avez construit
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – un outil CLI pour un environnement de développement WordPress instantané
 -   [WordPress Playground pour VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
--   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [annonce](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [plus de détails](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
--   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) qui alimente le [tutoriel HTML Tag Processor](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) et le [tutoriel Playground JS API](https://adamadam.blog/2023/04/12/interactive-intro-to-wordpress-playground-public-api/)
--   [Visualiseur de pull request Gutenberg](https://playground.wordpress.net/gutenberg.html)
--   [Démo en direct de l’extension Notifications](https://johnhooks.io/playground-experiment/)
+-   Traductions en direct : [Application](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [annonce](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [plus de détails](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Bloc de code interactif](https://wordpress.org/plugins/interactive-code-block/) qui alimente le [tutoriel HTML Tag Processor](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) et le [tutoriel API JS de Playground](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
+-   [Visualiseur de Pull Request Gutenberg](https://playground.wordpress.net/gutenberg.html)
+-   [Démo en direct de l'extension Notifications](https://johnhooks.io/playground-experiment/)
 -   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
--   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – la toute première app iOS exécutant WordPress sur votre téléphone
--   [Playground embedder](https://joost.blog/embedded-playground/) pour intégrer des exemples Playground dans la documentation WordPress.org à l’aide de codes courts
--   [Démos extension sur wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – un script utilisateur qui ajoute un onglet « démo » aux pages d’extensions sur WordPress.org
--   [Visualiseur de pull request](https://playground.wordpress.net/wordpress.html)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – la toute première application iOS exécutant WordPress sur votre téléphone
+-   [Intégrateur Playground](https://joost.blog/embedded-playground/) pour intégrer des exemples Playground dans la documentation WordPress.org à l'aide de shortcodes
+-   [Démos d'extensions sur wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – un script utilisateur qui ajoute un onglet « démo » aux pages d'extensions sur WordPress.org
+-   [Visualiseur de Pull Request WordPress](https://playground.wordpress.net/wordpress.html)
 -   [Synchronisation entre deux Playgrounds](https://playground.wordpress.net/demos/sync.html)
--   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [Voyage dans le temps](https://playground.wordpress.net/demos/time-traveling.html)
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
--   [Implementation PHP de Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+-   [Implémentation PHP des Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
 
-<!-- ## Reading materials -->
-## Documentation
+## Matériel de lecture
 
-<!---   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
--   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
--   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
--   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
--   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)    -->
--   [Build in-browser WordPress experiences with WordPress Playground et WebAssembly (en anglais)](https://web.dev/wordpress-playground/)
+-   [Créer des expériences WordPress dans le navigateur avec WordPress Playground et WebAssembly (en anglais)](https://web.dev/wordpress-playground/)
 -   [WordPress Playground sur developer.wordpress.org (en anglais)](https://developer.wordpress.org/playground)
--   [In-Browser WordPress Tech Demos : développement WordPress avec WordPress Playground (en anglais)](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [Démos techniques WordPress dans le navigateur : développement WordPress avec WordPress Playground (en anglais)](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
 -   [Annonce initiale sur make.wordpress.org (en anglais)](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
 -   [Discussion Hackernews (en anglais)](https://news.ycombinator.com/item?id=32960560)
 
-<!-- ## Videos    -->
 ## Vidéos
 
-<!-- -   Developer Hours Videos: [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/), [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
--   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
--   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
--   [Playground at WordCamp Gliwice (in polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4)
--   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy    -->
--   Vidéos Developer Hours (en anglais) : [zone Amériques (23 mai 2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/), [zone APAC/EMEA  (24 mai 2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
--   [Playground au « State of the Word » (en anglais)](https://youtu.be/VeigCZuxnfY?t=2912)
+-   Vidéos Developer Hours :
+    -   [Région Amériques (23 mai 2023) (en anglais)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [Région APAC/EMEA (24 mai 2023) (en anglais)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [Création de Blueprints WordPress Playground pour les tests et démos (28 mai 2024) (en anglais)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) par Birgit Pauli-Haack & Nick Diego
+    -   [Developer Hours : Tout ce que vous devez savoir sur WordPress Playground (17 décembre 2024) (en anglais)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) par Nick Diego & Ryan Welcher
+-   [Playground au State of the Word (en anglais)](https://youtu.be/VeigCZuxnfY?t=2912)
 -   [Playground au WCEU 2023 (en anglais)](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
--   [Playground au WordCamp Gliwice (en polonais)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4)
--   [Regarder « WordPress Playground : l’outil ultime d’apprentissage, de test et d’enseignement pour WordPress » (en anglais)](https://www.youtube.com/watch?v=dN_LaenY8bI) par Anne McCarthy
+-   [Regarder « WordPress Playground : l'outil ultime d'apprentissage, de test et d'enseignement pour WordPress » (en anglais)](https://www.youtube.com/watch?v=dN_LaenY8bI) par Anne McCarthy
+-   [WordPress Playground pour les développeurs (en anglais)](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) par Berislav Grgicak et Jonathan Bossenger
+-   [Support des thèmes de l'éditeur de code du bloc WordPress Playground (en anglais)](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) par Jonathan Bossenger
+-   [WordPress Playground – utiliser WordPress sans serveur au WCEU 2024 (en anglais)](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) par Adam Zielinski
+-   [Coder, Tester, Répéter : Accélérer le développement avec WordPress Playground au WordCamp Larissa 2024 (en anglais)](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) par Uros Tasic
+-   [Libérer les données avec WordPress Playground dans une extension de navigateur au WordCamp Pays-Bas 2024 (en anglais)](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) par Alex Kirk
+-   [Au-delà de Playground : WordPress comme outil et créateur de produits au WCUS 2024 (en anglais)](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) par Dennis Snell
+-   [Créer une démo avec Playground au WC Asia 2025 (en anglais)](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) par Birgit Pauli-Haack
+-   [Disséquer WordPress Playground au WordCamp Népal 2025 (en anglais)](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) par Sakar Upadhyaya Khatiwada
+-   [Créer des tests automatisés avec WordPress Playground au WCEU 2025 (en anglais)](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/) par Berislav Grgicak
+-   [De zéro à la démo : Maîtriser les Blueprints WordPress Playground au WCEU 2025 (en anglais)](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) par Birgit Pauli-Haack
+-   [Playground au WordCamp Gliwice (en polonais)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) par Adam Zielinski
+-   [WordPress Playground au WordCamp Wrocław 2024 (en polonais)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) par Adam Zielinski
+-   [WordPress Playground au WordCamp Gdynia 2025 (en polonais)](https://wordpress.tv/2025/04/21/wordpress-playground/) par Magdalena Paciorek
+-   [Découvrir Playground, l'outil de démo (en espagnol)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) par Alex Cuadra
+-   [WordPress Playground : Installation complète et fonctionnelle de WordPress (en espagnol)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) par Fernando García Rebolledo
+-   [Playground : Un WordPress jetable dans votre navigateur au WordCamp Madrid 2025 (en espagnol)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) par Álvaro Gómez Velasco
+-   [Utilisez WordPress avec juste un navigateur ! Tutoriel WordPress Playground : Utilisation de base de Playground (en japonais)](https://www.youtube.com/watch?v=6s_B0WvJauU) par Shimomura Tomoki
+-   [WordPress Playground : Comment utiliser les Blueprints (en japonais)](https://www.youtube.com/watch?v=Vcao6uXguWg) par Shimomura Tomoki
+-   [Développement rationalisé de thèmes de blocs : Utiliser WordPress Playground et GitHub pour le contrôle de version sans code des modifications de l'éditeur de site (en anglais)](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) par Birgit Pauli-Haack
+-   [Playground, le meilleur outil jamais inventé pour enseigner WordPress (en espagnol)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) par Nilo Vélez
+-   [Tester plus vite qu'un arrêt au stand de Red Bull : WordPress Playground et Blueprints WooCommerce (en anglais)](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) par Daniel Dudzic

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/resources.md
@@ -6,7 +6,15 @@ description: Une liste organisée de liens utiles vers des applications, des out
 
 # Liens et ressources
 
+<!--
+# Links and Resources
+-->
+
 :::tip
+
+<!--
+There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
+-->
 
 Un ensemble de redirections est en place pour faciliter l'accès à certains outils liés à Playground :
 
@@ -20,14 +28,48 @@ Un ensemble de redirections est en place pour faciliter l'accès à certains out
 </ul>
 :::
 
+<!--
+## Frequently sought links
+-->
+
 ## Liens fréquemment recherchés
+
+<!--
+-   [Demo](https://playground.wordpress.net/)
+-   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+-   [Documentation](https://wordpress.github.io/wordpress-playground/)
+-   [Playground tools Repository](https://github.com/WordPress/playground-tools)
+-->
 
 -   [Démo](https://playground.wordpress.net/)
 -   [Dépôt GitHub](https://github.com/WordPress/wordpress-playground)
 -   [Documentation](https://wordpress.github.io/wordpress-playground/)
 -   [Dépôt des outils Playground](https://github.com/WordPress/playground-tools)
 
+<!--
+## Apps built with WordPress Playground
+-->
+
 ## Applications créées avec WordPress Playground
+
+<!--
+-   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – a CLI tool for instant WordPress dev enviroment
+-   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+-   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
+-   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
+-   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
+-   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
+-   [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
+-   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
+-   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
+-   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
+-   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+-   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+-->
 
 -   [Démo officielle](https://playground.wordpress.net/) et l'application [vitrine](https://developer.wordpress.org/playground) – installez un thème, essayez une extension, créez quelques pages, exportez ce que vous avez construit
 -   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – un outil CLI pour un environnement de développement WordPress instantané
@@ -46,7 +88,19 @@ Un ensemble de redirections est en place pour faciliter l'accès à certains out
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
 -   [Implémentation PHP des Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
 
+<!--
+## Reading materials
+-->
+
 ## Matériel de lecture
+
+<!--
+-   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
+-   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
+-   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
+-->
 
 -   [Créer des expériences WordPress dans le navigateur avec WordPress Playground et WebAssembly (en anglais)](https://web.dev/wordpress-playground/)
 -   [WordPress Playground sur developer.wordpress.org (en anglais)](https://developer.wordpress.org/playground)
@@ -54,7 +108,43 @@ Un ensemble de redirections est en place pour faciliter l'accès à certains out
 -   [Annonce initiale sur make.wordpress.org (en anglais)](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
 -   [Discussion Hackernews (en anglais)](https://news.ycombinator.com/item?id=32960560)
 
+<!--
+## Videos
+-->
+
 ## Vidéos
+
+<!--
+-   Developer Hours Videos:
+    -   [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [Creating WordPress Playground Blueprints for Testing and Demos (May 28, 2024)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) by Birgit Pauli-Haack & Nick Diego
+    -   [Developer Hours: Everything you need to know about WordPress Playground (Dec 17, 2024)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) by Nick Diego & Ryan Welcher
+-   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
+-   [WordPress Playground for developers](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) by Berislav Grgicak and Jonathan Bossenger
+-   [WordPress Playground Block code editor theme support](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) by Jonathan Bossenger
+-   [WordPress Playground – use WordPress without a server at WCEU 2024](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) by Adam Zielinski
+-   [Code, Test, Repeat: Accelerating Development with WordPress Playground at WordCamp Larissa 2024](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) by Uros Tasic
+-   [Liberating data with WordPress Playground in a Browser Extension at WordCamp Netherlands 2024](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) by Alex Kirk
+-   [Beyond the Playground: WordPress as a Tool and Product Builder at WCUS 2024](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) by Dennis Snell
+-   [Create a demo with Playground at WC Asia 2025](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) by Birgit Pauli-Haack
+-   [Disssecting WordPress Playground at WordCamp Nepal 2025](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) by Sakar Upadhyaya Khatiwada
+-   [Building Automated Test with WordPress Playground at WCEU 2025](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/)by Berislav Grgicak
+-   [From Zero to Demo: Mastering WordPress Playground Blueprints at WCEU 2025](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) by Birgit Pauli-Haack
+-   [Playground at WordCamp Gliwice (in Polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) by Adam Zielinski
+-   [WordPress Playground at WordCamp Wrocław 2024 (in Polish)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) by Adam Zielinski
+-   [WordPress Playground at WordCamp Gdynia 2025 (in Polish)](https://wordpress.tv/2025/04/21/wordpress-playground/) by Magdalena Paciorek
+-   [Discovering Playground, the demo tool(in Spanish)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) by Alex Cuadra
+-   [WordPress Playground: Complete and functional WordPress installation(in Spanish)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) by Fernando García Rebolledo
+-   [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) by Álvaro Gómez Velasco
+-   [Use WordPress with just a browser! WordPress Playground Tutorial: Basic usage of Playground (in Japanese)](https://www.youtube.com/watch?v=6s_B0WvJauU) by Shimomura Tomoki
+-   [WordPress Playground: How to use Blueprints](https://www.youtube.com/watch?v=Vcao6uXguWg) by Shimomura Tomoki
+-   [Streamlined Block Theme Development: Using WordPress Playground and GitHub for No-Code Version Control of Site Editor Changes](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) by Birgit Pauli-Haack
+-   [Playground, la mejor herramienta jamás inventada para enseñar WordPress (in Spanish)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) by Nilo Vélez
+-   [Testing Faster Than a Red Bull Pit Stop: WordPress Playground and WooCommerce Blueprints](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) by Daniel Dudzic
+-->
 
 -   Vidéos Developer Hours :
     -   [Région Amériques (23 mai 2023) (en anglais)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)

--- a/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,0 +1,87 @@
+---
+title: લિંક્સ અને સંસાધનો
+slug: /resources
+description: WordPress Playground વિશે વધુ શીખવા માટે એપ્લિકેશન્સ, ટૂલ્સ, લેખો અને વિડિયોઝની ઉપયોગી લિંક્સની ક્યુરેટેડ સૂચિ.
+---
+
+# લિંક્સ અને સંસાધનો
+
+:::tip
+
+Playground સાથે સંબંધિત કેટલાક ટૂલ્સની ઍક્સેસને સરળ બનાવવા માટે રીડાયરેક્શન્સનો સેટ છે:
+
+<ul id="list-resources-redirections">
+<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → Playground ઇન્સ્ટન્સ</li>
+<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Playground ડોક્સ</li>
+<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Playground Blueprints Builder</li>
+<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → WordPress માટે Playground PR viewer</li>
+<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Gutenberg માટે Playground PR viewer</li>
+<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Playground Proxy Service <em>(વધુ માહિતી માટે <a href="/blueprints/steps/resources#urlreference">URLReference</a> જુઓ)</em></li>
+</ul>
+:::
+
+## વારંવાર શોધાતી લિંક્સ
+
+-   [Demo](https://playground.wordpress.net/)
+-   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+-   [Documentation](https://wordpress.github.io/wordpress-playground/)
+-   [Playground tools Repository](https://github.com/WordPress/playground-tools)
+
+## WordPress Playground સાથે બનાવેલ એપ્લિકેશન્સ
+
+-   [અધિકૃત demo](https://playground.wordpress.net/) અને [showcase](https://developer.wordpress.org/playground) એપ – થીમ ઇન્સ્ટોલ કરો, પ્લગિન અજમાવો, કેટલાક પૃષ્ઠો બનાવો, તમે જે બનાવ્યું છે તે નિકાસ કરો
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – ત્વરિત WordPress dev environment માટે CLI ટૂલ
+-   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+-   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) જે [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) અને [Playground JS API tutorial](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/) ને સંચાલિત કરે છે
+-   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
+-   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
+-   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – તમારા ફોન પર WordPress ચલાવતી પ્રથમ iOS એપ
+-   [Playground embedder](https://joost.blog/embedded-playground/) shortcodes નો ઉપયોગ કરીને WordPress.org documentation માં Playground ઉદાહરણો એમ્બેડ કરવા માટે
+-   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – એક user script જે WordPress.org પર plugin પૃષ્ઠો પર "demo" ટેબ ઉમેરે છે
+-   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
+-   [બે Playgrounds વચ્ચે સમન્વય](https://playground.wordpress.net/demos/sync.html)
+-   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+-   [Blueprints નું PHP implementation](https://playground.wordpress.net/demos/php-blueprints.html)
+
+## વાંચન સામગ્રી
+
+-   [WordPress Playground અને WebAssembly સાથે બ્રાઉઝરમાં WordPress અનુભવો બનાવો (અંગ્રેજીમાં)](https://web.dev/wordpress-playground/)
+-   [developer.wordpress.org પર WordPress Playground (અંગ્રેજીમાં)](https://developer.wordpress.org/playground)
+-   [બ્રાઉઝરમાં WordPress ટેક ડેમો: WordPress Playground સાથે WordPress વિકાસ (અંગ્રેજીમાં)](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [make.wordpress.org પર પ્રારંભિક જાહેરાત (અંગ્રેજીમાં)](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Hackernews ચર્ચા (અંગ્રેજીમાં)](https://news.ycombinator.com/item?id=32960560)
+
+## વિડિયોઝ
+
+-   Developer Hours વિડિયોઝ:
+    -   [અમેરિકા પ્રદેશ (23 મે, 2023) (અંગ્રેજીમાં)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [APAC/EMEA પ્રદેશ (24 મે, 2023) (અંગ્રેજીમાં)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [પરીક્ષણ અને ડેમો માટે WordPress Playground Blueprints બનાવવું (28 મે, 2024) (અંગ્રેજીમાં)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) Birgit Pauli-Haack & Nick Diego દ્વારા
+    -   [Developer Hours: WordPress Playground વિશે તમારે જાણવાની જરૂર છે તે બધું (17 ડિસેમ્બર, 2024) (અંગ્રેજીમાં)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) Nick Diego & Ryan Welcher દ્વારા
+-   [State of the Word પર Playground (અંગ્રેજીમાં)](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [WCEU 2023 પર Playground (અંગ્રેજીમાં)](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   ["WordPress Playground: WordPress માટે અંતિમ શીખવા, પરીક્ષણ અને શિક્ષણ સાધન" જુઓ (અંગ્રેજીમાં)](https://www.youtube.com/watch?v=dN_LaenY8bI) Anne McCarthy દ્વારા
+-   [વિકાસકર્તાઓ માટે WordPress Playground (અંગ્રેજીમાં)](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) Berislav Grgicak અને Jonathan Bossenger દ્વારા
+-   [WordPress Playground Block code editor theme support (અંગ્રેજીમાં)](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) Jonathan Bossenger દ્વારા
+-   [WordPress Playground – WCEU 2024 માં સર્વર વિના WordPress નો ઉપયોગ કરો (અંગ્રેજીમાં)](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) Adam Zielinski દ્વારા
+-   [Code, Test, Repeat: WordCamp Larissa 2024 માં WordPress Playground સાથે વિકાસને વેગ આપવો (અંગ્રેજીમાં)](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) Uros Tasic દ્વારા
+-   [WordCamp Netherlands 2024 માં બ્રાઉઝર એક્સટેન્શનમાં WordPress Playground સાથે ડેટા મુક્ત કરવું (અંગ્રેજીમાં)](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) Alex Kirk દ્વારા
+-   [Playground થી આગળ: WCUS 2024 માં સાધન અને ઉત્પાદન નિર્માતા તરીકે WordPress (અંગ્રેજીમાં)](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) Dennis Snell દ્વારા
+-   [WC Asia 2025 માં Playground સાથે ડેમો બનાવો (અંગ્રેજીમાં)](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) Birgit Pauli-Haack દ્વારા
+-   [WordCamp Nepal 2025 માં WordPress Playground નું વિચ્છેદન (અંગ્રેજીમાં)](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) Sakar Upadhyaya Khatiwada દ્વારા
+-   [WCEU 2025 માં WordPress Playground સાથે સ્વચાલિત પરીક્ષણ બનાવવું (અંગ્રેજીમાં)](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/) Berislav Grgicak દ્વારા
+-   [શૂન્યથી ડેમો સુધી: WCEU 2025 માં WordPress Playground Blueprints માં નિપુણતા મેળવવી (અંગ્રેજીમાં)](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) Birgit Pauli-Haack દ્વારા
+-   [WordCamp Gliwice પર Playground (પોલિશમાં)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) Adam Zielinski દ્વારા
+-   [WordCamp Wrocław 2024 પર WordPress Playground (પોલિશમાં)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) Adam Zielinski દ્વારા
+-   [WordCamp Gdynia 2025 પર WordPress Playground (પોલિશમાં)](https://wordpress.tv/2025/04/21/wordpress-playground/) Magdalena Paciorek દ્વારા
+-   [Playground ની શોધ, ડેમો ટૂલ (સ્પેનિશમાં)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) Alex Cuadra દ્વારા
+-   [WordPress Playground: સંપૂર્ણ અને કાર્યાત્મક WordPress ઇન્સ્ટોલેશન (સ્પેનિશમાં)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) Fernando García Rebolledo દ્વારા
+-   [Playground: WordCamp Madrid 2025 માં તમારા બ્રાઉઝરમાં ડિસ્પોઝેબલ WordPress (સ્પેનિશમાં)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) Álvaro Gómez Velasco દ્વારા
+-   [ફક્ત બ્રાઉઝર સાથે WordPress નો ઉપયોગ કરો! WordPress Playground ટ્યુટોરિયલ: Playground નો મૂળભૂત ઉપયોગ (જાપાનીઝમાં)](https://www.youtube.com/watch?v=6s_B0WvJauU) Shimomura Tomoki દ્વારા
+-   [WordPress Playground: Blueprints નો ઉપયોગ કેવી રીતે કરવો (જાપાનીઝમાં)](https://www.youtube.com/watch?v=Vcao6uXguWg) Shimomura Tomoki દ્વારા
+-   [સુવ્યવસ્થિત બ્લોક થીમ વિકાસ: સાઇટ એડિટર ફેરફારોના નો-કોડ વર્ઝન કંટ્રોલ માટે WordPress Playground અને GitHub નો ઉપયોગ (અંગ્રેજીમાં)](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) Birgit Pauli-Haack દ્વારા
+-   [Playground, WordPress શીખવવા માટે અત્યાર સુધી શોધાયેલ શ્રેષ્ઠ સાધન (સ્પેનિશમાં)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) Nilo Vélez દ્વારા
+-   [Red Bull pit stop કરતાં ઝડપથી પરીક્ષણ: WordPress Playground અને WooCommerce Blueprints (અંગ્રેજીમાં)](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) Daniel Dudzic દ્વારા

--- a/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/resources.md
@@ -6,7 +6,15 @@ description: WordPress Playground વિશે વધુ શીખવા મા�
 
 # લિંક્સ અને સંસાધનો
 
+<!--
+# Links and Resources
+-->
+
 :::tip
+
+<!--
+There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
+-->
 
 Playground સાથે સંબંધિત કેટલાક ટૂલ્સની ઍક્સેસને સરળ બનાવવા માટે રીડાયરેક્શન્સનો સેટ છે:
 
@@ -20,14 +28,48 @@ Playground સાથે સંબંધિત કેટલાક ટૂલ્સ
 </ul>
 :::
 
+<!--
+## Frequently sought links
+-->
+
 ## વારંવાર શોધાતી લિંક્સ
+
+<!--
+-   [Demo](https://playground.wordpress.net/)
+-   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+-   [Documentation](https://wordpress.github.io/wordpress-playground/)
+-   [Playground tools Repository](https://github.com/WordPress/playground-tools)
+-->
 
 -   [Demo](https://playground.wordpress.net/)
 -   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
 -   [Documentation](https://wordpress.github.io/wordpress-playground/)
 -   [Playground tools Repository](https://github.com/WordPress/playground-tools)
 
+<!--
+## Apps built with WordPress Playground
+-->
+
 ## WordPress Playground સાથે બનાવેલ એપ્લિકેશન્સ
+
+<!--
+-   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – a CLI tool for instant WordPress dev enviroment
+-   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+-   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
+-   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
+-   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
+-   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
+-   [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
+-   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
+-   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
+-   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
+-   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+-   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+-->
 
 -   [અધિકૃત demo](https://playground.wordpress.net/) અને [showcase](https://developer.wordpress.org/playground) એપ – થીમ ઇન્સ્ટોલ કરો, પ્લગિન અજમાવો, કેટલાક પૃષ્ઠો બનાવો, તમે જે બનાવ્યું છે તે નિકાસ કરો
 -   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – ત્વરિત WordPress dev environment માટે CLI ટૂલ
@@ -46,7 +88,19 @@ Playground સાથે સંબંધિત કેટલાક ટૂલ્સ
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
 -   [Blueprints નું PHP implementation](https://playground.wordpress.net/demos/php-blueprints.html)
 
+<!--
+## Reading materials
+-->
+
 ## વાંચન સામગ્રી
+
+<!--
+-   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
+-   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
+-   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
+-->
 
 -   [WordPress Playground અને WebAssembly સાથે બ્રાઉઝરમાં WordPress અનુભવો બનાવો (અંગ્રેજીમાં)](https://web.dev/wordpress-playground/)
 -   [developer.wordpress.org પર WordPress Playground (અંગ્રેજીમાં)](https://developer.wordpress.org/playground)
@@ -54,7 +108,43 @@ Playground સાથે સંબંધિત કેટલાક ટૂલ્સ
 -   [make.wordpress.org પર પ્રારંભિક જાહેરાત (અંગ્રેજીમાં)](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
 -   [Hackernews ચર્ચા (અંગ્રેજીમાં)](https://news.ycombinator.com/item?id=32960560)
 
+<!--
+## Videos
+-->
+
 ## વિડિયોઝ
+
+<!--
+-   Developer Hours Videos:
+    -   [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [Creating WordPress Playground Blueprints for Testing and Demos (May 28, 2024)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) by Birgit Pauli-Haack & Nick Diego
+    -   [Developer Hours: Everything you need to know about WordPress Playground (Dec 17, 2024)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) by Nick Diego & Ryan Welcher
+-   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
+-   [WordPress Playground for developers](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) by Berislav Grgicak and Jonathan Bossenger
+-   [WordPress Playground Block code editor theme support](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) by Jonathan Bossenger
+-   [WordPress Playground – use WordPress without a server at WCEU 2024](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) by Adam Zielinski
+-   [Code, Test, Repeat: Accelerating Development with WordPress Playground at WordCamp Larissa 2024](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) by Uros Tasic
+-   [Liberating data with WordPress Playground in a Browser Extension at WordCamp Netherlands 2024](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) by Alex Kirk
+-   [Beyond the Playground: WordPress as a Tool and Product Builder at WCUS 2024](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) by Dennis Snell
+-   [Create a demo with Playground at WC Asia 2025](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) by Birgit Pauli-Haack
+-   [Disssecting WordPress Playground at WordCamp Nepal 2025](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) by Sakar Upadhyaya Khatiwada
+-   [Building Automated Test with WordPress Playground at WCEU 2025](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/)by Berislav Grgicak
+-   [From Zero to Demo: Mastering WordPress Playground Blueprints at WCEU 2025](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) by Birgit Pauli-Haack
+-   [Playground at WordCamp Gliwice (in Polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) by Adam Zielinski
+-   [WordPress Playground at WordCamp Wrocław 2024 (in Polish)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) by Adam Zielinski
+-   [WordPress Playground at WordCamp Gdynia 2025 (in Polish)](https://wordpress.tv/2025/04/21/wordpress-playground/) by Magdalena Paciorek
+-   [Discovering Playground, the demo tool(in Spanish)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) by Alex Cuadra
+-   [WordPress Playground: Complete and functional WordPress installation(in Spanish)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) by Fernando García Rebolledo
+-   [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) by Álvaro Gómez Velasco
+-   [Use WordPress with just a browser! WordPress Playground Tutorial: Basic usage of Playground (in Japanese)](https://www.youtube.com/watch?v=6s_B0WvJauU) by Shimomura Tomoki
+-   [WordPress Playground: How to use Blueprints](https://www.youtube.com/watch?v=Vcao6uXguWg) by Shimomura Tomoki
+-   [Streamlined Block Theme Development: Using WordPress Playground and GitHub for No-Code Version Control of Site Editor Changes](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) by Birgit Pauli-Haack
+-   [Playground, la mejor herramienta jamás inventada para enseñar WordPress (in Spanish)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) by Nilo Vélez
+-   [Testing Faster Than a Red Bull Pit Stop: WordPress Playground and WooCommerce Blueprints](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) by Daniel Dudzic
+-->
 
 -   Developer Hours વિડિયોઝ:
     -   [અમેરિકા પ્રદેશ (23 મે, 2023) (અંગ્રેજીમાં)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/resources.md
@@ -6,7 +6,15 @@ description: WordPress Playground について詳しく知るためのアプリ�
 
 # リンクとリソース
 
+<!--
+# Links and Resources
+-->
+
 :::tip
+
+<!--
+There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
+-->
 
 Playground に関連するいくつかのツールへのアクセスを容易にするために、一連のリダイレクトが用意されています。
 
@@ -20,14 +28,48 @@ Playground に関連するいくつかのツールへのアクセスを容易に
 </ul>
 :::
 
+<!--
+## Frequently sought links
+-->
+
 ## よく検索されるリンク
+
+<!--
+-   [Demo](https://playground.wordpress.net/)
+-   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+-   [Documentation](https://wordpress.github.io/wordpress-playground/)
+-   [Playground tools Repository](https://github.com/WordPress/playground-tools)
+-->
 
 -   [Demo](https://playground.wordpress.net/)
 -   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
 -   [Documentation](https://wordpress.github.io/wordpress-playground/)
 -   [Playground tools Repository](https://github.com/WordPress/playground-tools)
 
+<!--
+## Apps built with WordPress Playground
+-->
+
 ## WordPress Playground で構築されたアプリ
+
+<!--
+-   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – a CLI tool for instant WordPress dev enviroment
+-   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+-   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
+-   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
+-   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
+-   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
+-   [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
+-   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
+-   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
+-   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
+-   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+-   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+-->
 
 -   [公式デモ](https://playground.wordpress.net/)と[ショーケース](https://developer.wordpress.org/playground)アプリ – テーマをインストールし、プラグインを試し、いくつかのページを作成し、構築したものをエクスポートします
 -   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – すぐに WordPress 開発環境を構築できる CLI ツール
@@ -46,7 +88,19 @@ Playground に関連するいくつかのツールへのアクセスを容易に
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
 -   [Blueprints の PHP 実装](https://playground.wordpress.net/demos/php-blueprints.html)
 
+<!--
+## Reading materials
+-->
+
 ## 読み物
+
+<!--
+-   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
+-   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
+-   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
+-->
 
 -   [WordPress Playground と WebAssembly でブラウザ内 WordPress 体験を構築する](https://web.dev/wordpress-playground/)
 -   [developer.wordpress.org の WordPress Playground](https://developer.wordpress.org/playground)
@@ -54,7 +108,43 @@ Playground に関連するいくつかのツールへのアクセスを容易に
 -   [make.wordpress.org での初期アナウンス](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
 -   [Hackernews ディスカッション](https://news.ycombinator.com/item?id=32960560)
 
+<!--
+## Videos
+-->
+
 ## ビデオ
+
+<!--
+-   Developer Hours Videos:
+    -   [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [Creating WordPress Playground Blueprints for Testing and Demos (May 28, 2024)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) by Birgit Pauli-Haack & Nick Diego
+    -   [Developer Hours: Everything you need to know about WordPress Playground (Dec 17, 2024)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) by Nick Diego & Ryan Welcher
+-   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
+-   [WordPress Playground for developers](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) by Berislav Grgicak and Jonathan Bossenger
+-   [WordPress Playground Block code editor theme support](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) by Jonathan Bossenger
+-   [WordPress Playground – use WordPress without a server at WCEU 2024](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) by Adam Zielinski
+-   [Code, Test, Repeat: Accelerating Development with WordPress Playground at WordCamp Larissa 2024](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) by Uros Tasic
+-   [Liberating data with WordPress Playground in a Browser Extension at WordCamp Netherlands 2024](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) by Alex Kirk
+-   [Beyond the Playground: WordPress as a Tool and Product Builder at WCUS 2024](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) by Dennis Snell
+-   [Create a demo with Playground at WC Asia 2025](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) by Birgit Pauli-Haack
+-   [Disssecting WordPress Playground at WordCamp Nepal 2025](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) by Sakar Upadhyaya Khatiwada
+-   [Building Automated Test with WordPress Playground at WCEU 2025](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/)by Berislav Grgicak
+-   [From Zero to Demo: Mastering WordPress Playground Blueprints at WCEU 2025](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) by Birgit Pauli-Haack
+-   [Playground at WordCamp Gliwice (in Polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) by Adam Zielinski
+-   [WordPress Playground at WordCamp Wrocław 2024 (in Polish)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) by Adam Zielinski
+-   [WordPress Playground at WordCamp Gdynia 2025 (in Polish)](https://wordpress.tv/2025/04/21/wordpress-playground/) by Magdalena Paciorek
+-   [Discovering Playground, the demo tool(in Spanish)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) by Alex Cuadra
+-   [WordPress Playground: Complete and functional WordPress installation(in Spanish)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) by Fernando García Rebolledo
+-   [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) by Álvaro Gómez Velasco
+-   [Use WordPress with just a browser! WordPress Playground Tutorial: Basic usage of Playground (in Japanese)](https://www.youtube.com/watch?v=6s_B0WvJauU) by Shimomura Tomoki
+-   [WordPress Playground: How to use Blueprints](https://www.youtube.com/watch?v=Vcao6uXguWg) by Shimomura Tomoki
+-   [Streamlined Block Theme Development: Using WordPress Playground and GitHub for No-Code Version Control of Site Editor Changes](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) by Birgit Pauli-Haack
+-   [Playground, la mejor herramienta jamás inventada para enseñar WordPress (in Spanish)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) by Nilo Vélez
+-   [Testing Faster Than a Red Bull Pit Stop: WordPress Playground and WooCommerce Blueprints](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) by Daniel Dudzic
+-->
 
 -   Developer Hours ビデオ:
     -   [アメリカ地域 (2023 年 5 月 23 日)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/resources.md
@@ -6,10 +6,6 @@ description: WordPress Playground について詳しく知るためのアプリ�
 
 # リンクとリソース
 
-<!--
-# Links and Resources
--->
-
 :::tip
 
 Playground に関連するいくつかのツールへのアクセスを容易にするために、一連のリダイレクトが用意されています。
@@ -24,27 +20,7 @@ Playground に関連するいくつかのツールへのアクセスを容易に
 </ul>
 :::
 
-<!--
-:::tip
-
-There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
-
-<ul id="list-resources-redirections">
-<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → Playground instance</li>
-<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Playground Docs</li>
-<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Playground Blueprints Builder</li>
-<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Playground PR viewer for WordPress</li>
-<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Playground PR viewer for Gutenberg</li>
-<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Playground Proxy Service <em>(see <a href="/blueprints/steps/resources#urlreference">URLReference</a> for more info)</em></li>
-</ul>
-:::
--->
-
 ## よく検索されるリンク
-
-<!--
-## Frequently sought links
--->
 
 -   [Demo](https://playground.wordpress.net/)
 -   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
@@ -53,86 +29,59 @@ There's a set of redirections in place to make it easier the access to some of t
 
 ## WordPress Playground で構築されたアプリ
 
-<!--
-## Apps built with WordPress Playground
--->
-
--   [公式デモ](https://playground.wordpress.net/)と[ショーケース](https://developer.wordpress.org/playground)アプリ – テーマをインストールし、プラグインを試し、いくつかのページを作成し、構築したものをエクスポートします。
+-   [公式デモ](https://playground.wordpress.net/)と[ショーケース](https://developer.wordpress.org/playground)アプリ – テーマをインストールし、プラグインを試し、いくつかのページを作成し、構築したものをエクスポートします
 -   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – すぐに WordPress 開発環境を構築できる CLI ツール
 -   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
--   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
--   [HTML タグ プロセッサ チュートリアル](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/)と[Playground JS API チュートリアル](https://adamadam.blog/2023/04/12/interactive-intro-to-wordpress-playground-public-api/)を支える[インタラクティブ コード ブロック](https://wordpress.org/plugins/interactive-code-block/)
--   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
+-   ライブ翻訳: [アプリ](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [アナウンス](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [詳細](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [HTML タグ プロセッサ チュートリアル](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/)と[Playground JS API チュートリアル](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)を支える[インタラクティブ コード ブロック](https://wordpress.org/plugins/interactive-code-block/)
+-   [Gutenberg Pull Request プレビューアー](https://playground.wordpress.net/gutenberg.html)
+-   [Notifications プラグインライブデモ](https://johnhooks.io/playground-experiment/)
 -   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
 -   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – スマートフォンで WordPress を実行する初の iOS アプリ
--   [Playground embedder](https://joost.blog/embedded-playground/) ショートコードを使用して WordPress.org のドキュメントに Playground の例を埋め込む
--   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – WordPress.org のプラグインページに「デモ」タブを追加するユーザースクリプト
--   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
--   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
--   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [Playground embedder](https://joost.blog/embedded-playground/) – ショートコードを使用して WordPress.org のドキュメントに Playground の例を埋め込む
+-   [wp.org のプラグインデモ](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – WordPress.org のプラグインページに「デモ」タブを追加するユーザースクリプト
+-   [WordPress Pull Request プレビューアー](https://playground.wordpress.net/wordpress.html)
+-   [2 つの Playground 間の同期](https://playground.wordpress.net/demos/sync.html)
+-   [タイムトラベル](https://playground.wordpress.net/demos/time-traveling.html)
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
--   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
-
-<!--
--   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
--   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – a CLI tool for instant WordPress dev enviroment
--   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
--   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
--   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://adamadam.blog/2023/04/12/interactive-intro-to-wordpress-playground-public-api/)
--   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
--   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
--   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
--   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
--   [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
--   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
--   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
--   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
--   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
--   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
--   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
--->
+-   [Blueprints の PHP 実装](https://playground.wordpress.net/demos/php-blueprints.html)
 
 ## 読み物
 
-<!--
-## Reading materials
--->
-
--   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
--   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
--   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
--   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
--   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
+-   [WordPress Playground と WebAssembly でブラウザ内 WordPress 体験を構築する](https://web.dev/wordpress-playground/)
+-   [developer.wordpress.org の WordPress Playground](https://developer.wordpress.org/playground)
+-   [ブラウザ内 WordPress テクノロジーデモ: WordPress Playground による WordPress 開発](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [make.wordpress.org での初期アナウンス](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Hackernews ディスカッション](https://news.ycombinator.com/item?id=32960560)
 
 ## ビデオ
 
-<!--
-## Videos
--->
-
--   Developer Hours Videos:
-    -   [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
-    -   [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
-    -   [Creating WordPress Playground Blueprints for Testing and Demos (May 28, 2024)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) by Birgit Pauli-Haack & Nick Diego
-    -   [Developer Hours: Everything you need to know about WordPress Playground (Dec 17, 2024)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) by Nick Diego & Ryan Welcher
--   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
--   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
--   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
--   [WordPress Playground for developers](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) by Berislav Grgicak and Jonathan Bossenger
--   [WordPress Playground Block code editor theme support](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) by Jonathan Bossenger
--   [WordPress Playground – use WordPress without a server at WCEU 2024](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) by Adam Zielinski
--   [Code, Test, Repeat: Accelerating Development with WordPress Playground at WordCamp Larissa 2024](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) by Uros Tasic
--   [Liberating data with WordPress Playground in a Browser Extension at WordCamp Netherlands 2024](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) by Alex Kirk
--   [Beyond the Playground: WordPress as a Tool and Product Builder at WCUS 2024](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) by Dennis Snell
--   [Create a demo with Playground at WC Asia 2025](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) by Birgit Pauli-Haack
--   [Disssecting WordPress Playground at WordCamp Nepal 2025](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) by Sakar Upadhyaya Khatiwada
--   [Building Automated Test with WordPress Playground at WCEU 2025](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/)by Berislav Grgicak
--   [From Zero to Demo: Mastering WordPress Playground Blueprints at WCEU 2025](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) by Birgit Pauli-Haack
--   [Playground at WordCamp Gliwice (in Polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) by Adam Zielinski
--   [WordPress Playground at WordCamp Wrocław 2024 (in Polish)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) by Adam Zielinski
--   [WordPress Playground at WordCamp Gdynia 2025 (in Polish)](https://wordpress.tv/2025/04/21/wordpress-playground/) by Magdalena Paciorek
--   [Discovering Playground, the demo tool(in Spanish)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) by Alex Cuadra
--   [WordPress Playground: Complete and functional WordPress installation(in Spanish)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) by Fernando García Rebolledo
--   [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) by Álvaro Gómez Velasco
--   [ブラウザだけで WordPress が使える！WordPress Playground チュートリアル 1 Playground の基本的な使い方 (日本語)](https://www.youtube.com/watch?v=6s_B0WvJauU) by Shimomura Tomoki
--   [WordPress Playground: ブループリントの使い方](https://www.youtube.com/watch?v=Vcao6uXguWg) by Shimomura Tomoki
+-   Developer Hours ビデオ:
+    -   [アメリカ地域 (2023 年 5 月 23 日)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [APAC/EMEA 地域 (2023 年 5 月 24 日)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [テストとデモのための WordPress Playground Blueprints の作成 (2024 年 5 月 28 日)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) Birgit Pauli-Haack & Nick Diego
+    -   [Developer Hours: WordPress Playground について知っておくべきすべて (2024 年 12 月 17 日)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) Nick Diego & Ryan Welcher
+-   [State of the Word での Playground](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [WCEU 2023 での Playground](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   [「WordPress Playground: WordPress のための究極の学習、テスト、教育ツール」を見る](https://www.youtube.com/watch?v=dN_LaenY8bI) Anne McCarthy
+-   [開発者のための WordPress Playground](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) Berislav Grgicak、Jonathan Bossenger
+-   [WordPress Playground Block コードエディターテーマサポート](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) Jonathan Bossenger
+-   [WordPress Playground – WCEU 2024 でサーバーなしで WordPress を使用](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) Adam Zielinski
+-   [コード、テスト、リピート: WordCamp Larissa 2024 での WordPress Playground による開発の加速](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) Uros Tasic
+-   [WordCamp オランダ 2024 でブラウザ拡張機能の WordPress Playground によるデータの解放](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) Alex Kirk
+-   [Playground を超えて: WCUS 2024 でのツールおよび製品ビルダーとしての WordPress](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) Dennis Snell
+-   [WC Asia 2025 で Playground を使用してデモを作成](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) Birgit Pauli-Haack
+-   [WordCamp ネパール 2025 での WordPress Playground の解剖](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) Sakar Upadhyaya Khatiwada
+-   [WCEU 2025 での WordPress Playground による自動テストの構築](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/) Berislav Grgicak
+-   [ゼロからデモへ: WCEU 2025 での WordPress Playground Blueprints のマスタリング](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) Birgit Pauli-Haack
+-   [WordCamp Gliwice での Playground (ポーランド語)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) Adam Zielinski
+-   [WordCamp Wrocław 2024 での WordPress Playground (ポーランド語)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) Adam Zielinski
+-   [WordCamp Gdynia 2025 での WordPress Playground (ポーランド語)](https://wordpress.tv/2025/04/21/wordpress-playground/) Magdalena Paciorek
+-   [Playground の発見、デモツール (スペイン語)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) Alex Cuadra
+-   [WordPress Playground: 完全かつ機能的な WordPress インストール (スペイン語)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) Fernando García Rebolledo
+-   [Playground: WordCamp Madrid 2025 でのブラウザ内使い捨て WordPress (スペイン語)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) Álvaro Gómez Velasco
+-   [ブラウザだけで WordPress が使える！WordPress Playground チュートリアル 1 Playground の基本的な使い方 (日本語)](https://www.youtube.com/watch?v=6s_B0WvJauU) Shimomura Tomoki
+-   [WordPress Playground: ブループリントの使い方 (日本語)](https://www.youtube.com/watch?v=Vcao6uXguWg) Shimomura Tomoki
+-   [合理化されたブロックテーマ開発: サイトエディターの変更のノーコードバージョン管理のための WordPress Playground と GitHub の使用](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) Birgit Pauli-Haack
+-   [Playground、WordPress を教えるためにこれまでに発明された最高のツール (スペイン語)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) Nilo Vélez
+-   [レッドブルのピットストップよりも速いテスト: WordPress Playground と WooCommerce Blueprints](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) Daniel Dudzic

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/resources.md
@@ -6,7 +6,15 @@ description: Uma lista de links úteis para aplicativos, ferramentas, artigos e 
 
 # Links e Recursos
 
+<!--
+# Links and Resources
+-->
+
 :::tip
+
+<!--
+There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
+-->
 
 Existe um conjunto de redirecionamentos para facilitar o acesso a algumas das ferramentas relacionadas ao Playground:
 
@@ -20,14 +28,48 @@ Existe um conjunto de redirecionamentos para facilitar o acesso a algumas das fe
 </ul>
 :::
 
+<!--
+## Frequently sought links
+-->
+
 ## Links frequentemente procurados
+
+<!--
+-   [Demo](https://playground.wordpress.net/)
+-   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+-   [Documentation](https://wordpress.github.io/wordpress-playground/)
+-   [Playground tools Repository](https://github.com/WordPress/playground-tools)
+-->
 
 -   [Demonstração](https://playground.wordpress.net/)
 -   [Repositório no GitHub](https://github.com/WordPress/wordpress-playground)
 -   [Documentação](https://wordpress.github.io/wordpress-playground/)
 -   [Repositório das ferramentas do Playground](https://github.com/WordPress/playground-tools)
 
+<!--
+## Apps built with WordPress Playground
+-->
+
 ## Aplicações construídas com o WordPress Playground
+
+<!--
+-   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – a CLI tool for instant WordPress dev enviroment
+-   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+-   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+-   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
+-   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
+-   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
+-   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+-   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
+-   [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
+-   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
+-   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
+-   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
+-   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+-   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+-   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+-->
 
 -   [Demonstração oficial](https://playground.wordpress.net/) e a aplicação de [vitrine](https://developer.wordpress.org/playground) – instale um tema, experimente um plugin, crie algumas páginas, exporte o que você construiu
 -   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – uma ferramenta CLI para ambientes de desenvolvimento WordPress instantâneos
@@ -46,7 +88,19 @@ Existe um conjunto de redirecionamentos para facilitar o acesso a algumas das fe
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
 -   [Implementação de Blueprints em PHP](https://playground.wordpress.net/demos/php-blueprints.html)
 
+<!--
+## Reading materials
+-->
+
 ## Materiais de leitura
+
+<!--
+-   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
+-   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
+-   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+-   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+-   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
+-->
 
 -   [Crie experiências WordPress no navegador com WordPress Playground e WebAssembly](https://web.dev/wordpress-playground/)
 -   [WordPress Playground em developer.wordpress.org](https://developer.wordpress.org/playground)
@@ -54,7 +108,43 @@ Existe um conjunto de redirecionamentos para facilitar o acesso a algumas das fe
 -   [Anúncio inicial em make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
 -   [Discussão no Hackernews](https://news.ycombinator.com/item?id=32960560)
 
+<!--
+## Videos
+-->
+
 ## Vídeos
+
+<!--
+-   Developer Hours Videos:
+    -   [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    -   [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    -   [Creating WordPress Playground Blueprints for Testing and Demos (May 28, 2024)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) by Birgit Pauli-Haack & Nick Diego
+    -   [Developer Hours: Everything you need to know about WordPress Playground (Dec 17, 2024)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) by Nick Diego & Ryan Welcher
+-   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
+-   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+-   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
+-   [WordPress Playground for developers](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) by Berislav Grgicak and Jonathan Bossenger
+-   [WordPress Playground Block code editor theme support](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) by Jonathan Bossenger
+-   [WordPress Playground – use WordPress without a server at WCEU 2024](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) by Adam Zielinski
+-   [Code, Test, Repeat: Accelerating Development with WordPress Playground at WordCamp Larissa 2024](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) by Uros Tasic
+-   [Liberating data with WordPress Playground in a Browser Extension at WordCamp Netherlands 2024](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) by Alex Kirk
+-   [Beyond the Playground: WordPress as a Tool and Product Builder at WCUS 2024](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) by Dennis Snell
+-   [Create a demo with Playground at WC Asia 2025](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) by Birgit Pauli-Haack
+-   [Disssecting WordPress Playground at WordCamp Nepal 2025](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) by Sakar Upadhyaya Khatiwada
+-   [Building Automated Test with WordPress Playground at WCEU 2025](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/)by Berislav Grgicak
+-   [From Zero to Demo: Mastering WordPress Playground Blueprints at WCEU 2025](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) by Birgit Pauli-Haack
+-   [Playground at WordCamp Gliwice (in Polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) by Adam Zielinski
+-   [WordPress Playground at WordCamp Wrocław 2024 (in Polish)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) by Adam Zielinski
+-   [WordPress Playground at WordCamp Gdynia 2025 (in Polish)](https://wordpress.tv/2025/04/21/wordpress-playground/) by Magdalena Paciorek
+-   [Discovering Playground, the demo tool(in Spanish)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) by Alex Cuadra
+-   [WordPress Playground: Complete and functional WordPress installation(in Spanish)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) by Fernando García Rebolledo
+-   [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) by Álvaro Gómez Velasco
+-   [Use WordPress with just a browser! WordPress Playground Tutorial: Basic usage of Playground (in Japanese)](https://www.youtube.com/watch?v=6s_B0WvJauU) by Shimomura Tomoki
+-   [WordPress Playground: How to use Blueprints](https://www.youtube.com/watch?v=Vcao6uXguWg) by Shimomura Tomoki
+-   [Streamlined Block Theme Development: Using WordPress Playground and GitHub for No-Code Version Control of Site Editor Changes](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) by Birgit Pauli-Haack
+-   [Playground, la mejor herramienta jamás inventada para enseñar WordPress (in Spanish)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) by Nilo Vélez
+-   [Testing Faster Than a Red Bull Pit Stop: WordPress Playground and WooCommerce Blueprints](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) by Daniel Dudzic
+-->
 
 -   Vídeos do Developer Hours:
     -   [Região das Américas, 23 de maio de 2023 (em inglês)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/resources.md
@@ -4,27 +4,7 @@ slug: /resources
 description: Uma lista de links úteis para aplicativos, ferramentas, artigos e vídeos para aprender mais sobre o WordPress Playground.
 ---
 
-<!--
-# Links and Resources
--->
-
 # Links e Recursos
-
-<!--
-:::tip
-
-There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
-
-<ul id="list-resources-redirections">
-<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → Playground instance</li>
-<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Playground Docs</li>
-<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Playground Blueprints Builder</li>
-<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Playground PR viewer for WordPress</li>
-<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Playground PR viewer for Gutenberg</li>
-<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Playground Proxy Service <em>(see <a href="/blueprints/steps/resources#urlreference">URLReference</a> for more info)</em></li>
-</ul>
-:::
--->
 
 :::tip
 
@@ -40,54 +20,20 @@ Existe um conjunto de redirecionamentos para facilitar o acesso a algumas das fe
 </ul>
 :::
 
-<!--
-## Frequently sought links
--->
-
 ## Links frequentemente procurados
-
-<!--
--   [Demo](https://playground.wordpress.net/)
--   [GitHub Repository](https://github.com/WordPress/wordpress-playground)
--   [Documentation](https://wordpress.github.io/wordpress-playground/)
--   [Playground tools Repository](https://github.com/WordPress/playground-tools)
--->
 
 -   [Demonstração](https://playground.wordpress.net/)
 -   [Repositório no GitHub](https://github.com/WordPress/wordpress-playground)
 -   [Documentação](https://wordpress.github.io/wordpress-playground/)
 -   [Repositório das ferramentas do Playground](https://github.com/WordPress/playground-tools)
 
-<!--
-## Apps built with WordPress Playground
--->
-
 ## Aplicações construídas com o WordPress Playground
 
-<!--
--   [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
--   [wp-now](https://www.npmjs.com/package/%40wp-now/wp-now) – a CLI tool for instant WordPress dev envs
--   [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
--   Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
--   [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://adamadam.blog/2023/04/12/interactive-intro-to-wordpress-playground-public-api/)
--   [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
--   [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
--   [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
--   [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
--   [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
--   [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
--   [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
--   [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
--   [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
--   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
--   [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
--->
-
 -   [Demonstração oficial](https://playground.wordpress.net/) e a aplicação de [vitrine](https://developer.wordpress.org/playground) – instale um tema, experimente um plugin, crie algumas páginas, exporte o que você construiu
--   [wp-now](https://www.npmjs.com/package/%40wp-now/wp-now) – uma ferramenta CLI para ambientes de desenvolvimento WordPress instantâneos
+-   [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – uma ferramenta CLI para ambientes de desenvolvimento WordPress instantâneos
 -   [WordPress Playground para VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
 -   Traduções ao vivo: [Aplicação](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [anúncio](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [mais detalhes](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
--   [Bloco de código interativo](https://wordpress.org/plugins/interactive-code-block/) que alimenta o [tutorial do Processador de Tags HTML](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) e o [tutorial da API JS do Playground](https://adamadam.blog/2023/04/12/interactive-intro-to-wordpress-playground-public-api/)
+-   [Bloco de código interativo](https://wordpress.org/plugins/interactive-code-block/) que alimenta o [tutorial do Processador de Tags HTML](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) e o [tutorial da API JS do Playground](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
 -   [Visualizador de Pull Requests do Gutenberg](https://playground.wordpress.net/gutenberg.html)
 -   [Demonstração ao vivo do plugin de notificações](https://johnhooks.io/playground-experiment/)
 -   [REPL do GraphQL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
@@ -100,19 +46,7 @@ Existe um conjunto de redirecionamentos para facilitar o acesso a algumas das fe
 -   [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
 -   [Implementação de Blueprints em PHP](https://playground.wordpress.net/demos/php-blueprints.html)
 
-<!--
-## Reading materials
--->
-
 ## Materiais de leitura
-
-<!--
--   [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
--   [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
--   [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
--   [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
--   [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
--->
 
 -   [Crie experiências WordPress no navegador com WordPress Playground e WebAssembly](https://web.dev/wordpress-playground/)
 -   [WordPress Playground em developer.wordpress.org](https://developer.wordpress.org/playground)
@@ -120,38 +54,7 @@ Existe um conjunto de redirecionamentos para facilitar o acesso a algumas das fe
 -   [Anúncio inicial em make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
 -   [Discussão no Hackernews](https://news.ycombinator.com/item?id=32960560)
 
-<!--
-## Videos
--->
-
 ## Vídeos
-
-<!--
--   Developer Hours Videos:
-    -   [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
-    -   [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
-    -   [Creating WordPress Playground Blueprints for Testing and Demos (May 28, 2024)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) by Birgit Pauli-Haack & Nick Diego
-    -   [Developer Hours: Everything you need to know about WordPress Playground (Dec 17, 2024)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) by Nick Diego & Ryan Welcher
--   [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
--   [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
--   [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
--   [WordPress Playground for developers](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) by Berislav Grgicak and Jonathan Bossenger
--   [WordPress Playground Block code editor theme support](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) by Jonathan Bossenger
--   [WordPress Playground – use WordPress without a server at WCEU 2024](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) by Adam Zielinski
--   [Code, Test, Repeat: Accelerating Development with WordPress Playground at WordCamp Larissa 2024](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) by Uros Tasic
--   [Liberating data with WordPress Playground in a Browser Extension at WordCamp Netherlands 2024](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) by Alex Kirk
--   [Beyond the Playground: WordPress as a Tool and Product Builder at WCUS 2024](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) by Dennis Snell
--   [Create a demo with Playground at WC Asia 2025](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) by Birgit Pauli-Haack
--   [Disssecting WordPress Playground at WordCamp Nepal 2025](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) by Sakar Upadhyaya Khatiwada
--   [Building Automated Test with WordPress Playground at WCEU 2025](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/)by Berislav Grgicak
--   [From Zero to Demo: Mastering WordPress Playground Blueprints at WCEU 2025](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) by Birgit Pauli-Haack
--   [Playground at WordCamp Gliwice (in Polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) by Adam Zielinski
--   [WordPress Playground at WordCamp Wrocław 2024 (in Polish)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) by Adam Zielinski
--   [WordPress Playground at WordCamp Gdynia 2025 (in Polish)](https://wordpress.tv/2025/04/21/wordpress-playground/) by Magdalena Paciorek
--   [Discovering Playground, the demo tool(in Spanish)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) by Alex Cuadra
--   [WordPress Playground: Complete and functional WordPress installation(in Spanish)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) by Fernando García Rebolledo
--   [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) by Álvaro Gómez Velasco
--->
 
 -   Vídeos do Developer Hours:
     -   [Região das Américas, 23 de maio de 2023 (em inglês)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
@@ -177,3 +80,8 @@ Existe um conjunto de redirecionamentos para facilitar o acesso a algumas das fe
 -   [Descobrindo o Playground, a ferramenta de demonstração (em espanhol)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) por Alex Cuadra
 -   [WordPress Playground: Instalação completa e funcional do WordPress (em espanhol)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) por Fernando García Rebolledo
 -   [Playground: Um WordPress descartável dentro do seu navegador no WordCamp Madrid 2025 (em espanhol)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentro-de-tu-navegador/) por Álvaro Gómez Velasco
+-   [Use WordPress com apenas um navegador! Tutorial do WordPress Playground: Uso básico do Playground (em japonês)](https://www.youtube.com/watch?v=6s_B0WvJauU) por Shimomura Tomoki
+-   [WordPress Playground: Como usar Blueprints (em japonês)](https://www.youtube.com/watch?v=Vcao6uXguWg) por Shimomura Tomoki
+-   [Desenvolvimento simplificado de temas em blocos: Usando WordPress Playground e GitHub para controle de versão sem código de alterações no editor de sites (em inglês)](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) por Birgit Pauli-Haack
+-   [Playground, a melhor ferramenta já inventada para ensinar WordPress (em espanhol)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) por Nilo Vélez
+-   [Testando mais rápido que um pit stop da Red Bull: WordPress Playground e Blueprints do WooCommerce (em inglês)](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) por Daniel Dudzic


### PR DESCRIPTION
This pull request adds new resources and updates documentation to improve discoverability and support for WordPress Playground, especially for Spanish-speaking users. The main changes include adding a new Spanish-language resources page and updating the list of video tutorials and presentations in both English and Spanish.

**Documentation enhancements:**

* Added a new Spanish-language resources page at `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/resources.md`, featuring curated links to apps, tools, articles, and videos related to WordPress Playground, as well as helpful redirections for easier access to Playground tools.

**Resource updates:**

* Updated the English resources list in `packages/docs/site/docs/main/resources.md` by adding three new video presentations: block theme development workflow, teaching with Playground, and WooCommerce Blueprint testing.
* Included the same new video presentations in the Spanish-language resources page, ensuring parity between the English and Spanish documentation.
