### PR TITLE
[Docs] Remove kapa AI button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,12 +59,12 @@
 				"yargs": "17.7.2"
 			},
 			"devDependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/plugin-client-redirects": "3.8.1",
-				"@docusaurus/plugin-ideal-image": "3.8.1",
-				"@docusaurus/preset-classic": "3.8.1",
-				"@docusaurus/theme-live-codeblock": "3.8.1",
-				"@docusaurus/tsconfig": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/plugin-client-redirects": "3.9.2",
+				"@docusaurus/plugin-ideal-image": "3.9.2",
+				"@docusaurus/preset-classic": "3.9.2",
+				"@docusaurus/theme-live-codeblock": "3.9.2",
+				"@docusaurus/tsconfig": "3.9.2",
 				"@nx/cypress": "19.8.4",
 				"@nx/devkit": "19.8.4",
 				"@nx/eslint-plugin": "20.8.0",
@@ -151,64 +151,137 @@
 				"fs-ext": "2.1.1"
 			}
 		},
+		"node_modules/@ai-sdk/gateway": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.5.tgz",
+			"integrity": "sha512-5TTDSl0USWY6YGnb4QmJGplFZhk+p9OT7hZevAaER6OGiZ17LB1GypsGYDpNo/MiVMklk8kX4gk6p1/R/EiJ8Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.0",
+				"@ai-sdk/provider-utils": "3.0.15",
+				"@vercel/oidc": "3.0.3"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/provider": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
+			"integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"json-schema": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@ai-sdk/provider-utils": {
+			"version": "3.0.15",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.15.tgz",
+			"integrity": "sha512-kOc6Pxb7CsRlNt+sLZKL7/VGQUd7ccl3/tIK+Bqf5/QhHR0Qm3qRBMz1IwU1RmjJEZA73x+KB5cUckbDl2WF7Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider": "2.0.0",
+				"@standard-schema/spec": "^1.0.0",
+				"eventsource-parser": "^3.0.6"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
+		"node_modules/@ai-sdk/react": {
+			"version": "2.0.86",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.86.tgz",
+			"integrity": "sha512-vqxbbMOKMpYFHZy0aYEO4jtDcKaFCHL/rEtTqAIDlH14GT0uusSjN99gkDHHG3EnbyJSQmk9gqtqbd1GDwlRRg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/provider-utils": "3.0.15",
+				"ai": "5.0.86",
+				"swr": "^2.2.5",
+				"throttleit": "2.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"react": "^18 || ^19 || ^19.0.0-rc",
+				"zod": "^3.25.76 || ^4.1.8"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@ai-sdk/react/node_modules/throttleit": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+			"integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@algolia/abtesting": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.7.0.tgz",
-			"integrity": "sha512-hOEItTFOvNLI6QX6TSGu7VE4XcUcdoKZT8NwDY+5mWwu87rGhkjlY7uesKTInlg6Sh8cyRkDBYRumxbkoBbBhA==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.8.0.tgz",
+			"integrity": "sha512-Hb4BkGNnvgCj3F9XzqjiFTpA5IGkjOXwGAOV13qtc27l2qNF8X9rzSp1H5hu8XewlC0DzYtQtZZIOYzRZDyuXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/autocomplete-core": {
-			"version": "1.17.9",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.9.tgz",
-			"integrity": "sha512-O7BxrpLDPJWWHv/DLA9DRFWs+iY1uOJZkqUwjS5HSZAGcl0hIVCQ97LTLewiZmZ402JYUrun+8NqFP+hCknlbQ==",
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
+			"integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/autocomplete-plugin-algolia-insights": "1.17.9",
-				"@algolia/autocomplete-shared": "1.17.9"
+				"@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
+				"@algolia/autocomplete-shared": "1.19.2"
 			}
 		},
 		"node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-			"version": "1.17.9",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.9.tgz",
-			"integrity": "sha512-u1fEHkCbWF92DBeB/KHeMacsjsoI0wFhjZtlCq2ddZbAehshbZST6Hs0Avkc0s+4UyBGbMDnSuXHLuvRWK5iDQ==",
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
+			"integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/autocomplete-shared": "1.17.9"
+				"@algolia/autocomplete-shared": "1.19.2"
 			},
 			"peerDependencies": {
 				"search-insights": ">= 1 < 3"
 			}
 		},
-		"node_modules/@algolia/autocomplete-preset-algolia": {
-			"version": "1.17.9",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.9.tgz",
-			"integrity": "sha512-Na1OuceSJeg8j7ZWn5ssMu/Ax3amtOwk76u4h5J4eK2Nx2KB5qt0Z4cOapCsxot9VcEN11ADV5aUSlQF4RhGjQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/autocomplete-shared": "1.17.9"
-			},
-			"peerDependencies": {
-				"@algolia/client-search": ">= 4.9.1 < 6",
-				"algoliasearch": ">= 4.9.1 < 6"
-			}
-		},
 		"node_modules/@algolia/autocomplete-shared": {
-			"version": "1.17.9",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.9.tgz",
-			"integrity": "sha512-iDf05JDQ7I0b7JEA/9IektxN/80a2MZ1ToohfmNS3rfeuQnIKI3IJlIafD0xu4StbtQTghx9T3Maa97ytkXenQ==",
+			"version": "1.19.2",
+			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
+			"integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -217,41 +290,41 @@
 			}
 		},
 		"node_modules/@algolia/client-abtesting": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.41.0.tgz",
-			"integrity": "sha512-iRuvbEyuHCAhIMkyzG3tfINLxTS7mSKo7q8mQF+FbQpWenlAlrXnfZTN19LRwnVjx0UtAdZq96ThMWGS6cQ61A==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.42.0.tgz",
+			"integrity": "sha512-JLyyG7bb7XOda+w/sp8ch7rEVy6LnWs3qtxr6VJJ2XIINqGsY6U+0L3aJ6QFliBRNUeEAr2QBDxSm8u9Sal5uA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-analytics": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.41.0.tgz",
-			"integrity": "sha512-OIPVbGfx/AO8l1V70xYTPSeTt/GCXPEl6vQICLAXLCk9WOUbcLGcy6t8qv0rO7Z7/M/h9afY6Af8JcnI+FBFdQ==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.42.0.tgz",
+			"integrity": "sha512-SkCrvtZpdSWjNq9NGu/TtOg4TbzRuUToXlQqV6lLePa2s/WQlEyFw7QYjrz4itprWG9ASuH+StDlq7n49F2sBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-common": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.41.0.tgz",
-			"integrity": "sha512-8Mc9niJvfuO8dudWN5vSUlYkz7U3M3X3m1crDLc9N7FZrIVoNGOUETPk3TTHviJIh9y6eKZKbq1hPGoGY9fqPA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.42.0.tgz",
+			"integrity": "sha512-6iiFbm2tRn6B2OqFv9XDTcw5LdWPudiJWIbRk+fsTX+hkPrPm4e1/SbU+lEYBciPoaTShLkDbRge4UePEyCPMQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -259,64 +332,64 @@
 			}
 		},
 		"node_modules/@algolia/client-insights": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.41.0.tgz",
-			"integrity": "sha512-vXzvCGZS6Ixxn+WyzGUVDeR3HO/QO5POeeWy1kjNJbEf6f+tZSI+OiIU9Ha+T3ntV8oXFyBEuweygw4OLmgfiQ==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.42.0.tgz",
+			"integrity": "sha512-iEokmw2k6FBa8g/TT7ClyEriaP/FUEmz3iczRoCklEHWSgoABMkaeYrxRXrA2yx76AN+gyZoC8FX0iCJ55dsOg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-personalization": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.41.0.tgz",
-			"integrity": "sha512-tkymXhmlcc7w/HEvLRiHcpHxLFcUB+0PnE9FcG6hfFZ1ZXiWabH+sX+uukCVnluyhfysU9HRU2kUmUWfucx1Dg==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.42.0.tgz",
+			"integrity": "sha512-ivVniRqX2ARd+jGvRHTxpWeOtO9VT+rK+OmiuRgkSunoTyxk0vjeDO7QkU7+lzBOXiYgakNjkZrBtIpW9c+muw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-query-suggestions": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.41.0.tgz",
-			"integrity": "sha512-vyXDoz3kEZnosNeVQQwf0PbBt5IZJoHkozKRIsYfEVm+ylwSDFCW08qy2YIVSHdKy69/rWN6Ue/6W29GgVlmKQ==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.42.0.tgz",
+			"integrity": "sha512-9+BIw6rerUfA+eLMIS2lF4mgoeBGTCIHiqb35PLn3699Rm3CaJXz03hChdwAWcA6SwGw0haYXYJa7LF0xI6EpA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-search": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.41.0.tgz",
-			"integrity": "sha512-G9I2atg1ShtFp0t7zwleP6aPS4DcZvsV4uoQOripp16aR6VJzbEnKFPLW4OFXzX7avgZSpYeBAS+Zx4FOgmpPw==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.42.0.tgz",
+			"integrity": "sha512-NZR7yyHj2WzK6D5X8gn+/KOxPdzYEXOqVdSaK/biU8QfYUpUuEA0sCWg/XlO05tPVEcJelF/oLrrNY3UjRbOww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -330,87 +403,87 @@
 			"license": "MIT"
 		},
 		"node_modules/@algolia/ingestion": {
-			"version": "1.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.41.0.tgz",
-			"integrity": "sha512-sxU/ggHbZtmrYzTkueTXXNyifn+ozsLP+Wi9S2hOBVhNWPZ8uRiDTDcFyL7cpCs1q72HxPuhzTP5vn4sUl74cQ==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.42.0.tgz",
+			"integrity": "sha512-MBkjRymf4BT6VOvMpJlg6kq8K+PkH9q+N+K4YMNdzTXlL40YwOa1wIWQ5LxP/Jhlz64kW5g9/oaMWY06Sy9dcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/monitoring": {
-			"version": "1.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.41.0.tgz",
-			"integrity": "sha512-UQ86R6ixraHUpd0hn4vjgTHbViNO8+wA979gJmSIsRI3yli2v89QSFF/9pPcADR6PbtSio/99PmSNxhZy+CR3Q==",
+			"version": "1.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.42.0.tgz",
+			"integrity": "sha512-kmLs7YfjT4cpr4FnhhRmnoSX4psh9KYZ9NAiWt/YcUV33m0B/Os5L4QId30zVXkOqAPAEpV5VbDPWep+/aoJdQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/recommend": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.41.0.tgz",
-			"integrity": "sha512-DxP9P8jJ8whJOnvmyA5mf1wv14jPuI0L25itGfOHSU6d4ZAjduVfPjTS3ROuUN5CJoTdlidYZE+DtfWHxJwyzQ==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.42.0.tgz",
+			"integrity": "sha512-U5yZ8+Jj+A4ZC0IMfElpPcddQ9NCoawD1dKyWmjHP49nzN2Z4284IFVMAJWR6fq/0ddGf4OMjjYO9cnF8L+5tw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/client-common": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.41.0.tgz",
-			"integrity": "sha512-C21J+LYkE48fDwtLX7YXZd2Fn7Fe0/DOEtvohSfr/ODP8dGDhy9faaYeWB0n1AvmZltugjkjAXT7xk0CYNIXsQ==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.42.0.tgz",
+			"integrity": "sha512-EbuxgteaYBlKgc2Fs3JzoPIKAIaevAIwmv1F+fakaEXeibG4pkmVNsyTUjpOZIgJ1kXeqNvDrcjRb6g3vYBJ9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0"
+				"@algolia/client-common": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-fetch": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.41.0.tgz",
-			"integrity": "sha512-FhJy/+QJhMx1Hajf2LL8og4J7SqOAHiAuUXq27cct4QnPhSIuIGROzeRpfDNH5BUbq22UlMuGd44SeD4HRAqvA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.42.0.tgz",
+			"integrity": "sha512-4vnFvY5Q8QZL9eDNkywFLsk/eQCRBXCBpE8HWs8iUsFNHYoamiOxAeYMin0W/nszQj6abc+jNxMChHmejO+ftQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0"
+				"@algolia/client-common": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-node-http": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.41.0.tgz",
-			"integrity": "sha512-tYv3rGbhBS0eZ5D8oCgV88iuWILROiemk+tQ3YsAKZv2J4kKUNvKkrX/If/SreRy4MGP2uJzMlyKcfSfO2mrsQ==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.42.0.tgz",
+			"integrity": "sha512-gkLNpU+b1pCIwk1hKTJz2NWQPT8gsfGhQasnZ5QVv4jd79fKRL/1ikd86P0AzuIQs9tbbhlMwxsSTyJmlq502w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.41.0"
+				"@algolia/client-common": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -2959,43 +3032,6 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/@csstools/postcss-cascade-layers/node_modules/@csstools/selector-specificity": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^7.0.0"
-			}
-		},
-		"node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@csstools/postcss-color-function": {
 			"version": "4.0.12",
 			"resolved": "https://registry.npmjs.org/@csstools/postcss-color-function/-/postcss-color-function-4.0.12.tgz",
@@ -3394,43 +3430,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
-			}
-		},
-		"node_modules/@csstools/postcss-is-pseudo-class/node_modules/@csstools/selector-specificity": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^7.0.0"
-			}
-		},
-		"node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/@csstools/postcss-light-dark-function": {
@@ -3834,20 +3833,6 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@csstools/postcss-sign-functions": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/@csstools/postcss-sign-functions/-/postcss-sign-functions-1.1.4.tgz",
@@ -3982,6 +3967,52 @@
 				"postcss": "^8.4"
 			}
 		},
