### PR TITLE
[CLI] `@wp-playground/cli start` persist sites

### DIFF
--- a/packages/playground/cli/src/mounts.ts
+++ b/packages/playground/cli/src/mounts.ts
@@ -177,14 +177,6 @@ export function expandAutoMounts(args: RunCLIArgs): RunCLIArgs {
 			newArgs.wordpressInstallMode =
 				'install-from-existing-files-if-needed';
 		}
-	} else {
-		/**
-		 * By default, mount the current working directory as the Playground root.
-		 * This allows users to run and PHP or HTML files using the Playground CLI.
-		 */
-		mount.push({ hostPath: path, vfsPath: '/wordpress' });
-		// @TODO: If overriding another mode, throw an error or print a warning.
-		newArgs.mode = 'mount-only';
 	}
 
 	return newArgs as RunCLIArgs;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -18,7 +18,7 @@ import type {
 } from '@wp-playground/blueprints';
 import { runBlueprintV1Steps } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import fs, { mkdirSync, readdirSync } from 'fs';
+import fs, { existsSync, mkdirSync, readdirSync, rmdirSync } from 'fs';
 import type { Server } from 'http';
 import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
 // @ts-ignore
@@ -352,6 +352,12 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				type: 'array',
 				string: true,
 				coerce: parseMountWithDelimiterArguments,
