### PR TITLE
[CLI] Print temp dir and mounts when `--verbosity=debug`

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -548,6 +548,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 			const nativeDirPath = await createPlaygroundCliTempDir(
 				tempDirNameDelimiter
 			);
+			logger.debug(`Native temp dir for VFS root: ${nativeDirPath}`);
 
 			// We do not know the system temp dir,
 			// but we can try to infer from the location of the current temp dir.
@@ -605,6 +606,21 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer> {
 						vfsPath: `/${subdirName}`,
 						hostPath: nativeSubdirPath,
 					});
+				}
+			}
+
+			if (args['mount-before-install']) {
+				for (const mount of args['mount-before-install']) {
+					logger.debug(
+						`Mount before WP install: ${mount.vfsPath} -> ${mount.hostPath}`
+					);
+				}
+			}
+			if (args['mount']) {
+				for (const mount of args['mount']) {
+					logger.debug(
+						`Mount after WP install: ${mount.vfsPath} -> ${mount.hostPath}`
+					);
 				}
 			}
 


### PR DESCRIPTION
## Motivation for the change, related issues

After recent conversations about where Playground CLI places WordPress files, I thought it would be useful to the CLI print the location of the native temp dir and mounts when `--verbosity=debug`.

## Implementation details

This PR uses `logger.debug()` to log the location of the native temp dir and the mounts. These messages will only show up when `--verbosity=debug` is specified.

## Testing Instructions (or ideally a Blueprint)

- CI
- Run `npx nx unbuilt-asyncify playground-cli -- server --mount=.:/tmp/test --verbosity=debug` and verify that the CLI prints the native temp dir and before/after mounts.
