### PR TITLE
[Website] Move dynamic extension files in assets/extensions directory

### DIFF
--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -49,8 +49,8 @@ export default defineConfig(({ mode }) => {
 		'CORS_PROXY_URL' in process.env
 			? process.env['CORS_PROXY_URL']
 			: mode === 'production'
-			? 'https://wordpress-playground-cors-proxy.net/?'
-			: 'http://127.0.0.1:5263/cors-proxy.php?';
+				? 'https://wordpress-playground-cors-proxy.net/?'
+				: 'http://127.0.0.1:5263/cors-proxy.php?';
 
 	plugins.push(
 		virtualModule({
@@ -105,6 +105,29 @@ export default defineConfig(({ mode }) => {
 			plugins: () => plugins,
 			rollupOptions: {
 				output: {
+					assetFileNames: (chunkInfo) => {
+						// Split Extensions or associated shared files into separate chunks
+						// that will be placed in assets/extensions/ directory
+						if (
+							chunkInfo.names?.[0]?.endsWith('.so') ||
+							chunkInfo.names?.[0]?.endsWith('.dat')
+						) {
+							return 'assets/extensions/[name]-[hash][extname]';
+						}
+
+						return 'assets/[name]-[hash][extname]';
+					},
+					chunkFileNames: (chunkInfo: any) => {
+						// Split Extensions or associated shared files into separate chunks
+						// that will be placed in assets/extensions/ directory
+						if (
+							chunkInfo.facadeModuleId.endsWith('.so') ||
+							chunkInfo.facadeModuleId.endsWith('.dat')
+						) {
+							return 'assets/extensions/[name]-[hash].js';
+						}
+						return 'assets/[name]-[hash].js';
+					},
 					// Ensure the service worker always has the same name
 					entryFileNames: (chunkInfo: any) => {
 						if (chunkInfo.name === 'service-worker') {
@@ -127,6 +150,20 @@ export default defineConfig(({ mode }) => {
 			rollupOptions: {
 				input: {
 					wordpress: path('/remote.html'),
+				},
+				output: {
+					assetFileNames: (chunkInfo) => {
+						// Split Extensions or associated shared files into separate chunks
+						// that will be placed in assets/extensions/ directory
+						if (
+							chunkInfo.names?.[0]?.endsWith('.so') ||
+							chunkInfo.names?.[0]?.endsWith('.dat')
+						) {
+							return 'assets/extensions/[name]-[hash][extname]';
+						}
+
+						return 'assets/[name]-[hash][extname]';
+					},
 				},
 			},
 			// Clean the output directory to make sure we include only the


### PR DESCRIPTION
## Motivation for the change, related issues

Currently, when displaying the [assets-required-for-offline-mode.json file](https://playground.wordpress.net/assets-required-for-offline-mode.json), Intl dynamic extension files are present. This is due to dynamic importing and Vite builds automatically assigning these files in the assets directory.

This pull request aims to move these files in the `assets/extensions` directory, an ignored directory for offline mode assets.  

## Implementation details

Added `chunkFileNames` and `assetFileNames` hooks in :

-  `packages/playground/website/vite.config.ts`
- `packages/playground/remote/vite.config.ts`

## Testing Instructions (or ideally a Blueprint)

run :

```
nx reset && nx run playground-website:build:standalone
```

You'll find the new file in `dist/packages/playground/website/assets-required-for-offline-mode.json` 