+		"node_modules/@csstools/selector-resolve-nested": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+			"integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^7.0.0"
+			}
+		},
+		"node_modules/@csstools/selector-specificity": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^7.0.0"
+			}
+		},
 		"node_modules/@csstools/utilities": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/utilities/-/utilities-2.0.0.tgz",
@@ -4084,23 +4115,26 @@
 			}
 		},
 		"node_modules/@docsearch/css": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.9.0.tgz",
-			"integrity": "sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.2.0.tgz",
+			"integrity": "sha512-65KU9Fw5fGsPPPlgIghonMcndyx1bszzrDQYLfierN+Ha29yotMHzVS94bPkZS6On9LS8dE4qmW4P/fGjtCf/g==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@docsearch/react": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.9.0.tgz",
-			"integrity": "sha512-mb5FOZYZIkRQ6s/NWnM98k879vu5pscWqTLubLFBO87igYYT4VzVazh4h5o/zCvTIZgEt3PvsCOMOswOUo9yHQ==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.2.0.tgz",
+			"integrity": "sha512-zSN/KblmtBcerf7Z87yuKIHZQmxuXvYc6/m0+qnjyNu+Ir67AVOagTa1zBqcxkVUVkmBqUExdcyrdo9hbGbqTw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/autocomplete-core": "1.17.9",
-				"@algolia/autocomplete-preset-algolia": "1.17.9",
-				"@docsearch/css": "3.9.0",
-				"algoliasearch": "^5.14.2"
+				"@ai-sdk/react": "^2.0.30",
+				"@algolia/autocomplete-core": "1.19.2",
+				"@docsearch/css": "4.2.0",
+				"ai": "^5.0.30",
+				"algoliasearch": "^5.28.0",
+				"marked": "^16.3.0",
+				"zod": "^4.1.8"
 			},
 			"peerDependencies": {
 				"@types/react": ">= 16.8.0 < 20.0.0",
@@ -4123,10 +4157,23 @@
 				}
 			}
 		},
+		"node_modules/@docsearch/react/node_modules/marked": {
+			"version": "16.4.1",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.1.tgz",
+			"integrity": "sha512-ntROs7RaN3EvWfy3EZi14H4YxmT6A5YvywfhO+0pm+cH/dnSQRmdAmoFIc3B9aiwTehyk7pESH4ofyBY+V5hZg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 20"
+			}
+		},
 		"node_modules/@docusaurus/babel": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
-			"integrity": "sha512-3brkJrml8vUbn9aeoZUlJfsI/GqyFcDgQJwQkmBtclJgWDEQBKKeagZfOgx0WfUQhagL1sQLNW0iBdxnI863Uw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
+			"integrity": "sha512-GEANdi/SgER+L7Japs25YiGil/AUDnFFHaCGPBbundxoWtCkA2lmy7/tFmgED4y1htAy6Oi4wkJEQdGssnw9MA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4140,29 +4187,29 @@
 				"@babel/runtime": "^7.25.9",
 				"@babel/runtime-corejs3": "^7.25.9",
 				"@babel/traverse": "^7.25.9",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
 				"babel-plugin-dynamic-import-node": "^2.3.3",
 				"fs-extra": "^11.1.1",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/bundler": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1.tgz",
-			"integrity": "sha512-/z4V0FRoQ0GuSLToNjOSGsk6m2lQUG4FRn8goOVoZSRsTrU8YR2aJacX5K3RG18EaX9b+52pN4m1sL3MQZVsQA==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.2.tgz",
+			"integrity": "sha512-ZOVi6GYgTcsZcUzjblpzk3wH1Fya2VNpd5jtHoCCFcJlMQ1EYXZetfAnRHLcyiFeBABaI1ltTYbOBtH/gahGVA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.25.9",
-				"@docusaurus/babel": "3.8.1",
-				"@docusaurus/cssnano-preset": "3.8.1",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
+				"@docusaurus/babel": "3.9.2",
+				"@docusaurus/cssnano-preset": "3.9.2",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
 				"babel-loader": "^9.2.1",
 				"clean-css": "^5.3.3",
 				"copy-webpack-plugin": "^11.0.0",
@@ -4183,7 +4230,7 @@
 				"webpackbar": "^6.0.1"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"@docusaurus/faster": "*"
@@ -4195,19 +4242,19 @@
 			}
 		},
 		"node_modules/@docusaurus/core": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1.tgz",
-			"integrity": "sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
+			"integrity": "sha512-HbjwKeC+pHUFBfLMNzuSjqFE/58+rLVKmOU3lxQrpsxLBOGosYco/Q0GduBb0/jEMRiyEqjNT/01rRdOMWq5pw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/babel": "3.8.1",
-				"@docusaurus/bundler": "3.8.1",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/mdx-loader": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/babel": "3.9.2",
+				"@docusaurus/bundler": "3.9.2",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/mdx-loader": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"boxen": "^6.2.1",
 				"chalk": "^4.1.2",
 				"chokidar": "^3.5.3",
@@ -4241,57 +4288,17 @@
 				"update-notifier": "^6.0.2",
 				"webpack": "^5.95.0",
 				"webpack-bundle-analyzer": "^4.10.2",
-				"webpack-dev-server": "^4.15.2",
+				"webpack-dev-server": "^5.2.2",
 				"webpack-merge": "^6.0.1"
 			},
 			"bin": {
 				"docusaurus": "bin/docusaurus.mjs"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"@mdx-js/react": "^3.0.0",
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/@docusaurus/core/node_modules/@docusaurus/mdx-loader": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
-			"integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
-				"@mdx-js/mdx": "^3.0.0",
-				"@slorber/remark-comment": "^1.0.0",
-				"escape-html": "^1.0.3",
-				"estree-util-value-to-estree": "^3.0.1",
-				"file-loader": "^6.2.0",
-				"fs-extra": "^11.1.1",
-				"image-size": "^2.0.2",
-				"mdast-util-mdx": "^3.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"rehype-raw": "^7.0.0",
-				"remark-directive": "^3.0.0",
-				"remark-emoji": "^4.0.0",
-				"remark-frontmatter": "^5.0.0",
-				"remark-gfm": "^4.0.0",
-				"stringify-object": "^3.3.0",
-				"tslib": "^2.6.0",
-				"unified": "^11.0.3",
-				"unist-util-visit": "^5.0.0",
-				"url-loader": "^4.1.1",
-				"vfile": "^6.0.1",
-				"webpack": "^5.88.1"
-			},
-			"engines": {
-				"node": ">=18.0"
-			},
-			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
 				"react-dom": "^18.0.0 || ^19.0.0"
 			}
@@ -4343,9 +4350,9 @@
 			}
 		},
 		"node_modules/@docusaurus/cssnano-preset": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1.tgz",
-			"integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
+			"integrity": "sha512-8gBKup94aGttRduABsj7bpPFTX7kbwu+xh3K9NMCF5K4bWBqTFYW+REKHF6iBVDHRJ4grZdIPbvkiHd/XNKRMQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4355,13 +4362,13 @@
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/logger": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
-			"integrity": "sha512-2wjeGDhKcExEmjX8k1N/MRDiPKXGF2Pg+df/bDDPnnJWHXnVEZxXj80d6jcxp1Gpnksl0hF8t/ZQw9elqj2+ww==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
+			"integrity": "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4369,7 +4376,7 @@
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/logger/node_modules/ansi-styles": {
@@ -4419,20 +4426,20 @@
 			}
 		},
 		"node_modules/@docusaurus/lqip-loader": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/lqip-loader/-/lqip-loader-3.8.1.tgz",
-			"integrity": "sha512-wSc/TDw6TjKle9MnFO4yqbc9120GIt6YIMT5obqThGcDcBXtkwUsSnw0ghEk22VXqAsgAxD/cGCp6O0SegRtYA==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/lqip-loader/-/lqip-loader-3.9.2.tgz",
+			"integrity": "sha512-Q9QO0E+HLKhcpKVOIXRVBdJ1bbxxpfSwBll5NsmGxcx1fArH0fFi68cpEztqBg7WwbFRb976MTlqlBuGrMLpuw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
+				"@docusaurus/logger": "3.9.2",
 				"file-loader": "^6.2.0",
 				"lodash": "^4.17.21",
 				"sharp": "^0.32.3",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/mdx-loader": {
@@ -4441,7 +4448,6 @@
 			"integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@docusaurus/logger": "3.9.2",
 				"@docusaurus/utils": "3.9.2",
@@ -4476,157 +4482,12 @@
 				"react-dom": "^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/logger": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
