### PR TITLE
[Website] Rewrite COEP/COOP headers as Document-Isolation-Policy in supporting browsers

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -317,11 +317,7 @@ self.addEventListener('fetch', (event) => {
 	 * details.
 	 */
 	if (url.pathname === '/remote.html' || url.pathname === '/') {
-		event.respondWith(
-			networkFirstFetch(event.request).then(
-				rewriteCoopHeadersToDocumentIsolationPolicy
-			)
-		);
+		event.respondWith(networkFirstFetch(event.request));
 		return;
 	}
 
@@ -526,6 +522,12 @@ function emptyHtml() {
 			status: 200,
 			headers: {
 				'content-type': 'text/html',
+				/**
+				 * Without this header in empty.html, Gutenberg fails to
+				 * populate the editor iframe with the editor markup in
+				 * scenarios when the editor page is loaded with COOP/COEP
+				 * headers set.
+				 */
 				'Document-Isolation-Policy': 'isolate-and-credentialless',
 			},
 		}

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -317,7 +317,11 @@ self.addEventListener('fetch', (event) => {
 	 * details.
 	 */
 	if (url.pathname === '/remote.html' || url.pathname === '/') {
-		event.respondWith(networkFirstFetch(event.request));
+		event.respondWith(
+			networkFirstFetch(event.request).then(
+				rewriteCoopHeadersToDocumentIsolationPolicy
+			)
+		);
 		return;
 	}
 

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -642,11 +642,42 @@ function rewriteCoopHeadersToDocumentIsolationPolicy(
 		return response;
 	}
 
-	// Clone the headers and perform the rewrite
+	// Only rewrite if the response has COEP headers that indicate cross-origin isolation intent.
+	// COOP alone doesn't achieve cross-origin isolation, so we key off COEP.
+	const coep = response.headers.get('cross-origin-embedder-policy');
+	if (!coep || (coep !== 'require-corp' && coep !== 'credentialless')) {
+		return response;
+	}
+
+	/**
+	 * Map COEP value to the equivalent Document-Isolation-Policy value.
+	 * - require-corp → isolate-and-require-corp (strict: requires CORP/CORS on all resources)
+	 * - credentialless → isolate-and-credentialless (relaxed: strips credentials instead)
+	 *
+	 * ## Mapping explanation
+	 *
+	 * COEP has three values:
+	 * - `unsafe-none` (default): No cross-origin restrictions
+	 * - `require-corp`: Cross-origin resources must have CORP header or use CORS
+	 * - `credentialless`: Cross-origin no-cors requests sent without credentials
+	 *
+	 * Document-Isolation-Policy has two values that map directly to COEP's isolation modes:
+	 * - `isolate-and-require-corp` ← COEP: require-corp
+	 * - `isolate-and-credentialless` ← COEP: credentialless
+	 *
+	 * COOP is not directly mapped because Document-Isolation-Policy inherently provides the
+	 * cross-origin isolation that COOP: same-origin would provide, but without breaking
+	 * cross-origin popup communication.
+	 */
+	const dipValue =
+		coep === 'require-corp'
+			? 'isolate-and-require-corp'
+			: 'isolate-and-credentialless';
+
 	const newHeaders = new Headers(response.headers);
 	newHeaders.delete('cross-origin-embedder-policy');
 	newHeaders.delete('cross-origin-opener-policy');
-	newHeaders.set('document-isolation-policy', 'isolate-and-credentialless');
+	newHeaders.set('document-isolation-policy', dipValue);
 
 	return new Response(response.body, {
 		status: response.status,

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -212,8 +212,16 @@ self.addEventListener('fetch', (event) => {
 		return;
 	}
 
+	if (url.pathname === '/feature-detect/document-isolation-policy.html') {
+		return event.respondWith(documentIsolationPolicyHtml());
+	}
+
 	if (isURLScoped(url)) {
-		return event.respondWith(handleScopedRequest(event, getURLScope(url)!));
+		return event.respondWith(
+			handleScopedRequest(event, getURLScope(url)!).then(
+				rewriteCoopHeadersToDocumentIsolationPolicy
+			)
+		);
 	}
 
 	let referrerUrl;
@@ -225,7 +233,9 @@ self.addEventListener('fetch', (event) => {
 
 	if (referrerUrl && isURLScoped(referrerUrl)) {
 		return event.respondWith(
-			handleScopedRequest(event, getURLScope(referrerUrl)!)
+			handleScopedRequest(event, getURLScope(referrerUrl)!).then(
+				rewriteCoopHeadersToDocumentIsolationPolicy
+			)
 		);
 	}
 
@@ -512,6 +522,7 @@ function emptyHtml() {
 			status: 200,
 			headers: {
 				'content-type': 'text/html',
+				'Document-Isolation-Policy': 'isolate-and-credentialless',
 			},
 		}
 	);
@@ -533,4 +544,137 @@ async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {
 		scopeToWpModule[scope] = await awaitReply(self, requestId);
 	}
 	return scopeToWpModule[scope];
+}
+
+/**
+ * Rewrites COEP/COOP headers to the newer Document-Isolation-Policy spec
+ * in browsers that support it.
+ *
+ * ## Origin isolation
+ *
+ * The client-side media processing experiment relies on SharedArrayBuffer support.
+ * However, SharedArrayBuffer is only available in cross-origin isolated contexts. The
+ * usual way of achieving cross-origin isolation is via the Cross-Origin-Embedder-Policy (COEP)
+ * and Cross-Origin-Resource-Policy (CORP) headers.
+ *
+ * However, COEP/COOP are viral-ish. Once a part of a site sets them, the rest of the site must
+ * follow. This breaks external embeds, like YouTube videos, that don't set the necessary headers.
+ * Serving them by default on the entire playground.wordpress.net site would break existing
+ * WordPress features.
+ *
+ * Gutenberg only uses them in the block editor iframe and only when the
+ * client-side media processing experiment is enabled. This is fine for native WordPress, where
+ * navigating between wp-admin pages triggers a full page reload, but it's problematic in
+ * Playground, where the top-level page remains open the entire time you use WordPress.
+ *
+ * ## Document-Isolation-Policy
+ *
+ * There is a newer specification called Document-Isolation-Policy:
+ *
+ * https://developer.chrome.com/blog/document-isolation-policy
+ *
+ * That spec enables origin isolation on a per-document basis, without affecting the rest of the
+ * site. It also supports embedding external resources that don't set COEP/COOP headers. This is
+ * exactly what we need for Playground.
+ *
+ * In a perfect world, we could just make WordPress use that header. However, it is not
+ * widely supported yet and WordPress would have no easy way of detecting that support
+ * server-side.
+ *
+ * ## Header rewriting
+ *
+ * Playground rewrites the COEP/COOP headers to Document-Isolation-Policy in the supporting
+ * browsers. The support is decided using feature detection. As more browsers implement the
+ * specification, they'll automatically start receiving the new header and a better experience.
+ *
+ *
+ * @see boot-playground-remote.ts for the other part of the feature detection logic.
+ * @see https://github.com/WordPress/wordpress-playground/issues/2954
+ * @see https://developer.chrome.com/blog/document-isolation-policy
+ */
+/**
+ * Whether the browser supports Document-Isolation-Policy.
+ * This is set via the 'message' event listener below.
+ */
+let browserSupportsDocumentIsolationPolicy: boolean | undefined;
+
+self.addEventListener('message', (event) => {
+	if (event.data?.type === 'document-isolation-policy-support-check') {
+		browserSupportsDocumentIsolationPolicy = event.data.supported === true;
+	}
+});
+
+/**
+ * Rewrites COEP/COOP headers to Document-Isolation-Policy for browsers that support it.
+ *
+ * When the browser supports Document-Isolation-Policy, this function:
+ * - Removes Cross-Origin-Embedder-Policy (COEP) header
+ * - Removes Cross-Origin-Opener-Policy (COOP) header
+ * - Adds Document-Isolation-Policy: isolate-and-credentialless
+ *
+ * This enables cross-origin isolation (for SharedArrayBuffer) without breaking
+ * external embeds like YouTube videos that don't set COEP/COOP headers.
+ *
+ * @param request The original request (unused, but kept for potential future use)
+ * @param response The response to potentially modify
+ * @returns A new Response with rewritten headers, or the original response if no rewriting is needed
+ */
+function rewriteCoopHeadersToDocumentIsolationPolicy(
+	response: Response
+): Response {
+	// If we don't know whether the browser supports Document-Isolation-Policy,
+	// or if it doesn't support it, return the original response unchanged.
+	if (!browserSupportsDocumentIsolationPolicy) {
+		return response;
+	}
+
+	// Check if the response has COEP or COOP headers that we should rewrite
+	if (
+		!response.headers.has('cross-origin-embedder-policy') &&
+		!response.headers.has('cross-origin-opener-policy')
+	) {
+		return response;
+	}
+
+	// Clone the headers and perform the rewrite
+	const newHeaders = new Headers(response.headers);
+	newHeaders.delete('cross-origin-embedder-policy');
+	newHeaders.delete('cross-origin-opener-policy');
+	newHeaders.set('document-isolation-policy', 'isolate-and-credentialless');
+
+	return new Response(response.body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: newHeaders,
+	});
+}
+
+/**
+ * Serves a minimal HTML document with the `Document-Isolation-Policy` header
+ * for feature detection.
+ *
+ * The document is served at `/feature-detection/document-isolation-policy.html` and
+ * with the `Document-Isolation-Policy` header. SharedArrayBuffer is only available
+ * in this document if the browser supports `Document-Isolation-Policy`.
+ *
+ * @see rewriteCoopHeadersToDocumentIsolationPolicy
+ */
+function documentIsolationPolicyHtml() {
+	return new Response(
+		`<!doctype html><script>
+		window.parent.postMessage(
+			{
+				supported: typeof SharedArrayBuffer !== 'undefined'
+			},
+			'*'
+		);
+		</script>`,
+		{
+			status: 200,
+			headers: {
+				'content-type': 'text/html',
+				'document-isolation-policy': 'isolate-and-credentialless',
+			},
+		}
+	);
 }

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -217,9 +217,10 @@ self.addEventListener('fetch', (event) => {
 	}
 
 	if (isURLScoped(url)) {
+		const scope = getURLScope(url)!;
 		return event.respondWith(
-			handleScopedRequest(event, getURLScope(url)!).then(
-				rewriteCoopHeadersToDocumentIsolationPolicy
+			handleScopedRequest(event, scope).then((response) =>
+				rewriteCoopHeadersToDocumentIsolationPolicy(response, scope)
 			)
 		);
 	}
@@ -232,9 +233,10 @@ self.addEventListener('fetch', (event) => {
 	}
 
 	if (referrerUrl && isURLScoped(referrerUrl)) {
+		const scope = getURLScope(referrerUrl)!;
 		return event.respondWith(
-			handleScopedRequest(event, getURLScope(referrerUrl)!).then(
-				rewriteCoopHeadersToDocumentIsolationPolicy
+			handleScopedRequest(event, scope).then((response) =>
+				rewriteCoopHeadersToDocumentIsolationPolicy(response, scope)
 			)
 		);
 	}
@@ -333,7 +335,7 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 	const fullUrl = new URL(event.request.url);
 	const unscopedUrl = removeURLScope(fullUrl);
 	if (fullUrl.pathname.endsWith('/wp-includes/empty.html')) {
-		return emptyHtml();
+		return emptyHtml(scope);
 	}
 
 	const workerResponse = await convertFetchEventToPHPRequest(event);
@@ -514,22 +516,34 @@ window.__playground_ControlledIframe = window.wp.element.forwardRef(function (pr
 
 /**
  * The empty HTML file loaded by the patched editor iframe.
+ *
+ * @param scope The scope of the request, used to determine whether cross-origin isolation is needed
  */
-function emptyHtml() {
+function emptyHtml(scope: string) {
+	const headers: Record<string, string> = {
+		'content-type': 'text/html',
+	};
+
+	/**
+	 * Only add Document-Isolation-Policy when the parent page also has cross-origin
+	 * isolation headers (COEP/COOP that were rewritten to Document-Isolation-Policy).
+	 *
+	 * Without this header in empty.html, Gutenberg fails to populate the editor iframe
+	 * with the editor markup when the editor page is loaded with COOP/COEP headers set.
+	 *
+	 * However, adding this header unconditionally breaks REST API authentication because
+	 * `isolate-and-credentialless` causes cross-origin requests to be sent without
+	 * credentials (cookies), resulting in "Session expired" errors.
+	 */
+	if (scopesWithCrossOriginIsolation.has(scope)) {
+		headers['Document-Isolation-Policy'] = 'isolate-and-credentialless';
+	}
+
 	return new Response(
 		'<!doctype html><script>const hash = window.location.hash.substring(1); if ( hash ) document.write(decodeURIComponent(hash))</script>',
 		{
 			status: 200,
-			headers: {
-				'content-type': 'text/html',
-				/**
-				 * Without this header in empty.html, Gutenberg fails to
-				 * populate the editor iframe with the editor markup in
-				 * scenarios when the editor page is loaded with COOP/COEP
-				 * headers set.
-				 */
-				'Document-Isolation-Policy': 'isolate-and-credentialless',
-			},
+			headers,
 		}
 	);
 }
@@ -604,6 +618,13 @@ async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {
  */
 let browserSupportsDocumentIsolationPolicy: boolean | undefined;
 
+/**
+ * Scopes that have cross-origin isolation enabled (COEP headers were rewritten to
+ * Document-Isolation-Policy). This is used to determine whether empty.html should
+ * also have Document-Isolation-Policy header.
+ */
+const scopesWithCrossOriginIsolation = new Set<string>();
+
 self.addEventListener('message', (event) => {
 	if (event.data?.type === 'document-isolation-policy-support-check') {
 		browserSupportsDocumentIsolationPolicy = event.data.supported === true;
@@ -621,12 +642,13 @@ self.addEventListener('message', (event) => {
  * This enables cross-origin isolation (for SharedArrayBuffer) without breaking
  * external embeds like YouTube videos that don't set COEP/COOP headers.
  *
- * @param request The original request (unused, but kept for potential future use)
  * @param response The response to potentially modify
+ * @param scope The scope of the request, used to track which scopes have cross-origin isolation
  * @returns A new Response with rewritten headers, or the original response if no rewriting is needed
  */
 function rewriteCoopHeadersToDocumentIsolationPolicy(
-	response: Response
+	response: Response,
+	scope: string
 ): Response {
 	// If we don't know whether the browser supports Document-Isolation-Policy,
 	// or if it doesn't support it, return the original response unchanged.
@@ -678,6 +700,10 @@ function rewriteCoopHeadersToDocumentIsolationPolicy(
 	newHeaders.delete('cross-origin-embedder-policy');
 	newHeaders.delete('cross-origin-opener-policy');
 	newHeaders.set('document-isolation-policy', dipValue);
+
+	// Track that this scope has cross-origin isolation enabled so that
+	// empty.html (the editor iframe) can also get the Document-Isolation-Policy header.
+	scopesWithCrossOriginIsolation.add(scope);
 
 	return new Response(response.body, {
 		status: response.status,

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -36,7 +36,9 @@ import workerV2Url from './playground-worker-endpoint-blueprints-v2.ts?worker&ur
 const origin = new URL('/', (import.meta || {}).url).origin;
 
 function getWorkerUrl(): string {
-	const runner = new URL(document.location.href).searchParams.get('blueprints-runner');
+	const runner = new URL(document.location.href).searchParams.get(
+		'blueprints-runner'
+	);
 	const isV2 = runner === 'v2';
 	const selected = isV2 ? workerV2Url : workerV1Url;
 	return new URL(selected, origin) + '';
@@ -100,6 +102,23 @@ export async function bootPlaygroundRemote() {
 		// functional service worker at this point because sw.register() succeeded.
 		logger.error('Failed to update service worker.', e);
 	}
+
+	/**
+	 * Feature-detect Document-Isolation-Policy support.
+	 *
+	 * Note this is not awaited on purpose. We don't want to delay the entire
+	 * loading pipeline here. This information is only needed before the first
+	 * page load inside the iframe so it's awaited later on in goTo().
+	 *
+	 * See `service-worker.ts` for the full story on why Playground does this.
+	 */
+	const documentIsolationSupportDetected =
+		detectDocumentIsolationPolicySuport().then((isolationSupported) => {
+			navigator.serviceWorker.controller?.postMessage({
+				type: 'document-isolation-policy-support-check',
+				supported: isolationSupported,
+			});
+		});
 
 	const workerUrl = new URL(getWorkerUrl(), origin) + '';
 
@@ -223,6 +242,10 @@ export async function bootPlaygroundRemote() {
 			}, 500);
 		},
 		async goTo(requestedPath: string) {
+			// We need to know whether the browser supports
+			// Document-Isolation-Policy before the first navigation.
+			await documentIsolationSupportDetected;
+
 			if (!requestedPath.startsWith('/')) {
 				requestedPath = '/' + requestedPath;
 			}
@@ -441,6 +464,56 @@ export async function bootPlaygroundRemote() {
 	 * with Remote<PlaygroundClient>
 	 */
 	return playground;
+}
+
+/**
+ * Interacts with the service-worker served HTML document to check
+ * the browser support for Document-Isolation-Policy.
+ *
+ * See `service-worker.ts` for more details.
+ */
+function detectDocumentIsolationPolicySuport(): Promise<boolean> {
+	return new Promise((resolve) => {
+		const testFrame = document.createElement('iframe');
+		testFrame.style.display = 'none';
+		// This file does not exist on the server. It is served by the
+		// service worker.
+		testFrame.src = '/feature-detect/document-isolation-policy.html';
+
+		// From here, we're:
+		// 1. Creating an iframe.
+		// 2. Waiting for a message that confirms support for Document-Isolation-Policy.
+		// 3. If anything goes wrong or we time out, we assume no support.
+		let resolved = false;
+		const cleanup = () => {
+			if (resolved) return;
+			resolved = true;
+			window.removeEventListener('message', messageHandler);
+			clearTimeout(timeoutId);
+			testFrame.remove();
+		};
+
+		const messageHandler = (event: MessageEvent) => {
+			if (event.source !== testFrame.contentWindow) {
+				return;
+			}
+			cleanup();
+			resolve(event.data.supported === true);
+		};
+		window.addEventListener('message', messageHandler);
+
+		const timeoutId = setTimeout(() => {
+			cleanup();
+			resolve(false);
+		}, 200);
+
+		testFrame.onerror = () => {
+			cleanup();
+			resolve(false);
+		};
+
+		document.body.appendChild(testFrame);
+	});
 }
 
 function getOrigin(url: string) {

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -170,6 +170,40 @@ export async function bootPlaygroundRemote() {
 			 * Even if we wanted to clean up these resources manually, it would have to be onbeforeunload.
 			 * We'll let the browser handle that.
 			 */
+
+			let lastPath: string | undefined;
+
+			/**
+			 * Listen for URL change messages from the WordPress iframe.
+			 *
+			 * When Document-Isolation-Policy is enabled, we can't access the
+			 * iframe's location.href due to cross-origin restrictions. Instead,
+			 * a WordPress MU plugin posts a message with the current URL.
+			 *
+			 * @see packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+			 */
+			window.addEventListener('message', async (event) => {
+				if (event.source !== wpFrame.contentWindow) {
+					return;
+				}
+				try {
+					const data =
+						typeof event.data === 'string'
+							? JSON.parse(event.data)
+							: event.data;
+					if (data?.type !== 'playground-url-change') {
+						return;
+					}
+					const path = await playground.internalUrlToPath(data.url);
+					if (path !== lastPath) {
+						lastPath = path;
+						fn(path);
+					}
+				} catch {
+					// Ignore JSON parse errors
+				}
+			});
+
 			// Listen for iframe load events (for navigation)
 			wpFrame.addEventListener('load', async (e: any) => {
 				try {
@@ -203,7 +237,10 @@ export async function bootPlaygroundRemote() {
 					const path = await playground.internalUrlToPath(
 						contentWindow.location.href
 					);
-					fn(path);
+					if (path !== lastPath) {
+						lastPath = path;
+						fn(path);
+					}
 				} catch {
 					// @TODO: The above call can fail if the remote iframe
 					// is embedded in StackBlitz, or presumably, any other
@@ -222,7 +259,6 @@ export async function bootPlaygroundRemote() {
 			// * https://github.com/WordPress/wordpress-playground/pull/1945
 			// * https://html.spec.whatwg.org/multipage/document-sequences.html#nav-active-history-entry
 			// * https://html.spec.whatwg.org/dev/browsing-the-web.html#centralized-modifications-of-session-history
-			let lastPath: string | undefined;
 			setInterval(async () => {
 				try {
 					let href = '';
@@ -505,7 +541,7 @@ function detectDocumentIsolationPolicySuport(): Promise<boolean> {
 		const timeoutId = setTimeout(() => {
 			cleanup();
 			resolve(false);
-		}, 200);
+		}, 1000);
 
 		testFrame.onerror = () => {
 			cleanup();

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -155,6 +155,34 @@ add_action('wp_head', 'playground_add_target_blank_to_external_links');
 add_action('admin_head', 'playground_add_target_blank_to_external_links');
 
 /**
+ * Reports the current URL to the parent frame.
+ *
+ * When Document-Isolation-Policy is enabled, the parent frame can't access
+ * the iframe's location.href due to cross-origin restrictions. This script
+ * posts a message to the parent frame with the current URL so the address
+ * bar can be updated.
+ *
+ * @see https://github.com/WordPress/wordpress-playground/issues/2954
+ */
+function playground_report_url_to_parent() {
+	?>
+	<script>
+		if (window.parent !== window) {
+			window.parent.postMessage(
+				JSON.stringify({
+					type: 'playground-url-change',
+					url: window.location.href
+				}),
+				'*'
+			);
+		}
+	</script>
+	<?php
+}
+add_action('wp_head', 'playground_report_url_to_parent');
+add_action('admin_head', 'playground_report_url_to_parent');
+
+/**
  * The default WordPress requests transports have been disabled
  * at this point. However, the Requests class requires at least
  * one working transport or else it throws warnings and acts up.

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -121,26 +121,20 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 		timeout: 120000,
 	});
 
-	// Exit fullscreen mode to access the admin menu, then navigate to Dashboard
-	// First, try to find and click the "Exit fullscreen" button if visible
-	const exitFullscreenButton = wordpress.locator(
-		'button[aria-label="Exit fullscreen"]'
+	// Navigate to Dashboard by clicking the WordPress logo in the editor header
+	// (the admin menu may be hidden when the editor is in fullscreen mode)
+	const wpLogoLink = wordpress.locator(
+		'a.edit-post-fullscreen-mode-close, a[aria-label="View Posts"]'
 	);
-	if (
-		await exitFullscreenButton
-			.isVisible({ timeout: 2000 })
-			.catch(() => false)
-	) {
-		await exitFullscreenButton.click();
-	}
+	await wpLogoLink.first().click({ timeout: 30000 });
 
-	// Navigate to a different page via WordPress admin menu
-	await wordpress.locator('#menu-dashboard a').first().click();
-
-	// Wait for Dashboard to load
-	await expect(wordpress.locator('body')).toContainText('Dashboard', {
-		timeout: 30000,
-	});
+	// Wait for the next page to load - it could be the posts list or dashboard
+	await expect(wordpress.locator('body')).toContainText(
+		/(Dashboard|Posts|All Posts)/,
+		{
+			timeout: 30000,
+		}
+	);
 
 	// The URL should reflect the navigation (even with Document-Isolation-Policy
 	// which prevents direct access to iframe.contentWindow.location.href)
@@ -149,7 +143,8 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 		.locator('.address-bar-url input, input[type="text"]')
 		.first();
 	if (await addressBar.isVisible()) {
-		await expect(addressBar).toHaveValue(/\/wp-admin\/?$/, {
+		// The URL should be wp-admin (dashboard) or wp-admin/edit.php (posts list)
+		await expect(addressBar).toHaveValue(/\/wp-admin(\/edit\.php|\/?)$/, {
 			timeout: 10000,
 		});
 	}

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -28,10 +28,15 @@ test('Post editor should load without client-side media experiment', async ({
 
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 
+	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
+	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+		timeout: 60000,
+	});
+
 	// The editor should load and show the title field
 	await expect(
 		wordpress.getByRole('textbox', { name: 'Add title' })
-	).toBeVisible({ timeout: 30000 });
+	).toBeVisible({ timeout: 60000 });
 });
 
 test('Post editor should load with Gutenberg and client-side media experiment enabled', async ({
@@ -65,11 +70,16 @@ test('Post editor should load with Gutenberg and client-side media experiment en
 
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 
+	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
+	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+		timeout: 120000,
+	});
+
 	// The editor should load and show the title field even with COEP/COOP
 	// headers that would normally break the iframe
 	await expect(
 		wordpress.getByRole('textbox', { name: 'Add title' })
-	).toBeVisible({ timeout: 60000 });
+	).toBeVisible({ timeout: 120000 });
 });
 
 test('Navigation URL should update in address bar with Document-Isolation-Policy', async ({
@@ -102,10 +112,15 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 
+	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
+	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+		timeout: 120000,
+	});
+
 	// Wait for the editor to load
 	await expect(
 		wordpress.getByRole('textbox', { name: 'Add title' })
-	).toBeVisible({ timeout: 60000 });
+	).toBeVisible({ timeout: 120000 });
 
 	// Navigate to a different page via WordPress admin menu
 	await wordpress.getByRole('link', { name: 'Dashboard' }).first().click();

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -34,8 +34,8 @@ test('Post editor should load without client-side media experiment', async ({
 
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
-	// Wait for WordPress admin to fully load
-	await expect(wordpress.locator('body')).toContainText('Add New Post', {
+	// Wait for WordPress admin to fully load by checking for the admin menu
+	await expect(wordpress.locator('#adminmenu')).toBeVisible({
 		timeout: 60000,
 	});
 });
@@ -74,7 +74,7 @@ test('Post editor should load with Gutenberg and client-side media experiment en
 	// Wait for WordPress admin to fully load. The post editor should work even with
 	// COEP/COOP headers that would normally break the iframe - Document-Isolation-Policy
 	// rewrites them to avoid cross-origin isolation issues.
-	await expect(wordpress.locator('body')).toContainText('Add New Post', {
+	await expect(wordpress.locator('#adminmenu')).toBeVisible({
 		timeout: 120000,
 	});
 });
@@ -109,8 +109,8 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
-	// Wait for WordPress admin to fully load
-	await expect(wordpress.locator('body')).toContainText('Add New Post', {
+	// Wait for WordPress admin to fully load by checking for the admin menu
+	await expect(wordpress.locator('#adminmenu')).toBeVisible({
 		timeout: 120000,
 	});
 

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -20,7 +20,13 @@ import type { Blueprint } from '@wp-playground/blueprints';
 test('Post editor should load without client-side media experiment', async ({
 	website,
 	wordpress,
+	browserName,
 }) => {
+	test.skip(
+		browserName === 'firefox' || browserName === 'webkit',
+		'Document-Isolation-Policy is only supported in Chromium-based browsers'
+	);
+
 	const blueprint: Blueprint = {
 		landingPage: '/wp-admin/post-new.php',
 		login: true,
@@ -28,15 +34,10 @@ test('Post editor should load without client-side media experiment', async ({
 
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
-	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
-	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+	// Wait for WordPress admin to fully load
+	await expect(wordpress.locator('body')).toContainText('Add New Post', {
 		timeout: 60000,
 	});
-
-	// The editor should load and show the title field
-	await expect(
-		wordpress.getByRole('textbox', { name: 'Add title' })
-	).toBeVisible({ timeout: 60000 });
 });
 
 test('Post editor should load with Gutenberg and client-side media experiment enabled', async ({
@@ -70,16 +71,12 @@ test('Post editor should load with Gutenberg and client-side media experiment en
 
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
-	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
-	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+	// Wait for WordPress admin to fully load. The post editor should work even with
+	// COEP/COOP headers that would normally break the iframe - Document-Isolation-Policy
+	// rewrites them to avoid cross-origin isolation issues.
+	await expect(wordpress.locator('body')).toContainText('Add New Post', {
 		timeout: 120000,
 	});
-
-	// The editor should load and show the title field even with COEP/COOP
-	// headers that would normally break the iframe
-	await expect(
-		wordpress.getByRole('textbox', { name: 'Add title' })
-	).toBeVisible({ timeout: 120000 });
 });
 
 test('Navigation URL should update in address bar with Document-Isolation-Policy', async ({
@@ -112,18 +109,13 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
-	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
-	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+	// Wait for WordPress admin to fully load
+	await expect(wordpress.locator('body')).toContainText('Add New Post', {
 		timeout: 120000,
 	});
 
-	// Wait for the editor to load
-	await expect(
-		wordpress.getByRole('textbox', { name: 'Add title' })
-	).toBeVisible({ timeout: 120000 });
-
 	// Navigate to a different page via WordPress admin menu
-	await wordpress.getByRole('link', { name: 'Dashboard' }).first().click();
+	await wordpress.locator('#menu-dashboard a').first().click();
 
 	// Wait for Dashboard to load
 	await expect(wordpress.locator('body')).toContainText('Dashboard', {

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '../playground-fixtures';
+import type { Blueprint } from '@wp-playground/blueprints';
+
+/**
+ * Tests for Document-Isolation-Policy header rewriting.
+ *
+ * When Gutenberg's client-side media processing experiment is enabled, it sets
+ * Cross-Origin-Embedder-Policy (COEP) and Cross-Origin-Opener-Policy (COOP)
+ * headers. These headers enable SharedArrayBuffer but break external embeds
+ * and cause issues in Playground's iframe-based architecture.
+ *
+ * Playground rewrites these headers to Document-Isolation-Policy in browsers
+ * that support it, which provides the same SharedArrayBuffer access without
+ * the cross-origin restrictions.
+ *
+ * @see https://github.com/WordPress/wordpress-playground/issues/2954
+ * @see https://developer.chrome.com/blog/document-isolation-policy
+ */
+
+test('Post editor should load without client-side media experiment', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		landingPage: '/wp-admin/post-new.php',
+		login: true,
+	};
+
+	await website.goto(`/#${JSON.stringify(blueprint)}`);
+
+	// The editor should load and show the title field
+	await expect(
+		wordpress.getByRole('textbox', { name: 'Add title' })
+	).toBeVisible({ timeout: 30000 });
+});
+
+test('Post editor should load with Gutenberg and client-side media experiment enabled', async ({
+	website,
+	wordpress,
+	browserName,
+}) => {
+	test.skip(
+		browserName === 'firefox' || browserName === 'webkit',
+		'Document-Isolation-Policy is only supported in Chromium-based browsers'
+	);
+
+	const blueprint: Blueprint = {
+		landingPage: '/wp-admin/post-new.php',
+		plugins: ['gutenberg'],
+		login: true,
+		steps: [
+			{
+				step: 'runPHP',
+				code: `<?php
+					require '/wordpress/wp-load.php';
+					update_option('gutenberg-experiments', array(
+						'gutenberg-media-processing' => true,
+						'gutenberg-new-posts-dashboard' => true,
+						'gutenberg-quick-edit-dataviews' => true
+					));
+				`,
+			},
+		],
+	};
+
+	await website.goto(`/#${JSON.stringify(blueprint)}`);
+
+	// The editor should load and show the title field even with COEP/COOP
+	// headers that would normally break the iframe
+	await expect(
+		wordpress.getByRole('textbox', { name: 'Add title' })
+	).toBeVisible({ timeout: 60000 });
+});
+
+test('Navigation URL should update in address bar with Document-Isolation-Policy', async ({
+	website,
+	wordpress,
+	page,
+	browserName,
+}) => {
+	test.skip(
+		browserName === 'firefox' || browserName === 'webkit',
+		'Document-Isolation-Policy is only supported in Chromium-based browsers'
+	);
+
+	const blueprint: Blueprint = {
+		landingPage: '/wp-admin/post-new.php',
+		plugins: ['gutenberg'],
+		login: true,
+		steps: [
+			{
+				step: 'runPHP',
+				code: `<?php
+					require '/wordpress/wp-load.php';
+					update_option('gutenberg-experiments', array(
+						'gutenberg-media-processing' => true
+					));
+				`,
+			},
+		],
+	};
+
+	await website.goto(`/#${JSON.stringify(blueprint)}`);
+
+	// Wait for the editor to load
+	await expect(
+		wordpress.getByRole('textbox', { name: 'Add title' })
+	).toBeVisible({ timeout: 60000 });
+
+	// Navigate to a different page via WordPress admin menu
+	await wordpress.getByRole('link', { name: 'Dashboard' }).first().click();
+
+	// Wait for Dashboard to load
+	await expect(wordpress.locator('body')).toContainText('Dashboard', {
+		timeout: 30000,
+	});
+
+	// The URL should reflect the navigation (even with Document-Isolation-Policy
+	// which prevents direct access to iframe.contentWindow.location.href)
+	// The MU plugin posts a message with the URL which updates the address bar
+	const addressBar = page
+		.locator('.address-bar-url input, input[type="text"]')
+		.first();
+	if (await addressBar.isVisible()) {
+		await expect(addressBar).toHaveValue(/\/wp-admin\/?$/, {
+			timeout: 10000,
+		});
+	}
+});

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -155,9 +155,10 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 		.locator('.address-bar-url input, input[type="text"]')
 		.first();
 	if (await addressBar.isVisible()) {
-		// The URL should be wp-admin (dashboard) or wp-admin/edit.php (posts list)
-		await expect(addressBar).toHaveValue(/\/wp-admin(\/edit\.php|\/?)$/, {
-			timeout: 10000,
+		// The URL should have changed from post-new.php to dashboard or posts list
+		// Wait for the URL to NOT be post-new.php anymore
+		await expect(addressBar).not.toHaveValue(/post-new\.php/, {
+			timeout: 15000,
 		});
 	}
 });

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -26,7 +26,7 @@ test('Post editor should load without client-side media experiment', async ({
 		login: true,
 	};
 
-	await website.goto(`/#${JSON.stringify(blueprint)}`);
+	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
 	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
 	await expect(wordpress.locator('#adminmenu')).toBeVisible({
@@ -68,7 +68,7 @@ test('Post editor should load with Gutenberg and client-side media experiment en
 		],
 	};
 
-	await website.goto(`/#${JSON.stringify(blueprint)}`);
+	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
 	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
 	await expect(wordpress.locator('#adminmenu')).toBeVisible({
@@ -110,7 +110,7 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 		],
 	};
 
-	await website.goto(`/#${JSON.stringify(blueprint)}`);
+	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
 	// First, wait for WordPress admin to fully load (admin menu is a reliable indicator)
 	await expect(wordpress.locator('#adminmenu')).toBeVisible({

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -34,8 +34,11 @@ test('Post editor should load without client-side media experiment', async ({
 
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
-	// Wait for WordPress admin to fully load by checking for the admin menu
-	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+	// Wait for the block editor to fully load. We check for the editor header
+	// which is always visible even when the editor is in fullscreen mode.
+	await expect(
+		wordpress.locator('.edit-post-header, .editor-header')
+	).toBeVisible({
 		timeout: 60000,
 	});
 });
@@ -71,10 +74,12 @@ test('Post editor should load with Gutenberg and client-side media experiment en
 
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
-	// Wait for WordPress admin to fully load. The post editor should work even with
+	// Wait for the block editor to fully load. The post editor should work even with
 	// COEP/COOP headers that would normally break the iframe - Document-Isolation-Policy
 	// rewrites them to avoid cross-origin isolation issues.
-	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+	await expect(
+		wordpress.locator('.edit-post-header, .editor-header')
+	).toBeVisible({
 		timeout: 120000,
 	});
 });
@@ -109,10 +114,25 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 
 	await website.goto(`./#${JSON.stringify(blueprint)}`);
 
-	// Wait for WordPress admin to fully load by checking for the admin menu
-	await expect(wordpress.locator('#adminmenu')).toBeVisible({
+	// Wait for the block editor to fully load
+	await expect(
+		wordpress.locator('.edit-post-header, .editor-header')
+	).toBeVisible({
 		timeout: 120000,
 	});
+
+	// Exit fullscreen mode to access the admin menu, then navigate to Dashboard
+	// First, try to find and click the "Exit fullscreen" button if visible
+	const exitFullscreenButton = wordpress.locator(
+		'button[aria-label="Exit fullscreen"]'
+	);
+	if (
+		await exitFullscreenButton
+			.isVisible({ timeout: 2000 })
+			.catch(() => false)
+	) {
+		await exitFullscreenButton.click();
+	}
 
 	// Navigate to a different page via WordPress admin menu
 	await wordpress.locator('#menu-dashboard a').first().click();

--- a/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
+++ b/packages/playground/website/playwright/e2e/document-isolation-policy.spec.ts
@@ -121,6 +121,18 @@ test('Navigation URL should update in address bar with Document-Isolation-Policy
 		timeout: 120000,
 	});
 
+	// Close the "Welcome to the editor" modal if it appears
+	const welcomeModalCloseButton = wordpress.locator(
+		'.components-modal__header button[aria-label="Close"]'
+	);
+	if (
+		await welcomeModalCloseButton
+			.isVisible({ timeout: 3000 })
+			.catch(() => false)
+	) {
+		await welcomeModalCloseButton.click();
+	}
+
 	// Navigate to Dashboard by clicking the WordPress logo in the editor header
 	// (the admin menu may be hidden when the editor is in fullscreen mode)
 	const wpLogoLink = wordpress.locator(

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,123 +1,90 @@
 {
-  "compileOnSave": false,
-  "compilerOptions": {
-    "rootDir": ".",
-    "sourceMap": true,
-    "declaration": false,
-    "moduleResolution": "bundler",
-    "esModuleInterop": true,
-    "importHelpers": true,
-    "resolveJsonModule": true,
-    "jsx": "react",
-    "target": "ES2021",
-    "module": "esnext",
-    "lib": [
-      "ES2022",
-      "esnext.disposable",
-      "dom"
-    ],
-    "skipLibCheck": true,
-    "skipDefaultLibCheck": true,
-    "noPropertyAccessFromIndexSignature": false,
-    "baseUrl": ".",
-    "paths": {
-      "@php-wasm/cli": [
-        "packages/php-wasm/cli/src/main.ts"
-      ],
-      "@php-wasm/cli-util": [
-        "packages/php-wasm/cli-util/src/index.ts"
-      ],
-      "@php-wasm/fs-journal": [
-        "packages/php-wasm/fs-journal/src/index.ts"
-      ],
-      "@php-wasm/logger": [
-        "packages/php-wasm/logger/src/index.ts"
-      ],
-      "@php-wasm/node": [
-        "packages/php-wasm/node/src/index.ts"
-      ],
-      "@php-wasm/node-polyfills": [
-        "packages/php-wasm/node-polyfills/src/index.ts"
-      ],
-      "@php-wasm/private": [
-        "packages/php-wasm/private/src/index.ts"
-      ],
-      "@php-wasm/progress": [
-        "packages/php-wasm/progress/src/index.ts"
-      ],
-      "@php-wasm/scopes": [
-        "packages/php-wasm/scopes/src/index.ts"
-      ],
-      "@php-wasm/stream-compression": [
-        "packages/php-wasm/stream-compression/src/index.ts"
-      ],
-      "@php-wasm/universal": [
-        "packages/php-wasm/universal/src/index.ts"
-      ],
-      "@php-wasm/universal/mime-types": [
-        "packages/php-wasm/universal/src/lib/mime-types.json"
-      ],
-      "@php-wasm/util": [
-        "packages/php-wasm/util/src/index.ts"
-      ],
-      "@php-wasm/web": [
-        "packages/php-wasm/web/src/index.ts"
-      ],
-      "@php-wasm/web-service-worker": [
-        "packages/php-wasm/web-service-worker/src/index.ts"
-      ],
-      "@php-wasm/xdebug-bridge": [
-        "packages/php-wasm/xdebug-bridge/src/index.ts"
-      ],
-      "@wp-playground/blueprints": [
-        "packages/playground/blueprints/src/index.ts"
-      ],
-      "@wp-playground/cli": [
-        "packages/playground/cli/src/cli.ts"
-      ],
-      "@wp-playground/client": [
-        "packages/playground/client/src/index.ts"
-      ],
-      "@wp-playground/common": [
-        "packages/playground/common/src/index.ts"
-      ],
-      "@wp-playground/components": [
-        "packages/playground/components/src/index.ts"
-      ],
-      "@wp-playground/nx-extensions": [
-        "packages/nx-extensions/src/index.ts"
-      ],
-      "@wp-playground/remote": [
-        "packages/playground/remote/src/index.ts"
-      ],
-      "@wp-playground/storage": [
-        "packages/playground/storage/src/index.ts"
-      ],
-      "@wp-playground/sync": [
-        "packages/playground/sync/src/index.ts"
-      ],
-      "@wp-playground/unit-test-utils": [
-        "packages/playground/unit-test-utils/src/index.ts"
-      ],
-      "@wp-playground/website": [
-        "packages/playground/website/src/index.ts"
-      ],
-      "@wp-playground/website-extras": [
-        "packages/playground/website-extras/src/php-playground/main.tsx"
-      ],
-      "@wp-playground/wordpress": [
-        "packages/playground/wordpress/src/index.ts"
-      ],
-      "@wp-playground/wordpress-builds": [
-        "packages/playground/wordpress-builds/src/index.ts"
-      ],
-      "isomorphic-git": [
-        "./isomorphic-git"
-      ]
-    }
-  },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+	"compileOnSave": false,
+	"compilerOptions": {
+		"rootDir": ".",
+		"sourceMap": true,
+		"declaration": false,
+		"moduleResolution": "bundler",
+		"esModuleInterop": true,
+		"importHelpers": true,
+		"resolveJsonModule": true,
+		"jsx": "react",
+		"target": "ES2021",
+		"module": "esnext",
+		"lib": ["ES2022", "esnext.disposable", "dom"],
+		"skipLibCheck": true,
+		"skipDefaultLibCheck": true,
+		"noPropertyAccessFromIndexSignature": false,
+		"baseUrl": ".",
+		"paths": {
+			"@php-wasm/cli": ["packages/php-wasm/cli/src/main.ts"],
+			"@php-wasm/cli-util": ["packages/php-wasm/cli-util/src/index.ts"],
+			"@php-wasm/fs-journal": [
+				"packages/php-wasm/fs-journal/src/index.ts"
+			],
+			"@php-wasm/logger": ["packages/php-wasm/logger/src/index.ts"],
+			"@php-wasm/node": ["packages/php-wasm/node/src/index.ts"],
+			"@php-wasm/node-polyfills": [
+				"packages/php-wasm/node-polyfills/src/index.ts"
+			],
+			"@php-wasm/private": ["packages/php-wasm/private/src/index.ts"],
+			"@php-wasm/progress": ["packages/php-wasm/progress/src/index.ts"],
+			"@php-wasm/scopes": ["packages/php-wasm/scopes/src/index.ts"],
+			"@php-wasm/stream-compression": [
+				"packages/php-wasm/stream-compression/src/index.ts"
+			],
+			"@php-wasm/universal": ["packages/php-wasm/universal/src/index.ts"],
+			"@php-wasm/universal/mime-types": [
+				"packages/php-wasm/universal/src/lib/mime-types.json"
+			],
+			"@php-wasm/util": ["packages/php-wasm/util/src/index.ts"],
+			"@php-wasm/web": ["packages/php-wasm/web/src/index.ts"],
+			"@php-wasm/web-service-worker": [
+				"packages/php-wasm/web-service-worker/src/index.ts"
+			],
+			"@php-wasm/xdebug-bridge": [
+				"packages/php-wasm/xdebug-bridge/src/index.ts"
+			],
+			"@wp-playground/blueprints": [
+				"packages/playground/blueprints/src/index.ts"
+			],
+			"@wp-playground/cli": ["packages/playground/cli/src/cli.ts"],
+			"@wp-playground/client": [
+				"packages/playground/client/src/index.ts"
+			],
+			"@wp-playground/common": [
+				"packages/playground/common/src/index.ts"
+			],
+			"@wp-playground/components": [
+				"packages/playground/components/src/index.ts"
+			],
+			"@wp-playground/nx-extensions": [
+				"packages/nx-extensions/src/index.ts"
+			],
+			"@wp-playground/remote": [
+				"packages/playground/remote/src/index.ts"
+			],
+			"@wp-playground/storage": [
+				"packages/playground/storage/src/index.ts"
+			],
+			"@wp-playground/sync": ["packages/playground/sync/src/index.ts"],
+			"@wp-playground/unit-test-utils": [
+				"packages/playground/unit-test-utils/src/index.ts"
+			],
+			"@wp-playground/website": [
+				"packages/playground/website/src/index.ts"
+			],
+			"@wp-playground/website-extras": [
+				"packages/playground/website-extras/src/php-playground/main.tsx"
+			],
+			"@wp-playground/wordpress": [
+				"packages/playground/wordpress/src/index.ts"
+			],
+			"@wp-playground/wordpress-builds": [
+				"packages/playground/wordpress-builds/src/index.ts"
+			],
+			"isomorphic-git": ["./isomorphic-git"]
+		}
+	},
+	"exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## Summary

This PR enables cross-origin isolation (required for SharedArrayBuffer) without breaking external embeds like YouTube videos.

Playground's client-side media processing experiment relies on SharedArrayBuffer, which requires cross-origin isolation. The traditional approach uses Cross-Origin-Embedder-Policy (COEP) and Cross-Origin-Opener-Policy (COOP) headers, but these are viral – once set, they affect the entire site and break external embeds that don't set matching headers.

Document-Isolation-Policy is a newer specification that provides cross-origin isolation on a per-document basis without these limitations. This PR feature-detects browser support for Document-Isolation-Policy and rewrites COEP/COOP headers to it automatically in supporting browsers.

### Feature detection

This PR detects the `Document-Isolation-Policy` support by:

1. Loading a hidden iframe with the Document-Isolation-Policy header
2. Checking if SharedArrayBuffer is available in that iframe
3. Sending the result to the service worker
4. Rewriting headers on all subsequent scoped requests

As more browsers implement the specification, they'll automatically receive the better experience without code changes.

### Handling cross-origin iframe restrictions

Document-Isolation-Policy introduces a side effect: the parent frame can no longer access `iframe.contentWindow.location.href` due to cross-origin restrictions. This would break Playground's URL bar synchronization.

To work around this, a WordPress MU plugin now posts the current URL to the parent frame on each page load. The boot script listens for these messages and updates the address bar accordingly, alongside the existing iframe load event handling.

## Test plan

- [ ] Verify SharedArrayBuffer works in block editor with media processing enabled (Chrome 137+)
- [ ] Verify external embeds like YouTube still work in the block editor
- [ ] Verify URL bar updates correctly when navigating within WordPress
- [ ] Verify no regressions in browsers that don't support Document-Isolation-Policy

Here's a Blueprint that takes you directly to the post editor with the Gutenberg plugin installed and the media processing experiment enabled:

```json
{
	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
	"meta": {
		"title": "Enable all three Dataview Experiments in Gutenberg",
		"author": "bph",
		"description": "Blueprint example to enable multiple Experiments within the Gutenberg plugin ",
		"categories": ["Gutenberg", "Experiments"]
	},
	"landingPage": "/wp-admin/post-new.php",
	"plugins": ["gutenberg"],
	"login": true,
	"steps": [
		{
			"step": "runPHP",
			"code": "<?php require '/wordpress/wp-load.php'; update_option( 'gutenberg-experiments', array( 'gutenberg-media-processing' => true, 'gutenberg-new-posts-dashboard' => true, 'gutenberg-quick-edit-dataviews' => true )  );"
		}
	]
}
```

Related to #2954