### PR TITLE
CLI: Replace '127.0.0.1' with 'localhost'

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ WordPress Playground exists to make WordPress instantly accessible for users, le
 
 Playground aims to facilitate:
 
--   Learning WordPress Through Exploration
--   Learning WordPress Development Through Writing Code
--   Instant access to the WordPress ecosystem
+- Learning WordPress Through Exploration
+- Learning WordPress Development Through Writing Code
+- Instant access to the WordPress ecosystem
 
 Learn more about the [vision](https://github.com/WordPress/wordpress-playground/issues/472) and the [roadmap](https://github.com/WordPress/wordpress-playground/issues/525).
 
@@ -87,8 +87,8 @@ WordPress [Playground Tools](https://github.com/WordPress/playground-tools) are 
 
 These tools include:
 
--   [Interactive Code Block for Gutenberg](https://github.com/WordPress/playground-tools/tree/trunk/packages/interactive-code-block/#readme)
--   [WordPress Playground for Visual Studio Code](https://github.com/WordPress/playground-tools/tree/trunk/packages/vscode-extension/#readme)
+- [Interactive Code Block for Gutenberg](https://github.com/WordPress/playground-tools/tree/trunk/packages/interactive-code-block/#readme)
+- [WordPress Playground for Visual Studio Code](https://github.com/WordPress/playground-tools/tree/trunk/packages/vscode-extension/#readme)
 
 ## Cloning WordPress Playground repo
 
@@ -110,7 +110,7 @@ npm install
 npm run dev
 ```
 
-A browser should open and take you to your very own client-side WordPress at [http://127.0.0.1:5400/](http://127.0.0.1:5400/)!
+A browser should open and take you to your very own client-side WordPress at [http://localhost:5400/](http://localhost:5400/)!
 
 Any changes you make to `.ts` files will be live-reloaded. Changes to `Dockerfile` require a full rebuild.
 
@@ -183,12 +183,12 @@ WordPress Playground is an open-source project and welcomes all contributors fro
 
 Here are a few quickstart guides to get you started:
 
--   Code contributions – see the [developer section](https://wordpress.github.io/wordpress-playground/docs/contributing/code).
--   Documentation – see the [documentation section](https://wordpress.github.io/wordpress-playground/docs/contributing/documentation).
--   Triage – see the [triage section](https://wordpress.github.io/wordpress-playground/contributing/#triaging-issues).
--   Contributions to translations – see the [translations section](https://wordpress.github.io/wordpress-playground/contributing/translations).
--   Reporting bugs – open an [issue](https://github.com/WordPress/wordpress-playground/issues/new) in the repository.
--   Ideas, designs or anything else – open a [GitHub discussion](https://github.com/WordPress/wordpress-playground/discussions) and let's talk!
+- Code contributions – see the [developer section](https://wordpress.github.io/wordpress-playground/docs/contributing/code).
+- Documentation – see the [documentation section](https://wordpress.github.io/wordpress-playground/docs/contributing/documentation).
+- Triage – see the [triage section](https://wordpress.github.io/wordpress-playground/contributing/#triaging-issues).
+- Contributions to translations – see the [translations section](https://wordpress.github.io/wordpress-playground/contributing/translations).
+- Reporting bugs – open an [issue](https://github.com/WordPress/wordpress-playground/issues/new) in the repository.
+- Ideas, designs or anything else – open a [GitHub discussion](https://github.com/WordPress/wordpress-playground/discussions) and let's talk!
 
 ## WordCamp Contributor Day
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -90,7 +90,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		const sharedOptions: Record<string, YargsOptions> = {
 			'site-url': {
 				describe:
-					'Site URL to use for WordPress. Defaults to http://127.0.0.1:{port}',
+					'Site URL to use for WordPress. Defaults to http://localhost:{port}',
 				type: 'string',
 			},
 			php: {
@@ -344,7 +344,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			// Advanced options for power users who need more control
 			'site-url': {
 				describe:
-					'Override the site URL. By default, derived from the port (http://127.0.0.1:<port>).',
+					'Override the site URL. By default, derived from the port (http://localhost:<port>).',
 				type: 'string',
 			},
 			mount: {
@@ -856,7 +856,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	const server = await startServer({
 		port: selectedPort,
 		onBind: async (server: Server, port: number) => {
-			const host = '127.0.0.1';
+			const host = 'localhost';
 			const serverUrl = `http://${host}:${port}`;
 			const siteUrl = args['site-url'] || serverUrl;
 

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -144,7 +144,7 @@ describe.each(blueprintVersions)(
 				const response = await fetch(siteUrlTestUrl);
 				expect(response.status).toBe(200);
 				const text = await response.text();
-				expect(text).toContain('http://127.0.0.1:9500');
+				expect(text).toContain('http://localhost:9500');
 			}
 		);
 
@@ -640,7 +640,7 @@ describe.each(blueprintVersions)(
 					// Just verify the server started successfully.
 					expect(cliServer).toBeDefined();
 					expect(cliServer.serverUrl).toMatch(
-						/^http:\/\/127\.0\.0\.1:\d+$/
+						/^http:\/\/localhost:\d+$/
 					);
 				}
 			);
@@ -726,7 +726,7 @@ describe('start command', () => {
 		});
 
 		// Verify server started successfully
-		expect(cliServer.serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+		expect(cliServer.serverUrl).toMatch(/^http:\/\/localhost:\d+$/);
 	});
 
 	test('should persist site in home directory', async () => {
@@ -754,7 +754,7 @@ describe('start command', () => {
 		});
 
 		// Verify server started successfully
-		expect(cliServer.serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+		expect(cliServer.serverUrl).toMatch(/^http:\/\/localhost:\d+$/);
 
 		// Verify the site directory was created
 		expect(existsSync(expectedSitePath)).toBe(true);
@@ -904,7 +904,7 @@ describe('start command', () => {
 		});
 
 		// Verify server started successfully
-		expect(cliServer.serverUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+		expect(cliServer.serverUrl).toMatch(/^http:\/\/localhost:\d+$/);
 
 		// Verify WordPress files are in the explicit mount location
 		const wpContentPath = path.join(wordpressDir, 'wp-content');

--- a/packages/playground/cli/tests/test-running-unbuilt-cli.sh
+++ b/packages/playground/cli/tests/test-running-unbuilt-cli.sh
@@ -16,7 +16,7 @@ function test_playground_cli() {
 	echo "Running Playground CLI with Nx target: $TARGET $@"
 	timeout -s TERM 30s npx nx "$TARGET" playground-cli server --php=8.3 $@ 2>&1 > playground-cli-test-output &
 	PID=$!
-	CLI_STARTUP_STRING='WordPress is running on http://127.0.0.1:9400'
+	CLI_STARTUP_STRING='WordPress is running on http://localhost:9400'
 
 	# Sleep until Playground CLI starts or the process times out.
 	while ps -p "$PID" > /dev/null && ! grep -q "$CLI_STARTUP_STRING" playground-cli-test-output; do
@@ -30,7 +30,7 @@ function test_playground_cli() {
 		echo "Playground CLI started successfully"
 		echo "Checking WordPress home page..."
 
-		HOME_PAGE_OUTPUT="$(curl -sL http://127.0.0.1:9400 || echo 'No output')"
+		HOME_PAGE_OUTPUT="$(curl -sL http://localhost:9400 || echo 'No output')"
 		if [[ $HOME_PAGE_OUTPUT != *"My WordPress Website"* ]]; then
 			echo "Home page output: $HOME_PAGE_OUTPUT"
 			echo "Error: Home page did not contain 'My WordPress Website'"


### PR DESCRIPTION
Closes #3132 

The idea is to switch from 127.0.0.1 to localhost for the reasons stated in that ticket (mainly WSL2 compatibility **out of the box**)

This PR is already passing the cli tests, but I've been looking into the whole repo and it appears that the `127.0.0.1` is deeply engrained into the thing. 

Still, I'm unsure why it was chosen over `localhost` so I would like hear more about this before trying to fix the 100+ coincidences of this in the code