### PR TITLE
[CI] Preserve artifacts from failed API documentation E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,6 +293,12 @@ jobs:
               run: npx playwright install --with-deps chromium
             - name: Verify docs API reference
               run: npx nx run docs-site:api-e2e
+            - uses: actions/upload-artifact@v4
+              if: ${{ !cancelled() }}
+              with:
+                  name: docs-api-e2e-report
+                  path: packages/docs/site/test-results/
+                  if-no-files-found: ignore
 
     test-built-npm-packages:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation for the change, related issues

The `Cl / test-docs-api-reference (pull_request)` job sometimes fails in a flaky way. This PR preserves the screenshots and videos from failed runs so we can investigate.
