### PR TITLE
[PHP] Remove unnecessary createRequire() from @php-wasm/web build scripts

### DIFF
--- a/packages/php-wasm/web-builds/7-2/build.js
+++ b/packages/php-wasm/web-builds/7-2/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/web-builds/7-3/build.js
+++ b/packages/php-wasm/web-builds/7-3/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/web-builds/7-4/build.js
+++ b/packages/php-wasm/web-builds/7-4/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/web-builds/8-0/build.js
+++ b/packages/php-wasm/web-builds/8-0/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/web-builds/8-1/build.js
+++ b/packages/php-wasm/web-builds/8-1/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/web-builds/8-2/build.js
+++ b/packages/php-wasm/web-builds/8-2/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/web-builds/8-3/build.js
+++ b/packages/php-wasm/web-builds/8-3/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/web-builds/8-4/build.js
+++ b/packages/php-wasm/web-builds/8-4/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/web-builds/8-5/build.js
+++ b/packages/php-wasm/web-builds/8-5/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',


### PR DESCRIPTION
## Motivation for the change, related issues

Attempts to solve the `createRequire is not e function` issue reported at https://github.com/WordPress/wordpress-playground/issues/3074

## Implementation details

Removes a unused `createRequire` definition from the ESM build script for every PHP web version

## Testing Instructions (or ideally a Blueprint)

None, we'll need to publish the packages and confirm they work. It seems terrible, but they're already broken at the moment so we're not risking anything. As a follow-up, we'll need to find a way to test the built web packages before publishing them.
