### PR TITLE
[CLI] Support .0 versions, e.g. 6.4.0

### DIFF
--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -638,10 +638,7 @@ const memoizedFetch = createMemoizedFetch(fetch);
  * // becomes https://wordpress.org/wordpress-6.6.2-RC1.zip and '6.6.2-RC1'
  *
  * const { releaseUrl, version } = await resolveWordPressRelease('6.6')
- * // becomes https://wordpress.org/wordpress-6.6.2.zip and '6.6.2' (latest patch)
- *
- * const { releaseUrl, version } = await resolveWordPressRelease('6.6.0')
- * // becomes https://wordpress.org/wordpress-6.6.zip and '6.6' (exact minor release)
+ * // becomes https://wordpress.org/wordpress-6.6.2.zip and '6.6.2'
  * ```
  *
  * @param versionQuery - The WordPress version query string to resolve.
@@ -682,20 +679,15 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 		(v: any) => v.response === 'autoupdate'
 	);
 
-	// Normalize version query: strip .0 patch version (e.g., "6.8.0" -> "6.8")
-	// This allows users to specify --wp=6.8.0 to get the exact 6.8 release
-	// Only strips .0 from patch position (third component), not minor position
-	const normalizedQuery = versionQuery.replace(/^(\d+\.\d+)\.0$/, '$1');
-
 	for (const apiVersion of latestVersions) {
-		if (normalizedQuery === 'beta' && apiVersion.version.includes('beta')) {
+		if (versionQuery === 'beta' && apiVersion.version.includes('beta')) {
 			return {
 				releaseUrl: apiVersion.download,
 				version: apiVersion.version,
 				source: 'api',
 			};
 		} else if (
-			normalizedQuery === 'latest' &&
+			versionQuery === 'latest' &&
 			!apiVersion.version.includes('beta')
 		) {
 			// The first non-beta item in the list is the latest version.
@@ -704,22 +696,9 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 				version: apiVersion.version,
 				source: 'api',
 			};
-		} else if (apiVersion.version === normalizedQuery) {
-			// Exact match - return this specific version
-			return {
-				releaseUrl: apiVersion.download,
-				version: apiVersion.version,
-				source: 'api',
-			};
-		}
-	}
-
-	// If no exact match found, try substring matching for partial versions
-	// (e.g., "6.8" can still match "6.8.3" for convenience)
-	for (const apiVersion of latestVersions) {
-		if (
-			apiVersion.version.substring(0, normalizedQuery.length) ===
-			normalizedQuery
+		} else if (
+			apiVersion.version.substring(0, versionQuery.length) ===
+			versionQuery
 		) {
 			return {
 				releaseUrl: apiVersion.download,
@@ -729,9 +708,16 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 		}
 	}
 
+	/**
+	 *
+	 */
+	if (versionQuery.match(/^\d+\.\d+\.0$/)) {
+		versionQuery = versionQuery.split('.').slice(0, 2).join('.');
+	}
+
 	return {
-		releaseUrl: `https://wordpress.org/wordpress-${normalizedQuery}.zip`,
-		version: normalizedQuery,
+		releaseUrl: `https://wordpress.org/wordpress-${versionQuery}.zip`,
+		version: versionQuery,
 		source: 'inferred',
 	};
 }

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -709,7 +709,14 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 	}
 
 	/**
+	 * Replace "6.8.0" with "6.8" to support installing the exact "6.8.0" release.
 	 *
+	 * The remote release ZIP file URL for 6.8.0 is `https://wordpress.org/wordpress-6.8.zip`.
+	 * However, we already resolve `6.8` to the latest patch version, so that's not an option.
+	 * Therefore, version "6.8.0" can be resolved by requesting a version string "6.8.0", which
+	 * we then convert to "6.8" to construct the correct remote ZIP file URL.
+	 *
+	 * @see https://github.com/WordPress/wordpress-playground/issues/2749
 	 */
 	if (versionQuery.match(/^\d+\.\d+\.0$/)) {
 		versionQuery = versionQuery.split('.').slice(0, 2).join('.');

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -638,7 +638,10 @@ const memoizedFetch = createMemoizedFetch(fetch);
  * // becomes https://wordpress.org/wordpress-6.6.2-RC1.zip and '6.6.2-RC1'
  *
  * const { releaseUrl, version } = await resolveWordPressRelease('6.6')
- * // becomes https://wordpress.org/wordpress-6.6.2.zip and '6.6.2'
+ * // becomes https://wordpress.org/wordpress-6.6.2.zip and '6.6.2' (latest patch)
+ *
+ * const { releaseUrl, version } = await resolveWordPressRelease('6.6.0')
+ * // becomes https://wordpress.org/wordpress-6.6.zip and '6.6' (exact minor release)
  * ```
  *
  * @param versionQuery - The WordPress version query string to resolve.
@@ -679,15 +682,20 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 		(v: any) => v.response === 'autoupdate'
 	);
 
+	// Normalize version query: strip .0 patch version (e.g., "6.8.0" -> "6.8")
+	// This allows users to specify --wp=6.8.0 to get the exact 6.8 release
+	// Only strips .0 from patch position (third component), not minor position
+	const normalizedQuery = versionQuery.replace(/^(\d+\.\d+)\.0$/, '$1');
+
 	for (const apiVersion of latestVersions) {
-		if (versionQuery === 'beta' && apiVersion.version.includes('beta')) {
+		if (normalizedQuery === 'beta' && apiVersion.version.includes('beta')) {
 			return {
 				releaseUrl: apiVersion.download,
 				version: apiVersion.version,
 				source: 'api',
 			};
 		} else if (
-			versionQuery === 'latest' &&
+			normalizedQuery === 'latest' &&
 			!apiVersion.version.includes('beta')
 		) {
 			// The first non-beta item in the list is the latest version.
@@ -696,9 +704,22 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 				version: apiVersion.version,
 				source: 'api',
 			};
-		} else if (
-			apiVersion.version.substring(0, versionQuery.length) ===
-			versionQuery
+		} else if (apiVersion.version === normalizedQuery) {
+			// Exact match - return this specific version
+			return {
+				releaseUrl: apiVersion.download,
+				version: apiVersion.version,
+				source: 'api',
+			};
+		}
+	}
+
+	// If no exact match found, try substring matching for partial versions
+	// (e.g., "6.8" can still match "6.8.3" for convenience)
+	for (const apiVersion of latestVersions) {
+		if (
+			apiVersion.version.substring(0, normalizedQuery.length) ===
+			normalizedQuery
 		) {
 			return {
 				releaseUrl: apiVersion.download,
@@ -709,8 +730,8 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 	}
 
 	return {
-		releaseUrl: `https://wordpress.org/wordpress-${versionQuery}.zip`,
-		version: versionQuery,
+		releaseUrl: `https://wordpress.org/wordpress-${normalizedQuery}.zip`,
+		version: normalizedQuery,
 		source: 'inferred',
 	};
 }

