### PR TITLE
[Website] Move the sidebar icon to the right

### DIFF
--- a/packages/playground/components/src/icons.tsx
+++ b/packages/playground/components/src/icons.tsx
@@ -168,7 +168,7 @@ export function SiteManagerIcon({
 				<rect
 					x="3"
 					y="3"
-					width="6"
+					width="7"
 					height="18"
 					rx="2"
 					ry="2"

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -57,7 +57,16 @@ export default function BrowserChrome({
 					})}
 					aria-label="Playground toolbar"
 				>
-					<div className={css.windowControls}>
+					<div className={addressBarClass}>
+						<AddressBar
+							url={url}
+							onUpdate={(newUrl) =>
+								clientInfo?.client.goTo(newUrl)
+							}
+						/>
+					</div>
+
+					<div className={css.toolbarButtons}>
 						<Button
 							variant="browser-chrome"
 							aria-label={
@@ -80,18 +89,7 @@ export default function BrowserChrome({
 								sidebarActive={siteManagerIsOpen}
 							/>
 						</Button>
-					</div>
 
-					<div className={addressBarClass}>
-						<AddressBar
-							url={url}
-							onUpdate={(newUrl) =>
-								clientInfo?.client.goTo(newUrl)
-							}
-						/>
-					</div>
-
-					<div className={css.toolbarButtons}>
 						{isMobileUi ? (
 							<>
 								<Button
@@ -100,7 +98,6 @@ export default function BrowserChrome({
 									onClick={onToggle}
 									aria-expanded={isModalOpen}
 									style={{
-										padding: '0 10px',
 										fill: '#FFF',
 										alignItems: 'center',
 										display: 'flex',
@@ -132,7 +129,6 @@ export default function BrowserChrome({
 										onClick={onToggle}
 										aria-expanded={isOpen}
 										style={{
-											padding: '0 10px',
 											fill: '#FFF',
 											alignItems: 'center',
 											display: 'flex',

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -59,17 +59,13 @@ body.is-embedded .fake-window-wrapper {
 	padding: 0 4px;
 }
 
-.window-controls {
-	display: flex;
-}
-
 .toolbar-buttons:empty {
 	display: none;
 }
 
 .toolbar-buttons {
 	display: flex;
-	gap: 10px;
+	gap: 0;
 	color: #fff;
 }
 

--- a/packages/playground/website/src/components/button/style.module.css
+++ b/packages/playground/website/src/components/button/style.module.css
@@ -23,6 +23,7 @@
 .button.button.button.is-browser-chrome {
 	display: flex;
 	align-items: center;
+	justify-content: center;
 	min-height: 40px;
 	min-width: 40px;
 	background: transparent;


### PR DESCRIPTION
## Motivation for the change, related issues

Moves the sidebar icon to the right to keep it in a stable position after clicking. When it was on the left, it did slide to the right as the sidebar expanded:

**Before**

<img width="3094" height="1274" alt="CleanShot 2025-10-23 at 14 13 49@2x" src="https://github.com/user-attachments/assets/8382454b-05a0-494b-bcac-973beb126e6d" />


**After**

<img width="3088" height="1280" alt="CleanShot 2025-10-23 at 14 13 28@2x" src="https://github.com/user-attachments/assets/103b6a3e-4b44-4255-9c53-6e0115ef0d73" />
