### PR TITLE
Rephrase Opcache module injection comments

### DIFF
--- a/packages/php-wasm/compile/opcache/opcache_module.c
+++ b/packages/php-wasm/compile/opcache/opcache_module.c
@@ -1,6 +1,6 @@
 /**
- * This file is a dummy file for the opcache extension. It is used to build the
- * opcache extension as a static extension.
+ * This file is glue code for the opcache extension. It is used to build
+ * the opcache extension as a static extension.
  */
 
 #include "php.h"

--- a/packages/php-wasm/compile/opcache/php_opcache.h
+++ b/packages/php-wasm/compile/opcache/php_opcache.h
@@ -1,7 +1,7 @@
-/*
- * This file is a dummy file for the opcache extension. It is used to build the
- * opcache extension as a static extension.
-*/
+/**
+ * This file is glue code for the opcache extension. It is used to build
+ * the opcache extension as a static extension.
+ */
 
 #ifndef PHP_OPCACHE_H
 #define PHP_OPCACHE_H

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -31,7 +31,7 @@ COPY ./php-wasm-dns-polyfill/ /root/php-src/ext/dns_polyfill
 # Polyfill for post_message_to_js functions
 COPY ./php-post-message-to-js/ /root/php-src/ext/post_message_to_js
 
-# Copy the dummy opcache_module.c and php_opcache.h files.
+# Copy the opcache_module.c and php_opcache.h files.
 COPY ./opcache/ /root/php-src/ext/opcache
 
 # Bring in the libraries
@@ -103,7 +103,7 @@ RUN if [ "$WITH_OPCACHE" = "yes" ]; \
 		fi; \
 		# Force OPcache to be built as a static extension. OPcache is always built as a shared extension.
 		/root/replace.sh 's/ext_shared=yes/ext_shared=no/g' /root/php-src/ext/opcache/config.m4; \
-		# Add the dummy opcache_module.c to the list of files to build for PHP < 8.5.0.
+		# Add the opcache_module.c to the list of files to build for PHP < 8.5.0.
 		# PHP 8.5 made OPcache a non-optional part of PHP https://wiki.php.net/rfc/make_opcache_required
 		if [[ "${PHP_VERSION:0:1}" -lt "8" || ("${PHP_VERSION:0:1}" -eq "8" && "${PHP_VERSION:2:1}" -le "4") ]]; then \
 			/root/replace.sh 's/shared_alloc_mmap.c/shared_alloc_mmap.c opcache_module.c/g' /root/php-src/ext/opcache/config.m4; \


### PR DESCRIPTION
## Motivation for the change, related issues

This pull request is set to remove the confusing word `dummy` in Opcache support comments.
