### PR TITLE
[CI] Add test for @php-wasm/node direct usage in Jest

### DIFF
--- a/packages/php-wasm/node-builds/7-2/src/index.ts
+++ b/packages/php-wasm/node-builds/7-2/src/index.ts
@@ -20,12 +20,33 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_7_2.js');
+	// Detect Jest environment and use require() to avoid dynamic import() issues
+	// For all other environments (ESM, modern CommonJS, Vitest), use dynamic import()
+	// which works in Node.js 12.20+ regardless of whether the code is running in ESM or CJS.
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const shouldUseRequire = process.env && process.env['JEST_WORKER_ID'];
+
+	if (shouldUseRequire) {
+		// Use require() specifically for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_7_2.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_7_2.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_7_2.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_7_2.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_7_2.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node-builds/7-3/src/index.ts
+++ b/packages/php-wasm/node-builds/7-3/src/index.ts
@@ -20,12 +20,33 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_7_3.js');
+	// Detect Jest environment and use require() to avoid dynamic import() issues
+	// For all other environments (ESM, modern CommonJS, Vitest), use dynamic import()
+	// which works in Node.js 12.20+ regardless of whether the code is running in ESM or CJS.
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const shouldUseRequire = process.env && process.env['JEST_WORKER_ID'];
+
+	if (shouldUseRequire) {
+		// Use require() specifically for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_7_3.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_7_3.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_7_3.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_7_3.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_7_3.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node-builds/7-4/src/index.ts
+++ b/packages/php-wasm/node-builds/7-4/src/index.ts
@@ -20,12 +20,33 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_7_4.js');
+	// Detect Jest environment and use require() to avoid dynamic import() issues
+	// For all other environments (ESM, modern CommonJS, Vitest), use dynamic import()
+	// which works in Node.js 12.20+ regardless of whether the code is running in ESM or CJS.
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const shouldUseRequire = process.env && process.env['JEST_WORKER_ID'];
+
+	if (shouldUseRequire) {
+		// Use require() specifically for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_7_4.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_7_4.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_7_4.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_7_4.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_7_4.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node-builds/8-0/src/index.ts
+++ b/packages/php-wasm/node-builds/8-0/src/index.ts
@@ -20,12 +20,33 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_8_0.js');
+	// Detect Jest environment and use require() to avoid dynamic import() issues
+	// For all other environments (ESM, modern CommonJS, Vitest), use dynamic import()
+	// which works in Node.js 12.20+ regardless of whether the code is running in ESM or CJS.
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const shouldUseRequire = process.env && process.env['JEST_WORKER_ID'];
+
+	if (shouldUseRequire) {
+		// Use require() specifically for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_8_0.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_8_0.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_8_0.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_8_0.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_8_0.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node-builds/8-1/src/index.ts
+++ b/packages/php-wasm/node-builds/8-1/src/index.ts
@@ -20,12 +20,33 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_8_1.js');
+	// Detect Jest environment and use require() to avoid dynamic import() issues
+	// For all other environments (ESM, modern CommonJS, Vitest), use dynamic import()
+	// which works in Node.js 12.20+ regardless of whether the code is running in ESM or CJS.
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const shouldUseRequire = process.env && process.env['JEST_WORKER_ID'];
+
+	if (shouldUseRequire) {
+		// Use require() specifically for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_8_1.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_8_1.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_8_1.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_8_1.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_8_1.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node-builds/8-2/src/index.ts
+++ b/packages/php-wasm/node-builds/8-2/src/index.ts
@@ -20,12 +20,33 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_8_2.js');
+	// Detect Jest environment and use require() to avoid dynamic import() issues
+	// For all other environments (ESM, modern CommonJS, Vitest), use dynamic import()
+	// which works in Node.js 12.20+ regardless of whether the code is running in ESM or CJS.
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const shouldUseRequire = process.env && process.env['JEST_WORKER_ID'];
+
+	if (shouldUseRequire) {
+		// Use require() specifically for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_8_2.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_8_2.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_8_2.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_8_2.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_8_2.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node-builds/8-3/src/index.ts
+++ b/packages/php-wasm/node-builds/8-3/src/index.ts
@@ -20,12 +20,34 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_8_3.js');
+	// Detect Jest environment and use require() instead of dynamic import()
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// For all other environments (ESM, modern CommonJS, Vitest), dynamic import() works fine.
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const isJest =
+		typeof process !== 'undefined' &&
+		process.env &&
+		process.env['JEST_WORKER_ID'];
+
+	if (isJest) {
+		// Use require() for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_8_3.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_8_3.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_8_3.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_8_3.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_8_3.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node-builds/8-4/src/index.ts
+++ b/packages/php-wasm/node-builds/8-4/src/index.ts
@@ -20,12 +20,33 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_8_4.js');
+	// Detect Jest environment and use require() to avoid dynamic import() issues
+	// For all other environments (ESM, modern CommonJS, Vitest), use dynamic import()
+	// which works in Node.js 12.20+ regardless of whether the code is running in ESM or CJS.
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const shouldUseRequire = process.env && process.env['JEST_WORKER_ID'];
+
+	if (shouldUseRequire) {
+		// Use require() specifically for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_8_4.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_8_4.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_8_4.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_8_4.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_8_4.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node-builds/8-5/src/index.ts
+++ b/packages/php-wasm/node-builds/8-5/src/index.ts
@@ -20,12 +20,33 @@ const packageDir = existsSync(join(currentDirPath, 'jspi'))
 	: dirname(currentDirPath);
 
 export async function getPHPLoaderModule(): Promise<PHPLoaderModule> {
-	if (await jspi()) {
-		// @ts-ignore
-		return await import('../jspi/php_8_5.js');
+	// Detect Jest environment and use require() to avoid dynamic import() issues
+	// For all other environments (ESM, modern CommonJS, Vitest), use dynamic import()
+	// which works in Node.js 12.20+ regardless of whether the code is running in ESM or CJS.
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const shouldUseRequire = process.env && process.env['JEST_WORKER_ID'];
+
+	if (shouldUseRequire) {
+		// Use require() specifically for Jest
+		if (await jspi()) {
+			// @ts-ignore
+			return require('../jspi/php_8_5.js');
+		} else {
+			// @ts-ignore
+			return require('../asyncify/php_8_5.js');
+		}
 	} else {
-		// @ts-ignore
-		return await import('../asyncify/php_8_5.js');
+		// Use dynamic import() for all other environments
+		if (await jspi()) {
+			// @ts-ignore
+			return await import('../jspi/php_8_5.js');
+		} else {
+			// @ts-ignore
+			return await import('../asyncify/php_8_5.js');
+		}
 	}
 }
 

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -10,12 +10,53 @@ import type { PHPLoaderModule, SupportedPHPVersion } from '@php-wasm/universal';
  * - @php-wasm/node-8-3
  * - etc.
  *
+ * In CommonJS environments (like Jest), we use require() to avoid dynamic import issues.
+ * In ESM environments, we use dynamic import().
+ *
  * @param version The PHP version to load.
  * @returns The PHP loader module.
  */
 export async function getPHPLoaderModule(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion
 ): Promise<PHPLoaderModule> {
+	// CommonJS: require() avoids dynamic import() issues without --experimental-vm-modules
+	if (
+		typeof module !== 'undefined' &&
+		typeof module.exports !== 'undefined'
+	) {
+		switch (version) {
+			case '8.5':
+				// @ts-ignore
+				return require('@php-wasm/node-8-5').getPHPLoaderModule();
+			case '8.4':
+				// @ts-ignore
+				return require('@php-wasm/node-8-4').getPHPLoaderModule();
+			case '8.3':
+				// @ts-ignore
+				return require('@php-wasm/node-8-3').getPHPLoaderModule();
+			case '8.2':
+				// @ts-ignore
+				return require('@php-wasm/node-8-2').getPHPLoaderModule();
+			case '8.1':
+				// @ts-ignore
+				return require('@php-wasm/node-8-1').getPHPLoaderModule();
+			case '8.0':
+				// @ts-ignore
+				return require('@php-wasm/node-8-0').getPHPLoaderModule();
+			case '7.4':
+				// @ts-ignore
+				return require('@php-wasm/node-7-4').getPHPLoaderModule();
+			case '7.3':
+				// @ts-ignore
+				return require('@php-wasm/node-7-3').getPHPLoaderModule();
+			case '7.2':
+				// @ts-ignore
+				return require('@php-wasm/node-7-2').getPHPLoaderModule();
+		}
+		throw new Error(`Unsupported PHP version ${version}`);
+	}
+
+	// In ESM, use dynamic import
 	switch (version) {
 		case '8.5':
 			// @ts-ignore

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -2,54 +2,27 @@ import { LatestSupportedPHPVersion } from '@php-wasm/universal';
 import type { PHPLoaderModule, SupportedPHPVersion } from '@php-wasm/universal';
 
 /**
- * Determines whether to use require() or dynamic import() to load PHP modules.
- */
-function getModuleLoadingStrategy(): 'require' | 'import' {
-	// Check if we're in Jest environment
-	// Jest runs tests in a VM context that doesn't support dynamic import() without
-	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
-	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
-	// See: https://jestjs.io/docs/ecmascript-modules
-	if (process.env && process.env['JEST_WORKER_ID']) {
-		// Use require() in Jest unless explicitly configured for ESM
-		return 'require';
-	}
-
-	// Check if require() is even available
-	// In pure ESM environments, require won't exist and we must use import()
-	if (typeof require !== 'function') {
-		return 'import';
-	}
-
-	// Check if we're in a CommonJS environment without module/module.exports
-	// If module or module.exports is undefined, we're in an ESM-only context
-	// where require() won't work anyway
-	if (
-		typeof module === 'undefined' ||
-		typeof module.exports === 'undefined'
-	) {
-		return 'import';
-	}
-
-	// All checks passed - we're in a Node.js environment that supports dynamic import()
-	// Modern Node.js (12.20+) supports dynamic import() in both ESM and CommonJS contexts
-	// This includes Vitest and other modern test runners
-	return 'import';
-}
-
-/**
  * Loads the PHP loader module for the given PHP version.
  *
- * Uses dynamic import() by default, falling back to require() in Jest environments
- * where dynamic import isn't supported without --experimental-vm-modules.
+ * Uses dynamic import() by default (works in ESM, modern CommonJS, and Vitest).
+ * Only uses require() in Jest environments where dynamic import() isn't supported
+ * without --experimental-vm-modules.
  */
 export async function getPHPLoaderModule(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion
 ): Promise<PHPLoaderModule> {
-	const loadingStrategy = getModuleLoadingStrategy();
+	// Detect Jest environment and use require() instead of dynamic import()
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// For all other environments (ESM, modern CommonJS, Vitest), dynamic import() works fine.
+	// See: https://jestjs.io/docs/ecmascript-modules
+	const isJest =
+		typeof process !== 'undefined' &&
+		process.env &&
+		process.env['JEST_WORKER_ID'];
 
-	if (loadingStrategy === 'require') {
-		// Use require() for environments that don't support dynamic import
+	if (isJest) {
+		// Use require() for Jest
 		switch (version) {
 			case '8.5':
 				// @ts-ignore
@@ -83,8 +56,8 @@ export async function getPHPLoaderModule(
 		}
 	}
 
-	// Use dynamic import() - the modern, preferred approach
-	// Works in: ESM, Vitest, modern Node.js CJS (12.20+), and with workspace symlinks
+	// Use dynamic import() for all other environments
+	// Works in: ESM, modern CommonJS (Node.js 12.20+), Vitest, and other modern test runners
 	switch (version) {
 		case '8.5':
 			// @ts-ignore

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -2,131 +2,118 @@ import { LatestSupportedPHPVersion } from '@php-wasm/universal';
 import type { PHPLoaderModule, SupportedPHPVersion } from '@php-wasm/universal';
 
 /**
+ * Determines whether to use require() or dynamic import() to load PHP modules.
+ */
+function getModuleLoadingStrategy(): 'require' | 'import' {
+	// Check if we're in Jest environment
+	// Jest runs tests in a VM context that doesn't support dynamic import() without
+	// the --experimental-vm-modules flag. Jest sets JEST_WORKER_ID when running tests.
+	// Error without flag: "A dynamic import callback was invoked without --experimental-vm-modules"
+	// See: https://jestjs.io/docs/ecmascript-modules
+	if (process.env && process.env['JEST_WORKER_ID']) {
+		// Use require() in Jest unless explicitly configured for ESM
+		return 'require';
+	}
+
+	// Check if require() is even available
+	// In pure ESM environments, require won't exist and we must use import()
+	if (typeof require !== 'function') {
+		return 'import';
+	}
+
+	// Check if we're in a CommonJS environment without module/module.exports
+	// If module or module.exports is undefined, we're in an ESM-only context
+	// where require() won't work anyway
+	if (
+		typeof module === 'undefined' ||
+		typeof module.exports === 'undefined'
+	) {
+		return 'import';
+	}
+
+	// All checks passed - we're in a Node.js environment that supports dynamic import()
+	// Modern Node.js (12.20+) supports dynamic import() in both ESM and CommonJS contexts
+	// This includes Vitest and other modern test runners
+	return 'import';
+}
+
+/**
  * Loads the PHP loader module for the given PHP version.
  *
- * Each PHP version is packaged separately to reduce bundle size:
- * - @php-wasm/node-8-5
- * - @php-wasm/node-8-4
- * - @php-wasm/node-8-3
- * - etc.
- *
- * ## Module Loading Strategy
- *
- * Uses a try-catch fallback approach:
- * 1. **Tries `import()` first** - Works in ESM, modern CJS (Node 12.20+), and test
- *    runners like Vitest
- * 2. **Falls back to `require()`** - Only if import() fails (rare in modern
- *    environments)
- *
- * ### Why This Approach?
- *
- * **Development**: In monorepo development, workspace symlinks point to source directories
- * without built files. Modern test runners (like Vitest) provide both `module` and `require`
- * but should use `import()` to work with these symlinks. The try-catch approach correctly
- * uses `import()` in these environments.
- *
- * **Production**: Published packages have built files in the correct locations, so both
- * `import()` (ESM consumers) and `require()` (old CJS consumers) work correctly.
- *
- * This avoids environment-specific detection hacks and is future-proof as environments evolve.
- *
- * @param version The PHP version to load.
- * @returns The PHP loader module.
+ * Uses dynamic import() by default, falling back to require() in Jest environments
+ * where dynamic import isn't supported without --experimental-vm-modules.
  */
 export async function getPHPLoaderModule(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion
 ): Promise<PHPLoaderModule> {
-	// Try dynamic import() first - the modern, preferred approach
-	// Works in: ESM, Vitest, modern Node.js CJS (12.20+), and with workspace symlinks
-	try {
+	const loadingStrategy = getModuleLoadingStrategy();
+
+	if (loadingStrategy === 'require') {
+		// Use require() for environments that don't support dynamic import
 		switch (version) {
 			case '8.5':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-8-5')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-8-5').getPHPLoaderModule();
 			case '8.4':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-8-4')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-8-4').getPHPLoaderModule();
 			case '8.3':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-8-3')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-8-3').getPHPLoaderModule();
 			case '8.2':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-8-2')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-8-2').getPHPLoaderModule();
 			case '8.1':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-8-1')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-8-1').getPHPLoaderModule();
 			case '8.0':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-8-0')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-8-0').getPHPLoaderModule();
 			case '7.4':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-7-4')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-7-4').getPHPLoaderModule();
 			case '7.3':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-7-3')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-7-3').getPHPLoaderModule();
 			case '7.2':
 				// @ts-ignore
-				return (
-					await import('@php-wasm/node-7-2')
-				).getPHPLoaderModule();
+				return require('@php-wasm/node-7-2').getPHPLoaderModule();
+			default:
+				throw new Error(`Unsupported PHP version ${version}`);
 		}
-		throw new Error(`Unsupported PHP version ${version}`);
-	} catch (error) {
-		// Fallback: Use require() only if import() failed
-		// This handles extremely rare cases: old Node.js versions or restricted environments
-		// where dynamic import() is not available
-		if (
-			typeof module !== 'undefined' &&
-			typeof module.exports !== 'undefined' &&
-			typeof require === 'function'
-		) {
-			switch (version) {
-				case '8.5':
-					// @ts-ignore
-					return require('@php-wasm/node-8-5').getPHPLoaderModule();
-				case '8.4':
-					// @ts-ignore
-					return require('@php-wasm/node-8-4').getPHPLoaderModule();
-				case '8.3':
-					// @ts-ignore
-					return require('@php-wasm/node-8-3').getPHPLoaderModule();
-				case '8.2':
-					// @ts-ignore
-					return require('@php-wasm/node-8-2').getPHPLoaderModule();
-				case '8.1':
-					// @ts-ignore
-					return require('@php-wasm/node-8-1').getPHPLoaderModule();
-				case '8.0':
-					// @ts-ignore
-					return require('@php-wasm/node-8-0').getPHPLoaderModule();
-				case '7.4':
-					// @ts-ignore
-					return require('@php-wasm/node-7-4').getPHPLoaderModule();
-				case '7.3':
-					// @ts-ignore
-					return require('@php-wasm/node-7-3').getPHPLoaderModule();
-				case '7.2':
-					// @ts-ignore
-					return require('@php-wasm/node-7-2').getPHPLoaderModule();
-			}
-		}
-		// Re-throw the original error if require() also isn't available
-		throw error;
+	}
+
+	// Use dynamic import() - the modern, preferred approach
+	// Works in: ESM, Vitest, modern Node.js CJS (12.20+), and with workspace symlinks
+	switch (version) {
+		case '8.5':
+			// @ts-ignore
+			return (await import('@php-wasm/node-8-5')).getPHPLoaderModule();
+		case '8.4':
+			// @ts-ignore
+			return (await import('@php-wasm/node-8-4')).getPHPLoaderModule();
+		case '8.3':
+			// @ts-ignore
+			return (await import('@php-wasm/node-8-3')).getPHPLoaderModule();
+		case '8.2':
+			// @ts-ignore
+			return (await import('@php-wasm/node-8-2')).getPHPLoaderModule();
+		case '8.1':
+			// @ts-ignore
+			return (await import('@php-wasm/node-8-1')).getPHPLoaderModule();
+		case '8.0':
+			// @ts-ignore
+			return (await import('@php-wasm/node-8-0')).getPHPLoaderModule();
+		case '7.4':
+			// @ts-ignore
+			return (await import('@php-wasm/node-7-4')).getPHPLoaderModule();
+		case '7.3':
+			// @ts-ignore
+			return (await import('@php-wasm/node-7-3')).getPHPLoaderModule();
+		case '7.2':
+			// @ts-ignore
+			return (await import('@php-wasm/node-7-2')).getPHPLoaderModule();
+		default:
+			throw new Error(`Unsupported PHP version ${version}`);
 	}
 }

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -10,8 +10,25 @@ import type { PHPLoaderModule, SupportedPHPVersion } from '@php-wasm/universal';
  * - @php-wasm/node-8-3
  * - etc.
  *
- * In CommonJS environments (like Jest), we use require() to avoid dynamic import issues.
- * In ESM environments, we use dynamic import().
+ * ## Module Loading Strategy
+ *
+ * Uses a try-catch fallback approach:
+ * 1. **Tries `import()` first** - Works in ESM, modern CJS (Node 12.20+), and test
+ *    runners like Vitest
+ * 2. **Falls back to `require()`** - Only if import() fails (rare in modern
+ *    environments)
+ *
+ * ### Why This Approach?
+ *
+ * **Development**: In monorepo development, workspace symlinks point to source directories
+ * without built files. Modern test runners (like Vitest) provide both `module` and `require`
+ * but should use `import()` to work with these symlinks. The try-catch approach correctly
+ * uses `import()` in these environments.
+ *
+ * **Production**: Published packages have built files in the correct locations, so both
+ * `import()` (ESM consumers) and `require()` (old CJS consumers) work correctly.
+ *
+ * This avoids environment-specific detection hacks and is future-proof as environments evolve.
  *
  * @param version The PHP version to load.
  * @returns The PHP loader module.
@@ -19,72 +36,97 @@ import type { PHPLoaderModule, SupportedPHPVersion } from '@php-wasm/universal';
 export async function getPHPLoaderModule(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion
 ): Promise<PHPLoaderModule> {
-	// CommonJS: require() avoids dynamic import() issues without --experimental-vm-modules
-	if (
-		typeof module !== 'undefined' &&
-		typeof module.exports !== 'undefined'
-	) {
+	// Try dynamic import() first - the modern, preferred approach
+	// Works in: ESM, Vitest, modern Node.js CJS (12.20+), and with workspace symlinks
+	try {
 		switch (version) {
 			case '8.5':
 				// @ts-ignore
-				return require('@php-wasm/node-8-5').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-8-5')
+				).getPHPLoaderModule();
 			case '8.4':
 				// @ts-ignore
-				return require('@php-wasm/node-8-4').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-8-4')
+				).getPHPLoaderModule();
 			case '8.3':
 				// @ts-ignore
-				return require('@php-wasm/node-8-3').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-8-3')
+				).getPHPLoaderModule();
 			case '8.2':
 				// @ts-ignore
-				return require('@php-wasm/node-8-2').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-8-2')
+				).getPHPLoaderModule();
 			case '8.1':
 				// @ts-ignore
-				return require('@php-wasm/node-8-1').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-8-1')
+				).getPHPLoaderModule();
 			case '8.0':
 				// @ts-ignore
-				return require('@php-wasm/node-8-0').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-8-0')
+				).getPHPLoaderModule();
 			case '7.4':
 				// @ts-ignore
-				return require('@php-wasm/node-7-4').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-7-4')
+				).getPHPLoaderModule();
 			case '7.3':
 				// @ts-ignore
-				return require('@php-wasm/node-7-3').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-7-3')
+				).getPHPLoaderModule();
 			case '7.2':
 				// @ts-ignore
-				return require('@php-wasm/node-7-2').getPHPLoaderModule();
+				return (
+					await import('@php-wasm/node-7-2')
+				).getPHPLoaderModule();
 		}
 		throw new Error(`Unsupported PHP version ${version}`);
+	} catch (error) {
+		// Fallback: Use require() only if import() failed
+		// This handles extremely rare cases: old Node.js versions or restricted environments
+		// where dynamic import() is not available
+		if (
+			typeof module !== 'undefined' &&
+			typeof module.exports !== 'undefined' &&
+			typeof require === 'function'
+		) {
+			switch (version) {
+				case '8.5':
+					// @ts-ignore
+					return require('@php-wasm/node-8-5').getPHPLoaderModule();
+				case '8.4':
+					// @ts-ignore
+					return require('@php-wasm/node-8-4').getPHPLoaderModule();
+				case '8.3':
+					// @ts-ignore
+					return require('@php-wasm/node-8-3').getPHPLoaderModule();
+				case '8.2':
+					// @ts-ignore
+					return require('@php-wasm/node-8-2').getPHPLoaderModule();
+				case '8.1':
+					// @ts-ignore
+					return require('@php-wasm/node-8-1').getPHPLoaderModule();
+				case '8.0':
+					// @ts-ignore
+					return require('@php-wasm/node-8-0').getPHPLoaderModule();
+				case '7.4':
+					// @ts-ignore
+					return require('@php-wasm/node-7-4').getPHPLoaderModule();
+				case '7.3':
+					// @ts-ignore
+					return require('@php-wasm/node-7-3').getPHPLoaderModule();
+				case '7.2':
+					// @ts-ignore
+					return require('@php-wasm/node-7-2').getPHPLoaderModule();
+			}
+		}
+		// Re-throw the original error if require() also isn't available
+		throw error;
 	}
-
-	// In ESM, use dynamic import
-	switch (version) {
-		case '8.5':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-5')).getPHPLoaderModule();
-		case '8.4':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-4')).getPHPLoaderModule();
-		case '8.3':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-3')).getPHPLoaderModule();
-		case '8.2':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-2')).getPHPLoaderModule();
-		case '8.1':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-1')).getPHPLoaderModule();
-		case '8.0':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-0')).getPHPLoaderModule();
-		case '7.4':
-			// @ts-ignore
-			return (await import('@php-wasm/node-7-4')).getPHPLoaderModule();
-		case '7.3':
-			// @ts-ignore
-			return (await import('@php-wasm/node-7-3')).getPHPLoaderModule();
-		case '7.2':
-			// @ts-ignore
-			return (await import('@php-wasm/node-7-2')).getPHPLoaderModule();
-	}
-	throw new Error(`Unsupported PHP version ${version}`);
 }

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/package.json
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/package.json
@@ -19,7 +19,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^22.14.1",
-		"@wp-playground/cli": "^1.2.3",
+		"@wp-playground/cli": "^3.0.39",
 		"@types/jest": "^29.5.14",
 		"jest": "^29.7.0",
 		"ts-jest": "^29.3.2",

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/php-wasm-node.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/php-wasm-node.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Test that @php-wasm/node works directly in Jest (CommonJS environment).
+ *
+ * This test verifies that the published @php-wasm/node package can be used
+ * directly in Jest without requiring --experimental-vm-modules or spawning
+ * a separate process via runCLI().
+ *
+ * Related issue: The per-version packages (@php-wasm/node-8-3, etc.) contain
+ * ESM syntax (import.meta.url) that breaks in Jest's CommonJS sandbox.
+ */
+
+const originalNode = jest.requireActual('@php-wasm/node');
+const originalUniversal = jest.requireActual('@php-wasm/universal');
+
+describe('@php-wasm/node direct usage in Jest', () => {
+	// Test with PHP 8.3 as a representative version
+	it('should load PHP runtime directly without spawning a child process', async () => {
+		// This call will fail with:
+		// - "TypeError: A dynamic import callback was invoked without --experimental-vm-modules"
+		// - or "SyntaxError: Cannot use 'import.meta' outside a module"
+		const runtimeId = await originalNode.loadNodeRuntime('8.3');
+
+		const php = new originalUniversal.PHP(runtimeId);
+
+		// Basic PHP execution test
+		const result = await php.run({
+			code: '<?php echo "Hello from PHP " . PHP_VERSION;',
+		});
+
+		expect(result.text).toContain('Hello from PHP 8.3');
+
+		php.exit();
+	}, 30000);
+});

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/php-wasm-node.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/php-wasm-node.spec.ts
@@ -1,12 +1,5 @@
 /**
  * Test that @php-wasm/node works directly in Jest (CommonJS environment).
- *
- * This test verifies that the published @php-wasm/node package can be used
- * directly in Jest without requiring --experimental-vm-modules or spawning
- * a separate process via runCLI().
- *
- * Related issue: The per-version packages (@php-wasm/node-8-3, etc.) contain
- * ESM syntax (import.meta.url) that breaks in Jest's CommonJS sandbox.
  */
 
 const originalNode = jest.requireActual('@php-wasm/node');


### PR DESCRIPTION
🚧 WIP

## Motivation for the change, related issues

After upgrading from `@php-wasm/node` v3.0.22 to v3.0.39, Jest tests that use `loadNodeRuntime()` directly fail with ESM-related errors.

The per-version packages introduced in #3062 contain JavaScript files that use ESM syntax (`import.meta.url`), which breaks when loaded in Jest's CommonJS sandbox.

**Error:**
```
TypeError: A dynamic import callback was invoked without --experimental-vm-modules

    at getPHPLoaderModule (node_modules/@php-wasm/node/index.cjs:54:7)
```

Or alternatively:
```
SyntaxError: Cannot use 'import.meta' outside a module

    /node_modules/@php-wasm/node-8-3/asyncify/php_8_3.js:5
    const require = createRequire(import.meta.url);
                                         ^^^^
```

This affects downstream projects (like [WordPress Studio](https://github.com/Automattic/studio)) that use `@php-wasm/node` directly in their Jest test suites.

## Implementation details

This PR adds a test that verifies `@php-wasm/node` can be used directly in Jest without:
- Requiring `--experimental-vm-modules` 
- Spawning a separate process via `runCLI()`

The test currently **fails** - it demonstrates the issue and will pass once a fix is implemented.

### Root Cause

The per-version packages (`@php-wasm/node-8-3`, etc.) contain ESM files:

```javascript
// @php-wasm/node-8-3/asyncify/php_8_3.js
import { createRequire } from 'module';
const require = createRequire(import.meta.url);  // ESM syntax
```

When `@php-wasm/node/index.cjs` dynamically imports these packages, Jest cannot handle the ESM dynamic imports in its CommonJS sandbox.

### Related PRs
- #3062 - Split php-wasm packages into per-PHP-version packages
- #3077 - Enable dynamic-import for published CJS packages  
- #3094 - Fix __dirname not defined error in intl extension (similar ESM/CJS issue)

## Testing Instructions (or ideally a Blueprint)

Run the test suite for `commonjs-and-jest`:

```bash
cd packages/playground/test-built-npm-packages/commonjs-and-jest
npm install
npm test
```

The new test `php-wasm-node.spec.ts` will fail with the error above, demonstrating the issue.