### PR TITLE
[Blueprints v1] Rewrite github.com/owner/repo/raw URLs

### DIFF
--- a/packages/playground/blueprints/src/lib/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.spec.ts
@@ -30,6 +30,17 @@ describe('UrlResource', () => {
 			'https://raw.githubusercontent.com/WordPress/wordpress-develop/trunk/src/wp-includes/version.php'
 		);
 	});
+
+	it('should translate github.com raw URLs into raw.githubusercontent.com URLs', () => {
+		const resource = new UrlResource({
+			resource: 'url',
+			url: 'https://github.com/adamziel/blueprints/raw/f49382e89099806a8eede4feba41a9a7ab89bcfe/blueprints%2Fbeta-rc%2Fblueprint.json',
+			caption: 'Example',
+		});
+		expect(resource.getURL()).toBe(
+			'https://raw.githubusercontent.com/adamziel/blueprints/f49382e89099806a8eede4feba41a9a7ab89bcfe/blueprints%2Fbeta-rc%2Fblueprint.json'
+		);
+	});
 });
 
 describe('GitDirectoryResource', () => {

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -529,7 +529,7 @@ export class UrlResource extends FetchResource {
 		 */
 		if (this.resource.url.startsWith('https://github.com/')) {
 			const match = this.resource.url.match(
-				/^https:\/\/github\.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)\/blob\/(?<branch>[^/]+)\/(?<path>.+[^/])$/
+				/^https:\/\/github\.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)\/(?:blob|raw)\/(?<branch>[^/]+)\/(?<path>.+[^/])$/
 			);
 			if (match?.groups) {
 				this.resource = {

--- a/packages/playground/website/builder/builder.ts
+++ b/packages/playground/website/builder/builder.ts
@@ -877,11 +877,14 @@ async function initializeBlueprint() {
 		try {
 			const blueprintUrl = new URL(urlParams.get('blueprint-url'));
 			if (blueprintUrl.hostname === 'github.com') {
-				blueprintUrl.pathname = blueprintUrl.pathname.replace(
-					/^\/([^/]+)\/([^/]+)\/blob/,
+				const rewrittenPath = blueprintUrl.pathname.replace(
+					/^\/([^/]+)\/([^/]+)\/(?:blob|raw)\//,
 					'/$1/$2/'
 				);
-				blueprintUrl.hostname = 'raw.githubusercontent.com';
+				if (rewrittenPath !== blueprintUrl.pathname) {
+					blueprintUrl.pathname = rewrittenPath;
+					blueprintUrl.hostname = 'raw.githubusercontent.com';
+				}
 			}
 			console.log('blueprintUrl.toString()', blueprintUrl.toString());
 			const response = await fetch(blueprintUrl.toString());

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -30,6 +30,29 @@ export type ResolvedBlueprint = {
 	source: BlueprintSource;
 };
 
+const githubBlobOrRawPathPattern = /^\/([^/]+)\/([^/]+)\/(?:blob|raw)\//;
+
+function normalizeBlueprintUrl(remoteUrl: string): string {
+	try {
+		const parsedUrl = new URL(remoteUrl);
+		if (parsedUrl.hostname !== 'github.com') {
+			return remoteUrl;
+		}
+		const rewrittenPath = parsedUrl.pathname.replace(
+			githubBlobOrRawPathPattern,
+			'/$1/$2/'
+		);
+		if (rewrittenPath === parsedUrl.pathname) {
+			return remoteUrl;
+		}
+		parsedUrl.pathname = rewrittenPath;
+		parsedUrl.hostname = 'raw.githubusercontent.com';
+		return parsedUrl.toString();
+	} catch {
+		return remoteUrl;
+	}
+}
+
 export async function resolveBlueprintFromURL(
 	url: URL,
 	defaultBlueprint?: string
@@ -59,13 +82,12 @@ export async function resolveBlueprintFromURL(
 		 * Support passing blueprints via query parameter, e.g.:
 		 * ?blueprint-url=https://example.com/blueprint.json
 		 */
+		const blueprintUrl = normalizeBlueprintUrl(query.get('blueprint-url')!);
 		return {
-			blueprint: await resolveRemoteBlueprint(
-				query.get('blueprint-url')!
-			),
+			blueprint: await resolveRemoteBlueprint(blueprintUrl),
 			source: {
 				type: 'remote-url',
-				url: query.get('blueprint-url')!,
+				url: blueprintUrl,
 			},
 		};
 	} else if (fragment.length) {


### PR DESCRIPTION
## Motivation for the change, related issues

I've noticed Playground did not rewrite this particular URL as a raw.githubusercontent URL:

```
https://github.com/adamziel/blueprints/raw/f49382e89099806a8eede4feba41a9a7ab89bcfe/blueprints%2Fbeta-rc%2Fblueprint.json
```

This PR adds a support for that in the `UrlResource`.

## Testing Instructions (or ideally a Blueprint)

* Confirm ?blueprint-url accepts https://github.com/adamziel/blueprints/raw/f49382e89099806a8eede4feba41a9a7ab89bcfe/blueprints%2Fbeta-rc%2Fblueprint.json
* CI tests included.
