### PR TITLE
[CI] Fix flaky e2e test for blueprint share button

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -345,6 +345,10 @@ test('should copy blueprint link to clipboard when share button is clicked', asy
 	);
 	await editor.waitFor({ timeout: 10000 });
 
+	// Wait for the URL hash to be computed (debounced by 500ms in the component)
+	// and the share button to be ready
+	await website.page.waitForTimeout(1000);
+
 	// Click the share button (copy link to blueprint)
 	const shareButton = website.page.getByRole('button', {
 		name: 'Copy link to blueprint',


### PR DESCRIPTION
## Summary

The share button test was failing in CI because it clicked the button before the URL hash was computed. The hash is computed with a 500ms debounce after the editor loads, so clicking too quickly resulted in the copy operation failing (newUrl was not ready yet).

Added a 1 second wait after the editor loads to ensure the debounce completes before attempting to click the share button.

## Test plan

- [x] Run the test locally with `npx playwright test --config=packages/playground/website/playwright/playwright.config.ts --grep "copy blueprint link" --project=chromium`
- [x] CI passes