### PR TITLE
[ xdebug ] Add Xdebug use case examples

### DIFF
--- a/examples/xdebug/.gitignore
+++ b/examples/xdebug/.gitignore
@@ -1,0 +1,5 @@
+**/node_modules/
+**/package-lock.json
+**/.idea/
+**/.vscode/
+**/.playground-xdebug-root

--- a/examples/xdebug/README.md
+++ b/examples/xdebug/README.md
@@ -51,7 +51,7 @@ http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@wp-playground-cli-3.0.12
 ...
 ```
 
-The requested lines must be be added in your separate project's `package.json` file :
+The requested lines must be added in your separate project's `package.json` file :
 
 ```json
 {

--- a/examples/xdebug/README.md
+++ b/examples/xdebug/README.md
@@ -6,7 +6,7 @@ Use PHP.wasm with Xdebug
 
 ## Appendix
 
-There are mostly four ways to run PHP.wasm :
+There are multiple ways to run PHP.wasm :
 
 #### 1. Directly from the [WordPress Playground](https://github.com/WordPress/wordpress-playground) repository
 

--- a/examples/xdebug/README.md
+++ b/examples/xdebug/README.md
@@ -1,0 +1,99 @@
+## About
+
+Use PHP.wasm with Xdebug
+
+<br>
+
+## Appendix
+
+There are mostly four ways to run PHP.wasm :
+
+#### 1. Directly from the [WordPress Playground](https://github.com/WordPress/wordpress-playground) repository
+
+```bash
+cd wordpress-playground
+```
+
+```
+// PHP.wasm CLI
+node \
+--no-warnings=ExperimentalWarning \
+--experimental-strip-types \
+--experimental-transform-types \
+--import ./packages/meta/src/node-es-module-loader/register.mts \
+./packages/php-wasm/cli/src/main.ts --xdebug
+```
+
+```
+// Playground CLI
+node \
+--no-warnings=ExperimentalWarning \
+--experimental-strip-types \
+--experimental-transform-types \
+--import ./packages/meta/src/node-es-module-loader/register.mts \
+./packages/playground/cli/src/cli.ts server --xdebug
+```
+
+<br>
+
+#### 2. Running the `local-package-repository` script in the [WordPress Playground](https://github.com/WordPress/wordpress-playground) repository
+
+```bash
+cd wordpress-playground
+
+npm run local-package-repository
+
+...
+http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@php-wasm-universal-3.0.12.tar.gz
+http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@php-wasm-node-3.0.12.tar.gz
+http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@php-wasm-cli-3.0.12.tar.gz
+http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@wp-playground-cli-3.0.12.tar.gz
+...
+```
+
+The requested lines must be be added in your separate project's `package.json` file :
+
+```json
+{
+	"type": "module",
+	"dependencies": {
+		"@php-wasm/node": "http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@php-wasm-node-3.0.12.tar.gz",
+		"@php-wasm/cli": "http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@php-wasm-cli-3.0.12.tar.gz",
+		"@wp-playground/cli": "http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@wp-playground-cli-3.0.12.tar.gz"
+	}
+}
+```
+
+```bash
+npm install
+```
+
+<br>
+
+#### 3. Installing the necessary packages from NPM
+
+```bash
+npm install @php-wasm/node @php-wasm/cli @wp-playground/cli
+```
+
+<br>
+
+#### 4. Running packages directly from NPX [PHP.wasm CLI and WP-Playground/CLI only]
+
+```bash
+npx @php-wasm/cli --xdebug
+
+npx @wp-playground/cli server --xdebug
+```
+
+<br>
+<br>
+
+## How to start
+
+#### 1. Choose the environment you want to use Xdebug in
+
+- chrome-devtools
+- ide
+
+#### 2. Follow the dedicated README file instructions

--- a/examples/xdebug/chrome-devtools/README.md
+++ b/examples/xdebug/chrome-devtools/README.md
@@ -44,7 +44,7 @@ http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@php-wasm-xdebug-bridge-3
 ...
 ```
 
-The requested lines must be be added in your separate project's `package.json` file :
+The requested lines must be added in your separate project's `package.json` file :
 
 ```json
 {

--- a/examples/xdebug/chrome-devtools/README.md
+++ b/examples/xdebug/chrome-devtools/README.md
@@ -14,7 +14,7 @@ Use PHP.wasm with Xdebug in Google Chrome Devtools with the Xdebug Bridge
 
 <br>
 
-There are mostly four ways to run the Google Chrome Devtools :
+There are multiple ways to run the Google Chrome Devtools :
 
 #### 1. Directly from the [WordPress Playground](https://github.com/WordPress/wordpress-playground) repository
 
@@ -80,7 +80,7 @@ npx @php-wasm/xdebug-bridge
 
 ## How to start
 
-#### 1. Go to the specific directory you would like to try
+#### 1. Copy the specific directory you would like to try
 
 - php-wasm-node
 - php-wasm-cli

--- a/examples/xdebug/chrome-devtools/README.md
+++ b/examples/xdebug/chrome-devtools/README.md
@@ -1,0 +1,89 @@
+## About
+
+Use PHP.wasm with Xdebug in Google Chrome Devtools with the Xdebug Bridge
+
+> [!WARNING]
+> Debugging with Google Chrome DevTools is still experimental
+
+<br>
+
+## Appendix
+
+> [!IMPORTANT]
+> Chrome Devtools retains breakpoints. To reset the Devtools, go to Settings > Preferences > Restore defaults and reload
+
+<br>
+
+There are mostly four ways to run the Google Chrome Devtools :
+
+#### 1. Directly from the [WordPress Playground](https://github.com/WordPress/wordpress-playground) repository
+
+```bash
+cd wordpress-playground
+
+// PHP.wasm CLI
+node \
+--no-warnings=ExperimentalWarning \
+--experimental-strip-types \
+--experimental-transform-types \
+--import ./packages/meta/src/node-es-module-loader/register.mts \
+./packages/php-wasm/xdebug-bridge/src/cli.ts
+```
+
+<br>
+
+#### 2. Running the `local-package-repository` script in the [WordPress Playground](https://github.com/WordPress/wordpress-playground) repository
+
+```bash
+cd wordpress-playground
+
+npm run local-package-repository
+
+...
+http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@php-wasm-xdebug-bridge-3.0.12.tar.gz
+...
+```
+
+The requested lines must be be added in your separate project's `package.json` file :
+
+```json
+{
+	"type": "module",
+	"dependencies": {
+		"@php-wasm/xdebug-bridge": "http://127.0.0.1:9724/7840495c41d5c5ae535da114/v3.0.12/@php-wasm-xdebug-bridge-3.0.12.tar.gz"
+	}
+}
+```
+
+```bash
+npm install
+```
+
+<br>
+
+#### 3. Installing the necessary packages from NPM
+
+```bash
+npm install @php-wasm/xdebug-bridge
+```
+
+<br>
+
+#### 4. Running package directly from NPX
+
+```bash
+npx @php-wasm/xdebug-bridge
+```
+
+<br>
+<br>
+
+## How to start
+
+#### 1. Go to the specific directory you would like to try
+
+- php-wasm-node
+- php-wasm-cli
+- wp-playground-cli
+
+#### 2. Follow the dedicated README file instructions

--- a/examples/xdebug/chrome-devtools/php-wasm-cli/README.md
+++ b/examples/xdebug/chrome-devtools/php-wasm-cli/README.md
@@ -1,0 +1,50 @@
+## About
+
+Use PHP.wasm CLI with Xdebug enabled
+
+> [!WARNING]
+> Debugging with Google Chrome DevTools is still experimental
+
+<br>
+
+## Installation
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+<br>
+
+#### 2. Run script with CLI
+
+```bash
+node_modules/.bin/php-wasm-cli --xdebug --experimental-devtools src/test.php
+```
+
+```
+Starting XDebug Bridge...
+Connect Chrome DevTools to CDP at:
+devtools://devtools/bundled/inspector.html?ws=localhost:9229
+```
+
+<br>
+
+#### 3. Connect to Chrome Devtools and open the Devtools Console
+
+```
+🎉 Welcome to WordPress Playground DevTools! 🎉
+   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+1. Add breakpoints in your files to start step debugging.
+2. Run your php file, project, plugin or theme using PHP.wasm or Playground CLI.
+3. Witness the magic break.
+```
+
+<br>
+
+#### 4. Witness the magic break
+
+> [!NOTE]
+> When using the PHP.wasm CLI with Xdebug enabled, execution will automatically break on the first line

--- a/examples/xdebug/chrome-devtools/php-wasm-cli/README.md
+++ b/examples/xdebug/chrome-devtools/php-wasm-cli/README.md
@@ -26,7 +26,7 @@ node_modules/.bin/php-wasm-cli --xdebug --experimental-devtools src/test.php
 ```
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 ```
 
 <br>

--- a/examples/xdebug/chrome-devtools/php-wasm-cli/package.json
+++ b/examples/xdebug/chrome-devtools/php-wasm-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"dependencies": {
-		"@php-wasm/cli": "^3.0.32"
+		"@php-wasm/cli": "^3.1.19"
 	}
 }

--- a/examples/xdebug/chrome-devtools/php-wasm-cli/package.json
+++ b/examples/xdebug/chrome-devtools/php-wasm-cli/package.json
@@ -1,0 +1,6 @@
+{
+	"type": "module",
+	"dependencies": {
+		"@php-wasm/cli": "^3.0.32"
+	}
+}

--- a/examples/xdebug/chrome-devtools/php-wasm-cli/src/test.php
+++ b/examples/xdebug/chrome-devtools/php-wasm-cli/src/test.php
@@ -1,0 +1,11 @@
+<?php
+
+$test = 42; // Set a breakpoint on this line
+
+echo "Output!\n";
+
+function test() {
+	echo "Hello Xdebug World!\n";
+}
+
+test();

--- a/examples/xdebug/chrome-devtools/php-wasm-node/README.md
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/README.md
@@ -35,7 +35,7 @@ node_modules/.bin/xdebug-bridge
 ```
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 ```
 
 <br>
@@ -105,7 +105,7 @@ node src/script-with-bridge.js
 ```
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 ```
 
 <br>
@@ -142,7 +142,7 @@ node src/script-with-bridge.js
 ```
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 ```
 
 <br>

--- a/examples/xdebug/chrome-devtools/php-wasm-node/README.md
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/README.md
@@ -1,0 +1,150 @@
+## About
+
+Use PHP.wasm Node with Xdebug enabled
+
+> [!WARNING]
+> Debugging with Google Chrome DevTools is still experimental
+
+<br>
+
+## Installation
+
+This directory shows how to use Xdebug with the Xdebug Bridge in multiple use cases :
+
+- [How to start a bridge before running a script](#how-to-start-a-bridge-before-running-a-script)
+- [How to run a script starting the bridge](#how-to-run-a-script-starting-the-bridge)
+
+<br>
+
+## <a id="how-to-start-a-bridge-before-running-a-script"></a>How to start a bridge before running a script
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+<br>
+
+#### 2. Run Xdebug bridge in a separate terminal
+
+```bash
+node_modules/.bin/xdebug-bridge
+```
+
+```
+Starting XDebug Bridge...
+Connect Chrome DevTools to CDP at:
+devtools://devtools/bundled/inspector.html?ws=localhost:9229
+```
+
+<br>
+
+#### 3. Connect to Google Chrome Devtools and open the Devtools Console
+
+```
+🎉 Welcome to WordPress Playground DevTools! 🎉
+   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+1. Add breakpoints in your files to start step debugging.
+2. Run your php file, project, plugin or theme using PHP.wasm or Playground CLI.
+3. Witness the magic break.
+```
+
+<br>
+
+#### 4. Run script
+
+```bash
+node src/script.js
+```
+
+```
+Output!
+Hello Xdebug World!
+```
+
+> [!NOTE]
+> Nothing happens because no breakpoints have been set yet
+
+<br>
+
+#### 5. Set a breakpoint in `src/test.php` in Chrome Devtools
+
+<br>
+
+#### 6. Re-run the script
+
+```bash
+node src/script.js
+```
+
+<br>
+
+#### 7. Witness the magic break
+
+<br>
+<br>
+
+## <a id="how-to-run-a-script-starting-the-bridge"></a>How to run a script starting the bridge
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+<br>
+
+#### 2. Run script
+
+```bash
+node src/script-with-bridge.js
+```
+
+```
+Starting XDebug Bridge...
+Connect Chrome DevTools to CDP at:
+devtools://devtools/bundled/inspector.html?ws=localhost:9229
+```
+
+<br>
+
+#### 3. Connect to Google Chrome Devtools and open the Devtools Console
+
+```
+🎉 Welcome to WordPress Playground DevTools! 🎉
+   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+1. Add breakpoints in your files to start step debugging.
+2. Run your php file, project, plugin or theme using PHP.wasm or Playground CLI.
+3. Witness the magic break.
+
+Output!
+Hello Xdebug World!
+```
+
+> [!NOTE]
+> Nothing happens because no breakpoints have been set yet
+
+<br>
+
+#### 4. Set a breakpoint in `src/test.php` in Chrome Devtools
+
+<br>
+
+#### 5. Re-run the script and reconnect to Devtools
+
+```bash
+node src/script-with-bridge.js
+```
+
+```
+Starting XDebug Bridge...
+Connect Chrome DevTools to CDP at:
+devtools://devtools/bundled/inspector.html?ws=localhost:9229
+```
+
+<br>
+
+#### 6. Witness the magic break

--- a/examples/xdebug/chrome-devtools/php-wasm-node/package.json
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/package.json
@@ -1,0 +1,7 @@
+{
+	"type": "module",
+	"dependencies": {
+		"@php-wasm/node": "^3.0.32",
+		"@php-wasm/xdebug-bridge": "^3.0.32"
+	}
+}

--- a/examples/xdebug/chrome-devtools/php-wasm-node/package.json
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"dependencies": {
-		"@php-wasm/node": "^3.0.32",
-		"@php-wasm/xdebug-bridge": "^3.0.32"
+		"@php-wasm/node": "^3.1.19",
+		"@php-wasm/xdebug-bridge": "^3.1.19"
 	}
 }

--- a/examples/xdebug/chrome-devtools/php-wasm-node/src/script-with-bridge.js
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/src/script-with-bridge.js
@@ -2,7 +2,7 @@ import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { startBridge } from '@php-wasm/xdebug-bridge';
 
-const php = new PHP(await loadNodeRuntime('8.5', { withXdebug: true }));
+const php = new PHP(await loadNodeRuntime('8.4', { withXdebug: true }));
 
 const bridge = await startBridge({ phpInstance: php });
 

--- a/examples/xdebug/chrome-devtools/php-wasm-node/src/script-with-bridge.js
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/src/script-with-bridge.js
@@ -1,0 +1,19 @@
+import { PHP } from '@php-wasm/universal';
+import { loadNodeRuntime } from '@php-wasm/node';
+import { startBridge } from '@php-wasm/xdebug-bridge';
+
+const php = new PHP(await loadNodeRuntime('8.5', { withXdebug: true }));
+
+const bridge = await startBridge({ phpInstance: php });
+
+bridge.start();
+
+const response = await php.runStream({ scriptPath: `src/test.php` });
+
+response.stdout.pipeTo(
+	new WritableStream({
+		write(chunk) {
+			process.stdout.write(chunk);
+		},
+	})
+);

--- a/examples/xdebug/chrome-devtools/php-wasm-node/src/script-with-bridge.js
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/src/script-with-bridge.js
@@ -1,19 +1,34 @@
 import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { startBridge } from '@php-wasm/xdebug-bridge';
+import fs from 'fs';
 
-const php = new PHP(await loadNodeRuntime('8.4', { withXdebug: true }));
+const php = new PHP(
+	await loadNodeRuntime('8.4', {
+		withXdebug: true,
+		emscriptenOptions: { processId: process.pid },
+	})
+);
 
 const bridge = await startBridge({ phpInstance: php });
 
 bridge.start();
 
+php.mkdir('src');
+
+php.writeFile('src/test.php', fs.readFileSync('./src/test.php'));
+
 const response = await php.runStream({ scriptPath: `src/test.php` });
 
-response.stdout.pipeTo(
-	new WritableStream({
-		write(chunk) {
-			process.stdout.write(chunk);
-		},
-	})
-);
+await response.stdout
+	.pipeTo(
+		new WritableStream({
+			write(chunk) {
+				process.stdout.write(chunk);
+			},
+		})
+	)
+	.catch((error) => {
+		process.stderr.write(error);
+		process.exit(1);
+	});

--- a/examples/xdebug/chrome-devtools/php-wasm-node/src/script.js
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/src/script.js
@@ -1,14 +1,29 @@
 import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
+import fs from 'fs';
 
-const php = new PHP(await loadNodeRuntime('8.4', { withXdebug: true }));
+const php = new PHP(
+	await loadNodeRuntime('8.4', {
+		withXdebug: true,
+		emscriptenOptions: { processId: process.pid },
+	})
+);
+
+php.mkdir('src');
+
+php.writeFile('src/test.php', fs.readFileSync('./src/test.php'));
 
 const response = await php.runStream({ scriptPath: `src/test.php` });
 
-response.stdout.pipeTo(
-	new WritableStream({
-		write(chunk) {
-			process.stdout.write(chunk);
-		},
-	})
-);
+await response.stdout
+	.pipeTo(
+		new WritableStream({
+			write(chunk) {
+				process.stdout.write(chunk);
+			},
+		})
+	)
+	.catch((error) => {
+		process.stderr.write(error);
+		process.exit(1);
+	});

--- a/examples/xdebug/chrome-devtools/php-wasm-node/src/script.js
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/src/script.js
@@ -1,7 +1,7 @@
 import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
 
-const php = new PHP(await loadNodeRuntime('8.5', { withXdebug: true }));
+const php = new PHP(await loadNodeRuntime('8.4', { withXdebug: true }));
 
 const response = await php.runStream({ scriptPath: `src/test.php` });
 

--- a/examples/xdebug/chrome-devtools/php-wasm-node/src/script.js
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/src/script.js
@@ -1,0 +1,14 @@
+import { PHP } from '@php-wasm/universal';
+import { loadNodeRuntime } from '@php-wasm/node';
+
+const php = new PHP(await loadNodeRuntime('8.5', { withXdebug: true }));
+
+const response = await php.runStream({ scriptPath: `src/test.php` });
+
+response.stdout.pipeTo(
+	new WritableStream({
+		write(chunk) {
+			process.stdout.write(chunk);
+		},
+	})
+);

--- a/examples/xdebug/chrome-devtools/php-wasm-node/src/test.php
+++ b/examples/xdebug/chrome-devtools/php-wasm-node/src/test.php
@@ -1,0 +1,11 @@
+<?php
+
+$test = 42; // Set a breakpoint on this line
+
+echo "Output!\n";
+
+function test() {
+	echo "Hello Xdebug World!\n";
+}
+
+test();

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/README.md
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/README.md
@@ -33,17 +33,16 @@ node src/script.js
 ```
 
 ```
-Starting a PHP server...
-Setting up WordPress undefined
-Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.8.3.zip
-Fetching SQLite integration plugin...
-Booting WordPress...
-PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
-Booted!
-Running the Blueprint...
-Running the Blueprint – 100%
-Finished running the blueprint
-WordPress is running on http://127.0.0.1:55673 with 1 worker(s)
+WordPress Playground CLI
+
+PHP 8.4  WordPress latest
+Extensions intl, xdebug
+Mount ./src → /wordpress
+
+Running Blueprint 100%
+
+Ready! WordPress is running on http://127.0.0.1:9400 (6 workers)
+
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
 devtools://devtools/bundled/inspector.html?ws=localhost:9229
@@ -115,7 +114,7 @@ Finished running the blueprint
 WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 ```
 
 <br>

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/README.md
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/README.md
@@ -1,0 +1,158 @@
+## About
+
+Use WP Playground CLI with Xdebug enabled
+
+> [!WARNING]
+> Debugging with Google Chrome DevTools is still experimental
+
+<br>
+
+## Appendix
+
+This directory shows how to use Xdebug with WP Playground CLI in Chrome Devtools in multiple use cases :
+
+- [How to debug a file](#how-to-debug-a-file)
+- [How to mount and debug a plugin](#how-to-mount-and-debug-a-plugin)
+
+<br>
+
+## <a id="how-to-debug-a-file"></a>How to debug a file
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+<br>
+
+#### 2. Run script
+
+```bash
+node src/script.js
+```
+
+```
+Starting a PHP server...
+Setting up WordPress undefined
+Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.8.3.zip
+Fetching SQLite integration plugin...
+Booting WordPress...
+PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
+Booted!
+Running the Blueprint...
+Running the Blueprint – 100%
+Finished running the blueprint
+WordPress is running on http://127.0.0.1:55673 with 1 worker(s)
+Starting XDebug Bridge...
+Connect Chrome DevTools to CDP at:
+devtools://devtools/bundled/inspector.html?ws=localhost:9229
+```
+
+<br>
+
+#### 3. Connect to Google Chrome Devtools and open the Devtools Console
+
+```
+🎉 Welcome to WordPress Playground DevTools! 🎉
+   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+1. Add breakpoints in your files to start step debugging.
+2. Run your php file, project, plugin or theme using PHP.wasm or Playground CLI.
+3. Witness the magic break.
+
+Output!
+Hello Xdebug World!
+```
+
+> [!NOTE]
+> Nothing happens because no breakpoints have been set yet
+
+<br>
+
+#### 4. Set a breakpoint in `PHP.wasm/wordpress/test.php` in Chrome Devtools
+
+<br>
+
+#### 5. Re-run script and reconnect to Chrome Devtools
+
+```bash
+node src/script.js
+```
+
+<br>
+
+#### 6. Witness the magic break
+
+<br>
+<br>
+
+## <a id="how-to-mount-and-debug-a-plugin"></a>How to mount and debug a plugin
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+#### 2. Run CLI command
+
+```bash
+node_modules/.bin/wp-playground-cli server --login --xdebug --experimental-devtools --mount=./plugin:/wordpress/wp-content/plugins/plugin
+```
+
+```
+Starting a PHP server...
+Setting up WordPress latest
+Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.8.3.zip
+Fetching SQLite integration plugin...
+Booting WordPress...
+PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
+Booted!
+Running the Blueprint...
+Logging in – 100%
+Finished running the blueprint
+WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
+Starting XDebug Bridge...
+Connect Chrome DevTools to CDP at:
+devtools://devtools/bundled/inspector.html?ws=localhost:9229
+```
+
+<br>
+
+#### 3. Activate the `Simple Admin Message` plugin in WP admin's plugins section
+
+> [!NOTE]
+> You should see the message being displayed, but nothing else happens because the debugging server is not running yet
+
+<br>
+
+#### 4. Deactivate the `Simple Admin Message` plugin in WP admin's plugins section
+
+<br>
+
+#### 5. Connect to Google Chrome Devtools and open the Devtools Console
+
+```
+🎉 Welcome to WordPress Playground DevTools! 🎉
+   ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+
+1. Add breakpoints in your files to start step debugging.
+2. Run your php file, project, plugin or theme using PHP.wasm or Playground CLI.
+3. Witness the magic break.
+```
+
+<br>
+
+#### 6. Set a breakpoint in `PHP.wasm/wordpress/wp-content/plugins/plugin/index.php` on the `$message` variable line
+
+<br>
+
+#### 7. Reactivate the `Simple Admin Message` plugin
+
+<br>
+
+#### 8. Witness the magic break
+
+> [!INFO]
+> You may need to click the ⏸️ button in the right sidebar of DevTools to resume the process if it appears paused

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/package.json
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/package.json
@@ -1,0 +1,6 @@
+{
+	"type": "module",
+	"dependencies": {
+		"@wp-playground/cli": "^3.0.32"
+	}
+}

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/package.json
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"dependencies": {
-		"@wp-playground/cli": "^3.0.32"
+		"@wp-playground/cli": "^3.1.19"
 	}
 }

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/plugin/index.php
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/plugin/index.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Simple Admin Message
+ * Description: Displays a simple message in the WordPress admin
+ * Version: 1.0
+ * Author: Playground Team
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Display admin notice
+function sam_display_admin_message() {
+    $message = 'Hello! This is a simple admin message.';
+    ?>
+    <div class="notice notice-info is-dismissible">
+        <p><?php _e($message, 'simple-admin-message'); ?></p>
+    </div>
+    <?php
+}
+
+add_action('admin_notices', 'sam_display_admin_message');

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/plugin/index.php
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/plugin/index.php
@@ -8,17 +8,17 @@
 
 // Prevent direct access
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 
 // Display admin notice
 function sam_display_admin_message() {
-    $message = 'Hello! This is a simple admin message.';
-    ?>
-    <div class="notice notice-info is-dismissible">
-        <p><?php _e($message, 'simple-admin-message'); ?></p>
-    </div>
-    <?php
+	$message = 'Hello! This is a simple admin message.';
+	?>
+	<div class="notice notice-info is-dismissible">
+		<p><?php _e($message, 'simple-admin-message'); ?></p>
+	</div>
+	<?php
 }
 
 add_action('admin_notices', 'sam_display_admin_message');

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/plugin/index.php
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/plugin/index.php
@@ -13,10 +13,9 @@ if (!defined('ABSPATH')) {
 
 // Display admin notice
 function sam_display_admin_message() {
-	$message = 'Hello! This is a simple admin message.';
 	?>
 	<div class="notice notice-info is-dismissible">
-		<p><?php _e($message, 'simple-admin-message'); ?></p>
+		<p><?php esc_html_e( 'Hello! This is a simple admin message.', 'simple-admin-message' ); ?></p>
 	</div>
 	<?php
 }

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/src/script.js
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/src/script.js
@@ -1,7 +1,7 @@
 import { runCLI } from '@wp-playground/cli';
 
 const cliServer = await runCLI({
-	php: '8.5',
+	php: '8.4',
 	command: 'server',
 	mount: [{ hostPath: './src', vfsPath: '/wordpress' }],
 	xdebug: true,

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/src/script.js
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/src/script.js
@@ -1,0 +1,15 @@
+import { runCLI } from '@wp-playground/cli';
+
+const cliServer = await runCLI({
+	php: '8.5',
+	command: 'server',
+	mount: [{ hostPath: './src', vfsPath: '/wordpress' }],
+	xdebug: true,
+	experimentalDevtools: true,
+});
+
+const response = await cliServer.playground.run({
+	scriptPath: `/wordpress/test.php`,
+});
+
+console.log(new TextDecoder().decode(response.bytes));

--- a/examples/xdebug/chrome-devtools/wp-playground-cli/src/test.php
+++ b/examples/xdebug/chrome-devtools/wp-playground-cli/src/test.php
@@ -1,0 +1,11 @@
+<?php
+
+$test = 42; // Set a breakpoint on this line
+
+echo "Output!\n";
+
+function test() {
+	echo "Hello Xdebug World!\n";
+}
+
+test();

--- a/examples/xdebug/ide/README.md
+++ b/examples/xdebug/ide/README.md
@@ -1,0 +1,91 @@
+## About
+
+Use PHP.wasm with Xdebug in your IDE
+
+<br>
+
+## Appendix
+
+Some IDEs need configuration to connect Xdebug with the IDE debugging server.
+
+>  [!NOTE]
+> PHP.wasm and Playground CLIs manage them out of the box by adding `--experimental-unsafe-ide-integration` option.
+
+#### VSCode
+
+A file named `launch.json` should be in the `.vscode` directory at the root of your project
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for XDebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9003,
+            "pathMappings": {
+                ...
+            }
+        }
+    ]
+}
+```
+
+To run the debugging server in VSCode : Run > Start Debugging
+
+> [!IMPORTANT]
+> Path mappings are essential in WP Playground CLI
+
+<br>
+
+#### PHPStorm
+
+PHPStorm has configured Xdebug port to 9003 by default
+
+To run the debugging server in PHPStorm : Bug Icon or Start Listening for PHP Debug Connections
+
+A file named `workspace.xml` should be in the `.idea` directory at the root of your project
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpDebugGeneral" notify_if_session_was_finished_without_being_paused="false" xdebug_force_break_when_no_path_mapping="false" xdebug_force_break_when_outside_project="false" />
+  <component name="PhpServers">
+    <servers>
+
+      <server host="example.com:443" port="80" name="Listen for Xdebug" />
+
+      // or [ Playground CLI ]
+
+      <server host="127.0.0.1:9400" port="80" name="Listen for Xdebug" use_path_mappings="true">
+        <path_mappings>
+          <mapping local-root="$PROJECT_DIR$/plugin" remote-root="/wordpress/wp-content/plugins/plugin" />
+        </path_mappings>
+      </server>
+
+    </servers>
+  </component>
+</project>
+```
+
+To stop breaking at first line in PHPStorm : Settings > PHP > Debug > Xdebug :
+
+- Disable > Force break at first line when no path mapping specified
+- Disable > Force break at first line when a script is outside the project
+
+To remove warning debug session finished without being paused in PHPStorm : Settings > PHP > Debug > Settings :
+
+- Disable > Notify if debug session was finished without being paused
+
+<br>
+
+## How to start
+
+#### 1. Go to the specific directory you would like to try
+
+- php-wasm-node
+- php-wasm-cli
+- wp-playground-cli
+
+#### 2. Follow the dedicated README file instructions

--- a/examples/xdebug/ide/README.md
+++ b/examples/xdebug/ide/README.md
@@ -8,8 +8,11 @@ Use PHP.wasm with Xdebug in your IDE
 
 Some IDEs need configuration to connect Xdebug with the IDE debugging server.
 
->  [!NOTE]
-> PHP.wasm and Playground CLIs manage them out of the box by adding `--experimental-unsafe-ide-integration` option.
+> [!NOTE]
+> PHP.wasm CLI and WP Playground CLI manage them out of the box by adding `--experimental-unsafe-ide-integration` option.
+
+> [!IMPORTANT]
+> PHP.wasm 8.5 handles path mapping and path skipping inside Xdebug. If you're running a PHP.wasm version below, you'll need to add these inside IDE configurations.
 
 #### VSCode
 
@@ -17,25 +20,28 @@ A file named `launch.json` should be in the `.vscode` directory at the root of y
 
 ```json
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Listen for XDebug",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                ...
-            }
-        }
-    ]
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Listen for XDebug",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"skipFiles": [
+				...
+			],
+			"pathMappings": {
+				...
+			}
+		}
+	]
 }
 ```
 
 To run the debugging server in VSCode : Run > Start Debugging
 
 > [!IMPORTANT]
-> Path mappings are essential in WP Playground CLI
+> Path mappings are essential in WP Playground CLI and PHP.wasm Node
 
 <br>
 
@@ -50,23 +56,34 @@ A file named `workspace.xml` should be in the `.idea` directory at the root of y
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="PhpDebugGeneral" notify_if_session_was_finished_without_being_paused="false" xdebug_force_break_when_no_path_mapping="false" xdebug_force_break_when_outside_project="false" />
-  <component name="PhpServers">
-    <servers>
+	<component name="PhpDebugGeneral" notify_if_session_was_finished_without_being_paused="false" xdebug_force_break_when_no_path_mapping="false" xdebug_force_break_when_outside_project="false" />
+	<component name="PhpServers">
+		<servers>
 
-      <server host="example.com:443" port="80" name="Listen for Xdebug" />
+		<server host="example.com:443" port="80" name="Listen for Xdebug" />
 
-      // or [ Playground CLI ]
+		// or [ WP Playground CLI ]
 
-      <server host="127.0.0.1:9400" port="80" name="Listen for Xdebug" use_path_mappings="true">
-        <path_mappings>
-          <mapping local-root="$PROJECT_DIR$/plugin" remote-root="/wordpress/wp-content/plugins/plugin" />
-        </path_mappings>
-      </server>
+		<server host="127.0.0.1:9400" port="80" name="Listen for Xdebug" use_path_mappings="true">
+			<path_mappings>
+			<mapping local-root="$PROJECT_DIR$" remote-root="/" />
+			</path_mappings>
+		</server>
 
-    </servers>
-  </component>
+		</servers>
+	</component>
 </project>
+```
+
+If you need to skip files from Xdebug, a file named `php.xml` should be in the `.idea` directory at the root of your project
+
+```xml
+<component name="PhpStepFilterConfiguration">
+	<skipped_files>
+		<skipped_file file="$PROJECT_DIR$/foo.php" />
+		<skipped_file file="$PROJECT_DIR$/baz" />
+	</skipped_files>
+</component>
 ```
 
 To stop breaking at first line in PHPStorm : Settings > PHP > Debug > Xdebug :