-			"integrity": "sha512-/SVCc57ByARzGSU60c50rMyQlBuMIJCjcsJlkphxY6B0GV4UH3tcA1994N8fFfbJ9kX3jIBe/xg3XP5qBtGDbA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"chalk": "^4.1.2",
-				"tslib": "^2.6.0"
-			},
-			"engines": {
-				"node": ">=20.0"
-			}
-		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/types": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-			"integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@mdx-js/mdx": "^3.0.0",
-				"@types/history": "^4.7.11",
-				"@types/mdast": "^4.0.2",
-				"@types/react": "*",
-				"commander": "^5.1.0",
-				"joi": "^17.9.2",
-				"react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
-				"utility-types": "^3.10.0",
-				"webpack": "^5.95.0",
-				"webpack-merge": "^5.9.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/utils": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
-			"integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/types": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
-				"escape-string-regexp": "^4.0.0",
-				"execa": "5.1.1",
-				"file-loader": "^6.2.0",
-				"fs-extra": "^11.1.1",
-				"github-slugger": "^1.5.0",
-				"globby": "^11.1.0",
-				"gray-matter": "^4.0.3",
-				"jiti": "^1.20.0",
-				"js-yaml": "^4.1.0",
-				"lodash": "^4.17.21",
-				"micromatch": "^4.0.5",
-				"p-queue": "^6.6.2",
-				"prompts": "^2.4.2",
-				"resolve-pathname": "^3.0.0",
-				"tslib": "^2.6.0",
-				"url-loader": "^4.1.1",
-				"utility-types": "^3.10.0",
-				"webpack": "^5.88.1"
-			},
-			"engines": {
-				"node": ">=20.0"
-			}
-		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/utils-common": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
-			"integrity": "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@docusaurus/types": "3.9.2",
-				"tslib": "^2.6.0"
-			},
-			"engines": {
-				"node": ">=20.0"
-			}
-		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/@docusaurus/utils-validation": {
-			"version": "3.9.2",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
-			"integrity": "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@docusaurus/logger": "3.9.2",
-				"@docusaurus/utils": "3.9.2",
-				"@docusaurus/utils-common": "3.9.2",
-				"fs-extra": "^11.2.0",
-				"joi": "^17.9.2",
-				"js-yaml": "^4.1.0",
-				"lodash": "^4.17.21",
-				"tslib": "^2.6.0"
-			},
-			"engines": {
-				"node": ">=20.0"
-			}
-		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/@docusaurus/mdx-loader/node_modules/fs-extra": {
 			"version": "11.3.2",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
 			"integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
 				"jsonfile": "^6.0.1",
@@ -4636,44 +4497,14 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@docusaurus/mdx-loader/node_modules/webpack-merge": {
-			"version": "5.10.0",
-			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
-			"integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"clone-deep": "^4.0.1",
-				"flat": "^5.0.2",
-				"wildcard": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/@docusaurus/module-type-aliases": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1.tgz",
-			"integrity": "sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.9.2.tgz",
+			"integrity": "sha512-8qVe2QA9hVLzvnxP46ysuofJUIc/yYQ82tvA/rBTrnpXtCjNSFLxEZfd5U8cYZuJIVlkPxamsIgwd5tGZXfvew==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/types": "3.8.1",
+				"@docusaurus/types": "3.9.2",
 				"@types/history": "^4.7.11",
 				"@types/react": "*",
 				"@types/react-router-config": "*",
@@ -4687,24 +4518,24 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-client-redirects": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.1.tgz",
-			"integrity": "sha512-F+86R7PBn6VNgy/Ux8w3ZRypJGJEzksbejQKlbTC8u6uhBUhfdXWkDp6qdOisIoW0buY5nLqucvZt1zNJzhJhA==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.9.2.tgz",
+			"integrity": "sha512-lUgMArI9vyOYMzLRBUILcg9vcPTCyyI2aiuXq/4npcMVqOr6GfmwtmBYWSbNMlIUM0147smm4WhpXD0KFboffw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"eta": "^2.2.0",
 				"fs-extra": "^11.1.1",
 				"lodash": "^4.17.21",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -4712,20 +4543,20 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-content-blog": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
-			"integrity": "sha512-vNTpMmlvNP9n3hGEcgPaXyvTljanAKIUkuG9URQ1DeuDup0OR7Ltvoc8yrmH+iMZJbcQGhUJF+WjHLwuk8HSdw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.9.2.tgz",
+			"integrity": "sha512-3I2HXy3L1QcjLJLGAoTvoBnpOwa6DPUa3Q0dMK19UTY9mhPkKQg/DYhAGTiBUKcTR0f08iw7kLPqOhIgdV3eVQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/mdx-loader": "3.8.1",
-				"@docusaurus/theme-common": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/mdx-loader": "3.9.2",
+				"@docusaurus/theme-common": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"cheerio": "1.0.0-rc.12",
 				"feed": "^4.2.2",
 				"fs-extra": "^11.1.1",
@@ -4738,7 +4569,7 @@
 				"webpack": "^5.88.1"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"@docusaurus/plugin-content-docs": "*",
@@ -4746,62 +4577,22 @@
 				"react-dom": "^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/mdx-loader": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
-			"integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
-				"@mdx-js/mdx": "^3.0.0",
-				"@slorber/remark-comment": "^1.0.0",
-				"escape-html": "^1.0.3",
-				"estree-util-value-to-estree": "^3.0.1",
-				"file-loader": "^6.2.0",
-				"fs-extra": "^11.1.1",
-				"image-size": "^2.0.2",
-				"mdast-util-mdx": "^3.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"rehype-raw": "^7.0.0",
-				"remark-directive": "^3.0.0",
-				"remark-emoji": "^4.0.0",
-				"remark-frontmatter": "^5.0.0",
-				"remark-gfm": "^4.0.0",
-				"stringify-object": "^3.3.0",
-				"tslib": "^2.6.0",
-				"unified": "^11.0.3",
-				"unist-util-visit": "^5.0.0",
-				"url-loader": "^4.1.1",
-				"vfile": "^6.0.1",
-				"webpack": "^5.88.1"
-			},
-			"engines": {
-				"node": ">=18.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			}
-		},
 		"node_modules/@docusaurus/plugin-content-docs": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
-			"integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
+			"integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/mdx-loader": "3.8.1",
-				"@docusaurus/module-type-aliases": "3.8.1",
-				"@docusaurus/theme-common": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/mdx-loader": "3.9.2",
+				"@docusaurus/module-type-aliases": "3.9.2",
+				"@docusaurus/theme-common": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"@types/react-router-config": "^5.0.7",
 				"combine-promises": "^1.1.0",
 				"fs-extra": "^11.1.1",
@@ -4813,47 +4604,7 @@
 				"webpack": "^5.88.1"
 			},
 			"engines": {
-				"node": ">=18.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/mdx-loader": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
-			"integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
-				"@mdx-js/mdx": "^3.0.0",
-				"@slorber/remark-comment": "^1.0.0",
-				"escape-html": "^1.0.3",
-				"estree-util-value-to-estree": "^3.0.1",
-				"file-loader": "^6.2.0",
-				"fs-extra": "^11.1.1",
-				"image-size": "^2.0.2",
-				"mdast-util-mdx": "^3.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"rehype-raw": "^7.0.0",
-				"remark-directive": "^3.0.0",
-				"remark-emoji": "^4.0.0",
-				"remark-frontmatter": "^5.0.0",
-				"remark-gfm": "^4.0.0",
-				"stringify-object": "^3.3.0",
-				"tslib": "^2.6.0",
-				"unified": "^11.0.3",
-				"unist-util-visit": "^5.0.0",
-				"url-loader": "^4.1.1",
-				"vfile": "^6.0.1",
-				"webpack": "^5.88.1"
-			},
-			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -4861,63 +4612,23 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-content-pages": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1.tgz",
-			"integrity": "sha512-a+V6MS2cIu37E/m7nDJn3dcxpvXb6TvgdNI22vJX8iUTp8eoMoPa0VArEbWvCxMY/xdC26WzNv4wZ6y0iIni/w==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.9.2.tgz",
+			"integrity": "sha512-s4849w/p4noXUrGpPUF0BPqIAfdAe76BLaRGAGKZ1gTDNiGxGcpsLcwJ9OTi1/V8A+AzvsmI9pkjie2zjIQZKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/mdx-loader": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/mdx-loader": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"fs-extra": "^11.1.1",
 				"tslib": "^2.6.0",
 				"webpack": "^5.88.1"
 			},
 			"engines": {
-				"node": ">=18.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/mdx-loader": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
-			"integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
-				"@mdx-js/mdx": "^3.0.0",
-				"@slorber/remark-comment": "^1.0.0",
-				"escape-html": "^1.0.3",
-				"estree-util-value-to-estree": "^3.0.1",
-				"file-loader": "^6.2.0",
-				"fs-extra": "^11.1.1",
-				"image-size": "^2.0.2",
-				"mdast-util-mdx": "^3.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"rehype-raw": "^7.0.0",
-				"remark-directive": "^3.0.0",
-				"remark-emoji": "^4.0.0",
-				"remark-frontmatter": "^5.0.0",
-				"remark-gfm": "^4.0.0",
-				"stringify-object": "^3.3.0",
-				"tslib": "^2.6.0",
-				"unified": "^11.0.3",
-				"unist-util-visit": "^5.0.0",
-				"url-loader": "^4.1.1",
-				"vfile": "^6.0.1",
-				"webpack": "^5.88.1"
-			},
-			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -4925,38 +4636,38 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-css-cascade-layers": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1.tgz",
-			"integrity": "sha512-VQ47xRxfNKjHS5ItzaVXpxeTm7/wJLFMOPo1BkmoMG4Cuz4nuI+Hs62+RMk1OqVog68Swz66xVPK8g9XTrBKRw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.9.2.tgz",
+			"integrity": "sha512-w1s3+Ss+eOQbscGM4cfIFBlVg/QKxyYgj26k5AnakuHkKxH6004ZtuLe5awMBotIYF2bbGDoDhpgQ4r/kcj4rQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/plugin-debug": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1.tgz",
-			"integrity": "sha512-nT3lN7TV5bi5hKMB7FK8gCffFTBSsBsAfV84/v293qAmnHOyg1nr9okEw8AiwcO3bl9vije5nsUvP0aRl2lpaw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.9.2.tgz",
+			"integrity": "sha512-j7a5hWuAFxyQAkilZwhsQ/b3T7FfHZ+0dub6j/GxKNFJp2h9qk/P1Bp7vrGASnvA9KNQBBL1ZXTe7jlh4VdPdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
 				"fs-extra": "^11.1.1",
 				"react-json-view-lite": "^2.3.0",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -4964,19 +4675,19 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-google-analytics": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1.tgz",
