### PR TITLE
Inject Playground commit ID to the built index.html

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -10340,7 +10340,7 @@ function validate14(
 																? validate12.errors
 																: vErrors.concat(
 																		validate12.errors
-																	);
+																  );
 														errors = vErrors.length;
 													}
 													var valid21 =
@@ -11019,7 +11019,7 @@ function validate14(
 																? validate12.errors
 																: vErrors.concat(
 																		validate12.errors
-																	);
+																  );
 														errors = vErrors.length;
 													}
 													var valid27 =
@@ -11435,7 +11435,7 @@ function validate14(
 																	? validate12.errors
 																	: vErrors.concat(
 																			validate12.errors
-																		);
+																	  );
 															errors =
 																vErrors.length;
 														}
@@ -11467,7 +11467,7 @@ function validate14(
 																		? validate18.errors
 																		: vErrors.concat(
 																				validate18.errors
-																			);
+																		  );
 																errors =
 																	vErrors.length;
 															}
@@ -11553,7 +11553,7 @@ function validate14(
 																		? validate12.errors
 																		: vErrors.concat(
 																				validate12.errors
-																			);
+																		  );
 																errors =
 																	vErrors.length;
 															}
@@ -12101,7 +12101,7 @@ function validate14(
 																	? validate12.errors
 																	: vErrors.concat(
 																			validate12.errors
-																		);
+																	  );
 															errors =
 																vErrors.length;
 														}
@@ -12133,7 +12133,7 @@ function validate14(
 																		? validate18.errors
 																		: vErrors.concat(
 																				validate18.errors
-																			);
+																		  );
 																errors =
 																	vErrors.length;
 															}
@@ -12219,7 +12219,7 @@ function validate14(
 																		? validate12.errors
 																		: vErrors.concat(
 																				validate12.errors
-																			);
+																		  );
 																errors =
 																	vErrors.length;
 															}
@@ -13969,7 +13969,7 @@ function validate14(
 																? validate30.errors
 																: vErrors.concat(
 																		validate30.errors
-																	);
+																  );
 														errors = vErrors.length;
 													}
 													var valid54 =
@@ -15456,7 +15456,7 @@ function validate14(
 																? validate32.errors
 																: vErrors.concat(
 																		validate32.errors
-																	);
+																  );
 														errors = vErrors.length;
 													}
 													var valid68 =
@@ -16180,7 +16180,7 @@ function validate14(
 																? validate12.errors
 																: vErrors.concat(
 																		validate12.errors
-																	);
+																  );
 														errors = vErrors.length;
 													}
 													var valid76 =
@@ -16810,7 +16810,7 @@ function validate14(
 																? validate12.errors
 																: vErrors.concat(
 																		validate12.errors
-																	);
+																  );
 														errors = vErrors.length;
 													}
 													var valid83 =
@@ -17589,7 +17589,7 @@ function validate14(
 																	? validate12.errors
 																	: vErrors.concat(
 																			validate12.errors
-																		);
+																	  );
 															errors =
 																vErrors.length;
 														}
@@ -18636,7 +18636,7 @@ function validate14(
 																	? validate18.errors
 																	: vErrors.concat(
 																			validate18.errors
-																		);
+																	  );
 															errors =
 																vErrors.length;
 														}
@@ -20513,7 +20513,7 @@ function validate11(
 																			? validate12.errors
 																			: vErrors.concat(
 																					validate12.errors
-																				);
+																			  );
 																	errors =
 																		vErrors.length;
 																}
@@ -21127,7 +21127,7 @@ function validate11(
 																					? validate14.errors
 																					: vErrors.concat(
 																							validate14.errors
-																						);
+																					  );
 																			errors =
 																				vErrors.length;
 																		}

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -185,6 +185,7 @@ export default defineConfig(({ command, mode }) => {
 							</head>`
 						);
 					} catch (e) {
+						// eslint-disable-next-line no-console
 						console.error('Failed to inject commit ID', e);
 						return html;
 					}

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -171,6 +171,25 @@ export default defineConfig(({ command, mode }) => {
 					}
 				},
 			} as Plugin,
+			{
+				name: 'inject-commit-id',
+				transformIndexHtml(html) {
+					try {
+						const commitId = require('child_process')
+							.execSync('git rev-parse HEAD')
+							.toString()
+							.trim();
+						return html.replace(
+							'</head>',
+							`<meta name="commit-id" content="${commitId}" />
+							</head>`
+						);
+					} catch (e) {
+						console.error('Failed to inject commit ID', e);
+						return html;
+					}
+				},
+			},
 		],
 
 		// Configuration for building your library.


### PR DESCRIPTION
## Motivation for the change, related issues

Injects a meta tag `<meta name="commit-id" content="${commitId}" />` to the built index.html to indicate which Playground version we're running.

cc @draganescu 