@@ -78,11 +95,33 @@ To remove warning debug session finished without being paused in PHPStorm : Sett
 
 - Disable > Notify if debug session was finished without being paused
 
+##### Optional - Add path mappings and skippings using Xdebug in PHP.wasm 8.5
+
+```typescript
+// With PHP.wasm Node
+const php = new PHP(await loadNodeRuntime('8.5', { withXdebug: {
+	pathMappings: [ { hostPath: process.cwd(), vfsPath: '/' } ],
+	pathSkippings: [ '/foo.php', '/bar' ]
+}}));
+
+
+// With WP playground CLI
+const cliServer = await runCLI({
+	php: '8.5',
+	command: 'server',
+	xdebug: {
+		pathMappings: [ { hostPath: './src', vfsPath: '/wordpress' } ],
+		pathSkippings: [ '/wordpress/foo.php', '/wordpress/bar' ] }
+	},
+	...
+});
+```
+
 <br>
 
 ## How to start
 
-#### 1. Go to the specific directory you would like to try
+#### 1. Copy the specific directory you would like to try
 
 - php-wasm-node
 - php-wasm-cli

--- a/examples/xdebug/ide/README.md
+++ b/examples/xdebug/ide/README.md
@@ -62,8 +62,6 @@ A file named `workspace.xml` should be in the `.idea` directory at the root of y
 
 		<server host="example.com:443" port="80" name="Listen for Xdebug" />
 
