### PR TITLE
[Website] Wider site info on smaller breakpoints

### DIFF
--- a/packages/playground/website/src/components/layout/style.module.css
+++ b/packages/playground/website/src/components/layout/style.module.css
@@ -134,6 +134,12 @@ body {
  * on smaller screens and never overflows out of the screen.
  */
 @media (max-width: 1126px) {
+	:root {
+		--site-info-panel-max-width: calc(
+			100vw - (2 * var(--site-manager-border-width)) -
+				var(--site-manager-site-list-width)
+		);
+	}
 	.site-manager-wrapper + .site-view {
 		display: none;
 	}

--- a/packages/playground/website/src/components/site-manager/style.module.css
+++ b/packages/playground/website/src/components/site-manager/style.module.css
@@ -41,6 +41,12 @@
 	max-width: var(--site-info-panel-max-width);
 }
 
+@media (max-width: 1126px) {
+	.site-info-resize-handle {
+		display: none !important;
+	}
+}
+
 .site-info-resize-handle {
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
## Motivation for the change, related issues

Expands site info to fill in the dark area that appears between ~870px and 1126px breakpoints.

Before:

<img width="2204" height="774" alt="CleanShot 2025-10-28 at 00 28 26@2x" src="https://github.com/user-attachments/assets/0e675bd7-5039-4079-b05d-9c802fc137bf" />

After:

<img width="2194" height="776" alt="CleanShot 2025-10-28 at 00 27 27@2x" src="https://github.com/user-attachments/assets/f5fa2c05-b955-4b2b-ba76-bddc742e975b" />

## Testing instructions

Scale your Playground window to the sizes listed above and confirm there's no blank dark area at any point.
