### PR TITLE
[i18n] Adding cli flags to Portuguese and Spanish

### DIFF
--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -169,9 +169,12 @@ a tu configuración única de WordPress. Con el Playground CLI, puedes usar los 
 El comando `server` soporta los siguientes argumentos opcionales:
 
 -   `--port=<port>`: El número de puerto para que el servidor escuche. Por defecto es 9400.
+-   `--version`: Mostrar número de versión.
 -   `--outfile`: Al construir, escribir en este archivo de salida.
+-   `--site-url=<url>`: URL del sitio a usar para WordPress. Por defecto es `http://127.0.0.1:{port}`.
 -   `--wp=<version>`: La versión de WordPress a usar. Por defecto es la última.
--   `--auto-mount`: Montar automáticamente el directorio actual (plugin, tema, wp-content, etc.).
+-   `--php=<version>`: Versión de PHP a usar. Opciones: `8.4`, `8.3`, `8.2`, `8.1`, `8.0`, `7.4`, `7.3`, `7.2`. Por defecto es `8.3`.
+-   `--auto-mount[=<path>]`: Montar automáticamente un directorio. Si no se proporciona una ruta, monta el directorio de trabajo actual. Puedes montar un directorio WordPress, un directorio de plugin, un directorio de tema, un directorio wp-content, o cualquier directorio que contenga archivos PHP y HTML.
 -   `--mount=<mapping>`: Montar manualmente un directorio (puede usarse múltiples veces). Formato: `"/host/path:/vfs/path"`.
 -   `--mount-before-install`: Montar un directorio al runtime PHP antes de la instalación de WordPress (puede usarse múltiples veces). Formato: `"/host/path:/vfs/path"`.
 -   `--mount-dir`: Montar un directorio al runtime PHP (puede usarse múltiples veces). Formato: `"/host/path"` `"/vfs/path"`.
@@ -181,8 +184,17 @@ El comando `server` soporta los siguientes argumentos opcionales:
 -   `--login`: Iniciar sesión automáticamente del usuario como administrador.
 -   `--skip-wordpress-setup`: No descargar ni instalar WordPress. Útil si estás montando un directorio WordPress completo.
 -   `--skip-sqlite-setup`: No configurar la integración de base de datos SQLite.
--   `--verbosity`: Salida de logs y mensajes de progreso. Las opciones son "quiet", "normal" o "debug". Por defecto es "normal".
+-   `--verbosity=<level>`: Salida de logs y mensajes de progreso. Opciones: `quiet`, `normal`, `debug`. Por defecto es `normal`.
 -   `--debug`: Imprimir el log de errores de PHP si ocurre un error durante el arranque.
+-   `--follow-symlinks`: Permitir que Playground siga enlaces simbólicos montando automáticamente directorios y archivos vinculados simbólicamente encontrados en directorios montados.
+-   `--internal-cookie-store`: Habilitar manejo interno de cookies. Cuando está habilitado, Playground administrará cookies internamente usando un HttpCookieStore que persiste cookies entre solicitudes. Cuando está deshabilitado, las cookies se manejan externamente (por ejemplo, por un navegador en entornos Node.js). Por defecto es false.
+-   `--xdebug`: Habilitar Xdebug. Por defecto es false.
+-   `--experimental-devtools`: Habilitar herramientas de desarrollo experimentales del navegador. Por defecto es false.
+-   `--experimental-multi-worker=<number>`: Habilitar soporte experimental multi-worker que requiere un directorio `/wordpress` respaldado por un sistema de archivos real. Pasa un número positivo para especificar el número de workers a usar. De lo contrario, por defecto es el número de CPUs menos 1.
+
+:::caution
+Con la bandera `--follow-symlinks`, los siguientes enlaces simbólicos expondrán archivos fuera de los directorios montados a Playground y podrían ser un riesgo de seguridad.
+:::
 
 ## ¿Necesitas ayuda con el CLI?
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -271,26 +271,13 @@ com sua configuração WordPress única. Com o Playground CLI, você pode usar o
 
 O comando `server` suporta os seguintes argumentos opcionais:
 
-<!-- -   `--port=<port>`: The port number for the server to listen on. Defaults to 9400. -->
-<!-- -   `--outfile`: When building, write to this output file. -->
-<!-- -   `--wp=<version>`: The version of WordPress to use. Defaults to the latest. -->
-<!-- -   `--auto-mount`: Automatically mount the current directory (plugin, theme, wp-content, etc.). -->
-<!-- -   `--mount=<mapping>`: Manually mount a directory (can be used multiple times). Format: `"/host/path:/vfs/path"`. -->
-<!-- -   `--mount-before-install`: Mount a directory to the PHP runtime before WordPress installation (can be used multiple times). Format: `"/host/path:/vfs/path"`. -->
-<!-- -   `--mount-dir`: Mount a directory to the PHP runtime (can be used multiple times). Format: `"/host/path"` `"/vfs/path"`. -->
-<!-- -   `--mount-dir-before-install`: Mount a directory before WordPress installation (can be used multiple times). Format: `"/host/path"` `"/vfs/path"` -->
-<!-- -   `--blueprint=<path>`: The path to a JSON Blueprint file to execute. -->
-<!-- -   `--blueprint-may-read-adjacent-files`: Consent flag: Allow "bundled" resources in a local blueprint to read files in the same directory as the blueprint file. -->
-<!-- -   `--login`: Automatically log the user in as an administrator. -->
-<!-- -   `--skip-wordpress-setup`: Do not download or install WordPress. Useful if you are mounting a full WordPress directory. -->
-<!-- -   `--skip-sqlite-setup`: Do not set up the SQLite database integration. -->
-<!-- -   `--verbosity`: Output logs and progress messages. Choices are "quiet", "normal" or "debug". Defaults to "normal". -->
-<!-- -   `--debug`: Print the PHP error log if an error occurs during boot. -->
-
 -   `--port=<port>`: O número da porta para o servidor escutar. Padrão é 9400.
