### PR TITLE
[ Intl ] Implement Intl in blueprints

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -69,7 +69,8 @@
 					"type": "object",
 					"properties": {
 						"intl": {
-							"type": "boolean"
+							"type": "boolean",
+							"description": "Should boot with support for Intl dynamic extension"
 						},
 						"networking": {
 							"type": "boolean",

--- a/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
+++ b/packages/playground/blueprints/src/lib/resolve-runtime-configuration.ts
@@ -12,6 +12,7 @@ export async function resolveRuntimeConfiguration(
 		const compiledBlueprint = await compileBlueprintV1(
 			blueprint as BlueprintV1
 		);
+
 		return {
 			wpVersion: compiledBlueprint.versions.wp,
 			phpVersion: compiledBlueprint.versions.php,

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -98,6 +98,7 @@ export interface CompiledBlueprintV1 {
 		wp: string;
 	};
 	features: {
+		/** Should boot with support for Intl dynamic extension */
 		intl: boolean;
 		/** Should boot with support for network request via wp_safe_remote_get? */
 		networking: boolean;

--- a/packages/playground/blueprints/src/lib/v1/types.ts
+++ b/packages/playground/blueprints/src/lib/v1/types.ts
@@ -68,6 +68,7 @@ export type BlueprintV1Declaration = {
 		wp: string | 'latest';
 	};
 	features?: {
+		/** Should boot with support for Intl dynamic extension */
 		intl?: boolean;
 		/** Should boot with support for network request via wp_safe_remote_get? */
 		networking?: boolean;

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -58,6 +58,7 @@ export class BlueprintsV1Handler {
 			shouldInstallWordPress,
 			phpVersion: runtimeConfiguration.phpVersion,
 			wpVersion: runtimeConfiguration.wpVersion,
+			withIntl: runtimeConfiguration.intl,
 			withNetworking: runtimeConfiguration.networking,
 			corsProxyUrl: corsProxy,
 			sqliteDriverVersion,

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -37,6 +37,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 		sqliteDriverVersion = LatestSqliteDriverVersion,
 		phpVersion,
 		sapiName = 'cli',
+		withIntl = false,
 		withNetworking = true,
 		shouldInstallWordPress = true,
 		corsProxyUrl,
@@ -61,6 +62,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				sapiName,
 				corsProxyUrl,
 				knownRemoteAssetPaths,
+				withIntl,
 				withNetworking,
 				phpVersion: phpVersion!,
 			});

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
@@ -19,6 +19,7 @@ class PlaygroundWorkerEndpointV2 extends PlaygroundWorkerEndpoint {
 		wpVersion,
 		phpVersion,
 		sapiName = 'cli',
+		withIntl = false,
 		withNetworking = true,
 		corsProxyUrl,
 		blueprint,
@@ -41,6 +42,7 @@ class PlaygroundWorkerEndpointV2 extends PlaygroundWorkerEndpoint {
 				sapiName,
 				corsProxyUrl,
 				knownRemoteAssetPaths,
+				withIntl,
 				withNetworking,
 				phpVersion: phpVersion!,
 			});

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -61,6 +61,7 @@ export type WorkerBootOptions = {
 	phpVersion?: SupportedPHPVersion;
 	sapiName?: string;
 	scope: string;
+	withIntl: boolean;
 	withNetworking: boolean;
 	mounts?: Array<MountDescriptor>;
 	shouldInstallWordPress?: boolean;
@@ -119,6 +120,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		sapiName,
 		corsProxyUrl,
 		knownRemoteAssetPaths,
+		withIntl,
 		withNetworking,
 		phpVersion,
 	}: {
@@ -126,6 +128,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		sapiName: string;
 		corsProxyUrl?: string;
 		knownRemoteAssetPaths: Set<string>;
+		withIntl: boolean;
 		withNetworking: boolean;
 		phpVersion: SupportedPHPVersion;
 	}) {
@@ -180,6 +183,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 			createPhpRuntime: async () => {
 				let wasmUrl = '';
 				return await loadWebRuntime(phpVersion, {
+					withIntl,
 					tcpOverFetch,
 					onPhpLoaderModuleLoaded: (phpLoaderModule) => {
 						wasmUrl = phpLoaderModule.dependencyFilename;

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -257,54 +257,50 @@ test('wp-cli step should create a post', async ({ website, wordpress }) => {
 	).toBeVisible();
 });
 
-// TODO: Follow-up on integrating Intl functions in blueprints V1 and V2
-// test('Intl functions should be disabled by default', async ({
-// 	website,
-// 	wordpress,
-// }) => {
-// 	const blueprint: Blueprint = {
-// 		landingPage: '/intl-test.php',
-// 		steps: [
-// 			{
-// 				step: 'writeFile',
-// 				path: '/wordpress/intl-test.php',
-// 				data: `<?php
-// 					$functions = get_extension_funcs('intl');
-// 					var_dump($functions);
-// 				`,
-// 			},
-// 		],
-// 	};
-// 	await website.goto(`/#${JSON.stringify(blueprint)}`);
-// 	await expect(wordpress.locator('body')).toContainText('bool(false)');
-// });
+test('Intl functions should be disabled by default', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		landingPage: '/intl-test.php',
+		steps: [
+			{
+				step: 'writeFile',
+				path: '/wordpress/intl-test.php',
+				data: `<?php
+					$functions = get_extension_funcs('intl');
+					var_dump($functions);
+				`,
+			},
+		],
+	};
+	await website.goto(`/#${JSON.stringify(blueprint)}`);
+	await expect(wordpress.locator('body')).toContainText('bool(false)');
+});
 
-// test('Intl functions should work when intl is enabled', async ({
-// 	website,
-// 	wordpress,
-// }, testInfo) => {
-// 	if (testInfo.project.name === 'chromium') {
-// 		test.skip(true, 'Skipping this test on Chromium due to unknown issues');
-// 	}
-// 	const blueprint: Blueprint = {
-// 		landingPage: '/intl-test.php',
-// 		features: { intl: true },
-// 		steps: [
-// 			{
-// 				step: 'writeFile',
-// 				path: '/wordpress/intl-test.php',
-// 				data: `<?php
-// 					$formatter = numfmt_create('en-US', NumberFormatter::CURRENCY);
-// 					echo numfmt_format($formatter, 100.00);
-// 					$formatter = numfmt_create('fr-FR', NumberFormatter::CURRENCY);
-// 					echo numfmt_format($formatter, 100.00);
-// 				`,
-// 			},
-// 		],
-// 	};
-// 	await website.goto(`/#${JSON.stringify(blueprint)}`);
-// 	await expect(wordpress.locator('body')).toContainText('$100.00100,00\xA0€');
-// });
+test('Intl functions should work when intl is enabled', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		landingPage: '/intl-test.php',
+		features: { intl: true },
+		steps: [
+			{
+				step: 'writeFile',
+				path: '/wordpress/intl-test.php',
+				data: `<?php
+					$formatter = numfmt_create('en-US', NumberFormatter::CURRENCY);
+					echo numfmt_format($formatter, 100.00);
+					$formatter = numfmt_create('fr-FR', NumberFormatter::CURRENCY);
+					echo numfmt_format($formatter, 100.00);
+				`,
+			},
+		],
+	};
+	await website.goto(`/#${JSON.stringify(blueprint)}`);
+	await expect(wordpress.locator('body')).toContainText('$100.00100,00\xA0€');
+});
 
 test('HTTPS requests via curl_exec() should work', async ({
 	website,

--- a/packages/playground/website/playwright/playwright.config.ts
+++ b/packages/playground/website/playwright/playwright.config.ts
@@ -39,7 +39,6 @@ export const playwrightConfig: PlaywrightTestConfig = {
 				},
 			},
 		},
-
 		{
 			name: 'firefox',
 			use: { ...devices['Desktop Firefox'] },


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request adds a `intl` feature enabling Intl extension dynamic loading at runtime in Blueprints

[Roadmap](https://github.com/WordPress/wordpress-playground/issues/2943)

## Implementation details

- Add `withIntl` and the `intl` feature throughout the process of request handling booting 

## Testing Instructions (or ideally a Blueprint)

CI