### PR TITLE
[Website] Add quick navigation popover to address bar

### DIFF
--- a/packages/playground/website/src/components/address-bar/index.tsx
+++ b/packages/playground/website/src/components/address-bar/index.tsx
@@ -1,29 +1,146 @@
-import React, { useCallback } from 'react';
+import React, {
+	useCallback,
+	useState,
+	useRef,
+	useEffect,
+	useLayoutEffect,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { Icon } from '@wordpress/components';
+import { home, wordpress, layout, pin } from '@wordpress/icons';
 import css from './style.module.css';
+
+/**
+ * Custom SVG icons matching WordPress admin dashicons exactly.
+ * Source: https://github.com/WordPress/dashicons/tree/master/svg-min
+ */
+const DashiconPlugins = () => (
+	<svg
+		width="20"
+		height="20"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path d="M13.11 4.36L9.87 7.6 8 5.73l3.24-3.24c.35-.34 1.05-.2 1.56.32.52.51.66 1.21.31 1.55zm-8 1.77l.91-1.12 9.01 9.01-1.19.84c-.71.71-2.63 1.16-3.82 1.16H6.14L4.9 17.26c-.59.59-1.54.59-2.12 0-.59-.58-.59-1.53 0-2.12l1.24-1.24v-3.88c0-1.13.4-3.19 1.09-3.89zm7.26 3.97l3.24-3.24c.34-.35 1.04-.21 1.55.31.52.51.66 1.21.31 1.55l-3.24 3.25z" />
+	</svg>
+);
+
+const DashiconAppearance = () => (
+	<svg
+		width="20"
+		height="20"
+		viewBox="0 0 20 20"
+		fill="currentColor"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<path d="M14.48 11.06L7.41 3.99l1.5-1.5c.5-.56 2.3-.47 3.51.32 1.21.8 1.43 1.28 2.91 2.1 1.18.64 2.45 1.26 4.45.85zm-.71.71L6.7 4.7 4.93 6.47c-.39.39-.39 1.02 0 1.41l1.06 1.06c.39.39.39 1.03 0 1.42-.6.6-1.43 1.11-2.21 1.69-.35.26-.7.53-1.01.84C1.43 14.23.4 16.08 1.4 17.07c.99 1 2.84-.03 4.18-1.36.31-.31.58-.66.85-1.02.57-.78 1.08-1.61 1.69-2.21.39-.39 1.02-.39 1.41 0l1.06 1.06c.39.39 1.02.39 1.41 0z" />
+	</svg>
+);
+
+interface QuickNavItem {
+	label: string;
+	path: string;
+	icon: JSX.Element;
+}
+
+const quickNavItems: QuickNavItem[] = [
+	{ label: 'Homepage', path: '/', icon: <Icon icon={home} size={20} /> },
+	{
+		label: 'Dashboard',
+		path: '/wp-admin/',
+		icon: <Icon icon={wordpress} size={20} />,
+	},
+	{
+		label: 'Site Editor',
+		path: '/wp-admin/site-editor.php',
+		icon: <Icon icon={layout} size={20} />,
+	},
+	{
+		label: 'New Post',
+		path: '/wp-admin/post-new.php',
+		icon: <Icon icon={pin} size={20} />,
+	},
+	{
+		label: 'Plugins',
+		path: '/wp-admin/plugins.php',
+		icon: <DashiconPlugins />,
+	},
+	{
+		label: 'Themes',
+		path: '/wp-admin/themes.php',
+		icon: <DashiconAppearance />,
+	},
+];
 
 interface AddressBarProps {
 	url?: string;
 	onUpdate?: (url: string) => void;
 }
-export default function AddressBar({ url, onUpdate }: AddressBarProps) {
-	const input = React.useRef<HTMLInputElement>(null);
-	const [value, setValue] = React.useState(url || '');
-	const [isFocused, setIsFocused] = React.useState(false);
 
-	React.useEffect(() => {
+export default function AddressBar({ url, onUpdate }: AddressBarProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [value, setValue] = useState(url || '');
+	const [isFocused, setIsFocused] = useState(false);
+	const [isOpen, setIsOpen] = useState(false);
+	const [selectedIndex, setSelectedIndex] = useState(-1);
+	const [dropdownPosition, setDropdownPosition] = useState({
+		top: 0,
+		left: 0,
+		width: 0,
+	});
+
+	useEffect(() => {
 		if (!isFocused && url) {
 			setValue(url);
 		}
 	}, [isFocused, url]);
 
+	// Update dropdown position when open
+	useLayoutEffect(() => {
+		if (isOpen && inputRef.current) {
+			const rect = inputRef.current.getBoundingClientRect();
+			setDropdownPosition({
+				top: rect.bottom + 4,
+				left: rect.left,
+				width: rect.width,
+			});
+		}
+	}, [isOpen]);
+
+	// Close dropdown when clicking outside
+	useEffect(() => {
+		function handleClickOutside(e: MouseEvent) {
+			const target = e.target as Node;
+			if (
+				containerRef.current &&
+				!containerRef.current.contains(target) &&
+				!(target as Element).closest?.('#address-bar-suggestions')
+			) {
+				setIsOpen(false);
+				setSelectedIndex(-1);
+			}
+		}
+		document.addEventListener('mousedown', handleClickOutside);
+		return () =>
+			document.removeEventListener('mousedown', handleClickOutside);
+	}, []);
+
 	const handleSubmit = useCallback(
 		function (e: React.FormEvent<HTMLFormElement>) {
 			e.preventDefault();
-			const requestedPath = input.current!.value;
-			onUpdate?.(requestedPath);
-			input.current!.blur();
+			if (selectedIndex >= 0) {
+				onUpdate?.(quickNavItems[selectedIndex].path);
+				setIsOpen(false);
+				setSelectedIndex(-1);
+			} else {
+				const requestedPath = inputRef.current!.value;
+				onUpdate?.(requestedPath);
+			}
+			inputRef.current!.blur();
 		},
-		[onUpdate]
+		[onUpdate, selectedIndex]
 	);
 
 	const handleRefresh = useCallback(
@@ -35,6 +152,123 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 		},
 		[url, onUpdate]
 	);
+
+	const handleNavigation = useCallback(
+		(path: string) => {
+			onUpdate?.(path);
+			setIsOpen(false);
+			setSelectedIndex(-1);
+			inputRef.current?.blur();
+		},
+		[onUpdate]
+	);
+
+	const handleKeyDown = useCallback(
+		(e: React.KeyboardEvent<HTMLInputElement>) => {
+			if (!isOpen) {
+				if (e.key === 'ArrowDown') {
+					e.preventDefault();
+					setIsOpen(true);
+					setSelectedIndex(0);
+				}
+				return;
+			}
+
+			switch (e.key) {
+				case 'ArrowDown':
+					e.preventDefault();
+					setSelectedIndex((prev) =>
+						prev < quickNavItems.length - 1 ? prev + 1 : prev
+					);
+					break;
+				case 'ArrowUp':
+					e.preventDefault();
+					setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1));
+					if (selectedIndex === 0) {
+						setIsOpen(false);
+					}
+					break;
+				case 'Escape':
+					e.preventDefault();
+					setIsOpen(false);
+					setSelectedIndex(-1);
+					break;
+				case 'Enter':
+					if (selectedIndex >= 0) {
+						e.preventDefault();
+						handleNavigation(quickNavItems[selectedIndex].path);
+					}
+					break;
+			}
+		},
+		[isOpen, selectedIndex, handleNavigation]
+	);
+
+	const handleFocus = useCallback(() => {
+		setIsFocused(true);
+		setIsOpen(true);
+		setSelectedIndex(-1);
+	}, []);
+
+	const handleBlur = useCallback(() => {
+		setIsFocused(false);
+		// Small delay to allow click events on dropdown items to fire
+		setTimeout(() => {
+			if (!document.activeElement?.closest('#address-bar-suggestions')) {
+				setIsOpen(false);
+				setSelectedIndex(-1);
+			}
+		}, 150);
+	}, []);
+
+	const handleChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			setValue(e.target.value);
+			setSelectedIndex(-1);
+		},
+		[]
+	);
+
+	const dropdown = isOpen
+		? createPortal(
+				<ul
+					id="address-bar-suggestions"
+					className={css.suggestions}
+					role="listbox"
+					style={{
+						top: dropdownPosition.top,
+						left: dropdownPosition.left,
+						width: dropdownPosition.width,
+					}}
+				>
+					{quickNavItems.map((item, index) => (
+						<li
+							key={item.path}
+							id={`suggestion-${index}`}
+							role="option"
+							aria-selected={index === selectedIndex}
+							className={`${css.suggestionItem} ${index === selectedIndex ? css.suggestionItemSelected : ''}`}
+							onMouseDown={(e) => {
+								e.preventDefault();
+								handleNavigation(item.path);
+							}}
+							onMouseEnter={() => setSelectedIndex(index)}
+						>
+							<span className={css.suggestionIcon}>
+								{item.icon}
+							</span>
+							<span className={css.suggestionLabel}>
+								{item.label}
+							</span>
+							<span className={css.suggestionPath}>
+								{item.path}
+							</span>
+						</li>
+					))}
+				</ul>,
+				document.body
+			)
+		: null;
 
 	return (
 		<form className={css.form} onSubmit={handleSubmit}>
@@ -58,20 +292,30 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 					/>
 				</svg>
 			</button>
-			<div className={css.inputContainer}>
+			<div className={css.inputContainer} ref={containerRef}>
 				<input
-					ref={input}
+					ref={inputRef}
 					className={css.input}
 					value={value}
-					onChange={(e) => setValue(e.target.value)}
-					onFocus={() => setIsFocused(true)}
-					onBlur={() => setIsFocused(false)}
+					onChange={handleChange}
+					onFocus={handleFocus}
+					onBlur={handleBlur}
+					onKeyDown={handleKeyDown}
 					name="url"
 					type="text"
-					aria-label='URL to visit in the WordPress site, like"/wp-admin"'
+					aria-label='URL to visit in the WordPress site, like "/wp-admin"'
+					aria-expanded={isOpen}
+					aria-haspopup="listbox"
+					aria-controls="address-bar-suggestions"
+					aria-activedescendant={
+						selectedIndex >= 0
+							? `suggestion-${selectedIndex}`
+							: undefined
+					}
 					autoComplete="off"
 				/>
 			</div>
+			{dropdown}
 			<input className={css.submit} type="submit" tabIndex={-1} />
 		</form>
 	);

