### PR TITLE
Add CI workflow to build and release the DevTools extension

### DIFF
--- a/.github/workflows/publish-devtools-extension.yml
+++ b/.github/workflows/publish-devtools-extension.yml
@@ -1,0 +1,135 @@
+name: Release DevTools Extension
+
+on:
+    workflow_dispatch:
+        inputs:
+            version_bump:
+                description: 'Version bump type'
+                required: true
+                default: 'patch'
+                type: choice
+                options:
+                    - patch
+                    - minor
+                    - major
+
+jobs:
+    publish:
+        # Only run this workflow from the trunk branch and when triggered by a Playground maintainer
+        if: >
+            github.ref == 'refs/heads/trunk' && (
+                github.actor == 'adamziel' ||
+                github.actor == 'dmsnell' ||
+                github.actor == 'bgrgicak' ||
+                github.actor == 'brandonpayton' ||
+                github.actor == 'zaerl' ||
+                github.actor == 'ashfame' ||
+                github.actor == 'janjakes' ||
+                github.actor == 'mho22'
+            )
+
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+                  persist-credentials: true
+                  submodules: true
+
+            - name: Configure git
+              run: |
+                  git config --global user.name "github-actions[bot]"
+                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+            - uses: ./.github/actions/prepare-playground
+
+            - name: Determine version
+              id: version
+              run: |
+                  # Get the latest devtools-extension tag
+                  LATEST_TAG=$(git tag -l 'devtools-extension-v*' --sort=-v:refname | head -n 1)
+
+                  if [ -z "$LATEST_TAG" ]; then
+                      # No existing tags, start at 0.0.1
+                      NEW_VERSION="0.0.1"
+                  else
+                      # Extract version from tag (devtools-extension-v0.0.1 -> 0.0.1)
+                      CURRENT_VERSION="${LATEST_TAG#devtools-extension-v}"
+
+                      # Split version into parts
+                      IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+                      # Bump according to input
+                      case "${{ inputs.version_bump }}" in
+                          major)
+                              MAJOR=$((MAJOR + 1))
+                              MINOR=0
+                              PATCH=0
+                              ;;
+                          minor)
+                              MINOR=$((MINOR + 1))
+                              PATCH=0
+                              ;;
+                          patch)
+                              PATCH=$((PATCH + 1))
+                              ;;
+                      esac
+
+                      NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+                  fi
+
+                  echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  echo "tag=devtools-extension-v$NEW_VERSION" >> $GITHUB_OUTPUT
+                  echo "New version: $NEW_VERSION"
+
+            - name: Update manifest version
+              run: |
+                  # Update the version in manifest.json
+                  cd packages/playground/devtools-extension
+                  jq '.version = "${{ steps.version.outputs.version }}"' public/manifest.json > tmp.json
+                  mv tmp.json public/manifest.json
+
+            - name: Build extension
+              run: npx nx build playground-devtools-extension
+
+            - name: Package extension
+              run: |
+                  cd dist/packages/playground/devtools-extension
+                  zip -r ../../../../playground-devtools-extension-${{ steps.version.outputs.version }}.zip .
+
+            - name: Create tag
+              run: |
+                  git tag ${{ steps.version.outputs.tag }}
+                  git push origin ${{ steps.version.outputs.tag }}
+
+            - name: Create GitHub Release
+              uses: softprops/action-gh-release@v2
+              with:
+                  tag_name: ${{ steps.version.outputs.tag }}
+                  name: WordPress Playground DevTools Extension ${{ steps.version.outputs.version }}
+                  body: |
+                      ## WordPress Playground DevTools Extension v${{ steps.version.outputs.version }}
+
+                      A Chrome DevTools extension for inspecting and editing files in WordPress Playground instances.
+
+                      ### Installation
+
+                      1. Download the `playground-devtools-extension-${{ steps.version.outputs.version }}.zip` file
+                      2. Extract it to a folder
+                      3. Open Chrome and go to `chrome://extensions/`
+                      4. Enable "Developer mode" (toggle in top right)
+                      5. Click "Load unpacked" and select the extracted folder
+
+                      ### Usage
+
+                      1. Open a page containing a WordPress Playground instance
+                      2. Open Chrome DevTools (F12)
+                      3. Click on the "Playground" tab
+                      4. Browse and edit files in the Playground instance
+                  files: |
+                      playground-devtools-extension-${{ steps.version.outputs.version }}.zip
+                  draft: false
+                  prerelease: false

