### PR TITLE
[Website] Add support Gutenberg's client-side media processing experiment

### DIFF
--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -60,6 +60,16 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 		delete phpResponse.headers['x-frame-options'];
 
 		/*
+		 * Remove COEP/COOP headers set by Gutenberg's client-side media processing.
+		 * These headers require all iframes to also have COEP, breaking embeds.
+		 * We use Document-Isolation-Policy instead, which provides cross-origin
+		 * isolation without cascading requirements to child frames.
+		 * See: https://github.com/WordPress/wordpress-playground/issues/2954
+		 */
+		delete phpResponse.headers['cross-origin-embedder-policy'];
+		delete phpResponse.headers['cross-origin-opener-policy'];
+
+		/*
 		 * Content-Security-Policy can get in the way when PHP is
 		 * being displayed in an iframe. WordPress 6.9 added a new
 		 * `Content-Security-Policy: frame-ancestors 'self';` header that
@@ -92,6 +102,17 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 				delete phpResponse.headers['content-security-policy'];
 			}
 		}
+
+		/*
+		 * Add Document-Isolation-Policy header to enable SharedArrayBuffer
+		 * for Gutenberg's client-side media processing experiment.
+		 * This header enables cross-origin isolation on a per-frame basis
+		 * without requiring child frames to support COEP.
+		 * See: https://github.com/WordPress/wordpress-playground/issues/2954
+		 */
+		phpResponse.headers['document-isolation-policy'] = [
+			'isolate-and-credentialless',
+		];
 	} catch (e) {
 		console.error(e, { url: url.toString() });
 		throw e;
@@ -286,27 +307,32 @@ export function removeContentSecurityPolicyDirective(
 
 	// Parse based on the CSP spec:
 	// https://w3c.github.io/webappsec-csp/#parse-serialized-policy
-	return cspHeader
-		// "For each token returned by strictly splitting serialized
-		// on the U+003B SEMICOLON character (;):"
-		.split(';')
-		.filter((rawDirective: string) => {
-			// "Strip leading and trailing ASCII whitespace from token."
-			const trimmedDirective = rawDirective
-				.replace(leadingAsciiWhitespace, '')
-				.replace(trailingAsciiWhitespace, '');
+	return (
+		cspHeader
+			// "For each token returned by strictly splitting serialized
+			// on the U+003B SEMICOLON character (;):"
+			.split(';')
+			.filter((rawDirective: string) => {
+				// "Strip leading and trailing ASCII whitespace from token."
+				const trimmedDirective = rawDirective
+					.replace(leadingAsciiWhitespace, '')
+					.replace(trailingAsciiWhitespace, '');
 
-			// "Let directive name be the result of collecting a sequence
-			// of code points from token which are not ASCII whitespace."
-			const [directiveName] = trimmedDirective.split(
-				asciiWhitespace,
-				// The directive name is the first token.
-				1
-			);
+				// "Let directive name be the result of collecting a sequence
+				// of code points from token which are not ASCII whitespace."
+				const [directiveName] = trimmedDirective.split(
+					asciiWhitespace,
+					// The directive name is the first token.
+					1
+				);
 
-			// "Directive names are case-insensitive, that is:
-			// script-SRC 'none' and ScRiPt-sRc 'none' are equivalent."
-			return directiveName.toLowerCase() !== directiveToRemove.toLowerCase();
-		})
-		.join(';');
+				// "Directive names are case-insensitive, that is:
+				// script-SRC 'none' and ScRiPt-sRc 'none' are equivalent."
+				return (
+					directiveName.toLowerCase() !==
+					directiveToRemove.toLowerCase()
+				);
+			})
+			.join(';')
+	);
 }

--- a/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.ts
@@ -12,7 +12,11 @@ export async function fetchWithCorsProxy(
 	let requestUrlObj = playgroundUrlObj
 		? new URL(requestObject.url, playgroundUrlObj)
 		: new URL(requestObject.url);
-	if (requestUrlObj.protocol === 'http:') {
+	// Upgrade HTTP to HTTPS, except for localhost where HTTPS is usually not available.
+	const isLocalhost =
+		requestUrlObj.hostname === 'localhost' ||
+		requestUrlObj.hostname === '127.0.0.1';
+	if (requestUrlObj.protocol === 'http:' && !isLocalhost) {
 		requestUrlObj.protocol = 'https:';
 		const httpsUrl = requestUrlObj.toString();
 		requestObject = await cloneRequest(requestObject, { url: httpsUrl });

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -512,6 +512,9 @@ function emptyHtml() {
 			status: 200,
 			headers: {
 				'content-type': 'text/html',
+				// Enable cross-origin isolation for SharedArrayBuffer support.
+				// See: https://github.com/WordPress/wordpress-playground/issues/2954
+				'document-isolation-policy': 'isolate-and-credentialless',
 			},
 		}
 	);


### PR DESCRIPTION
## Motivation for the change, related issues

Gutenberg's client-side media processing experiment requires `SharedArrayBuffer`, which needs cross-origin isolation. Gutenberg achieves this via COEP/COOP headers, but these headers require all embedded iframes to also support COEP - breaking YouTube embeds and other third-party content in Playground.

This fix uses [Document Isolation Policy](https://developer.chrome.com/blog/document-isolation-policy) that is available since Chrome 137+ (currently desktop only).

Fixes https://github.com/WordPress/wordpress-playground/issues/2954.

## Implementation details

Uses [Document Isolation Policy](https://developer.chrome.com/blog/document-isolation-policy) (Chrome 137+) instead of COEP/COOP. This provides per-frame cross-origin isolation without cascading requirements to child frames.

**Changes:**
1. Strip `cross-origin-embedder-policy` and `cross-origin-opener-policy` headers set by Gutenberg in the service worker
2. Add `document-isolation-policy: isolate-and-credentialless` header to all PHP responses
3. Add the header to the `emptyHtml()` response used by the patched Gutenberg editor iframe

**Limitations:**
- Document Isolation Policy is Chrome 137+ desktop only
- Firefox/Safari users won't have SharedArrayBuffer support for this feature
- Other browsers will simply ignore the header - no breaking changes

## Testing Instructions (or ideally a Blueprint)

1. Run `npx nx dev playground-website`.
2. Go to http://127.0.0.1:5400/website-server/?gutenberg-branch=trunk.
3. Go to **Gutenberg → Experiments** → Enable **"Client-side media processing"** and save.
4. Create a new post and upload an image.
5. Verify the upload works without console errors about `SharedArrayBuffer`.
6. Verify YouTube embeds still work in posts.
