### PR TITLE
[CI] Remove a few predefined runner files before releasing npm packages

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -37,6 +37,19 @@ jobs:
             NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         steps:
+            - name: Free up runner disk space
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  echo "Disk usage before cleanup:"
+                  df -h
+                  sudo rm -rf /usr/local/lib/android
+                  sudo rm -rf /usr/share/dotnet
+                  sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+                  sudo rm -rf /opt/ghc
+                  sudo rm -rf /opt/hostedtoolcache/CodeQL
+                  echo "Disk usage after cleanup:"
+                  df -h
             - uses: actions/checkout@v4
               with:
                   ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -55,7 +55,12 @@ jobs:
                   echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
                   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             - uses: ./.github/actions/prepare-playground
-            # Version bump, release, tag a new version on GitHub
+            - name: Remove the website and docs packages to save some disk space – CI runner runs out!
+              run: |
+                  rm -rf packages/docs
+                  rm -rf packages/playground/website
+                  rm -rf packages/playground/website-extras
+                  rm -rf packages/playground/website-deployment
             - name: Release new version of NPM packages
               shell: bash
               run: npx lerna@6.6.2 publish ${{ inputs.version_bump || 'patch' }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || 'latest' }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -68,6 +68,7 @@ jobs:
                   echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
                   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             - uses: ./.github/actions/prepare-playground
+            # Version bump, release, tag a new version on GitHub
             - name: Release new version of NPM packages
               shell: bash
               run: npx lerna@6.6.2 publish ${{ inputs.version_bump || 'patch' }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || 'latest' }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -68,12 +68,6 @@ jobs:
                   echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
                   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
             - uses: ./.github/actions/prepare-playground
-            - name: Remove the website and docs packages to save some disk space – CI runner runs out!
-              run: |
-                  rm -rf packages/docs
-                  rm -rf packages/playground/website
-                  rm -rf packages/playground/website-extras
-                  rm -rf packages/playground/website-deployment
             - name: Release new version of NPM packages
               shell: bash
               run: npx lerna@6.6.2 publish ${{ inputs.version_bump || 'patch' }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || 'latest' }}


### PR DESCRIPTION
## Motivation for the change, related issues

Updates the publish-npm-packages.yml job to prevent the CI runner from running out of disk space.

https://github.com/WordPress/wordpress-playground/actions/runs/18473424159/job/52632469981

```
lerna ERR! 
lerna ERR! lerna ENOSPC: no space left on device, write
```

## Implementation details

Removes a bunch of large files that seem to be present at the start of the job:

```
            - name: Free up runner disk space
              shell: bash
              run: |
                  set -euo pipefail
                  echo "Disk usage before cleanup:"
                  df -h
                  sudo rm -rf /usr/local/lib/android
                  sudo rm -rf /usr/share/dotnet
                  sudo rm -rf "$AGENT_TOOLSDIRECTORY"
                  sudo rm -rf /opt/ghc
                  sudo rm -rf /opt/hostedtoolcache/CodeQL
                  echo "Disk usage after cleanup:"
                  df -h
```

## Testing Instructions (or ideally a Blueprint)

GitHub and testing CI PRs? Haha. Nope. Merge, run the job, hope for the best.
