### PR TITLE
Remove default WP_DEBUG constants from CLI worker

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -144,11 +144,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 
 		try {
 			const constants: Record<string, string | number | boolean | null> =
-				{
-					WP_DEBUG: true,
-					WP_DEBUG_LOG: true,
-					WP_DEBUG_DISPLAY: false,
-				};
+				{};
 			let wordpressBooted = false;
 			const requestHandler = await bootWordPressAndRequestHandler({
 				siteUrl,


### PR DESCRIPTION
## Motivation for the change, related issues

I propose removing WP_DEBUG, WP_DEBUG_LOG, and WP_DEBUG_DISPLAY constants that were being set by default in the CLI blueprint v1 worker. These debugging constants should be opt-in rather than enabled by default.

## Implementation details

Emptying the constants array.

## Testing Instructions (or ideally a Blueprint)

- Test if the newly created site doesn't have constants set
- Use Blueprint to set constants and confirm they are set

```
{
  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
  "steps": [
    {
      "step": "defineWpConfigConsts",
      "consts": {
        "WP_DEBUG": true,
        "WP_DEBUG_LOG": true,
        "WP_DEBUG_DISPLAY": true
      }
    }
  ]
}
```