### PR TITLE
[Website] Make all iframes controlled by the service worker – attempt 2

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -343,7 +343,9 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 	}
 
 	// Serve the iframe loader HTML for trapped iframes
-	if (fullUrl.pathname.endsWith('/wp-includes/playground-iframe-loader.html')) {
+	if (
+		fullUrl.pathname.endsWith('/wp-includes/playground-iframe-loader.html')
+	) {
 		return iframeLoaderHtml(scope);
 	}
 
@@ -669,13 +671,13 @@ function iframeLoaderHtml(scope: string) {
 			if (content.includes('<head>')) {
 				content = content.replace('<head>', '<head>' + trapScript);
 			} else if (content.match(/<head\\s/)) {
-				content = content.replace(/<head[^>]*>/, '\$&' + trapScript);
+				content = content.replace(/<head[^>]*>/, '$&' + trapScript);
 			} else if (content.includes('<html>')) {
 				content = content.replace('<html>', '<html>' + trapScript);
 			} else if (content.match(/<html\\s/)) {
-				content = content.replace(/<html[^>]*>/, '\$&' + trapScript);
+				content = content.replace(/<html[^>]*>/, '$&' + trapScript);
 			} else if (content.toLowerCase().startsWith('<!doctype')) {
-				content = content.replace(/(<!doctype[^>]*>)/i, '\$1' + trapScript);
+				content = content.replace(/(<!doctype[^>]*>)/i, '$1' + trapScript);
 			} else {
 				content = trapScript + content;
 			}

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -121,6 +121,10 @@ import {
 	shouldCacheUrl,
 } from './src/lib/offline-mode-cache';
 
+// The iframes-trap script that gets injected into HTML responses
+/* @ts-ignore */
+import iframesTrapScript from './src/lib/iframe-trap/iframes-trap.js?raw';
+
 if (!(self as any).document) {
 	// Workaround: vite translates import.meta.url
 	// to document.currentScript which fails inside of
@@ -338,6 +342,11 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 		return emptyHtml(scope);
 	}
 
+	// Serve the iframe loader HTML for trapped iframes
+	if (fullUrl.pathname.endsWith('/wp-includes/playground-iframe-loader.html')) {
+		return iframeLoaderHtml(scope);
+	}
+
 	const workerResponse = await convertFetchEventToPHPRequest(event);
 
 	if (
@@ -423,7 +432,59 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 		});
 	}
 
+	// Inject the iframes-trap script into HTML responses to ensure all iframes
+	// are controlled by the service worker.
+	const contentType = workerResponse.headers.get('content-type') || '';
+	if (contentType.includes('text/html')) {
+		return injectIframesTrapScript(workerResponse);
+	}
+
 	return workerResponse;
+}
+
+/**
+ * Injects the iframes-trap.js script into an HTML response.
+ *
+ * This script intercepts iframe creation and modification to ensure all iframes
+ * use URLs controlled by the service worker, preventing network requests from
+ * bypassing the service worker.
+ *
+ * The script is injected as early as possible in the document to intercept
+ * iframe creation before any other scripts run.
+ */
+async function injectIframesTrapScript(response: Response): Promise<Response> {
+	const html = await response.text();
+
+	// Create the script tag to inject
+	const scriptTag = `<script data-playground-iframes-trap>${iframesTrapScript}</script>`;
+
+	let modifiedHtml: string;
+
+	// Try to inject right after <head> for earliest execution
+	if (html.includes('<head>')) {
+		modifiedHtml = html.replace('<head>', '<head>' + scriptTag);
+	} else if (html.includes('<head ')) {
+		// Handle <head with attributes
+		modifiedHtml = html.replace(/<head[^>]*>/, '$&' + scriptTag);
+	} else if (html.includes('<html>')) {
+		// Fallback: inject after <html>
+		modifiedHtml = html.replace('<html>', '<html>' + scriptTag);
+	} else if (html.includes('<html ')) {
+		// Handle <html with attributes
+		modifiedHtml = html.replace(/<html[^>]*>/, '$&' + scriptTag);
+	} else if (html.toLowerCase().startsWith('<!doctype')) {
+		// Fallback: inject after doctype
+		modifiedHtml = html.replace(/(<!doctype[^>]*>)/i, '$1' + scriptTag);
+	} else {
+		// Last resort: prepend to document
+		modifiedHtml = scriptTag + html;
+	}
+
+	return new Response(modifiedHtml, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: response.headers,
+	});
 }
 
 reportServiceWorkerMetrics(self);