--- a/packages/playground/website/src/components/address-bar/index.tsx
+++ b/packages/playground/website/src/components/address-bar/index.tsx
@@ -1,12 +1,5 @@
-import React, {
-	useCallback,
-	useState,
-	useRef,
-	useEffect,
-	useLayoutEffect,
-} from 'react';
-import { createPortal } from 'react-dom';
-import { Icon } from '@wordpress/components';
+import React, { useState, useRef, useEffect } from 'react';
+import { Icon, MenuItem, NavigableMenu, Popover } from '@wordpress/components';
 import { home, wordpress, layout, pin } from '@wordpress/icons';
 import css from './style.module.css';
 
@@ -81,15 +74,12 @@ interface AddressBarProps {
 export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
+	const menuRef = useRef<HTMLDivElement>(null);
 	const [value, setValue] = useState(url || '');
 	const [isFocused, setIsFocused] = useState(false);
 	const [isOpen, setIsOpen] = useState(false);
-	const [selectedIndex, setSelectedIndex] = useState(-1);
-	const [dropdownPosition, setDropdownPosition] = useState({
-		top: 0,
-		left: 0,
-		width: 0,
-	});
+	const [focusMenu, setFocusMenu] = useState(false);
+	const [menuWidth, setMenuWidth] = useState(0);
 
 	useEffect(() => {
 		if (!isFocused && url) {
@@ -97,178 +87,108 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 		}
 	}, [isFocused, url]);
 
-	// Update dropdown position when open
-	useLayoutEffect(() => {
-		if (isOpen && inputRef.current) {
-			const rect = inputRef.current.getBoundingClientRect();
-			setDropdownPosition({
-				top: rect.bottom + 4,
-				left: rect.left,
-				width: rect.width,
-			});
+	// Update menu width when popover opens and track resize
+	useEffect(() => {
+		if (!isOpen || !inputRef.current) {
+			return;
 		}
+		setMenuWidth(inputRef.current.offsetWidth);
+
+		const resizeObserver = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				setMenuWidth(entry.contentRect.width);
+			}
+		});
+		resizeObserver.observe(inputRef.current);
+		return () => resizeObserver.disconnect();
 	}, [isOpen]);
 
-	// Close dropdown when clicking outside
+	// Focus the first menu item when focusMenu is set
 	useEffect(() => {
-		function handleClickOutside(e: MouseEvent) {
-			const target = e.target as Node;
-			if (
-				containerRef.current &&
-				!containerRef.current.contains(target) &&
-				!(target as Element).closest?.('#address-bar-suggestions')
-			) {
-				setIsOpen(false);
-				setSelectedIndex(-1);
+		if (focusMenu && menuRef.current) {
+			const firstItem = menuRef.current.querySelector(
+				'button, [role="menuitem"]'
+			) as HTMLElement;
+			if (firstItem) {
+				firstItem.focus();
 			}
+			setFocusMenu(false);
 		}
-		document.addEventListener('mousedown', handleClickOutside);
-		return () =>
-			document.removeEventListener('mousedown', handleClickOutside);
-	}, []);
+	}, [focusMenu]);
 
-	const handleSubmit = useCallback(
-		function (e: React.FormEvent<HTMLFormElement>) {
+	function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+		e.preventDefault();
+		const requestedPath = inputRef.current!.value;
+		onUpdate?.(requestedPath);
+		inputRef.current!.blur();
+		setIsOpen(false);
+	}
+
+	function handleRefresh(e: React.MouseEvent<HTMLButtonElement>) {
+		e.preventDefault();
+		if (url) {
+			onUpdate?.(url);
+		}
+	}
+
+	function handleNavigation(path: string) {
+		onUpdate?.(path);
+		setIsOpen(false);
+		inputRef.current?.blur();
+	}
+
+	function handleInputKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+		if (e.key === 'ArrowDown') {
 			e.preventDefault();
-			if (selectedIndex >= 0) {
-				onUpdate?.(quickNavItems[selectedIndex].path);
-				setIsOpen(false);
-				setSelectedIndex(-1);
-			} else {
-				const requestedPath = inputRef.current!.value;
-				onUpdate?.(requestedPath);
-			}
-			inputRef.current!.blur();
-		},
-		[onUpdate, selectedIndex]
-	);
-
-	const handleRefresh = useCallback(
-		function (e: React.MouseEvent<HTMLButtonElement>) {
-			e.preventDefault();
-			if (url) {
-				onUpdate?.(url);
-			}
-		},
-		[url, onUpdate]
-	);
-
-	const handleNavigation = useCallback(
-		(path: string) => {
-			onUpdate?.(path);
-			setIsOpen(false);
-			setSelectedIndex(-1);
-			inputRef.current?.blur();
-		},
-		[onUpdate]
-	);
-
-	const handleKeyDown = useCallback(
-		(e: React.KeyboardEvent<HTMLInputElement>) => {
 			if (!isOpen) {
-				if (e.key === 'ArrowDown') {
-					e.preventDefault();
-					setIsOpen(true);
-					setSelectedIndex(0);
-				}
-				return;
+				setIsOpen(true);
 			}
+			setFocusMenu(true);
+		} else if (e.key === 'Escape') {
+			setIsOpen(false);
+		}
+	}
 
-			switch (e.key) {
-				case 'ArrowDown':
-					e.preventDefault();
-					setSelectedIndex((prev) =>
-						prev < quickNavItems.length - 1 ? prev + 1 : prev
-					);
-					break;
-				case 'ArrowUp':
-					e.preventDefault();
-					setSelectedIndex((prev) => (prev > 0 ? prev - 1 : -1));
-					if (selectedIndex === 0) {
-						setIsOpen(false);
-					}
-					break;
-				case 'Escape':
-					e.preventDefault();
-					setIsOpen(false);
-					setSelectedIndex(-1);
-					break;
-				case 'Enter':
-					if (selectedIndex >= 0) {
-						e.preventDefault();
-						handleNavigation(quickNavItems[selectedIndex].path);
-					}
-					break;
-			}
-		},
-		[isOpen, selectedIndex, handleNavigation]
-	);
-
-	const handleFocus = useCallback(() => {
+	function handleFocus() {
 		setIsFocused(true);
 		setIsOpen(true);
-		setSelectedIndex(-1);
-	}, []);
+	}
 
