### PR TITLE
[Docs] Adding data persistence information

### DIFF
--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -88,6 +88,24 @@ npx @wp-playground/cli@latest server --mount-before-install=.:/wordpress/
 On Windows, the path format `/host/path:/vfs/path` can cause issues. To resolve this, use the flags `--mount-dir` and `--mount-dir-before-install`. These flags let you specify host and virtual file system paths in an alternative format`"/host/path"` `"/vfs/path"`.
 :::
 
+### Understanding Data Persistence and SQLite Location
+
+By default, Playground CLI stores WordPress files and the SQLite database in temporary directories:
+
+-   `<TEMP-DIR>/wordpress` - WordPress installation (wp-admin, wp-includes, wp-content, etc.)
+-   `<TEMP-DIR>/internal` - Playground runtime config and platform mu-plugins
+-   `<TEMP-DIR>/tmp` - Temporary files
+
+**Where is the SQLite database stored?**
+
+The SQLite database location depends on what you mount:
+
+-   **Auto-mounting wp-content or full WordPress**: Database writes to your mounted folder at `wp-content/database/.ht.sqlite` (persisted locally)
+-   **Auto-mounting plugin/theme only**: Database writes to temp directories (lost when server stops)
+-   **Custom mounts**: Database location follows your mount configuration
+
+To ensure database persistence when developing plugins or themes, consider mounting the entire wp-content directory.
+
 ## Command and Arguments
 
 Playground CLI is simple, configurable, and unopinionated. You can set it up according

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -90,21 +90,60 @@ On Windows, the path format `/host/path:/vfs/path` can cause issues. To resolve 
 
 ### Understanding Data Persistence and SQLite Location
 
-By default, Playground CLI stores WordPress files and the SQLite database in temporary directories:
+By default, Playground CLI stores WordPress files and the SQLite database in **temporary directories on your operating system**:
 
--   `<TEMP-DIR>/wordpress` - WordPress installation (wp-admin, wp-includes, wp-content, etc.)
--   `<TEMP-DIR>/internal` - Playground runtime config and platform mu-plugins
--   `<TEMP-DIR>/tmp` - Temporary files
+```
+<OS-TEMP-DIR>/playground-<random-id>/
+├── wordpress/          # WordPress installation
+├── internal/          # Playground runtime config
+└── tmp/              # Temporary PHP files
+```
 
-**Where is the SQLite database stored?**
+**Finding Your Temp Directory:**
 
-The SQLite database location depends on what you mount:
+The actual location depends on your OS:
 
--   **Auto-mounting wp-content or full WordPress**: Database writes to your mounted folder at `wp-content/database/.ht.sqlite` (persisted locally)
--   **Auto-mounting plugin/theme only**: Database writes to temp directories (lost when server stops)
+-   **macOS/Linux**: `/tmp/playground-<random-id>/`
+-   **Windows**: `C:\Users\<username>\AppData\Local\Temp\playground-<random-id>\`
+
+When you start the CLI, it outputs the temp directory path. Look for:
+
+```bash
+npx @wp-playground/cli@latest server
+# Output shows: Using temporary directory: /tmp/playground-abc123/
+```
+
+**Where is the SQLite Database Stored?**
+
+The database location depends on what you mount:
+
+-   **Auto-mounting wp-content or full WordPress**:
+
+    -   Database: `<your-local-project>/wp-content/database/.ht.sqlite`
+    -   ✅ **Persisted locally** in your project folder
+
+-   **Auto-mounting plugin/theme only**:
+
+    -   Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    -   ⚠️ **Lost when server stops** (temp directories are cleaned up)
+
 -   **Custom mounts**: Database location follows your mount configuration
 
-To ensure database persistence when developing plugins or themes, consider mounting the entire wp-content directory.
+**Automatic Cleanup:**
+Playground CLI automatically removes temp directories that are:
+
+-   Older than 2 days
+-   No longer associated with a running process
+
+**Recommendation:** To persist both your code and database when developing plugins or themes, mount the entire `wp-content` directory instead of just the plugin/theme folder.
+
+**Example: Mounting wp-content for persistence**
+
+```bash
+# Mount your entire wp-content directory
+cd my-wordpress-project
+npx @wp-playground/cli@latest server --mount=./wp-content:/wordpress/wp-content
+```
 
 ## Command and Arguments
 

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -101,16 +101,28 @@ By default, Playground CLI stores WordPress files and the SQLite database in **t
 
 **Finding Your Temp Directory:**
 
-The actual location depends on your OS:
+The actual location depends on your OS (these are examples or common possibilities):
 
--   **macOS/Linux**: `/tmp/playground-<random-id>/`
--   **Windows**: `C:\Users\<username>\AppData\Local\Temp\playground-<random-id>\`
+-   **macOS/Linux**: May be under `/tmp/` or `/private/var/folders/` (varies by system)
+-   **Windows**: `C:\Users\<username>\AppData\Local\Temp\`
 
-When you start the CLI, it outputs the temp directory path. Look for:
+To see the exact temp directory path being used, run the CLI with the `--verbosity=debug` flag:
 
 ```bash
