### PR TITLE
[i18n] Updating Contributor badge and Contributor day pages

### DIFF
--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
@@ -1,20 +1,20 @@
 ---
-title: Insignia de Colaborador de WordPress Playground
+title: Insignia de colaborador de WordPress Playground
 slug: /contributing/contributor-badge
-description: Descubre los criterios para la Insignia de Colaborador de WordPress Playground y cómo solicitarla para tu perfil de WordPress.org.
+description: Descubre los criterios para la insignia de colaborador de WordPress Playground y cómo solicitarla para tu perfil de WordPress.org.
 ---
 
 <!--
 # Playground Contributor Badge
 -->
 
-# Insignia de Colaborador de Playground
+# Insignia de colaborador de Playground
 
 <!--
 This page provides detailed information on the Playground Contributor Badge and the process of requesting it on your [WordPress.org](https://wordpress.org) profile.
 -->
 
-Esta página proporciona información detallada sobre la Insignia de Colaborador de Playground y el proceso para solicitarla en tu perfil de [WordPress.org](https://wordpress.org).
+Esta página proporciona información detallada sobre la insignia de colaborador de Playground y el proceso para solicitarla en tu perfil de [WordPress.org](https://wordpress.org).
 
 ---
 
@@ -22,7 +22,7 @@ Esta página proporciona información detallada sobre la Insignia de Colaborador
 ## Getting Started
 -->
 
-## Comenzando
+## Primeros pasos
 
 <!--
 Any contribution to the WordPress Playground project is highly valued. The Playground team recognizes contributions across several key areas:
@@ -36,9 +36,9 @@ Any contribution to the WordPress Playground project is highly valued. The Playg
 
 Cualquier contribución al proyecto WordPress Playground es muy valorada. El equipo de Playground reconoce contribuciones en varias áreas clave:
 
--   **Código de Playground:** Realizar cambios de código y revisar el proyecto principal.
--   **Interfaz de Playground:** Mejorar la interfaz de usuario de la experiencia web.
--   **Documentación:** Escribir, actualizar y revisar documentación.
+-   **Código de Playground:** Realizar cambios en el código y revisar el proyecto principal.
+-   **Interfaz de Playground:** Mejorar la interfaz de usuario de la web.
+-   **Documentación:** Escribir, actualizar y revisar la documentación.
 -   **Traducción:** Traducir cualquier parte del proyecto.
 -   **Galería de Blueprints:** Crear nuevos blueprints o mejorar los existentes.
 
@@ -46,13 +46,13 @@ Cualquier contribución al proyecto WordPress Playground es muy valorada. El equ
 ## Playground Contributor Badge
 -->
 
-## Insignia de Colaborador de Playground
+## Insignia de colaborador de Playground
 
 <!--
 To get a Playground Contributor Badge, you must have made at least one eligible contribution from the list above. The team may choose to award the badge for other contributions or a combination of the above at the team's discretion.
 -->
 
-Para obtener una Insignia de Colaborador de Playground, debes haber realizado al menos una contribución elegible de la lista anterior. El equipo puede optar por otorgar la insignia por otras contribuciones o una combinación de las anteriores a discreción del equipo.
+Para obtener la insignia de colaborador de Playground, debes haber realizado al menos una contribución válida de la lista anterior. El equipo puede optar por otorgar la insignia por otras contribuciones o por una combinación de las anteriores, a su discreción.
 
 ![Playground Contributor Badge](@site/static/img/contributing/playground-contributor-badge.webp)
 
@@ -60,13 +60,13 @@ Para obtener una Insignia de Colaborador de Playground, debes haber realizado al
 ## Playground Team Badge
 -->
 
-## Insignia del Equipo de Playground
+## Insignia del equipo de Playground
 
 <!--
 If you are currently a contributor and have been actively involved in the Playground project for the past **twelve months**, you are eligible for a **Playground Team Badge**.
 -->
 
-Si actualmente eres un colaborador y has estado activamente involucrado en el proyecto Playground durante los últimos **doce meses**, eres elegible para una **Insignia del Equipo de Playground**.
+Si actualmente eres un colaborador y has participado activamente en el proyecto Playground durante los últimos **doce meses**, eres elegible para una **Insignia del equipo de Playground**.
 
 ![Playground Contributor Badge](@site/static/img/contributing/playground-team-badge.webp)
 
@@ -74,7 +74,7 @@ Si actualmente eres un colaborador y has estado activamente involucrado en el pr
 ## Requesting a Profile Badge
 -->
 
-## Solicitar una Insignia de Perfil
+## Solicitar la insignia para el perfil
 
 <!--
 If you meet the criteria, you can request a badge. Please include links to resources (such as GitHub pull requests, issues, or translated strings) that show you have met the criteria. Send a request at the links bellow:
@@ -83,10 +83,10 @@ If you meet the criteria, you can request a badge. Please include links to resou
 -   [Team Badge](https://profiles.wordpress.org/associations/playground-team/)
 -->
 
-Si cumples con los criterios, puedes solicitar una insignia. Por favor, incluye enlaces a recursos (como pull requests de GitHub, issues o cadenas traducidas) que demuestren que has cumplido con los criterios. Envía una solicitud en los enlaces a continuación:
+Si cumples con los criterios, puedes solicitar una insignia. Por favor, incluye enlaces a recursos (como pull requests de GitHub, issues o cadenas traducidas) que demuestren que has cumplido con los criterios. Envía una solicitud en los enlaces que aparecen a continuación:
 
--   [Contributor Badge](https://profiles.wordpress.org/associations/playground-contributor/)
--   [Team Badge](https://profiles.wordpress.org/associations/playground-team/)
+-   [Insignia de colaborador](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [Insignia del equipo](https://profiles.wordpress.org/associations/playground-team/)
 
 <!--
 ### Request form
@@ -94,10 +94,10 @@ Si cumples con los criterios, puedes solicitar una insignia. Por favor, incluye 
 
 ### Formulario de solicitud
 
-![Playground Contributor Badge](@site/static/img/contributing/request-contributor-badge.webp)
+![Insignia de colaborador de Playground](@site/static/img/contributing/request-contributor-badge.webp)
 
 <!--
 To access the request, the user should be logged in with their WordPress.org account and open the Request Membership tab, after submitting the required information. A Playground Team Representative will confirm your contribution and assign the badge. The team will perform a weekly review of contributions and award badges at that time. Updates on new badges awarded will be posted during the Playground Team meeting.
 -->
 
-Para acceder a la solicitud, el usuario debe iniciar sesión con su cuenta de WordPress.org y abrir la pestaña Request Membership, después de enviar la información requerida. Un Representante del Equipo de Playground confirmará tu contribución y asignará la insignia. El equipo realizará una revisión semanal de las contribuciones y otorgará insignias en ese momento. Las actualizaciones sobre las nuevas insignias otorgadas se publicarán durante la reunión del Equipo de Playground.
+Para acceder a la solicitud, el usuario debe iniciar sesión con su cuenta de WordPress.org y abrir la pestaña «Request Membership», después de enviar la información requerida. Un representante del equipo de Playground confirmará tu contribución y te asignará la insignia. El equipo realizará una revisión semanal de las contribuciones y otorgará insignias en ese momento. Las actualizaciones sobre las nuevas insignias otorgadas se publicarán durante la reunión del equipo de Playground.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
@@ -1,0 +1,103 @@
+---
+title: Insignia de Colaborador de WordPress Playground
+slug: /contributing/contributor-badge
+description: Descubre los criterios para la Insignia de Colaborador de WordPress Playground y cómo solicitarla para tu perfil de WordPress.org.
+---
+
+<!--
+# Playground Contributor Badge
+-->
+
+# Insignia de Colaborador de Playground
+
+<!--
+This page provides detailed information on the Playground Contributor Badge and the process of requesting it on your [WordPress.org](https://wordpress.org) profile.
+-->
+
+Esta página proporciona información detallada sobre la Insignia de Colaborador de Playground y el proceso para solicitarla en tu perfil de [WordPress.org](https://wordpress.org).
+
+---
+
+<!--
+## Getting Started
+-->
+
+## Comenzando
+
+<!--
+Any contribution to the WordPress Playground project is highly valued. The Playground team recognizes contributions across several key areas:
+
+-   **Playground Code:** Making code changes and reviewing the core project.
+-   **Playground UI:** Improving the user interface of the web experience.
+-   **Documentation:** Writing, updating, and reviewing documentation.
+-   **Translation:** Translating any part of the project.
+-   **Blueprints Gallery:** Creating new blueprints or improving existing ones.
+-->
+
+Cualquier contribución al proyecto WordPress Playground es muy valorada. El equipo de Playground reconoce contribuciones en varias áreas clave:
+
+-   **Código de Playground:** Realizar cambios de código y revisar el proyecto principal.
+-   **Interfaz de Playground:** Mejorar la interfaz de usuario de la experiencia web.
+-   **Documentación:** Escribir, actualizar y revisar documentación.
+-   **Traducción:** Traducir cualquier parte del proyecto.
+-   **Galería de Blueprints:** Crear nuevos blueprints o mejorar los existentes.
+
+<!--
+## Playground Contributor Badge
+-->
+
+## Insignia de Colaborador de Playground
+
+<!--
+To get a Playground Contributor Badge, you must have made at least one eligible contribution from the list above. The team may choose to award the badge for other contributions or a combination of the above at the team's discretion.
+-->
+
+Para obtener una Insignia de Colaborador de Playground, debes haber realizado al menos una contribución elegible de la lista anterior. El equipo puede optar por otorgar la insignia por otras contribuciones o una combinación de las anteriores a discreción del equipo.
+
+![Playground Contributor Badge](@site/static/img/contributing/playground-contributor-badge.webp)
+
+<!--
+## Playground Team Badge
+-->
+
+## Insignia del Equipo de Playground
+
+<!--
+If you are currently a contributor and have been actively involved in the Playground project for the past **twelve months**, you are eligible for a **Playground Team Badge**.
+-->
+
+Si actualmente eres un colaborador y has estado activamente involucrado en el proyecto Playground durante los últimos **doce meses**, eres elegible para una **Insignia del Equipo de Playground**.
+
+![Playground Contributor Badge](@site/static/img/contributing/playground-team-badge.webp)
+
+<!--
+## Requesting a Profile Badge
+-->
+
+## Solicitar una Insignia de Perfil
+
+<!--
+If you meet the criteria, you can request a badge. Please include links to resources (such as GitHub pull requests, issues, or translated strings) that show you have met the criteria. Send a request at the links bellow:
+
+-   [Contributor Badge](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [Team Badge](https://profiles.wordpress.org/associations/playground-team/)
+-->
+
+Si cumples con los criterios, puedes solicitar una insignia. Por favor, incluye enlaces a recursos (como pull requests de GitHub, issues o cadenas traducidas) que demuestren que has cumplido con los criterios. Envía una solicitud en los enlaces a continuación:
+
+-   [Contributor Badge](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [Team Badge](https://profiles.wordpress.org/associations/playground-team/)
+
+<!--
+### Request form
+-->
+
+### Formulario de solicitud
+
+![Playground Contributor Badge](@site/static/img/contributing/request-contributor-badge.webp)
+
+<!--
+To access the request, the user should be logged in with their WordPress.org account and open the Request Membership tab, after submitting the required information. A Playground Team Representative will confirm your contribution and assign the badge. The team will perform a weekly review of contributions and award badges at that time. Updates on new badges awarded will be posted during the Playground Team meeting.
+-->
+
+Para acceder a la solicitud, el usuario debe iniciar sesión con su cuenta de WordPress.org y abrir la pestaña Request Membership, después de enviar la información requerida. Un Representante del Equipo de Playground confirmará tu contribución y asignará la insignia. El equipo realizará una revisión semanal de las contribuciones y otorgará insignias en ese momento. Las actualizaciones sobre las nuevas insignias otorgadas se publicarán durante la reunión del Equipo de Playground.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -1,5 +1,7 @@
 ---
 slug: /contributing/contributor-day
+title: Día del Contribuidor de WordCamp
+description: Una guía sobre cómo contribuir a WordPress Playground y cómo puede ayudarte en el Día del Contribuidor.
 ---
 
 <!--
@@ -9,13 +11,97 @@ slug: /contributing/contributor-day
 # Día del Contribuidor de WordCamp
 
 <!--
-The [WordPress Playground VS Code extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) and [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) streamline the process of setting up a local WordPress environment. WordPress Playground powers both—no Docker, MySQL, or Apache required.
+WordCamp Contributor Day is an event where the WordPress community comes together to contribute to the WordPress project. This guide focuses on how you can contribute to the WordPress Playground project or how the Playground can assist you in contributing to WordPress Core.
 -->
 
-La [extensión de WordPress Playground para VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) y [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) agilizan el proceso de configuración de un entorno local de WordPress. WordPress Playground impulsa ambos, sin necesidad de Docker, MySQL o Apache.
+El Día del Contribuidor de WordCamp es un evento donde la comunidad de WordPress se reúne para contribuir al proyecto WordPress. Esta guía se centra en cómo puedes contribuir al proyecto WordPress Playground o cómo Playground puede ayudarte a contribuir a WordPress Core.
 
 <!--
-Keep reading to learn how to use these tools for [local development](/developers/local-development/wp-playground-cli) when contributing to WordPress. Please note that the extension and the NPM package are under development, and not all [Make WordPress teams](https://make.wordpress.org/) are fully supported.
+## Who Can Contribute?
+-->
+
+## ¿Quién puede contribuir?
+
+<!--
+Some events will have a dedicated table for the project. The WordPress Playground contributor tables welcome all kinds of contributions, not just from developers. Whether you are a writer, coder, tester, plugin or theme developer, marketer, site owner, or any other type of user, you are encouraged to contribute.
+-->
+
+Algunos eventos tendrán una mesa dedicada al proyecto. Las mesas de contribuidores de WordPress Playground dan la bienvenida a todo tipo de contribuciones, no solo de desarrolladores. Ya seas escritor, programador, probador, desarrollador de plugins o temas, especialista en marketing, propietario de sitio o cualquier otro tipo de usuario, te animamos a contribuir.
+
+<!--
+We value diverse contributions across various areas, including community building, testing, documentation, and design.
+-->
+
+Valoramos las contribuciones diversas en varias áreas, incluyendo construcción de comunidad, pruebas, documentación y diseño.
+
+<!--
+## How to Contribute to the Playground Project
+-->
+
+## Cómo contribuir al proyecto Playground
+
+<!--
+This section outlines how you can contribute directly to the WordPress Playground project and its associated tools:
+-->
+
+Esta sección describe cómo puedes contribuir directamente al proyecto WordPress Playground y sus herramientas asociadas:
+
+<!--
+-   **Documentation:** Enhance our documentation by improving existing content, developing new guides, or translating materials into different languages.
+-   **Blueprints:** Create plugin demos for plugins at the WordPress Plugin repository, or develop new Blueprints to enrich our project documentation.
+-   **Testing the Playground Environment:** Engage in testing the WordPress Playground project itself. You can do this by carefully crafting new issues that describe problems you encounter and suggesting actionable solutions. Test our WordPress web instance (the playground.wordpress.net site), or explore the various applications powered by Playground. Test these tools, observe their functionality, and provide detailed feedback.
+-   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
+-->
+
+-   **Documentación:** Mejora nuestra documentación mejorando el contenido existente, desarrollando nuevas guías o traduciendo materiales a diferentes idiomas.
+-   **Blueprints:** Crea demostraciones de plugins para los plugins en el repositorio de Plugins de WordPress, o desarrolla nuevos Blueprints para enriquecer nuestra documentación del proyecto.
+-   **Pruebas del entorno Playground:** Participa en las pruebas del proyecto WordPress Playground en sí. Puedes hacer esto creando cuidadosamente nuevos issues que describan los problemas que encuentres y sugiriendo soluciones prácticas. Prueba nuestra instancia web de WordPress (el sitio playground.wordpress.net), o explora las diversas aplicaciones impulsadas por Playground. Prueba estas herramientas, observa su funcionalidad y proporciona comentarios detallados.
+-   **Retroalimentación del producto:** Tus ideas son invaluables para mejorar la experiencia de Playground. Esto incluye comentarios generales sobre la instancia web, la aplicación y cualquier herramienta del lado del servidor.
+
+<!--
+All feedback, including reported issues and test results, can be submitted through our GitHub repository.
+-->
+
+Todos los comentarios, incluidos los issues reportados y los resultados de las pruebas, pueden enviarse a través de nuestro repositorio de GitHub.
+
+<!--
+### Follow-up and Continued Engagement
+-->
+
+### Seguimiento y compromiso continuo
+
+<!--
+While many tasks are completed during the event, your contribution journey doesn't have to end there. You are welcome to continue working on your issues or pull requests after Contributor Day. We anticipate ongoing activity from contributors who take on tasks beyond the event. Please note that if a pull request shows no activity for one month, it may be considered abandoned and subsequently closed.
+-->
+
+Si bien muchas tareas se completan durante el evento, tu viaje de contribución no tiene que terminar ahí. Eres bienvenido a continuar trabajando en tus issues o pull requests después del Día del Contribuidor. Anticipamos actividad continua de los contribuidores que asumen tareas más allá del evento. Ten en cuenta que si un pull request no muestra actividad durante un mes, puede considerarse abandonado y posteriormente cerrado.
+
+<!--
+### Getting Help and Staying Engaged
+-->
+
+### Obtener ayuda y mantenerse comprometido
+
+<!--
+During Contributor Day, you can find direct assistance and interact with us at the dedicated Playground table. For continuous support and community interaction, you can connect with us on the `#playground` channel on WordPress Slack or via GitHub.
+-->
+
+Durante el Día del Contribuidor, puedes encontrar asistencia directa e interactuar con nosotros en la mesa dedicada de Playground. Para soporte continuo e interacción con la comunidad, puedes conectarte con nosotros en el canal `#playground` de WordPress Slack o a través de GitHub.
+
+<!--
+## How to use Playground at Contributor Day
+-->
+
+## Cómo usar Playground en el Día del Contribuidor
+
+<!--
+Now we are going to cover how the Playground can assist you during the Contributor Day. The [WordPress Playground VS Code extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) and [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) streamline the process of setting up a local WordPress environment. WordPress Playground powers both—no Docker, MySQL, or Apache required.
+-->
+
+Ahora vamos a cubrir cómo Playground puede ayudarte durante el Día del Contribuidor. La [extensión de WordPress Playground para VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) y [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) agilizan el proceso de configuración de un entorno local de WordPress. WordPress Playground impulsa ambos, sin necesidad de Docker, MySQL o Apache.
+
+<!--
+Keep reading to learn how to use these tools for [local development](/developers/local-development/wp-playground-cli) when contributing to WordPress. Please note that the extension and the NPM package are under development, and not all [Make WordPress teams](https://make.wordpress.org/) are fully supported.
 -->
 
 Sigue leyendo para aprender a usar estas herramientas para el [desarrollo local](/developers/local-development/wp-playground-cli) al contribuir a WordPress. Ten en cuenta que la extensión y el paquete NPM están en desarrollo, y no todos los [equipos de Make WordPress](https://make.wordpress.org/) son totalmente compatibles.
@@ -41,7 +127,7 @@ La [extensión de Playground para Visual Studio Code](https://marketplace.visual
 <!--
 1. Open VS Code and navigate to the **Extensions** tab (**View > Extensions**).
 2. In the search bar, type _WordPress Playground_ and click **Install**.
-3. To interact with Playground, click the new icon in the **Activity Bar** and hit the **Start WordPress Server** button.
+3. To interact with Playground, click the new icon in the **Activity Bar** and hit the **Start WordPress Server** button.
 4. A new tab will open in your browser within seconds.
 -->
 
@@ -57,10 +143,10 @@ La [extensión de Playground para Visual Studio Code](https://marketplace.visual
 ### Paquete NPM @wp-playground/cli
 
 <!--
-`@wp-playground/cli` is a CLI tool that allows you to spin up a WordPress site with a single command. No Docker, MySQL, or Apache are required.
+[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) is a CLI tool that allows you to spin up a WordPress site with a single command. No Docker, MySQL, or Apache are required.
 -->
 
-`@wp-playground/cli` es una herramienta de línea de comandos que te permite levantar un sitio de WordPress con un solo comando. No se requiere Docker, MySQL o Apache.
+[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) es una herramienta de línea de comandos que te permite levantar un sitio de WordPress con un solo comando. No se requiere Docker, MySQL o Apache.
 
 <!--
 #### Prerequisites
@@ -69,7 +155,7 @@ La [extensión de Playground para Visual Studio Code](https://marketplace.visual
 #### Requisitos previos
 
 <!--
-`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven’t yet, [download and install](https://nodejs.org/en/download) both before you begin.
+`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
 -->
 
 `@wp-playground/cli` requiere Node.js 20.18 o superior y NPM. Si aún no lo has hecho, [descarga e instala](https://nodejs.org/en/download) ambos antes de comenzar.
@@ -87,7 +173,7 @@ Dependiendo del equipo de Make WordPress al que contribuyas, es posible que nece
 #### Ejecutando `@wp-playground/cli`
 
 <!--
-You don’t have to install `@wp-playground/cli` on your device to use it. Navigate to your plugin or theme directory and start `@wp-playground/cli` with the following commands:
+You don't have to install `@wp-playground/cli` on your device to use it. Navigate to your plugin or theme directory and start `@wp-playground/cli` with the following commands:
 -->
 
 No es necesario que instales `@wp-playground/cli` en tu dispositivo para usarlo. Ve a tu directorio de plugins o temas e inicia `@wp-playground/cli` con los siguientes comandos:
@@ -129,7 +215,7 @@ npm run dev
 <!--
 :::info
 
-If you’re unsure about the steps listed above, visit the official [Gutenberg Project Contributor Guide](https://developer.wordpress.org/block-editor/contributors/). Note that in this case, `@wp-playground/cli` replaces `wp-env`.
+If you're unsure about the steps listed above, visit the official [Gutenberg Project Contributor Guide](https://developer.wordpress.org/block-editor/contributors/). Note that in this case, `@wp-playground/cli` replaces `wp-env`.
 
 :::
 -->
@@ -152,7 +238,7 @@ npx @wp-playground/cli@latest server --auto-mount
 ```
 
 <!--
-When you’re ready, commit and push your changes to your forked repository on GitHub and open a Pull Request on the Gutenberg repository.
+When you're ready, commit and push your changes to your forked repository on GitHub and open a Pull Request on the Gutenberg repository.
 -->
 
 Cuando estés listo, haz commit y push de tus cambios a tu repositorio "forkeado" en GitHub y abre un Pull Request en el repositorio de Gutenberg.
@@ -193,14 +279,14 @@ npx @wp-playground/cli@latest server --auto-mount
 #### Probar un PR de Gutenberg con Playground en el navegador
 
 <!--
-You don’t need a local development environment to test Gutenberg PRs—use Playground to do it directly in the browser.
+You don't need a [local development environment](/developers/local-development/) to test Gutenberg PRs—use Playground to do it directly in the browser.
 -->
 
-No necesitas un entorno de desarrollo local para probar los PRs de Gutenberg; usa Playground para hacerlo directamente en el navegador.
+No necesitas un [entorno de desarrollo local](/developers/local-development/) para probar los PRs de Gutenberg; usa Playground para hacerlo directamente en el navegador.
 
 <!--
-1. Copy the ID of the PR you’d like to test (pick one from the [list of open Pull Requests](https://github.com/WordPress/gutenberg/pulls)).
-2. Open Playground’s [Gutenberg PR Previewer](https://playground.wordpress.net/gutenberg.html) and paste the ID you copied.
+1. Copy the ID of the PR you'd like to test (pick one from the [list of open Pull Requests](https://github.com/WordPress/gutenberg/pulls)).
+2. Open Playground's [Gutenberg PR Previewer](https://playground.wordpress.net/gutenberg.html) and paste the ID you copied.
 3. Once you click **Go**, Playground will verify the PR is valid and open a new tab with the relevant PR, allowing you to review the proposed changes.
 -->
 
@@ -227,7 +313,7 @@ Puedes traducir los plugins de WordPress compatibles cargando el plugin que quie
 ## Obtén ayuda y contribuye a WordPress Playground
 
 <!--
-Have a question or an idea for a new feature? Found a bug? Something’s not working as expected? We’re here to help:
+Have a question or an idea for a new feature? Found a bug? Something's not working as expected? We're here to help:
 -->
 
 ¿Tienes alguna pregunta o una idea para una nueva función? ¿Has encontrado un error? ¿Algo no funciona como se esperaba? Estamos aquí para ayudar:

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
@@ -39,6 +39,12 @@ If you feel up to it, write the content in the issue description, and the projec
 Si te animas, escribe el contenido en la descripción del issue, y los contribuidores del proyecto se encargarán del resto.
 
 <!--
+Would you like to see the documentation in your language? Check the [Translation section](/contributing/translations).
+-->
+
+¿Te gustaría ver la documentación en tu idioma? Consulta la [sección de Traducciones](/contributing/translations).
+
+<!--
 ### Forking the repo, edit files locally and opening Pull Requests
 -->
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -1,0 +1,329 @@
+---
+slug: /contributing/contributor-day
+title: Dia do Contribuidor do WordCamp
+description: Um guia sobre como contribuir com o WordPress Playground e como ele pode te ajudar no Dia do Contribuidor.
+---
+
+<!--
+# WordCamp Contributor Day
+-->
+
+# Dia do Contribuidor do WordCamp
+
+<!--
+WordCamp Contributor Day is an event where the WordPress community comes together to contribute to the WordPress project. This guide focuses on how you can contribute to the WordPress Playground project or how the Playground can assist you in contributing to WordPress Core.
+-->
+
+O Dia do Contribuidor do WordCamp é um evento onde a comunidade WordPress se reúne para contribuir com o projeto WordPress. Este guia foca em como você pode contribuir com o projeto WordPress Playground ou como o Playground pode ajudá-lo a contribuir com o WordPress Core.
+
+<!--
+## Who Can Contribute?
+-->
+
+## Quem pode contribuir?
+
+<!--
+Some events will have a dedicated table for the project. The WordPress Playground contributor tables welcome all kinds of contributions, not just from developers. Whether you are a writer, coder, tester, plugin or theme developer, marketer, site owner, or any other type of user, you are encouraged to contribute.
+-->
+
+Alguns eventos terão uma mesa dedicada ao projeto. As mesas de contribuidores do WordPress Playground recebem todos os tipos de contribuições, não apenas de desenvolvedores. Seja você escritor, programador, testador, desenvolvedor de plugins ou temas, profissional de marketing, proprietário de site ou qualquer outro tipo de usuário, você é encorajado a contribuir.
+
+<!--
+We value diverse contributions across various areas, including community building, testing, documentation, and design.
+-->
+
+Valorizamos contribuições diversas em várias áreas, incluindo construção de comunidade, testes, documentação e design.
+
+<!--
+## How to Contribute to the Playground Project
+-->
+
+## Como contribuir com o projeto Playground
+
+<!--
+This section outlines how you can contribute directly to the WordPress Playground project and its associated tools:
+-->
+
+Esta seção descreve como você pode contribuir diretamente com o projeto WordPress Playground e suas ferramentas associadas:
+
+<!--
+-   **Documentation:** Enhance our documentation by improving existing content, developing new guides, or translating materials into different languages.
+-   **Blueprints:** Create plugin demos for plugins at the WordPress Plugin repository, or develop new Blueprints to enrich our project documentation.
+-   **Testing the Playground Environment:** Engage in testing the WordPress Playground project itself. You can do this by carefully crafting new issues that describe problems you encounter and suggesting actionable solutions. Test our WordPress web instance (the playground.wordpress.net site), or explore the various applications powered by Playground. Test these tools, observe their functionality, and provide detailed feedback.
+-   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
+-->
+
+-   **Documentação:** Melhore nossa documentação aprimorando o conteúdo existente, desenvolvendo novos guias ou traduzindo materiais para diferentes idiomas.
+-   **Blueprints:** Crie demonstrações de plugins para os plugins no repositório de Plugins do WordPress, ou desenvolva novos Blueprints para enriquecer nossa documentação do projeto.
+-   **Testes do ambiente Playground:** Participe dos testes do próprio projeto WordPress Playground. Você pode fazer isso criando cuidadosamente novos issues que descrevam os problemas que você encontrou e sugerindo soluções práticas. Teste nossa instância web do WordPress (o site playground.wordpress.net), ou explore os vários aplicativos alimentados pelo Playground. Teste essas ferramentas, observe sua funcionalidade e forneça feedback detalhado.
+-   **Feedback do produto:** Suas ideias são inestimáveis para melhorar a experiência do Playground. Isso inclui feedback geral sobre a instância web, o aplicativo e quaisquer ferramentas do lado do servidor.
+
+<!--
+All feedback, including reported issues and test results, can be submitted through our GitHub repository.
+-->
+
+Todos os feedbacks, incluindo issues reportados e resultados de testes, podem ser enviados através do nosso repositório GitHub.
+
+<!--
+### Follow-up and Continued Engagement
+-->
+
+### Acompanhamento e engajamento contínuo
+
+<!--
+While many tasks are completed during the event, your contribution journey doesn't have to end there. You are welcome to continue working on your issues or pull requests after Contributor Day. We anticipate ongoing activity from contributors who take on tasks beyond the event. Please note that if a pull request shows no activity for one month, it may be considered abandoned and subsequently closed.
+-->
+
+Embora muitas tarefas sejam concluídas durante o evento, sua jornada de contribuição não precisa terminar aí. Você é bem-vindo para continuar trabalhando em seus issues ou pull requests após o Dia do Contribuidor. Antecipamos atividade contínua de contribuidores que assumem tarefas além do evento. Por favor, note que se um pull request não mostrar atividade por um mês, ele pode ser considerado abandonado e subsequentemente fechado.
+
+<!--
+### Getting Help and Staying Engaged
+-->
+
+### Obtendo ajuda e mantendo-se engajado
+
+<!--
+During Contributor Day, you can find direct assistance and interact with us at the dedicated Playground table. For continuous support and community interaction, you can connect with us on the `#playground` channel on WordPress Slack or via GitHub.
+-->
+
+Durante o Dia do Contribuidor, você pode encontrar assistência direta e interagir conosco na mesa dedicada do Playground. Para suporte contínuo e interação com a comunidade, você pode se conectar conosco no canal `#playground` do WordPress Slack ou via GitHub.
+
+<!--
+## How to use Playground at Contributor Day
+-->
+
+## Como usar o Playground no Dia do Contribuidor
+
+<!--
+Now we are going to cover how the Playground can assist you during the Contributor Day. The [WordPress Playground VS Code extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) and [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) streamline the process of setting up a local WordPress environment. WordPress Playground powers both—no Docker, MySQL, or Apache required.
+-->
+
+Agora vamos cobrir como o Playground pode ajudá-lo durante o Dia do Contribuidor. A [extensão WordPress Playground para VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) e [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) simplificam o processo de configuração de um ambiente WordPress local. O WordPress Playground alimenta ambos—sem necessidade de Docker, MySQL ou Apache.
+
+<!--
+Keep reading to learn how to use these tools for [local development](/developers/local-development/wp-playground-cli) when contributing to WordPress. Please note that the extension and the NPM package are under development, and not all [Make WordPress teams](https://make.wordpress.org/) are fully supported.
+-->
+
+Continue lendo para aprender como usar essas ferramentas para [desenvolvimento local](/developers/local-development/wp-playground-cli) ao contribuir com o WordPress. Por favor, note que a extensão e o pacote NPM estão em desenvolvimento, e nem todos os [times do Make WordPress](https://make.wordpress.org/) são totalmente suportados.
+
+<!--
+## Getting Started
+-->
+
+## Começando
+
+<!--
+### VS Code Playground extension
+-->
+
+### Extensão Playground para VS Code
+
+<!--
+The [Visual Studio Code Playground extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) is a friendly zero-setup development environment.
+-->
+
+A [extensão Playground para Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) é um ambiente de desenvolvimento amigável e sem configuração.
+
+<!--
+1. Open VS Code and navigate to the **Extensions** tab (**View > Extensions**).
+2. In the search bar, type _WordPress Playground_ and click **Install**.
+3. To interact with Playground, click the new icon in the **Activity Bar** and hit the **Start WordPress Server** button.
+4. A new tab will open in your browser within seconds.
+-->
+
+1. Abra o VS Code e navegue até a aba **Extensões** (**Visualizar > Extensões**).
+2. Na barra de pesquisa, digite _WordPress Playground_ e clique em **Instalar**.
+3. Para interagir com o Playground, clique no novo ícone na **Barra de Atividades** e pressione o botão **Iniciar Servidor WordPress**.
+4. Uma nova aba será aberta no seu navegador em segundos.
+
+<!--
+### @wp-playground/cli NPM package
+-->
+
+### Pacote NPM @wp-playground/cli
+
+<!--
+[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) is a CLI tool that allows you to spin up a WordPress site with a single command. No Docker, MySQL, or Apache are required.
+-->
+
+[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) é uma ferramenta CLI que permite criar um site WordPress com um único comando. Não é necessário Docker, MySQL ou Apache.
+
+<!--
+#### Prerequisites
+-->
+
+#### Pré-requisitos
+
+<!--
+`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
+-->
+
+`@wp-playground/cli` requer Node.js 20.18 ou mais recente e NPM. Se você ainda não fez isso, [baixe e instale](https://nodejs.org/en/download) ambos antes de começar.
+
+<!--
+Depending on the Make WordPress team you contribute to, you may need a different Node.js version than the one you have installed. You can use Node Version Manager (NVM) to switch between versions. [Find the installation guide here](https://github.com/nvm-sh/nvm#installing-and-updating).
+-->
+
+Dependendo do time do Make WordPress para o qual você contribui, você pode precisar de uma versão diferente do Node.js da que você tem instalada. Você pode usar o Node Version Manager (NVM) para alternar entre versões. [Encontre o guia de instalação aqui](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+<!--
+#### Running `@wp-playground/cli`
+-->
+
+#### Executando `@wp-playground/cli`
+
+<!--
+You don't have to install `@wp-playground/cli` on your device to use it. Navigate to your plugin or theme directory and start `@wp-playground/cli` with the following commands:
+-->
+
+Você não precisa instalar `@wp-playground/cli` no seu dispositivo para usá-lo. Navegue até o diretório do seu plugin ou tema e inicie `@wp-playground/cli` com os seguintes comandos:
+
+```bash
+cd my-plugin-or-theme-directory
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+<!--
+## Ideas for contributors
+-->
+
+## Ideias para contribuidores
+
+<!--
+### Create a Gutenberg Pull Request (PR)
+-->
+
+### Criar um Pull Request (PR) do Gutenberg
+
+<!--
+1. Fork the [Gutenberg repository](https://github.com/WordPress/gutenberg) in your GitHub account.
+2. Then, clone the forked repository to download the files.
+3. Install the necessary dependencies and build the code in development mode.
+-->
+
+1. Faça um fork do [repositório Gutenberg](https://github.com/WordPress/gutenberg) na sua conta GitHub.
+2. Então, clone o repositório "forkado" para baixar os arquivos.
+3. Instale as dependências necessárias e compile o código em modo de desenvolvimento.
+
+```bash
+git clone git@github.com:WordPress/gutenberg.git
+cd gutenberg
+npm install
+npm run dev
+```
+
+<!--
+:::info
+
+If you're unsure about the steps listed above, visit the official [Gutenberg Project Contributor Guide](https://developer.wordpress.org/block-editor/contributors/). Note that in this case, `@wp-playground/cli` replaces `wp-env`.
+
+:::
+-->
+
+:::info
+
+Se você não tiver certeza sobre os passos listados acima, visite o [Guia do Contribuidor do Projeto Gutenberg](https://developer.wordpress.org/block-editor/contributors/) oficial. Note que neste caso, `@wp-playground/cli` substitui `wp-env`.
+
+:::
+
+<!--
+Open a new terminal terminal tab, navigate to the Gutenberg directory, and start WordPress using `@wp-playground/cli`:
+-->
+
+Abra uma nova aba do terminal, navegue até o diretório Gutenberg e inicie o WordPress usando `@wp-playground/cli`:
+
+```bash
+cd gutenberg
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+<!--
+When you're ready, commit and push your changes to your forked repository on GitHub and open a Pull Request on the Gutenberg repository.
+-->
+
+Quando estiver pronto, faça commit e push das suas alterações para o seu repositório "forkado" no GitHub e abra um Pull Request no repositório Gutenberg.
+
+<!--
+### Test a Gutenberg PR
+-->
+
+### Testar um PR do Gutenberg
+
+<!--
+1. To test other Gutenberg PRs, checkout the branch associated with it.
+2. Pull the latest changes to ensure your local copy is up to date.
+3. Next, install the necessary dependencies, ensuring your testing environment matches the latest changes.
+4. Finally, build the code in development mode.
+-->
+
+1. Para testar outros PRs do Gutenberg, faça checkout para a branch associada a ele.
+2. Faça pull das últimas alterações para garantir que sua cópia local esteja atualizada.
+3. Em seguida, instale as dependências necessárias, garantindo que seu ambiente de teste corresponda às últimas alterações.
+4. Finalmente, compile o código em modo de desenvolvimento.
+
+```bash
+# copy the branch-name from GitHub #
+git checkout branch-name
+git pull
+npm install
+npm run dev
+
+# In a different terminal inside the Gutenberg directory *
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+<!--
+#### Test a Gutenberg PR with Playground in the browser
+-->
+
+#### Testar um PR do Gutenberg com Playground no navegador
+
+<!--
+You don't need a [local development environment](/developers/local-development/) to test Gutenberg PRs—use Playground to do it directly in the browser.
+-->
+
+Você não precisa de um [ambiente de desenvolvimento local](/developers/local-development/) para testar PRs do Gutenberg—use o Playground para fazer isso diretamente no navegador.
+
+<!--
+1. Copy the ID of the PR you'd like to test (pick one from the [list of open Pull Requests](https://github.com/WordPress/gutenberg/pulls)).
+2. Open Playground's [Gutenberg PR Previewer](https://playground.wordpress.net/gutenberg.html) and paste the ID you copied.
+3. Once you click **Go**, Playground will verify the PR is valid and open a new tab with the relevant PR, allowing you to review the proposed changes.
+-->
+
+1. Copie o ID do PR que você gostaria de testar (escolha um da [lista de Pull Requests abertos](https://github.com/WordPress/gutenberg/pulls)).
+2. Abra o [Visualizador de PRs do Gutenberg](https://playground.wordpress.net/gutenberg.html) do Playground e cole o ID que você copiou.
+3. Assim que você clicar em **Ir**, o Playground verificará se o PR é válido e abrirá uma nova aba com o PR relevante, permitindo que você revise as mudanças propostas.
+
+<!--
+## Translate WordPress Plugins with Playground in the browser
+-->
+
+## Traduzir Plugins WordPress com Playground no navegador
+
+<!--
+You can translate supported WordPress Plugins by loading the plugin you want to translate and use Inline Translation. If the plugin developers have added the option, you'll find the **Translate Live** link on the top right toolbar of the translation view. You can read more about this exciting new option on [this Polyglots blog post](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/).
+-->
+
+Você pode traduzir Plugins WordPress suportados carregando o plugin que você deseja traduzir e usar a Tradução Inline. Se os desenvolvedores do plugin adicionaram a opção, você encontrará o link **Traduzir ao Vivo** na barra de ferramentas superior direita da visualização de tradução. Você pode ler mais sobre esta nova e empolgante opção nesta [postagem do blog Polyglots](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/).
+
+<!--
+## Get help and contribute to WordPress Playground
+-->
+
+## Obtenha ajuda e contribua com o WordPress Playground
+
+<!--
+Have a question or an idea for a new feature? Found a bug? Something's not working as expected? We're here to help:
+-->
+
+Tem uma pergunta ou uma ideia para um novo recurso? Encontrou um bug? Algo não está funcionando como esperado? Estamos aqui para ajudar:
+
+<!--
+-   During Contributor Day, you can reach us at the **Playground table**.
+-   Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is the VS Code extension, NPM package, or the plugins, open an issue on the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
+-   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-->
+
+-   Durante o Dia do Contribuidor, você pode nos encontrar na **mesa do Playground**.
+-   Abra um issue no [repositório GitHub do WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se seu foco é a extensão VS Code, pacote NPM ou os plugins, abra um issue no [repositório Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+-   Compartilhe seu feedback no [canal Slack **#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
@@ -41,6 +41,12 @@ If you feel up to it, write the content in the issue description, and the projec
 Se você se sentir à vontade, escreva o conteúdo na descrição da issue, e os contribuidores do projeto cuidarão do resto.
 
 <!--
+Would you like to see the documentation in your language? Check the [Translation section](/contributing/translations).
+-->
+
+Gostaria de ver a documentação no seu idioma? Confira a [seção de Traduções](/contributing/translations).
+
+<!--
 ### Forking the repo, edit files locally and opening Pull Requests
 -->
 


### PR DESCRIPTION
This pull request adds a new Spanish documentation page describing the criteria and process for requesting the WordPress Playground Contributor Badge, and significantly expands and improves the Spanish guide for Contributor Day. The Contributor Day guide now provides a more comprehensive and inclusive overview of how to contribute to the Playground project, details the use of Playground tools, and clarifies instructions and terminology for Spanish-speaking contributors. Minor improvements and clarifications are also made to other contributing documentation.

**New documentation and major content expansion:**

* Added a new page `contributor-badge.md` with detailed information on the Playground Contributor Badge, including eligibility, request process, and badge types for WordPress.org profiles.
* Greatly expanded the content of `contributor-day.md` to include sections on who can contribute, types of contributions, ongoing engagement, getting help, and step-by-step instructions for using Playground tools during Contributor Day. This makes the guide more welcoming and practical for a wider audience.