### PR TITLE
[CI] Fix flaky API docs E2E test

### DIFF
--- a/packages/docs/site/tests/api-reference.spec.ts
+++ b/packages/docs/site/tests/api-reference.spec.ts
@@ -28,9 +28,9 @@ test.describe('Docs API reference', () => {
 		});
 
 		await page.goto(apiPath, {
-			waitUntil: 'networkidle',
+			waitUntil: 'domcontentloaded',
 		});
-		await expect(page.locator('.apiPage')).toBeVisible();
+		await expect(page.locator('.apiPage')).toBeVisible({ timeout: 30000 });
 
 		expect(
 			pageErrors,


### PR DESCRIPTION
## Summary

The API reference E2E test was flaky because it used `waitUntil: 'networkidle'`, which waits for no network activity for 500ms. This condition often never triggers due to analytics scripts, service workers, or background requests - even when the page is fully rendered and functional.

This PR switches to `domcontentloaded` for navigation and relies on the element visibility check (`.apiPage`) to determine when the page is ready. This is more reliable because it tests what actually matters: the content being visible to users.