-	const handleBlur = useCallback(() => {
+	function handleBlur() {
 		setIsFocused(false);
-		// Small delay to allow click events on dropdown items to fire
+		// Close popover if focus moves outside the component
+		// Use setTimeout to allow focus to move to menu items first
 		setTimeout(() => {
-			if (!document.activeElement?.closest('#address-bar-suggestions')) {
+			const isInInput = inputRef.current?.contains(
+				document.activeElement
+			);
+			const isInMenu = menuRef.current?.contains(document.activeElement);
+			if (!isInInput && !isInMenu) {
 				setIsOpen(false);
-				setSelectedIndex(-1);
 			}
-		}, 150);
-	}, []);
+		}, 0);
+	}
 
-	const handleChange = useCallback(
-		(e: React.ChangeEvent<HTMLInputElement>) => {
-			setValue(e.target.value);
-			setSelectedIndex(-1);
-		},
-		[]
-	);
+	function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+		setValue(e.target.value);
+	}
 
-	const dropdown = isOpen
-		? createPortal(
-				<ul
-					id="address-bar-suggestions"
-					className={css.suggestions}
-					role="listbox"
-					style={{
-						top: dropdownPosition.top,
-						left: dropdownPosition.left,
-						width: dropdownPosition.width,
-					}}
-				>
-					{quickNavItems.map((item, index) => (
-						<li
-							key={item.path}
-							id={`suggestion-${index}`}
-							role="option"
-							aria-selected={index === selectedIndex}
-							className={`${css.suggestionItem} ${index === selectedIndex ? css.suggestionItemSelected : ''}`}
-							onMouseDown={(e) => {
-								e.preventDefault();
-								handleNavigation(item.path);
-							}}
-							onMouseEnter={() => setSelectedIndex(index)}
-						>
-							<span className={css.suggestionIcon}>
-								{item.icon}
-							</span>
-							<span className={css.suggestionLabel}>
-								{item.label}
-							</span>
-							<span className={css.suggestionPath}>
-								{item.path}
-							</span>
-						</li>
-					))}
-				</ul>,
-				document.body
-			)
-		: null;
+	function handleMenuKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			setIsOpen(false);
+			inputRef.current?.focus();
+		} else if (e.key === 'ArrowUp') {
+			const firstItem = menuRef.current?.querySelector(
+				'button, [role="menuitem"]'
+			);
+			if (document.activeElement === firstItem) {
+				e.preventDefault();
+				e.stopPropagation();
+				inputRef.current?.focus();
+			}
+		}
+	}
 
 	return (
 		<form className={css.form} onSubmit={handleSubmit}>
@@ -300,22 +220,49 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 					onChange={handleChange}
 					onFocus={handleFocus}
 					onBlur={handleBlur}
-					onKeyDown={handleKeyDown}
+					onKeyDown={handleInputKeyDown}
 					name="url"
 					type="text"
 					aria-label='URL to visit in the WordPress site, like "/wp-admin"'
-					aria-expanded={isOpen}
-					aria-haspopup="listbox"
-					aria-controls="address-bar-suggestions"
-					aria-activedescendant={
-						selectedIndex >= 0
-							? `suggestion-${selectedIndex}`
-							: undefined
-					}
 					autoComplete="off"
 				/>
+				{isOpen && (
+					<Popover
+						placement="bottom-start"
+						onClose={() => setIsOpen(false)}
+						anchor={inputRef.current}
+						noArrow={true}
+						focusOnMount={false}
+						className={css.popover}
+					>
+						<NavigableMenu
+							ref={menuRef}
+							className={css.suggestions}
+							onKeyDownCapture={handleMenuKeyDown}
+							onBlur={handleBlur}
+							style={{ width: menuWidth }}
+						>
+							{quickNavItems.map((item) => (
+								<MenuItem
+									key={item.path}
+									className={css.suggestionItem}
+									onClick={() => handleNavigation(item.path)}
+								>
+									<span className={css.suggestionIcon}>
+										{item.icon}
+									</span>
+									<span className={css.suggestionLabel}>
+										{item.label}
+									</span>
+									<span className={css.suggestionPath}>
+										{item.path}
+									</span>
+								</MenuItem>
+							))}
+						</NavigableMenu>
+					</Popover>
+				)}
 			</div>
-			{dropdown}
 			<input className={css.submit} type="submit" tabIndex={-1} />
 		</form>
 	);

