### PR TITLE
[CLI] Add high-level `start` command for easy local WordPress development

### DIFF
--- a/packages/playground/cli/src/mounts.ts
+++ b/packages/playground/cli/src/mounts.ts
@@ -121,7 +121,7 @@ export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
 		],
 	};
 
-	if (isPluginFilename(path)) {
+	if (isPluginDirectory(path)) {
 		const pluginName = basename(path);
 		mount.push({
 			hostPath: path,
@@ -219,7 +219,7 @@ export function isThemeDirectory(path: string): boolean {
 	return !!themeNameRegex.exec(styleCssContent);
 }
 
-export function isPluginFilename(path: string): boolean {
+export function isPluginDirectory(path: string): boolean {
 	const files = fs.readdirSync(path);
 	const pluginNameRegex = /^(?:[ \t]*<\?php)?[ \t/*#@]*Plugin Name:(.*)$/im;
 	const pluginNameMatch = files

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -347,7 +347,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				string: true,
 				coerce: parseMountWithDelimiterArguments,
 			},
-			'no-auto-detect': {
+			'no-auto-mount': {
 				describe:
 					'Disable automatic project type detection. Use --mount to manually specify mounts instead.',
 				type: 'boolean',
@@ -379,7 +379,8 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 								'  wp-playground start                    # Start in current directory\n' +
 								'  wp-playground start --path=./my-plugin # Start with a specific path\n' +
 								'  wp-playground start --wp=6.7 --php=8.3 # Use specific versions\n' +
-								'  wp-playground start --no-browser       # Skip opening browser'
+								'  wp-playground start --no-browser       # Skip opening browser\n' +
+								'  wp-playground start --no-auto-mount    # Disable auto-detection'
 						)
 						.options(startCommandOptions)
 			)
@@ -573,7 +574,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			shouldOpenBrowser = args['browser'] !== false;
 
 			// Enable auto-mount unless explicitly disabled
-			if (!args['no-auto-detect']) {
+			if (!args['no-auto-mount']) {
 				args['auto-mount'] = (args['path'] as string) || process.cwd();
 			}
 
@@ -704,7 +705,7 @@ export interface RunCLIArgs {
 	// --------- Start command args -----------
 	path?: string;
 	browser?: boolean;
-	noAutoDetect?: boolean;
+	noAutoMount?: boolean;
 }
 
 type PlaygroundCliWorker =

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -324,10 +324,11 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				type: 'boolean',
 				default: false,
 			},
-			browser: {
-				describe: 'Open the site in your default browser on startup.',
+			'skip-browser': {
+				describe:
+					'Do not open the site in your default browser on startup.',
 				type: 'boolean',
-				default: true,
+				default: false,
 			},
 			quiet: {
 				describe: 'Suppress non-essential output.',
@@ -379,7 +380,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 								'  wp-playground start                    # Start in current directory\n' +
 								'  wp-playground start --path=./my-plugin # Start with a specific path\n' +
 								'  wp-playground start --wp=6.7 --php=8.3 # Use specific versions\n' +
-								'  wp-playground start --no-browser       # Skip opening browser\n' +
+								'  wp-playground start --skip-browser     # Skip opening browser\n' +
 								'  wp-playground start --no-auto-mount    # Disable auto-detection'
 						)
 						.options(startCommandOptions)
@@ -571,7 +572,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 
 		// Transform 'start' command args to server-compatible args
 		if (command === 'start') {
-			shouldOpenBrowser = args['browser'] !== false;
+			shouldOpenBrowser = args['skip-browser'] !== true;
 
 			// Enable auto-mount unless explicitly disabled
 			if (!args['no-auto-mount']) {
@@ -704,7 +705,7 @@ export interface RunCLIArgs {
 
 	// --------- Start command args -----------
 	path?: string;
-	browser?: boolean;
+	skipBrowser?: boolean;
 	noAutoMount?: boolean;
 }
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -45,6 +45,7 @@ import { BlueprintsV1Handler } from './blueprints-v1/blueprints-v1-handler';
 import { startBridge } from '@php-wasm/xdebug-bridge';
 import path from 'path';
 import os from 'os';
+import { exec } from 'child_process';
 import {
 	cleanupStalePlaygroundTempDirs,
 	createPlaygroundCliTempDir,
@@ -280,6 +281,80 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			},
 		};
 
+		/**
+		 * Options for the high-level `start` command.
+		 * This command provides a simplified, opinionated interface for common use cases,
+		 * similar to wp-now. It auto-detects project type and uses sensible defaults.
+		 */
+		const startCommandOptions: Record<string, YargsOptions> = {
+			path: {
+				describe:
+					'Path to the project directory. Playground will auto-detect if this is a plugin, theme, wp-content, or WordPress directory.',
+				type: 'string',
+				default: process.cwd(),
+			},
+			php: {
+				describe: 'PHP version to use.',
+				type: 'string',
+				default: RecommendedPHPVersion,
+				choices: SupportedPHPVersions,
+			},
+			wp: {
+				describe: 'WordPress version to use.',
+				type: 'string',
+				default: 'latest',
+			},
+			port: {
+				describe: 'Port to listen on.',
+				type: 'number',
+				default: 9400,
+			},
+			blueprint: {
+				describe:
+					'Path to a Blueprint JSON file to execute on startup.',
+				type: 'string',
+			},
+			login: {
+				describe: 'Auto-login as the admin user.',
+				type: 'boolean',
+				default: true,
+			},
+			xdebug: {
+				describe: 'Enable Xdebug for debugging.',
+				type: 'boolean',
+				default: false,
+			},
+			browser: {
+				describe: 'Open the site in your default browser on startup.',
+				type: 'boolean',
+				default: true,
+			},
+			quiet: {
+				describe: 'Suppress non-essential output.',
+				type: 'boolean',
+				default: false,
+			},
+			// Advanced options for power users who need more control
+			'site-url': {
+				describe:
+					'Override the site URL. By default, derived from the port (http://127.0.0.1:<port>).',
+				type: 'string',
+			},
+			mount: {
+				describe:
+					'Mount a directory to the PHP runtime (can be used multiple times). Format: /host/path:/vfs/path. Use this for additional mounts beyond auto-detection.',
+				type: 'array',
+				string: true,
+				coerce: parseMountWithDelimiterArguments,
+			},
+			'no-auto-detect': {
+				describe:
+					'Disable automatic project type detection. Use --mount to manually specify mounts instead.',
+				type: 'boolean',
+				default: false,
+			},
+		};
+
 		const buildSnapshotOnlyOptions: Record<string, YargsOptions> = {
 			outfile: {
 				describe: 'When building, write to this output file.',
@@ -291,8 +366,26 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		const yargsObject = yargs(argsToParse)
 			.usage('Usage: wp-playground <command> [options]')
 			.command(
+				'start',
+				'Start a local WordPress server with automatic project detection (recommended)',
+				(yargsInstance: Argv) =>
+					yargsInstance
+						.usage(
+							'Usage: wp-playground start [options]\n\n' +
+								'The easiest way to run WordPress locally. Automatically detects\n' +
+								'if your directory contains a plugin, theme, wp-content, or\n' +
+								'WordPress installation and configures everything for you.\n\n' +
+								'Examples:\n' +
+								'  wp-playground start                    # Start in current directory\n' +
+								'  wp-playground start --path=./my-plugin # Start with a specific path\n' +
+								'  wp-playground start --wp=6.7 --php=8.3 # Use specific versions\n' +
+								'  wp-playground start --no-browser       # Skip opening browser'
+						)
+						.options(startCommandOptions)
+			)
+			.command(
 				'server',
-				'Start a local WordPress server',
+				'Start a local WordPress server (advanced, low-level)',
 				(yargsInstance: Argv) =>
 					yargsInstance.options({
 						...sharedOptions,
@@ -463,14 +556,40 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 
 		const command = args._[0] as string;
 
-		if (!['run-blueprint', 'server', 'build-snapshot'].includes(command)) {
+		if (
+			!['start', 'run-blueprint', 'server', 'build-snapshot'].includes(
+				command
+			)
+		) {
 			yargsObject.showHelp();
 			process.exit(1);
 		}
 
+		// Track whether to open browser (only for 'start' command)
+		let shouldOpenBrowser = false;
+
+		// Transform 'start' command args to server-compatible args
+		if (command === 'start') {
+			shouldOpenBrowser = args['browser'] !== false;
+
+			// Enable auto-mount unless explicitly disabled
+			if (!args['no-auto-detect']) {
+				args['auto-mount'] = (args['path'] as string) || process.cwd();
+			}
+
+			// Verbosity handling
+			if (args['quiet']) {
+				args['verbosity'] = 'quiet';
+			}
+
+			// Intl is always enabled for the start command
+			args['intl'] = true;
+		}
+
 		const cliArgs = {
 			...args,
-			command,
+			// The 'start' command internally runs as 'server'
+			command: command === 'start' ? 'server' : command,
 			mount: [
 				...((args['mount'] as Mount[]) || []),
 				...((args['mount-dir'] as Mount[]) || []),
@@ -485,6 +604,11 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		if (cliServer === undefined) {
 			// No server was started, so we are done with our work.
 			process.exit(0);
+		}
+
+		// Open browser for the 'start' command
+		if (shouldOpenBrowser) {
+			openInBrowser(cliServer.serverUrl);
 		}
 
 		const cleanUpCliAndExit = (() => {
@@ -535,7 +659,7 @@ export interface RunCLIArgs {
 		| BlueprintV1Declaration
 		| BlueprintV2Declaration
 		| BlueprintBundle;
-	command: 'server' | 'run-blueprint' | 'build-snapshot';
+	command: 'start' | 'server' | 'run-blueprint' | 'build-snapshot';
 	debug?: boolean;
 	login?: boolean;
 	mount?: Mount[];
@@ -576,6 +700,11 @@ export interface RunCLIArgs {
 	'db-path'?: string;
 	'truncate-new-site-directory'?: boolean;
 	allow?: string;
+
+	// --------- Start command args -----------
+	path?: string;
+	browser?: boolean;
+	noAutoDetect?: boolean;
 }
 
 type PlaygroundCliWorker =
@@ -1303,6 +1432,35 @@ async function exposeFileLockManager(fileLockManager: FileLockManagerForNode) {
 		await exposeSyncAPI(fileLockManager, port1);
 	}
 	return port2;
+}
+
+/**
+ * Open a URL in the user's default browser.
+ * Works cross-platform: macOS, Windows, and Linux.
+ */
+function openInBrowser(url: string): void {
+	const platform = os.platform();
+	let command: string;
+
+	switch (platform) {
+		case 'darwin':
+			command = `open "${url}"`;
+			break;
+		case 'win32':
+			command = `start "" "${url}"`;
+			break;
+		default:
+			// Linux and other Unix-like systems
+			command = `xdg-open "${url}"`;
+			break;
+	}
+
+	exec(command, (error) => {
+		if (error) {
+			// Don't fail the CLI if browser opening fails, just log a debug message
+			logger.debug(`Could not open browser: ${error.message}`);
+		}
+	});
 }
 
 async function zipSite(

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -576,7 +576,8 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 
 			// Enable auto-mount unless explicitly disabled
 			if (!args['no-auto-mount']) {
-				args['auto-mount'] = (args['path'] as string) || process.cwd();
+				args['auto-mount'] = args['autoMount'] =
+					(args['path'] as string) || process.cwd();
 			}
 
 			// Verbosity handling

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -324,6 +324,8 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				type: 'boolean',
 				default: false,
 			},
+			'experimental-unsafe-ide-integration':
+				sharedOptions['experimental-unsafe-ide-integration'],
 			'skip-browser': {
 				describe:
 					'Do not open the site in your default browser on startup.',

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -740,6 +740,28 @@ describe.each(blueprintVersions)(
 	60_000 * 5
 );
 
+describe('start command', () => {
+	test('should work with default options', async () => {
+		// The start command internally runs as 'server' with auto-mount enabled
+		await using cliServer = await runCLI({
+			command: 'server',
+			// Simulating what 'start' command does:
+			// - enables auto-mount with current directory
+			// - enables login by default
+			// - enables intl
+			login: true,
+			intl: true,
+			// Skip WordPress setup for speed since we're just testing the command structure
+			wordpressInstallMode: 'do-not-attempt-installing',
+			skipSqliteSetup: true,
+			blueprint: undefined,
+		});
+
+		// Verify server started successfully
+		expect(cliServer.serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+	});
+});
+
 describe('other run-cli behaviors', () => {
 	describe('auto-login', () => {
 		test('should clear old auto-login cookie', async () => {


### PR DESCRIPTION
## Summary

This PR introduces a new `start` command to Playground CLI that provides a simple, wp-now-style experience for running WordPress locally. It's designed to make the CLI accessible to developers who just want to run a command and get going, without needing to understand low-level options.

The existing `server` command remains available for advanced users who need fine-grained control over mounts, WordPress installation modes, and other low-level options.

## Migrating from wp-now

This change unlocks officially deprecating `@wp-now/wp-now` and recommending everyone switch to `@wp-playground/cli`. Here's how wp-now commands map to the new `start` command:

| wp-now | Playground CLI |
|--------|----------------|
| `npx @wp-now/wp-now start` | `npx @wp-playground/cli start` |
| `wp-now start --php=8.3` | `playground start --php=8.3` |
| `wp-now start --wp=6.7` | `playground start --wp=6.7` |
| `wp-now start --port=8000` | `playground start --port=8000` |
| `wp-now start --blueprint=bp.json` | `playground start --blueprint=bp.json` |
| `wp-now start --path=./my-plugin` | `playground start --path=./my-plugin` |
| `wp-now start --skip-browser` | `playground start --skip-browser` |
| `wp-now start --reset` | `playground start --reset` (implemented in https://github.com/WordPress/wordpress-playground/pull/3119) |

The API is intentionally similar. Both tools automatically detect plugin, theme, wp-content, or WordPress directories. Both work with no additional flags.

Improvements over wp-now:

- **Auto-login by default**: No need to manually log in after starting
- **Browser opens automatically**: Site launches in your default browser (use `--skip-browser` to disable)
- **Manual mounts available**: Use `--mount /host/path:/vfs/path` for additional mounts beyond auto-detection
- **Escape hatch**: Use `--no-auto-mount` to disable auto-detection and manually control mounts
- **Site URL override**: Use `--site-url` when you need a specific URL

Differences with wp-now:

- ~~Playground CLI does not persist sites in the same way as wp-now does. In `wp-now`, you can run `wp-now start` in a directory, get a site, make some changes to that site, then close the server, come back the next day, start the server again, and continue working on that same site. Playground CLI doesn't do it. Every server is ephemeral. You can store your changes by explicitly mounting wp-content to a local directory, but there's no automation in place to do it for you. If the users will request this feature, we can consider adding it, but I'm skipping it in the initial rollout as it would add a lot of complexity that the Playground CLI tool was intentionally designed not to handle implicitly.~~

^ This was implemented later on in https://github.com/WordPress/wordpress-playground/pull/3119

## Usage

```bash
# Start in current directory (auto-detects project type)
playground start

# Reset the previously created site and start fresh
playground start --reset

# Start with a specific path
playground start --path=./my-plugin

# Use specific PHP and WordPress versions
playground start --wp=6.7 --php=8.3

# Don't open browser automatically
playground start --skip-browser

# Enable Xdebug for debugging
playground start --xdebug

# Disable auto-detection and use manual mounts
playground start --no-auto-mount --mount ./my-plugin:/wordpress/wp-content/plugins/my-plugin

# Override the site URL
playground start --site-url=https://my-local-site.test
```

## CLI Flags Reference

| Flag | Type | Default | Description |
|------|------|---------|-------------|
| `--path` | string | current directory | Path to the project directory. Playground auto-detects if this is a plugin, theme, wp-content, or WordPress directory. |
| `--php` | string | `8.3` | PHP version to use. Choices: `7.2`, `7.3`, `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5` |
| `--wp` | string | `latest` | WordPress version to use. |
| `--port` | number | `9400` | Port to listen on. |
| `--blueprint` | string | — | Path to a Blueprint JSON file to execute on startup. |
| `--login` | boolean | `true` | Auto-login as the admin user. |
| `--xdebug` | boolean | `false` | Enable Xdebug for debugging. |
| `--skip-browser` | boolean | `false` | Do not open the site in your default browser on startup. |
| `--quiet` | boolean | `false` | Suppress non-essential output. |
| `--site-url` | string | — | Override the site URL. By default, derived from the port (`http://127.0.0.1:<port>`). |
| `--mount` | array | — | Mount a directory to the PHP runtime (can be used multiple times). Format: `/host/path:/vfs/path`. Use this for additional mounts beyond auto-detection. |
| `--no-auto-mount` | boolean | `false` | Disable automatic project type detection. Use `--mount` to manually specify mounts instead. |

## Test plan

- [x] Run `playground start --help` and verify options are displayed correctly
- [x] Run `playground start` in a plugin directory and verify auto-detection works
- [x] Verify browser opens automatically on startup
- [x] Verify `--skip-browser` suppresses browser opening
- [x] Run existing CLI tests to ensure no regressions