--- a/.github/workflows/publish-devtools-extension.yml
+++ b/.github/workflows/publish-devtools-extension.yml
@@ -46,34 +46,55 @@ jobs:
 
             - uses: ./.github/actions/prepare-playground
 
+            # Version Bumping Strategy:
+            #
+            # The extension uses semantic versioning (MAJOR.MINOR.PATCH) with its own
+            # version sequence independent of the main WordPress Playground project.
+            #
+            # Version tags follow the pattern: devtools-extension-vX.Y.Z
+            # This naming clearly indicates these versions are extension-specific.
+            #
+            # How bumping works:
+            # - If no tags exist yet, we start at 0.0.1
+            # - Otherwise, we find the latest tag and increment based on the bump type:
+            #   - patch: 0.0.1 -> 0.0.2 (bug fixes, small changes)
+            #   - minor: 0.0.2 -> 0.1.0 (new features, backwards compatible)
+            #   - major: 0.1.0 -> 1.0.0 (breaking changes)
+            #
+            # The version is stored in Git tags only, not committed to the repository.
+            # The manifest.json version is updated at build time from the computed version.
             - name: Determine version
               id: version
               run: |
-                  # Get the latest devtools-extension tag
+                  # Find the most recent devtools-extension tag, sorted by version number
                   LATEST_TAG=$(git tag -l 'devtools-extension-v*' --sort=-v:refname | head -n 1)
 
                   if [ -z "$LATEST_TAG" ]; then
-                      # No existing tags, start at 0.0.1
+                      # No existing tags found - this is the first release
                       NEW_VERSION="0.0.1"
                   else
-                      # Extract version from tag (devtools-extension-v0.0.1 -> 0.0.1)
+                      # Extract the version number from the tag name
+                      # Example: devtools-extension-v0.0.1 -> 0.0.1
                       CURRENT_VERSION="${LATEST_TAG#devtools-extension-v}"
 
-                      # Split version into parts
+                      # Split version string into components
                       IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
 
-                      # Bump according to input
+                      # Apply the requested version bump
                       case "${{ inputs.version_bump }}" in
                           major)
+                              # Breaking changes: increment major, reset minor and patch
                               MAJOR=$((MAJOR + 1))
                               MINOR=0
                               PATCH=0
                               ;;
                           minor)
+                              # New features: increment minor, reset patch
                               MINOR=$((MINOR + 1))
                               PATCH=0
                               ;;
                           patch)
+                              # Bug fixes: increment patch only
                               PATCH=$((PATCH + 1))
                               ;;
                       esac

--- a/packages/playground/devtools-extension/public/manifest.json
+++ b/packages/playground/devtools-extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "WordPress Playground DevTools",
-	"version": "1.0.0",
+	"version": "0.0.0",
 	"description": "DevTools panel for inspecting and editing WordPress Playground instances",
 	"icons": {
 		"16": "icons/icon-16.png",


### PR DESCRIPTION
## Summary

This adds a GitHub Actions workflow that builds the WordPress Playground DevTools browser extension and publishes it as a GitHub release.

The extension has its own versioning scheme starting at 0.0.1, separate from the main project versions. Tags follow the pattern `devtools-extension-vX.Y.Z` to clearly indicate these versions are specific to the extension, not the broader WordPress Playground project.

### Workflow features

- Triggered manually via workflow_dispatch with version bump type selection (patch/minor/major)
- Determines the next version by checking existing `devtools-extension-v*` tags
- Updates the manifest.json version before building
- Builds the extension using the existing nx build target
- Creates a tagged GitHub release with installation instructions and the packaged extension zip

### How to use

1. Go to Actions → "Release DevTools Extension"
2. Click "Run workflow"
3. Select the version bump type (patch, minor, or major)
4. The workflow will create a new release at https://github.com/WordPress/wordpress-playground/releases with the `devtools-extension-vX.Y.Z` tag

## Test plan

- [ ] Merge this PR
- [ ] Trigger the workflow manually from the Actions tab
- [ ] Verify a new release is created with the correct version tag
- [ ] Download and test the extension zip from the release