-		// or [ WP Playground CLI ]
-
 		<server host="127.0.0.1:9400" port="80" name="Listen for Xdebug" use_path_mappings="true">
 			<path_mappings>
 			<mapping local-root="$PROJECT_DIR$" remote-root="/" />

--- a/examples/xdebug/ide/php-wasm-cli/README.md
+++ b/examples/xdebug/ide/php-wasm-cli/README.md
@@ -1,0 +1,93 @@
+## About
+
+Use PHP.wasm CLI with Xdebug enabled
+
+<br>
+
+## Installation
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+<br>
+
+#### 2. Run script with CLI
+
+```bash
+node_modules/.bin/php-wasm-cli --xdebug --experimental-unsafe-ide-integration src/test.php
+```
+
+If no project settings directory was found :
+
+```
+Xdebug configuration failed.
+No IDE-specific project settings directory was found in the current working directory.
+
+Output!
+Hello Xdebug World!
+```
+
+If `.vscode` directory exists :
+
+```
+Xdebug configured successfully
+Updated IDE config: .vscode/launch.json
+
+VS Code / Cursor instructions:
+  1. Ensure you have installed an IDE extension for PHP Debugging
+     (The PHP Debug extension by Xdebug has been a solid option)
+  2. Open the Run and Debug panel on the left sidebar
+  3. Select "PHP.wasm CLI - Listen for Xdebug" from the dropdown
+  3. Click "start debugging"
+  5. Set a breakpoint.
+  6. Run your command with PHP.wasm CLI.
+
+
+Output!
+Hello Xdebug World!
+```
+
+If `.idea` directory exists :
+
+```
+Xdebug configured successfully
+Updated IDE config: .idea/workspace.xml
+
+PhpStorm instructions:
+  1. Choose "PHP.wasm CLI - Listen for Xdebug" debug configuration in the toolbar
+  2. Click the debug button (bug icon)`
+  3. Set a breakpoint.
+  4. Run your command with PHP.wasm CLI.
+
+Output!
+Hello Xdebug World!
+```
+
+> [!NOTE]
+> Nothing happens because the debugging server is not running yet
+
+<br>
+
+#### 3. Start debugging in your IDE
+
+<br>
+
+#### 4. Set a breakpoint in `src/test.php`
+
+<br>
+
+#### 5. Re-run script with CLI
+
+```bash
+node_modules/.bin/php-wasm-cli --xdebug --experimental-unsafe-ide-integration src/test.php
+```
+
+<br>
+
+#### 6. Witness the magic break
+
+> [!NOTE]
+> When using the PHP.wasm CLI with Xdebug enabled, execution will automatically break on the first line

--- a/examples/xdebug/ide/php-wasm-cli/README.md
+++ b/examples/xdebug/ide/php-wasm-cli/README.md
@@ -37,13 +37,13 @@ Xdebug configured successfully
 Updated IDE config: .vscode/launch.json
 
 VS Code / Cursor instructions:
-  1. Ensure you have installed an IDE extension for PHP Debugging
-     (The PHP Debug extension by Xdebug has been a solid option)
-  2. Open the Run and Debug panel on the left sidebar
-  3. Select "PHP.wasm CLI - Listen for Xdebug" from the dropdown
-  3. Click "start debugging"
-  5. Set a breakpoint.
-  6. Run your command with PHP.wasm CLI.
+	1. Ensure you have installed an IDE extension for PHP Debugging
+	   (The PHP Debug extension by Xdebug has been a solid option)
+	2. Open the Run and Debug panel on the left sidebar
+	3. Select "PHP.wasm CLI - Listen for Xdebug" from the dropdown
+	3. Click "start debugging"
+	5. Set a breakpoint.
+	6. Run your command with PHP.wasm CLI.
 
 
 Output!
@@ -57,10 +57,10 @@ Xdebug configured successfully
 Updated IDE config: .idea/workspace.xml
 
 PhpStorm instructions:
-  1. Choose "PHP.wasm CLI - Listen for Xdebug" debug configuration in the toolbar
-  2. Click the debug button (bug icon)`
-  3. Set a breakpoint.
-  4. Run your command with PHP.wasm CLI.
+	1. Choose "PHP.wasm CLI - Listen for Xdebug" debug configuration in the toolbar
+	2. Click the debug button (bug icon)`
+	3. Set a breakpoint.
+	4. Run your command with PHP.wasm CLI.
 
 Output!
 Hello Xdebug World!

--- a/examples/xdebug/ide/php-wasm-cli/README.md
+++ b/examples/xdebug/ide/php-wasm-cli/README.md
@@ -58,7 +58,7 @@ Updated IDE config: .idea/workspace.xml
 
 PhpStorm instructions:
 	1. Choose "PHP.wasm CLI - Listen for Xdebug" debug configuration in the toolbar
-	2. Click the debug button (bug icon)`
+	2. Click the debug button (bug icon)
 	3. Set a breakpoint.
 	4. Run your command with PHP.wasm CLI.
 

