### PR TITLE
Delete api page and api link

### DIFF
--- a/packages/docs/site/docs/blueprints/intro.md
+++ b/packages/docs/site/docs/blueprints/intro.md
@@ -22,7 +22,6 @@ Blueprints are JSON files for setting up your very own WordPress Playground inst
 -   [**Documentation**](/) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
 -   👉 [**Blueprints**](/blueprints) (you're here) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from this Blueprints docs hub.
 -   [**Developers**](/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
--   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
 
 ## Navigating the Blueprints documentation hub
 

--- a/packages/docs/site/docs/developers/intro-devs.md
+++ b/packages/docs/site/docs/developers/intro-devs.md
@@ -13,7 +13,6 @@ Hi! Welcome to WordPress Playground Developer documentation.
 -   [**Documentation**](/) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
 -   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
 -   👉 [**Developers**](/developers) (you're here) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in this Developers docs hub.
--   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
 
 ## Navigating the Developers documentation hub
 

--- a/packages/docs/site/docs/main/intro.md
+++ b/packages/docs/site/docs/main/intro.md
@@ -22,7 +22,6 @@ Playground is an online tool to experiment and learn about WordPress. This site 
 -   👉 [**Documentation**](/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
 -   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
 -   [**Developers**](/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
--   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
 
 ## Navigating this documentation hub
 

--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -168,11 +168,6 @@ const config = {
 						label: 'Developers',
 					},
 					{
-						to: 'api',
-						label: 'API Reference',
-						position: 'left',
-					},
-					{
 						href: 'https://github.com/WordPress/wordpress-playground',
 						position: 'right',
 						className: 'header-github-link',
@@ -207,10 +202,6 @@ const config = {
 							{
 								label: 'Developers',
 								to: '/developers',
-							},
-							{
-								label: 'API Reference',
-								to: '/api',
 							},
 						],
 					},


### PR DESCRIPTION
## Motivation for the change, related issues
Delete api page and api link

## Implementation details
The API Reference pages for header navigation and footer navigation no longer exist.
If you click on the link, you will see the message `This page crashed.`, so delete the link.
https://wordpress.github.io/wordpress-playground/api
<img width="1600" height="900" alt="api" src="https://github.com/user-attachments/assets/28cf6a77-0cdb-44e0-a82c-e21da67f6950" />

Remove the link to the api page.

## Testing Instructions (or ideally a Blueprint)
