### PR TITLE
[PHP] Use platform: "browser" in esbuild config for web builds

### DIFF
--- a/packages/php-wasm/web-builds/7-2/build.js
+++ b/packages/php-wasm/web-builds/7-2/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/7-2/build.js
+++ b/packages/php-wasm/web-builds/7-2/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/7-3/build.js
+++ b/packages/php-wasm/web-builds/7-3/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/7-3/build.js
+++ b/packages/php-wasm/web-builds/7-3/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/7-4/build.js
+++ b/packages/php-wasm/web-builds/7-4/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/7-4/build.js
+++ b/packages/php-wasm/web-builds/7-4/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-0/build.js
+++ b/packages/php-wasm/web-builds/8-0/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-0/build.js
+++ b/packages/php-wasm/web-builds/8-0/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-1/build.js
+++ b/packages/php-wasm/web-builds/8-1/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-1/build.js
+++ b/packages/php-wasm/web-builds/8-1/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-2/build.js
+++ b/packages/php-wasm/web-builds/8-2/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-2/build.js
+++ b/packages/php-wasm/web-builds/8-2/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-3/build.js
+++ b/packages/php-wasm/web-builds/8-3/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-3/build.js
+++ b/packages/php-wasm/web-builds/8-3/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-4/build.js
+++ b/packages/php-wasm/web-builds/8-4/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-4/build.js
+++ b/packages/php-wasm/web-builds/8-4/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-5/build.js
+++ b/packages/php-wasm/web-builds/8-5/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'web',
+		platform: 'browser',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {

--- a/packages/php-wasm/web-builds/8-5/build.js
+++ b/packages/php-wasm/web-builds/8-5/build.js
@@ -51,7 +51,7 @@ async function build() {
 		supported: { 'dynamic-import': true },
 		outExtension: { '.js': '.cjs' },
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {
@@ -70,7 +70,7 @@ async function build() {
 	await esbuild.build({
 		entryPoints: [`${packagePath}/src/index.ts`],
 		outdir: distPath,
-		platform: 'node',
+		platform: 'web',
 		assetNames: '[name]',
 		chunkNames: '[name]',
 		logOverride: {


### PR DESCRIPTION
## Motivation for the change, related issues

As @mho22 [noticed](https://github.com/WordPress/wordpress-playground/issues/3074#issuecomment-3689220423), we should use `platform: 'browser'` instead of `platform: 'node'` in the esbuild config for `@php-wasm/web-*` packages. This PR does just that.

## Testing Instructions (or ideally a Blueprint)

CI