### PR TITLE
[i18n] Docs: Add Bengali translation for contributor-day-table-lead.md

### DIFF
--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/contributing/contributor-day-table-lead.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/contributing/contributor-day-table-lead.md
@@ -1,0 +1,217 @@
+---
+slug: /contributing/table-lead-guide
+title: কন্ট্রিবিউটর ডে টেবিল লিড করার নির্দেশিকা
+description: ওয়ার্ডক্যাম্পের কন্ট্রিবিউটর ডে-তে ওয়ার্ডপ্রেস প্লেগ্রাউন্ড টেবিল কিভাবে লিড করবেন তার গাইড।
+---
+
+<!--
+# Contributor Day Table Leadership Guide
+-->
+
+# কন্ট্রিবিউটর ডে টেবিল লিডারশিপ গাইড
+
+<!--
+This guide helps table leads prepare for and manage a WordPress Playground contributor table at WordCamp events.
+-->
+
+এই গাইড টেবিল লিডদের ওয়ার্ডক্যাম্প ইভেন্টে ওয়ার্ডপ্রেস প্লেগ্রাউন্ড কন্ট্রিবিউটর টেবিল প্রস্তুত এবং ম্যানেজ করতে সাহায্য করে।
+
+<!--
+## Before Contributor Day
+-->
+
+## কন্ট্রিবিউটর ডে-এর আগে
+
+<!--
+### Pre-Work Checklist
+-->
+
+### প্রি-ওয়ার্ক চেকলিস্ট
+
+<!--
+-   **Curate "Good First Issues"**: Review and update the [good first issues list](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) on GitHub. These should be straightforward tasks that new contributors can complete independently. If you find a bug that is not on the list but could be part of it, contact the playground team at the Slack channel.
+-->
+
+-   **"Good First Issues" কিউরেট করুন**: গিটহাবে [good first issues list](https://github.com/WordPress/wordpress-playground/labels/good%20first%20issue) রিভিউ এবং আপডেট করুন। এগুলো এমন সহজ টাস্ক হওয়া উচিত যা নতুন কন্ট্রিবিউটররা স্বাধীনভাবে সম্পন্ন করতে পারে। আপনি যদি এমন কোনো বাগ খুঁজে পান যা তালিকায় নেই কিন্তু থাকা উচিত, তাহলে স্ল্যাক চ্যানেলে প্লেগ্রাউন্ড টিমের সাথে যোগাযোগ করুন।
+
+<!--
+-   **Coordinate with the Playground Team**: Confirm if Playground team members are available online to provide remote support during the event, especially for flagship WordCamps. Due to timezone differences, align in advance at the #playground channel to check their availability.
+-->
+
+-   **প্লেগ্রাউন্ড টিমের সাথে সমন্বয় করুন**: ইভেন্টের সময় রিমোট সাপোর্ট দেওয়ার জন্য প্লেগ্রাউন্ড টিমের সদস্যরা অনলাইনে আছেন কিনা নিশ্চিত করুন, বিশেষ করে ফ্ল্যাগশিপ ওয়ার্ডক্যাম্পগুলোর জন্য। টাইমজোনের পার্থক্যের কারণে, তাদের অ্যাভেইলেবিলিটি চেক করতে আগে থেকেই #playground চ্যানেলে এলাইন করুন।
+
+<!--
+-   **Connect with Local Contributors**: Identify regular contributors in the region attending the event. Check on the #playground Slack Channel if an active community member is participating in the contributor day. This is an opportunity to gather feedback and strengthen community connections.
+-->
+
+-   **লোকাল কন্ট্রিবিউটরদের সাথে সংযোগ করুন**: ইভেন্টে অংশগ্রহণকারী এলাকার নিয়মিত কন্ট্রিবিউটরদের চিহ্নিত করুন। #playground স্ল্যাক চ্যানেলে কোনো অ্যাক্টিভ কমিউনিটি মেম্বার কন্ট্রিবিউটর ডে-তে অংশ নিচ্ছেন কিনা চেক করুন। এটি ফিডব্যাক সংগ্রহ এবং কমিউনিটি কানেকশন শক্তিশালী করার সুযোগ।
+
+<!--
+-   **Check the Playground Repository**: If you never contribute with the WordPress Playground Repository, you should get familiar with this a good section at the documentation that can guide you to understand the project is [Developers > Architecture](/developers/architecture) it will contain information how the project is organized. If you have any questions, please get in touch with the team at the Playground Slack channel.
+-->
+
+-   **প্লেগ্রাউন্ড রিপোজিটরি চেক করুন**: আপনি যদি কখনো ওয়ার্ডপ্রেস প্লেগ্রাউন্ড রিপোজিটরিতে কন্ট্রিবিউট না করে থাকেন, তাহলে এটির সাথে পরিচিত হওয়া উচিত। ডকুমেন্টেশনের একটি ভালো সেকশন যা প্রজেক্ট বুঝতে গাইড করতে পারে তা হলো [Developers > Architecture](/developers/architecture) - এতে প্রজেক্ট কিভাবে অর্গানাইজ করা হয়েছে সেই তথ্য থাকবে। কোনো প্রশ্ন থাকলে, প্লেগ্রাউন্ড স্ল্যাক চ্যানেলে টিমের সাথে যোগাযোগ করুন।
+
+<!--
+## Starting the Day
+-->
+
+## দিন শুরু করা
+
+<!--
+### Setup and Onboarding
+-->
+
+### সেটআপ এবং অনবোর্ডিং
+
+<!--
+1. **Create Your Agenda**: Prepare a flexible checklist of key activities while allowing for organic collaboration. Share it in the project documentation if helpful.
+-->
+
+1. **আপনার এজেন্ডা তৈরি করুন**: অর্গানিক কোলাবোরেশনের সুযোগ রেখে মূল অ্যাক্টিভিটিগুলোর একটি ফ্লেক্সিবল চেকলিস্ট প্রস্তুত করুন। সহায়ক হলে প্রজেক্ট ডকুমেন্টেশনে শেয়ার করুন।
+
+<!--
+2. **Guide Contributors to Slack**: Direct everyone to the [`#playground` channel on WordPress Slack](https://wordpress.slack.com/archives/C04EWKGDJ0K). This centralizes communication and enables asynchronous collaboration with late arrivals.
+-->
+
+2. **কন্ট্রিবিউটরদের স্ল্যাকে গাইড করুন**: সবাইকে [ওয়ার্ডপ্রেস স্ল্যাকের `#playground` চ্যানেলে](https://wordpress.slack.com/archives/C04EWKGDJ0K) নিয়ে যান। এটি কমিউনিকেশন সেন্ট্রালাইজ করে এবং দেরিতে আসা ব্যক্তিদের সাথে অ্যাসিনক্রোনাস কোলাবোরেশন এনাবল করে।
+
+<!--
+3. **Post a Welcome Message**: Share an initial message in the Slack channel announcing your presence (in-person or online) and welcoming contributions from everyone.
+-->
+
+3. **ওয়েলকাম মেসেজ পোস্ট করুন**: স্ল্যাক চ্যানেলে আপনার উপস্থিতি (ইন-পার্সন বা অনলাইন) ঘোষণা করে এবং সবার কন্ট্রিবিউশনকে স্বাগত জানিয়ে একটি প্রাথমিক মেসেজ শেয়ার করুন।
+
+<!--
+4. **Share Essential Links**: Post these resources in the `#playground` channel:
+
+    - [WordPress Playground Web Instance](https://playground.wordpress.net/)
+    - [Playground Documentation](https://wordpress.github.io/wordpress-playground/)
+    - [Playground Step Library](https://akirk.github.io/playground-step-library/)
+    - [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+    - [Contributor Day guide](/contributing/contributor-day/)
+-->
+
+4. **এসেনশিয়াল লিঙ্ক শেয়ার করুন**: `#playground` চ্যানেলে এই রিসোর্সগুলো পোস্ট করুন:
+
+    - [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ওয়েব ইন্সট্যান্স](https://playground.wordpress.net/)
+    - [প্লেগ্রাউন্ড ডকুমেন্টেশন](https://wordpress.github.io/wordpress-playground/)
+    - [প্লেগ্রাউন্ড স্টেপ লাইব্রেরি](https://akirk.github.io/playground-step-library/)
+    - [গিটহাব রিপোজিটরি](https://github.com/WordPress/wordpress-playground)
+    - [কন্ট্রিবিউটর ডে গাইড](/contributing/contributor-day/)
+
+<!--
+5. **Introduce the GitHub Repository**: Provide a brief walkthrough of the repository structure, highlighting different packages and their purposes for first-time contributors.
+-->
+
+5. **গিটহাব রিপোজিটরি পরিচয় করিয়ে দিন**: প্রথমবার কন্ট্রিবিউটরদের জন্য বিভিন্ন প্যাকেজ এবং তাদের উদ্দেশ্য হাইলাইট করে রিপোজিটরি স্ট্রাকচারের একটি সংক্ষিপ্ত ওয়াকথ্রু দিন।
+
+<!--
+## During the Day
+-->
+
+## দিনের মধ্যে
+
+<!--
+### Managing Contributions
+-->
+
+### কন্ট্রিবিউশন ম্যানেজ করা
+
+<!--
+**Encourage Different Contribution Types**:
+
+Check the contributors' levels, try to understand based on their level how they can contribute to the project in the short window of a contributor day. Ask if the participants need help and redirect them to the related documentation page. Also, encourage them to ask questions at the [#playground Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K). Here are some suggestions for ways of contributing:
+-->
+
+**বিভিন্ন ধরনের কন্ট্রিবিউশনে উৎসাহিত করুন**:
+
+কন্ট্রিবিউটরদের লেভেল চেক করুন, তাদের লেভেলের উপর ভিত্তি করে বোঝার চেষ্টা করুন কন্ট্রিবিউটর ডে-এর সংক্ষিপ্ত সময়ে তারা কিভাবে প্রজেক্টে কন্ট্রিবিউট করতে পারে। অংশগ্রহণকারীদের সাহায্য প্রয়োজন কিনা জিজ্ঞাসা করুন এবং তাদের সংশ্লিষ্ট ডকুমেন্টেশন পেজে রিডাইরেক্ট করুন। এছাড়াও, তাদের [#playground স্ল্যাক চ্যানেলে](https://wordpress.slack.com/archives/C04EWKGDJ0K) প্রশ্ন জিজ্ঞাসা করতে উৎসাহিত করুন। কন্ট্রিবিউট করার কিছু পরামর্শ এখানে দেওয়া হলো:
+
+<!--
+-   Documentation improvements and translations.
+-   Carefully crafted issues describing problems with actionable solutions.
+-   Blueprint creation and plugin demos at the WordPress plugin repository.
+-   Testing and product feedback.
+-->
+
+-   ডকুমেন্টেশন উন্নতি এবং অনুবাদ।
+-   অ্যাকশনেবল সমাধান সহ সমস্যা বর্ণনা করে সাবধানতার সাথে তৈরি ইস্যু।
+-   ওয়ার্ডপ্রেস প্লাগইন রিপোজিটরিতে ব্লুপ্রিন্ট তৈরি এবং প্লাগইন ডেমো।
+-   টেস্টিং এবং প্রোডাক্ট ফিডব্যাক।
+
+<!--
+**Foster Collaboration**: Look for cross-table opportunities. For example, contributors at the [Polyglots/Translation table](https://make.wordpress.org/polyglots/) might translate Playground documentation, or the [Core Test team](https://make.wordpress.org/test/) could provide valuable Playground feedback.
+-->
+
+**কোলাবোরেশন ফস্টার করুন**: ক্রস-টেবিল সুযোগ খুঁজুন। উদাহরণস্বরূপ, [Polyglots/Translation টেবিলের](https://make.wordpress.org/polyglots/) কন্ট্রিবিউটররা প্লেগ্রাউন্ড ডকুমেন্টেশন অনুবাদ করতে পারেন, অথবা [Core Test টিম](https://make.wordpress.org/test/) মূল্যবান প্লেগ্রাউন্ড ফিডব্যাক প্রদান করতে পারে।
+
+<!--
+**Collect Feedback**: Ask contributors about their experience and note improvement suggestions. Report this in the [#playground Slack Channel](https://wordpress.slack.com/archives/C04EWKGDJ0K) if possible.
+-->
+
+**ফিডব্যাক সংগ্রহ করুন**: কন্ট্রিবিউটরদের তাদের অভিজ্ঞতা সম্পর্কে জিজ্ঞাসা করুন এবং উন্নতির পরামর্শ নোট করুন। সম্ভব হলে [#playground স্ল্যাক চ্যানেলে](https://wordpress.slack.com/archives/C04EWKGDJ0K) এটি রিপোর্ট করুন।
+
+<!--
+## After the Event
+-->
+
+## ইভেন্টের পরে
+
+<!--
+### Follow-Up and Support
+-->
+
+### ফলো-আপ এবং সাপোর্ট
+
+<!--
+1. **Review Pull Requests**: List PRs created during the day and assess their completion likelihood. Most contributions have a short momentum window—engagement within the first two weeks is critical.
+-->
+
+1. **পুল রিকোয়েস্ট রিভিউ করুন**: দিনে তৈরি হওয়া PR গুলো তালিকাভুক্ত করুন এবং তাদের সম্পন্ন হওয়ার সম্ভাবনা মূল্যায়ন করুন। বেশিরভাগ কন্ট্রিবিউশনের একটি সংক্ষিপ্ত মোমেন্টাম উইন্ডো থাকে—প্রথম দুই সপ্তাহের মধ্যে এনগেজমেন্ট অত্যন্ত গুরুত্বপূর্ণ।
+
+<!--
+2. **Set Clear Expectations**: For incomplete PRs, follow this approach:
+
+    - After one month of inactivity, leave a comment asking if the author plans to complete the work.
+    - If no response after two more weeks, inform them that the PR may be taken over by another contributor or closed.
+-->
+
+2. **ক্লিয়ার এক্সপেক্টেশন সেট করুন**: অসম্পূর্ণ PR-এর জন্য, এই অ্যাপ্রোচ ফলো করুন:
+
+    - এক মাস নিষ্ক্রিয়তার পরে, লেখক কাজ সম্পন্ন করার প্ল্যান করছেন কিনা জিজ্ঞাসা করে একটি কমেন্ট দিন।
+    - আরো দুই সপ্তাহ পরে কোনো রেসপন্স না পেলে, তাদের জানান যে PR অন্য কন্ট্রিবিউটর নিতে পারেন অথবা বন্ধ করা হতে পারে।
+
+<!--
+3. **Stay Active on Slack**: Continue supporting new contributors through the `#playground` channel, answering questions and helping them become regular contributors.
+-->
+
+3. **স্ল্যাকে অ্যাক্টিভ থাকুন**: `#playground` চ্যানেলের মাধ্যমে নতুন কন্ট্রিবিউটরদের সাপোর্ট করতে থাকুন, প্রশ্নের উত্তর দিন এবং তাদের নিয়মিত কন্ট্রিবিউটর হতে সাহায্য করুন।
+
+<!--
+4. **Reflect and Improve**: Review collected feedback and your experience to refine this guide for future events. Feel free to submit a Pull Request to this guide!
+-->
+
+4. **রিফ্লেক্ট এবং ইমপ্রুভ করুন**: ভবিষ্যৎ ইভেন্টের জন্য এই গাইড পরিমার্জন করতে সংগৃহীত ফিডব্যাক এবং আপনার অভিজ্ঞতা রিভিউ করুন। এই গাইডে একটি পুল রিকোয়েস্ট সাবমিট করতে দ্বিধা করবেন না!
+
+<!--
+## Getting Help
+-->
+
+## সাহায্য পাওয়া
+
+<!--
+-   **During the Event**: Connect with contributors at the Playground table.
+-   **Ongoing Support**: Use the [`#playground` Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+-   **Report Issues**: Submit to the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new).
+-->
+
+-   **ইভেন্টের সময়**: প্লেগ্রাউন্ড টেবিলে কন্ট্রিবিউটরদের সাথে সংযোগ করুন।
+-   **চলমান সাপোর্ট**: [`#playground` স্ল্যাক চ্যানেল](https://wordpress.slack.com/archives/C04EWKGDJ0K) ব্যবহার করুন।
+-   **ইস্যু রিপোর্ট করুন**: [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড গিটহাব রিপোজিটরিতে](https://github.com/WordPress/wordpress-playground/issues/new) সাবমিট করুন।
+
+<!--
+For more information on contributing to WordPress Playground, see the [Contributor Day guide](/contributing/contributor-day).
+-->
+
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ডে কন্ট্রিবিউট করার বিষয়ে আরো তথ্যের জন্য, [কন্ট্রিবিউটর ডে গাইড](/contributing/contributor-day) দেখুন।


### PR DESCRIPTION
## What is this PR doing?

Adds Bengali (বাংলা) translation of [contributor-day-table-lead.md](cci:7://file:///Users/noruzzamanrubel/Desktop/WPContribution/wordpress-playground/packages/docs/site/docs/main/contributing/contributor-day-table-lead.md:0:0-0:0) documentation.

## Implementation details

- Follows the established format: English text in HTML comments (`<!-- -->`), Bengali translation after each section
- All links and references preserved