--- a/examples/xdebug/ide/php-wasm-cli/package.json
+++ b/examples/xdebug/ide/php-wasm-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"dependencies": {
-		"@php-wasm/cli": "^3.0.32"
+		"@php-wasm/cli": "^3.1.19"
 	}
 }

--- a/examples/xdebug/ide/php-wasm-cli/package.json
+++ b/examples/xdebug/ide/php-wasm-cli/package.json
@@ -1,0 +1,6 @@
+{
+	"type": "module",
+	"dependencies": {
+		"@php-wasm/cli": "^3.0.32"
+	}
+}

--- a/examples/xdebug/ide/php-wasm-cli/src/test.php
+++ b/examples/xdebug/ide/php-wasm-cli/src/test.php
@@ -1,0 +1,11 @@
+<?php
+
+$test = 42; // Set a breakpoint on this line
+
+echo "Output!\n";
+
+function test() {
+	echo "Hello Xdebug World!\n";
+}
+
+test();

--- a/examples/xdebug/ide/php-wasm-node/README.md
+++ b/examples/xdebug/ide/php-wasm-node/README.md
@@ -1,0 +1,96 @@
+## About
+
+Use PHP.wasm Node with Xdebug enabled
+
+<br>
+
+## Installation
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+<br>
+
+#### 2. Run script
+
+```bash
+node src/script.js
+```
+
+```
+Output!
+Hello Xdebug World!
+```
+
+> [!NOTE]
+> Nothing happens because the debugging server is not running yet
+
+<br>
+
+#### 3. Add IDE configuration
+
+#### VSCode
+
+A file named `launch.json` should be in the `.vscode` directory at the root of your project
+
+```json
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Listen for XDebug",
+			"type": "php",
+			"request": "launch",
+			"port": 9003
+		}
+	]
+}
+```
+
+#### PHPStorm
+
+A file named `workspace.xml` should be in the `.idea` directory at the root of your project
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpDebugGeneral" notify_if_session_was_finished_without_being_paused="false" xdebug_force_break_when_no_path_mapping="false" xdebug_force_break_when_outside_project="false" />
+  <component name="PhpServers">
+    <servers>
+      <server host="example.com:443" port="80" name="Listen for Xdebug" />
+    </servers>
+  </component>
+</project>
+```
+
+To stop breaking at first line in PHPStorm : Settings > PHP > Debug > Xdebug :
+
+- Disable > Force break at first line when no path mapping specified
+- Disable > Force break at first line when a script is outside the project
+
+To remove warning debug session finished without being paused in PHPStorm : Settings > PHP > Debug > Settings :
+
+- Disable > Notify if debug session was finished without being paused
+
+<br>
+
+#### 4. Start debugging in your IDE
+
+<br>
+
+#### 5. Set a breakpoint in `src/test.php`
+
+<br>
+
+#### 6. Re-run the script
+
+```bash
+node src/script.js
+```
+
+<br>
+
+#### 7. Witness the magic break

--- a/examples/xdebug/ide/php-wasm-node/README.md
+++ b/examples/xdebug/ide/php-wasm-node/README.md
@@ -32,6 +32,9 @@ Hello Xdebug World!
 
 #### 3. Add IDE configuration
 
+> [!IMPORTANT]
+> PHP.wasm 8.5 handles path mapping and path skipping inside Xdebug. If you're running a PHP.wasm version below, you'll need to add these inside IDE configurations.
+
 #### VSCode
 
 A file named `launch.json` should be in the `.vscode` directory at the root of your project
@@ -44,7 +47,13 @@ A file named `launch.json` should be in the `.vscode` directory at the root of y
 			"name": "Listen for XDebug",
 			"type": "php",
 			"request": "launch",
-			"port": 9003
+			"port": 9003,
+			"skipFiles": [
+				...
+			],
+			"pathMappings": {
+				...
+			}
 		}
 	]
 }
@@ -57,13 +66,24 @@ A file named `workspace.xml` should be in the `.idea` directory at the root of y
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="PhpDebugGeneral" notify_if_session_was_finished_without_being_paused="false" xdebug_force_break_when_no_path_mapping="false" xdebug_force_break_when_outside_project="false" />
-  <component name="PhpServers">
-    <servers>
-      <server host="example.com:443" port="80" name="Listen for Xdebug" />
-    </servers>
-  </component>
+	<component name="PhpDebugGeneral" notify_if_session_was_finished_without_being_paused="false" xdebug_force_break_when_no_path_mapping="false" xdebug_force_break_when_outside_project="false" />
+	<component name="PhpServers">
+		<servers>
+			<server host="example.com:443" port="80" name="Listen for Xdebug" />
+		</servers>
+	</component>
 </project>
+```
+
+If you need to skip files from Xdebug, a file named `php.xml` should be in the `.idea` directory at the root of your project
+
+```xml
+<component name="PhpStepFilterConfiguration">
+	<skipped_files>
+		<skipped_file file="$PROJECT_DIR$/foo.php" />
+		<skipped_file file="$PROJECT_DIR$/baz" />
+	</skipped_files>
+</component>
 ```
 
 To stop breaking at first line in PHPStorm : Settings > PHP > Debug > Xdebug :
