### PR TITLE
Fix unmount of nested mounts in PHP runtime hotswap

### DIFF
--- a/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
+++ b/packages/php-wasm/node/src/test/rotate-php-runtime.spec.ts
@@ -213,6 +213,59 @@ describe.each([true, false])(
 			).toBe('plugin-3');
 		});
 
+		it('Preserves a nested NODEFS mount through PHP runtime recreation', async () => {
+			// Rotate the PHP runtime
+			const recreateRuntimeSpy = vitest.fn(recreateRuntime);
+
+			const php = new PHP(await recreateRuntime());
+			php.enableRuntimeRotation({
+				recreateRuntime: recreateRuntimeSpy,
+				maxRequests: 1,
+			});
+
+			// Create a temporary directory and a file in it
+			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'temp-'));
+			const dirToMountAsParent = path.join(tempDir, 'parent');
+			fs.mkdirSync(dirToMountAsParent);
+			const dirToMountAsNested = path.join(tempDir, 'nested');
+			fs.mkdirSync(dirToMountAsNested);
+
+			// Mount the parent and nested child directories
+			await php.mount(
+				'/parent',
+				createNodeFsMountHandler(dirToMountAsParent)
+			);
+			await php.mount(
+				'/parent/nested',
+				createNodeFsMountHandler(dirToMountAsNested)
+			);
+
+			const childFile = path.join(dirToMountAsNested, 'nested.php');
+			const nestedPhpCode = `<?php echo "nested file";`;
+			fs.writeFileSync(childFile, nestedPhpCode);
+			const parentFileThatReferencesChildFile = path.join(
+				dirToMountAsParent,
+				'test.php'
+			);
+			const parentPhpCode = `<?php require_once __DIR__ . '/nested/nested.php';`;
+			fs.writeFileSync(parentFileThatReferencesChildFile, parentPhpCode);
+
+			// Confirm output based on nested NODEFS mount is the same before and after rotation.
+			const scriptPath = '/parent/test.php';
+			const firstResult = await php.run({ scriptPath });
+			expect(firstResult.text).toBe('nested file');
+			const secondResult = await php.run({ scriptPath });
+			expect(secondResult.text).toBe('nested file');
+
+			expect(recreateRuntimeSpy).toHaveBeenCalledTimes(1);
+
+			// Infer that the nested NODEFS mounts are not lost
+			expect(php.readFileAsText('/parent/nested/nested.php')).toBe(
+				nestedPhpCode
+			);
+			expect(php.readFileAsText(scriptPath)).toBe(parentPhpCode);
+		});
+
 		it('Free up the available PHP memory', async () => {
 			const freeMemory = (php: PHP) =>
 				php[__private__dont__use].HEAPU32.reduce(

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1398,11 +1398,20 @@ export class PHP implements Disposable {
 		const oldCWD = oldFS.cwd();
 		oldFS.chdir('/');
 
-		// Unmount all the mount handlers
-		const mountHandlers: { mountHandler: MountHandler; vfsPath: string }[] =
-			[];
-		for (const [vfsPath, mount] of Object.entries(this.#mounts)) {
-			mountHandlers.push({ mountHandler: mount.mountHandler, vfsPath });
+		// Remember mounts to apply to new runtime
+		const mountHandlersToReapplyInOrder = Object.entries(this.#mounts).map(
+			([vfsPath, mount]) => ({
+				mountHandler: mount.mountHandler,
+				vfsPath,
+			})
+		);
+
+		// Unmount all the mount handlers in reverse order because each nested
+		// mount depends upon the parent mount which preceded it.
+		const mountsToUnmountInReverseOrder = Object.values(
+			this.#mounts
+		).reverse();
+		for (const mount of mountsToUnmountInReverseOrder) {
 			await mount.unmount();
 		}
 
@@ -1441,8 +1450,8 @@ export class PHP implements Disposable {
 			}
 		}
 
-		// Re-mount all the mount handlers
-		for (const { mountHandler, vfsPath } of mountHandlers) {
+		// Re-mount all the mount handlers in order
+		for (const { mountHandler, vfsPath } of mountHandlersToReapplyInOrder) {
 			this.mkdir(vfsPath);
 			await this.mount(vfsPath, mountHandler);
 		}


### PR DESCRIPTION
## Motivation for the change, related issues

Today, if we nest a NODEFS mount inside another NODEFS mount, hot-swapping the PHP runtime fails when we attempt to unmount a nested mount from a parent that has already been unmounted. This PR fixes that issue.

cc @adamziel who [mentioned an issue](https://github.com/WordPress/wordpress-playground/pull/2836#discussion_r2485963372) that looked like this one.

## Implementation details

This PR changes PHP runtime hot-swapping to unmount mounts in reverse order, and the attempted unmount no longer fails.

## Testing Instructions (or ideally a Blueprint)

- CI