-npx @wp-playground/cli@latest server
-# Output shows: Using temporary directory: /tmp/playground-abc123/
+npx @wp-playground/cli@latest server --verbosity=debug
+```
+
+This will output something like:
+
+```
+Native temp dir for VFS root:
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC
+Mount before WP install: /home ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/home
+Mount before WP install: /tmp ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/tmp
+Mount before WP install: /wordpress ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/wordpress
 ```
 
 **Where is the SQLite Database Stored?**

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -1,0 +1,311 @@
+---
+title: Playground CLI
+slug: /developers/local-development/wp-playground-cli
+---
+
+# Playground CLI
+
+[@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) es una herramienta de línea de comandos que simplifica el flujo de desarrollo y pruebas de WordPress.
+Playground CLI soporta el montaje automático de un directorio con un plugin, tema o instalación de WordPress. Pero si necesitas flexibilidad, el CLI soporta comandos de montaje para personalizar tu entorno local.
+
+**Características principales:**
+
+-   **Configuración Rápida**: Configura un entorno WordPress local en segundos.
+-   **Flexibilidad**: Permite la configuración para adaptarse a diferentes escenarios.
+-   **Entorno Simple**: Sin configuración extra, solo una versión compatible de Node, y estás listo para usarlo.
+
+## Requisitos
+
+El Playground CLI requiere Node.js 20.18 o superior, que es la versión recomendada de Soporte a Largo Plazo (LTS). Puedes descargarlo desde el [sitio web de Node.js](https://nodejs.org/en/download).
+
+## Inicio Rápido
+
+Para ejecutar el Playground CLI, abre una línea de comandos y usa el siguiente comando:
+
+```bash
+npx @wp-playground/cli@latest server
+```
+
+![Playground CLI en Acción](@site/static/img/developers/npx-wp-playground-server.gif)
+
+Con el comando anterior, solo obtienes una instancia fresca de WordPress para probar. La mayoría de los desarrolladores querrán probar su propio trabajo. Para probar un plugin o un tema, navega a la carpeta de tu proyecto y ejecuta el CLI con la bandera `--auto-mount`:
+
+```bash
+cd my-plugin-or-theme-directory
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+### Elegir una Versión de WordPress y PHP
+
+Por defecto, el CLI carga la última versión estable de WordPress y PHP 8.3 debido a su rendimiento mejorado. Para especificar tus versiones preferidas, puedes usar las banderas `--wp=<version>` y `--php=<version>`:
+
+```bash
+npx @wp-playground/cli@latest server --wp=6.8 --php=8.3
+```
+
+### Cargar Blueprints
+
+Una forma de llevar tu experiencia de desarrollo con Playground CLI al siguiente nivel es integrar con [Blueprints](/blueprints/getting-started/). Para aquellos que no estén familiarizados con esta tecnología, permite a los desarrolladores configurar el estado inicial para sus instancias de WordPress Playground.
+
+Usando la bandera `--blueprint=<blueprint-address>`, los desarrolladores pueden ejecutar un Playground con un estado inicial personalizado. Usaremos el ejemplo a continuación para hacer esto.
+
+**(my-blueprint.json)**
+
+```bash
+{
+  "landingPage": "/wp-admin/options-general.php?page=akismet-key-config",
+  "login": true,
+  "plugins": [
+    "hello-dolly",
+    "https://raw.githubusercontent.com/adamziel/blueprints/trunk/docs/assets/hello-from-the-dashboard.zip"
+  ]
+}
+```
+
+Comando CLI cargando un blueprint:
+
+```bash
+npx @wp-playground/cli@latest server --blueprint=my-blueprint.json
+```
+
+### Montar carpetas manualmente
+
+Algunos proyectos tienen una estructura específica que requiere una configuración personalizada; por ejemplo, tu repositorio contiene todos los archivos en la carpeta `/wp-content/`. Entonces en este escenario, puedes especificar al Playground CLI que montará tu proyecto desde esa carpeta usando la bandera `--mount`.
+
+```bash
+npx @wp-playground/cli@latest server --mount=.:/wordpress/wp-content/plugins/MY-PLUGIN-DIRECTORY
+```
+
+### Montar antes de la instalación de WordPress
+
+Considera montar tus archivos de proyecto de WordPress antes de que comience la instalación de WordPress. Este enfoque es beneficioso si quieres sobrescribir el proceso de arranque de Playground, ya que puede ayudar a conectar Playground con `WP-CLI`. La bandera `--mount-before-install` soporta este proceso.
+
+```bash
+npx @wp-playground/cli@latest server --mount-before-install=.:/wordpress/
+```
+
+:::info
+En Windows, el formato de ruta `/host/path:/vfs/path` puede causar problemas. Para resolver esto, usa las banderas `--mount-dir` y `--mount-dir-before-install`. Estas banderas te permiten especificar rutas del host y del sistema de archivos virtual en un formato alternativo `"/host/path"` `"/vfs/path"`.
+:::
+
+### Entender la Persistencia de Datos y Ubicación de SQLite
+
+Por defecto, Playground CLI almacena archivos de WordPress y la base de datos SQLite en **directorios temporales en tu sistema operativo**:
+
+```
+<OS-TEMP-DIR>/playground-<random-id>/
+├── wordpress/          # Instalación WordPress
+├── internal/          # Configuración del runtime de Playground
+└── tmp/              # Archivos temporales PHP
+```
+
+**Encontrar tu Directorio Temporal:**
+
+La ubicación real depende de tu SO (estos son ejemplos o posibilidades comunes):
+
+-   **macOS/Linux**: Puede estar bajo `/tmp/` o `/private/var/folders/` (varía según el sistema)
+-   **Windows**: `C:\Users\<username>\AppData\Local\Temp\`
+
+Para ver la ruta exacta del directorio temporal que se está usando, ejecuta el CLI con la bandera `--verbosity=debug`:
+
+```bash
+npx @wp-playground/cli@latest server --verbosity=debug
+```
+
+Esto mostrará algo como:
+
+```
+Native temp dir for VFS root:
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC
+Mount before WP install: /home ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/home
+Mount before WP install: /tmp ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/tmp
+Mount before WP install: /wordpress ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/wordpress
+```
+
+**¿Dónde se Almacena la Base de Datos SQLite?**
+
+La ubicación de la base de datos depende de lo que montes:
+
+-   **Montaje automático de wp-content o WordPress completo**:
+
+    -   Base de datos: `<tu-proyecto-local>/wp-content/database/.ht.sqlite`
+    -   ✅ **Persistido localmente** en la carpeta de tu proyecto
+
+-   **Montaje automático solo de plugin/tema**:
+
+    -   Base de datos: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    -   ⚠️ **Perdido cuando el servidor se detiene** (los directorios temporales se limpian)
+
+-   **Montajes personalizados**: La ubicación de la base de datos sigue tu configuración de montaje
+
+**Limpieza Automática:**
+Playground CLI elimina automáticamente los directorios temporales que son:
+
+-   Más antiguos de 2 días
+-   Ya no están asociados con un proceso en ejecución
+
+**Recomendación:** Para persistir tanto tu código como la base de datos al desarrollar plugins o temas, monta el directorio `wp-content` completo en lugar de solo la carpeta del plugin/tema.
+
+**Ejemplo: Montar wp-content para persistencia**
+
+```bash
+# Monta tu directorio wp-content completo
+cd my-wordpress-project
+npx @wp-playground/cli@latest server --mount=./wp-content:/wordpress/wp-content
+```
+
+## Comandos y Argumentos
+
+Playground CLI es simple, configurable y sin opiniones. Puedes configurarlo de acuerdo
+a tu configuración única de WordPress. Con el Playground CLI, puedes usar los siguientes comandos de nivel superior:
+
+-   **`server`**: (Por defecto) Inicia un servidor WordPress local.
+-   **`run-blueprint`**: Ejecuta un archivo Blueprint sin iniciar un servidor web.
+-   **`build-snapshot`**: Construye una instantánea ZIP de un sitio WordPress basado en un Blueprint.
+
+El comando `server` soporta los siguientes argumentos opcionales:
+
+-   `--port=<port>`: El número de puerto para que el servidor escuche. Por defecto es 9400.
+-   `--outfile`: Al construir, escribir en este archivo de salida.
+-   `--wp=<version>`: La versión de WordPress a usar. Por defecto es la última.
+-   `--auto-mount`: Montar automáticamente el directorio actual (plugin, tema, wp-content, etc.).
+-   `--mount=<mapping>`: Montar manualmente un directorio (puede usarse múltiples veces). Formato: `"/host/path:/vfs/path"`.
+-   `--mount-before-install`: Montar un directorio al runtime PHP antes de la instalación de WordPress (puede usarse múltiples veces). Formato: `"/host/path:/vfs/path"`.
+-   `--mount-dir`: Montar un directorio al runtime PHP (puede usarse múltiples veces). Formato: `"/host/path"` `"/vfs/path"`.
+-   `--mount-dir-before-install`: Montar un directorio antes de la instalación de WordPress (puede usarse múltiples veces). Formato: `"/host/path"` `"/vfs/path"`
+-   `--blueprint=<path>`: La ruta a un archivo JSON Blueprint para ejecutar.
+-   `--blueprint-may-read-adjacent-files`: Bandera de consentimiento: Permitir que recursos "empaquetados" en un blueprint local lean archivos en el mismo directorio que el archivo blueprint.
+-   `--login`: Iniciar sesión automáticamente del usuario como administrador.
+-   `--skip-wordpress-setup`: No descargar ni instalar WordPress. Útil si estás montando un directorio WordPress completo.
+-   `--skip-sqlite-setup`: No configurar la integración de base de datos SQLite.
+-   `--verbosity`: Salida de logs y mensajes de progreso. Las opciones son "quiet", "normal" o "debug". Por defecto es "normal".
+-   `--debug`: Imprimir el log de errores de PHP si ocurre un error durante el arranque.
+
+## ¿Necesitas ayuda con el CLI?
+
+Con el Playground CLI, puedes usar la bandera `--help` para obtener la lista completa de comandos y argumentos disponibles.
+
+```bash
+npx @wp-playground/cli@latest --help
+```
+
+## Uso Programático con JavaScript
+
+El Playground CLI también puede ser controlado programáticamente desde tu código JavaScript/TypeScript usando la función `runCLI`. Esto te da acceso directo a todas las funcionalidades del CLI dentro de tu código, lo cual es útil para automatizar pruebas end-to-end. Cubramos los conceptos básicos del uso de `runCLI`.
+
+### Ejecutar una instancia de WordPress con una versión específica
+
+Usando la función `runCLI`, puedes especificar opciones como las versiones de PHP y WordPress. En el ejemplo a continuación, solicitamos PHP 8.3, la última versión de WordPress, y iniciar sesión automáticamente. Todos los argumentos soportados están definidos en el tipo `RunCLIArgs`.
+
+```TypeScript
+import { runCLI, RunCLIArgs, RunCLIServer } from "@wp-playground/cli";
+
+let cliServer: RunCLIServer;
+
+cliServer = await runCLI({
+    command: 'server',
+    php: '8.3',
+    wp: 'latest',
+    login: true
+} as RunCLIArgs);
+```
+
+Para ejecutar el código anterior, el desarrollador puede establecer su método preferido. Una forma simple de ejecutar este código es guardarlo como un archivo `.ts` y ejecutarlo con una herramienta como `tsx`. Por ejemplo: `tsx my-script.ts`
+
+### Configurar un Blueprint
+
+Puedes proporcionar un blueprint de dos maneras: ya sea como un objeto literal pasado directamente a la propiedad `blueprint`, o como una cadena que contiene la ruta a un archivo `.json` externo.
+
+```TypeScript
+import { runCLI, RunCLIServer } from "@wp-playground/cli";
+
+let cliServer: RunCLIServer;
+
+cliServer = await runCLI({
+  command: 'server',
+  wp: 'latest',
+  blueprint: {
+    steps: [
+        {
+          "step": "setSiteOptions",
+          "options": {
+              "blogname": "Blueprint Title",
+              "blogdescription": "A great blog description"
+          }
+        }
+    ],
+  },
+});
+```
+
+Para una seguridad de tipos completa al definir tu objeto blueprint, puedes importar y usar el tipo `BlueprintDeclaration` del paquete `@wp-playground/blueprints`:
+
+```TypeScript
+import type { BlueprintDeclaration } from '@wp-playground/blueprints';
+
+const myBlueprint: BlueprintDeclaration = {
+  landingPage: "/wp-admin/",
+  steps: [
+    {
+      "step": "installTheme",
+      "themeData": {
+        "resource": "wordpress.org/themes",
+        "slug": "twentytwentyone"
+      },
+      "options": {
+        "activate": true
+      }
+    }
+  ]
+};
+```
+
+### Montar un plugin programáticamente
+
+Es posible montar directorios locales programáticamente usando `runCLI`. Las opciones `mount` y `mount-before-install` están disponibles. La propiedad `hostPath` espera una ruta a un directorio en tu máquina local. Esta ruta debe ser relativa a donde se está ejecutando tu script.
+
+```TypeScript
+	cliServer = await runCLI({
+      command: 'server',
+      login: true,
+      'mount-before-install': [
+        {
+          hostPath: './[my-plugin-local-path]',
+          vfsPath: '/wordpress/wp-content/plugins/my-plugin',
+        },
+      ],
+    });
+```
+
+Con esas opciones podemos combinar el montaje de partes del proyecto con blueprints, por ejemplo:
+
+```TypeScript
+
+import { runCLI, RunCLIArgs, RunCLIServer } from "@wp-playground/cli";
+
+let cliServer: RunCLIServer;
+
+cliServer = await runCLI({
+    command: 'server',
+    php: '8.3',
+    wp: 'latest',
+    login: true,
+    mount: [
+        {
+            "hostPath": "./plugin/",
+            "vfsPath": "/wordpress/wp-content/plugins/playwright-test"
+        }
+    ],
+    blueprint: {
+        steps: [
+            {
+                "step": "activatePlugin",
+                "pluginPath": "/wordpress/wp-content/plugins/playwright-test/plugin-playwright.php"
+            }
+        ]
+    }
+} as RunCLIArgs);
+```

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -137,6 +137,118 @@ npx @wp-playground/cli@latest server --mount-before-install=.:/wordpress/
 No Windows, o formato de caminho `/host/path:/vfs/path` pode causar problemas. Para resolver isso, use as flags `--mount-dir` e `--mount-dir-before-install`. Estas flags permitem que você especifique caminhos do host e do sistema de arquivos virtual em um formato alternativo `"/host/path"` `"/vfs/path"`.
 :::
 
+<!-- ### Understanding Data Persistence and SQLite Location -->
+
+### Entendendo a Persistência de Dados e Localização do SQLite
+
+<!-- By default, Playground CLI stores WordPress files and the SQLite database in **temporary directories on your operating system**: -->
+
+Por padrão, o Playground CLI armazena arquivos WordPress e o banco de dados SQLite em **diretórios temporários no seu sistema operacional**:
+
+```
+<OS-TEMP-DIR>/playground-<random-id>/
+├── wordpress/          # Instalação WordPress
+├── internal/          # Configuração do runtime do Playground
+└── tmp/              # Arquivos temporários PHP
+```
+
+<!-- **Finding Your Temp Directory:** -->
+
+**Encontrando Seu Diretório Temporário:**
+
+<!-- The actual location depends on your OS (these are examples or common possibilities): -->
+
+A localização real depende do seu SO (estes são exemplos ou possibilidades comuns):
+
+<!-- -   **macOS/Linux**: May be under `/tmp/` or `/private/var/folders/` (varies by system) -->
+<!-- -   **Windows**: `C:\Users\<username>\AppData\Local\Temp\` -->
+
+-   **macOS/Linux**: Pode estar em `/tmp/` ou `/private/var/folders/` (varia por sistema)
+-   **Windows**: `C:\Users\<username>\AppData\Local\Temp\`
+
+<!-- To see the exact temp directory path being used, run the CLI with the `--verbosity=debug` flag: -->
+
+Para ver o caminho exato do diretório temporário sendo usado, execute o CLI com a flag `--verbosity=debug`:
+
+```bash
+npx @wp-playground/cli@latest server --verbosity=debug
+```
+
+<!-- This will output something like: -->
+
+Isso exibirá algo como:
+
+```
+Native temp dir for VFS root:
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC
+Mount before WP install: /home ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/home
+Mount before WP install: /tmp ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/tmp
+Mount before WP install: /wordpress ->
+/private/var/folders/c8/mwz12ycx4s509056kby3hk180000gn/T/node-playground-cli-site-62926--62926-yQNOdvJVIgYC/wordpress
+```
+
+<!-- **Where is the SQLite Database Stored?** -->
+
+**Onde o Banco de Dados SQLite é Armazenado?**
+
+<!-- The database location depends on what you mount: -->
+
+A localização do banco de dados depende do que você montar:
+
+<!-- -   **Auto-mounting wp-content or full WordPress**: -->
+
+-   **Auto-montagem de wp-content ou WordPress completo**:
+
+    <!-- -   Database: `<your-local-project>/wp-content/database/.ht.sqlite` -->
+    <!-- -   ✅ **Persisted locally** in your project folder -->
+
+    -   Banco de dados: `<seu-projeto-local>/wp-content/database/.ht.sqlite`
+    -   ✅ **Persistido localmente** na pasta do seu projeto
+
+<!-- -   **Auto-mounting plugin/theme only**: -->
+
+-   **Auto-montagem apenas de plugin/tema**:
+
+    <!-- -   Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite` -->
+    <!-- -   ⚠️ **Lost when server stops** (temp directories are cleaned up) -->
+
+    -   Banco de dados: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    -   ⚠️ **Perdido quando o servidor para** (diretórios temporários são limpos)
+
+<!-- -   **Custom mounts**: Database location follows your mount configuration -->
+
+-   **Montagens personalizadas**: A localização do banco de dados segue sua configuração de montagem
+
+<!-- **Automatic Cleanup:** -->
+
+**Limpeza Automática:**
+
+<!-- Playground CLI automatically removes temp directories that are: -->
+
+O Playground CLI remove automaticamente diretórios temporários que são:
+
+<!-- -   Older than 2 days -->
+<!-- -   No longer associated with a running process -->
+
+-   Mais antigos que 2 dias
+-   Não mais associados com um processo em execução
+
+<!-- **Recommendation:** To persist both your code and database when developing plugins or themes, mount the entire `wp-content` directory instead of just the plugin/theme folder. -->
+
+**Recomendação:** Para persistir tanto seu código quanto o banco de dados ao desenvolver plugins ou temas, monte o diretório `wp-content` inteiro em vez de apenas a pasta do plugin/tema.
+
+<!-- **Example: Mounting wp-content for persistence** -->
+
+**Exemplo: Montando wp-content para persistência**
+
+```bash
+# Mount your entire wp-content directory
+cd my-wordpress-project
+npx @wp-playground/cli@latest server --mount=./wp-content:/wordpress/wp-content
+```
+
 <!-- ## Command and Arguments -->
 
 ## Comandos e Argumentos
