### PR TITLE
[Blueprints] Fix setSiteLanguage blueprint step to use option instead of constant

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/set-site-language.ts
+++ b/packages/playground/blueprints/src/lib/steps/set-site-language.ts
@@ -1,7 +1,7 @@
 import type { StepHandler } from '.';
 import { unzipFile } from '@wp-playground/common';
 import { logger } from '@php-wasm/logger';
-import { Semaphore } from '@php-wasm/util';
+import { phpVar, Semaphore } from '@php-wasm/util';
 /**
  * @inheritDoc setSiteLanguage
  * @hasRunnableExample
@@ -59,9 +59,15 @@ export const setSiteLanguage: StepHandler<SetSiteLanguageStep> = async (
 ) => {
 	progress?.tracker.setCaption(progress?.initialCaption || 'Translating');
 
-	await playground.defineConstant('WPLANG', language);
-
 	const docroot = await playground.documentRoot;
+
+	await playground.defineConstant('WPLANG', language);
+	await playground.run({
+		code: `<?php
+		require_once ${phpVar(docroot)} . '/wp-load.php';
+		update_option('WPLANG', ${phpVar(language)});
+		`,
+	});
 
 	const wpVersion = (
 		await playground.run({

--- a/packages/playground/blueprints/src/tests/steps/set-site-language.spec.ts
+++ b/packages/playground/blueprints/src/tests/steps/set-site-language.spec.ts
@@ -1,4 +1,16 @@
-import { getWordPressTranslationUrl } from '../../lib/steps/set-site-language';
+import type { UniversalPHP } from '@php-wasm/universal';
+import type * as PlaygroundCommon from '@wp-playground/common';
+import { unzipFile } from '@wp-playground/common';
+import { vi } from 'vitest';
+import {
+	getWordPressTranslationUrl,
+	setSiteLanguage,
+} from '../../lib/steps/set-site-language';
+
+vi.mock('@wp-playground/common', async (importOriginal) => ({
+	...(await importOriginal<typeof PlaygroundCommon>()),
+	unzipFile: vi.fn(),
+}));
 
 describe('getWordPressTranslationUrl()', () => {
 	[
@@ -49,5 +61,55 @@ describe('getWordPressTranslationUrl()', () => {
 		await expect(
 			getWordPressTranslationUrl('6.6-RC', 'en_US')
 		).rejects.toThrow();
+	});
+});
+
+describe('Blueprint step setSiteLanguage()', () => {
+	const originalFetch = global.fetch;
+
+	afterEach(() => {
+		global.fetch = originalFetch;
+		vi.mocked(unzipFile).mockReset();
+	});
+
+	it('persists the selected language in the WPLANG option', async () => {
+		global.fetch = vi
+			.fn()
+			.mockResolvedValueOnce({
+				json: async () => ({
+					translations: [
+						{
+							language: 'es_ES',
+							package: 'https://example.com/es_ES.zip',
+						},
+					],
+				}),
+			})
+			.mockResolvedValueOnce({
+				ok: true,
+				arrayBuffer: async () => new ArrayBuffer(0),
+			});
+
+		const defineConstant = vi.fn();
+		const run = vi
+			.fn()
+			.mockResolvedValueOnce({ text: '' })
+			.mockResolvedValueOnce({ text: '6.8' })
+			.mockResolvedValueOnce({ json: [] })
+			.mockResolvedValueOnce({ json: [] });
+		const playground = {
+			defineConstant,
+			documentRoot: Promise.resolve('/wordpress'),
+			run,
+			isDir: vi.fn().mockResolvedValue(true),
+			mkdir: vi.fn(),
+		} as unknown as UniversalPHP;
+
+		await setSiteLanguage(playground, { language: 'es_ES' });
+
+		expect(defineConstant).toHaveBeenCalledWith('WPLANG', 'es_ES');
+		const updateLanguageCall = run.mock.calls[0][0] as { code: string };
+		expect(updateLanguageCall.code).toContain("update_option('WPLANG'");
+		expect(updateLanguageCall.code).toContain('ImVzX0VTIg==');
 	});
 });


### PR DESCRIPTION
## What it does

Updates the `setSiteLanguage` Blueprint step so the selected locale is persisted in WordPress via the `WPLANG` option.

The step still defines the `WPLANG` constant before the first WordPress bootstrap, so the active Playground runtime can switch language immediately during the Blueprint run.

## Rationale

`define('WPLANG', ...)` affects the current bootstrap, but it does not update the site setting stored in WordPress. After the Blueprint finishes, WordPress can still report the old locale in Settings > General because the `WPLANG` option was never changed.

Persisting the option makes the Blueprint result match the WordPress admin setting while keeping the immediate runtime behavior from the existing constant definition.

## Implementation

After defining `WPLANG`, the step bootstraps WordPress and calls:

```php
update_option('WPLANG', $language);
```

The test coverage now asserts both parts of the behavior: the constant is still defined, and the generated PHP updates the `WPLANG` option for the selected language.

## Testing instructions

Focused checks run locally:

```bash
npx vitest run packages/playground/blueprints/src/tests/steps/set-site-language.spec.ts --config packages/playground/blueprints/vite.config.ts
npx nx run playground-blueprints:lint --skip-nx-cache
npx prettier --check packages/playground/blueprints/src/lib/steps/set-site-language.ts packages/playground/blueprints/src/tests/steps/set-site-language.spec.ts
git diff --check
```