### PR TITLE
[i18n] Adding quick start guide and web instance pages in Spanish

### DIFF
--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md
@@ -2,81 +2,189 @@
 title: Introducción
 slug: /
 id: introduction
+description: Bienvenido a la documentación de WordPress Playground. Esta página introduce la estructura de la documentación y te ayuda a orientarte.
 ---
+
+<!--
+# WordPress Playground Docs
+-->
 
 # Documentación de WordPress Playground
 
-:::info **¿Estabas buscando la web oficial de WordPress Playground?**
+<!--
+:::info **Looking for the official Playground website?**
 
-La web oficial de WordPress Playground está disponible en [wordpress.org/playground/](https://wordpress.org/playground/). El sitio en el que estas alberga a la documentación de WordPress Playground.
+WordPress Playground website moved to [wordpress.org/playground/](https://wordpress.org/playground/). The site you're at now hosts the documentation.
+
+:::
+-->
+
+:::info **¿Buscas el sitio web oficial de Playground?**
+
+El sitio web de WordPress Playground se trasladó a [wordpress.org/playground/](https://wordpress.org/playground/). El sitio en el que te encuentras ahora alberga la documentación.
 
 :::
 
-👋 !Hola! Bienvenido a la documentación de WordPress Playground.
+<!--
+👋 Hi! Welcome to WordPress Playground documentation.
+-->
 
-WordPress Playground es una herramienta online con la que puedes experimentar y aprender sobre WordPress. En este sitio (Documentación) encontrarás toda la información que necesitas para empezar a usar Playground.
+👋 ¡Hola! Bienvenido a la documentación de WordPress Playground.
 
-<p class="docs-hubs">La documentación de WordPress Playground está repartida en cuatro hubs diferentes (subsites):</p>
+<!--
+Playground is an online tool to experiment and learn about WordPress. This site (Documentation) is where you will find all the information you need to start using Playground.
+-->
 
--   👉 [**Documentación**](/) (estás aqui) – Introducción a WP Playground, guías de inicio y tu punto de entrada a la Documentación de WP Playground.
--   [**Blueprints**](/blueprints) – Blueprints son archivos JSON files para configurar tu instancia de WordPress Playground instance. Descubre sus posibilidades en el hub de documentación de Blueprints.
--   [**Desarrolladores**](/developers) – WordPress Playground ha sido ceeado como una herramientas programable. Descubre todo lo que puedes hacer desde tu código con Wp Playground en el hub de documentación para Desarrolladores.
--   [**Referencia de la API**](/api) – Referencia de todas las APIs públicas de WordPress Playground.
+Playground es una herramienta en línea para experimentar y aprender sobre WordPress. Este sitio (Documentación) es donde encontrarás toda la información que necesitas para comenzar a usar Playground.
+
+<!--
+<p class="docs-hubs">The WordPress Playground documentation is distributed across four separate hubs (subsites):</p>
+
+-   👉 [**Documentation**](/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
+-   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
+-   [**Developers**](/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
+-   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
+-->
+
+<p class="docs-hubs">La documentación de WordPress Playground está distribuida en cuatro hubs separados (subsitios):</p>
+
+-   👉 [**Documentación**](/) (estás aquí) – Introducción a WP Playground, guías de inicio y tu punto de entrada a la documentación de WP Playground.
+-   [**Blueprints**](/blueprints) – Los Blueprints son archivos JSON para configurar tu instancia de WordPress Playground. Aprende sobre sus posibilidades desde el hub de documentación de Blueprints.
+-   [**Desarrolladores**](/developers) – WordPress Playground fue creado como una herramienta programable. Descubre todo lo que puedes hacer con él desde tu código en el hub de documentación para Desarrolladores.
+-   [**Referencia de la API**](/api) – Todas las APIs expuestas por WordPress Playground
+
+<!--
+## Navigating this documentation hub
+-->
 
 ## Navegando este hub de documentación
 
-Este hub de documentación está focalizado en ayudarte a empezar a trabajar con WordPress Playground y está organizado en las siguientes secciones:
+<!--
+This docs hub is focused on starting with WordPress Playground and is divided into the following major sections.
 
--   **[Guía de inicio rapido](/quick-start-guide)**: Para aquellos que quieren empezar con WordPress Playground, en esta guía aprenderás como poner en marcha rapidamente [un sitio WordPress](/quick-start-guide#start-a-new-wordpress-site) para [probar un bloque, un tema o un plugin](/quick-start-guide#try-a-block-a-theme-or-a-plugin) o para [testear una versión específicad de WordPress o PHP](/quick-start-guide#use-a-specific-wordpress-or-php-version).
+-   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/quick-start-guide#use-a-specific-wordpress-or-php-version).
 
--   **[La instancia de WP Playground](/web-instance)**: Aprende los detalles de la instancia pública de WP Playground que está disponible en https://playground.wordpress.net/
+-   **[Playground web instance](/web-instance)**: Learn more about the Playground instance you get at https://playground.wordpress.net/
 
--   **[Sobre WP Playground](/about)**: Visita esta sección para aprender sobre WordPress Playground, cómo es de seguro, lo que puedes hacer con Playground y algunas de sus limitaciines.
+-   **[About Playground](/about)**: To learn about WordPress Playground, how safe it is, what you can do with and some of its current limitations, visit this section.
 
-    Descubre como sacar partido de WordPress Playground para [Construir](/about/build), [Testear](/about/test), y [Lanzar](/about/launch) tus productos.
+    Discover how you can leverage WordPress Playground to [Build](./about/build), [Test](./about/test), and [Launch](./about/launch) your products.
 
--   **[Guías](/guides/)**: Explora estas guías para aprender más en profundidad sobre algunos de los conceptos o aplicaciones prácticas más populares de WordPress Playground!
+-   **[Guides](/guides)**: Explore our comprehensive guides to master new skills, find step-by-step instructions, and unlock valuable insights. Dive in to learn and grow!
 
--   **[Contribuir](/contributing/)**: WordPress Playground es un proyecto open-source y todas las aportaciones al mismo son bienvenidas. Puedes contribuir al proyecto ayudando con el código, con el diseño, con la documentación o con la organización de tareas. En esta sección encontrarás información sobre cómo contribuir al proyecto.
+-   **[Contributing](/contributing)**: WordPress Playground is an open-source project that welcomes all contributors—from code to design, documentation to triage. Learn here how to contribute.
 
--   **[Enlaces y recursos](/resources)**: Una compilación de enlaces útiles y recursos relacionados con WordPress Playground.
+-   **[Links and resources](/resources)**: A nice compilation of useful links and resources related to WordPress Playground.
+-->
+
+Este hub de documentación está enfocado en comenzar con WordPress Playground y está dividido en las siguientes secciones principales.
+
+-   **[Guía de inicio rápido](/quick-start-guide)**: Para aquellos que recién comienzan con WordPress Playground, aquí es donde puedes ponerte en marcha rápidamente con WordPress Playground para [iniciar un nuevo sitio de WordPress](/quick-start-guide#start-a-new-wordpress-site) y [probar un bloque/tema/plugin](/quick-start-guide#try-a-block-a-theme-or-a-plugin) o [probar una versión específica de WordPress/PHP](/quick-start-guide#use-a-specific-wordpress-or-php-version).
+
+-   **[Instancia web de Playground](/web-instance)**: Aprende más sobre la instancia de Playground que obtienes en https://playground.wordpress.net/
+
+-   **[Acerca de Playground](/about)**: Para aprender sobre WordPress Playground, qué tan seguro es, qué puedes hacer con él y algunas de sus limitaciones actuales, visita esta sección.
+
+    Descubre cómo puedes aprovechar WordPress Playground para [Construir](./about/build), [Probar](./about/test) y [Lanzar](./about/launch) tus productos.
+
+-   **[Guías](/guides)**: Explora nuestras guías completas para dominar nuevas habilidades, encontrar instrucciones paso a paso y desbloquear información valiosa. ¡Sumérgete para aprender y crecer!
+
+-   **[Contribuir](/contributing)**: WordPress Playground es un proyecto de código abierto que da la bienvenida a todos los contribuidores, desde código hasta diseño, documentación hasta clasificación. Aprende aquí cómo contribuir.
+
+-   **[Enlaces y recursos](/resources)**: Una buena recopilación de enlaces útiles y recursos relacionados con WordPress Playground.
+
+<!--
+## First steps
+-->
 
 ## Primeros pasos
 
-Ya seas un desarrollador, un usuario sin conocimientos técnicos o alguien interesado en contribuir al proyecto, esta documentación te ayudará a dar tus primeros pasos con WordPress Playground.
+<!--
+Whether you're a developer, a non-technical user, or a contributor, these docs will guide you as you start your learning journey:
 
--   [Empieza a usar WordPress Playground](/quick-start-guide) en 5 minutos.
--   [Empieza a desarrollar](/developers/build-your-first-app) con WordPress Playground.
--   Utiliza Playground como un [entorno de desarrollo local](/developers/local-development/) con zero-setup.
--   Infórmate sobre las [limitaciones](/developers/limitations) de WP Playground.
+-   [Start using WordPress Playground](/quick-start-guide) in 5 minutes (and check out the [demo site](https://playground.wordpress.net/))
+-   [Get started for developing](/developers/build-your-first-app) with WordPress Playground
+-   Use Playground as a zero-setup [local development environment](/developers/local-development/)
+-   Read about the [limitations](/developers/limitations)
 -   [WordCamp Contributor Day](/contributing/contributor-day)
+-->
+
+Ya seas desarrollador, usuario no técnico o contribuidor, estas documentaciones te guiarán mientras comienzas tu viaje de aprendizaje:
+
+-   [Comienza a usar WordPress Playground](/quick-start-guide) en 5 minutos (y mira el [sitio de demostración](https://playground.wordpress.net/))
+-   [Comienza a desarrollar](/developers/build-your-first-app) con WordPress Playground
+-   Usa Playground como un [entorno de desarrollo local](/developers/local-development/) sin configuración
+-   Lee sobre las [limitaciones](/developers/limitations)
+-   [Día del Contribuidor de WordCamp](/contributing/contributor-day)
+
+<!--
+:::tip
+Read [**Introduction to Playground: running WordPress in the browser**](https://developer.wordpress.org/news/2024/04/05/introduction-to-playground-running-wordpress-in-the-browser/) blog post in the [WordPress Developer Blog](https://developer.wordpress.org/news) for a great introduction to WordPress Playground
+:::
+-->
 
 :::tip
-El articulo [**Introduction to Playground: running WordPress in the browser**](https://developer.wordpress.org/news/2024/04/05/introduction-to-playground-running-wordpress-in-the-browser/) del [Blog para Desarrolladores de WordPress](https://developer.wordpress.org/news) es una gran introducción a WordPress Playground.
+Lee la publicación del blog [**Introducción a Playground: ejecutando WordPress en el navegador**](https://developer.wordpress.org/news/2024/04/05/introduction-to-playground-running-wordpress-in-the-browser/) en el [Blog de Desarrolladores de WordPress](https://developer.wordpress.org/news) para una excelente introducción a WordPress Playground
 :::
 
-## Profundiza un poco más
+<!--
+## Take a deep dive
+-->
 
-Si eres un desarrollador o un usuario técnico, quizás quieras ver directamente las APIs de WP Playground que hay disponibles:
+## Profundiza más
+
+<!--
+If you're a developer or tech user, you may want to check directly the APIs available:
+-->
+
+Si eres desarrollador o usuario técnico, es posible que desees revisar directamente las APIs disponibles:
 
 import APIList from '@site/docs/\_fragments/\_api_list.mdx';
 
--   Las [APIs de Playground](/developers/apis/) y algunos conceptos básicos.
--   [Enlaces y recursos](/resources)
+<!--
+-   Read about [Playground APIs](/developers/apis/) and basic concepts
+-   Review [links and resources](/resources)
+-   Choose the right API for your app <APIList />
+-   Dive into the [architecture](/developers/architecture) and learn how it all works
+-->
+
+-   Lee sobre las [APIs de Playground](/developers/apis/) y conceptos básicos
+-   Revisa [enlaces y recursos](/resources)
 -   Elige la API adecuada para tu aplicación <APIList />
--   Profundiza en la [arquitectura](/developers/architecture) y aprende como WP Playground funciona internamente.
+-   Sumérgete en la [arquitectura](/developers/architecture) y aprende cómo funciona todo
 
-## Involúcrate
+<!--
+## Get Involved
+-->
 
-WordPress Playground es un proyecto open-source y todas las aportaciones al mismo son bienvenidas, desde código hasta diseño, desde documentación hasta organización de tareas del proyecto. No te preocupes, ¡_no necesitas saber de WebAssembly_ para contribuir al proyecto!
+## Participa
 
--   Echa un vistazo al [Contributors Handbook](/contributing/) para todo lo que necesitas saber para contribuir al proyecto.
--   Únete al canal de Slack `#playground` (en la página [WordPress Slack](https://make.wordpress.org/chat/) encontrarás la información sobre como acceder al Slack de WordPress)
+<!--
+WordPress Playground is an open-source project and welcomes all contributors from code to design, and from documentation to triage. Don't worry, _you don't need to know WebAssembly_ to contribute!
 
-Como con todos los proyectos de WordPress, queremos asegurar en entorno seguro y acogedor para todos. Con esto en mente, se espera de todos los contribuidores que cumplan con nuestro [código de conducta](https://make.wordpress.org/handbook/community-code-of-conduct/).
+-   See the [Contributors Handbook](/contributing) for all the details on how you can contribute.
+-   Join us in the `#playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
+
+As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).
+-->
+
+WordPress Playground es un proyecto de código abierto y da la bienvenida a todos los contribuidores, desde código hasta diseño, y desde documentación hasta clasificación. No te preocupes, ¡_no necesitas saber WebAssembly_ para contribuir!
+
+-   Consulta el [Manual de Contribuidores](/contributing) para todos los detalles sobre cómo puedes contribuir.
+-   Únete a nosotros en el canal `#playground` en Slack (consulta la [página de WordPress Slack](https://make.wordpress.org/chat/) para información de registro)
+
+Al igual que con todos los proyectos de WordPress, queremos asegurar un entorno acogedor para todos. Con esto en mente, se espera que todos los contribuidores sigan nuestro [Código de Conducta](https://make.wordpress.org/handbook/community-code-of-conduct/).
+
+<!--
+## License
+-->
 
 ## Licencia
 
-WordPress Playground es software libre disponible bajor los términos de la GNU General Public License version 2 o (si lo prefieres) cualquier versión posterior. La licencia completa está disponible en [LICENSE.md](https://github.com/WordPress/wordpress-playground/blob/trunk/LICENSE).
+<!--
+WordPress Playground is free software released under the terms of the GNU General Public License version 2 or (at your option) any later version. For a complete license, see [LICENSE.md](https://github.com/WordPress/wordpress-playground/blob/trunk/LICENSE).
+-->
+
+WordPress Playground es software libre lanzado bajo los términos de la Licencia Pública General de GNU versión 2 o (a tu elección) cualquier versión posterior. Para una licencia completa, consulta [LICENSE.md](https://github.com/WordPress/wordpress-playground/blob/trunk/LICENSE).
 
 <br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -1,0 +1,279 @@
+---
+title: Guía de inicio rápido
+slug: /quick-start-guide
+description: Una guía de 5 minutos para comenzar con Playground. Aprende a probar plugins, probar temas y usar diferentes versiones de WP/PHP.
+---
+
+import ThisIsQueryApi from '@site/docs/\_fragments/\_this_is_query_api.md';
+
+<!--
+# Start using WordPress Playground in 5 minutes
+-->
+
+# Comienza a usar WordPress Playground en 5 minutos
+
+<!--
+WordPress Playground can help you with any of the following:
+-->
+
+WordPress Playground puede ayudarte con cualquiera de las siguientes tareas:
+
+import TOCInline from '@theme/TOCInline';
+
+<TOCInline toc={toc} />
+
+<!--
+This page will guide you through each of these. Oh, and if you're a visual learner – here's a video:
+-->
+
+Esta página te guiará a través de cada una de ellas. Ah, y si eres un aprendiz visual, aquí hay un video:
+
+<iframe width="752" height="423.2" title="Getting started with WordPress Playground" src="https://video.wordpress.com/v/3UBIXJ9S?autoPlay=false&amp;height=1080&amp;width=1920&amp;fill=true" class="editor-media-modal-detail__preview is-video" allowFullScreen></iframe>
+
+<!--
+## Start a new WordPress site
+-->
+
+## Inicia un nuevo sitio de WordPress
+
+<!--
+Every time you visit the [official demo on playground.wordpress.net](https://playground.wordpress.net/), you get a fresh WordPress site.
+-->
+
+Cada vez que visitas la [demostración oficial en playground.wordpress.net](https://playground.wordpress.net/), obtienes un sitio de WordPress nuevo.
+
+<!--
+You can then create pages, upload plugins, themes, import your own site, and do most things you would do on a regular WordPress.
+-->
+
+Luego puedes crear páginas, subir plugins, temas, importar tu propio sitio y hacer la mayoría de las cosas que harías en un WordPress normal.
+
+<!--
+It's that easy to start!
+-->
+
+¡Es así de fácil comenzar!
+
+<!--
+The entire site lives in your browser and is scraped when you close the tab. Want to start over? Just refresh the page!
+-->
+
+Todo el sitio vive en tu navegador y se elimina cuando cierras la pestaña. ¿Quieres empezar de nuevo? ¡Solo actualiza la página!
+
+<!--
+:::info WordPress Playground is private
+
+Everything you build stays in your browser and is **not** sent anywhere. Once you're finished, you can export your site as a zip file. Or just refresh the page and start over!
+
+:::
+-->
+
+:::info WordPress Playground es privado
+
+Todo lo que construyes permanece en tu navegador y **no** se envía a ninguna parte. Una vez que termines, puedes exportar tu sitio como un archivo zip. ¡O simplemente actualiza la página y comienza de nuevo!
+
+:::
+
+<!--
+## Try a block, a theme, or a plugin
+-->
+
+## Prueba un bloque, un tema o un plugin
+
+<!--
+You can upload any plugin or theme you want in [/wp-admin/](https://playground.wordpress.net/?url=/wp-admin/).
+-->
+
+Puedes subir cualquier plugin o tema que desees en [/wp-admin/](https://playground.wordpress.net/?url=/wp-admin/).
+
+<!--
+To save a few clicks, you can preinstall plugins or themes from the WordPress plugin directory by adding a `plugin` or `theme` parameter to the URL. For example, to install the coblocks plugin, you can use this URL:
+-->
+
+Para ahorrar algunos clics, puedes preinstalar plugins o temas del directorio de plugins de WordPress agregando un parámetro `plugin` o `theme` a la URL. Por ejemplo, para instalar el plugin coblocks, puedes usar esta URL:
+
+https://playground.wordpress.net/?plugin=coblocks
+
+<!--
+Or this URL to preinstall the `pendant` theme:
+-->
+
+O esta URL para preinstalar el tema `pendant`:
+
+https://playground.wordpress.net/?theme=pendant
+
+<!--
+In case you would like to install multiple themes and plugins, it is possible to repeat the `theme` or `plugin` parameters:
+-->
+
+En caso de que desees instalar múltiples temas y plugins, es posible repetir los parámetros `theme` o `plugin`:
+
+https://playground.wordpress.net/?theme=pendant&theme=acai
+
+<!--
+You can also mix and match these parameters and even add multiple plugins:
+-->
+
+También puedes mezclar y combinar estos parámetros e incluso agregar múltiples plugins:
+
+https://playground.wordpress.net/?plugin=coblocks&plugin=friends&theme=pendant
+
+<ThisIsQueryApi />
+
+<!--
+## Save your site
+-->
+
+## Guarda tu sitio
+
+<!--
+To keep your WordPress Playground site for longer than a single browser session, you can export it as a `.zip` file.
+
+1. Open the Playground site manager panel:
+-->
+
+Para mantener tu sitio de WordPress Playground por más tiempo que una sola sesión del navegador, puedes exportarlo como un archivo `.zip`.
+
+1. Abre el panel del administrador de sitios de Playground:
+
+![Site Manager](@site/static/img/open-site-manager.webp)
+
+<!--
+2. Use the "Download as .zip" button in the additional actions menu
+-->
+
+2. Usa el botón "Descargar como .zip" en el menú de acciones adicionales
+
+![Export button](@site/static/img/site-manager-menu.webp)
+
+<!--
+The exported file contains the complete site you've built. You could host it on any server that supports PHP and SQLite. All WordPress core files, plugins, themes, and everything else you've added to your site are in there.
+-->
+
+El archivo exportado contiene el sitio completo que has construido. Podrías alojarlo en cualquier servidor que admita PHP y SQLite. Todos los archivos principales de WordPress, plugins, temas y todo lo demás que hayas agregado a tu sitio están allí.
+
+<!--
+The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
+-->
+
+El archivo de base de datos SQLite también está incluido en la exportación, lo encontrarás en `wp-content/database/.ht.sqlite`. Ten en cuenta que los archivos que comienzan con un punto están ocultos por defecto en la mayoría de los sistemas operativos, por lo que es posible que necesites habilitar la opción "Mostrar archivos ocultos" en tu administrador de archivos.
+
+<!--
+## Restore a saved site
+-->
+
+## Restaura un sitio guardado
+
+<!--
+You can restore the saved site using the "Import from .zip" button in the site management panel:
+-->
+
+Puedes restaurar el sitio guardado usando el botón "Importar desde .zip" en el panel de administración del sitio:
+
+![Import from .zip button](@site/static/img/site-manager-import-actions-menu.webp)
+
+<!--
+## Use a specific WordPress or PHP version
+-->
+
+## Usa una versión específica de WordPress o PHP
+
+<!--
+The quickest way to change the version of WordPress or PHP is by using the settings panel on the [official demo site](https://playground.wordpress.net/):
+-->
+
+La forma más rápida de cambiar la versión de WordPress o PHP es usando el panel de configuración en el [sitio de demostración oficial](https://playground.wordpress.net/):
+
+![WordPress Playground Settings menu](@site/static/img/playground-settings-menu.webp)
+
+<!--
+:::info Test your plugin or theme
+
+Compatibility testing with so many WordPress and PHP versions was always a pain. WordPress Playground makes this process effortless – use it to your advantage!
+
+:::
+-->
+
+:::info Prueba tu plugin o tema
+
+Las pruebas de compatibilidad con tantas versiones de WordPress y PHP siempre fueron un dolor de cabeza. WordPress Playground hace este proceso sin esfuerzo: ¡úsalo a tu favor!
+
+:::
+
+<!--
+You can also use the `wp` and `php` [query parameters](/developers/apis/query-api) to open Playground with the right versions already loaded:
+
+-   https://playground.wordpress.net/?wp=6.5
+-   https://playground.wordpress.net/?php=8.3
+-   https://playground.wordpress.net/?php=8.2&wp=6.2
+-->
+
+También puedes usar los [parámetros de consulta](/developers/apis/query-api) `wp` y `php` para abrir Playground con las versiones correctas ya cargadas:
+
+-   https://playground.wordpress.net/?wp=6.5
+-   https://playground.wordpress.net/?php=8.3
+-   https://playground.wordpress.net/?php=8.2&wp=6.2
+
+<ThisIsQueryApi />
+
+<!--
+To learn more about preparing content for demos, see the [providing content for your demo guide](/guides/providing-content-for-your-demo).
+-->
+
+Para aprender más sobre la preparación de contenido para demostraciones, consulta la [guía de proporcionar contenido para tu demostración](/guides/providing-content-for-your-demo).
+
+<!--
+:::info Major versions only
+
+You can specify major versions like `wp=6.2` or `php=8.1` and expect the most recent release in that line. You cannot, however, request older minor versions so neither `wp=6.1.2` nor `php=7.4.9` will work.
+
+:::
+-->
+
+:::info Solo versiones principales
+
+Puedes especificar versiones principales como `wp=6.2` o `php=8.1` y esperar la versión más reciente en esa línea. Sin embargo, no puedes solicitar versiones menores antiguas, por lo que ni `wp=6.1.2` ni `php=7.4.9` funcionarán.
+
+:::
+
+<!--
+## Import a WXR file
+-->
+
+## Importa un archivo WXR
+
+<!--
+You can import a WordPress export file by uploading a WXR file in [/wp-admin/](https://playground.wordpress.net/?url=/wp-admin/import.php).
+-->
+
+Puedes importar un archivo de exportación de WordPress cargando un archivo WXR en [/wp-admin/](https://playground.wordpress.net/?url=/wp-admin/import.php).
+
+<!--
+You can also use [JSON Blueprints](/blueprints). See [getting started with Blueprints](/blueprints/getting-started) to learn more.
+-->
+
+También puedes usar [Blueprints JSON](/blueprints). Consulta [comenzando con Blueprints](/blueprints/getting-started) para aprender más.
+
+<!--
+This is different from the import feature described above. The import feature exports the entire site, including the database. This import feature imports a WXR file into an existing site.
+-->
+
+Esto es diferente de la función de importación descrita anteriormente. La función de importación exporta todo el sitio, incluida la base de datos. Esta función de importación importa un archivo WXR en un sitio existente.
+
+<!--
+## Build apps with WordPress Playground
+-->
+
+## Construye aplicaciones con WordPress Playground
+
+<!--
+WordPress Playground is programmable, which means you can [build WordPress apps](/developers/build-your-first-app), setup plugin demos, and even use it as a zero-setup [local development environment](/developers/local-development/).
+-->
+
+WordPress Playground es programable, lo que significa que puedes [construir aplicaciones de WordPress](/developers/build-your-first-app), configurar demostraciones de plugins e incluso usarlo como un [entorno de desarrollo local](/developers/local-development/) sin configuración.
+
+<!--
+To learn more about developing with WordPress Playground, check out the [development quick start](/developers/build-your-first-app) section.
+-->
+
+Para aprender más sobre el desarrollo con WordPress Playground, consulta la sección de [inicio rápido de desarrollo](/developers/build-your-first-app).

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -1,0 +1,169 @@
+---
+title: Instancia Web
+slug: /web-instance
+description: Una guía detallada de la interfaz web en playground.wordpress.net, cubriendo la barra de herramientas, configuración y administrador de instancias.
+---
+
+<!--
+# WordPress Playground web instance
+-->
+
+# Instancia web de WordPress Playground
+
+<!--
+[https://playground.wordpress.net/](https://playground.wordpress.net/) is a versatile web tool that allows developers to run WordPress in a browser without needing a server. This environment is particularly useful for testing plugins, themes, and other WordPress features quickly and efficiently.
+-->
+
+[https://playground.wordpress.net/](https://playground.wordpress.net/) es una herramienta web versátil que permite a los desarrolladores ejecutar WordPress en un navegador sin necesidad de un servidor. Este entorno es particularmente útil para probar plugins, temas y otras características de WordPress de manera rápida y eficiente.
+
+<!--
+Some key features:
+
+-   **Browser-based**: No local server setup required.
+-   **Instant Setup**: Run WordPress with a single click.
+-   **Testing Environment**: Ideal for testing plugins and themes.
+-->
+
+Algunas características clave:
+
+-   **Basado en navegador**: No se requiere configuración de servidor local.
+-   **Configuración instantánea**: Ejecuta WordPress con un solo clic.
+-   **Entorno de prueba**: Ideal para probar plugins y temas.
+
+<!--
+The [Query Params API](/developers/apis/query-api/) allows you to directly load specific configurations into a Playground instance. This includes setting a particular WordPress version, theme, or plugin. You can also define more complex setups using blueprints (see [examples here](/quick-start-guide#try-a-block-a-theme-or-a-plugin)).
+-->
+
+La [API de parámetros de consulta](/developers/apis/query-api/) te permite cargar directamente configuraciones específicas en una instancia de Playground. Esto incluye establecer una versión particular de WordPress, tema o plugin. También puedes definir configuraciones más complejas usando blueprints (consulta [ejemplos aquí](/quick-start-guide#try-a-block-a-theme-or-a-plugin)).
+
+<!--
+From the Playground website, some toolbars are also available to customize your Playground instance and provide quick access to some resources and utilities.
+-->
+
+Desde el sitio web de Playground, también hay algunas barras de herramientas disponibles para personalizar tu instancia de Playground y proporcionar acceso rápido a algunos recursos y utilidades.
+
+![Playground Toolbar Snapshot](@site/static/img/about/toolbar-playground.webp)
+
+<!--
+## Customize Playground
+-->
+
+## Personalizar Playground
+
+<!--
+On the toolbar, you'll find:
+
+-   **Playground Settings**: A panel for configuring your current instance, like PHP and WordPress versions.
+-   **Playground Manager**: This panel lets you manage WordPress Playground instances, allowing you to save, import, and export them.
+-->
+
+En la barra de herramientas, encontrarás:
+
+-   **Configuración de Playground**: Un panel para configurar tu instancia actual, como las versiones de PHP y WordPress.
+-   **Administrador de Playground**: Este panel te permite administrar instancias de WordPress Playground, permitiéndote guardar, importar y exportarlas.
+
+<!--
+### Playground Settings
+-->
+
+### Configuración de Playground
+
+![snapshot of customize Playground window at Playground instance](@site/static/img/about/playground-settings-panel.webp)
+
+<!--
+The options available from the **Playground Settings Panel**, correspond to the following [Query API options](/developers/apis/query-api#available-options):
+
+-   `language`: Sets the WordPress instance language.
+-   `multisite`: Enables WordPress multisite support.
+-   `networking`: Grants network access, allowing fetches from the WordPress plugin directory and internal WordPress APIs.
+-   `php`: Specifies the PHP version for the instance.
+-   `wp`: Defines the WordPress version.
+-->
+
+Las opciones disponibles desde el **Panel de Configuración de Playground**, corresponden a las siguientes [opciones de la API de consulta](/developers/apis/query-api#available-options):
+
+-   `language`: Establece el idioma de la instancia de WordPress.
+-   `multisite`: Habilita el soporte multisitio de WordPress.
+-   `networking`: Otorga acceso a la red, permitiendo obtener datos del directorio de plugins de WordPress y las APIs internas de WordPress.
+-   `php`: Especifica la versión de PHP para la instancia.
+-   `wp`: Define la versión de WordPress.
+
+<!--
+## Playground Manager
+-->
+
+## Administrador de Playground
+
+![Playground settings panel allow users to manage multiple instances](@site/static/img/about/playground-manager-panel.webp)
+
+<!--
+This panel enables users to manage Playground instances. It displays a list of saved Playgrounds and provides access to the current Playground's settings, along with a **Save Button** to store your configurations locally in your browser for later reloading.
+-->
+
+Este panel permite a los usuarios administrar instancias de Playground. Muestra una lista de Playgrounds guardados y proporciona acceso a la configuración del Playground actual, junto con un **Botón Guardar** para almacenar tus configuraciones localmente en tu navegador para volver a cargarlas más tarde.
+
+![Save Playground Button](@site/static/img/about/playground-manager-save-instance.webp)
+
+<!--
+Once you click on save, an instance will be stored with a generated name to be revisited anytime. The Playground Manager also has options to export(Additional actions menu) and import(Import actions menu) WordPress Playground instances:
+-->
+
+Una vez que hagas clic en guardar, se almacenará una instancia con un nombre generado para ser revisitada en cualquier momento. El Administrador de Playground también tiene opciones para exportar (menú de acciones adicionales) e importar (menú de acciones de importación) instancias de WordPress Playground:
+
+<!--
+### Additional actions menu
+-->
+
+### Menú de acciones adicionales
+
+![Additional actions Menu](@site/static/img/about/playground-manager-additional-actions.webp)
+
+<!--
+-   **Export Pull Request to GitHub**: This option allows you to export WordPress plugins, themes, and entire wp-content directories as pull requests to any public GitHub repository. Check [here](https://www.youtube.com/watch?v=gKrij8V3nK0&t=2488s) a demo of using this option.
+-   **Download as zip**: It creates a `.zip` with the setup of the Playground instance, including any themes or plugins installed. This `.zip` won't include content and database changes.
+-   **Report error**: If you have any issues with WP Playground, you can report it using the form available from this option. You can help resolve issues with Playground by sharing the error details with the development team behind Playground.
+-   **View Blueprint**: This option will open the current blueprint used for the Playground instance in the [Blueprints Builder tool](https://playground.wordpress.net/builder/builder.html). From this tool you'll be able to edit the blueprint online and run a new Playground instance with your edited version of the blueprint.
+-->
+
+-   **Exportar Pull Request a GitHub**: Esta opción te permite exportar plugins de WordPress, temas y directorios completos de wp-content como pull requests a cualquier repositorio público de GitHub. Mira [aquí](https://www.youtube.com/watch?v=gKrij8V3nK0&t=2488s) una demostración del uso de esta opción.
+-   **Descargar como zip**: Crea un `.zip` con la configuración de la instancia de Playground, incluidos los temas o plugins instalados. Este `.zip` no incluirá contenido ni cambios en la base de datos.
+-   **Reportar error**: Si tienes algún problema con WP Playground, puedes reportarlo usando el formulario disponible desde esta opción. Puedes ayudar a resolver problemas con Playground compartiendo los detalles del error con el equipo de desarrollo detrás de Playground.
+-   **Ver Blueprint**: Esta opción abrirá el blueprint actual utilizado para la instancia de Playground en la [herramienta Blueprints Builder](https://playground.wordpress.net/builder/builder.html). Desde esta herramienta podrás editar el blueprint en línea y ejecutar una nueva instancia de Playground con tu versión editada del blueprint.
+
+<span id="edit-the-blueprint"></span>
+
+[![snapshot of Builder mode of WordPress Playground](@site/static/img/about/blueprint-builder.webp)](https://playground.wordpress.net/builder/builder.html)
+
+<!--
+### Import actions menu
+-->
+
+### Menú de acciones de importación
+
+![Import actions Menu](@site/static/img/about/playground-manager-import-actions.webp)
+
+<!--
+-   **Import from zip**: It allows you to recreate a Playground instance using any `.zip` generated with the "Download as zip" option.
+-   **Preview a Gutenberg PR**: Allow testers run branches from the Gutenberg repository to test pull requests instantly.
+-   **Import from GitHub**: This option allows you to import plugins, themes, and wp-content directories directly from your public GitHub repositories. To enable this feature, connect your GitHub account with WordPress Playground.
+-->
+
+-   **Importar desde zip**: Te permite recrear una instancia de Playground usando cualquier `.zip` generado con la opción "Descargar como zip".
+-   **Previsualizar un PR de Gutenberg**: Permite a los testers ejecutar ramas del repositorio de Gutenberg para probar pull requests instantáneamente.
+-   **Importar desde GitHub**: Esta opción te permite importar plugins, temas y directorios de wp-content directamente desde tus repositorios públicos de GitHub. Para habilitar esta función, conecta tu cuenta de GitHub con WordPress Playground.
+
+<!--
+:::caution
+
+The site at https://playground.wordpress.net is there to support the community, but there are no guarantees it will continue to work if the traffic grows significantly.
+
+If you need certain availability, you should [host your own WordPress Playground](/developers/architecture/host-your-own-playground).
+:::
+-->
+
+:::caution
+
+El sitio en https://playground.wordpress.net está ahí para apoyar a la comunidad, pero no hay garantías de que continúe funcionando si el tráfico crece significativamente.
+
+Si necesitas cierta disponibilidad, deberías [alojar tu propio WordPress Playground](/developers/architecture/host-your-own-playground).
+:::


### PR DESCRIPTION
This pull request adds a new "Guía de inicio rápido" (Quick Start Guide) to the Spanish documentation and significantly improves the introduction page for WordPress Playground. The changes focus on providing clearer explanations, better organization, and more helpful navigation for Spanish-speaking users. The introduction page now includes a more detailed overview, improved section descriptions, and clearer instructions for getting started and contributing.

**New documentation and improved structure:**

* Added a comprehensive `quick-start-guide.md` in Spanish, covering how to start a WordPress Playground site, test plugins/themes, save/restore sites, use different WP/PHP versions, import WXR files, and build apps.
* Enhanced the introduction in `intro.md` with a new description, improved section breakdowns, and clearer guidance for navigating the documentation hubs.

**Content quality and clarity improvements:**

* Rewrote and expanded section explanations, including clearer instructions for first steps, deeper technical dives, and how to get involved with the project.
* Improved translation accuracy and consistency throughout the introduction page, aligning Spanish content more closely with the original English documentation.

**Contributor and licensing information:**

* Updated contributor instructions and code of conduct references to provide a more welcoming and inclusive environment for new contributors.
* Clarified licensing terms and added a direct link to the full license document.