### PR TITLE
[Website] MySQL admin tool improvements

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -377,6 +377,56 @@ test.describe('Database panel', () => {
 		expect(newPage.url()).toContain('/adminer/');
 		await expect(newPage.locator('body')).toContainText('Adminer');
 		await expect(newPage.locator('body')).toContainText('wp_posts');
+
+		// Browse the "wp_posts" table
+		await newPage
+			.locator('#tables a.structure[title="Show structure"]')
+			.filter({ hasText: 'wp_posts' })
+			.click();
+		await newPage.waitForLoadState();
+		await newPage.getByRole('link', { name: 'select data' }).click();
+		await newPage.waitForLoadState();
+		const adminerRows = newPage.locator('table.checkable tbody tr');
+		await expect(adminerRows.first()).toContainText(
+			'Welcome to WordPress.'
+		);
+
+		// Click "edit" on a row
+		await adminerRows.first().getByRole('link', { name: 'edit' }).click();
+		await newPage.waitForLoadState();
+		await expect(newPage.locator('form#form')).toBeVisible();
+		await expect(newPage.locator('form#form')).toContainText(
+			'Welcome to WordPress.'
+		);
+
+		// Update the post content
+		const postContentTextarea = newPage.locator(
+			'textarea[name="fields[post_content]"]'
+		);
+		await postContentTextarea.click();
+		await postContentTextarea.clear();
+		await postContentTextarea.fill('Updated post content.');
+		await newPage
+			.getByRole('button', { name: 'Save', exact: true })
+			.click();
+		await newPage.waitForLoadState();
+
+		// Go back row listing and verify the updated content
+		await newPage.getByRole('link', { name: 'Select data' }).click();
+		await newPage.waitForLoadState();
+		await expect(
+			newPage.locator('table.checkable tbody tr').first()
+		).toContainText('Updated post content.');
+
+		// Go to SQL tab and execute "SHOW TABLES"
+		await newPage.getByRole('link', { name: 'SQL command' }).click();
+		await newPage.waitForLoadState();
+		const sqlTextarea = newPage.locator('textarea[name="query"]');
+		await sqlTextarea.fill('SHOW TABLES', { force: true });
+		await newPage.getByRole('button', { name: 'Execute' }).click();
+		await newPage.waitForLoadState();
+		await expect(newPage.locator('body')).toContainText('wp_posts');
+
 		await newPage.close();
 	});
 
@@ -399,6 +449,60 @@ test.describe('Database panel', () => {
 		expect(newPage.url()).toContain('/phpmyadmin');
 		await expect(newPage.locator('body')).toContainText('phpMyAdmin');
 		await expect(newPage.locator('body')).toContainText('wp_posts');
+
+		// Browse the "wp_posts" table
+		const wpPostsRow = newPage
+			.locator('tr')
+			.filter({ hasText: 'wp_posts' })
+			.first();
+		await expect(wpPostsRow).toBeVisible({ timeout: 10000 });
+		await wpPostsRow.getByRole('link', { name: 'Browse' }).click();
+		await newPage.waitForLoadState();
+		const pmaRows = newPage.locator('table.table_results tbody tr');
+		await expect(pmaRows.first()).toContainText('Welcome to WordPress.');
+
+		// Click "edit" on a row
+		await pmaRows
+			.first()
+			.getByRole('link', { name: 'Edit' })
+			.first()
+			.click();
+		await newPage.waitForLoadState();
+		const pmaForm = newPage.locator(
+			'form#insertForm, form[name="insertForm"]'
+		);
+		await expect(pmaForm).toBeVisible({ timeout: 10000 });
+		await expect(pmaForm).toContainText('Welcome to WordPress.');
+
+		// Update the post content
+		const postContentRow = pmaForm
+			.locator('tr')
+			.filter({ hasText: 'post_content' })
+			.first();
+		const postContentTextarea = postContentRow.locator('textarea').first();
+		await postContentTextarea.click();
+		await postContentTextarea.clear();
+		await postContentTextarea.fill('Updated post content.');
+		await newPage.getByRole('button', { name: 'Go' }).first().click();
+
+		// Verify the updated content
+		await newPage.waitForLoadState();
+		await expect(
+			newPage.locator('table.table_results tbody tr').first()
+		).toContainText('Updated post content.');
+
+		// Go to SQL tab and execute "SHOW TABLES"
+		await newPage
+			.locator('#topmenu')
+			.getByRole('link', { name: 'SQL' })
+			.click();
+		await newPage.waitForLoadState();
+		await newPage.locator('.CodeMirror').click();
+		await newPage.keyboard.type('SHOW TABLES');
+		await newPage.getByRole('button', { name: 'Go' }).click();
+		await newPage.waitForLoadState();
+		await expect(newPage.locator('body')).toContainText('wp_posts');
+
 		await newPage.close();
 	});
 });

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -193,10 +193,16 @@ if (!defined('Adminer\DRIVER')) {
 		}
 
 		function fetch_field(): \stdClass {
-			$column = (object) $this->columns[$this->col_offset++];
-			$column->type = $column->{'mysqli:type'};
-			$column->charsetnr = $column->{'mysqli:charsetnr'};
-			return $column;
+			$column = $this->columns[$this->col_offset++];
+
+			// Adminer expects MySQLi-like column metadata rather than PDO syntax.
+			// The SQLite driver provides it in "mysqli:" prefixed metadata keys.
+			foreach ($column as $key => $value) {
+				if (strpos($key, 'mysqli:') === 0) {
+					$column[substr($key, 7)] = $value;
+				}
+			}
+			return (object) $column;
 		}
 	}
 

