### PR TITLE
[CLI] Support TERM=dumb

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -102,7 +102,7 @@ export class BlueprintsV1Handler {
 						wpDetails.releaseUrl,
 						`${wpDetails.version}.zip`,
 						monitor
-				  );
+					);
 			logger.log(
 				`Resolved WordPress release URL: ${wpDetails?.releaseUrl}`
 			);
@@ -265,7 +265,7 @@ export class BlueprintsV1Handler {
 							'latest',
 						...(resolvedBlueprint?.preferredVersions || {}),
 					},
-			  };
+				};
 	}
 
 	writeProgressUpdate(
@@ -274,6 +274,9 @@ export class BlueprintsV1Handler {
 		finalUpdate: boolean
 	) {
 		if (this.args.verbosity === LogVerbosity.Quiet.name) {
+			return;
+		}
+		if (!this.shouldRenderProgress(writeStream)) {
 			return;
 		}
 		if (message === this.lastProgressMessage) {
@@ -295,5 +298,13 @@ export class BlueprintsV1Handler {
 			// Fall back to writing one line per progress update
 			writeStream.write(`${message}\n`);
 		}
+	}
+
+	private shouldRenderProgress(writeStream: NodeJS.WriteStream) {
+		const termIsDumb = (process.env.TERM || '').toLowerCase() === 'dumb';
+		const ciFlag = (process.env.CI || '').toLowerCase();
+		const runningInCI = ciFlag === '1' || ciFlag === 'true';
+
+		return writeStream.isTTY && !termIsDumb && !runningInCI;
 	}
 }

--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -25,6 +25,7 @@ import {
 	type SpawnedWorker,
 	type WorkerType,
 } from '../run-cli';
+import { shouldRenderProgress } from '../utils/progress';
 
 /**
  * Boots Playground CLI workers using Blueprint version 1.
@@ -276,7 +277,7 @@ export class BlueprintsV1Handler {
 		if (this.args.verbosity === LogVerbosity.Quiet.name) {
 			return;
 		}
-		if (!this.shouldRenderProgress(writeStream)) {
+		if (!shouldRenderProgress(writeStream)) {
 			return;
 		}
 		if (message === this.lastProgressMessage) {
@@ -298,13 +299,5 @@ export class BlueprintsV1Handler {
 			// Fall back to writing one line per progress update
 			writeStream.write(`${message}\n`);
 		}
-	}
-
-	private shouldRenderProgress(writeStream: NodeJS.WriteStream) {
-		const termIsDumb = (process.env['TERM'] || '').toLowerCase() === 'dumb';
-		const ciFlag = (process.env['CI'] || '').toLowerCase();
-		const runningInCI = ciFlag === '1' || ciFlag === 'true';
-
-		return writeStream.isTTY && !termIsDumb && !runningInCI;
 	}
 }

--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -301,8 +301,8 @@ export class BlueprintsV1Handler {
 	}
 
 	private shouldRenderProgress(writeStream: NodeJS.WriteStream) {
-		const termIsDumb = (process.env.TERM || '').toLowerCase() === 'dumb';
-		const ciFlag = (process.env.CI || '').toLowerCase();
+		const termIsDumb = (process.env['TERM'] || '').toLowerCase() === 'dumb';
+		const ciFlag = (process.env['CI'] || '').toLowerCase();
 		const runningInCI = ciFlag === '1' || ciFlag === 'true';
 
 		return writeStream.isTTY && !termIsDumb && !runningInCI;

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -6,6 +6,7 @@ import type {
 } from './worker-thread-v2';
 import type { MessagePort as NodeMessagePort } from 'worker_threads';
 import type { RunCLIArgs, SpawnedWorker, WorkerType } from '../run-cli';
+import { shouldRenderProgress } from '../utils/progress';
 
 /**
  * Boots Playground CLI workers using Blueprint version 2.
@@ -108,7 +109,7 @@ export class BlueprintsV2Handler {
 		message: string,
 		finalUpdate: boolean
 	) {
-		if (!this.shouldRenderProgress(writeStream)) {
+		if (!shouldRenderProgress(writeStream)) {
 			return;
 		}
 		if (message === this.lastProgressMessage) {
@@ -130,14 +131,5 @@ export class BlueprintsV2Handler {
 			// Fall back to writing one line per progress update
 			writeStream.write(`${message}\n`);
 		}
-	}
-
-	private shouldRenderProgress(writeStream: NodeJS.WriteStream) {
-		const termIsDumb =
-			(process?.env['TERM'] || '').toLowerCase() === 'dumb';
-		const ciFlag = (process?.env['CI'] || '').toLowerCase();
-		const runningInCI = ciFlag === '1' || ciFlag === 'true';
-
-		return writeStream.isTTY && !termIsDumb && !runningInCI;
 	}
 }

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -108,6 +108,9 @@ export class BlueprintsV2Handler {
 		message: string,
 		finalUpdate: boolean
 	) {
+		if (!this.shouldRenderProgress(writeStream)) {
+			return;
+		}
 		if (message === this.lastProgressMessage) {
 			// Avoid repeating the same message
 			return;
@@ -127,5 +130,14 @@ export class BlueprintsV2Handler {
 			// Fall back to writing one line per progress update
 			writeStream.write(`${message}\n`);
 		}
+	}
+
+	private shouldRenderProgress(writeStream: NodeJS.WriteStream) {
+		const termIsDumb =
+			(process?.env['TERM'] || '').toLowerCase() === 'dumb';
+		const ciFlag = (process?.env['CI'] || '').toLowerCase();
+		const runningInCI = ciFlag === '1' || ciFlag === 'true';
+
+		return writeStream.isTTY && !termIsDumb && !runningInCI;
 	}
 }

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -39,6 +39,7 @@ import type {
 	PhpIniOptions,
 	PHPInstanceCreatedHook,
 } from '@wp-playground/wordpress';
+import { shouldRenderProgress } from '../utils/progress';
 
 async function mountResources(php: PHP, mounts: Mount[]) {
 	for (const mount of mounts) {
@@ -85,21 +86,13 @@ function tracePhpWasm(processId: number, format: string, ...args: any[]) {
 Object.defineProperty(process.stdout, 'isTTY', { value: true });
 Object.defineProperty(process.stderr, 'isTTY', { value: true });
 
-const shouldRenderProgress = () => {
-	const termIsDumb = (process.env.TERM || '').toLowerCase() === 'dumb';
-	const ciFlag = (process.env.CI || '').toLowerCase();
-	const runningInCI = ciFlag === '1' || ciFlag === 'true';
-
-	return !termIsDumb && !runningInCI;
-};
-
 /**
  * Output writer that ensures that progress bars are not printed on the same line as other output.
  */
 const output = {
 	lastWriteWasProgress: false,
 	progress(data: string) {
-		if (!shouldRenderProgress()) {
+		if (!shouldRenderProgress(process.stdout)) {
 			return;
 		}
 		if (!process.stdout.isTTY) {

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -74,7 +74,8 @@ function tracePhpWasm(processId: number, format: string, ...args: any[]) {
 }
 
 /**
- * Force TTY status to preserve ANSI control codes in the output.
+ * Force TTY status to preserve ANSI control codes in the output
+ * when the environment is interactive.
  *
  * This script is spawned as `new Worker()` and process.stdout and process.stderr are
  * WritableWorkerStdio objects. By default, they strip ANSI control codes from the output
@@ -84,12 +85,23 @@ function tracePhpWasm(processId: number, format: string, ...args: any[]) {
 Object.defineProperty(process.stdout, 'isTTY', { value: true });
 Object.defineProperty(process.stderr, 'isTTY', { value: true });
 
+const shouldRenderProgress = () => {
+	const termIsDumb = (process.env.TERM || '').toLowerCase() === 'dumb';
+	const ciFlag = (process.env.CI || '').toLowerCase();
+	const runningInCI = ciFlag === '1' || ciFlag === 'true';
+
+	return !termIsDumb && !runningInCI;
+};
+
 /**
  * Output writer that ensures that progress bars are not printed on the same line as other output.
  */
 const output = {
 	lastWriteWasProgress: false,
 	progress(data: string) {
+		if (!shouldRenderProgress()) {
+			return;
+		}
 		if (!process.stdout.isTTY) {
 			// eslint-disable-next-line no-console
 			console.log(data);
@@ -382,9 +394,8 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 			if ((await streamedResponse!.exitCode) !== 0) {
 				// exitCode != 1 means the blueprint execution failed. Let's throw an error.
 				// and clean up.
-				const syncResponse = await PHPResponse.fromStreamedResponse(
-					streamedResponse
-				);
+				const syncResponse =
+					await PHPResponse.fromStreamedResponse(streamedResponse);
 				throw new PHPExecutionFailureError(
 					`PHP.run() failed with exit code ${syncResponse.exitCode}.`,
 					syncResponse,

--- a/packages/playground/cli/src/utils/progress.ts
+++ b/packages/playground/cli/src/utils/progress.ts
@@ -1,0 +1,17 @@
+export function shouldRenderProgress(
+	writeStream?: { isTTY?: boolean } | null
+): boolean {
+	const termIsDumb = (process.env.TERM || '').toLowerCase() === 'dumb';
+	const ciFlag = (process.env.CI || '').toLowerCase();
+	const runningInCI = ciFlag === '1' || ciFlag === 'true';
+
+	if (termIsDumb || runningInCI) {
+		return false;
+	}
+
+	if (writeStream) {
+		return Boolean(writeStream.isTTY);
+	}
+
+	return true;
+}

--- a/packages/playground/cli/src/utils/progress.ts
+++ b/packages/playground/cli/src/utils/progress.ts
@@ -1,8 +1,8 @@
 export function shouldRenderProgress(
 	writeStream?: { isTTY?: boolean } | null
 ): boolean {
-	const termIsDumb = (process.env.TERM || '').toLowerCase() === 'dumb';
-	const ciFlag = (process.env.CI || '').toLowerCase();
+	const termIsDumb = (process.env['TERM'] || '').toLowerCase() === 'dumb';
+	const ciFlag = (process.env['CI'] || '').toLowerCase();
 	const runningInCI = ciFlag === '1' || ciFlag === 'true';
 
 	if (termIsDumb || runningInCI) {


### PR DESCRIPTION
## Motivation for the change, related issues

Detects a "dumb terminal" and CI environments in the CLI worker to avoid using rich output features such as line rewriting.

Why?

Because CI logs for the playground-cli tests are polluted with progress updates:

```
  Downloading WordPress 8%...
  Downloading WordPress 9%...
  Downloading WordPress 10%...
  Downloading WordPress 11%...
  Downloading WordPress 12%...
  Downloading WordPress 13%...
  Downloading WordPress 14%...
  Downloading WordPress 15%...
  Resolving data reference #5: https://downloads.w.org/release/wordpress-6.3.7.zip – 23.76%
  Resolving data reference #5: https://downloads.w.org/release/wordpress-6.3.7.zip – 23.76%
  Resolving data reference #5: https://downloads.w.org/release/wordpress-6.3.7.zip – 23.76%
  Resolving data reference #5: https://downloads.w.org/release/wordpress-6.3.7.zip – 23.77%
  Resolving data reference #5: https://downloads.w.org/release/wordpress-6.3.7.zip – 23.77%
  Resolving data reference #5: https://downloads.w.org/release/wordpress-6.3.7.zip – 23.77%
```

## Testing Instructions (or ideally a Blueprint)

Inspect the CLI CI tests output and confirm it's clean.