### PR TITLE
[Docs] Updating CLI flags list

### DIFF
--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -118,7 +118,6 @@ The `server` command supports the following optional arguments:
 -   `--verbosity=<level>`: Output logs and progress messages. Choices: `quiet`, `normal`, `debug`. Defaults to `normal`.
 -   `--debug`: Print the PHP error log if an error occurs during boot.
 -   `--follow-symlinks`: Allow Playground to follow symlinks by automatically mounting symlinked directories and files encountered in mounted directories.
--   `--quiet`: Do not output logs and progress messages.
 -   `--internal-cookie-store`: Enable internal cookie handling. When enabled, Playground will manage cookies internally using an HttpCookieStore that persists cookies across requests. When disabled, cookies are handled externally (e.g., by a browser in Node.js environments). Defaults to false.
 -   `--xdebug`: Enable Xdebug. Defaults to false.
 -   `--experimental-devtools`: Enable experimental browser development tools. Defaults to false.

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -100,7 +100,9 @@ to your unique WordPress setup. With the Playground CLI, you can use the followi
 The `server` command supports the following optional arguments:
 
 -   `--port=<port>`: The port number for the server to listen on. Defaults to 9400.
+-   `--version`: Show version number.
 -   `--outfile`: When building, write to this output file.
+-   `--site-url=<url>`: Site URL to use for WordPress. Defaults to `http://127.0.0.1:{port}`.
 -   `--wp=<version>`: The version of WordPress to use. Defaults to the latest.
 -   `--php=<version>`: PHP version to use. Choices: `8.4`, `8.3`, `8.2`, `8.1`, `8.0`, `7.4`, `7.3`, `7.2`. Defaults to `8.3`.
 -   `--auto-mount[=<path>]`: Automatically mount a directory. If no path is provided, mounts the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.
@@ -113,10 +115,14 @@ The `server` command supports the following optional arguments:
 -   `--login`: Automatically log the user in as an administrator.
 -   `--skip-wordpress-setup`: Do not download or install WordPress. Useful if you are mounting a full WordPress directory.
 -   `--skip-sqlite-setup`: Do not set up the SQLite database integration.
--   `--verbosity`: Output logs and progress messages. Choices are "quiet", "normal" or "debug". Defaults to "normal".
+-   `--verbosity=<level>`: Output logs and progress messages. Choices: `quiet`, `normal`, `debug`. Defaults to `normal`.
 -   `--debug`: Print the PHP error log if an error occurs during boot.
 -   `--follow-symlinks`: Allow Playground to follow symlinks by automatically mounting symlinked directories and files encountered in mounted directories.
 -   `--quiet`: Do not output logs and progress messages.
+-   `--internal-cookie-store`: Enable internal cookie handling. When enabled, Playground will manage cookies internally using an HttpCookieStore that persists cookies across requests. When disabled, cookies are handled externally (e.g., by a browser in Node.js environments). Defaults to false.
+-   `--xdebug`: Enable Xdebug. Defaults to false.
+-   `--experimental-devtools`: Enable experimental browser development tools. Defaults to false.
+-   `--experimental-multi-worker=<number>`: Enable experimental multi-worker support which requires a `/wordpress` directory backed by a real filesystem. Pass a positive number to specify the number of workers to use. Otherwise, defaults to the number of CPUs minus 1.
 
 :::caution
 With the flag `--follow-symlinks`, the following symlinks will expose files outside mounted directories to Playground and could be a security risk.

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -102,7 +102,8 @@ The `server` command supports the following optional arguments:
 -   `--port=<port>`: The port number for the server to listen on. Defaults to 9400.
 -   `--outfile`: When building, write to this output file.
 -   `--wp=<version>`: The version of WordPress to use. Defaults to the latest.
--   `--auto-mount`: Automatically mount the current directory (plugin, theme, wp-content, etc.).
+-   `--php=<version>`: PHP version to use. Choices: `8.4`, `8.3`, `8.2`, `8.1`, `8.0`, `7.4`, `7.3`, `7.2`. Defaults to `8.3`.
+-   `--auto-mount[=<path>]`: Automatically mount a directory. If no path is provided, mounts the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.
 -   `--mount=<mapping>`: Manually mount a directory (can be used multiple times). Format: `"/host/path:/vfs/path"`.
 -   `--mount-before-install`: Mount a directory to the PHP runtime before WordPress installation (can be used multiple times). Format: `"/host/path:/vfs/path"`.
 -   `--mount-dir`: Mount a directory to the PHP runtime (can be used multiple times). Format: `"/host/path"` `"/vfs/path"`.
@@ -114,6 +115,12 @@ The `server` command supports the following optional arguments:
 -   `--skip-sqlite-setup`: Do not set up the SQLite database integration.
 -   `--verbosity`: Output logs and progress messages. Choices are "quiet", "normal" or "debug". Defaults to "normal".
 -   `--debug`: Print the PHP error log if an error occurs during boot.
+-   `--follow-symlinks`: Allow Playground to follow symlinks by automatically mounting symlinked directories and files encountered in mounted directories.
+-   `--quiet`: Do not output logs and progress messages.
+
+:::caution
+With the flag `--follow-symlinks`, the following symlinks will expose files outside mounted directories to Playground and could be a security risk.
+:::
 
 ## Need some help with the CLI?
 


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request updates the documentation for the `wp-playground-cli` server command, expanding and clarifying the available command-line options. The most important changes include the addition of new flags, improved descriptions for existing options, and important security notes regarding symlink handling.

**New and updated CLI options:**

* Added a `--php=<version>` option to specify the PHP version, with supported versions listed and a default of `8.3`.
* Enhanced the `--auto-mount` option to accept an optional path argument (`--auto-mount[=<path>]`), allowing users to specify which directory to mount or default to the current working directory. The documentation now clarifies what types of directories can be mounted.
* Introduced a `--follow-symlinks` flag, enabling Playground to automatically mount symlinked directories and files within mounted directories.
* Added a `--quiet` flag to suppress logs and progress messages.

**Security and usage notes:**

* Added a cautionary note about the security implications of using the `--follow-symlinks` flag, warning that it may expose files outside mounted directories.
