### PR TITLE
Fix npm trusted publisher by upgrading to Lerna 9 and npm 11.5.1+

### DIFF
--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -69,9 +69,14 @@ jobs:
                   registry-url: 'https://registry.npmjs.org'
                   cache: 'npm'
 
+            # npm 11.5.1+ is required for trusted publisher OIDC authentication
+            - name: Upgrade npm for trusted publishing
+              run: npm install -g npm@latest
+
             - uses: ./.github/actions/prepare-playground
 
             - name: Publish NPM packages
               # Version bump, release, tag a new version on GitHub
+              # Lerna 9+ is required for OIDC trusted publishing support
               run: >
-                  npx lerna@7.1.3 publish ${{ inputs.version_bump || 'patch' }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || 'latest' }}
+                  npx lerna@9 publish ${{ inputs.version_bump || 'patch' }} --yes --no-private --loglevel=verbose --dist-tag=${{ inputs.dist_tag || 'latest' }}


### PR DESCRIPTION
## Summary

This PR fixes the E404 errors when publishing npm packages with the trusted publisher (OIDC) setup.

The npm trusted publisher setup requires two dependencies that we weren't meeting:

1. **Lerna 9.0.0+** - OIDC trusted publishing support was added in Lerna v9.0.0. We were using 7.1.3.
2. **npm 11.5.1+** - The OIDC token handling required for trusted publishing needs npm 11.5.1 or later. GitHub Actions runners don't include the latest npm by default.

These changes upgrade Lerna from 7.1.3 to 9.x and explicitly install the latest npm before publishing.

## Research sources

- [Lerna OIDC Trusted Publishing docs](https://lerna.js.org/docs/recipes/oidc-trusted-publishing)
- [npm/cli issue #8730 - OIDC publish failing](https://github.com/npm/cli/issues/8730)
- [GitHub community discussion on 404 errors](https://github.com/orgs/community/discussions/173102)

## Test plan

- [ ] Manually trigger the "Release NPM packages" workflow on trunk to verify packages publish successfully