### PR TITLE
Add .orig and .rej files to .gitignore for patching leftovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ testem.log
 /.env
 packages/playground/website/cypress/downloads
 vite.config.ts.timestamp-*.mjs
+*.orig
+*.rej
 
 # System Files
 .DS_Store


### PR DESCRIPTION
## Motivation for the change, related issues

When applying patches if there are any issues or patch is not applying well or there are merge problems, `rej` and `orig` tend to appear

## Implementation details
Just adding these two extensions to `gitignore`