### PR TITLE
Persist blueprint bundle when saving temporary site to OPFS

### DIFF
--- a/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
@@ -1,0 +1,167 @@
+/**
+ * Storage for blueprint bundles alongside persisted sites.
+ *
+ * When a temporary site is persisted, its blueprint bundle (including
+ * blueprint.json and all bundled resources) is copied to the site's
+ * storage directory under a `blueprint-bundle` subdirectory.
+ */
+
+import { StreamedFile } from '@php-wasm/stream-compression';
+import type { Filesystem } from '@wp-playground/storage';
+import { getDirectoryPathForSlug } from './opfs-site-storage';
+
+const BUNDLE_DIR_NAME = 'blueprint-bundle';
+
+/**
+ * Get the OPFS directory handle for a site's blueprint bundle.
+ */
+async function getBundleDirectoryHandle(
+	siteSlug: string,
+	create = false
+): Promise<FileSystemDirectoryHandle | null> {
+	try {
+		let handle = await navigator.storage.getDirectory();
+		const sitePath = getDirectoryPathForSlug(siteSlug);
+
+		// Navigate to the site directory
+		for (const segment of sitePath.split('/').filter(Boolean)) {
+			handle = await handle.getDirectoryHandle(segment, { create });
+		}
+
+		// Get or create the bundle directory
+		return await handle.getDirectoryHandle(BUNDLE_DIR_NAME, { create });
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Check if a site has a persisted blueprint bundle.
+ */
+export async function hasBlueprintBundle(siteSlug: string): Promise<boolean> {
+	const bundleDir = await getBundleDirectoryHandle(siteSlug, false);
+	if (!bundleDir) {
+		return false;
+	}
+	// Check if there's at least one entry
+	for await (const _ of bundleDir.entries()) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Copy files from a source filesystem to a site's blueprint bundle storage.
+ */
+export async function persistBlueprintBundle(
+	siteSlug: string,
+	source: {
+		listFiles(path: string): Promise<string[]>;
+		isDir(path: string): Promise<boolean>;
+		readFileAsBuffer(path: string): Promise<Uint8Array>;
+	}
+): Promise<void> {
+	const bundleDir = await getBundleDirectoryHandle(siteSlug, true);
+	if (!bundleDir) {
+		throw new Error('Could not create blueprint bundle directory');
+	}
+
+	// Clear existing bundle
+	for await (const [name] of bundleDir.entries()) {
+		await bundleDir.removeEntry(name, { recursive: true });
+	}
+
+	// Copy all files from source
+	const copyDir = async (
+		sourcePath: string,
+		destHandle: FileSystemDirectoryHandle
+	) => {
+		const entries = await source.listFiles(sourcePath);
+		for (const name of entries) {
+			const fullPath =
+				sourcePath === '/' ? `/${name}` : `${sourcePath}/${name}`;
+			if (await source.isDir(fullPath)) {
+				const subDir = await destHandle.getDirectoryHandle(name, {
+					create: true,
+				});
+				await copyDir(fullPath, subDir);
+			} else {
+				const content = await source.readFileAsBuffer(fullPath);
+				const fileHandle = await destHandle.getFileHandle(name, {
+					create: true,
+				});
+				const writable = await fileHandle.createWritable();
+				await writable.write(content as unknown as ArrayBuffer);
+				await writable.close();
+			}
+		}
+	};
+
+	await copyDir('/', bundleDir);
+}
+
+/**
+ * Delete a site's blueprint bundle.
+ */
+export async function deleteBlueprintBundle(siteSlug: string): Promise<void> {
+	try {
+		let handle = await navigator.storage.getDirectory();
+		const sitePath = getDirectoryPathForSlug(siteSlug);
+
+		for (const segment of sitePath.split('/').filter(Boolean)) {
+			handle = await handle.getDirectoryHandle(segment);
+		}
+
+		await handle.removeEntry(BUNDLE_DIR_NAME, { recursive: true });
+	} catch {
+		// Bundle doesn't exist or couldn't be deleted
+	}
+}
+
+/**
+ * Create a Filesystem that reads from a site's persisted blueprint bundle.
+ * This implements the Filesystem interface required by BlueprintBundle.
+ */
+export class PersistedBlueprintBundle implements Filesystem {
+	private readonly bundleDir: FileSystemDirectoryHandle;
+
+	private constructor(bundleDir: FileSystemDirectoryHandle) {
+		this.bundleDir = bundleDir;
+	}
+
+	static async create(siteSlug: string): Promise<PersistedBlueprintBundle> {
+		const bundleDir = await getBundleDirectoryHandle(siteSlug, false);
+		if (!bundleDir) {
+			throw new Error(`No blueprint bundle found for site '${siteSlug}'`);
+		}
+		return new PersistedBlueprintBundle(bundleDir);
+	}
+
+	async read(path: string): Promise<StreamedFile> {
+		const segments = path.split('/').filter(Boolean);
+		const fileName = segments.pop();
+		if (!fileName) {
+			throw new Error(`Invalid file path: ${path}`);
+		}
+
+		let dir = this.bundleDir;
+		for (const segment of segments) {
+			dir = await dir.getDirectoryHandle(segment);
+		}
+
+		const fileHandle = await dir.getFileHandle(fileName);
+		const file = await fileHandle.getFile();
+		const content = new Uint8Array(await file.arrayBuffer());
+
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(content);
+				controller.close();
+			},
+		});
+
+		return new StreamedFile(stream, path, {
+			filesize: content.byteLength,
+		});
+	}
+}

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -17,6 +17,7 @@ import {
 } from '@wp-playground/blueprints';
 import type { SupportedPHPVersion } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