-			"integrity": "sha512-Hrb/PurOJsmwHAsfMDH6oVpahkEGsx7F8CWMjyP/dw1qjqmdS9rcV1nYCGlM8nOtD3Wk/eaThzUB5TSZsGz+7Q==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.9.2.tgz",
+			"integrity": "sha512-mAwwQJ1Us9jL/lVjXtErXto4p4/iaLlweC54yDUK1a97WfkC6Z2k5/769JsFgwOwOP+n5mUQGACXOEQ0XDuVUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -4984,20 +4695,20 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-google-gtag": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1.tgz",
-			"integrity": "sha512-tKE8j1cEZCh8KZa4aa80zpSTxsC2/ZYqjx6AAfd8uA8VHZVw79+7OTEP2PoWi0uL5/1Is0LF5Vwxd+1fz5HlKg==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.9.2.tgz",
+			"integrity": "sha512-YJ4lDCphabBtw19ooSlc1MnxtYGpjFV9rEdzjLsUnBCeis2djUyCozZaFhCg6NGEwOn7HDDyMh0yzcdRpnuIvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"@types/gtag.js": "^0.0.12",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -5005,19 +4716,19 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-google-tag-manager": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1.tgz",
-			"integrity": "sha512-iqe3XKITBquZq+6UAXdb1vI0fPY5iIOitVjPQ581R1ZKpHr0qe+V6gVOrrcOHixPDD/BUKdYwkxFjpNiEN+vBw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.9.2.tgz",
+			"integrity": "sha512-LJtIrkZN/tuHD8NqDAW1Tnw0ekOwRTfobWPsdO15YxcicBo2ykKF0/D6n0vVBfd3srwr9Z6rzrIWYrMzBGrvNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -5025,24 +4736,24 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-ideal-image": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-ideal-image/-/plugin-ideal-image-3.8.1.tgz",
-			"integrity": "sha512-Y+ts2dAvBFqLjt5VjpEn15Ct4D93RyZXcpdU3gtrrQETg2V2aSRP4jOXexoUzJACIOG5IWjEXCUeaoVT9o7GFQ==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-ideal-image/-/plugin-ideal-image-3.9.2.tgz",
+			"integrity": "sha512-YYYbmC2wSYFd7o4//5rPXt9+DkZwfwjCUmyGi5OIVqEbwELK80o3COXs2Xd0BtVIpuRvG7pKCYrMQwVo32Y9qw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/lqip-loader": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/lqip-loader": "3.9.2",
 				"@docusaurus/responsive-loader": "^1.7.0",
-				"@docusaurus/theme-translations": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/theme-translations": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"sharp": "^0.32.3",
 				"tslib": "^2.6.0",
 				"webpack": "^5.88.1"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"jimp": "*",
@@ -5056,24 +4767,24 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-sitemap": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
-			"integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
+			"integrity": "sha512-WLh7ymgDXjG8oPoM/T4/zUP7KcSuFYRZAUTl8vR6VzYkfc18GBM4xLhcT+AKOwun6kBivYKUJf+vlqYJkm+RHw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"fs-extra": "^11.1.1",
 				"sitemap": "^7.1.1",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -5081,23 +4792,23 @@
 			}
 		},
 		"node_modules/@docusaurus/plugin-svgr": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1.tgz",
-			"integrity": "sha512-rW0LWMDsdlsgowVwqiMb/7tANDodpy1wWPwCcamvhY7OECReN3feoFwLjd/U4tKjNY3encj0AJSTxJA+Fpe+Gw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.9.2.tgz",
+			"integrity": "sha512-n+1DE+5b3Lnf27TgVU5jM1d4x5tUh2oW5LTsBxJX4PsAPV0JGcmI6p3yLYtEY0LRVEIJh+8RsdQmRE66wSV8mw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"@svgr/core": "8.1.0",
 				"@svgr/webpack": "^8.1.0",
 				"tslib": "^2.6.0",
 				"webpack": "^5.88.1"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -5105,30 +4816,30 @@
 			}
 		},
 		"node_modules/@docusaurus/preset-classic": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz",
-			"integrity": "sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.9.2.tgz",
+			"integrity": "sha512-IgyYO2Gvaigi21LuDIe+nvmN/dfGXAiMcV/murFqcpjnZc7jxFAxW+9LEjdPt61uZLxG4ByW/oUmX/DDK9t/8w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/plugin-content-blog": "3.8.1",
-				"@docusaurus/plugin-content-docs": "3.8.1",
-				"@docusaurus/plugin-content-pages": "3.8.1",
-				"@docusaurus/plugin-css-cascade-layers": "3.8.1",
-				"@docusaurus/plugin-debug": "3.8.1",
-				"@docusaurus/plugin-google-analytics": "3.8.1",
-				"@docusaurus/plugin-google-gtag": "3.8.1",
-				"@docusaurus/plugin-google-tag-manager": "3.8.1",
-				"@docusaurus/plugin-sitemap": "3.8.1",
-				"@docusaurus/plugin-svgr": "3.8.1",
-				"@docusaurus/theme-classic": "3.8.1",
-				"@docusaurus/theme-common": "3.8.1",
-				"@docusaurus/theme-search-algolia": "3.8.1",
-				"@docusaurus/types": "3.8.1"
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/plugin-content-blog": "3.9.2",
+				"@docusaurus/plugin-content-docs": "3.9.2",
+				"@docusaurus/plugin-content-pages": "3.9.2",
+				"@docusaurus/plugin-css-cascade-layers": "3.9.2",
+				"@docusaurus/plugin-debug": "3.9.2",
+				"@docusaurus/plugin-google-analytics": "3.9.2",
+				"@docusaurus/plugin-google-gtag": "3.9.2",
+				"@docusaurus/plugin-google-tag-manager": "3.9.2",
+				"@docusaurus/plugin-sitemap": "3.9.2",
+				"@docusaurus/plugin-svgr": "3.9.2",
+				"@docusaurus/theme-classic": "3.9.2",
+				"@docusaurus/theme-common": "3.9.2",
+				"@docusaurus/theme-search-algolia": "3.9.2",
+				"@docusaurus/types": "3.9.2"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -5161,28 +4872,27 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-classic": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1.tgz",
-			"integrity": "sha512-bqDUCNqXeYypMCsE1VcTXSI1QuO4KXfx8Cvl6rYfY0bhhqN6d2WZlRkyLg/p6pm+DzvanqHOyYlqdPyP0iz+iw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.9.2.tgz",
+			"integrity": "sha512-IGUsArG5hhekXd7RDb11v94ycpJpFdJPkLnt10fFQWOVxAtq5/D7hT6lzc2fhyQKaaCE62qVajOMKL7OiAFAIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/mdx-loader": "3.8.1",
-				"@docusaurus/module-type-aliases": "3.8.1",
-				"@docusaurus/plugin-content-blog": "3.8.1",
-				"@docusaurus/plugin-content-docs": "3.8.1",
-				"@docusaurus/plugin-content-pages": "3.8.1",
-				"@docusaurus/theme-common": "3.8.1",
-				"@docusaurus/theme-translations": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/mdx-loader": "3.9.2",
+				"@docusaurus/module-type-aliases": "3.9.2",
+				"@docusaurus/plugin-content-blog": "3.9.2",
+				"@docusaurus/plugin-content-docs": "3.9.2",
+				"@docusaurus/plugin-content-pages": "3.9.2",
+				"@docusaurus/theme-common": "3.9.2",
+				"@docusaurus/theme-translations": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"@mdx-js/react": "^3.0.0",
 				"clsx": "^2.0.0",
-				"copy-text-to-clipboard": "^3.2.0",
 				"infima": "0.2.0-alpha.45",
 				"lodash": "^4.17.21",
 				"nprogress": "^0.2.0",
@@ -5195,47 +4905,7 @@
 				"utility-types": "^3.10.0"
 			},
 			"engines": {
-				"node": ">=18.0"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/mdx-loader": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
-			"integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
-				"@mdx-js/mdx": "^3.0.0",
-				"@slorber/remark-comment": "^1.0.0",
-				"escape-html": "^1.0.3",
-				"estree-util-value-to-estree": "^3.0.1",
-				"file-loader": "^6.2.0",
-				"fs-extra": "^11.1.1",
-				"image-size": "^2.0.2",
-				"mdast-util-mdx": "^3.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"rehype-raw": "^7.0.0",
-				"remark-directive": "^3.0.0",
-				"remark-emoji": "^4.0.0",
-				"remark-frontmatter": "^5.0.0",
-				"remark-gfm": "^4.0.0",
-				"stringify-object": "^3.3.0",
-				"tslib": "^2.6.0",
-				"unified": "^11.0.3",
-				"unist-util-visit": "^5.0.0",
-				"url-loader": "^4.1.1",
-				"vfile": "^6.0.1",
-				"webpack": "^5.88.1"
-			},
-			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -5267,16 +4937,16 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-common": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1.tgz",
-			"integrity": "sha512-UswMOyTnPEVRvN5Qzbo+l8k4xrd5fTFu2VPPfD6FcW/6qUtVLmJTQCktbAL3KJ0BVXGm5aJXz/ZrzqFuZERGPw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.9.2.tgz",
+			"integrity": "sha512-6c4DAbR6n6nPbnZhY2V3tzpnKnGL+6aOsLvFL26VRqhlczli9eWG0VDUNoCQEPnGwDMhPS42UhSAnz5pThm5Ag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/mdx-loader": "3.8.1",
-				"@docusaurus/module-type-aliases": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
+				"@docusaurus/mdx-loader": "3.9.2",
+				"@docusaurus/module-type-aliases": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
 				"@types/history": "^4.7.11",
 				"@types/react": "*",
 				"@types/react-router-config": "*",
@@ -5287,50 +4957,10 @@
 				"utility-types": "^3.10.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"@docusaurus/plugin-content-docs": "*",
-				"react": "^18.0.0 || ^19.0.0",
-				"react-dom": "^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/@docusaurus/theme-common/node_modules/@docusaurus/mdx-loader": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
-			"integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
-				"@mdx-js/mdx": "^3.0.0",
-				"@slorber/remark-comment": "^1.0.0",
-				"escape-html": "^1.0.3",
-				"estree-util-value-to-estree": "^3.0.1",
-				"file-loader": "^6.2.0",
-				"fs-extra": "^11.1.1",
-				"image-size": "^2.0.2",
-				"mdast-util-mdx": "^3.0.0",
-				"mdast-util-to-string": "^4.0.0",
-				"rehype-raw": "^7.0.0",
-				"remark-directive": "^3.0.0",
-				"remark-emoji": "^4.0.0",
-				"remark-frontmatter": "^5.0.0",
-				"remark-gfm": "^4.0.0",
-				"stringify-object": "^3.3.0",
-				"tslib": "^2.6.0",
-				"unified": "^11.0.3",
-				"unist-util-visit": "^5.0.0",
-				"url-loader": "^4.1.1",
-				"vfile": "^6.0.1",
-				"webpack": "^5.88.1"
-			},
-			"engines": {
-				"node": ">=18.0"
-			},
-			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
 				"react-dom": "^18.0.0 || ^19.0.0"
 			}
@@ -5360,16 +4990,16 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-live-codeblock": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-live-codeblock/-/theme-live-codeblock-3.8.1.tgz",
-			"integrity": "sha512-TuCdnbJdTCAR4xv/dEU9m299/+hr+DrxQnQyK1mAmxnvWM/KrfaWdKMfjJ9h4hHa54ctPGm6ykdTvZic0GWdIw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-live-codeblock/-/theme-live-codeblock-3.9.2.tgz",
+			"integrity": "sha512-cgxxZh18dI5Q4iV0GLmwqXtgZbTLOnb0TYgZRiUh0mnIGbuNWFUhUYXXl5owKbDfIXFdFAiI/owJKM83howEAw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/theme-common": "3.8.1",
-				"@docusaurus/theme-translations": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/theme-common": "3.9.2",
+				"@docusaurus/theme-translations": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
 				"@philpl/buble": "^0.19.7",
 				"clsx": "^2.0.0",
 				"fs-extra": "^11.1.1",