--- a/packages/playground/wordpress/src/test/resolve-wordpress-release.spec.ts
+++ b/packages/playground/wordpress/src/test/resolve-wordpress-release.spec.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock the WordPress API response
+const mockApiResponse = {
+	offers: [
+		{
+			version: '6.8.3',
+			download: 'https://wordpress.org/wordpress-6.8.3.zip',
+			response: 'autoupdate',
+		},
+		{
+			version: '6.8',
+			download: 'https://wordpress.org/wordpress-6.8.zip',
+			response: 'autoupdate',
+		},
+		{
+			version: '6.7.1',
+			download: 'https://wordpress.org/wordpress-6.7.1.zip',
+			response: 'autoupdate',
+		},
+		{
+			version: '6.6.2',
+			download: 'https://wordpress.org/wordpress-6.6.2.zip',
+			response: 'autoupdate',
+		},
+		{
+			version: '6.9-beta1',
+			download: 'https://wordpress.org/wordpress-6.9-beta1.zip',
+			response: 'autoupdate',
+		},
+	],
+};
+
+// Mock the fetch function before importing the module
+const mockFetch = vi.fn(() =>
+	Promise.resolve({
+		json: () => Promise.resolve(mockApiResponse),
+	} as Response)
+);
+
+// Mock the common module to bypass memoization
+vi.mock('@wp-playground/common', async () => {
+	const actual = await vi.importActual('@wp-playground/common');
+	return {
+		...actual,
+		createMemoizedFetch: () => mockFetch,
+	};
+});
+
+// Import after mocks are set up
+const { resolveWordPressRelease } = await import('../index');
+
+describe('resolveWordPressRelease', () => {
+	beforeEach(() => {
+		mockFetch.mockClear();
+	});
+
+	it('resolves latest to the first non-beta version', async () => {
+		const result = await resolveWordPressRelease('latest');
+		expect(result.version).toBe('6.8.3');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-6.8.3.zip'
+		);
+		expect(result.source).toBe('api');
+	});
+
+	it('resolves beta to a beta version', async () => {
+		const result = await resolveWordPressRelease('beta');
+		expect(result.version).toBe('6.9-beta1');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-6.9-beta1.zip'
+		);
+		expect(result.source).toBe('api');
+	});
+
+	it('resolves exact version match for minor release with .0 suffix', async () => {
+		const result = await resolveWordPressRelease('6.8.0');
+		expect(result.version).toBe('6.8');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-6.8.zip'
+		);
+		expect(result.source).toBe('api');
+	});
+
+	it('resolves exact version match for minor release without .0 suffix', async () => {
+		const result = await resolveWordPressRelease('6.8');
+		expect(result.version).toBe('6.8');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-6.8.zip'
+		);
+		expect(result.source).toBe('api');
+	});
+
+	it('falls back to substring matching when no exact match exists', async () => {
+		// 6.7 doesn't exist exactly, but 6.7.1 does (starts with 6.7)
+		const result = await resolveWordPressRelease('6.7');
+		expect(result.version).toBe('6.7.1');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-6.7.1.zip'
+		);
+		expect(result.source).toBe('api');
+	});
+
+	it('resolves specific patch version', async () => {
+		const result = await resolveWordPressRelease('6.6.2');
+		expect(result.version).toBe('6.6.2');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-6.6.2.zip'
+		);
+		expect(result.source).toBe('api');
+	});
+
+	it('returns inferred URL for version not in API', async () => {
+		const result = await resolveWordPressRelease('5.0');
+		expect(result.version).toBe('5.0');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-5.0.zip'
+		);
+		expect(result.source).toBe('inferred');
+	});
+
+	it('normalizes .0 suffix for version not in API', async () => {
+		const result = await resolveWordPressRelease('5.0.0');
+		expect(result.version).toBe('5.0');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-5.0.zip'
+		);
+		expect(result.source).toBe('inferred');
+	});
+
+	it('resolves trunk to nightly build', async () => {
+		const result = await resolveWordPressRelease('trunk');
+		expect(result.version).toContain('nightly-');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/nightly-builds/wordpress-latest.zip'
+		);
+		expect(result.source).toBe('inferred');
+	});
+
+	it('resolves nightly to nightly build', async () => {
+		const result = await resolveWordPressRelease('nightly');
+		expect(result.version).toContain('nightly-');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/nightly-builds/wordpress-latest.zip'
+		);
+		expect(result.source).toBe('inferred');
+	});
+
+	it('resolves custom URL with HTTPS', async () => {
+		const customUrl = 'https://example.com/my-wordpress.zip';
+		const result = await resolveWordPressRelease(customUrl);
+		expect(result.version).toContain('custom-');
+		expect(result.releaseUrl).toBe(customUrl);
+		expect(result.source).toBe('inferred');
+	});
+
+	it('resolves custom URL with HTTP', async () => {
+		const customUrl = 'http://example.com/my-wordpress.zip';
+		const result = await resolveWordPressRelease(customUrl);
+		expect(result.version).toContain('custom-');
+		expect(result.releaseUrl).toBe(customUrl);
+		expect(result.source).toBe('inferred');
+	});
+});

