### PR TITLE
[Boot] Verify permalink structure is actually set

### DIFF
--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -529,12 +529,17 @@ async function installWordPress(php: PHP) {
 				exit;
 			}
 			require $wp_load;
+			$nice_permalinks = '/%year%/%monthnum%/%day%/%postname%/';
 			$option_result = update_option(
 				'permalink_structure',
-				'/%year%/%monthnum%/%day%/%postname%/'
+				$nice_permalinks
 			);
 			ob_clean();
-			echo $option_result ? '1' : '0';
+			if ( get_option( 'permalink_structure' ) === $nice_permalinks ) {
+				echo '1';
+			} else {
+				echo '0';
+			}
 			ob_end_flush();
 		`,
 		env: {


### PR DESCRIPTION
The previous implementation of installWordPress() relied on `update_option`'s return value to determine if pretty permalinks were successfully enabled. However, `update_option` returns false when the value hasn't changed, e.g. when it already was set to what we need. This led to incorrect detection.

This PR explicitly verifies the final `permalink_structure` value instead of relying on implicit `update_option()` return.

## Testing Instructions (or ideally a Blueprint)

CI