@@ -5377,7 +5007,7 @@
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -5395,22 +5025,22 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-search-algolia": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1.tgz",
-			"integrity": "sha512-NBFH5rZVQRAQM087aYSRKQ9yGEK9eHd+xOxQjqNpxMiV85OhJDD4ZGz6YJIod26Fbooy54UWVdzNU0TFeUUUzQ==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.9.2.tgz",
+			"integrity": "sha512-GBDSFNwjnh5/LdkxCKQHkgO2pIMX1447BxYUBG2wBiajS21uj64a+gH/qlbQjDLxmGrbrllBrtJkUHxIsiwRnw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docsearch/react": "^3.9.0",
-				"@docusaurus/core": "3.8.1",
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/plugin-content-docs": "3.8.1",
-				"@docusaurus/theme-common": "3.8.1",
-				"@docusaurus/theme-translations": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-validation": "3.8.1",
-				"algoliasearch": "^5.17.1",
-				"algoliasearch-helper": "^3.22.6",
+				"@docsearch/react": "^3.9.0 || ^4.1.0",
+				"@docusaurus/core": "3.9.2",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/plugin-content-docs": "3.9.2",
+				"@docusaurus/theme-common": "3.9.2",
+				"@docusaurus/theme-translations": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-validation": "3.9.2",
+				"algoliasearch": "^5.37.0",
+				"algoliasearch-helper": "^3.26.0",
 				"clsx": "^2.0.0",
 				"eta": "^2.2.0",
 				"fs-extra": "^11.1.1",
@@ -5419,7 +5049,7 @@
 				"utility-types": "^3.10.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			},
 			"peerDependencies": {
 				"react": "^18.0.0 || ^19.0.0",
@@ -5437,9 +5067,9 @@
 			}
 		},
 		"node_modules/@docusaurus/theme-translations": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.1.tgz",
-			"integrity": "sha512-OTp6eebuMcf2rJt4bqnvuwmm3NVXfzfYejL+u/Y1qwKhZPrjPoKWfk1CbOP5xH5ZOPkiAsx4dHdQBRJszK3z2g==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.9.2.tgz",
+			"integrity": "sha512-vIryvpP18ON9T9rjgMRFLr2xJVDpw1rtagEGf8Ccce4CkTrvM/fRB8N2nyWYOW5u3DdjkwKw5fBa+3tbn9P4PA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5447,25 +5077,26 @@
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/tsconfig": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.8.1.tgz",
-			"integrity": "sha512-XBWCcqhRHhkhfolnSolNL+N7gj3HVE3CoZVqnVjfsMzCoOsuQw2iCLxVVHtO+rePUUfouVZHURDgmqIySsF66A==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.9.2.tgz",
+			"integrity": "sha512-j6/Fp4Rlpxsc632cnRnl5HpOWeb6ZKssDj6/XzzAzVGXXfm9Eptx3rxCC+fDzySn9fHTS+CWJjPineCR1bB5WQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@docusaurus/types": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1.tgz",
-			"integrity": "sha512-ZPdW5AB+pBjiVrcLuw3dOS6BFlrG0XkS2lDGsj8TizcnREQg3J8cjsgfDviszOk4CweNfwo1AEELJkYaMUuOPg==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
+			"integrity": "sha512-Ux1JUNswg+EfUEmajJjyhIohKceitY/yzjRUpu04WXgvVz+fbhVC0p+R0JhvEu4ytw8zIAys2hrdpQPBHRIa8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@mdx-js/mdx": "^3.0.0",
 				"@types/history": "^4.7.11",
+				"@types/mdast": "^4.0.2",
 				"@types/react": "*",
 				"commander": "^5.1.0",
 				"joi": "^17.9.2",
@@ -5495,15 +5126,15 @@
 			}
 		},
 		"node_modules/@docusaurus/utils": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1.tgz",
-			"integrity": "sha512-P1ml0nvOmEFdmu0smSXOqTS1sxU5tqvnc0dA4MTKV39kye+bhQnjkIKEE18fNOvxjyB86k8esoCIFM3x4RykOQ==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
+			"integrity": "sha512-lBSBiRruFurFKXr5Hbsl2thmGweAPmddhF3jb99U4EMDA5L+e5Y1rAkOS07Nvrup7HUMBDrCV45meaxZnt28nQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/types": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/types": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
 				"escape-string-regexp": "^4.0.0",
 				"execa": "5.1.1",
 				"file-loader": "^6.2.0",
@@ -5524,33 +5155,33 @@
 				"webpack": "^5.88.1"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/utils-common": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1.tgz",
-			"integrity": "sha512-zTZiDlvpvoJIrQEEd71c154DkcriBecm4z94OzEE9kz7ikS3J+iSlABhFXM45mZ0eN5pVqqr7cs60+ZlYLewtg==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
+			"integrity": "sha512-I53UC1QctruA6SWLvbjbhCpAw7+X7PePoe5pYcwTOEXD/PxeP8LnECAhTHHwWCblyUX5bMi4QLRkxvyZ+IT8Aw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/types": "3.8.1",
+				"@docusaurus/types": "3.9.2",
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/utils-validation": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1.tgz",
-			"integrity": "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
+			"integrity": "sha512-l7yk3X5VnNmATbwijJkexdhulNsQaNDwoagiwujXoxFbWLcxHQqNQ+c/IAlzrfMMOfa/8xSBZ7KEKDesE/2J7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@docusaurus/logger": "3.8.1",
-				"@docusaurus/utils": "3.8.1",
-				"@docusaurus/utils-common": "3.8.1",
+				"@docusaurus/logger": "3.9.2",
+				"@docusaurus/utils": "3.9.2",
+				"@docusaurus/utils-common": "3.9.2",
 				"fs-extra": "^11.2.0",
 				"joi": "^17.9.2",
 				"js-yaml": "^4.1.0",
@@ -5558,7 +5189,7 @@
 				"tslib": "^2.6.0"
 			},
 			"engines": {
-				"node": ">=18.0"
+				"node": ">=20.0"
 			}
 		},
 		"node_modules/@docusaurus/utils-validation/node_modules/fs-extra": {
@@ -7375,6 +7006,126 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@jsonjoy.com/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/codegen": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+			"integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pack": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+			"integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/base64": "^1.1.2",
+				"@jsonjoy.com/buffers": "^1.2.0",
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/json-pointer": "^1.0.2",
+				"@jsonjoy.com/util": "^1.9.0",
+				"hyperdyperid": "^1.2.0",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/json-pointer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+			"integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/codegen": "^1.0.0",
+				"@jsonjoy.com/util": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+			"integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jsonjoy.com/buffers": "^1.0.0",
+				"@jsonjoy.com/codegen": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/@leichtgewicht/ip-codec": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -7680,215 +7431,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nrwl/tao": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.10.0.tgz",
-			"integrity": "sha512-QNAanpINbr+Pod6e1xNgFbzK1x5wmZl+jMocgiEFXZ67KHvmbD6MAQQr0MMz+GPhIu7EE4QCTLTyCEMlAG+K5Q==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"nx": "16.10.0",
-				"tslib": "^2.3.0"
-			},
-			"bin": {
-				"tao": "index.js"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-darwin-arm64": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.10.0.tgz",
-			"integrity": "sha512-YF+MIpeuwFkyvM5OwgY/rTNRpgVAI/YiR0yTYCZR+X3AAvP775IVlusNgQ3oedTBRUzyRnI4Tknj1WniENFsvQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-darwin-x64": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.10.0.tgz",
-			"integrity": "sha512-ypi6YxwXgb0kg2ixKXE3pwf5myVNUgWf1CsV5OzVccCM8NzheMO51KDXTDmEpXdzUsfT0AkO1sk5GZeCjhVONg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-freebsd-x64": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.10.0.tgz",
-			"integrity": "sha512-UeEYFDmdbbDkTQamqvtU8ibgu5jQLgFF1ruNb/U4Ywvwutw2d4ruOMl2e0u9hiNja9NFFAnDbvzrDcMo7jYqYw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-arm-gnueabihf": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.10.0.tgz",
-			"integrity": "sha512-WV3XUC2DB6/+bz1sx+d1Ai9q2Cdr+kTZRN50SOkfmZUQyEBaF6DRYpx/a4ahhxH3ktpNfyY8Maa9OEYxGCBkQA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-arm64-gnu": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.10.0.tgz",
-			"integrity": "sha512-aWIkOUw995V3ItfpAi5FuxQ+1e9EWLS1cjWM1jmeuo+5WtaKToJn5itgQOkvSlPz+HSLgM3VfXMvOFALNk125g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-arm64-musl": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.10.0.tgz",
-			"integrity": "sha512-uO6Gg+irqpVcCKMcEPIQcTFZ+tDI02AZkqkP7koQAjniLEappd8DnUBSQdcn53T086pHpdc264X/ZEpXFfrKWQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-x64-gnu": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.10.0.tgz",
-			"integrity": "sha512-134PW/u/arNFAQKpqMJniC7irbChMPz+W+qtyKPAUXE0XFKPa7c1GtlI/wK2dvP9qJDZ6bKf0KtA0U/m2HMUOA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-x64-musl": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.10.0.tgz",
-			"integrity": "sha512-q8sINYLdIJxK/iUx9vRk5jWAWb/2O0PAbOJFwv4qkxBv4rLoN7y+otgCZ5v0xfx/zztFgk/oNY4lg5xYjIso2Q==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-win32-arm64-msvc": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.10.0.tgz",
-			"integrity": "sha512-moJkL9kcqxUdJSRpG7dET3UeLIciwrfP08mzBQ12ewo8K8FzxU8ZUsTIVVdNrwt01CXOdXoweGfdQLjJ4qTURA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-win32-x64-msvc": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.10.0.tgz",
-			"integrity": "sha512-5iV2NKZnzxJwZZ4DM5JVbRG/nkhAbzEskKaLBB82PmYGKzaDHuMHP1lcPoD/rtYMlowZgNA/RQndfKvPBPwmXA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"peer": true,
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/@zkochan/js-yaml": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
-			"integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
 		"node_modules/@lerna/legacy-package-management/node_modules/bl": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7969,31 +7511,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@lerna/legacy-package-management/node_modules/dotenv": {
-			"version": "16.3.2",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.2.tgz",
-			"integrity": "sha512-HTlk5nmhkm8F6JcdXvHIzaorzCoziNQT9mGxLPVXW8wJF1TiGSL60ZGB4gHWabHOaMmWmhvk2/lPHfnBiT78AQ==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/motdotla/dotenv?sponsor=1"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/dotenv-expand": {
-			"version": "10.0.0",
-			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
-			"integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@lerna/legacy-package-management/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -8069,26 +7586,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/@lerna/legacy-package-management/node_modules/graceful-fs": {
@@ -8190,14 +7687,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/jsonc-parser": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/@lerna/legacy-package-management/node_modules/locate-path": {
 			"version": "6.0.0",
@@ -8446,133 +7935,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/nx": {
-			"version": "16.10.0",
-			"resolved": "https://registry.npmjs.org/nx/-/nx-16.10.0.tgz",
-			"integrity": "sha512-gZl4iCC0Hx0Qe1VWmO4Bkeul2nttuXdPpfnlcDKSACGu3ZIo+uySqwOF8yBAxSTIf8xe2JRhgzJN1aFkuezEBg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@nrwl/tao": "16.10.0",
-				"@parcel/watcher": "2.0.4",
-				"@yarnpkg/lockfile": "^1.1.0",
-				"@yarnpkg/parsers": "3.0.0-rc.46",
-				"@zkochan/js-yaml": "0.0.6",
-				"axios": "^1.0.0",
-				"chalk": "^4.1.0",
-				"cli-cursor": "3.1.0",
-				"cli-spinners": "2.6.1",
-				"cliui": "^8.0.1",
-				"dotenv": "~16.3.1",
-				"dotenv-expand": "~10.0.0",
-				"enquirer": "~2.3.6",
-				"figures": "3.2.0",
-				"flat": "^5.0.2",
-				"fs-extra": "^11.1.0",
-				"glob": "7.1.4",
-				"ignore": "^5.0.4",
-				"jest-diff": "^29.4.1",
-				"js-yaml": "4.1.0",
-				"jsonc-parser": "3.2.0",
-				"lines-and-columns": "~2.0.3",
-				"minimatch": "3.0.5",
-				"node-machine-id": "1.1.12",
-				"npm-run-path": "^4.0.1",
-				"open": "^8.4.0",
-				"semver": "7.5.3",
-				"string-width": "^4.2.3",
-				"strong-log-transformer": "^2.1.0",
-				"tar-stream": "~2.2.0",
-				"tmp": "~0.2.1",
-				"tsconfig-paths": "^4.1.2",
-				"tslib": "^2.3.0",
-				"v8-compile-cache": "2.3.0",
-				"yargs": "^17.6.2",
-				"yargs-parser": "21.1.1"
-			},
-			"bin": {
-				"nx": "bin/nx.js"
-			},
-			"optionalDependencies": {
-				"@nx/nx-darwin-arm64": "16.10.0",
-				"@nx/nx-darwin-x64": "16.10.0",
-				"@nx/nx-freebsd-x64": "16.10.0",
-				"@nx/nx-linux-arm-gnueabihf": "16.10.0",
-				"@nx/nx-linux-arm64-gnu": "16.10.0",
-				"@nx/nx-linux-arm64-musl": "16.10.0",
-				"@nx/nx-linux-x64-gnu": "16.10.0",
-				"@nx/nx-linux-x64-musl": "16.10.0",
-				"@nx/nx-win32-arm64-msvc": "16.10.0",
-				"@nx/nx-win32-x64-msvc": "16.10.0"
-			},
-			"peerDependencies": {
-				"@swc-node/register": "^1.6.7",
-				"@swc/core": "^1.3.85"
-			},
-			"peerDependenciesMeta": {
-				"@swc-node/register": {
-					"optional": true
-				},
-				"@swc/core": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/nx/node_modules/fs-extra": {
-			"version": "11.3.2",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-			"integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/nx/node_modules/semver": {
-			"version": "7.5.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@lerna/legacy-package-management/node_modules/nx/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@lerna/legacy-package-management/node_modules/ora": {
@@ -10085,6 +9447,20 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@npmcli/query/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/@npmcli/run-script": {
@@ -12906,6 +12282,16 @@
 				"@octokit/openapi-types": "^24.2.0"
 			}
 		},
+		"node_modules/@opentelemetry/api": {
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
 		"node_modules/@parcel/watcher": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz",
@@ -14524,6 +13910,13 @@
 				"micromark-util-symbol": "^1.0.1"
 			}
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+			"integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@svgr/babel-plugin-add-jsx-attribute": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -15104,32 +14497,19 @@
 			}
 		},
 		"node_modules/@types/express": {
-			"version": "4.17.24",
-			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.24.tgz",
-			"integrity": "sha512-Mbrt4SRlXSTWryOnHAh2d4UQ/E7n9lZyGSi6KgX+4hkuL9soYbLOVXVhnk/ODp12YsGc95f4pOvqywJ6kngUwg==",
+			"version": "4.17.25",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+			"integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^4.17.33",
 				"@types/qs": "*",
-				"@types/serve-static": "*"
+				"@types/serve-static": "^1"
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
-			"integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"@types/qs": "*",
-				"@types/range-parser": "*",
-				"@types/send": "*"
-			}
-		},
-		"node_modules/@types/express/node_modules/@types/express-serve-static-core": {
 			"version": "4.19.7",
 			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
 			"integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
@@ -15529,9 +14909,9 @@
 			}
 		},
 		"node_modules/@types/retry": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"version": "0.12.2",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+			"integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16775,84 +16155,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/@typescript-eslint/parser": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
