### PR TITLE
[Blueprints] Add dispose functions in afterEach hooks in tests

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
@@ -25,6 +25,11 @@ describe('Blueprint step activatePlugin()', () => {
 		php = await handler.getPrimaryPhp();
 	});
 
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
 	it('should activate a plugin file located in the plugins directory', async () => {
 		const docroot = handler.documentRoot;
 		php.writeFile(

--- a/packages/playground/blueprints/src/lib/steps/activate-theme.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-theme.spec.ts
@@ -25,6 +25,11 @@ describe('Blueprint step activateTheme()', () => {
 		php = await handler.getPrimaryPhp();
 	});
 
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
 	it('should activate the theme', async () => {
 		const docroot = php.documentRoot;
 		php.mkdir(`${docroot}/wp-content/themes/test-theme`);

--- a/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/define-wp-config-consts.spec.ts
@@ -10,6 +10,10 @@ describe('defineBeforeRun', () => {
 		php = new PHP(await loadNodeRuntime(RecommendedPHPVersion));
 	});
 
+	afterEach(() => {
+		php.exit();
+	});
+
 	it('should define the constants before running the requested script', async () => {
 		const constants = {
 			SITE_URL: 'http://test.url',

--- a/packages/playground/blueprints/src/lib/steps/import-theme-starter-content.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-theme-starter-content.spec.ts
@@ -24,6 +24,11 @@ describe('Blueprint step importThemeStarterContent', () => {
 		php = await handler.getPrimaryPhp();
 	});
 
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
 	it('Should import theme starter content', async () => {
 		const docroot = php.documentRoot;
 		// Create a test theme with starter content, Must have at a minimum

--- a/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/import-wxr.spec.ts
@@ -91,6 +91,11 @@ describe('Blueprint step importWxr', () => {
 		});
 	}, 30_000);
 
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
 	it(
 		'Should import a WXR file with JSON-encoded UTF-8 characters',
 		async () => {
@@ -270,7 +275,7 @@ describe('Blueprint step importWxr', () => {
 			const result = await php.run({
 				code: `<?php
 			require getenv('DOCROOT') . '/wp-load.php';
-			
+
 			// Get all imported posts
 			$posts = get_posts([
 				'post_type' => ['post', 'page'],
@@ -279,10 +284,10 @@ describe('Blueprint step importWxr', () => {
 				'orderby' => 'ID',
 				'order' => 'ASC'
 			]);
-			
+
 			// Get admin user info
 			$admin_user = get_user_by('login', 'admin');
-			
+
 			$post_authors = [];
 			foreach ($posts as $post) {
 				$author = get_user_by('ID', $post->post_author);
@@ -295,7 +300,7 @@ describe('Blueprint step importWxr', () => {
 					'author_display_name' => $author ? $author->display_name : null,
 				];
 			}
-			
+
 			echo json_encode([
 				'admin_user_id' => $admin_user ? $admin_user->ID : null,
 				'admin_user_login' => $admin_user ? $admin_user->user_login : null,

--- a/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-plugin.spec.ts
@@ -14,8 +14,8 @@ async function zipFiles(
 	const zipFilePath = `/${zipFileName}`;
 
 	await php.run({
-		code: `<?php $zip = new ZipArchive(); 
-					 $zip->open("${zipFilePath}", ZIPARCHIVE::CREATE); 
+		code: `<?php $zip = new ZipArchive();
+					 $zip->open("${zipFilePath}", ZIPARCHIVE::CREATE);
 					 $files = ${phpVar(files)};
 					 foreach($files as $path => $content) {
 						$zip->addFromString($path, $content);
@@ -84,6 +84,10 @@ describe('Blueprint step installPlugin', () => {
 		pluginsPath = `${rootPath}/wp-content/plugins`;
 		php.mkdir(pluginsPath);
 		installedPluginPath = `${pluginsPath}/${pluginName}`;
+	});
+
+	afterEach(() => {
+		php.exit();
 	});
 
 	it('should install a plugin', async () => {

--- a/packages/playground/blueprints/src/lib/steps/install-theme.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/install-theme.spec.ts
@@ -46,8 +46,9 @@ describe('Blueprint step installTheme', () => {
 		expect(php.fileExists(zipFilePath)).toBe(true);
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		php.exit();
+		await handler[Symbol.asyncDispose]();
 	});
 
 	const expectedThemeIndexPhpPath =
@@ -179,7 +180,11 @@ describe('Blueprint step installTheme', () => {
 					targetFolderName: 'test-expected-theme',
 				},
 			});
-			expect(php.fileExists(`${rootPath}/wp-content/themes/test-expected-theme/`)).toBe(true);
+			expect(
+				php.fileExists(
+					`${rootPath}/wp-content/themes/test-expected-theme/`
+				)
+			).toBe(true);
 		});
 	});
 });

--- a/packages/playground/blueprints/src/lib/steps/login.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/login.spec.ts
@@ -26,6 +26,11 @@ describe('Blueprint step login', () => {
 		php = await handler.getPrimaryPhp();
 	});
 
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
 	const requestFollowRedirects = async (request: PHPRequest) => {
 		let response = await handler.request(request);
 		while (response.httpStatusCode === 302) {

--- a/packages/playground/blueprints/src/lib/steps/mkdir.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/mkdir.spec.ts
@@ -16,6 +16,7 @@ describe('Blueprint step mkdir', () => {
 
 	afterEach(() => {
 		loggerErrorSpy.mockRestore();
+		php.exit();
 	});
 
 	it('should create a directory', async () => {

--- a/packages/playground/blueprints/src/lib/steps/mv.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/mv.spec.ts
@@ -18,6 +18,7 @@ describe('Blueprint step mv()', () => {
 
 	afterEach(() => {
 		loggerErrorSpy.mockRestore();
+		php.exit();
 	});
 
 	it('should move a file', async () => {

--- a/packages/playground/blueprints/src/lib/steps/reset-data.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/reset-data.spec.ts
@@ -24,11 +24,15 @@ describe('Blueprint step resetData()', () => {
 		php = await handler.getPrimaryPhp();
 	});
 
+	afterEach(() => {
+		php.exit();
+	});
+
 	it('should assign ID=1 to the first post created after applying the resetData step', async () => {
 		php.writeFile(`${docroot}/index.php`, `<?php echo 'Hello World';`);
 		await resetData(php, {});
 		const result = await php.run({
-			code: `<?php 
+			code: `<?php
 			require "/php/wp-load.php";
 			// Create a new WordPress post
 			$postId = wp_insert_post([

--- a/packages/playground/blueprints/src/lib/steps/rm.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/rm.spec.ts
@@ -18,6 +18,7 @@ describe('Blueprint step rm()', () => {
 
 	afterEach(() => {
 		loggerErrorSpy.mockRestore();
+		php.exit();
 	});
 
 	it('should remove a file', async () => {

--- a/packages/playground/blueprints/src/lib/steps/rmdir.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/rmdir.spec.ts
@@ -18,6 +18,7 @@ describe('Blueprint step rmdir()', () => {
 
 	afterEach(() => {
 		loggerErrorSpy.mockRestore();
+		php.exit();
 	});
 
 	it('should remove a directory', async () => {

--- a/packages/playground/blueprints/src/lib/steps/run-php.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-php.spec.ts
@@ -17,6 +17,7 @@ describe('Blueprint step runPHP', () => {
 
 	afterEach(() => {
 		loggerErrorSpy.mockRestore();
+		php.exit();
 	});
 
 	it('should run PHP code', async () => {

--- a/packages/playground/blueprints/src/lib/steps/run-sql.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-sql.spec.ts
@@ -50,6 +50,11 @@ describe('Blueprint step runSql', () => {
 		);
 	});
 
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
 	it('should split and "run" sql queries', async () => {
 		// Test a single query
 		await runSql(php, {

--- a/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/site-data.spec.ts
@@ -24,6 +24,11 @@ describe('Blueprint step setSiteOptions()', () => {
 		php = await handler.getPrimaryPhp();
 	});
 
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
 	it('should set the site option', async () => {
 		await setSiteOptions(php, {
 			options: {

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
@@ -31,6 +31,10 @@ describe('Blueprint step wpCLI', () => {
 		php = await handler.getPrimaryPhp();
 	});
 
+	afterEach(() => {
+		php.exit();
+	});
+
 	it('should run wp-cli commands', async () => {
 		const result = await wpCLI(php, {
 			command:

--- a/packages/playground/blueprints/src/lib/steps/write-file.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/write-file.spec.ts
@@ -18,6 +18,7 @@ describe('Blueprint step writeFile()', () => {
 
 	afterEach(() => {
 		loggerErrorSpy.mockRestore();
+		php.exit();
 	});
 
 	it('should write a file with string data', async () => {

--- a/packages/playground/blueprints/src/lib/steps/write-files.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/write-files.spec.ts
@@ -16,6 +16,11 @@ describe('writeFiles', () => {
 		php = await handler.getPrimaryPhp();
 	});
 
+	afterEach(async () => {
+		php.exit();
+		await handler[Symbol.asyncDispose]();
+	});
+
 	it('should write files to the document root', async () => {
 		await writeFiles(php, {
 			writeToPath: '/wordpress/wp-content/plugins/test-plugin',


### PR DESCRIPTION
## Motivation for the change, related issues

Based on [this comment](https://github.com/WordPress/wordpress-playground/pull/2910#issuecomment-3552020628) 

The `nx run playground-blueprints:"test:vite"` command systematically fails due to 10 seconds timeout on the `should activate a plugin file located in the plugins directory` test.

IIRC I also faced that situation with the PHP.wasm node tests and adding dispose methods made the trick. Let's see if it works here too.

## Implementation details

Adding the following portion of code where necessary :

```typescript
afterEach(async () => {
	php.exit();
	await handler[Symbol.asyncDispose]();
});
```

## Testing Instructions

CI