### PR TITLE
[Blueprints] ensure git:directory resource returns non-empty-name

### DIFF
--- a/packages/playground/blueprints/src/lib/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.spec.ts
@@ -55,9 +55,6 @@ describe('GitDirectoryResource', () => {
 
 		it('defaults to the repo root when path is omitted', async () => {
 			const url = 'https://github.com/WordPress/wordpress-playground';
-			const fallbackName = url
-				.replaceAll(/[^a-zA-Z0-9-.]/g, '-')
-				.replaceAll(/-+/g, '-');
 			const resource = new GitDirectoryResource({
 				resource: 'git:directory',
 				url,
@@ -67,8 +64,15 @@ describe('GitDirectoryResource', () => {
 			});
 			const { files, name } = await resource.resolve();
 
-			expect(name).toBe(fallbackName);
-			expect(resource.name).toBe('.github');
+			// Human-readable name
+			expect(resource.name).toBe(
+				'https://github.com/WordPress/wordpress-playground (trunk) at .github'
+			);
+
+			// Filename
+			expect(name).toBe(
+				'https-github.com-WordPress-wordpress-playground-trunk-at-.github'
+			);
 			expect(files['dependabot.yml']).toBeInstanceOf(Uint8Array);
 		});
 	});
@@ -77,24 +81,34 @@ describe('GitDirectoryResource', () => {
 		it('should return a non-empty name when path is omitted', async () => {
 			const resource = new GitDirectoryResource({
 				resource: 'git:directory',
-				url: 'https://github.com/WordPress/wordpress-playground',
+				url: 'https://github.com/WordPress/link-manager',
 				ref: 'trunk',
 			});
-			expect(resource.name).toBe(
-				'https-github.com-WordPress-wordpress-playground-trunk'
-			);
+			const { name } = await resource.resolve();
+			expect(name).toBe('https-github.com-WordPress-link-manager-trunk');
+		});
+
+		it('should return a non-empty name when path is empty', async () => {
+			const resource = new GitDirectoryResource({
+				resource: 'git:directory',
+				url: 'https://github.com/WordPress/link-manager',
+				ref: 'trunk',
+				path: '',
+			});
+			const { name } = await resource.resolve();
+			expect(name).toBe('https-github.com-WordPress-link-manager-trunk');
 		});
 
 		it('should return a non-empty name when path has no letters', async () => {
 			const resource = new GitDirectoryResource({
 				resource: 'git:directory',
-				url: 'https://github.com/WordPress/wordpress-playground',
+				url: 'https://github.com/WordPress/link-manager',
 				ref: 'trunk',
-				path: '../',
+				// A path with only a few files to avoid timing out.
+				path: '/',
 			});
-			expect(resource.name).toBe(
-				'https-github.com-WordPress-wordpress-playground-trunk'
-			);
+			const { name } = await resource.resolve();
+			expect(name).toBe('https-github.com-WordPress-link-manager-trunk');
 		});
 	});
 });

--- a/packages/playground/blueprints/src/lib/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.spec.ts
@@ -72,6 +72,31 @@ describe('GitDirectoryResource', () => {
 			expect(files['dependabot.yml']).toBeInstanceOf(Uint8Array);
 		});
 	});
