### PR TITLE
[PHP] Add mmap support to proxyFS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -380,6 +380,7 @@
 			"integrity": "sha512-ZsOJqu4HOG5BlvIFnMU0YKjQ9ZI6r3C31dg2jk5kMWPSdhJpYL9xa5hEe7aieE+707dXeMI4ej3diy6mXdZpgA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@algolia/client-common": "5.46.2",
 				"@algolia/requester-browser-xhr": "5.46.2",
@@ -550,6 +551,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -2512,6 +2514,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.19.0.tgz",
 			"integrity": "sha512-61Hfv3cF07XvUxNeC3E7jhG8XNi1Yom1G0lRC936oLnlF+jrbrv8rc/J98XlYzcsAoTVupfsf5fLej1aI8kyIg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
@@ -2524,6 +2527,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
 			"integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.4.0",
@@ -2536,6 +2540,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
 			"integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/language": "^6.0.0",
@@ -2549,6 +2554,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.10.tgz",
 			"integrity": "sha512-h/SceTVsN5r+WE+TVP2g3KDvNoSzbSrtZXCKo4vkKdbfT5t4otuVgngGdFukOO/rwRD2++pCxoh6xD4TEVMkQA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/lang-css": "^6.0.0",
@@ -2566,6 +2572,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
 			"integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/language": "^6.6.0",
@@ -2581,6 +2588,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
 			"integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@lezer/json": "^1.0.0"
@@ -2591,6 +2599,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.3.4.tgz",
 			"integrity": "sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.7.1",
 				"@codemirror/lang-html": "^6.0.0",
@@ -2606,6 +2615,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
 			"integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/lang-html": "^6.0.0",
 				"@codemirror/language": "^6.0.0",
@@ -2633,6 +2643,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
 			"integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
@@ -2658,6 +2669,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
 			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
@@ -2669,6 +2681,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
 			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
@@ -2690,6 +2703,7 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.3.tgz",
 			"integrity": "sha512-x2t87+oqwB1mduiQZ6huIghjMt4uZKFEdj66IcXw7+a5iBEvv9lh7EWDRHI7crnD4BMGpnyq/RzmCGbiEZLcvQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.5.0",
 				"crelt": "^1.0.6",
@@ -2838,6 +2852,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2860,6 +2875,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2969,6 +2985,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -3390,6 +3407,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -4464,6 +4482,7 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
 			"integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@docusaurus/logger": "3.9.2",
 				"@docusaurus/utils": "3.9.2",
@@ -4582,6 +4601,7 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
 			"integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@docusaurus/core": "3.9.2",
 				"@docusaurus/logger": "3.9.2",
@@ -5345,6 +5365,7 @@
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
 			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -7411,6 +7432,7 @@
 			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
 			"integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/mdx": "^2.0.0"
 			},
@@ -8815,6 +8837,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@napi-rs/wasm-runtime": "0.2.4",
 				"@yarnpkg/lockfile": "^1.1.0",
@@ -10082,6 +10105,7 @@
 			"integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^3.0.0",
 				"@octokit/graphql": "^5.0.0",
@@ -10592,6 +10616,7 @@
 			"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -12685,6 +12710,7 @@
 			"integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.21.3",
 				"@svgr/babel-preset": "8.1.0",
@@ -13443,6 +13469,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -14094,6 +14121,7 @@
 			"integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.9.2"
 			}
@@ -14539,6 +14567,7 @@
 			"integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.9.2"
 			}
@@ -14778,7 +14807,6 @@
 			"integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "8.52.0",
 				"@typescript-eslint/visitor-keys": "8.52.0"
@@ -14797,7 +14825,6 @@
 			"integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "8.52.0",
 				"eslint-visitor-keys": "^4.2.1"
@@ -14816,7 +14843,6 @@
 			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -17745,6 +17771,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -17874,6 +17901,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
 			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -17935,6 +17963,7 @@
 			"integrity": "sha512-qqAXW9QvKf2tTyhpDA4qXv1IfBwD2eduSW6tUEBFIfCeE9gn9HQ9I5+MaKoenRuHrzk5sQoNh1/iof8mY7uD6Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@algolia/abtesting": "1.12.2",
 				"@algolia/client-abtesting": "5.46.2",
@@ -19303,6 +19332,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -21394,6 +21424,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -21728,6 +21759,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cypress/request": "^3.0.6",
 				"@cypress/xvfb": "^1.2.4",
@@ -23297,6 +23329,7 @@
 			"integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -24605,6 +24638,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -28388,6 +28422,7 @@
 			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -28472,24 +28507,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/jest-circus/node_modules/babel-plugin-macros": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@babel/runtime": "^7.12.5",
-				"cosmiconfig": "^7.0.0",
-				"resolve": "^1.19.0"
-			},
-			"engines": {
-				"node": ">=10",
-				"npm": ">=6"
-			}
-		},
 		"node_modules/jest-circus/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -28514,7 +28531,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
@@ -30943,6 +30959,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@nrwl/tao": "16.10.0",
 				"@parcel/watcher": "2.0.4",
@@ -32080,6 +32097,7 @@
 			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -36061,6 +36079,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -36119,6 +36138,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@napi-rs/wasm-runtime": "0.2.4",
 				"@nrwl/tao": "19.8.4",
@@ -36464,6 +36484,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -37981,6 +38002,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -38884,6 +38906,7 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -39934,6 +39957,7 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -40026,6 +40050,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -40097,6 +40122,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -40229,6 +40255,7 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
 			"integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/react": "*"
 			},
@@ -40973,6 +41000,7 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
 			"integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.1",
 				"@types/hoist-non-react-statics": "^3.3.1",
@@ -41081,6 +41109,7 @@
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
 			"integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.13",
 				"history": "^4.9.0",