@@ -74,6 +94,21 @@ To stop breaking at first line in PHPStorm : Settings > PHP > Debug > Xdebug :
 To remove warning debug session finished without being paused in PHPStorm : Settings > PHP > Debug > Settings :
 
 - Disable > Notify if debug session was finished without being paused
+
+<br>
+
+##### Optional - Add path mappings and skippings using Xdebug in PHP.wasm 8.5
+
+```typescript
+const php = new PHP(
+	await loadNodeRuntime('8.5', {
+		withXdebug: {
+			pathMappings: [{ hostPath: process.cwd(), vfsPath: '/' }],
+			pathSkippings: ['/foo.php', '/bar'],
+		},
+	})
+);
+```
 
 <br>
 

--- a/examples/xdebug/ide/php-wasm-node/package.json
+++ b/examples/xdebug/ide/php-wasm-node/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"dependencies": {
-		"@php-wasm/node": "^3.0.32"
+		"@php-wasm/node": "^3.1.19"
 	}
 }

--- a/examples/xdebug/ide/php-wasm-node/package.json
+++ b/examples/xdebug/ide/php-wasm-node/package.json
@@ -1,0 +1,6 @@
+{
+	"type": "module",
+	"dependencies": {
+		"@php-wasm/node": "^3.0.32"
+	}
+}

--- a/examples/xdebug/ide/php-wasm-node/src/script.js
+++ b/examples/xdebug/ide/php-wasm-node/src/script.js
@@ -5,10 +5,15 @@ const php = new PHP(await loadNodeRuntime('8.4', { withXdebug: true }));
 
 const response = await php.runStream({ scriptPath: `src/test.php` });
 
-await response.stdout.pipeTo(
-	new WritableStream({
-		write(chunk) {
-			process.stdout.write(chunk);
-		},
-	})
-);
+await response.stdout
+	.pipeTo(
+		new WritableStream({
+			write(chunk) {
+				process.stdout.write(chunk);
+			},
+		})
+	)
+	.catch((err) => {
+		process.stderr.write(`Stream error: ${err}\n`);
+		process.exit(1);
+	});

--- a/examples/xdebug/ide/php-wasm-node/src/script.js
+++ b/examples/xdebug/ide/php-wasm-node/src/script.js
@@ -1,7 +1,7 @@
 import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
 
-const php = new PHP(await loadNodeRuntime('8.5', { withXdebug: true }));
+const php = new PHP(await loadNodeRuntime('8.4', { withXdebug: true }));
 
 const response = await php.runStream({ scriptPath: `src/test.php` });
 

--- a/examples/xdebug/ide/php-wasm-node/src/script.js
+++ b/examples/xdebug/ide/php-wasm-node/src/script.js
@@ -1,7 +1,17 @@
 import { PHP } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
+import fs from 'fs';
 
-const php = new PHP(await loadNodeRuntime('8.4', { withXdebug: true }));
+const php = new PHP(
+	await loadNodeRuntime('8.4', {
+		withXdebug: true,
+		emscriptenOptions: { processId: process.pid },
+	})
+);
+
+php.mkdir('src');
+
+php.writeFile('src/test.php', fs.readFileSync('./src/test.php'));
 
 const response = await php.runStream({ scriptPath: `src/test.php` });
 
@@ -13,7 +23,7 @@ await response.stdout
 			},
 		})
 	)