+import { PersistedBlueprintBundle } from './opfs-blueprint-bundle-storage';
 
 const ROOT_PATH = '/sites';
 // TODO: Decide on metadata filename
@@ -131,7 +132,27 @@ class OpfsSiteStorage {
 		// TODO: Backfill site info file if missing, detecting actual WP version if possible
 		//       ^ do not do it implicitly. Require user interaction. Maybe constrain this just
 		//         to the site files import flow.
-		return storedFormatToMetadata(await file.text());
+		const siteInfo = storedFormatToMetadata(await file.text());
+
+		// If the blueprint source points to the bundle directory, load from there.
+		// This allows the site to access bundled resources, not just the JSON declaration.
+		if (
+			siteInfo.metadata.originalBlueprintSource?.type ===
+			BUNDLE_DIR_SOURCE_TYPE
+		) {
+			try {
+				siteInfo.metadata.originalBlueprint =
+					await PersistedBlueprintBundle.create(siteInfo.slug);
+			} catch (error) {
+				logger.error(
+					`Failed to load blueprint bundle for site ${siteInfo.slug}`,
+					error
+				);
+				// Continue with the JSON declaration
+			}
+		}
+
+		return siteInfo;
 	}
 
 	async delete(slug: string): Promise<void> {
@@ -154,14 +175,26 @@ export function getDirectoryNameForSlug(slug: string) {
 	return `site-${slug}`.replaceAll(/[^a-zA-Z0-9_-]/g, '-');
 }
 
+const BUNDLE_DIR_SOURCE_TYPE = 'bundle-directory';
+
 async function metadataToStoredFormat(
 	slug: string,
-	{ originalBlueprint, ...metadata }: SiteMetadata
+	{ originalBlueprint, originalBlueprintSource, ...metadata }: SiteMetadata
 ): Promise<string> {
+	// If the blueprint is stored in the bundle directory, don't duplicate it in the JSON.
+	// The bundle files are stored separately in the blueprint-bundle directory.
+	const isBundleDirectory =
+		originalBlueprintSource?.type === BUNDLE_DIR_SOURCE_TYPE;
+
 	return JSON.stringify(
 		{
 			slug,
-			originalBlueprint: await getBlueprintDeclaration(originalBlueprint),
+			originalBlueprintSource,
+			// Only store the blueprint declaration if it's NOT a bundle directory.
+			// For bundle directories, the full bundle is stored separately.
+			originalBlueprint: isBundleDirectory
+				? undefined
+				: await getBlueprintDeclaration(originalBlueprint),
 			...metadata,
 		},
 		undefined,

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -6,6 +6,7 @@ import {
 	opfsSiteStorage,
 	getDirectoryPathForSlug,
 } from '../opfs/opfs-site-storage';
+import { persistBlueprintBundle } from '../opfs/opfs-blueprint-bundle-storage';
 import type { PlaygroundReduxState } from './store';
 import type store from './store';
 import { selectClientBySiteSlug, updateClientInfo } from './slice-clients';
@@ -76,6 +77,33 @@ export function persistTemporarySite(
 			// between successful and failed saves.
 			storage: 'none',
 		});
+
+		// Persist the blueprint bundle if available.
+		// Check if originalBlueprint is a filesystem (from clicking "Run Blueprint").
+		let bundleWasPersisted = false;
+		const originalBlueprint = siteInfo.metadata.originalBlueprint;
+		if (
+			originalBlueprint &&
+			typeof originalBlueprint === 'object' &&
+			'listFiles' in originalBlueprint &&
+			'isDir' in originalBlueprint &&
+			'readFileAsBuffer' in originalBlueprint
+		) {
+			try {
+				await persistBlueprintBundle(
+					siteSlug,
+					originalBlueprint as {
+						listFiles(path: string): Promise<string[]>;
+						isDir(path: string): Promise<boolean>;
+						readFileAsBuffer(path: string): Promise<Uint8Array>;
+					}
+				);
+				bundleWasPersisted = true;
+			} catch (error) {
+				logger.error('Failed to persist blueprint bundle', error);
+				// Continue with the save - the bundle is optional
+			}
+		}
 
 		let mountDescriptor: Omit<MountDescriptor, 'initialSyncDirection'>;
 		if (storageType === 'opfs') {
@@ -192,10 +220,18 @@ export function persistTemporarySite(
 					// on the next page load.
 					runtimeConfiguration: {
 						...siteInfo.metadata.runtimeConfiguration,
-						constants: await getPlaygroundDefinedPHPConstants(
-							playground
-						),
+						constants:
+							await getPlaygroundDefinedPHPConstants(playground),
 					},
+					// If we persisted a blueprint bundle, point to it so we can
+					// load the full bundle (not just the declaration) on next load.
+					...(bundleWasPersisted
+						? {
+								originalBlueprintSource: {
+									type: 'bundle-directory' as const,
+								},
+							}
+						: {}),
 					...(trimmedName ? { name: trimmedName } : {}),
 				},
 			})

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -23,6 +23,9 @@ export type BlueprintSource =
 	  }
 	| {
 			type: 'none';
+	  }
+	| {
+			type: 'bundle-directory';
 	  };
 
 export type ResolvedBlueprint = {


### PR DESCRIPTION
## Motivation for the change, related issues

When saving a temporary site to OPFS, stores the associated blueprint bundle into the OPFS alongside the site data. Right now, the bundled files are not preserved. It's not a big problem today, but the upcoming bundle editor (#2942) makes the problem much more prominent. Thus, let's solve it before making bundles more prominent.
