### PR TITLE
[ playground-storage ] Add `vite-plugin-dts` to Playground Storage

### DIFF
--- a/packages/playground/storage/package.json
+++ b/packages/playground/storage/package.json
@@ -34,6 +34,7 @@
 	},
 	"license": "GPL-2.0-or-later",
 	"type": "module",
+	"types": "index.d.ts",
 	"dependencies": {
 		"async-lock": "^1.4.1",
 		"clean-git-ref": "^2.0.1",

--- a/packages/playground/storage/vite.config.ts
+++ b/packages/playground/storage/vite.config.ts
@@ -1,5 +1,9 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite';
+
+import dts from 'vite-plugin-dts';
+import { join } from 'path';
+
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -21,6 +25,11 @@ export default defineConfig({
 	},
 
 	plugins: [
+		dts({
+			entryRoot: 'src',
+			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
+		}),
 		viteTsConfigPaths({
 			root: '../../../',
 		}),


### PR DESCRIPTION
## Motivation for the change, related issues

Based on comment :

> Hey folks! While working on blueprint support in the Studio CLI, I started using the `@wp-playground/storage` package and noticed that no TypeScript definition files are published for it on npm. Might be because the `vite-plugin-dts` isn’t used in the Vite config for the storage package

## Implementation details

- Added the `vite-plugin-dts` plugin in the `playground-storage` Vite plugins in `packages/playground/storage/vite.config.ts`

## Testing Instructions (or ideally a Blueprint)

TBD