### PR TITLE
[PHP] Enable dynamic-import for published CJS packages

### DIFF
--- a/packages/php-wasm/node-builds/7-2/build.js
+++ b/packages/php-wasm/node-builds/7-2/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node-builds/7-3/build.js
+++ b/packages/php-wasm/node-builds/7-3/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node-builds/7-4/build.js
+++ b/packages/php-wasm/node-builds/7-4/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node-builds/8-0/build.js
+++ b/packages/php-wasm/node-builds/8-0/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node-builds/8-1/build.js
+++ b/packages/php-wasm/node-builds/8-1/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node-builds/8-2/build.js
+++ b/packages/php-wasm/node-builds/8-2/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node-builds/8-3/build.js
+++ b/packages/php-wasm/node-builds/8-3/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node-builds/8-4/build.js
+++ b/packages/php-wasm/node-builds/8-4/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node-builds/8-5/build.js
+++ b/packages/php-wasm/node-builds/8-5/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/node/build.js
+++ b/packages/php-wasm/node/build.js
@@ -26,7 +26,7 @@ async function build() {
 			'packages/php-wasm/node/src/noop.ts',
 		],
 		supported: {
-			'dynamic-import': false,
+			'dynamic-import': true,
 		},
 		outExtension: { '.js': '.cjs' },
 		outdir: 'dist/packages/php-wasm/node',

--- a/packages/php-wasm/web-builds/7-2/build.js
+++ b/packages/php-wasm/web-builds/7-2/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/web-builds/7-3/build.js
+++ b/packages/php-wasm/web-builds/7-3/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/web-builds/7-4/build.js
+++ b/packages/php-wasm/web-builds/7-4/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/web-builds/8-0/build.js
+++ b/packages/php-wasm/web-builds/8-0/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/web-builds/8-1/build.js
+++ b/packages/php-wasm/web-builds/8-1/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/web-builds/8-2/build.js
+++ b/packages/php-wasm/web-builds/8-2/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/web-builds/8-3/build.js
+++ b/packages/php-wasm/web-builds/8-3/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/web-builds/8-4/build.js
+++ b/packages/php-wasm/web-builds/8-4/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',

--- a/packages/php-wasm/web-builds/8-5/build.js
+++ b/packages/php-wasm/web-builds/8-5/build.js
@@ -48,7 +48,7 @@ async function build() {
 	// CommonJS build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		supported: { 'dynamic-import': false },
+		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
 		platform: 'node',


### PR DESCRIPTION
## Motivation for the change, related issues

Related to https://github.com/WordPress/wordpress-playground/issues/3072

Enables the `dynamic-import` ESBuild option to output CJS packages that still a dynamic import instead of require – similarly as before merging #3062.

## Testing Instructions (or ideally a Blueprint)

CI