--- a/packages/playground/website/src/components/address-bar/style.module.css
+++ b/packages/playground/website/src/components/address-bar/style.module.css
@@ -29,6 +29,7 @@
 }
 
 .input-container {
+	position: relative;
 	display: flex;
 	width: 100%;
 	align-items: center;
@@ -54,9 +55,71 @@
 	border-radius: 8px;
 	color: #b4becb;
 	transition: color 0.5s ease;
+	width: 100%;
 }
 
 .input:focus,
 .input:hover {
 	color: #fff;
+}
+
+.input:focus {
+	outline: none;
+}
+
+/* Suggestions dropdown - styled like browser autocomplete */
+.suggestions {
+	position: fixed;
+	background: #3c434a;
+	border-radius: 8px;
+	margin: 0;
+	padding: 4px 0;
+	list-style: none;
+	z-index: 100000;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+	max-height: 320px;
+	overflow-y: auto;
+}
+
+.suggestion-item {
+	display: flex;
+	align-items: center;
+	padding: 8px 12px;
+	cursor: pointer;
+	gap: 10px;
+	color: #e0e6eb;
+	font-size: 14px;
+	transition: background 0.1s ease;
+}
+
+.suggestion-item:hover,
+.suggestion-item-selected {
+	background: #4f5861;
+}
+
+.suggestion-icon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: #8ab4f8;
+	flex-shrink: 0;
+	width: 20px;
+}
+
+.suggestion-icon svg {
+	fill: currentColor;
+}
+
+.suggestion-label {
+	color: #e8eaed;
+	font-size: 14px;
+	white-space: nowrap;
+}
+
+.suggestion-path {
+	color: #9aa0a6;
+	font-size: 13px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }

--- a/packages/playground/website/src/components/address-bar/style.module.css
+++ b/packages/playground/website/src/components/address-bar/style.module.css
@@ -67,16 +67,27 @@
 	outline: none;
 }
 
+/* Popover container */
+.popover {
+	z-index: 100000;
+}
+
+/* Override WordPress Popover default styles */
+.popover :global(.components-popover__content) {
+	background: #3c434a;
+	border: none;
+	border-radius: 8px;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+	padding: 0;
+}
+
 /* Suggestions dropdown - styled like browser autocomplete */
 .suggestions {
-	position: fixed;
 	background: #3c434a;
 	border-radius: 8px;
 	margin: 0;
 	padding: 4px 0;
 	list-style: none;
-	z-index: 100000;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 	max-height: 320px;
 	overflow-y: auto;
 }
@@ -90,11 +101,16 @@
 	color: #e0e6eb;
 	font-size: 14px;
 	transition: background 0.1s ease;
+	height: auto;
+	min-height: 0;
 }
 
 .suggestion-item:hover,
-.suggestion-item-selected {
+.suggestion-item:focus {
 	background: #4f5861;
+	color: #e0e6eb;
+	outline: none;
+	box-shadow: none;
 }
 
 .suggestion-icon {
@@ -104,6 +120,7 @@
 	color: #8ab4f8;
 	flex-shrink: 0;
 	width: 20px;
+	margin-right: 8px;
 }
 
 .suggestion-icon svg {
@@ -114,6 +131,7 @@
 	color: #e8eaed;
 	font-size: 14px;
 	white-space: nowrap;
+	margin-right: 8px;
 }
 
 .suggestion-path {


### PR DESCRIPTION
## Summary

Adds a dropdown popover to the address bar with quick navigation shortcuts:

<img width="2284" height="1598" alt="CleanShot 2025-12-20 at 23 15 42@2x" src="https://github.com/user-attachments/assets/0d1c7f56-1ceb-4dd6-87b3-fe6515cd8c07" />

Uses WordPress components (Popover, NavigableMenu, MenuItem) for consistent behavior and accessibility. Keyboard navigation included.

## Test plan

- [ ] Click on the address bar - dropdown should appear with 6 navigation options
- [ ] Press Arrow Down to move focus into the dropdown
- [ ] Use Arrow Up/Down to navigate between items
- [ ] Press Enter on an item to navigate to that page
- [ ] Press Escape to close the dropdown
- [ ] Click outside the dropdown to close it
- [ ] Verify icons match WordPress admin dashicons
- [ ] Resize window and verify dropdown width adjusts to match input