+
+	describe('name', () => {
+		it('should return a non-empty name when path is omitted', async () => {
+			const resource = new GitDirectoryResource({
+				resource: 'git:directory',
+				url: 'https://github.com/WordPress/wordpress-playground',
+				ref: 'trunk',
+			});
+			expect(resource.name).toBe(
+				'https-github.com-WordPress-wordpress-playground-trunk'
+			);
+		});
+
+		it('should return a non-empty name when path has no letters', async () => {
+			const resource = new GitDirectoryResource({
+				resource: 'git:directory',
+				url: 'https://github.com/WordPress/wordpress-playground',
+				ref: 'trunk',
+				path: '../',
+			});
+			expect(resource.name).toBe(
+				'https-github.com-WordPress-wordpress-playground-trunk'
+			);
+		});
+	});
 });
 
 describe('BlueprintResource', () => {

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -5,7 +5,7 @@ import {
 } from '@php-wasm/progress';
 import type { FileTree, UniversalPHP } from '@php-wasm/universal';
 import type { Semaphore } from '@php-wasm/util';
-import { dirname, randomFilename } from '@php-wasm/util';
+import { randomFilename } from '@php-wasm/util';
 import {
 	listDescendantFiles,
 	listGitFiles,
@@ -586,32 +586,35 @@ export class GitDirectoryResource extends Resource<Directory> {
 			name.substring(requestedPath.length).replace(/^\/+/, '')
 		);
 		return {
-			name:
-				dirname(this.reference.path || '') ||
-				this.reference.url
-					.replaceAll(/[^a-zA-Z0-9-.]/g, '-')
-					.replaceAll(/-+/g, '-'),
+			name: this.filename,
 			files,
 		};
 	}
 
-	/** @inheritDoc */
-	get name() {
-		// Make sure we always return a valid, non-empty filename.
-		const toAlnum = (str: string) =>
-			str
+	/**
+	 * Generate a nice, non-empty filename – the installPlugin step depends on it.
+	 */
+	get filename() {
+		return (
+			this.name
 				.replaceAll(/[^a-zA-Z0-9-.]/g, '-')
 				.replaceAll(/-+/g, '-')
-				.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '');
-		return (
-			[
-				toAlnum(this.reference.url),
-				toAlnum(this.reference.ref ?? ''),
-				toAlnum(this.reference.path ?? ''),
-			]
-				.filter((segment) => segment.length > 0)
-				.join('-') || randomFilename()
+				.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '') ||
+			randomFilename()
 		);
+	}
+
+	/** @inheritDoc */
+	get name() {
+		return [
+			this.reference.url,
+			this.reference.ref ? `(${this.reference.ref})` : '',
+			this.reference.path?.replace(/^\/+/, '')
+				? `at ${this.reference.path}`
+				: '',
+		]
+			.filter((segment) => segment.length > 0)
+			.join(' ');
 	}
 }
 

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -5,7 +5,7 @@ import {
 } from '@php-wasm/progress';
 import type { FileTree, UniversalPHP } from '@php-wasm/universal';
 import type { Semaphore } from '@php-wasm/util';
-import { dirname } from '@php-wasm/util';
+import { dirname, randomFilename } from '@php-wasm/util';
 import {
 	listDescendantFiles,
 	listGitFiles,
@@ -597,13 +597,21 @@ export class GitDirectoryResource extends Resource<Directory> {
 
 	/** @inheritDoc */
 	get name() {
-		const path = this.reference.path ?? '';
-		if (!path) {
-			return this.reference.url
+		// Make sure we always return a valid, non-empty filename.
+		const toAlnum = (str: string) =>
+			str
 				.replaceAll(/[^a-zA-Z0-9-.]/g, '-')
-				.replaceAll(/-+/g, '-');
-		}
-		return path.split('/').pop() || '';
+				.replaceAll(/-+/g, '-')
+				.replace(/^[^a-zA-Z0-9]+|[^a-zA-Z0-9]+$/g, '');
+		return (
+			[
+				toAlnum(this.reference.url),
+				toAlnum(this.reference.ref ?? ''),
+				toAlnum(this.reference.path ?? ''),
+			]
+				.filter((segment) => segment.length > 0)
+				.join('-') || randomFilename()
+		);
 	}
 }
 


### PR DESCRIPTION
## Motivation for the change, related issues

Before this PR, this step would fail:

```js
{
		"step": "installPlugin",
		"pluginData": {
			"resource": "git:directory",
			"url": "https://github.com/juanma-wp/meetup-cheltenham-workshop/",
			"ref": "final",
			"path": "/"
		},
		"options": {
			"activate": true
		}
},
```

This is because `installPlugin` names the plugin directory inside `wp-content` after the filename of the resolved resource, and the `git:directory` resource would use `path` to generate a filename called `/`.

With this PR, `git:directory` generates a directory name using the full set of information from the resource spec: URL, ref, path. The names are now more like this: `https-github.com-WordPress-wordpress-playground-trunk`.

## Testing Instructions (or ideally a Blueprint)

CI – this PR comes with tests

cc @juanmaguitar 
