### PR TITLE
[CLI] Fix incorrect Xdebug mappings for absolute host paths

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -645,7 +645,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				);
 
 				const symlinkMount: Mount = {
-					hostPath: `./${symlinkName}`,
+					hostPath: path.join('.', path.sep, symlinkName),
 					vfsPath: '/',
 				};
 

--- a/packages/playground/cli/src/xdebug-path-mappings.ts
+++ b/packages/playground/cli/src/xdebug-path-mappings.ts
@@ -206,9 +206,8 @@ export function updatePhpStormConfig(
 				path_mappings: mappings.map((mapping) => ({
 					mapping: [],
 					':@': {
-						'local-root': `$PROJECT_DIR$/${path.relative(
-							options.projectDir,
-							mapping.hostPath
+						'local-root': `$PROJECT_DIR$/${toPosixPath(
+							path.relative(options.projectDir, mapping.hostPath)
 						)}`,
 						'remote-root': mapping.vfsPath,
 					},
@@ -420,9 +419,8 @@ export function updateVSCodeConfig(
 			request: 'launch',
 			port: 9003,
 			pathMappings: mappings.reduce((acc, mount) => {
-				acc[mount.vfsPath] = `\${workspaceFolder}/${path.relative(
-					options.workspaceDir,
-					mount.hostPath
+				acc[mount.vfsPath] = `\${workspaceFolder}/${toPosixPath(
+					path.relative(options.workspaceDir, mount.hostPath)
 				)}`;
 				return acc;
 			}, {} as VSCodeConfigMetaData),
@@ -693,4 +691,8 @@ function jsoncApplyEdits(content: string, edits: JSONC.Edit[]) {
 	}
 
 	return json;
+}
+
+function toPosixPath(pathStr: string) {
+	return pathStr.replaceAll(path.sep, path.posix.sep);
 }

--- a/packages/playground/cli/src/xdebug-path-mappings.ts
+++ b/packages/playground/cli/src/xdebug-path-mappings.ts
@@ -169,6 +169,7 @@ export type PhpStormConfigOptions = {
 	name: string;
 	host: string;
 	port: number;
+	projectDir: string;
 	mappings: Mount[];
 	ideKey: string;
 };
@@ -205,9 +206,9 @@ export function updatePhpStormConfig(
 				path_mappings: mappings.map((mapping) => ({
 					mapping: [],
 					':@': {
-						'local-root': `$PROJECT_DIR$/${mapping.hostPath.replace(
-							/^\.\/?/,
-							''
+						'local-root': `$PROJECT_DIR$/${path.relative(
+							options.projectDir,
+							mapping.hostPath
 						)}`,
 						'remote-root': mapping.vfsPath,
 					},
@@ -363,6 +364,7 @@ export function updatePhpStormConfig(
 
 export type VSCodeConfigOptions = {
 	name: string;
+	workspaceDir: string;
 	mappings: Mount[];
 };
 
@@ -418,11 +420,9 @@ export function updateVSCodeConfig(
 			request: 'launch',
 			port: 9003,
 			pathMappings: mappings.reduce((acc, mount) => {
-				acc[
-					mount.vfsPath
-				] = `\${workspaceFolder}/${mount.hostPath.replace(
-					/^\.\/?/,
-					''
+				acc[mount.vfsPath] = `\${workspaceFolder}/${path.relative(
+					options.workspaceDir,
+					mount.hostPath
 				)}`;
 				return acc;
 			}, {} as VSCodeConfigMetaData),
@@ -497,6 +497,7 @@ export async function addXdebugIDEConfig({
 				name,
 				host,
 				port,
+				projectDir: cwd,
 				mappings,
 				ideKey,
 			});
@@ -533,6 +534,7 @@ export async function addXdebugIDEConfig({
 			const content = fs.readFileSync(vsCodeConfigFilePath, 'utf-8');
 			const updatedJson = updateVSCodeConfig(content, {
 				name,
+				workspaceDir: cwd,
 				mappings,
 			});
 

--- a/packages/playground/cli/tests/xdebug-path-mappings.spec.ts
+++ b/packages/playground/cli/tests/xdebug-path-mappings.spec.ts
@@ -92,6 +92,7 @@ describe('updatePhpStormConfig', () => {
 		name: 'Test Server',
 		host: 'localhost',
 		port: 8080,
+		projectDir: process.cwd(),
 		mappings: [
 			{
 				hostPath: './src',
@@ -260,6 +261,47 @@ describe('updatePhpStormConfig', () => {
 					},
 					{
 						hostPath: 'baz/qux',
+						vfsPath: '/var/www/html/baz/qux',
+					},
+				],
+			};
+
+			const xml =
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
+			const result = updatePhpStormConfig(xml, options);
+
+			const expected = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpServers">
+		<servers>
+			<server name="Test Server" host="localhost:8080" use_path_mappings="true">
+				<path_mappings>
+					<mapping local-root="$PROJECT_DIR$/foo/bar" remote-root="/var/www/html/foo/bar"/>
+					<mapping local-root="$PROJECT_DIR$/baz/qux" remote-root="/var/www/html/baz/qux"/>
+				</path_mappings>
+			</server>
+		</servers>
+	</component>
+	<component name="RunManager">
+		<configuration name="Test Server" type="PhpRemoteDebugRunConfigurationType" factoryName="PHP Remote Debug" filter_connections="FILTER" server_name="Test Server" session_id="PLAYGROUNDCLI">
+			<method v="2"/>
+		</configuration>
+	</component>
+</project>`;
+
+			expectXMLEquals(result, expected);
+		});
+
+		it('should make absolute hostPath relative to project directory', () => {
+			const options: PhpStormConfigOptions = {
+				...defaultOptions,
+				mappings: [
+					{
+						hostPath: `${defaultOptions.projectDir}/foo/bar`,
+						vfsPath: '/var/www/html/foo/bar',
+					},
+					{
+						hostPath: `${defaultOptions.projectDir}/baz/qux`,
 						vfsPath: '/var/www/html/baz/qux',
 					},
 				],
@@ -694,6 +736,7 @@ describe('updatePhpStormConfig', () => {
 describe('updateVSCodeConfig', () => {
 	const defaultOptions: VSCodeConfigOptions = {
 		name: 'Test Configuration',
+		workspaceDir: process.cwd(),
 		mappings: [
 			{
 				hostPath: './src',
@@ -863,6 +906,42 @@ describe('updateVSCodeConfig', () => {
 					},
 					{
 						hostPath: 'baz/qux',
+						vfsPath: '/var/www/html/baz/qux',
+					},
+				],
+			};
+
+			const json = '{\n    "configurations": []\n}';
+			const result = updateVSCodeConfig(json, options);
+
+			const expected = `{
+    "configurations": [
+        {
+            "name": "Test Configuration",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                "/var/www/html/foo/bar": "\${workspaceFolder}/foo/bar",
+                "/var/www/html/baz/qux": "\${workspaceFolder}/baz/qux"
+            }
+        }
+    ]
+}`;
+
+			expectJSONEquals(result, expected);
+		});
+
+		it('should make absolute hostPath relative to workspace folder', () => {
+			const options: VSCodeConfigOptions = {
+				...defaultOptions,
+				mappings: [
+					{
+						hostPath: `${defaultOptions.workspaceDir}/foo/bar`,
+						vfsPath: '/var/www/html/foo/bar',
+					},
+					{
+						hostPath: `${defaultOptions.workspaceDir}/baz/qux`,
 						vfsPath: '/var/www/html/baz/qux',
 					},
 				],


### PR DESCRIPTION
## Motivation for the change, related issues

When auto-mounting a plugin dir and using Xdebug IDE integration, I am seeing the following incorrect path mappings for a local project dir of `/Users/brandon/src/test-plugin`:
- VSCode: `"/wordpress/wp-content/plugins/test-plugin": "${workspaceFolder}//Users/brandon/src/test-plugin"`
- PhpStorm: `<mapping local-root="$PROJECT_DIR$//Users/brandon/src/test-plugin" remote-root="/wordpress/wp-content/plugins/test-plugin"></mapping>`

## Implementation details

This PR fixes such paths so they are mapped like:
- VSCode: `"/wordpress/wp-content/plugins/test-plugin": "${workspaceFolder}/"`
- PhpStorm: `<mapping local-root="$PROJECT_DIR$/" remote-root="/wordpress/wp-content/plugins/test-plugin"></mapping>`

I also added two new tests cases for this.

## Testing Instructions (or ideally a Blueprint)

- CI
