### PR TITLE
[CLI] Define CLI --flags for each command individually

### DIFF
--- a/packages/php-wasm/xdebug-bridge/src/lib/run-cli.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/run-cli.ts
@@ -20,7 +20,7 @@ interface CLIArgs {
 }
 
 function parseCliArgs(): CLIArgs {
-	return yargs(hideBin(process.argv))
+	const { _, $0, ...parsed } = yargs<CLIArgs>(hideBin(process.argv))
 		.usage(
 			`
 XDebug Bridge Server CLI
@@ -62,7 +62,10 @@ Examples:
 		`
 		)
 		.wrap(null)
-		.parseSync() as CLIArgs;
+		.strict()
+		.parseSync();
+
+	return parsed;
 }
 
 export async function main(): Promise<void> {

--- a/packages/php-wasm/xdebug-bridge/src/lib/run-cli.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/run-cli.ts
@@ -20,7 +20,7 @@ interface CLIArgs {
 }
 
 function parseCliArgs(): CLIArgs {
-	const { _, $0, ...parsed } = yargs<CLIArgs>(hideBin(process.argv))
+	return yargs(hideBin(process.argv))
 		.usage(
 			`
 XDebug Bridge Server CLI
@@ -63,9 +63,7 @@ Examples:
 		)
 		.wrap(null)
 		.strict()
-		.parseSync();
-
-	return parsed;
+		.parseSync() as CLIArgs;
 }
 
 export async function main(): Promise<void> {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -288,31 +288,31 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			},
 		};
 
-		const commandWithOptions =
-			(commandOptions: Record<string, YargsOptions> = {}) =>
-			(yargsInstance: Argv) =>
-				yargsInstance.options({ ...sharedOptions, ...commandOptions });
-
 		const yargsObject = yargs(argsToParse)
 			.usage('Usage: wp-playground <command> [options]')
 			.command(
 				'server',
 				'Start a local WordPress server',
-				commandWithOptions({
-					...serverOnlyOptions,
-				})
+				(yargsInstance: Argv) =>
+					yargsInstance.options({
+						...sharedOptions,
+						...serverOnlyOptions,
+					})
 			)
 			.command(
 				'run-blueprint',
 				'Execute a Blueprint without starting a server',
-				commandWithOptions()
+				(yargsInstance: Argv) =>
+					yargsInstance.options({ ...sharedOptions })
 			)
 			.command(
 				'build-snapshot',
 				'Build a ZIP snapshot of a WordPress site based on a Blueprint',
-				commandWithOptions({
-					...buildSnapshotOnlyOptions,
-				})
+				(yargsInstance: Argv) =>
+					yargsInstance.options({
+						...sharedOptions,
+						...buildSnapshotOnlyOptions,
+					})
 			)
 			.demandCommand(1, 'Please specify a command')
 			.strictCommands()
@@ -675,7 +675,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	}
 
 	const selectedPort =
-		args.command === 'server' ? (args['port'] as number) ?? 9400 : 0;
+		args.command === 'server' ? ((args['port'] as number) ?? 9400) : 0;
 
 	// Declare file lock manager outside scope of startServer
 	// so we can look at it when debugging request handling.

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -341,10 +341,14 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					args['wordpressInstallMode'] = 'do-not-attempt-installing';
 				}
 
-				if (args.wp !== undefined && !isValidWordPressSlug(args.wp)) {
+				if (
+					args['wp'] !== undefined &&
+					typeof args['wp'] === 'string' &&
+					!isValidWordPressSlug(args['wp'])
+				) {
 					try {
 						// Check if is valid URL
-						new URL(args.wp);
+						new URL(args['wp']);
 					} catch {
 						throw new Error(
 							'Unrecognized WordPress version. Please use "latest", a URL, or a numeric version such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
@@ -352,12 +356,16 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					}
 				}
 
-				if (args['site-url'] !== undefined && args['site-url'] !== '') {
+				const siteUrlArg = args['site-url'];
+				if (
+					typeof siteUrlArg === 'string' &&
+					siteUrlArg.trim() !== ''
+				) {
 					try {
-						new URL(args['site-url']);
+						new URL(siteUrlArg);
 					} catch {
 						throw new Error(
-							`Invalid site-url "${args['site-url']}". Please provide a valid URL (e.g., http://localhost:8080 or https://example.com)`
+							`Invalid site-url "${siteUrlArg}". Please provide a valid URL (e.g., http://localhost:8080 or https://example.com)`
 						);
 					}
 				}
@@ -365,7 +373,9 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				if (args['auto-mount']) {
 					let autoMountIsDir = false;
 					try {
-						const autoMountStats = fs.statSync(args['auto-mount']);
+						const autoMountStats = fs.statSync(
+							args['auto-mount'] as string
+						);
 						autoMountIsDir = autoMountStats.isDirectory();
 					} catch {
 						autoMountIsDir = false;
@@ -385,7 +395,11 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 							'The --experimental-multi-worker flag is only supported when running the server command.'
 						);
 					}
-					if (args['experimental-multi-worker'] <= 1) {
+					if (
+						args['experimental-multi-worker'] !== undefined &&
+						typeof args['experimental-multi-worker'] === 'number' &&
+						args['experimental-multi-worker'] <= 1
+					) {
 						throw new Error(
 							'The --experimental-multi-worker flag must be a positive integer greater than 1.'
 						);
@@ -457,10 +471,13 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		const cliArgs = {
 			...args,
 			command,
-			mount: [...(args.mount || []), ...(args['mount-dir'] || [])],
+			mount: [
+				...((args['mount'] as Mount[]) || []),
+				...((args['mount-dir'] as Mount[]) || []),
+			],
 			'mount-before-install': [
-				...(args['mount-before-install'] || []),
-				...(args['mount-dir-before-install'] || []),
+				...((args['mount-before-install'] as Mount[]) || []),
+				...((args['mount-dir-before-install'] as Mount[]) || []),
 			],
 		} as RunCLIArgs;
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -633,6 +633,9 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 		args.intl = true;
 	}
 
+	const selectedPort =
+		args.command === 'server' ? (args['port'] as number) ?? 9400 : 0;
+
 	// Declare file lock manager outside scope of startServer
 	// so we can look at it when debugging request handling.
 	const nativeFlockSync =
@@ -657,7 +660,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	logger.log('Starting a PHP server...');
 
 	return startServer({
-		port: args['port'] as number,
+		port: selectedPort,
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';
 			const serverUrl = `http://${host}:${port}`;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -37,7 +37,7 @@ import { SupportedPHPVersions } from '@php-wasm/universal';
 import { cpus } from 'os';
 import { jspi } from 'wasm-feature-detect';
 import type { MessagePort as NodeMessagePort } from 'worker_threads';
-import yargs from 'yargs';
+import yargs, { type Argv, type Options as YargsOptions } from 'yargs';
 import { isValidWordPressSlug } from './is-valid-wordpress-slug';
 import { resolveBlueprint } from './resolve-blueprint';
 import { BlueprintsV2Handler } from './blueprints-v2/blueprints-v2-handler';
@@ -84,93 +84,71 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		 * @TODO This looks similar to Query API args https://wordpress.github.io/wordpress-playground/developers/apis/query-api/
 		 *       Perhaps the two could be handled by the same code?
 		 */
-		const yargsObject = yargs(argsToParse)
-			.usage('Usage: wp-playground <command> [options]')
-			.command('server', 'Start a local WordPress server')
-			.command(
-				'run-blueprint',
-				'Execute a Blueprint without starting a server'
-			)
-			.command(
-				'build-snapshot',
-				'Build a ZIP snapshot of a WordPress site based on a Blueprint'
-			)
-			.demandCommand(1, 'Please specify a command')
-			.strictCommands()
-			.option('outfile', {
-				describe: 'When building, write to this output file.',
-				type: 'string',
-				default: 'wordpress.zip',
-			})
-			.option('port', {
-				describe: 'Port to listen on when serving.',
-				type: 'number',
-				default: 9400,
-			})
-			.option('site-url', {
+		const sharedOptions: Record<string, YargsOptions> = {
+			'site-url': {
 				describe:
 					'Site URL to use for WordPress. Defaults to http://127.0.0.1:{port}',
 				type: 'string',
-			})
-			.option('php', {
+			},
+			php: {
 				describe: 'PHP version to use.',
 				type: 'string',
 				default: RecommendedPHPVersion,
 				choices: SupportedPHPVersions,
-			})
-			.option('wp', {
+			},
+			wp: {
 				describe: 'WordPress version to use.',
 				type: 'string',
 				default: 'latest',
-			})
+			},
 			// @TODO: Support read-only mounts, e.g. via WORKERFS, a custom
 			// ReadOnlyNODEFS, or by copying the files into MEMFS
-			.option('mount', {
+			mount: {
 				describe:
 					'Mount a directory to the PHP runtime (can be used multiple times). Format: /host/path:/vfs/path',
 				type: 'array',
 				string: true,
 				coerce: parseMountWithDelimiterArguments,
-			})
-			.option('mount-before-install', {
+			},
+			'mount-before-install': {
 				describe:
 					'Mount a directory to the PHP runtime before WordPress installation (can be used multiple times). Format: /host/path:/vfs/path',
 				type: 'array',
 				string: true,
 				coerce: parseMountWithDelimiterArguments,
-			})
-			.option('mount-dir', {
+			},
+			'mount-dir': {
 				describe:
 					'Mount a directory to the PHP runtime (can be used multiple times). Format: "/host/path" "/vfs/path"',
 				type: 'array',
 				nargs: 2,
 				array: true,
 				coerce: parseMountDirArguments,
-			})
-			.option('mount-dir-before-install', {
+			},
+			'mount-dir-before-install': {
 				describe:
 					'Mount a directory before WordPress installation (can be used multiple times). Format: "/host/path" "/vfs/path"',
 				type: 'string',
 				nargs: 2,
 				array: true,
 				coerce: parseMountDirArguments,
-			})
-			.option('login', {
+			},
+			login: {
 				describe: 'Should log the user in',
 				type: 'boolean',
 				default: false,
-			})
-			.option('blueprint', {
+			},
+			blueprint: {
 				describe: 'Blueprint to execute.',
 				type: 'string',
-			})
-			.option('blueprint-may-read-adjacent-files', {
+			},
+			'blueprint-may-read-adjacent-files': {
 				describe:
 					'Consent flag: Allow "bundled" resources in a local blueprint to read files in the same directory as the blueprint file.',
 				type: 'boolean',
 				default: false,
-			})
-			.option('wordpress-install-mode', {
+			},
+			'wordpress-install-mode': {
 				describe:
 					'Control how Playground prepares WordPress before booting.',
 				type: 'string',
@@ -181,76 +159,76 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					'install-from-existing-files-if-needed',
 					'do-not-attempt-installing',
 				] as const,
-			})
-			.option('skip-wordpress-install', {
+			},
+			'skip-wordpress-install': {
 				describe: '[Deprecated] Use --wordpress-install-mode instead.',
 				type: 'boolean',
 				hidden: true,
-			})
-			.option('skip-sqlite-setup', {
+			},
+			'skip-sqlite-setup': {
 				describe:
 					'Skip the SQLite integration plugin setup to allow the WordPress site to use MySQL.',
 				type: 'boolean',
 				default: false,
-			})
+			},
 			// Hidden - Deprecated in favor of verbosity
-			.option('quiet', {
+			quiet: {
 				describe: 'Do not output logs and progress messages.',
 				type: 'boolean',
 				default: false,
 				hidden: true,
-			})
-			.option('verbosity', {
+			},
+			verbosity: {
 				describe: 'Output logs and progress messages.',
 				type: 'string',
 				choices: Object.values(LogVerbosity).map(
 					(verbosity) => verbosity.name
 				),
 				default: 'normal',
-			})
-			.option('debug', {
+			},
+			debug: {
 				describe:
 					'Print PHP error log content if an error occurs during Playground boot.',
 				type: 'boolean',
 				default: false,
-			})
-			.option('auto-mount', {
+			},
+			'auto-mount': {
 				describe: `Automatically mount the specified directory. If no path is provided, mount the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.`,
 				type: 'string',
-			})
-			.option('follow-symlinks', {
+			},
+			'follow-symlinks': {
 				describe:
 					'Allow Playground to follow symlinks by automatically mounting symlinked directories and files encountered in mounted directories. \nWarning: Following symlinks will expose files outside mounted directories to Playground and could be a security risk.',
 				type: 'boolean',
 				default: false,
-			})
-			.option('experimental-trace', {
+			},
+			'experimental-trace': {
 				describe:
 					'Print detailed messages about system behavior to the console. Useful for troubleshooting.',
 				type: 'boolean',
 				default: false,
 				// Hide this option because we want to replace with a more general log-level flag.
 				hidden: true,
-			})
-			.option('internal-cookie-store', {
+			},
+			'internal-cookie-store': {
 				describe:
 					'Enable internal cookie handling. When enabled, Playground will manage cookies internally using ' +
 					'an HttpCookieStore that persists cookies across requests. When disabled, cookies are handled ' +
 					'externally (e.g., by a browser in Node.js environments).',
 				type: 'boolean',
 				default: false,
-			})
-			.option('intl', {
+			},
+			intl: {
 				describe: 'Enable Intl.',
 				type: 'boolean',
 				default: true,
-			})
-			.option('xdebug', {
+			},
+			xdebug: {
 				describe: 'Enable Xdebug.',
 				type: 'boolean',
 				default: false,
-			})
-			.option('experimental-unsafe-ide-integration', {
+			},
+			'experimental-unsafe-ide-integration': {
 				describe:
 					'Enable experimental IDE development tools. This option edits IDE config files ' +
 					'to set Xdebug path mappings and web server details. CAUTION: If there are bugs, ' +
@@ -263,16 +241,31 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				choices: ['', 'vscode', 'phpstorm'],
 				coerce: (value?: string) =>
 					value === '' ? ['vscode', 'phpstorm'] : [value],
-			})
-			.option('experimental-devtools', {
-				describe: 'Enable experimental browser development tools.',
+			},
+			'experimental-blueprints-v2-runner': {
+				describe: 'Use the experimental Blueprint V2 runner.',
 				type: 'boolean',
-			})
-			.conflicts(
-				'experimental-unsafe-ide-integration',
-				'experimental-devtools'
-			)
-			.option('experimental-multi-worker', {
+				default: false,
+				// Remove the "hidden" flag once Blueprint V2 is fully supported
+				hidden: true,
+			},
+			mode: {
+				describe:
+					'Blueprints v2 runner mode to use. This option is required when using the --experimental-blueprints-v2-runner flag with a blueprint.',
+				type: 'string',
+				choices: ['create-new-site', 'apply-to-existing-site'],
+				// Remove the "hidden" flag once Blueprint V2 is fully supported
+				hidden: true,
+			},
+		};
+
+		const serverOnlyOptions: Record<string, YargsOptions> = {
+			port: {
+				describe: 'Port to listen on when serving.',
+				type: 'number',
+				default: 9400,
+			},
+			'experimental-multi-worker': {
 				describe:
 					'Enable experimental multi-worker support which requires ' +
 					'a /wordpress directory backed by a real filesystem. ' +
@@ -280,22 +273,53 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					'Otherwise, default to the number of CPUs minus 1.',
 				type: 'number',
 				coerce: (value?: number) => value ?? cpus().length - 1,
-			})
-			.option('experimental-blueprints-v2-runner', {
-				describe: 'Use the experimental Blueprint V2 runner.',
+			},
+			'experimental-devtools': {
+				describe: 'Enable experimental browser development tools.',
 				type: 'boolean',
-				default: false,
-				// Remove the "hidden" flag once Blueprint V2 is fully supported
-				hidden: true,
-			})
-			.option('mode', {
-				describe:
-					'Blueprints v2 runner mode to use. This option is required when using the --experimental-blueprints-v2-runner flag with a blueprint.',
+			},
+		};
+
+		const buildSnapshotOnlyOptions: Record<string, YargsOptions> = {
+			outfile: {
+				describe: 'When building, write to this output file.',
 				type: 'string',
-				choices: ['create-new-site', 'apply-to-existing-site'],
-				// Remove the "hidden" flag once Blueprint V2 is fully supported
-				hidden: true,
-			})
+				default: 'wordpress.zip',
+			},
+		};
+
+		const commandWithOptions =
+			(commandOptions: Record<string, YargsOptions> = {}) =>
+			(yargsInstance: Argv) =>
+				yargsInstance.options({ ...sharedOptions, ...commandOptions });
+
+		const yargsObject = yargs(argsToParse)
+			.usage('Usage: wp-playground <command> [options]')
+			.command(
+				'server',
+				'Start a local WordPress server',
+				commandWithOptions({
+					...serverOnlyOptions,
+				})
+			)
+			.command(
+				'run-blueprint',
+				'Execute a Blueprint without starting a server',
+				commandWithOptions()
+			)
+			.command(
+				'build-snapshot',
+				'Build a ZIP snapshot of a WordPress site based on a Blueprint',
+				commandWithOptions({
+					...buildSnapshotOnlyOptions,
+				})
+			)
+			.demandCommand(1, 'Please specify a command')
+			.strictCommands()
+			.conflicts(
+				'experimental-unsafe-ide-integration',
+				'experimental-devtools'
+			)
 			.showHelpOnFail(false)
 			.fail((msg, err, yargsInstance) => {
 				if (err) {

--- a/packages/playground/cli/tests/file-locking.spec.ts
+++ b/packages/playground/cli/tests/file-locking.spec.ts
@@ -23,6 +23,8 @@ describe('Playground CLI file locking', () => {
 
 		cliServer = await runCLI({
 			command: 'server',
+			// Use a unique port to avoid conflicts with other test suites
+			port: 9600,
 			mount: [
 				{
 					hostPath: nativeTestDir,

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -25,12 +25,17 @@ import { type Log, logger } from '@php-wasm/logger';
 const blueprintVersions = [
 	{
 		version: 1,
-		suiteCliArgs: {},
+		suiteCliArgs: {
+			// Use a consistent port to avoid conflicts with other test suites
+			port: 9500,
+		},
 		expectedHomePageTitle: 'My WordPress Website',
 	},
 	{
 		version: 2,
 		suiteCliArgs: {
+			// Use a consistent port to avoid conflicts with other test suites
+			port: 9500,
 			'experimental-blueprints-v2-runner': true,
 		},
 		expectedHomePageTitle: 'WordPress Site',
@@ -139,7 +144,6 @@ describe.each(blueprintVersions)(
 				cliServer = await runCLI({
 					...suiteCliArgs,
 					command: 'server',
-					port: 9500,
 				});
 				await cliServer.playground.writeFile(
 					'/wordpress/site-url.php',

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -25,18 +25,16 @@ import { type Log, logger } from '@php-wasm/logger';
 const blueprintVersions = [
 	{
 		version: 1,
-		suiteCliArgs: {
-			// Use a consistent port to avoid conflicts with other test suites
-			port: 9500,
-		},
 		expectedHomePageTitle: 'My WordPress Website',
+		suiteCliArgs: {
+			'experimental-trace': false,
+		},
 	},
 	{
 		version: 2,
 		suiteCliArgs: {
-			// Use a consistent port to avoid conflicts with other test suites
-			port: 9500,
 			'experimental-blueprints-v2-runner': true,
+			'experimental-trace': false,
 		},
 		expectedHomePageTitle: 'WordPress Site',
 	},
@@ -45,26 +43,14 @@ const blueprintVersions = [
 describe.each(blueprintVersions)(
 	'run-cli with Blueprints v$version',
 	({ version, suiteCliArgs, expectedHomePageTitle }) => {
-		let cliServer: RunCLIServer;
-
 		// TODO: Find out why Blueprints v2 tests fail on Windows and fix them.
 		const isBlueprintsV2OnWindows =
 			os.platform() === 'win32' && version === 2;
 
-		afterEach(async () => {
-			if (cliServer) {
-				try {
-					await cliServer[Symbol.asyncDispose]();
-				} catch {
-					// Ignore any dispose-related errors
-				}
-			}
-		});
-
 		test.skipIf(isBlueprintsV2OnWindows)(
 			'should set PHP version',
 			async () => {
-				cliServer = await runCLI({
+				await using cliServer = await runCLI({
 					...suiteCliArgs,
 					command: 'server',
 					php: '8.0',
@@ -89,7 +75,7 @@ describe.each(blueprintVersions)(
 		test.skipIf(isBlueprintsV2OnWindows)(
 			'should have Intl extension enabled by default',
 			async () => {
-				cliServer = await runCLI({
+				await using cliServer = await runCLI({
 					...suiteCliArgs,
 					command: 'server',
 					php: '8.0',
@@ -118,7 +104,7 @@ describe.each(blueprintVersions)(
 			'should use custom site-url when provided',
 			async () => {
 				const customSiteUrl = 'https://example.com';
-				cliServer = await runCLI({
+				await using cliServer = await runCLI({
 					...suiteCliArgs,
 					command: 'server',
 					'site-url': customSiteUrl,
@@ -141,8 +127,9 @@ describe.each(blueprintVersions)(
 		test.skipIf(isBlueprintsV2OnWindows)(
 			'should use default site-url when not provided',
 			async () => {
-				cliServer = await runCLI({
+				await using cliServer = await runCLI({
 					...suiteCliArgs,
+					port: 9500,
 					command: 'server',
 				});
 				await cliServer.playground.writeFile(
@@ -167,7 +154,7 @@ describe.each(blueprintVersions)(
 					MinifiedWordPressVersionsList[
 						MinifiedWordPressVersionsList.length - 1
 					];
-				cliServer = await runCLI({
+				await using cliServer = await runCLI({
 					...suiteCliArgs,
 					command: 'server',
 					wp: oldestSupportedVersion,
@@ -190,7 +177,7 @@ describe.each(blueprintVersions)(
 		test.skipIf(isBlueprintsV2OnWindows)(
 			'should run blueprint',
 			async () => {
-				cliServer = await runCLI({
+				await using cliServer = await runCLI({
 					...suiteCliArgs,
 					command: 'server',
 					blueprint: {
@@ -259,7 +246,7 @@ describe.each(blueprintVersions)(
 						// Use a junction on Windows to avoid elevated permissions requirement.
 						os.platform() === 'win32' ? 'junction' : null
 					);
-					cliServer = await runCLI({
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						...testArgs,
 						debug: true,
@@ -309,7 +296,7 @@ describe.each(blueprintVersions)(
 					const tmpDir = await mkdtemp(
 						path.join(tmpdir(), 'playground-test-')
 					);
-					cliServer = await runCLI({
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						command: 'server',
 						'experimental-blueprints-v2-runner': true,
@@ -339,32 +326,35 @@ describe.each(blueprintVersions)(
 					);
 
 					const port = 3019;
+					let homeUrl: URL;
 
-					// Create a new site so we can load it as an existing site later.
-					cliServer = await runCLI({
-						...suiteCliArgs,
-						port,
-						command: 'server',
-						'experimental-blueprints-v2-runner': true,
-						mode: 'create-new-site',
-						'mount-before-install': [
-							{
-								hostPath: tmpDir,
-								vfsPath: '/wordpress',
-							},
-						],
-					});
-					// Confirm the new site looks intact with its WP installed.
-					const homeUrl = new URL('/', cliServer.serverUrl);
-					const setupResponse = await fetch(homeUrl);
-					expect(setupResponse.status).toBe(200);
-					const setupText = await setupResponse.text();
-					expect(setupText).toContain(
-						`<title>${expectedHomePageTitle}</title>`
-					);
-					await cliServer.server.close();
+					{
+						// Create a new site so we can load it as an existing site later.
+						await using cliServer = await runCLI({
+							...suiteCliArgs,
+							port,
+							command: 'server',
+							'experimental-blueprints-v2-runner': true,
+							mode: 'create-new-site',
+							'mount-before-install': [
+								{
+									hostPath: tmpDir,
+									vfsPath: '/wordpress',
+								},
+							],
+						});
+						// Confirm the new site looks intact with its WP installed.
+						homeUrl = new URL('/', cliServer.serverUrl);
+						const setupResponse = await fetch(homeUrl);
+						expect(setupResponse.status).toBe(200);
+						const setupText = await setupResponse.text();
+						expect(setupText).toContain(
+							`<title>${expectedHomePageTitle}</title>`
+						);
+					}
 
-					cliServer = await runCLI({
+					// eslint-disable-next-line
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						port,
 						command: 'server',
@@ -394,7 +384,8 @@ describe.each(blueprintVersions)(
 					);
 
 					// Create a new site so we can load it as an existing site later.
-					cliServer = await runCLI({
+					// eslint-disable-next-line
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						'site-url': 'http://playground-domain/',
 						'db-engine': 'sqlite',
@@ -426,7 +417,7 @@ describe.each(blueprintVersions)(
 				}
 				return hash.digest('hex');
 			};
-			const getActiveTheme = async () => {
+			const getActiveTheme = async (cliServer: RunCLIServer) => {
 				const response = await cliServer.playground.run({
 					code: `<?php
 					require_once '/wordpress/wp-load.php';
@@ -452,7 +443,7 @@ describe.each(blueprintVersions)(
 							'plugin'
 						)
 					);
-					cliServer = await runCLI({
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						command: 'server',
 						autoMount: '',
@@ -485,13 +476,13 @@ describe.each(blueprintVersions)(
 							'theme'
 						)
 					);
-					cliServer = await runCLI({
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						command: 'server',
 						autoMount: '',
 					});
 
-					expect(await getActiveTheme()).toBe('Yolo Theme');
+					expect(await getActiveTheme(cliServer)).toBe('Yolo Theme');
 
 					const homeUrl = new URL('/', cliServer.serverUrl);
 					const response = await fetch(homeUrl);
@@ -518,7 +509,7 @@ describe.each(blueprintVersions)(
 							'wp-content'
 						)
 					);
-					cliServer = await runCLI({
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						command: 'server',
 						autoMount: '',
@@ -542,7 +533,7 @@ describe.each(blueprintVersions)(
 							'static-html'
 						)
 					);
-					cliServer = await runCLI({
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						command: 'server',
 						autoMount: '',
@@ -561,7 +552,7 @@ describe.each(blueprintVersions)(
 					vi.spyOn(process, 'cwd').mockReturnValue(
 						path.join(import.meta.dirname, 'mount-examples', 'php')
 					);
-					cliServer = await runCLI({
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						command: 'server',
 						autoMount: '',
@@ -604,7 +595,7 @@ describe.each(blueprintVersions)(
 
 					const checksum = await getDirectoryChecksum(tmpDir);
 
-					cliServer = await runCLI({
+					await using cliServer = await runCLI({
 						...suiteCliArgs,
 						command: 'server',
 						autoMount: '',
@@ -627,6 +618,8 @@ describe.each(blueprintVersions)(
 
 		describe('verbosity', () => {
 			let output: string[];
+			// Track cliServer at describe level for cleanup even if tests timeout
+			let cliServer: RunCLIServer | undefined;
 
 			function logToVariable(log: Log, arg?: string) {
 				output.push(`${log.message}${arg ? arg : ''}`);
@@ -641,53 +634,65 @@ describe.each(blueprintVersions)(
 				output = [];
 			});
 
+			afterEach(async () => {
+				if (cliServer) {
+					await cliServer[Symbol.asyncDispose]();
+					cliServer = undefined;
+				}
+			});
+
 			test.skipIf(isBlueprintsV2OnWindows)(
 				'should output main logs by default',
 				async ({ skip }) => {
+					// Skip v2 early to avoid starting expensive WordPress download
+					// @TODO: Fix this test for v2 in CI. It passes locally but not on GitHub.
+					if (version === 2) {
+						skip();
+						return;
+					}
+
 					cliServer = await runCLI({
 						...suiteCliArgs,
 						command: 'server',
 					});
 
-					if (version === 1) {
-						expect(output).toEqual(
-							expect.arrayContaining([
-								'Starting a PHP server...',
-								'Starting up workers',
-								expect.stringMatching(
-									/^Resolved WordPress release URL: https:\/\/downloads\.w(ordpress)?\.org\/release\/wordpress-\d+\.\d+(?:\.\d+|-RC\d+|-beta\d+)?\.zip$/
-								),
-								'Fetching SQLite integration plugin...',
-								'Booting WordPress...',
-								'Booted!',
-								'Running the Blueprint...',
-								'Finished running the blueprint',
-								'Preparing workers...',
-								expect.stringMatching(
-									/^WordPress is running on http:\/\/127\.0\.0\.1:\d+ with \d+ worker\(s\)$/
-								),
-							])
-						);
-					} else {
-						// @TODO: Fix this test in CI. It passes locally but not on GitHub.
-						skip();
-						expect(output).toEqual(
-							expect.arrayContaining([
-								'Starting a PHP server...',
-								'Setting up WordPress undefined',
-								'Booted!',
-								expect.stringMatching(
-									/^WordPress is running on http:\/\/127\.0\.0\.1:\d+$/
-								),
-							])
-						);
-					}
+					expect(output).toEqual(
+						expect.arrayContaining([
+							'Starting a PHP server...',
+							'Starting up workers',
+							expect.stringMatching(
+								/^Resolved WordPress release URL: https:\/\/downloads\.w(ordpress)?\.org\/release\/wordpress-\d+\.\d+(?:\.\d+|-RC\d+|-beta\d+)?\.zip$/
+							),
+							'Fetching SQLite integration plugin...',
+							'Booting WordPress...',
+							'Booted!',
+							'Running the Blueprint...',
+							'Finished running the blueprint',
+							'Preparing workers...',
+							expect.stringMatching(
+								/^WordPress is running on http:\/\/127\.0\.0\.1:\d+ with \d+ worker\(s\)$/
+							),
+						])
+					);
 				}
 			);
+
+			// Skip WordPress setup for verbosity tests - they only check logging behavior.
+			// For v1, use wordpressInstallMode. For v2, explicitly set mode.
+			const skipWordPressSetup =
+				version === 2
+					? { mode: 'mount-only' as const }
+					: {
+							wordpressInstallMode:
+								'do-not-attempt-installing' as const,
+							skipSqliteSetup: true,
+							blueprint: undefined,
+						};
 
 			test('should not output debug logs with verbosity option set to normal', async () => {
 				cliServer = await runCLI({
 					...suiteCliArgs,
+					...skipWordPressSetup,
 					command: 'server',
 					verbosity: 'normal',
 				});
@@ -704,6 +709,7 @@ describe.each(blueprintVersions)(
 				async () => {
 					cliServer = await runCLI({
 						...suiteCliArgs,
+						...skipWordPressSetup,
 						command: 'server',
 						verbosity: 'debug',
 					});
@@ -721,6 +727,7 @@ describe.each(blueprintVersions)(
 				async () => {
 					cliServer = await runCLI({
 						...suiteCliArgs,
+						...skipWordPressSetup,
 						command: 'server',
 						verbosity: 'quiet',
 					});
@@ -734,21 +741,9 @@ describe.each(blueprintVersions)(
 );
 
 describe('other run-cli behaviors', () => {
-	let cliServer: RunCLIServer;
-
-	afterEach(async () => {
-		if (cliServer) {
-			try {
-				await cliServer[Symbol.asyncDispose]();
-			} catch {
-				// Ignore any dispose-related errors
-			}
-		}
-	});
-
 	describe('auto-login', () => {
 		test('should clear old auto-login cookie', async () => {
-			cliServer = await runCLI({
+			await using cliServer = await runCLI({
 				command: 'server',
 				wordpressInstallMode: 'do-not-attempt-installing',
 				skipSqliteSetup: true,
@@ -782,7 +777,7 @@ describe('other run-cli behaviors', () => {
 
 	describe('error handling', () => {
 		test('should return 500 when the request handler throws an error', async () => {
-			cliServer = await runCLI({
+			await using cliServer = await runCLI({
 				command: 'server',
 				wordpressInstallMode: 'do-not-attempt-installing',
 				blueprint: undefined,


### PR DESCRIPTION
## Motivation for the change, related issues

Running `wp-playground --help` previously displayed all CLI flags in one long list, making it difficult to tell which flags are relevant to which command. This PR scopes flags to their relevant commands so that running `wp-playground server --help` shows only the flags relevant to the `server` command.

**Before**

<img width="2952" height="1544" alt="CleanShot 2025-12-15 at 16 02 30@2x" src="https://github.com/user-attachments/assets/73e1e37b-5e21-4361-9c4e-6c00775cca50" />


**After**

<img width="2386" height="458" alt="CleanShot 2025-12-15 at 16 01 55@2x" src="https://github.com/user-attachments/assets/67ad42a5-a25b-40c9-8dc2-fc474f07a49e" />


## Implementation details

Refactors the CLI option declarations from a long chain of `.option()` calls to object-based option groups:

- `sharedOptions`: Options available to all commands (php, wp, mount, blueprint, etc.)
- `serverOnlyOptions`: Options specific to the `server` command (port, multi-worker, devtools)
- `buildSnapshotOnlyOptions`: Options specific to the `build-snapshot` command (outfile)

A `commandWithOptions()` helper function applies the appropriate options to each command, combining shared options with command-specific ones.

## Testing Instructions

Run `wp-playground --help` to see the cleaner top-level help, then run `wp-playground server --help` or `wp-playground build-snapshot --help` to verify command-specific options are displayed correctly.