### PR TITLE
[i18n] Adding French translation to guides/index.md

### DIFF
--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/index.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/index.md
@@ -1,0 +1,43 @@
+---
+title: 📖 Guides
+slug: /guides
+description: Un guide de WordPress Playground pour vous aider à comprendre et à travailler sur divers sujets et cas d’utilisation associés.
+sidebar_class_name: navbar-build-item
+---
+
+# Guides
+<!-- # Guides -->
+
+Dans cette section, nous présentons une sélection de guides qui vous aideront à travailler avec [WordPress Playground](/) et à mieux comprendre différents sujets liés à cet outil.
+<!-- In this section we present a selection of guides that will help you to both work with, and to better understand, a variety of topics related to [WordPress Playground](/). -->
+
+##[Comment déployer un site WordPress réel dans une application iOS native via Playground ?](/guides/wordpress-native-ios-app)
+<!-- ## [How to ship a real WordPress site in a native iOS app via Playground?](/guides/wordpress-native-ios-app) -->
+
+Découvrez « Blocknotes », la première application à exécuter WordPress nativement sur iOS via WordPress Playground. Elle présente le potentiel d’intégration web mobile transparente grâce à WebAssembly et à l’éditeur de blocs WordPress.
+<!-- Check "Blocknotes", the first app to run WordPress natively on iOS via WordPress Playground. It showcases the potential for seamless mobile web integration using WebAssembly and the WordPress block editor. -->
+
+##[Fournir du contenu pour votre démo avec WordPress Playground](/guides/providing-content-for-your-demo)
+<!-- ## [Providing content for your demo with WordPress Playground](/guides/providing-content-for-your-demo) -->
+
+Pour fournir une bonne démo de votre thème ou de votre extension via Playground, vous pouvez en charger le contenu par défaut et mettre ainsi en avant les fonctionnalités de votre produit. Consultez ce guide pour apprendre comment faire.
+<!-- To provide a good demo of your theme or plugin via Playground, you may want to load it with default content that highlights the features of your product. Check this guide to learn how to do so. -->
+
+##[WordPress Playground pour le développement de thèmes](/guides/for-theme-developers)
+<!-- ## [WordPress Playground for Theme Developers](/guides/for-theme-developers) -->
+
+Ce guide vous présentera les réglages essentiels pour créer une démo de thème entièrement avec de WordPress Playground et comment en tirer parti pendant la phase de construction.
+<!-- This guide will show you the essential settings to fully create a theme demo using WordPress Playground and how you can leverage it during the building stage. -->
+
+##[WordPress Playground pour le développement d’extensions](/guides/for-plugin-developers)
+<!-- ## [WordPress Playground for Plugin Developers](/guides/for-plugin-developers) -->
+
+Ce guide vous présentera les réglages de base pour présenter votre extension à l’aide de WordPress Playground et comment l’utiliser pendant la phase de développement.
+<!-- This guide will show you the basic settings to showcase your plugin using WordPress Playground and how to use it while developing your plugin. -->
+
+:::info
+Traduction par [@jabbari01](https://profiles.wordpress.org/jabbari01/)
+et relecture par [@jdy68](https://profiles.wordpress.org/jdy68/)
+:::
+Dernière mise à jour le 8 octobre 2025
+:::


### PR DESCRIPTION
## Implementation details
Add French translation `index.md` in the `guides` repertory

part of #2621

cc [fellyph](@github.com/fellyph)