### PR TITLE
[i18n] Add contributor day leadership guide in Portuguese

### DIFF
--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributor-day-table-lead.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributor-day-table-lead.md
@@ -1,0 +1,78 @@
+---
+slug: /contributing/table-lead-guide
+title: Como liderar o dia do contribuidor
+description: Como liderar a mesa do WordPress Playground no dia do contribuidor do WordCamp.
+---
+
+# Guia de liderença para o dia do contribuidor
+
+Este guia ajuda os contribuidores a se prepararem e gerenciarem uma mesa de contribuição do WordPress Playground em eventos WordCamp.
+
+## Antes do dia do contribuidor
+
+### Lista prévia
+
+-   **Organizar "Good First Issues"**: Revise e atualize a [good first issues list](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) no GitHub. Devem ser tarefas diretas que novos contribuidores possam completar de forma independente. Se encontrar um erro que não está na lista, mas que poderia fazer parte dela, entre em contato com a equipe do Playground no canal do Slack.
+-   **Coordenar com a Equipe do Playground**: Confirme se os membros da equipe do Playground estão disponíveis online para fornecer suporte remoto durante o evento, especialmente para WordCamps de grande porte. Devido a diferenças de fuso horário, alinhe-se com antecedência no canal #playground para verificar a disponibilidade.
+-   **Conecte com contribuidores locais**: Identifique contribuidores regulares na região que estão participando do evento. Verifique no Canal Slack #playground se um membro ativo da comunidade está participando do dia do contribuidor. Esta é uma oportunidade para coletar feedback e fortalecer as conexões comunitárias.
+-   **Confira o repositorio do Playground**: Se você nunca contribuiu com o repositório do WordPress Playground, você deve primeiro se familiarizar com ele. Uma seção na documentação que pode guiá-lo a entender o projeto é a [Desenvolvedores > Arquitetura](/developers/architecture). Ela conterá informações sobre como o projeto está organizado. Se tiver alguma dúvida, entre em contato com a equipe no canal Slack do Playground.
+
+## Iniciando o dia
+
+### Configuração e Integração
+
+1. **Crie sua agenda**: Prepare uma lista de verificação das principais atividades, ao mesmo tempo que permite a colaboração orgânica. Compartilhe-a na documentação do projeto, se for útil.
+
+2. **Oriente os contribuidores ao Slack**: Direcione todos para o [canal `#playground` no Slack do WordPress](https://wordpress.slack.com/archives/C04EWKGDJ0K). Isso centraliza a comunicação e permite a colaboração assíncrona com os recém-chegados.
+
+3. **Publique uma mensagem de boas-vindas**: Compartilhe uma mensagem inicial no canal Slack anunciando sua presença (pessoalmente ou online) e dando as boas-vindas às contribuições de todos.
+
+4. **Compartilhe links essenciais**: Publique estes recursos no canal `#playground`:
+
+    - [Instância Web do WordPress Playground](https://playground.wordpress.net/)
+    - [Documentação do Playground](https://wordpress.github.io/wordpress-playground/)
+    - [Biblioteca de etapas](https://akirk.github.io/playground-step-library/)
+    - [Repositório do GitHub](https://github.com/WordPress/wordpress-playground)
+    - [Guia do dia do contribuidor](/contributing/contributor-day/)
+
+5. **Apresente o Repositório GitHub**: Forneça uma breve visão geral da estrutura do repositório, destacando diferentes pacotes e seus propósitos para os contribuidores de primeira viagem.
+
+## Durante o dia
+
+### Gerenciando Contribuições
+
+**Incentive diferentes tipos de contribuição:**:
+
+Verifique os níveis dos contribuidores, tente entender com base no nível deles como podem contribuir para o projeto no curto período de tempo de um dia do contribuidor. Pergunte se os participantes precisam de ajuda e os redirecione para a página de documentação relacionada. Além disso, incentive-os a fazer perguntas no [Canal #playground do Slack](https://wordpress.slack.com/archives/C04EWKGDJ0K). Aqui estão algumas sugestões de formas de contribuir:
+
+-   Melhorias e traduções de documentação.
+-   Tíquetes cuidadosamente elaborados, descrevendo problemas com soluções acionáveis.
+-   Criação de Blueprints e demos de plugins no repositório de plugins do WordPress.
+-   Testes e feedback do produto.
+
+**Fomentar a Colaboração**: Procure por oportunidades entre mesas. Por exemplo, contribuidores da [mesa de Traduções/Poliglotas ](https://make.wordpress.org/polyglots/) podem traduzir a documentação do Playground, ou a mesa do [time de testes do núcleo](https://make.wordpress.org/test/) pode fornecer feedback valioso sobre o Playground.
+
+**Coletar Feedback**: Pergunte aos contribuidores sobre sua experiência e anote sugestões de melhoria. Relate isso no [canal #playground do Slack](https://wordpress.slack.com/archives/C04EWKGDJ0K) se possível.
+
+## Depois do evento
+
+### Acompanhamento e Suporte
+
+1. **Revisar Pull Requests (PRs)**: Liste as PRs criadas durante o dia e avalie a probabilidade de serem concluídas. A maioria das contribuições tem uma janela de momentum curta, e o engajamento dentro das primeiras duas semanas é crítico.
+
+2. **Definir expectativas claras**: Para PRs incompletas, siga esta abordagem:
+
+    - Após um mês de inatividade, deixe um comentário perguntando se o autor planeja completar o trabalho.
+    - Se não houver resposta após mais duas semanas, informe que a PR poderá ser assumida por outro contribuidor ou fechada.
+
+3. **Mantenha-se ativo no Slack**: Continue a apoiar novos contribuidores através do canal #playground, respondendo a perguntas e ajudando-os a se tornarem contribuidores regulares.
+
+4. **Refletir e melhorar**: Revise o feedback coletado e sua experiência para refinar este guia para eventos futuros. Sinta-se à vontade para enviar um Pull Request para este guia!
+
+## Obtendo ajuda
+
+-   **Durante o evento**: Conecte-se com contribuidores na mesa do Playground.
+-   **Suporte contínuo**: Use o [canal `#playground` do Slack](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   **Report Issues**: Envie para o [Repositorio do WordPress Playground no GitHub](https://github.com/WordPress/wordpress-playground/issues/new).
+
+Para mais informações sobre como contribuir para o WordPress Playground, consulte o [Guia do dia do contribuidor](/contributing/contributor-day).


### PR DESCRIPTION
Translated the Contributor Day Table Leadership Guide to Portuguese, updating titles and descriptions throughout the document.
Motivation for the change, related issues

Running to 100% brazilian translated project
Implementation details

Translated using original file as a draft