-			"integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.46.2",
-				"@typescript-eslint/types": "8.46.2",
-				"@typescript-eslint/typescript-estree": "8.46.2",
-				"@typescript-eslint/visitor-keys": "8.46.2",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			},
-			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <6.0.0"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
-			"integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@typescript-eslint/types": "8.46.2",
-				"@typescript-eslint/visitor-keys": "8.46.2"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.46.2",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
-			"integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@typescript-eslint/types": "8.46.2",
-				"eslint-visitor-keys": "^4.2.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"peer": true,
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
 		"node_modules/@typescript-eslint/project-service": {
 			"version": "8.46.2",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
@@ -17197,6 +16499,16 @@
 			},
 			"peerDependencies": {
 				"react": ">= 16.8.0"
+			}
+		},
+		"node_modules/@vercel/oidc": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.3.tgz",
+			"integrity": "sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 20"
 			}
 		},
 		"node_modules/@vitejs/plugin-react": {
@@ -19840,6 +19152,25 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/ai": {
+			"version": "5.0.86",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-5.0.86.tgz",
+			"integrity": "sha512-ooHwNTkLdedFf98iQhtSc5btc/P4UuXuOpYneoifq0190vqosLunNdW8Hs6CiE0Am7YOGNplDK56JIPlHZIL4w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@ai-sdk/gateway": "2.0.5",
+				"@ai-sdk/provider": "2.0.0",
+				"@ai-sdk/provider-utils": "3.0.15",
+				"@opentelemetry/api": "1.9.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.76 || ^4.1.8"
+			}
+		},
 		"node_modules/ajv": {
 			"version": "8.12.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -19903,26 +19234,26 @@
 			}
 		},
 		"node_modules/algoliasearch": {
-			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.41.0.tgz",
-			"integrity": "sha512-9E4b3rJmYbBkn7e3aAPt1as+VVnRhsR4qwRRgOzpeyz4PAOuwKh0HI4AN6mTrqK0S0M9fCCSTOUnuJ8gPY/tvA==",
+			"version": "5.42.0",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.42.0.tgz",
+			"integrity": "sha512-X5+PtWc9EJIPafT/cj8ZG+6IU3cjRRnlHGtqMHK/9gsiupQbAyYlH5y7qt/FtsAhfX5AICHffZy69ZAsVrxWkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/abtesting": "1.7.0",
-				"@algolia/client-abtesting": "5.41.0",
-				"@algolia/client-analytics": "5.41.0",
-				"@algolia/client-common": "5.41.0",
-				"@algolia/client-insights": "5.41.0",
-				"@algolia/client-personalization": "5.41.0",
-				"@algolia/client-query-suggestions": "5.41.0",
-				"@algolia/client-search": "5.41.0",
-				"@algolia/ingestion": "1.41.0",
-				"@algolia/monitoring": "1.41.0",
-				"@algolia/recommend": "5.41.0",
-				"@algolia/requester-browser-xhr": "5.41.0",
-				"@algolia/requester-fetch": "5.41.0",
-				"@algolia/requester-node-http": "5.41.0"
+				"@algolia/abtesting": "1.8.0",
+				"@algolia/client-abtesting": "5.42.0",
+				"@algolia/client-analytics": "5.42.0",
+				"@algolia/client-common": "5.42.0",
+				"@algolia/client-insights": "5.42.0",
+				"@algolia/client-personalization": "5.42.0",
+				"@algolia/client-query-suggestions": "5.42.0",
+				"@algolia/client-search": "5.42.0",
+				"@algolia/ingestion": "1.42.0",
+				"@algolia/monitoring": "1.42.0",
+				"@algolia/recommend": "5.42.0",
+				"@algolia/requester-browser-xhr": "5.42.0",
+				"@algolia/requester-fetch": "5.42.0",
+				"@algolia/requester-node-http": "5.42.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -21498,6 +20829,22 @@
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.0.0"
+			}
+		},
+		"node_modules/bundle-name": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+			"integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"run-applescript": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/byte-size": {
@@ -23124,19 +22471,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/copy-text-to-clipboard": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.2.tgz",
-			"integrity": "sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/copy-webpack-plugin": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
@@ -23477,20 +22811,6 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/css-declaration-sorter": {
 			"version": "7.3.0",
 			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.0.tgz",
@@ -23530,43 +22850,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
-			}
-		},
-		"node_modules/css-has-pseudo/node_modules/@csstools/selector-specificity": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^7.0.0"
-			}
-		},
-		"node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/css-loader": {
@@ -24388,17 +23671,34 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/default-gateway": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
-			"integrity": "sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==",
+		"node_modules/default-browser": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+			"integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
 			"dev": true,
-			"license": "BSD-2-Clause",
+			"license": "MIT",
 			"dependencies": {
-				"execa": "^5.0.0"
+				"bundle-name": "^4.1.0",
+				"default-browser-id": "^5.0.0"
 			},
 			"engines": {
-				"node": ">= 10"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/default-browser-id": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+			"integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/defaults": {
@@ -26446,6 +25746,16 @@
 				"bare-events": "^2.7.0"
 			}
 		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+			"integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -27413,13 +26723,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/fs-monkey": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
-			"integrity": "sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==",
-			"dev": true,
-			"license": "Unlicense"
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -28042,6 +27345,23 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/glob-to-regex.js": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+			"integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/glob-to-regexp": {
@@ -28876,23 +28196,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/html-entities": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
-			"integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/mdevils"
-				},
-				{
-					"type": "patreon",
-					"url": "https://patreon.com/mdevils"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -29341,6 +28644,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/typicode"
+			}
+		},
+		"node_modules/hyperdyperid": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+			"integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -30221,6 +29534,41 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/is-inside-container": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^3.0.0"
+			},
+			"bin": {
+				"is-inside-container": "cli.js"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-inside-container/node_modules/is-docker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-installed-globally": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
@@ -30282,6 +29630,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-network-error": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.0.tgz",
+			"integrity": "sha512-6oIwpsgRfnDiyEDLMay/GqCl3HoAtH5+RUKW29gYkL0QA+ipzpDLA16yQs7/RHCSu+BwgbJaOUqa4A99qNVQVw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-npm": {
@@ -30925,24 +30286,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/jest-circus/node_modules/babel-plugin-macros": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@babel/runtime": "^7.12.5",
-				"cosmiconfig": "^7.0.0",
-				"resolve": "^1.19.0"
-			},
-			"engines": {
-				"node": ">=10",
-				"npm": ">=6"
-			}
-		},
 		"node_modules/jest-circus/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -30958,25 +30301,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest-circus/node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/jest-circus/node_modules/dedent": {
@@ -32813,9 +32137,9 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.11.1",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.11.1.tgz",
-			"integrity": "sha512-SEET7oNfgSaB6Ym0jufAdCeo3meJVeCaaDyzRygy0xsp2BFKCprcfHljTq4QkzTLUxEKkFK6OK4811YM2oSrRg==",
+			"version": "2.12.0",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.12.0.tgz",
+			"integrity": "sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -35158,16 +34482,22 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-3.5.3.tgz",
-			"integrity": "sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==",
+			"version": "4.50.0",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.50.0.tgz",
+			"integrity": "sha512-N0LUYQMUA1yS5tJKmMtU9yprPm6ZIg24yr/OVv/7t6q0kKDIho4cBbXRi1XKttUmNYDYgF/q45qrKE/UhGO0CA==",
 			"dev": true,
-			"license": "Unlicense",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"fs-monkey": "^1.0.4"
+				"@jsonjoy.com/json-pack": "^1.11.0",
+				"@jsonjoy.com/util": "^1.9.0",
+				"glob-to-regex.js": "^1.0.1",
+				"thingies": "^2.5.0",
+				"tree-dump": "^1.0.3",
+				"tslib": "^2.0.0"
 			},
