### PR TITLE
docs: Fix MDN link for Access-Control-Allow-Origin header

### DIFF
--- a/packages/docs/site/docs/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/docs/blueprints/02-using-blueprints.md
@@ -90,7 +90,7 @@ When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` qu
 
 [https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
 
-Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin):
+Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
 
 ```
 Access-Control-Allow-Origin: *

--- a/packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md
+++ b/packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md
@@ -40,7 +40,7 @@ When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` qu
 
 [https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
 
-Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin):
+Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
 
 ```
 Access-Control-Allow-Origin: *


### PR DESCRIPTION
## Description
This PR fixes a broken MDN documentation link in the Blueprints documentation.

## Changes
- Updated the `Access-Control-Allow-Origin` header documentation link from:
  - Old: `https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin`
  - New: `https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin`

## Why
The previous link was using an incorrect URL path structure. The correct MDN URL includes `/Reference/` in the path to properly link to the HTTP headers reference documentation.

## File Changed
- `packages/docs/site/docs/blueprints/02-using-blueprints.md`
- `packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md`

## Testing
- [x] Verified the new link points to the correct MDN documentation page
- [x] Confirmed no other instances of the old link exist in the documentation