### PR TITLE
[PHP] Fix external dynamic imports issue in PHP.wasm Web

### DIFF
--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -8,6 +8,8 @@ import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteIgnoreImports } from '../../vite-extensions/vite-ignore-imports';
 // eslint-disable-next-line @nx/enforce-module-boundaries
+import { viteExternalDynamicImports } from '../../vite-extensions/vite-external-dynamic-imports';
+// eslint-disable-next-line @nx/enforce-module-boundaries
 import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { getExternalModules } from '../../vite-extensions/vite-external-modules';
@@ -27,6 +29,23 @@ export default defineConfig({
 		viteIgnoreImports({
 			extensions: ['wasm', 'so', 'dat'],
 		}),
+		/*
+		 * This transforms rewrite dynamic import paths so they work from the dist output.
+		 *
+		 * Why the '../../../' prefix? Rollup computes the final import path relative to
+		 * where the source file was located. Since everything gets bundled into
+		 * index.js at the dist root, we need to "climb out" of the source directory
+		 * structure. Rollup then normalizes '../../../foo' to './foo' in the output.
+		 */
+		viteExternalDynamicImports([
+			{
+				// Source: src/lib/extensions/intl/with-intl.ts
+				// Input:  './lib/extensions/intl/shared/icu.dat'
+				// Output: './shared/icu.dat'
+				regex: /icu\.dat$/,
+				transform: (specifier) => `../../../${specifier}`,
+			},
+		]),
 		...viteGlobalExtensions,
 	],
 

--- a/packages/vite-extensions/vite-external-dynamic-imports.ts
+++ b/packages/vite-extensions/vite-external-dynamic-imports.ts
@@ -1,0 +1,71 @@
+import type { Plugin } from 'vite';
+
+export interface ExternalDynamicImportRule {
+	regex: RegExp;
+	transform: (specifier: string) => string;
+}
+
+/**
+ * Rewrites dynamic import paths so they resolve correctly from the dist output.
+ *
+ * Vite can't extract static assets in library mode (https://github.com/vitejs/vite/issues/3295).
+ * Without this plugin, dynamic imports like `import('../../public/php/jspi/php_8_4.js')`
+ * would either be bundled (inlining 5MB+ of WASM as base64) or break entirely.
+ *
+ * This plugin works together with rollup's `external` option:
+ * 1. This plugin rewrites the import paths to be relative to the dist output location
+ * 2. The `external` option marks these imports as external so they're preserved as
+ *    literal `import()` statements in the bundle
+ *
+ * The result is that the final bundle contains imports like `import('./php/jspi/php_8_4.js')`
+ * which allows consumers to provide their own loaders for these files.
+ */
+export function viteExternalDynamicImports(
+	rules: ExternalDynamicImportRule[]
+): Plugin {
+	let command: 'build' | 'serve';
+
+	const matchedRules = new Set<ExternalDynamicImportRule>();
+
+	return {
+		name: 'vite-external-dynamic-imports',
+
+		configResolved(config) {
+			command = config.command;
+		},
+
+		resolveDynamicImport(specifier) {
+			if (command !== 'build' || typeof specifier !== 'string') return;
+
+			for (const rule of rules) {
+				if (new RegExp(rule.regex).test(specifier)) {
+					matchedRules.add(rule);
+					return rule.transform(specifier);
+				}
+			}
+
+			return null;
+		},
+
+		buildEnd() {
+			if (command !== 'build') return;
+
+			const unusedRules = rules.filter((rule) => !matchedRules.has(rule));
+
+			if (unusedRules.length > 0) {
+				const details = unusedRules
+					.map((rule) => `- ${rule.regex}`)
+					.join('\n');
+
+				this.error(
+					`vite-external-dynamic-imports: The following rules did not match any dynamic imports:\n${details}\n\n` +
+						`This is likely a misconfiguration or a stale regex.`
+				);
+			}
+		},
+	};
+}
+
+// Backwards compatibility alias
+export const vitePreserveLoadersImports = viteExternalDynamicImports;
+export type PreserveLoadersRule = ExternalDynamicImportRule;


### PR DESCRIPTION
## Motivation for the change, related issues

Fixing follow-up issue https://github.com/WordPress/wordpress-playground/pull/3085

I previously removed the Vite extension for External Dynamic Imports thinking it was no longer necessary to fix the issue initiated by the per-PHP-package split pull request. I was wrong. This pull request re-creates the plugin but modifies the behavior to fix the current issue.

The current issue returns this : 

```
Error: Error during dependency optimization:

✘ [ERROR] Could not resolve "./lib/extensions/intl/shared/icu.dat"

    node_modules/@php-wasm/web/index.js:2269:88:
      2269 │ ...wait import("./lib/extensions/intl/shared/icu.dat")).default,...
           ╵                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Implementation details

Re-create the `vite-external-dynamic-imports` file but :

```diff
    regex: /icu\.dat$/,
-    transform: (specifier) =>
-	`./${specifier.split('/').slice(-2).join('/')}`,
+    transform: (specifier) => `../../../${specifier}`,
},
```

## Testing Instructions (or ideally a Blueprint)

CI