-			"engines": {
-				"node": ">= 4.0.0"
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
 			}
 		},
 		"node_modules/memize": {
@@ -37946,9 +37276,9 @@
 			}
 		},
 		"node_modules/node-abi": {
-			"version": "3.78.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.78.0.tgz",
-			"integrity": "sha512-E2wEyrgX/CqvicaQYU3Ze1PFGjc4QYPGsjUrlYkqAE0WjHEZwgOsGMPMzkMse4LjJbDmaEuDX3CM036j5K2DSQ==",
+			"version": "3.80.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.80.0.tgz",
+			"integrity": "sha512-LyPuZJcI9HVwzXK1GPxWNzrr+vr8Hp/3UqlmWxxh8p54U1ZbclOqbSog9lWHaCX+dBaiGi6n/hIX+mKu74GmPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -39723,17 +39053,21 @@
 			}
 		},
 		"node_modules/p-retry": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+			"integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/retry": "0.12.0",
+				"@types/retry": "0.12.2",
+				"is-network-error": "^1.0.0",
 				"retry": "^0.13.1"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-retry/node_modules/retry": {
@@ -40620,20 +39954,6 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/postcss-calc": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz",
@@ -40649,6 +39969,20 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.2"
+			}
+		},
+		"node_modules/postcss-calc/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/postcss-clamp": {
@@ -40875,20 +40209,6 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/postcss-dir-pseudo-class": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-9.0.1.tgz",
@@ -40913,20 +40233,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
-			}
-		},
-		"node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/postcss-discard-comments": {
@@ -40997,6 +40303,20 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-discard-unused/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/postcss-double-position-gradients": {
 			"version": "6.0.4",
 			"resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-6.0.4.tgz",
@@ -41051,20 +40371,6 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/postcss-focus-within": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-9.0.1.tgz",
@@ -41089,20 +40395,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
-			}
-		},
-		"node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/postcss-font-variant": {
@@ -41297,6 +40589,20 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-merge-rules/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/postcss-minify-font-values": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.1.0.tgz",
@@ -41365,6 +40671,20 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/postcss-modules-extract-imports": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
@@ -41396,20 +40716,6 @@
 				"postcss": "^8.1.0"
 			}
 		},
-		"node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/postcss-modules-scope": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
@@ -41424,20 +40730,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.1.0"
-			}
-		},
-		"node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/postcss-modules-values": {
@@ -41482,66 +40774,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4"
-			}
-		},
-		"node_modules/postcss-nesting/node_modules/@csstools/selector-resolve-nested": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
-			"integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^7.0.0"
-			}
-		},
-		"node_modules/postcss-nesting/node_modules/@csstools/selector-specificity": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
-			"integrity": "sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/csstools"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/csstools"
-				}
-			],
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"postcss-selector-parser": "^7.0.0"
-			}
-		},
-		"node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/postcss-normalize-charset": {
@@ -41916,20 +41148,6 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
-			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/postcss-reduce-idents": {
 			"version": "6.0.3",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-6.0.3.tgz",
@@ -42015,24 +41233,10 @@
 				"postcss": "^8.4"
 			}
 		},
-		"node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
+		"node_modules/postcss-selector-parser": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
 			"integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cssesc": "^3.0.0",
-				"util-deprecate": "^1.0.2"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/postcss-selector-parser": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -42090,6 +41294,20 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4.31"
+			}
+		},
+		"node_modules/postcss-unique-selectors/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/postcss-urlrebase": {
@@ -45086,6 +44304,19 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/run-applescript": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+			"integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/run-async": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -45294,14 +44525,6 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
-		},
-		"node_modules/search-insights": {
-			"version": "2.17.3",
-			"resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-			"integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/section-matter": {
 			"version": "1.0.0",
@@ -47409,6 +46632,20 @@
 				"postcss": "^8.4.31"
 			}
 		},
+		"node_modules/stylehacks/node_modules/postcss-selector-parser": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+			"integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/stylis": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
@@ -47571,6 +46808,20 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/swr": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/swr/-/swr-2.3.6.tgz",
+			"integrity": "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.3",
+				"use-sync-external-store": "^1.4.0"
+			},
+			"peerDependencies": {
+				"react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/symbol-tree": {
@@ -47994,6 +47245,23 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/thingies": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+			"integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "^2"
+			}
+		},
 		"node_modules/throttleit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
@@ -48255,6 +47523,23 @@
 			},
 			"engines": {
 				"node": ">=14"
+			}
+		},
+		"node_modules/tree-dump": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+			"integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
 			}
 		},
 		"node_modules/tree-kill": {
@@ -50620,79 +49905,106 @@
 			}
 		},
 		"node_modules/webpack-dev-middleware": {
-			"version": "5.3.4",
-			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
-			"integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
+			"version": "7.4.5",
+			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
+			"integrity": "sha512-uxQ6YqGdE4hgDKNf7hUiPXOdtkXvBJXrfEGYSx7P7LC8hnUYGK70X6xQXUvXeNyBDDcsiQXpG2m3G9vxowaEuA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"colorette": "^2.0.10",
-				"memfs": "^3.4.3",
-				"mime-types": "^2.1.31",
+				"memfs": "^4.43.1",
+				"mime-types": "^3.0.1",
+				"on-finished": "^2.4.1",
 				"range-parser": "^1.2.1",
 				"schema-utils": "^4.0.0"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.0.0 || ^5.0.0"
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/webpack-dev-server": {
-			"version": "4.15.2",
-			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
-			"integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+		"node_modules/webpack-dev-middleware/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/webpack-dev-middleware/node_modules/mime-types": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+			"integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/bonjour": "^3.5.9",
-				"@types/connect-history-api-fallback": "^1.3.5",
-				"@types/express": "^4.17.13",
-				"@types/serve-index": "^1.9.1",
-				"@types/serve-static": "^1.13.10",
-				"@types/sockjs": "^0.3.33",
-				"@types/ws": "^8.5.5",
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/webpack-dev-server": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+			"integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/bonjour": "^3.5.13",
+				"@types/connect-history-api-fallback": "^1.5.4",
+				"@types/express": "^4.17.21",
+				"@types/express-serve-static-core": "^4.17.21",
+				"@types/serve-index": "^1.9.4",
+				"@types/serve-static": "^1.15.5",
+				"@types/sockjs": "^0.3.36",
+				"@types/ws": "^8.5.10",
 				"ansi-html-community": "^0.0.8",
-				"bonjour-service": "^1.0.11",
-				"chokidar": "^3.5.3",
+				"bonjour-service": "^1.2.1",
+				"chokidar": "^3.6.0",
 				"colorette": "^2.0.10",
 				"compression": "^1.7.4",
 				"connect-history-api-fallback": "^2.0.0",
-				"default-gateway": "^6.0.3",
-				"express": "^4.17.3",
+				"express": "^4.21.2",
 				"graceful-fs": "^4.2.6",
-				"html-entities": "^2.3.2",
-				"http-proxy-middleware": "^2.0.3",
-				"ipaddr.js": "^2.0.1",
-				"launch-editor": "^2.6.0",
-				"open": "^8.0.9",
-				"p-retry": "^4.5.0",
-				"rimraf": "^3.0.2",
-				"schema-utils": "^4.0.0",
-				"selfsigned": "^2.1.1",
+				"http-proxy-middleware": "^2.0.9",
+				"ipaddr.js": "^2.1.0",
+				"launch-editor": "^2.6.1",
+				"open": "^10.0.3",
+				"p-retry": "^6.2.0",
+				"schema-utils": "^4.2.0",
+				"selfsigned": "^2.4.1",
 				"serve-index": "^1.9.1",
 				"sockjs": "^0.3.24",
 				"spdy": "^4.0.2",
-				"webpack-dev-middleware": "^5.3.4",
-				"ws": "^8.13.0"
+				"webpack-dev-middleware": "^7.4.2",
+				"ws": "^8.18.0"
 			},
 			"bin": {
 				"webpack-dev-server": "bin/webpack-dev-server.js"
 			},
 			"engines": {
-				"node": ">= 12.13.0"
+				"node": ">= 18.12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"webpack": "^4.37.0 || ^5.0.0"
+				"webpack": "^5.0.0"
 			},
 			"peerDependenciesMeta": {
 				"webpack": {
@@ -50703,37 +50015,17 @@
 				}
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+		"node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
 			"engines": {
-				"node": "*"
+				"node": ">=12"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
@@ -50784,34 +50076,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+		"node_modules/webpack-dev-server/node_modules/open": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+			"integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
 			"dev": true,
-			"license": "ISC",
+			"license": "MIT",
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"default-browser": "^5.2.1",
+				"define-lazy-prop": "^3.0.0",
+				"is-inside-container": "^1.0.0",
+				"wsl-utils": "^0.1.0"
 			},
 			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/rimraf": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-			"deprecated": "Rimraf versions prior to v4 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^7.1.3"
-			},
-			"bin": {
-				"rimraf": "bin.js"
+				"node": ">=18"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/webpack-merge": {
@@ -51516,6 +50797,38 @@
 				}
 			}
 		},
