### PR TITLE
Exclude wordpress-builds/public path in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
       schedule:
           interval: 'daily'
       exclude-paths:
-          - packages/playground/wordpress-builds/build
+          - packages/playground/wordpress-builds/public
           - isomorphic-git
       ignore:
           # Ignore all non-security updates - only allow security updates for high or critical vulnerabilities


### PR DESCRIPTION
## Motivation for the change, related issues

Based on https://github.com/WordPress/wordpress-playground/pull/3057

Instead of modifying the `package-lock.json` files inside the `wordpress-builds` directory like I did in the previous pull request, I fixed the incorrect path in `dependabot.yml`.

## Implementation details

```diff
exclude-paths:
- - packages/playground/wordpress-builds/build
+ - packages/playground/wordpress-builds/public
  - isomorphic-git
```

## Testing Instructions (or ideally a Blueprint)

If this pull request is merged, [this Security issue](https://github.com/WordPress/wordpress-playground/security/dependabot/132) will no longer be open.