### PR TITLE
[PHP] Add php-wasm-cli smoke test for proc_open in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,15 @@ jobs:
             - uses: ./.github/actions/prepare-playground
             - run: packages/playground/cli/tests/test-running-unbuilt-cli.sh
 
+    test-php-wasm-cli-smoke:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: true
+            - uses: ./.github/actions/prepare-playground
+            - run: packages/php-wasm/cli/tests/smoke-test.sh
+
     build:
         runs-on: ubuntu-latest
         steps:

--- a/packages/php-wasm/cli/tests/proc_open_test.php
+++ b/packages/php-wasm/cli/tests/proc_open_test.php
@@ -1,0 +1,29 @@
+<?php
+$descriptorspec = array(
+   0 => array("pipe", "r"),
+   1 => array("pipe", "w"),
+   2 => array("pipe", "w")
+);
+
+$process = proc_open('echo "Hello from proc_open"', $descriptorspec, $pipes);
+
+if (is_resource($process)) {
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+
+    $stderr = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+
+    $return_value = proc_close($process);
+
+    if (trim($stdout) === 'Hello from proc_open') {
+        echo "proc_open test passed!\n";
+        exit(0);
+    } else {
+        echo "proc_open test failed! Expected 'Hello from proc_open', got: '$stdout'\n";
+        exit(1);
+    }
+} else {
+    echo "proc_open failed to create process\n";
+    exit(1);
+}

--- a/packages/php-wasm/cli/tests/smoke-test.sh
+++ b/packages/php-wasm/cli/tests/smoke-test.sh
@@ -13,7 +13,16 @@ fi
 
 echo "Running php-wasm-cli smoke test with proc_open..."
 
-# Run the test using the unbuilt php-wasm-cli
-npx nx dev php-wasm-cli -- packages/php-wasm/cli/tests/proc_open_test.php
+# Run the test using the unbuilt php-wasm-cli and capture output
+output=$(npx nx dev php-wasm-cli -- packages/php-wasm/cli/tests/proc_open_test.php 2>&1)
 
-echo "php-wasm-cli smoke test completed!"
+# Assert that the output contains the expected success message
+if echo "$output" | grep -q "proc_open test passed!"; then
+    echo "Assertion passed: proc_open test output contains expected success message"
+    echo "php-wasm-cli smoke test completed!"
+else
+    echo "Assertion failed: Expected output to contain 'proc_open test passed!'"
+    echo "Actual output:"
+    echo "$output"
+    exit 1
+fi

--- a/packages/php-wasm/cli/tests/smoke-test.sh
+++ b/packages/php-wasm/cli/tests/smoke-test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Ensure Node 23+ is available for JSPI support
+if node -e 'if (parseInt(process.versions.node) < 23) { process.exit(1); }'; then
+	echo "Node $(node -v) detected, proceeding with smoke test..."
+else
+	source ~/.nvm/nvm.sh
+	nvm install 23
+	npm ci
+fi
+
+echo "Running php-wasm-cli smoke test with proc_open..."
+
+# Run the test using the unbuilt php-wasm-cli
+npx nx dev php-wasm-cli -- packages/php-wasm/cli/tests/proc_open_test.php
+
+echo "php-wasm-cli smoke test completed!"


### PR DESCRIPTION
Adds a simple smoke test that verifies proc_open works correctly in php-wasm-cli. This test runs a PHP script that spawns a child process via proc_open and confirms the output is captured properly. This will prevent [breaking php-wasm/cli](https://github.com/WordPress/wordpress-playground/pull/3012).

To test, just confirm there's a php-wasm-cli smoke test on the list of CI checks.