### PR TITLE
[Docs] Updating sidebar to add Xdebug pages

### DIFF
--- a/packages/docs/site/docs/developers/07-xdebug/01-introduction.md
+++ b/packages/docs/site/docs/developers/07-xdebug/01-introduction.md
@@ -1,10 +1,10 @@
 ---
-title: Using Xdebug with PHP WASM - Introduction
+title: Debugging with Xdebug in WordPress Playground
 slug: /developers/xdebug/introduction
 description: Debug PHP code running in WebAssembly within WordPress Playground using Xdebug, Chrome DevTools, and IDE integration.
 ---
 
-# Using Xdebug with PHP WASM
+# Debugging with Xdebug in WordPress Playground
 
 Xdebug is a debugging extension for PHP that lets you set breakpoints, inspect variables, and step through your code. WordPress Playground includes Xdebug in its WebAssembly-compiled PHP, so you can debug WordPress code running directly in your browser or IDE.
 

--- a/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md
@@ -1,10 +1,10 @@
 ---
 slug: /contributing/table-lead-guide
-title: Table Lead Guide for Contributor Day
+title: How to Lead a Contributor Day Table
 description: How to lead a WordPress Playground table at Contributor Day of a WordCamp.
 ---
 
-# Table Lead Guide for Contributor Day
+# Contributor Day Table Leadership Guide
 
 This guide helps table leads prepare for and manage a WordPress Playground contributor table at WordCamp events.
 

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -62,6 +62,7 @@ const sidebars = {
 						'main/contributing/coding-standards',
 						'main/contributing/contributor-day',
 						'main/contributing/contributor-badge',
+						'main/contributing/contributor-day-table-lead',
 						'main/contributing/documentation',
 						'main/contributing/translations',
 					],
@@ -138,6 +139,18 @@ const sidebars = {
 						'developers/local-development/wp-playground-cli',
 						'developers/local-development/vscode-extension',
 						'developers/local-development/php-wasm-node',
+					],
+				},
+				{
+					type: 'category',
+					label: 'Xdebug on Playground',
+					link: {
+						type: 'doc',
+						id: 'developers/xdebug/introduction',
+					},
+					items: [
+						'developers/xdebug/introduction',
+						'developers/xdebug/getting-started',
 					],
 				},
 				{


### PR DESCRIPTION
This pull request updates the sidebar to add links to the Xdebug and contributor guides documentation. This Pull request also includes renaming documentation titles for better readability.

**Documentation improvements:**

* Renamed the Xdebug introduction documentation page and its title to "Debugging with Xdebug in WordPress Playground" for increased clarity and alignment with user expectations.
* Updated the contributor day table lead guide title and heading to "How to Lead a Contributor Day Table" and "Contributor Day Table Leadership Guide" to make the guide's purpose more explicit.

**Sidebar organization:**

* Added the new contributor day table lead guide (`main/contributing/contributor-day-table-lead`) to the contributing section of the sidebar for easier access.
* Created a new "Xdebug on Playground" sidebar category, including links to the introduction and getting started guides, making Xdebug documentation easier to find and navigate.
