### PR TITLE
[Website] Make saved sites sidebar more narrow

### DIFF
--- a/packages/playground/website/src/components/layout/style.module.css
+++ b/packages/playground/website/src/components/layout/style.module.css
@@ -1,5 +1,5 @@
 :root {
-	--site-manager-site-list-width: 320px;
+	--site-manager-site-list-width: 300px;
 	--site-manager-site-info-min-width: 555px;
 	--site-manager-width-desktop: calc(
 		var(--site-manager-site-list-width) +

--- a/packages/playground/website/src/components/layout/style.module.css
+++ b/packages/playground/website/src/components/layout/style.module.css
@@ -1,5 +1,5 @@
 :root {
-	--site-manager-site-list-width: 300px;
+	--site-manager-site-list-width: 280px;
 	--site-manager-site-info-min-width: 555px;
 	--site-manager-width-desktop: calc(
 		var(--site-manager-site-list-width) +


### PR DESCRIPTION
Changed --site-manager-site-list-width from 320px to 300px to make the sidebar with saved sites more compact. This improves the #2813  experience.

## Testing Instructions (or ideally a Blueprint)

Go to local Playground confirm the left sidebar is more narrow and yet still useful