### PR TITLE
[Node] Improve error messages when dynamic imports fail in Node vm contexts

### DIFF
--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -78,10 +78,10 @@ export async function getPHPLoaderModule(
 		) {
 			throw new Error(
 				`Node.js crashed on a 'import.meta' statement. This happens when running ` +
-					`in a node:vm context. Jest, the testing library, does that. Unfortunately, ` +
-					`node:vm does not support 'import.meta' statements and, by extension, it cannot ` +
-					`run the @php-wasm/node package. Consider switching from Jest to vitest ` +
-					`or another testing library.`,
+					`in a node:vm context. Some testing libraries like Jest use node:vm contexts, ` +
+					`which do not support 'import.meta' statements and, by extension, cannot ` +
+					`run the @php-wasm/node package. Consider using a different test runner ` +
+					`such as vitest, or running your code outside of a vm context.`,
 				{
 					cause: error,
 				}
@@ -98,10 +98,10 @@ export async function getPHPLoaderModule(
 		) {
 			throw new Error(
 				`Node.js crashed on a 'import()' statement. This happens when running ` +
-					`in a node:vm context. Jest, the testing library, does that. Unfortunately, ` +
-					`node:vm does not support 'import()' statements and, by extension, it cannot ` +
-					`run the @php-wasm/node package. Consider switching from Jest to vitest ` +
-					`or another testing library.`,
+					`in a node:vm context. Some testing libraries like Jest use node:vm contexts, ` +
+					`which do not support 'import()' statements and, by extension, cannot ` +
+					`run the @php-wasm/node package. Consider using a different test runner ` +
+					`such as vitest, or running your code outside of a vm context.`,
 				{
 					cause: error,
 				}

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -14,36 +14,99 @@ import type { PHPLoaderModule, SupportedPHPVersion } from '@php-wasm/universal';
  * @returns The PHP loader module.
  */
 export async function getPHPLoaderModule(
-	version: SupportedPHPVersion = LatestSupportedPHPVersion
+	version: SupportedPHPVersion | string = LatestSupportedPHPVersion
 ): Promise<PHPLoaderModule> {
-	switch (version) {
-		case '8.5':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-5')).getPHPLoaderModule();
-		case '8.4':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-4')).getPHPLoaderModule();
-		case '8.3':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-3')).getPHPLoaderModule();
-		case '8.2':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-2')).getPHPLoaderModule();
-		case '8.1':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-1')).getPHPLoaderModule();
-		case '8.0':
-			// @ts-ignore
-			return (await import('@php-wasm/node-8-0')).getPHPLoaderModule();
-		case '7.4':
-			// @ts-ignore
-			return (await import('@php-wasm/node-7-4')).getPHPLoaderModule();
-		case '7.3':
-			// @ts-ignore
-			return (await import('@php-wasm/node-7-3')).getPHPLoaderModule();
-		case '7.2':
-			// @ts-ignore
-			return (await import('@php-wasm/node-7-2')).getPHPLoaderModule();
+	try {
+		switch (version) {
+			case '8.5':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-8-5')
+				).getPHPLoaderModule();
+			case '8.4':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-8-4')
+				).getPHPLoaderModule();
+			case '8.3':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-8-3')
+				).getPHPLoaderModule();
+			case '8.2':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-8-2')
+				).getPHPLoaderModule();
+			case '8.1':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-8-1')
+				).getPHPLoaderModule();
+			case '8.0':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-8-0')
+				).getPHPLoaderModule();
+			case '7.4':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-7-4')
+				).getPHPLoaderModule();
+			case '7.3':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-7-3')
+				).getPHPLoaderModule();
+			case '7.2':
+				// @ts-ignore
+				return (
+					await import('@php-wasm/node-7-2')
+				).getPHPLoaderModule();
+		}
+
+		throw new Error(`Unsupported PHP version ${version}`);
+	} catch (errorCandidate) {
+		if (!errorCandidate || typeof errorCandidate !== 'object') {
+			throw errorCandidate;
+		}
+		const error = errorCandidate as { message?: string; code?: string };
+		if (
+			error.message?.includes(
+				`SyntaxError: Cannot use 'import.meta' outside a module`
+			)
+		) {
+			throw new Error(
+				`Node.js crashed on a 'import.meta' statement. This happens when running ` +
+					`in a node:vm context. Jest, the testing library, does that. Unfortunately, ` +
+					`node:vm does not support 'import.meta' statements and, by extension, it cannot ` +
+					`run the @php-wasm/node package. Consider switching from Jest to vitest ` +
+					`or another testing library.`,
+				{
+					cause: error,
+				}
+			);
+		} else if (
+			error?.code === `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` ||
+			error?.code === `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING_FLAG` ||
+			error?.message?.includes(
+				`A dynamic import callback was invoked without --experimental-vm-modules`
+			) ||
+			error?.message?.includes(
+				`A dynamic import callback was not specified`
+			)
+		) {
+			throw new Error(
+				`Node.js crashed on a 'import()' statement. This happens when running ` +
+					`in a node:vm context. Jest, the testing library, does that. Unfortunately, ` +
+					`node:vm does not support 'import()' statements and, by extension, it cannot ` +
+					`run the @php-wasm/node package. Consider switching from Jest to vitest ` +
+					`or another testing library.`,
+				{
+					cause: error,
+				}
+			);
+		}
+		throw error;
 	}
