### PR TITLE
Stop CSP frame-ancestors from breaking embedded Playgrounds

### DIFF
--- a/packages/php-wasm/web-service-worker/src/utils.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.spec.ts
@@ -1,4 +1,8 @@
-import { cloneRequest, getRequestHeaders } from './utils';
+import {
+	cloneRequest,
+	getRequestHeaders,
+	removeContentSecurityPolicyDirective,
+} from './utils';
 
 describe('cloneRequest', () => {
 	it('should clone request headers', async () => {
@@ -26,5 +30,81 @@ describe('getRequestHeaders', () => {
 			'content-type': 'text/plain',
 			'x-wp-nonce': '123456',
 		});
+	});
+});
+
+describe('removeContentSecurityPolicyDirective', () => {
+	it('should remove the specified directive from the middle of the Content-Security-Policy header value', () => {
+		const cspHeader =
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';";
+		const directiveToRemove = 'frame-ancestors';
+		const filteredCspHeader = removeContentSecurityPolicyDirective(
+			directiveToRemove,
+			cspHeader
+		);
+		expect(filteredCspHeader).toBe(
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self';"
+		);
+	});
+
+	it('should remove the specified directive from the beginning of the Content-Security-Policy header value', () => {
+		const cspHeader =
+			"frame-ancestors 'self'; default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self';";
+		const directiveToRemove = 'frame-ancestors';
+		const filteredCspHeader = removeContentSecurityPolicyDirective(
+			directiveToRemove,
+			cspHeader
+		);
+		expect(filteredCspHeader).toBe(
+			" default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self';"
+		);
+	});
+
+	it('should remove the specified directive from the end of the Content-Security-Policy header value', () => {
+		const cspHeader =
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'self';";
+		const directiveToRemove = 'frame-ancestors';
+		const filteredCspHeader = removeContentSecurityPolicyDirective(
+			directiveToRemove,
+			cspHeader
+		);
+		expect(filteredCspHeader).toBe(
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self';"
+		);
+	});
+
+	it('should remove the specified directive from the Content-Security-Policy header value when there are multiple directives', () => {
+		const cspHeader =
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'self'; frame-ancestors 'self';";
+		const directiveToRemove = 'frame-ancestors';
+		const filteredCspHeader = removeContentSecurityPolicyDirective(
+			directiveToRemove,
+			cspHeader
+		);
+		expect(filteredCspHeader).toBe(
+			"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self';"
+		);
+	});
+
+	it('should remove the specified directive when preceded by every type of ASCII whitespace', () => {
+		const cspHeader =
+			"default-src 'self';\u{9}\u{A}\u{C}\u{D}\u{20}frame-ancestors 'self';";
+		const directiveToRemove = 'frame-ancestors';
+		const filteredCspHeader = removeContentSecurityPolicyDirective(
+			directiveToRemove,
+			cspHeader
+		);
+		expect(filteredCspHeader).toBe("default-src 'self';");
+	});
+
+	it('should remove the specified directive when followed by every type of ASCII whitespace', () => {
+		const cspHeader =
+			"default-src 'self'; frame-ancestors\u{9}\u{A}\u{C}\u{D}\u{20}'self';";
+		const directiveToRemove = 'frame-ancestors';
+		const filteredCspHeader = removeContentSecurityPolicyDirective(
+			directiveToRemove,
+			cspHeader
+		);
+		expect(filteredCspHeader).toBe("default-src 'self';");
 	});
 });

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -80,6 +80,8 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 							(directive: string) =>
 								!directive
 									.trimStart()
+									// Directive names are case-insensitive.
+									.toLowerCase()
 									.startsWith('frame-ancestors')
 						)
 						.join(';')

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -55,9 +55,44 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 		const requestId = await broadcastMessageExpectReply(message, scope);
 		phpResponse = await awaitReply(self, requestId);
 
-		// X-frame-options gets in a way when PHP is
+		// X-frame-options gets in the way when PHP is
 		// being displayed in an iframe.
 		delete phpResponse.headers['x-frame-options'];
