### PR TITLE
[Docs] Adding link at the docs sidebar for PR preview link page

### DIFF
--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/github-action-pr-preview.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/github-action-pr-preview.md
@@ -1,0 +1,451 @@
+---
+title: Agregar botones de vista previa de PR con GitHub Actions
+slug: /guides/github-action-pr-preview
+description: Agregar automáticamente botones de vista previa de Playground a las solicitudes de extracción para tu plugin o tema de WordPress.
+---
+
+<!--
+The Playground PR Preview action adds a preview button to your pull requests. Clicking the button launches Playground with your plugin or theme installed from the PR branch:
+-->
+
+La acción de vista previa de PR de Playground agrega un botón de vista previa a tus solicitudes de extracción. Al hacer clic en el botón se inicia Playground con tu plugin o tema instalado desde la rama del PR:
+
+![PR Preview Button](@site/static/img/try-it-in-playground.png)
+
+<!--
+For complete configuration options and advanced features, see the [action-wp-playground-pr-preview workflow README](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2).
+-->
+
+Para opciones de configuración completas y características avanzadas, consulta el [README del flujo de trabajo action-wp-playground-pr-preview](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2).
+
+<!--
+## How it works
+-->
+
+## Cómo funciona
+
+<!--
+The action runs on pull request events (opened, updated, edited). It can either update the PR description with a preview button or post the button as a comment.
+-->
+
+La acción se ejecuta en eventos de solicitudes de extracción (abierta, actualizada, editada). Puede actualizar la descripción del PR con un botón de vista previa o publicar el botón como un comentario.
+
+<!--
+## Basic setup for plugins
+-->
+
+## Configuración básica para plugins
+
+<!--
+For plugins without a build step, create `.github/workflows/pr-preview.yml`:
+-->
+
+Para plugins sin un paso de compilación, crea `.github/workflows/pr-preview.yml`:
+
+```yaml
+name: PR Preview
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+jobs:
+    preview:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Post Playground Preview Button
+              uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  mode: 'append-to-description'
+                  plugin-path: .
+```
+
+<!--
+The `plugin-path: .` setting points to your plugin directory. For subdirectories like `plugins/my-plugin`, use `plugin-path: plugins/my-plugin`.
+-->
+
+La configuración `plugin-path: .` apunta a tu directorio de plugin. Para subdirectorios como `plugins/my-plugin`, usa `plugin-path: plugins/my-plugin`.
+
+<!--
+See [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) for a live example of this workflow in action.
+-->
+
+Consulta [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) para ver un ejemplo en vivo de este flujo de trabajo en acción.
+
+<!--
+## Basic setup for themes
+-->
+
+## Configuración básica para temas
+
+<!--
+For themes, use `theme-path` instead of `plugin-path`:
+-->
+
+Para temas, usa `theme-path` en lugar de `plugin-path`:
+
+```yaml
+name: PR Preview
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+jobs:
+    preview:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Post Playground Preview Button
+              uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  theme-path: .
+```
+
+<!--
+## Button placement
+-->
+
+## Ubicación del botón
+
+<!--
+By default, the action updates the PR description (`mode: append-to-description`). To post as a comment instead:
+-->
+
+Por defecto, la acción actualiza la descripción del PR (`mode: append-to-description`). Para publicar como un comentario en su lugar:
+
+```yaml
+with:
+    plugin-path: .
+    mode: comment
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+<!--
+The action wraps the button in HTML markers and updates it on subsequent runs. By default, it restores the button if you remove it. To prevent restoration:
+-->
+
+La acción envuelve el botón en marcadores HTML y lo actualiza en ejecuciones posteriores. Por defecto, restaura el botón si lo eliminas. Para evitar la restauración:
+
+```yaml
+with:
+    plugin-path: .
+    restore-button-if-removed: false
+```
+
+<!--
+## Working with built artifacts
+-->
+
+## Trabajar con artefactos compilados
+
+<!--
+For plugins or themes requiring compilation, the workflow involves building the code, exposing it via GitHub releases, and creating a blueprint that references the public URL.
+-->
+
+Para plugins o temas que requieren compilación, el flujo de trabajo implica compilar el código, exponerlo a través de versiones de GitHub y crear un blueprint que haga referencia a la URL pública.
+
+<!--
+Example workflow (see [complete documentation](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#advanced-testing-built-ci-artifacts)):
+-->
+
+Ejemplo de flujo de trabajo (consulta la [documentación completa](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#advanced-testing-built-ci-artifacts)):
+
+```yaml
+name: PR Preview with Build
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Build
+              run: |
+                  npm install
+                  npm run build
+                  zip -r plugin.zip dist/
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: built-plugin
+                  path: plugin.zip
+
+    expose-build:
+        needs: build
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        outputs:
+            artifact-url: ${{ steps.expose.outputs.artifact-url }}
+        steps:
+            - name: Expose built artifact
+              id: expose
+              uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+              with:
+                  artifact-name: 'built-plugin'
+                  pr-number: ${{ github.event.pull_request.number }}
+                  commit-sha: ${{ github.sha }}
+                  artifacts-to-keep: '2'
+
+    create-blueprint:
+        needs: expose-build
+        runs-on: ubuntu-latest
+        outputs:
+            blueprint: ${{ steps.blueprint.outputs.result }}
+        steps:
+            - uses: actions/github-script@v7
+              id: blueprint
+              with:
+                  script: |
+                      const blueprint = {
+                        steps: [{
+                          step: "installPlugin",
+                          pluginZipFile: {
+                            resource: "url",
+                            url: "${{ needs.expose-build.outputs.artifact-url }}"
+                          }
+                        }]
+                      };
+                      return JSON.stringify(blueprint);
+                  result-encoding: string
+
+    preview:
+        needs: create-blueprint
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  blueprint: ${{ needs.create-blueprint.outputs.blueprint }}
+```
+
+<!--
+The `artifacts-to-keep` setting controls how many builds to retain per PR. For themes, change `installPlugin` to `installTheme`.
+-->
+
+La configuración `artifacts-to-keep` controla cuántas compilaciones se deben retener por PR. Para temas, cambia `installPlugin` a `installTheme`.
+
+<!--
+See [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) for a complete working example.
+-->
+
+Consulta [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) para ver un ejemplo completo en funcionamiento.
+
+<!--
+## Custom blueprints
+-->
+
+## Blueprints personalizados
+
+<!--
+Use blueprints to configure the Playground environment. You can install additional plugins, set WordPress options, import content, or run custom PHP.
+-->
+
+Usa blueprints para configurar el entorno de Playground. Puedes instalar plugins adicionales, establecer opciones de WordPress, importar contenido o ejecutar PHP personalizado.
+
+<!--
+Example installing your plugin with WooCommerce:
+-->
+
+Ejemplo instalando tu plugin con WooCommerce:
+
+```yaml
+jobs:
+    create-blueprint:
+        name: Create Blueprint
+        runs-on: ubuntu-latest
+        outputs:
+            blueprint: ${{ steps.blueprint.outputs.result }}
+        steps:
+            - name: Create Blueprint
+              id: blueprint
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const blueprint = {
+                        steps: [
+                          {
+                            step: "installPlugin",
+                            pluginData: {
+                              resource: "git:directory",
+                              url: `https://github.com/${context.repo.owner}/${context.repo.repo}.git`,
+                              ref: context.payload.pull_request.head.ref,
+                              path: "/"
+                            }
+                          },
+                          {
+                            step: "installPlugin",
+                            pluginData: {
+                              resource: "wordpress.org/plugins",
+                              slug: "woocommerce"
+                            }
+                          }
+                        ]
+                      };
+                      return JSON.stringify(blueprint);
+                  result-encoding: string
+
+    preview:
+        needs: create-blueprint
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  blueprint: ${{ needs.create-blueprint.outputs.blueprint }}
+```
+
+<!--
+Or reference an external blueprint:
+-->
+
+O referencia un blueprint externo:
+
+```yaml
+with:
+    blueprint-url: https://example.com/path/to/blueprint.json
+```
+
+<!--
+See [Blueprints documentation](/blueprints) for all available steps and configuration options.
+-->
+
+Consulta la [documentación de Blueprints](/blueprints) para ver todos los pasos y opciones de configuración disponibles.
+
+<!--
+## Template customization
+-->
+
+## Personalización de plantillas
+
+<!--
+Customize the preview content using template variables:
+-->
+
+Personaliza el contenido de vista previa usando variables de plantilla:
+
+```yaml
+with:
+    plugin-path: .
+    description-template: |
+        ### Test this PR in WordPress Playground
+
+        {{PLAYGROUND_BUTTON}}
+
+        **Branch:** {{PR_HEAD_REF}}
+```
+
+<!--
+Available variables: `{{PLAYGROUND_BUTTON}}`, `{{PLUGIN_SLUG}}`, `{{THEME_SLUG}}`, `{{PR_NUMBER}}`, `{{PR_TITLE}}`, `{{PR_HEAD_REF}}`, and more.
+-->
+
+Variables disponibles: `{{PLAYGROUND_BUTTON}}`, `{{PLUGIN_SLUG}}`, `{{THEME_SLUG}}`, `{{PR_NUMBER}}`, `{{PR_TITLE}}`, `{{PR_HEAD_REF}}`, y más.
+
+<!--
+See the workflow README for the [complete list](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#description-template).
+-->
+
+Consulta el README del flujo de trabajo para ver la [lista completa](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#description-template).
+
+<!--
+## Artifact exposure
+-->
+
+## Exposición de artefactos
+
+<!--
+The `expose-artifact-on-public-url` action uploads built files to a single release (tagged `ci-artifacts` by default). Each artifact gets a unique filename like `pr-123-abc1234.zip`. Old artifacts are automatically cleaned up based on `artifacts-to-keep`.
+-->
+
+La acción `expose-artifact-on-public-url` carga archivos compilados en una sola versión (etiquetada como `ci-artifacts` por defecto). Cada artefacto obtiene un nombre de archivo único como `pr-123-abc1234.zip`. Los artefactos antiguos se limpian automáticamente según `artifacts-to-keep`.
+
+<!--
+Configuration options: [Expose Artifact Inputs](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#expose-artifact-inputs)
+-->
+
+Opciones de configuración: [Expose Artifact Inputs](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#expose-artifact-inputs)
+
+<!--
+## Troubleshooting
+-->
+
+## Solución de problemas
+
+<!--
+**Button not appearing:** Workflow file must exist on the default branch. Check Actions tab for errors.
+-->
+
+**El botón no aparece:** El archivo de flujo de trabajo debe existir en la rama predeterminada. Verifica la pestaña Actions para ver errores.
+
+<!--
+**Preview fails to load:** Verify path points to valid plugin/theme directory. Check build logs for artifacts.
+-->
+
+**La vista previa no se carga:** Verifica que la ruta apunte a un directorio válido de plugin/tema. Verifica los registros de compilación para artefactos.
+
+<!--
+**Not activated:** Check browser console for PHP errors. Dependencies may be missing.
+-->
+
+**No activado:** Verifica la consola del navegador para errores de PHP. Pueden faltar dependencias.
+
+<!--
+**Permissions errors:** Set permissions at job level.
+-->
+
+**Errores de permisos:** Establece permisos a nivel de trabajo.
+
+<!--
+More: [workflow README](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2)
+-->
+
+Más información: [README del flujo de trabajo](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2)
+
+<!--
+## Examples
+-->
+
+## Ejemplos
+
+<!--
+-   [WordPress/blueprints](https://github.com/WordPress/blueprints/pull/155) - Blueprint previews
+-   [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) - Plugin without build
+-   [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) - Plugin with build
+-->
+
+-   [WordPress/blueprints](https://github.com/WordPress/blueprints/pull/155) - Vistas previas de blueprint
+-   [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) - Plugin sin compilación
+-   [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) - Plugin con compilación
+
+<!--
+## Next steps
+-->
+
+## Próximos pasos
+
+<!--
+-   Add demo content ([guide](/guides/providing-content-for-your-demo))
+-   Create custom blueprints ([docs](/blueprints))
+-   Integrate with testing workflows
+-   Customize templates for reviewers
+-->
+
+-   Agregar contenido de demostración ([guía](/guides/providing-content-for-your-demo))
+-   Crear blueprints personalizados ([documentación](/blueprints))
+-   Integrar con flujos de trabajo de pruebas
+-   Personalizar plantillas para revisores

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/github-action-pr-preview.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/github-action-pr-preview.md
@@ -1,0 +1,451 @@
+---
+title: Ajout de boutons d'aperçu de PR avec GitHub Actions
+slug: /guides/github-action-pr-preview
+description: Ajoutez automatiquement des boutons d'aperçu Playground aux pull requests de votre plugin ou thème WordPress.
+---
+
+<!--
+The Playground PR Preview action adds a preview button to your pull requests. Clicking the button launches Playground with your plugin or theme installed from the PR branch:
+-->
+
+L'action d'aperçu de PR Playground ajoute un bouton d'aperçu à vos pull requests. Cliquer sur le bouton lance Playground avec votre plugin ou thème installé depuis la branche du PR :
+
+![PR Preview Button](@site/static/img/try-it-in-playground.png)
+
+<!--
+For complete configuration options and advanced features, see the [action-wp-playground-pr-preview workflow README](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2).
+-->
+
+Pour les options de configuration complètes et les fonctionnalités avancées, consultez le [README du workflow action-wp-playground-pr-preview](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2).
+
+<!--
+## How it works
+-->
+
+## Comment ça fonctionne
+
+<!--
+The action runs on pull request events (opened, updated, edited). It can either update the PR description with a preview button or post the button as a comment.
+-->
+
+L'action s'exécute sur les événements de pull request (ouvert, mis à jour, édité). Elle peut mettre à jour la description du PR avec un bouton d'aperçu ou publier le bouton sous forme de commentaire.
+
+<!--
+## Basic setup for plugins
+-->
+
+## Configuration de base pour les plugins
+
+<!--
+For plugins without a build step, create `.github/workflows/pr-preview.yml`:
+-->
+
+Pour les plugins sans étape de build, créez `.github/workflows/pr-preview.yml` :
+
+```yaml
+name: PR Preview
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+jobs:
+    preview:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Post Playground Preview Button
+              uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  mode: 'append-to-description'
+                  plugin-path: .
+```
+
+<!--
+The `plugin-path: .` setting points to your plugin directory. For subdirectories like `plugins/my-plugin`, use `plugin-path: plugins/my-plugin`.
+-->
+
+Le paramètre `plugin-path: .` pointe vers le répertoire de votre plugin. Pour les sous-répertoires comme `plugins/my-plugin`, utilisez `plugin-path: plugins/my-plugin`.
+
+<!--
+See [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) for a live example of this workflow in action.
+-->
+
+Consultez [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) pour un exemple en direct de ce workflow en action.
+
+<!--
+## Basic setup for themes
+-->
+
+## Configuration de base pour les thèmes
+
+<!--
+For themes, use `theme-path` instead of `plugin-path`:
+-->
+
+Pour les thèmes, utilisez `theme-path` au lieu de `plugin-path` :
+
+```yaml
+name: PR Preview
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+jobs:
+    preview:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Post Playground Preview Button
+              uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  theme-path: .
+```
+
+<!--
+## Button placement
+-->
+
+## Positionnement du bouton
+
+<!--
+By default, the action updates the PR description (`mode: append-to-description`). To post as a comment instead:
+-->
+
+Par défaut, l'action met à jour la description du PR (`mode: append-to-description`). Pour publier sous forme de commentaire à la place :
+
+```yaml
+with:
+    plugin-path: .
+    mode: comment
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+<!--
+The action wraps the button in HTML markers and updates it on subsequent runs. By default, it restores the button if you remove it. To prevent restoration:
+-->
+
+L'action enveloppe le bouton dans des marqueurs HTML et le met à jour lors des exécutions suivantes. Par défaut, elle restaure le bouton si vous le supprimez. Pour éviter la restauration :
+
+```yaml
+with:
+    plugin-path: .
+    restore-button-if-removed: false
+```
+
+<!--
+## Working with built artifacts
+-->
+
+## Travailler avec des artefacts compilés
+
+<!--
+For plugins or themes requiring compilation, the workflow involves building the code, exposing it via GitHub releases, and creating a blueprint that references the public URL.
+-->
+
+Pour les plugins ou thèmes nécessitant une compilation, le workflow implique de compiler le code, de l'exposer via les releases GitHub et de créer un blueprint qui référence l'URL publique.
+
+<!--
+Example workflow (see [complete documentation](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#advanced-testing-built-ci-artifacts)):
+-->
+
+Exemple de workflow (voir la [documentation complète](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#advanced-testing-built-ci-artifacts)) :
+
+```yaml
+name: PR Preview with Build
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Build
+              run: |
+                  npm install
+                  npm run build
+                  zip -r plugin.zip dist/
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: built-plugin
+                  path: plugin.zip
+
+    expose-build:
+        needs: build
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        outputs:
+            artifact-url: ${{ steps.expose.outputs.artifact-url }}
+        steps:
+            - name: Expose built artifact
+              id: expose
+              uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+              with:
+                  artifact-name: 'built-plugin'
+                  pr-number: ${{ github.event.pull_request.number }}
+                  commit-sha: ${{ github.sha }}
+                  artifacts-to-keep: '2'
+
+    create-blueprint:
+        needs: expose-build
+        runs-on: ubuntu-latest
+        outputs:
+            blueprint: ${{ steps.blueprint.outputs.result }}
+        steps:
+            - uses: actions/github-script@v7
+              id: blueprint
+              with:
+                  script: |
+                      const blueprint = {
+                        steps: [{
+                          step: "installPlugin",
+                          pluginZipFile: {
+                            resource: "url",
+                            url: "${{ needs.expose-build.outputs.artifact-url }}"
+                          }
+                        }]
+                      };
+                      return JSON.stringify(blueprint);
+                  result-encoding: string
+
+    preview:
+        needs: create-blueprint
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  blueprint: ${{ needs.create-blueprint.outputs.blueprint }}
+```
+
+<!--
+The `artifacts-to-keep` setting controls how many builds to retain per PR. For themes, change `installPlugin` to `installTheme`.
+-->
+
+Le paramètre `artifacts-to-keep` contrôle combien de builds conserver par PR. Pour les thèmes, changez `installPlugin` en `installTheme`.
+
+<!--
+See [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) for a complete working example.
+-->
+
+Consultez [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) pour un exemple complet fonctionnel.
+
+<!--
+## Custom blueprints
+-->
+
+## Blueprints personnalisés
+
+<!--
+Use blueprints to configure the Playground environment. You can install additional plugins, set WordPress options, import content, or run custom PHP.
+-->
+
+Utilisez les blueprints pour configurer l'environnement Playground. Vous pouvez installer des plugins supplémentaires, définir des options WordPress, importer du contenu ou exécuter du PHP personnalisé.
+
+<!--
+Example installing your plugin with WooCommerce:
+-->
+
+Exemple d'installation de votre plugin avec WooCommerce :
+
+```yaml
+jobs:
+    create-blueprint:
+        name: Create Blueprint
+        runs-on: ubuntu-latest
+        outputs:
+            blueprint: ${{ steps.blueprint.outputs.result }}
+        steps:
+            - name: Create Blueprint
+              id: blueprint
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const blueprint = {
+                        steps: [
+                          {
+                            step: "installPlugin",
+                            pluginData: {
+                              resource: "git:directory",
+                              url: `https://github.com/${context.repo.owner}/${context.repo.repo}.git`,
+                              ref: context.payload.pull_request.head.ref,
+                              path: "/"
+                            }
+                          },
+                          {
+                            step: "installPlugin",
+                            pluginData: {
+                              resource: "wordpress.org/plugins",
+                              slug: "woocommerce"
+                            }
+                          }
+                        ]
+                      };
+                      return JSON.stringify(blueprint);
+                  result-encoding: string
+
+    preview:
+        needs: create-blueprint
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  blueprint: ${{ needs.create-blueprint.outputs.blueprint }}
+```
+
+<!--
+Or reference an external blueprint:
+-->
+
+Ou référencez un blueprint externe :
+
+```yaml
+with:
+    blueprint-url: https://example.com/path/to/blueprint.json
+```
+
+<!--
+See [Blueprints documentation](/blueprints) for all available steps and configuration options.
+-->
+
+Consultez la [documentation des Blueprints](/blueprints) pour tous les pas disponibles et les options de configuration.
+
+<!--
+## Template customization
+-->
+
+## Personnalisation du template
+
+<!--
+Customize the preview content using template variables:
+-->
+
+Personnalisez le contenu de l'aperçu en utilisant des variables de template :
+
+```yaml
+with:
+    plugin-path: .
+    description-template: |
+        ### Test this PR in WordPress Playground
+
+        {{PLAYGROUND_BUTTON}}
+
+        **Branch:** {{PR_HEAD_REF}}
+```
+
+<!--
+Available variables: `{{PLAYGROUND_BUTTON}}`, `{{PLUGIN_SLUG}}`, `{{THEME_SLUG}}`, `{{PR_NUMBER}}`, `{{PR_TITLE}}`, `{{PR_HEAD_REF}}`, and more.
+-->
+
+Variables disponibles : `{{PLAYGROUND_BUTTON}}`, `{{PLUGIN_SLUG}}`, `{{THEME_SLUG}}`, `{{PR_NUMBER}}`, `{{PR_TITLE}}`, `{{PR_HEAD_REF}}`, et plus.
+
+<!--
+See the workflow README for the [complete list](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#description-template).
+-->
+
+Consultez le README du workflow pour la [liste complète](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#description-template).
+
+<!--
+## Artifact exposure
+-->
+
+## Exposition des artefacts
+
+<!--
+The `expose-artifact-on-public-url` action uploads built files to a single release (tagged `ci-artifacts` by default). Each artifact gets a unique filename like `pr-123-abc1234.zip`. Old artifacts are automatically cleaned up based on `artifacts-to-keep`.
+-->
+
+L'action `expose-artifact-on-public-url` télécharge les fichiers compilés vers une seule release (étiquetée `ci-artifacts` par défaut). Chaque artefact obtient un nom de fichier unique comme `pr-123-abc1234.zip`. Les anciens artefacts sont automatiquement nettoyés en fonction de `artifacts-to-keep`.
+
+<!--
+Configuration options: [Expose Artifact Inputs](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#expose-artifact-inputs)
+-->
+
+Options de configuration : [Expose Artifact Inputs](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#expose-artifact-inputs)
+
+<!--
+## Troubleshooting
+-->
+
+## Dépannage
+
+<!--
+**Button not appearing:** Workflow file must exist on the default branch. Check Actions tab for errors.
+-->
+
+**Le bouton n'apparaît pas :** Le fichier de workflow doit exister sur la branche par défaut. Vérifiez l'onglet Actions pour les erreurs.
+
+<!--
+**Preview fails to load:** Verify path points to valid plugin/theme directory. Check build logs for artifacts.
+-->
+
+**L'aperçu ne se charge pas :** Vérifiez que le chemin pointe vers un répertoire de plugin/thème valide. Vérifiez les logs de build pour les artefacts.
+
+<!--
+**Not activated:** Check browser console for PHP errors. Dependencies may be missing.
+-->
+
+**Non activé :** Vérifiez la console du navigateur pour les erreurs PHP. Les dépendances peuvent être manquantes.
+
+<!--
+**Permissions errors:** Set permissions at job level.
+-->
+
+**Erreurs de permissions :** Définissez les permissions au niveau du job.
+
+<!--
+More: [workflow README](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2)
+-->
+
+Plus d'informations : [README du workflow](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2)
+
+<!--
+## Examples
+-->
+
+## Exemples
+
+<!--
+-   [WordPress/blueprints](https://github.com/WordPress/blueprints/pull/155) - Blueprint previews
+-   [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) - Plugin without build
+-   [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) - Plugin with build
+-->
+
+-   [WordPress/blueprints](https://github.com/WordPress/blueprints/pull/155) - Aperçus de blueprint
+-   [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) - Plugin sans build
+-   [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) - Plugin avec build
+
+<!--
+## Next steps
+-->
+
+## Prochaines étapes
+
+<!--
+-   Add demo content ([guide](/guides/providing-content-for-your-demo))
+-   Create custom blueprints ([docs](/blueprints))
+-   Integrate with testing workflows
+-   Customize templates for reviewers
+-->
+
+-   Ajouter du contenu de démonstration ([guide](/guides/providing-content-for-your-demo))
+-   Créer des blueprints personnalisés ([documentation](/blueprints))
+-   Intégrer avec les workflows de tests
+-   Personnaliser les templates pour les réviseurs

--- a/packages/docs/site/i18n/pt/docusaurus-plugin-content-docs/current/main/guides/github-action-pr-preview.md
+++ b/packages/docs/site/i18n/pt/docusaurus-plugin-content-docs/current/main/guides/github-action-pr-preview.md
@@ -1,0 +1,451 @@
+---
+title: Adicionando Botões de Pré-visualização de PR com GitHub Actions
+slug: /guides/github-action-pr-preview
+description: Adicione automaticamente botões de pré-visualização do Playground aos pull requests do seu plugin ou tema WordPress.
+---
+
+<!--
+The Playground PR Preview action adds a preview button to your pull requests. Clicking the button launches Playground with your plugin or theme installed from the PR branch:
+-->
+
+A ação de Pré-visualização de PR do Playground adiciona um botão de pré-visualização aos seus pull requests. Clicar no botão inicia o Playground com seu plugin ou tema instalado a partir da branch do PR:
+
+![PR Preview Button](@site/static/img/try-it-in-playground.png)
+
+<!--
+For complete configuration options and advanced features, see the [action-wp-playground-pr-preview workflow README](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2).
+-->
+
+Para opções de configuração completas e recursos avançados, consulte o [README do workflow action-wp-playground-pr-preview](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2).
+
+<!--
+## How it works
+-->
+
+## Como funciona
+
+<!--
+The action runs on pull request events (opened, updated, edited). It can either update the PR description with a preview button or post the button as a comment.
+-->
+
+A ação é executada em eventos de pull request (aberto, atualizado, editado). Ela pode atualizar a descrição do PR com um botão de pré-visualização ou postar o botão como um comentário.
+
+<!--
+## Basic setup for plugins
+-->
+
+## Configuração básica para plugins
+
+<!--
+For plugins without a build step, create `.github/workflows/pr-preview.yml`:
+-->
+
+Para plugins sem uma etapa de build, crie `.github/workflows/pr-preview.yml`:
+
+```yaml
+name: PR Preview
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+jobs:
+    preview:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Post Playground Preview Button
+              uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  mode: 'append-to-description'
+                  plugin-path: .
+```
+
+<!--
+The `plugin-path: .` setting points to your plugin directory. For subdirectories like `plugins/my-plugin`, use `plugin-path: plugins/my-plugin`.
+-->
+
+A configuração `plugin-path: .` aponta para o diretório do seu plugin. Para subdiretórios como `plugins/my-plugin`, use `plugin-path: plugins/my-plugin`.
+
+<!--
+See [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) for a live example of this workflow in action.
+-->
+
+Veja [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) para um exemplo ao vivo deste workflow em ação.
+
+<!--
+## Basic setup for themes
+-->
+
+## Configuração básica para temas
+
+<!--
+For themes, use `theme-path` instead of `plugin-path`:
+-->
+
+Para temas, use `theme-path` em vez de `plugin-path`:
+
+```yaml
+name: PR Preview
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+jobs:
+    preview:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+        steps:
+            - name: Post Playground Preview Button
+              uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  theme-path: .
+```
+
+<!--
+## Button placement
+-->
+
+## Posicionamento do botão
+
+<!--
+By default, the action updates the PR description (`mode: append-to-description`). To post as a comment instead:
+-->
+
+Por padrão, a ação atualiza a descrição do PR (`mode: append-to-description`). Para postar como um comentário:
+
+```yaml
+with:
+    plugin-path: .
+    mode: comment
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+<!--
+The action wraps the button in HTML markers and updates it on subsequent runs. By default, it restores the button if you remove it. To prevent restoration:
+-->
+
+A ação envolve o botão em marcadores HTML e o atualiza em execuções subsequentes. Por padrão, ela restaura o botão se você o remover. Para evitar a restauração:
+
+```yaml
+with:
+    plugin-path: .
+    restore-button-if-removed: false
+```
+
+<!--
+## Working with built artifacts
+-->
+
+## Trabalhando com artefatos compilados
+
+<!--
+For plugins or themes requiring compilation, the workflow involves building the code, exposing it via GitHub releases, and creating a blueprint that references the public URL.
+-->
+
+Para plugins ou temas que requerem compilação, o workflow envolve compilar o código, expô-lo através de releases do GitHub e criar um blueprint que referencia a URL pública.
+
+<!--
+Example workflow (see [complete documentation](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#advanced-testing-built-ci-artifacts)):
+-->
+
+Exemplo de workflow (veja a [documentação completa](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#advanced-testing-built-ci-artifacts)):
+
+```yaml
+name: PR Preview with Build
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, edited]
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Build
+              run: |
+                  npm install
+                  npm run build
+                  zip -r plugin.zip dist/
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: built-plugin
+                  path: plugin.zip
+
+    expose-build:
+        needs: build
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        outputs:
+            artifact-url: ${{ steps.expose.outputs.artifact-url }}
+        steps:
+            - name: Expose built artifact
+              id: expose
+              uses: WordPress/action-wp-playground-pr-preview/.github/actions/expose-artifact-on-public-url@v2
+              with:
+                  artifact-name: 'built-plugin'
+                  pr-number: ${{ github.event.pull_request.number }}
+                  commit-sha: ${{ github.sha }}
+                  artifacts-to-keep: '2'
+
+    create-blueprint:
+        needs: expose-build
+        runs-on: ubuntu-latest
+        outputs:
+            blueprint: ${{ steps.blueprint.outputs.result }}
+        steps:
+            - uses: actions/github-script@v7
+              id: blueprint
+              with:
+                  script: |
+                      const blueprint = {
+                        steps: [{
+                          step: "installPlugin",
+                          pluginZipFile: {
+                            resource: "url",
+                            url: "${{ needs.expose-build.outputs.artifact-url }}"
+                          }
+                        }]
+                      };
+                      return JSON.stringify(blueprint);
+                  result-encoding: string
+
+    preview:
+        needs: create-blueprint
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  blueprint: ${{ needs.create-blueprint.outputs.blueprint }}
+```
+
+<!--
+The `artifacts-to-keep` setting controls how many builds to retain per PR. For themes, change `installPlugin` to `installTheme`.
+-->
+
+A configuração `artifacts-to-keep` controla quantos builds manter por PR. Para temas, altere `installPlugin` para `installTheme`.
+
+<!--
+See [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) for a complete working example.
+-->
+
+Veja [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) para um exemplo completo funcionando.
+
+<!--
+## Custom blueprints
+-->
+
+## Blueprints personalizados
+
+<!--
+Use blueprints to configure the Playground environment. You can install additional plugins, set WordPress options, import content, or run custom PHP.
+-->
+
+Use blueprints para configurar o ambiente do Playground. Você pode instalar plugins adicionais, definir opções do WordPress, importar conteúdo ou executar PHP personalizado.
+
+<!--
+Example installing your plugin with WooCommerce:
+-->
+
+Exemplo instalando seu plugin com WooCommerce:
+
+```yaml
+jobs:
+    create-blueprint:
+        name: Create Blueprint
+        runs-on: ubuntu-latest
+        outputs:
+            blueprint: ${{ steps.blueprint.outputs.result }}
+        steps:
+            - name: Create Blueprint
+              id: blueprint
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const blueprint = {
+                        steps: [
+                          {
+                            step: "installPlugin",
+                            pluginData: {
+                              resource: "git:directory",
+                              url: `https://github.com/${context.repo.owner}/${context.repo.repo}.git`,
+                              ref: context.payload.pull_request.head.ref,
+                              path: "/"
+                            }
+                          },
+                          {
+                            step: "installPlugin",
+                            pluginData: {
+                              resource: "wordpress.org/plugins",
+                              slug: "woocommerce"
+                            }
+                          }
+                        ]
+                      };
+                      return JSON.stringify(blueprint);
+                  result-encoding: string
+
+    preview:
+        needs: create-blueprint
+        runs-on: ubuntu-latest
+        permissions:
+            pull-requests: write
+        steps:
+            - uses: WordPress/action-wp-playground-pr-preview@v2
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  blueprint: ${{ needs.create-blueprint.outputs.blueprint }}
+```
+
+<!--
+Or reference an external blueprint:
+-->
+
+Ou referencie um blueprint externo:
+
+```yaml
+with:
+    blueprint-url: https://example.com/path/to/blueprint.json
+```
+
+<!--
+See [Blueprints documentation](/blueprints) for all available steps and configuration options.
+-->
+
+Consulte a [documentação de Blueprints](/blueprints) para todos os passos disponíveis e opções de configuração.
+
+<!--
+## Template customization
+-->
+
+## Personalização de template
+
+<!--
+Customize the preview content using template variables:
+-->
+
+Personalize o conteúdo da pré-visualização usando variáveis de template:
+
+```yaml
+with:
+    plugin-path: .
+    description-template: |
+        ### Test this PR in WordPress Playground
+
+        {{PLAYGROUND_BUTTON}}
+
+        **Branch:** {{PR_HEAD_REF}}
+```
+
+<!--
+Available variables: `{{PLAYGROUND_BUTTON}}`, `{{PLUGIN_SLUG}}`, `{{THEME_SLUG}}`, `{{PR_NUMBER}}`, `{{PR_TITLE}}`, `{{PR_HEAD_REF}}`, and more.
+-->
+
+Variáveis disponíveis: `{{PLAYGROUND_BUTTON}}`, `{{PLUGIN_SLUG}}`, `{{THEME_SLUG}}`, `{{PR_NUMBER}}`, `{{PR_TITLE}}`, `{{PR_HEAD_REF}}`, e mais.
+
+<!--
+See the workflow README for the [complete list](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#description-template).
+-->
+
+Consulte o README do workflow para a [lista completa](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#description-template).
+
+<!--
+## Artifact exposure
+-->
+
+## Exposição de artefatos
+
+<!--
+The `expose-artifact-on-public-url` action uploads built files to a single release (tagged `ci-artifacts` by default). Each artifact gets a unique filename like `pr-123-abc1234.zip`. Old artifacts are automatically cleaned up based on `artifacts-to-keep`.
+-->
+
+A ação `expose-artifact-on-public-url` faz upload de arquivos compilados para um único release (marcado como `ci-artifacts` por padrão). Cada artefato recebe um nome de arquivo único como `pr-123-abc1234.zip`. Artefatos antigos são automaticamente limpos com base em `artifacts-to-keep`.
+
+<!--
+Configuration options: [Expose Artifact Inputs](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#expose-artifact-inputs)
+-->
+
+Opções de configuração: [Expose Artifact Inputs](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2#expose-artifact-inputs)
+
+<!--
+## Troubleshooting
+-->
+
+## Solução de problemas
+
+<!--
+**Button not appearing:** Workflow file must exist on the default branch. Check Actions tab for errors.
+-->
+
+**Botão não aparece:** O arquivo de workflow deve existir no branch padrão. Verifique a aba Actions para erros.
+
+<!--
+**Preview fails to load:** Verify path points to valid plugin/theme directory. Check build logs for artifacts.
+-->
+
+**Pré-visualização falha ao carregar:** Verifique se o caminho aponta para um diretório válido de plugin/tema. Verifique os logs de build para artefatos.
+
+<!--
+**Not activated:** Check browser console for PHP errors. Dependencies may be missing.
+-->
+
+**Não ativado:** Verifique o console do navegador para erros de PHP. As dependências podem estar faltando.
+
+<!--
+**Permissions errors:** Set permissions at job level.
+-->
+
+**Erros de permissão:** Defina permissões no nível do job.
+
+<!--
+More: [workflow README](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2)
+-->
+
+Mais informações: [README do workflow](https://github.com/WordPress/action-wp-playground-pr-preview/tree/v2)
+
+<!--
+## Examples
+-->
+
+## Exemplos
+
+<!--
+-   [WordPress/blueprints](https://github.com/WordPress/blueprints/pull/155) - Blueprint previews
+-   [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) - Plugin without build
+-   [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) - Plugin with build
+-->
+
+-   [WordPress/blueprints](https://github.com/WordPress/blueprints/pull/155) - Pré-visualizações de blueprint
+-   [adamziel/preview-in-playground-button-plugin-example](https://github.com/adamziel/preview-in-playground-button-plugin-example/pull/3) - Plugin sem build
+-   [adamziel/preview-in-playground-button-built-artifact-example](https://github.com/adamziel/preview-in-playground-button-built-artifact-example/pull/2) - Plugin com build
+
+<!--
+## Next steps
+-->
+
+## Próximos passos
+
+<!--
+-   Add demo content ([guide](/guides/providing-content-for-your-demo))
+-   Create custom blueprints ([docs](/blueprints))
+-   Integrate with testing workflows
+-   Customize templates for reviewers
+-->
+
+-   Adicionar conteúdo de demonstração ([guia](/guides/providing-content-for-your-demo))
+-   Criar blueprints personalizados ([documentação](/blueprints))
+-   Integrar com workflows de testes
+-   Personalizar templates para revisores

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -48,6 +48,7 @@ const sidebars = {
 						'main/guides/for-plugin-developers',
 						'main/guides/for-theme-developers',
 						'main/guides/providing-content-for-your-demo',
+						'main/guides/github-action-pr-preview',
 					],
 				},
 				{


### PR DESCRIPTION
This pull request makes a minor update to the documentation sidebar configuration. The change adds a new guide to the plugin and theme developer documentation section.

* Added `'main/guides/github-action-pr-preview'` to the sidebar list in `packages/docs/site/sidebars.js`, making the new GitHub Action PR Preview guide accessible in the documentation navigation.
* Added Portuguese, Spanish, and French translations.

<img width="1752" height="885" alt="Screenshot 2025-11-13 at 20 32 29" src="https://github.com/user-attachments/assets/ecff1a6b-1f59-4066-995f-57fe0e34ce51" />
