### PR TITLE
[Docs] Fix documentation site build failures

### DIFF
--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/for-plugin-developers.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/for-plugin-developers.md
@@ -272,19 +272,7 @@ El ejemplo de [Instalar plugin desde un gist](https://playground.wordpress.net/b
 When providing a link to a WordPress Playground instance with some plugins activated, you may also want to customize the initial setup for that Playground instance using those plugins. With Playground's [Blueprints](/blueprints/getting-started) you can load/activate plugins and configure the Playground instance.
 -->
 
-Cuando proporcionas un enlace a una instancia de WordPress Playground con algunos plugins activados, es posible que también quieras personalizar la configuración inicial de esa instancia de Playground utilizando esos plugins. Con los [Blueprints](/blueprints/getting-started) de Playground puedes cargar/activar plugins y configurar la instancia de Playground.
-
-<!--
-:::tip
-
-Some useful tools and resources provided by the Playground project to work with blueprints are:
-
--   Check the [Blueprints Gallery](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md) to explore real-world code examples of using WordPress Playground to launch a WordPress site with a variety of setups.
--   The [WordPress Playground Step Library](https://akirk.github.io/playground-step-library/#) tool provides a visual interface to drag or click the steps to create a blueprint for WordPress Playground. You can also create your own steps!
--   The [Blueprints builder](https://playground.wordpress.net/builder/builder.html) tool allows you edit your blueprint online and run it directly in a Playground instance.
-
-:::
--->
+Cuando proporcionas un enlace a una instancia de WordPress Playlist con algunos plugins activados, es posible que también quieras personalizar la configuración inicial de esa instancia de Playground utilizando esos plugins. Con los [Blueprints](/blueprints/getting-started) de Playground puedes cargar/activar plugins y configurar la instancia de Playground.
 
 :::tip
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/resources.md
@@ -18,18 +18,6 @@ There's a set of redirections in place to make it easier the access to some of t
 
 Hay un conjunto de redirecciones para facilitar el acceso a algunas de las herramientas relacionadas con Playground:
 
-<!--
-<ul id="list-resources-redirections">
-<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → Playground instance</li>
-<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Playground Docs</li>
-<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Playground Blueprints Builder</li>
-<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Playground PR viewer for WordPress</li>
-<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Playground PR viewer for Gutenberg</li>
-<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Playground Proxy Service <em>(see <a href="/blueprints/steps/resources#urlreference">URLReference</a> for more info)</em></li>
-</ul>
-:::
--->
-
 <ul id="list-resources-redirections">
 <li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → Instancia de Playground</li>
 <li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Documentación de Playground</li>


### PR DESCRIPTION
## Motivation for the change, related issues

Removes the two HTML comments with HTML code snippets in them to fix the following docs site build error:

```
Error: MDX compilation failed for file "/home/runner/work/wordpress-playground/wordpress-playground/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/for-plugin-developers.md"
Cause: Unexpected character `!` (U+0021) before name, expected a character that can start a name, such as a letter, `$`, or `_` (note: to create a comment in MDX, use `{/* text */}`)
Details:
```

It must have fell through the cracks in one of the recent translation PRs based on an older version of `trunk` that did not yet have docs site e2e tests.

cc @fellyph 