### PR TITLE
[CLI] Fix __dirname not defined error in intl extension

### DIFF
--- a/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
@@ -5,6 +5,7 @@ import type {
 } from '@php-wasm/universal';
 import { LatestSupportedPHPVersion, FSHelpers } from '@php-wasm/universal';
 import fs from 'fs';
+import path from 'path';
 import { getIntlExtensionModule } from './get-intl-extension-module';
 
 export async function withIntl(
@@ -16,7 +17,9 @@ export async function withIntl(
 	const extension = fs.readFileSync(extensionPath);
 
 	const dataName = 'icu.dat';
-	const dataPath = `${__dirname}/shared/${dataName}`;
+	const moduleDir =
+		typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
+	const dataPath = path.join(moduleDir, 'shared', dataName);
 	const ICUData = fs.readFileSync(dataPath);
 
 	return {

--- a/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
@@ -5,7 +5,6 @@ import type {
 } from '@php-wasm/universal';
 import { LatestSupportedPHPVersion, FSHelpers } from '@php-wasm/universal';
 import fs from 'fs';
-import path from 'path';
 import { getIntlExtensionModule } from './get-intl-extension-module';
 
 export async function withIntl(
@@ -17,9 +16,7 @@ export async function withIntl(
 	const extension = fs.readFileSync(extensionPath);
 
 	const dataName = 'icu.dat';
-	const moduleDir =
-		typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-	const dataPath = path.join(moduleDir, 'shared', dataName);
+	const dataPath = `${__dirname}/shared/${dataName}`;
 	const ICUData = fs.readFileSync(dataPath);
 
 	return {

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/run-tests.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/run-tests.ts
@@ -117,6 +117,6 @@ if (numTimedOut > 0) {
 	console.log(red(`${numTimedOut} / ${results.length} tests timed out`));
 }
 
-if (numFailed > 0) {
+if (numFailed > 0 || numTimedOut > 0) {
 	process.exit(1);
 }


### PR DESCRIPTION
## Motivation for the change, related issues

Running `npx @wp-playground/cli server --debug` currently fails for v3.0.38.

```
Unhandled rejection: ReferenceError: __dirname is not defined
    at withIntl (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@php-wasm/node/index.js:485:20)
    at async loadNodeRuntime (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@php-wasm/node/index.js:611:25)
    at async Object.createPhpRuntime (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@wp-playground/cli/worker-thread-v1.js:138:48)
    at async t (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@wp-playground/wordpress/index.js:451:15)
    at async PHPProcessManager.phpFactory (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@php-wasm/universal/index.js:2559:21)
    at async PHPProcessManager.doSpawn (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@php-wasm/universal/index.js:2363:17)
    at async PHPProcessManager.getPrimaryPhp (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@php-wasm/universal/index.js:2289:135)
    at async PHPRequestHandler.getPrimaryPhp (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@php-wasm/universal/index.js:2585:12)
    at async L (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@wp-playground/wordpress/index.js:384:13)
    at async V (file:///Users/brandon/.npm/_npx/8ab79f7a2a3f35a4/node_modules/@wp-playground/wordpress/index.js:380:10)
```

I think our tests for built npm packages should have caught this before merging, so I would like to look into that before merging this fix.

cc @mho22 

## Implementation details

Use conditional logic to determine the module directory: prefer __dirname when available (CommonJS), fall back to import.meta.dirname (ESM). Also switch to path.join for more robust path construction.

## Testing Instructions (or ideally a Blueprint)

- CI
