### PR TITLE
[Meta] Normalize ws package version override in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
 		"react-dom": "18.3.1",
 		"typescript": "5.4.5",
 		"@playwright/test": "1.55.1",
-		"ws": "^8.18.0",
+		"ws": "8.18.3",
 		"tmp": "0.2.5",
 		"form-data": "^4.0.4"
 	},


### PR DESCRIPTION
Use a specific version of the `"ws"` package override to, hopefully, get Lerna 9 to accept the generated graph of package.json files and publish the npm packages.
