### PR TITLE
Disable nx cache

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,7 @@
 		"default": {
 			"runner": "nx/tasks-runners/default",
 			"options": {
-				"cacheableOperations": ["build", "lint", "test", "e2e"]
+				"cacheableOperations": []
 			}
 		}
 	},


### PR DESCRIPTION
I sometimes run into local failures because NX cache kept the result of some operation that is now invalidated. At the same time, it doesn't seem to save that much time. Let's disable it.