### PR TITLE
Resolve WP wrong version and additional debug information

### DIFF
--- a/packages/playground/common/src/index.ts
+++ b/packages/playground/common/src/index.ts
@@ -66,7 +66,8 @@ export const unzipFile = async (
 				$zip->close();
 				chmod($extractTo, 0777);
             } else {
-                throw new Exception("Could not unzip file: " . $zip->getStatusString());
+                $fileSize = file_exists($zipPath) ? filesize($zipPath) : 'unknown';
+                throw new Exception("Could not unzip file. Error code: " . $res . ". File size: " . $fileSize . " bytes.");
             }
         }
         unzip(${js.zipPath}, ${js.extractToPath}, ${js.overwriteFiles});

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -649,7 +649,9 @@ const memoizedFetch = createMemoizedFetch(fetch);
  * @returns The resolved WordPress release URL and version string.
  */
 export async function resolveWordPressRelease(versionQuery = 'latest') {
-	if (
+	if (versionQuery === null) {
+		versionQuery = 'latest';
+	} else if (
 		versionQuery.startsWith('https://') ||
 		versionQuery.startsWith('http://')
 	) {
@@ -692,7 +694,8 @@ export async function resolveWordPressRelease(versionQuery = 'latest') {
 			};
 		} else if (
 			versionQuery === 'latest' &&
-			!apiVersion.version.includes('beta')
+			!apiVersion.version.includes('beta') &&
+			!apiVersion.version.includes('RC')
 		) {
 			// The first non-beta item in the list is the latest version.
 			return {

--- a/packages/playground/wordpress/src/test/resolve-wordpress-release.spec.ts
+++ b/packages/playground/wordpress/src/test/resolve-wordpress-release.spec.ts
@@ -28,6 +28,11 @@ const mockApiResponse = {
 			download: 'https://wordpress.org/wordpress-6.9-beta1.zip',
 			response: 'autoupdate',
 		},
+		{
+			version: '6.9-RC1',
+			download: 'https://wordpress.org/wordpress-6.9-RC1.zip',
+			response: 'autoupdate',
+		},
 	],
 };
 
@@ -55,7 +60,7 @@ describe('resolveWordPressRelease', () => {
 		mockFetch.mockClear();
 	});
 
-	it('resolves latest to the first non-beta version', async () => {
+	it('resolves latest to the first non-beta or release candidate version', async () => {
 		const result = await resolveWordPressRelease('latest');
 		expect(result.version).toBe('6.8.3');
 		expect(result.releaseUrl).toBe(
@@ -160,5 +165,14 @@ describe('resolveWordPressRelease', () => {
 		expect(result.version).toContain('custom-');
 		expect(result.releaseUrl).toBe(customUrl);
 		expect(result.source).toBe('inferred');
+	});
+
+	it('resolves null version to the first non-beta or release candidate version', async () => {
+		const result = await resolveWordPressRelease(null as any);
+		expect(result.version).toBe('6.8.3');
+		expect(result.releaseUrl).toBe(
+			'https://wordpress.org/wordpress-6.8.3.zip'
+		);
+		expect(result.source).toBe('api');
 	});
 });


### PR DESCRIPTION
## Motivation for the change, related issues
When passing `null` as a CLI `wp` argument, the `https://wordpress.org/wordpress-null.zip` is downloaded. DOTORG outputs a "Release not found." generic text file that is cached as a good one. This PR adds two quick fixes:

1. Resolve `null` versions to `latest`
2. Output additional information in the unzip function
3. `latest` now skips RC1 and uses the latest stable

## Implementation details

## Testing Instructions (or ideally a Blueprint)