@@ -41683,7 +41712,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -42340,6 +42370,7 @@
 			"integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -42576,6 +42607,7 @@
 			"integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -45488,6 +45520,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -45926,7 +45959,8 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/tsscmp": {
 			"version": "1.0.6",
@@ -46412,6 +46446,7 @@
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -46897,6 +46932,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -47251,6 +47287,7 @@
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -47794,6 +47831,7 @@
 			"integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "2.1.9",
 				"@vitest/mocker": "2.1.9",
@@ -47895,6 +47933,7 @@
 			"integrity": "sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@volar/typescript": "~1.11.1",
 				"@vue/language-core": "1.8.27",
@@ -47999,6 +48038,7 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
 			"integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -48927,6 +48967,7 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
 			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -49053,7 +49094,8 @@
 			"integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
 			"deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/xterm-addon-fit": {
 			"version": "0.8.0",
@@ -49224,6 +49266,7 @@
 			"integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lib0": "^0.2.99"
 			},
@@ -49275,6 +49318,7 @@
 			"integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -380,7 +380,6 @@
 			"integrity": "sha512-ZsOJqu4HOG5BlvIFnMU0YKjQ9ZI6r3C31dg2jk5kMWPSdhJpYL9xa5hEe7aieE+707dXeMI4ej3diy6mXdZpgA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@algolia/client-common": "5.46.2",
 				"@algolia/requester-browser-xhr": "5.46.2",
@@ -551,7 +550,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -2514,7 +2512,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.19.0.tgz",
 			"integrity": "sha512-61Hfv3cF07XvUxNeC3E7jhG8XNi1Yom1G0lRC936oLnlF+jrbrv8rc/J98XlYzcsAoTVupfsf5fLej1aI8kyIg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
@@ -2527,7 +2524,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
 			"integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.4.0",
@@ -2540,7 +2536,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
 			"integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/language": "^6.0.0",
@@ -2554,7 +2549,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.10.tgz",
 			"integrity": "sha512-h/SceTVsN5r+WE+TVP2g3KDvNoSzbSrtZXCKo4vkKdbfT5t4otuVgngGdFukOO/rwRD2++pCxoh6xD4TEVMkQA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/lang-css": "^6.0.0",
@@ -2572,7 +2566,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
 			"integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/language": "^6.6.0",
@@ -2588,7 +2581,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-json/-/lang-json-6.0.2.tgz",
 			"integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@lezer/json": "^1.0.0"
@@ -2599,7 +2591,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.3.4.tgz",
 			"integrity": "sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.7.1",
 				"@codemirror/lang-html": "^6.0.0",
@@ -2615,7 +2606,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
 			"integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/lang-html": "^6.0.0",
 				"@codemirror/language": "^6.0.0",
@@ -2643,7 +2633,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
 			"integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
@@ -2669,7 +2658,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
 			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
@@ -2681,7 +2669,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
 			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
@@ -2703,7 +2690,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.3.tgz",
 			"integrity": "sha512-x2t87+oqwB1mduiQZ6huIghjMt4uZKFEdj66IcXw7+a5iBEvv9lh7EWDRHI7crnD4BMGpnyq/RzmCGbiEZLcvQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.5.0",
 				"crelt": "^1.0.6",
@@ -2852,7 +2838,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2875,7 +2860,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2985,7 +2969,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -3407,7 +3390,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -4482,7 +4464,6 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
 			"integrity": "sha512-wiYoGwF9gdd6rev62xDU8AAM8JuLI/hlwOtCzMmYcspEkzecKrP8J8X+KpYnTlACBUUtXNJpSoCwFWJhLRevzQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@docusaurus/logger": "3.9.2",
 				"@docusaurus/utils": "3.9.2",
@@ -4601,7 +4582,6 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.9.2.tgz",
 			"integrity": "sha512-C5wZsGuKTY8jEYsqdxhhFOe1ZDjH0uIYJ9T/jebHwkyxqnr4wW0jTkB72OMqNjsoQRcb0JN3PcSeTwFlVgzCZg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@docusaurus/core": "3.9.2",
 				"@docusaurus/logger": "3.9.2",
@@ -5365,7 +5345,6 @@
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
 			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -7432,7 +7411,6 @@
 			"resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
 			"integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/mdx": "^2.0.0"
 			},
@@ -8837,7 +8815,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@napi-rs/wasm-runtime": "0.2.4",
 				"@yarnpkg/lockfile": "^1.1.0",
@@ -10105,7 +10082,6 @@
 			"integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^3.0.0",
 				"@octokit/graphql": "^5.0.0",
@@ -10616,7 +10592,6 @@
 			"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -12710,7 +12685,6 @@
 			"integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/core": "^7.21.3",
 				"@svgr/babel-preset": "8.1.0",
@@ -13469,7 +13443,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-V0kuGBX3+prX+DQ/7r2qsv1NsdfnCLnTgnRJ1pYnxykBhGMz+qj+box5lq7XsO5mtZsBqpjwwTu/7wszPfMBcw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -14121,7 +14094,6 @@
 			"integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.9.2"
 			}
@@ -14567,7 +14539,6 @@
 			"integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.9.2"
 			}
@@ -14807,6 +14778,7 @@
 			"integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "8.52.0",
 				"@typescript-eslint/visitor-keys": "8.52.0"
@@ -14825,6 +14797,7 @@
 			"integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "8.52.0",
 				"eslint-visitor-keys": "^4.2.1"
@@ -14843,6 +14816,7 @@
 			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -17771,7 +17745,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -17901,7 +17874,6 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
 			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -17963,7 +17935,6 @@
 			"integrity": "sha512-qqAXW9QvKf2tTyhpDA4qXv1IfBwD2eduSW6tUEBFIfCeE9gn9HQ9I5+MaKoenRuHrzk5sQoNh1/iof8mY7uD6Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@algolia/abtesting": "1.12.2",
 				"@algolia/client-abtesting": "5.46.2",
@@ -19332,7 +19303,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -21424,7 +21394,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -21759,7 +21728,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cypress/request": "^3.0.6",
 				"@cypress/xvfb": "^1.2.4",
@@ -23329,7 +23297,6 @@
 			"integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -24638,7 +24605,6 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -28422,7 +28388,6 @@
 			"integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "^29.7.0",
 				"@jest/types": "^29.6.3",
@@ -28507,6 +28472,24 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/jest-circus/node_modules/babel-plugin-macros": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.12.5",
+				"cosmiconfig": "^7.0.0",
+				"resolve": "^1.19.0"
+			},
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/jest-circus/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -28531,6 +28514,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
@@ -30959,7 +30943,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@nrwl/tao": "16.10.0",
 				"@parcel/watcher": "2.0.4",
@@ -32097,7 +32080,6 @@
 			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -36079,7 +36061,6 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -36138,7 +36119,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@napi-rs/wasm-runtime": "0.2.4",
 				"@nrwl/tao": "19.8.4",
@@ -36484,7 +36464,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -38002,7 +37981,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -38906,7 +38884,6 @@
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
 			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
 				"util-deprecate": "^1.0.2"
@@ -39957,7 +39934,6 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -40050,7 +40026,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -40122,7 +40097,6 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -40255,7 +40229,6 @@
 			"resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
 			"integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/react": "*"
 			},
@@ -41000,7 +40973,6 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-8.1.3.tgz",
 			"integrity": "sha512-n0ZrutD7DaX/j9VscF+uTALI3oUPa/pO4Z3soOBIjuRn/FzVu6aehhysxZCLi6y7duMf52WNZGMl7CtuK5EnRw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.1",
 				"@types/hoist-non-react-statics": "^3.3.1",
@@ -41109,7 +41081,6 @@
 			"resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
 			"integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.12.13",
 				"history": "^4.9.0",
@@ -41712,8 +41683,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -42370,7 +42340,6 @@
 			"integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -42607,7 +42576,6 @@
 			"integrity": "sha512-wovtnV2PxzteLlfNzbgm1tFXPLoZILYAMJtvoXXkD7/+1uP41eKkIt1ypWq5/q2uT94qHjXehEYfmjKOvjL9sg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
 				"immutable": "^4.0.0",
@@ -45520,7 +45488,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -45959,8 +45926,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tsscmp": {
 			"version": "1.0.6",
@@ -46446,7 +46412,6 @@
 			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -46932,7 +46897,6 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -47287,7 +47251,6 @@
 			"integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -47831,7 +47794,6 @@
 			"integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "2.1.9",
 				"@vitest/mocker": "2.1.9",
@@ -47933,7 +47895,6 @@
 			"integrity": "sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@volar/typescript": "~1.11.1",
 				"@vue/language-core": "1.8.27",
@@ -48038,7 +47999,6 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
 			"integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -48967,7 +48927,6 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
 			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -49094,8 +49053,7 @@
 			"integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
 			"deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/xterm-addon-fit": {
 			"version": "0.8.0",
@@ -49266,7 +49224,6 @@
 			"integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"lib0": "^0.2.99"
 			},
@@ -49318,7 +49275,6 @@
 			"integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -238,7 +238,8 @@
 					"php-networking.spec.ts",
 					"php-dynamic-loading.spec.ts",
 					"php-mysqli.spec.ts",
-					"php-process-manager.spec.ts"
+					"php-process-manager.spec.ts",
+					"proxyfs-mmap.spec.ts"
 				]
 			}
 		},
@@ -254,7 +255,8 @@
 					"php-networking.spec.ts",
 					"php-dynamic-loading.spec.ts",
 					"php-mysqli.spec.ts",
-					"php-process-manager.spec.ts"
+					"php-process-manager.spec.ts",
+					"proxyfs-mmap.spec.ts"
 				]
 			}
 		},

