### PR TITLE
[Website] Restore the visible button selection in the sidebar

### DIFF
--- a/packages/playground/website/src/components/site-manager/sidebar/style.module.css
+++ b/packages/playground/website/src/components/site-manager/sidebar/style.module.css
@@ -51,13 +51,13 @@
 	border-radius: 4px;
 	margin-bottom: 2px;
 }
-.sidebar-item:hover,
-.sidebar-item--selected {
+.sidebar-item.sidebar-item:hover,
+.sidebar-item.sidebar-item--selected {
 	color: var(--site-manager-text-color) !important;
 	background-color: #353535;
 }
 
-.sidebar-item--selected:hover {
+.sidebar-item.sidebar-item--selected:hover {
 	background-color: #545454;
 }
 


### PR DESCRIPTION
## Motivation for the change, related issues

Restores the highlight of the selected button in the sidebar that got somehow lost in production:

<img width="1790" height="792" alt="CleanShot 2025-10-21 at 19 34 08@2x" src="https://github.com/user-attachments/assets/b4f9b5ec-16f6-4020-96a0-480bc2934cab" />
