### PR TITLE
[Website] Add Playground refresh button

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -67,6 +67,50 @@ test('should reflect the URL update from the navigation bar in the WordPress sit
 	);
 });
 
+test('should refresh the WordPress site when clicking the refresh button', async ({
+	website,
+	wordpress,
+}) => {
+	// Navigate to a page that we can verify was refreshed
+	const blueprint: Blueprint = {
+		landingPage: '/test-refresh.php',
+		steps: [
+			{
+				step: 'writeFile',
+				path: '/wordpress/test-refresh.php',
+				data: '<?php echo "Initial Load: " . time(); ?>',
+			},
+		],
+	};
+	await website.goto(`./#${JSON.stringify(blueprint)}`);
+	await website.ensureSiteManagerIsClosed();
+
+	// Get the initial content
+	const initialContent = await wordpress.locator('body').textContent();
+	expect(initialContent).toMatch(/Initial Load: \d+/);
+
+	// Wait a moment to ensure the timestamp will be different
+	await website.page.waitForTimeout(1000);
+
+	// Click the refresh button
+	const refreshButton = website.page.getByLabel('Refresh');
+	await expect(refreshButton).toBeVisible();
+	await refreshButton.click();
+
+	// Wait for WordPress to reload
+	await website.waitForNestedIframes();
+
+	// Verify the page was refreshed by checking the timestamp changed
+	const refreshedContent = await wordpress.locator('body').textContent();
+	expect(refreshedContent).toMatch(/Initial Load: \d+/);
+	expect(refreshedContent).not.toBe(initialContent);
+
+	// Verify the URL in the address bar stayed the same
+	await expect(website.page.locator('input[name="url"]')).toHaveValue(
+		'/test-refresh.php'
+	);
+});
+
 test('should correctly load /wp-admin without the trailing slash', async ({
 	website,
 	browserName,

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -60,17 +60,22 @@ export default function BrowserChrome({
 					<div className={addressBarClass}>
 						{showAddressBar && (
 							<Button
-								className={css.refreshButton}
+								variant="browser-chrome"
 								aria-label="Refresh"
 								onClick={() => {
 									if (clientInfo && url) {
 										clientInfo.client.goTo(url);
 									}
 								}}
+								style={{
+									fill: '#FFF',
+									alignItems: 'center',
+									display: 'flex',
+								}}
 							>
 								<svg
-									width="20"
-									height="20"
+									width="24"
+									height="24"
 									viewBox="0 0 24 24"
 									fill="none"
 									xmlns="http://www.w3.org/2000/svg"

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -58,6 +58,33 @@ export default function BrowserChrome({
 					aria-label="Playground toolbar"
 				>
 					<div className={addressBarClass}>
+						{showAddressBar && (
+							<Button
+								className={css.refreshButton}
+								aria-label="Refresh"
+								onClick={() => {
+									if (clientInfo && url) {
+										clientInfo.client.goTo(url);
+									}
+								}}
+							>
+								<svg
+									width="20"
+									height="20"
+									viewBox="0 0 24 24"
+									fill="none"
+									xmlns="http://www.w3.org/2000/svg"
+									aria-hidden="true"
+								>
+									<path
+										d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+										fill="currentColor"
+										stroke="currentColor"
+										strokeWidth="0.5"
+									/>
+								</svg>
+							</Button>
+						)}
 						<AddressBar
 							url={url}
 							onUpdate={(newUrl) =>

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -85,32 +85,6 @@ body.is-embedded .fake-window-wrapper {
 	pointer-events: none;
 }
 
-.refresh-button.refresh-button {
-	flex-shrink: 0;
-	background: transparent !important;
-	color: #fff !important;
-	border: none !important;
-	padding: 8px !important;
-	min-width: 40px !important;
-	width: 40px !important;
-	min-height: 40px !important;
-	height: 40px !important;
-	display: flex !important;
-	align-items: center !important;
-	justify-content: center !important;
-	border-radius: 4px !important;
-}
-
-.refresh-button.refresh-button:hover {
-	opacity: 0.8 !important;
-}
-
-.refresh-button svg {
-	width: 22px;
-	height: 22px;
-	color: #fff;
-}
-
 .padded {
 	padding: 24px;
 }

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -76,11 +76,39 @@ body.is-embedded .fake-window-wrapper {
 	width: 100%;
 	opacity: 1;
 	transition: opacity ease-in 0.25s;
+	gap: 8px;
+	align-items: center;
 }
 
 .address-bar-slot.is-hidden {
 	opacity: 0;
 	pointer-events: none;
+}
+
+.refresh-button.refresh-button {
+	flex-shrink: 0;
+	background: transparent !important;
+	color: #fff !important;
+	border: none !important;
+	padding: 8px !important;
+	min-width: 40px !important;
+	width: 40px !important;
+	min-height: 40px !important;
+	height: 40px !important;
+	display: flex !important;
+	align-items: center !important;
+	justify-content: center !important;
+	border-radius: 4px !important;
+}
+
+.refresh-button.refresh-button:hover {
+	opacity: 0.8 !important;
+}
+
+.refresh-button svg {
+	width: 22px;
+	height: 22px;
+	color: #fff;
 }
 
 .padded {


### PR DESCRIPTION
## Motivation for the change, related issues

Now that Playground has a code editor, a refresh button will be useful to allow quick page refreshing for testing:

<img width="2070" height="1976" alt="CleanShot 2025-10-27 at 01 07 52@2x" src="https://github.com/user-attachments/assets/805c558c-f1ed-4d62-afc7-bdca6be19757" />

## Testing Instructions (or ideally a Blueprint)

Apply this PR locally, confirm the refresh button is displayed and that it, indeed, refreshes the Playground page.