### PR TITLE
[ php-wasm-cli ] Correct `require is not defined` error

### DIFF
--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -4,13 +4,14 @@
 import os from 'os';
 import { writeFileSync, existsSync, mkdtempSync, chmodSync } from 'fs';
 import { rootCertificates } from 'tls';
+import { spawn } from 'child_process';
 
 import {
 	LatestSupportedPHPVersion,
 	SupportedPHPVersionsList,
 } from '@php-wasm/universal';
 /* eslint-disable no-console */
-import type { SupportedPHPVersion } from '@php-wasm/universal';
+import type { SpawnHandler, SupportedPHPVersion } from '@php-wasm/universal';
 import { FileLockManagerForNode } from '@php-wasm/node';
 import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime, useHostFilesystem } from '@php-wasm/node';
@@ -129,7 +130,7 @@ ${process.argv[0]} ${process.execArgv.join(' ')} ${process.argv[1]}
 			withXdebug: hasXdebugOption,
 		})
 	);
-	php.setSpawnHandler(require('child_process').spawn);
+	php.setSpawnHandler(spawn as SpawnHandler);
 
 	useHostFilesystem(php);
 


### PR DESCRIPTION
## Motivation for the change, related issues

Runnin `php-wasm-cli -v` with the latest CLI resulted in : 

```
ReferenceError: require is not defined
    at run (file:///wordpress-playground/packages/php-wasm/cli/src/main.ts:132:6)
```

## Implementation details

Replace `php.setSpawnHandler(require('child_process').spawn);` with `php.setSpawnHandler(spawn as SpawnHandler);`

## Testing Instructions (or ideally a Blueprint)

Before

```
node --no-warnings --experimental-wasm-stack-switching --experimental-wasm-jspi --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/php-wasm/cli/src/main.ts -v

file:///wordpress-playground/packages/php-wasm/cli/src/main.ts:132
        php.setSpawnHandler(require('child_process').spawn);
            ^

ReferenceError: require is not defined
    at run (file:///wordpress-playground/packages/php-wasm/cli/src/main.ts:132:6)
```

After

```
node --no-warnings --experimental-wasm-stack-switching --experimental-wasm-jspi --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/php-wasm/cli/src/main.ts -v

PHP 8.5.0-dev (cli) (built: Dec  9 2025 09:54:34) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.5.0-dev, Copyright (c) Zend Technologies
    with Zend OPcache v8.5.0-dev, Copyright (c), by Zend Technologies
```