### PR TITLE
Correct issues related to unsupported parameter property in strip-only mode

### DIFF
--- a/packages/playground/blueprints/src/lib/resolve-remote-blueprint.ts
+++ b/packages/playground/blueprints/src/lib/resolve-remote-blueprint.ts
@@ -7,13 +7,12 @@ import {
 import type { BlueprintBundle } from './types';
 
 export class BlueprintFetchError extends Error {
-	constructor(
-		message: string,
-		public readonly url: string,
-		options?: ErrorOptions
-	) {
+	public readonly url: string;
+
+	constructor(message: string, url: string, options?: ErrorOptions) {
 		super(message, options);
 		this.name = 'BlueprintFetchError';
+		this.url = url;
 	}
 }
 

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -44,9 +44,12 @@ import { defaultWpCliPath, defaultWpCliResource } from '../steps/wp-cli';
 import type { ErrorObject } from 'ajv';
 
 export class InvalidBlueprintError extends Error {
-	constructor(message: string, public readonly validationErrors?: unknown) {
+	public readonly validationErrors?: unknown;
+
+	constructor(message: string, validationErrors?: unknown) {
 		super(message);
 		this.name = 'InvalidBlueprintError';
+		this.validationErrors = validationErrors;
 	}
 }
 

--- a/packages/playground/storage/src/lib/git-sparse-checkout.ts
+++ b/packages/playground/storage/src/lib/git-sparse-checkout.ts
@@ -34,11 +34,16 @@ if (typeof globalThis.Buffer === 'undefined') {
  * Custom error class for git authentication failures.
  */
 export class GitAuthenticationError extends Error {
-	constructor(public repoUrl: string, public status: number) {
+	public repoUrl: string;
+	public status: number;
+
+	constructor(repoUrl: string, status: number) {
 		super(
 			`Authentication required to access private repository: ${repoUrl}`
 		);
 		this.name = 'GitAuthenticationError';
+		this.repoUrl = repoUrl;
+		this.status = status;
 	}
 }
 


### PR DESCRIPTION
## Motivation for the change, related issues

While trying to run `npm run local-package-repository` I faced these type of Typescript errors 

```
Version number df6471b7770cee7792040577 copied to clipboard
Use Ctrl+C to stop the server
node:internal/modules/run_main:123
    triggerUncaughtException(
    ^

file:///Users/mho/Work/projects/xdebug/wordpress-playground/packages/playground/blueprints/src/lib/v1/compile.ts:47
export class InvalidBlueprintError extends Error {
    constructor(message: string, public readonly validationErrors?: unknown) {
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        super(message);

SyntaxError [ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX]: TypeScript parameter property is not supported in strip-only mode
    at parseTypeScript (node:internal/modules/typescript:63:40)
    at processTypeScriptCode (node:internal/modules/typescript:133:42)
    at stripTypeScriptModuleTypes (node:internal/modules/typescript:163:10)
    at ModuleLoader.<anonymous> (node:internal/modules/esm/translators:605:16)
    at #translate (node:internal/modules/esm/loader:546:20)
    at afterLoad (node:internal/modules/esm/loader:596:29)
    at async ModuleJob._link (node:internal/modules/esm/module_job:162:19) {
  code: 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX'
}

Node.js v22.21.1
```

## Implementation details

Remove parameter properties in three files.

## Testing Instructions (or ideally a Blueprint)

Run `npm run local-package-repository` successfully