+		"node_modules/wsl-utils": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+			"integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-wsl": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/wsl-utils/node_modules/is-wsl": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+			"integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-inside-container": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/xdg-basedir": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-5.1.0.tgz",
@@ -51812,6 +51125,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.1.12",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz",
+			"integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/zwitch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7431,6 +7431,215 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nrwl/tao": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nrwl/tao/-/tao-16.10.0.tgz",
+			"integrity": "sha512-QNAanpINbr+Pod6e1xNgFbzK1x5wmZl+jMocgiEFXZ67KHvmbD6MAQQr0MMz+GPhIu7EE4QCTLTyCEMlAG+K5Q==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"nx": "16.10.0",
+				"tslib": "^2.3.0"
+			},
+			"bin": {
+				"tao": "index.js"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-darwin-arm64": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-arm64/-/nx-darwin-arm64-16.10.0.tgz",
+			"integrity": "sha512-YF+MIpeuwFkyvM5OwgY/rTNRpgVAI/YiR0yTYCZR+X3AAvP775IVlusNgQ3oedTBRUzyRnI4Tknj1WniENFsvQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-darwin-x64": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-darwin-x64/-/nx-darwin-x64-16.10.0.tgz",
+			"integrity": "sha512-ypi6YxwXgb0kg2ixKXE3pwf5myVNUgWf1CsV5OzVccCM8NzheMO51KDXTDmEpXdzUsfT0AkO1sk5GZeCjhVONg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-freebsd-x64": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-freebsd-x64/-/nx-freebsd-x64-16.10.0.tgz",
+			"integrity": "sha512-UeEYFDmdbbDkTQamqvtU8ibgu5jQLgFF1ruNb/U4Ywvwutw2d4ruOMl2e0u9hiNja9NFFAnDbvzrDcMo7jYqYw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-arm-gnueabihf": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm-gnueabihf/-/nx-linux-arm-gnueabihf-16.10.0.tgz",
+			"integrity": "sha512-WV3XUC2DB6/+bz1sx+d1Ai9q2Cdr+kTZRN50SOkfmZUQyEBaF6DRYpx/a4ahhxH3ktpNfyY8Maa9OEYxGCBkQA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-arm64-gnu": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-16.10.0.tgz",
+			"integrity": "sha512-aWIkOUw995V3ItfpAi5FuxQ+1e9EWLS1cjWM1jmeuo+5WtaKToJn5itgQOkvSlPz+HSLgM3VfXMvOFALNk125g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-arm64-musl": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-16.10.0.tgz",
+			"integrity": "sha512-uO6Gg+irqpVcCKMcEPIQcTFZ+tDI02AZkqkP7koQAjniLEappd8DnUBSQdcn53T086pHpdc264X/ZEpXFfrKWQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-x64-gnu": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-16.10.0.tgz",
+			"integrity": "sha512-134PW/u/arNFAQKpqMJniC7irbChMPz+W+qtyKPAUXE0XFKPa7c1GtlI/wK2dvP9qJDZ6bKf0KtA0U/m2HMUOA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-linux-x64-musl": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-16.10.0.tgz",
+			"integrity": "sha512-q8sINYLdIJxK/iUx9vRk5jWAWb/2O0PAbOJFwv4qkxBv4rLoN7y+otgCZ5v0xfx/zztFgk/oNY4lg5xYjIso2Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-win32-arm64-msvc": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-16.10.0.tgz",
+			"integrity": "sha512-moJkL9kcqxUdJSRpG7dET3UeLIciwrfP08mzBQ12ewo8K8FzxU8ZUsTIVVdNrwt01CXOdXoweGfdQLjJ4qTURA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@nx/nx-win32-x64-msvc": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/@nx/nx-win32-x64-msvc/-/nx-win32-x64-msvc-16.10.0.tgz",
+			"integrity": "sha512-5iV2NKZnzxJwZZ4DM5JVbRG/nkhAbzEskKaLBB82PmYGKzaDHuMHP1lcPoD/rtYMlowZgNA/RQndfKvPBPwmXA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/@zkochan/js-yaml": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.6.tgz",
+			"integrity": "sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/@lerna/legacy-package-management/node_modules/bl": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7511,6 +7720,31 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/@lerna/legacy-package-management/node_modules/dotenv": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.2.tgz",
+			"integrity": "sha512-HTlk5nmhkm8F6JcdXvHIzaorzCoziNQT9mGxLPVXW8wJF1TiGSL60ZGB4gHWabHOaMmWmhvk2/lPHfnBiT78AQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/motdotla/dotenv?sponsor=1"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/dotenv-expand": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+			"integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@lerna/legacy-package-management/node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -7586,6 +7820,26 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/glob": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@lerna/legacy-package-management/node_modules/graceful-fs": {
@@ -7687,6 +7941,14 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@lerna/legacy-package-management/node_modules/locate-path": {
 			"version": "6.0.0",
@@ -7935,6 +8197,133 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/nx": {
+			"version": "16.10.0",
+			"resolved": "https://registry.npmjs.org/nx/-/nx-16.10.0.tgz",
+			"integrity": "sha512-gZl4iCC0Hx0Qe1VWmO4Bkeul2nttuXdPpfnlcDKSACGu3ZIo+uySqwOF8yBAxSTIf8xe2JRhgzJN1aFkuezEBg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@nrwl/tao": "16.10.0",
+				"@parcel/watcher": "2.0.4",
+				"@yarnpkg/lockfile": "^1.1.0",
+				"@yarnpkg/parsers": "3.0.0-rc.46",
+				"@zkochan/js-yaml": "0.0.6",
+				"axios": "^1.0.0",
+				"chalk": "^4.1.0",
+				"cli-cursor": "3.1.0",
+				"cli-spinners": "2.6.1",
+				"cliui": "^8.0.1",
+				"dotenv": "~16.3.1",
+				"dotenv-expand": "~10.0.0",
+				"enquirer": "~2.3.6",
+				"figures": "3.2.0",
+				"flat": "^5.0.2",
+				"fs-extra": "^11.1.0",
+				"glob": "7.1.4",
+				"ignore": "^5.0.4",
+				"jest-diff": "^29.4.1",
+				"js-yaml": "4.1.0",
+				"jsonc-parser": "3.2.0",
+				"lines-and-columns": "~2.0.3",
+				"minimatch": "3.0.5",
+				"node-machine-id": "1.1.12",
+				"npm-run-path": "^4.0.1",
+				"open": "^8.4.0",
+				"semver": "7.5.3",
+				"string-width": "^4.2.3",
+				"strong-log-transformer": "^2.1.0",
+				"tar-stream": "~2.2.0",
+				"tmp": "~0.2.1",
+				"tsconfig-paths": "^4.1.2",
+				"tslib": "^2.3.0",
+				"v8-compile-cache": "2.3.0",
+				"yargs": "^17.6.2",
+				"yargs-parser": "21.1.1"
+			},
+			"bin": {
+				"nx": "bin/nx.js"
+			},
+			"optionalDependencies": {
+				"@nx/nx-darwin-arm64": "16.10.0",
+				"@nx/nx-darwin-x64": "16.10.0",
+				"@nx/nx-freebsd-x64": "16.10.0",
+				"@nx/nx-linux-arm-gnueabihf": "16.10.0",
+				"@nx/nx-linux-arm64-gnu": "16.10.0",
+				"@nx/nx-linux-arm64-musl": "16.10.0",
+				"@nx/nx-linux-x64-gnu": "16.10.0",
+				"@nx/nx-linux-x64-musl": "16.10.0",
+				"@nx/nx-win32-arm64-msvc": "16.10.0",
+				"@nx/nx-win32-x64-msvc": "16.10.0"
+			},
+			"peerDependencies": {
+				"@swc-node/register": "^1.6.7",
+				"@swc/core": "^1.3.85"
+			},
+			"peerDependenciesMeta": {
+				"@swc-node/register": {
+					"optional": true
+				},
+				"@swc/core": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/nx/node_modules/fs-extra": {
+			"version": "11.3.2",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+			"integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/nx/node_modules/semver": {
+			"version": "7.5.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+			"integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+			"dev": true,
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@lerna/legacy-package-management/node_modules/nx/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@lerna/legacy-package-management/node_modules/ora": {
@@ -16153,6 +16542,84 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@typescript-eslint/parser": {
+			"version": "8.46.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
+			"integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/scope-manager": "8.46.2",
+				"@typescript-eslint/types": "8.46.2",
+				"@typescript-eslint/typescript-estree": "8.46.2",
+				"@typescript-eslint/visitor-keys": "8.46.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0",
+				"typescript": ">=4.8.4 <6.0.0"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+			"version": "8.46.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
+			"integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.46.2",
+				"@typescript-eslint/visitor-keys": "8.46.2"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+			"version": "8.46.2",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
+			"integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@typescript-eslint/types": "8.46.2",
+				"eslint-visitor-keys": "^4.2.1"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
@@ -30286,6 +30753,24 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/jest-circus/node_modules/babel-plugin-macros": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/jest-circus/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -30301,6 +30786,25 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/jest-circus/node_modules/cosmiconfig": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/jest-circus/node_modules/dedent": {
@@ -44525,6 +45029,14 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
+		},
+		"node_modules/search-insights": {
+			"version": "2.17.3",
+			"resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+			"integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/section-matter": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -112,12 +112,12 @@
 		"yargs": "17.7.2"
 	},
 	"devDependencies": {
-		"@docusaurus/core": "3.8.1",
-		"@docusaurus/plugin-client-redirects": "3.8.1",
-		"@docusaurus/plugin-ideal-image": "3.8.1",
-		"@docusaurus/preset-classic": "3.8.1",
-		"@docusaurus/theme-live-codeblock": "3.8.1",
-		"@docusaurus/tsconfig": "3.8.1",
+		"@docusaurus/core": "3.9.2",
+		"@docusaurus/plugin-client-redirects": "3.9.2",
+		"@docusaurus/plugin-ideal-image": "3.9.2",
+		"@docusaurus/preset-classic": "3.9.2",
+		"@docusaurus/theme-live-codeblock": "3.9.2",
+		"@docusaurus/tsconfig": "3.9.2",
 		"@nx/cypress": "19.8.4",
 		"@nx/devkit": "19.8.4",
 		"@nx/eslint-plugin": "20.8.0",

--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -25,7 +25,11 @@ const config = {
 	projectName: 'wordpress-playground', // Usually your repo name.
 
 	onBrokenLinks: 'throw',
-	onBrokenMarkdownLinks: 'throw',
+	markdown: {
+		hooks: {
+			onBrokenMarkdownLinks: 'throw',
+		},
+	},
 
 	// Even if you don't use internalization, you can use this field to set useful
 	// metadata like html lang. For example, if your site is Chinese, you may want

--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -99,7 +99,6 @@ const config = {
 				},
 			},
 		],
-		'./plugins/kapa-ai-plugin.js',
 	],
 
 	presets: [

--- a/packages/docs/site/src/theme/Navbar/Search/index.js
+++ b/packages/docs/site/src/theme/Navbar/Search/index.js
@@ -2,30 +2,9 @@ import React from 'react';
 import Search from '@theme-original/Navbar/Search';
 
 export default function SearchWrapper(props) {
-	const handleClick = (e) => {
-		e.preventDefault();
-		window.Kapa?.open?.();
-	};
-
 	/*
-	 * This add the Kapa AI button to the end of the navbar. It is impossible to add it
-	 * by using themeConfig.navbar.items because the Search component it hardcoded.
-	 * See https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/Navbar/Content/index.tsx#L100
-	 *
-	 * By swizzling the Search component, we can add the Kapa AI button to the right of it.
+	 * This component wraps the Search component.
+	 * Previously used to add Kapa AI button, but that has been removed.
 	 */
-	return (
-		<>
-			<Search {...props} />
-			<div>
-				<a
-					className="kapa-ai-button"
-					onClick={handleClick}
-					aria-label="Ask AI"
-				>
-					Ask AI
-				</a>
-			</div>
-		</>
-	);
+	return <Search {...props} />;
 }


### PR DESCRIPTION
Removes kapa AI button from the Playground doc site – it triggers a React error [here](https://wordpress.github.io/wordpress-playground/api/blueprints/interface/EnableMultisiteStep/#Index):

<img width="2786" height="1226" alt="CleanShot 2025-11-03 at 11 07 10@2x" src="https://github.com/user-attachments/assets/0ed25935-012c-4664-b95f-ecbb845ae1aa" />

This is a temporary measure to fix the documentation page until the error is figured out—assuming we continue with Kapa AI (it's a free trial).

This PR also updates the Docusaurus version from `3.8.1` to `3.9.2`. It doesn't seem strictly necessary but was a low-hanging fruit to co-locate with this PR.

## Testing instructions

Build the doc site locally, confirm there's no error at `/wordpress-playground/api/blueprints/interface/EnableMultisiteStep/#Index`