### PR TITLE
Fix `runPHPWithOptions` demo

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/run-php-with-options.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-php-with-options.ts
@@ -8,7 +8,7 @@ import type { PHPRunOptions } from '@php-wasm/universal';
  *
  * <code>
  * {
- * 		"step": "runPHP",
+ * 		"step": "runPHPWithOptions",
  * 		"options": {
  * 			"code": "<?php echo $_SERVER['CONTENT_TYPE']; ?>",
  * 			"headers": {


### PR DESCRIPTION
## Motivation for the change, related issues

Fixing the `runPHPWithOptions` demo in docs.

Related issue: #1162

## Implementation details

Rename step from `runPHP` to `runPHPWithOptions` in doc comment

## Testing Instructions (or ideally a Blueprint)

1. Open https://wordpress.github.io/wordpress-playground/blueprints/steps/#RunPHPWithOptionsStep
2. Click the `Try it out!` button to create spin up WordPress with auto generated example blueprint.
3. The playground should run w/o any errors.
