### PR TITLE
Correct out of memory issue

### DIFF
--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -1,7 +1,6 @@
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import { exposeAPI } from '@php-wasm/web';
 import {
-	PHPWorkerGlobalScope,
 	PlaygroundWorkerEndpoint,
 	type WorkerBootOptions,
 } from './playground-worker-endpoint';
@@ -27,6 +26,10 @@ import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
  *
  * https://github.com/emscripten-core/emscripten/blob/6d61ffd7076309cb08af37aba496f25c23cdb5a4/src/lib/libeventloop.js#L57
  */
+interface PHPWorkerGlobalScope extends WorkerGlobalScope {
+	setImmediate: (fn: () => void) => void;
+}
+
 (globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
 	setTimeout(fn, 0);
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -20,9 +20,15 @@ import type { PHP } from '@php-wasm/universal';
 /* @ts-ignore */
 import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
 
+/*
+ * Provide `setImmediate` so Emscripten doesn’t install its message-based
+ * polyfill, which retains references to the Wasm HEAP and prevents the
+ * PHP instance from being garbage-collected.
+ *
+ * https://github.com/emscripten-core/emscripten/blob/6d61ffd7076309cb08af37aba496f25c23cdb5a4/src/lib/libeventloop.js#L57
+ */
 (globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
 	setTimeout(fn, 0);
-(globalThis as PHPWorkerGlobalScope).clearImmediate = () => {};
 
 // post message to parent
 self.postMessage('worker-script-started');

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -1,6 +1,10 @@
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import { exposeAPI } from '@php-wasm/web';
-import { PlaygroundWorkerEndpoint } from './playground-worker-endpoint';
+import {
+	PHPWorkerGlobalScope,
+	PlaygroundWorkerEndpoint,
+	type WorkerBootOptions,
+} from './playground-worker-endpoint';
 import { randomString } from '@php-wasm/util';
 import {
 	getSqliteDriverModuleDetails,
@@ -15,7 +19,10 @@ import { createDirectoryHandleMountHandler } from '@php-wasm/web';
 import type { PHP } from '@php-wasm/universal';
 /* @ts-ignore */
 import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
-import type { WorkerBootOptions } from './playground-worker-endpoint';
+
+(globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
+	setTimeout(fn, 0);
+(globalThis as PHPWorkerGlobalScope).clearImmediate = () => {};
 
 // post message to parent
 self.postMessage('worker-script-started');

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -19,20 +19,6 @@ import type { PHP } from '@php-wasm/universal';
 /* @ts-ignore */
 import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
 
-/*
- * Provide `setImmediate` so Emscripten doesn’t install its message-based
- * polyfill, which retains references to the Wasm HEAP and prevents the
- * PHP instance from being garbage-collected.
- *
- * https://github.com/emscripten-core/emscripten/blob/6d61ffd7076309cb08af37aba496f25c23cdb5a4/src/lib/libeventloop.js#L57
- */
-interface PHPWorkerGlobalScope extends WorkerGlobalScope {
-	setImmediate: (fn: () => void) => void;
-}
-
-(globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
-	setTimeout(fn, 0);
-
 // post message to parent
 self.postMessage('worker-script-started');
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
@@ -9,20 +9,6 @@ import type { BlueprintV2Declaration } from '@wp-playground/blueprints';
 /* @ts-ignore */
 import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
 
-/*
- * Provide `setImmediate` so Emscripten doesn’t install its message-based
- * polyfill, which retains references to the Wasm HEAP and prevents the
- * PHP instance from being garbage-collected.
- *
- * https://github.com/emscripten-core/emscripten/blob/6d61ffd7076309cb08af37aba496f25c23cdb5a4/src/lib/libeventloop.js#L57
- */
-interface PHPWorkerGlobalScope extends WorkerGlobalScope {
-	setImmediate: (fn: () => void) => void;
-}
-
-(globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
-	setTimeout(fn, 0);
-
 // post message to parent
 self.postMessage('worker-script-started');
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
@@ -1,7 +1,6 @@
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import { exposeAPI } from '@php-wasm/web';
 import {
-	PHPWorkerGlobalScope,
 	PlaygroundWorkerEndpoint,
 	type WorkerBootOptions,
 } from './playground-worker-endpoint';
@@ -17,6 +16,10 @@ import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
  *
  * https://github.com/emscripten-core/emscripten/blob/6d61ffd7076309cb08af37aba496f25c23cdb5a4/src/lib/libeventloop.js#L57
  */
+interface PHPWorkerGlobalScope extends WorkerGlobalScope {
+	setImmediate: (fn: () => void) => void;
+}
+
 (globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
 	setTimeout(fn, 0);
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
@@ -1,11 +1,18 @@
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import { exposeAPI } from '@php-wasm/web';
-import { PlaygroundWorkerEndpoint } from './playground-worker-endpoint';
-import type { WorkerBootOptions } from './playground-worker-endpoint';
+import {
+	PHPWorkerGlobalScope,
+	PlaygroundWorkerEndpoint,
+	type WorkerBootOptions,
+} from './playground-worker-endpoint';
 import { runBlueprintV2 } from '@wp-playground/blueprints';
 import type { BlueprintV2Declaration } from '@wp-playground/blueprints';
 /* @ts-ignore */
 import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
+
+(globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
+	setTimeout(fn, 0);
+(globalThis as PHPWorkerGlobalScope).clearImmediate = () => {};
 
 // post message to parent
 self.postMessage('worker-script-started');

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
@@ -10,9 +10,15 @@ import type { BlueprintV2Declaration } from '@wp-playground/blueprints';
 /* @ts-ignore */
 import { corsProxyUrl as defaultCorsProxyUrl } from 'virtual:cors-proxy-url';
 
+/*
+ * Provide `setImmediate` so Emscripten doesn’t install its message-based
+ * polyfill, which retains references to the Wasm HEAP and prevents the
+ * PHP instance from being garbage-collected.
+ *
+ * https://github.com/emscripten-core/emscripten/blob/6d61ffd7076309cb08af37aba496f25c23cdb5a4/src/lib/libeventloop.js#L57
+ */
 (globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
 	setTimeout(fn, 0);
-(globalThis as PHPWorkerGlobalScope).clearImmediate = () => {};
 
 // post message to parent
 self.postMessage('worker-script-started');

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -49,6 +49,10 @@ import { networkingDisabledFunctions } from './disabled-functions';
 import playgroundWebMuPlugin from './playground-mu-plugin/0-playground.php?raw';
 import { WordPressFetchNetworkTransport } from './wordpress-fetch-network-transport';
 
+interface PHPWorkerGlobalScope extends WorkerGlobalScope {
+	setImmediate: (fn: () => void) => void;
+}
+
 export interface MountDescriptor {
 	mountpoint: string;
 	device: MountDevice;
@@ -103,6 +107,17 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 
 	constructor(monitor: EmscriptenDownloadMonitor) {
 		super(undefined, monitor);
+
+		/*
+		 * Provide `setImmediate` so Emscripten doesn’t install its message-based
+		 * polyfill, which retains references to the Wasm HEAP and prevents the
+		 * PHP instance from being garbage-collected.
+		 *
+		 * https://github.com/emscripten-core/emscripten/blob/6d61ffd7076309cb08af37aba496f25c23cdb5a4/src/lib/libeventloop.js#L57
+		 */
+		(globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
+			setTimeout(fn, 0);
+
 		this.downloadMonitor = monitor;
 		const monitoredFetch = (input: RequestInfo | URL, init?: RequestInit) =>
 			this.downloadMonitor.monitorFetch(fetch(input, init));

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -49,6 +49,11 @@ import { networkingDisabledFunctions } from './disabled-functions';
 import playgroundWebMuPlugin from './playground-mu-plugin/0-playground.php?raw';
 import { WordPressFetchNetworkTransport } from './wordpress-fetch-network-transport';
 
+export interface PHPWorkerGlobalScope extends WorkerGlobalScope {
+	setImmediate: (fn: () => void) => void;
+	clearImmediate: (id?: number) => void;
+}
+
 export interface MountDescriptor {
 	mountpoint: string;
 	device: MountDevice;

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -51,7 +51,6 @@ import { WordPressFetchNetworkTransport } from './wordpress-fetch-network-transp
 
 export interface PHPWorkerGlobalScope extends WorkerGlobalScope {
 	setImmediate: (fn: () => void) => void;
-	clearImmediate: (id?: number) => void;
 }
 
 export interface MountDescriptor {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -49,10 +49,6 @@ import { networkingDisabledFunctions } from './disabled-functions';
 import playgroundWebMuPlugin from './playground-mu-plugin/0-playground.php?raw';
 import { WordPressFetchNetworkTransport } from './wordpress-fetch-network-transport';
 
-export interface PHPWorkerGlobalScope extends WorkerGlobalScope {
-	setImmediate: (fn: () => void) => void;
-}
-
 export interface MountDescriptor {
 	mountpoint: string;
 	device: MountDevice;


### PR DESCRIPTION
## Motivation for the change, related issues

Related issues : 

- https://github.com/WordPress/wordpress-playground/issues/2991
- https://github.com/WordPress/wordpress-playground/issues/3016

Emscripten checks for `globalThis.setImmediate` during initialization. If it is missing [ as in Web Workers ], Emscripten installs its own message-based polyfill, which attaches a global "message" event listener. That polyfill captures references to the current Wasm HEAP, preventing proper garbage collection when unloading or replacing a PHP instance.

Defining a lightweight `setImmediate` here forces Emscripten to skip its polyfill and avoids the memory leak.

## Implementation details

Implement this line in Playground Worker Endpoints :

```
(globalThis as PHPWorkerGlobalScope).setImmediate = (fn: () => void) =>
	setTimeout(fn, 0);
```

## Testing Instructions (or ideally a Blueprint)

Out of memory blueprint :

[Blueprint](https://playground.wordpress.net/?name=Blueprint+preview&blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fblueprints%2Ftrunk%2Fblueprints%2Fportfolio-vueo%2Fblueprint.json&random=5mpqw8db9ew)

Notice the 10+Gb usage in the Memory tab JavaScript VM instances 

Correct blueprint : 

1. Pull this branch
2. Run `npm run dev`
3. Go to the blueprint tab
4. Copy and paste the files from the Out of memory blueprint
5. Run blueprint

Notice the 3.5Gb usage in the Memory tab JavaScript VM instances.

After 30 seconds, notice the 2.4Gb usage in. the Memory tab Javascript VM instances, thanks to garbage collection.