### PR TITLE
[website] Updating Run Blueprint button

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -697,10 +697,10 @@ test('should edit a blueprint in the blueprint editor and recreate the playgroun
 	// Wait a moment for the change to be processed
 	await website.page.waitForTimeout(500);
 
-	// Click the "Recreate Playground from this Blueprint" button
+	// Click the "Run Blueprint" button
 	await website.page
 		.getByRole('button', {
-			name: 'Recreate Playground from this Blueprint',
+			name: 'Run Blueprint',
 		})
 		.click();
 

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -139,8 +139,9 @@ export function SiteInfoPanel({
 			const blueprint = JSON.parse(blueprintCode);
 
 			// Resolve runtime configuration from the new blueprint
-			const runtimeConfiguration =
-				await resolveRuntimeConfiguration(blueprint);
+			const runtimeConfiguration = await resolveRuntimeConfiguration(
+				blueprint
+			);
 
 			// Remove the current playground client to trigger cleanup
 			dispatch(removeClientInfo(site.slug));
@@ -359,7 +360,7 @@ export function SiteInfoPanel({
 															site.metadata
 																.whenCreated - 2
 														)
-													)
+												  )
 												: '';
 											switch (site.metadata.storage) {
 												case 'local-fs':
@@ -561,8 +562,8 @@ export function SiteInfoPanel({
 												disabled={isRecreating}
 											>
 												{isRecreating
-													? 'Recreating...'
-													: 'Recreate Playground from this Blueprint'}
+													? 'Running...'
+													: 'Run Blueprint'}
 											</Button>
 										</div>
 									) : (


### PR DESCRIPTION
This pull request updates the UI and related test for running blueprints in the playground, focusing on renaming the "Recreate Playground from this Blueprint" action to "Run Blueprint" for clarity and consistency. The changes affect both the user interface and the corresponding end-to-end test.

UI/UX improvements:

* The button label in the `SiteInfoPanel` component has been changed from "Recreate Playground from this Blueprint" to "Run Blueprint", and its loading state label from "Recreating..." to "Running..." to better reflect the action's purpose.
* The Playwright end-to-end test has been updated to click the "Run Blueprint" button instead of the previous label, ensuring the test matches the new UI wording.
