### PR TITLE
[PHP web] Remove runtimes from internal map after initialization to prevent memory leaks

### DIFF
--- a/packages/php-wasm/node/src/test/php-file-locking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-file-locking.spec.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
-	getLoadedRuntime,
+	popLoadedRuntime,
 	PHP,
 	proxyFileSystem,
 	type SupportedPHPVersion,
@@ -1544,12 +1544,12 @@ error_log = ${errorLogPath}
 			const opts = {
 				emscriptenOptions: { ENV: { DOCROOT: '/wordpress' } },
 			};
-			const runtime1 = getLoadedRuntime(
+			const runtime1 = popLoadedRuntime(
 				await loadNodeRuntime('8.3', opts)
 			);
 			runtime1.FS.mkdir('/wordpress');
 
-			const runtime2 = getLoadedRuntime(
+			const runtime2 = popLoadedRuntime(
 				await loadNodeRuntime('8.3', opts)
 			);
 			runtime2.FS.mkdir('/wordpress');

--- a/packages/php-wasm/node/src/test/php-networking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-networking.spec.ts
@@ -2,7 +2,7 @@ import {
 	PHP,
 	SupportedPHPVersions,
 	setPhpIniEntries,
-	getLoadedRuntime,
+	popLoadedRuntime,
 	type SupportedPHPVersion,
 } from '@php-wasm/universal';
 import express from 'express';
@@ -344,7 +344,7 @@ describe.each(phpVersions)('PHP %s', (phpVersion) => {
 			it('should close server when runtime is exited', async () => {
 				const id = await loadNodeRuntime(phpVersion, options);
 				const php = new PHP(id);
-				const rt = getLoadedRuntime(id);
+				const rt = popLoadedRuntime(id);
 
 				expect(rt.outboundNetworkProxyServer).toBeDefined();
 				expect(rt.outboundNetworkProxyServer).toBeInstanceOf(

--- a/packages/php-wasm/node/src/test/php-networking.spec.ts
+++ b/packages/php-wasm/node/src/test/php-networking.spec.ts
@@ -343,8 +343,10 @@ describe.each(phpVersions)('PHP %s', (phpVersion) => {
 
 			it('should close server when runtime is exited', async () => {
 				const id = await loadNodeRuntime(phpVersion, options);
+				const rt = popLoadedRuntime(id, {
+					dangerouslyKeepTheRuntimeInTheMap: true,
+				});
 				const php = new PHP(id);
-				const rt = popLoadedRuntime(id);
 
 				expect(rt.outboundNetworkProxyServer).toBeDefined();
 				expect(rt.outboundNetworkProxyServer).toBeInstanceOf(

--- a/packages/php-wasm/node/vite.config.ts
+++ b/packages/php-wasm/node/vite.config.ts
@@ -84,6 +84,9 @@ export default defineConfig(function () {
 			cache: {
 				dir: '../../../node_modules/.vitest',
 			},
+			env: {
+				TEST: JSON.stringify(true),
+			},
 			poolOptions: {
 				// This is needed to allow `--expose-gc` to be passed to the
 				// forked test process.

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -53,7 +53,7 @@ export {
 export type { SupportedPHPVersion } from './supported-php-versions';
 export { PHP, __private__dont__use, PHPExecutionFailureError } from './php';
 export type { MountHandler, UnmountFunction } from './php';
-export { loadPHPRuntime, getLoadedRuntime } from './load-php-runtime';
+export { loadPHPRuntime, popLoadedRuntime } from './load-php-runtime';
 export type { Emscripten } from './emscripten-types';
 export type {
 	DataModule,

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -186,11 +186,54 @@ declare const WorkerGlobalScope: object | undefined;
 
 export type PHPRuntimeId = number;
 
-export function popLoadedRuntime(id: PHPRuntimeId): PHPRuntime {
+/**
+ * Retrieves a PHP runtime by its ID and removes it from the internal registry.
+ *
+ * When you call `loadPHPRuntime()`, it creates an Emscripten-based PHP instance and
+ * stores it in a module-level Map keyed by a numeric ID. This function is the only
+ * way to retrieve that runtime object so you can actually use it.
+ *
+ * The "pop" semantic is intentional: retrieving a runtime also removes it from the
+ * registry. This prevents memory leaks since the registry would otherwise hold
+ * references to every runtime ever created. Once you pop a runtime, you own it and
+ * are responsible for its lifecycle.
+ *
+ * Typical usage flow:
+ * ```ts
+ * // 1. Load a PHP runtime (returns just the ID)
+ * const runtimeId = await loadPHPRuntime(phpLoaderModule);
+ *
+ * // 2. Pop the runtime to get the actual Emscripten module
+ * const phpRuntime = popLoadedRuntime(runtimeId);
+ *
+ * // 3. Now you can use phpRuntime to run PHP code, access the filesystem, etc.
+ * ```
+ *
+ * @param id - The numeric ID returned by `loadPHPRuntime()`.
+ * @param options.dangerouslyKeepTheRuntimeInTheMap - Test-only escape hatch. When true,
+ *        retrieves the runtime without removing it from the registry. This violates
+ *        the function's contract and only works when `process.env.TEST` is set.
+ *        Never use this in production code.
+ * @returns The PHP runtime object (an Emscripten module instance).
+ * @throws If no runtime exists with the given ID.
+ */
+export function popLoadedRuntime(
+	id: PHPRuntimeId,
+	{
+		dangerouslyKeepTheRuntimeInTheMap = false,
+	}: { dangerouslyKeepTheRuntimeInTheMap?: boolean } = {}
+): PHPRuntime {
 	const runtime = loadedRuntimes.get(id);
 	if (!runtime) {
 		throw new Error(`Runtime with id ${id} not found`);
 	}
+	if (dangerouslyKeepTheRuntimeInTheMap) {
+		if (!process?.env?.['TEST']) {
+			throw new Error('Cannot pop runtime in non-test environment');
+		}
+		return runtime;
+	}
+
 	loadedRuntimes.delete(id);
 	return runtime;
 }

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -186,8 +186,13 @@ declare const WorkerGlobalScope: object | undefined;
 
 export type PHPRuntimeId = number;
 
-export function getLoadedRuntime(id: PHPRuntimeId): PHPRuntime {
-	return loadedRuntimes.get(id);
+export function popLoadedRuntime(id: PHPRuntimeId): PHPRuntime {
+	const runtime = loadedRuntimes.get(id);
+	if (!runtime) {
+		throw new Error(`Runtime with id ${id} not found`);
+	}
+	loadedRuntimes.delete(id);
+	return runtime;
 }
 
 export const currentJsRuntime = (function () {

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -10,7 +10,7 @@ import type { ListFilesOptions, RmDirOptions } from './fs-helpers';
 import { FSHelpers } from './fs-helpers';
 import { isExitCode } from './is-exit-code';
 import type { PHPRuntimeId } from './load-php-runtime';
-import { getLoadedRuntime } from './load-php-runtime';
+import { popLoadedRuntime } from './load-php-runtime';
 import type { PHPRequestHandler } from './php-request-handler';
 import { PHPResponse, StreamedPHPResponse } from './php-response';
 import type {
@@ -258,7 +258,7 @@ export class PHP implements Disposable {
 		if (this[__private__dont__use]) {
 			throw new Error('PHP runtime already initialized.');
 		}
-		const runtime = getLoadedRuntime(runtimeId);
+		const runtime = popLoadedRuntime(runtimeId);
 		if (!runtime) {
 			throw new Error('Invalid PHP runtime id.');
 		}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,123 +1,90 @@
 {
-  "compileOnSave": false,
-  "compilerOptions": {
-    "rootDir": ".",
-    "sourceMap": true,
-    "declaration": false,
-    "moduleResolution": "bundler",
-    "esModuleInterop": true,
-    "importHelpers": true,
-    "resolveJsonModule": true,
-    "jsx": "react",
-    "target": "ES2021",
-    "module": "esnext",
-    "lib": [
-      "ES2022",
-      "esnext.disposable",
-      "dom"
-    ],
-    "skipLibCheck": true,
-    "skipDefaultLibCheck": true,
-    "noPropertyAccessFromIndexSignature": false,
-    "baseUrl": ".",
-    "paths": {
-      "@php-wasm/cli": [
-        "packages/php-wasm/cli/src/main.ts"
-      ],
-      "@php-wasm/cli-util": [
-        "packages/php-wasm/cli-util/src/index.ts"
-      ],
-      "@php-wasm/fs-journal": [
-        "packages/php-wasm/fs-journal/src/index.ts"
-      ],
-      "@php-wasm/logger": [
-        "packages/php-wasm/logger/src/index.ts"
-      ],
-      "@php-wasm/node": [
-        "packages/php-wasm/node/src/index.ts"
-      ],
-      "@php-wasm/node-polyfills": [
-        "packages/php-wasm/node-polyfills/src/index.ts"
-      ],
-      "@php-wasm/private": [
-        "packages/php-wasm/private/src/index.ts"
-      ],
-      "@php-wasm/progress": [
-        "packages/php-wasm/progress/src/index.ts"
-      ],
-      "@php-wasm/scopes": [
-        "packages/php-wasm/scopes/src/index.ts"
-      ],
-      "@php-wasm/stream-compression": [
-        "packages/php-wasm/stream-compression/src/index.ts"
-      ],
-      "@php-wasm/universal": [
-        "packages/php-wasm/universal/src/index.ts"
-      ],
-      "@php-wasm/universal/mime-types": [
-        "packages/php-wasm/universal/src/lib/mime-types.json"
-      ],
-      "@php-wasm/util": [
-        "packages/php-wasm/util/src/index.ts"
-      ],
-      "@php-wasm/web": [
-        "packages/php-wasm/web/src/index.ts"
-      ],
-      "@php-wasm/web-service-worker": [
-        "packages/php-wasm/web-service-worker/src/index.ts"
-      ],
-      "@php-wasm/xdebug-bridge": [
-        "packages/php-wasm/xdebug-bridge/src/index.ts"
-      ],
-      "@wp-playground/blueprints": [
-        "packages/playground/blueprints/src/index.ts"
-      ],
-      "@wp-playground/cli": [
-        "packages/playground/cli/src/cli.ts"
-      ],
-      "@wp-playground/client": [
-        "packages/playground/client/src/index.ts"
-      ],
-      "@wp-playground/common": [
-        "packages/playground/common/src/index.ts"
-      ],
-      "@wp-playground/components": [
-        "packages/playground/components/src/index.ts"
-      ],
-      "@wp-playground/nx-extensions": [
-        "packages/nx-extensions/src/index.ts"
-      ],
-      "@wp-playground/remote": [
-        "packages/playground/remote/src/index.ts"
-      ],
-      "@wp-playground/storage": [
-        "packages/playground/storage/src/index.ts"
-      ],
-      "@wp-playground/sync": [
-        "packages/playground/sync/src/index.ts"
-      ],
-      "@wp-playground/unit-test-utils": [
-        "packages/playground/unit-test-utils/src/index.ts"
-      ],
-      "@wp-playground/website": [
-        "packages/playground/website/src/index.ts"
-      ],
-      "@wp-playground/website-extras": [
-        "packages/playground/website-extras/src/php-playground/main.tsx"
-      ],
-      "@wp-playground/wordpress": [
-        "packages/playground/wordpress/src/index.ts"
-      ],
-      "@wp-playground/wordpress-builds": [
-        "packages/playground/wordpress-builds/src/index.ts"
-      ],
-      "isomorphic-git": [
-        "./isomorphic-git"
-      ]
-    }
-  },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+	"compileOnSave": false,
+	"compilerOptions": {
+		"rootDir": ".",
+		"sourceMap": true,
+		"declaration": false,
+		"moduleResolution": "bundler",
+		"esModuleInterop": true,
+		"importHelpers": true,
+		"resolveJsonModule": true,
+		"jsx": "react",
+		"target": "ES2021",
+		"module": "esnext",
+		"lib": ["ES2022", "esnext.disposable", "dom"],
+		"skipLibCheck": true,
+		"skipDefaultLibCheck": true,
+		"noPropertyAccessFromIndexSignature": false,
+		"baseUrl": ".",
+		"paths": {
+			"@php-wasm/cli": ["packages/php-wasm/cli/src/main.ts"],
+			"@php-wasm/cli-util": ["packages/php-wasm/cli-util/src/index.ts"],
+			"@php-wasm/fs-journal": [
+				"packages/php-wasm/fs-journal/src/index.ts"
+			],
+			"@php-wasm/logger": ["packages/php-wasm/logger/src/index.ts"],
+			"@php-wasm/node": ["packages/php-wasm/node/src/index.ts"],
+			"@php-wasm/node-polyfills": [
+				"packages/php-wasm/node-polyfills/src/index.ts"
+			],
+			"@php-wasm/private": ["packages/php-wasm/private/src/index.ts"],
+			"@php-wasm/progress": ["packages/php-wasm/progress/src/index.ts"],
+			"@php-wasm/scopes": ["packages/php-wasm/scopes/src/index.ts"],
+			"@php-wasm/stream-compression": [
+				"packages/php-wasm/stream-compression/src/index.ts"
+			],
+			"@php-wasm/universal": ["packages/php-wasm/universal/src/index.ts"],
+			"@php-wasm/universal/mime-types": [
+				"packages/php-wasm/universal/src/lib/mime-types.json"
+			],
+			"@php-wasm/util": ["packages/php-wasm/util/src/index.ts"],
+			"@php-wasm/web": ["packages/php-wasm/web/src/index.ts"],
+			"@php-wasm/web-service-worker": [
+				"packages/php-wasm/web-service-worker/src/index.ts"
+			],
+			"@php-wasm/xdebug-bridge": [
+				"packages/php-wasm/xdebug-bridge/src/index.ts"
+			],
+			"@wp-playground/blueprints": [
+				"packages/playground/blueprints/src/index.ts"
+			],
+			"@wp-playground/cli": ["packages/playground/cli/src/cli.ts"],
+			"@wp-playground/client": [
+				"packages/playground/client/src/index.ts"
+			],
+			"@wp-playground/common": [
+				"packages/playground/common/src/index.ts"
+			],
+			"@wp-playground/components": [
+				"packages/playground/components/src/index.ts"
+			],
+			"@wp-playground/nx-extensions": [
+				"packages/nx-extensions/src/index.ts"
+			],
+			"@wp-playground/remote": [
+				"packages/playground/remote/src/index.ts"
+			],
+			"@wp-playground/storage": [
+				"packages/playground/storage/src/index.ts"
+			],
+			"@wp-playground/sync": ["packages/playground/sync/src/index.ts"],
+			"@wp-playground/unit-test-utils": [
+				"packages/playground/unit-test-utils/src/index.ts"
+			],
+			"@wp-playground/website": [
+				"packages/playground/website/src/index.ts"
+			],
+			"@wp-playground/website-extras": [
+				"packages/playground/website-extras/src/php-playground/main.tsx"
+			],
+			"@wp-playground/wordpress": [
+				"packages/playground/wordpress/src/index.ts"
+			],
+			"@wp-playground/wordpress-builds": [
+				"packages/playground/wordpress-builds/src/index.ts"
+			],
+			"isomorphic-git": ["./isomorphic-git"]
+		}
+	},
+	"exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## Summary

The `loadedRuntimes` map was holding references to PHP runtime objects indefinitely, even after they were consumed by a `PHP` instance. Since JavaScript's garbage collector can't reclaim objects that are still referenced, these runtime objects stayed in memory forever – a classic memory leak.

This commit renames `getLoadedRuntime` to `popLoadedRuntime` and changes its behavior to delete the entry from the map immediately after retrieval. Each runtime ID is only valid for a single use anyway – once a `PHP` instance takes ownership of a runtime, that ID should never be used again.

The new name reflects the semantics: you're not just "getting" a runtime, you're taking ownership and removing it from the pool.

## Test plan

- Existing tests updated to use `popLoadedRuntime`
- Run the full test suite to verify no regressions