### PR TITLE
[php-wasm] Add support for `rm` command in sandboxed spawn handler

### DIFF
--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -81,7 +81,7 @@ export function sandboxedSpawnHandlerFactory(
 			return;
 		}
 
-		if (!['php', 'ls', 'pwd'].includes(binaryName ?? '')) {
+		if (!['php', 'ls', 'pwd', 'rm'].includes(binaryName ?? '')) {
 			// 127 is the exit code "for command not found".
 			processApi.exit(127);
 			return;
@@ -148,6 +148,20 @@ export function sandboxedSpawnHandlerFactory(
 				}
 				case 'pwd': {
 					processApi.stdout(cwd + '\n');
+					// Technical limitation of subprocesses – we need to
+					// wait before exiting to give consumer a chance to read
+					// the output.
+					await new Promise((resolve) => setTimeout(resolve, 10));
+					processApi.exit(0);
+					break;
+				}
+				case 'rm': {
+					const target = args[args.length - 1];
+					if (await php.isDir(target)) {
+						await php.rmdir(target, { recursive: true });
+					} else if (await php.isFile(target)) {
+						await php.unlink(target);
+					}
 					// Technical limitation of subprocesses – we need to
 					// wait before exiting to give consumer a chance to read
 					// the output.

--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -3,6 +3,7 @@ import type { PHP } from './php';
 import type { PHPWorker } from './php-worker';
 import type { Remote } from './comlink-sync';
 import { logger } from '@php-wasm/logger';
+import yargs from 'yargs';
 
 function wait(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -160,47 +161,54 @@ export function sandboxedSpawnHandlerFactory(
 					break;
 				}
 				case 'rm': {
-					const target = args[args.length - 1];
-					const flags = args.slice(1, -1).join(' ');
+					const parsedArgs = yargs(args.slice(1))
+						.option('r', {
+							alias: 'recursive',
+							type: 'boolean',
+							default: false,
+						})
+						.option('f', {
+							alias: 'force',
+							type: 'boolean',
+							default: false,
+						})
+						.parse() as any;
 
-					if (args.length < 2 || target.startsWith('-')) {
-						processApi.stderr('usage: rm [-rf] file\n');
-						// Technical limitation of subprocesses – we need to
-						// wait before exiting to give consumer a chance to read
-						// the output.
-						await wait(10);
-						processApi.exit(1);
-						break;
-					}
+					const targets = parsedArgs._.map(String);
+					const isRecursive = parsedArgs.recursive;
+					const isForce = parsedArgs.force;
 
-					const isRecursive = flags.includes('r');
-					const isForce = flags.includes('f');
+					const errorMessages = [] as string[];
 
-					let errorMessage = '';
-
-					if (await php.isDir(target)) {
-						if (isRecursive) {
-							await php.rmdir(target, { recursive: true });
-						} else {
-							errorMessage = `rm: cannot remove '${target}': Is a directory\n`;
+					for (const target of targets) {
+						if (await php.isDir(target)) {
+							if (isRecursive) {
+								await php.rmdir(target, { recursive: true });
+							} else {
+								errorMessages.push(
+									`rm: ${target}: is a directory`
+								);
+							}
+						} else if (await php.isFile(target)) {
+							await php.unlink(target);
+						} else if (!isForce) {
+							errorMessages.push(
+								`rm: ${target}: No such file or directory`
+							);
 						}
-					} else if (await php.isFile(target)) {
-						await php.unlink(target);
-					}
-					// Target doesn't exist and -f flag is not set
-					else if (!isForce) {
-						errorMessage = `rm: cannot remove '${target}': No such file or directory\n`;
 					}
 
-					if (errorMessage) {
-						processApi.stderr(errorMessage);
+					const hasErrors = errorMessages.length > 0;
+
+					if (hasErrors) {
+						processApi.stderr(errorMessages.join('\n'));
 						// Technical limitation of subprocesses – we need to
 						// wait before exiting to give consumer a chance to read
 						// the output.
 						await wait(10);
 					}
 
-					processApi.exit(errorMessage ? 1 : 0);
+					processApi.exit(hasErrors ? 1 : 0);
 					break;
 				}
 			}

--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -3,7 +3,7 @@ import type { PHP } from './php';
 import type { PHPWorker } from './php-worker';
 import type { Remote } from './comlink-sync';
 import { logger } from '@php-wasm/logger';
-import yargs from 'yargs';
+import yargsParser from 'yargs-parser';
 
 function wait(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -161,22 +161,11 @@ export function sandboxedSpawnHandlerFactory(
 					break;
 				}
 				case 'rm': {
-					const parsedArgs = yargs(args.slice(1))
-						.option('r', {
-							alias: 'recursive',
-							type: 'boolean',
-							default: false,
-						})
-						.option('f', {
-							alias: 'force',
-							type: 'boolean',
-							default: false,
-						})
-						.parse() as any;
+					const parsedArgs = yargsParser(args.slice(1)) as any;
 
 					const targets = parsedArgs._.map(String);
-					const isRecursive = parsedArgs.recursive;
-					const isForce = parsedArgs.force;
+					const isRecursive = parsedArgs.recursive ?? parsedArgs.r;
+					const isForce = parsedArgs.force ?? parsedArgs.f;
 
 					const errorMessages = [] as string[];
 

--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -3,7 +3,7 @@ import type { PHP } from './php';
 import type { PHPWorker } from './php-worker';
 import type { Remote } from './comlink-sync';
 import { logger } from '@php-wasm/logger';
-import yargsParser from 'yargs-parser';
+import yargsParser from 'yargs-parser/browser';
 
 function wait(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -161,11 +161,19 @@ export function sandboxedSpawnHandlerFactory(
 					break;
 				}
 				case 'rm': {
-					const parsedArgs = yargsParser(args.slice(1)) as any;
+					const parsedArgs = yargsParser(args.slice(1), {
+						alias: {
+							recursive: ['r'],
+							force: ['f'],
+						},
+						boolean: ['recursive', 'force'],
+					}) as any;
+
+					console.log('Parsed rm args:', parsedArgs);
 
 					const targets = parsedArgs._.map(String);
-					const isRecursive = parsedArgs.recursive ?? parsedArgs.r;
-					const isForce = parsedArgs.force ?? parsedArgs.f;
+					const isRecursive = parsedArgs.recursive;
+					const isForce = parsedArgs.force;
 
 					const errorMessages = [] as string[];
 

--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -167,9 +167,7 @@ export function sandboxedSpawnHandlerFactory(
 							force: ['f'],
 						},
 						boolean: ['recursive', 'force'],
-					}) as any;
-
-					console.log('Parsed rm args:', parsedArgs);
+					});
 
 					const targets = parsedArgs._.map(String);
 					const isRecursive = parsedArgs.recursive;

--- a/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
+++ b/packages/php-wasm/universal/src/lib/sandboxed-spawn-handler-factory.ts
@@ -4,6 +4,10 @@ import type { PHPWorker } from './php-worker';
 import type { Remote } from './comlink-sync';
 import { logger } from '@php-wasm/logger';
 
+function wait(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
  * An isomorphic proc_open() handler that implements typical shell in TypeScript
  * without relying on a server runtime. It can be used in the browser and Node.js
@@ -142,7 +146,7 @@ export function sandboxedSpawnHandlerFactory(
 					// Technical limitation of subprocesses – we need to
 					// wait before exiting to give consumer a chance to read
 					// the output.
-					await new Promise((resolve) => setTimeout(resolve, 10));
+					await wait(10);
 					processApi.exit(0);
 					break;
 				}
@@ -151,22 +155,52 @@ export function sandboxedSpawnHandlerFactory(
 					// Technical limitation of subprocesses – we need to
 					// wait before exiting to give consumer a chance to read
 					// the output.
-					await new Promise((resolve) => setTimeout(resolve, 10));
+					await wait(10);
 					processApi.exit(0);
 					break;
 				}
 				case 'rm': {
 					const target = args[args.length - 1];
+					const flags = args.slice(1, -1).join(' ');
+
+					if (args.length < 2 || target.startsWith('-')) {
+						processApi.stderr('usage: rm [-rf] file\n');
+						// Technical limitation of subprocesses – we need to
+						// wait before exiting to give consumer a chance to read
+						// the output.
+						await wait(10);
+						processApi.exit(1);
+						break;
+					}
+
+					const isRecursive = flags.includes('r');
+					const isForce = flags.includes('f');
+
+					let errorMessage = '';
+
 					if (await php.isDir(target)) {
-						await php.rmdir(target, { recursive: true });
+						if (isRecursive) {
+							await php.rmdir(target, { recursive: true });
+						} else {
+							errorMessage = `rm: cannot remove '${target}': Is a directory\n`;
+						}
 					} else if (await php.isFile(target)) {
 						await php.unlink(target);
 					}
-					// Technical limitation of subprocesses – we need to
-					// wait before exiting to give consumer a chance to read
-					// the output.
-					await new Promise((resolve) => setTimeout(resolve, 10));
-					processApi.exit(0);
+					// Target doesn't exist and -f flag is not set
+					else if (!isForce) {
+						errorMessage = `rm: cannot remove '${target}': No such file or directory\n`;
+					}
+
+					if (errorMessage) {
+						processApi.stderr(errorMessage);
+						// Technical limitation of subprocesses – we need to
+						// wait before exiting to give consumer a chance to read
+						// the output.
+						await wait(10);
+					}
+
+					processApi.exit(errorMessage ? 1 : 0);
 					break;
 				}
 			}


### PR DESCRIPTION
## Motivation for the change

The `wp plugin uninstall <plugin-name>` command uses `rm -rf` to delete the plugin files, and the current sandboxed spawn handler doesn't have support for it, so I am just adding it.

Closes: #2653 

## Implementation details

Adding support for `rm` in the sandboxed spawn handler.

## Testing Instructions (or ideally a Blueprint)

The following blueprint should run without any error, and the `Hello Dolly` plugin should be deleted:
```json
{
  "login": true,
  "landingPage": "/wp-admin/plugins.php",
  "steps": [
    {
      "step": "wp-cli",
      "command": "wp plugin uninstall hello"
    }
  ]
}
```
