### PR TITLE
[ Intl ] Implement Intl in Playground CLI

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -74,7 +74,11 @@ const schema11 = {
 				features: {
 					type: 'object',
 					properties: {
-						intl: { type: 'boolean' },
+						intl: {
+							type: 'boolean',
+							description:
+								'Should boot with support for Intl dynamic extension',
+						},
 						networking: {
 							type: 'boolean',
 							description:
@@ -1452,7 +1456,11 @@ const schema12 = {
 		features: {
 			type: 'object',
 			properties: {
-				intl: { type: 'boolean' },
+				intl: {
+					type: 'boolean',
+					description:
+						'Should boot with support for Intl dynamic extension',
+				},
 				networking: {
 					type: 'boolean',
 					description:

--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -152,6 +152,7 @@ export class BlueprintsV1Handler {
 			followSymlinks,
 			trace,
 			internalCookieStore: this.args.internalCookieStore,
+			withIntl: this.args.intl,
 			// We do not enable Xdebug by default for the initial worker
 			// because we do not imagine users expect to hit breakpoints
 			// until Playground has fully booted.
@@ -208,6 +209,7 @@ export class BlueprintsV1Handler {
 			// @TODO: Move this to the request handler or else every worker
 			//        will have a separate cookie store.
 			internalCookieStore: this.args.internalCookieStore,
+			withIntl: this.args.intl,
 			withXdebug: !!this.args.xdebug,
 			nativeInternalDirPath,
 		});

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -42,6 +42,7 @@ export type WorkerBootOptions = {
 	 * Default: false.
 	 */
 	internalCookieStore?: boolean;
+	withIntl?: boolean;
 	withXdebug?: boolean;
 	nativeInternalDirPath: string;
 };
@@ -64,6 +65,7 @@ interface WorkerBootRequestHandlerOptions {
 	nativeInternalDirPath: string;
 	mountsBeforeWpInstall: Array<Mount>;
 	mountsAfterWpInstall: Array<Mount>;
+	withIntl?: boolean;
 	withXdebug?: boolean;
 }
 
@@ -292,6 +294,7 @@ function createPhpRuntimeFactory(
 					},
 				},
 				followSymlinks: options.followSymlinks,
+				withIntl: options.withIntl,
 				withXdebug: options.withXdebug,
 			}
 		);

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -57,6 +57,7 @@ export class BlueprintsV2Handler {
 			processIdSpaceLength: this.processIdSpaceLength,
 			trace: this.args.debug || false,
 			blueprint: this.args.blueprint!,
+			withIntl: this.args.intl,
 			// We do not enable Xdebug by default for the initial worker
 			// because we do not imagine users expect to hit breakpoints
 			// until Playground has fully booted.
@@ -93,6 +94,7 @@ export class BlueprintsV2Handler {
 			firstProcessId,
 			processIdSpaceLength: this.processIdSpaceLength,
 			trace: this.args.debug || false,
+			withIntl: this.args.intl,
 			withXdebug: !!this.args.xdebug,
 			nativeInternalDirPath,
 			mountsBeforeWpInstall: this.args['mount-before-install'] || [],

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -154,6 +154,7 @@ export type SecondaryWorkerBootArgs = {
 	processIdSpaceLength: number;
 	trace: boolean;
 	nativeInternalDirPath: string;
+	withIntl?: boolean;
 	withXdebug?: boolean;
 	mountsBeforeWpInstall?: Array<Mount>;
 	mountsAfterWpInstall?: Array<Mount>;
@@ -424,6 +425,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 		processIdSpaceLength,
 		trace,
 		nativeInternalDirPath,
+		withIntl,
 		withXdebug,
 		onPHPInstanceCreated,
 	}: WorkerBootRequestHandlerOptions) {
@@ -459,6 +461,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 							phpWasmInitOptions: { nativeInternalDirPath },
 						},
 						followSymlinks: allow?.includes('follow-symlinks'),
+						withIntl: withIntl,
 						withXdebug,
 					});
 				},

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -240,6 +240,11 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				type: 'boolean',
 				default: false,
 			})
+			.option('intl', {
+				describe: 'Enable Intl.',
+				type: 'boolean',
+				default: true,
+			})
 			.option('xdebug', {
 				describe: 'Enable Xdebug.',
 				type: 'boolean',
@@ -506,6 +511,7 @@ export interface RunCLIArgs {
 	experimentalTrace?: boolean;
 	internalCookieStore?: boolean;
 	'additional-blueprint-steps'?: any[];
+	intl?: boolean;
 	xdebug?: boolean | { ideKey?: string };
 	experimentalUnsafeIdeIntegration?: string[];
 	experimentalDevtools?: boolean;
@@ -620,6 +626,11 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			(v) => v.name === args.verbosity
 		)!.severity;
 		logger.setSeverityFilterLevel(severity);
+	}
+
+	// Enables Intl dynamic extension by default
+	if (!args.intl) {
+		args.intl = true;
 	}
 
 	// Declare file lock manager outside scope of startServer

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -82,6 +82,34 @@ describe.each(blueprintVersions)(
 		);
 
 		test.skipIf(isBlueprintsV2OnWindows)(
+			'should have Intl extension enabled by default',
+			async () => {
+				cliServer = await runCLI({
+					...suiteCliArgs,
+					command: 'server',
+					php: '8.0',
+					// Let's skip the cost of WordPress setup because it is
+					// irrelevant for this test.
+					wordpressInstallMode: 'do-not-attempt-installing',
+					skipSqliteSetup: true,
+					blueprint: undefined,
+				});
+
+				await cliServer.playground.writeFile(
+					'/wordpress/intl.php',
+					`<?php
+					var_dump(extension_loaded(\'intl\'));
+					var_dump(class_exists(\'Collator\'));`
+				);
+				const versionUrl = new URL('/intl.php', cliServer.serverUrl);
+				const response = await fetch(versionUrl);
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain('bool(true)\nbool(true)\n');
+			}
+		);
+
+		test.skipIf(isBlueprintsV2OnWindows)(
 			'should use custom site-url when provided',
 			async () => {
 				const customSiteUrl = 'https://example.com';

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -98,8 +98,8 @@ describe.each(blueprintVersions)(
 				await cliServer.playground.writeFile(
 					'/wordpress/intl.php',
 					`<?php
-					var_dump(extension_loaded(\'intl\'));
-					var_dump(class_exists(\'Collator\'));`
+					var_dump(extension_loaded('intl'));
+					var_dump(class_exists('Collator'));`
 				);
 				const versionUrl = new URL('/intl.php', cliServer.serverUrl);
 				const response = await fetch(versionUrl);


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request adds a `intl` feature enabling `Intl` extension dynamic loading at runtime in Playground CLI. By default.

https://github.com/WordPress/wordpress-playground/issues/2943

## Implementation details

Add the `intl` CLI option, the `intl` feature and `withIntl` throughout the process of Playground CLI PHP runtime loading.

## Testing Instructions (or ideally a Blueprint)

CLI - `should have Intl extension enabled by default` in `run-cli.spec.ts`