### PR TITLE
Fix SQLite plugin logging to respect skip option

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -108,11 +108,14 @@ export class BlueprintsV1Handler {
 			);
 		}
 
-		logger.log(`Fetching SQLite integration plugin...`);
-
-		const sqliteIntegrationPluginZip = this.args.skipSqliteSetup
-			? undefined
-			: await fetchSqliteIntegration(monitor);
+		let sqliteIntegrationPluginZip;
+		if (this.args.skipSqliteSetup) {
+			logger.log(`Skipping SQLite integration plugin setup...`);
+			sqliteIntegrationPluginZip = undefined;
+		} else {
+			logger.log(`Fetching SQLite integration plugin...`);
+			sqliteIntegrationPluginZip = await fetchSqliteIntegration(monitor);
+		}
 
 		const followSymlinks = this.args.followSymlinks === true;
 		const trace = this.args.experimentalTrace === true;


### PR DESCRIPTION
## Motivation for the change, related issues

Fixes logging in the CLI blueprints handler to display "Skipping SQLite integration plugin setup..." when `--skip-sqlite-setup` is used, instead of always showing "Fetching SQLite integration plugin..." regardless of the skip option.

## Implementation details

Modified `packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts` to conditionally log the appropriate message based on `skipSqliteSetup`.

## Testing Instructions (or ideally a Blueprint)

 To test this change:
  1. Set up [Playground repository locally](https://github.com/wojtekn/wordpress-playground/blob/trunk/README.md#running-wordpress-playground-locally)
  2. Run the CLI with `--skip-sqlite-setup` flag and verify the log shows "Skipping..." message
  3. Run the CLI without the flag and verify it shows "Fetching..." message

  Example commands:
  ```bash
  # Should show "Skipping SQLite integration plugin setup..."
  node --no-warnings=ExperimentalWarning  --experimental-strip-types --experimental-transform-types --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts server --skip-sqlite-setup

  # Should show "Fetching SQLite integration plugin..."
  node --no-warnings=ExperimentalWarning  --experimental-strip-types --experimental-transform-types --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts server
