### PR TITLE
[ Intl ] Fix Intl feature inside Blueprints in Playground

### DIFF
--- a/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
@@ -19,7 +19,7 @@ export async function withIntl(
 	const dataName = 'icudt74l.dat';
 	const moduleDir =
 		typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-	const dataPath = path.join(moduleDir, 'shared', dataName);
+	const dataPath = path.join(moduleDir, 'shared', 'icu.dat');
 	const ICUData = fs.readFileSync(dataPath);
 
 	const extensionName = 'intl.so';

--- a/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
@@ -12,15 +12,19 @@ export async function withIntl(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion,
 	options: EmscriptenOptions
 ): Promise<EmscriptenOptions> {
-	const extensionName = 'intl.so';
-	const extensionPath = await getIntlExtensionModule(version);
-	const extension = fs.readFileSync(extensionPath);
-
-	const dataName = 'icu.dat';
+	/*
+	 * The Intl extension is hard-coded to look for the `icudt74l` filename,
+	 * which means the ICU data file must use that exact name.
+	 */
+	const dataName = 'icudt74l.dat';
 	const moduleDir =
 		typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
 	const dataPath = path.join(moduleDir, 'shared', dataName);
 	const ICUData = fs.readFileSync(dataPath);
+
+	const extensionName = 'intl.so';
+	const extensionPath = await getIntlExtensionModule(version);
+	const extension = fs.readFileSync(extensionPath);
 
 	return {
 		...options,
@@ -78,9 +82,6 @@ export async function withIntl(
 			 * via the ICU_DATA environment variable.
 			 * By default, this variable is set to '/internal/shared',
 			 * which corresponds to the actual file location.
-			 *
-			 * The Intl extension is hard-coded to look for the `icudt74l` filename,
-			 * which means the ICU data file must use that exact name.
 			 */
 			if (
 				!FSHelpers.fileExists(
@@ -90,7 +91,7 @@ export async function withIntl(
 			) {
 				phpRuntime.FS.mkdirTree(phpRuntime.ENV.ICU_DATA);
 				phpRuntime.FS.writeFile(
-					`${phpRuntime.ENV.ICU_DATA}/icudt74l.dat`,
+					`${phpRuntime.ENV.ICU_DATA}/${dataName}`,
 					new Uint8Array(ICUData)
 				);
 			}

--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -9,7 +9,10 @@ import fs from 'fs';
 import { getPHPLoaderModule } from '.';
 import { withNetworking } from './networking/with-networking';
 import type { FileLockManager } from './file-lock-manager';
-import { withXdebug, type XdebugOptions } from './extensions/xdebug/with-xdebug';
+import {
+	withXdebug,
+	type XdebugOptions,
+} from './extensions/xdebug/with-xdebug';
 import { withIntl } from './extensions/intl/with-intl';
 import { joinPaths } from '@php-wasm/util';
 import type { Promised } from '@php-wasm/util';
@@ -222,6 +225,68 @@ export async function loadNodeRuntime(
 			 * https://github.com/emscripten-core/emscripten/pull/19400/files#diff-456b6256111c90ca5e6bdb583ab87108cd51cbbefc812c4785ea315c0728b3a8R11
 			 */
 			phpRuntime.FS.root.mount.opts.root = '.';
+
+			/**
+			 * Emscripten's PROXYFS does not support real kernel-backed mmap().
+			 * However, some native code relies on mmap() to obtain a contiguous
+			 * read-only view of a file. This implementation emulates mmap by
+			 * allocating memory in the Wasm heap and eagerly reading the file
+			 * contents into it.
+			 *
+			 * This preserves expected mmap behavior (read-only, offset-based access)
+			 * while remaining compatible with virtual filesystem backends.
+			 */
+			phpRuntime.FS.filesystems.PROXYFS.stream_ops.mmap = (
+				stream: any,
+				length: number,
+				position: number
+			) => {
+				if (
+					phpRuntime.phpVersion.major === 7 &&
+					phpRuntime.phpVersion.minor <= 3
+				) {
+					const path = phpRuntime.FS.getPath(stream.node);
+
+					if (!path.endsWith('.dat')) {
+						const fs = stream.node.mount.opts.fs;
+						const stat = fs.fstat(stream.nfd);
+						length = stat.size >>> 0;
+					}
+				}
+
+				if (position !== 0) return -22;
+
+				const ptr = phpRuntime.malloc(length);
+
+				if (!ptr) return -12;
+
+				const heap = phpRuntime.HEAPU8.subarray(ptr, ptr + length);
+
+				let total = 0;
+
+				while (total < length) {
+					const n = phpRuntime.FS.filesystems.PROXYFS.stream_ops.read(
+						stream,
+						heap,
+						total,
+						length - total,
+						null
+					);
+
+					if (n <= 0) break;
+					total += n;
+				}
+
+				if (total !== length) {
+					phpRuntime.free(ptr);
+					return -5;
+				}
+
+				return {
+					ptr,
+					allocated: true,
+				};
+			};
 		},
 	};
 

--- a/packages/php-wasm/node/src/test/php-dynamic-loading.spec.ts
+++ b/packages/php-wasm/node/src/test/php-dynamic-loading.spec.ts
@@ -1,6 +1,7 @@
 import { loadNodeRuntime } from '..';
 import {
 	PHP,
+	proxyFileSystem,
 	SupportedPHPVersions,
 	setPhpIniEntries,
 } from '@php-wasm/universal';
@@ -223,6 +224,36 @@ describe.each(phpVersions)('PHP %s', async (phpVersion) => {
 			 * which means the ICU data file must use that exact name.
 			 */
 			expect(php.listFiles('/internal/shared')).toContain('icudt74l.dat');
+		});
+
+		it('reads the icu data in PROXYFS', async () => {
+			const newPhp = new PHP(
+				await loadNodeRuntime(phpVersion as any, {
+					withIntl: true,
+				})
+			);
+
+			proxyFileSystem(php, newPhp, ['/internal/shared']);
+
+			const response = await newPhp.runStream({
+				code: `<?php
+						$data = array(
+							'F' => 'Foo',
+							'Br' => 'Bar',
+							'Bz' => 'Bz',
+						);
+
+						$collator = new Collator('en_US');
+						$collator->asort($data, Collator::SORT_STRING);
+						var_dump($data);
+					?>`,
+			});
+
+			newPhp.exit();
+
+			expect(await response.stdoutText).toEqual(
+				'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
+			);
 		});
 
 		it('uses intl functions', async () => {

--- a/packages/php-wasm/web/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/web/src/lib/extensions/intl/with-intl.ts
@@ -88,7 +88,7 @@ export async function withIntl(
 			if (
 				!FSHelpers.fileExists(
 					phpRuntime.FS,
-					`${phpRuntime.ENV.ICU_DATA}/${dataName}`
+					`${phpRuntime.ENV.ICU_DATA}/icudt74l.dat`
 				)
 			) {
 				phpRuntime.FS.mkdirTree(phpRuntime.ENV.ICU_DATA);

--- a/packages/php-wasm/web/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/web/src/lib/extensions/intl/with-intl.ts
@@ -13,16 +13,20 @@ export async function withIntl(
 ): Promise<EmscriptenOptions> {
 	const memoizedFetch = createMemoizedFetch(fetch);
 
+	/*
+	 * The Intl extension is hard-coded to look for the `icudt74l` filename,
+	 * which means the ICU data file must use that exact name.
+	 */
+	const dataName = 'icudt74l.dat';
 	const extensionName = 'intl.so';
-	const dataName = 'icu.dat';
 
-	const extensionPath = await getIntlExtensionModule(version);
 	// @ts-ignore
 	const dataPath = (await import('./shared/icu.dat')).default;
+	const extensionPath = await getIntlExtensionModule(version);
 
-	const [extension, ICUData] = await Promise.all([
-		memoizedFetch(extensionPath).then((response) => response.arrayBuffer()),
+	const [ICUData, extension] = await Promise.all([
 		memoizedFetch(dataPath).then((response) => response.arrayBuffer()),
+		memoizedFetch(extensionPath).then((response) => response.arrayBuffer()),
 	]);
 
 	return {
@@ -81,19 +85,16 @@ export async function withIntl(
 			 * via the ICU_DATA environment variable.
 			 * By default, this variable is set to '/internal/shared',
 			 * which corresponds to the actual file location.
-			 *
-			 * The Intl extension is hard-coded to look for the `icudt74l` filename,
-			 * which means the ICU data file must use that exact name.
 			 */
 			if (
 				!FSHelpers.fileExists(
 					phpRuntime.FS,
-					`${phpRuntime.ENV.ICU_DATA}/icudt74l.dat`
+					`${phpRuntime.ENV.ICU_DATA}/${dataName}`
 				)
 			) {
 				phpRuntime.FS.mkdirTree(phpRuntime.ENV.ICU_DATA);
 				phpRuntime.FS.writeFile(
-					`${phpRuntime.ENV.ICU_DATA}/icudt74l.dat`,
+					`${phpRuntime.ENV.ICU_DATA}/${dataName}`,
 					new Uint8Array(ICUData)
 				);
 			}

--- a/packages/php-wasm/web/src/lib/load-runtime.ts
+++ b/packages/php-wasm/web/src/lib/load-runtime.ts
@@ -1,6 +1,7 @@
 import type {
 	SupportedPHPVersion,
 	EmscriptenOptions,
+	PHPRuntime,
 	PHPLoaderModule,
 } from '@php-wasm/universal';
 import { loadPHPRuntime } from '@php-wasm/universal';
@@ -66,6 +67,68 @@ export async function loadWebRuntime(
 	let emscriptenOptions: EmscriptenOptions | Promise<EmscriptenOptions> = {
 		...fakeWebsocket(),
 		...(loaderOptions.emscriptenOptions || {}),
+		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
+			/**
+			 * Emscripten's PROXYFS does not support real kernel-backed mmap().
+			 * However, some native code relies on mmap() to obtain a contiguous
+			 * read-only view of a file. This implementation emulates mmap by
+			 * allocating memory in the Wasm heap and eagerly reading the file
+			 * contents into it.
+			 *
+			 * This preserves expected mmap behavior (read-only, offset-based access)
+			 * while remaining compatible with virtual filesystem backends.
+			 */
+			phpRuntime.FS.filesystems.PROXYFS.stream_ops.mmap = (
+				stream: any,
+				length: number,
+				position: number
+			) => {
+				if (
+					phpRuntime.phpVersion.major === 7 &&
+					phpRuntime.phpVersion.minor <= 3
+				) {
+					const path = phpRuntime.FS.getPath(stream.node);
+
+					if (!path.endsWith('.dat')) {
+						const fs = stream.node.mount.opts.fs;
+						const stat = fs.fstat(stream.nfd);
+						length = stat.size >>> 0;
+					}
+				}
+				if (position !== 0) return -22;
+
+				const ptr = phpRuntime.malloc(length);
+
+				if (!ptr) return -12;
+
+				const heap = phpRuntime.HEAPU8.subarray(ptr, ptr + length);
+
+				let total = 0;
+
+				while (total < length) {
+					const n = phpRuntime.FS.filesystems.PROXYFS.stream_ops.read(
+						stream,
+						heap,
+						total,
+						length - total,
+						total
+					);
+
+					if (n <= 0) break;
+					total += n;
+				}
+
+				if (total !== length) {
+					phpRuntime.free(ptr);
+					return -5;
+				}
+
+				return {
+					ptr,
+					allocated: true,
+				};
+			};
+		},
 	};
 
 	if (loaderOptions.tcpOverFetch) {

--- a/packages/php-wasm/web/src/test/php-dynamic-loading.spec.ts
+++ b/packages/php-wasm/web/src/test/php-dynamic-loading.spec.ts
@@ -109,6 +109,46 @@ SupportedPHPVersions.forEach((phpVersion) => {
 			test.expect(result).toContain('icudt74l.dat');
 		});
 
+		test('reads the icu data in PROXYFS', async ({ page }) => {
+			const result = await page.evaluate(async (phpVersion) => {
+				const oldPhp = new window.PHP(
+					await window.loadWebRuntime(phpVersion as any, {
+						withIntl: true,
+					})
+				);
+				const newPhp = new window.PHP(
+					await window.loadWebRuntime(phpVersion as any, {
+						withIntl: true,
+					})
+				);
+
+				window.proxyFileSystem(oldPhp, newPhp, ['/internal/shared']);
+
+				const response = await newPhp.runStream({
+					code: `<?php
+							$data = array(
+								'F' => 'Foo',
+								'Br' => 'Bar',
+								'Bz' => 'Bz',
+							);
+
+							$collator = new Collator('en_US');
+							$collator->asort($data, Collator::SORT_STRING);
+							var_dump($data);
+						?>`,
+				});
+
+				newPhp.exit();
+				oldPhp.exit();
+
+				return await response.stdoutText;
+			}, phpVersion);
+
+			test.expect(result).toEqual(
+				'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
+			);
+		});
+
 		test('uses intl functions', async ({ page }) => {
 			const result = await page.evaluate(async (phpVersion) => {
 				const php = new window.PHP(

--- a/packages/php-wasm/web/src/test/playwright/globals.d.ts
+++ b/packages/php-wasm/web/src/test/playwright/globals.d.ts
@@ -1,9 +1,10 @@
-import type { PHP } from '@php-wasm/universal';
+import type { PHP, proxyFileSystem } from '@php-wasm/universal';
 import type { loadWebRuntime } from '../../lib';
 
 declare global {
 	interface Window {
 		PHP: typeof PHP;
 		loadWebRuntime: typeof loadWebRuntime;
+		proxyFileSystem: typeof proxyFileSystem;
 	}
 }

--- a/packages/php-wasm/web/src/test/playwright/globals.ts
+++ b/packages/php-wasm/web/src/test/playwright/globals.ts
@@ -1,5 +1,6 @@
-import { PHP } from '@php-wasm/universal';
+import { PHP, proxyFileSystem } from '@php-wasm/universal';
 import { loadWebRuntime } from '../../lib';
 
 (window as any).PHP = PHP;
 (window as any).loadWebRuntime = loadWebRuntime;
+(window as any).proxyFileSystem = proxyFileSystem;

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -512,7 +512,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 							phpWasmInitOptions: { nativeInternalDirPath },
 						},
 						followSymlinks: allow?.includes('follow-symlinks'),
-						withIntl: withIntl,
+						withIntl,
 						withXdebug,
 					});
 				},

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -8,7 +8,7 @@ import {
 	BlueprintReflection,
 } from '.';
 import { collectPhpLogs, logger } from '@php-wasm/logger';
-import { consumeAPI } from '@php-wasm/universal';
+import { consumeAPI, type UniversalPHP } from '@php-wasm/universal';
 
 export class BlueprintsV1Handler {
 	private readonly options: StartPlaygroundOptions;
@@ -78,7 +78,7 @@ export class BlueprintsV1Handler {
 				corsProxy,
 				gitAdditionalHeadersCallback,
 			});
-			await runBlueprintV1Steps(compiled, playground);
+			await runBlueprintV1Steps(compiled, playground as UniversalPHP);
 		}
 
 		/**

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -257,10 +257,7 @@ test('wp-cli step should create a post', async ({ website, wordpress }) => {
 	).toBeVisible();
 });
 
-test('Intl functions should be disabled by default', async ({
-	website,
-	wordpress,
-}) => {
+test('Intl should be disabled by default', async ({ website, wordpress }) => {
 	const blueprint: Blueprint = {
 		landingPage: '/intl-test.php',
 		steps: [
@@ -283,12 +280,12 @@ test('Intl functions should work when intl is enabled', async ({
 	wordpress,
 }) => {
 	const blueprint: Blueprint = {
-		landingPage: '/intl-test.php',
+		landingPage: '/intl-functions-test.php',
 		features: { intl: true },
 		steps: [
 			{
 				step: 'writeFile',
-				path: '/wordpress/intl-test.php',
+				path: '/wordpress/intl-functions-test.php',
 				data: `<?php
 					$formatter = numfmt_create('en-US', NumberFormatter::CURRENCY);
 					echo numfmt_format($formatter, 100.00);
@@ -300,6 +297,37 @@ test('Intl functions should work when intl is enabled', async ({
 	};
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 	await expect(wordpress.locator('body')).toContainText('$100.00100,00\xA0€');
+});
+
+test('Intl classes should work when intl is enabled', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		landingPage: '/intl-classes-test.php',
+		features: { intl: true },
+		steps: [
+			{
+				step: 'writeFile',
+				path: '/wordpress/intl-classes-test.php',
+				data: `<?php
+							$data = array(
+								'F' => 'Foo',
+								'Br' => 'Bar',
+								'Bz' => 'Bz',
+							);
+
+							$collator = new Collator('en_US');
+							$collator->asort($data, Collator::SORT_STRING);
+							var_dump($data);
+						?>`,
+			},
+		],
+	};
+	await website.goto(`/#${JSON.stringify(blueprint)}`);
+	await expect(wordpress.locator('body')).toContainText(
+		'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
+	);
 });
 
 test('HTTPS requests via curl_exec() should work', async ({


### PR DESCRIPTION
## Motivation for the change, related issues

Based on [this issue](https://github.com/WordPress/wordpress-playground/issues/2466). 

Related to [this function](https://github.com/woocommerce/woocommerce/blob/8ac0f33cdf38cbdf1ca6b935309ccf9e184ccdd4/plugins/woocommerce/includes/wc-core-functions.php#L1957).

It looks like the ICU data is not found when running the below Blueprint. Even if the file is located in `/internal/shared` before running the `playground.run(...)` in `run-php.ts`. 

## Implementation details

- Added a new `Intl classes should work when intl is enabled` test in `playground/website/playwright/e2e/blueprints.spec.ts` 

## Blueprint

```json
{
	"features": {
		"intl": true
	},
	"steps": [
		{
			"step": "runPHP",
			"code": "<?php \n\n$data = array(\n    'F' => 'Foo',\n    'Br' => 'Bar',\n    'Bz' => 'Bz',\n);\n\n$collator = new Collator('en_US');\n$collator->asort($data, Collator::SORT_STRING);\n\nthrow new Exception( json_encode($data, JSON_PRETTY_PRINT ) );"
		}
	]
}
```

Should throw : 

```
Uncaught Exception: {
    "Br": "Bar",
    "Bz": "Bz",
    "F": "Foo"
} 
```

But throws : 

```
Uncaught IntlException: Constructor failed
```