### PR TITLE
[Blueprints] Preserve more error information on failed fetch

### DIFF
--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -388,7 +388,8 @@ export abstract class FetchResource extends Resource<File> {
 			throw new Error(
 				`Could not download "${url}".\n\n` +
 					`Confirm that the URL is correct, the server is reachable, and the file is` +
-					`actually served at that URL. Original error: \n ${e}`
+					`actually served at that URL. Original error: \n ${e}`,
+				{ cause: e }
 			);
 		}
 	}


### PR DESCRIPTION
## Motivation for the change, related issues

Before this PR a failed fetch would only print surface level error:

```
 [WordPress Server Child] Failed to start server: Error: Error when executing the blueprint step #3 ({"step":"installPlugin","pluginData":{"resource":"wordpress.org/plugins","slug":"woocommerce"}}) : Could not download "https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip".
```

After this PR a failed fetch includes the original error cause and provides the full error information including the original stack trace. 

## Implementation details

Just adds `{ cause: error }`
