### PR TITLE
[Website] Retain address bar when opening the sidebar

### DIFF
--- a/packages/playground/components/src/icons.tsx
+++ b/packages/playground/components/src/icons.tsx
@@ -178,7 +178,7 @@ export function SiteManagerIcon({
 				<rect
 					x="3"
 					y="3"
-					width="6"
+					width="8"
 					height="18"
 					rx="2"
 					ry="2"

--- a/packages/playground/components/src/icons.tsx
+++ b/packages/playground/components/src/icons.tsx
@@ -144,7 +144,13 @@ export function getLogoDataURL(logo: { mime: string; data: string }): string {
 	return `data:${logo.mime};base64,${logo.data}`;
 }
 
-export function SiteManagerIcon({ size = 24 }: { size?: number }) {
+export function SiteManagerIcon({
+	size = 24,
+	sidebarActive = false,
+}: {
+	size?: number;
+	sidebarActive?: boolean;
+}) {
 	return (
 		<svg
 			width={size}
@@ -158,15 +164,29 @@ export function SiteManagerIcon({ size = 24 }: { size?: number }) {
 			strokeLinejoin="round"
 		>
 			<rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
-			<rect
-				x="3"
-				y="3"
-				width="6"
-				height="18"
-				rx="2"
-				ry="2"
-				fill="currentColor"
-			></rect>
+			{sidebarActive ? (
+				<rect
+					x="3"
+					y="3"
+					width="6"
+					height="18"
+					rx="2"
+					ry="2"
+					fill="currentColor"
+				></rect>
+			) : (
+				<rect
+					x="3"
+					y="3"
+					width="6"
+					height="18"
+					rx="2"
+					ry="2"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+				></rect>
+			)}
 		</svg>
 	);
 }

--- a/packages/playground/website/playwright/website-page.ts
+++ b/packages/playground/website/playwright/website-page.ts
@@ -38,20 +38,26 @@ export class WebsitePage {
 	}
 
 	async ensureSiteManagerIsOpen() {
-		const siteManagerHeading = this.page.locator('.main-sidebar');
-		if (await siteManagerHeading.isHidden({ timeout: 5000 })) {
-			await this.page.getByLabel('Open Site Manager').click();
+		const siteManager = this.page.locator('.main-sidebar');
+		if (!(await siteManager.isVisible())) {
+			await this.page
+				.getByRole('button', { name: 'Open Site Manager' })
+				.click();
 		}
-		await expect(siteManagerHeading).toBeVisible();
+		await expect(siteManager).toBeVisible();
 	}
 
 	async ensureSiteManagerIsClosed() {
-		const openSiteButton = this.page.locator('div[title="Open site"]');
-		if (await openSiteButton.isVisible({ timeout: 5000 })) {
-			await openSiteButton.click();
+		const siteManager = this.page.locator('.main-sidebar');
+		if (await siteManager.isVisible()) {
+			const closeButton = this.page.getByRole('button', {
+				name: 'Close Site Manager',
+			});
+			if (await closeButton.isVisible()) {
+				await closeButton.click();
+			}
 		}
-		const siteManagerHeading = this.page.locator('.main-sidebar');
-		await expect(siteManagerHeading).not.toBeVisible();
+		await expect(siteManager).not.toBeVisible();
 	}
 
 	async getSiteTitle(): Promise<string> {

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -51,7 +51,12 @@ export default function BrowserChrome({
 	return (
 		<div className={wrapperClass} data-cy="simulated-browser">
 			<div className={`${css.window} browser-chrome-window`}>
-				<header className={css.toolbar} aria-label="Playground toolbar">
+				<header
+					className={classNames(css.toolbar, {
+						[css.withSidebarOpen]: siteManagerIsOpen,
+					})}
+					aria-label="Playground toolbar"
+				>
 					<div className={css.windowControls}>
 						<Button
 							variant="browser-chrome"

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -20,13 +20,11 @@ import { SiteManagerIcon } from '@wp-playground/components';
 
 interface BrowserChromeProps {
 	children?: React.ReactNode;
-	hideToolbar?: boolean;
 	className?: string;
 }
 
 export default function BrowserChrome({
 	children,
-	hideToolbar,
 	className,
 }: BrowserChromeProps) {
 	const clientInfo = useAppSelector(getActiveClientInfo);
@@ -34,6 +32,9 @@ export default function BrowserChrome({
 	const showAddressBar = !!clientInfo;
 	const url = clientInfo?.url;
 	const dispatch = useAppDispatch();
+	const siteManagerIsOpen = useAppSelector(
+		(state) => state.ui.siteManagerIsOpen
+	);
 	const addressBarClass = classNames(css.addressBarSlot, {
 		[css.isHidden]: !showAddressBar,
 	});
@@ -50,22 +51,29 @@ export default function BrowserChrome({
 	return (
 		<div className={wrapperClass} data-cy="simulated-browser">
 			<div className={`${css.window} browser-chrome-window`}>
-				<header
-					className={`
-						${css.toolbar}
-						${hideToolbar ? css.toolbarHidden : ''}
-					`}
-					aria-label="Playground toolbar"
-				>
+				<header className={css.toolbar} aria-label="Playground toolbar">
 					<div className={css.windowControls}>
 						<Button
 							variant="browser-chrome"
-							aria-label="Open Site Manager"
+							aria-label={
+								siteManagerIsOpen
+									? 'Close Site Manager'
+									: 'Open Site Manager'
+							}
+							aria-pressed={siteManagerIsOpen}
+							className={classNames(css.openSiteManagerButton, {
+								[css.openSiteManagerButtonActive]:
+									siteManagerIsOpen,
+							})}
 							onClick={() => {
-								dispatch(setSiteManagerOpen(true));
+								dispatch(
+									setSiteManagerOpen(!siteManagerIsOpen)
+								);
 							}}
 						>
-							<SiteManagerIcon size={26} />
+							<SiteManagerIcon
+								sidebarActive={siteManagerIsOpen}
+							/>
 						</Button>
 					</div>
 

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -51,8 +51,12 @@ body.is-embedded .fake-window-wrapper {
 	align-items: center;
 	max-height: 100px;
 	overflow: hidden;
-	transition: max-height 0.2s ease-in-out;
+	transition: max-height 0.2s ease-in-out, padding 0.2s ease-in-out;
 	gap: 10px;
+}
+
+.toolbar.with-sidebar-open {
+	padding: 0 4px;
 }
 
 .window-controls {

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -46,7 +46,7 @@ body.is-embedded .fake-window-wrapper {
 	background: #1e2327;
 	width: 100%;
 	margin: 0 auto;
-	padding: 0 22px;
+	padding: 0 12px;
 	height: 50px;
 	align-items: center;
 	max-height: 100px;

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -55,10 +55,6 @@ body.is-embedded .fake-window-wrapper {
 	gap: 10px;
 }
 
-.toolbar-hidden {
-	max-height: 0;
-}
-
 .window-controls {
 	display: flex;
 }

--- a/packages/playground/website/src/components/layout/index.tsx
+++ b/packages/playground/website/src/components/layout/index.tsx
@@ -25,10 +25,7 @@ import {
 	supportedDisplayModes,
 	PlaygroundViewport,
 } from '../playground-viewport';
-import {
-	setActiveModal,
-	setSiteManagerOpen,
-} from '../../lib/state/redux/slice-ui';
+import { setActiveModal } from '../../lib/state/redux/slice-ui';
 import { ImportFormModal } from '../import-form-modal';
 import { PreviewPRModal } from '../../github/preview-pr';
 import { MissingSiteModal } from '../missing-site-modal';
@@ -64,7 +61,6 @@ export function Layout() {
 		(state) => state.ui.siteManagerIsOpen
 	);
 	const siteManagerWrapperRef = useRef<HTMLDivElement>(null);
-	const dispatch = useAppDispatch();
 
 	return (
 		<div className={`${css.layout}`}>
@@ -89,20 +85,8 @@ export function Layout() {
 				</div>
 			</CSSTransition>
 			<div className={css.siteView}>
-				{siteManagerIsOpen && (
-					<div
-						title="Open site"
-						className={css.siteViewOverlay}
-						onClick={() => {
-							dispatch(setSiteManagerOpen(false));
-						}}
-					/>
-				)}
 				<div className={css.siteViewContent}>
-					<PlaygroundViewport
-						displayMode={displayMode}
-						hideToolbar={siteManagerIsOpen}
-					/>
+					<PlaygroundViewport displayMode={displayMode} />
 				</div>
 			</div>
 		</div>

--- a/packages/playground/website/src/components/layout/style.module.css
+++ b/packages/playground/website/src/components/layout/style.module.css
@@ -97,7 +97,8 @@ body {
 
 .site-manager-wrapper + .site-view {
 	position: relative;
-	border-width: 0;
+	border-width: var(--site-manager-border-width);
+	border-top-width: 0;
 	border-left-width: 0;
 	.site-view-content {
 		border-radius: var(--site-manager-border-radius);

--- a/packages/playground/website/src/components/layout/style.module.css
+++ b/packages/playground/website/src/components/layout/style.module.css
@@ -3,8 +3,8 @@
 	--site-manager-site-info-min-width: 555px;
 	--site-manager-width-desktop: calc(
 		var(--site-manager-site-list-width) +
-		var(--site-manager-site-info-min-width) +
-		2 * var(--site-manager-border-width)
+			var(--site-manager-site-info-min-width) + 2 *
+			var(--site-manager-border-width)
 	);
 	--site-view-min-width: 320px;
 	--site-manager-background-color: #1e1e1e;
@@ -97,19 +97,11 @@ body {
 
 .site-manager-wrapper + .site-view {
 	position: relative;
-	border-width: var(--site-manager-border-width);
+	border-width: 0;
 	border-left-width: 0;
 	.site-view-content {
 		border-radius: var(--site-manager-border-radius);
 	}
-}
-
-.site-manager-wrapper:not(
-		.site-manager-wrapper-exit-active,
-		.site-manager-wrapper-enter-active
-	)
-	+ .site-view:hover {
-	transform: scale(1.01);
 }
 
 .site-manager-wrapper-exit-active + .site-view {
@@ -124,19 +116,6 @@ body {
 	overflow: hidden;
 	transition: border-radius 300ms;
 	height: 100%;
-}
-
-.site-view-overlay {
-	content: '';
-	display: block;
-	width: 100%;
-	height: 100dvh;
-	background-color: transparent;
-	position: absolute;
-	top: 0;
-	left: 0;
-	z-index: 1;
-	cursor: pointer;
 }
 
 /*

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -29,20 +29,18 @@ interface PlaygroundViewportProps {
 	displayMode?: DisplayMode;
 	children?: React.ReactNode;
 	siteSlug?: string;
-	hideToolbar?: boolean;
 	className?: string;
 }
 
 export const PlaygroundViewport = ({
 	displayMode = 'browser-full-screen',
-	hideToolbar,
 	className,
 }: PlaygroundViewportProps) => {
 	if (displayMode === 'seamless') {
 		return <KeepAliveTemporarySitesViewport />;
 	}
 	return (
-		<BrowserChrome hideToolbar={hideToolbar} className={className}>
+		<BrowserChrome className={className}>
 			<KeepAliveTemporarySitesViewport />
 		</BrowserChrome>
 	);

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -107,7 +107,7 @@ export function SiteInfoPanel({
 						justify="space-between"
 						align="flex-start"
 						expanded={true}
-						className={css.padded}
+						className={`${css.padded} ${css.siteInfoHeader}`}
 						style={{ paddingBottom: 10 }}
 					>
 						{mobileUi && (

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -93,6 +93,16 @@
 	width: 100%;
 }
 
+.site-info-header {
+	color: inherit;
+
+	&:has(.site-info-header-details-created-at:empty),
+	&:not(:has(.site-info-header-details-created-at)) {
+		justify-content: center;
+		align-items: center;
+	}
+}
+
 .site-info-header-icon {
 	box-sizing: border-box;
 


### PR DESCRIPTION
## Motivation for the change, related issues

With this PR, you can interact with the Playground while the sidebar is active. It's no longer one or the other. The sidebar button toggles the sidebars on and off:


https://github.com/user-attachments/assets/574a5548-f70c-423e-ae2e-bbe01ffb61c4




## Testing Instructions (or ideally a Blueprint)

Confirm you can use the address bar and interact with Playground while the sidebar is active.

cc @fellyph @akirk 