### PR TITLE
[Website] Use a kapa.ai widget for blueprint error troubleshooting

### DIFF
--- a/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
+++ b/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
@@ -39,7 +39,7 @@ export function SiteErrorModal({
 		isSubmittingReport,
 		handleSubmitReport,
 	} = useErrorReporting(site);
-	const { openWithQuery } = useKapaAI();
+	const kapaAI = useKapaAI();
 
 	const helpers: PresentationHelpers = {
 		deleteSite: () => {
@@ -71,6 +71,9 @@ export function SiteErrorModal({
 	});
 
 	const detailText = formatErrorDetails(errorDetails);
+	const shouldShowKapaButton =
+		!isReporting && detailText && kapaAI.isEnabled();
+
 	return (
 		<Modal
 			title={
@@ -147,10 +150,12 @@ export function SiteErrorModal({
 				</div>
 				{view.actions.length || !view.isDeveloperError || detailText ? (
 					<div className={css.errorModalFooter}>
-						{!isReporting && detailText && (
+						{shouldShowKapaButton && (
 							<Button
 								variant="secondary"
-								onClick={() => openWithQuery(detailText)}
+								onClick={() =>
+									kapaAI.openWithQuery(detailText!)
+								}
 							>
 								Troubleshoot with AI
 							</Button>

--- a/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
+++ b/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
@@ -154,7 +154,7 @@ export function SiteErrorModal({
 							<Button
 								variant="secondary"
 								onClick={() =>
-									kapaAI.openWithQuery(detailText!)
+									kapaAI.openWithErrorMessage(detailText!)
 								}
 							>
 								Troubleshoot with AI

--- a/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
+++ b/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
@@ -39,7 +39,7 @@ export function SiteErrorModal({
 		isSubmittingReport,
 		handleSubmitReport,
 	} = useErrorReporting(site);
-	const { isConfigured: isKapaAIConfigured, openWithQuery } = useKapaAI();
+	const { openWithQuery } = useKapaAI();
 
 	const helpers: PresentationHelpers = {
 		deleteSite: () => {
@@ -147,7 +147,7 @@ export function SiteErrorModal({
 				</div>
 				{view.actions.length || !view.isDeveloperError || detailText ? (
 					<div className={css.errorModalFooter}>
-						{isKapaAIConfigured && !isReporting && detailText && (
+						{!isReporting && detailText && (
 							<Button
 								variant="secondary"
 								onClick={() => openWithQuery(detailText)}

--- a/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
+++ b/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
@@ -20,6 +20,7 @@ import type {
 } from './types';
 import { getSiteErrorView } from './get-site-error-view';
 import type { SiteInfo } from '../../lib/state/redux/slice-sites';
+import { useKapaAI } from './use-kapa-ai';
 
 export function SiteErrorModal({
 	error,
@@ -38,6 +39,7 @@ export function SiteErrorModal({
 		isSubmittingReport,
 		handleSubmitReport,
 	} = useErrorReporting(site);
+	const { isConfigured: isKapaAIConfigured, openWithQuery } = useKapaAI();
 
 	const helpers: PresentationHelpers = {
 		deleteSite: () => {
@@ -143,8 +145,16 @@ export function SiteErrorModal({
 						</p>
 					)}
 				</div>
-				{view.actions.length || !view.isDeveloperError ? (
+				{view.actions.length || !view.isDeveloperError || detailText ? (
 					<div className={css.errorModalFooter}>
+						{isKapaAIConfigured && !isReporting && detailText && (
+							<Button
+								variant="secondary"
+								onClick={() => openWithQuery(detailText)}
+							>
+								Troubleshoot with AI
+							</Button>
+						)}
 						{!view.isDeveloperError &&
 						!view.hideReportButton &&
 						!isReporting &&

--- a/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
+++ b/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
@@ -78,7 +78,7 @@ export function useKapaAI() {
 		);
 	};
 
-	const openWithQuery = useCallback(async (query: string) => {
+	const openWithErrorMessage = useCallback(async (errorMessage: string) => {
 		if (!isEnabled()) {
 			return;
 		}
@@ -89,9 +89,15 @@ export function useKapaAI() {
 			if (hasSubmittedQuery.current) {
 				window.Kapa.open();
 			} else {
+				const urlParams = new URLSearchParams(window.location.search);
+				const hasExternalBlueprint = urlParams.has('blueprint-url');
+				const contextPrefix = hasExternalBlueprint
+					? ''
+					: `Given the URL query parameters ${window.location.search}, `;
+
 				window.Kapa.open({
 					mode: 'ai',
-					query: `Suggest a solution or troubleshooting steps for the following error: ${query}`,
+					query: `${contextPrefix}Suggest a solution or troubleshooting steps for the following error: ${errorMessage}`,
 					submit: true,
 				});
 				hasSubmittedQuery.current = true;
@@ -101,6 +107,6 @@ export function useKapaAI() {
 
 	return {
 		isEnabled,
-		openWithQuery,
+		openWithErrorMessage,
 	};
 }

--- a/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
+++ b/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
@@ -1,0 +1,97 @@
+import { useEffect, useCallback, useState } from 'react';
+// @ts-ignore - Virtual module injected by Vite
+import { kapaWebsiteId } from 'virtual:kapa-ai-config';
+
+declare global {
+	interface Window {
+		Kapa?: {
+			open: (options?: {
+				mode?: 'ai' | 'search';
+				query?: string;
+				submit?: boolean;
+			}) => void;
+			close: () => void;
+			render: (options?: { onRender?: () => void }) => void;
+			unmount: () => void;
+		};
+	}
+}
+
+const KAPA_SCRIPT_ID = 'kapa-widget-script';
+
+export function useKapaAI() {
+	const [isLoaded, setIsLoaded] = useState(false);
+	const isConfigured = Boolean(kapaWebsiteId);
+
+	useEffect(() => {
+		if (!isConfigured) {
+			return;
+		}
+
+		// Check if script already exists
+		if (document.getElementById(KAPA_SCRIPT_ID)) {
+			if (window.Kapa) {
+				setIsLoaded(true);
+			}
+			return;
+		}
+
+		const script = document.createElement('script');
+		script.id = KAPA_SCRIPT_ID;
+		script.src = 'https://widget.kapa.ai/kapa-widget.bundle.js';
+		script.async = true;
+		script.setAttribute('data-website-id', kapaWebsiteId);
+		script.setAttribute('data-project-name', 'WordPress Playground');
+		script.setAttribute('data-project-color', '#3858e9');
+		script.setAttribute(
+			'data-project-logo',
+			'https://playground.wordpress.net/logo-square.png'
+		);
+		script.setAttribute('data-button-hide', 'true');
+
+		script.onload = () => {
+			const checkKapa = setInterval(() => {
+				if (window.Kapa) {
+					clearInterval(checkKapa);
+					setIsLoaded(true);
+				}
+			}, 100);
+
+			setTimeout(() => clearInterval(checkKapa), 5000);
+		};
+
+		document.body.appendChild(script);
+	}, [isConfigured]);
+
+	const openWithQuery = useCallback((query: string) => {
+		if (window.Kapa) {
+			window.Kapa.open({
+				mode: 'ai',
+				query: `Suggest a solution or troubleshooting steps for the following error: ${query}`,
+				submit: true,
+			});
+
+			// Move widget container inside screen overlay so it appears on top
+			const moveContainer = () => {
+				const container = document.getElementById(
+					'kapa-widget-container'
+				);
+				const overlay = document.querySelector(
+					'.components-modal__screen-overlay'
+				);
+				if (container && overlay) {
+					overlay.insertBefore(container, overlay.firstChild);
+				} else {
+					setTimeout(moveContainer, 50);
+				}
+			};
+			setTimeout(moveContainer, 50);
+		}
+	}, []);
+
+	return {
+		isConfigured,
+		isLoaded,
+		openWithQuery,
+	};
+}

--- a/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
+++ b/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
@@ -1,6 +1,7 @@
-import { useEffect, useCallback, useState, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 const KAPA_WEBSITE_ID = 'a8b85529-1773-4710-b35f-c9ebc70ffcb6';
+const KAPA_SCRIPT_ID = 'kapa-widget-script';
 
 declare global {
 	interface Window {
@@ -17,17 +18,21 @@ declare global {
 	}
 }
 
-const KAPA_SCRIPT_ID = 'kapa-widget-script';
-
-export function useKapaAI() {
-	const [isLoaded, setIsLoaded] = useState(false);
-	const hasSubmittedQuery = useRef(false);
-
-	useEffect(() => {
-		// Check if script already exists
+function loadKapaScript(): Promise<void> {
+	return new Promise((resolve) => {
+		// Check if script already exists and loaded
 		if (document.getElementById(KAPA_SCRIPT_ID)) {
 			if (window.Kapa) {
-				setIsLoaded(true);
+				resolve();
+			} else {
+				// Script exists but not loaded yet, wait for it
+				const checkKapa = setInterval(() => {
+					if (window.Kapa) {
+						clearInterval(checkKapa);
+						resolve();
+					}
+				}, 100);
+				setTimeout(() => clearInterval(checkKapa), 5000);
 			}
 			return;
 		}
@@ -54,17 +59,32 @@ export function useKapaAI() {
 			const checkKapa = setInterval(() => {
 				if (window.Kapa) {
 					clearInterval(checkKapa);
-					setIsLoaded(true);
+					resolve();
 				}
 			}, 100);
-
 			setTimeout(() => clearInterval(checkKapa), 5000);
 		};
 
 		document.body.appendChild(script);
-	}, []);
+	});
+}
 
-	const openWithQuery = useCallback((query: string) => {
+export function useKapaAI() {
+	const hasSubmittedQuery = useRef(false);
+	const isEnabled = () => {
+		return (
+			window.location.hostname === 'playground.wordpress.net' ||
+			process.env.NODE_ENV === 'development'
+		);
+	};
+
+	const openWithQuery = useCallback(async (query: string) => {
+		if (!isEnabled()) {
+			return;
+		}
+
+		await loadKapaScript();
+
 		if (window.Kapa) {
 			if (hasSubmittedQuery.current) {
 				window.Kapa.open();
@@ -80,7 +100,7 @@ export function useKapaAI() {
 	}, []);
 
 	return {
-		isLoaded,
+		isEnabled,
 		openWithQuery,
 	};
 }

--- a/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
+++ b/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useState, useRef } from 'react';
-// @ts-ignore - Virtual module injected by Vite
-import { kapaWebsiteId } from 'virtual:kapa-ai-config';
+
+const KAPA_WEBSITE_ID = 'a8b85529-1773-4710-b35f-c9ebc70ffcb6';
 
 declare global {
 	interface Window {
@@ -21,14 +21,9 @@ const KAPA_SCRIPT_ID = 'kapa-widget-script';
 
 export function useKapaAI() {
 	const [isLoaded, setIsLoaded] = useState(false);
-	const isConfigured = Boolean(kapaWebsiteId);
 	const hasSubmittedQuery = useRef(false);
 
 	useEffect(() => {
-		if (!isConfigured) {
-			return;
-		}
-
 		// Check if script already exists
 		if (document.getElementById(KAPA_SCRIPT_ID)) {
 			if (window.Kapa) {
@@ -41,7 +36,7 @@ export function useKapaAI() {
 		script.id = KAPA_SCRIPT_ID;
 		script.src = 'https://widget.kapa.ai/kapa-widget.bundle.js';
 		script.async = true;
-		script.setAttribute('data-website-id', kapaWebsiteId);
+		script.setAttribute('data-website-id', KAPA_WEBSITE_ID);
 		script.setAttribute(
 			'data-project-name',
 			'WordPress Playground AI Assistant'
@@ -67,7 +62,7 @@ export function useKapaAI() {
 		};
 
 		document.body.appendChild(script);
-	}, [isConfigured]);
+	}, []);
 
 	const openWithQuery = useCallback((query: string) => {
 		if (window.Kapa) {
@@ -85,7 +80,6 @@ export function useKapaAI() {
 	}, []);
 
 	return {
-		isConfigured,
 		isLoaded,
 		openWithQuery,
 	};

--- a/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
+++ b/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState } from 'react';
+import { useEffect, useCallback, useState, useRef } from 'react';
 // @ts-ignore - Virtual module injected by Vite
 import { kapaWebsiteId } from 'virtual:kapa-ai-config';
 
@@ -22,6 +22,7 @@ const KAPA_SCRIPT_ID = 'kapa-widget-script';
 export function useKapaAI() {
 	const [isLoaded, setIsLoaded] = useState(false);
 	const isConfigured = Boolean(kapaWebsiteId);
+	const hasSubmittedQuery = useRef(false);
 
 	useEffect(() => {
 		if (!isConfigured) {
@@ -41,13 +42,18 @@ export function useKapaAI() {
 		script.src = 'https://widget.kapa.ai/kapa-widget.bundle.js';
 		script.async = true;
 		script.setAttribute('data-website-id', kapaWebsiteId);
-		script.setAttribute('data-project-name', 'WordPress Playground');
+		script.setAttribute(
+			'data-project-name',
+			'WordPress Playground AI Assistant'
+		);
 		script.setAttribute('data-project-color', '#3858e9');
 		script.setAttribute(
 			'data-project-logo',
-			'https://playground.wordpress.net/logo-square.png'
+			'https://wordpress.github.io/wordpress-playground/img/playground-logo.svg'
 		);
 		script.setAttribute('data-button-hide', 'true');
+		script.setAttribute('data-modal-z-index', '100001');
+		script.setAttribute('data-scale-factor', '1.3');
 
 		script.onload = () => {
 			const checkKapa = setInterval(() => {
@@ -65,27 +71,16 @@ export function useKapaAI() {
 
 	const openWithQuery = useCallback((query: string) => {
 		if (window.Kapa) {
-			window.Kapa.open({
-				mode: 'ai',
-				query: `Suggest a solution or troubleshooting steps for the following error: ${query}`,
-				submit: true,
-			});
-
-			// Move widget container inside screen overlay so it appears on top
-			const moveContainer = () => {
-				const container = document.getElementById(
-					'kapa-widget-container'
-				);
-				const overlay = document.querySelector(
-					'.components-modal__screen-overlay'
-				);
-				if (container && overlay) {
-					overlay.insertBefore(container, overlay.firstChild);
-				} else {
-					setTimeout(moveContainer, 50);
-				}
-			};
-			setTimeout(moveContainer, 50);
+			if (hasSubmittedQuery.current) {
+				window.Kapa.open();
+			} else {
+				window.Kapa.open({
+					mode: 'ai',
+					query: `Suggest a solution or troubleshooting steps for the following error: ${query}`,
+					submit: true,
+				});
+				hasSubmittedQuery.current = true;
+			}
 		}
 	}, []);
 

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -43,8 +43,8 @@ export default defineConfig(({ command, mode }) => {
 		'CORS_PROXY_URL' in process.env
 			? process.env.CORS_PROXY_URL
 			: mode === 'production'
-				? 'https://wordpress-playground-cors-proxy.net/?'
-				: '/cors-proxy/?';
+			? 'https://wordpress-playground-cors-proxy.net/?'
+			: '/cors-proxy/?';
 
 	return {
 		// Split traffic from this server on dev so that the iframe content and
@@ -114,13 +114,6 @@ export default defineConfig(({ command, mode }) => {
 				name: 'cors-proxy-url',
 				content: `
 				export const corsProxyUrl = ${JSON.stringify(corsProxyUrl || undefined)};`,
-			}),
-			virtualModule({
-				name: 'kapa-ai-config',
-				content: `
-				export const kapaWebsiteId = ${JSON.stringify(
-					process.env.KAPA_WEBSITE_ID || ''
-				)};`,
 			}),
 			// GitHub OAuth flow
 			{

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -115,6 +115,13 @@ export default defineConfig(({ command, mode }) => {
 				content: `
 				export const corsProxyUrl = ${JSON.stringify(corsProxyUrl || undefined)};`,
 			}),
+			virtualModule({
+				name: 'kapa-ai-config',
+				content: `
+				export const kapaWebsiteId = ${JSON.stringify(
+					process.env.KAPA_WEBSITE_ID || ''
+				)};`,
+			}),
 			// GitHub OAuth flow
 			{
 				name: 'configure-server',


### PR DESCRIPTION
This adds a "Troubleshoot with AI" button below the error message when running a blueprint. For example for a URL like ?plugin=doesntexist

<img width="1808" height="1660" alt="Screenshot 2025-12-17 at 15 25 20" src="https://github.com/user-attachments/assets/e8b8c910-bbee-4650-9ae3-d2c7b7e27165" />

kapa.ai will then try to provide an answer:

<img width="1790" height="1882" alt="Screenshot 2025-12-17 at 15 26 56" src="https://github.com/user-attachments/assets/83d91b70-2e74-4b41-a68e-045e9539ec55" />

To trigger the above error you can run http://127.0.0.1:5400/website-server/?plugin=doesntexist locally.

