### PR TITLE
[Blueprints] Detect network firewall interference during requests

### DIFF
--- a/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCorsProxy } from './fetch-with-cors-proxy';
+import { FirewallInterferenceError } from './firewall-interference-error';
 
 describe('fetchWithCorsProxy', () => {
 	afterEach(() => {
@@ -19,10 +20,15 @@ describe('fetchWithCorsProxy', () => {
 	});
 
 	it('upgrades HTTP URLs before retrying via the CORS proxy', async () => {
+		const corsProxyHeaders = new Headers();
+		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
+
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockRejectedValueOnce(new Error('network fail'))
-			.mockResolvedValueOnce(new Response('proxied'));
+			.mockResolvedValueOnce(
+				new Response('proxied', { headers: corsProxyHeaders })
+			);
 
 		await fetchWithCorsProxy(
 			'http://example.com/wp-cron.php',
@@ -38,5 +44,48 @@ describe('fetchWithCorsProxy', () => {
 		expect(proxiedRequest.url).toBe(
 			'https://proxy.test/?url=https://example.com/wp-cron.php'
 		);
+	});
+
+	it('throws FirewallInterferenceError when CORS proxy response lacks identification header', async () => {
+		vi.spyOn(globalThis, 'fetch')
+			.mockRejectedValueOnce(new Error('network fail'))
+			.mockResolvedValueOnce(
+				new Response('blocked', {
+					status: 403,
+					statusText: 'Forbidden',
+					// Note: no X-Playground-Cors-Proxy header
+				})
+			);
+
+		await expect(
+			fetchWithCorsProxy(
+				'https://example.com/resource.zip',
+				undefined,
+				'https://proxy.test/?url='
+			)
+		).rejects.toThrow(FirewallInterferenceError);
+	});
+
+	it('returns response normally when CORS proxy header is present', async () => {
+		const headers = new Headers();
+		headers.set('X-Playground-Cors-Proxy', 'true');
+
+		vi.spyOn(globalThis, 'fetch')
+			.mockRejectedValueOnce(new Error('network fail'))
+			.mockResolvedValueOnce(
+				new Response('proxied', {
+					status: 200,
+					headers,
+				})
+			);
+
+		const response = await fetchWithCorsProxy(
+			'https://example.com/resource.zip',
+			undefined,
+			'https://proxy.test/?url='
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe('proxied');
 	});
 });

--- a/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.ts
@@ -1,4 +1,7 @@
 import { cloneRequest, teeRequest } from '@php-wasm/web-service-worker';
+import { FirewallInterferenceError } from './firewall-interference-error';
+
+const CORS_PROXY_HEADER = 'X-Playground-Cors-Proxy';
 
 export async function fetchWithCorsProxy(
 	input: RequestInfo,
@@ -60,6 +63,19 @@ export async function fetchWithCorsProxy(
 			...(requestIntendsToPassCredentials && { credentials: 'include' }),
 		});
 
-		return await fetch(newRequest, init);
+		const response = await fetch(newRequest, init);
+
+		// Check for firewall interference: if we got a response but it's
+		// missing the CORS proxy identification header, the response likely
+		// came from a network firewall rather than the actual CORS proxy.
+		if (!response.headers.has(CORS_PROXY_HEADER)) {
+			throw new FirewallInterferenceError(
+				requestObject.url,
+				response.status,
+				response.statusText
+			);
+		}
+
+		return response;
 	}
 }

--- a/packages/php-wasm/web/src/lib/firewall-interference-error.ts
+++ b/packages/php-wasm/web/src/lib/firewall-interference-error.ts
@@ -12,7 +12,9 @@ export class FirewallInterferenceError extends Error {
 
 	constructor(url: string, status: number, statusText: string) {
 		super(
-			`Response from ${url} appears intercepted by network firewall (HTTP ${status})`
+			`Could not fetch ${url} – your network appears to be blocking this request (HTTP ${status}). ` +
+				`This often happens on school, university, or corporate networks. ` +
+				`Try switching to a different network, using a VPN, or asking your IT administrator to allow requests to playground.wordpress.net.`
 		);
 		this.name = 'FirewallInterferenceError';
 		this.url = url;

--- a/packages/php-wasm/web/src/lib/firewall-interference-error.ts
+++ b/packages/php-wasm/web/src/lib/firewall-interference-error.ts
@@ -1,0 +1,22 @@
+/**
+ * Error thrown when a CORS proxy response appears to have been
+ * intercepted by a network firewall or corporate proxy.
+ *
+ * This is detected when a response from the CORS proxy is missing
+ * the X-Playground-Cors-Proxy header that legitimate responses include.
+ */
+export class FirewallInterferenceError extends Error {
+	public readonly url: string;
+	public readonly status: number;
+	public readonly statusText: string;
+
+	constructor(url: string, status: number, statusText: string) {
+		super(
+			`Response from ${url} appears intercepted by network firewall (HTTP ${status})`
+		);
+		this.name = 'FirewallInterferenceError';
+		this.url = url;
+		this.status = status;
+		this.statusText = statusText;
+	}
+}

--- a/packages/php-wasm/web/src/lib/firewall-interference-error.ts
+++ b/packages/php-wasm/web/src/lib/firewall-interference-error.ts
@@ -14,7 +14,7 @@ export class FirewallInterferenceError extends Error {
 		super(
 			`Could not fetch ${url} – your network appears to be blocking this request (HTTP ${status}). ` +
 				`This often happens on school, university, or corporate networks. ` +
-				`Try switching to a different network, using a VPN, or asking your IT administrator to allow requests to playground.wordpress.net.`
+				`Try switching to a different network or using a VPN.`
 		);
 		this.name = 'FirewallInterferenceError';
 		this.url = url;

--- a/packages/php-wasm/web/src/lib/index.ts
+++ b/packages/php-wasm/web/src/lib/index.ts
@@ -16,6 +16,7 @@ export type {
 export * from './tls/certificates';
 export type { TCPOverFetchOptions } from './tcp-over-fetch-websocket';
 export { fetchWithCorsProxy } from './fetch-with-cors-proxy';
+export { FirewallInterferenceError } from './firewall-interference-error';
 export {
 	consumeAPI,
 	exposeAPI,

--- a/packages/playground/blueprints/src/index.ts
+++ b/packages/playground/blueprints/src/index.ts
@@ -54,7 +54,10 @@ export type {
 	VFSReference,
 	VFSResource,
 } from './lib/v1/resources';
-export { BlueprintFilesystemRequiredError } from './lib/v1/resources';
+export {
+	BlueprintFilesystemRequiredError,
+	ResourceDownloadError,
+} from './lib/v1/resources';
 export * from './lib/steps';
 export * from './lib/steps/handlers';
 export type {

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -38,6 +38,19 @@ export class BlueprintFilesystemRequiredError extends Error {
 	}
 }
 
+/**
+ * Error thrown when a resource could not be downloaded from a URL.
+ */
+export class ResourceDownloadError extends Error {
+	public readonly url: string;
+
+	constructor(message: string, url: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = 'ResourceDownloadError';
+		this.url = url;
+	}
+}
+
 export type { FileTree };
 export const ResourceTypes = [
 	'vfs',
@@ -240,7 +253,7 @@ export abstract class Resource<T extends File | Directory> {
 }
 
 export abstract class ResourceDecorator<
-	T extends File | Directory
+	T extends File | Directory,
 > extends Resource<T> {
 	protected resource: Resource<T>;
 	constructor(resource: Resource<T>) {
@@ -368,14 +381,20 @@ export abstract class FetchResource extends Resource<File> {
 				await this.playground?.absoluteUrl
 			);
 			if (!response.ok) {
-				throw new Error(`Could not download "${url}"`);
+				throw new ResourceDownloadError(
+					`Could not download "${url}"`,
+					url
+				);
 			}
 			response = await cloneResponseMonitorProgress(
 				response,
 				this.progress?.loadingListener ?? noop
 			);
 			if (response.status !== 200) {
-				throw new Error(`Could not download "${url}"`);
+				throw new ResourceDownloadError(
+					`Could not download "${url}"`,
+					url
+				);
 			}
 			const filename =
 				this.name ||
@@ -385,10 +404,11 @@ export abstract class FetchResource extends Resource<File> {
 				encodeURIComponent(url);
 			return new File([await response.blob()], filename);
 		} catch (e) {
-			throw new Error(
+			throw new ResourceDownloadError(
 				`Could not download "${url}".\n\n` +
 					`Confirm that the URL is correct, the server is reachable, and the file is` +
 					`actually served at that URL. Original error: \n ${e}`,
+				url,
 				{ cause: e }
 			);
 		}
@@ -770,7 +790,7 @@ export function toDirectoryZipName(rawInput: string) {
  * A decorator for a resource that adds caching functionality.
  */
 export class CachedResource<
-	T extends File | Directory
+	T extends File | Directory,
 > extends ResourceDecorator<T> {
 	protected override promise?: Promise<T>;
 
@@ -788,7 +808,7 @@ export class CachedResource<
  * through a semaphore.
  */
 export class SemaphoreResource<
-	T extends File | Directory
+	T extends File | Directory,
 > extends ResourceDecorator<T> {
 	private readonly semaphore: Semaphore;
 	constructor(resource: Resource<T>, semaphore: Semaphore) {

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -20,6 +20,11 @@ if (should_respond_with_cors_headers($server_host, $origin)) {
     header('Access-Control-Allow-Credentials: true');
     header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
     header('Access-Control-Allow-Headers: Accept, Authorization, Content-Type, git-protocol, wp_blog, wp_install, x-cors-proxy-allowed-request-headers');
+    // Identify this response as coming from the legitimate CORS proxy.
+    // Network firewalls may intercept requests and return error responses
+    // without this header, allowing clients to detect interference.
+    header('X-Playground-Cors-Proxy: true');
+    header('Access-Control-Expose-Headers: X-Playground-Cors-Proxy');
 }
 if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     header("Allow: GET, POST, OPTIONS");

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -257,16 +257,6 @@ test('should edit a blueprint in the blueprint editor and recreate the playgroun
 	);
 	await editor.waitFor({ timeout: 10000 });
 
-	await editor.click();
-
-	// Delete all content in the editor (Cmd+A or Ctrl+A)
-	await website.page.keyboard.press(
-		process.platform === 'darwin' ? 'Meta+A' : 'Control+A'
-	);
-
-	await website.page.keyboard.press('Backspace');
-	await website.page.waitForTimeout(200);
-
 	// Create a simple blueprint that writes "Blueprint test" to index.php
 	const blueprint = JSON.stringify(
 		{
@@ -283,19 +273,26 @@ test('should edit a blueprint in the blueprint editor and recreate the playgroun
 		2
 	);
 
-	// Type the new blueprint with a delay between keystrokes
-	await website.page.keyboard.type(blueprint, { delay: 50 });
+	// Focus the editor and select all existing content
+	await editor.click();
+	await website.page.keyboard.press(
+		process.platform === 'darwin' ? 'Meta+A' : 'Control+A'
+	);
 
-	// Remove the autoinserted brackets until the end of the Blueprint
-	await website.page.keyboard.down('Shift');
-	for (let i = 0; i < 4; i++) {
-		await website.page.keyboard.press('ArrowDown');
-	}
+	// Dispatch a paste event to replace content - avoids auto-bracket insertion issues
+	await website.page.evaluate((content) => {
+		const dataTransfer = new DataTransfer();
+		dataTransfer.setData('text/plain', content);
+		document.activeElement?.dispatchEvent(
+			new ClipboardEvent('paste', {
+				clipboardData: dataTransfer,
+				bubbles: true,
+				cancelable: true,
+			})
+		);
+	}, blueprint);
 
-	// Delete the selected lines
-	await website.page.keyboard.press('Backspace');
-
-	// Wait a moment for the change to be processed
+	// Wait for validation to complete (linter has 300ms debounce)
 	await website.page.waitForTimeout(500);
 
 	// Click the "Run Blueprint" button

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -46,6 +46,8 @@ export function getSiteErrorView(
 			return blueprintValidationFailedView(context);
 		case 'directory-handle-unknown-error':
 			return directoryHandleUnknownErrorView();
+		case 'network-firewall-interference':
+			return networkFirewallInterferenceView(context);
 		case 'site-boot-failed':
 		default:
 			return genericSiteBootFailedView(context);
@@ -271,6 +273,64 @@ function directoryHandleUnknownErrorView(): SiteErrorViewConfig {
 			</p>
 		),
 		actions: [],
+	};
+}
+
+function networkFirewallInterferenceView({
+	helpers,
+}: SiteErrorViewContext): SiteErrorViewConfig {
+	return {
+		title: 'Network blocked this request',
+		isDeveloperError: false,
+		detailSummaryOverride: 'Technical details',
+		body: (
+			<>
+				<p className={css.errorLead}>
+					Your network appears to be blocking requests to external
+					resources. This commonly happens on university, school, or
+					corporate networks with security filters.
+				</p>
+				<p>
+					<strong>What you can try:</strong>
+				</p>
+				<ul className={css.errorList}>
+					<li>
+						Switch to a different network (like mobile data or a
+						personal Wi-Fi)
+					</li>
+					<li>Use a VPN to bypass network restrictions</li>
+					<li>
+						Ask your network administrator to allow requests to{' '}
+						<code>playground.wordpress.net</code>
+					</li>
+				</ul>
+				<p>
+					<a
+						target="_blank"
+						rel="noopener noreferrer"
+						href="https://wordpress.github.io/wordpress-playground/troubleshooting/network-issues"
+					>
+						Learn more about network troubleshooting ↗
+					</a>
+				</p>
+			</>
+		),
+		actions: [
+			<Button
+				variant="secondary"
+				key="retry"
+				onClick={() => window.location.reload()}
+			>
+				Retry
+			</Button>,
+			<Button
+				variant="primary"
+				key="start-without-blueprint"
+				onClick={helpers.reloadWithoutBlueprint}
+			>
+				Start without a Blueprint
+			</Button>,
+		],
 	};
 }
 

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -5,6 +5,8 @@ import type { SiteError } from '../../lib/state/redux/slice-ui';
 import type { SiteInfo } from '../../lib/state/redux/slice-sites';
 import type { BlueprintStepError, PresentationHelpers } from './types';
 import { BlueprintStepErrorDetails } from './blueprint-step-error-details';
+// @ts-ignore
+import { corsProxyUrl } from 'virtual:cors-proxy-url';
 
 export interface SiteErrorViewContext {
 	error: SiteError;
@@ -279,6 +281,15 @@ function directoryHandleUnknownErrorView(): SiteErrorViewConfig {
 function networkFirewallInterferenceView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
+	// Extract hostnames from the current site and CORS proxy URLs
+	const currentHost = window.location.hostname;
+	let corsProxyHost: string | undefined;
+	try {
+		corsProxyHost = new URL(corsProxyUrl).hostname;
+	} catch {
+		// corsProxyUrl might be a relative URL or invalid
+	}
+
 	return {
 		title: 'Network blocked this request',
 		isDeveloperError: false,
@@ -301,7 +312,13 @@ function networkFirewallInterferenceView({
 					<li>Use a VPN to bypass network restrictions</li>
 					<li>
 						Ask your network administrator to allow requests to{' '}
-						<code>playground.wordpress.net</code>
+						<code>{currentHost}</code>
+						{corsProxyHost && corsProxyHost !== currentHost && (
+							<>
+								{' '}
+								and <code>{corsProxyHost}</code>
+							</>
+						)}
 					</li>
 				</ul>
 				<p>

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -286,6 +286,9 @@ function directoryHandleUnknownErrorView(): SiteErrorViewConfig {
 /**
  * Extract the target URL that Playground was trying to fetch from the error details.
  * This is the original URL (e.g., a plugin download), not the CORS proxy URL.
+ *
+ * First checks for a structured `url` property on the error object (preferred),
+ * then falls back to pattern matching in the error message.
  */
 function extractTargetUrl(errorDetails: unknown): string | undefined {
 	if (!errorDetails || typeof errorDetails !== 'object') {
@@ -293,6 +296,13 @@ function extractTargetUrl(errorDetails: unknown): string | undefined {
 	}
 
 	const details = errorDetails as Record<string, unknown>;
+
+	// Prefer the structured url property if available
+	if (typeof details.url === 'string' && details.url) {
+		return details.url;
+	}
+
+	// Fall back to pattern matching in the message for backwards compatibility
 	const message = (details.rawMessage || details.message || '') as string;
 
 	// "Could not fetch {url}" from FirewallInterferenceError

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -13,12 +13,14 @@ export interface SiteErrorViewContext {
 	site: SiteInfo;
 	blueprintStepError?: BlueprintStepError;
 	helpers: PresentationHelpers;
+	errorDetails?: unknown;
 }
 
 export interface SiteErrorViewConfig {
 	title: string;
 	isDeveloperError: boolean;
 	detailSummaryOverride?: string;
+	hideReportButton?: boolean;
 	body: React.ReactNode;
 	actions: React.ReactNode[];
 }
@@ -28,7 +30,10 @@ export function getSiteErrorView(
 ): SiteErrorViewConfig {
 	const { error, blueprintStepError } = context;
 
-	if (blueprintStepError) {
+	// Show specific error views for certain error types, even if they occurred
+	// during a blueprint step. These errors have dedicated user-friendly views
+	// that provide better guidance than the generic step error view.
+	if (blueprintStepError && error !== 'network-firewall-interference') {
 		return blueprintStepExecutionView(context);
 	}
 
@@ -278,57 +283,152 @@ function directoryHandleUnknownErrorView(): SiteErrorViewConfig {
 	};
 }
 
+/**
+ * Extract the target URL that Playground was trying to fetch from the error details.
+ * This is the original URL (e.g., a plugin download), not the CORS proxy URL.
+ */
+function extractTargetUrl(errorDetails: unknown): string | undefined {
+	if (!errorDetails || typeof errorDetails !== 'object') {
+		return undefined;
+	}
+
+	const details = errorDetails as Record<string, unknown>;
+	const message = (details.rawMessage || details.message || '') as string;
+
+	// "Could not fetch {url}" from FirewallInterferenceError
+	const fetchMatch = message.match(/Could not fetch ([^\s]+)/);
+	if (fetchMatch) {
+		return fetchMatch[1];
+	}
+
+	// "Could not download "{url}"" from resource fetching
+	const downloadMatch = message.match(/Could not download "([^"]+)"/);
+	if (downloadMatch) {
+		return downloadMatch[1];
+	}
+
+	return undefined;
+}
+
 function networkFirewallInterferenceView({
 	helpers,
+	errorDetails,
 }: SiteErrorViewContext): SiteErrorViewConfig {
-	// Extract hostnames from the current site and CORS proxy URLs
-	const currentHost = window.location.hostname;
+	// The target URL is what Playground was trying to download (e.g., a plugin)
+	const targetUrl = extractTargetUrl(errorDetails);
+
+	// The CORS proxy is what's actually being blocked - all external requests
+	// go through it due to browser security restrictions
 	let corsProxyHost: string | undefined;
+	let testUrl: string | undefined;
 	try {
 		corsProxyHost = new URL(corsProxyUrl).hostname;
+		testUrl = `${corsProxyUrl}https://wordpress.org`;
 	} catch {
-		// corsProxyUrl might be a relative URL or invalid
+		// corsProxyUrl might be a relative URL
+	}
+
+	const effectiveTargetUrl = targetUrl
+		? corsProxyUrl
+			? `${corsProxyUrl}?${encodeURIComponent(targetUrl)}`
+			: targetUrl
+		: undefined;
+	let effectiveTargetHost: string | undefined;
+	try {
+		if (effectiveTargetUrl) {
+			effectiveTargetHost = new URL(effectiveTargetUrl).hostname;
+		}
+	} catch {
+		// Invalid URL
 	}
 
 	return {
 		title: 'Network blocked this request',
 		isDeveloperError: false,
+		hideReportButton: true,
 		detailSummaryOverride: 'Technical details',
 		body: (
 			<>
-				<p className={css.errorLead}>
-					Your network appears to be blocking requests to external
-					resources. This commonly happens on university, school, or
-					corporate networks with security filters.
-				</p>
 				<p>
-					<strong>What you can try:</strong>
-				</p>
-				<ul className={css.errorList}>
-					<li>
-						Switch to a different network (like mobile data or a
-						personal Wi-Fi)
-					</li>
-					<li>Use a VPN to bypass network restrictions</li>
-					<li>
-						Ask your network administrator to allow requests to{' '}
-						<code>{currentHost}</code>
-						{corsProxyHost && corsProxyHost !== currentHost && (
+					<strong style={{ fontWeight: 'bold' }}>
+						Playground couldn't download a file
+						{effectiveTargetHost && (
 							<>
 								{' '}
-								and <code>{corsProxyHost}</code>
+								from <code>{effectiveTargetHost}</code>
 							</>
 						)}
+						.
+					</strong>{' '}
+					Your network appears to be blocking the request.
+				</p>
+
+				<p>
+					Playground runs entirely in your browser. To download
+					plugins, themes, and other files, it routes requests through
+					a CORS proxy server
+					{corsProxyHost && (
+						<>
+							{' '}
+							at <code>{corsProxyHost}</code>
+						</>
+					)}
+					. Your network seems to be blocking this proxy — a common
+					issue on school, university, and corporate networks.
+				</p>
+
+				<p>
+					<strong style={{ fontWeight: 'bold' }}>
+						Verify this is a network issue
+					</strong>
+				</p>
+				<p>Try opening this link in a new browser tab:</p>
+				<p>
+					<a href={testUrl} target="_blank" rel="noopener noreferrer">
+						{testUrl}
+					</a>
+				</p>
+
+				<ul className={css.errorList}>
+					<li>
+						<strong style={{ fontWeight: 'bold' }}>
+							Link fails to load?
+						</strong>{' '}
+						Your network is blocking the proxy. Try a different
+						network (mobile data, personal Wi-Fi), use a VPN, or
+						contact your IT administrator.
+					</li>
+					<li>
+						<strong style={{ fontWeight: 'bold' }}>
+							Link works fine?
+						</strong>{' '}
+						This might be a bug in Playground. Please{' '}
+						<a
+							href="https://github.com/WordPress/wordpress-playground/issues/new"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							open an issue on GitHub
+						</a>{' '}
+						so we can investigate.
 					</li>
 				</ul>
+
 				<p>
-					<a
-						target="_blank"
-						rel="noopener noreferrer"
-						href="https://wordpress.github.io/wordpress-playground/troubleshooting/network-issues"
-					>
-						Learn more about network troubleshooting ↗
-					</a>
+					<strong style={{ fontWeight: 'bold' }}>
+						For IT administrators
+					</strong>
+				</p>
+				<p>
+					Allow outbound HTTPS requests to{' '}
+					<code>{corsProxyHost || 'the CORS proxy domain'}</code>
+					{window.location.hostname !== corsProxyHost && (
+						<>
+							{' '}
+							and <code>{window.location.hostname}</code>
+						</>
+					)}
+					.
 				</p>
 			</>
 		),

--- a/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
+++ b/packages/playground/website/src/components/site-error-modal/site-error-modal.tsx
@@ -65,6 +65,7 @@ export function SiteErrorModal({
 		site,
 		blueprintStepError,
 		helpers,
+		errorDetails,
 	});
 
 	const detailText = formatErrorDetails(errorDetails);
@@ -145,6 +146,7 @@ export function SiteErrorModal({
 				{view.actions.length || !view.isDeveloperError ? (
 					<div className={css.errorModalFooter}>
 						{!view.isDeveloperError &&
+						!view.hideReportButton &&
 						!isReporting &&
 						!reportSubmitted ? (
 							<Button

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -39,24 +39,30 @@ import {
 } from '../../../github/git-auth-helpers';
 
 /**
- * Search through an error's cause chain to find an error with a specific name.
+ * Search through an error's cause chain to find a FirewallInterferenceError.
  * Checks both instanceof and the error's name property to handle cases where
  * instanceof fails due to module boundaries or error serialization.
+ *
+ * Returns the FirewallInterferenceError if found, or undefined if not.
  */
-function findFirewallErrorInCauseChain(error: unknown): boolean {
+function findFirewallErrorInCauseChain(
+	error: unknown
+): FirewallInterferenceError | Error | undefined {
 	let current: unknown = error;
 	while (current) {
+		if (current instanceof FirewallInterferenceError) {
+			return current;
+		}
 		if (
-			current instanceof FirewallInterferenceError ||
-			(current instanceof Error &&
-				current.name === 'FirewallInterferenceError')
+			current instanceof Error &&
+			current.name === 'FirewallInterferenceError'
 		) {
-			return true;
+			return current;
 		}
 		current =
 			current instanceof Error ? (current as Error).cause : undefined;
 	}
-	return false;
+	return undefined;
 }
 
 export function bootSiteClient(
@@ -192,6 +198,7 @@ export function bootSiteClient(
 			logger.error(e);
 			logTrackingEvent('error', { source: 'bootSiteClient' });
 
+			const firewallError = findFirewallErrorInCauseChain(e);
 			if (
 				(e as any).name === 'ArtifactExpiredError' ||
 				(e as any).originalErrorClassName === 'ArtifactExpiredError'
@@ -216,11 +223,11 @@ export function bootSiteClient(
 						details: e,
 					})
 				);
-			} else if (findFirewallErrorInCauseChain(e)) {
+			} else if (firewallError) {
 				dispatch(
 					setActiveSiteError({
 						error: 'network-firewall-interference',
-						details: e,
+						details: firewallError,
 					})
 				);
 			} else if (

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -16,7 +16,10 @@ import {
 	InvalidBlueprintError,
 } from '@wp-playground/blueprints';
 import { logger } from '@php-wasm/logger';
-import { setupPostMessageRelay } from '@php-wasm/web';
+import {
+	FirewallInterferenceError,
+	setupPostMessageRelay,
+} from '@php-wasm/web';
 import { startPlaygroundWeb } from '@wp-playground/client';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import { getRemoteUrl } from '../../config';
@@ -34,6 +37,27 @@ import {
 	createGitAuthHeaders,
 	shouldShowGitHubAuthModal,
 } from '../../../github/git-auth-helpers';
+
+/**
+ * Search through an error's cause chain to find an error with a specific name.
+ * Checks both instanceof and the error's name property to handle cases where
+ * instanceof fails due to module boundaries or error serialization.
+ */
+function findFirewallErrorInCauseChain(error: unknown): boolean {
+	let current: unknown = error;
+	while (current) {
+		if (
+			current instanceof FirewallInterferenceError ||
+			(current instanceof Error &&
+				current.name === 'FirewallInterferenceError')
+		) {
+			return true;
+		}
+		current =
+			current instanceof Error ? (current as Error).cause : undefined;
+	}
+	return false;
+}
 
 export function bootSiteClient(
 	siteSlug: string,
@@ -189,6 +213,13 @@ export function bootSiteClient(
 				dispatch(
 					setActiveSiteError({
 						error: 'blueprint-validation-failed',
+						details: e,
+					})
+				);
+			} else if (findFirewallErrorInCauseChain(e)) {
+				dispatch(
+					setActiveSiteError({
+						error: 'network-firewall-interference',
 						details: e,
 					})
 				);

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -16,10 +16,7 @@ import {
 	InvalidBlueprintError,
 } from '@wp-playground/blueprints';
 import { logger } from '@php-wasm/logger';
-import {
-	FirewallInterferenceError,
-	setupPostMessageRelay,
-} from '@php-wasm/web';
+import { setupPostMessageRelay } from '@php-wasm/web';
 import { startPlaygroundWeb } from '@wp-playground/client';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import { getRemoteUrl } from '../../config';
@@ -37,33 +34,7 @@ import {
 	createGitAuthHeaders,
 	shouldShowGitHubAuthModal,
 } from '../../../github/git-auth-helpers';
-
-/**
- * Search through an error's cause chain to find a FirewallInterferenceError.
- * Checks both instanceof and the error's name property to handle cases where
- * instanceof fails due to module boundaries or error serialization.
- *
- * Returns the FirewallInterferenceError if found, or undefined if not.
- */
-function findFirewallErrorInCauseChain(
-	error: unknown
-): FirewallInterferenceError | Error | undefined {
-	let current: unknown = error;
-	while (current) {
-		if (current instanceof FirewallInterferenceError) {
-			return current;
-		}
-		if (
-			current instanceof Error &&
-			current.name === 'FirewallInterferenceError'
-		) {
-			return current;
-		}
-		current =
-			current instanceof Error ? (current as Error).cause : undefined;
-	}
-	return undefined;
-}
+import { findFirewallErrorInCauseChain } from './error-utils';
 
 export function bootSiteClient(
 	siteSlug: string,

--- a/packages/playground/website/src/lib/state/redux/error-utils.ts
+++ b/packages/playground/website/src/lib/state/redux/error-utils.ts
@@ -1,0 +1,28 @@
+import { FirewallInterferenceError } from '@php-wasm/web';
+
+/**
+ * Search through an error's cause chain to find a FirewallInterferenceError.
+ * Checks both instanceof and the error's name property to handle cases where
+ * instanceof fails due to module boundaries or error serialization.
+ *
+ * Returns the FirewallInterferenceError if found, or undefined if not.
+ */
+export function findFirewallErrorInCauseChain(
+	error: unknown
+): FirewallInterferenceError | Error | undefined {
+	let current: unknown = error;
+	while (current) {
+		if (current instanceof FirewallInterferenceError) {
+			return current;
+		}
+		if (
+			current instanceof Error &&
+			current.name === 'FirewallInterferenceError'
+		) {
+			return current;
+		}
+		current =
+			current instanceof Error ? (current as Error).cause : undefined;
+	}
+	return undefined;
+}

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -22,30 +22,9 @@ import {
 	applyQueryOverrides,
 } from '../url/resolve-blueprint-from-url';
 import { logger } from '@php-wasm/logger';
-import { FirewallInterferenceError } from '@php-wasm/web';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-
-/**
- * Search through an error's cause chain to find an error with a specific name.
- * Checks both instanceof and the error's name property to handle cases where
- * instanceof fails due to module boundaries or error serialization.
- */
-function findFirewallErrorInCauseChain(error: unknown): boolean {
-	let current: unknown = error;
-	while (current) {
-		if (
-			current instanceof FirewallInterferenceError ||
-			(current instanceof Error &&
-				current.name === 'FirewallInterferenceError')
-		) {
-			return true;
-		}
-		current =
-			current instanceof Error ? (current as Error).cause : undefined;
-	}
-	return false;
-}
+import { findFirewallErrorInCauseChain } from './error-utils';
 
 /**
  * The Site model used to represent a site within Playground.

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -22,8 +22,28 @@ import {
 	applyQueryOverrides,
 } from '../url/resolve-blueprint-from-url';
 import { logger } from '@php-wasm/logger';
+import { FirewallInterferenceError } from '@php-wasm/web';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
+
+/**
+ * Search through an error's cause chain to find an instance of a specific error type.
+ * Returns the found error instance or undefined if not found.
+ */
+function findErrorInCauseChain<T extends Error>(
+	error: unknown,
+	errorClass: new (...args: any[]) => T
+): T | undefined {
+	let current: unknown = error;
+	while (current) {
+		if (current instanceof errorClass) {
+			return current;
+		}
+		current =
+			current instanceof Error ? (current as Error).cause : undefined;
+	}
+	return undefined;
+}
 
 /**
  * The Site model used to represent a site within Playground.
@@ -350,6 +370,18 @@ export function setTemporarySiteSpec(
 				'Error resolving blueprint: Blueprint could not be downloaded or loaded.',
 				e
 			);
+
+			// Check if the error (or its cause chain) is a FirewallInterferenceError
+			const isFirewallError = findErrorInCauseChain(
+				e,
+				FirewallInterferenceError
+			);
+			if (isFirewallError) {
+				return showTemporarySiteError({
+					error: 'network-firewall-interference',
+					details: isFirewallError,
+				});
+			}
 
 			return showTemporarySiteError({
 				error: 'blueprint-fetch-failed',

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -27,22 +27,24 @@ import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 
 /**
- * Search through an error's cause chain to find an instance of a specific error type.
- * Returns the found error instance or undefined if not found.
+ * Search through an error's cause chain to find an error with a specific name.
+ * Checks both instanceof and the error's name property to handle cases where
+ * instanceof fails due to module boundaries or error serialization.
  */
-function findErrorInCauseChain<T extends Error>(
-	error: unknown,
-	errorClass: new (...args: any[]) => T
-): T | undefined {
+function findFirewallErrorInCauseChain(error: unknown): boolean {
 	let current: unknown = error;
 	while (current) {
-		if (current instanceof errorClass) {
-			return current;
+		if (
+			current instanceof FirewallInterferenceError ||
+			(current instanceof Error &&
+				current.name === 'FirewallInterferenceError')
+		) {
+			return true;
 		}
 		current =
 			current instanceof Error ? (current as Error).cause : undefined;
 	}
-	return undefined;
+	return false;
 }
 
 /**
@@ -372,14 +374,10 @@ export function setTemporarySiteSpec(
 			);
 
 			// Check if the error (or its cause chain) is a FirewallInterferenceError
-			const isFirewallError = findErrorInCauseChain(
-				e,
-				FirewallInterferenceError
-			);
-			if (isFirewallError) {
+			if (findFirewallErrorInCauseChain(e)) {
 				return showTemporarySiteError({
 					error: 'network-firewall-interference',
-					details: isFirewallError,
+					details: e,
 				});
 			}
 

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -12,7 +12,8 @@ export type SiteError =
 	| 'github-artifact-expired'
 	| 'blueprint-fetch-failed'
 	| 'blueprint-filesystem-required'
-	| 'blueprint-validation-failed';
+	| 'blueprint-validation-failed'
+	| 'network-firewall-interference';
 
 export type SiteManagerSection = 'sidebar' | 'site-details' | 'blueprints';
 
@@ -37,8 +38,7 @@ export type SerializedPlainErrorDetails = {
 	stack?: string;
 };
 
-export interface SerializedBlueprintStepErrorDetails
-	extends SerializedPlainErrorDetails {
+export interface SerializedBlueprintStepErrorDetails extends SerializedPlainErrorDetails {
 	type: 'blueprint-step-error';
 	stepNumber: number;
 	step: Record<string, unknown>;

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -36,6 +36,7 @@ export type SerializedPlainErrorDetails = {
 	message?: string;
 	name?: string;
 	stack?: string;
+	url?: string;
 };
 
 export interface SerializedBlueprintStepErrorDetails extends SerializedPlainErrorDetails {
@@ -55,6 +56,21 @@ const serializeSiteErrorDetails = (
 	details?: unknown
 ): SerializedSiteErrorDetails | undefined => {
 	if (details instanceof BlueprintStepExecutionError) {
+		// Look for a url property in the cause chain
+		let url: string | undefined;
+		let current: unknown = details.cause;
+		while (current && !url) {
+			if (
+				current &&
+				typeof current === 'object' &&
+				'url' in current &&
+				typeof (current as any).url === 'string'
+			) {
+				url = (current as any).url;
+			}
+			current = current instanceof Error ? current.cause : undefined;
+		}
+
 		return {
 			type: 'blueprint-step-error',
 			stepNumber: details.stepNumber,
@@ -67,6 +83,7 @@ const serializeSiteErrorDetails = (
 					: details.message,
 			name: details.name,
 			stack: details.stack,
+			url,
 		};
 	}
 	if (details instanceof Error) {
@@ -74,6 +91,10 @@ const serializeSiteErrorDetails = (
 			message: details.message,
 			name: details.name,
 			stack: details.stack,
+			url:
+				'url' in details && typeof details.url === 'string'
+					? details.url
+					: undefined,
 		};
 	}
 	if (typeof details === 'string') {
@@ -95,11 +116,16 @@ const serializeSiteErrorDetails = (
 			'stack' in details && typeof (details as any).stack === 'string'
 				? (details as any).stack
 				: undefined;
-		if (maybeMessage || maybeName || maybeStack) {
+		const maybeUrl =
+			'url' in details && typeof (details as any).url === 'string'
+				? (details as any).url
+				: undefined;
+		if (maybeMessage || maybeName || maybeStack || maybeUrl) {
 			return {
 				message: maybeMessage,
 				name: maybeName,
 				stack: maybeStack,
+				url: maybeUrl,
 			};
 		}
 	}


### PR DESCRIPTION
## Summary

Users on university and enterprise networks sometimes encounter confusing errors when their network firewalls intercept fetch requests. HTTP 404 or 500 status codes appear that don't come from the actual server, making troubleshooting difficult.

This PR detects firewall interference by adding a special header (`X-Playground-Cors-Proxy`) to CORS proxy responses. When a proxied request receives a response lacking this header, we know something intercepted it. The UI then shows a helpful error modal explaining what happened and suggesting concrete next steps:

<img width="3084" height="2416" alt="CleanShot 2025-12-16 at 11 39 07@2x" src="https://github.com/user-attachments/assets/a72b134c-b3d5-4c88-b716-0c8c7a0ff64a" />

(Note it only says 127.0.0.1 because it's a screenshot from my local environment. In production it will list a domain name)

## Changes

- Added `X-Playground-Cors-Proxy: true` header to CORS proxy responses
- Created `FirewallInterferenceError` class to represent detected interference
- Updated `fetchWithCorsProxy` to check for the header and throw when missing
- Added new error type `network-firewall-interference` to the UI error system
- Created an error modal view with actionable guidance (switch networks, use VPN, contact IT)
- Added tests for the detection logic

## Test plan

- [ ] Verify tests pass: `npx nx test php-wasm-web --testFile=fetch-with-cors-proxy.spec.ts`
- [ ] Manual test: Block `wordpress-playground-cors-proxy.net` in browser dev tools and trigger a blueprint that fetches remote resources
- [ ] Verify the new error modal appears with helpful messaging

Closes #3030