### PR TITLE
[Website] Fix flaky phpMyAdmin test

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -450,18 +450,31 @@ test.describe('Database panel', () => {
 		await expect(newPage.locator('body')).toContainText('phpMyAdmin');
 		await expect(newPage.locator('body')).toContainText('wp_posts');
 
+		/*
+		 * Before clicking a link in phpMyAdmin, we need to wait for any AJAX
+		 * requests to be done. This prevents flaky tests (mainly in Firefox).
+		 *
+		 * @see https://github.com/phpmyadmin/phpmyadmin/blob/3925c2237701050ee34f5ba79d74fda808673d4f/resources/js/modules/ajax.ts
+		 */
+		const waitForAjaxIdle = async () =>
+			newPage.waitForFunction(() => {
+				return (window as any).AJAX?.active === false;
+			});
+
 		// Browse the "wp_posts" table
 		const wpPostsRow = newPage
 			.locator('tr')
 			.filter({ hasText: 'wp_posts' })
 			.first();
 		await expect(wpPostsRow).toBeVisible({ timeout: 10000 });
+		await waitForAjaxIdle();
 		await wpPostsRow.getByRole('link', { name: 'Browse' }).click();
 		await newPage.waitForLoadState();
 		const pmaRows = newPage.locator('table.table_results tbody tr');
 		await expect(pmaRows.first()).toContainText('Welcome to WordPress.');
 
 		// Click "edit" on a row
+		await waitForAjaxIdle();
 		await pmaRows
 			.first()
 			.getByRole('link', { name: 'Edit' })

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -360,7 +360,7 @@ test.describe('Database panel', () => {
 
 	test('should load and open Adminer', async ({ website, context }) => {
 		const adminerButton = website.page.getByRole('button', {
-			name: /Open Adminer/i,
+			name: 'Open Adminer',
 		});
 		await expect(adminerButton).toBeVisible();
 		await expect(adminerButton).toBeEnabled();
@@ -432,7 +432,7 @@ test.describe('Database panel', () => {
 
 	test('should load and open phpMyAdmin', async ({ website, context }) => {
 		const phpMyAdminButton = website.page.getByRole('button', {
-			name: /Open phpMyAdmin/i,
+			name: 'Open phpMyAdmin',
 		});
 		await expect(phpMyAdminButton).toBeVisible();
 		await expect(phpMyAdminButton).toBeEnabled();
@@ -466,7 +466,7 @@ test.describe('Database panel', () => {
 			.locator('tr')
 			.filter({ hasText: 'wp_posts' })
 			.first();
-		await expect(wpPostsRow).toBeVisible({ timeout: 10000 });
+		await expect(wpPostsRow).toBeVisible();
 		await waitForAjaxIdle();
 		await wpPostsRow.getByRole('link', { name: 'Browse' }).click();
 		await newPage.waitForLoadState();
@@ -481,14 +481,12 @@ test.describe('Database panel', () => {
 			.first()
 			.click();
 		await newPage.waitForLoadState();
-		const pmaForm = newPage.locator(
-			'form#insertForm, form[name="insertForm"]'
-		);
-		await expect(pmaForm).toBeVisible({ timeout: 10000 });
-		await expect(pmaForm).toContainText('Welcome to WordPress.');
+		const editForm = newPage.locator('form#insertForm');
+		await expect(editForm).toBeVisible();
+		await expect(editForm).toContainText('Welcome to WordPress.');
 
 		// Update the post content
-		const postContentRow = pmaForm
+		const postContentRow = editForm
 			.locator('tr')
 			.filter({ hasText: 'post_content' })
 			.first();


### PR DESCRIPTION
## Motivation for the change, related issues
The phpMyAdmin E2E test seems to be flaky in Firefox:

```
  ✘  32 [firefox] › packages/playground/website/playwright/e2e/website-ui.spec.ts:433:6 › Database panel › should load and open phpMyAdmin (retry #3) (42.0s)


  1) [firefox] › packages/playground/website/playwright/e2e/website-ui.spec.ts:433:6 › Database panel › should load and open phpMyAdmin 

    Error: expect(locator).toBeVisible() failed

    Locator:  locator('form#insertForm, form[name="insertForm"]')
    Expected: visible
    Received: <element(s) not found>
    Timeout:  10000ms

    Call log:
      - Expect "toBeVisible" with timeout 10000ms
      - waiting for locator('form#insertForm, form[name="insertForm"]')


      472 | 			'form#insertForm, form[name="insertForm"]'
      473 | 		);
    > 474 | 		await expect(pmaForm).toBeVisible({ timeout: 10000 });
          | 		                      ^
      475 | 		await expect(pmaForm).toContainText('Welcome to WordPress.');
      476 |
      477 | 		// Update the post content
        at /home/runner/work/wordpress-playground/wordpress-playground/packages/playground/website/playwright/e2e/website-ui.spec.ts:474:25

    Error Context: packages/playground/website/test-results/website-ui-Database-panel-should-load-and-open-phpMyAdmin-firefox/error-context.md
```

## Implementation details
The issue appears to be that phpMyAdmin handles screen navigation using custom AJAX handlers, which may ignore link clicks when another AJAX request is still in progress. This is implemented in their [AJAX module](https://github.com/phpmyadmin/phpmyadmin/blob/3925c2237701050ee34f5ba79d74fda808673d4f/resources/js/modules/ajax.ts) that is exposed globally on `window.AJAX`.

I tried other approaches like waiting for a loader to disappear, but no luck. This approach seems to be the only reliable one.

## Testing Instructions (or ideally a Blueprint)
See the CI passing.