--- a/packages/php-wasm/node/src/test/php-dynamic-loading.spec.ts
+++ b/packages/php-wasm/node/src/test/php-dynamic-loading.spec.ts
@@ -2,6 +2,7 @@ import { loadNodeRuntime } from '..';
 import {
 	PHP,
 	SupportedPHPVersions,
+	proxyFileSystem,
 	setPhpIniEntries,
 } from '@php-wasm/universal';
 import fs from 'fs';
@@ -223,6 +224,36 @@ describe.each(phpVersions)('PHP %s', async (phpVersion) => {
 			 * which means the ICU data file must use that exact name.
 			 */
 			expect(php.listFiles('/internal/shared')).toContain('icudt74l.dat');
+		});
+
+		it('reads the icu data in PROXYFS', async () => {
+			const newPhp = new PHP(
+				await loadNodeRuntime(phpVersion as any, {
+					withIntl: true,
+				})
+			);
+
+			proxyFileSystem(php, newPhp, ['/internal/shared']);
+
+			const response = await newPhp.runStream({
+				code: `<?php
+						$data = array(
+							'F' => 'Foo',
+							'Br' => 'Bar',
+							'Bz' => 'Bz',
+						);
+
+						$collator = new Collator('en_US');
+						$collator->asort($data, Collator::SORT_STRING);
+						var_dump($data);
+					?>`,
+			});
+
+			newPhp.exit();
+
+			expect(await response.stdoutText).toEqual(
+				'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
+			);
 		});
 
 		it('uses intl functions', async () => {

--- a/packages/php-wasm/node/src/test/proxyfs-mmap.spec.ts
+++ b/packages/php-wasm/node/src/test/proxyfs-mmap.spec.ts
@@ -1,0 +1,254 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+	PHP,
+	proxyFileSystem,
+	type SupportedPHPVersion,
+} from '@php-wasm/universal';
+import { SupportedPHPVersions } from '@php-wasm/universal';
+import { createNodeFsMountHandler, loadNodeRuntime } from '../lib';
+
+const phpVersionsToTest =
+	'PHP' in process.env
+		? [process.env['PHP']! as SupportedPHPVersion]
+		: SupportedPHPVersions;
+
+// PHP versions that support the Intl extension with ICU
+const phpVersionsWithIntl: SupportedPHPVersion[] = ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
+
+/**
+ * These tests verify that PROXYFS properly supports mmap operations.
+ *
+ * PROXYFS proxies filesystem operations from one Emscripten FS instance to another,
+ * enabling file sharing between PHP instances. Without mmap support, libraries like
+ * ICU (used by the Intl extension) fail because they rely on memory-mapping data files.
+ *
+ * See: https://github.com/WordPress/wordpress-playground/pull/3073
+ */
+describe.each(phpVersionsToTest)('PHP %s: PROXYFS mmap', (phpVersion) => {
+	const vfsMountPoint = '/test';
+
+	let tempDir: string;
+
+	beforeEach(async () => {
+		tempDir = mkdtempSync(join(tmpdir(), 'php-wasm-proxyfs-mmap-'));
+	});
+
+	afterEach(async () => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	async function createPhpWithTestMount(): Promise<PHP> {
+		const runtimeId = await loadNodeRuntime(phpVersion);
+		const php = new PHP(runtimeId);
+		php.mount(vfsMountPoint, createNodeFsMountHandler(tempDir));
+		return php;
+	}
+
+	describe('mmap via PROXYFS', () => {
+		it('should read file contents through PROXYFS using file_get_contents', async () => {
+			// This test verifies that basic file reading works through PROXYFS,
+			// which exercises the underlying read operations that mmap depends on.
+			const testContent = 'Hello from PROXYFS!';
+			writeFileSync(join(tempDir, 'test.txt'), testContent);
+
+			using php1 = await createPhpWithTestMount();
+			using php2 = new PHP(await loadNodeRuntime(phpVersion));
+
+			// Mount PROXYFS on php2, pointing to php1's filesystem
+			proxyFileSystem(php1, php2, [vfsMountPoint]);
+
+			const result = await php2.run({
+				code: `<?php
+					$content = file_get_contents('${vfsMountPoint}/test.txt');
+					echo $content;
+				`,
+			});
+
+			expect(result.exitCode).toBe(0);
+			expect(result.text).toBe(testContent);
+		});
+
+		it('should read binary files through PROXYFS', async () => {
+			// Binary file reading is important for mmap as ICU data files are binary.
+			const binaryData = Buffer.from([
+				0x00, 0x01, 0x02, 0x03, 0xff, 0xfe, 0xfd,
+			]);
+			writeFileSync(join(tempDir, 'binary.dat'), binaryData);
+
+			using php1 = await createPhpWithTestMount();
+			using php2 = new PHP(await loadNodeRuntime(phpVersion));
+
+			proxyFileSystem(php1, php2, [vfsMountPoint]);
+
+			const result = await php2.run({
+				code: `<?php
+					$content = file_get_contents('${vfsMountPoint}/binary.dat');
+					// Output bytes as hex
+					echo bin2hex($content);
+				`,
+			});
+
+			expect(result.exitCode).toBe(0);
+			expect(result.text).toBe('00010203fffefd');
+		});
+
+		it('should read large files through PROXYFS', async () => {
+			// Larger files test the mmap implementation's ability to handle
+			// multi-byte reads that span memory pages.
+			const largeContent = 'x'.repeat(1024 * 100); // 100KB
+			writeFileSync(join(tempDir, 'large.txt'), largeContent);
+
+			using php1 = await createPhpWithTestMount();
+			using php2 = new PHP(await loadNodeRuntime(phpVersion));
+
+			proxyFileSystem(php1, php2, [vfsMountPoint]);
+
+			const result = await php2.run({
+				code: `<?php
+					$content = file_get_contents('${vfsMountPoint}/large.txt');
+					echo strlen($content);
+				`,
+			});
+
+			expect(result.exitCode).toBe(0);
+			expect(result.text).toBe(String(largeContent.length));
+		});
+
+		it('should read file at specific position through PROXYFS', async () => {
+			// This tests partial file reading which is related to mmap with position offset.
+			const testContent = 'ABCDEFGHIJ';
+			writeFileSync(join(tempDir, 'position.txt'), testContent);
+
+			using php1 = await createPhpWithTestMount();
+			using php2 = new PHP(await loadNodeRuntime(phpVersion));
+
+			proxyFileSystem(php1, php2, [vfsMountPoint]);
+
+			const result = await php2.run({
+				code: `<?php
+					$fp = fopen('${vfsMountPoint}/position.txt', 'r');
+					fseek($fp, 3);
+					$content = fread($fp, 4);
+					fclose($fp);
+					echo $content;
+				`,
+			});
+
+			expect(result.exitCode).toBe(0);
+			expect(result.text).toBe('DEFG');
+		});
+
+		it('should allow both PHP instances to read the same file simultaneously', async () => {
+			// This tests concurrent access through PROXYFS, which is important
+			// for understanding how mmap might behave with shared memory.
+			const testContent = 'Shared content';
+			writeFileSync(join(tempDir, 'shared.txt'), testContent);
+
+			using php1 = await createPhpWithTestMount();
+			using php2 = new PHP(await loadNodeRuntime(phpVersion));
+
+			proxyFileSystem(php1, php2, [vfsMountPoint]);
+
+			const [result1, result2] = await Promise.all([
+				php1.run({
+					code: `<?php echo file_get_contents('${vfsMountPoint}/shared.txt');`,
+				}),
+				php2.run({
+					code: `<?php echo file_get_contents('${vfsMountPoint}/shared.txt');`,
+				}),
+			]);
+
+			expect(result1.exitCode).toBe(0);
+			expect(result2.exitCode).toBe(0);
+			expect(result1.text).toBe(testContent);
+			expect(result2.text).toBe(testContent);
+		});
+	});
+});
+
+/**
+ * These tests verify that ICU/Intl works through PROXYFS.
+ *
+ * The Intl extension relies on ICU, which uses mmap to load its data files.
+ * Without proper mmap support in PROXYFS, ICU fails to initialize the Collator
+ * class and other Intl functionality when the /internal/shared directory
+ * (which contains the ICU data file) is accessed through PROXYFS.
+ *
+ * The proxyFileSystem() function now automatically adds mmap support to PROXYFS
+ * at runtime, so these tests should pass without rebuilding PHP.
+ *
+ * See: https://github.com/WordPress/wordpress-playground/pull/3073
+ */
+describe.each(
+	phpVersionsToTest.filter((v) => phpVersionsWithIntl.includes(v))
+)('PHP %s: Intl extension via PROXYFS (mmap)', (phpVersion) => {
+	it('should use Collator through PROXYFS', async () => {
+		// Create php1 with Intl support - it has the ICU data file
+		using php1 = new PHP(
+			await loadNodeRuntime(phpVersion, { withIntl: true })
+		);
+
+		// Create php2 with Intl support
+		using php2 = new PHP(
+			await loadNodeRuntime(phpVersion, { withIntl: true })
+		);
+
+		// Mount PROXYFS on php2, sharing /internal/shared from php1.
+		// This is where the ICU data file (icudt74l.dat) lives.
+		// ICU uses mmap to read this file, so this tests that our
+		// PROXYFS mmap implementation works correctly.
+		// proxyFileSystem() automatically adds mmap support to PROXYFS.
+		proxyFileSystem(php1, php2, ['/internal/shared']);
+
+		// Test that Collator works in php2 through PROXYFS.
+		// This would fail without mmap support because ICU's uprv_mapFile
+		// function uses mmap to load the data file.
+		const result = await php2.run({
+			code: `<?php
+				try {
+					$collator = new Collator('en_US');
+					$data = ['banana', 'apple', 'cherry'];
+					$collator->sort($data);
+					echo json_encode($data);
+				} catch (IntlException $e) {
+					echo 'IntlException: ' . $e->getMessage();
+				} catch (Exception $e) {
+					echo 'Exception: ' . $e->getMessage();
+				}
+			`,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.text).toBe('["apple","banana","cherry"]');
+	});
+
+	it('should use NumberFormatter through PROXYFS', async () => {
+		using php1 = new PHP(
+			await loadNodeRuntime(phpVersion, { withIntl: true })
+		);
+
+		using php2 = new PHP(
+			await loadNodeRuntime(phpVersion, { withIntl: true })
+		);
+
+		proxyFileSystem(php1, php2, ['/internal/shared']);
+
+		const result = await php2.run({
+			code: `<?php
+				try {
+					$formatter = new NumberFormatter('en_US', NumberFormatter::CURRENCY);
+					echo $formatter->format(1234.56);
+				} catch (IntlException $e) {
+					echo 'IntlException: ' . $e->getMessage();
+				} catch (Exception $e) {
+					echo 'Exception: ' . $e->getMessage();
+				}
+			`,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.text).toBe('$1,234.56');
+	});
+});

--- a/packages/php-wasm/node/src/test/proxyfs-mmap.spec.ts
+++ b/packages/php-wasm/node/src/test/proxyfs-mmap.spec.ts
@@ -14,9 +14,6 @@ const phpVersionsToTest =
 		? [process.env['PHP']! as SupportedPHPVersion]
 		: SupportedPHPVersions;
 
-// PHP versions that support the Intl extension with ICU
-const phpVersionsWithIntl: SupportedPHPVersion[] = ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
-
 /**
  * These tests verify that PROXYFS properly supports mmap operations.
  *
@@ -181,9 +178,7 @@ describe.each(phpVersionsToTest)('PHP %s: PROXYFS mmap', (phpVersion) => {
  *
  * See: https://github.com/WordPress/wordpress-playground/pull/3073
  */
-describe.each(
-	phpVersionsToTest.filter((v) => phpVersionsWithIntl.includes(v))
-)('PHP %s: Intl extension via PROXYFS (mmap)', (phpVersion) => {
+describe.each(phpVersionsToTest)('PHP %s: Intl extension via PROXYFS (mmap)', (phpVersion) => {
 	it('should use Collator through PROXYFS', async () => {
 		// Create php1 with Intl support - it has the ICU data file
 		using php1 = new PHP(

--- a/packages/php-wasm/node/src/test/proxyfs-mmap.spec.ts
+++ b/packages/php-wasm/node/src/test/proxyfs-mmap.spec.ts
@@ -15,7 +15,7 @@ const phpVersionsToTest =
 		: SupportedPHPVersions;
 
 // PHP versions that support the Intl extension with ICU
-const phpVersionsWithIntl: SupportedPHPVersion[] = ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
+const phpVersionsWithIntl: SupportedPHPVersion[] = ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5'];
 
 /**
  * These tests verify that PROXYFS properly supports mmap operations.

--- a/packages/php-wasm/universal/src/lib/proxy-file-system.ts
+++ b/packages/php-wasm/universal/src/lib/proxy-file-system.ts
@@ -53,8 +53,8 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 		}
 
 		// For non-.dat files, get the actual file size from the proxied filesystem.
-		// This is needed because older PHP versions (7.2-7.4) may pass incorrect
-		// length values for certain file types.
+		// This is needed because PHP 7.4 may pass incorrect length values for
+		// certain file types.
 		const path = FS.getPath(stream.node);
 		if (!path.endsWith('.dat')) {
 			// Get the proxied filesystem from the mount options

--- a/packages/php-wasm/universal/src/lib/proxy-file-system.ts
+++ b/packages/php-wasm/universal/src/lib/proxy-file-system.ts
@@ -53,14 +53,6 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 			throw new FS.ErrnoError(19); // ENODEV
 		}
 
-		const proxyFS = stream.node.mount.opts.fs;
-		if (proxyFS && stream.nfd !== undefined) {
-			const stat = proxyFS.fstat(stream.nfd);
-			if (stat && stat.size !== undefined) {
-				length = stat.size >>> 0;
-			}
-		}
-
 		// ICU only maps files from offset 0, so we don't support partial mapping
 		if (position !== 0) {
 			throw new FS.ErrnoError(22); // EINVAL

--- a/packages/php-wasm/universal/src/lib/proxy-file-system.ts
+++ b/packages/php-wasm/universal/src/lib/proxy-file-system.ts
@@ -53,19 +53,11 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 			throw new FS.ErrnoError(19); // ENODEV
 		}
 
-		// PHP 7.4's mmap implementation passes the wrong length for files that aren't
-		// ICU data files (.dat). Instead of passing the actual file size, it passes
-		// a value from the stat buffer that doesn't represent the file's true length.
-		// Work around this by querying the actual file size from the proxied filesystem
-		// using fstat. ICU .dat files work correctly, so skip this workaround for them.
-		const path = FS.getPath(stream.node);
-		if (!path.endsWith('.dat')) {
-			const proxyFS = stream.node.mount.opts.fs;
-			if (proxyFS && stream.nfd !== undefined) {
-				const stat = proxyFS.fstat(stream.nfd);
-				if (stat && stat.size !== undefined) {
-					length = stat.size >>> 0;
-				}
+		const proxyFS = stream.node.mount.opts.fs;
+		if (proxyFS && stream.nfd !== undefined) {
+			const stat = proxyFS.fstat(stream.nfd);
+			if (stat && stat.size !== undefined) {
+				length = stat.size >>> 0;
 			}
 		}
 

--- a/packages/php-wasm/universal/src/lib/proxy-file-system.ts
+++ b/packages/php-wasm/universal/src/lib/proxy-file-system.ts
@@ -52,24 +52,54 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 			throw new FS.ErrnoError(19); // ENODEV
 		}
 
-		// Allocate memory for the mapped region using the runtime's malloc
-		const ptr = runtime.wasmExports.malloc(length);
+		// For non-.dat files, get the actual file size from the proxied filesystem.
+		// This is needed because older PHP versions (7.2-7.4) may pass incorrect
+		// length values for certain file types.
+		const path = FS.getPath(stream.node);
+		if (!path.endsWith('.dat')) {
+			// Get the proxied filesystem from the mount options
+			const proxyFS = stream.node.mount.opts.fs;
+			if (proxyFS && stream.nfd !== undefined) {
+				const stat = proxyFS.fstat(stream.nfd);
+				if (stat && stat.size !== undefined) {
+					length = stat.size >>> 0;
+				}
+			}
+		}
+
+		// Only support mmap from the beginning of the file
+		if (position !== 0) {
+			throw new FS.ErrnoError(22); // EINVAL
+		}
+
+		// Allocate memory for the mapped region using the runtime's malloc.
+		const ptr = runtime.malloc(length);
 		if (!ptr) {
 			throw new FS.ErrnoError(48); // ENOMEM
 		}
 
-		// Read the file contents into the allocated memory
-		const bytesRead = stream.stream_ops.read(
-			stream,
-			runtime.HEAPU8,
-			ptr,
-			length,
-			position
-		);
+		// Create a view into the heap for reading
+		const heap = runtime.HEAPU8.subarray(ptr, ptr + length);
+		let total = 0;
 
-		// If we read fewer bytes than requested, zero-fill the rest
-		if (bytesRead < length) {
-			runtime.HEAPU8.fill(0, ptr + bytesRead, ptr + length);
+		// Eagerly read the entire file contents into the allocated memory
+		while (total < length) {
+			const bytesRead = stream.stream_ops.read(
+				stream,
+				heap,
+				total,
+				length - total,
+				total
+			);
+
+			if (bytesRead <= 0) break;
+			total += bytesRead;
+		}
+
+		// If we couldn't read the expected amount, free memory and return error
+		if (total !== length) {
+			runtime.free(ptr);
+			throw new FS.ErrnoError(5); // EIO
 		}
 
 		return { ptr: ptr, allocated: true };
@@ -119,8 +149,10 @@ export function proxyFileSystem(
 
 	// We can't just import the symbol from the library because
 	// Playground CLI is built as ESM and php-wasm-node is built as
-	// CJS and the imported symbols will different in the production build.
-	const __private__symbol = Object.getOwnPropertySymbols(sourceOfTruth)[0];
+	// CJS and the imported symbols will differ in the production build.
+	// Get symbols from both instances to ensure correct property access.
+	const replicaSymbol = Object.getOwnPropertySymbols(replica)[0];
+	const sourceSymbol = Object.getOwnPropertySymbols(sourceOfTruth)[0];
 	for (const path of paths) {
 		if (!replica.fileExists(path)) {
 			replica.mkdir(path);
@@ -129,13 +161,13 @@ export function proxyFileSystem(
 			sourceOfTruth.mkdir(path);
 		}
 		// @ts-ignore
-		replica[__private__symbol].FS.mount(
+		replica[replicaSymbol].FS.mount(
 			// @ts-ignore
-			replica[__private__symbol].PROXYFS,
+			replica[replicaSymbol].PROXYFS,
 			{
 				root: path,
 				// @ts-ignore
-				fs: sourceOfTruth[__private__symbol].FS,
+				fs: sourceOfTruth[sourceSymbol].FS,
 			},
 			path
 		);

--- a/packages/php-wasm/universal/src/lib/proxy-file-system.ts
+++ b/packages/php-wasm/universal/src/lib/proxy-file-system.ts
@@ -1,6 +1,101 @@
 import type { PHP } from './php';
 
 /**
+ * Ensures PROXYFS has mmap support.
+ *
+ * PROXYFS proxies filesystem operations from one Emscripten FS instance to another,
+ * enabling file sharing between PHP instances. However, PROXYFS lacks mmap support
+ * by default, which causes libraries like ICU (used by the Intl extension) to fail
+ * when trying to memory-map data files through a proxied filesystem.
+ *
+ * This function adds mmap and msync methods to PROXYFS.stream_ops if they don't
+ * already exist. The mmap implementation reads the file contents via the proxied
+ * filesystem and copies them into allocated memory, simulating mmap behavior.
+ *
+ * @param phpInstance - The PHP instance whose PROXYFS should be patched
+ */
+function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
+	const __private__symbol = Object.getOwnPropertySymbols(phpInstance)[0];
+	// @ts-ignore
+	const runtime = phpInstance[__private__symbol];
+	const PROXYFS = runtime.PROXYFS;
+	const FS = runtime.FS;
+
+	// Skip if mmap is already defined
+	if (PROXYFS.stream_ops.mmap) {
+		return;
+	}
+
+	/**
+	 * Memory-map a file from a proxied filesystem.
+	 *
+	 * Since PROXYFS doesn't have direct access to the underlying buffer,
+	 * we allocate new memory and copy the file contents into it.
+	 */
+	PROXYFS.stream_ops.mmap = function (
+		stream: any,
+		length: number,
+		position: number,
+		prot: number,
+		flags: number
+	) {
+		// Only files can be memory-mapped
+		if (!FS.isFile(stream.node.mode)) {
+			throw new FS.ErrnoError(19); // ENODEV
+		}
+
+		// Allocate memory for the mapped region using the runtime's malloc
+		const ptr = runtime.wasmExports.malloc(length);
+		if (!ptr) {
+			throw new FS.ErrnoError(48); // ENOMEM
+		}
+
+		// Read the file contents into the allocated memory
+		const bytesRead = stream.stream_ops.read(
+			stream,
+			runtime.HEAPU8,
+			ptr,
+			length,
+			position
+		);
+
+		// If we read fewer bytes than requested, zero-fill the rest
+		if (bytesRead < length) {
+			runtime.HEAPU8.fill(0, ptr + bytesRead, ptr + length);
+		}
+
+		return { ptr: ptr, allocated: true };
+	};
+
+	/**
+	 * Sync memory-mapped changes back to the file.
+	 *
+	 * This is called when munmap is invoked. If the mapping was MAP_SHARED,
+	 * the changes should be written back to the file.
+	 */
+	PROXYFS.stream_ops.msync = function (
+		stream: any,
+		buffer: Uint8Array,
+		offset: number,
+		length: number,
+		mmapFlags: number
+	) {
+		// MAP_PRIVATE (flags & 2) means changes are not written back
+		if (!(mmapFlags & 2)) {
+			stream.stream_ops.write(
+				stream,
+				buffer,
+				offset,
+				length,
+				offset,
+				false
+			);
+		}
+		return 0;
+	};
+}
+
+/**
  * Proxy specific paths to the parent's MEMFS instance.
  * This is useful for sharing the WordPress installation
  * between the parent and child processes.
@@ -10,6 +105,10 @@ export function proxyFileSystem(
 	replica: PHP,
 	paths: string[]
 ) {
+	// Ensure PROXYFS has mmap support before mounting.
+	// This is needed for libraries like ICU that rely on memory-mapping files.
+	ensureProxyFSHasMmapSupport(replica);
+
 	// We can't just import the symbol from the library because
 	// Playground CLI is built as ESM and php-wasm-node is built as
 	// CJS and the imported symbols will different in the production build.

--- a/packages/php-wasm/universal/src/lib/proxy-file-system.ts
+++ b/packages/php-wasm/universal/src/lib/proxy-file-system.ts
@@ -31,7 +31,14 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 	 *
 	 * Since PROXYFS doesn't have direct access to the underlying buffer,
 	 * we allocate new memory and copy the file contents into it.
+	 *
+	 * @param stream - The file stream to map
+	 * @param length - Number of bytes to map
+	 * @param position - File offset to start mapping from
+	 * @param prot - Memory protection flags (unused, we always allocate read/write)
+	 * @param flags - Mapping flags (unused)
 	 */
+	/* eslint-disable @typescript-eslint/no-unused-vars */
 	PROXYFS.stream_ops.mmap = function (
 		stream: any,
 		length: number,
@@ -39,6 +46,7 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 		prot: number,
 		flags: number
 	) {
+		/* eslint-enable @typescript-eslint/no-unused-vars */
 		// Only files can be memory-mapped
 		if (!FS.isFile(stream.node.mode)) {
 			throw new FS.ErrnoError(19); // ENODEV

--- a/packages/php-wasm/universal/src/lib/proxy-file-system.ts
+++ b/packages/php-wasm/universal/src/lib/proxy-file-system.ts
@@ -1,16 +1,16 @@
 import type { PHP } from './php';
 
 /**
- * Ensures PROXYFS has mmap support.
+ * Adds mmap support to PROXYFS for memory-mapping files across PHP instances.
  *
- * PROXYFS proxies filesystem operations from one Emscripten FS instance to another,
- * enabling file sharing between PHP instances. However, PROXYFS lacks mmap support
- * by default, which causes libraries like ICU (used by the Intl extension) to fail
- * when trying to memory-map data files through a proxied filesystem.
+ * Without mmap, libraries like ICU fail when accessing data files through PROXYFS.
+ * ICU calls mmap to load icudt74l.dat when initializing Intl classes like Collator
+ * and NumberFormatter. PROXYFS has no mmap implementation by default, causing these
+ * calls to fail even when the data file exists in the proxied filesystem.
  *
- * This function adds mmap and msync methods to PROXYFS.stream_ops if they don't
- * already exist. The mmap implementation reads the file contents via the proxied
- * filesystem and copies them into allocated memory, simulating mmap behavior.
+ * This patches PROXYFS.stream_ops to add mmap and msync methods. The mmap implementation
+ * allocates memory, reads the file through PROXYFS's existing read operations, and
+ * returns a pointer to the allocated buffer—matching the behavior of POSIX mmap.
  *
  * @param phpInstance - The PHP instance whose PROXYFS should be patched
  */
@@ -27,16 +27,17 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 	}
 
 	/**
-	 * Memory-map a file from a proxied filesystem.
+	 * Maps a file into memory by allocating a buffer and reading the file contents into it.
 	 *
-	 * Since PROXYFS doesn't have direct access to the underlying buffer,
-	 * we allocate new memory and copy the file contents into it.
+	 * PROXYFS has no direct access to the underlying file buffer, so we simulate mmap
+	 * by allocating memory with malloc and copying the file contents through read operations.
 	 *
 	 * @param stream - The file stream to map
-	 * @param length - Number of bytes to map
-	 * @param position - File offset to start mapping from
+	 * @param length - Number of bytes to map (may be incorrect for non-.dat files in PHP 7.4)
+	 * @param position - File offset to start mapping from (must be 0)
 	 * @param prot - Memory protection flags (unused, we always allocate read/write)
 	 * @param flags - Mapping flags (unused)
+	 * @returns Object with ptr (pointer to allocated memory) and allocated flag
 	 */
 	/* eslint-disable @typescript-eslint/no-unused-vars */
 	PROXYFS.stream_ops.mmap = function (
@@ -52,12 +53,13 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 			throw new FS.ErrnoError(19); // ENODEV
 		}
 
-		// For non-.dat files, get the actual file size from the proxied filesystem.
-		// This is needed because PHP 7.4 may pass incorrect length values for
-		// certain file types.
+		// PHP 7.4's mmap implementation passes the wrong length for files that aren't
+		// ICU data files (.dat). Instead of passing the actual file size, it passes
+		// a value from the stat buffer that doesn't represent the file's true length.
+		// Work around this by querying the actual file size from the proxied filesystem
+		// using fstat. ICU .dat files work correctly, so skip this workaround for them.
 		const path = FS.getPath(stream.node);
 		if (!path.endsWith('.dat')) {
-			// Get the proxied filesystem from the mount options
 			const proxyFS = stream.node.mount.opts.fs;
 			if (proxyFS && stream.nfd !== undefined) {
 				const stat = proxyFS.fstat(stream.nfd);
@@ -67,37 +69,37 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 			}
 		}
 
-		// Only support mmap from the beginning of the file
+		// ICU only maps files from offset 0, so we don't support partial mapping
 		if (position !== 0) {
 			throw new FS.ErrnoError(22); // EINVAL
 		}
 
-		// Allocate memory for the mapped region using the runtime's malloc.
 		const ptr = runtime.malloc(length);
 		if (!ptr) {
 			throw new FS.ErrnoError(48); // ENOMEM
 		}
 
-		// Create a view into the heap for reading
+		// Read the file into the allocated memory. Create a subarray view of the heap
+		// so read operations write directly to the correct memory location without
+		// needing offset calculations.
 		const heap = runtime.HEAPU8.subarray(ptr, ptr + length);
-		let total = 0;
+		let totalBytesRead = 0;
 
-		// Eagerly read the entire file contents into the allocated memory
-		while (total < length) {
+		while (totalBytesRead < length) {
 			const bytesRead = stream.stream_ops.read(
 				stream,
 				heap,
-				total,
-				length - total,
-				total
+				totalBytesRead,
+				length - totalBytesRead,
+				totalBytesRead
 			);
 
 			if (bytesRead <= 0) break;
-			total += bytesRead;
+			totalBytesRead += bytesRead;
 		}
 
-		// If we couldn't read the expected amount, free memory and return error
-		if (total !== length) {
+		// Partial reads indicate I/O errors or premature EOF
+		if (totalBytesRead !== length) {
 			runtime.free(ptr);
 			throw new FS.ErrnoError(5); // EIO
 		}
@@ -106,10 +108,20 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 	};
 
 	/**
-	 * Sync memory-mapped changes back to the file.
+	 * Writes memory-mapped changes back to the file when the mapping is shared.
 	 *
-	 * This is called when munmap is invoked. If the mapping was MAP_SHARED,
-	 * the changes should be written back to the file.
+	 * Called by munmap to persist changes made to the mapped memory region.
+	 * MAP_PRIVATE mappings (flag bit 2) keep changes in memory only, while
+	 * MAP_SHARED mappings write changes back to the underlying file.
+	 *
+	 * ICU only reads from its data files, so this rarely gets called in practice.
+	 *
+	 * @param stream - The file stream
+	 * @param buffer - The memory buffer containing changes
+	 * @param offset - Offset in the buffer
+	 * @param length - Number of bytes to sync
+	 * @param mmapFlags - Flags from the original mmap call
+	 * @returns 0 on success
 	 */
 	PROXYFS.stream_ops.msync = function (
 		stream: any,
@@ -118,7 +130,7 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 		length: number,
 		mmapFlags: number
 	) {
-		// MAP_PRIVATE (flags & 2) means changes are not written back
+		// MAP_PRIVATE (flag bit 2) means changes stay in memory
 		if (!(mmapFlags & 2)) {
 			stream.stream_ops.write(
 				stream,
@@ -134,17 +146,24 @@ function ensureProxyFSHasMmapSupport(phpInstance: PHP) {
 }
 
 /**
- * Proxy specific paths to the parent's MEMFS instance.
- * This is useful for sharing the WordPress installation
- * between the parent and child processes.
+ * Mounts directories from one PHP instance's filesystem into another using PROXYFS.
+ *
+ * This enables file sharing between PHP instances without duplicating the files in memory.
+ * For example, mounting /wordpress from the parent instance into a child worker allows
+ * both to access the same WordPress installation without copying the entire directory.
+ *
+ * The function automatically patches PROXYFS with mmap support before mounting, ensuring
+ * libraries like ICU can memory-map data files through the proxied filesystem.
+ *
+ * @param sourceOfTruth - The PHP instance containing the original files
+ * @param replica - The PHP instance that will access files through PROXYFS
+ * @param paths - Absolute paths to mount (e.g., ['/wordpress', '/internal/shared'])
  */
 export function proxyFileSystem(
 	sourceOfTruth: PHP,
 	replica: PHP,
 	paths: string[]
 ) {
-	// Ensure PROXYFS has mmap support before mounting.
-	// This is needed for libraries like ICU that rely on memory-mapping files.
 	ensureProxyFSHasMmapSupport(replica);
 
 	// We can't just import the symbol from the library because

--- a/packages/php-wasm/web/src/test/php-dynamic-loading.spec.ts
+++ b/packages/php-wasm/web/src/test/php-dynamic-loading.spec.ts
@@ -109,6 +109,46 @@ SupportedPHPVersions.forEach((phpVersion) => {
 			test.expect(result).toContain('icudt74l.dat');
 		});
 
+		test('reads the icu data in PROXYFS', async ({ page }) => {
+			const result = await page.evaluate(async (phpVersion) => {
+				const oldPhp = new window.PHP(
+					await window.loadWebRuntime(phpVersion as any, {
+						withIntl: true,
+					})
+				);
+				const newPhp = new window.PHP(
+					await window.loadWebRuntime(phpVersion as any, {
+						withIntl: true,
+					})
+				);
+
+				window.proxyFileSystem(oldPhp, newPhp, ['/internal/shared']);
+
+				const response = await newPhp.runStream({
+					code: `<?php
+							$data = array(
+								'F' => 'Foo',
+								'Br' => 'Bar',
+								'Bz' => 'Bz',
+							);
+
+							$collator = new Collator('en_US');
+							$collator->asort($data, Collator::SORT_STRING);
+							var_dump($data);
+						?>`,
+				});
+
+				newPhp.exit();
+				oldPhp.exit();
+
+				return await response.stdoutText;
+			}, phpVersion);
+
+			test.expect(result).toEqual(
+				'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
+			);
+		});
+
 		test('uses intl functions', async ({ page }) => {
 			const result = await page.evaluate(async (phpVersion) => {
 				const php = new window.PHP(

--- a/packages/php-wasm/web/src/test/playwright/globals.d.ts
+++ b/packages/php-wasm/web/src/test/playwright/globals.d.ts
@@ -5,5 +5,6 @@ declare global {
 	interface Window {
 		PHP: typeof PHP;
 		loadWebRuntime: typeof loadWebRuntime;
+		proxyFileSystem: typeof proxyFileSystem;
 	}
 }

--- a/packages/php-wasm/web/src/test/playwright/globals.ts
+++ b/packages/php-wasm/web/src/test/playwright/globals.ts
@@ -1,5 +1,6 @@
-import { PHP } from '@php-wasm/universal';
+import { PHP, proxyFileSystem } from '@php-wasm/universal';
 import { loadWebRuntime } from '../../lib';
 
 (window as any).PHP = PHP;
 (window as any).loadWebRuntime = loadWebRuntime;
+(window as any).proxyFileSystem = proxyFileSystem;

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -283,12 +283,12 @@ test('Intl functions should work when intl is enabled', async ({
 	wordpress,
 }) => {
 	const blueprint: Blueprint = {
-		landingPage: '/intl-test.php',
+		landingPage: '/intl-functions-test.php',
 		features: { intl: true },
 		steps: [
 			{
 				step: 'writeFile',
-				path: '/wordpress/intl-test.php',
+				path: '/wordpress/intl-functions-test.php',
 				data: `<?php
 					$formatter = numfmt_create('en-US', NumberFormatter::CURRENCY);
 					echo numfmt_format($formatter, 100.00);
@@ -300,6 +300,37 @@ test('Intl functions should work when intl is enabled', async ({
 	};
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 	await expect(wordpress.locator('body')).toContainText('$100.00100,00\xA0€');
+});
+
+test('Intl classes should work when intl is enabled', async ({
+	website,
+	wordpress,
+}) => {
+	const blueprint: Blueprint = {
+		landingPage: '/intl-classes-test.php',
+		features: { intl: true },
+		steps: [
+			{
+				step: 'writeFile',
+				path: '/wordpress/intl-classes-test.php',
+				data: `<?php
+							$data = array(
+								'F' => 'Foo',
+								'Br' => 'Bar',
+								'Bz' => 'Bz',
+							);
+
+							$collator = new Collator('en_US');
+							$collator->asort($data, Collator::SORT_STRING);
+							var_dump($data);
+						?>`,
+			},
+		],
+	};
+	await website.goto(`/#${JSON.stringify(blueprint)}`);
+	await expect(wordpress.locator('body')).toContainText(
+		'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
+	);
 });
 
 test('HTTPS requests via curl_exec() should work', async ({

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -278,56 +278,53 @@ test('Intl functions should be disabled by default', async ({
 	await expect(wordpress.locator('body')).toContainText('bool(false)');
 });
 
-['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4', '7.3', '7.2'].forEach(
-	(phpVersion) => {
-		test(`Intl functions should work when intl is enabled for PHP ${phpVersion}`, async ({
-			website,
-			wordpress,
-		}) => {
-			const blueprint: Blueprint = {
-				landingPage: '/intl-functions-test.php',
-				preferredVersions: {
-					php: phpVersion,
-				},
-				features: { intl: true },
-				steps: [
-					{
-						step: 'writeFile',
-						path: '/wordpress/intl-functions-test.php',
-						data: `<?php
+['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4'].forEach((phpVersion) => {
+	test(`Intl functions should work when intl is enabled for PHP ${phpVersion}`, async ({
+		website,
+		wordpress,
+	}) => {
+		const blueprint: Blueprint = {
+			landingPage: '/intl-functions-test.php',
+			preferredVersions: {
+				php: phpVersion,
+			},
+			features: { intl: true },
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/intl-functions-test.php',
+					data: `<?php
 					$formatter = numfmt_create('en-US', NumberFormatter::CURRENCY);
 					echo numfmt_format($formatter, 100.00);
 					$formatter = numfmt_create('fr-FR', NumberFormatter::CURRENCY);
 					echo numfmt_format($formatter, 100.00);
 				`,
-					},
-				],
-			};
-			await website.goto(`/#${JSON.stringify(blueprint)}`);
-			await expect(wordpress.locator('body')).toContainText(
-				'$100.00100,00\xA0€'
-			);
-		});
-	}
-);
-
-['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4', '7.3', '7.2'].forEach(
-	(phpVersion) => {
-		test(`Intl classes should work when intl is enabled for PHP ${phpVersion}`, async ({
-			website,
-			wordpress,
-		}) => {
-			const blueprint: Blueprint = {
-				landingPage: '/intl-classes-test.php',
-				preferredVersions: {
-					php: phpVersion,
 				},
-				features: { intl: true },
-				steps: [
-					{
-						step: 'writeFile',
-						path: '/wordpress/intl-classes-test.php',
-						data: `<?php
+			],
+		};
+		await website.goto(`/#${JSON.stringify(blueprint)}`);
+		await expect(wordpress.locator('body')).toContainText(
+			'$100.00100,00\xA0€'
+		);
+	});
+});
+
+['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4'].forEach((phpVersion) => {
+	test(`Intl classes should work when intl is enabled for PHP ${phpVersion}`, async ({
+		website,
+		wordpress,
+	}) => {
+		const blueprint: Blueprint = {
+			landingPage: '/intl-classes-test.php',
+			preferredVersions: {
+				php: phpVersion,
+			},
+			features: { intl: true },
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/intl-classes-test.php',
+					data: `<?php
 							$data = array(
 								'F' => 'Foo',
 								'Br' => 'Bar',
@@ -338,16 +335,15 @@ test('Intl functions should be disabled by default', async ({
 							$collator->asort($data, Collator::SORT_STRING);
 							var_dump($data);
 						?>`,
-					},
-				],
-			};
-			await website.goto(`/#${JSON.stringify(blueprint)}`);
-			await expect(wordpress.locator('body')).toContainText(
-				'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
-			);
-		});
-	}
-);
+				},
+			],
+		};
+		await website.goto(`/#${JSON.stringify(blueprint)}`);
+		await expect(wordpress.locator('body')).toContainText(
+			'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
+		);
+	});
+});
 
 test('HTTPS requests via curl_exec() should work', async ({
 	website,

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -2,6 +2,12 @@ import { test, expect } from '../playground-fixtures';
 import type { Blueprint } from '@wp-playground/blueprints';
 import { encodeStringAsBase64 } from '../../src/lib/base64';
 
+// We can't import the SupportedPHPVersions versions directly from the remote package
+// because of ESModules vs CommonJS incompatibilities. Let's just import the
+// JSON file directly. @ts-ignore
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { SupportedPHPVersions } from '../../../../php-wasm/universal/src/lib/supported-php-versions.ts';
+
 test('Base64-encoded Blueprints should work', async ({
 	website,
 	wordpress,
@@ -278,7 +284,7 @@ test('Intl functions should be disabled by default', async ({
 	await expect(wordpress.locator('body')).toContainText('bool(false)');
 });
 
-['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4'].forEach((phpVersion) => {
+SupportedPHPVersions.forEach((phpVersion) => {
 	test(`Intl functions should work when intl is enabled for PHP ${phpVersion}`, async ({
 		website,
 		wordpress,
@@ -309,7 +315,7 @@ test('Intl functions should be disabled by default', async ({
 	});
 });
 
-['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4'].forEach((phpVersion) => {
+SupportedPHPVersions.forEach((phpVersion) => {
 	test(`Intl classes should work when intl is enabled for PHP ${phpVersion}`, async ({
 		website,
 		wordpress,

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -278,42 +278,56 @@ test('Intl functions should be disabled by default', async ({
 	await expect(wordpress.locator('body')).toContainText('bool(false)');
 });
 
-test('Intl functions should work when intl is enabled', async ({
-	website,
-	wordpress,
-}) => {
-	const blueprint: Blueprint = {
-		landingPage: '/intl-functions-test.php',
-		features: { intl: true },
-		steps: [
-			{
-				step: 'writeFile',
-				path: '/wordpress/intl-functions-test.php',
-				data: `<?php
+['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4', '7.3', '7.2'].forEach(
+	(phpVersion) => {
+		test(`Intl functions should work when intl is enabled for PHP ${phpVersion}`, async ({
+			website,
+			wordpress,
+		}) => {
+			const blueprint: Blueprint = {
+				landingPage: '/intl-functions-test.php',
+				preferredVersions: {
+					php: phpVersion,
+				},
+				features: { intl: true },
+				steps: [
+					{
+						step: 'writeFile',
+						path: '/wordpress/intl-functions-test.php',
+						data: `<?php
 					$formatter = numfmt_create('en-US', NumberFormatter::CURRENCY);
 					echo numfmt_format($formatter, 100.00);
 					$formatter = numfmt_create('fr-FR', NumberFormatter::CURRENCY);
 					echo numfmt_format($formatter, 100.00);
 				`,
-			},
-		],
-	};
-	await website.goto(`/#${JSON.stringify(blueprint)}`);
-	await expect(wordpress.locator('body')).toContainText('$100.00100,00\xA0€');
-});
+					},
+				],
+			};
+			await website.goto(`/#${JSON.stringify(blueprint)}`);
+			await expect(wordpress.locator('body')).toContainText(
+				'$100.00100,00\xA0€'
+			);
+		});
+	}
+);
 
-test('Intl classes should work when intl is enabled', async ({
-	website,
-	wordpress,
-}) => {
-	const blueprint: Blueprint = {
-		landingPage: '/intl-classes-test.php',
-		features: { intl: true },
-		steps: [
-			{
-				step: 'writeFile',
-				path: '/wordpress/intl-classes-test.php',
-				data: `<?php
+['8.5', '8.4', '8.3', '8.2', '8.1', '8.0', '7.4', '7.3', '7.2'].forEach(
+	(phpVersion) => {
+		test(`Intl classes should work when intl is enabled for PHP ${phpVersion}`, async ({
+			website,
+			wordpress,
+		}) => {
+			const blueprint: Blueprint = {
+				landingPage: '/intl-classes-test.php',
+				preferredVersions: {
+					php: phpVersion,
+				},
+				features: { intl: true },
+				steps: [
+					{
+						step: 'writeFile',
+						path: '/wordpress/intl-classes-test.php',
+						data: `<?php
 							$data = array(
 								'F' => 'Foo',
 								'Br' => 'Bar',
@@ -324,14 +338,16 @@ test('Intl classes should work when intl is enabled', async ({
 							$collator->asort($data, Collator::SORT_STRING);
 							var_dump($data);
 						?>`,
-			},
-		],
-	};
-	await website.goto(`/#${JSON.stringify(blueprint)}`);
-	await expect(wordpress.locator('body')).toContainText(
-		'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
-	);
-});
+					},
+				],
+			};
+			await website.goto(`/#${JSON.stringify(blueprint)}`);
+			await expect(wordpress.locator('body')).toContainText(
+				'array(3) {\n  ["Br"]=>\n  string(3) "Bar"\n  ["Bz"]=>\n  string(2) "Bz"\n  ["F"]=>\n  string(3) "Foo"\n}\n'
+			);
+		});
+	}
+);
 
 test('HTTPS requests via curl_exec() should work', async ({
 	website,


### PR DESCRIPTION
## What it does

Adds `mmap` support to PROXYFS so the Intl extension works when `/internal/shared` (which contains ICU data files) is accessed through a proxied filesystem. This PR is based on [@mho22](https://github.com/mho22)'s excellent work in [WordPress/wordpress-playground#3073](https://github.com/WordPress/wordpress-playground/pull/3073).

## Rationale

PROXYFS proxies filesystem operations between PHP instances, enabling file sharing. The Intl extension depends on ICU, which uses `mmap` to load its data file (`icudt74l.dat`). Without `mmap` support in PROXYFS, ICU initialization fails when accessing the data file through a proxied mount.

This showed up when trying to use `Collator` or `NumberFormatter` in a PHP instance where `/internal/shared` was mounted via PROXYFS—the classes would fail to instantiate even though the extension was loaded.

## Implementation

Added `ensureProxyFSHasMmapSupport()` that patches PROXYFS at runtime:

**`mmap` implementation:**
- Allocates memory using the runtime's `malloc`
- Reads the entire file into that memory via PROXYFS's existing `read` operation
- Returns a pointer to the allocated buffer

**Special handling for PHP 7.4:**
- PHP 7.4 sometimes passes incorrect `length` values to `mmap` for non-`.dat` files
- Solution: query the actual file size from the proxied filesystem using `fstat`

**`msync` implementation:**
- Writes changes back to the file if mapping was `MAP_SHARED`
- Skips write for `MAP_PRIVATE` (changes stay in memory only)

The patch is applied automatically when calling `proxyFileSystem()`, so existing code gets mmap support without changes.

## Testing instructions

Run the new test suite:

```bash
npm test -- proxyfs-mmap.spec.ts
```

Tests verify:
- Basic file operations through PROXYFS (read, binary files, large files, concurrent access)
- Intl classes (`Collator`, `NumberFormatter`) work through PROXYFS
- All tests run across PHP 7.4–8.5

E2E tests verify Intl works in blueprints:

```bash
npm run test:e2e -- blueprints.spec.ts -g "Intl"
```