-	.catch((err) => {
-		process.stderr.write(`Stream error: ${err}\n`);
+	.catch((error) => {
+		process.stderr.write(error);
 		process.exit(1);
 	});

--- a/examples/xdebug/ide/php-wasm-node/src/script.js
+++ b/examples/xdebug/ide/php-wasm-node/src/script.js
@@ -5,7 +5,7 @@ const php = new PHP(await loadNodeRuntime('8.4', { withXdebug: true }));
 
 const response = await php.runStream({ scriptPath: `src/test.php` });
 
-response.stdout.pipeTo(
+await response.stdout.pipeTo(
 	new WritableStream({
 		write(chunk) {
 			process.stdout.write(chunk);

--- a/examples/xdebug/ide/php-wasm-node/src/script.js
+++ b/examples/xdebug/ide/php-wasm-node/src/script.js
@@ -1,0 +1,14 @@
+import { PHP } from '@php-wasm/universal';
+import { loadNodeRuntime } from '@php-wasm/node';
+
+const php = new PHP(await loadNodeRuntime('8.5', { withXdebug: true }));
+
+const response = await php.runStream({ scriptPath: `src/test.php` });
+
+response.stdout.pipeTo(
+	new WritableStream({
+		write(chunk) {
+			process.stdout.write(chunk);
+		},
+	})
+);

--- a/examples/xdebug/ide/php-wasm-node/src/test.php
+++ b/examples/xdebug/ide/php-wasm-node/src/test.php
@@ -1,0 +1,11 @@
+<?php
+
+$test = 42; // Set a breakpoint on this line
+
+echo "Output!\n";
+
+function test() {
+	echo "Hello Xdebug World!\n";
+}
+
+test();

--- a/examples/xdebug/ide/wp-playground-cli/README.md
+++ b/examples/xdebug/ide/wp-playground-cli/README.md
@@ -68,7 +68,7 @@ VS Code / Cursor instructions:
 	   (The PHP Debug extension by Xdebug has been a solid option)
 	2. Open the Run and Debug panel on the left sidebar
 	3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
-	3. Click "start debugging"
+	4. Click "start debugging"
 	5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
 	6. Visit Playground in your browser to hit the breakpoint
 

--- a/examples/xdebug/ide/wp-playground-cli/README.md
+++ b/examples/xdebug/ide/wp-playground-cli/README.md
@@ -1,0 +1,266 @@
+## About
+
+Use WP Playground CLI with Xdebug enabled
+
+<br>
+
+## Appendix
+
+This directory shows how to use Xdebug with WP Playground CLI in multiple use cases :
+
+- [How to debug a file](#how-to-debug-a-file)
+- [How to mount and debug a plugin](#how-to-mount-and-debug-a-plugin)
+
+<br>
+
+## <a id="how-to-debug-a-file"></a>How to debug a file
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+<br>
+
+#### 2. Run script
+
+```bash
+node src/script.js
+```
+
+If no project settings directory was found :
+
+```
+Starting a PHP server...
+
+Xdebug configuration failed.
+No IDE-specific project settings directory was found in the current working directory.
+
+
+Starting up workers
+Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
+Fetching SQLite integration plugin...
+Booting WordPress...
+PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
+Booted!
+Running the Blueprint...
+Running the Blueprint – 100%
+Finished running the blueprint
+Preparing workers...
+WordPress is running on http://127.0.0.1:53369 with 1 worker(s)
+
+Output!
+Hello Xdebug World!
+```
+
+If `.vscode` directory exists :
+
+```
+Starting a PHP server...
+
+Xdebug configured successfully
+Updated IDE config: .vscode/launch.json
+Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
+
+VS Code / Cursor instructions:
+  1. Ensure you have installed an IDE extension for PHP Debugging
+     (The PHP Debug extension by Xdebug has been a solid option)
+  2. Open the Run and Debug panel on the left sidebar
+  3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
+  3. Click "start debugging"
+  5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+  6. Visit Playground in your browser to hit the breakpoint
+
+
+Starting up workers
+Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
+Fetching SQLite integration plugin...
+Booting WordPress...
+PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
+Booted!
+Running the Blueprint...
+Running the Blueprint – 100%
+Finished running the blueprint
+Preparing workers...
+WordPress is running on http://127.0.0.1:53391 with 1 worker(s)
+
+Output!
+Hello Xdebug World!
+```
+
+If `.idea` directory exists :
+
+```
+Starting a PHP server...
+
+Xdebug configured successfully
+Updated IDE config: .idea/workspace.xml
+Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
+
+PhpStorm instructions:
+  1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
+  2. Click the debug button (bug icon)`
+  3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+  4. Visit Playground in your browser to hit the breakpoint
+
+Starting up workers
+Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
+Fetching SQLite integration plugin...
+Booting WordPress...
+PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
+Booted!
+Running the Blueprint...
+Running the Blueprint – 100%
+Finished running the blueprint
+Preparing workers...
+WordPress is running on http://127.0.0.1:53416 with 1 worker(s)
+
+Output!
+Hello Xdebug World!
+```
+
+> [!NOTE]
+> Nothing happens because the debugging server is not running yet
+
+<br>
+
+#### 3. Start debugging in your IDE
+
+<br>
+
+#### 4. Set a breakpoint in `src/test.php`
+
+<br>
+
+#### 5. Re-run script
+
+```bash
+node src/script.js
+```
+
+<br>
+
+#### 6. Witness the magic break
+
+<br>
+<br>
+
+## <a id="how-to-mount-and-debug-a-plugin"></a>How to mount and debug a plugin
+
+#### 1. Install dependencies
+
+```bash
+npm install
+```
+
+#### 2. Run CLI command
+
+```bash
+node_modules/.bin/wp-playground-cli server --login --xdebug --experimental-unsafe-ide-integration --mount=./plugin:/wordpress/wp-content/plugins/plugin
+```
+
+If no project settings directory was found :
+
+```
+Starting a PHP server...
+
+Xdebug configuration failed.
+No IDE-specific project settings directory was found in the current working directory.
+
+
+Starting up workers
+Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
+Fetching SQLite integration plugin...
+Booting WordPress...
+PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
+Booted!
+Running the Blueprint...
+Logging in – 100%
+Finished running the blueprint
+Preparing workers...
+WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
+```
+
+If `.vscode` directory exists :
+
+```
+Starting a PHP server...
+
+Xdebug configured successfully
+Updated IDE config: .vscode/launch.json
+Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
+
+VS Code / Cursor instructions:
+  1. Ensure you have installed an IDE extension for PHP Debugging
+     (The PHP Debug extension by Xdebug has been a solid option)
+  2. Open the Run and Debug panel on the left sidebar
+  3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
+  3. Click "start debugging"
+  5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+  6. Visit Playground in your browser to hit the breakpoint
+
+
+Starting up workers
+Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
+Fetching SQLite integration plugin...
+Booting WordPress...
+PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
+Booted!
+Running the Blueprint...
+Logging in – 100%
+Finished running the blueprint
+Preparing workers...
+WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
+```
+
+If `.idea` directory exists :
+
+```
+Starting a PHP server...
+
+Xdebug configured successfully
+Updated IDE config: .idea/workspace.xml
+Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
+
+PhpStorm instructions:
+  1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
+  2. Click the debug button (bug icon)`
+  3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+  4. Visit Playground in your browser to hit the breakpoint
+
+Starting up workers
+Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
+Fetching SQLite integration plugin...
+Booting WordPress...
+PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
+Booted!
+Running the Blueprint...
+Logging in – 100%
+Finished running the blueprint
+Preparing workers...
+WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
+```
+
+<br>
+
+#### 3. Activate the `Simple Admin Message` plugin in WP admin's plugins section
+
+> [!NOTE]
+> You should see the message being displayed, but nothing else happens because the debugging server is not running yet
+
+<br>
+
+#### 4. Start debugging in your IDE
+
+<br>
+
+#### 5. Set a breakpoint in `plugin/index.php` on the `$message` variable line
+
+<br>
+
+#### 6. Deactivate and reactivate the `Simple Admin Message` plugin
+
+<br>
+
+#### 7. Witness the magic break

--- a/examples/xdebug/ide/wp-playground-cli/README.md
+++ b/examples/xdebug/ide/wp-playground-cli/README.md
@@ -32,23 +32,21 @@ node src/script.js
 If no project settings directory was found :
 
 ```
-Starting a PHP server...
+WordPress Playground CLI
+
+PHP 8.4  WordPress latest
+Extensions intl, xdebug
+Mount ./src → /wordpress
+
 
 Xdebug configuration failed.
 No IDE-specific project settings directory was found in the current working directory.
 
 
-Starting up workers
-Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
-Fetching SQLite integration plugin...
-Booting WordPress...
-PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
-Booted!
-Running the Blueprint...
-Running the Blueprint – 100%
-Finished running the blueprint
-Preparing workers...
-WordPress is running on http://127.0.0.1:53369 with 1 worker(s)
+Running Blueprint 100%
+
+Ready! WordPress is running on http://127.0.0.1:9400 (6 workers)
+
 
 Output!
 Hello Xdebug World!
@@ -57,33 +55,31 @@ Hello Xdebug World!
 If `.vscode` directory exists :
 
 ```
-Starting a PHP server...
+WordPress Playground CLI
+
+PHP 8.4  WordPress latest
+Extensions intl, xdebug
+Mount ./src → /wordpress
+
 
 Xdebug configured successfully
 Updated IDE config: .vscode/launch.json
 Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
 
 VS Code / Cursor instructions:
-	1. Ensure you have installed an IDE extension for PHP Debugging
-	   (The PHP Debug extension by Xdebug has been a solid option)
-	2. Open the Run and Debug panel on the left sidebar
-	3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
-	4. Click "start debugging"
-	5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
-	6. Visit Playground in your browser to hit the breakpoint
+  1. Ensure you have installed an IDE extension for PHP Debugging
+     (The PHP Debug extension by Xdebug has been a solid option)
+  2. Open the Run and Debug panel on the left sidebar
+  3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
+  3. Click "start debugging"
+  5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+  6. Visit Playground in your browser to hit the breakpoint
 
 
-Starting up workers
-Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
-Fetching SQLite integration plugin...
-Booting WordPress...
-PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
-Booted!
-Running the Blueprint...
-Running the Blueprint – 100%
-Finished running the blueprint
-Preparing workers...
-WordPress is running on http://127.0.0.1:53391 with 1 worker(s)
+Running Blueprint 100%
+
+Ready! WordPress is running on http://127.0.0.1:9400 (6 workers)
+
 
 Output!
 Hello Xdebug World!
@@ -92,29 +88,27 @@ Hello Xdebug World!
 If `.idea` directory exists :
 
 ```
-Starting a PHP server...
+WordPress Playground CLI
+
+PHP 8.4  WordPress latest
+Extensions intl, xdebug
+Mount ./src → /wordpress
+
 
 Xdebug configured successfully
-Updated IDE config: .idea/workspace.xml
+Updated IDE config: .idea/workspace.xml .idea/php.xml
 Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
 
 PhpStorm instructions:
-	1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
-	2. Click the debug button (bug icon)`
-	3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
-	4. Visit Playground in your browser to hit the breakpoint
+  1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
+  2. Click the debug button (bug icon)`
+  3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+  4. Visit Playground in your browser to hit the breakpoint
 
-Starting up workers
-Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
-Fetching SQLite integration plugin...
-Booting WordPress...
-PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
-Booted!
-Running the Blueprint...
-Running the Blueprint – 100%
-Finished running the blueprint
-Preparing workers...
-WordPress is running on http://127.0.0.1:53416 with 1 worker(s)
+Running Blueprint 100%
+
+Ready! WordPress is running on http://127.0.0.1:9400 (6 workers)
+
 
 Output!
 Hello Xdebug World!
@@ -177,83 +171,74 @@ node_modules/.bin/wp-playground-cli server --login --xdebug --experimental-unsaf
 If no project settings directory was found :
 
 ```
-Starting a PHP server...
+WordPress Playground CLI
+
+PHP 8.3  WordPress latest
+Extensions intl, redis, memcached, xdebug
+Mount ./plugin → /wordpress/wp-content/plugins/plugin
+
 
 Xdebug configuration failed.
 No IDE-specific project settings directory was found in the current working directory.
 
 
-Starting up workers
-Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
-Fetching SQLite integration plugin...
-Booting WordPress...
-PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
-Booted!
-Running the Blueprint...
-Logging in – 100%
-Finished running the blueprint
-Preparing workers...
-WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
+Logging in 100%
+
+Ready! WordPress is running on http://127.0.0.1:9400 (6 workers)
 ```
 
 If `.vscode` directory exists :
 
 ```
-Starting a PHP server...
+WordPress Playground CLI
+
+PHP 8.3  WordPress latest
+Extensions intl, redis, memcached, xdebug
+Mount ./plugin → /wordpress/wp-content/plugins/plugin
+
 
 Xdebug configured successfully
 Updated IDE config: .vscode/launch.json
 Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
 
 VS Code / Cursor instructions:
-	1. Ensure you have installed an IDE extension for PHP Debugging
-	   (The PHP Debug extension by Xdebug has been a solid option)
-	2. Open the Run and Debug panel on the left sidebar
-	3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
-	3. Click "start debugging"
-	5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
-	6. Visit Playground in your browser to hit the breakpoint
+  1. Ensure you have installed an IDE extension for PHP Debugging
+     (The PHP Debug extension by Xdebug has been a solid option)
+  2. Open the Run and Debug panel on the left sidebar
+  3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
+  3. Click "start debugging"
+  5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+  6. Visit Playground in your browser to hit the breakpoint
 
 
-Starting up workers
-Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
-Fetching SQLite integration plugin...
-Booting WordPress...
-PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
-Booted!
-Running the Blueprint...
-Logging in – 100%
-Finished running the blueprint
-Preparing workers...
-WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
+Logging in 100%
+
+Ready! WordPress is running on http://127.0.0.1:9400 (6 workers)
 ```
 
 If `.idea` directory exists :
 
 ```
-Starting a PHP server...
+WordPress Playground CLI
+
+PHP 8.3  WordPress latest
+Extensions intl, redis, memcached, xdebug
+Mount ./plugin → /wordpress/wp-content/plugins/plugin
+
 
 Xdebug configured successfully
-Updated IDE config: .idea/workspace.xml
+Updated IDE config: .idea/workspace.xml .idea/php.xml
 Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
 
 PhpStorm instructions:
-	1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
-	2. Click the debug button (bug icon)`
-	3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
-	4. Visit Playground in your browser to hit the breakpoint
+  1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
+  2. Click the debug button (bug icon)`
+  3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+  4. Visit Playground in your browser to hit the breakpoint
 
-Starting up workers
-Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
-Fetching SQLite integration plugin...
-Booting WordPress...
-PHP.request() is deprecated. Please use new PHPRequestHandler() instead.
-Booted!
-Running the Blueprint...
-Logging in – 100%
-Finished running the blueprint
-Preparing workers...
-WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
+Logging in 100%
+
+Ready! WordPress is running on http://127.0.0.1:9400 (6 workers)
 ```
 
 <br>

--- a/examples/xdebug/ide/wp-playground-cli/README.md
+++ b/examples/xdebug/ide/wp-playground-cli/README.md
@@ -64,13 +64,13 @@ Updated IDE config: .vscode/launch.json
 Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
 
 VS Code / Cursor instructions:
-  1. Ensure you have installed an IDE extension for PHP Debugging
-     (The PHP Debug extension by Xdebug has been a solid option)
-  2. Open the Run and Debug panel on the left sidebar
-  3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
-  3. Click "start debugging"
-  5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
-  6. Visit Playground in your browser to hit the breakpoint
+	1. Ensure you have installed an IDE extension for PHP Debugging
+	   (The PHP Debug extension by Xdebug has been a solid option)
+	2. Open the Run and Debug panel on the left sidebar
+	3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
+	3. Click "start debugging"
+	5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+	6. Visit Playground in your browser to hit the breakpoint
 
 
 Starting up workers
@@ -99,10 +99,10 @@ Updated IDE config: .idea/workspace.xml
 Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
 
 PhpStorm instructions:
-  1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
-  2. Click the debug button (bug icon)`
-  3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
-  4. Visit Playground in your browser to hit the breakpoint
+	1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
+	2. Click the debug button (bug icon)`
+	3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+	4. Visit Playground in your browser to hit the breakpoint
 
 Starting up workers
 Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip
@@ -122,6 +122,20 @@ Hello Xdebug World!
 
 > [!NOTE]
 > Nothing happens because the debugging server is not running yet
+
+##### Optional - Add path mappings and skippings using Xdebug in PHP.wasm 8.5
+
+```typescript
+const cliServer = await runCLI({
+	php: '8.5',
+	command: 'server',
+	xdebug: {
+		pathMappings: [ { hostPath: './src', vfsPath: '/wordpress' } ],
+		pathSkippings: [ '/wordpress/foo.php', '/wordpress/bar' ] }
+	},
+	...
+});
+```
 
 <br>
 
@@ -192,13 +206,13 @@ Updated IDE config: .vscode/launch.json
 Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
 
 VS Code / Cursor instructions:
-  1. Ensure you have installed an IDE extension for PHP Debugging
-     (The PHP Debug extension by Xdebug has been a solid option)
-  2. Open the Run and Debug panel on the left sidebar
-  3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
-  3. Click "start debugging"
-  5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
-  6. Visit Playground in your browser to hit the breakpoint
+	1. Ensure you have installed an IDE extension for PHP Debugging
+	   (The PHP Debug extension by Xdebug has been a solid option)
+	2. Open the Run and Debug panel on the left sidebar
+	3. Select "WP Playground CLI - Listen for Xdebug" from the dropdown
+	3. Click "start debugging"
+	5. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+	6. Visit Playground in your browser to hit the breakpoint
 
 
 Starting up workers
@@ -224,10 +238,10 @@ Updated IDE config: .idea/workspace.xml
 Playground source root: .playground-xdebug-root – you can set breakpoints and preview Playground's VFS structure in there.
 
 PhpStorm instructions:
-  1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
-  2. Click the debug button (bug icon)`
-  3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
-  4. Visit Playground in your browser to hit the breakpoint
+	1. Choose "WP Playground CLI - Listen for Xdebug" debug configuration in the toolbar
+	2. Click the debug button (bug icon)`
+	3. Set a breakpoint. For example, in .playground-xdebug-root/wordpress/index.php
+	4. Visit Playground in your browser to hit the breakpoint
 
 Starting up workers
 Resolved WordPress release URL: https://downloads.w.org/release/wordpress-6.9.zip

--- a/examples/xdebug/ide/wp-playground-cli/package.json
+++ b/examples/xdebug/ide/wp-playground-cli/package.json
@@ -1,0 +1,6 @@
+{
+	"type": "module",
+	"dependencies": {
+		"@wp-playground/cli": "^3.0.32"
+	}
+}

--- a/examples/xdebug/ide/wp-playground-cli/package.json
+++ b/examples/xdebug/ide/wp-playground-cli/package.json
@@ -1,6 +1,6 @@
 {
 	"type": "module",
 	"dependencies": {
-		"@wp-playground/cli": "^3.0.32"
+		"@wp-playground/cli": "^3.1.19"
 	}
 }

--- a/examples/xdebug/ide/wp-playground-cli/plugin/index.php
+++ b/examples/xdebug/ide/wp-playground-cli/plugin/index.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Simple Admin Message
+ * Description: Displays a simple message in the WordPress admin
+ * Version: 1.0
+ * Author: Playground Team
+ */
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+// Display admin notice
+function sam_display_admin_message() {
+    $message = 'Hello! This is a simple admin message.';
+    ?>
+    <div class="notice notice-info is-dismissible">
+        <p><?php _e($message, 'simple-admin-message'); ?></p>
+    </div>
+    <?php
+}
+
+add_action('admin_notices', 'sam_display_admin_message');

--- a/examples/xdebug/ide/wp-playground-cli/plugin/index.php
+++ b/examples/xdebug/ide/wp-playground-cli/plugin/index.php
@@ -8,17 +8,17 @@
 
 // Prevent direct access
 if (!defined('ABSPATH')) {
-    exit;
+	exit;
 }
 
 // Display admin notice
 function sam_display_admin_message() {
-    $message = 'Hello! This is a simple admin message.';
-    ?>
-    <div class="notice notice-info is-dismissible">
-        <p><?php _e($message, 'simple-admin-message'); ?></p>
-    </div>
-    <?php
+	$message = 'Hello! This is a simple admin message.';
+	?>
+	<div class="notice notice-info is-dismissible">
+		<p><?php _e($message, 'simple-admin-message'); ?></p>
+	</div>
+	<?php
 }
 
 add_action('admin_notices', 'sam_display_admin_message');

--- a/examples/xdebug/ide/wp-playground-cli/plugin/index.php
+++ b/examples/xdebug/ide/wp-playground-cli/plugin/index.php
@@ -13,10 +13,9 @@ if (!defined('ABSPATH')) {
 
 // Display admin notice
 function sam_display_admin_message() {
-	$message = 'Hello! This is a simple admin message.';
 	?>
 	<div class="notice notice-info is-dismissible">
-		<p><?php _e($message, 'simple-admin-message'); ?></p>
+		<p><?php esc_html_e( 'Hello! This is a simple admin message.', 'simple-admin-message' ); ?></p>
 	</div>
 	<?php
 }

--- a/examples/xdebug/ide/wp-playground-cli/src/script.js
+++ b/examples/xdebug/ide/wp-playground-cli/src/script.js
@@ -1,0 +1,15 @@
+import { runCLI } from '@wp-playground/cli';
+
+const cliServer = await runCLI({
+	php: '8.4',
+	command: 'server',
+	mount: [{ hostPath: './src', vfsPath: '/wordpress' }],
+	xdebug: true,
+	experimentalUnsafeIdeIntegration: ['phpstorm', 'vscode'],
+});
+
+const response = await cliServer.playground.run({
+	scriptPath: `/wordpress/test.php`,
+});
+
+console.log(new TextDecoder().decode(response.bytes));

--- a/examples/xdebug/ide/wp-playground-cli/src/test.php
+++ b/examples/xdebug/ide/wp-playground-cli/src/test.php
@@ -1,0 +1,11 @@
+<?php
+
+$test = 42; // Set a breakpoint on this line
+
+echo "\nOutput!\n";
+
+function test() {
+	echo "Hello Xdebug World!\n";
+}
+
+test();

--- a/packages/docs/site/docs/developers/07-xdebug/02-getting-started.md
+++ b/packages/docs/site/docs/developers/07-xdebug/02-getting-started.md
@@ -95,14 +95,14 @@ Booting WordPress...
 WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 
 Chrome connected! Initializing Xdebug receiver...
 XDebug receiver running on port 9003
 Running a PHP script with Xdebug enabled...
 ```
 
-By clicking on the provided URL, for example, `devtools://devtools/bundled/inspector.html?ws=localhost:9229`, you can access DevTools connected to your application, with the ability to inspect all files of a WordPress instance.
+By clicking on the provided URL, for example, `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229`, you can access DevTools connected to your application, with the ability to inspect all files of a WordPress instance.
 
 ![Chrome Devtools integrated with Xdebug](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/developers/xdebug/playground-xdebug-on-devtools.webp)
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/07-xdebug/02-getting-started.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/07-xdebug/02-getting-started.md
@@ -68,16 +68,16 @@ Booting WordPress...
 WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 
 Chrome connected! Initializing Xdebug receiver...
 XDebug receiver running on port 9003
 Running a PHP script with Xdebug enabled...
 ```
 
-<!-- By clicking on the provided URL, for example, `devtools://devtools/bundled/inspector.html?ws=localhost:9229`, you can access DevTools connected to your application, with the ability to inspect all files of a WordPress instance. -->
+<!-- By clicking on the provided URL, for example, `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229`, you can access DevTools connected to your application, with the ability to inspect all files of a WordPress instance. -->
 
-Al hacer clic en la URL proporcionada, por ejemplo, `devtools://devtools/bundled/inspector.html?ws=localhost:9229`, puedes acceder a DevTools conectado con tu aplicación, con la posibilidad de inspeccionar todos los archivos de una instancia WordPress.
+Al hacer clic en la URL proporcionada, por ejemplo, `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229`, puedes acceder a DevTools conectado con tu aplicación, con la posibilidad de inspeccionar todos los archivos de una instancia WordPress.
 
 ![Chrome Devtools integrated with Xdebug](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/developers/xdebug/playground-xdebug-on-devtools.webp)
 

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/07-xdebug/02-getting-started.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/07-xdebug/02-getting-started.md
@@ -68,16 +68,16 @@ Booting WordPress...
 WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 
 Chrome connected! Initializing Xdebug receiver...
 XDebug receiver running on port 9003
 Running a PHP script with Xdebug enabled...
 ```
 
-<!-- By clicking on the provided URL, for example, `devtools://devtools/bundled/inspector.html?ws=localhost:9229`, you can access DevTools connected to your application, with the ability to inspect all files of a WordPress instance. -->
+<!-- By clicking on the provided URL, for example, `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229`, you can access DevTools connected to your application, with the ability to inspect all files of a WordPress instance. -->
 
-En cliquant sur l'URL fournie, par exemple, `devtools://devtools/bundled/inspector.html?ws=localhost:9229`, vous pouvez accéder à DevTools connecté à votre application, avec la possibilité d'inspecter tous les fichiers d'une instance WordPress.
+En cliquant sur l'URL fournie, par exemple, `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229`, vous pouvez accéder à DevTools connecté à votre application, avec la possibilité d'inspecter tous les fichiers d'une instance WordPress.
 
 ![Chrome Devtools integrated with Xdebug](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/developers/xdebug/playground-xdebug-on-devtools.webp)
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/07-xdebug/02-getting-started.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/07-xdebug/02-getting-started.md
@@ -68,16 +68,16 @@ Booting WordPress...
 WordPress is running on http://127.0.0.1:9400 with 1 worker(s)
 Starting XDebug Bridge...
 Connect Chrome DevTools to CDP at:
-devtools://devtools/bundled/inspector.html?ws=localhost:9229
+devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229
 
 Chrome connected! Initializing Xdebug receiver...
 XDebug receiver running on port 9003
 Running a PHP script with Xdebug enabled...
 ```
 
-<!-- By clicking on the provided URL, for example, `devtools://devtools/bundled/inspector.html?ws=localhost:9229`, you can access DevTools connected to your application, with the ability to inspect all files of a WordPress instance. -->
+<!-- By clicking on the provided URL, for example, `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229`, you can access DevTools connected to your application, with the ability to inspect all files of a WordPress instance. -->
 
-Clicando na URL fornecida, por exemplo, `devtools://devtools/bundled/inspector.html?ws=localhost:9229`, você pode acessar o DevTools conectado à sua aplicação, com a possibilidade de inspecionar todos os arquivos de uma instância WordPress.
+Clicando na URL fornecida, por exemplo, `devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229`, você pode acessar o DevTools conectado à sua aplicação, com a possibilidade de inspecionar todos os arquivos de uma instância WordPress.
 
 ![Chrome Devtools integrated with Xdebug](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/developers/xdebug/playground-xdebug-on-devtools.webp)
 

--- a/packages/php-wasm/xdebug-bridge/README.md
+++ b/packages/php-wasm/xdebug-bridge/README.md
@@ -25,7 +25,7 @@ import { startBridge } from './xdebug-bridge/src/start-bridge';
 
 // Start with custom configuration
 const server = startBridge({
-	cdpHost: 'localhost', // CDP connection host
+	cdpHost: '127.0.0.1', // CDP connection host
 	cdpPort: 9229, // CDP connection port
 	dbgpPort: 9003, // XDebug connection port
 	phpRoot: './', // Root to directory
@@ -49,22 +49,22 @@ npx xdebug-bridge --help
 
 ## Configuration Options (CLI)
 
--   `port`: Xdebug port to listen on (default: 9003)
--   `host`: Xdebug host to bind to (default: 'localhost')
--   `php-root`: Path to PHP root directory (default: './')
--   `verbosity`: Output logs and progress messages (choices: "quiet", "normal", "debug") (default: "normal")
--   `help`: Display help
+- `port`: Xdebug port to listen on (default: 9003)
+- `host`: Xdebug host to bind to (default: 'localhost')
+- `php-root`: Path to PHP root directory (default: './')
+- `verbosity`: Output logs and progress messages (choices: "quiet", "normal", "debug") (default: "normal")
+- `help`: Display help
 
 ## Configuration Options (API)
 
--   `cdpPort`: Port to listen for CDP connections (default: 9229)
--   `cdpHost`: Host to bind to (default: 'localhost')
--   `dbgpPort`: Port to listen for XDebug connections (default: 9003)
--   `phpRoot`: Root path for php files
--   `verbosity`: Output logs and progress messages (choices: "quiet", "normal", "debug") (default: "normal")
--   `phpInstance`: PHP instance
--   `getPHPFile`: Custom file listing function
--   `breakOnFirstLine`: Breaks on the first breakable line
+- `cdpPort`: Port to listen for CDP connections (default: 9229)
+- `cdpHost`: Host to bind to (default: '127.0.0.1')
+- `dbgpPort`: Port to listen for XDebug connections (default: 9003)
+- `phpRoot`: Root path for php files
+- `verbosity`: Output logs and progress messages (choices: "quiet", "normal", "debug") (default: "normal")
+- `phpInstance`: PHP instance
+- `getPHPFile`: Custom file listing function
+- `breakOnFirstLine`: Breaks on the first breakable line
 
 ## Events
 
@@ -72,14 +72,14 @@ The bridge listens to events for monitoring connection activity:
 
 #### From Xdebug
 
--   `connected`: Xdebug Server has started
--   `disconnected`: Xdebug Server has stopped
--   `message`: Raw XDebug data received
--   `error`: Xdebug Server error occurred
+- `connected`: Xdebug Server has started
+- `disconnected`: Xdebug Server has stopped
+- `message`: Raw XDebug data received
+- `error`: Xdebug Server error occurred
 
 #### To Devtools
 
--   `clientConnected`: Devtools client connected
--   `clientDisconnected`: Devtools client disconnected
--   `message`: Raw Devtools data received
--   `error`: Devtools client error occurred
+- `clientConnected`: Devtools client connected
+- `clientDisconnected`: Devtools client disconnected
+- `message`: Raw Devtools data received
+- `error`: Devtools client error occurred

--- a/packages/php-wasm/xdebug-bridge/src/lib/run-cli.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/run-cli.ts
@@ -82,7 +82,7 @@ export async function main(): Promise<void> {
 
 	const bridge = await startBridge({
 		cdpPort: 9229,
-		cdpHost: args.host,
+		cdpHost: '127.0.0.1',
 		dbgpPort: args.port,
 		phpRoot: args.phpRoot,
 	});

--- a/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
+++ b/packages/php-wasm/xdebug-bridge/src/lib/start-bridge.ts
@@ -19,7 +19,7 @@ export type StartBridgeConfig = {
 export async function startBridge(config: StartBridgeConfig) {
 	const cdpPort = config.cdpPort ?? 9229;
 	const dbgpPort = config.dbgpPort ?? 9003;
-	const cdpHost = config.cdpHost ?? 'localhost';
+	const cdpHost = config.cdpHost ?? '127.0.0.1';
 	const phpRoot = config.phpRoot ?? process.cwd();
 	const breakOnFirstLine = config.breakOnFirstLine ?? false;
 

--- a/packages/php-wasm/xdebug-bridge/src/tests/run-cli.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/tests/run-cli.spec.ts
@@ -30,8 +30,9 @@ describe('CLI', () => {
 
 		expect(startBridge).toHaveBeenCalledWith({
 			cdpPort: 9229,
-			cdpHost: 'localhost',
+			cdpHost: '127.0.0.1',
 			dbgpPort: 9003,
+			phpRoot: undefined,
 		});
 
 		const bridge = await (startBridge as any).mock.results[0].value;

--- a/packages/php-wasm/xdebug-bridge/src/tests/start-bridge.spec.ts
+++ b/packages/php-wasm/xdebug-bridge/src/tests/start-bridge.spec.ts
@@ -167,7 +167,7 @@ describe('Bridge', () => {
 			expect(output).toEqual([
 				'Starting XDebug Bridge...',
 				'Connect Chrome DevTools to CDP at:',
-				`devtools://devtools/bundled/inspector.html?ws=localhost:9229\n`,
+				`devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229\n`,
 				'Chrome connected! Initializing Xdebug receiver...',
 				'XDebug receiver running on port 9003',
 				'Running a PHP script with Xdebug enabled...',
@@ -188,7 +188,7 @@ describe('Bridge', () => {
 			expect(output).toEqual([
 				'Starting XDebug Bridge...',
 				'Connect Chrome DevTools to CDP at:',
-				`devtools://devtools/bundled/inspector.html?ws=localhost:9229\n`,
+				`devtools://devtools/bundled/inspector.html?ws=127.0.0.1:9229\n`,
 				'Chrome connected! Initializing Xdebug receiver...',
 				'XDebug receiver running on port 9003',
 				'Running a PHP script with Xdebug enabled...',


### PR DESCRIPTION
## Motivation for the change, related issues

To help developers familiarize themselves with the Xdebug dynamic extension, several use case examples have been implemented. 

## Implementation details

Added Xdebug use cases for : 

```
- PHP.wasm CLI in VSCode
- PHP.wasm Node in VSCode
- Playground CLI in VSCode
```
```
- PHP.wasm CLI in PhpStorm
- PHP.wasm Node in PhpStorm
- Playground CLI in PhpStorm
```
```
- PHP.wasm CLI in Chrome Devtools
- PHP.wasm Node in Chrome Devtools
- Playground CLI in Chrome Devtools
```

## Testing Instructions (or ideally a Blueprint)

- Clone this repository
- cd `examples/xdebug/ide` or `examples/xdebug/chrome-devtools` 
- explore the different use cases and follow the steps in the dedicated `README.md` files