### PR TITLE
Updated `runPHPWithOptions` example

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/run-php-with-options.ts
+++ b/packages/playground/blueprints/src/lib/steps/run-php-with-options.ts
@@ -10,10 +10,8 @@ import type { PHPRunOptions } from '@php-wasm/universal';
  * {
  * 		"step": "runPHPWithOptions",
  * 		"options": {
- * 			"code": "<?php echo $_SERVER['CONTENT_TYPE']; ?>",
- * 			"headers": {
- * 				"Content-type": "text/plain"
- * 			}
+ * 			"code": "<?php require_once '/wordpress/wp-load.php'; update_option('blogname', file_get_contents('php://input'));?>",
+ * 			"body": "Site Name Modified by runPHPWithOptions"
  * 		}
  * }
  * </code>


### PR DESCRIPTION
## Motivation for the change, related issues

Made `runPHPWithOptions` example more meaningful by making visible changes.

Related issue: #1162

## Implementation details

Updated PHP code to modify the site name using input body.

## Testing Instructions (or ideally a Blueprint)

1. Open https://wordpress.github.io/wordpress-playground/blueprints/steps/#RunPHPWithOptionsStep
2. Click the `Try it out!` button to create spin up WordPress with auto generated example blueprint.
3. The playground should run w/o any errors and site name should be same as input body (`Site Name Modified by runPHPWithOptions`)
