### PR TITLE
[PHP] Remove unnecessary createRequire() banner from the remaining builds

### DIFF
--- a/packages/php-wasm/node-builds/7-2/build.js
+++ b/packages/php-wasm/node-builds/7-2/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node-builds/7-3/build.js
+++ b/packages/php-wasm/node-builds/7-3/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node-builds/7-4/build.js
+++ b/packages/php-wasm/node-builds/7-4/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node-builds/8-0/build.js
+++ b/packages/php-wasm/node-builds/8-0/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node-builds/8-1/build.js
+++ b/packages/php-wasm/node-builds/8-1/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node-builds/8-2/build.js
+++ b/packages/php-wasm/node-builds/8-2/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node-builds/8-3/build.js
+++ b/packages/php-wasm/node-builds/8-3/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node-builds/8-4/build.js
+++ b/packages/php-wasm/node-builds/8-4/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node-builds/8-5/build.js
+++ b/packages/php-wasm/node-builds/8-5/build.js
@@ -69,13 +69,6 @@ async function build() {
 	// ESM build
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: distPath,
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node/build.js
+++ b/packages/php-wasm/node/build.js
@@ -53,13 +53,6 @@ async function build() {
 			'packages/php-wasm/node/src/index.ts',
 			'packages/php-wasm/node/src/noop.ts',
 		],
-		banner: {
-			js: `import { createRequire as topLevelCreateRequire } from 'module';
-const require = topLevelCreateRequire(import.meta.url);
-const __filename = import.meta.filename;
-const __dirname = import.meta.dirname;
-`,
-		},
 		outdir: 'dist/packages/php-wasm/node',
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/php-wasm/node/build.js
+++ b/packages/php-wasm/node/build.js
@@ -53,6 +53,13 @@ async function build() {
 			'packages/php-wasm/node/src/index.ts',
 			'packages/php-wasm/node/src/noop.ts',
 		],
+		banner: {
+			js: `import { createRequire as topLevelCreateRequire } from 'module';
+const require = topLevelCreateRequire(import.meta.url);
+const __filename = import.meta.filename;
+const __dirname = import.meta.dirname;
+`,
+		},
 		outdir: 'dist/packages/php-wasm/node',
 		platform: 'node',
 		assetNames: '[name]',

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -11,6 +11,7 @@ SupportedPHPVersions.filter(
 			const cli = await runCLI({
 				command: 'server',
 				php: phpVersion as any,
+				port: 0, // Use random available port to avoid conflicts
 			});
 			try {
 				// Make a request

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -20,6 +20,7 @@ describe(`PHP ${phpVersion}`, { concurrency: 1 }, () => {
 		const cli = await runCLI({
 			command: 'server',
 			php: phpVersion,
+			port: 0, // Use random available port to avoid conflicts
 			quiet: true,
 		});
 		try {
@@ -124,6 +125,7 @@ describe(`PHP ${phpVersion}`, { concurrency: 1 }, () => {
 			const cli = await runCLI({
 				command: 'server',
 				php: phpVersion,
+				port: 0, // Use random available port to avoid conflicts
 				quiet: true,
 				blueprint: {
 					steps: [


### PR DESCRIPTION
## Motivation for the change, related issues

This PR follows up on #3076, removing the remaining instances of the `createRequire` JS banner from `packages/php-wasm/node-builds/*/build.js` build scripts. That code is unnecessary and the created require function is not used.

## Testing Instructions (or ideally a Blueprint)

CI