-	throw new Error(`Unsupported PHP version ${version}`);
 }

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -95,7 +95,8 @@ export async function getPHPLoaderModule(
 			) ||
 			error?.message?.includes(
 				`A dynamic import callback was not specified`
-			)
+			) ||
+			error?.message?.includes(`Must use import to load ES Module`)
 		) {
 			throw new Error(
 				`Node.js crashed on a 'import()' statement. This happens when running ` +

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -81,8 +81,8 @@ export async function getPHPLoaderModule(
 					`in a node:vm context. Some testing libraries like Jest use heavily customized ` +
 					`runtime contexts, involving node:vm, jest-runtime, and custom require() implementations. ` +
 					`These contexts do not support 'import.meta' statements and, by extension, cannot ` +
-					`run the @php-wasm/node package. Consider using a different test runner ` +
-					`such as vitest.`,
+					`run the @php-wasm/node package. ` +
+					`Consider using the --experimental-vm-modules flag or switching to a different test runner such as vitest.`,
 				{
 					cause: error,
 				}
@@ -102,7 +102,7 @@ export async function getPHPLoaderModule(
 					`in a node:vm context. Some testing libraries like Jest use runtime contexts, ` +
 					`involving node:vm, jest-runtime, or other custom require() implementations. These contexts do not support ` +
 					'import() statements and, by extension, cannot run the @php-wasm/node package. ' +
-					`Consider using a different test runner such as vitest.`,
+					`Consider using the --experimental-vm-modules flag or switching to a different test runner such as vitest.`,
 				{
 					cause: error,
 				}

--- a/packages/php-wasm/node/src/lib/get-php-loader-module.ts
+++ b/packages/php-wasm/node/src/lib/get-php-loader-module.ts
@@ -78,10 +78,11 @@ export async function getPHPLoaderModule(
 		) {
 			throw new Error(
 				`Node.js crashed on a 'import.meta' statement. This happens when running ` +
-					`in a node:vm context. Some testing libraries like Jest use node:vm contexts, ` +
-					`which do not support 'import.meta' statements and, by extension, cannot ` +
+					`in a node:vm context. Some testing libraries like Jest use heavily customized ` +
+					`runtime contexts, involving node:vm, jest-runtime, and custom require() implementations. ` +
+					`These contexts do not support 'import.meta' statements and, by extension, cannot ` +
 					`run the @php-wasm/node package. Consider using a different test runner ` +
-					`such as vitest, or running your code outside of a vm context.`,
+					`such as vitest.`,
 				{
 					cause: error,
 				}
@@ -98,10 +99,10 @@ export async function getPHPLoaderModule(
 		) {
 			throw new Error(
 				`Node.js crashed on a 'import()' statement. This happens when running ` +
-					`in a node:vm context. Some testing libraries like Jest use node:vm contexts, ` +
-					`which do not support 'import()' statements and, by extension, cannot ` +
-					`run the @php-wasm/node package. Consider using a different test runner ` +
-					`such as vitest, or running your code outside of a vm context.`,
+					`in a node:vm context. Some testing libraries like Jest use runtime contexts, ` +
+					`involving node:vm, jest-runtime, or other custom require() implementations. These contexts do not support ` +
+					'import() statements and, by extension, cannot run the @php-wasm/node package. ' +
+					`Consider using a different test runner such as vitest.`,
 				{
 					cause: error,
 				}

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -55,10 +55,10 @@ SupportedPHPVersions.filter(
 	 * @see https://github.com/vercel/next.js/issues/41725
 	 * @see https://github.com/WordPress/wordpress-playground/pull/3099 and the discussion.
 	 */
-	it('Should throw a helpful error when loading PHP loader module in Jest', async () => {
+	it('Should throw a helpful error when loading PHP loader module in vm context', async () => {
 		await expect(getPHPLoaderModule('8.5')).rejects.toThrow(
 			expect.objectContaining({
-				message: expect.stringContaining('Jest'),
+				message: expect.stringContaining('node:vm context'),
 			})
 		);
 
@@ -66,10 +66,12 @@ SupportedPHPVersions.filter(
 			await getPHPLoaderModule('8.5');
 			fail('Expected getPHPLoaderModule to throw an error');
 		} catch (error: any) {
-			// Verify the error message is helpful and mentions Jest
-			expect(error.message).toMatch(
-				/Consider switching from Jest to vitest/
-			);
+			// Verify the error message is helpful and mentions the issue
+			expect(error.message).toMatch(/node:vm context/);
+			// Verify it mentions testing libraries as examples
+			expect(error.message).toMatch(/testing libraries like Jest/);
+			// Verify it suggests alternatives
+			expect(error.message).toMatch(/vitest/);
 		}
 	});
 });

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -67,7 +67,7 @@ SupportedPHPVersions.filter(
 			fail('Expected getPHPLoaderModule to throw an error');
 		} catch (error: any) {
 			expect(error.message).toMatch(
-				/Consider using a different test runner/
+				/switching to a different test runner such as vitest/
 			);
 		}
 	});

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -66,12 +66,9 @@ SupportedPHPVersions.filter(
 			await getPHPLoaderModule('8.5');
 			fail('Expected getPHPLoaderModule to throw an error');
 		} catch (error: any) {
-			// Verify the error message is helpful and mentions the issue
-			expect(error.message).toMatch(/node:vm context/);
-			// Verify it mentions testing libraries as examples
-			expect(error.message).toMatch(/testing libraries like Jest/);
-			// Verify it suggests alternatives
-			expect(error.message).toMatch(/vitest/);
+			expect(error.message).toMatch(
+				/Consider using a different test runner/
+			);
 		}
 	});
 });

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -1,4 +1,5 @@
 const { SupportedPHPVersions } = require('@php-wasm/universal');
+const { getPHPLoaderModule } = require('@php-wasm/node');
 const { runCLI } = require('@wp-playground/cli');
 const path = require('path');
 
@@ -44,6 +45,31 @@ SupportedPHPVersions.filter(
 			const resolvedBasePath = require.resolve(`@wp-playground/cli`);
 			const filePath = path.join(resolvedBasePath, file);
 			expect(filePath).toBeTruthy();
+		}
+	});
+
+	/**
+	 * Jest struggles with dynamic imports in vm contexts. This test ensures that
+	 * the error thrown is helpful and actionable.
+	 *
+	 * @see https://github.com/vercel/next.js/issues/41725
+	 * @see https://github.com/WordPress/wordpress-playground/pull/3099 and the discussion.
+	 */
+	it('Should throw a helpful error when loading PHP loader module in Jest', async () => {
+		await expect(getPHPLoaderModule('8.5')).rejects.toThrow(
+			expect.objectContaining({
+				message: expect.stringContaining('Jest'),
+			})
+		);
+
+		try {
+			await getPHPLoaderModule('8.5');
+			fail('Expected getPHPLoaderModule to throw an error');
+		} catch (error: any) {
+			// Verify the error message is helpful and mentions Jest
+			expect(error.message).toMatch(
+				/Consider switching from Jest to vitest/
+			);
 		}
 	});
 });


### PR DESCRIPTION
## Summary

Makes the `getPHPLoaderModule()` failures in `jest` context clearer.

## Rationale

When `getPHPLoaderModule()` runs in `jest` context, it crashes with errors similar to this:

```
SyntaxError: Cannot use 'import.meta' outside a module
```

Meanwhile, calling `getPHPLoaderModule()` via vanilla `node` binary in a CommonJS context works just fine.

This seems to be caused by Jest using:

* The `node:vm` module which impacts the CJS/ESM interop
* Its own `require()` and `import()` handlers with limited CJS/ESM interop
* As Jest says, `Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.` That default configuration seems to be rather limited.

One solution is running node with the `--experimental-vm-modules` flag. Another is to switch to another test runner.  This PR makes both solutions clear in the error message.

## What changed

The function now rethrows the following `getPHPLoaderModule()` errors with more specific error details:

1. **import.meta errors** - When code tries to use import.meta in a vm context
2. **Dynamic import callback errors** - When import() statements fail due to missing vm module support

## Test plan

Added a Jest test that verifies the error handling works correctly and produces the expected helpful error message.