### PR TITLE
Enforce single PHP instance per CLI worker for correct file locking

### DIFF
--- a/packages/php-wasm/node/src/lib/index.ts
+++ b/packages/php-wasm/node/src/lib/index.ts
@@ -6,3 +6,10 @@ export * from './node-fs-mount';
 export * from './file-lock-manager';
 export * from './file-lock-manager-for-node';
 export * from './xdebug/with-xdebug';
+export {
+	createNodePhpCliHandler,
+	createRemotePhpCliHandler,
+	PhpSubprocessManager,
+	type PhpSubprocessOptions,
+	type PhpSubprocessResult,
+} from './node-php-cli-handler';

--- a/packages/php-wasm/node/src/lib/node-php-cli-handler.ts
+++ b/packages/php-wasm/node/src/lib/node-php-cli-handler.ts
@@ -1,0 +1,201 @@
+import { spawn } from 'child_process';
+import type { PHPCliHandler, ProcessOptions } from '@php-wasm/universal';
+import type { ProcessApi } from '@php-wasm/util';
+import { consumeAPI } from '@php-wasm/universal';
+import type { MessagePort } from 'worker_threads';
+
+/**
+ * Result of running a PHP subprocess.
+ */
+export interface PhpSubprocessResult {
+	stdout: Uint8Array;
+	stderr: Uint8Array;
+	exitCode: number;
+}
+
+/**
+ * Options for running a PHP subprocess.
+ */
+export interface PhpSubprocessOptions {
+	cwd?: string;
+	env?: Record<string, string>;
+}
+
+/**
+ * Manager for spawning PHP subprocesses.
+ *
+ * This class runs in the main process and handles subprocess spawning
+ * on behalf of worker threads. Workers communicate with this manager
+ * via MessagePort using Comlink.
+ */
+export class PhpSubprocessManager {
+	private phpWasmEntryPoint: string;
+	private nodePath: string;
+	private nodeArgs: string[];
+
+	constructor(options: {
+		phpWasmEntryPoint: string;
+		nodePath?: string;
+		nodeArgs?: string[];
+	}) {
+		this.phpWasmEntryPoint = options.phpWasmEntryPoint;
+		this.nodePath = options.nodePath ?? process.execPath;
+		this.nodeArgs = options.nodeArgs ?? [];
+	}
+
+	/**
+	 * Run a PHP CLI command as a subprocess.
+	 *
+	 * @param args - The PHP CLI arguments (without 'php' prefix)
+	 * @param options - Subprocess options
+	 * @returns The subprocess result with stdout, stderr, and exit code
+	 */
+	async runCli(
+		args: string[],
+		options: PhpSubprocessOptions = {}
+	): Promise<PhpSubprocessResult> {
+		return new Promise((resolve) => {
+			const child = spawn(
+				this.nodePath,
+				[...this.nodeArgs, this.phpWasmEntryPoint, ...args],
+				{
+					cwd: options.cwd,
+					env: {
+						...process.env,
+						...options.env,
+						// Set SHELL_PIPE to 0 to ensure WP-CLI formats
+						// the output as ASCII tables.
+						// @see https://github.com/wp-cli/wp-cli/issues/1102
+						SHELL_PIPE: '0',
+					},
+					stdio: ['pipe', 'pipe', 'pipe'],
+				}
+			);
+
+			const stdoutChunks: Buffer[] = [];
+			const stderrChunks: Buffer[] = [];
+
+			child.stdout?.on('data', (chunk: Buffer) => {
+				stdoutChunks.push(chunk);
+			});
+
+			child.stderr?.on('data', (chunk: Buffer) => {
+				stderrChunks.push(chunk);
+			});
+
+			child.on('close', (code) => {
+				resolve({
+					stdout: new Uint8Array(Buffer.concat(stdoutChunks)),
+					stderr: new Uint8Array(Buffer.concat(stderrChunks)),
+					exitCode: code ?? 0,
+				});
+			});
+
+			child.on('error', (error) => {
+				resolve({
+					stdout: new Uint8Array(),
+					stderr: new TextEncoder().encode(
+						`Failed to spawn PHP process: ${error.message}\n`
+					),
+					exitCode: 1,
+				});
+			});
+		});
+	}
+}
+
+/**
+ * Creates a PHP CLI handler that communicates with a PhpSubprocessManager
+ * running in the main process via a MessagePort.
+ *
+ * This is used in worker threads where we can't spawn subprocesses directly.
+ * Instead, we send a message to the main process which spawns the subprocess
+ * and returns the result.
+ *
+ * @param port - MessagePort connected to a PhpSubprocessManager in the main process
+ * @returns A PHPCliHandler that can be used with createPhpSpawnHandler
+ *
+ * @example
+ * ```ts
+ * // In main process:
+ * const manager = new PhpSubprocessManager({
+ *   phpWasmEntryPoint: '/path/to/php-wasm/cli/main.js',
+ * });
+ * exposeAPI(manager, null, port1);
+ *
+ * // In worker:
+ * const phpCliHandler = createRemotePhpCliHandler(port2);
+ * const spawnHandler = createPhpSpawnHandler({
+ *   getPrimaryPhp: () => requestHandler.getPrimaryPhp(),
+ *   phpCliHandler,
+ * });
+ * ```
+ */
+export function createRemotePhpCliHandler(port: MessagePort): PHPCliHandler {
+	const manager = consumeAPI<PhpSubprocessManager>(port);
+
+	return async (
+		args: string[],
+		processApi: ProcessApi,
+		processOptions: ProcessOptions
+	) => {
+		// Skip 'php' from args since the manager invokes php-wasm CLI directly
+		const phpArgs = args.slice(1);
+
+		const result = await manager.runCli(phpArgs, {
+			cwd: processOptions.cwd,
+			env: processOptions.env,
+		});
+
+		// Send output to the process API
+		if (result.stdout.length > 0) {
+			processApi.stdout(result.stdout);
+		}
+		if (result.stderr.length > 0) {
+			processApi.stderr(result.stderr);
+		}
+
+		processApi.exit(result.exitCode);
+	};
+}
+
+/**
+ * Creates a PHP CLI handler that spawns subprocesses directly.
+ *
+ * This should only be used in the main process, not in worker threads.
+ * For worker threads, use createRemotePhpCliHandler instead.
+ *
+ * @param options - Configuration options
+ * @returns A PHPCliHandler that can be used with createPhpSpawnHandler
+ */
+export function createNodePhpCliHandler(options: {
+	phpWasmEntryPoint: string;
+	nodePath?: string;
+	nodeArgs?: string[];
+}): PHPCliHandler {
+	const manager = new PhpSubprocessManager(options);
+
+	return async (
+		args: string[],
+		processApi: ProcessApi,
+		processOptions: ProcessOptions
+	) => {
+		// Skip 'php' from args since we're invoking the php-wasm CLI directly
+		const phpArgs = args.slice(1);
+
+		const result = await manager.runCli(phpArgs, {
+			cwd: processOptions.cwd,
+			env: processOptions.env,
+		});
+
+		// Send output to the process API
+		if (result.stdout.length > 0) {
+			processApi.stdout(result.stdout);
+		}
+		if (result.stderr.length > 0) {
+			processApi.stderr(result.stderr);
+		}
+
+		processApi.exit(result.exitCode);
+	};
+}