--- a/packages/playground/wordpress/src/test/resolve-wordpress-release.spec.ts
+++ b/packages/playground/wordpress/src/test/resolve-wordpress-release.spec.ts
@@ -79,14 +79,14 @@ describe('resolveWordPressRelease', () => {
 		expect(result.releaseUrl).toBe(
 			'https://wordpress.org/wordpress-6.8.zip'
 		);
-		expect(result.source).toBe('api');
+		expect(result.source).toBe('inferred');
 	});
 
 	it('resolves exact version match for minor release without .0 suffix', async () => {
 		const result = await resolveWordPressRelease('6.8');
-		expect(result.version).toBe('6.8');
-		expect(result.releaseUrl).toBe(
-			'https://wordpress.org/wordpress-6.8.zip'
+		expect(result.version).toMatch(/^6\.8\.(?!0$)\d+$/);
+		expect(result.releaseUrl).toMatch(
+			/^https:\/\/wordpress\.org\/wordpress-6\.8\.(?!0$)\d+\.zip$/
 		);
 		expect(result.source).toBe('api');
 	});


### PR DESCRIPTION
## Motivation for the change, related issues

Allows CLI to load WordPress versions ending with `.0`, such as `6.8.0`, by passing `--wp=6.8.0`.

Before this PR, the only way to install exactly the `6.8.0` version was passing the URL to the zip file. `--wp=6.8.0` would not work – the version string is used to construct the download URL (`https://wordpress.org/wordpress-${versionQuery}.zip`), but the actual zip file on WordPress.org is named `6.8.zip`, not `6.8.0`. At the same time, the string `6.8` is implicitly resolves to the latest point release, e.g. `6.8.14`.

Resolves #2749

## Implementation details

We just remove the trailing `.0` before constructing the URL.

It would be useful to avoid inferring the release URL entirely and request the 6.8.0 details directly from `https://api.wordpress.org/core/version-check/1.7/?channel=beta`, I'm not sure how to do that. Any ideas @dd32?

## Testing Instructions (or ideally a Blueprint)

* CI – this PR ships a new test suite `resolve-wordpress-release.spec.ts`
* Run `node --no-warnings=ExperimentalWarning  --experimental-strip-types --experimental-transform-types --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts server --wp=6.8.0` and confirm WordPress 6.8.0 is getting installed
