### PR TITLE
[CLI] Deprecate `--debug` switch in favor of `--verbosity=debug`

### DIFF
--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -55,7 +55,7 @@ export class BlueprintsV2Handler {
 			siteUrl: this.siteUrl,
 			firstProcessId: 1,
 			processIdSpaceLength: this.processIdSpaceLength,
-			trace: this.args.debug || false,
+			trace: this.args.verbosity === 'debug',
 			blueprint: this.args.blueprint!,
 			withIntl: this.args.intl,
 			// We do not enable Xdebug by default for the initial worker
@@ -95,7 +95,7 @@ export class BlueprintsV2Handler {
 			siteUrl: this.siteUrl,
 			firstProcessId,
 			processIdSpaceLength: this.processIdSpaceLength,
-			trace: this.args.debug || false,
+			trace: this.args.verbosity === 'debug',
 			withIntl: this.args.intl,
 			withXdebug: !!this.args.xdebug,
 			nativeInternalDirPath,

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -396,7 +396,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 							const red = '\x1b[31m';
 							const bold = '\x1b[1m';
 							const reset = '\x1b[0m';
-							if (args.debug && message.details) {
+							if (args.verbosity === 'debug' && message.details) {
 								output.stderr(
 									`${red}${bold}Fatal error:${reset} Uncaught ${message.details.exception}: ${message.details.message}\n` +
 										`  at ${message.details.file}:${message.details.line}\n` +
@@ -418,7 +418,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 			 * When we're debugging, every bit of information matters – let's immediately output
 			 * everything we get from the PHP output streams.
 			 */
-			if (args.debug) {
+			if (args.verbosity === 'debug') {
 				streamedResponse!.stdout.pipeTo(
 					new WritableStream({
 						write(chunk) {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -191,6 +191,8 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					'Print PHP error log content if an error occurs during Playground boot.',
 				type: 'boolean',
 				default: false,
+				// Hide this deprecated option. Use verbosity=debug instead.
+				hidden: true,
 			},
 			'auto-mount': {
 				describe: `Automatically mount the specified directory. If no path is provided, mount the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.`,
@@ -647,19 +649,15 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 		args.wordpressInstallMode = 'download-and-install';
 	}
 
-	// Keeping 'quiet' option to preserve backward compatibility
+	// Keeping the '--quiet' option to preserve backward compatibility
 	if (args.quiet) {
 		args.verbosity = 'quiet';
 		delete args['quiet'];
 	}
-
-	// Promote "debug" flag to verbosity but keep args.debug around – the
-	// program behavior may change in more ways than just logging verbosity
-	// when debug mode is enabled, e.g. error objects may carry additional details.
+	// Keeping the '--debug' option to preserve backward compatibility
 	if (args.debug) {
 		args.verbosity = 'debug';
-	} else if (args.verbosity === 'debug') {
-		args.debug = true;
+		delete args['debug'];
 	}
 
 	if (args.verbosity) {
@@ -1140,7 +1138,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					},
 				};
 			} catch (error) {
-				if (!args.debug) {
+				if (args.verbosity !== 'debug') {
 					throw error;
 				}
 				let phpLogs = '';


### PR DESCRIPTION
## Motivation for the change, related issues

Cleans up a stale `--debug` CLI switch that, effectively, does the same thing as `--verbosity=debug`. After this PR, `--verbosity=debug` is the recommended option.

## Testing Instructions (or ideally a Blueprint)

CI