+			},
+			'reset-site': {
+				describe:
+					'Deletes the stored site directory and starts a new site from scratch.',
+				type: 'boolean',
+				default: false,
 			},
 			'no-auto-mount': {
 				describe:
@@ -720,6 +726,9 @@ export interface RunCLIServer extends AsyncDisposable {
 
 const bold = (text: string) =>
 	process.stdout.isTTY ? '\x1b[1m' + text + '\x1b[0m' : text;
+
+const red = (text: string) =>
+	process.stdout.isTTY ? '\x1b[31m' + text + '\x1b[0m' : text;
 
 const dim = (text: string) =>
 	process.stdout.isTTY ? `\x1b[2m${text}\x1b[0m` : text;
@@ -1315,7 +1324,9 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
  * (Yes, the `start` command is just a convenience wrapper to provide useful defaults
  * for the `server` command.)
  */
-function expandStartCommandArgs(args: RunCLIArgs): RunCLIArgs {
+function expandStartCommandArgs(
+	args: RunCLIArgs & { 'reset-site'?: boolean }
+): RunCLIArgs {
 	let newArgs = { ...args, command: 'server' };
 
 	/**
@@ -1365,6 +1376,12 @@ function expandStartCommandArgs(args: RunCLIArgs): RunCLIArgs {
 			'.wordpress-playground/sites',
 			currentSiteHash
 		);
+		console.log('Site files stored at:', hostPath);
+
+		if (existsSync(hostPath) && (args['reset-site'] as boolean)) {
+			console.log('Resetting site...');
+			rmdirSync(hostPath, { recursive: true });
+		}
 		mkdirSync(hostPath, { recursive: true });
 		newArgs['mount-before-install'] = [
 			...((newArgs['mount-before-install'] || []) as Mount[]),
@@ -1378,10 +1395,24 @@ function expandStartCommandArgs(args: RunCLIArgs): RunCLIArgs {
 					'download-and-install'
 				: // After that, reuse the WordPress installation from the initial run.
 					'install-from-existing-files-if-needed';
-
-		console.log('Site files stored at:', hostPath);
 	} else {
 		console.log('Site files stored at:', existingSiteRootMount?.hostPath);
+		if (args['reset-site']) {
+			console.log(``);
+			console.log(
+				red(
+					`This site is not managed by Playground CLI and cannot be reset.`
+				)
+			);
+			console.log(
+				`(It's not stored in the ~/.wordpress-playground/sites/<site-id> directory.)`
+			);
+			console.log(``);
+			console.log(
+				`You may still remove the site's directory manually if you wish.`
+			);
+			process.exit(1);
+		}
 	}
 
 	return newArgs as RunCLIArgs;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -702,6 +702,7 @@ export interface RunCLIArgs {
 	path?: string;
 	skipBrowser?: boolean;
 	noAutoMount?: boolean;
+	'reset-site'?: boolean;
 }
 
 type PlaygroundCliWorker =

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -18,7 +18,7 @@ import type {
 } from '@wp-playground/blueprints';
 import { runBlueprintV1Steps } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import fs, { mkdirSync } from 'fs';
+import fs, { mkdirSync, readdirSync } from 'fs';
 import type { Server } from 'http';
 import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
 // @ts-ignore
@@ -58,6 +58,7 @@ import {
 	createTempDirSymlink,
 	removeTempDirSymlink,
 } from '@php-wasm/cli-util';
+import { createHash } from 'crypto';
 
 // Inlined worker URLs for static analysis by downstream bundlers
 // These are replaced at build time by the Vite plugin in vite.config.ts
@@ -571,32 +572,9 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			process.exit(1);
 		}
 
-		// Track whether to open browser (only for 'start' command)
-		let shouldOpenBrowser = false;
-
-		// Transform 'start' command args to server-compatible args
-		if (command === 'start') {
-			shouldOpenBrowser = args['skip-browser'] !== true;
-
-			// Enable auto-mount unless explicitly disabled
-			if (!args['no-auto-mount']) {
-				args['auto-mount'] = args['autoMount'] =
-					(args['path'] as string) || process.cwd();
-			}
-
-			// Verbosity handling
-			if (args['quiet']) {
-				args['verbosity'] = 'quiet';
-			}
-
-			// Intl is always enabled for the start command
-			args['intl'] = true;
-		}
-
 		const cliArgs = {
 			...args,
-			// The 'start' command internally runs as 'server'
-			command: command === 'start' ? 'server' : command,
+			command,
 			mount: [
 				...((args['mount'] as Mount[]) || []),
 				...((args['mount-dir'] as Mount[]) || []),
@@ -611,11 +589,6 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		if (cliServer === undefined) {
 			// No server was started, so we are done with our work.
 			process.exit(0);
-		}
-
-		// Open browser for the 'start' command
-		if (shouldOpenBrowser) {
-			openInBrowser(cliServer.serverUrl);
 		}
 
 		const cleanUpCliAndExit = (() => {
@@ -640,6 +613,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		process.on('SIGINT', cleanUpCliAndExit);
 		process.on('SIGTERM', cleanUpCliAndExit);
 	} catch (e) {
+		console.error(e);
 		if (!(e instanceof Error)) {
 			throw e;
 		}
@@ -659,6 +633,16 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		}
 		process.exit(1);
 	}
+}
+
+function getMountForVfsPath(
+	mounts: Mount[],
+	vfsPath: string
+): Mount | undefined {
+	return mounts.find(
+		(mount) =>
+			mount.vfsPath.replace(/\/$/, '') === vfsPath.replace(/\/$/, '')
+	);
 }
 
 export interface RunCLIArgs {
@@ -753,6 +737,9 @@ export async function runCLI(
 	args: RunCLIArgs & { command: 'build-snapshot' | 'run-blueprint' }
 ): Promise<void>;
 export async function runCLI(
+	args: RunCLIArgs & { command: 'start' }
+): Promise<RunCLIServer>;
+export async function runCLI(
 	args: RunCLIArgs & { command: 'server' }
 ): Promise<RunCLIServer>;
 export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void>;
@@ -765,10 +752,10 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 		RemoteAPI<PlaygroundCliWorker>
 	> = new Map();
 
-	/**
-	 * Expand auto-mounts to include the necessary mounts and steps
-	 * when running in auto-mount mode.
-	 */
+	if (args.command === 'start') {
+		args = expandStartCommandArgs(args);
+	}
+
 	if (args.autoMount !== undefined) {
 		if (args.autoMount === '') {
 			// No auto-mount path was provided, so use the current working directory.
@@ -832,7 +819,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 	logger.log('Starting a PHP server...');
 
-	return startServer({
+	const server = await startServer({
 		port: selectedPort,
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';
@@ -1315,6 +1302,89 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			return await loadBalancer.handleRequest(request);
 		},
 	});
+
+	if (server && args.command === 'start' && !args.skipBrowser) {
+		openInBrowser(server.serverUrl);
+	}
+	return server;
+}
+
+/**
+ * Transforms CLI args for the `start` command into the `server` command arguments.
+ *
+ * (Yes, the `start` command is just a convenience wrapper to provide useful defaults
+ * for the `server` command.)
+ */
+function expandStartCommandArgs(args: RunCLIArgs): RunCLIArgs {
+	let newArgs = { ...args, command: 'server' };
+
+	/**
+	 * Enable auto-mount unless explicitly disabled
+	 */
+	if (!args.noAutoMount) {
+		newArgs.autoMount = path.resolve(process.cwd(), newArgs['path'] ?? '');
+		newArgs = expandAutoMounts(newArgs as RunCLIArgs);
+		// Delete the autoMount argument to avoid double expansion later on.
+		delete newArgs.autoMount;
+	}
+
+	const existingSiteRootMount =
+		getMountForVfsPath(
+			newArgs['mount-before-install'] || [],
+			'/wordpress'
+		) || getMountForVfsPath(newArgs.mount || [], '/wordpress');
+
+	/**
+	 * Persist the site into a ~/.wordpress-playground/sites/<site-id> directory,
+	 * but only if we don't have an explicit mount for the /wordpress VFS path.
+	 *
+	 * Why the limitation?
+	 *
+	 * Because we can only do one of the two:
+	 *
+	 * 1. Mount host path /my/wordpress/site directory at /wordpress VFS path
+	 * 2. Mount host path ~/.wordpress-playground/sites/<site-id> directory at /wordpress VFS path
+	 *
+	 * When either the user or expandAutoMounts() already provided a mount for the /wordpress VFS path,
+	 * it means a WordPress installation is already present in that directory. In this case, that's our
+	 * persistent store.
+	 */
+	if (!existingSiteRootMount) {
+		/**
+		 * Persist the sites by default by mounting a real, stable directory
+		 * as the site root.
+		 */
+		const currentSitePath = newArgs['autoMount'] || process.cwd();
+		const currentSiteHash = createHash('sha256')
+			.update(currentSitePath as string)
+			.digest('hex');
+
+		const homeDir = os.homedir();
+		const hostPath = path.join(
+			homeDir,
+			'.wordpress-playground/sites',
+			currentSiteHash
+		);
+		mkdirSync(hostPath, { recursive: true });
+		newArgs['mount-before-install'] = [
+			...((newArgs['mount-before-install'] || []) as Mount[]),
+			{ vfsPath: '/wordpress', hostPath },
+		];
+
+		newArgs.wordpressInstallMode =
+			readdirSync(hostPath).length === 0
+				? // Only download WordPress on the first run when the site directory is still
+					// empty.
+					'download-and-install'
+				: // After that, reuse the WordPress installation from the initial run.
+					'install-from-existing-files-if-needed';
+
+		console.log('Site files stored at:', hostPath);
+	} else {
+		console.log('Site files stored at:', existingSiteRootMount?.hostPath);
+	}
+
+	return newArgs as RunCLIArgs;
 }
 
 export type SpawnedWorker = {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -353,7 +353,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				string: true,
 				coerce: parseMountWithDelimiterArguments,
 			},
-			'reset-site': {
+			reset: {
 				describe:
 					'Deletes the stored site directory and starts a new site from scratch.',
 				type: 'boolean',
@@ -702,7 +702,7 @@ export interface RunCLIArgs {
 	path?: string;
 	skipBrowser?: boolean;
 	noAutoMount?: boolean;
-	'reset-site'?: boolean;
+	reset?: boolean;
 }
 
 type PlaygroundCliWorker =
@@ -1326,7 +1326,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
  * for the `server` command.)
  */
 function expandStartCommandArgs(
-	args: RunCLIArgs & { 'reset-site'?: boolean }
+	args: RunCLIArgs & { reset?: boolean }
 ): RunCLIArgs {
 	let newArgs = { ...args, command: 'server' };
 
@@ -1379,7 +1379,7 @@ function expandStartCommandArgs(
 		);
 		console.log('Site files stored at:', hostPath);
 
-		if (existsSync(hostPath) && (args['reset-site'] as boolean)) {
+		if (existsSync(hostPath) && (args['reset'] as boolean)) {
 			console.log('Resetting site...');
 			rmdirSync(hostPath, { recursive: true });
 		}
@@ -1398,7 +1398,7 @@ function expandStartCommandArgs(
 					'install-from-existing-files-if-needed';
 	} else {
 		console.log('Site files stored at:', existingSiteRootMount?.hostPath);
-		if (args['reset-site']) {
+		if (args['reset']) {
 			console.log(``);
 			console.log(
 				red(

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -841,7 +841,7 @@ describe('start command', () => {
 		}
 	}, 180000);
 
-	test('should reset site when --reset-site is provided', async () => {
+	test('should reset site when --reset is provided', async () => {
 		const tmpDir = await mkdtemp(path.join(tmpdir(), 'playground-test-'));
 		const homeDir = os.homedir();
 		const currentSiteHash = createHash('sha256')
@@ -874,12 +874,12 @@ describe('start command', () => {
 			);
 		}
 
-		// Second run with --reset-site - should delete the old site
+		// Second run with --reset - should delete the old site
 		{
 			await using cliServer = await runCLI({
 				command: 'start',
 				skipBrowser: true,
-				'reset-site': true,
+				reset: true,
 			});
 
 			// Verify the marker file does not exist

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -525,29 +525,6 @@ describe.each(blueprintVersions)(
 			);
 
 			test.skipIf(isBlueprintsV2OnWindows)(
-				'should run a static html project using --auto-mount',
-				async () => {
-					vi.spyOn(process, 'cwd').mockReturnValue(
-						path.join(
-							import.meta.dirname,
-							'mount-examples',
-							'static-html'
-						)
-					);
-					await using cliServer = await runCLI({
-						...suiteCliArgs,
-						command: 'server',
-						autoMount: '',
-					});
-					const homeUrl = new URL('/', cliServer.serverUrl);
-					const response = await fetch(homeUrl);
-					expect(response.status).toBe(200);
-					const text = await response.text();
-					expect(text).toContain('<title>Static HTML</title>');
-				}
-			);
-
-			test.skipIf(isBlueprintsV2OnWindows)(
 				'should run a php project using --auto-mount',
 				async () => {
 					vi.spyOn(process, 'cwd').mockReturnValue(

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -17,6 +17,7 @@ import {
 	unlinkSync,
 	existsSync,
 	lstatSync,
+	rmSync,
 } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { MinifiedWordPressVersionsList } from '@wp-playground/wordpress-builds';
@@ -399,9 +400,9 @@ describe.each(blueprintVersions)(
 						],
 					});
 					const wpContentDirPath = path.join(tmpDir, 'wp-content');
-					expect(
-						await lstatSync(wpContentDirPath)?.isDirectory()
-					).toBe(true);
+					expect(lstatSync(wpContentDirPath)?.isDirectory()).toBe(
+						true
+					);
 				},
 				60000
 			);
@@ -760,6 +761,189 @@ describe('start command', () => {
 		// Verify server started successfully
 		expect(cliServer.serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
 	});
+
+	test('should persist site in home directory', async () => {
+		const tmpDir = await mkdtemp(path.join(tmpdir(), 'playground-test-'));
+		const homeDir = os.homedir();
+		const currentSiteHash = createHash('sha256')
+			.update(tmpDir)
+			.digest('hex');
+		const expectedSitePath = path.join(
+			homeDir,
+			'.wordpress-playground/sites',
+			currentSiteHash
+		);
+
+		// Clean up if the site directory already exists
+		if (existsSync(expectedSitePath)) {
+			rmSync(expectedSitePath, { recursive: true, force: true });
+		}
+
+		vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+		await using cliServer = await runCLI({
+			command: 'start',
+			skipBrowser: true,
+		});
+
+		// Verify server started successfully
+		expect(cliServer.serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+		// Verify the site directory was created
+		expect(existsSync(expectedSitePath)).toBe(true);
+		expect(lstatSync(expectedSitePath).isDirectory()).toBe(true);
+
+		// Verify WordPress files exist in the persisted directory
+		const wpContentPath = path.join(expectedSitePath, 'wp-content');
+		expect(existsSync(wpContentPath)).toBe(true);
+		expect(lstatSync(wpContentPath).isDirectory()).toBe(true);
+
+		// Clean up
+		if ((process.cwd as unknown as MockInstance).mockRestore) {
+			(process.cwd as unknown as MockInstance).mockRestore();
+		}
+	}, 120000);
+
+	test('should reuse existing persisted site on subsequent runs', async () => {
+		const tmpDir = await mkdtemp(path.join(tmpdir(), 'playground-test-'));
+		const homeDir = os.homedir();
+		const currentSiteHash = createHash('sha256')
+			.update(tmpDir)
+			.digest('hex');
+		const expectedSitePath = path.join(
+			homeDir,
+			'.wordpress-playground/sites',
+			currentSiteHash
+		);
+
+		// Clean up if the site directory already exists
+		if (existsSync(expectedSitePath)) {
+			rmSync(expectedSitePath, { recursive: true, force: true });
+		}
+
+		vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+		// First run - create the site
+		{
+			await using cliServer = await runCLI({
+				command: 'start',
+				skipBrowser: true,
+			});
+
+			// Add a marker file to verify the site is reused
+			await cliServer.playground.writeFile(
+				'/wordpress/marker.txt',
+				'site-marker'
+			);
+		}
+
+		// Second run - should reuse the same site
+		{
+			await using cliServer = await runCLI({
+				command: 'start',
+				skipBrowser: true,
+			});
+
+			// Verify the marker file exists
+			const markerExists = await cliServer.playground.fileExists(
+				'/wordpress/marker.txt'
+			);
+			expect(markerExists).toBe(true);
+
+			if (markerExists) {
+				const markerContent = await cliServer.playground.readFileAsText(
+					'/wordpress/marker.txt'
+				);
+				expect(markerContent).toBe('site-marker');
+			}
+		}
+
+		// Clean up
+		if ((process.cwd as unknown as MockInstance).mockRestore) {
+			(process.cwd as unknown as MockInstance).mockRestore();
+		}
+	}, 180000);
+
+	test('should reset site when --reset-site is provided', async () => {
+		const tmpDir = await mkdtemp(path.join(tmpdir(), 'playground-test-'));
+		const homeDir = os.homedir();
+		const currentSiteHash = createHash('sha256')
+			.update(tmpDir)
+			.digest('hex');
+		const expectedSitePath = path.join(
+			homeDir,
+			'.wordpress-playground/sites',
+			currentSiteHash
+		);
+
+		// Clean up if the site directory already exists
+		if (existsSync(expectedSitePath)) {
+			rmSync(expectedSitePath, { recursive: true, force: true });
+		}
+
+		vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+
+		// First run - create the site with a marker
+		{
+			await using cliServer = await runCLI({
+				command: 'start',
+				skipBrowser: true,
+			});
+
+			// Add a marker file
+			await cliServer.playground.writeFile(
+				'/wordpress/marker.txt',
+				'should-be-deleted'
+			);
+		}
+
+		// Second run with --reset-site - should delete the old site
+		{
+			await using cliServer = await runCLI({
+				command: 'start',
+				skipBrowser: true,
+				'reset-site': true,
+			});
+
+			// Verify the marker file does not exist
+			const markerExists = await cliServer.playground.fileExists(
+				'/wordpress/marker.txt'
+			);
+			expect(markerExists).toBe(false);
+		}
+
+		// Clean up
+		if ((process.cwd as unknown as MockInstance).mockRestore) {
+			(process.cwd as unknown as MockInstance).mockRestore();
+		}
+	}, 180000);
+
+	test('should not persist when using explicit mount for /wordpress', async () => {
+		const tmpDir = await mkdtemp(path.join(tmpdir(), 'playground-test-'));
+		const wordpressDir = path.join(tmpDir, 'wordpress-custom');
+		mkdirSync(wordpressDir, { recursive: true });
+
+		// When we explicitly mount /wordpress, the site should be stored there,
+		// not in ~/.wordpress-playground/sites/
+		await using cliServer = await runCLI({
+			command: 'start',
+			skipBrowser: true,
+			'mount-before-install': [
+				{
+					hostPath: wordpressDir,
+					vfsPath: '/wordpress',
+				},
+			],
+		});
+
+		// Verify server started successfully
+		expect(cliServer.serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+
+		// Verify WordPress files are in the explicit mount location
+		const wpContentPath = path.join(wordpressDir, 'wp-content');
+		expect(existsSync(wpContentPath)).toBe(true);
+		expect(lstatSync(wpContentPath).isDirectory()).toBe(true);
+	}, 120000);
 });
 
 describe('other run-cli behaviors', () => {


### PR DESCRIPTION
## Motivation for the change, related issues

Makes `npx @wp-playground/cli start` persist the created site – just like `wp-now` does. With this PR, Playground CLI has a feature parity with wp-cli and we can move forward with the `wp-now` deprecation.

Follow-ups on https://github.com/WordPress/wordpress-playground/pull/3040

## Implementation details

Whenever there's no mount specified for `/wordpress`, Playground CLI will mount the host path `~/.wordpress-playground/sites/<path hash>` at the `/wordpress` VFS location.

There's also a `--reset` CLI flag that wipes out the stored files and starts a fresh site.

That's the gist of it.

This simple logic comes with a few caveats:

* The `~/.wordpress-playground` mount will not happen if the user explicitly mounts `/my/cool/site` at `/wordpress`. We can't mount two host directories at `/wordpress` so the explicit path wins.
* The `~/.wordpress-playground` mount will not happen if the auto mounting is enabled, and the `/my/project/path` contains a full WordPress installation. The reason is the same as above.
* I've removed the "just mount `cwd` at `/wordpress`" fallback in the auto-mounting logic. It doesn't seem that useful and it also interfered with the `~/.wordpress-playground` mount. If we really need that logic in the future, we can restore it behind an explicit option.

I've also moved the `start` command logic inside the `runCli()` function, it seems cleaner that way. Really, the CLI code could use some cleanup sooner than later to clearly separate the Typescript definitions for each command's args and clearly separate their handlers. But that's out of scope here.

## Testing Instructions (or ideally a Blueprint)

* Run `nx dev playground-cli start`
* Change site title or add a page
* Kill the server
* Run `nx dev playground-cli start` again
* Confirm your changes are still there
* Kill the server
* Run `nx dev playground-cli start --reset-site`
* Confirm you got a fresh new site