--- a/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-extensions/DbiMysqli.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-extensions/DbiMysqli.php
@@ -193,6 +193,8 @@ class Result implements ResultInterface {
 	public function getFieldsMeta(): array {
 		$meta = array();
 		foreach ($this->columns as $column) {
+			$flags = $column['flags'] ?? array();
+
 			// PhpMyAdmin expects MySQLi-like column metadata rather than PDO syntax.
 			// The SQLite driver provides it in "mysqli:" prefixed metadata keys.
 			foreach ($column as $key => $value) {
@@ -200,6 +202,28 @@ class Result implements ResultInterface {
 					$column[substr($key, 7)] = $value;
 				}
 			}
+
+			// Convert PDO-style flags array to MySQLi-style integer bitmask.
+			// TODO: Remove this when the driver implements "mysqli:flags".
+			$mysqli_flags = 0;
+			foreach ($flags as $flag) {
+				switch ($flag) {
+					case 'primary_key':
+						$mysqli_flags |= \MYSQLI_PRI_KEY_FLAG;
+						break;
+					case 'unique_key':
+						$mysqli_flags |= \MYSQLI_UNIQUE_KEY_FLAG;
+						break;
+					case 'not_null':
+						$mysqli_flags |= \MYSQLI_NOT_NULL_FLAG;
+						break;
+					case 'auto_increment':
+						$mysqli_flags |= \MYSQLI_AUTO_INCREMENT_FLAG;
+						break;
+				}
+			}
+			$column['flags'] = $mysqli_flags;
+
 			$field = (object) $column;
 			$meta[] = new FieldMetadata($field->type, $field->flags, $field);
 		}

--- a/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-extensions/DbiMysqli.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-extensions/DbiMysqli.php
@@ -193,7 +193,15 @@ class Result implements ResultInterface {
 	public function getFieldsMeta(): array {
 		$meta = array();
 		foreach ($this->columns as $column) {
-			$meta[] = new FieldMetadata($column['mysqli:type'], $column['mysqli:flags'], (object) $column);
+			// PhpMyAdmin expects MySQLi-like column metadata rather than PDO syntax.
+			// The SQLite driver provides it in "mysqli:" prefixed metadata keys.
+			foreach ($column as $key => $value) {
+				if (strpos($key, 'mysqli:') === 0) {
+					$column[substr($key, 7)] = $value;
+				}
+			}
+			$field = (object) $column;
+			$meta[] = new FieldMetadata($field->type, $field->flags, $field);
 		}
 		return $meta;
 	}


### PR DESCRIPTION
## Motivation for the change, related issues
Fixes row editing in phpMyAdmin:

<img width="903" height="507" alt="Screenshot 2025-12-01 at 20 31 50" src="https://github.com/user-attachments/assets/717b6329-d650-46dc-bf9b-c6c56564c05f" />

## Implementation details
PhpMyAdmin needs MySQLi-like column metadata for row editing.

I also added more tests to cover this functionality.

## Testing Instructions (or ideally a Blueprint)
1. Run `npx nx dev playground-website`.
2. Go to http://127.0.0.1:5400/website-server/, open settings and go to the Database panel.
3. Click on phpMyAdmin, browse some table data, and click the row "Edit" button.
4. Editing should work and save the data.