--- a/packages/php-wasm/node/src/test/php-part-1.spec.ts
+++ b/packages/php-wasm/node/src/test/php-part-1.spec.ts
@@ -1,7 +1,7 @@
 import {
 	getPhpIniEntries,
 	PHP,
-	PHPProcessManager,
+	PHPRequestHandler,
 	sandboxedSpawnHandlerFactory,
 	setPhpIniEntries,
 	type SpawnedPHP,
@@ -1830,9 +1830,9 @@ describe('sandboxedSpawnHandlerFactory', () => {
 	const phpVersion = RecommendedPHPVersion;
 	let php: PHP;
 	let spawnedPhp: SpawnedPHP;
-	let processManager: PHPProcessManager;
+	let requestHandler: PHPRequestHandler;
 	beforeEach(async () => {
-		processManager = new PHPProcessManager({
+		requestHandler = new PHPRequestHandler({
 			phpFactory: async () => {
 				const php = new PHP(
 					await loadNodeRuntime(phpVersion as any, {})
@@ -1850,17 +1850,19 @@ describe('sandboxedSpawnHandlerFactory', () => {
 					'Hello, world!'
 				);
 				await php.setSpawnHandler(
-					sandboxedSpawnHandlerFactory(processManager)
+					sandboxedSpawnHandlerFactory(requestHandler)
 				);
 				return php;
 			},
 			maxPhpInstances: 5,
+			documentRoot: '/tmp/shared-test-directory',
+			absoluteUrl: 'http://localhost',
 		});
-		spawnedPhp = await processManager.acquirePHPInstance();
+		spawnedPhp = await requestHandler.processManager!.acquirePHPInstance();
 		php = spawnedPhp.php;
 	});
 	afterEach(async () => {
-		await processManager[Symbol.asyncDispose]();
+		await requestHandler[Symbol.asyncDispose]();
 		spawnedPhp?.reap();
 	});
 	it.each([

--- a/packages/php-wasm/node/src/test/php-part-2.spec.ts
+++ b/packages/php-wasm/node/src/test/php-part-2.spec.ts
@@ -2,7 +2,7 @@ import {
 	__private__dont__use,
 	loadPHPRuntime,
 	PHP,
-	PHPProcessManager,
+	PHPRequestHandler,
 	sandboxedSpawnHandlerFactory,
 	setPhpIniEntries,
 	type SpawnedPHP,
@@ -1160,9 +1160,9 @@ describe('sandboxedSpawnHandlerFactory', () => {
 	const phpVersion = RecommendedPHPVersion;
 	let php: PHP;
 	let spawnedPhp: SpawnedPHP;
-	let processManager: PHPProcessManager;
+	let requestHandler: PHPRequestHandler;
 	beforeEach(async () => {
-		processManager = new PHPProcessManager({
+		requestHandler = new PHPRequestHandler({
 			phpFactory: async () => {
 				const php = new PHP(
 					await loadNodeRuntime(phpVersion as any, {})
@@ -1180,17 +1180,19 @@ describe('sandboxedSpawnHandlerFactory', () => {
 					'Hello, world!'
 				);
 				await php.setSpawnHandler(
-					sandboxedSpawnHandlerFactory(processManager)
+					sandboxedSpawnHandlerFactory(requestHandler)
 				);
 				return php;
 			},
 			maxPhpInstances: 5,
+			documentRoot: '/tmp/shared-test-directory',
+			absoluteUrl: 'http://localhost',
 		});
-		spawnedPhp = await processManager.acquirePHPInstance();
+		spawnedPhp = await requestHandler.processManager!.acquirePHPInstance();
 		php = spawnedPhp.php;
 	});
 	afterEach(async () => {
-		await processManager[Symbol.asyncDispose]();
+		await requestHandler[Symbol.asyncDispose]();
 		spawnedPhp?.reap();
 	});
 	it.each([

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -24,11 +24,15 @@ export { HttpCookieStore } from './http-cookie-store';
 export type { IteratePhpFilesOptions as IterateFilesOptions } from './iterate-files';
 export { iteratePhpFiles as iterateFiles } from './iterate-files';
 export { writeFilesStreamToPhp } from './write-files-stream-to-php';
-export { PHPProcessManager } from './php-process-manager';
+export {
+	PHPProcessManager,
+	SingularPHPProcessManager,
+} from './php-process-manager';
 export type {
 	MaxPhpInstancesError,
 	PHPFactory,
 	PHPFactoryOptions,
+	PHPProcessManagerInterface,
 	ProcessManagerOptions,
 	SpawnedPHP,
 } from './php-process-manager';
@@ -84,7 +88,14 @@ export {
 
 export { isExitCode } from './is-exit-code';
 export { proxyFileSystem, isPathToSharedFS } from './proxy-file-system';
-export { sandboxedSpawnHandlerFactory } from './sandboxed-spawn-handler-factory';
+export {
+	createPhpSpawnHandler,
+	createProcessManagerCliHandler,
+	sandboxedSpawnHandlerFactory,
+	type PHPCliHandler,
+	type ProcessOptions,
+	type SpawnHandlerOptions,
+} from './sandboxed-spawn-handler-factory';
 
 export * from './api';
 export type { WithAPIState as WithIsReady } from './api';

--- a/packages/php-wasm/universal/src/lib/php-process-manager.ts
+++ b/packages/php-wasm/universal/src/lib/php-process-manager.ts
@@ -7,6 +7,16 @@ export type PHPFactoryOptions = {
 
 export type PHPFactory = (options: PHPFactoryOptions) => Promise<PHP>;
 
+/**
+ * Common interface for PHP process managers.
+ */
+export interface PHPProcessManagerInterface extends AsyncDisposable {
+	getPrimaryPhp(): Promise<PHP>;
+	acquirePHPInstance(options?: {
+		considerPrimary?: boolean;
+	}): Promise<SpawnedPHP>;
+}
+
 export interface ProcessManagerOptions {
 	/**
 	 * The maximum number of PHP instances that can exist at
@@ -71,7 +81,7 @@ export class MaxPhpInstancesError extends Error {
  * requests requires extra time to spin up a few PHP instances. This is a more
  * resource-friendly tradeoff than keeping 5 idle instances at all times.
  */
-export class PHPProcessManager implements AsyncDisposable {
+export class PHPProcessManager implements PHPProcessManagerInterface {
 	private primaryPhp?: PHP;
 	private primaryPhpPromise?: Promise<SpawnedPHP>;
 	private primaryIdle = true;
@@ -264,5 +274,68 @@ export class PHPProcessManager implements AsyncDisposable {
 				instance.then(({ reap }) => reap())
 			)
 		);
+	}
+}
+
+/**
+ * A PHP Process manager that manages exactly one PHP instance.
+ *
+ * This is useful for CLI environments where we want each OS process to have
+ * exactly one PHP instance for correct file locking behavior. Kernel-level
+ * file locks are per-process, so multiple PHP instances in the same process
+ * would share locks and defeat the purpose of locking.
+ *
+ * Unlike PHPProcessManager which can spawn multiple instances, this manager:
+ * - Never creates or destroys PHP instances (the instance is provided at construction)
+ * - Refuses to acquire if the instance is already acquired
+ * - Implements the same interface as PHPProcessManager for compatibility
+ */
+export class SingularPHPProcessManager implements PHPProcessManagerInterface {
+	private php: PHP;
+	private phpPromise?: Promise<PHP>;
+	private phpFactory?: PHPFactory;
+	private acquired = false;
+
+	constructor(options: { php?: PHP; phpFactory?: PHPFactory }) {
+		if (!options.php && !options.phpFactory) {
+			throw new Error(
+				'SingularPHPProcessManager requires either php or phpFactory'
+			);
+		}
+		this.php = options.php!;
+		this.phpFactory = options.phpFactory;
+	}
+
+	async getPrimaryPhp(): Promise<PHP> {
+		if (!this.php) {
+			if (!this.phpPromise) {
+				this.phpPromise = this.phpFactory!({ isPrimary: true });
+			}
+			this.php = await this.phpPromise;
+			this.phpPromise = undefined;
+		}
+		return this.php;
+	}
+
+	async acquirePHPInstance(): Promise<SpawnedPHP> {
+		if (this.acquired) {
+			throw new AcquireTimeoutError(
+				'SingularPHPProcessManager: Cannot acquire PHP instance - already in use. ' +
+					'This manager only supports one concurrent acquisition.'
+			);
+		}
+		this.acquired = true;
+		return {
+			php: await this.getPrimaryPhp(),
+			reap: () => {
+				this.acquired = false;
+			},
+		};
+	}
+
+	async [Symbol.asyncDispose]() {
+		if (this.php) {
+			this.php.exit();
+		}
 	}
 }

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -10,8 +10,16 @@ import { normalizeHeaders } from './php';
 import { PHPResponse } from './php-response';
 import type { PHPRequest, PHPRunOptions } from './universal-php';
 import { encodeAsMultipart } from './encode-as-multipart';
-import type { PHPFactoryOptions, SpawnedPHP } from './php-process-manager';
-import { MaxPhpInstancesError, PHPProcessManager } from './php-process-manager';
+import type {
+	PHPFactoryOptions,
+	PHPProcessManagerInterface,
+	SpawnedPHP,
+} from './php-process-manager';
+import {
+	MaxPhpInstancesError,
+	PHPProcessManager,
+	SingularPHPProcessManager,
+} from './php-process-manager';
 import { HttpCookieStore } from './http-cookie-store';
 import mimeTypes from './mime-types.json';
 
@@ -84,35 +92,16 @@ export type PHPRequestHandlerFactoryArgs = PHPFactoryOptions & {
 	requestHandler: PHPRequestHandler;
 };
 
-export type PHPRequestHandlerConfiguration = BaseConfiguration &
-	(
-		| {
-				/**
-				 * PHPProcessManager is required because the request handler needs
-				 * to make a decision for each request.
-				 *
-				 * Static assets are served using the primary PHP's filesystem, even
-				 * when serving 100 static files concurrently. No new PHP interpreter
-				 * is ever created as there's no need for it.
-				 *
-				 * Dynamic PHP requests, however, require grabbing an available PHP
-				 * interpreter, and that's where the PHPProcessManager comes in.
-				 */
-				processManager: PHPProcessManager;
-		  }
-		| {
-				phpFactory: (
-					requestHandler: PHPRequestHandlerFactoryArgs
-				) => Promise<PHP>;
-				/**
-				 * The maximum number of PHP instances that can exist at
-				 * the same time.
-				 */
-				maxPhpInstances?: number;
-		  }
-	) & {
-		cookieStore?: CookieStore | false;
-	};
+export type PHPRequestHandlerConfiguration = BaseConfiguration & {
+	phpFactory: (requestHandler: PHPRequestHandlerFactoryArgs) => Promise<PHP>;
+	/**
+	 * The maximum number of PHP instances that can exist at
+	 * the same time.
+	 */
+	maxPhpInstances?: number;
+} & {
+	cookieStore?: CookieStore | false;
+};
 
 /**
  * Handles HTTP requests using PHP runtime as a backend.
@@ -178,7 +167,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 	#ABSOLUTE_URL: string;
 	#cookieStore: CookieStore | false;
 	rewriteRules: RewriteRule[];
-	processManager: PHPProcessManager;
+	processManager: PHPProcessManagerInterface;
 	getFileNotFoundAction: FileNotFoundGetActionCallback;
 
 	/**
@@ -202,26 +191,28 @@ export class PHPRequestHandler implements AsyncDisposable {
 			getFileNotFoundAction = () => ({ type: '404' }),
 		} = config;
 
-		if ('processManager' in config) {
-			this.processManager = config.processManager;
+		const phpFactory = async (info: PHPFactoryOptions) => {
+			const php = await config.phpFactory!({
+				...info,
+				requestHandler: this,
+			});
+
+			// Always set managed PHP's cwd to the document root.
+			if (!php.isDir(documentRoot)) {
+				php.mkdir(documentRoot);
+			}
+			php.chdir(documentRoot);
+
+			// @TODO: Decouple PHP and request handler
+			(php as any).requestHandler = this;
+			return php;
+		};
+
+		if (config.maxPhpInstances === 1) {
+			this.processManager = new SingularPHPProcessManager({ phpFactory });
 		} else {
 			this.processManager = new PHPProcessManager({
-				phpFactory: async (info) => {
-					const php = await config.phpFactory!({
-						...info,
-						requestHandler: this,
-					});
-
-					// Always set managed PHP's cwd to the document root.
-					if (!php.isDir(documentRoot)) {
-						php.mkdir(documentRoot);
-					}
-					php.chdir(documentRoot);
-
-					// @TODO: Decouple PHP and request handler
-					(php as any).requestHandler = this;
-					return php;
-				},
+				phpFactory,
 				maxPhpInstances: config.maxPhpInstances,
 			});
 		}
@@ -245,8 +236,8 @@ export class PHPRequestHandler implements AsyncDisposable {
 		this.#PORT = url.port
 			? Number(url.port)
 			: url.protocol === 'https:'
-			? 443
-			: 80;
+				? 443
+				: 80;
 		this.#PROTOCOL = (url.protocol || '').replace(':', '');
 		const isNonStandardPort = this.#PORT !== 443 && this.#PORT !== 80;
 		this.#HOST = [
@@ -578,7 +569,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 	): Promise<PHPResponse> {
 		let spawnedPHP: SpawnedPHP | undefined = undefined;
 		try {
-			spawnedPHP = await this.processManager!.acquirePHPInstance({
+			spawnedPHP = await this.processManager.acquirePHPInstance({
 				considerPrimary: true,
 			});
 		} catch (e) {

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -229,9 +229,10 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 	 * @returns A PHP instance with a consistent chroot.
 	 */
 	private async acquirePHPInstance() {
-		const { php, reap } = await _private
-			.get(this)!
-			.requestHandler!.processManager.acquirePHPInstance();
+		const requestHandler = _private.get(this)!.requestHandler!;
+		const { php, reap } =
+			await requestHandler.processManager.acquirePHPInstance();
+
 		if (this.chroot !== null) {
 			php.chdir(this.chroot);
 		}

--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -1,131 +1,204 @@
-import { createSpawnHandler } from '@php-wasm/util';
-import type { PHPProcessManager } from './php-process-manager';
+import { createSpawnHandler, type ProcessApi } from '@php-wasm/util';
+import type { PHP } from './php';
+import type { SpawnHandler } from './universal-php';
+
+export interface ProcessOptions {
+	cwd?: string;
+	env?: Record<string, string>;
+}
 
 /**
- * An isomorphic proc_open() handler that implements typical shell in TypeScript
- * without relying on a server runtime. It can be used in the browser and Node.js
- * alike whenever you need to spawn a PHP subprocess, query the terminal size, etc.
- * It is open for future expansion if more shell or busybox calls are needed, but
- * advanced shell features such as piping, stream redirection etc. are outside of
- * the scope of this minimal handler. If they become vital at any point, let's
- * explore bringing in an actual shell implementation or at least a proper command
- * parser.
+ * Handler for PHP CLI commands. Called when a PHP command is spawned.
+ * Should stream output to processApi and call processApi.exit() when done.
  */
-export function sandboxedSpawnHandlerFactory(
-	processManager: PHPProcessManager
-) {
-	return createSpawnHandler(async function (args, processApi, options) {
-		processApi.notifySpawn();
-		if (args[0] === 'exec') {
-			args.shift();
-		}
+export type PHPCliHandler = (
+	args: string[],
+	processApi: ProcessApi,
+	options: ProcessOptions
+) => Promise<void>;
 
-		if (args[0].endsWith('.php') || args[0].endsWith('.phar')) {
-			args.unshift('php');
-		}
+export interface SpawnHandlerOptions {
+	/**
+	 * Function to get a PHP instance for filesystem operations (ls, pwd).
+	 */
+	getPrimaryPhp: () => Promise<PHP>;
 
-		const binaryName = args[0].split('/').pop();
+	/**
+	 * Handler for PHP CLI commands.
+	 * If not provided, PHP commands will return exit code 127 (command not found).
+	 */
+	phpCliHandler?: PHPCliHandler;
+}
 
-		// Mock programs required by wp-cli:
-		if (
-			args[0] === '/usr/bin/env' &&
-			args[1] === 'stty' &&
-			args[2] === 'size'
-		) {
-			// These numbers are hardcoded because this
-			// spawnHandler is transmitted as a string to
-			// the PHP backend and has no access to local
-			// scope. It would be nice to find a way to
-			// transfer / proxy a live object instead.
-			// @TODO: Do not hardcode this
-			processApi.stdout(`18 140`);
-			processApi.exit(0);
-		} else if (binaryName === 'tput' && args[1] === 'cols') {
-			processApi.stdout(`140`);
-			processApi.exit(0);
-		} else if (binaryName === 'less') {
-			processApi.on('stdin', (data) => {
-				processApi.stdout(data);
-			});
-			// Exit after the stdin stream is exhausted.
-			await new Promise((resolve) => {
-				processApi.childProcess.stdin.on('finish', () => {
-					resolve(true);
+/**
+ * Creates a spawn handler for proc_open() calls that handles common shell commands.
+ *
+ * This handler implements typical shell commands in TypeScript without relying on
+ * a server runtime. It can be used in the browser and Node.js alike whenever you
+ * need to spawn a PHP subprocess, query the terminal size, etc.
+ *
+ * Supported commands:
+ * - `php` - Runs PHP CLI (requires phpCliHandler)
+ * - `ls` - Lists files using PHP filesystem
+ * - `pwd` - Prints working directory
+ * - `stty size` - Returns terminal size (hardcoded)
+ * - `tput cols` - Returns terminal columns (hardcoded)
+ * - `less` - Pipes stdin to stdout
+ *
+ * Advanced shell features such as piping, stream redirection etc. are outside of
+ * the scope of this minimal handler.
+ */
+export function createPhpSpawnHandler(
+	options: SpawnHandlerOptions
+): SpawnHandler {
+	const { getPrimaryPhp, phpCliHandler } = options;
+
+	return createSpawnHandler(
+		async function (args, processApi, processOptions) {
+			processApi.notifySpawn();
+
+			if (args[0] === 'exec') {
+				args.shift();
+			}
+
+			if (args[0].endsWith('.php') || args[0].endsWith('.phar')) {
+				args.unshift('php');
+			}
+
+			const binaryName = args[0].split('/').pop();
+
+			// Mock programs required by wp-cli:
+			if (
+				args[0] === '/usr/bin/env' &&
+				args[1] === 'stty' &&
+				args[2] === 'size'
+			) {
+				// These numbers are hardcoded because this
+				// spawnHandler is transmitted as a string to
+				// the PHP backend and has no access to local
+				// scope. It would be nice to find a way to
+				// transfer / proxy a live object instead.
+				// @TODO: Do not hardcode this
+				processApi.stdout(`18 140`);
+				processApi.exit(0);
+				return;
+			}
+
+			if (binaryName === 'tput' && args[1] === 'cols') {
+				processApi.stdout(`140`);
+				processApi.exit(0);
+				return;
+			}
+
+			if (binaryName === 'less') {
+				processApi.on('stdin', (data: Uint8Array | string) => {
+					processApi.stdout(
+						data instanceof Uint8Array ? data.buffer : data
+					);
 				});
-			});
-			processApi.exit(0);
-			return;
-		}
+				// Exit after the stdin stream is exhausted.
+				await new Promise((resolve) => {
+					processApi.childProcess.stdin.on('finish', () => {
+						resolve(true);
+					});
+				});
+				processApi.exit(0);
+				return;
+			}
 
-		if (!['php', 'ls', 'pwd'].includes(binaryName ?? '')) {
+			// Handle PHP commands
+			if (binaryName === 'php') {
+				if (phpCliHandler) {
+					await phpCliHandler(args, processApi, processOptions);
+				} else {
+					processApi.stderr(
+						'PHP subprocess spawning is not available in this environment.\n'
+					);
+					processApi.exit(127);
+				}
+				return;
+			}
+
+			// Handle filesystem commands using PHP's filesystem
+			if (binaryName === 'ls' || binaryName === 'pwd') {
+				const php = await getPrimaryPhp();
+
+				try {
+					if (processOptions.cwd) {
+						php.chdir(processOptions.cwd as string);
+					}
+
+					const cwd = php.cwd();
+
+					if (binaryName === 'ls') {
+						const files = php.listFiles(args[1] ?? cwd);
+						for (const file of files) {
+							processApi.stdout(file + '\n');
+						}
+					} else if (binaryName === 'pwd') {
+						processApi.stdout(cwd + '\n');
+					}
+
+					// Technical limitation of subprocesses – we need to
+					// wait before exiting to give consumer a chance to read
+					// the output.
+					await new Promise((resolve) => setTimeout(resolve, 10));
+					processApi.exit(0);
+				} catch (e) {
+					processApi.exit(1);
+					throw e;
+				}
+				return;
+			}
+
 			// 127 is the exit code "for command not found".
 			processApi.exit(127);
-			return;
 		}
+	);
+}
 
-		const { php, reap } = await processManager.acquirePHPInstance({
-			considerPrimary: false,
-		});
+/**
+ * Creates a PHP CLI handler that spawns PHP instances via PHPProcessManager.
+ * This is used for web environments where multiple PHP instances can coexist
+ * in the same process.
+ */
+export function createProcessManagerCliHandler(
+	acquirePHPInstance: () => Promise<{ php: PHP; reap: () => void }>
+): PHPCliHandler {
+	return async (args, processApi, options) => {
+		const { php, reap } = await acquirePHPInstance();
 
 		try {
 			if (options.cwd) {
 				php.chdir(options.cwd as string);
 			}
 
-			const cwd = php.cwd();
-			switch (binaryName) {
-				case 'php': {
-					// Figure out more about setting env, putenv(), etc.
-					const result = await php.cli(args, {
-						env: {
-							...options.env,
-							SCRIPT_PATH: args[1],
-							// Set SHELL_PIPE to 0 to ensure WP-CLI formats
-							// the output as ASCII tables.
-							// @see https://github.com/wp-cli/wp-cli/issues/1102
-							SHELL_PIPE: '0',
-						},
-					});
+			const result = await php.cli(args, {
+				env: {
+					...options.env,
+					SCRIPT_PATH: args[1],
+					// Set SHELL_PIPE to 0 to ensure WP-CLI formats
+					// the output as ASCII tables.
+					// @see https://github.com/wp-cli/wp-cli/issues/1102
+					SHELL_PIPE: '0',
+				},
+			});
 
-					result.stdout.pipeTo(
-						new WritableStream({
-							write(chunk) {
-								processApi.stdout(chunk as any as ArrayBuffer);
-							},
-						})
-					);
-					result.stderr.pipeTo(
-						new WritableStream({
-							write(chunk) {
-								processApi.stderr(chunk as any as ArrayBuffer);
-							},
-						})
-					);
-					processApi.exit(await result.exitCode);
-					break;
-				}
-				case 'ls': {
-					const files = php.listFiles(args[1] ?? cwd);
-					for (const file of files) {
-						processApi.stdout(file + '\n');
-					}
-					// Technical limitation of subprocesses – we need to
-					// wait before exiting to give consumer a chance to read
-					// the output.
-					await new Promise((resolve) => setTimeout(resolve, 10));
-					processApi.exit(0);
-					break;
-				}
-				case 'pwd': {
-					processApi.stdout(cwd + '\n');
-					// Technical limitation of subprocesses – we need to
-					// wait before exiting to give consumer a chance to read
-					// the output.
-					await new Promise((resolve) => setTimeout(resolve, 10));
-					processApi.exit(0);
-					break;
-				}
-			}
+			result.stdout.pipeTo(
+				new WritableStream({
+					write(chunk) {
+						processApi.stdout(chunk as any as ArrayBuffer);
+					},
+				})
+			);
+			result.stderr.pipeTo(
+				new WritableStream({
+					write(chunk) {
+						processApi.stderr(chunk as any as ArrayBuffer);
+					},
+				})
+			);
+			processApi.exit(await result.exitCode);
 		} catch (e) {
 			// An exception here means the PHP runtime has crashed.
 			processApi.exit(1);
@@ -133,5 +206,36 @@ export function sandboxedSpawnHandlerFactory(
 		} finally {
 			reap();
 		}
+	};
+}
+
+/**
+ * Legacy wrapper that creates a spawn handler using PHPRequestHandler.
+ *
+ * For web environments with multi-instance PHP support (maxPhpInstances > 1),
+ * this creates a spawn handler that can spawn new PHP instances for subprocesses.
+ *
+ * For CLI environments with single-instance PHP (maxPhpInstances = 1), use
+ * createPhpSpawnHandler directly with your own phpCliHandler (or none).
+ */
+export function sandboxedSpawnHandlerFactory(requestHandler: {
+	processManager?: {
+		acquirePHPInstance: (options?: {
+			considerPrimary?: boolean;
+		}) => Promise<{ php: PHP; reap: () => void }>;
+	};
+	getPrimaryPhp: () => Promise<PHP>;
+}): SpawnHandler {
+	const { processManager } = requestHandler;
+
+	return createPhpSpawnHandler({
+		getPrimaryPhp: () => requestHandler.getPrimaryPhp(),
+		phpCliHandler: processManager
+			? createProcessManagerCliHandler(() =>
+					processManager.acquirePHPInstance({
+						considerPrimary: false,
+					})
+				)
+			: undefined,
 	});
 }

--- a/packages/php-wasm/util/src/lib/index.ts
+++ b/packages/php-wasm/util/src/lib/index.ts
@@ -10,7 +10,11 @@ export {
 	isParentOf,
 	ensureAbsolutePath,
 } from './paths';
-export { createSpawnHandler } from './create-spawn-handler';
+export {
+	createSpawnHandler,
+	ProcessApi,
+	type ProcessOptions,
+} from './create-spawn-handler';
 export { randomString } from './random-string';
 export { randomFilename } from './random-filename';
 export { splitShellCommand } from './split-shell-command';

--- a/packages/php-wasm/util/src/lib/semaphore.ts
+++ b/packages/php-wasm/util/src/lib/semaphore.ts
@@ -12,8 +12,8 @@ export interface SemaphoreOptions {
 }
 
 export class AcquireTimeoutError extends Error {
-	constructor() {
-		super('Acquiring lock timed out');
+	constructor(message = 'Acquiring lock timed out') {
+		super(message);
 	}
 }
 

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -1,13 +1,13 @@
 import type { FileLockManager } from '@php-wasm/node';
-import { loadNodeRuntime } from '@php-wasm/node';
+import { createRemotePhpCliHandler, loadNodeRuntime } from '@php-wasm/node';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import type { RemoteAPI, SupportedPHPVersion } from '@php-wasm/universal';
 import {
+	createPhpSpawnHandler,
 	PHPWorker,
 	consumeAPI,
 	consumeAPISync,
 	exposeAPI,
-	sandboxedSpawnHandlerFactory,
 } from '@php-wasm/universal';
 import { sprintf } from '@php-wasm/util';
 import { RecommendedPHPVersion } from '@wp-playground/common';
@@ -46,6 +46,11 @@ export type WorkerBootOptions = {
 	internalCookieStore?: boolean;
 	withXdebug?: boolean;
 	nativeInternalDirPath: string;
+	/**
+	 * MessagePort connected to a PhpSubprocessManager in the main process.
+	 * Used for spawning PHP subprocesses when PHP calls proc_open('php ...').
+	 */
+	phpSubprocessManagerPort?: MessagePort;
 };
 
 export type PrimaryWorkerBootOptions = WorkerBootOptions & {
@@ -67,6 +72,7 @@ interface WorkerBootRequestHandlerOptions {
 	mountsBeforeWpInstall: Array<Mount>;
 	mountsAfterWpInstall: Array<Mount>;
 	withXdebug?: boolean;
+	phpSubprocessManagerPort?: MessagePort;
 }
 
 /**
@@ -142,6 +148,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 		internalCookieStore,
 		withXdebug,
 		nativeInternalDirPath,
+		phpSubprocessManagerPort,
 	}: PrimaryWorkerBootOptions) {
 		if (this.booted) {
 			throw new Error('Playground already booted');
@@ -192,7 +199,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 						? new File(
 								[sqliteIntegrationPluginZip],
 								'sqlite-integration-plugin.zip'
-						  )
+							)
 						: undefined,
 				sapiName: 'cli',
 				createFiles: {
@@ -205,9 +212,18 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 					allow_url_fopen: '1',
 					disable_functions: '',
 				},
+				maxPhpInstances: 1,
 				cookieStore: internalCookieStore ? undefined : false,
 				dataSqlPath,
-				spawnHandler: sandboxedSpawnHandlerFactory,
+				spawnHandler: (requestHandler) =>
+					createPhpSpawnHandler({
+						getPrimaryPhp: () => requestHandler.getPrimaryPhp(),
+						phpCliHandler: phpSubprocessManagerPort
+							? createRemotePhpCliHandler(
+									phpSubprocessManagerPort
+								)
+							: undefined,
+					}),
 				async onPHPInstanceCreated(php) {
 					await mountResources(php, mountsBeforeWpInstall);
 					if (wordpressBooted) {
@@ -249,6 +265,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 		mountsBeforeWpInstall,
 		mountsAfterWpInstall,
 		withXdebug,
+		phpSubprocessManagerPort,
 	}: WorkerBootRequestHandlerOptions) {
 		if (this.booted) {
 			throw new Error('Playground already booted');
@@ -291,7 +308,16 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 				},
 				sapiName: 'cli',
 				cookieStore: false,
-				spawnHandler: sandboxedSpawnHandlerFactory,
+				maxPhpInstances: 1,
+				spawnHandler: (requestHandler) =>
+					createPhpSpawnHandler({
+						getPrimaryPhp: () => requestHandler.getPrimaryPhp(),
+						phpCliHandler: phpSubprocessManagerPort
+							? createRemotePhpCliHandler(
+									phpSubprocessManagerPort
+								)
+							: undefined,
+					}),
 			});
 			this.__internal_setRequestHandler(requestHandler);
 

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -97,6 +97,7 @@ export class BlueprintsV2Handler {
 			nativeInternalDirPath,
 			mountsBeforeWpInstall: this.args['mount-before-install'] || [],
 			mountsAfterWpInstall: this.args.mount || [],
+			maxPhpInstances: 1,
 		};
 
 		await playground.bootWorker(workerBootArgs);

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -1,6 +1,10 @@
 import { errorLogPath, logger } from '@php-wasm/logger';
 import type { FileLockManager } from '@php-wasm/node';
-import { createNodeFsMountHandler, loadNodeRuntime } from '@php-wasm/node';
+import {
+	createNodeFsMountHandler,
+	createRemotePhpCliHandler,
+	loadNodeRuntime,
+} from '@php-wasm/node';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import type {
 	PHP,
@@ -9,13 +13,13 @@ import type {
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
 import {
+	createPhpSpawnHandler,
 	PHPExecutionFailureError,
 	PHPResponse,
 	PHPWorker,
 	consumeAPI,
 	consumeAPISync,
 	exposeAPI,
-	sandboxedSpawnHandlerFactory,
 } from '@php-wasm/universal';
 import { sprintf } from '@php-wasm/util';
 import {
@@ -153,10 +157,16 @@ export type SecondaryWorkerBootArgs = {
 	firstProcessId: number;
 	processIdSpaceLength: number;
 	trace: boolean;
+	maxPhpInstances: number;
 	nativeInternalDirPath: string;
 	withXdebug?: boolean;
 	mountsBeforeWpInstall?: Array<Mount>;
 	mountsAfterWpInstall?: Array<Mount>;
+	/**
+	 * MessagePort connected to a PhpSubprocessManager in the main process.
+	 * Used for spawning PHP subprocesses when PHP calls proc_open('php ...').
+	 */
+	phpSubprocessManagerPort?: MessagePort;
 };
 
 export type WorkerBootRequestHandlerOptions = Omit<
@@ -224,6 +234,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 			phpIniEntries: {
 				'openssl.cafile': '/internal/shared/ca-bundle.crt',
 			},
+			maxPhpInstances: 1,
 			onPHPInstanceCreated: async (php: PHP) => {
 				await mountResources(php, args['mount-before-install'] || []);
 				if (this.blueprintTargetResolved) {
@@ -269,6 +280,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 
 	async runBlueprintV2(args: WorkerRunBlueprintArgs) {
 		const requestHandler = this.__internal_getRequestHandler()!;
+
 		const { php, reap } =
 			await requestHandler.processManager.acquirePHPInstance({
 				considerPrimary: false,
@@ -426,6 +438,8 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 		nativeInternalDirPath,
 		withXdebug,
 		onPHPInstanceCreated,
+		maxPhpInstances,
+		phpSubprocessManagerPort,
 	}: WorkerBootRequestHandlerOptions) {
 		if (this.booted) {
 			throw new Error('Playground already booted');
@@ -468,7 +482,16 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 				constants,
 				phpIniEntries,
 				cookieStore: false,
-				spawnHandler: sandboxedSpawnHandlerFactory,
+				spawnHandler: (requestHandler) =>
+					createPhpSpawnHandler({
+						getPrimaryPhp: () => requestHandler.getPrimaryPhp(),
+						phpCliHandler: phpSubprocessManagerPort
+							? createRemotePhpCliHandler(
+									phpSubprocessManagerPort
+								)
+							: undefined,
+					}),
+				maxPhpInstances,
 			});
 			this.__internal_setRequestHandler(requestHandler);
 

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -3,13 +3,11 @@ import type {
 	FileNotFoundAction,
 	FileNotFoundGetActionCallback,
 	FileTree,
-	PHPProcessManager,
 	SpawnHandler,
 } from '@php-wasm/universal';
 import {
 	PHP,
 	PHPRequestHandler,
-	sandboxedSpawnHandlerFactory,
 	setPhpIniEntries,
 	withPHPIniValues,
 	writeFiles,
@@ -62,7 +60,13 @@ export interface BootRequestHandlerOptions {
 	 */
 	siteUrl: string;
 	documentRoot?: string;
-	spawnHandler?: (processManager: PHPProcessManager) => SpawnHandler;
+	/**
+	 * Factory function that creates a spawn handler for proc_open() calls.
+	 * Receives the PHPRequestHandler which provides access to:
+	 * - getPrimaryPhp(): For filesystem operations
+	 * - processManager: For multi-instance spawning (when maxPhpInstances > 1)
+	 */
+	spawnHandler?: (requestHandler: PHPRequestHandler) => SpawnHandler;
 	/**
 	 * PHP.ini entries to define before running any code. They'll
 	 * be used for all requests.
@@ -111,6 +115,12 @@ export interface BootRequestHandlerOptions {
 	 * the CookieStore interface.
 	 */
 	cookieStore?: CookieStore | false;
+
+	/**
+	 * The maximum number of PHP instances that can exist at
+	 * the same time. Passed to the PHPProcessManager constructor.
+	 */
+	maxPhpInstances?: number;
 }
 
 export type WordPressInstallMode =
@@ -354,7 +364,7 @@ async function assertValidDatabaseConnection(
 }
 
 export async function bootRequestHandler(options: BootRequestHandlerOptions) {
-	const spawnHandler = options.spawnHandler ?? sandboxedSpawnHandlerFactory;
+	const spawnHandler = options.spawnHandler;
 	async function createPhp(
 		requestHandler: PHPRequestHandler,
 		isPrimary: boolean
@@ -414,9 +424,7 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 		// Spawn handler is responsible for spawning processes for all the
 		// `popen()`, `proc_open()` etc. calls.
 		if (spawnHandler) {
-			await php.setSpawnHandler(
-				spawnHandler(requestHandler.processManager)
-			);
+			await php.setSpawnHandler(spawnHandler(requestHandler));
 		}
 
 		// Rotate the PHP runtime periodically to avoid memory leak-related crashes.
@@ -442,6 +450,7 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 		getFileNotFoundAction:
 			options.getFileNotFoundAction ?? getFileNotFoundActionForWordPress,
 		cookieStore: options.cookieStore,
+		maxPhpInstances: options.maxPhpInstances,
 	});
 
 	return requestHandler;

--- a/packages/playground/wordpress/src/version-detect.ts
+++ b/packages/playground/wordpress/src/version-detect.ts
@@ -7,6 +7,7 @@ export async function getLoadedWordPressVersion(
 		await requestHandler.processManager.acquirePHPInstance({
 			considerPrimary: true,
 		});
+
 	try {
 		const result = await php.run({
 			code: `<?php


### PR DESCRIPTION
## Summary

When PHP acquires file locks via `flock()`, the locks are managed at the kernel level per-process. Multiple PHP WASM instances within the same OS process would share those locks, defeating the purpose of file locking for concurrent access control.

This PR ensures CLI workers use exactly one PHP instance by:

- Adding `maxPhpInstances` option to `PHPRequestHandler` that, when set to 1, bypasses `PHPProcessManager` entirely and uses a single PHP instance directly
- Refactoring the spawn handler into a unified `createPhpSpawnHandler()` that accepts a configurable `phpCliHandler` for subprocess spawning
- CLI workers now use `createPhpSpawnHandler` without a PHP CLI handler, meaning `proc_open('php ...')` returns exit code 127 instead of spawning in-process
- Web environments continue using `sandboxedSpawnHandlerFactory` which spawns PHP instances via `PHPProcessManager`

## New Spawn Handler API

```typescript
// Core handler - works everywhere
createPhpSpawnHandler({
  getPrimaryPhp: () => Promise<PHP>,  // For ls, pwd commands
  phpCliHandler?: PHPCliHandler,       // Optional: handles php commands
})

// Helper for multi-instance mode (web)
createProcessManagerCliHandler(acquirePHPInstance)

// Legacy wrapper - auto-detects mode based on processManager presence
sandboxedSpawnHandlerFactory(requestHandler)
```

## Test plan

- [x] TypeScript compiles without errors
- [x] Lint passes
- [x] `sandboxedSpawnHandlerFactory` tests pass
- [ ] Manual test: CLI worker handles HTTP requests correctly
- [ ] Manual test: `proc_open('ls')` works in CLI
- [ ] Manual test: `proc_open('php ...')` returns exit code 127 in CLI