### PR TITLE
[PHP.wasm] Major overhaul of URL rewriting and setting $_SERVER variables

### DIFF
--- a/packages/php-wasm/compile/php/php_wasm.c
+++ b/packages/php-wasm/compile/php/php_wasm.c
@@ -1451,6 +1451,11 @@ static void wasm_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC
 	value = SG(request_info).request_uri;
 	if (value != NULL)
 	{
+		/**
+		 * REQUEST_URI represents the requested path relative to the site root.
+		 * This is **before** any URL rewriting rules (e.g. apache .htaccess) have been
+		 * applied.
+		 */
 		php_register_variable("REQUEST_URI", value, track_vars_array TSRMLS_CC);
 	}
 
@@ -1459,7 +1464,8 @@ static void wasm_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC
 	{
 		// Confirm path translated starts with the document root
 		/**
-		 * PHP_SELF is the script path relative to the document root.
+		 * PHP_SELF represents the requested script path after any URL rewriting rules
+		 * (e.g. apache .htaccess) have been applied.
 		 *
 		 * For example:
 		 *
@@ -1478,6 +1484,10 @@ static void wasm_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC
 			char *script_name = wasm_server_context->path_translated + strlen(wasm_server_context->document_root);
 			char *script_filename = wasm_server_context->path_translated;
 			char *php_self = wasm_server_context->path_translated + strlen(wasm_server_context->document_root);
+			/**
+			 * SCRIPT_NAME represents the path to the PHP script being executed after
+			 * any URL rewriting rules (e.g. apache .htaccess) have been applied.
+			 */
 			php_register_variable("SCRIPT_NAME", estrdup(script_name), track_vars_array TSRMLS_CC);
 			php_register_variable("SCRIPT_FILENAME", estrdup(script_filename), track_vars_array TSRMLS_CC);
 			php_register_variable("PHP_SELF", estrdup(php_self), track_vars_array TSRMLS_CC);

--- a/packages/php-wasm/compile/php/php_wasm.c
+++ b/packages/php-wasm/compile/php/php_wasm.c
@@ -1464,8 +1464,9 @@ static void wasm_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC
 	{
 		// Confirm path translated starts with the document root
 		/**
-		 * PHP_SELF represents the requested script path after any URL rewriting rules
-		 * (e.g. apache .htaccess) have been applied.
+		 * PHP_SELF represents the requested script path resolved to a filesystem path relative to the document
+		 * root. This is after any URL rewriting rules (e.g. apache .htaccess)
+		 * have been applied.
 		 *
 		 * For example:
 		 *

--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -41,8 +41,8 @@ interface ConfigForRequestTests {
 	absoluteUrl: string | undefined;
 }
 
-const configsForRequestTests: ConfigForRequestTests[] =
-	SupportedPHPVersions.map((phpVersion) => {
+let configsForRequestTests: ConfigForRequestTests[] = SupportedPHPVersions.map(
+	(phpVersion) => {
 		const documentRoots = [
 			'/',
 			// TODO: Re-enable when we can avoid GH workflow cancelation.
@@ -64,7 +64,14 @@ const configsForRequestTests: ConfigForRequestTests[] =
 				absoluteUrl,
 			}));
 		});
-	}).flat(2);
+	}
+).flat(2);
+
+if ('PHP' in process.env) {
+	configsForRequestTests = configsForRequestTests.filter(
+		(config) => config.phpVersion === process.env['PHP']
+	);
+}
 
 describe.each(configsForRequestTests)(
 	'[PHP $phpVersion, DocRoot $docRoot, AbsUrl $absoluteUrl] PHPRequestHandler – request',
@@ -156,6 +163,7 @@ describe.each(configsForRequestTests)(
 		});
 
 		it('should serve a static file with urlencoded entities in the path', async () => {
+			console.log({ absoluteUrl, docRoot });
 			php.writeFile(
 				joinPaths(docRoot, 'Screenshot 2024-04-05 at 7.13.36 AM.html'),
 				`Hello World`
@@ -670,8 +678,12 @@ describe.each(configsForRequestTests)(
 	}
 );
 
-describe.each(SupportedPHPVersions)(
-	'[PHP %s] PHPRequestHandler – PHP_SELF',
+let phpVersions = SupportedPHPVersions;
+if ('PHP' in process.env) {
+	phpVersions = [process.env['PHP']] as any;
+}
+describe.each(phpVersions)(
+	'[PHP %s] PHPRequestHandler – $_SERVER entries',
 	(phpVersion) => {
 		let handler: PHPRequestHandler;
 		beforeEach(async () => {
@@ -731,6 +743,234 @@ describe.each(SupportedPHPVersions)(
 			});
 
 			expect(response.text).toEqual('/var/www');
+		});
+
+		describe('PHP Dev Server scenario (with PATH_INFO)', () => {
+			it('should set $_SERVER variables correctly for script with PATH_INFO', async () => {
+				const php = await handler.getPrimaryPhp();
+				php.mkdirTree('/var/www/subdir');
+				php.writeFile(
+					'/var/www/subdir/script.php',
+					`<?php
+						echo json_encode([
+							'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+							'SCRIPT_NAME' => $_SERVER['SCRIPT_NAME'],
+							'SCRIPT_FILENAME' => $_SERVER['SCRIPT_FILENAME'],
+							'PATH_INFO' => $_SERVER['PATH_INFO'] ?? '(not set)',
+							'PHP_SELF' => $_SERVER['PHP_SELF'],
+						]);
+					`
+				);
+
+				const response = await handler.request({
+					url: '/subdir/script.php/b.php/c.php',
+				});
+
+				const result = response.json;
+				expect(result['REQUEST_URI']).toEqual(
+					'/subdir/script.php/b.php/c.php'
+				);
+				expect(result['SCRIPT_NAME']).toEqual('/subdir/script.php');
+				expect(result['SCRIPT_FILENAME']).toEqual(
+					'/var/www/subdir/script.php'
+				);
+				expect(result['PATH_INFO']).toEqual('/b.php/c.php');
+				expect(result['PHP_SELF']).toEqual(
+					'/subdir/script.php/b.php/c.php'
+				);
+			});
+		});
+
+		describe('Apache vanilla request scenario', () => {
+			it('should set $_SERVER variables correctly for vanilla request with query string', async () => {
+				const php = await handler.getPrimaryPhp();
+				php.mkdirTree('/var/www/subdir');
+				php.writeFile(
+					'/var/www/subdir/script.php',
+					`<?php
+						echo json_encode([
+							'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+							'SCRIPT_NAME' => $_SERVER['SCRIPT_NAME'],
+							'SCRIPT_FILENAME' => $_SERVER['SCRIPT_FILENAME'],
+							'PATH_INFO' => $_SERVER['PATH_INFO'] ?? '(not set)',
+							'PHP_SELF' => $_SERVER['PHP_SELF'],
+							'QUERY_STRING' => $_SERVER['QUERY_STRING'] ?? '',
+							'REQUEST_METHOD' => $_SERVER['REQUEST_METHOD'],
+							'DOCUMENT_ROOT' => $_SERVER['DOCUMENT_ROOT'],
+							'GET_param' => $_GET['param'] ?? '(not set)',
+						]);
+					`
+				);
+
+				const response = await handler.request({
+					url: '/subdir/script.php?param=value',
+				});
+
+				const result = response.json;
+				expect(result['REQUEST_URI']).toEqual(
+					'/subdir/script.php?param=value'
+				);
+				expect(result['SCRIPT_NAME']).toEqual('/subdir/script.php');
+				expect(result['SCRIPT_FILENAME']).toEqual(
+					'/var/www/subdir/script.php'
+				);
+				expect(result['PATH_INFO']).toEqual('');
+				// This should actually be a missing key, not an empty string.
+				// @TODO: Adjust this inconsistency.
+				// expect(result['PATH_INFO']).toEqual('(not set)');
+				expect(result['PHP_SELF']).toEqual('/subdir/script.php');
+				expect(result['QUERY_STRING']).toEqual('param=value');
+				expect(result['REQUEST_METHOD']).toEqual('GET');
+				expect(result['DOCUMENT_ROOT']).toEqual('/var/www');
+				expect(result['GET_param']).toEqual('value');
+			});
+		});
+
+		describe('Apache rewriting rules scenario', () => {
+			it('should set $_SERVER variables correctly when rewrite rules are applied', async () => {
+				const handlerWithRewrite = new PHPRequestHandler({
+					phpFactory: async () =>
+						new PHP(await loadNodeRuntime(phpVersion)),
+					documentRoot: '/var/www',
+					maxPhpInstances: 1,
+					rewriteRules: [
+						{
+							match: /^\/api\/v1\/user\/([0-9]+)$/,
+							replacement:
+								'/subdir/script.php?endpoint=user&id=$1',
+						},
+					],
+				});
+				const php = await handlerWithRewrite.getPrimaryPhp();
+				php.mkdirTree('/var/www/subdir');
+				php.writeFile(
+					'/var/www/subdir/script.php',
+					`<?php
+						echo json_encode([
+							'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+							'SCRIPT_NAME' => $_SERVER['SCRIPT_NAME'],
+							'SCRIPT_FILENAME' => $_SERVER['SCRIPT_FILENAME'],
+							'PATH_INFO' => $_SERVER['PATH_INFO'] ?? '(not set)',
+							'PHP_SELF' => $_SERVER['PHP_SELF'],
+							'QUERY_STRING' => $_SERVER['QUERY_STRING'] ?? '',
+							'GET_endpoint' => $_GET['endpoint'] ?? '(not set)',
+							'GET_id' => $_GET['id'] ?? '(not set)',
+						]);
+					`
+				);
+
+				const response = await handlerWithRewrite.request({
+					url: '/api/v1/user/123',
+				});
+
+				const result = response.json;
+				// REQUEST_URI should be the original URL (before rewriting) per Apache behavior
+				expect(result['REQUEST_URI']).toEqual('/api/v1/user/123');
+				// SCRIPT_NAME is the path to the script relative to document root
+				expect(result['SCRIPT_NAME']).toEqual('/subdir/script.php');
+				// SCRIPT_FILENAME is the absolute path to the script file
+				expect(result['SCRIPT_FILENAME']).toEqual(
+					'/var/www/subdir/script.php'
+				);
+				// PATH_INFO is not set for this type of rewrite
+				expect(result['PATH_INFO']).toEqual('(not set)');
+				// PHP_SELF should be the script path per Apache behavior
+				expect(result['PHP_SELF']).toEqual('/subdir/script.php');
+				// QUERY_STRING should contain the rewritten query parameters
+				expect(result['QUERY_STRING']).toEqual('endpoint=user&id=123');
+				// $_GET should have the parsed query parameters
+				expect(result['GET_endpoint']).toEqual('user');
+				expect(result['GET_id']).toEqual('123');
+
+				php.exit();
+			});
+
+			it('should preserve original REQUEST_URI while rewriting to a different script', async () => {
+				const handlerWithRewrite = new PHPRequestHandler({
+					phpFactory: async () =>
+						new PHP(await loadNodeRuntime(phpVersion)),
+					documentRoot: '/var/www',
+					maxPhpInstances: 1,
+					rewriteRules: [
+						{
+							match: /^\/pretty\/url/,
+							replacement: '/index.php?page=pretty',
+						},
+					],
+				});
+				const php = await handlerWithRewrite.getPrimaryPhp();
+				php.writeFile(
+					'/var/www/index.php',
+					`<?php
+						echo json_encode([
+							'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+							'PHP_SELF' => $_SERVER['PHP_SELF'],
+							'SCRIPT_NAME' => $_SERVER['SCRIPT_NAME'],
+						]);
+					`
+				);
+
+				const response = await handlerWithRewrite.request({
+					url: '/pretty/url',
+				});
+
+				const result = response.json;
+				// REQUEST_URI should be the original URL per Apache behavior
+				expect(result['REQUEST_URI']).toEqual('/pretty/url');
+				// PHP_SELF should be the script path per Apache behavior
+				expect(result['PHP_SELF']).toEqual('/index.php');
+				// SCRIPT_NAME is the script path
+				expect(result['SCRIPT_NAME']).toEqual('/index.php');
+
+				php.exit();
+			});
+
+			it('should preserve the original query params through URL rewriting', async () => {
+				const handlerWithRewrite = new PHPRequestHandler({
+					phpFactory: async () =>
+						new PHP(await loadNodeRuntime(phpVersion)),
+					documentRoot: '/var/www',
+					maxPhpInstances: 1,
+					rewriteRules: [
+						{
+							match: /^\/pretty\/url/,
+							replacement: '/index.php?page=pretty',
+						},
+					],
+				});
+				const php = await handlerWithRewrite.getPrimaryPhp();
+				php.writeFile(
+					'/var/www/index.php',
+					`<?php
+						echo json_encode([
+							'REQUEST_URI' => $_SERVER['REQUEST_URI'],
+							'PHP_SELF' => $_SERVER['PHP_SELF'],
+							'SCRIPT_NAME' => $_SERVER['SCRIPT_NAME'],
+							'QUERY_STRING' => $_SERVER['QUERY_STRING'],
+						]);
+					`
+				);
+
+				const response = await handlerWithRewrite.request({
+					url: '/pretty/url?foo=bar&page=different-value',
+				});
+
+				const result = response.json;
+				// REQUEST_URI should be the original URL per Apache behavior
+				expect(result['REQUEST_URI']).toEqual(
+					'/pretty/url?foo=bar&page=different-value'
+				);
+				// QUERY_STRING should contain all the query parameters: original + rewritten
+				expect(result['QUERY_STRING']).toEqual(
+					'page=pretty&foo=bar&page=different-value'
+				);
+				// PHP_SELF should be the script path per Apache behavior
+				expect(result['PHP_SELF']).toEqual('/index.php');
+				// SCRIPT_NAME is the script path
+				expect(result['SCRIPT_NAME']).toEqual('/index.php');
+
+				php.exit();
+			});
 		});
 	}
 );

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -84,12 +84,6 @@ export type PHPRequestHandlerFactoryArgs = PHPFactoryOptions & {
 	requestHandler: PHPRequestHandler;
 };
 
-interface PHPRequestWrapper {
-	request: PHPRequest;
-	originalRequestUrl: URL;
-	rewrittenRequestUrl: URL;
-}
-
 export type PHPRequestHandlerConfiguration = BaseConfiguration &
 	(
 		| {
@@ -490,13 +484,10 @@ export class PHPRequestHandler implements AsyncDisposable {
 		// file-not-found fallback actions may redirect to non-existent files.
 		if (primaryPhp.isFile(fsPath)) {
 			if (fsPath.endsWith('.php')) {
-				const effectiveRequest: PHPRequestWrapper = {
+				const response = await this.#spawnPHPAndDispatchRequest(
 					request,
 					originalRequestUrl,
 					rewrittenRequestUrl,
-				};
-				const response = await this.#spawnPHPAndDispatchRequest(
-					effectiveRequest,
 					fsPath
 				);
 
@@ -576,7 +567,9 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * Spawns a new PHP instance and dispatches a request to it.
 	 */
 	async #spawnPHPAndDispatchRequest(
-		requestWrapper: PHPRequestWrapper,
+		request: PHPRequest,
+		originalRequestUrl: URL,
+		rewrittenRequestUrl: URL,
 		scriptPath: string
 	): Promise<PHPResponse> {
 		let spawnedPHP: SpawnedPHP | undefined = undefined;
@@ -594,7 +587,9 @@ export class PHPRequestHandler implements AsyncDisposable {
 		try {
 			return await this.#dispatchToPHP(
 				spawnedPHP.php,
-				requestWrapper,
+				request,
+				originalRequestUrl,
+				rewrittenRequestUrl,
 				scriptPath
 			);
 		} finally {
@@ -611,10 +606,11 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 */
 	async #dispatchToPHP(
 		php: PHP,
-		requestWrapper: PHPRequestWrapper,
+		request: PHPRequest,
+		originalRequestUrl: URL,
+		rewrittenRequestUrl: URL,
 		scriptPath: string
 	): Promise<PHPResponse> {
-		const { request, rewrittenRequestUrl } = requestWrapper;
 		let preferredMethod: PHPRunOptions['method'] = 'GET';
 
 		const headers: Record<string, string> = {
@@ -641,18 +637,11 @@ export class PHPRequestHandler implements AsyncDisposable {
 				),
 				protocol: this.#PROTOCOL,
 				method: request.method || preferredMethod,
-				$_SERVER: {
-					REMOTE_ADDR: '127.0.0.1',
-					DOCUMENT_ROOT: this.#DOCROOT,
-					HTTPS: this.#ABSOLUTE_URL.startsWith('https://')
-						? 'on'
-						: '',
-					...this.prepare$_SERVER(
-						requestWrapper.originalRequestUrl,
-						requestWrapper.rewrittenRequestUrl,
-						scriptPath
-					),
-				},
+				$_SERVER: this.prepare$_SERVER(
+					originalRequestUrl,
+					rewrittenRequestUrl,
+					scriptPath
+				),
 				body,
 				scriptPath,
 				headers,
@@ -766,7 +755,12 @@ export class PHPRequestHandler implements AsyncDisposable {
 		rewrittenRequestUrl: URL,
 		resolvedScriptPath: string
 	): Record<string, string> {
-		const $_SERVER: Record<string, string> = {};
+		const $_SERVER: Record<string, string> = {
+			REMOTE_ADDR: '127.0.0.1',
+			DOCUMENT_ROOT: this.#DOCROOT,
+			HTTPS: this.#ABSOLUTE_URL.startsWith('https://') ? 'on' : '',
+		};
+
 		/**
 		 * REQUEST_URI
 		 *

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -367,17 +367,23 @@ export class PHPRequestHandler implements AsyncDisposable {
 			isAbsolute ? undefined : DEFAULT_BASE_URL
 		);
 
-		const normalizedRequestedPath = applyRewriteRules(
-			removePathPrefix(
-				decodeURIComponent(requestedUrl.pathname),
-				this.#PATHNAME
-			),
+		const siteRelativePath = removePathPrefix(
+			decodeURIComponent(requestedUrl.pathname),
+			this.#PATHNAME
+		);
+		const rewrittenRequestPath = applyRewriteRules(
+			siteRelativePath,
 			this.rewriteRules
+		);
+		const rewrittenRequestUrl = new URL(requestedUrl.toString());
+		rewrittenRequestUrl.pathname = joinPaths(
+			this.#PATHNAME,
+			rewrittenRequestPath
 		);
 
 		const primaryPhp = await this.getPrimaryPhp();
 
-		let fsPath = joinPaths(this.#DOCROOT, normalizedRequestedPath);
+		let fsPath = joinPaths(this.#DOCROOT, rewrittenRequestPath);
 
 		if (primaryPhp.isDir(fsPath)) {
 			// Ensure directory URIs have a trailing slash. Otherwise,
@@ -421,9 +427,8 @@ export class PHPRequestHandler implements AsyncDisposable {
 		}
 
 		if (!primaryPhp.isFile(fsPath)) {
-			const fileNotFoundAction = this.getFileNotFoundAction(
-				normalizedRequestedPath
-			);
+			const fileNotFoundAction =
+				this.getFileNotFoundAction(rewrittenRequestPath);
 			switch (fileNotFoundAction.type) {
 				case 'response':
 					return fileNotFoundAction.response;
@@ -450,7 +455,8 @@ export class PHPRequestHandler implements AsyncDisposable {
 				const effectiveRequest: PHPRequest = {
 					...request,
 					// Pass along URL with the #fragment filtered out
-					url: requestedUrl.toString(),
+					url: rewrittenRequestUrl.toString(),
+					urlBeforeRewriting: requestedUrl.toString(),
 				};
 				const response = await this.#spawnPHPAndDispatchRequest(
 					effectiveRequest,

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -443,13 +443,12 @@ export class PHPRequestHandler implements AsyncDisposable {
 			 * If /var/www/file.php/index.php does not exist, but /var/www/file.php does,
 			 * use /var/www/file.php. This is also what Apache and PHP Dev Server do.
 			 */
-			let pathToTry = rewrittenRequestUrl.pathname;
-			while (true) {
+			let pathToTry = dirname(rewrittenRequestUrl.pathname);
+			while (
+				pathToTry.startsWith('/') &&
+				pathToTry !== dirname(pathToTry)
+			) {
 				pathToTry = dirname(pathToTry);
-				if (pathToTry === '/' || !pathToTry.includes('/')) {
-					// We've tried all segments for a partial path.
-					break;
-				}
 				if (primaryPhp.isFile(joinPaths(this.#DOCROOT, pathToTry))) {
 					fsPath = joinPaths(this.#DOCROOT, pathToTry);
 					break;

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -637,7 +637,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 				),
 				protocol: this.#PROTOCOL,
 				method: request.method || preferredMethod,
-				$_SERVER: this.prepare_$_SERVER_variables(
+				$_SERVER: this.prepare_$_SERVER_superglobal(
 					originalRequestUrl,
 					rewrittenRequestUrl,
 					scriptPath
@@ -750,7 +750,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * $_GET['param']              | value
 	 * ```
 	 */
-	private prepare_$_SERVER_variables(
+	private prepare_$_SERVER_superglobal(
 		originalRequestUrl: URL,
 		rewrittenRequestUrl: URL,
 		resolvedScriptPath: string

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -637,7 +637,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 				),
 				protocol: this.#PROTOCOL,
 				method: request.method || preferredMethod,
-				$_SERVER: this.prepare$_SERVER(
+				$_SERVER: this.prepare_$_SERVER_variables(
 					originalRequestUrl,
 					rewrittenRequestUrl,
 					scriptPath
@@ -750,7 +750,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * $_GET['param']              | value
 	 * ```
 	 */
-	private prepare$_SERVER(
+	private prepare_$_SERVER_variables(
 		originalRequestUrl: URL,
 		rewrittenRequestUrl: URL,
 		resolvedScriptPath: string

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -443,13 +443,18 @@ export class PHPRequestHandler implements AsyncDisposable {
 			 * If /var/www/file.php/index.php does not exist, but /var/www/file.php does,
 			 * use /var/www/file.php. This is also what Apache and PHP Dev Server do.
 			 */
-			let pathToTry = dirname(rewrittenRequestUrl.pathname);
+			let pathToTry = rewrittenRequestUrl.pathname;
 			while (
 				pathToTry.startsWith('/') &&
 				pathToTry !== dirname(pathToTry)
 			) {
 				pathToTry = dirname(pathToTry);
-				if (primaryPhp.isFile(joinPaths(this.#DOCROOT, pathToTry))) {
+				const resolvedPathToTry = joinPaths(this.#DOCROOT, pathToTry);
+				if (
+					primaryPhp.isFile(resolvedPathToTry) &&
+					// Only run partial path resolution for PHP files.
+					resolvedPathToTry.endsWith('.php')
+				) {
 					fsPath = joinPaths(this.#DOCROOT, pathToTry);
 					break;
 				}

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -1,4 +1,4 @@
-import { joinPaths } from '@php-wasm/util';
+import { dirname, joinPaths } from '@php-wasm/util';
 import {
 	ensurePathPrefix,
 	toRelativeUrl,
@@ -373,25 +373,16 @@ export class PHPRequestHandler implements AsyncDisposable {
 			isAbsolute ? undefined : DEFAULT_BASE_URL
 		);
 
-		// Apply the rewrite rules to the original request URL:
-		const siteRelativePath = removePathPrefix(
-			decodeURIComponent(originalRequestUrl.pathname),
-			this.#PATHNAME
-		);
-		const rewrittenRequestPath = applyRewriteRules(
-			siteRelativePath,
-			this.rewriteRules
-		);
-		const rewrittenRequestUrl = new URL(originalRequestUrl.toString());
-		rewrittenRequestUrl.pathname = joinPaths(
-			this.#PATHNAME,
-			rewrittenRequestPath
-		);
-
+		const rewrittenRequestUrl = this.#applyRewriteRules(originalRequestUrl);
 		const primaryPhp = await this.getPrimaryPhp();
-
-		let fsPath = joinPaths(this.#DOCROOT, rewrittenRequestPath);
-
+		let fsPath = joinPaths(
+			this.#DOCROOT,
+			/**
+			 * URL.pathname returns a URL-encoded path. We need to decode it
+			 * before using it as a filesystem path.
+			 */
+			decodeURIComponent(rewrittenRequestUrl.pathname)
+		);
 		if (primaryPhp.isDir(fsPath)) {
 			// Ensure directory URIs have a trailing slash. Otherwise,
 			// relative URIs in index.php or index.html files are relative
@@ -428,14 +419,47 @@ export class PHPRequestHandler implements AsyncDisposable {
 				const possibleIndexPath = joinPaths(fsPath, possibleIndexFile);
 				if (primaryPhp.isFile(possibleIndexPath)) {
 					fsPath = possibleIndexPath;
+
+					// Include the resolved index file in the final rewritten request URL.
+					rewrittenRequestUrl.pathname = joinPaths(
+						rewrittenRequestUrl.pathname,
+						possibleIndexFile
+					);
 					break;
 				}
 			}
 		}
 
 		if (!primaryPhp.isFile(fsPath)) {
-			const fileNotFoundAction =
-				this.getFileNotFoundAction(rewrittenRequestPath);
+			/**
+			 * Try resolving a partial path.
+			 *
+			 * Example:
+			 *
+			 * – Request URL: /file.php/index.php
+			 * – Document Root: /var/www
+			 *
+			 * If /var/www/file.php/index.php does not exist, but /var/www/file.php does,
+			 * use /var/www/file.php. This is also what Apache and PHP Dev Server do.
+			 */
+			let pathToTry = rewrittenRequestUrl.pathname;
+			while (true) {
+				pathToTry = dirname(pathToTry);
+				if (pathToTry === '/' || !pathToTry.includes('/')) {
+					// We've tried all segments for a partial path.
+					break;
+				}
+				if (primaryPhp.isFile(joinPaths(this.#DOCROOT, pathToTry))) {
+					fsPath = joinPaths(this.#DOCROOT, pathToTry);
+					break;
+				}
+			}
+		}
+
+		if (!primaryPhp.isFile(fsPath)) {
+			const fileNotFoundAction = this.getFileNotFoundAction(
+				rewrittenRequestUrl.pathname
+			);
 			switch (fileNotFoundAction.type) {
 				case 'response':
 					return fileNotFoundAction.response;
@@ -490,6 +514,32 @@ export class PHPRequestHandler implements AsyncDisposable {
 		} else {
 			return PHPResponse.forHttpCode(404);
 		}
+	}
+
+	/**
+	 * Apply the rewrite rules to the original request URL.
+	 *
+	 * @param originalRequestUrl - The original request URL.
+	 * @returns The rewritten request URL.
+	 */
+	#applyRewriteRules(originalRequestUrl: URL): URL {
+		const siteRelativePath = removePathPrefix(
+			decodeURIComponent(originalRequestUrl.pathname),
+			this.#PATHNAME
+		);
+		const rewrittenRequestPath = applyRewriteRules(
+			siteRelativePath,
+			this.rewriteRules
+		);
+		const rewrittenRequestUrl = new URL(
+			joinPaths(this.#PATHNAME, rewrittenRequestPath),
+			originalRequestUrl.toString()
+		);
+		// Merge the query string parameters from the original request URL.
+		for (const [key, value] of originalRequestUrl.searchParams.entries()) {
+			rewrittenRequestUrl.searchParams.append(key, value);
+		}
+		return rewrittenRequestUrl;
 	}
 
 	/**
@@ -590,7 +640,11 @@ export class PHPRequestHandler implements AsyncDisposable {
 					HTTPS: this.#ABSOLUTE_URL.startsWith('https://')
 						? 'on'
 						: '',
-					...this.prepare$_SERVER(requestWrapper, scriptPath),
+					...this.prepare$_SERVER(
+						requestWrapper.originalRequestUrl,
+						requestWrapper.rewrittenRequestUrl,
+						scriptPath
+					),
 				},
 				body,
 				scriptPath,
@@ -665,7 +719,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * $_SERVER['REQUEST_URI']             | /api/v1/user/123
 	 * $_SERVER['SCRIPT_NAME']             | /subdir/script.php
 	 * $_SERVER['SCRIPT_FILENAME']         | /var/www/html/subdir/script.php
-	 * $_SERVER['PATH_INFO']               | (not set)
+	 * $_SERVER['PATH_INFO']               | (key not set)
 	 * $_SERVER['PHP_SELF']                | /subdir/script.php
 	 * $_SERVER['QUERY_STRING']            | endpoint=user&id=123
 	 * $_SERVER['REDIRECT_STATUS']         | 200
@@ -688,10 +742,10 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * $_SERVER['REQUEST_URI']     | /subdir/script.php?param=value
 	 * $_SERVER['SCRIPT_NAME']     | /subdir/script.php
 	 * $_SERVER['SCRIPT_FILENAME'] | /var/www/html/subdir/script.php
-	 * $_SERVER['PATH_INFO']       | (not set)
+	 * $_SERVER['PATH_INFO']       | (key not set)
 	 * $_SERVER['PHP_SELF']        | /subdir/script.php
-	 * $_SERVER['REDIRECT_URL']    | (not set)
-	 * $_SERVER['REDIRECT_STATUS'] | (not set)
+	 * $_SERVER['REDIRECT_URL']    | (key not set)
+	 * $_SERVER['REDIRECT_STATUS'] | (key not set)
 	 * $_SERVER['QUERY_STRING']    | param=value
 	 * $_SERVER['REQUEST_METHOD']  | GET
 	 * $_SERVER['DOCUMENT_ROOT']   | /var/www/html
@@ -701,54 +755,125 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * ```
 	 */
 	private prepare$_SERVER(
-		{
-			// request,
-			originalRequestUrl,
-			rewrittenRequestUrl,
-		}: PHPRequestWrapper,
+		originalRequestUrl: URL,
+		rewrittenRequestUrl: URL,
 		resolvedScriptPath: string
 	): Record<string, string> {
 		const $_SERVER: Record<string, string> = {};
 		/**
 		 * REQUEST_URI
 		 *
-		 * Path + query string extracted from the
-		 * requested URL **after** applying URL rewriting.
+		 * The original path + query string extracted from the requested URL
+		 * **before** applying any URL rewriting.
 		 */
 		$_SERVER['REQUEST_URI'] =
-			rewrittenRequestUrl.pathname + rewrittenRequestUrl.search;
+			originalRequestUrl.pathname + originalRequestUrl.search;
 
-		/**
-		 * SCRIPT_NAME
-		 *
-		 * Filesystem path of the script relative to the document root.
-		 * Note this is a filesystem path so URL rewriting is not applicable here.
-		 */
 		if (resolvedScriptPath.startsWith(this.#DOCROOT)) {
+			/**
+			 * SCRIPT_NAME
+			 *
+			 * > Contains the current script's path. This is useful for pages
+			 * > which need to point to themselves.
+			 *
+			 * Filesystem path of the script relative to the document root.
+			 * Note this is a filesystem path so URL rewriting is not applicable here.
+			 */
 			$_SERVER['SCRIPT_NAME'] = resolvedScriptPath.substring(
 				this.#DOCROOT.length
 			);
-		}
 
-		/**
-		 * PHP_SELF
-		 *
-		 * Path extracted from the requested URL up to
-		 * the resolved script path **before** applying URL
-		 * rewriting. See the php dev server example above.
-		 *
-		 * Requesting `/subdir/script.php/b.php/c.php` will set
-		 * PHP_SELF to `/subdir/script.php/b.php/c.php`.
-		 */
-		$_SERVER['PHP_SELF'] = originalRequestUrl.pathname;
+			/**
+			 * PHP_SELF – the path sourced from the final **request URL** after the
+			 * rewrite rules have been applied.
+			 *
+			 * php.net documentation is very misleading on this one:
+			 *
+			 * > The filename of the currently executing script, relative
+			 * > to the document root. For instance, $_SERVER['PHP_SELF']
+			 * > in a script at the address http://example.com/foo/bar.php
+			 * > would be /foo/bar.php.
+			 *
+			 * @see https://www.php.net/manual/en/reserved.variables.server.php#:~:text=PHP_SELF
+			 *
+			 * This is not what Apache, nor what the PHP dev server do:
+			 *
+			 * – Document Root: /var/www
+			 * – Script file:   /var/www/subdir/script.php
+			 * – Requesting     /subdir/script.php/b.php/c.php
+			 *
+			 *   $_SERVER['PHP_SELF'] = "/subdir/script.php/b.php/c.php"
+			 *
+			 * So, in that regard, it is a URL path, not a filesystem path.
+			 *
+			 * When URL rewriting is involved, it's the same.
+			 *
+			 * Consider this Apache example from above:
+			 *
+			 * – Document Root: /var/www/html
+			 * – Script file:   /var/www/html/subdir/script.php
+			 * – Rewrite rule:  ^api/v1/user/([0-9]+)$ /subdir/script.php?endpoint=user&id=$1 [L,QSA]
+			 * – Requesting     /api/v1/user/123
+			 *
+			 *   $_SERVER['PHP_SELF'] = "/subdir/script.php"
+			 *
+			 * So, on the face value, this is a filesystem path. However, see
+			 * what happens if we slightly modify that rewrite rule to:
+			 *
+			 * – Rewrite rule:  ^api/v1/user/([0-9]+)$ /subdir/script.php/next.php
+			 *                                                           ^^^^^^^^^
+			 * – Requesting     /api/v1/user/123
+			 *
+			 *   $_SERVER['PHP_SELF'] = "/subdir/script.php/next.php"
+			 *
+			 * So:
+			 * * PHP_SELF is not sourced from the filesystem path.
+			 * * PHP_SELF is sourced from the final request URL after the
+			 *   rewrite rules have been applied.
+			 */
+			$_SERVER['PHP_SELF'] = rewrittenRequestUrl.pathname;
+
+			/**
+			 * PATH_INFO
+			 *
+			 * > Contains any client-provided pathname information trailing the actual
+			 * > script filename but preceding the query string, if available. For instance,
+			 * > if the current script was accessed via the URI http://www.example.com/php/path_info.php/some/stuff?foo=bar,
+			 * > then $_SERVER['PATH_INFO'] would contain /some/stuff.
+			 *
+			 * This **does not** include the query string.
+			 *
+			 * @see https://www.php.net/manual/en/reserved.variables.server.php#:~:text=PATH_INFO
+			 */
+			if ($_SERVER['REQUEST_URI'].startsWith($_SERVER['SCRIPT_NAME'])) {
+				$_SERVER['PATH_INFO'] = $_SERVER['REQUEST_URI'].substring(
+					$_SERVER['SCRIPT_NAME'].length
+				);
+				// Remove the query string if present.
+				if ($_SERVER['PATH_INFO'].includes('?')) {
+					$_SERVER['PATH_INFO'] = $_SERVER['PATH_INFO'].substring(
+						0,
+						$_SERVER['PATH_INFO'].indexOf('?')
+					);
+				}
+			}
+		}
 
 		/**
 		 * QUERY_STRING
 		 *
-		 * Query string extracted from the requested URL
-		 * **after** applying URL rewriting.
+		 * The query string from the original and rewritten request URLs.
+		 * Does not include the leading question mark.
+		 *
+		 * Note it contains all the query parameters from the original
+		 * URL merged with the new parameters from the rewritten request URLs.
+		 *
+		 * Example:
+		 *    – Original request URL: /pretty/url?foo=bar&page=different-value
+		 *    – Rewritten request URL: /pretty/url?page=pretty
+		 *    – QUERY_STRING: page=pretty&foo=bar&page=different-value
 		 */
-		$_SERVER['QUERY_STRING'] = rewrittenRequestUrl.search;
+		$_SERVER['QUERY_STRING'] = rewrittenRequestUrl.search.substring(1);
 
 		/**
 		 * There's a few relevant entries we are NOT setting here:
@@ -793,7 +918,8 @@ export function inferMimeType(path: string): string {
 export function applyRewriteRules(path: string, rules: RewriteRule[]): string {
 	for (const rule of rules) {
 		if (new RegExp(rule.match).test(path)) {
-			return path.replace(rule.match, rule.replacement);
+			path = path.replace(rule.match, rule.replacement);
+			break;
 		}
 	}
 	return path;

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -84,6 +84,12 @@ export type PHPRequestHandlerFactoryArgs = PHPFactoryOptions & {
 	requestHandler: PHPRequestHandler;
 };
 
+interface PHPRequestWrapper {
+	request: PHPRequest;
+	originalRequestUrl: URL;
+	rewrittenRequestUrl: URL;
+}
+
 export type PHPRequestHandlerConfiguration = BaseConfiguration &
 	(
 		| {
@@ -453,11 +459,10 @@ export class PHPRequestHandler implements AsyncDisposable {
 		// file-not-found fallback actions may redirect to non-existent files.
 		if (primaryPhp.isFile(fsPath)) {
 			if (fsPath.endsWith('.php')) {
-				const effectiveRequest: PHPRequest = {
-					...request,
-					// Pass along URL with the #fragment filtered out
-					url: rewrittenRequestUrl.toString(),
-					urlBeforeRewriting: originalRequestUrl.toString(),
+				const effectiveRequest: PHPRequestWrapper = {
+					request,
+					originalRequestUrl,
+					rewrittenRequestUrl,
 				};
 				const response = await this.#spawnPHPAndDispatchRequest(
 					effectiveRequest,
@@ -514,7 +519,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * Spawns a new PHP instance and dispatches a request to it.
 	 */
 	async #spawnPHPAndDispatchRequest(
-		request: PHPRequest,
+		request: PHPRequestWrapper,
 		scriptPath: string
 	): Promise<PHPResponse> {
 		let spawnedPHP: SpawnedPHP | undefined = undefined;
@@ -549,9 +554,10 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 */
 	async #dispatchToPHP(
 		php: PHP,
-		request: PHPRequest,
+		requestWrapper: PHPRequestWrapper,
 		scriptPath: string
 	): Promise<PHPResponse> {
+		const { request, rewrittenRequestUrl } = requestWrapper;
 		let preferredMethod: PHPRunOptions['method'] = 'GET';
 
 		const headers: Record<string, string> = {
@@ -573,7 +579,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 		try {
 			const response = await php.run({
 				relativeUri: ensurePathPrefix(
-					toRelativeUrl(new URL(request.url)),
+					toRelativeUrl(new URL(rewrittenRequestUrl.toString())),
 					this.#PATHNAME
 				),
 				protocol: this.#PROTOCOL,
@@ -584,6 +590,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 					HTTPS: this.#ABSOLUTE_URL.startsWith('https://')
 						? 'on'
 						: '',
+					...this.prepare$_SERVER(requestWrapper, scriptPath),
 				},
 				body,
 				scriptPath,
@@ -603,6 +610,156 @@ export class PHPRequestHandler implements AsyncDisposable {
 			}
 			throw error;
 		}
+	}
+
+	/**
+	 * Computes the essential $_SERVER entries for a request.
+	 *
+	 * php_wasm.c sets some defaults, assuming it runs as a CLI script.
+	 * This function overrides them with the values correct in the request
+	 * context.
+	 *
+	 * @TODO: Consolidate the $_SERVER setting logic into a single place instead
+	 *        of splitting it between the C SAPI and the TypeScript code. The PHP
+	 *        class has a `.cli()` method that could take care of the CLI-specific
+	 *        $_SERVER values.
+	 *
+	 * Path and URL-related $_SERVER entries are theoretically documented
+	 * at https://www.php.net/manual/en/reserved.variables.server.php,
+	 * but that page is not very helpful in practice. Here are tables derived
+	 * by interacting with PHP servers:
+	 *
+	 * ## PHP Dev Server
+	 *
+	 * Setup:
+	 *   – `/home/adam/subdir/script.php` file contains `<?php phpinfo(); ?>`
+	 *   – `php -S 127.0.0.1:8041` running in `/home/adam` directory
+	 *   – A request is sent to `http://127.0.0.1:8041/subdir/script.php/b.php/c.php`
+	 *
+	 * Results:
+	 *
+	 * $_SERVER['REQUEST_URI']    | `/subdir/script.php/b.php/c.php`
+	 * $_SERVER['SCRIPT_NAME']    | `/subdir/script.php`
+	 * $_SERVER['SCRIPT_FILENAME']| `/home/adam/subdir/script.php`
+	 * $_SERVER['PATH_INFO']      | `/b.php/c.php`
+	 * $_SERVER['PHP_SELF']       | `/subdir/script.php/b.php/c.php`
+	 *
+	 * ## Apache – rewriting rules
+	 *
+	 * Setup:
+	 *   – `/var/www/html/subdir/script.php` file contains `<?php phpinfo(); ?>`
+	 *   – Apache is listening on port 8041
+	 *   – The document root is `/var/www/html`
+	 *   – A request is sent to `http://127.0.0.1:8041/api/v1/user/123`
+	 *
+	 * .htaccess file:
+	 *
+	 * ```apache
+	 * RewriteEngine On
+	 * RewriteRule ^api/v1/user/([0-9]+)$ /subdir/script.php?endpoint=user&id=$1 [L,QSA]
+	 * ```
+	 *
+	 * Results:
+	 *
+	 * ```
+	 * $_SERVER['REQUEST_URI']             | /api/v1/user/123
+	 * $_SERVER['SCRIPT_NAME']             | /subdir/script.php
+	 * $_SERVER['SCRIPT_FILENAME']         | /var/www/html/subdir/script.php
+	 * $_SERVER['PATH_INFO']               | (not set)
+	 * $_SERVER['PHP_SELF']                | /subdir/script.php
+	 * $_SERVER['QUERY_STRING']            | endpoint=user&id=123
+	 * $_SERVER['REDIRECT_STATUS']         | 200
+	 * $_SERVER['REDIRECT_URL']            | /api/v1/user/123
+	 * $_SERVER['REDIRECT_QUERY_STRING']   | endpoint=user&id=123
+	 * === $_GET Variables ===
+	 * $_GET['endpoint']                   | user
+	 * $_GET['id']                         | 123
+	 * ```
+	 *
+	 * ## Apache – vanilla request
+	 *
+	 * Setup:
+	 *    – The same as above.
+	 *    – A request sent http://localhost:8041/subdir/script.php?param=value
+	 *
+	 * Results:
+	 *
+	 * ```
+	 * $_SERVER['REQUEST_URI']     | /subdir/script.php?param=value
+	 * $_SERVER['SCRIPT_NAME']     | /subdir/script.php
+	 * $_SERVER['SCRIPT_FILENAME'] | /var/www/html/subdir/script.php
+	 * $_SERVER['PATH_INFO']       | (not set)
+	 * $_SERVER['PHP_SELF']        | /subdir/script.php
+	 * $_SERVER['REDIRECT_URL']    | (not set)
+	 * $_SERVER['REDIRECT_STATUS'] | (not set)
+	 * $_SERVER['QUERY_STRING']    | param=value
+	 * $_SERVER['REQUEST_METHOD']  | GET
+	 * $_SERVER['DOCUMENT_ROOT']   | /var/www/html
+	 *
+	 * === $_GET Variables ===
+	 * $_GET['param']              | value
+	 * ```
+	 */
+	private prepare$_SERVER(
+		{
+			// request,
+			originalRequestUrl,
+			rewrittenRequestUrl,
+		}: PHPRequestWrapper,
+		resolvedScriptPath: string
+	): Record<string, string> {
+		const $_SERVER: Record<string, string> = {};
+		/**
+		 * REQUEST_URI
+		 *
+		 * Path + query string extracted from the
+		 * requested URL **after** applying URL rewriting.
+		 */
+		$_SERVER['REQUEST_URI'] =
+			rewrittenRequestUrl.pathname + rewrittenRequestUrl.search;
+
+		/**
+		 * SCRIPT_NAME
+		 *
+		 * Filesystem path of the script relative to the document root.
+		 * Note this is a filesystem path so URL rewriting is not applicable here.
+		 */
+		if (resolvedScriptPath.startsWith(this.#DOCROOT)) {
+			$_SERVER['SCRIPT_NAME'] = resolvedScriptPath.substring(
+				this.#DOCROOT.length
+			);
+		}
+
+		/**
+		 * PHP_SELF
+		 *
+		 * Path extracted from the requested URL up to
+		 * the resolved script path **before** applying URL
+		 * rewriting. See the php dev server example above.
+		 *
+		 * Requesting `/subdir/script.php/b.php/c.php` will set
+		 * PHP_SELF to `/subdir/script.php/b.php/c.php`.
+		 */
+		$_SERVER['PHP_SELF'] = originalRequestUrl.pathname;
+
+		/**
+		 * QUERY_STRING
+		 *
+		 * Query string extracted from the requested URL
+		 * **after** applying URL rewriting.
+		 */
+		$_SERVER['QUERY_STRING'] = rewrittenRequestUrl.search;
+
+		/**
+		 * There's a few relevant entries we are NOT setting here:
+		 *
+		 *    – SCRIPT_FILENAME: Absolute path to the script file. It is set by
+		 *      php_wasm.c.
+		 *    – REDIRECT_STATUS: Apache sets it, but it's optional so we skip it.
+		 *    – REDIRECT_URL: Apache sets it, but it's optional so we skip it.
+		 *    – REDIRECT_QUERY_STRING: Apache sets it, but it's optional so we skip it.
+		 */
+		return $_SERVER;
 	}
 
 	async [Symbol.asyncDispose]() {

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -361,21 +361,22 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 */
 	async request(request: PHPRequest): Promise<PHPResponse> {
 		const isAbsolute = URL.canParse(request.url);
-		const requestedUrl = new URL(
+		const originalRequestUrl = new URL(
 			// Remove the hash part of the URL as it's not meant for the server.
 			request.url.split('#')[0],
 			isAbsolute ? undefined : DEFAULT_BASE_URL
 		);
 
+		// Apply the rewrite rules to the original request URL:
 		const siteRelativePath = removePathPrefix(
-			decodeURIComponent(requestedUrl.pathname),
+			decodeURIComponent(originalRequestUrl.pathname),
 			this.#PATHNAME
 		);
 		const rewrittenRequestPath = applyRewriteRules(
 			siteRelativePath,
 			this.rewriteRules
 		);
-		const rewrittenRequestUrl = new URL(requestedUrl.toString());
+		const rewrittenRequestUrl = new URL(originalRequestUrl.toString());
 		rewrittenRequestUrl.pathname = joinPaths(
 			this.#PATHNAME,
 			rewrittenRequestPath
@@ -410,7 +411,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 			if (!fsPath.endsWith('/')) {
 				return new PHPResponse(
 					301,
-					{ Location: [`${requestedUrl.pathname}/`] },
+					{ Location: [`${rewrittenRequestUrl.pathname}/`] },
 					new Uint8Array(0)
 				);
 			}
@@ -456,7 +457,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 					...request,
 					// Pass along URL with the #fragment filtered out
 					url: rewrittenRequestUrl.toString(),
-					urlBeforeRewriting: requestedUrl.toString(),
+					urlBeforeRewriting: originalRequestUrl.toString(),
 				};
 				const response = await this.#spawnPHPAndDispatchRequest(
 					effectiveRequest,

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -569,7 +569,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * Spawns a new PHP instance and dispatches a request to it.
 	 */
 	async #spawnPHPAndDispatchRequest(
-		request: PHPRequestWrapper,
+		requestWrapper: PHPRequestWrapper,
 		scriptPath: string
 	): Promise<PHPResponse> {
 		let spawnedPHP: SpawnedPHP | undefined = undefined;
@@ -587,7 +587,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 		try {
 			return await this.#dispatchToPHP(
 				spawnedPHP.php,
-				request,
+				requestWrapper,
 				scriptPath
 			);
 		} finally {

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -378,10 +378,17 @@ export class PHPRequestHandler implements AsyncDisposable {
 		let fsPath = joinPaths(
 			this.#DOCROOT,
 			/**
-			 * URL.pathname returns a URL-encoded path. We need to decode it
-			 * before using it as a filesystem path.
+			 * Turn a URL such as `https://playground/scope:my-site/wp-admin/index.php`
+			 * into a site-relative path, such as `/wp-admin/index.php`.
 			 */
-			decodeURIComponent(rewrittenRequestUrl.pathname)
+			removePathPrefix(
+				/**
+				 * URL.pathname returns a URL-encoded path. We need to decode it
+				 * before using it as a filesystem path.
+				 */
+				decodeURIComponent(rewrittenRequestUrl.pathname),
+				this.#PATHNAME
+			)
 		);
 		if (primaryPhp.isDir(fsPath)) {
 			// Ensure directory URIs have a trailing slash. Otherwise,

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -681,6 +681,7 @@ export class PHP implements Disposable {
 					requestHeaders,
 					port
 				);
+
 				for (const key in $_SERVER) {
 					this.#setServerGlobalEntry(key, $_SERVER[key]);
 				}

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -650,9 +650,8 @@ export class PHP implements Disposable {
 					);
 				}
 				this.#setRelativeRequestUri(
-					request.relativeUriBeforeRewriting ||
-						request.relativeUri ||
-						''
+					// request.relativeUriBeforeRewriting ||
+					request.relativeUri || ''
 				);
 				this.#setRequestMethod(request.method || 'GET');
 				const requestHeaders = normalizeHeaders(request.headers || {});

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -649,10 +649,7 @@ export class PHP implements Disposable {
 						`The script path "${request.scriptPath}" does not exist.`
 					);
 				}
-				this.#setRelativeRequestUri(
-					// request.relativeUriBeforeRewriting ||
-					request.relativeUri || ''
-				);
+				this.#setRelativeRequestUri(request.relativeUri || '');
 				this.#setRequestMethod(request.method || 'GET');
 				const requestHeaders = normalizeHeaders(request.headers || {});
 				const host = requestHeaders['host'] || 'example.com:443';
@@ -687,6 +684,10 @@ export class PHP implements Disposable {
 				for (const key in $_SERVER) {
 					this.#setServerGlobalEntry(key, $_SERVER[key]);
 				}
+				this.#setServerGlobalEntry(
+					'PHP_SELF',
+					request.relativeUri || ''
+				);
 
 				const env = request.env || {};
 				for (const key in env) {
@@ -773,6 +774,7 @@ export class PHP implements Disposable {
 			$_SERVER[`${HTTP_prefix}${name.toUpperCase().replace(/-/g, '_')}`] =
 				headers[name];
 		}
+
 		return $_SERVER;
 	}
 

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -681,9 +681,6 @@ export class PHP implements Disposable {
 					requestHeaders,
 					port
 				);
-				if (request.relativeUri) {
-					this.#setServerGlobalEntry('PHP_SELF', request.relativeUri);
-				}
 				for (const key in $_SERVER) {
 					this.#setServerGlobalEntry(key, $_SERVER[key]);
 				}
@@ -773,7 +770,6 @@ export class PHP implements Disposable {
 			$_SERVER[`${HTTP_prefix}${name.toUpperCase().replace(/-/g, '_')}`] =
 				headers[name];
 		}
-
 		return $_SERVER;
 	}
 

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -649,7 +649,11 @@ export class PHP implements Disposable {
 						`The script path "${request.scriptPath}" does not exist.`
 					);
 				}
-				this.#setRelativeRequestUri(request.relativeUri || '');
+				this.#setRelativeRequestUri(
+					request.relativeUriBeforeRewriting ||
+						request.relativeUri ||
+						''
+				);
 				this.#setRequestMethod(request.method || 'GET');
 				const requestHeaders = normalizeHeaders(request.headers || {});
 				const host = requestHeaders['host'] || 'example.com:443';

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -681,13 +681,12 @@ export class PHP implements Disposable {
 					requestHeaders,
 					port
 				);
+				if (request.relativeUri) {
+					this.#setServerGlobalEntry('PHP_SELF', request.relativeUri);
+				}
 				for (const key in $_SERVER) {
 					this.#setServerGlobalEntry(key, $_SERVER[key]);
 				}
-				this.#setServerGlobalEntry(
-					'PHP_SELF',
-					request.relativeUri || ''
-				);
 
 				const env = request.env || {};
 				for (const key in env) {

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -101,12 +101,6 @@ export interface PHPRequest {
 	url: string;
 
 	/**
-	 * Request URL before any URL rewriting rules (e.g. apache .htaccess)
-	 * have been applied.
-	 */
-	urlBeforeRewriting?: string;
-
-	/**
 	 * Request headers.
 	 */
 	headers?: PHPRequestHeaders;
@@ -126,13 +120,6 @@ export interface PHPRunOptions {
 	 * have been applied.
 	 */
 	relativeUri?: string;
-
-	/**
-	 * Request path following the domain:port part –
-	 * before any URL rewriting rules (e.g. apache .htaccess)
-	 * have been applied.
-	 */
-	relativeUriBeforeRewriting?: string;
 
 	/**
 	 * Path of the .php file to execute.

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -101,6 +101,12 @@ export interface PHPRequest {
 	url: string;
 
 	/**
+	 * Request URL before any URL rewriting rules (e.g. apache .htaccess)
+	 * have been applied.
+	 */
+	urlBeforeRewriting?: string;
+
+	/**
 	 * Request headers.
 	 */
 	headers?: PHPRequestHeaders;
@@ -115,9 +121,18 @@ export interface PHPRequest {
 
 export interface PHPRunOptions {
 	/**
-	 * Request path following the domain:port part.
+	 * Request path following the domain:port part –
+	 * after any URL rewriting rules (e.g. apache .htaccess)
+	 * have been applied.
 	 */
 	relativeUri?: string;
+
+	/**
+	 * Request path following the domain:port part –
+	 * before any URL rewriting rules (e.g. apache .htaccess)
+	 * have been applied.
+	 */
+	relativeUriBeforeRewriting?: string;
 
 	/**
 	 * Path of the .php file to execute.

--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -1300,7 +1300,8 @@ const schema11 = {
 			properties: {
 				relativeUri: {
 					type: 'string',
-					description: 'Request path following the domain:port part.',
+					description:
+						'Request path following the domain:port part – after any URL rewriting rules (e.g. apache .htaccess) have been applied.',
 				},
 				scriptPath: {
 					type: 'string',
@@ -6932,7 +6933,8 @@ const schema34 = {
 	properties: {
 		relativeUri: {
 			type: 'string',
-			description: 'Request path following the domain:port part.',
+			description:
+				'Request path following the domain:port part – after any URL rewriting rules (e.g. apache .htaccess) have been applied.',
 		},
 		scriptPath: {
 			type: 'string',

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -1585,7 +1585,7 @@
 			"properties": {
 				"relativeUri": {
 					"type": "string",
-					"description": "Request path following the domain:port part."
+					"description": "Request path following the domain:port part – after any URL rewriting rules (e.g. apache .htaccess) have been applied."
 				},
 				"scriptPath": {
 					"type": "string",

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.spec.ts
@@ -82,7 +82,7 @@ describe('Blueprint step enableMultisite', () => {
 			 */
 			await login(php, {});
 			const response = await requestFollowRedirects({
-				url: '/',
+				url: absoluteUrl,
 			});
 			expect(response.httpStatusCode).toEqual(200);
 			expect(response.text).toContain('My Sites');

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -58,6 +58,6 @@ export const enableMultisite: StepHandler<EnableMultisiteStep> = async (
 	});
 
 	await wpCLI(playground, {
-		command: 'wp core multisite-convert --base=' + sitePath,
+		command: `wp core multisite-convert --base="${sitePath}"`,
 	});
 };

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -58,6 +58,6 @@ export const enableMultisite: StepHandler<EnableMultisiteStep> = async (
 	});
 
 	await wpCLI(playground, {
-		command: 'wp core multisite-convert',
+		command: 'wp core multisite-convert --base=' + sitePath,
 	});
 };

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
@@ -57,7 +57,7 @@ describe('Blueprint step importWxr', () => {
 			slug: 'wordpress-importer',
 		});
 		importerPlugin = await (await pluginResource.resolve()).arrayBuffer();
-	});
+	}, 30_000);
 
 	beforeEach(async () => {
 		handler = await bootWordPressAndRequestHandler({
@@ -89,7 +89,7 @@ describe('Blueprint step importWxr', () => {
 				activate: true,
 			},
 		});
-	});
+	}, 30_000);
 
 	it(
 		'Should import a WXR file with JSON-encoded UTF-8 characters',

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
@@ -120,7 +120,7 @@ describe('Blueprint step importWxr', () => {
 
 		expect(json.post_content).toEqual(expectedPostContent);
 		expect(json.post_title).toEqual(`"Issue\\Issue"`);
-	});
+	}, 30_000);
 
 	it('Should create and associate wp_theme taxonomy terms for Site Editor templates', async () => {
 		const fileData = await readFile(
@@ -139,7 +139,7 @@ describe('Blueprint step importWxr', () => {
 		expect(json.terms_associated_count).toBe(1);
 		expect(json.adonay_term_exists).toBe(true);
 		expect(json.associated_term_slugs).toEqual(['adonay']);
-	});
+	}, 30_000);
 
 	it('Should rewrite site URLs in the imported content', async () => {
 		const fileData = await readFile(
@@ -188,7 +188,7 @@ describe('Blueprint step importWxr', () => {
 `;
 
 		expect(json.post_content).toEqual(expectedPostContent);
-	});
+	}, 30_000);
 
 	it('Should rewrite site URLs in the imported content (tt5 playground content)', async () => {
 		const fileData = await readFile(
@@ -238,7 +238,7 @@ describe('Blueprint step importWxr', () => {
 <!-- /wp:paragraph -->`;
 
 		expect(json.post_content).toEqual(expectedPostContent);
-	});
+	}, 30_000);
 
 	it('Should replace all post authors with admin user', async () => {
 		const fileData = await readFile(
@@ -308,5 +308,5 @@ describe('Blueprint step importWxr', () => {
 		const postTitles = json.post_authors.map((p: any) => p.post_title);
 		expect(postTitles).toContain('Comprehensive Post');
 		expect(postTitles).toContain('Comprehensive Page');
-	});
+	}, 30_000);
 });

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
@@ -91,20 +91,22 @@ describe('Blueprint step importWxr', () => {
 		});
 	});
 
-	it('Should import a WXR file with JSON-encoded UTF-8 characters', async () => {
-		const fileData = await readFile(
-			__dirname + '/fixtures/import-wxr-slash-issue.xml'
-		);
-		const file = new File([fileData], 'import.wxr');
+	it(
+		'Should import a WXR file with JSON-encoded UTF-8 characters',
+		async () => {
+			const fileData = await readFile(
+				__dirname + '/fixtures/import-wxr-slash-issue.xml'
+			);
+			const file = new File([fileData], 'import.wxr');
 
-		await importWxr(php, { file });
+			await importWxr(php, { file });
 
-		const expectedPostContent = `<!-- wp:inseri-core/text-editor {"blockId":"DSrQIjN5UjosCHJQImF5z","blockName":"textEditor","height":60,"content":"\\u0022#test\\u0022","contentType":"application/json"} -->
+			const expectedPostContent = `<!-- wp:inseri-core/text-editor {"blockId":"DSrQIjN5UjosCHJQImF5z","blockName":"textEditor","height":60,"content":"\\u0022#test\\u0022","contentType":"application/json"} -->
 <div class="wp-block-inseri-core-text-editor" data-attributes="{&quot;blockId&quot;:&quot;DSrQIjN5UjosCHJQImF5z&quot;,&quot;blockName&quot;:&quot;textEditor&quot;,&quot;content&quot;:&quot;\\&quot;#test\\&quot;&quot;,&quot;contentType&quot;:&quot;application/json&quot;,&quot;editable&quot;:false,&quot;height&quot;:60,&quot;isVisible&quot;:true,&quot;label&quot;:&quot;&quot;}">is loading ...</div>
 <!-- /wp:inseri-core/text-editor -->`;
 
-		const result = await php.run({
-			code: `<?php
+			const result = await php.run({
+				code: `<?php
 			require getenv('DOCROOT') . '/wp-load.php';
 			$posts = get_posts();
 			echo json_encode([
@@ -112,45 +114,53 @@ describe('Blueprint step importWxr', () => {
 				'post_title' => $posts[0]->post_title,
 			]);
 			`,
-			env: {
-				DOCROOT: handler.documentRoot,
-			},
-		});
-		const json = result.json;
+				env: {
+					DOCROOT: handler.documentRoot,
+				},
+			});
+			const json = result.json;
 
-		expect(json.post_content).toEqual(expectedPostContent);
-		expect(json.post_title).toEqual(`"Issue\\Issue"`);
-	}, 30_000);
+			expect(json.post_content).toEqual(expectedPostContent);
+			expect(json.post_title).toEqual(`"Issue\\Issue"`);
+		},
+		{ timeout: 30_000 }
+	);
 
-	it('Should create and associate wp_theme taxonomy terms for Site Editor templates', async () => {
-		const fileData = await readFile(
-			__dirname + '/fixtures/import-wxr-site-editor-template.xml'
-		);
-		const file = new File([fileData], 'import.wxr');
+	it(
+		'Should create and associate wp_theme taxonomy terms for Site Editor templates',
+		async () => {
+			const fileData = await readFile(
+				__dirname + '/fixtures/import-wxr-site-editor-template.xml'
+			);
+			const file = new File([fileData], 'import.wxr');
 
-		await importWxr(php, { file });
+			await importWxr(php, { file });
 
-		const result = await checkTemplateImportResults();
-		const json = result.json;
+			const result = await checkTemplateImportResults();
+			const json = result.json;
 
-		// Verify the template was imported and taxonomy association worked
-		expect(json.template_found).toBe(true);
-		expect(json.template_title).toEqual('Index');
-		expect(json.terms_associated_count).toBe(1);
-		expect(json.adonay_term_exists).toBe(true);
-		expect(json.associated_term_slugs).toEqual(['adonay']);
-	}, 30_000);
+			// Verify the template was imported and taxonomy association worked
+			expect(json.template_found).toBe(true);
+			expect(json.template_title).toEqual('Index');
+			expect(json.terms_associated_count).toBe(1);
+			expect(json.adonay_term_exists).toBe(true);
+			expect(json.associated_term_slugs).toEqual(['adonay']);
+		},
+		{ timeout: 30_000 }
+	);
 
-	it('Should rewrite site URLs in the imported content', async () => {
-		const fileData = await readFile(
-			__dirname + '/fixtures/import-wxr-base-url-rewriting.xml'
-		);
-		const file = new File([fileData], 'import.wxr');
+	it(
+		'Should rewrite site URLs in the imported content',
+		async () => {
+			const fileData = await readFile(
+				__dirname + '/fixtures/import-wxr-base-url-rewriting.xml'
+			);
+			const file = new File([fileData], 'import.wxr');
 
-		await importWxr(php, { file });
+			await importWxr(php, { file });
 
-		const result = await php.run({
-			code: `<?php
+			const result = await php.run({
+				code: `<?php
 			require getenv('DOCROOT') . '/wp-load.php';
 			$posts = get_posts();
 			echo json_encode([
@@ -158,14 +168,14 @@ describe('Blueprint step importWxr', () => {
 				'post_title' => $posts[0]->post_title,
 			]);
 			`,
-			env: {
-				DOCROOT: handler.documentRoot,
-			},
-		});
-		const json = result.json;
+				env: {
+					DOCROOT: handler.documentRoot,
+				},
+			});
+			const json = result.json;
 
-		const newSiteUrl = handler.absoluteUrl;
-		const expectedPostContent = `<!-- wp:paragraph -->
+			const newSiteUrl = handler.absoluteUrl;
+			const expectedPostContent = `<!-- wp:paragraph -->
 <p>
     <!-- Rewrites URLs that match the base URL -->
     URLs to rewrite:
@@ -187,20 +197,24 @@ describe('Blueprint step importWxr', () => {
 <!-- /wp:image -->
 `;
 
-		expect(json.post_content).toEqual(expectedPostContent);
-	}, 30_000);
+			expect(json.post_content).toEqual(expectedPostContent);
+		},
+		{ timeout: 30_000 }
+	);
 
-	it('Should rewrite site URLs in the imported content (tt5 playground content)', async () => {
-		const fileData = await readFile(
-			__dirname +
-				'/fixtures/import-tt5-subset-of-demo-blueprint-playgroundcontent.xml'
-		);
-		const file = new File([fileData], 'import.wxr');
+	it(
+		'Should rewrite site URLs in the imported content (tt5 playground content)',
+		async () => {
+			const fileData = await readFile(
+				__dirname +
+					'/fixtures/import-tt5-subset-of-demo-blueprint-playgroundcontent.xml'
+			);
+			const file = new File([fileData], 'import.wxr');
 
-		await importWxr(php, { file });
+			await importWxr(php, { file });
 
-		const result = await php.run({
-			code: `<?php
+			const result = await php.run({
+				code: `<?php
 			require getenv('DOCROOT') . '/wp-load.php';
 			$post = get_post(63);
 			echo json_encode([
@@ -208,14 +222,14 @@ describe('Blueprint step importWxr', () => {
 				'post_title' => $post->post_title,
 			]);
 			`,
-			env: {
-				DOCROOT: handler.documentRoot,
-			},
-		});
-		const json = result.json;
+				env: {
+					DOCROOT: handler.documentRoot,
+				},
+			});
+			const json = result.json;
 
-		// const newSiteUrl = php.absoluteUrl;
-		const expectedPostContent = `<!-- wp:paragraph -->
+			// const newSiteUrl = php.absoluteUrl;
+			const expectedPostContent = `<!-- wp:paragraph -->
 <p>Template are the blueprints for different layouts for your web pages. There following template are available in the theme:</p>
 <!-- /wp:paragraph -->
 
@@ -237,20 +251,24 @@ describe('Blueprint step importWxr', () => {
 <p></p>
 <!-- /wp:paragraph -->`;
 
-		expect(json.post_content).toEqual(expectedPostContent);
-	}, 30_000);
+			expect(json.post_content).toEqual(expectedPostContent);
+		},
+		{ timeout: 30_000 }
+	);
 
-	it('Should replace all post authors with admin user', async () => {
-		const fileData = await readFile(
-			__dirname + '/fixtures/import-wxr-comprehensive.xml'
-		);
-		const file = new File([fileData], 'import.wxr');
+	it(
+		'Should replace all post authors with admin user',
+		async () => {
+			const fileData = await readFile(
+				__dirname + '/fixtures/import-wxr-comprehensive.xml'
+			);
+			const file = new File([fileData], 'import.wxr');
 
-		await resetData(php, {});
-		await importWxr(php, { file });
+			await resetData(php, {});
+			await importWxr(php, { file });
 
-		const result = await php.run({
-			code: `<?php
+			const result = await php.run({
+				code: `<?php
 			require getenv('DOCROOT') . '/wp-load.php';
 			
 			// Get all imported posts
@@ -285,28 +303,30 @@ describe('Blueprint step importWxr', () => {
 				'post_authors' => $post_authors,
 			]);
 			`,
-			env: {
-				DOCROOT: handler.documentRoot,
-			},
-		});
-		const json = result.json;
+				env: {
+					DOCROOT: handler.documentRoot,
+				},
+			});
+			const json = result.json;
 
-		// Verify admin user exists
-		expect(json.admin_user_id).toBeTruthy();
-		expect(json.admin_user_login).toBe('admin');
+			// Verify admin user exists
+			expect(json.admin_user_id).toBeTruthy();
+			expect(json.admin_user_login).toBe('admin');
 
-		// Verify we imported the expected posts (1 post + 1 page from comprehensive fixture)
-		expect(json.total_posts).toBe(2);
+			// Verify we imported the expected posts (1 post + 1 page from comprehensive fixture)
+			expect(json.total_posts).toBe(2);
 
-		// Verify all imported posts are authored by admin
-		json.post_authors.forEach((postAuthor: any) => {
-			expect(postAuthor.author_id).toBe(json.admin_user_id + '');
-			expect(postAuthor.author_login).toBe('admin');
-		});
+			// Verify all imported posts are authored by admin
+			json.post_authors.forEach((postAuthor: any) => {
+				expect(postAuthor.author_id).toBe(json.admin_user_id + '');
+				expect(postAuthor.author_login).toBe('admin');
+			});
 
-		// Verify specific posts exist with correct titles
-		const postTitles = json.post_authors.map((p: any) => p.post_title);
-		expect(postTitles).toContain('Comprehensive Post');
-		expect(postTitles).toContain('Comprehensive Page');
-	}, 30_000);
+			// Verify specific posts exist with correct titles
+			const postTitles = json.post_authors.map((p: any) => p.post_title);
+			expect(postTitles).toContain('Comprehensive Post');
+			expect(postTitles).toContain('Comprehensive Page');
+		},
+		{ timeout: 30_000 }
+	);
 });

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -189,6 +189,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				.join(',');
 		}
 
+		const parsedSiteUrl = new URL(siteUrl);
 		const requestHandler = await bootRequestHandler({
 			siteUrl,
 			createPhpRuntime: async () => {
@@ -259,8 +260,18 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				},
 			},
 			getFileNotFoundAction(relativeUri: string) {
-				if (!knownRemoteAssetPaths.has(relativeUri)) {
-					return getFileNotFoundActionForWordPress(relativeUri);
+				/**
+				 * Known remote asset paths are stored as site-relative paths. We
+				 * need to remove the site root path prefix (e.g. scope:my-site) from
+				 * the request URL's pathname.
+				 */
+				const siteRelativePath =
+					parsedSiteUrl.pathname.length > 0 &&
+					relativeUri.startsWith(parsedSiteUrl.pathname)
+						? relativeUri.substring(parsedSiteUrl.pathname.length)
+						: relativeUri;
+				if (!knownRemoteAssetPaths.has(siteRelativePath)) {
+					return getFileNotFoundActionForWordPress(siteRelativePath);
 				}
 				// This path is listed as a remote asset. Mark it as a static file
 				// so the service worker knows it can issue a real fetch() to the server.

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -85,7 +85,7 @@ export default defineConfig(({ mode }) => {
 		server: {
 			port: remoteDevServerPort,
 			host: remoteDevServerHost,
-			allowedHosts: ['playground.test'],
+			allowedHosts: ['playground.test', 'playground-preview.test'],
 			fs: {
 				// Allow serving files from the 'packages' directory
 				allow: ['../../'],

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable comment-length/limit-multi-line-comments */
 import { test, expect } from '../playground-fixtures';
 
 // We can't import the WordPress versions directly from the remote package
@@ -130,21 +131,63 @@ test('should retain encoded control characters in the URL', async ({
 	wordpress,
 	browserName,
 }) => {
-	test.skip(
-		browserName === 'firefox' || browserName === 'webkit',
-		`It's unclear why this test fails in Firefox and Safari. The actual feature seems to be working in manual testing. ` +
-			`Let's figure this out and re-enable the test at one point. The upsides of merging the original PR sill ` +
-			`outweighted the downsides of disabling the test on FF.`
-	);
+	// A beautiful URL with encoded non-printable control characters.
 	const path =
 		'/wp-admin/admin.php?page=html-api-debugger&html=%3Cdiv%3E%0A1%0A2%0A3%0A%3C%2Fdiv%3E';
 	const queryApiParams = new URLSearchParams();
-	queryApiParams.set('url', path);
+
+	// Keep the landing page as a `url` to make sure we handle percent-encoding correctly.
+	// In particular, we don't want to ever double-decode or double-encode the URL.
+	queryApiParams.set('url', encodeURIComponent(path));
 	queryApiParams.set('plugin', 'html-api-debugger');
+
+	/**
+	 * The Blueprint below prevents WordPress from messing up our URL.
+	 *
+	 * WordPress is trying really hard to make things difficult for us.
+	 * It ships the following code in wp-admin <head> to confuse the user
+	 * by showing them a different URL in the browser's address bar than
+	 * the one they've typed in. This is after PHP processed the original
+	 * request carrying the original URL:
+	 *
+	 *     <link id="wp-admin-canonical" rel="canonical" href="http://127.0.0.1:5400/scope:excited-peaceful-river/wp-admin/admin.php?page=html-api-debugger&#038;html=%3Cdiv%3E123%3C%2Fdiv%3E" />
+	 *     <script>
+	 *         if ( window.history.replaceState ) {
+	 *             window.history.replaceState( null, null, document.getElementById( 'wp-admin-canonical' ).href + window.location.hash );
+	 *         }
+	 *     </script>
+	 *
+	 * Not on our watch! This Blueprint disables the history API to make sure
+	 * the address bar displays the actual URL we've sent to the server to
+	 * generate the page.
+	 */
+	const blueprint = {
+		steps: [
+			{
+				step: 'writeFile',
+				path: '/wordpress/wp-content/mu-plugins/0-disable-history.php',
+				data: `<?php
+					add_action('admin_init', function() {
+						echo '<script>
+						for(const k in window.history) {
+							window.history[k] = null;
+						}
+						console.log(\\'history disabled\\');
+						</script>';
+					}, 100000);
+				?>`,
+			},
+		],
+	};
+
 	// We need to use the html-api-debugger plugin to test this because
 	// most wp-admin pages enforce a redirect to a sanitized (broken)
 	// version of the URL.
-	await website.goto(`./?${queryApiParams.toString()}`);
+	await website.goto(
+		`./?url=${encodeURIComponent(
+			path
+		)}&plugin=html-api-debugger#${JSON.stringify(blueprint)}`
+	);
 	expect(
 		await wordpress
 			.locator('body')

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -138,12 +138,13 @@ test('should retain encoded control characters in the URL', async ({
 	);
 	const path =
 		'/wp-admin/admin.php?page=html-api-debugger&html=%3Cdiv%3E%0A1%0A2%0A3%0A%3C%2Fdiv%3E';
+	const queryApiParams = new URLSearchParams();
+	queryApiParams.set('url', path);
+	queryApiParams.set('plugin', 'html-api-debugger');
 	// We need to use the html-api-debugger plugin to test this because
 	// most wp-admin pages enforce a redirect to a sanitized (broken)
 	// version of the URL.
-	await website.goto(
-		`./?url=${encodeURIComponent(path)}&plugin=html-api-debugger`
-	);
+	await website.goto(`./?${queryApiParams.toString()}`);
 	expect(
 		await wordpress
 			.locator('body')

--- a/packages/playground/wordpress/src/rewrite-rules.ts
+++ b/packages/playground/wordpress/src/rewrite-rules.ts
@@ -1,3 +1,167 @@
 import type { RewriteRule } from '@php-wasm/universal';
 
-export const wordPressRewriteRules: RewriteRule[] = [];
+/**
+ * WordPress rewrite rules adapted for Playground.
+ *
+ * These rules are matched against the requested path without the site path prefix.
+ *
+ * For example:
+ *
+ *     * The site URL is `https://playground.wordpress.net/scope:ambitious-chic-country/`.
+ *     * The site path prefix is `/scope:ambitious-chic-country/`.
+ *     * The requested URL is `https://playground.wordpress.net/scope:ambitious-chic-country/wp-admin/index.php`,
+ *     * The requested path without the site path prefix is `/wp-admin/index.php`.
+ *
+ * And so, the rewrite rules are matched against `/wp-admin/index.php`.
+ * This is similar to setting the `RewriteBase` to `/scope:ambitious-chic-country`.
+ *
+ * ## Rationale
+ *
+ * WordPress does not use a single, static set of rewrite rules. Rather, it generates
+ * its own .htaccess file based on the current configuration using the save_mod_rewrite_rules()
+ * function:
+ *
+ * https://developer.wordpress.org/reference/functions/save_mod_rewrite_rules/
+ *
+ * Here's a few examples of what that .htaccess might look like for different
+ * WordPress configurations:
+ *
+ * ### Vanilla WordPress single-site installation
+ *
+ * ```apache
+ * RewriteBase /
+ * RewriteRule ^index\.php$ - [L]
+ * RewriteCond %{REQUEST_FILENAME} !-f
+ * RewriteCond %{REQUEST_FILENAME} !-d
+ * RewriteRule . /index.php [L]
+ * ```
+ *
+ * ### Single-site installation living at a /subdirectory/
+ *
+ * ```apache
+ * # https://developer.wordpress.org/advanced-administration/server/wordpress-in-directory/:
+ * RewriteCond %{REQUEST_URI} !^/subdirectory/
+ * RewriteCond %{REQUEST_FILENAME} !-f
+ * RewriteCond %{REQUEST_FILENAME} !-d
+ * RewriteRule ^(.*)$ /subdirectory/$1
+ * RewriteRule ^(/)?$ subdirectory/index.php [L]
+ * ```
+ *
+ * Some sources also set the RewriteBase to `/subdirectory/`.
+ *
+ * ### Multisite installation using subfolder network type
+ *
+ * ```apache
+ * # https://wordpress.org/documentation/article/htaccess/#multisite
+ *
+ * RewriteBase /
+ * RewriteRule ^index\.php$ - [L]
+ *
+ * // add a trailing slash to /wp-admin
+ * RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+ *
+ * RewriteCond %{REQUEST_FILENAME} -f [OR]
+ * RewriteCond %{REQUEST_FILENAME} -d
+ * RewriteRule ^ - [L]
+ * RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+ * RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ $2 [L]
+ * RewriteRule . index.php [L]
+ * ```
+ *
+ * # Multisite living at /scope:ambitious-chic-country/
+ *
+ * ```apache
+ * RewriteBase /scope:ambitious-chic-country/
+ * RewriteRule ^index\.php$ - [L]
+ *
+ * // Add a trailing slash to /wp-admin
+ * RewriteRule ^([_0-9a-zA-Z-]+/)?wp-admin$ $1wp-admin/ [R=301,L]
+ *
+ * RewriteCond %{REQUEST_FILENAME} -f [OR]
+ * RewriteCond %{REQUEST_FILENAME} -d
+ * RewriteRule ^ - [L]
+ *
+ * // The `wordpress/` prefix matches the document root, but seeing
+ * // it here is unexpected. @TODO: Why is it being added by WordPress?
+ * RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) wordpress/$2 [L]
+ * RewriteRule ^([_0-9a-zA-Z-]+/)?(.*\.php)$ wordpress/$2 [L]
+ * RewriteRule . index.php [L]
+ * ```
+ *
+ * ## .htaccess syntax
+ *
+ * Here's an excerpt/summary from the .htaccess documentation [^1][^2] for
+ * convenience:
+ *
+ *     The mod_rewrite module uses a rule-based rewriting engine, based
+ *     on a PCRE regular-expression parser, to rewrite requested URLs on
+ *     the fly. By default, mod_rewrite maps a URL to a filesystem path.
+ *     However, it can also be used to redirect one URL to another URL,
+ *     or to invoke an internal proxy fetch.
+ *
+ *     ## RewriteBase Directive
+ *
+ *     The RewriteBase directive specifies the URL prefix to be used for
+ *     per-directory (htaccess) RewriteRule directives that substitute a
+ *     relative path.
+ *
+ *     Syntax:
+ *          RewriteBase URL-path
+ *
+ *     (Setting RewriteBase to "/" makes it possible to use RewriteRule
+ *      patterns that **do not** start with a slash.)
+ *
+ *     ## RewriteRule Directive
+ *
+ *     Defines rules for the rewriting engine.
+ *
+ *     Syntax:
+ *          RewriteRule Pattern Substitution [flags]
+ *
+ *     ## Flags
+ *
+ *        - L|Last
+ *            Stop processing the rule set. In most contexts, this means
+ *            that if the rule matches, no further rules will be processed
+ *
+ *        - NC|No Case
+ *            Ignore case when matching.
+ *
+ *        - R|Redirect
+ *            Causes a HTTP redirect to be issued to the browser.
+ *
+ * ## Differences with .htaccess
+ *
+ * [1] https://httpd.apache.org/docs/current/rewrite/intro.html
+ * [2] https://httpd.apache.org/docs/current/rewrite/flags.html
+ */
+export const wordPressRewriteRules: RewriteRule[] = [
+	/**
+	 * Substitutes the multisite WordPress rewrite rule:
+	 *
+	 * RewriteBase /
+	 * RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+	 */
+	{
+		match: new RegExp(
+			`^(` +
+				/* The .htaccess rule does not have an explicit initial slash,
+				   but it's still implied by `RewriteBase /` */
+				`/` +
+				`[_0-9a-zA-Z-/]+` +
+				`)?` +
+				/**
+				 * Avoid discarding the initial slash of the rewritten URL.
+				 * .htaccess places the trailing slash in the first group. It
+				 * relies on the implicit `RewriteBase /` again – the final,
+				 * rewritten URL still has the `/` at the beginning. This rule
+				 * does not have an implied RewriteBase, so the only way to preserve
+				 * the `/` at the beginning is to avoid replacing it.
+				 */
+				'(/' +
+				// The rest of the pattern is the same:
+				`wp-(content|admin|includes)/.*)`
+		),
+		replacement: '$2',
+	},
+];

--- a/packages/playground/wordpress/src/rewrite-rules.ts
+++ b/packages/playground/wordpress/src/rewrite-rules.ts
@@ -130,6 +130,10 @@ import type { RewriteRule } from '@php-wasm/universal';
  *        - R|Redirect
  *            Causes a HTTP redirect to be issued to the browser.
  *
+ *        (Note that Playground does not implement analogs of these flags as
+ *         there was no need for them yet. They're only described here for
+ *         convenience to help you read the original .htaccess rules.)
+ *
  * ## Differences with .htaccess
  *
  * [1] https://httpd.apache.org/docs/current/rewrite/intro.html

--- a/packages/playground/wordpress/src/rewrite-rules.ts
+++ b/packages/playground/wordpress/src/rewrite-rules.ts
@@ -4,8 +4,12 @@ import type { RewriteRule } from '@php-wasm/universal';
  * The default rewrite rules for WordPress.
  */
 export const wordPressRewriteRules: RewriteRule[] = [
+	/**
+	 * Substitutes this .htaccess rule:
+	 * RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
+	 */
 	{
-		match: /^\/(.*?)(\/wp-(content|admin|includes)\/.*)/g,
+		match: /^(.*?)(\/wp-(content|admin|includes)\/.*)/g,
 		replacement: '$2',
 	},
 ];

--- a/packages/playground/wordpress/src/rewrite-rules.ts
+++ b/packages/playground/wordpress/src/rewrite-rules.ts
@@ -1,15 +1,3 @@
 import type { RewriteRule } from '@php-wasm/universal';
 
-/**
- * The default rewrite rules for WordPress.
- */
-export const wordPressRewriteRules: RewriteRule[] = [
-	/**
-	 * Substitutes this .htaccess rule:
-	 * RewriteRule ^([_0-9a-zA-Z-]+/)?(wp-(content|admin|includes).*) $2 [L]
-	 */
-	{
-		match: /^(.*?)(\/wp-(content|admin|includes)\/.*)/g,
-		replacement: '$2',
-	},
-];
+export const wordPressRewriteRules: RewriteRule[] = [];

--- a/packages/playground/wordpress/src/rewrite-rules.ts
+++ b/packages/playground/wordpress/src/rewrite-rules.ts
@@ -144,12 +144,9 @@ export const wordPressRewriteRules: RewriteRule[] = [
 	 */
 	{
 		match: new RegExp(
-			`^(` +
-				/* The .htaccess rule does not have an explicit initial slash,
-				   but it's still implied by `RewriteBase /` */
-				`/` +
-				`[_0-9a-zA-Z-/]+` +
-				`)?` +
+			/* The .htaccess rule does not have an explicit initial slash,
+				but it's still implied by `RewriteBase /` */
+			`^(/[_0-9a-zA-Z-]+)?` +
 				/**
 				 * Avoid discarding the initial slash of the rewritten URL.
 				 * .htaccess places the trailing slash in the first group. It

--- a/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
+++ b/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
@@ -37,7 +37,7 @@ describe('Test WordPress rewrites', () => {
 		);
 	});
 
-	it('Should only target the initial wp-admin|wp-content|wp-includes path (1)', async () => {
+	it('Should only target the first instance of a wp-admin|wp-content|wp-includes dir in a path (1)', async () => {
 		expect(
 			applyRewriteRules(
 				'/wp-content/themes/Newspaper/includes/wp-booster/wp-admin/images/plugins/tagdiv-small.png',
@@ -48,7 +48,7 @@ describe('Test WordPress rewrites', () => {
 		);
 	});
 
-	it('Should only target the initial wp-admin|wp-content|wp-includes path (2)', async () => {
+	it('Should only target the first instance of a wp-admin|wp-content|wp-includes dir in a path (2)', async () => {
 		expect(
 			applyRewriteRules(
 				'/wp-content/themes/Newspaper/includes/wp-booster/wp-content/images/plugins/tagdiv-small.png',

--- a/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
+++ b/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
@@ -37,17 +37,6 @@ describe('Test WordPress rewrites', () => {
 		);
 	});
 
-	it('Should strip multisite prefix and scope', async () => {
-		expect(
-			applyRewriteRules(
-				'/scope:0.1/test/wp-content/themes/twentytwentyfour/assets/images/windows.webp',
-				wordPressRewriteRules
-			)
-		).toBe(
-			'/wp-content/themes/twentytwentyfour/assets/images/windows.webp'
-		);
-	});
-
 	it('Should only target the initial wp-admin|wp-content|wp-includes path (1)', async () => {
 		expect(
 			applyRewriteRules(

--- a/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
+++ b/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
@@ -47,4 +47,15 @@ describe('Test WordPress rewrites', () => {
 			'/wp-content/themes/twentytwentyfour/assets/images/windows.webp'
 		);
 	});
+
+	it('Should only target the initial wp-admin|wp-content|wp-includes path', async () => {
+		expect(
+			applyRewriteRules(
+				'/wp-content/themes/Newspaper/includes/wp-booster/wp-admin/images/plugins/tagdiv-small.png',
+				wordPressRewriteRules
+			)
+		).toBe(
+			'/wp-content/themes/Newspaper/includes/wp-booster/wp-admin/images/plugins/tagdiv-small.png'
+		);
+	});
 });

--- a/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
+++ b/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
@@ -58,4 +58,26 @@ describe('Test WordPress rewrites', () => {
 			'/wp-content/themes/Newspaper/includes/wp-booster/wp-admin/images/plugins/tagdiv-small.png'
 		);
 	});
+
+	it('Should only target the initial wp-admin|wp-content|wp-includes path (2)', async () => {
+		expect(
+			applyRewriteRules(
+				'/wp-content/themes/Newspaper/includes/wp-booster/wp-content/images/plugins/tagdiv-small.png',
+				wordPressRewriteRules
+			)
+		).toBe(
+			'/wp-content/themes/Newspaper/includes/wp-booster/wp-content/images/plugins/tagdiv-small.png'
+		);
+	});
+
+	it('Should not strip wp-content prefix from a path', async () => {
+		expect(
+			applyRewriteRules(
+				'/wp-content/themes/twentytwentyfour/assets/images/windows.webp',
+				wordPressRewriteRules
+			)
+		).toBe(
+			'/wp-content/themes/twentytwentyfour/assets/images/windows.webp'
+		);
+	});
 });

--- a/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
+++ b/packages/playground/wordpress/src/test/rewrite-rules.spec.ts
@@ -48,7 +48,7 @@ describe('Test WordPress rewrites', () => {
 		);
 	});
 
-	it('Should only target the initial wp-admin|wp-content|wp-includes path', async () => {
+	it('Should only target the initial wp-admin|wp-content|wp-includes path (1)', async () => {
 		expect(
 			applyRewriteRules(
 				'/wp-content/themes/Newspaper/includes/wp-booster/wp-admin/images/plugins/tagdiv-small.png',

--- a/packages/playground/wordpress/src/test/version-detect.spec.ts
+++ b/packages/playground/wordpress/src/test/version-detect.spec.ts
@@ -16,21 +16,27 @@ describe('Test WP version detection', async () => {
 	for (const expectedWordPressVersion of Object.keys(
 		MinifiedWordPressVersions
 	)) {
-		it(`detects WP ${expectedWordPressVersion} at runtime`, async () => {
-			const handler = await bootWordPressAndRequestHandler({
-				createPhpRuntime: async () =>
-					await loadNodeRuntime(RecommendedPHPVersion),
-				siteUrl: 'http://playground-domain/',
-				wordPressZip: await getWordPressModule(
+		it(
+			`detects WP ${expectedWordPressVersion} at runtime`,
+			async () => {
+				const handler = await bootWordPressAndRequestHandler({
+					createPhpRuntime: async () =>
+						await loadNodeRuntime(RecommendedPHPVersion),
+					siteUrl: 'http://playground-domain/',
+					wordPressZip: await getWordPressModule(
+						expectedWordPressVersion
+					),
+					sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+				});
+				const loadedWordPressVersion = await getLoadedWordPressVersion(
+					handler
+				);
+				expect(loadedWordPressVersion).to.equal(
 					expectedWordPressVersion
-				),
-				sqliteIntegrationPluginZip: await getSqliteDriverModule(),
-			});
-			const loadedWordPressVersion = await getLoadedWordPressVersion(
-				handler
-			);
-			expect(loadedWordPressVersion).to.equal(expectedWordPressVersion);
-		});
+				);
+			},
+			{ timeout: 30_000 }
+		);
 	}
 
 	it('errors when unable to read version at runtime', async () => {
@@ -90,9 +96,13 @@ describe('Test WP version detection', async () => {
 	};
 
 	for (const [input, expected] of Object.entries(versionMap)) {
-		it(`maps '${input}' to '${expected}'`, () => {
-			const result = versionStringToLoadedWordPressVersion(input);
-			expect(result).to.equal(expected);
-		}, 30_000);
+		it(
+			`maps '${input}' to '${expected}'`,
+			() => {
+				const result = versionStringToLoadedWordPressVersion(input);
+				expect(result).to.equal(expected);
+			},
+			{ timeout: 30_000 }
+		);
 	}
 });

--- a/packages/playground/wordpress/src/test/version-detect.spec.ts
+++ b/packages/playground/wordpress/src/test/version-detect.spec.ts
@@ -93,6 +93,6 @@ describe('Test WP version detection', async () => {
 		it(`maps '${input}' to '${expected}'`, () => {
 			const result = versionStringToLoadedWordPressVersion(input);
 			expect(result).to.equal(expected);
-		});
+		}, 30_000);
 	}
 });


### PR DESCRIPTION
## The Problem

The PHP request handler wasn't correctly applying URL rewriting and setting the correct `$_SERVER` variables. Apache distinguishes between unrewritten and rewritten URLs when setting `$_SERVER['PHP_SELF']`, $_SERVER['REQUEST_URI']` and other. Before this PR, Playground wasn't doing that.

[PHP Documentation on `$_SERVER`](http://php.net/manual/en/reserved.variables.server.php) has some pointers, but they're far from exhaustive. I went ahead and started actual Apache and PHP Dev Server instances and noted their behavior in different scenarios, such as:

* PHP Dev Server with PATH_INFO: Requesting /subdir/script.php/b.php/c.php where only /subdir/script.php exists
* Apache vanilla request: Simple request to /subdir/script.php?param=value
* Apache with rewrite rules: Requesting /api/v1/user/123 which rewrites to /subdir/script.php?endpoint=user&id=$1

I've found a lot of nuanced behaviors that I've described in details in the relevant contextual block comment.

## Motivation for the change, related issues

As reported in #2855, the default Playground rewrite rule malforms this URL:

```
 /wp-content/themes/Newspaper/includes/wp-booster/wp-admin/images/plugins/tagdiv-small.png
```

It transforms it to just:

```
/wp-admin/images/plugins/tagdiv-small.png
```

At first I thought it's a small issue with the rewrite rule, and then I've discovered a rabbit hole of nuance.

## Implementation highlights

* Added a `PHPRequestHandler.prepare_$_SERVER_superglobal()` method that produces the right $_SERVER values given a specific request URL and its rewrite. It correctly populates `REQUEST_URI`, `PHP_SELF`, `SCRIPT_NAME`, `PATH_INFO`, and `QUERY_STRING`. This partially overrides what `php_wasm.c` do. I'd like to consolidate all that logic in a follow-up PR.
* Added partial resolution logic to handle request paths such as `/file.php/index.php` where the full path doesn't exist but `/file.php` does. This matches Apache and PHP Dev Server behavior.
* Added a `PHPRequestHandler.#applyRewriteRules()` method that applies the URL rewrite and merges the newly generated query parameters with the ones from the the original URL.

##  Test Coverage

Added test suites covering the same scenarios I've tested with Apache and PHP dev server. We send a request to a specific URL given some server-side rewrites or no rewrites at all, and then we confirm Playground produces `$_SERVER` values consistent with those servers.