@@ -195,10 +307,150 @@ O comando `server` suporta os seguintes argumentos opcionais:
 
 ## Precisa de ajuda com o CLI?
 
-<!-- With the Playground CLI, you can use the `--help` to get some support about the available commands. -->
+<!-- With the Playground CLI, you can use the `--help` flag to get the full list of available commands and arguments. -->
 
-Com o Playground CLI, você pode usar `--help` para obter suporte sobre os comandos disponíveis.
+Com o Playground CLI, você pode usar a flag `--help` para obter a lista completa de comandos e argumentos disponíveis.
 
 ```bash
 npx @wp-playground/cli@latest --help
+```
+
+<!-- ## Programmatic Usage with JavaScript -->
+
+## Uso Programático com JavaScript
+
+<!-- The Playground CLI can also be controlled programmatically from your JavaScript/TypeScript code using the `runCLI` function. This gives you direct access to all CLI functionalities within your code, which is useful for automating end-to-end tests. Let's cover the basics of using `runCLI`. -->
+
+O Playground CLI também pode ser controlado programaticamente a partir do seu código JavaScript/TypeScript usando a função `runCLI`. Isso fornece acesso direto a todas as funcionalidades do CLI dentro do seu código, o que é útil para automatizar testes end-to-end. Vamos cobrir o básico do uso de `runCLI`.
+
+<!-- ### Running a WordPress instance with a specific version -->
+
+### Executando uma instância WordPress com uma versão específica
+
+<!-- Using the `runCLI` function, you can specify options like the PHP and WordPress versions. In the example below, we request PHP 8.3, the latest version of WordPress, and to be automatically logged in. All supported arguments are defined in the `RunCLIArgs` type. -->
+
+Usando a função `runCLI`, você pode especificar opções como as versões do PHP e WordPress. No exemplo abaixo, solicitamos PHP 8.3, a versão mais recente do WordPress, e para fazer login automaticamente. Todos os argumentos suportados são definidos no tipo `RunCLIArgs`.
+
+```TypeScript
+import { runCLI, RunCLIArgs, RunCLIServer } from "@wp-playground/cli";
+
+let cliServer: RunCLIServer;
+
+cliServer = await runCLI({
+    command: 'server',
+    php: '8.3',
+    wp: 'latest',
+    login: true
+} as RunCLIArgs);
+```
+
+<!-- To execute the code above, the developer can set their preferred method. A simple way to execute this code is to save it as a `.ts` file and run it with a tool like `tsx`. For example: `tsx my-script.ts` -->
+
+Para executar o código acima, o desenvolvedor pode definir seu método preferido. Uma maneira simples de executar este código é salvá-lo como um arquivo `.ts` e executá-lo com uma ferramenta como `tsx`. Por exemplo: `tsx meu-script.ts`
+
+<!-- ### Setting a Blueprint -->
+
+### Definindo um Blueprint
+
+<!-- You can provide a blueprint in two ways: either as an object literal directly passed to the `blueprint` property, or as a string containing the path to an external `.json` file. -->
+
+Você pode fornecer um blueprint de duas maneiras: como um objeto literal passado diretamente para a propriedade `blueprint`, ou como uma string contendo o caminho para um arquivo `.json` externo.
+
+```TypeScript
+import { runCLI, RunCLIServer } from "@wp-playground/cli";
+
+let cliServer: RunCLIServer;
+
+cliServer = await runCLI({
+  command: 'server',
+  wp: 'latest',
+  blueprint: {
+    steps: [
+        {
+          "step": "setSiteOptions",
+          "options": {
+              "blogname": "Blueprint Title",
+              "blogdescription": "A great blog description"
+          }
+        }
+    ],
+  },
+});
+```
+
+<!-- For full type-safety when defining your blueprint object, you can import and use the `BlueprintDeclaration` type from the `@wp-playground/blueprints` package: -->
+
+Para total segurança de tipo ao definir seu objeto blueprint, você pode importar e usar o tipo `BlueprintDeclaration` do pacote `@wp-playground/blueprints`:
+
+```TypeScript
+import type { BlueprintDeclaration } from '@wp-playground/blueprints';
+
+const myBlueprint: BlueprintDeclaration = {
+  landingPage: "/wp-admin/",
+  steps: [
+    {
+      "step": "installTheme",
+      "themeData": {
+        "resource": "wordpress.org/themes",
+        "slug": "twentytwentyone"
+      },
+      "options": {
+        "activate": true
+      }
+    }
+  ]
+};
+```
+
+<!-- ### Mounting a plugin programmatically -->
+
+### Montando um plugin programaticamente
+
+<!-- It is possible to mount local directories programmatically using `runCLI`. The options `mount` and `mount-before-install` are available. The `hostPath` property expects a path to a directory on your local machine. This path should be relative to where your script is being executed. -->
+
+É possível montar diretórios locais programaticamente usando `runCLI`. As opções `mount` e `mount-before-install` estão disponíveis. A propriedade `hostPath` espera um caminho para um diretório na sua máquina local. Este caminho deve ser relativo a onde seu script está sendo executado.
+
+```TypeScript
+	cliServer = await runCLI({
+      command: 'server',
+      login: true,
+      'mount-before-install': [
+        {
+          hostPath: './[my-plugin-local-path]',
+          vfsPath: '/wordpress/wp-content/plugins/my-plugin',
+        },
+      ],
+    });
+```
+
+<!-- With those options we can combine mounting parts of the project with blueprints, for example: -->
+
+Com essas opções podemos combinar a montagem de partes do projeto com blueprints, por exemplo:
+
+```TypeScript
+
+import { runCLI, RunCLIArgs, RunCLIServer } from "@wp-playground/cli";
+
+let cliServer: RunCLIServer;
+
+cliServer = await runCLI({
+    command: 'server',
+    php: '8.3',
+    wp: 'latest',
+    login: true,
+    mount: [
+        {
+            "hostPath": "./plugin/",
+            "vfsPath": "/wordpress/wp-content/plugins/playwright-test"
+        }
+    ],
+    blueprint: {
+        steps: [
+            {
+                "step": "activatePlugin",
+                "pluginPath": "/wordpress/wp-content/plugins/playwright-test/plugin-playwright.php"
+            }
+        ]
+    }
+} as RunCLIArgs);
 ```


### PR DESCRIPTION
This pull request adds new documentation to clarify how data persistence works and where the SQLite database is stored when using the Playground CLI. This helps developers understand how to ensure their data is saved between sessions, especially when working with plugins or themes.

Documentation improvements:

* Added a new section explaining the default locations for WordPress files and the SQLite database when using Playground CLI, including details on how mounting different directories affects database persistence.