### PR TITLE
Add some improvements in the Spanish translations

### DIFF
--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -1,20 +1,20 @@
 ---
 slug: /contributing/contributor-day
-title: Día del Contribuidor de WordCamp
-description: Una guía sobre cómo contribuir a WordPress Playground y cómo puede ayudarte en el Día del Contribuidor.
+title: Día del contribuidor en una WordCamp
+description: Una guía sobre cómo contribuir a WordPress Playground y cómo puede ayudarte en el día del contribuidor.
 ---
 
 <!--
 # WordCamp Contributor Day
 -->
 
-# Día del Contribuidor de WordCamp
+# Día del contribuidor en una WordCamp
 
 <!--
 WordCamp Contributor Day is an event where the WordPress community comes together to contribute to the WordPress project. This guide focuses on how you can contribute to the WordPress Playground project or how the Playground can assist you in contributing to WordPress Core.
 -->
 
-El Día del Contribuidor de WordCamp es un evento donde la comunidad de WordPress se reúne para contribuir al proyecto WordPress. Esta guía se centra en cómo puedes contribuir al proyecto WordPress Playground o cómo Playground puede ayudarte a contribuir a WordPress Core.
+El día del contribuidor en una WordCamp es un evento donde la comunidad de WordPress se reúne para contribuir al proyecto WordPress. Esta guía se centra en cómo puedes contribuir al proyecto WordPress Playground o cómo Playground puede ayudarte a contribuir a WordPress Core.
 
 <!--
 ## Who Can Contribute?
@@ -26,13 +26,13 @@ El Día del Contribuidor de WordCamp es un evento donde la comunidad de WordPres
 Some events will have a dedicated table for the project. The WordPress Playground contributor tables welcome all kinds of contributions, not just from developers. Whether you are a writer, coder, tester, plugin or theme developer, marketer, site owner, or any other type of user, you are encouraged to contribute.
 -->
 
-Algunos eventos tendrán una mesa dedicada al proyecto. Las mesas de contribuidores de WordPress Playground dan la bienvenida a todo tipo de contribuciones, no solo de desarrolladores. Ya seas escritor, programador, probador, desarrollador de plugins o temas, especialista en marketing, propietario de sitio o cualquier otro tipo de usuario, te animamos a contribuir.
+Algunos eventos tendrán una mesa dedicada al proyecto. Las mesas de contribuidores de WordPress Playground aceptan todo tipo de contribuciones, no solo de desarrolladores. Ya seas escritor, programador, verificador, desarrollador de plugins o temas, especialista en marketing, propietario de un sitio o cualquier otro tipo de usuario, te animamos a contribuir.
 
 <!--
 We value diverse contributions across various areas, including community building, testing, documentation, and design.
 -->
 
-Valoramos las contribuciones diversas en varias áreas, incluyendo construcción de comunidad, pruebas, documentación y diseño.
+Valoramos las contribuciones diversas en varias áreas, incluyendo la creación de comunidades, las pruebas, la documentación y el diseño.
 
 <!--
 ## How to Contribute to the Playground Project
@@ -53,16 +53,16 @@ Esta sección describe cómo puedes contribuir directamente al proyecto WordPres
 -   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
 -->
 
