### PR TITLE
[CI] Enable trusted publisher-based publishing

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -70,5 +70,6 @@ jobs:
       - uses: ./.github/actions/prepare-playground
 
       - name: Publish NPM packages
+        # Version bump, release, tag a new version on GitHub
         run: >
           npx lerna@7.1.3 publish ${{ inputs.version_bump || 'patch' }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || 'latest' }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -12,6 +12,7 @@ on:
         required: false
         default: 'latest'
   schedule:
+    # Auto-publish every Monday
     - cron: '0 9 * * 1'
 
 permissions:

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -1,75 +1,78 @@
 name: Release NPM packages
 
 on:
-    workflow_dispatch:
-        # Require a version bump (patch, minor, major) and an optional dist tag
-        inputs:
-            version_bump:
-                description: 'Version bump (patch, minor, or major)'
-                required: true
-                default: 'patch'
-            dist_tag:
-                description: 'Dist tag (latest, next, etc.)'
-                required: false
-                default: 'latest'
-    schedule:
-        # Auto-publish every Monday
-        - cron: '0 9 * * 1'
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump (patch, minor, or major)'
+        required: true
+        default: 'patch'
+      dist_tag:
+        description: 'Dist tag (latest, next, etc.)'
+        required: false
+        default: 'latest'
+  schedule:
+    - cron: '0 9 * * 1'
+
+permissions:
+  id-token: write
+  contents: write
 
 jobs:
-    release:
-        # Only run this workflow from the trunk branch and when it's triggered by a Playground maintainer
-        if: >
-            github.ref == 'refs/heads/trunk' && (
-                github.actor == 'adamziel' ||
-                github.actor == 'dmsnell' ||
-                github.actor == 'bgrgicak' ||
-                github.actor == 'brandonpayton' ||
-                github.actor == 'zaerl' ||
-                github.actor == 'janjakes' ||
-                github.actor == 'mho22'
-            )
+  release:
+    if: >
+      github.ref == 'refs/heads/trunk' && (
+        github.actor == 'adamziel' ||
+        github.actor == 'dmsnell' ||
+        github.actor == 'bgrgicak' ||
+        github.actor == 'brandonpayton' ||
+        github.actor == 'zaerl' ||
+        github.actor == 'janjakes' ||
+        github.actor == 'mho22'
+      )
 
-        # Specify runner + deployment step
-        runs-on: ubuntu-latest
-        environment:
-            name: npm
-        env:
-            NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        steps:
-            - name: Free up runner disk space
-              shell: bash
-              run: |
-                  set -euo pipefail
-                  echo "Disk usage before cleanup:"
-                  df -h
-                  sudo rm -rf /usr/local/lib/android
-                  sudo rm -rf /usr/share/dotnet
-                  sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-                  sudo rm -rf /opt/ghc
-                  sudo rm -rf /opt/hostedtoolcache/CodeQL
-                  echo "Disk usage after cleanup:"
-                  df -h
-            - uses: actions/checkout@v4
-              with:
-                  ref: ${{ github.event.pull_request.head.ref }}
-                  clean: true
-                  persist-credentials: false
-                  submodules: true
-            - name: Config git user
-              run: |
-                  git config --global user.name "deployment_bot"
-                  git config --global user.email "deployment_bot@users.noreply.github.com"
-                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
-            - name: Authenticate with Registry
-              run: |
-                  echo "@php-wasm:registry=https://registry.npmjs.org/" > ~/.npmrc
-                  echo "@wp-playground:registry=https://registry.npmjs.org/" >> ~/.npmrc
-                  echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
-                  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-            - uses: ./.github/actions/prepare-playground
-            # Version bump, release, tag a new version on GitHub
-            - name: Release new version of NPM packages
-              shell: bash
-              run: npx lerna@7.1.3 publish ${{ inputs.version_bump || 'patch' }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || 'latest' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+
+    steps:
+      - name: Free up runner disk space
+        run: |
+          set -euo pipefail
+          df -h
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h
+
+      - uses: actions/checkout@v4
+        with:
+          ref: trunk
+          clean: true
+          persist-credentials: true
+          submodules: true
+
+      - name: Configure git user
+        run: |
+          git config --global user.name "deployment_bot"
+          git config --global user.email "deployment_bot@users.noreply.github.com"
+
+      - name: Set up Node.js with OIDC
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - uses: ./.github/actions/prepare-playground
+
+      - name: Publish NPM packages
+        run: >
+          npx lerna@7.1.3 publish
+          ${{ inputs.version_bump || 'patch' }}
+          --yes
+          --no-private
+          --loglevel=verbose
+          --dist-tag=${{ inputs.dist_tag || 'latest' }}

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -20,6 +20,7 @@ permissions:
 
 jobs:
   release:
+    # Only run this workflow from the trunk branch and when it's triggered by a Playground maintainer
     if: >
       github.ref == 'refs/heads/trunk' && (
         github.actor == 'adamziel' ||
@@ -70,9 +71,4 @@ jobs:
 
       - name: Publish NPM packages
         run: >
-          npx lerna@7.1.3 publish
-          ${{ inputs.version_bump || 'patch' }}
-          --yes
-          --no-private
-          --loglevel=verbose
-          --dist-tag=${{ inputs.dist_tag || 'latest' }}
+          npx lerna@7.1.3 publish ${{ inputs.version_bump || 'patch' }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || 'latest' }}


### PR DESCRIPTION
## Motivation for the change, related issues

Rewires the publish package's job to use trusted publisher's setup. Here is why it wasn't used before:

* Injecting `NPM_TOKEN` and writing `.npmrc` disables OIDC and forces legacy auth.
* Checkout using `github.event.pull_request.head.ref` – releases need to be deterministic and always run from trunk. This change limits our ability to publish a preview version of the packages with a different dist tag, which seems fine in practice since we haven't used it at all. 

Technically unrelated, but I've coupled this change with this PR: we're no longer rewriting the Git remote with a secret token. The baked in GITHUB_TOKEN already has the required permissions.