+
+		// Content-Security-Policy can get in the way when PHP is
+		// being displayed in an iframe. WordPress 6.9 added a new
+		// `Content-Security-Policy: frame-ancestors 'self';` header that
+		// is breaking folks who embed a Playground from another origin.
+		// https://core.trac.wordpress.org/changeset/60657/
+		//
+		// Let's prune the frame-ancestors and avoid clobbering other CSP directives.
+		if (phpResponse.headers['content-security-policy']) {
+			const filteredCspHeaders = phpResponse.headers[
+				'content-security-policy'
+			]
+				// Remove any frame-ancestors directives.
+				.map((originalValue: string) =>
+					originalValue
+						.split(';')
+						.filter(
+							(directive: string) =>
+								!directive
+									.trimStart()
+									.startsWith('frame-ancestors')
+						)
+						.join(';')
+				)
+				// Remove empty or whitespace-only values.
+				.filter((value: string) => value.trim().length > 0);
+
+			if (filteredCspHeaders.length > 0) {
+				phpResponse.headers['content-security-policy'] =
+					filteredCspHeaders;
+			} else {
+				// There are no remaining CSP directives, so let's remove the header altogether.
+				delete phpResponse.headers['content-security-policy'];
+			}
+		}
 	} catch (e) {
 		console.error(e, { url: url.toString() });
 		throw e;

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -71,6 +71,15 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 		 * NOTE: We expect all header names to be lowercase.
 		 */
 		if (phpResponse.headers['content-security-policy']) {
+			// ASCII whitespace:
+			// @see https://infra.spec.whatwg.org/#ascii-whitespace
+			// eslint-disable-next-line no-control-regex
+			const leadingAsciiWhitespace = /^[\u{9}\u{A}\u{C}\u{D}\u{20}]+/u;
+			// eslint-disable-next-line no-control-regex
+			const trailingAsciiWhitespace = /[\u{9}\u{A}\u{C}\u{D}\u{20}]+$/u;
+			// eslint-disable-next-line no-control-regex
+			const asciiWhitespace = /[\u{9}\u{A}\u{C}\u{D}\u{20}]/u;
+
 			const filteredCspHeaders = phpResponse.headers[
 				'content-security-policy'
 			]
@@ -82,14 +91,16 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 						// "For each token returned by strictly splitting serialized
 						// on the U+003B SEMICOLON character (;):"
 						.split(';')
-						.filter((directive: string) => {
+						.filter((rawDirective: string) => {
+							// "Strip leading and trailing ASCII whitespace from token."
+							const trimmedDirective = rawDirective
+								.replace(leadingAsciiWhitespace, '')
+								.replace(trailingAsciiWhitespace, '');
+
 							// "Let directive name be the result of collecting a sequence
 							// of code points from token which are not ASCII whitespace."
-							//
-							// @see https://infra.spec.whatwg.org/#ascii-whitespace
-							const [directiveName] = directive.split(
-								// eslint-disable-next-line no-control-regex
-								/[\u{9}\u{A}\u{C}\u{D}\u{20}]/u,
+							const [directiveName] = trimmedDirective.split(
+								asciiWhitespace,
 								// The directive name is the first token.
 								1
 							);
@@ -284,4 +295,10 @@ export function getRequestHeaders(request: Request) {
 		headers[key] = value;
 	});
 	return headers;
+}
+
+export function removeContentSecurityPolicyDirective(directive: string) {
+	return directive.split(';').filter((directive: string) => {
+		return directive.toLowerCase() !== 'content-security-policy';
+	});
 }

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -71,48 +71,15 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 		 * NOTE: We expect all header names to be lowercase.
 		 */
 		if (phpResponse.headers['content-security-policy']) {
-			// ASCII whitespace:
-			// @see https://infra.spec.whatwg.org/#ascii-whitespace
-			// eslint-disable-next-line no-control-regex
-			const leadingAsciiWhitespace = /^[\u{9}\u{A}\u{C}\u{D}\u{20}]+/u;
-			// eslint-disable-next-line no-control-regex
-			const trailingAsciiWhitespace = /[\u{9}\u{A}\u{C}\u{D}\u{20}]+$/u;
-			// eslint-disable-next-line no-control-regex
-			const asciiWhitespace = /[\u{9}\u{A}\u{C}\u{D}\u{20}]/u;
-
 			const filteredCspHeaders = phpResponse.headers[
 				'content-security-policy'
 			]
 				// Remove any frame-ancestors directives.
 				.map((originalValue: string) =>
-					// Parse based on the CSP spec:
-					// https://w3c.github.io/webappsec-csp/#parse-serialized-policy
-					originalValue
-						// "For each token returned by strictly splitting serialized
-						// on the U+003B SEMICOLON character (;):"
-						.split(';')
-						.filter((rawDirective: string) => {
-							// "Strip leading and trailing ASCII whitespace from token."
-							const trimmedDirective = rawDirective
-								.replace(leadingAsciiWhitespace, '')
-								.replace(trailingAsciiWhitespace, '');
-
-							// "Let directive name be the result of collecting a sequence
-							// of code points from token which are not ASCII whitespace."
-							const [directiveName] = trimmedDirective.split(
-								asciiWhitespace,
-								// The directive name is the first token.
-								1
-							);
-
-							return (
-								// "Directive names are case-insensitive, that is:
-								// script-SRC 'none' and ScRiPt-sRc 'none' are equivalent."
-								directiveName.toLowerCase() !==
-								'frame-ancestors'
-							);
-						})
-						.join(';')
+					removeContentSecurityPolicyDirective(
+						'frame-ancestors',
+						originalValue
+					)
 				)
 				// Remove empty or whitespace-only values.
 				.filter((value: string) => value.trim().length > 0);
@@ -297,8 +264,49 @@ export function getRequestHeaders(request: Request) {
 	return headers;
 }
 
-export function removeContentSecurityPolicyDirective(directive: string) {
-	return directive.split(';').filter((directive: string) => {
-		return directive.toLowerCase() !== 'content-security-policy';
-	});
+/**
+ * Removes the specified directive from the Content-Security-Policy header value.
+ *
+ * @param directiveToRemove The directive name to remove.
+ * @param cspHeader The Content-Security-Policy header value to filter.
+ * @returns The filtered Content-Security-Policy header value.
+ */
+export function removeContentSecurityPolicyDirective(
+	directiveToRemove: string,
+	cspHeader: string
+) {
+	// ASCII whitespace:
+	// @see https://infra.spec.whatwg.org/#ascii-whitespace
+	// eslint-disable-next-line no-control-regex
+	const leadingAsciiWhitespace = /^[\u{9}\u{A}\u{C}\u{D}\u{20}]+/u;
+	// eslint-disable-next-line no-control-regex
+	const trailingAsciiWhitespace = /[\u{9}\u{A}\u{C}\u{D}\u{20}]+$/u;
+	// eslint-disable-next-line no-control-regex
+	const asciiWhitespace = /[\u{9}\u{A}\u{C}\u{D}\u{20}]/u;
+
+	// Parse based on the CSP spec:
+	// https://w3c.github.io/webappsec-csp/#parse-serialized-policy
+	return cspHeader
+		// "For each token returned by strictly splitting serialized
+		// on the U+003B SEMICOLON character (;):"
+		.split(';')
+		.filter((rawDirective: string) => {
+			// "Strip leading and trailing ASCII whitespace from token."
+			const trimmedDirective = rawDirective
+				.replace(leadingAsciiWhitespace, '')
+				.replace(trailingAsciiWhitespace, '');
+
+			// "Let directive name be the result of collecting a sequence
+			// of code points from token which are not ASCII whitespace."
+			const [directiveName] = trimmedDirective.split(
+				asciiWhitespace,
+				// The directive name is the first token.
+				1
+			);
+
+			// "Directive names are case-insensitive, that is:
+			// script-SRC 'none' and ScRiPt-sRc 'none' are equivalent."
+			return directiveName.toLowerCase() !== directiveToRemove.toLowerCase();
+		})
+		.join(';');
 }

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -59,25 +59,33 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 		// being displayed in an iframe.
 		delete phpResponse.headers['x-frame-options'];
 
-		// Content-Security-Policy can get in the way when PHP is
-		// being displayed in an iframe. WordPress 6.9 added a new
-		// `Content-Security-Policy: frame-ancestors 'self';` header that
-		// is breaking folks who embed a Playground from another origin.
-		// https://core.trac.wordpress.org/changeset/60657/
-		//
-		// Let's prune the frame-ancestors and avoid clobbering other CSP directives.
+		/*
+		 * Content-Security-Policy can get in the way when PHP is
+		 * being displayed in an iframe. WordPress 6.9 added a new
+		 * `Content-Security-Policy: frame-ancestors 'self';` header that
+		 * is breaking folks who embed a Playground from another origin.
+		 * https://core.trac.wordpress.org/changeset/60657/
+		 *
+		 * Let's prune the frame-ancestors and avoid clobbering other CSP directives.
+		 *
+		 * NOTE: We expect all header names to be lowercase.
+		 */
 		if (phpResponse.headers['content-security-policy']) {
 			const filteredCspHeaders = phpResponse.headers[
 				'content-security-policy'
 			]
 				// Remove any frame-ancestors directives.
 				.map((originalValue: string) =>
-					// Parse loosely based on:
+					// Parse based on the CSP spec:
 					// https://w3c.github.io/webappsec-csp/#parse-serialized-policy
 					originalValue
+						// "For each token returned by strictly splitting serialized
+						// on the U+003B SEMICOLON character (;):"
 						.split(';')
 						.filter((directive: string) => {
-							// Split on ASCII whitespace:
+							// "Let directive name be the result of collecting a sequence
+							// of code points from token which are not ASCII whitespace."
+							//
 							// @see https://infra.spec.whatwg.org/#ascii-whitespace
 							const [directiveName] = directive.split(
 								// eslint-disable-next-line no-control-regex
@@ -85,7 +93,10 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 								// The directive name is the first token.
 								1
 							);
+
 							return (
+								// "Directive names are case-insensitive, that is:
+								// script-SRC 'none' and ScRiPt-sRc 'none' are equivalent."
 								directiveName.toLowerCase() !==
 								'frame-ancestors'
 							);

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -76,14 +76,20 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 					// https://w3c.github.io/webappsec-csp/#parse-serialized-policy
 					originalValue
 						.split(';')
-						.filter(
-							(directive: string) =>
-								!directive
-									.trimStart()
-									// Directive names are case-insensitive.
-									.toLowerCase()
-									.startsWith('frame-ancestors')
-						)
+						.filter((directive: string) => {
+							// Split on ASCII whitespace:
+							// @see https://infra.spec.whatwg.org/#ascii-whitespace
+							const [directiveName] = directive.split(
+								// eslint-disable-next-line no-control-regex
+								/[\u{9}\u{A}\u{C}\u{D}\u{20}]/u,
+								// The directive name is the first token.
+								1
+							);
+							return (
+								directiveName.toLowerCase() !==
+								'frame-ancestors'
+							);
+						})
 						.join(';')
 				)
 				// Remove empty or whitespace-only values.

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -72,6 +72,8 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 			]
 				// Remove any frame-ancestors directives.
 				.map((originalValue: string) =>
+					// Parse loosely based on:
+					// https://w3c.github.io/webappsec-csp/#parse-serialized-policy
 					originalValue
 						.split(';')
 						.filter(


### PR DESCRIPTION
## Motivation for the change, related issues

Telex is currently experiencing an issue embedding Playground after WordPress 6.9 added a `Content-Security-Policy: frame-ancestors 'self';` header to admin pages.

The WP commit is here:
https://core.trac.wordpress.org/changeset/60657/

## Implementation details

Let's avoid breakage by filtering the `frame-ancestors` directive from `Content-Security-Policy` headers.

## Testing Instructions (or ideally a Blueprint)

- CI
- To test locally, load WP 6.9, open the dev tools Network tab, navigate to the site-editor page, and confirm there is no such Content-Security-Policy header in the requests for site-editor.php.