--   **Documentación:** Mejora nuestra documentación mejorando el contenido existente, desarrollando nuevas guías o traduciendo materiales a diferentes idiomas.
--   **Blueprints:** Crea demostraciones de plugins para los plugins en el repositorio de Plugins de WordPress, o desarrolla nuevos Blueprints para enriquecer nuestra documentación del proyecto.
--   **Pruebas del entorno Playground:** Participa en las pruebas del proyecto WordPress Playground en sí. Puedes hacer esto creando cuidadosamente nuevos issues que describan los problemas que encuentres y sugiriendo soluciones prácticas. Prueba nuestra instancia web de WordPress (el sitio playground.wordpress.net), o explora las diversas aplicaciones impulsadas por Playground. Prueba estas herramientas, observa su funcionalidad y proporciona comentarios detallados.
--   **Retroalimentación del producto:** Tus ideas son invaluables para mejorar la experiencia de Playground. Esto incluye comentarios generales sobre la instancia web, la aplicación y cualquier herramienta del lado del servidor.
+-   **Documentación:** Mejora nuestra documentación perfeccionando el contenido existente, desarrollando nuevas guías o traduciendo materiales a diferentes idiomas.
+-   **Blueprints:** Crea demostraciones de plugins para los plugins del repositorio de plugins de WordPress o desarrolla nuevos Blueprints para enriquecer la documentación de nuestro proyecto.
+-   **Pruebas del entorno Playground:** Participa en las pruebas del propio proyecto WordPress Playground. Puedes hacerlo elaborando cuidadosamente nuevas incidencias que describan los problemas que encuentres y sugiriendo soluciones viables. Prueba nuestra instancia web de WordPress (el sitio playground.wordpress.net) o explora las diversas aplicaciones que funcionan con Playground. Prueba estas herramientas, observa su funcionalidad y proporciona comentarios detallados.
+-   **Comentarios sobre el producto:** Tus opiniones son muy valiosas para mejorar la experiencia de Playground. Esto incluye comentarios generales sobre la instancia web, la aplicación y cualquier herramienta del lado del servidor.
 
 <!--
 All feedback, including reported issues and test results, can be submitted through our GitHub repository.
 -->
 
-Todos los comentarios, incluidos los issues reportados y los resultados de las pruebas, pueden enviarse a través de nuestro repositorio de GitHub.
+Todos los comentarios, incluidos los problemas notificados y los resultados de las pruebas, pueden enviarse a través de nuestro repositorio de GitHub.
 
 <!--
 ### Follow-up and Continued Engagement
@@ -74,7 +74,7 @@ Todos los comentarios, incluidos los issues reportados y los resultados de las p
 While many tasks are completed during the event, your contribution journey doesn't have to end there. You are welcome to continue working on your issues or pull requests after Contributor Day. We anticipate ongoing activity from contributors who take on tasks beyond the event. Please note that if a pull request shows no activity for one month, it may be considered abandoned and subsequently closed.
 -->
 
-Si bien muchas tareas se completan durante el evento, tu viaje de contribución no tiene que terminar ahí. Eres bienvenido a continuar trabajando en tus issues o pull requests después del Día del Contribuidor. Anticipamos actividad continua de los contribuidores que asumen tareas más allá del evento. Ten en cuenta que si un pull request no muestra actividad durante un mes, puede considerarse abandonado y posteriormente cerrado.
+Aunque muchas tareas se completan durante el evento, tu contribución no tiene por qué terminar ahí. Te invitamos a seguir trabajando en tus incidencias o pull requests después del día del contribuidor. Esperamos que los colaboradores sigan trabajando en las tareas que hayan asumido más allá del evento. Ten en cuenta que si un pull request no muestra actividad durante un mes, puede considerarse abandonado y se cerrará.
 
 <!--
 ### Getting Help and Staying Engaged
@@ -86,25 +86,25 @@ Si bien muchas tareas se completan durante el evento, tu viaje de contribución 
 During Contributor Day, you can find direct assistance and interact with us at the dedicated Playground table. For continuous support and community interaction, you can connect with us on the `#playground` channel on WordPress Slack or via GitHub.
 -->
 
-Durante el Día del Contribuidor, puedes encontrar asistencia directa e interactuar con nosotros en la mesa dedicada de Playground. Para soporte continuo e interacción con la comunidad, puedes conectarte con nosotros en el canal `#playground` de WordPress Slack o a través de GitHub.
+Durante el día del contribuidor, podrás encontrar asistencia directa e interactuar con nosotros en la mesa dedicada a Playground. Para obtener asistencia continua e interactuar con la comunidad, puedes conectarte con nosotros en el canal `#playground` del Slack de WordPress o a través de GitHub.
 
 <!--
 ## How to use Playground at Contributor Day
 -->
 