+-   `--version`: Mostrar número da versão.
 -   `--outfile`: Ao construir, escrever neste arquivo de saída.
+-   `--site-url=<url>`: URL do site a usar para WordPress. Padrão é `http://127.0.0.1:{port}`.
 -   `--wp=<version>`: A versão do WordPress a usar. Padrão é a mais recente.
--   `--auto-mount`: Montar automaticamente o diretório atual (plugin, tema, wp-content, etc.).
+-   `--php=<version>`: Versão do PHP a usar. Opções: `8.4`, `8.3`, `8.2`, `8.1`, `8.0`, `7.4`, `7.3`, `7.2`. Padrão é `8.3`.
+-   `--auto-mount[=<path>]`: Montar automaticamente um diretório. Se nenhum caminho for fornecido, monta o diretório de trabalho atual. Você pode montar um diretório WordPress, um diretório de plugin, um diretório de tema, um diretório wp-content, ou qualquer diretório contendo arquivos PHP e HTML.
 -   `--mount=<mapping>`: Montar manualmente um diretório (pode ser usado múltiplas vezes). Formato: `"/host/path:/vfs/path"`.
 -   `--mount-before-install`: Montar um diretório no runtime PHP antes da instalação do WordPress (pode ser usado múltiplas vezes). Formato: `"/host/path:/vfs/path"`.
 -   `--mount-dir`: Montar um diretório no runtime PHP (pode ser usado múltiplas vezes). Formato: `"/host/path"` `"/vfs/path"`.
@@ -300,8 +287,17 @@ O comando `server` suporta os seguintes argumentos opcionais:
 -   `--login`: Fazer login automaticamente do usuário como administrador.
 -   `--skip-wordpress-setup`: Não baixar ou instalar WordPress. Útil se você está montando um diretório WordPress completo.
 -   `--skip-sqlite-setup`: Não configurar a integração do banco de dados SQLite.
--   `--verbosity`: Saída de logs e mensagens de progresso. Opções são "quiet", "normal" ou "debug". Padrão é "normal".
+-   `--verbosity=<level>`: Saída de logs e mensagens de progresso. Opções: `quiet`, `normal`, `debug`. Padrão é `normal`.
 -   `--debug`: Imprimir o log de erro do PHP se um erro ocorrer durante a inicialização.
+-   `--follow-symlinks`: Permitir que o Playground siga links simbólicos montando automaticamente diretórios e arquivos vinculados simbolicamente encontrados em diretórios montados.
+-   `--internal-cookie-store`: Habilitar tratamento interno de cookies. Quando habilitado, o Playground gerenciará cookies internamente usando um HttpCookieStore que persiste cookies entre requisições. Quando desabilitado, cookies são tratados externamente (por exemplo, por um navegador em ambientes Node.js). Padrão é false.
+-   `--xdebug`: Habilitar Xdebug. Padrão é false.
+-   `--experimental-devtools`: Habilitar ferramentas de desenvolvimento experimentais do navegador. Padrão é false.
+-   `--experimental-multi-worker=<number>`: Habilitar suporte experimental multi-worker que requer um diretório `/wordpress` apoiado por um sistema de arquivos real. Passe um número positivo para especificar o número de workers a usar. Caso contrário, padrão é o número de CPUs menos 1.
+
+:::caution
+Com a flag `--follow-symlinks`, os seguintes links simbólicos irão expor arquivos fora dos diretórios montados ao Playground e podem ser um risco de segurança.
+:::
 
 <!-- ## Need some help with the CLI? -->
 


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request updates the documentation for the Playground CLI in Spanish and Portuguese, enhancing the descriptions of command-line arguments for clarity and completeness. It adds several new options, improves the explanation of existing ones, and introduces important cautions about security implications.

**Documentation improvements and new options:**

* Added documentation for new CLI flags: `--version`, `--site-url`, `--php`, `--auto-mount[=<path>]`, `--follow-symlinks`, `--internal-cookie-store`, `--xdebug`, `--experimental-devtools`, and `--experimental-multi-worker=<number>`, with clear explanations and defaults in both Spanish and Portuguese files. [[1]](diffhunk://#diff-c6e3b1ddd984502ddbd2dacd1aaa0d301242ea8881ab42eb148b1f035248453aR172-R177) [[2]](diffhunk://#diff-20436eab017eaff67b9f1b471e09761def8b5a1c69eef3fb964ebaa7db970497L274-R280)
* Improved the description of the `--verbosity` flag to specify the accepted values and default, using a more consistent format. [[1]](diffhunk://#diff-c6e3b1ddd984502ddbd2dacd1aaa0d301242ea8881ab42eb148b1f035248453aL184-R197) [[2]](diffhunk://#diff-20436eab017eaff67b9f1b471e09761def8b5a1c69eef3fb964ebaa7db970497L303-R300)

**Security and usage cautions:**

* Added caution blocks warning that enabling `--follow-symlinks` may expose files outside mounted directories, highlighting potential security risks. [[1]](diffhunk://#diff-c6e3b1ddd984502ddbd2dacd1aaa0d301242ea8881ab42eb148b1f035248453aL184-R197) [[2]](diffhunk://#diff-20436eab017eaff67b9f1b471e09761def8b5a1c69eef3fb964ebaa7db970497L303-R300)

These changes ensure users have up-to-date and accurate information about the Playground CLI's capabilities and potential security considerations.
