### PR TITLE
[Blueprints] Use _SERVER['HTTPS'] in the import step

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -61,6 +61,15 @@ async function importWithDefaultImporter(
 		data: file,
 	});
 	await playground.run({
+		$_SERVER: {
+			/**
+			 * get_site_url() infers the protocol from $_SERVER['HTTPS'] instead of
+			 * using the stored siteurl option. The importer relies on that behavior
+			 * when rewriting links in the WXR payload, so we populate the flag here
+			 * just as the web request layer would.
+			 */
+			HTTPS: (await playground.absoluteUrl).startsWith('https://'),
+		},
 		code: `<?php
 	define('WP_LOAD_IMPORTERS', true);
 	require 'wp-load.php';

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.ts
@@ -68,7 +68,7 @@ async function importWithDefaultImporter(
 			 * when rewriting links in the WXR payload, so we populate the flag here
 			 * just as the web request layer would.
 			 */
-			HTTPS: (await playground.absoluteUrl).startsWith('https://'),
+			HTTPS: (await playground.absoluteUrl).startsWith('https://') ? 'on' : '',
 		},
 		code: `<?php
 	define('WP_LOAD_IMPORTERS', true);


### PR DESCRIPTION
## Motivation for the change, related issues

Importing WXR content with URL rewriting enabled replaces the protocol in some URLs from `https` to `http`.

## Implementation details

Sets `$_SERVER['HTTPS'] = "on"` in the `importWxr` Blueprint step. The `php.run()` method called in the `importWxr` step does not set it automatically – that's a role of the request handler. The WXR importer relies on the `get_site_url()` WordPress function, which weirdly takes the `site_url` option and replaces the protocol based on the `$_SERVER['https']` value.

## Testing Instructions (or ideally a Blueprint)

Import this WXR file via `?importWxr` query parameter and confirm all the URLs are https:

https://gist.github.com/adamziel/a3d1a1941608e068e4b3d557ee2e8202/raw/aa659a130e1104cedeea8a63155a117dcb693dc8/tt25export.xml

The tricky part is, you need to serve Playground on a https url for this to work.

cc @bph 