@@ -541,6 +602,100 @@ function emptyHtml(scope: string) {
 
 	return new Response(
 		'<!doctype html><script>const hash = window.location.hash.substring(1); if ( hash ) document.write(decodeURIComponent(hash))</script>',
+		{
+			status: 200,
+			headers,
+		}
+	);
+}
+
+/**
+ * The iframe loader HTML file used by iframes-trap.js.
+ *
+ * This file is served at /wp-includes/playground-iframe-loader.html and is used
+ * to load content for trapped iframes (srcdoc, about:blank, blob:, data: URLs).
+ *
+ * The loader:
+ * 1. Reads the content ID from the URL query string
+ * 2. Requests the content from the parent window via postMessage
+ * 3. Writes the content to the document
+ * 4. Injects the iframes-trap.js script to handle nested iframes
+ *
+ * @param scope The scope of the request
+ */
+function iframeLoaderHtml(scope: string) {
+	const headers: Record<string, string> = {
+		'content-type': 'text/html',
+	};
+
+	if (scopesWithCrossOriginIsolation.has(scope)) {
+		headers['Document-Isolation-Policy'] = 'isolate-and-credentialless';
+	}
+
+	// The loader script that requests content from the parent window
+	const loaderScript = `
+(function() {
+	const params = new URLSearchParams(window.location.search);
+	const id = params.get('id');
+
+	if (!id) {
+		console.error('[iframe-loader] No content ID provided');
+		return;
+	}
+
+	// Request content from parent
+	function requestContent() {
+		if (window.parent && window.parent !== window) {
+			window.parent.postMessage({
+				type: 'playground-iframe-content-request',
+				id: id
+			}, '*');
+		}
+	}
+
+	// Listen for content response
+	window.addEventListener('message', function handler(event) {
+		if (event.data && event.data.type === 'playground-iframe-content-response' && event.data.id === id) {
+			window.removeEventListener('message', handler);
+
+			let content = event.data.content || '';
+
+			// Inject the iframes-trap script INTO the content BEFORE writing it.
+			// This ensures the trap runs before any inline scripts in the content,
+			// allowing us to intercept nested iframe creation.
+			const trapScript = '<script data-playground-iframes-trap>' + ${JSON.stringify(iframesTrapScript)} + '<\\/script>';
+
+			// Try to inject right after <head> for earliest execution
+			if (content.includes('<head>')) {
+				content = content.replace('<head>', '<head>' + trapScript);
+			} else if (content.match(/<head\\s/)) {
+				content = content.replace(/<head[^>]*>/, '\$&' + trapScript);
+			} else if (content.includes('<html>')) {
+				content = content.replace('<html>', '<html>' + trapScript);
+			} else if (content.match(/<html\\s/)) {
+				content = content.replace(/<html[^>]*>/, '\$&' + trapScript);
+			} else if (content.toLowerCase().startsWith('<!doctype')) {
+				content = content.replace(/(<!doctype[^>]*>)/i, '\$1' + trapScript);
+			} else {
+				content = trapScript + content;
+			}
+
+			// Write the content to the document (trap script will run first)
+			document.open();
+			document.write(content);
+			document.close();
+		}
+	});
+
+	// Request content immediately and also after a short delay in case parent isn't ready
+	requestContent();
+	setTimeout(requestContent, 50);
+	setTimeout(requestContent, 200);
+})();
+`;
+
+	return new Response(
+		`<!doctype html><html><head></head><body><script>${loaderScript}</script></body></html>`,
 		{
 			status: 200,
 			headers,

--- a/packages/playground/remote/src/lib/iframe-trap/iframes-trap.js
+++ b/packages/playground/remote/src/lib/iframe-trap/iframes-trap.js
@@ -1,22 +1,20 @@
 /**
  * iframes-trap.js
  *
- * This script intercepts iframe creation and modification to ensure all iframes
- * are controlled by the service worker. Iframes created with about:blank, srcdoc,
- * data:, or blob: URLs are NOT controlled by the parent page's service worker,
- * which means network requests from these iframes bypass the service worker entirely.
+ * This script ensures resources loaded from uncontrolled iframes (about:blank, srcdoc,
+ * data:, blob:) can still be fetched through the service worker.
  *
- * This causes issues in WordPress Playground where:
- * - CSS files fail to load in the site editor
- * - TinyMCE can't load media images
- * - Other assets requested from uncontrolled iframes fail
+ * The problem: Iframes with these URLs are NOT controlled by the parent's service worker,
+ * which means fetch/XHR requests and resource loading bypass the SW entirely. This causes
+ * CSS files, images, and other assets to fail with 404 errors in WordPress Playground.
  *
  * The solution:
- * 1. Override DOM methods used to create/modify iframes
- * 2. When src/srcdoc is set on an iframe, intercept it
- * 3. Store the initial HTML in a shared storage (window.__iframeContents)
- * 4. Set the iframe's src to a controlled URL (/wp-includes/playground-iframe-loader.html)
- * 5. The loader requests content from parent via postMessage and renders it
+ * 1. For iframes using src/srcdoc with static content, redirect to a SW-controlled loader
+ * 2. For iframes populated via document.write() (like TinyMCE), inject a resource proxy
+ *    script that routes fetch/XHR through the parent window (which IS SW-controlled)
+ *
+ * This approach preserves TinyMCE's ability to interact with its iframe document while
+ * still allowing resources to load through the service worker.
  *
  * Related browser bugs:
  * - Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=880768
@@ -32,163 +30,297 @@
     }
     window.__playgroundIframesTrapInstalled = true;
 
-    // Storage for iframe initial content, keyed by unique ID
-    if (!window.__iframeContents) {
-        window.__iframeContents = new Map();
+    // Get scope prefix for URLs
+    function getScopePrefix() {
+        const currentPath = window.location.pathname;
+        const scopeMatch = currentPath.match(/^(\/scope:[^/]+\/)/);
+        return scopeMatch ? scopeMatch[1] : '/';
     }
+    const scopePrefix = getScopePrefix();
 
-    // Map from iframe element to its content ID
-    if (!window.__iframeIdMap) {
-        window.__iframeIdMap = new WeakMap();
-    }
+    // Counter for generating unique request IDs
+    let requestIdCounter = 0;
 
-    // Counter for generating unique iframe IDs
-    let iframeIdCounter = 0;
-
-    // The base URL for the iframe loader (controlled by the service worker)
-    const IFRAME_LOADER_URL = '/wp-includes/playground-iframe-loader.html';
+    // Pending resource requests from child iframes
+    const pendingRequests = new Map();
 
     /**
-     * Listen for content requests from iframe loaders
+     * The resource proxy script that gets injected into iframes.
+     * This script intercepts fetch/XHR and routes them through the parent window.
      */
+    const resourceProxyScript = `
+(function() {
+    if (window.__playgroundResourceProxyInstalled) return;
+    window.__playgroundResourceProxyInstalled = true;
+
+    const pendingRequests = new Map();
+    let requestId = 0;
+
+    // Listen for responses from parent
     window.addEventListener('message', function(event) {
-        if (event.data && event.data.type === 'playground-iframe-content-request') {
-            const id = event.data.id;
-            const contentData = window.__iframeContents.get(id);
-
-            if (contentData && event.source) {
-                event.source.postMessage({
-                    type: 'playground-iframe-content-response',
-                    id: id,
-                    content: contentData.content,
-                    originalUrl: contentData.originalUrl
-                }, '*');
-
-                // Clean up after delivering content
-                window.__iframeContents.delete(id);
+        if (event.data && event.data.type === 'playground-resource-response') {
+            const pending = pendingRequests.get(event.data.requestId);
+            if (pending) {
+                pendingRequests.delete(event.data.requestId);
+                if (event.data.error) {
+                    pending.reject(new Error(event.data.error));
+                } else {
+                    pending.resolve(event.data);
+                }
             }
         }
     });
 
-    /**
-     * Determines if a URL needs to be trapped (redirected through our loader)
-     */
-    function shouldTrapUrl(url) {
-        if (!url) return false;
+    // Request a resource through the parent window
+    function requestResource(url, options) {
+        return new Promise(function(resolve, reject) {
+            const id = ++requestId;
+            pendingRequests.set(id, { resolve: resolve, reject: reject });
 
-        // Trap about:blank
-        if (url === 'about:blank') return true;
-
-        // Trap blob: URLs
-        if (url.startsWith('blob:')) return true;
-
-        // Trap data: URLs
-        if (url.startsWith('data:')) return true;
-
-        // Trap javascript: URLs
-        if (url.startsWith('javascript:')) return true;
-
-        return false;
-    }
-
-    /**
-     * Read a blob URL synchronously and return its text content
-     */
-    function readBlobSync(blobUrl) {
-        try {
-            const xhr = new XMLHttpRequest();
-            xhr.open('GET', blobUrl, false); // synchronous
-            xhr.overrideMimeType('text/plain;charset=utf-8');
-            xhr.send();
-            return xhr.responseText;
-        } catch (e) {
-            console.warn('[iframes-trap] Failed to read blob URL:', e);
-            return '';
-        } finally {
-            // Revoke the blob URL to free memory
+            // Resolve relative URLs against current location
+            let absoluteUrl;
             try {
-                URL.revokeObjectURL(blobUrl);
+                absoluteUrl = new URL(url, window.location.href).href;
             } catch (e) {
-                // Ignore errors
+                absoluteUrl = url;
             }
-        }
-    }
 
-    /**
-     * Generate a unique ID for storing iframe content
-     */
-    function generateIframeId() {
-        return `iframe-${Date.now()}-${++iframeIdCounter}`;
-    }
+            window.parent.postMessage({
+                type: 'playground-resource-request',
+                requestId: id,
+                url: absoluteUrl,
+                options: options || {}
+            }, '*');
 
-    /**
-     * Store content and return the loader URL
-     */
-    function storeContentAndGetLoaderUrl(content, originalUrl) {
-        const id = generateIframeId();
-        window.__iframeContents.set(id, {
-            content: content,
-            originalUrl: originalUrl,
-            timestamp: Date.now()
-        });
-
-        // Clean up old entries (older than 1 minute)
-        const now = Date.now();
-        for (const [key, value] of window.__iframeContents.entries()) {
-            if (now - value.timestamp > 60000) {
-                window.__iframeContents.delete(key);
-            }
-        }
-
-        return `${IFRAME_LOADER_URL}?id=${id}`;
-    }
-
-    /**
-     * Process a src value and return either the original or a trapped URL
-     */
-    function processSrc(src) {
-        if (!shouldTrapUrl(src)) {
-            return { trapped: false, url: src };
-        }
-
-        let content = '';
-
-        if (src === 'about:blank') {
-            content = '<!doctype html><html><head></head><body></body></html>';
-        } else if (src.startsWith('blob:')) {
-            content = readBlobSync(src);
-        } else if (src.startsWith('data:')) {
-            // Parse data URL
-            try {
-                const match = src.match(/^data:([^;,]*)(;base64)?,(.*)$/);
-                if (match) {
-                    const isBase64 = !!match[2];
-                    const data = match[3];
-                    content = isBase64 ? atob(data) : decodeURIComponent(data);
+            // Timeout after 30 seconds
+            setTimeout(function() {
+                if (pendingRequests.has(id)) {
+                    pendingRequests.delete(id);
+                    reject(new Error('Resource request timeout: ' + url));
                 }
-            } catch (e) {
-                console.warn('[iframes-trap] Failed to parse data URL:', e);
-            }
-        } else if (src.startsWith('javascript:')) {
-            // For javascript: URLs, create an empty document
-            content = '<!doctype html><html><head></head><body></body></html>';
+            }, 30000);
+        });
+    }
+
+    // Override fetch
+    const originalFetch = window.fetch;
+    window.fetch = function(input, init) {
+        const url = typeof input === 'string' ? input : input.url;
+
+        // Only proxy http/https URLs or relative URLs
+        if (url && (url.startsWith('http') || url.startsWith('/') || !url.includes(':'))) {
+            return requestResource(url, {
+                method: init?.method || 'GET',
+                headers: init?.headers || {},
+                body: init?.body
+            }).then(function(response) {
+                return new Response(response.body, {
+                    status: response.status,
+                    statusText: response.statusText,
+                    headers: response.headers
+                });
+            });
         }
 
-        const loaderUrl = storeContentAndGetLoaderUrl(content, src);
-        return { trapped: true, url: loaderUrl };
+        return originalFetch.apply(this, arguments);
+    };
+
+    // Override XMLHttpRequest
+    const OriginalXHR = window.XMLHttpRequest;
+    window.XMLHttpRequest = function() {
+        const xhr = new OriginalXHR();
+        const originalOpen = xhr.open.bind(xhr);
+        const originalSend = xhr.send.bind(xhr);
+
+        let method = 'GET';
+        let url = '';
+        let async = true;
+
+        xhr.open = function(m, u, a) {
+            method = m;
+            url = u;
+            async = a !== false;
+            return originalOpen.apply(this, arguments);
+        };
+
+        xhr.send = function(body) {
+            // Only proxy http/https URLs or relative URLs
+            if (url && (url.startsWith('http') || url.startsWith('/') || !url.includes(':'))) {
+                const self = this;
+
+                requestResource(url, { method: method, body: body })
+                    .then(function(response) {
+                        Object.defineProperty(self, 'status', { value: response.status, writable: false });
+                        Object.defineProperty(self, 'statusText', { value: response.statusText, writable: false });
+                        Object.defineProperty(self, 'responseText', { value: response.body, writable: false });
+                        Object.defineProperty(self, 'response', { value: response.body, writable: false });
+                        Object.defineProperty(self, 'readyState', { value: 4, writable: false });
+
+                        if (self.onreadystatechange) self.onreadystatechange();
+                        if (self.onload) self.onload();
+                    })
+                    .catch(function(error) {
+                        Object.defineProperty(self, 'status', { value: 0, writable: false });
+                        Object.defineProperty(self, 'readyState', { value: 4, writable: false });
+
+                        if (self.onreadystatechange) self.onreadystatechange();
+                        if (self.onerror) self.onerror(error);
+                    });
+
+                return;
+            }
+
+            return originalSend.apply(this, arguments);
+        };
+
+        return xhr;
+    };
+
+    // Handle CSS loading by observing link elements
+    const observer = new MutationObserver(function(mutations) {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+                // Handle <link rel="stylesheet">
+                if (node.tagName === 'LINK' && node.rel === 'stylesheet' && node.href) {
+                    loadStylesheet(node);
+                }
+
+                // Handle <img> elements
+                if (node.tagName === 'IMG' && node.src) {
+                    loadImage(node);
+                }
+
+                // Check children
+                if (node.querySelectorAll) {
+                    node.querySelectorAll('link[rel="stylesheet"]').forEach(loadStylesheet);
+                    node.querySelectorAll('img[src]').forEach(loadImage);
+                }
+            }
+        }
+    });
+
+    function loadStylesheet(link) {
+        if (link.dataset.proxyLoading) return;
+        link.dataset.proxyLoading = 'true';
+
+        const href = link.href;
+        requestResource(href, { method: 'GET' })
+            .then(function(response) {
+                if (response.status === 200) {
+                    const style = document.createElement('style');
+                    style.textContent = response.body;
+                    link.parentNode.insertBefore(style, link);
+                    link.remove();
+                }
+            })
+            .catch(function(err) {
+                console.warn('[resource-proxy] Failed to load stylesheet:', href, err);
+            });
     }
+
+    function loadImage(img) {
+        if (img.dataset.proxyLoading) return;
+        img.dataset.proxyLoading = 'true';
+
+        const src = img.src;
+        // Skip data URLs and blob URLs
+        if (src.startsWith('data:') || src.startsWith('blob:')) return;
+
+        requestResource(src, { method: 'GET', responseType: 'base64' })
+            .then(function(response) {
+                if (response.status === 200 && response.base64) {
+                    img.src = 'data:' + (response.contentType || 'image/png') + ';base64,' + response.base64;
+                }
+            })
+            .catch(function(err) {
+                console.warn('[resource-proxy] Failed to load image:', src, err);
+            });
+    }
+
+    // Start observing
+    if (document.body) {
+        observer.observe(document.body, { childList: true, subtree: true });
+    } else {
+        document.addEventListener('DOMContentLoaded', function() {
+            observer.observe(document.body, { childList: true, subtree: true });
+        });
+    }
+
+    console.log('[resource-proxy] Installed in iframe');
+})();
+`;
 
     /**
-     * Process a srcdoc value and return a trapped URL
+     * Listen for resource requests from child iframes and fulfill them
+     * through our SW-controlled context
      */
-    function processSrcdoc(srcdoc) {
-        if (!srcdoc) {
-            return { trapped: false, url: null };
-        }
+    window.addEventListener('message', function(event) {
+        if (event.data && event.data.type === 'playground-resource-request') {
+            const { requestId, url, options } = event.data;
 
-        const loaderUrl = storeContentAndGetLoaderUrl(srcdoc, 'srcdoc');
-        return { trapped: true, url: loaderUrl };
-    }
+            // Resolve the URL relative to our scope
+            let resolvedUrl;
+            try {
+                resolvedUrl = new URL(url, window.location.href).href;
+            } catch (e) {
+                resolvedUrl = url;
+            }
+
+            // Fetch the resource through our SW-controlled context
+            const fetchOptions = {
+                method: options.method || 'GET',
+                headers: options.headers || {},
+            };
+            if (options.body && fetchOptions.method !== 'GET') {
+                fetchOptions.body = options.body;
+            }
+
+            fetch(resolvedUrl, fetchOptions)
+                .then(async function(response) {
+                    let body;
+                    let base64;
+                    const contentType = response.headers.get('content-type') || '';
+
+                    // For images, return as base64
+                    if (options.responseType === 'base64' || contentType.startsWith('image/')) {
+                        const arrayBuffer = await response.arrayBuffer();
+                        const bytes = new Uint8Array(arrayBuffer);
+                        let binary = '';
+                        for (let i = 0; i < bytes.length; i++) {
+                            binary += String.fromCharCode(bytes[i]);
+                        }
+                        base64 = btoa(binary);
+                    } else {
+                        body = await response.text();
+                    }
+
+                    // Send response back to iframe
+                    if (event.source) {
+                        event.source.postMessage({
+                            type: 'playground-resource-response',
+                            requestId: requestId,
+                            status: response.status,
+                            statusText: response.statusText,
+                            headers: Object.fromEntries(response.headers.entries()),
+                            body: body,
+                            base64: base64,
+                            contentType: contentType
+                        }, '*');
+                    }
+                })
+                .catch(function(error) {
+                    if (event.source) {
+                        event.source.postMessage({
+                            type: 'playground-resource-response',
+                            requestId: requestId,
+                            error: error.message
+                        }, '*');
+                    }
+                });
+        }
+    });
 
     // Store original descriptors
     const originalSrcDescriptor = Object.getOwnPropertyDescriptor(
@@ -197,134 +329,182 @@
     const originalSrcdocDescriptor = Object.getOwnPropertyDescriptor(
         HTMLIFrameElement.prototype, 'srcdoc'
     );
+    const originalContentDocumentDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLIFrameElement.prototype, 'contentDocument'
+    );
+    const originalContentWindowDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLIFrameElement.prototype, 'contentWindow'
+    );
 
-    // Track which iframes we've trapped to avoid infinite loops
-    const trappedIframes = new WeakSet();
-
-    /**
-     * Override the src property
-     */
-    Object.defineProperty(HTMLIFrameElement.prototype, 'src', {
-        get: function() {
-            return originalSrcDescriptor.get.call(this);
-        },
-        set: function(value) {
-            // If we're in the middle of trapping, use the original setter
-            if (trappedIframes.has(this)) {
-                trappedIframes.delete(this);
-                return originalSrcDescriptor.set.call(this, value);
-            }
-
-            const result = processSrc(value);
-            if (result.trapped) {
-                // Mark as trapped and set the loader URL
-                trappedIframes.add(this);
-                // Also clear any srcdoc that might interfere
-                if (this.hasAttribute('srcdoc')) {
-                    this.removeAttribute('srcdoc');
-                }
-            }
-            return originalSrcDescriptor.set.call(this, result.url);
-        },
-        configurable: true,
-        enumerable: true
-    });
+    // Track iframes we've processed
+    const processedIframes = new WeakSet();
 
     /**
-     * Override the srcdoc property
+     * Inject the resource proxy script into an iframe's document
      */
-    Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', {
-        get: function() {
-            return originalSrcdocDescriptor.get.call(this);
-        },
-        set: function(value) {
-            const result = processSrcdoc(value);
-            if (result.trapped) {
-                // When srcdoc is set, we need to use src instead
-                trappedIframes.add(this);
-                return originalSrcDescriptor.set.call(this, result.url);
+    function injectResourceProxy(iframe) {
+        if (processedIframes.has(iframe)) return;
+
+        try {
+            const doc = originalContentDocumentDescriptor.get.call(iframe);
+            if (!doc) return;
+
+            // Check if script already injected
+            if (doc.__playgroundResourceProxyInstalled) return;
+
+            processedIframes.add(iframe);
+
+            // Inject the script
+            const script = doc.createElement('script');
+            script.textContent = resourceProxyScript;
+            if (doc.head) {
+                doc.head.appendChild(script);
+            } else if (doc.body) {
+                doc.body.insertBefore(script, doc.body.firstChild);
+            } else if (doc.documentElement) {
+                doc.documentElement.appendChild(script);
             }
-            return originalSrcdocDescriptor.set.call(this, value);
-        },
-        configurable: true,
-        enumerable: true
-    });
 
-    /**
-     * Override setAttribute to catch src and srcdoc attribute changes
-     */
-    const originalSetAttribute = Element.prototype.setAttribute;
-    Element.prototype.setAttribute = function(name, value) {
-        if (this.tagName === 'IFRAME') {
-            const lowerName = name.toLowerCase();
-            if (lowerName === 'src') {
-                this.src = value;
-                return;
-            }
-            if (lowerName === 'srcdoc') {
-                this.srcdoc = value;
-                return;
-            }
-        }
-        return originalSetAttribute.call(this, name, value);
-    };
-
-    /**
-     * Override document.createElement to intercept iframe creation with attributes
-     * This handles cases like: createElement('iframe', { src: 'about:blank' })
-     */
-    const originalCreateElement = document.createElement.bind(document);
-    document.createElement = function(tagName, options) {
-        const element = originalCreateElement(tagName, options);
-        // The interception happens when src/srcdoc are set, so no extra work needed here
-        return element;
-    };
-
-    /**
-     * Observe DOM for dynamically inserted iframes with src/srcdoc attributes
-     * This catches iframes inserted via innerHTML or similar methods
-     */
-    const observer = new MutationObserver(function(mutations) {
-        for (const mutation of mutations) {
-            for (const node of mutation.addedNodes) {
-                if (node.nodeType !== Node.ELEMENT_NODE) continue;
-
-                // Check if the added node is an iframe
-                if (node.tagName === 'IFRAME') {
-                    processIframe(node);
-                }
-
-                // Check for iframes within the added node
-                if (node.querySelectorAll) {
-                    const iframes = node.querySelectorAll('iframe');
-                    for (const iframe of iframes) {
-                        processIframe(iframe);
-                    }
-                }
-            }
-        }
-    });
-
-    function processIframe(iframe) {
-        // If the iframe already has a srcdoc attribute, trap it
-        const srcdoc = iframe.getAttribute('srcdoc');
-        if (srcdoc) {
-            iframe.srcdoc = srcdoc;
-            return;
-        }
-
-        // If the iframe has a src that should be trapped
-        const src = iframe.getAttribute('src');
-        if (src && shouldTrapUrl(src)) {
-            iframe.src = src;
+            console.log('[iframes-trap] Injected resource proxy into iframe');
+        } catch (e) {
+            // Cross-origin iframes will throw, which is fine
         }
     }
 
-    // Start observing the document
-    observer.observe(document.documentElement || document.body || document, {
-        childList: true,
-        subtree: true
+    /**
+     * Track iframes that are being written to via contentDocument.write()
+     */
+    const iframesBeingWritten = new WeakMap();
+
+    function getWriteTracker(iframe) {
+        if (!iframesBeingWritten.has(iframe)) {
+            iframesBeingWritten.set(iframe, {
+                content: '',
+                isOpen: false
+            });
+        }
+        return iframesBeingWritten.get(iframe);
+    }
+
+    /**
+     * Create a proxy for the document that injects our resource proxy script
+     * into content written via document.write()
+     */
+    function createDocumentProxy(iframe, originalDoc) {
+        if (originalDoc.__playgroundProxied) return originalDoc;
+        originalDoc.__playgroundProxied = true;
+
+        const tracker = getWriteTracker(iframe);
+
+        const originalOpen = originalDoc.open.bind(originalDoc);
+        const originalWrite = originalDoc.write.bind(originalDoc);
+        const originalWriteln = originalDoc.writeln.bind(originalDoc);
+        const originalClose = originalDoc.close.bind(originalDoc);
+
+        originalDoc.open = function() {
+            tracker.content = '';
+            tracker.isOpen = true;
+            return originalOpen.apply(this, arguments);
+        };
+
+        originalDoc.write = function(content) {
+            if (tracker.isOpen && content) {
+                tracker.content += content;
+            }
+            return originalWrite.apply(this, arguments);
+        };
+
+        originalDoc.writeln = function(content) {
+            if (tracker.isOpen && content) {
+                tracker.content += content + '\n';
+            }
+            return originalWriteln.apply(this, arguments);
+        };
+
+        originalDoc.close = function() {
+            const result = originalClose.apply(this, arguments);
+
+            // After close, inject our resource proxy script
+            if (tracker.isOpen) {
+                tracker.isOpen = false;
+
+                // Inject resource proxy script after a microtask to let the DOM settle
+                Promise.resolve().then(function() {
+                    try {
+                        const script = originalDoc.createElement('script');
+                        script.textContent = resourceProxyScript;
+                        if (originalDoc.head) {
+                            originalDoc.head.appendChild(script);
+                        } else if (originalDoc.body) {
+                            originalDoc.body.appendChild(script);
+                        }
+                        console.log('[iframes-trap] Injected resource proxy after document.write');
+                    } catch (e) {
+                        console.warn('[iframes-trap] Failed to inject resource proxy:', e);
+                    }
+                });
+            }
+
+            return result;
+        };
+
+        return originalDoc;
+    }
+
+    // Track which iframes have been proxied
+    const proxiedIframes = new WeakSet();
+
+    /**
+     * Check if an iframe should have its document proxied
+     */
+    function shouldProxyIframe(iframe) {
+        if (proxiedIframes.has(iframe)) return false;
+
+        const src = originalSrcDescriptor.get.call(iframe);
+
+        // Proxy if no src (about:blank) or explicitly about:blank
+        if (!src || src === '' || src === 'about:blank') {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Override contentDocument to intercept document.write() calls
+     */
+    Object.defineProperty(HTMLIFrameElement.prototype, 'contentDocument', {
+        get: function() {
+            const doc = originalContentDocumentDescriptor.get.call(this);
+
+            if (doc && shouldProxyIframe(this)) {
+                proxiedIframes.add(this);
+                return createDocumentProxy(this, doc);
+            }
+
+            return doc;
+        },
+        configurable: true,
+        enumerable: true
     });
 
-    console.log('[iframes-trap] Installed successfully');
+    /**
+     * Override contentWindow to also intercept document access
+     */
+    Object.defineProperty(HTMLIFrameElement.prototype, 'contentWindow', {
+        get: function() {
+            const win = originalContentWindowDescriptor.get.call(this);
+
+            if (win && win.document && shouldProxyIframe(this)) {
+                proxiedIframes.add(this);
+                createDocumentProxy(this, win.document);
+            }
+
+            return win;
+        },
+        configurable: true,
+        enumerable: true
+    });
+
+    console.log('[iframes-trap] Installed successfully (resource proxy mode)');
 })();

--- a/packages/playground/remote/src/lib/iframe-trap/iframes-trap.js
+++ b/packages/playground/remote/src/lib/iframe-trap/iframes-trap.js
@@ -1,0 +1,330 @@
+/**
+ * iframes-trap.js
+ *
+ * This script intercepts iframe creation and modification to ensure all iframes
+ * are controlled by the service worker. Iframes created with about:blank, srcdoc,
+ * data:, or blob: URLs are NOT controlled by the parent page's service worker,
+ * which means network requests from these iframes bypass the service worker entirely.
+ *
+ * This causes issues in WordPress Playground where:
+ * - CSS files fail to load in the site editor
+ * - TinyMCE can't load media images
+ * - Other assets requested from uncontrolled iframes fail
+ *
+ * The solution:
+ * 1. Override DOM methods used to create/modify iframes
+ * 2. When src/srcdoc is set on an iframe, intercept it
+ * 3. Store the initial HTML in a shared storage (window.__iframeContents)
+ * 4. Set the iframe's src to a controlled URL (/wp-includes/playground-iframe-loader.html)
+ * 5. The loader requests content from parent via postMessage and renders it
+ *
+ * Related browser bugs:
+ * - Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=880768
+ * - Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1293277
+ * - Spec: https://github.com/w3c/ServiceWorker/issues/765
+ */
+(function() {
+    'use strict';
+
+    // Prevent multiple injections
+    if (window.__playgroundIframesTrapInstalled) {
+        return;
+    }
+    window.__playgroundIframesTrapInstalled = true;
+
+    // Storage for iframe initial content, keyed by unique ID
+    if (!window.__iframeContents) {
+        window.__iframeContents = new Map();
+    }
+
+    // Map from iframe element to its content ID
+    if (!window.__iframeIdMap) {
+        window.__iframeIdMap = new WeakMap();
+    }
+
+    // Counter for generating unique iframe IDs
+    let iframeIdCounter = 0;
+
+    // The base URL for the iframe loader (controlled by the service worker)
+    const IFRAME_LOADER_URL = '/wp-includes/playground-iframe-loader.html';
+
+    /**
+     * Listen for content requests from iframe loaders
+     */
+    window.addEventListener('message', function(event) {
+        if (event.data && event.data.type === 'playground-iframe-content-request') {
+            const id = event.data.id;
+            const contentData = window.__iframeContents.get(id);
+
+            if (contentData && event.source) {
+                event.source.postMessage({
+                    type: 'playground-iframe-content-response',
+                    id: id,
+                    content: contentData.content,
+                    originalUrl: contentData.originalUrl
+                }, '*');
+
+                // Clean up after delivering content
+                window.__iframeContents.delete(id);
+            }
+        }
+    });
+
+    /**
+     * Determines if a URL needs to be trapped (redirected through our loader)
+     */
+    function shouldTrapUrl(url) {
+        if (!url) return false;
+
+        // Trap about:blank
+        if (url === 'about:blank') return true;
+
+        // Trap blob: URLs
+        if (url.startsWith('blob:')) return true;
+
+        // Trap data: URLs
+        if (url.startsWith('data:')) return true;
+
+        // Trap javascript: URLs
+        if (url.startsWith('javascript:')) return true;
+
+        return false;
+    }
+
+    /**
+     * Read a blob URL synchronously and return its text content
+     */
+    function readBlobSync(blobUrl) {
+        try {
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', blobUrl, false); // synchronous
+            xhr.overrideMimeType('text/plain;charset=utf-8');
+            xhr.send();
+            return xhr.responseText;
+        } catch (e) {
+            console.warn('[iframes-trap] Failed to read blob URL:', e);
+            return '';
+        } finally {
+            // Revoke the blob URL to free memory
+            try {
+                URL.revokeObjectURL(blobUrl);
+            } catch (e) {
+                // Ignore errors
+            }
+        }
+    }
+
+    /**
+     * Generate a unique ID for storing iframe content
+     */
+    function generateIframeId() {
+        return `iframe-${Date.now()}-${++iframeIdCounter}`;
+    }
+
+    /**
+     * Store content and return the loader URL
+     */
+    function storeContentAndGetLoaderUrl(content, originalUrl) {
+        const id = generateIframeId();
+        window.__iframeContents.set(id, {
+            content: content,
+            originalUrl: originalUrl,
+            timestamp: Date.now()
+        });
+
+        // Clean up old entries (older than 1 minute)
+        const now = Date.now();
+        for (const [key, value] of window.__iframeContents.entries()) {
+            if (now - value.timestamp > 60000) {
+                window.__iframeContents.delete(key);
+            }
+        }
+
+        return `${IFRAME_LOADER_URL}?id=${id}`;
+    }
+
+    /**
+     * Process a src value and return either the original or a trapped URL
+     */
+    function processSrc(src) {
+        if (!shouldTrapUrl(src)) {
+            return { trapped: false, url: src };
+        }
+
+        let content = '';
+
+        if (src === 'about:blank') {
+            content = '<!doctype html><html><head></head><body></body></html>';
+        } else if (src.startsWith('blob:')) {
+            content = readBlobSync(src);
+        } else if (src.startsWith('data:')) {
+            // Parse data URL
+            try {
+                const match = src.match(/^data:([^;,]*)(;base64)?,(.*)$/);
+                if (match) {
+                    const isBase64 = !!match[2];
+                    const data = match[3];
+                    content = isBase64 ? atob(data) : decodeURIComponent(data);
+                }
+            } catch (e) {
+                console.warn('[iframes-trap] Failed to parse data URL:', e);
+            }
+        } else if (src.startsWith('javascript:')) {
+            // For javascript: URLs, create an empty document
+            content = '<!doctype html><html><head></head><body></body></html>';
+        }
+
+        const loaderUrl = storeContentAndGetLoaderUrl(content, src);
+        return { trapped: true, url: loaderUrl };
+    }
+
+    /**
+     * Process a srcdoc value and return a trapped URL
+     */
+    function processSrcdoc(srcdoc) {
+        if (!srcdoc) {
+            return { trapped: false, url: null };
+        }
+
+        const loaderUrl = storeContentAndGetLoaderUrl(srcdoc, 'srcdoc');
+        return { trapped: true, url: loaderUrl };
+    }
+
+    // Store original descriptors
+    const originalSrcDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLIFrameElement.prototype, 'src'
+    );
+    const originalSrcdocDescriptor = Object.getOwnPropertyDescriptor(
+        HTMLIFrameElement.prototype, 'srcdoc'
+    );
+
+    // Track which iframes we've trapped to avoid infinite loops
+    const trappedIframes = new WeakSet();
+
+    /**
+     * Override the src property
+     */
+    Object.defineProperty(HTMLIFrameElement.prototype, 'src', {
+        get: function() {
+            return originalSrcDescriptor.get.call(this);
+        },
+        set: function(value) {
+            // If we're in the middle of trapping, use the original setter
+            if (trappedIframes.has(this)) {
+                trappedIframes.delete(this);
+                return originalSrcDescriptor.set.call(this, value);
+            }
+
+            const result = processSrc(value);
+            if (result.trapped) {
+                // Mark as trapped and set the loader URL
+                trappedIframes.add(this);
+                // Also clear any srcdoc that might interfere
+                if (this.hasAttribute('srcdoc')) {
+                    this.removeAttribute('srcdoc');
+                }
+            }
+            return originalSrcDescriptor.set.call(this, result.url);
+        },
+        configurable: true,
+        enumerable: true
+    });
+
+    /**
+     * Override the srcdoc property
+     */
+    Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', {
+        get: function() {
+            return originalSrcdocDescriptor.get.call(this);
+        },
+        set: function(value) {
+            const result = processSrcdoc(value);
+            if (result.trapped) {
+                // When srcdoc is set, we need to use src instead
+                trappedIframes.add(this);
+                return originalSrcDescriptor.set.call(this, result.url);
+            }
+            return originalSrcdocDescriptor.set.call(this, value);
+        },
+        configurable: true,
+        enumerable: true
+    });
+
+    /**
+     * Override setAttribute to catch src and srcdoc attribute changes
+     */
+    const originalSetAttribute = Element.prototype.setAttribute;
+    Element.prototype.setAttribute = function(name, value) {
+        if (this.tagName === 'IFRAME') {
+            const lowerName = name.toLowerCase();
+            if (lowerName === 'src') {
+                this.src = value;
+                return;
+            }
+            if (lowerName === 'srcdoc') {
+                this.srcdoc = value;
+                return;
+            }
+        }
+        return originalSetAttribute.call(this, name, value);
+    };
+
+    /**
+     * Override document.createElement to intercept iframe creation with attributes
+     * This handles cases like: createElement('iframe', { src: 'about:blank' })
+     */
+    const originalCreateElement = document.createElement.bind(document);
+    document.createElement = function(tagName, options) {
+        const element = originalCreateElement(tagName, options);
+        // The interception happens when src/srcdoc are set, so no extra work needed here
+        return element;
+    };
+
+    /**
+     * Observe DOM for dynamically inserted iframes with src/srcdoc attributes
+     * This catches iframes inserted via innerHTML or similar methods
+     */
+    const observer = new MutationObserver(function(mutations) {
+        for (const mutation of mutations) {
+            for (const node of mutation.addedNodes) {
+                if (node.nodeType !== Node.ELEMENT_NODE) continue;
+
+                // Check if the added node is an iframe
+                if (node.tagName === 'IFRAME') {
+                    processIframe(node);
+                }
+
+                // Check for iframes within the added node
+                if (node.querySelectorAll) {
+                    const iframes = node.querySelectorAll('iframe');
+                    for (const iframe of iframes) {
+                        processIframe(iframe);
+                    }
+                }
+            }
+        }
+    });
+
+    function processIframe(iframe) {
+        // If the iframe already has a srcdoc attribute, trap it
+        const srcdoc = iframe.getAttribute('srcdoc');
+        if (srcdoc) {
+            iframe.srcdoc = srcdoc;
+            return;
+        }
+
+        // If the iframe has a src that should be trapped
+        const src = iframe.getAttribute('src');
+        if (src && shouldTrapUrl(src)) {
+            iframe.src = src;
+        }
+    }
+
+    // Start observing the document
+    observer.observe(document.documentElement || document.body || document, {
+        childList: true,
+        subtree: true
+    });
+
+    console.log('[iframes-trap] Installed successfully');
+})();

--- a/packages/playground/website/playwright/e2e/classic-editor.spec.ts
+++ b/packages/playground/website/playwright/e2e/classic-editor.spec.ts
@@ -1,0 +1,272 @@
+import { test, expect } from '../playground-fixtures';
+import type { Blueprint } from '@wp-playground/blueprints';
+
+/**
+ * Tests for the Classic Editor plugin with TinyMCE.
+ *
+ * These tests verify that iframes created by TinyMCE (which use about:blank)
+ * can still load resources through the service worker via the resource proxy.
+ *
+ * Related issue: Iframes with about:blank, srcdoc, data:, or blob: URLs are
+ * NOT controlled by the parent page's service worker, causing CSS and other
+ * resources to fail loading. The iframes-trap.js resource proxy fixes this.
+ */
+
+const classicEditorBlueprint: Blueprint = {
+	landingPage: '/wp-admin/post-new.php',
+	login: true,
+	steps: [
+		{
+			step: 'installPlugin',
+			pluginData: {
+				resource: 'wordpress.org/plugins',
+				slug: 'classic-editor',
+			},
+			options: { activate: true },
+		},
+	],
+};
+
+test.describe('Classic Editor (TinyMCE)', () => {
+	test('should load TinyMCE editor with proper styling', async ({
+		website,
+		wordpress,
+	}) => {
+		await website.goto(`/#${JSON.stringify(classicEditorBlueprint)}`);
+
+		// Wait for TinyMCE to initialize - the editor iframe should be present
+		const tinymceIframe = wordpress.frameLocator('#content_ifr');
+		await expect(tinymceIframe.locator('body')).toBeVisible();
+
+		// The TinyMCE body should have proper styling (not unstyled)
+		// When CSS fails to load, the body would have no contenteditable styling
+		await expect(tinymceIframe.locator('body')).toHaveAttribute(
+			'contenteditable',
+			'true'
+		);
+
+		// Verify the toolbar is visible (indicates TinyMCE JS loaded correctly)
+		await expect(wordpress.locator('.wp-editor-tabs')).toBeVisible();
+	});
+
+	test('should allow typing in TinyMCE editor', async ({
+		website,
+		wordpress,
+	}) => {
+		await website.goto(`/#${JSON.stringify(classicEditorBlueprint)}`);
+
+		// Wait for TinyMCE to initialize
+		const tinymceIframe = wordpress.frameLocator('#content_ifr');
+		const editorBody = tinymceIframe.locator('body');
+		await expect(editorBody).toBeVisible();
+
+		// Click on the editor to focus it
+		await editorBody.click();
+
+		// Type some text
+		const testText = 'Hello from Playwright test! Testing TinyMCE typing.';
+		await editorBody.pressSequentially(testText, { delay: 10 });
+
+		// Verify the text was entered
+		await expect(editorBody).toContainText(testText);
+	});
+
+	test('should preserve text after switching between Visual and Text tabs', async ({
+		website,
+		wordpress,
+	}) => {
+		await website.goto(`/#${JSON.stringify(classicEditorBlueprint)}`);
+
+		// Wait for TinyMCE to initialize
+		const tinymceIframe = wordpress.frameLocator('#content_ifr');
+		const editorBody = tinymceIframe.locator('body');
+		await expect(editorBody).toBeVisible();
+
+		// Type some text in Visual mode
+		await editorBody.click();
+		const testText = 'Test content for tab switching';
+		await editorBody.pressSequentially(testText, { delay: 10 });
+
+		// Switch to Text (HTML) tab
+		await wordpress.locator('#content-html').click();
+
+		// Wait a moment for TinyMCE to sync content to textarea
+		// TinyMCE syncs content asynchronously when switching tabs
+		await wordpress.locator('#content').waitFor({ state: 'visible' });
+
+		// Verify the text is in the textarea (use inputValue for textarea elements)
+		const textarea = wordpress.locator('#content');
+		await expect(textarea).toHaveValue(new RegExp(testText));
+
+		// Switch back to Visual tab
+		await wordpress.locator('#content-tmce').click();
+
+		// Verify text is still there in the visual editor
+		await expect(tinymceIframe.locator('body')).toContainText(testText);
+	});
+
+	test('should open Add Media dialog', async ({ website, wordpress }) => {
+		await website.goto(`/#${JSON.stringify(classicEditorBlueprint)}`);
+
+		// Wait for TinyMCE to initialize
+		const tinymceIframe = wordpress.frameLocator('#content_ifr');
+		await expect(tinymceIframe.locator('body')).toBeVisible();
+
+		// Click the Add Media button
+		await wordpress.locator('#insert-media-button').click();
+
+		// The media modal should open
+		await expect(wordpress.locator('.media-modal')).toBeVisible();
+
+		// Verify the Upload Files tab is available
+		await expect(
+			wordpress.locator('.media-menu-item').filter({ hasText: 'Upload files' })
+		).toBeVisible();
+	});
+
+	test('should upload an image via Add Media', async ({
+		website,
+		wordpress,
+		page,
+	}) => {
+		await website.goto(`/#${JSON.stringify(classicEditorBlueprint)}`);
+
+		// Wait for TinyMCE to initialize
+		const tinymceIframe = wordpress.frameLocator('#content_ifr');
+		await expect(tinymceIframe.locator('body')).toBeVisible();
+
+		// First, create a test image file in WordPress using the playground API
+		await page.waitForFunction(() => Boolean((window as any).playground));
+		await page.evaluate(async () => {
+			const playground = (window as any).playground;
+			// Create a simple 1x1 red PNG image (base64 encoded)
+			const pngBase64 =
+				'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+			const binaryString = atob(pngBase64);
+			const bytes = new Uint8Array(binaryString.length);
+			for (let i = 0; i < binaryString.length; i++) {
+				bytes[i] = binaryString.charCodeAt(i);
+			}
+			await playground.writeFile('/wordpress/wp-content/test-image.png', bytes);
+		});
+
+		// Click the Add Media button
+		await wordpress.locator('#insert-media-button').click();
+		await expect(wordpress.locator('.media-modal')).toBeVisible();
+
+		// Switch to Media Library tab
+		const mediaLibraryTab = wordpress
+			.locator('.media-menu-item')
+			.filter({ hasText: 'Media Library' });
+		await mediaLibraryTab.click();
+
+		// Click "Upload files" tab
+		const uploadTab = wordpress
+			.locator('.media-menu-item')
+			.filter({ hasText: 'Upload files' });
+		await uploadTab.click();
+
+		// Wait for the upload UI to be ready
+		await expect(wordpress.locator('.upload-ui')).toBeVisible();
+
+		// Set up file chooser listener and trigger file input
+		const fileChooserPromise = page.waitForEvent('filechooser');
+
+		// Click the "Select Files" button to trigger the file chooser
+		await wordpress.locator('.browser, input[type="file"]').first().click();
+
+		const fileChooser = await fileChooserPromise;
+
+		// Create a simple test PNG file
+		const pngBase64 =
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==';
+		const buffer = Buffer.from(pngBase64, 'base64');
+
+		await fileChooser.setFiles({
+			name: 'test-upload.png',
+			mimeType: 'image/png',
+			buffer,
+		});
+
+		// Wait for the upload to complete and the image to appear in the library
+		await expect(
+			wordpress.locator('.attachment, .thumbnail').first()
+		).toBeVisible({ timeout: 30000 });
+	});
+
+	test('should insert uploaded image into editor', async ({
+		website,
+		wordpress,
+		page,
+	}) => {
+		await website.goto(`/#${JSON.stringify(classicEditorBlueprint)}`);
+
+		// Wait for TinyMCE to initialize
+		const tinymceIframe = wordpress.frameLocator('#content_ifr');
+		await expect(tinymceIframe.locator('body')).toBeVisible();
+
+		// Click the Add Media button
+		await wordpress.locator('#insert-media-button').click();
+		await expect(wordpress.locator('.media-modal')).toBeVisible();
+
+		// Upload a file
+		const uploadTab = wordpress
+			.locator('.media-menu-item')
+			.filter({ hasText: 'Upload files' });
+		await uploadTab.click();
+
+		const fileChooserPromise = page.waitForEvent('filechooser');
+		await wordpress.locator('.browser, input[type="file"]').first().click();
+		const fileChooser = await fileChooserPromise;
+
+		const pngBase64 =
+			'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNk+M9QzwAEjDAGNzYAAIoaB/lnPAJMAAAAAElFTkSuQmCC';
+		const buffer = Buffer.from(pngBase64, 'base64');
+
+		await fileChooser.setFiles({
+			name: 'test-image-insert.png',
+			mimeType: 'image/png',
+			buffer,
+		});
+
+		// Wait for upload to complete
+		await expect(
+			wordpress.locator('.attachment.selected, .attachment.save-ready').first()
+		).toBeVisible({ timeout: 30000 });
+
+		// Click "Insert into post" button
+		await wordpress.locator('.media-button-insert').click();
+
+		// Verify the image was inserted into the editor
+		await expect(tinymceIframe.locator('img')).toBeVisible({ timeout: 10000 });
+	});
+
+	test('should apply bold formatting to text', async ({
+		website,
+		wordpress,
+	}) => {
+		await website.goto(`/#${JSON.stringify(classicEditorBlueprint)}`);
+
+		// Wait for TinyMCE to initialize
+		const tinymceIframe = wordpress.frameLocator('#content_ifr');
+		const editorBody = tinymceIframe.locator('body');
+		await expect(editorBody).toBeVisible();
+
+		// Type some text
+		await editorBody.click();
+		await editorBody.pressSequentially('This is bold text', { delay: 10 });
+
+		// Select all text with Ctrl+A
+		await editorBody.press('Control+a');
+
+		// Click the Bold button in the toolbar
+		await wordpress
+			.locator('.mce-i-bold, button[aria-label="Bold"]')
+			.first()
+			.click();
+
+		// Verify the text is now bold (wrapped in <strong> or <b>)
+		const boldText = tinymceIframe.locator('strong, b');
+		await expect(boldText).toContainText('This is bold text');
+	});
+});


### PR DESCRIPTION
Explores making all iframes controlled by the Playground service worker.

Iframes created as `about:blank` / `srcdoc` / `data` / `blob` are not controlled by this
service worker. This means that all network calls initiated by these iframes are
sent directly to the network. This means Gutenberg cannot load any CSS files,
TInyMCE can't load media images, etc.

Only iframes created with `src` pointing to a URL already controlled by this service worker
are themselves controlled.

## Explored solution

We inject a `iframes-trap.js` script into every HTML page to override a set of DOM
methods used to create iframes. We, then, override a bunch of core DOM methods such
as `HTMLIFrameElement.prototype.src` setter or `document.open` to disable every
possible way of creating an uncontrolled iframe. Furthermore, we ensure the same
`iframes-trap.js` script is injected into every created iframe (which has a recursive effect
over all stacked nested iframes at every level).

As a result, every same-origin iframe is forced onto a real navigation that the SW can control,
so all fetches (including <img> inside editors like TinyMCE) go through our handler
without per-product patches.

This PR does not yet replace the previous Gutenberg shim, but it should before merging.

### References

- Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=880768
- Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1293277
- Spec discussion: https://github.com/w3c/ServiceWorker/issues/765
- Gutenberg context: https://github.com/WordPress/gutenberg/pull/38855
- Playground historical issue: https://github.com/WordPress/wordpress-playground/issues/42

Fixes #2919
Fixes #42

cc @akirk @brandonpayton @ellatrix @draganescu 