-## Cómo usar Playground en el Día del Contribuidor
+## Cómo usar Playground en el día del contribuidor
 
 <!--
 Now we are going to cover how the Playground can assist you during the Contributor Day. The [WordPress Playground VS Code extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) and [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) streamline the process of setting up a local WordPress environment. WordPress Playground powers both—no Docker, MySQL, or Apache required.
 -->
 
-Ahora vamos a cubrir cómo Playground puede ayudarte durante el Día del Contribuidor. La [extensión de WordPress Playground para VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) y [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) agilizan el proceso de configuración de un entorno local de WordPress. WordPress Playground impulsa ambos, sin necesidad de Docker, MySQL o Apache.
+Ahora vamos a explicar cómo Playground puede ayudarte durante el día del contribuidor. La [extensión de WordPress Playground para VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) y [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) agilizan el proceso de configuración de un entorno local de WordPress. WordPress Playground lo hace sin la necesidad de Docker, MySQL ni Apache.
 
 <!--
 Keep reading to learn how to use these tools for [local development](/developers/local-development/wp-playground-cli) when contributing to WordPress. Please note that the extension and the NPM package are under development, and not all [Make WordPress teams](https://make.wordpress.org/) are fully supported.
 -->
 
-Sigue leyendo para aprender a usar estas herramientas para el [desarrollo local](/developers/local-development/wp-playground-cli) al contribuir a WordPress. Ten en cuenta que la extensión y el paquete NPM están en desarrollo, y no todos los [equipos de Make WordPress](https://make.wordpress.org/) son totalmente compatibles.
+Sigue leyendo para aprender a usar estas herramientas para el [desarrollo local](/developers/local-development/wp-playground-cli) cuando contribuyas a WordPress. Ten en cuenta que la extensión y el paquete NPM están en fase de desarrollo y no todos los [equipos de Make WordPress](https://make.wordpress.org/) son totalmente compatibles.
 
 <!--
 ## Getting Started
@@ -122,7 +122,7 @@ Sigue leyendo para aprender a usar estas herramientas para el [desarrollo local]
 The [Visual Studio Code Playground extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) is a friendly zero-setup development environment.
 -->
 
-La [extensión de Playground para Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) es un entorno de desarrollo amigable y sin configuración.
+La [extensión de Playground para Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) es un entorno de desarrollo fácil de usar, que no requiere configuración.
 
 <!--
 1. Open VS Code and navigate to the **Extensions** tab (**View > Extensions**).
@@ -133,8 +133,8 @@ La [extensión de Playground para Visual Studio Code](https://marketplace.visual
 
 1. Abre VS Code y ve a la pestaña **Extensiones** (**Ver > Extensiones**).
 2. En la barra de búsqueda, escribe _WordPress Playground_ y haz clic en **Instalar**.
-3. Para interactuar con Playground, haz clic en el nuevo icono en la **Barra de Actividad** y pulsa el botón **Iniciar Servidor de WordPress**.
-4. Se abrirá una nueva pestaña en tu navegador en segundos.
+3. Para interactuar con Playground, haz clic en el nuevo icono en la **Barra de actividad** y pulsa el botón **Iniciar servidor de WordPress**.
+4. En unos segundos se abrirá una nueva pestaña en tu navegador.
 
 <!--
 ### @wp-playground/cli NPM package
@@ -146,7 +146,7 @@ La [extensión de Playground para Visual Studio Code](https://marketplace.visual
 [`@wp-playground/cli`](/developers/local-development/wp-playground-cli) is a CLI tool that allows you to spin up a WordPress site with a single command. No Docker, MySQL, or Apache are required.
 -->
 
-[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) es una herramienta de línea de comandos que te permite levantar un sitio de WordPress con un solo comando. No se requiere Docker, MySQL o Apache.
+[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) es una herramienta de línea de comandos que te permite crear un sitio WordPress con un único comando. No necesitas Docker, MySQL ni Apache.
 
 <!--
 #### Prerequisites
@@ -179,7 +179,7 @@ You don't have to install `@wp-playground/cli` on your device to use it. Navigat
 No es necesario que instales `@wp-playground/cli` en tu dispositivo para usarlo. Ve a tu directorio de plugins o temas e inicia `@wp-playground/cli` con los siguientes comandos:
 
 ```bash
-cd my-plugin-or-theme-directory
+cd mi-directorio-de-plugins-o-temas
 npx @wp-playground/cli@latest server --auto-mount
 ```
 
@@ -187,13 +187,13 @@ npx @wp-playground/cli@latest server --auto-mount
 ## Ideas for contributors
 -->
 
-## Ideas para contribuidores
+## Ideas para colaboradores
 
 <!--
 ### Create a Gutenberg Pull Request (PR)
 -->
 
-### Crear un Pull Request (PR) de Gutenberg
+### Crear un pull request (PR) en Gutenberg
 
 <!--
 1. Fork the [Gutenberg repository](https://github.com/WordPress/gutenberg) in your GitHub account.
@@ -202,7 +202,7 @@ npx @wp-playground/cli@latest server --auto-mount
 -->
 
 1. Haz un fork del [repositorio de Gutenberg](https://github.com/WordPress/gutenberg) en tu cuenta de GitHub.
-2. Luego, clona el repositorio "forkeado" para descargar los archivos.
+2. Luego, clona el repositorio bifurcado para descargar los archivos.
 3. Instala las dependencias necesarias y compila el código en modo de desarrollo.
 
 ```bash
@@ -210,7 +210,6 @@ git clone git@github.com:WordPress/gutenberg.git
 cd gutenberg
 npm install
 npm run dev
-```
 
 <!--
 :::info
@@ -222,7 +221,7 @@ If you're unsure about the steps listed above, visit the official [Gutenberg Pro
 
 :::info
 
-Si no estás seguro de los pasos anteriores, visita la [Guía del Contribuidor del Proyecto Gutenberg](https://developer.wordpress.org/block-editor/contributors/) oficial. Ten en cuenta que en este caso, `@wp-playground/cli` reemplaza a `wp-env`.
+Si no estás seguro de los pasos anteriores, visita la [guía oficial para colaboradores del proyecto Gutenberg](https://developer.wordpress.org/block-editor/contributors/). Ten en cuenta que, en este caso, `@wp-playground/cli` sustituye a `wp-env`.
 
 :::
 
@@ -230,7 +229,7 @@ Si no estás seguro de los pasos anteriores, visita la [Guía del Contribuidor d
 Open a new terminal terminal tab, navigate to the Gutenberg directory, and start WordPress using `@wp-playground/cli`:
 -->
 
-Abre una nueva pestaña de terminal, navega al directorio de Gutenberg e inicia WordPress usando `@wp-playground/cli`:
+Abre una nueva pestaña en tu terminal, navega hasta el directorio de Gutenberg e inicia WordPress usando `@wp-playground/cli`:
 
 ```bash
 cd gutenberg
@@ -241,7 +240,7 @@ npx @wp-playground/cli@latest server --auto-mount
 When you're ready, commit and push your changes to your forked repository on GitHub and open a Pull Request on the Gutenberg repository.
 -->
 
-Cuando estés listo, haz commit y push de tus cambios a tu repositorio "forkeado" en GitHub y abre un Pull Request en el repositorio de Gutenberg.
+Cuando estés listo, confirma y envía tus cambios al repositorio bifurcado en GitHub y abre un Pull Request en el repositorio de Gutenberg.
 
 <!--
 ### Test a Gutenberg PR
@@ -256,19 +255,19 @@ Cuando estés listo, haz commit y push de tus cambios a tu repositorio "forkeado
 4. Finally, build the code in development mode.
 -->
 
-1. Para probar otros PRs de Gutenberg, haz checkout a la rama asociada a él.
-2. Haz pull de los últimos cambios para asegurarte de que tu copia local esté actualizada.
-3. A continuación, instala las dependencias necesarias, asegurándote de que tu entorno de prueba coincida con los últimos cambios.
+1. Para probar otros PRs de Gutenberg, haz checkout en la rama asociada a él.
+2. Descarga los últimos cambios para asegurarte de que tu copia local está actualizada.
+3. A continuación, instala las dependencias necesarias, asegurándote de que tu entorno de pruebas coincide con los últimos cambios.
 4. Finalmente, compila el código en modo de desarrollo.
 
 ```bash
-# copy the branch-name from GitHub #
-git checkout branch-name
+# copia el nombre-de-la-rama desde GitHub #
+git checkout nombre-de-la-rama
 git pull
 npm install
 npm run dev
 
-# In a different terminal inside the Gutenberg directory *
+# En una terminal diferente dentro del directorio de Gutenberg *
 npx @wp-playground/cli@latest server --auto-mount
 ```
 
@@ -290,8 +289,8 @@ No necesitas un [entorno de desarrollo local](/developers/local-development/) pa
 3. Once you click **Go**, Playground will verify the PR is valid and open a new tab with the relevant PR, allowing you to review the proposed changes.
 -->
 
-1. Copia el ID del PR que te gustaría probar (elige uno de la [lista de Pull Requests abiertos](https://github.com/WordPress/gutenberg/pulls)).
-2. Abre el [Visualizador de PRs de Gutenberg](https://playground.wordpress.net/gutenberg.html) de Playground y pega el ID que copiaste.
+1. Copia el ID del PR que te gustaría probar (elige uno de la [lista de pull requests abiertos](https://github.com/WordPress/gutenberg/pulls)).
+2. Abre el [visualizador de PRs de Gutenberg](https://playground.wordpress.net/gutenberg.html) de Playground y pega el ID que has copiado.
 3. Una vez que hagas clic en **Ir**, Playground verificará que el PR es válido y abrirá una nueva pestaña con el PR correspondiente, permitiéndote revisar los cambios propuestos.
 
 <!--
@@ -304,19 +303,19 @@ No necesitas un [entorno de desarrollo local](/developers/local-development/) pa
 You can translate supported WordPress Plugins by loading the plugin you want to translate and use Inline Translation. If the plugin developers have added the option, you'll find the **Translate Live** link on the top right toolbar of the translation view. You can read more about this exciting new option on [this Polyglots blog post](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/).
 -->
 
-Puedes traducir los plugins de WordPress compatibles cargando el plugin que quieres traducir y usando la Traducción en Línea. Si los desarrolladores del plugin han añadido la opción, encontrarás el enlace **Traducir en vivo** en la barra de herramientas superior derecha de la vista de traducción. Puedes leer más sobre esta nueva y emocionante opción en [esta entrada del blog de Polyglots](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/).
+Puedes traducir los plugins de WordPress compatibles cargando el plugin que quieres traducir y usando la traducción en Línea. Si los desarrolladores del plugin han añadido la opción, encontrarás el enlace **Translate Live** en la barra de herramientas superior derecha de la vista de traducción. Puedes obtener más información sobre esta nueva y emocionante opción en [esta entrada del blog de Polyglots](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/).
 
 <!--
 ## Get help and contribute to WordPress Playground
 -->
 
-## Obtén ayuda y contribuye a WordPress Playground
+## Obtener ayuda y contribuir a WordPress Playground
 
 <!--
 Have a question or an idea for a new feature? Found a bug? Something's not working as expected? We're here to help:
 -->
 
-¿Tienes alguna pregunta o una idea para una nueva función? ¿Has encontrado un error? ¿Algo no funciona como se esperaba? Estamos aquí para ayudar:
+¿Tienes alguna pregunta o una idea para una nueva función? ¿Has encontrado un error? ¿Hay algo que no funciona como esperabas? Estamos aquí para ayudarte:
 
 <!--
 -   During Contributor Day, you can reach us at the **Playground table**.
@@ -324,6 +323,6 @@ Have a question or an idea for a new feature? Found a bug? Something's not worki
 -   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
 -->
 
--   Durante el Día del Contribuidor, puedes encontrarnos en la **mesa de Playground**.
--   Abre un issue en el [repositorio de GitHub de WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Si tu enfoque es la extensión de VS Code, el paquete NPM o los plugins, abre un issue en el [repositorio de Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
--   Comparte tus comentarios en el canal de Slack [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   Durante el día del contribuidor, puedes encontrarnos en la **mesa de Playground**.
+-   Abre una incidencia en el [repositorio de WordPress Playground en GitHub](https://github.com/WordPress/wordpress-playground/issues/new). Si te interesa la extensión de VS Code, el paquete NPM o los plugins, abre una incidencia en el [repositorio de Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+-   Comparte tus comentarios en el canal de Slack de [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
@@ -12,13 +12,13 @@ slug: /contributing/documentation
 [WordPress Playground's documentation site](/) is maintained by volunteers like you, who'd love your help.
 -->
 
-El [sitio de documentación de WordPress Playground](/) es mantenido por voluntarios como tú, a quienes les encantaría tu ayuda.
+El [sitio de documentación de WordPress Playground](/) lo mantienen voluntarios como tú, que agradecerían tu ayuda.
 
 <!--
 All documentation-related issues are labeled [`[Type] Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Documentation%22) or [`[Type] Developer Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Developer%20Documentation%22) in the [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) repository. Browse the list of open issues to find one you'd like to work on. Alternatively, if you believe something is missing from the current documentation, open an issue to discuss your suggestion.
 -->
 
-Todos los problemas relacionados con la documentación están etiquetados como [`[Type] Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Documentation%22) o [`[Type] Developer Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Developer%20Documentation%22) en el repositorio [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground). Explora la lista de problemas abiertos para encontrar uno en el que te gustaría trabajar. Alternativamente, si crees que falta algo en la documentación actual, abre un issue para discutir tu sugerencia.
+Todas las cuestiones relacionadas con la documentación se etiquetan como [`[Type] Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Documentation%22) o [`[Type] Developer Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Developer%20Documentation%22) en el repositorio [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground). Explora la lista de incidencias abiertas para encontrar una en la que te gustaría trabajar. Alternativamente, si crees que falta algo en la documentación actual, abre una incidencia para discutir tu sugerencia.
 
 <!--
 ## How can I contribute?
@@ -30,31 +30,31 @@ Todos los problemas relacionados con la documentación están etiquetados como [
 You can contribute by [opening an issue in the project repository](https://github.com/WordPress/wordpress-playground/issues/new) and describing what you'd like to add or change.
 -->
 
-Puedes contribuir [abriendo un issue en el repositorio del proyecto](https://github.com/WordPress/wordpress-playground/issues/new) y describiendo lo que te gustaría añadir o cambiar.
+Puedes contribuir [abriendo una incidencia en el repositorio del proyecto](https://github.com/WordPress/wordpress-playground/issues/new) y describiendo lo que te gustaría añadir o cambiar.
 
 <!--
 If you feel up to it, write the content in the issue description, and the project contributors will take care of the rest.
 -->
 
-Si te animas, escribe el contenido en la descripción del issue, y los contribuidores del proyecto se encargarán del resto.
+Si te animas, escribe el contenido en la descripción de la incidencia y los contribuidores del proyecto se encargarán del resto.
 
 <!--
 Would you like to see the documentation in your language? Check the [Translation section](/contributing/translations).
 -->
 
-¿Te gustaría ver la documentación en tu idioma? Consulta la [sección de Traducciones](/contributing/translations).
+¿Te gustaría ver la documentación en tu idioma? Consulta la [sección de traducciones](/contributing/translations).
 
 <!--
 ### Forking the repo, edit files locally and opening Pull Requests
 -->
 
-### Hacer un fork del repositorio, editar archivos localmente y abrir Pull Requests
+### Bifurcar el repositorio, editar archivos localmente y abrir pull requests
 
 <!--
 If you are familiar with markdown, you can [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the `wordpress-playground` repo and propose changes and new documentation pages by submitting a Pull Request.
 -->
 
-Si estás familiarizado con markdown, puedes hacer un [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) del repositorio `wordpress-playground` y proponer cambios y nuevas páginas de documentación enviando un Pull Request.
+Si estás familiarizado con markdown, puedes [bifurcar](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) el repositorio `wordpress-playground` y proponer cambios y nuevas páginas de documentación enviando un pull request.
 
 <!--
 The process of creating a branch to open new PRs with translated pages on the [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) repository is the same than contributing to other WordPress repositories such as gutenberg:
@@ -80,7 +80,7 @@ Los archivos de documentación (archivos `.md`) se almacenan en el repositorio d
 If logged in GitHub, you can also edit existing files (or add new ones) and submit a PR directly from the GitHub UI:
 -->
 
-Si has iniciado sesión en GitHub, también puedes editar archivos existentes (o añadir nuevos) y enviar un PR directamente desde la interfaz de usuario de GitHub:
+Si has iniciado sesión en GitHub, también puedes editar archivos existentes (o añadir otros nuevos) y enviar un PR directamente desde la interfaz de usuario de GitHub:
 
 <!--
 1. Find the page you'd like to edit or the directory of the chapter you'd like to add a new page to.
@@ -90,11 +90,11 @@ Si has iniciado sesión en GitHub, también puedes editar archivos existentes (o
 5. When you're done, click the **Commit Changes** button and submit a Pull Request.
 -->
 
-1. Encuentra la página que te gustaría editar o el directorio del capítulo al que te gustaría añadir una nueva página.
+1. Busca la página que te gustaría editar o el directorio del capítulo al que te gustaría añadir una nueva página.
 2. Haz clic en el botón **Añadir archivos** para añadir un nuevo archivo, o haz clic en un archivo existente y luego en el icono del lápiz para editarlo.
-3. GitHub te pedirá que hagas un fork del repositorio y crees una nueva rama con tus cambios.
-4. Se abrirá un editor donde podrás hacer los cambios.
-5. Cuando hayas terminado, haz clic en el botón **Commit Changes** y envía un Pull Request.
+3. GitHub te pedirá que bifurques el repositorio y crees una nueva rama con tus cambios.
+4. Se abrirá un editor en el que podrás hacer los cambios.
+5. Cuando hayas terminado, haz clic en el botón **Confirmar cambios** y envía un pull request.
 
 <!--
 That's it! You've just contributed to the WordPress Playground documentation.
@@ -112,19 +112,19 @@ Este enfoque significa que no necesitas clonar el repositorio, configurar un ent
 The downside is that you won't be able to preview your changes. Keep reading to learn how to review your changes before submitting a Pull Request.
 -->
 
-La desventaja es que no podrás previsualizar tus cambios. Sigue leyendo para aprender a revisar tus cambios antes de enviar un Pull Request.
+La desventaja es que no podrás previsualizar tus cambios. Sigue leyendo para aprender cómo revisar tus cambios antes de enviar un pull request.
 
 <!--
 ### Local preview
 -->
 
-### Previsualización local
+### Vista previa local
 
 <!--
 Clone the repository and navigate to the directory on your device. Now run the following commands:
 -->
 
-Clona el repositorio y navega al directorio en tu dispositivo. Ahora ejecuta los siguientes comandos:
+Clona el repositorio y navega hasta el directorio en tu dispositivo. Ahora ejecuta los siguientes comandos:
 
 ```bash
 npm install
@@ -136,4 +136,4 @@ npm run dev:docs
 The documentation site opens in a new browser tab and refreshes automatically with each change. Continue to edit the relevant file in your code editor and test the changes in real-time.
 -->
 
-El sitio de documentación se abre en una nueva pestaña del navegador y se actualiza automáticamente con cada cambio. Continúa editando el archivo relevante en tu editor de código y prueba los cambios en tiempo real.
+El sitio de documentación se abre en una nueva pestaña del navegador y se actualiza automáticamente con cada cambio. Continúa editando el archivo correspondiente en tu editor de código y prueba los cambios en tiempo real.


### PR DESCRIPTION
## Motivation for the change, related issues

In the https://github.com/WordPress/wordpress-playground/pull/2782 PR, I forgot to review two Spanish translations, and the branch was merged before I had time to review them.

## Implementation details

This PR only add some improvements in the Spanish translations in two files:
- packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
- packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/documentation.md