### PR TITLE
[i18n] Adding Italian translations

### DIFF
--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/_category_.json
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/_category_.json
@@ -1,0 +1,3 @@
+{
+	"label": "Contribuire"
+}

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/code.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/code.md
@@ -1,0 +1,173 @@
+---
+slug: /contributing/code
+title: Contributi al codice
+description: Una guida per i contributi al codice, che copre come fare il fork del repository, configurare un ambiente locale e inviare una pull request.
+---
+
+<!--
+# Code contributions
+-->
+
+# Contributi al codice
+
+<!--
+Like all WordPress projects, Playground uses GitHub to manage code and track issues. The main repository is at [https://github.com/WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) and the Playground Tools repository is at [https://github.com/WordPress/playground-tools/](https://github.com/WordPress/playground-tools/).
+
+:::info Contribute to Playground Tools
+
+This guide includes links to the main repository, but all the steps and options apply for both. If you're interested in the plugins or [local development](/developers/local-development/) tools—start there.
+
+:::
+
+Browse [the list of open issues](https://github.com/wordpress/wordpress-playground/issues) to find what to work on. The [`Good First Issue`](https://github.com/wordpress/wordpress-playground/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) label is a recommended starting point for first-time contributors.
+
+Be sure to review the following resources before you begin:
+
+-   [Coding principles](/contributing/coding-standards)
+-   [Architecture](/developers/architecture)
+-   [Vision and Philosophy](https://github.com/WordPress/wordpress-playground/issues/472)
+-   [WordPress Playground Roadmap](https://github.com/WordPress/wordpress-playground/issues/525)
+-->
+
+Come tutti i progetti WordPress, Playground usa GitHub per gestire il codice e tracciare le issue. Il repository principale è su [https://github.com/WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) e il repository Playground Tools è su [https://github.com/WordPress/playground-tools/](https://github.com/WordPress/playground-tools/).
+
+:::info Contribuire a Playground Tools
+
+Questa guida include link al repository principale, ma tutti i passaggi e le opzioni si applicano ad entrambi. Se sei interessato ai plugin o agli strumenti di [sviluppo locale](/developers/local-development/)—inizia da lì.
+
+:::
+
+Sfoglia [l'elenco delle issue aperte](https://github.com/wordpress/wordpress-playground/issues) per trovare su cosa lavorare. L'etichetta [`Good First Issue`](https://github.com/wordpress/wordpress-playground/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Issue%22) è un punto di partenza consigliato per i contributori alle prime armi.
+
+Assicurati di rivedere le seguenti risorse prima di iniziare:
+
+-   [Principi di codifica](/contributing/coding-standards)
+-   [Architettura](/developers/architecture)
+-   [Visione e Filosofia](https://github.com/WordPress/wordpress-playground/issues/472)
+-   [Roadmap di WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/525)
+
+<!--
+## Contribute Pull Requests
+
+[Fork the Playground repository](https://github.com/WordPress/wordpress-playground/fork) and clone it to your local machine. To do that, copy and paste these commands into your terminal:
+
+```bash
+git clone -b trunk --single-branch --depth 1 --recurse-submodules
+
+# replace `YOUR-GITHUB-USERNAME` with your GitHub username:
+git@github.com:YOUR-GITHUB-USERNAME/wordpress-playground.git
+cd wordpress-playground
+npm install
+```
+
+Create a branch, make changes, and test it locally by running the following command:
+
+```bash
+npm run dev
+```
+
+Playground will open in a new browser tab and refresh automatically with each change.
+
+When your'e ready, commit the changes and submit a Pull Request.
+
+:::info Formatting
+
+We handle code formatting and linting automatically. Relax, type away, and let the machines do the work.
+
+:::
+-->
+
+## Contribuire con Pull Request
+
+[Fai il fork del repository Playground](https://github.com/WordPress/wordpress-playground/fork) e clonalo sulla tua macchina locale. Per farlo, copia e incolla questi comandi nel tuo terminale:
+
+```bash
+git clone -b trunk --single-branch --depth 1 --recurse-submodules
+
+# sostituisci `YOUR-GITHUB-USERNAME` con il tuo username GitHub:
+git@github.com:YOUR-GITHUB-USERNAME/wordpress-playground.git
+cd wordpress-playground
+npm install
+```
+
+Crea un branch, fai le modifiche e testalo localmente eseguendo il seguente comando:
+
+```bash
+npm run dev
+```
+
+Playground si aprirà in una nuova scheda del browser e si aggiornerà automaticamente ad ogni modifica.
+
+Quando sei pronto, committa le modifiche e invia una Pull Request.
+
+:::info Formattazione
+
+Gestiamo automaticamente la formattazione del codice e il linting. Rilassati, scrivi e lascia che le macchine facciano il lavoro.
+
+:::
+
+<!--
+### Running a local Multisite
+
+WordPress Multisite has a few [restrictions when run locally](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/#restrictions). If you plan to test a Multisite network using Playground's `enableMultisite` step, make sure you either change `wp-now`'s default port or set a local test domain running via HTTPS.
+
+To change `wp-now`'s default port to the one supported by WordPress Multisite, run it using the `--port=80` flag:
+
+```bash
+npx @wp-now/wp-now start --port=80
+```
+
+There are a few ways to set up a local test domain, including editing your `hosts` file. If you're unsure how to do that, we suggest installing [Laravel Valet](https://laravel.com/docs/11.x/valet) and then running the following command:
+
+```bash
+valet proxy playground.test http://127.0.0.1:5400 --secure
+```
+
+Your dev server is now available on https://playground.test.
+-->
+
+### Eseguire un Multisite locale
+
+WordPress Multisite ha alcune [restrizioni quando viene eseguito localmente](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/#restrictions). Se prevedi di testare una rete Multisite usando il passo `enableMultisite` di Playground, assicurati di cambiare la porta predefinita di `wp-now` o di impostare un dominio di test locale in esecuzione tramite HTTPS.
+
+Per cambiare la porta predefinita di `wp-now` a quella supportata da WordPress Multisite, eseguilo usando il flag `--port=80`:
+
+```bash
+npx @wp-now/wp-now start --port=80
+```
+
+Ci sono diversi modi per impostare un dominio di test locale, incluso modificare il tuo file `hosts`. Se non sei sicuro di come farlo, suggeriamo di installare [Laravel Valet](https://laravel.com/docs/11.x/valet) e poi eseguire il seguente comando:
+
+```bash
+valet proxy playground.test http://127.0.0.1:5400 --secure
+```
+
+Il tuo server di sviluppo è ora disponibile su https://playground.test.
+
+<!--
+## Debugging
+
+### Use VS Code and Chrome
+
+If you're using VS Code and have Chrome installed, you can debug Playground in the code editor:
+
+-   Open the project folder in VS Code.
+-   Select Run > Start Debugging from the main menu or press `F5`/`fn`+`F5`.
+
+### Debugging PHP
+
+Playground logs PHP errors in the browser console after every PHP request.
+-->
+
+## Debug
+
+### Usa VS Code e Chrome
+
+Se stai usando VS Code e hai Chrome installato, puoi fare il debug di Playground nell'editor di codice:
+
+-   Apri la cartella del progetto in VS Code.
+-   Seleziona Esegui > Avvia debug dal menu principale o premi `F5`/`fn`+`F5`.
+
+### Debug di PHP
+
+Playground registra gli errori PHP nella console del browser dopo ogni richiesta PHP.

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/coding-standards.md
@@ -1,0 +1,105 @@
+---
+slug: /contributing/coding-standards
+title: Principi di codifica
+description: Dettaglia i principi di codifica per Playground, concentrandosi su messaggi di errore utili, un'API pubblica minimale e Blueprints.
+---
+
+<!--
+# Coding principles
+-->
+
+# Principi di codifica
+
+<!--
+## Error messages
+
+A good error message informs the user of the following steps to take. Any ambiguity in errors thrown by Playground [Public APIs](/developers/apis/) will prompt the developers to open issues.
+
+Consider a network error, for example—can we infer the type of error and display a relevant message summarizing the next steps?
+
+-   **Network error**: "Your internet connection twitched. Try to reload the page.
+-   **404**: "Could not find the file".
+-   **403**: "The server blocked access to the file".
+-   **CORS**: clarify it's a browser security feature and add a link to a detailed explanation (on MDN or another reliable source). Suggest the user move their file somewhere else, like `raw.githubusercontent.com`, and link to a resource explaining how to set up CORS headers on their servers.
+
+We handle code formatting and linting automatically. Relax, type away, and let the machines do the work.
+-->
+
+## Messaggi di errore
+
+Un buon messaggio di errore informa l'utente sui passaggi successivi da seguire. Qualsiasi ambiguità negli errori generati dalle [API pubbliche](/developers/apis/) di Playground spingerà gli sviluppatori ad aprire issue.
+
+Considera un errore di rete, per esempio—possiamo dedurre il tipo di errore e visualizzare un messaggio rilevante che riassuma i prossimi passaggi?
+
+-   **Errore di rete**: "La tua connessione internet ha avuto un problema. Prova a ricaricare la pagina."
+-   **404**: "Impossibile trovare il file".
+-   **403**: "Il server ha bloccato l'accesso al file".
+-   **CORS**: chiarisci che è una funzionalità di sicurezza del browser e aggiungi un link a una spiegazione dettagliata (su MDN o un'altra fonte affidabile). Suggerisci all'utente di spostare il proprio file altrove, come `raw.githubusercontent.com`, e linka a una risorsa che spiega come impostare gli header CORS sui loro server.
+
+Gestiamo automaticamente la formattazione del codice e il linting. Rilassati, scrivi e lascia che le macchine facciano il lavoro.
+
+<!--
+## Public API
+
+Playground aims to keep the narrowest possible API scope.
+
+Public APIs are easy to add and hard to remove. It only takes one PR to introduce a new API, but it may take a thousand to remove it, especially if other projects have already consumed it.
+
+-   Don't expose unnecessary functions, classes, constants, or other components.
+-->
+
+## API pubblica
+
+Playground mira a mantenere lo scope dell'API il più ristretto possibile.
+
+Le API pubbliche sono facili da aggiungere e difficili da rimuovere. Serve solo una PR per introdurre una nuova API, ma potrebbero servire mille per rimuoverla, specialmente se altri progetti l'hanno già utilizzata.
+
+-   Non esporre funzioni, classi, costanti o altri componenti non necessari.
+
+<!--
+## Blueprints
+
+[Blueprints](/blueprints/getting-started) are the primary way to interact with Playground. These JSON files describe a set of steps that Playground executes in order.
+
+### Guidelines
+
+Blueprint steps should be **concise and focused**. They should do one thing and do it well.
+
+-   If you need to create a new step, try refactoring an existing one first.
+-   If that's not enough, ensure the new step delivers a new capability. Don't replicate the functionality of existing steps.
+-   Assume the step would be called more than once.
+-   Assume it would run in a specific order.
+-   Add unit tests to verify that.
+
+Blueprints should be **intuitive and straightforward**.
+
+-   Don't require arguments that can be optional.
+-   Use plain argument. For example, `slug` instead of `path`.
+-   Define constants in virtual JSON files—don't modify PHP files.
+-   Define a TypeScript type for the Blueprint. That's how Playground generates its JSON schema.
+-   Write a function to handle a Blueprint step. Accept the argument of the type you defined.
+-   Provide a usage example in the doc string. It's automatically reflected in the docs.
+-->
+
+## Blueprints
+
+I [Blueprints](/blueprints/getting-started) sono il modo principale per interagire con Playground. Questi file JSON descrivono una serie di passaggi che Playground esegue in ordine.
+
+### Linee guida
+
+I passaggi dei Blueprints dovrebbero essere **concisi e mirati**. Dovrebbero fare una cosa e farla bene.
+
+-   Se devi creare un nuovo passaggio, prova prima a refactorizzare uno esistente.
+-   Se non è sufficiente, assicurati che il nuovo passaggio fornisca una nuova capacità. Non replicare la funzionalità dei passaggi esistenti.
+-   Assumi che il passaggio verrà chiamato più di una volta.
+-   Assumi che verrà eseguito in un ordine specifico.
+-   Aggiungi test unitari per verificarlo.
+
+I Blueprints dovrebbero essere **intuitivi e diretti**.
+
+-   Non richiedere argomenti che possono essere opzionali.
+-   Usa argomenti semplici. Per esempio, `slug` invece di `path`.
+-   Definisci le costanti in file JSON virtuali—non modificare i file PHP.
+-   Definisci un tipo TypeScript per il Blueprint. È così che Playground genera il suo schema JSON.
+-   Scrivi una funzione per gestire un passaggio del Blueprint. Accetta l'argomento del tipo che hai definito.
+-   Fornisci un esempio di utilizzo nella stringa di documentazione. Viene automaticamente riflesso nella documentazione.

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-badge.md
@@ -1,0 +1,97 @@
+---
+title: Badge Contributore WordPress Playground
+slug: /contributing/contributor-badge
+description: Scopri i criteri per il Badge Contributore WordPress Playground e come richiederlo per il tuo profilo WordPress.org.
+---
+
+<!--
+# Playground Contributor Badge
+
+This page provides detailed information on the Playground Contributor Badge and the process of requesting it on your [WordPress.org](https://wordpress.org) profile.
+
+---
+-->
+
+# Badge Contributore Playground
+
+Questa pagina fornisce informazioni dettagliate sul Badge Contributore Playground e sul processo per richiederlo sul tuo profilo [WordPress.org](https://wordpress.org).
+
+---
+
+<!--
+## Getting Started
+
+Any contribution to the WordPress Playground project is highly valued. The Playground team recognizes contributions across several key areas:
+
+-   **Playground Code:** Making code changes and reviewing the core project.
+-   **Playground UI:** Improving the user interface of the web experience.
+-   **Documentation:** Writing, updating, and reviewing documentation.
+-   **Translation:** Translating any part of the project.
+-   **Blueprints Gallery:** Creating new blueprints or improving existing ones.
+-->
+
+## Per iniziare
+
+Ogni contributo al progetto WordPress Playground è molto apprezzato. Il team Playground riconosce i contributi in diverse aree chiave:
+
+-   **Codice Playground:** Fare modifiche al codice e rivedere il progetto principale.
+-   **Interfaccia Playground:** Migliorare l'interfaccia utente dell'esperienza web.
+-   **Documentazione:** Scrivere, aggiornare e rivedere la documentazione.
+-   **Traduzione:** Tradurre qualsiasi parte del progetto.
+-   **Galleria Blueprints:** Creare nuovi blueprints o migliorare quelli esistenti.
+
+<!--
+## Playground Contributor Badge
+
+To get a Playground Contributor Badge, you must have made at least one eligible contribution from the list above. The team may choose to award the badge for other contributions or a combination of the above at the team's discretion.
+
+![Playground Contributor Badge](@site/static/img/contributing/playground-contributor-badge.webp)
+-->
+
+## Badge Contributore Playground
+
+Per ottenere un Badge Contributore Playground, devi aver fatto almeno un contributo idoneo dall'elenco sopra. Il team può scegliere di assegnare il badge per altri contributi o una combinazione di quelli sopra a discrezione del team.
+
+![Badge Contributore Playground](@site/static/img/contributing/playground-contributor-badge.webp)
+
+<!--
+## Playground Team Badge
+
+If you are currently a contributor and have been actively involved in the Playground project for the past **twelve months**, you are eligible for a **Playground Team Badge**.
+
+![Playground Contributor Badge](@site/static/img/contributing/playground-team-badge.webp)
+-->
+
+## Badge Team Playground
+
+Se sei attualmente un contributore e sei stato attivamente coinvolto nel progetto Playground negli ultimi **dodici mesi**, sei idoneo per un **Badge Team Playground**.
+
+![Badge Team Playground](@site/static/img/contributing/playground-team-badge.webp)
+
+<!--
+## Requesting a Profile Badge
+
+If you meet the criteria, you can request a badge. Please include links to resources (such as GitHub pull requests, issues, or translated strings) that show you have met the criteria. Send a request at the links bellow:
+
+-   [Contributor Badge](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [Team Badge](https://profiles.wordpress.org/associations/playground-team/)
+
+### Request form
+
+![Playground Contributor Badge](@site/static/img/contributing/request-contributor-badge.webp)
+
+To access the request, the user should be logged in with their WordPress.org account and open the Request Membership tab, after submitting the required information. A Playground Team Representative will confirm your contribution and assign the badge. The team will perform a weekly review of contributions and award badges at that time. Updates on new badges awarded will be posted during the Playground Team meeting.
+-->
+
+## Richiedere un Badge Profilo
+
+Se soddisfi i criteri, puoi richiedere un badge. Per favore includi link a risorse (come pull request GitHub, issue o stringhe tradotte) che dimostrino che hai soddisfatto i criteri. Invia una richiesta ai link seguenti:
+
+-   [Badge Contributore](https://profiles.wordpress.org/associations/playground-contributor/)
+-   [Badge Team](https://profiles.wordpress.org/associations/playground-team/)
+
+### Modulo di richiesta
+
+![Badge Contributore Playground](@site/static/img/contributing/request-contributor-badge.webp)
+
+Per accedere alla richiesta, l'utente dovrebbe essere loggato con il proprio account WordPress.org e aprire la scheda Richiedi Appartenenza, dopo aver inviato le informazioni richieste. Un Rappresentante del Team Playground confermerà il tuo contributo e assegnerà il badge. Il team eseguirà una revisione settimanale dei contributi e assegnerà i badge in quel momento. Gli aggiornamenti sui nuovi badge assegnati verranno pubblicati durante la riunione del Team Playground.

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day-table-lead.md
@@ -1,13 +1,20 @@
 ---
 slug: /contributing/table-lead-guide
-title: Table Lead Guide for Contributor Day
-description: How to lead a WordPress Playground table at the Contributor Day of a WordCamp.
+title: Guida per il Leader del Tavolo al Contributor Day
+description: Come guidare un tavolo WordPress Playground al Contributor Day di un WordCamp.
 ---
 
+<!--
 # Table Lead Guide for Contributor Day
 
 This guide helps table leads prepare for and manage a WordPress Playground contributor table at WordCamp events.
+-->
 
+# Guida per il Leader del Tavolo al Contributor Day
+
+Questa guida aiuta i leader dei tavoli a preparare e gestire un tavolo contributori WordPress Playground agli eventi WordCamp.
+
+<!--
 ## Before Contributor Day
 
 ### Pre-Work Checklist
@@ -16,7 +23,18 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 -   **Coordinate with the Playground Team**: Confirm if Playground team members are available online to provide remote support during the event, especially for flagship WordCamps. Due to timezone differences, align in advance at the #playground channel to check their availability.
 -   **Connect with Local Contributors**: Identify regular contributors in the region attending the event. Check on the #playground Slack Channel if an active community member is participating in the contributor day. This is an opportunity to gather feedback and strengthen community connections.
 - **Check the Playground Repository**: If you have never contributed to the WordPress Playground Repository, you should get familiar with this section of the documentation that can guide you to understand how the project is organized. [Developers > Architecture](/developers/architecture) will contain information on how the project is organized. If you have any questions, please get in touch with the team at the Playground Slack channel.
+-->
 
+## Prima del Contributor Day
+
+### Checklist di preparazione
+
+-   **Curato "Good First Issues"**: Rivedi e aggiorna l'[elenco delle good first issues](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) su GitHub. Questi dovrebbero essere compiti semplici che i nuovi contributori possono completare autonomamente. Se trovi un bug che non è nell'elenco ma potrebbe farne parte, contatta il team Playground sul canale Slack.
+-   **Coordina con il Team Playground**: Conferma se i membri del team Playground sono disponibili online per fornire supporto remoto durante l'evento, specialmente per i WordCamp principali. A causa delle differenze di fuso orario, allineati in anticipo sul canale #playground per verificare la loro disponibilità.
+-   **Connettiti con i Contributori Locali**: Identifica i contributori regolari nella regione che partecipano all'evento. Controlla sul canale Slack #playground se un membro attivo della community sta partecipando al contributor day. Questa è un'opportunità per raccogliere feedback e rafforzare le connessioni della community.
+-   **Controlla il Repository Playground**: Se non hai mai contribuito al repository WordPress Playground, dovresti familiarizzare con questa sezione della documentazione che può guidarti a capire come il progetto è organizzato. [Developers > Architecture](/developers/architecture) conterrà informazioni su come il progetto è organizzato. Se hai domande, per favore contatta il team sul canale Slack Playground.
+
+<!--
 ## Starting the Day
 
 ### Setup and Onboarding
@@ -36,68 +54,7 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
     - [Contributor Day guide](/contributing/contributor-day/)
 
 5. **Introduce the GitHub Repository**: Provide a brief walkthrough of the repository structure, highlighting different packages and their purposes for first-time contributors.
-
-## During the Day
-
-### Managing Contributions
-
-**Encourage Different Contribution Types**:
-
-Check the contributors' levels, try to understand, based on their level, how they can contribute to the project in the short window of a contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing:
-
--   Documentation improvements and translations.
--   Carefully crafted issues describing problems with actionable solutions.
--   Blueprint creation and plugin demos at the WordPress plugin repository.
--   Testing and product feedback.
-
-**Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the [Polyglots/Translation table](https://make.wordpress.org/polyglots/) might translate Playground documentation, or the [Core Test team](https://make.wordpress.org/test/) could provide valuable Playground feedback.
-
-**Collect Feedback**: Ask contributors about their experience and note improvement suggestions. Report this in the [#playground Slack Channel](https://wordpress.slack.com/archives/C04EWKGDJ0K) if possible.
-
-## After the Event
-
-### Follow-Up and Support
-
-1. **Review Pull Requests**: List PRs created during the day and assess their completion likelihood. Most contributions have a short momentum window—engagement within the first two weeks is critical.
-
-2. **Set Clear Expectations**: For incomplete PRs, follow this approach:
-
-    - After one month of inactivity, leave a comment asking if the author plans to complete the work.
-    - If no response after two more weeks, inform them that the PR may be taken over by another contributor or closed.
-
-3. **Stay Active on Slack**: Continue supporting new contributors through the `#playground` channel, answering questions and helping them become regular contributors.
-
-4. **Reflect and Improve**: Review collected feedback and your experience to refine this guide for future events. Feel free to submit a Pull Request to this guide!
-
-## Getting Help
-
--   **During the Event**: Connect with contributors at the Playground table.
--   **Ongoing Support**: Use the [`#playground` Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
--   **Report Issues**: Submit to the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new).
-
-For more information on contributing to WordPress Playground, see the [Contributor Day guide](/contributing/contributor-day).
 -->
-
----
-
-slug: /contributing/table-lead-guide
-title: Guida per il Leader del Tavolo al Contributor Day
-description: Come guidare un tavolo WordPress Playground al Contributor Day di un WordCamp.
-
----
-
-# Guida per il Leader del Tavolo al Contributor Day
-
-Questa guida aiuta i leader dei tavoli a preparare e gestire un tavolo contributori WordPress Playground agli eventi WordCamp.
-
-## Prima del Contributor Day
-
-### Checklist di preparazione
-
--   **Curato "Good First Issues"**: Rivedi e aggiorna l'[elenco delle good first issues](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) su GitHub. Questi dovrebbero essere compiti semplici che i nuovi contributori possono completare autonomamente. Se trovi un bug che non è nell'elenco ma potrebbe farne parte, contatta il team Playground sul canale Slack.
--   **Coordina con il Team Playground**: Conferma se i membri del team Playground sono disponibili online per fornire supporto remoto durante l'evento, specialmente per i WordCamp principali. A causa delle differenze di fuso orario, allineati in anticipo sul canale #playground per verificare la loro disponibilità.
--   **Connettiti con i Contributori Locali**: Identifica i contributori regolari nella regione che partecipano all'evento. Controlla sul canale Slack #playground se un membro attivo della community sta partecipando al contributor day. Questa è un'opportunità per raccogliere feedback e rafforzare le connessioni della community.
--   **Controlla il Repository Playground**: Se non hai mai contribuito al repository WordPress Playground, dovresti familiarizzare con questa buona sezione della documentazione che può guidarti a capire il progetto è [Developers > Architecture](/developers/architecture) conterrà informazioni su come il progetto è organizzato. Se hai domande, per favore contatta il team sul canale Slack Playground.
 
 ## Inizio della giornata
 
@@ -119,6 +76,25 @@ Questa guida aiuta i leader dei tavoli a preparare e gestire un tavolo contribut
 
 5. **Introduci il repository GitHub**: Fornisci una breve panoramica della struttura del repository, evidenziando i diversi pacchetti e i loro scopi per i contributori alle prime armi.
 
+<!--
+## During the Day
+
+### Managing Contributions
+
+**Encourage Different Contribution Types**:
+
+Check the contributors' levels, try to understand, based on their level, how they can contribute to the project in the short window of a contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing:
+
+-   Documentation improvements and translations.
+-   Carefully crafted issues describing problems with actionable solutions.
+-   Blueprint creation and plugin demos at the WordPress plugin repository.
+-   Testing and product feedback.
+
+**Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the [Polyglots/Translation table](https://make.wordpress.org/polyglots/) might translate Playground documentation, or the [Core Test team](https://make.wordpress.org/test/) could provide valuable Playground feedback.
+
+**Collect Feedback**: Ask contributors about their experience and note improvement suggestions. Report this in the [#playground Slack Channel](https://wordpress.slack.com/archives/C04EWKGDJ0K) if possible.
+-->
+
 ## Durante la giornata
 
 ### Gestione dei contributi
@@ -136,6 +112,23 @@ Controlla i livelli dei contributori, prova a capire in base al loro livello com
 
 **Raccogli feedback**: Chiedi ai contributori della loro esperienza e annota suggerimenti di miglioramento. Segnala questo nel [canale Slack #playground](https://wordpress.slack.com/archives/C04EWKGDJ0K) se possibile.
 
+<!--
+## After the Event
+
+### Follow-Up and Support
+
+1. **Review Pull Requests**: List PRs created during the day and assess their completion likelihood. Most contributions have a short momentum window—engagement within the first two weeks is critical.
+
+2. **Set Clear Expectations**: For incomplete PRs, follow this approach:
+
+    - After one month of inactivity, leave a comment asking if the author plans to complete the work.
+    - If no response after two more weeks, inform them that the PR may be taken over by another contributor or closed.
+
+3. **Stay Active on Slack**: Continue supporting new contributors through the `#playground` channel, answering questions and helping them become regular contributors.
+
+4. **Reflect and Improve**: Review collected feedback and your experience to refine this guide for future events. Feel free to submit a Pull Request to this guide!
+-->
+
 ## Dopo l'evento
 
 ### Follow-up e supporto
@@ -150,6 +143,16 @@ Controlla i livelli dei contributori, prova a capire in base al loro livello com
 3. **Rimani attivo su Slack**: Continua a supportare i nuovi contributori attraverso il canale `#playground`, rispondendo alle domande e aiutandoli a diventare contributori regolari.
 
 4. **Rifletti e migliora**: Rivedi il feedback raccolto e la tua esperienza per affinare questa guida per eventi futuri. Sentiti libero di inviare una Pull Request a questa guida!
+
+<!--
+## Getting Help
+
+-   **During the Event**: Connect with contributors at the Playground table.
+-   **Ongoing Support**: Use the [`#playground` Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   **Report Issues**: Submit to the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new).
+
+For more information on contributing to WordPress Playground, see the [Contributor Day guide](/contributing/contributor-day).
+-->
 
 ## Ottenere aiuto
 

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day-table-lead.md
@@ -1,9 +1,7 @@
-## <!--
-
+---
 slug: /contributing/table-lead-guide
 title: Table Lead Guide for Contributor Day
-description: How to lead a WordPress Playground table at Contributor Day of a WordCamp.
-
+description: How to lead a WordPress Playground table at the Contributor Day of a WordCamp.
 ---
 
 # Table Lead Guide for Contributor Day
@@ -17,7 +15,7 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 -   **Curate "Good First Issues"**: Review and update the [good first issues list](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) on GitHub. These should be straightforward tasks that new contributors can complete independently. If you find a bug that is not on the list but could be part of it, contact the playground team at the Slack channel.
 -   **Coordinate with the Playground Team**: Confirm if Playground team members are available online to provide remote support during the event, especially for flagship WordCamps. Due to timezone differences, align in advance at the #playground channel to check their availability.
 -   **Connect with Local Contributors**: Identify regular contributors in the region attending the event. Check on the #playground Slack Channel if an active community member is participating in the contributor day. This is an opportunity to gather feedback and strengthen community connections.
--   **Check the Playground Repository**: If you never contribute with the WordPress Playground Repository, you should get familiar with this a good section at the documentation that can guide you to understand the project is [Developers > Architecture](/developers/architecture) it will contain information how the project is organized. If you have any questions, please get in touch with the team at the Playground Slack channel.
+- **Check the Playground Repository**: If you have never contributed to the WordPress Playground Repository, you should get familiar with this section of the documentation that can guide you to understand how the project is organized. [Developers > Architecture](/developers/architecture) will contain information on how the project is organized. If you have any questions, please get in touch with the team at the Playground Slack channel.
 
 ## Starting the Day
 
@@ -45,7 +43,7 @@ This guide helps table leads prepare for and manage a WordPress Playground contr
 
 **Encourage Different Contribution Types**:
 
-Check the contributors' levels, try to understand based on their level how they can contribute to the project in the short window of a contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing:
+Check the contributors' levels, try to understand, based on their level, how they can contribute to the project in the short window of a contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing:
 
 -   Documentation improvements and translations.
 -   Carefully crafted issues describing problems with actionable solutions.
@@ -96,7 +94,7 @@ Questa guida aiuta i leader dei tavoli a preparare e gestire un tavolo contribut
 
 ### Checklist di preparazione
 
--   **Curato "Good First Issues"**: Rivedi e aggiorna l'[elenco delle good first issues](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) su GitHub. Questi dovrebbero essere compiti semplici che i nuovi contributori possono completare autonomamente. Se trovi un bug che non è nell'elenco ma potrebbe farne parte, contatta il team playground sul canale Slack.
+-   **Curato "Good First Issues"**: Rivedi e aggiorna l'[elenco delle good first issues](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) su GitHub. Questi dovrebbero essere compiti semplici che i nuovi contributori possono completare autonomamente. Se trovi un bug che non è nell'elenco ma potrebbe farne parte, contatta il team Playground sul canale Slack.
 -   **Coordina con il Team Playground**: Conferma se i membri del team Playground sono disponibili online per fornire supporto remoto durante l'evento, specialmente per i WordCamp principali. A causa delle differenze di fuso orario, allineati in anticipo sul canale #playground per verificare la loro disponibilità.
 -   **Connettiti con i Contributori Locali**: Identifica i contributori regolari nella regione che partecipano all'evento. Controlla sul canale Slack #playground se un membro attivo della community sta partecipando al contributor day. Questa è un'opportunità per raccogliere feedback e rafforzare le connessioni della community.
 -   **Controlla il Repository Playground**: Se non hai mai contribuito al repository WordPress Playground, dovresti familiarizzare con questa buona sezione della documentazione che può guidarti a capire il progetto è [Developers > Architecture](/developers/architecture) conterrà informazioni su come il progetto è organizzato. Se hai domande, per favore contatta il team sul canale Slack Playground.
@@ -129,7 +127,7 @@ Questa guida aiuta i leader dei tavoli a preparare e gestire un tavolo contribut
 
 Controlla i livelli dei contributori, prova a capire in base al loro livello come possono contribuire al progetto nella breve finestra di un contributor day. Chiedi se i partecipanti hanno bisogno di aiuto e reindirizzali alla pagina di documentazione correlata. Inoltre, incoraggiali a fare domande sul [canale Slack #playground](https://wordpress.slack.com/archives/C04EWKGDJ0K). Ecco alcuni suggerimenti per modi di contribuire:
 
--   Miglioramenti alla documentazione e traduzioni.
+-   Miglioramenti alla documentazione e alle traduzioni.
 -   Issue accuratamente redatte che descrivono problemi con soluzioni praticabili.
 -   Creazione di Blueprints e demo di plugin nel repository plugin WordPress.
 -   Test e feedback sul prodotto.

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day-table-lead.md
@@ -1,0 +1,162 @@
+## <!--
+
+slug: /contributing/table-lead-guide
+title: Table Lead Guide for Contributor Day
+description: How to lead a WordPress Playground table at Contributor Day of a WordCamp.
+
+---
+
+# Table Lead Guide for Contributor Day
+
+This guide helps table leads prepare for and manage a WordPress Playground contributor table at WordCamp events.
+
+## Before Contributor Day
+
+### Pre-Work Checklist
+
+-   **Curate "Good First Issues"**: Review and update the [good first issues list](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) on GitHub. These should be straightforward tasks that new contributors can complete independently. If you find a bug that is not on the list but could be part of it, contact the playground team at the Slack channel.
+-   **Coordinate with the Playground Team**: Confirm if Playground team members are available online to provide remote support during the event, especially for flagship WordCamps. Due to timezone differences, align in advance at the #playground channel to check their availability.
+-   **Connect with Local Contributors**: Identify regular contributors in the region attending the event. Check on the #playground Slack Channel if an active community member is participating in the contributor day. This is an opportunity to gather feedback and strengthen community connections.
+-   **Check the Playground Repository**: If you never contribute with the WordPress Playground Repository, you should get familiar with this a good section at the documentation that can guide you to understand the project is [Developers > Architecture](/developers/architecture) it will contain information how the project is organized. If you have any questions, please get in touch with the team at the Playground Slack channel.
+
+## Starting the Day
+
+### Setup and Onboarding
+
+1. **Create Your Agenda**: Prepare a flexible checklist of key activities while allowing for organic collaboration. Share it in the project documentation if helpful.
+
+2. **Guide Contributors to Slack**: Direct everyone to the [`#playground` channel on WordPress Slack](https://wordpress.slack.com/archives/C04EWKGDJ0K). This centralizes communication and enables asynchronous collaboration with late arrivals.
+
+3. **Post a Welcome Message**: Share an initial message in the Slack channel announcing your presence (in-person or online) and welcoming contributions from everyone.
+
+4. **Share Essential Links**: Post these resources in the `#playground` channel:
+
+    - [WordPress Playground Web Instance](https://playground.wordpress.net/)
+    - [Playground Documentation](https://wordpress.github.io/wordpress-playground/)
+    - [Playground Step Library](https://akirk.github.io/playground-step-library/)
+    - [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+    - [Contributor Day guide](/contributing/contributor-day/)
+
+5. **Introduce the GitHub Repository**: Provide a brief walkthrough of the repository structure, highlighting different packages and their purposes for first-time contributors.
+
+## During the Day
+
+### Managing Contributions
+
+**Encourage Different Contribution Types**:
+
+Check the contributors' levels, try to understand based on their level how they can contribute to the project in the short window of a contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing:
+
+-   Documentation improvements and translations.
+-   Carefully crafted issues describing problems with actionable solutions.
+-   Blueprint creation and plugin demos at the WordPress plugin repository.
+-   Testing and product feedback.
+
+**Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the [Polyglots/Translation table](https://make.wordpress.org/polyglots/) might translate Playground documentation, or the [Core Test team](https://make.wordpress.org/test/) could provide valuable Playground feedback.
+
+**Collect Feedback**: Ask contributors about their experience and note improvement suggestions. Report this in the [#playground Slack Channel](https://wordpress.slack.com/archives/C04EWKGDJ0K) if possible.
+
+## After the Event
+
+### Follow-Up and Support
+
+1. **Review Pull Requests**: List PRs created during the day and assess their completion likelihood. Most contributions have a short momentum window—engagement within the first two weeks is critical.
+
+2. **Set Clear Expectations**: For incomplete PRs, follow this approach:
+
+    - After one month of inactivity, leave a comment asking if the author plans to complete the work.
+    - If no response after two more weeks, inform them that the PR may be taken over by another contributor or closed.
+
+3. **Stay Active on Slack**: Continue supporting new contributors through the `#playground` channel, answering questions and helping them become regular contributors.
+
+4. **Reflect and Improve**: Review collected feedback and your experience to refine this guide for future events. Feel free to submit a Pull Request to this guide!
+
+## Getting Help
+
+-   **During the Event**: Connect with contributors at the Playground table.
+-   **Ongoing Support**: Use the [`#playground` Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   **Report Issues**: Submit to the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new).
+
+For more information on contributing to WordPress Playground, see the [Contributor Day guide](/contributing/contributor-day).
+-->
+
+---
+
+slug: /contributing/table-lead-guide
+title: Guida per il Leader del Tavolo al Contributor Day
+description: Come guidare un tavolo WordPress Playground al Contributor Day di un WordCamp.
+
+---
+
+# Guida per il Leader del Tavolo al Contributor Day
+
+Questa guida aiuta i leader dei tavoli a preparare e gestire un tavolo contributori WordPress Playground agli eventi WordCamp.
+
+## Prima del Contributor Day
+
+### Checklist di preparazione
+
+-   **Curato "Good First Issues"**: Rivedi e aggiorna l'[elenco delle good first issues](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) su GitHub. Questi dovrebbero essere compiti semplici che i nuovi contributori possono completare autonomamente. Se trovi un bug che non è nell'elenco ma potrebbe farne parte, contatta il team playground sul canale Slack.
+-   **Coordina con il Team Playground**: Conferma se i membri del team Playground sono disponibili online per fornire supporto remoto durante l'evento, specialmente per i WordCamp principali. A causa delle differenze di fuso orario, allineati in anticipo sul canale #playground per verificare la loro disponibilità.
+-   **Connettiti con i Contributori Locali**: Identifica i contributori regolari nella regione che partecipano all'evento. Controlla sul canale Slack #playground se un membro attivo della community sta partecipando al contributor day. Questa è un'opportunità per raccogliere feedback e rafforzare le connessioni della community.
+-   **Controlla il Repository Playground**: Se non hai mai contribuito al repository WordPress Playground, dovresti familiarizzare con questa buona sezione della documentazione che può guidarti a capire il progetto è [Developers > Architecture](/developers/architecture) conterrà informazioni su come il progetto è organizzato. Se hai domande, per favore contatta il team sul canale Slack Playground.
+
+## Inizio della giornata
+
+### Setup e onboarding
+
+1. **Crea la tua agenda**: Prepara un elenco flessibile di attività chiave permettendo la collaborazione organica. Condividilo nella documentazione del progetto se utile.
+
+2. **Guida i contributori a Slack**: Indirizza tutti al canale [`#playground` su WordPress Slack](https://wordpress.slack.com/archives/C04EWKGDJ0K). Questo centralizza la comunicazione e abilita la collaborazione asincrona con gli arrivi tardivi.
+
+3. **Pubblica un messaggio di benvenuto**: Condividi un messaggio iniziale nel canale Slack annunciando la tua presenza (di persona o online) e accogliendo i contributi da tutti.
+
+4. **Condividi link essenziali**: Pubblica queste risorse nel canale `#playground`:
+
+    - [Istanza web WordPress Playground](https://playground.wordpress.net/)
+    - [Documentazione Playground](https://wordpress.github.io/wordpress-playground/)
+    - [Libreria Step Playground](https://akirk.github.io/playground-step-library/)
+    - [Repository GitHub](https://github.com/WordPress/wordpress-playground)
+    - [Guida Contributor Day](/contributing/contributor-day/)
+
+5. **Introduci il repository GitHub**: Fornisci una breve panoramica della struttura del repository, evidenziando i diversi pacchetti e i loro scopi per i contributori alle prime armi.
+
+## Durante la giornata
+
+### Gestione dei contributi
+
+**Incoraggia diversi tipi di contributi**:
+
+Controlla i livelli dei contributori, prova a capire in base al loro livello come possono contribuire al progetto nella breve finestra di un contributor day. Chiedi se i partecipanti hanno bisogno di aiuto e reindirizzali alla pagina di documentazione correlata. Inoltre, incoraggiali a fare domande sul [canale Slack #playground](https://wordpress.slack.com/archives/C04EWKGDJ0K). Ecco alcuni suggerimenti per modi di contribuire:
+
+-   Miglioramenti alla documentazione e traduzioni.
+-   Issue accuratamente redatte che descrivono problemi con soluzioni praticabili.
+-   Creazione di Blueprints e demo di plugin nel repository plugin WordPress.
+-   Test e feedback sul prodotto.
+
+**Favorisci la collaborazione**: Cerca opportunità cross-table. Per esempio, i contributori al [tavolo Polyglots/Traduzione](https://make.wordpress.org/polyglots/) potrebbero tradurre la documentazione Playground, o il [team Core Test](https://make.wordpress.org/test/) potrebbe fornire feedback preziosi su Playground.
+
+**Raccogli feedback**: Chiedi ai contributori della loro esperienza e annota suggerimenti di miglioramento. Segnala questo nel [canale Slack #playground](https://wordpress.slack.com/archives/C04EWKGDJ0K) se possibile.
+
+## Dopo l'evento
+
+### Follow-up e supporto
+
+1. **Rivedi le Pull Request**: Elenca le PR create durante la giornata e valuta la probabilità di completamento. La maggior parte dei contributi ha una finestra di slancio breve—il coinvolgimento entro le prime due settimane è critico.
+
+2. **Stabilisci aspettative chiare**: Per le PR incomplete, segui questo approccio:
+
+    - Dopo un mese di inattività, lascia un commento chiedendo se l'autore prevede di completare il lavoro.
+    - Se non c'è risposta dopo altre due settimane, informali che la PR potrebbe essere presa in carico da un altro contributore o chiusa.
+
+3. **Rimani attivo su Slack**: Continua a supportare i nuovi contributori attraverso il canale `#playground`, rispondendo alle domande e aiutandoli a diventare contributori regolari.
+
+4. **Rifletti e migliora**: Rivedi il feedback raccolto e la tua esperienza per affinare questa guida per eventi futuri. Sentiti libero di inviare una Pull Request a questa guida!
+
+## Ottenere aiuto
+
+-   **Durante l'evento**: Connettiti con i contributori al tavolo Playground.
+-   **Supporto continuo**: Usa il [canale Slack `#playground`](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   **Segnala issue**: Invia al [repository GitHub WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new).
+
+Per maggiori informazioni su come contribuire a WordPress Playground, vedi la [guida Contributor Day](/contributing/contributor-day).

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -1,0 +1,418 @@
+---
+slug: /contributing/contributor-day
+title: WordCamp Contributor Day
+description: Una guida su come contribuire a WordPress Playground e come può supportarti al Contributor Day.
+---
+
+<!--
+# WordCamp Contributor Day
+
+WordCamp Contributor Day is an event where the WordPress community comes together to contribute to the WordPress project. This guide focuses on how you can contribute to the WordPress Playground project or how the Playground can assist you in contributing to WordPress Core.
+-->
+
+# WordCamp Contributor Day
+
+Il WordCamp Contributor Day è un evento in cui la community WordPress si riunisce per contribuire al progetto WordPress. Questa guida si concentra su come puoi contribuire al progetto WordPress Playground o su come Playground può aiutarti a contribuire a WordPress Core.
+
+<!--
+## Who Can Contribute?
+
+Some events will have a dedicated table for the project. The WordPress Playground contributor tables welcome all kinds of contributions, not just from developers. Whether you are a writer, coder, tester, plugin or theme developer, marketer, site owner, or any other type of user, you are encouraged to contribute.
+
+We value diverse contributions across various areas, including community building, testing, documentation, and design.
+-->
+
+## Chi può contribuire?
+
+Alcuni eventi avranno un tavolo dedicato per il progetto. I tavoli contributori WordPress Playground accolgono tutti i tipi di contributi, non solo dagli sviluppatori. Che tu sia uno scrittore, programmatore, tester, sviluppatore di plugin o temi, marketer, proprietario di sito o qualsiasi altro tipo di utente, sei incoraggiato a contribuire.
+
+Valutiamo contributi diversificati in varie aree, inclusi community building, testing, documentazione e design.
+
+<!--
+## How to Contribute to the Playground Project
+
+This section outlines how you can contribute directly to the WordPress Playground project and its associated tools:
+
+-   **Documentation:** Enhance our documentation by improving existing content, developing new guides, or translating materials into different languages.
+-   **Blueprints:** Create plugin demos for plugins at the WordPress Plugin repository, or develop new Blueprints to enrich our project documentation.
+-   **Testing the Playground Environment:** Engage in testing the WordPress Playground project itself. You can do this by carefully crafting new issues that describe problems you encounter and suggesting actionable solutions. Test our WordPress web instance (the playground.wordpress.net site), or explore the various applications powered by Playground. Test these tools, observe their functionality, and provide detailed feedback.
+-   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
+
+All feedback, including reported issues and test results, can be submitted through our GitHub repository.
+-->
+
+## Come contribuire al progetto Playground
+
+Questa sezione descrive come puoi contribuire direttamente al progetto WordPress Playground e ai suoi strumenti associati:
+
+-   **Documentazione:** Migliora la nostra documentazione migliorando il contenuto esistente, sviluppando nuove guide o traducendo materiali in diverse lingue.
+-   **Blueprints:** Crea demo di plugin per i plugin nel repository WordPress Plugin, o sviluppa nuovi Blueprints per arricchire la nostra documentazione del progetto.
+-   **Testare l'ambiente Playground:** Impegnati nel testare il progetto WordPress Playground stesso. Puoi farlo creando attentamente nuove issue che descrivono i problemi che incontri e suggerendo soluzioni praticabili. Testa la nostra istanza web WordPress (il sito playground.wordpress.net), o esplora le varie applicazioni alimentate da Playground. Testa questi strumenti, osserva la loro funzionalità e fornisci feedback dettagliati.
+-   **Feedback sul prodotto:** Le tue intuizioni sono preziose per migliorare l'esperienza Playground. Questo include feedback generale sull'istanza web, l'applicazione e qualsiasi strumento lato server.
+
+Tutti i feedback, inclusi issue segnalate e risultati dei test, possono essere inviati tramite il nostro repository GitHub.
+
+<!--
+### Follow-up and Continued Engagement
+
+While many tasks are completed during the event, your contribution journey doesn't have to end there. You are welcome to continue working on your issues or pull requests after Contributor Day. We anticipate ongoing activity from contributors who take on tasks beyond the event. Please note that if a pull request shows no activity for one month, it may be considered abandoned and subsequently closed.
+-->
+
+### Follow-up e coinvolgimento continuo
+
+Mentre molti compiti vengono completati durante l'evento, il tuo viaggio di contribuzione non deve finire lì. Sei il benvenuto a continuare a lavorare sulle tue issue o pull request dopo il Contributor Day. Prevediamo attività continuative dai contributori che si assumono compiti oltre l'evento. Nota che se una pull request non mostra attività per un mese, può essere considerata abbandonata e successivamente chiusa.
+
+<!--
+### Getting Help and Staying Engaged
+
+During Contributor Day, you can find direct assistance and interact with us at the dedicated Playground table. For continuous support and community interaction, you can connect with us on the `#playground` channel on WordPress Slack or via GitHub.
+-->
+
+### Ottenere aiuto e rimanere coinvolti
+
+Durante il Contributor Day, puoi trovare assistenza diretta e interagire con noi al tavolo Playground dedicato. Per supporto continuo e interazione con la community, puoi contattarci sul canale `#playground` su WordPress Slack o tramite GitHub.
+
+<!--
+## How to use Playground at Contributor Day
+
+Now we are going to cover how the Playground can assist you during the Contributor Day. The [WordPress Playground VS Code extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) and [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) streamline the process of setting up a local WordPress environment. WordPress Playground powers both—no Docker, MySQL, or Apache required.
+
+Keep reading to learn how to use these tools for [local development](/developers/local-development/wp-playground-cli) when contributing to WordPress. Please note that the extension and the NPM package are under development, and not all [Make WordPress teams](https://make.wordpress.org/) are fully supported.
+-->
+
+## Come usare Playground al Contributor Day
+
+Ora copriremo come Playground può aiutarti durante il Contributor Day. L'[estensione WordPress Playground VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) e [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) semplificano il processo di configurazione di un ambiente WordPress locale. WordPress Playground alimenta entrambi—non sono richiesti Docker, MySQL o Apache.
+
+Continua a leggere per imparare come usare questi strumenti per lo [sviluppo locale](/developers/local-development/wp-playground-cli) quando contribuisci a WordPress. Nota che l'estensione e il pacchetto NPM sono in sviluppo, e non tutti i [team Make WordPress](https://make.wordpress.org/) sono completamente supportati.
+
+<!--
+## Getting Started
+
+### VS Code Playground extension
+
+The [Visual Studio Code Playground extension](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) is a friendly zero-setup development environment.
+
+1. Open VS Code and navigate to the **Extensions** tab (**View > Extensions**).
+2. In the search bar, type _WordPress Playground_ and click **Install**.
+3. To interact with Playground, click the new icon in the **Activity Bar** and hit the **Start WordPress Server** button.
+4. A new tab will open in your browser within seconds.
+-->
+
+## Per iniziare
+
+### Estensione VS Code Playground
+
+L'[estensione Visual Studio Code Playground](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) è un ambiente di sviluppo amichevole senza configurazione.
+
+1. Apri VS Code e naviga alla scheda **Estensioni** (**Visualizza > Estensioni**).
+2. Nella barra di ricerca, digita _WordPress Playground_ e clicca **Installa**.
+3. Per interagire con Playground, clicca la nuova icona nella **Barra delle attività** e premi il pulsante **Avvia server WordPress**.
+4. Una nuova scheda si aprirà nel tuo browser in pochi secondi.
+
+<!--
+### @wp-playground/cli NPM package
+
+[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) is a CLI tool that allows you to spin up a WordPress site with a single command. No Docker, MySQL, or Apache are required.
+
+#### Prerequisites
+
+`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
+
+Depending on the Make WordPress team you contribute to, you may need a different Node.js version than the one you have installed. You can use Node Version Manager (NVM) to switch between versions. [Find the installation guide here](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+#### Running `@wp-playground/cli`
+
+You don't have to install `@wp-playground/cli` on your device to use it. Navigate to your plugin or theme directory and start `@wp-playground/cli` with the following commands:
+
+```bash
+cd my-plugin-or-theme-directory
+npx @wp-playground/cli@latest server --auto-mount
+```
+-->
+
+### Pacchetto NPM @wp-playground/cli
+
+[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) è uno strumento CLI che ti permette di avviare un sito WordPress con un singolo comando. Non sono richiesti Docker, MySQL o Apache.
+
+#### Prerequisiti
+
+`@wp-playground/cli` richiede Node.js 20.18 o più recente e NPM. Se non li hai ancora, [scarica e installa](https://nodejs.org/en/download) entrambi prima di iniziare.
+
+A seconda del team Make WordPress a cui contribuisci, potresti aver bisogno di una versione Node.js diversa da quella che hai installato. Puoi usare Node Version Manager (NVM) per passare tra le versioni. [Trova la guida all'installazione qui](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+#### Eseguire `@wp-playground/cli`
+
+Non devi installare `@wp-playground/cli` sul tuo dispositivo per usarlo. Naviga nella directory del tuo plugin o tema e avvia `@wp-playground/cli` con i seguenti comandi:
+
+```bash
+cd my-plugin-or-theme-directory
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+<!--
+## Ideas for contributors
+
+### Create a Gutenberg Pull Request (PR)
+
+1. Fork the [Gutenberg repository](https://github.com/WordPress/gutenberg) in your GitHub account.
+2. Then, clone the forked repository to download the files.
+3. Install the necessary dependencies and build the code in development mode.
+
+```bash
+git clone git@github.com:WordPress/gutenberg.git
+cd gutenberg
+npm install
+npm run dev
+```
+
+:::info
+
+If you're unsure about the steps listed above, visit the official [Gutenberg Project Contributor Guide](https://developer.wordpress.org/block-editor/contributors/). Note that in this case, `@wp-playground/cli` replaces `wp-env`.
+
+:::
+
+Open a new terminal terminal tab, navigate to the Gutenberg directory, and start WordPress using `@wp-playground/cli`:
+
+```bash
+cd gutenberg
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+When you're ready, commit and push your changes to your forked repository on GitHub and open a Pull Request on the Gutenberg repository.
+
+### Test a Gutenberg PR
+
+1. To test other Gutenberg PRs, checkout the branch associated with it.
+2. Pull the latest changes to ensure your local copy is up to date.
+3. Next, install the necessary dependencies, ensuring your testing environment matches the latest changes.
+4. Finally, build the code in development mode.
+
+```bash
+# copy the branch-name from GitHub #
+git checkout branch-name
+git pull
+npm install
+npm run dev
+
+# In a different terminal inside the Gutenberg directory *
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+#### Test a Gutenberg PR with Playground in the browser
+
+You don't need a [local development environment](/developers/local-development/) to test Gutenberg PRs—use Playground to do it directly in the browser.
+
+1. Copy the ID of the PR you'd like to test (pick one from the [list of open Pull Requests](https://github.com/WordPress/gutenberg/pulls)).
+2. Open Playground's [Gutenberg PR Previewer](https://playground.wordpress.net/gutenberg.html) and paste the ID you copied.
+3. Once you click **Go**, Playground will verify the PR is valid and open a new tab with the relevant PR, allowing you to review the proposed changes.
+
+## Translate WordPress Plugins with Playground in the browser
+
+You can translate supported WordPress Plugins by loading the plugin you want to translate and use Inline Translation. If the plugin developers have added the option, you'll find the **Translate Live** link on the top right toolbar of the translation view. You can read more about this exciting new option on [this Polyglots blog post](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/).
+
+## Get help and contribute to WordPress Playground
+
+Have a question or an idea for a new feature? Found a bug? Something's not working as expected? We're here to help:
+
+-   During Contributor Day, you can reach us at the **Playground table**.
+-   Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is the VS Code extension, NPM package, or the plugins, open an issue on the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
+-   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-->
+
+## Idee per i contributori
+
+### Creare una Pull Request (PR) Gutenberg
+
+1. Fai il fork del [repository Gutenberg](https://github.com/WordPress/gutenberg) nel tuo account GitHub.
+2. Poi, clona il repository forkato per scaricare i file.
+3. Installa le dipendenze necessarie e compila il codice in modalità sviluppo.
+
+```bash
+git clone git@github.com:WordPress/gutenberg.git
+cd gutenberg
+npm install
+npm run dev
+```
+
+:::info
+
+Se non sei sicuro dei passaggi elencati sopra, visita la [Guida ufficiale per contributori del progetto Gutenberg](https://developer.wordpress.org/block-editor/contributors/). Nota che in questo caso, `@wp-playground/cli` sostituisce `wp-env`.
+
+:::
+
+Apri una nuova scheda del terminale, naviga nella directory Gutenberg e avvia WordPress usando `@wp-playground/cli`:
+
+```bash
+cd gutenberg
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+Quando sei pronto, committa e invia le tue modifiche al tuo repository forkato su GitHub e apri una Pull Request sul repository Gutenberg.
+
+### Testare una PR Gutenberg
+
+1. Per testare altre PR Gutenberg, fai il checkout del branch associato.
+2. Esegui il pull delle ultime modifiche per assicurarti che la tua copia locale sia aggiornata.
+3. Poi, installa le dipendenze necessarie, assicurandoti che il tuo ambiente di test corrisponda alle ultime modifiche.
+4. Infine, compila il codice in modalità sviluppo.
+
+```bash
+# copia il nome del branch da GitHub #
+git checkout branch-name
+git pull
+npm install
+npm run dev
+
+# In un terminale diverso all'interno della directory Gutenberg *
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+#### Testare una PR Gutenberg con Playground nel browser
+
+Non hai bisogno di un [ambiente di sviluppo locale](/developers/local-development/) per testare le PR Gutenberg—usa Playground per farlo direttamente nel browser.
+
+1. Copia l'ID della PR che vorresti testare (scegli una dall'[elenco delle Pull Request aperte](https://github.com/WordPress/gutenberg/pulls)).
+2. Apri il [Gutenberg PR Previewer](https://playground.wordpress.net/gutenberg.html) di Playground e incolla l'ID che hai copiato.
+3. Una volta che clicchi **Vai**, Playground verificherà che la PR sia valida e aprirà una nuova scheda con la PR rilevante, permettendoti di rivedere le modifiche proposte.
+
+## Tradurre plugin WordPress con Playground nel browser
+
+Puoi tradurre i plugin WordPress supportati caricando il plugin che vuoi tradurre e usando la traduzione inline. Se gli sviluppatori del plugin hanno aggiunto l'opzione, troverai il link **Traduci in tempo reale** nella barra degli strumenti in alto a destra della vista di traduzione. Puoi leggere di più su questa entusiasmante nuova opzione su [questo post del blog Polyglots](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/).
+
+## Ottenere aiuto e contribuire a WordPress Playground
+
+Hai una domanda o un'idea per una nuova funzionalità? Hai trovato un bug? Qualcosa non funziona come previsto? Siamo qui per aiutare:
+
+-   Durante il Contributor Day, puoi raggiungerci al **tavolo Playground**.
+-   Apri una issue sul [repository GitHub WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se il tuo focus è l'estensione VS Code, il pacchetto NPM o i plugin, apri una issue sul [repository Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+-   Condividi il tuo feedback sul canale Slack [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+
+## Chi può contribuire?
+
+Alcuni eventi avranno un tavolo dedicato per il progetto. I tavoli contributori WordPress Playground accolgono tutti i tipi di contributi, non solo dagli sviluppatori. Che tu sia uno scrittore, programmatore, tester, sviluppatore di plugin o temi, marketer, proprietario di sito o qualsiasi altro tipo di utente, sei incoraggiato a contribuire.
+
+Valutiamo contributi diversificati in varie aree, inclusi community building, testing, documentazione e design.
+
+## Come contribuire al progetto Playground
+
+Questa sezione descrive come puoi contribuire direttamente al progetto WordPress Playground e ai suoi strumenti associati:
+
+-   **Documentazione:** Migliora la nostra documentazione migliorando il contenuto esistente, sviluppando nuove guide o traducendo materiali in diverse lingue.
+-   **Blueprints:** Crea demo di plugin per i plugin nel repository WordPress Plugin, o sviluppa nuovi Blueprints per arricchire la nostra documentazione del progetto.
+-   **Testare l'ambiente Playground:** Impegnati nel testare il progetto WordPress Playground stesso. Puoi farlo creando attentamente nuove issue che descrivono i problemi che incontri e suggerendo soluzioni praticabili. Testa la nostra istanza web WordPress (il sito playground.wordpress.net), o esplora le varie applicazioni alimentate da Playground. Testa questi strumenti, osserva la loro funzionalità e fornisci feedback dettagliati.
+-   **Feedback sul prodotto:** Le tue intuizioni sono preziose per migliorare l'esperienza Playground. Questo include feedback generale sull'istanza web, l'applicazione e qualsiasi strumento lato server.
+
+Tutti i feedback, inclusi issue segnalate e risultati dei test, possono essere inviati tramite il nostro repository GitHub.
+
+### Follow-up e coinvolgimento continuo
+
+Mentre molti compiti vengono completati durante l'evento, il tuo viaggio di contribuzione non deve finire lì. Sei il benvenuto a continuare a lavorare sulle tue issue o pull request dopo il Contributor Day. Prevediamo attività continuative dai contributori che si assumono compiti oltre l'evento. Nota che se una pull request non mostra attività per un mese, può essere considerata abbandonata e successivamente chiusa.
+
+### Ottenere aiuto e rimanere coinvolti
+
+Durante il Contributor Day, puoi trovare assistenza diretta e interagire con noi al tavolo Playground dedicato. Per supporto continuo e interazione con la community, puoi contattarci sul canale `#playground` su WordPress Slack o tramite GitHub.
+
+## Come usare Playground al Contributor Day
+
+Ora copriremo come Playground può aiutarti durante il Contributor Day. L'[estensione WordPress Playground VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) e [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) semplificano il processo di configurazione di un ambiente WordPress locale. WordPress Playground alimenta entrambi—non sono richiesti Docker, MySQL o Apache.
+
+Continua a leggere per imparare come usare questi strumenti per lo [sviluppo locale](/developers/local-development/wp-playground-cli) quando contribuisci a WordPress. Nota che l'estensione e il pacchetto NPM sono in sviluppo, e non tutti i [team Make WordPress](https://make.wordpress.org/) sono completamente supportati.
+
+## Per iniziare
+
+### Estensione VS Code Playground
+
+L'[estensione Visual Studio Code Playground](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground) è un ambiente di sviluppo amichevole senza configurazione.
+
+1. Apri VS Code e naviga alla scheda **Estensioni** (**Visualizza > Estensioni**).
+2. Nella barra di ricerca, digita _WordPress Playground_ e clicca **Installa**.
+3. Per interagire con Playground, clicca la nuova icona nella **Barra delle attività** e premi il pulsante **Avvia server WordPress**.
+4. Una nuova scheda si aprirà nel tuo browser in pochi secondi.
+
+### Pacchetto NPM @wp-playground/cli
+
+[`@wp-playground/cli`](/developers/local-development/wp-playground-cli) è uno strumento CLI che ti permette di avviare un sito WordPress con un singolo comando. Non sono richiesti Docker, MySQL o Apache.
+
+#### Prerequisiti
+
+`@wp-playground/cli` richiede Node.js 20.18 o più recente e NPM. Se non li hai ancora, [scarica e installa](https://nodejs.org/en/download) entrambi prima di iniziare.
+
+A seconda del team Make WordPress a cui contribuisci, potresti aver bisogno di una versione Node.js diversa da quella che hai installato. Puoi usare Node Version Manager (NVM) per passare tra le versioni. [Trova la guida all'installazione qui](https://github.com/nvm-sh/nvm#installing-and-updating).
+
+#### Eseguire `@wp-playground/cli`
+
+Non devi installare `@wp-playground/cli` sul tuo dispositivo per usarlo. Naviga nella directory del tuo plugin o tema e avvia `@wp-playground/cli` con i seguenti comandi:
+
+```bash
+cd my-plugin-or-theme-directory
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+## Idee per i contributori
+
+### Creare una Pull Request (PR) Gutenberg
+
+1. Fai il fork del [repository Gutenberg](https://github.com/WordPress/gutenberg) nel tuo account GitHub.
+2. Poi, clona il repository forkato per scaricare i file.
+3. Installa le dipendenze necessarie e compila il codice in modalità sviluppo.
+
+```bash
+git clone git@github.com:WordPress/gutenberg.git
+cd gutenberg
+npm install
+npm run dev
+```
+
+:::info
+
+Se non sei sicuro dei passaggi elencati sopra, visita la [Guida ufficiale per contributori del progetto Gutenberg](https://developer.wordpress.org/block-editor/contributors/). Nota che in questo caso, `@wp-playground/cli` sostituisce `wp-env`.
+
+:::
+
+Apri una nuova scheda del terminale, naviga nella directory Gutenberg e avvia WordPress usando `@wp-playground/cli`:
+
+```bash
+cd gutenberg
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+Quando sei pronto, committa e invia le tue modifiche al tuo repository forkato su GitHub e apri una Pull Request sul repository Gutenberg.
+
+### Testare una PR Gutenberg
+
+1. Per testare altre PR Gutenberg, fai il checkout del branch associato.
+2. Esegui il pull delle ultime modifiche per assicurarti che la tua copia locale sia aggiornata.
+3. Poi, installa le dipendenze necessarie, assicurandoti che il tuo ambiente di test corrisponda alle ultime modifiche.
+4. Infine, compila il codice in modalità sviluppo.
+
+```bash
+# copia il nome del branch da GitHub #
+git checkout branch-name
+git pull
+npm install
+npm run dev
+
+# In un terminale diverso all'interno della directory Gutenberg *
+npx @wp-playground/cli@latest server --auto-mount
+```
+
+#### Testare una PR Gutenberg con Playground nel browser
+
+Non hai bisogno di un [ambiente di sviluppo locale](/developers/local-development/) per testare le PR Gutenberg—usa Playground per farlo direttamente nel browser.
+
+1. Copia l'ID della PR che vorresti testare (scegli una dall'[elenco delle Pull Request aperte](https://github.com/WordPress/gutenberg/pulls)).
+2. Apri il [Gutenberg PR Previewer](https://playground.wordpress.net/gutenberg.html) di Playground e incolla l'ID che hai copiato.
+3. Una volta che clicchi **Vai**, Playground verificherà che la PR sia valida e aprirà una nuova scheda con la PR rilevante, permettendoti di rivedere le modifiche proposte.
+
+## Tradurre plugin WordPress con Playground nel browser
+
+Puoi tradurre i plugin WordPress supportati caricando il plugin che vuoi tradurre e usando la traduzione inline. Se gli sviluppatori del plugin hanno aggiunto l'opzione, troverai il link **Traduci in tempo reale** nella barra degli strumenti in alto a destra della vista di traduzione. Puoi leggere di più su questa entusiasmante nuova opzione su [questo post del blog Polyglots](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/).
+
+## Ottenere aiuto e contribuire a WordPress Playground
+
+Hai una domanda o un'idea per una nuova funzionalità? Hai trovato un bug? Qualcosa non funziona come previsto? Siamo qui per aiutare:
+
+-   Durante il Contributor Day, puoi raggiungerci al **tavolo Playground**.
+-   Apri una issue sul [repository GitHub WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se il tuo focus è l'estensione VS Code, il pacchetto NPM o i plugin, apri una issue sul [repository Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+-   Condividi il tuo feedback sul canale Slack [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/documentation.md
@@ -1,0 +1,127 @@
+---
+slug: /contributing/documentation
+title: Contributi alla documentazione
+description: Una guida su come contribuire alla documentazione Playground, dall'apertura di issue all'invio di pull request.
+---
+
+<!--
+# Documentation contributions
+-->
+
+# Contributi alla documentazione
+
+<!--
+[WordPress Playground's documentation site](/) is maintained by volunteers like you, who'd love your help.
+-->
+
+Il [sito di documentazione di WordPress Playground](/) è mantenuto da volontari come te, che apprezzerebbero il tuo aiuto.
+
+<!--
+All documentation-related issues are labeled [`[Type] Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Documentation%22) or [`[Type] Developer Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Developer%20Documentation%22) in the [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) repository. Browse the list of open issues to find one you'd like to work on. Alternatively, if you believe something is missing from the current documentation, open an issue to discuss your suggestion.
+-->
+
+Tutte le issue relative alla documentazione sono etichettate [`[Type] Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Documentation%22) o [`[Type] Developer Documentation`](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%5BType%5D%20Developer%20Documentation%22) nel repository [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground). Sfoglia l'elenco delle issue aperte per trovarne una su cui vorresti lavorare. In alternativa, se ritieni che qualcosa manchi dalla documentazione attuale, apri una issue per discutere il tuo suggerimento.
+
+<!--
+## How can I contribute?
+-->
+
+## Come posso contribuire?
+
+<!--
+You can contribute by [opening an issue in the project repository](https://github.com/WordPress/wordpress-playground/issues/new) and describing what you'd like to add or change.
+-->
+
+Puoi contribuire [aprendo una issue nel repository del progetto](https://github.com/WordPress/wordpress-playground/issues/new) e descrivendo cosa vorresti aggiungere o cambiare.
+
+<!--
+If you feel up to it, write the content in the issue description, and the project contributors will take care of the rest.
+-->
+
+Se ti senti all'altezza, scrivi il contenuto nella descrizione dell'issue, e i contributori del progetto si occuperanno del resto.
+
+<!--
+Would you like to see the documentation in your language? Check the [Translation section](/contributing/translations).
+-->
+
+Vorresti vedere la documentazione nella tua lingua? Controlla la [sezione Traduzioni](/contributing/translations).
+
+<!--
+### Forking the repo, edit files locally and opening Pull Requests
+
+If you are familiar with markdown, you can [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) the `wordpress-playground` repo and propose changes and new documentation pages by submitting a Pull Request.
+
+The process of creating a branch to open new PRs with translated pages on the [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) repository is the same than contributing to other WordPress repositories such as gutenberg:
+https://developer.wordpress.org/block-editor/contributors/code/git-workflow/
+
+The documentation files (`.md` files) are stored in Playground's GitHub repository, [under `/packages/docs/site/docs`](https://github.com/WordPress/wordpress-playground/tree/trunk/packages/docs/site/docs) for English and [`/packages/docs/site/i18n`](https://github.com/WordPress/wordpress-playground/tree/trunk/packages/docs/site/i18n) for other languages.
+-->
+
+### Fare il fork del repository, modificare i file localmente e aprire Pull Request
+
+Se hai familiarità con markdown, puoi [fare il fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) del repository `wordpress-playground` e proporre modifiche e nuove pagine di documentazione inviando una Pull Request.
+
+Il processo di creazione di un branch per aprire nuove PR con pagine tradotte sul repository [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) è lo stesso del contribuire ad altri repository WordPress come gutenberg:
+https://developer.wordpress.org/block-editor/contributors/code/git-workflow/
+
+I file di documentazione (file `.md`) sono memorizzati nel repository GitHub di Playground, [sotto `/packages/docs/site/docs`](https://github.com/WordPress/wordpress-playground/tree/trunk/packages/docs/site/docs) per l'inglese e [`/packages/docs/site/i18n`](https://github.com/WordPress/wordpress-playground/tree/trunk/packages/docs/site/i18n) per altre lingue.
+
+<!--
+### Edit in the browser
+
+If logged in GitHub, you can also edit existing files (or add new ones) and submit a PR directly from the GitHub UI:
+
+1. Find the page you'd like to edit or the directory of the chapter you'd like to add a new page to.
+2. Click the **Add Files** button to add a new file, or click on an existing file and then click the pencil icon to edit it.
+3. GitHub will ask you to fork the repository and create a new branch with your changes.
+4. An editor will open where you can make the changes.
+5. When you're done, click the **Commit Changes** button and submit a Pull Request.
+
+That's it! You've just contributed to the WordPress Playground documentation.
+
+This approach means you don't need to clone the repository, set up a local development environment, or run any commands.
+
+The downside is that you won't be able to preview your changes. Keep reading to learn how to review your changes before submitting a Pull Request.
+-->
+
+### Modificare nel browser
+
+Se sei loggato su GitHub, puoi anche modificare file esistenti (o aggiungerne di nuovi) e inviare una PR direttamente dall'interfaccia GitHub:
+
+1. Trova la pagina che vorresti modificare o la directory del capitolo a cui vorresti aggiungere una nuova pagina.
+2. Clicca il pulsante **Add Files** per aggiungere un nuovo file, o clicca su un file esistente e poi clicca l'icona della matita per modificarlo.
+3. GitHub ti chiederà di fare il fork del repository e creare un nuovo branch con le tue modifiche.
+4. Si aprirà un editor dove puoi fare le modifiche.
+5. Quando hai finito, clicca il pulsante **Commit Changes** e invia una Pull Request.
+
+Ecco fatto! Hai appena contribuito alla documentazione WordPress Playground.
+
+Questo approccio significa che non devi clonare il repository, configurare un ambiente di sviluppo locale o eseguire comandi.
+
+Lo svantaggio è che non sarai in grado di visualizzare in anteprima le tue modifiche. Continua a leggere per imparare come rivedere le tue modifiche prima di inviare una Pull Request.
+
+<!--
+### Local preview
+
+Clone the repository and navigate to the directory on your device. Now run the following commands:
+
+```bash
+npm install
+npm run build:docs
+npm run dev:docs
+```
+
+The documentation site opens in a new browser tab and refreshes automatically with each change. Continue to edit the relevant file in your code editor and test the changes in real-time.
+-->
+
+### Anteprima locale
+
+Clona il repository e naviga nella directory sul tuo dispositivo. Ora esegui i seguenti comandi:
+
+```bash
+npm install
+npm run build:docs
+npm run dev:docs
+```
+
+Il sito di documentazione si apre in una nuova scheda del browser e si aggiorna automaticamente ad ogni modifica. Continua a modificare il file rilevante nel tuo editor di codice e testa le modifiche in tempo reale.

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/index.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/index.md
@@ -1,0 +1,102 @@
+---
+title: Contribuire al progetto WordPress Playground
+slug: /contributing
+id: introduction
+description: Il punto di partenza per contribuire a WordPress Playground. Trova le linee guida per codice, documentazione e segnalazione di bug.
+---
+
+<!--
+# Contributing to WordPress Playground project
+-->
+
+# Contribuire al progetto WordPress Playground
+
+<!--
+WordPress Playground is an open-source project that welcomes contributors of all kinds, from code to design, documentation to triage.
+-->
+
+WordPress Playground è un progetto open-source che accoglie contributori di tutti i tipi, dal codice al design, dalla documentazione al triage.
+
+<!--
+## How can I contribute?
+
+-   Code? See the [developer section](/contributing/code).
+-   Documentation? See the [documentation section](/contributing/documentation).
+-   Reporting bugs? Open a [new issue](https://github.com/WordPress/wordpress-playground/issues/new) in the main GitHub repository, or in [Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+-   Ideas, designs, or anything else? Open a [GitHub discussion](https://github.com/WordPress/wordpress-playground/discussions), and let's talk!
+-   Translation? see the [translation section](/contributing/translations).
+-->
+
+## Come posso contribuire?
+
+-   Codice? Vedi la [sezione sviluppatori](/contributing/code).
+-   Documentazione? Vedi la [sezione documentazione](/contributing/documentation).
+-   Segnalare bug? Apri una [nuova issue](https://github.com/WordPress/wordpress-playground/issues/new) nel repository principale GitHub, o in [Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+-   Idee, design o qualsiasi altra cosa? Apri una [discussione GitHub](https://github.com/WordPress/wordpress-playground/discussions), e parliamone!
+-   Traduzione? Vedi la [sezione traduzioni](/contributing/translations).
+
+<!--
+## Guidelines
+
+-   As with all WordPress projects, we want to ensure a welcoming and respectful environment for everyone. Please read our community's [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/) to learn more.
+-   Code contributors should review the [coding principles](/contributing/coding-standards).
+-   You maintain copyright over any contribution you make. By submitting a Pull Request, you agree to release that code under [WordPress Playground License](https://github.com/WordPress/wordpress-playground?tab=GPL-2.0-1-ov-file#readme).
+-->
+
+## Linee guida
+
+-   Come in tutti i progetti WordPress, vogliamo garantire un ambiente accogliente e rispettoso per tutti. Per favore leggi il [Codice di Condotta](https://make.wordpress.org/handbook/community-code-of-conduct/) della nostra community per saperne di più.
+-   I contributori di codice dovrebbero rivedere i [principi di codifica](/contributing/coding-standards).
+-   Mantieni il copyright su qualsiasi contributo che fai. Inviando una Pull Request, accetti di rilasciare quel codice sotto la [Licenza WordPress Playground](https://github.com/WordPress/wordpress-playground?tab=GPL-2.0-1-ov-file#readme).
+
+<!--
+## Triaging issues
+
+Want to help sort through open issues and resolve potential bugs? Here's how:
+
+1. Review the [list of open issues](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aopen+is%3Aissue) and find the ones that you can help with. Same goes for the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues?q=is%3Aopen+is%3Aissue).
+2. Read through the description and comments.
+3. If it's a bug you can reproduce, add a descriptive comment or a potential fix.
+4. Otherwise, add a comment with any additional information that may be helpful.
+-->
+
+## Gestione delle issue
+
+Vuoi aiutare a ordinare le issue aperte e risolvere potenziali bug? Ecco come:
+
+1. Rivedi l'[elenco delle issue aperte](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aopen+is%3Aissue) e trova quelle con cui puoi aiutare. Lo stesso vale per il [repository Playground Tools](https://github.com/WordPress/playground-tools/issues?q=is%3Aopen+is%3Aissue).
+2. Leggi la descrizione e i commenti.
+3. Se è un bug che puoi riprodurre, aggiungi un commento descrittivo o una potenziale soluzione.
+4. Altrimenti, aggiungi un commento con qualsiasi informazione aggiuntiva che possa essere utile.
+
+<!--
+## A note on contributing and the GPL license
+
+WordPress Playground and the WordPress project are strongly rooted in free and open source software. Specifically, WordPress Playground is licenced under GPLv2 (or later) from the [Free Software Foundation](https://www.fsf.org/). You can [read the text of the license here](https://github.com/WordPress/wordpress-playground/blob/trunk/LICENSE) and if that feels overwhelming, WordPress.org has a [friendly GPL Primer](https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/gpl-primer/).
+
+As such, please be aware of the implications that your contributions will fall under:
+
+-   When you contribute, you agree to license your contributions under the GPLv2 (or later) license
+-   The GPL license has strong copyleft provisions that ensure all derivative works remain open-source and under the same license terms, thereby promoting a collaborative development environment.
+-   The GPL license encourages contributing any changes, bug fixes, or new features back to the original codebase.
+-   The GPL license ensures that the project remains free and open-source, not only in terms of cost but also with respect to the freedom to use, modify, and distribute the software.
+
+If you have any questions about how the above might affect your contributions, please feel free to reach out on WP Slack and the [`meta-playground` channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+
+Thank you again for your contributions! 🎉
+-->
+
+## Una nota su contribuire e la licenza GPL
+
+WordPress Playground e il progetto WordPress sono fortemente radicati nel software libero e open source. In particolare, WordPress Playground è rilasciato sotto licenza GPLv2 (o successiva) dalla [Free Software Foundation](https://www.fsf.org/). Puoi [leggere il testo della licenza qui](https://github.com/WordPress/wordpress-playground/blob/trunk/LICENSE) e se ti sembra troppo complesso, WordPress.org ha un [GPL Primer amichevole](https://make.wordpress.org/community/handbook/wordcamp-organizer/planning-details/gpl-primer/).
+
+Di conseguenza, per favore sii consapevole delle implicazioni che i tuoi contributi avranno:
+
+-   Quando contribuisci, accetti di rilasciare i tuoi contributi sotto la licenza GPLv2 (o successiva)
+-   La licenza GPL ha forti disposizioni copyleft che garantiscono che tutte le opere derivate rimangano open-source e sotto gli stessi termini di licenza, promuovendo così un ambiente di sviluppo collaborativo.
+-   La licenza GPL incoraggia a contribuire con qualsiasi modifica, correzione di bug o nuova funzionalità al codice sorgente originale.
+-   La licenza GPL garantisce che il progetto rimanga libero e open-source, non solo in termini di costo ma anche rispetto alla libertà di utilizzare, modificare e distribuire il software.
+
+Se hai domande su come quanto sopra potrebbe influenzare i tuoi contributi, sentiti libero di contattarci su WP Slack nel canale [`meta-playground`](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+
+Grazie ancora per i tuoi contributi! 🎉

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -669,9 +669,9 @@ To simplify the review process, please keep the original English text as a comme
 Playground is an online tool to experiment and learn about WordPress. This site (Documentation) is where you will find all the information you need to start using Playground.
 -->
 
-👋 Olá! Bem vindo a documentação oficial do WordPress Playground.
+👋 Ciao! Benvenuto nella documentazione ufficiale di WordPress Playground.
 
-WordPress Playground é uma ferramenta online onde podes testar e aprender mais sobre o WordPress. Nesta página(Documentação) irá encontrar todas as informações necessárias para começar a trabalhar com o Playground.
+WordPress Playground è uno strumento online dove puoi testare e imparare di più su WordPress. In questa pagina (Documentazione) troverai tutte le informazioni necessarie per iniziare a lavorare con Playground.
 
 ```
 

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -1,0 +1,712 @@
+---
+slug: /contributing/translations
+title: Contributi alle traduzioni
+description: Impara come tradurre la documentazione Playground, inclusa la struttura dei file, i test locali e il processo di revisione.
+---
+
+<!--
+# Contributions to translations
+-->
+
+# Contributi alle traduzioni
+
+<!--
+Help make WordPress Playground accessible to a global audience by translating its documentation. This guide provides everything you need to know to get started. Contributing translations follows the same workflow as any other documentation change. You can either fork the [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) repository and create a pull request (PR) with your changes or edit pages directly using the GitHub UI.
+-->
+
+Aiuta a rendere WordPress Playground accessibile a un pubblico globale traducendo la sua documentazione. Questa guida fornisce tutto ciò che devi sapere per iniziare. Contribuire alle traduzioni segue lo stesso workflow di qualsiasi altra modifica alla documentazione. Puoi fare il fork del repository [WordPress/wordpress-playground](https://github.com/WordPress/wordpress-playground) e creare una pull request (PR) con le tue modifiche o modificare le pagine direttamente usando l'interfaccia GitHub.
+
+<!--
+:::info
+For a detailed guide on the contribution workflow (forking, creating PRs, etc.), please see our [documentation contribution guide](/contributing/documentation#how-can-i-contribute)
+:::
+-->
+
+:::info
+Per una guida dettagliata sul workflow di contribuzione (fork, creazione di PR, ecc.), per favore vedi la nostra [guida ai contributi alla documentazione](/contributing/documentation#how-can-i-contribute)
+:::
+
+<!--
+## How Translations Work
+-->
+
+## Come funzionano le traduzioni
+
+<!--
+Playground's documentation site is built with Docusaurus, which handles the internationalization (i18n) features.
+-->
+
+Il sito di documentazione Playground è costruito con Docusaurus, che gestisce le funzionalità di internazionalizzazione (i18n).
+
+<!--
+:::info
+To learn more about how Docusaurus manages translations, see the [Internationalization section](https://docusaurus.io/docs/i18n/introduction) of the official Docusaurus documentation.
+:::
+-->
+
+:::info
+Per saperne di più su come Docusaurus gestisce le traduzioni, vedi la [sezione Internazionalizzazione](https://docusaurus.io/docs/i18n/introduction) della documentazione ufficiale di Docusaurus.
+:::
+
+<!--
+### Configuration
+
+Available languages are defined in the `packages/docs/site/docusaurus.config.js` file. For example:
+
+```
+i18n: {
+  defaultLocale: 'en',
+  path: 'i18n',
+  locales: ['en', 'fr'],
+  localeConfigs: {
+	en: {
+		label: 'English',
+		path: 'en',
+	},
+	fr: {
+		label: 'French',
+		path: 'fr',
+	},
+  },
+}
+```
+-->
+
+### Configurazione
+
+Le lingue disponibili sono definite nel file `packages/docs/site/docusaurus.config.js`. Per esempio:
+
+```
+i18n: {
+  defaultLocale: 'en',
+  path: 'i18n',
+  locales: ['en', 'fr'],
+  localeConfigs: {
+	en: {
+		label: 'English',
+		path: 'en',
+	},
+	fr: {
+		label: 'French',
+		path: 'fr',
+	},
+  },
+}
+```
+
+<!--
+### File Structure
+
+All translated documentation pages are located within the `packages/docs/site/i18n/` directory, organized by language code.
+
+For a language to work correctly, its file structure must mirror the original English documentation found in `packages/docs/site/docs`.
+
+For example, the Spanish (es) translation for `docs/main/intro.md` must be placed at:
+packages`/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`.
+
+If a translated file does not exist for a specific language, Docusaurus will automatically fall back to the English version of that page.
+-->
+
+### Struttura dei file
+
+Tutte le pagine di documentazione tradotte si trovano nella directory `packages/docs/site/i18n/`, organizzate per codice lingua.
+
+Affinché una lingua funzioni correttamente, la sua struttura dei file deve rispecchiare la documentazione inglese originale trovata in `packages/docs/site/docs`.
+
+Per esempio, la traduzione spagnola (es) per `docs/main/intro.md` deve essere posizionata in:
+`packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/intro.md`.
+
+Se un file tradotto non esiste per una lingua specifica, Docusaurus passerà automaticamente alla versione inglese di quella pagina.
+
+<!--
+### Generating Translation Files
+
+When adding a new language, you can generate the necessary JSON files for UI strings (like button labels and navigation items) by running the following command from the `packages/docs/site` directory:
+
+```bash
+npm run write-translations -- --locale <LANGUAGE_CODE>
+```
+
+With the proper i18n `docusaurus.config.js` configuration and files under `i18n` when running `npm run build:docs` from the root of the project, specific folders under `dist` for each language will be created.
+-->
+
+### Generare i file di traduzione
+
+Quando aggiungi una nuova lingua, puoi generare i file JSON necessari per le stringhe dell'interfaccia utente (come etichette dei pulsanti e elementi di navigazione) eseguendo il seguente comando dalla directory `packages/docs/site`:
+
+```bash
+npm run write-translations -- --locale <LANGUAGE_CODE>
+```
+
+Con la configurazione i18n corretta in `docusaurus.config.js` e i file sotto `i18n`, quando esegui `npm run build:docs` dalla root del progetto, verranno create cartelle specifiche sotto `dist` per ogni lingua.
+
+<!--
+## Testing Translations Locally
+
+To preview your changes for an existing language:
+
+1. Modify or add a translated file in the appropriate language directory, such as `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/`.
+2. From the `/packages/docs/site` directory, run the local development server for your target language. For example, to test Spanish (es):
+
+```bash
+
+npm run dev -- --locale es
+
+```
+-->
+
+## Testare le traduzioni localmente
+
+Per visualizzare in anteprima le tue modifiche per una lingua esistente:
+
+1. Modifica o aggiungi un file tradotto nella directory della lingua appropriata, come `packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/`.
+2. Dalla directory `/packages/docs/site`, esegui il server di sviluppo locale per la tua lingua target. Per esempio, per testare lo spagnolo (es):
+
+```bash
+
+npm run dev -- --locale es
+
+```
+
+<!--
+## The Language Switcher
+
+The language switcher is a dropdown menu that allows users to select their preferred language.
+
+![Documentation Language Switcher](@site/static/img/contributing/language-switcher-docs.webp)
+-->
+
+## Il selettore della lingua
+
+Il selettore della lingua è un menu a tendina che permette agli utenti di selezionare la loro lingua preferita.
+
+![Selettore lingua documentazione](@site/static/img/contributing/language-switcher-docs.webp)
+
+<!--
+### Making a language publicly available on the Language Switcher
+
+We recommend only adding a language to the switcher when a significant portion of the documentation has been translated. This avoids a poor user experience where switching to a new language results in seeing mostly untranslated English content.
+
+As a guideline, a language should be made publicly available in the switcher only when the entire "Documentation" hub is translated, including these key sections:
+
+-   [Quick Start Guide](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+-   [Playground web instance](https://wordpress.github.io/wordpress-playground/web-instance)
+-   [About Playground](https://wordpress.github.io/wordpress-playground/about)
+-   [Guides](https://wordpress.github.io/wordpress-playground/guides)
+-   [Contributing](https://wordpress.github.io/wordpress-playground/contributing)
+-   [Links and Resources](https://wordpress.github.io/wordpress-playground/resources)
+
+All languages are available once the i18n setup for a language is complete and the correct file structure is in place under `i18n`.
+
+-   https://wordpress.github.io/wordpress-playground/
+-   https://wordpress.github.io/wordpress-playground/es/
+-   https://wordpress.github.io/wordpress-playground/fr/
+
+Assuming the `fr` language is the first language with the Documentation hub pages (Quick Start Guide, Playground web instance, About Playground, Guides,... ) completely translated to French, the `docusaurus.config.js` should look like this in that branch so `npm run build:docs` properly generate the `fr` subsite and only displays the french language in the `localeDropdown` language switcher.
+
+```
+  {
+    "i18n": {
+      "defaultLocale": "en",
+      "path": "i18n",
+      "locales": [
+        "en",
+        "fr"
+      ],
+      "localeConfigs": {
+        "en": {
+          "label": "English",
+          "path": "en"
+        },
+        "fr": {
+          "label": "French",
+          "path": "fr"
+        }
+      }
+    }
+  },
+  {
+    "type": "localeDropdown",
+    "position": "right"
+  }
+```
+-->
+
+### Rendere una lingua pubblicamente disponibile nel selettore della lingua
+
+Raccomandiamo di aggiungere una lingua al selettore solo quando una parte significativa della documentazione è stata tradotta. Questo evita una scarsa esperienza utente dove passare a una nuova lingua risulta nel vedere principalmente contenuto inglese non tradotto.
+
+Come linea guida, una lingua dovrebbe essere resa pubblicamente disponibile nel selettore solo quando l'intero hub "Documentazione" è tradotto, inclusi questi capitoli chiave:
+
+-   [Guida rapida](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+-   [Istanza web Playground](https://wordpress.github.io/wordpress-playground/web-instance)
+-   [Informazioni su Playground](https://wordpress.github.io/wordpress-playground/about)
+-   [Guide](https://wordpress.github.io/wordpress-playground/guides)
+-   [Contribuire](https://wordpress.github.io/wordpress-playground/contributing)
+-   [Link e risorse](https://wordpress.github.io/wordpress-playground/resources)
+
+Tutte le lingue sono disponibili una volta che la configurazione i18n per una lingua è completa e la struttura dei file corretta è in posto sotto `i18n`.
+
+-   https://wordpress.github.io/wordpress-playground/
+-   https://wordpress.github.io/wordpress-playground/es/
+-   https://wordpress.github.io/wordpress-playground/fr/
+
+Assumendo che la lingua `fr` sia la prima lingua con le pagine dell'hub Documentazione (Guida rapida, Istanza web Playground, Informazioni su Playground, Guide,... ) completamente tradotte in francese, il `docusaurus.config.js` dovrebbe apparire così in quel branch così `npm run build:docs` genera correttamente il sottosito `fr` e mostra solo la lingua francese nel selettore della lingua `localeDropdown`.
+
+```
+  {
+    "i18n": {
+      "defaultLocale": "en",
+      "path": "i18n",
+      "locales": [
+        "en",
+        "fr"
+      ],
+      "localeConfigs": {
+        "en": {
+          "label": "English",
+          "path": "en"
+        },
+        "fr": {
+          "label": "French",
+          "path": "fr"
+        }
+      }
+    }
+  },
+  {
+    "type": "localeDropdown",
+    "position": "right"
+  }
+```
+
+<!--
+## Translation Workflow
+
+Follow these steps to translate a page:
+
+1. **Check for an Existing Translation Issue**: First, [search the repository issues](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20%5Btranslation%5D%20progress) to see if a tracking issue for your desired language already exists. If it does, comment on the issue to claim the page(s) you would like to translate.
+2. **Create a New Translation Issue**: If no issue exists, please create a new one to track the translation progress for the language. You can model it after issue [#2202](https://github.com/WordPress/wordpress-playground/issues/2202) and use the markdown checklist below to track progress.
+3. **Translate the File**:
+
+-   Check if you have the latest version of the documentation
+-   Copy the original .md file from `packages/docs/site/docs/...` to the corresponding path in the language directory (e.g., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). It is crucial to replicate the original file structure.
+-   Translate the content of the new file, keeping the original content commented out `<!-- English Content -->`.
+
+-   The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
+-   Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
+
+4. **Create a pull request with your changes**
+
+-   Add a prefix to the title `[i18n]` to help to identify the translations
+-   Describe the pages that you translated
+-   Request a review at `#playground` or `#polyglots` at `wordpress.slack.com`
+
+:::info
+We highly recommend submitting pull requests with a small number of translated pages. This approach simplifies the review process and allows for a more gradual and manageable integration of your work.
+:::
+-->
+
+## Workflow di traduzione
+
+Segui questi passaggi per tradurre una pagina:
+
+1. **Cerca una issue di traduzione esistente**: Prima, [cerca le issue del repository](https://github.com/WordPress/wordpress-playground/issues?q=is%3Aissue%20state%3Aopen%20%5Btranslation%5D%20progress) per vedere se esiste già una issue di tracciamento per la lingua desiderata. Se esiste, commenta l'issue per rivendicare la/e pagina/e che vorresti tradurre.
+2. **Crea una nuova issue di traduzione**: Se non esiste una issue, per favore creane una nuova per tracciare i progressi della traduzione per la lingua. Puoi modellarla sull'issue [#2202](https://github.com/WordPress/wordpress-playground/issues/2202) e usare la checklist markdown qui sotto per tracciare i progressi.
+3. **Traduci il file**:
+
+-   Controlla se hai l'ultima versione della documentazione
+-   Copia il file .md originale da `packages/docs/site/docs/...` al percorso corrispondente nella directory della lingua (es., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). È cruciale replicare la struttura dei file originale.
+-   Traduci il contenuto del nuovo file, mantenendo il contenuto originale commentato `<!-- Contenuto inglese -->`.
+-   Le risorse sono elencate in `packages/docs/site/static/img/` posiziona le risorse dentro la cartella di traduzione solo quando richiede contenuto localizzato.
+-   Una volta che le traduzioni sono pronte, controlla se lo script di build della documentazione funziona correttamente `npm run build:docs`.
+
+4. **Crea una pull request con le tue modifiche**
+
+-   Aggiungi un prefisso al titolo `[i18n]` per aiutare a identificare le traduzioni
+-   Descrivi le pagine che hai tradotto
+-   Richiedi una revisione su `#playground` o `#polyglots` su `wordpress.slack.com`
+
+:::info
+Raccomandiamo fortemente di inviare pull request con un piccolo numero di pagine tradotte. Questo approccio semplifica il processo di revisione e permette un'integrazione più graduale e gestibile del tuo lavoro.
+:::
+
+<!--
+### Translation Tracking Template
+
+You can use the following markdown in your tracking issue:
+
+```
+## Remaining translation pages
+
+<details open>
+<summary><h3>Main</h3></summary>
+
+- about
+  - [ ] build.md #2291
+  - [ ] index.md #2282
+  - [ ] launch.md #2292
+  - [ ] test.md #2302
+- contributing
+  - [ ] code.md #2218
+  - [ ] coding-standards.md #2219
+  - [ ] contributor-day.md #2246
+  - [ ] contributor-badge.md
+  - [ ] documentation.md #2271
+  - [ ] translations.md #2201
+- guides
+  - [ ] for-plugin-developers.md #2210
+  - [ ] for-theme-developers.md #2211
+  - [ ] index.md #2209
+  - [ ] providing-content-for-your-demo.md #2213
+  - [ ] wordpress-native-ios-app.md #2214
+- [ ] intro.md #2198
+- [ ] quick-start-guide.md #2204
+- [ ] resources.md #2207
+- [ ] web-instance.md #2208
+
+</details>
+
+<details open>
+<summary><h3>Blueprints</h3></summary>
+
+- blueprints
+  - [ ] 01-index.md #2305
+  - [ ] 02-using-blueprints.md #2330
+  - [ ] 03-data-format.md #2340
+   - [ ] 04-resources.md #2352
+   - [ ] 05-steps-shorthands.md  #2386
+  - [ ] 05-steps.md  #2386
+  - [ ] 06-bundles.md #2438
+   - [ ] 07-json-api-and-function-api.md #2438
+   - [ ] 08-examples.md #2474
+   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
+   - [ ] intro.md #2489
+   - tutorial
+       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
+       - [ ] 02-how-to-load-run-blueprints.md #2526
+       - [ ] 03-build-your-first-blueprint.md
+       - [ ] index.md #2511
+</details>
+
+<details open>
+<summary><h3>Developers</h3></summary>
+
+- [ ] developers
+   - [ ] 03-build-an-app
+      - [ ] 01-index.md
+   - [ ] 05-local-development
+      - [ ] 01-wp-now.md
+      - [ ] 02-vscode-extension.md
+      - [ ] 03-php-wasm-node.md
+      - [ ] intro.md
+   - [ ] 06-apis
+      - [ ] 01-index.md
+      - [ ] javascript-api
+         - [ ] 01-index.md
+         - [ ] 02-index-html-vs-remote-html.md
+         - [ ] 03-playground-api-client.md
+         - [ ] 04-blueprint-json-in-api-client.md
+         - [ ] 05-blueprint-functions-in-api-client.md
+         - [ ] 06-mount-data.md
+      - [ ] query-api
+          - [ ] 01-index.md
+   - [ ] 23-architecture
+      - [ ] 01-index.md
+      - [ ] 02-wasm-php-overview.md
+      - [ ] 03-wasm-php-compiling.md
+      - [ ] 04-wasm-php-javascript-module.md
+      - [ ] 05-wasm-php-filesystem.md
+      - [ ] 07-wasm-asyncify.md
+      - [ ] 08-browser-concepts.md
+      - [ ] 09-browser-tab-orchestrates-execution.md
+      - [ ] 10-browser-iframe-rendering.md
+      - [ ] 11-browser-php-worker-threads.md
+      - [ ] 12-browser-service-workers.md
+      - [ ] 13-browser-scopes.md
+      - [ ] 14-browser-cross-process-communication.md
+      - [ ] 15-wordpress.md
+      - [ ] 16-wordpress-database.md
+      - [ ] 17-browser-wordpress.md
+      - [ ] 18-host-your-own-playground.md
+   - [ ] 24-limitations
+      - [ ] 01-index.md
+   - [ ] intro-devs.md
+</details>
+```
+-->
+
+### Template di tracciamento traduzioni
+
+Puoi usare il seguente markdown nella tua issue di tracciamento:
+
+```
+## Pagine di traduzione rimanenti
+
+<details open>
+<summary><h3>Main</h3></summary>
+
+- about
+  - [ ] build.md #2291
+  - [ ] index.md #2282
+  - [ ] launch.md #2292
+  - [ ] test.md #2302
+- contributing
+  - [ ] code.md #2218
+  - [ ] coding-standards.md #2219
+  - [ ] contributor-day.md #2246
+  - [ ] contributor-badge.md
+  - [ ] documentation.md #2271
+  - [ ] translations.md #2201
+- guides
+  - [ ] for-plugin-developers.md #2210
+  - [ ] for-theme-developers.md #2211
+  - [ ] index.md #2209
+  - [ ] providing-content-for-your-demo.md #2213
+  - [ ] wordpress-native-ios-app.md #2214
+- [ ] intro.md #2198
+- [ ] quick-start-guide.md #2204
+- [ ] resources.md #2207
+- [ ] web-instance.md #2208
+
+</details>
+
+<details open>
+<summary><h3>Blueprints</h3></summary>
+
+- blueprints
+  - [ ] 01-index.md #2305
+  - [ ] 02-using-blueprints.md #2330
+  - [ ] 03-data-format.md #2340
+   - [ ] 04-resources.md #2352
+   - [ ] 05-steps-shorthands.md  #2386
+  - [ ] 05-steps.md  #2386
+  - [ ] 06-bundles.md #2438
+   - [ ] 07-json-api-and-function-api.md #2438
+   - [ ] 08-examples.md #2474
+   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
+   - [ ] intro.md #2489
+   - tutorial
+       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
+       - [ ] 02-how-to-load-run-blueprints.md #2526
+       - [ ] 03-build-your-first-blueprint.md
+       - [ ] index.md #2511
+</details>
+
+<details open>
+<summary><h3>Developers</h3></summary>
+
+- [ ] developers
+   - [ ] 03-build-an-app
+      - [ ] 01-index.md
+   - [ ] 05-local-development
+      - [ ] 01-wp-now.md
+      - [ ] 02-vscode-extension.md
+      - [ ] 03-php-wasm-node.md
+      - [ ] intro.md
+   - [ ] 06-apis
+      - [ ] 01-index.md
+      - [ ] javascript-api
+         - [ ] 01-index.md
+         - [ ] 02-index-html-vs-remote-html.md
+         - [ ] 03-playground-api-client.md
+         - [ ] 04-blueprint-json-in-api-client.md
+         - [ ] 05-blueprint-functions-in-api-client.md
+         - [ ] 06-mount-data.md
+      - [ ] query-api
+          - [ ] 01-index.md
+   - [ ] 23-architecture
+      - [ ] 01-index.md
+      - [ ] 02-wasm-php-overview.md
+      - [ ] 03-wasm-php-compiling.md
+      - [ ] 04-wasm-php-javascript-module.md
+      - [ ] 05-wasm-php-filesystem.md
+      - [ ] 07-wasm-asyncify.md
+      - [ ] 08-browser-concepts.md
+      - [ ] 09-browser-tab-orchestrates-execution.md
+      - [ ] 10-browser-iframe-rendering.md
+      - [ ] 11-browser-php-worker-threads.md
+      - [ ] 12-browser-service-workers.md
+      - [ ] 13-browser-scopes.md
+      - [ ] 14-browser-cross-process-communication.md
+      - [ ] 15-wordpress.md
+      - [ ] 16-wordpress-database.md
+      - [ ] 17-browser-wordpress.md
+      - [ ] 18-host-your-own-playground.md
+   - [ ] 24-limitations
+      - [ ] 01-index.md
+   - [ ] intro-devs.md
+</details>
+```
+
+<!--
+### Translating with the GitHub Web Interface
+
+If you prefer not to use developer tools, you can easily contribute translations directly on the GitHub website. All you need is a free GitHub account.
+
+This guide will show you how to both update an existing translation and add a brand-new one.
+
+---
+-->
+
+### Tradurre con l'interfaccia web GitHub
+
+Se preferisci non usare strumenti per sviluppatori, puoi facilmente contribuire alle traduzioni direttamente sul sito GitHub. Tutto ciò di cui hai bisogno è un account GitHub gratuito.
+
+Questa guida ti mostrerà come aggiornare una traduzione esistente e aggiungerne una completamente nuova.
+
+---
+
+<!--
+#### Updating an Existing Translation
+
+1.  **Navigate to the file.** Go to the repository and find the file you want to update. Translation files are located in a folder named after their language code. For example, all French translations are in `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`.
+
+2.  **Open the editor.** Select the file you wish to edit and click the pencil icon (**Edit this file**) in the upper right corner.
+    ![Editing existing translation](@site/static/img/contributing/editing-translations.webp)
+
+3.  **Fork the repository.** GitHub will automatically prompt you to **Fork this repository**. This creates a personal copy for you to edit safely. Click the button to proceed.
+
+4.  **Make your changes.** The editor will open in your browser. Update the text with your improved translations.
+
+5.  **Propose your changes.** Once you are finished, scroll to the bottom of the page. Add a brief title and description of your changes (e.g., "Fixing typos in French translation") and click the **Propose changes** button.
+
+6.  **Create a Pull Request.** On the next screen, click the **Create pull request** button. This will submit your changes to the project maintainers for review.
+
+---
+-->
+
+#### Aggiornare una traduzione esistente
+
+1.  **Naviga al file.** Vai al repository e trova il file che vuoi aggiornare. I file di traduzione si trovano in una cartella denominata con il codice della lingua. Per esempio, tutte le traduzioni francesi sono in `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`.
+
+2.  **Apri l'editor.** Seleziona il file che desideri modificare e clicca l'icona della matita (**Modifica questo file**) nell'angolo in alto a destra.
+    ![Modifica traduzione esistente](@site/static/img/contributing/editing-translations.webp)
+
+3.  **Fai il fork del repository.** GitHub ti chiederà automaticamente di **Fare il fork di questo repository**. Questo crea una copia personale per te da modificare in sicurezza. Clicca il pulsante per procedere.
+
+4.  **Fai le tue modifiche.** L'editor si aprirà nel tuo browser. Aggiorna il testo con le tue traduzioni migliorate.
+
+5.  **Proponi le tue modifiche.** Una volta finito, scorri fino in fondo alla pagina. Aggiungi un breve titolo e descrizione delle tue modifiche (es., "Correzione di errori di battitura nella traduzione francese") e clicca il pulsante **Proponi modifiche**.
+
+6.  **Crea una Pull Request.** Nella schermata successiva, clicca il pulsante **Crea pull request**. Questo invierà le tue modifiche ai maintainer del progetto per la revisione.
+
+---
+
+<!--
+#### Adding a New Translation
+
+1.  **Determine the correct file path.** The new file's path and name must mirror the original English file.
+
+    -   **English original:** `packages/docs/site/docs/main/contributing/documentation.md`
+    -   **French translation:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
+
+2.  **Create the new file.** Navigate to the correct language folder (e.g., `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Click **Add file** > **Create new file**.
+    ![Creating a new translation](@site/static/img/contributing/adding-file-github-ui.webp)
+
+    -   **Pro Tip:** In the filename box, you can create new folders by typing the folder name followed by a `/`. For example, typing `main/contributing/documentation.md` will create the `main` and `contributing` folders automatically.
+
+3.  **Fork the repository.** Just like before, GitHub will prompt you to **Fork this repository**. Click the button to create your personal copy.
+
+4.  **Add the translated content.** The editor will open with an empty file. For the convenience of reviewers, please copy the content from the original English file and paste it into your new file, wrapping it in comment tags. Add your translation below it.
+
+    ```markdown
+    <!--
+    This is the original English content.
+    It helps reviewers understand the context of the translation.
+    -->
+
+    Ceci est le contenu traduit en français.
+    ```
+
+    ![GitHub UI Editor](@site/static/img/contributing/editor-github-ui.webp)
+
+5.  **Commit the new file.** When you are done, scroll to the bottom. Add a title for your new file (e.g., "Add French translation for documentation.md") and click the **Commit new file** button.
+
+6.  **Create a Pull Request.** On the next screen, click **Create pull request** to submit your new translation for review.
+    -->
+
+#### Aggiungere una nuova traduzione
+
+1.  **Determina il percorso del file corretto.** Il percorso e il nome del nuovo file devono rispecchiare il file inglese originale.
+
+    -   **Originale inglese:** `packages/docs/site/docs/main/contributing/documentation.md`
+    -   **Traduzione francese:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
+
+2.  **Crea il nuovo file.** Naviga nella cartella della lingua corretta (es., `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Clicca **Add file** > **Create new file**.
+    ![Creazione nuova traduzione](@site/static/img/contributing/adding-file-github-ui.webp)
+
+    -   **Suggerimento:** Nella casella del nome file, puoi creare nuove cartelle digitando il nome della cartella seguito da `/`. Per esempio, digitando `main/contributing/documentation.md` creerà automaticamente le cartelle `main` e `contributing`.
+
+3.  **Fai il fork del repository.** Proprio come prima, GitHub ti chiederà di **Fare il fork di questo repository**. Clicca il pulsante per creare la tua copia personale.
+
+4.  **Aggiungi il contenuto tradotto.** L'editor si aprirà con un file vuoto. Per comodità dei revisori, per favore copia il contenuto dal file inglese originale e incollalo nel tuo nuovo file, avvolgendolo in tag di commento. Aggiungi la tua traduzione sotto di esso.
+
+    ```markdown
+    <!--
+    Questo è il contenuto inglese originale.
+    Aiuta i revisori a capire il contesto della traduzione.
+    -->
+
+    Questo è il contenuto tradotto in italiano.
+    ```
+
+    ![Editor interfaccia GitHub](@site/static/img/contributing/editor-github-ui.webp)
+
+5.  **Committa il nuovo file.** Quando hai finito, scorri fino in fondo. Aggiungi un titolo per il tuo nuovo file (es., "Aggiungi traduzione italiana per documentation.md") e clicca il pulsante **Commit new file**.
+
+6.  **Crea una Pull Request.** Nella schermata successiva, clicca **Create pull request** per inviare la tua nuova traduzione per la revisione.
+
+<!--
+## Review Process
+
+To simplify the review process, please keep the original English text as a comment directly above the translated content.
+
+```
+<!--
+👋 Hi! Welcome to WordPress Playground documentation.
+
+Playground is an online tool to experiment and learn about WordPress. This site (Documentation) is where you will find all the information you need to start using Playground.
+-->
+
+👋 Olá! Bem vindo a documentação oficial do WordPress Playground.
+
+WordPress Playground é uma ferramenta online onde podes testar e aprender mais sobre o WordPress. Nesta página(Documentação) irá encontrar todas as informações necessárias para começar a trabalhar com o Playground.
+
+```
+
+:::info
+This practice also helps the maintenance team identify outdated translations. When the original English content is updated, we can search the codebase for the old text (now in comments) and flag the corresponding translation for review.
+:::
+
+To find a reviewer fluent in the language of your PR, you can post a request on the [Make WordPress Polyglots blog](https://make.wordpress.org/polyglots/). Be sure to include the locale tag (e.g., #ja for Japanese) to notify the appropriate General Translation Editors (GTEs).
+
+When the PR is merged, the translated version of that page should appear under `https://wordpress.github.io/wordpress-playground/{%LANGUAGE%}`, if you are contributing for the first time request your [Contributor Badge](/contributing/contributor-badge).
+-->
+
+## Processo di revisione
+
+Per semplificare il processo di revisione, per favore mantieni il testo inglese originale come commento direttamente sopra il contenuto tradotto.
+
+```
+
+<!--
+👋 Ciao! Benvenuto nella documentazione WordPress Playground.
+
+Playground è uno strumento online per sperimentare e imparare su WordPress. Questo sito (Documentazione) è dove troverai tutte le informazioni di cui hai bisogno per iniziare a usare Playground.
+-->
+
+👋 Ciao! Benvenuto nella documentazione ufficiale di WordPress Playground.
+
+WordPress Playground è uno strumento online dove puoi testare e imparare di più su WordPress. In questa pagina (Documentazione) troverai tutte le informazioni necessarie per iniziare a lavorare con Playground.
+
+```
+
+:::info
+Questa pratica aiuta anche il team di manutenzione a identificare traduzioni obsolete. Quando il contenuto inglese originale viene aggiornato, possiamo cercare nel codebase il vecchio testo (ora nei commenti) e segnalare la traduzione corrispondente per la revisione.
+:::
+
+Per trovare un revisore fluente nella lingua della tua PR, puoi pubblicare una richiesta sul [blog Make WordPress Polyglots](https://make.wordpress.org/polyglots/). Assicurati di includere il tag locale (es., #it per l'italiano) per notificare gli Editor Generali di Traduzione (GTE) appropriati.
+
+Quando la PR viene mergiata, la versione tradotta di quella pagina dovrebbe apparire su `https://wordpress.github.io/wordpress-playground/{%LANGUAGE%}`, se stai contribuendo per la prima volta richiedi il tuo [Badge Contributore](/contributing/contributor-badge).
+```

--- a/packages/docs/site/i18n/it/docusaurus-theme-classic/footer.json
+++ b/packages/docs/site/i18n/it/docusaurus-theme-classic/footer.json
@@ -1,0 +1,42 @@
+{
+	"link.title.Docs": {
+		"message": "Documentazione",
+		"description": "The title of the footer links column with title=Docs in the footer"
+	},
+	"link.title.Community": {
+		"message": "Community",
+		"description": "The title of the footer links column with title=Community in the footer"
+	},
+	"link.item.label.Documentation": {
+		"message": "Documentazione",
+		"description": "The label of footer link with label=Documentation linking to /"
+	},
+	"link.item.label.Blueprints": {
+		"message": "Blueprint",
+		"description": "The label of footer link with label=Blueprints linking to /blueprints"
+	},
+	"link.item.label.Developers": {
+		"message": "Sviluppatori",
+		"description": "The label of footer link with label=Developers linking to /developers"
+	},
+	"link.item.label.API Reference": {
+		"message": "Riferimento API",
+		"description": "The label of footer link with label=API Reference linking to /api"
+	},
+	"link.item.label.GitHub": {
+		"message": "GitHub",
+		"description": "The label of footer link with label=GitHub linking to https://github.com/WordPress/wordpress-playground"
+	},
+	"link.item.label.#playground on Slack": {
+		"message": "#playground su Slack",
+		"description": "The label of footer link with label=#playground on Slack linking to https://make.wordpress.org/chat"
+	},
+	"copyright": {
+		"message": "Copyright © 2025 WordPress Playground, Inc. Costruito con Docusaurus.",
+		"description": "The footer copyright"
+	},
+	"logo.alt": {
+		"message": "Il Codice è Poesia",
+		"description": "The alt text of footer logo"
+	}
+}

--- a/packages/docs/site/i18n/it/docusaurus-theme-classic/navbar.json
+++ b/packages/docs/site/i18n/it/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,26 @@
+{
+	"title": {
+		"message": "WordPress Playground",
+		"description": "The title in the navbar"
+	},
+	"logo.alt": {
+		"message": "WordPress Playground",
+		"description": "The alt text of navbar logo"
+	},
+	"item.label.Documentation": {
+		"message": "Documentazione",
+		"description": "Navbar item with label Documentation"
+	},
+	"item.label.Blueprints": {
+		"message": "Blueprint",
+		"description": "Navbar item with label Blueprints"
+	},
+	"item.label.Developers": {
+		"message": "Sviluppatori",
+		"description": "Navbar item with label Developers"
+	},
+	"item.label.API Reference": {
+		"message": "Riferimento API",
+		"description": "Navbar item with label API Reference"
+	}
+}

--- a/packages/docs/site/i18n/it/kapa-ai-plugin/kapa-ai.json
+++ b/packages/docs/site/i18n/it/kapa-ai-plugin/kapa-ai.json
@@ -1,0 +1,18 @@
+{
+	"kapaAi.modalTitle": {
+		"message": "Assistente IA di WordPress Playground",
+		"description": "Title for Kapa AI modal"
+	},
+	"kapaAi.exampleQuestionsTitle": {
+		"message": "Prova a chiedermi...",
+		"description": "Title for example questions section"
+	},
+	"kapaAi.disclaimer": {
+		"message": "Questo **assistente IA risponde a domande su WordPress Playground** utilizzando la [documentazione](https://wordpress.github.io/wordpress-playground/) e le issue di GitHub (https://github.com/WordPress/wordpress-playground/issues) dell'anno scorso",
+		"description": "Disclaimer text for Kapa AI"
+	},
+	"kapaAi.exampleQuestions": {
+		"message": "Come usare l'API dei Blueprint?,Come cambiare la versione di PHP?,Come importare un file WXR?,Come montare file locali?",
+		"description": "Example questions for Kapa AI"
+	}
+}


### PR DESCRIPTION
This pull request adds new Italian translations for the WordPress Playground documentation, specifically for the "Contributing" section. It introduces three new files: a category label, a comprehensive code contribution guide, and documentation for contributor badges. These additions provide Italian-speaking contributors with localized guidelines and information on how to participate and be recognized within the project.

**New Italian documentation:**

* Contributing section label:
  - Added `_category_.json` to label the section as "Contribuire".

* Code contribution guidelines:
  - Added `code.md` with detailed instructions on contributing code, running a local development environment, debugging, and best practices, all translated into Italian.
  - Added `coding-standards.md` outlining coding principles, error message standards, API design, and blueprint guidelines, fully localized.

* Contributor recognition:
  - Added `contributor-badge.md` explaining the criteria and process for obtaining the WordPress Playground Contributor and Team badges, including instructions and visual examples, in Italian.
