### PR TITLE
[CLI] Fix explicit, relative auto-mount for plugins and themes

### DIFF
--- a/packages/playground/cli/src/mounts.ts
+++ b/packages/playground/cli/src/mounts.ts
@@ -111,7 +111,7 @@ const ACTIVATE_FIRST_THEME_STEP = {
  * Auto-mounts resolution logic:
  */
 export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
-	const path = args.autoMount!;
+	const absolutePath = path.resolve(args.autoMount!);
 
 	const mount = [...(args.mount || [])];
 	const mountBeforeInstall = [...(args['mount-before-install'] || [])];
@@ -125,20 +125,22 @@ export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
 		],
 	};
 
-	if (isPluginFilename(path)) {
-		const pluginName = basename(path);
+	if (isPluginFilename(absolutePath)) {
+		const pluginName = basename(absolutePath);
 		mount.push({
-			hostPath: path,
+			hostPath: absolutePath,
 			vfsPath: `/wordpress/wp-content/plugins/${pluginName}`,
 		});
 		newArgs['additional-blueprint-steps'].push({
 			step: 'activatePlugin',
-			pluginPath: `/wordpress/wp-content/plugins/${basename(path)}`,
+			pluginPath: `/wordpress/wp-content/plugins/${basename(
+				absolutePath
+			)}`,
 		});
-	} else if (isThemeDirectory(path)) {
-		const themeName = basename(path);
+	} else if (isThemeDirectory(absolutePath)) {
+		const themeName = basename(absolutePath);
 		mount.push({
-			hostPath: path,
+			hostPath: absolutePath,
 			vfsPath: `/wordpress/wp-content/themes/${themeName}`,
 		});
 		newArgs['additional-blueprint-steps'].push(
@@ -152,11 +154,11 @@ export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
 						themeFolderName: themeName,
 				  }
 		);
-	} else if (containsWpContentDirectories(path)) {
+	} else if (containsWpContentDirectories(absolutePath)) {
 		/**
 		 * Mount each wp-content file and directory individually.
 		 */
-		const files = fs.readdirSync(path);
+		const files = fs.readdirSync(absolutePath);
 		for (const file of files) {
 			/**
 			 * WordPress already ships with the wp-content/index.php file
@@ -167,13 +169,16 @@ export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
 				continue;
 			}
 			mount.push({
-				hostPath: `${path}/${file}`,
+				hostPath: `${absolutePath}/${file}`,
 				vfsPath: `/wordpress/wp-content/${file}`,
 			});
 		}
 		newArgs['additional-blueprint-steps'].push(ACTIVATE_FIRST_THEME_STEP);
-	} else if (containsFullWordPressInstallation(path)) {
-		mountBeforeInstall.push({ hostPath: path, vfsPath: '/wordpress' });
+	} else if (containsFullWordPressInstallation(absolutePath)) {
+		mountBeforeInstall.push({
+			hostPath: absolutePath,
+			vfsPath: '/wordpress',
+		});
 		// @TODO: If overriding another mode, throw an error or print a warning.
 		newArgs.mode = 'apply-to-existing-site';
 		newArgs['additional-blueprint-steps'].push(ACTIVATE_FIRST_THEME_STEP);
@@ -182,7 +187,7 @@ export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
 		 * By default, mount the current working directory as the Playground root.
 		 * This allows users to run and PHP or HTML files using the Playground CLI.
 		 */
-		mount.push({ hostPath: path, vfsPath: '/wordpress' });
+		mount.push({ hostPath: absolutePath, vfsPath: '/wordpress' });
 		// @TODO: If overriding another mode, throw an error or print a warning.
 		newArgs.mode = 'mount-only';
 	}


### PR DESCRIPTION
## Motivation for the change, related issues

Providing a relative path to `--auto-mount` for Plugins and Themes is failing. For example, I am seeing the following when working from a test plugin dir:
```
npx @wp-playground/cli server --auto-mount=.                                             
Starting a PHP server...
Setting up WordPress latest
Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.8.3.zip
Fetching SQLite integration plugin...
Booting WordPress...
PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
Booted!
Running the Blueprint...
Activating /wordpress/wp-content/plugins/. – 99%
Plugin /wordpress/wp-content/plugins/. activation printed the following bytes: The plugin does not have a valid header.
Activating /wordpress/wp-content/plugins/. – 100%
Error when executing the blueprint step #0 ({"step":"activatePlugin","pluginPath":"/wordpress/wp-content/plugins/."}) : 
Plugin /wordpress/wp-content/plugins/. could not be activated – WordPress exited with no error. Sometimes, when 
$_SERVER or site options are not configured correctly, WordPress exits early with a 301 redirect. Inspect the "debug" logs in 
the console for more details. caused by Plugin /wordpress/wp-content/plugins/. could not be activated – WordPress exited 
with no error. Sometimes, when $_SERVER or site options are not configured correctly, WordPress exits early with a 301 
redirect. Inspect the "debug" logs in the console for more details.
```

The main part is:
`Error when executing the blueprint step #0 ({"step":"activatePlugin","pluginPath":"/wordpress/wp-content/plugins/."})`

This PR updates the `--auto-mount` code to resolve the path passed to it, so it doesn't matter whether using the empty `--auto-mount` default or some other relative path. All paths will become absolute paths to avoid these issues.

## Implementation details

This PR normalizes all auto-mounted paths to absolute paths before inspection.

## Testing Instructions (or ideally a Blueprint)

- CI
