### PR TITLE
[Website] Blueprint Editor: Update the URL when typing

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -363,7 +363,8 @@ test('should copy blueprint link to clipboard when share button is clicked', asy
 	const clipboardContent = await website.page.evaluate(() =>
 		navigator.clipboard.readText()
 	);
-	expect(clipboardContent).toMatch(/^https?:\/\/[^/]+\/#[A-Za-z0-9+/=]+$/);
+	// URL format: http(s)://host/optional-path/#base64
+	expect(clipboardContent).toMatch(/^https?:\/\/[^#]+#[A-Za-z0-9+/=]+$/);
 
 	// Verify the base64 portion decodes to valid JSON
 	const base64Part = clipboardContent.split('#')[1];

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -242,12 +242,7 @@ test('should edit a file in the code editor and see changes in the viewport', as
 test('should edit a blueprint in the blueprint editor and recreate the playground', async ({
 	website,
 	wordpress,
-	browserName,
 }) => {
-	test.skip(
-		browserName === 'firefox',
-		'Firefox has inconsistent keyboard handling in the CodeMirror editor, causing the blueprint to have validation errors'
-	);
 	await website.goto('./');
 
 	// Open site manager
@@ -278,27 +273,33 @@ test('should edit a blueprint in the blueprint editor and recreate the playgroun
 		2
 	);
 
-	// Focus the editor and select all existing content
+	// Focus the editor
 	await editor.click();
+	// Wait a moment for the editor to be fully ready
+	await website.page.waitForTimeout(100);
+
+	// Select all existing content
 	await website.page.keyboard.press(
 		process.platform === 'darwin' ? 'Meta+A' : 'Control+A'
 	);
 
-	// Dispatch a paste event to replace content - avoids auto-bracket insertion issues
-	await website.page.evaluate((content) => {
-		const dataTransfer = new DataTransfer();
-		dataTransfer.setData('text/plain', content);
-		document.activeElement?.dispatchEvent(
-			new ClipboardEvent('paste', {
-				clipboardData: dataTransfer,
-				bubbles: true,
-				cancelable: true,
-			})
-		);
-	}, blueprint);
+	// Delete the selected content
+	await website.page.keyboard.press('Backspace');
+	await website.page.waitForTimeout(100);
+
+	// Use Playwright's fill method on the contenteditable .cm-content element
+	// This is more reliable than character-by-character typing which triggers
+	// auto-bracket insertion
+	const cmContent = editor.locator('.cm-content');
+	await cmContent.fill(blueprint);
 
 	// Wait for validation to complete (linter has 300ms debounce)
 	await website.page.waitForTimeout(500);
+
+	// Verify the blueprint was inserted by checking the editor content
+	await expect(cmContent).toContainText('writeFile', {
+		timeout: 5000,
+	});
 
 	// Click the "Run Blueprint" button
 	await website.page

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -9,7 +9,6 @@ import {
 import { logger } from '@php-wasm/logger';
 import { Button, Icon, Notice } from '@wordpress/components';
 import { download, link } from '@wordpress/icons';
-import { encodeStringAsBase64 } from '../../lib/base64';
 import {
 	resolveRuntimeConfiguration,
 	type BlueprintValidationResult,
@@ -42,7 +41,7 @@ import {
 	type SupportedLanguage,
 } from './infer-language-from-blueprint';
 import { StringEditorModal } from './string-editor-modal';
-// Reuse the file browser layout styles to keep UI consistent
+import { useBlueprintUrlHash } from '../../lib/hooks/use-blueprint-url-hash';
 import { useDebouncedCallback } from '../../lib/hooks/use-debounced-callback';
 import { removeClientInfo } from '../../lib/state/redux/slice-clients';
 import type { SiteInfo } from '../../lib/state/redux/slice-sites';
@@ -296,8 +295,27 @@ export const BlueprintBundleEditor = forwardRef<
 			contentStart: 0,
 			contentEnd: 0,
 		});
-	// Track whether the bundle only contains blueprint.json (and thus can be shared via URL)
-	const [isBundleShareable, setIsBundleShareable] = useState(true);
+
+	// Use the URL hash hook to track shareability and compute URL hash
+	const { urlHash, isShareable: isBundleShareable } = useBlueprintUrlHash(
+		filesystem as EventedFilesystem,
+		currentPath === BLUEPRINT_JSON_PATH ? code : '',
+		{ disabled: readOnly || currentPath !== BLUEPRINT_JSON_PATH }
+	);
+	const newUrl = useMemo(() => {
+		if (readOnly) {
+			return false;
+		}
+		const url = new URL(window.location.href);
+		if (urlHash) {
+			url.hash = urlHash;
+		} else if (url.hash) {
+			url.hash = '';
+		} else {
+			return false;
+		}
+		return url.toString();
+	}, [urlHash, readOnly]);
 
 	const editorRef = useRef<CodeEditorHandle | null>(null);
 	// Store the CodeMirror EditorView for string editor operations
@@ -353,71 +371,12 @@ export const BlueprintBundleEditor = forwardRef<
 		};
 	}, [filesystem]);
 
-	// Check if the bundle only contains blueprint.json (can be shared via URL).
-	// Blueprint bundles with additional files cannot be encoded in a URL hash.
-	const checkBundleShareability = useCallback(async () => {
-		try {
-			const rootEntries = await filesystem.listFiles('/');
-			const isShareable =
-				rootEntries.length === 1 && rootEntries[0] === 'blueprint.json';
-			setIsBundleShareable(isShareable);
-			return isShareable;
-		} catch {
-			setIsBundleShareable(false);
-			return false;
-		}
-	}, [filesystem]);
-
-	// Check shareability on initial load and whenever the filesystem changes
+	// Sync the URL hash from the hook to the browser's location
 	useEffect(() => {
-		checkBundleShareability();
-
-		const handleFilesystemChange = () => {
-			checkBundleShareability();
-		};
-		filesystem.addEventListener('change', handleFilesystemChange);
-		return () => {
-			filesystem.removeEventListener('change', handleFilesystemChange);
-		};
-	}, [filesystem, checkBundleShareability]);
-
-	// Update URL hash when blueprint.json changes for shareable URLs.
-	// This keeps the URL in sync with the editor content so users can share
-	// their work in progress by copying the current URL.
-	const updateUrlHash = useDebouncedCallback(
-		(blueprintContent: string, shareable: boolean) => {
-			const newUrl = new URL(window.location.href);
-
-			if (!shareable) {
-				// Bundle has additional files - clear the URL hash
-				if (newUrl.hash) {
-					newUrl.hash = '';
-					window.history.replaceState(null, '', newUrl.toString());
-				}
-				return;
-			}
-
-			try {
-				// Validate that it's valid JSON before updating the URL
-				JSON.parse(blueprintContent);
-				const encodedBlueprint = encodeStringAsBase64(blueprintContent);
-				newUrl.hash = encodedBlueprint;
-				window.history.replaceState(null, '', newUrl.toString());
-			} catch {
-				// Don't update URL if blueprint is invalid JSON
-			}
-		},
-		500,
-		[]
-	);
-
-	useEffect(() => {
-		// Only update URL for temporary sites when editing blueprint.json
-		if (readOnly || currentPath !== BLUEPRINT_JSON_PATH) {
-			return;
+		if (false !== newUrl) {
+			window.history.replaceState(null, '', newUrl.toString());
 		}
-		updateUrlHash(code, isBundleShareable);
-	}, [code, currentPath, readOnly, isBundleShareable, updateUrlHash]);
+	}, [newUrl]);
 
 	const handleRecreateFromBlueprint = useCallback(async () => {
 		if (!site || site.metadata.storage !== 'none' || readOnly) {
@@ -651,27 +610,15 @@ export const BlueprintBundleEditor = forwardRef<
 		}
 	}, [filesystem]);
 
-	const handleShareBlueprint = useCallback(async () => {
+	const handleShareBlueprint = async () => {
+		if (false === newUrl) {
+			alert(
+				'Linking to blueprint bundles is not supported yet. Only single-file blueprints can be shared via link.'
+			);
+			return;
+		}
 		try {
-			// Check if the bundle contains anything other than blueprint.json
-			const rootEntries = await filesystem.listFiles('/');
-			if (
-				rootEntries.length !== 1 ||
-				rootEntries[0] !== 'blueprint.json'
-			) {
-				alert(
-					'Linking to blueprint bundles is not supported yet. Only single-file blueprints can be shared via link.'
-				);
-				return;
-			}
-
-			// Read the blueprint.json content
-			const blueprintContent =
-				await filesystem.readFileAsText(BLUEPRINT_JSON_PATH);
-
-			const base64Blueprint = encodeStringAsBase64(blueprintContent);
-			const shareUrl = `${window.location.origin}${window.location.pathname}#${base64Blueprint}`;
-			await navigator.clipboard.writeText(shareUrl);
+			await navigator.clipboard.writeText(newUrl);
 
 			setSuccessMessage('Link copied to clipboard!');
 			setTimeout(() => setSuccessMessage(null), 2000);
@@ -679,7 +626,7 @@ export const BlueprintBundleEditor = forwardRef<
 			logger.error('Failed to share blueprint', error);
 			setSaveError('Could not copy link. Try again.');
 		}
-	}, [filesystem]);
+	};
 
 	useImperativeHandle(
 		ref,
@@ -755,6 +702,7 @@ export const BlueprintBundleEditor = forwardRef<
 									className={styles.editorToolbarButton}
 									onClick={handleShareBlueprint}
 									title="Copy link to blueprint"
+									disabled={!isBundleShareable}
 								>
 									<Icon icon={link} />
 								</Button>

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -702,6 +702,7 @@ export const BlueprintBundleEditor = forwardRef<
 									className={styles.editorToolbarButton}
 									onClick={handleShareBlueprint}
 									title="Copy link to blueprint"
+									aria-label="Copy link to blueprint"
 									disabled={!isBundleShareable}
 								>
 									<Icon icon={link} />

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -296,6 +296,8 @@ export const BlueprintBundleEditor = forwardRef<
 			contentStart: 0,
 			contentEnd: 0,
 		});
+	// Track whether the bundle only contains blueprint.json (and thus can be shared via URL)
+	const [isBundleShareable, setIsBundleShareable] = useState(true);
 
 	const editorRef = useRef<CodeEditorHandle | null>(null);
 	// Store the CodeMirror EditorView for string editor operations
@@ -350,6 +352,72 @@ export const BlueprintBundleEditor = forwardRef<
 			cancelled = true;
 		};
 	}, [filesystem]);
