### PR TITLE
[ Intl ] Parallelize memoizedFetch methods when enabling Intl in PHP.wasm web

### DIFF
--- a/packages/php-wasm/web/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/web/src/lib/extensions/intl/with-intl.ts
@@ -14,14 +14,17 @@ export async function withIntl(
 	const memoizedFetch = createMemoizedFetch(fetch);
 
 	const extensionName = 'intl.so';
-	const extensionPath = (await getIntlExtensionModule(version)).default;
-	const extension = await (await memoizedFetch(extensionPath)).arrayBuffer();
-
 	const dataName = 'icu.dat';
+
+	const extensionPath = (await getIntlExtensionModule(version)).default;
 	// @ts-ignore
 	const dataPath = (await import('../../../../public/shared/icu.dat'))
 		.default;
-	const ICUData = await (await memoizedFetch(dataPath)).arrayBuffer();
+
+	const [extension, ICUData] = await Promise.all([
+		memoizedFetch(extensionPath).then((response) => response.arrayBuffer()),
+		memoizedFetch(dataPath).then((response) => response.arrayBuffer()),
+	]);
 
 	return {
 		...options,


### PR DESCRIPTION
## Motivation for the change, related issues

Follow-up on https://github.com/WordPress/wordpress-playground/pull/2591. When enabling, intl, we fetch two files : 

- The `intl.so` extension
- The `icu.dat` data file

This pull request suggest to parallelize these fetches.  

## Implementation details

Use of a `Promise.all` to run simultaneously the two fetches.

## Testing Instructions (or ideally a Blueprint)

CI