### PR TITLE
[Website] Controlled iframe for the latest Guteneberg version

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -393,13 +393,11 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 	// @see controlledIframe below for more details.
 	if (
 		// WordPress Core version of block-editor.js
-		unscopedUrl.pathname.endsWith('/wp-includes/js/dist/block-editor.js') ||
-		unscopedUrl.pathname.endsWith(
-			'/wp-includes/js/dist/block-editor.min.js'
-		) ||
+		unscopedUrl.pathname.endsWith('/block-editor.js') ||
+		unscopedUrl.pathname.endsWith('/block-editor.min.js') ||
 		// Gutenberg version of block-editor.js
-		unscopedUrl.pathname.endsWith('/build/block-editor/index.js') ||
-		unscopedUrl.pathname.endsWith('/build/block-editor/index.min.js')
+		unscopedUrl.pathname.endsWith('/block-editor/index.js') ||
+		unscopedUrl.pathname.endsWith('/block-editor/index.min.js')
 	) {
 		const script = await workerResponse.text();
 		const newScript = `${controlledIframe} ${script.replace(
@@ -470,15 +468,15 @@ window.__playground_ControlledIframe = window.wp.element.forwardRef(function (pr
 		 */
 		const __playground_readBlobAsText = function (url) {
 			try {
-			let xhr = new XMLHttpRequest();
-			xhr.open('GET', url, false);
-			xhr.overrideMimeType('text/plain;charset=utf-8');
-			xhr.send();
-			return xhr.responseText;
+				let xhr = new XMLHttpRequest();
+				xhr.open('GET', url, false);
+				xhr.overrideMimeType('text/plain;charset=utf-8');
+				xhr.send();
+				return xhr.responseText;
 			} catch(e) {
-			return '';
+				return '';
 			} finally {
-			URL.revokeObjectURL(url);
+				URL.revokeObjectURL(url);
 			}
 		};
 		if (props.srcDoc) {


### PR DESCRIPTION
## Motivation for the change, related issues

[Missing CSS and images because the Gutenberg iframe isn't controlled by the service worker](https://github.com/WordPress/wordpress-playground/issues/646#top)strikes back in the latest Gutenberg release. This PR adjusts the script rewriting expression to resolve it.

## Testing Instructions (or ideally a Blueprint)

Visit http://127.0.0.1:5400/website-server/?gutenberg-pr=72916&url=%2Fwp-admin%2Fpost-new.php

Below is what you should see..

Before this PR:

<img width="3608" height="1834" alt="CleanShot 2025-11-03 at 17 03 20@2x" src="https://github.com/user-attachments/assets/f2020598-54f4-4f40-9d1f-1ce9078bf97d" />

After this PR:

<img width="3620" height="1840" alt="CleanShot 2025-11-03 at 17 00 36@2x" src="https://github.com/user-attachments/assets/f81d17be-0caf-49ec-8b5c-b546fe230aec" />