+
+	// Check if the bundle only contains blueprint.json (can be shared via URL).
+	// Blueprint bundles with additional files cannot be encoded in a URL hash.
+	const checkBundleShareability = useCallback(async () => {
+		try {
+			const rootEntries = await filesystem.listFiles('/');
+			const isShareable =
+				rootEntries.length === 1 && rootEntries[0] === 'blueprint.json';
+			setIsBundleShareable(isShareable);
+			return isShareable;
+		} catch {
+			setIsBundleShareable(false);
+			return false;
+		}
+	}, [filesystem]);
+
+	// Check shareability on initial load and whenever the filesystem changes
+	useEffect(() => {
+		checkBundleShareability();
+
+		const handleFilesystemChange = () => {
+			checkBundleShareability();
+		};
+		filesystem.addEventListener('change', handleFilesystemChange);
+		return () => {
+			filesystem.removeEventListener('change', handleFilesystemChange);
+		};
+	}, [filesystem, checkBundleShareability]);
+
+	// Update URL hash when blueprint.json changes for shareable URLs.
+	// This keeps the URL in sync with the editor content so users can share
+	// their work in progress by copying the current URL.
+	const updateUrlHash = useDebouncedCallback(
+		(blueprintContent: string, shareable: boolean) => {
+			const newUrl = new URL(window.location.href);
+
+			if (!shareable) {
+				// Bundle has additional files - clear the URL hash
+				if (newUrl.hash) {
+					newUrl.hash = '';
+					window.history.replaceState(null, '', newUrl.toString());
+				}
+				return;
+			}
+
+			try {
+				// Validate that it's valid JSON before updating the URL
+				JSON.parse(blueprintContent);
+				const encodedBlueprint = encodeStringAsBase64(blueprintContent);
+				newUrl.hash = encodedBlueprint;
+				window.history.replaceState(null, '', newUrl.toString());
+			} catch {
+				// Don't update URL if blueprint is invalid JSON
+			}
+		},
+		500,
+		[]
+	);
+
+	useEffect(() => {
+		// Only update URL for temporary sites when editing blueprint.json
+		if (readOnly || currentPath !== BLUEPRINT_JSON_PATH) {
+			return;
+		}
+		updateUrlHash(code, isBundleShareable);
+	}, [code, currentPath, readOnly, isBundleShareable, updateUrlHash]);
 
 	const handleRecreateFromBlueprint = useCallback(async () => {
 		if (!site || site.metadata.storage !== 'none' || readOnly) {
@@ -738,6 +806,16 @@ export const BlueprintBundleEditor = forwardRef<
 							<div style={{ padding: '8px 16px' }}>
 								<Notice status="success" isDismissible={false}>
 									{successMessage}
+								</Notice>
+							</div>
+						) : null}
+						{!readOnly && !isBundleShareable ? (
+							<div style={{ padding: '8px 16px' }}>
+								<Notice status="warning" isDismissible={false}>
+									This Blueprint bundle contains multiple
+									files and cannot be shared via URL. Use the
+									download button to export the bundle as a
+									zip file.
 								</Notice>
 							</div>
 						) : null}

--- a/packages/playground/website/src/lib/hooks/use-blueprint-url-hash.ts
+++ b/packages/playground/website/src/lib/hooks/use-blueprint-url-hash.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { EventedFilesystem } from '@wp-playground/storage';
+import { encodeStringAsBase64 } from '../base64';
+import { useDebouncedCallback } from './use-debounced-callback';
+
+export interface UseBlueprintUrlHashResult {
+	/**
+	 * The URL hash for the current blueprint, or null if the bundle
+	 * contains multiple files and can't be shared via URL.
+	 */
+	urlHash: string | null;
+
+	/**
+	 * Whether the bundle can be shared via URL (only contains blueprint.json).
+	 */
+	isShareable: boolean;
+}
+
+export interface UseBlueprintUrlHashOptions {
+	/** Whether to skip URL hash computation (e.g., for read-only mode) */
+	disabled?: boolean;
+	/** Debounce delay in ms (default: 500) */
+	debounceMs?: number;
+}
+
+/**
+ * Hook that computes a shareable URL hash for a blueprint bundle.
+ *
+ * Returns the base64-encoded blueprint content if the bundle only contains
+ * blueprint.json, or null if the bundle has additional files.
+ *
+ * @param filesystem - The filesystem containing the blueprint bundle
+ * @param blueprintContent - The current content of blueprint.json
+ * @param options - Configuration options
+ */
+export function useBlueprintUrlHash(
+	filesystem: EventedFilesystem | null,
+	blueprintContent: string,
+	options: UseBlueprintUrlHashOptions = {}
+): UseBlueprintUrlHashResult {
+	const { disabled = false, debounceMs = 500 } = options;
+
+	const [isShareable, setIsShareable] = useState(true);
+	const [urlHash, setUrlHash] = useState<string | null>(null);
+
+	// Check if the bundle only contains blueprint.json (can be shared via URL).
+	// Blueprint bundles with additional files cannot be encoded in a URL hash.
+	const checkBundleShareability = useCallback(async () => {
+		if (!filesystem) {
+			setIsShareable(false);
+			return false;
+		}
+		try {
+			const rootEntries = await filesystem.listFiles('/');
+			const shareable =
+				rootEntries.length === 1 && rootEntries[0] === 'blueprint.json';
+			setIsShareable(shareable);
+			return shareable;
+		} catch {
+			setIsShareable(false);
+			return false;
+		}
+	}, [filesystem]);
+
+	// Check shareability on initial load and whenever the filesystem changes
+	useEffect(() => {
+		if (!filesystem) {
+			return;
+		}
+
+		checkBundleShareability();
+
+		const handleFilesystemChange = () => {
+			checkBundleShareability();
+		};
+		filesystem.addEventListener('change', handleFilesystemChange);
+		return () => {
+			filesystem.removeEventListener('change', handleFilesystemChange);
+		};
+	}, [filesystem, checkBundleShareability]);
+
+	// Compute the URL hash when blueprint content changes.
+	// Debounced to avoid excessive encoding on rapid typing.
+	const computeUrlHash = useDebouncedCallback(
+		(content: string, shareable: boolean) => {
+			if (disabled || !shareable) {
+				setUrlHash(null);
+				return;
+			}
+
+			try {
+				// Validate that it's valid JSON before encoding
+				JSON.parse(content);
+				const encoded = encodeStringAsBase64(content);
+				setUrlHash(encoded);
+			} catch {
+				// Don't update hash if blueprint is invalid JSON
+				setUrlHash(null);
+			}
+		},
+		debounceMs,
+		[]
+	);
+
+	useEffect(() => {
+		if (disabled) {
+			setUrlHash(null);
+			return;
+		}
+		computeUrlHash(blueprintContent, isShareable);
+	}, [blueprintContent, isShareable, disabled, computeUrlHash]);
+
+	return { urlHash, isShareable };
+}


### PR DESCRIPTION
## Motivation for the change, related issues

When you edit a Blueprint on a temporary Playground, the URL now stays in sync with your changes. This means you can copy the URL at any point and share it with someone else—they'll see the exact Blueprint you're working on.

The Blueprint is base64-encoded into the URL hash, which keeps it shareable without requiring any server-side storage. The URL only updates when the Blueprint is valid JSON, so you won't accidentally share a broken link mid-edit.

## Testing Instructions (or ideally a Blueprint)

1. Edit a Blueprint on a temporary site
2. Refresh the page
3. Confirm your change is visible in the editor

cc @SirLouen 