### PR TITLE
[PHP.wasm] Document bundler configuration for the .dat file import in `@php-wasm/web`

### DIFF
--- a/packages/php-wasm/web/README.md
+++ b/packages/php-wasm/web/README.md
@@ -43,6 +43,39 @@ console.log(response.text);
 // Hello John
 ```
 
+## Usage with bundlers
+
+If you use `@php-wasm/web` with a bundler such as Vite, you may see the following errors:
+
+```
+01:31:50 [vite] (client) error while updating dependencies:
+Error: Error during dependency optimization:
+
+✘ [ERROR] No loader is configured for ".dat" files: app/node_modules/@php-wasm/web/shared/icudt74l.dat
+
+    app/node_modules/@php-wasm/web/shared/icudt74l.js:1:25:
+      1 │ import dataFilename from './icudt74l.dat';
+```
+
+The `@php-wasm/web` package imports a non-JavaScript asset file using the import syntax. This ensures
+all the required dependencies may be tracked statically, but it creates an inconvenience for apps relying
+on bundlers.
+
+To resolve that error, you'll need to configure your bundler to resolve the import above to the URL
+of the `icudt74l.dat` in your app, e.g. `https://playground.wordpress.net/assets/icudt74l.dat`.
+
+In Vite, you can use the `assetsInclude` option:
+
+```js
+export default defineConfig({
+	assetsInclude: [/\.dat$/],
+});
+```
+
+Other bundlers will typically have analogous options or plugins. If you create a working configuration for
+WebPack, esbuild, or another bundler, feel free to propose a new configuration example for this README at
+https://github.com/WordPress/wordpress-playground/edit/trunk/packages/php-wasm/web/README.md
+
 ## Attribution
 
 `@php-wasm/web` started as a fork of the original PHP to WebAssembly build published by Oraoto in https://github.com/oraoto/pib and modified by Sean Morris in https://github.com/seanmorris/php-wasm.

--- a/packages/php-wasm/web/README.md
+++ b/packages/php-wasm/web/README.md
@@ -1,6 +1,6 @@
 # WebAssembly PHP for the web
 
-This package ships WebAssembly PHP binaries and the JavaScript API optimized for the web and a low bundle size. It comes with the Libzip extension and the SQLite extension.
+This package ships WebAssembly PHP binaries and the JavaScript API optimized for the web and a low bundle size.
 
 Here's how to use it:
 
@@ -8,10 +8,10 @@ Here's how to use it:
 import { PHP, PHPRequestHandler } from '@php-wasm/universal';
 import { loadWebRuntime } from '@php-wasm/web';
 
-// loadWebRuntime() calls import('php.wasm') and import('icu.dat') internally.
+// loadWebRuntime() calls import('php.wasm').
 // Your bundler must resolve import('php.wasm') as a static file URL.
 // If you use Webpack, you can use the file-loader to do so.
-const php = new PHP(await loadWebRuntime('8.3'));
+const php = new PHP(await loadWebRuntime('8.5'));
 
 let response;
 
@@ -48,27 +48,29 @@ console.log(response.text);
 If you use `@php-wasm/web` with a bundler such as Vite, you may see the following errors:
 
 ```
-01:31:50 [vite] (client) error while updating dependencies:
-Error: Error during dependency optimization:
+✘ [ERROR] No loader is configured for ".dat" files: node_modules/@php-wasm/web/shared/icu.dat
 
-✘ [ERROR] No loader is configured for ".dat" files: app/node_modules/@php-wasm/web/shared/icudt74l.dat
-
-    app/node_modules/@php-wasm/web/shared/icudt74l.js:1:25:
-      1 │ import dataFilename from './icudt74l.dat';
+    node_modules/@php-wasm/web/index.js:2276:88:
+      2276 │ ...i), a = (await import("./shared/icu.dat")).default, [_, S] = ...
 ```
 
-The `@php-wasm/web` package imports a non-JavaScript asset file using the import syntax. This ensures
+The `@php-wasm/web` package imports a few non-JavaScript assets file using the import syntax. This ensures
 all the required dependencies may be tracked statically, but it creates an inconvenience for apps relying
 on bundlers.
 
 To resolve that error, you'll need to configure your bundler to resolve the import above to the URL
-of the `icudt74l.dat` in your app, e.g. `https://playground.wordpress.net/assets/icudt74l.dat`.
+of the `icu.dat` in your app, e.g. `https://playground.wordpress.net/assets/icu.dat`.
 
-In Vite, you can use the `assetsInclude` option:
+In Vite, you can use the following options to support importing all the required assets types:
 
 ```js
 export default defineConfig({
-	assetsInclude: [/\.dat$/],
+  assetsInclude: [/\.dat$/, /\.wasm$/, /\.so$/, /\.la$/],
+  optimizeDeps: {
+     exclude: [
+      '@php-wasm/web'
+    ]
+  }
 });
 ```
 


### PR DESCRIPTION
Added instructions for using `@php-wasm/web` with bundlers like Vite. The `import dataFilename from './icudt741.dat';` like published in the package will typically trip up bundlers with their default configuration.

cc @fellyph @mho22 @brandonpayton
