### PR TITLE
Clean up URL when dismissing missing site modal

### DIFF
--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -96,13 +96,17 @@ export function EnsurePlaygroundSiteIsSelected({
 			}
 
 			// If only the 'modal' parameter changes in searchParams, don't reload the page
-			const notRefreshingParam = 'modal';
+			const notRefreshingParams = ['modal', 'site-slug'];
 			const oldParams = new URLSearchParams(prevUrl?.search);
 			const newParams = new URLSearchParams(url?.search);
-			oldParams.delete(notRefreshingParam);
-			newParams.delete(notRefreshingParam);
+			for (const param of notRefreshingParams) {
+				oldParams.delete(param);
+				newParams.delete(param);
+			}
 			const avoidUnnecessaryTempSiteReload =
-				activeSite && oldParams.toString() === newParams.toString();
+				activeSite &&
+				activeSite.metadata.storage === 'none' &&
+				oldParams.toString() === newParams.toString();
 			if (avoidUnnecessaryTempSiteReload) {
 				return;
 			}

--- a/packages/playground/website/src/components/missing-site-modal/index.tsx
+++ b/packages/playground/website/src/components/missing-site-modal/index.tsx
@@ -80,6 +80,12 @@ export function MissingSiteModal() {
 						onClick={(e: React.MouseEvent) => {
 							e.preventDefault();
 							e.stopPropagation();
+
+							// Remove site-slug from URL without reloading
+							const url = new URL(window.location.href);
+							url.searchParams.delete('site-slug');
+							window.history.replaceState({}, '', url.toString());
+
 							closeModal();
 						}}
 					>


### PR DESCRIPTION
## What it does

Removes the `site-slug` parameter from the URL when dismissing the missing site modal without saving, and prevents WordPress from reloading when this happens.

## Rationale

When you load `?site-slug=my-project` for a site that doesn't exist, the missing site modal appears. Previously, if you clicked "Keep using an Unsaved Playground", the URL kept the `site-slug` parameter even though you're now on a generic temporary playground.

Removing the parameter makes sense (the playground has no meaningful slug), but naively removing it caused WordPress to reload because `ensure-playground-site-is-selected.tsx` detected the URL change and created a new temporary site.

## Implementation

**1. Remove site-slug when dismissing** (`missing-site-modal/index.tsx`):

```typescript
onClick={(e: React.MouseEvent) => {
    e.preventDefault();
    e.stopPropagation();

    // Remove site-slug from URL without reloading
    const url = new URL(window.location.href);
    url.searchParams.delete('site-slug');
    window.history.replaceState({}, '', url.toString());

    closeModal();
}}
```

**2. Prevent reload on site-slug removal** (`ensure-playground-site-is-selected.tsx`):

Updated the logic that determines whether to create a new temporary site. Now when comparing old vs new URL parameters, we ignore both `modal` AND `site-slug` for temporary sites (storage === 'none'). This prevents creating a new WordPress instance when only these parameters change.

```typescript
// Ignore these params when checking if we need to reload
const notRefreshingParams = ['modal', 'site-slug'];
const oldParams = new URLSearchParams(prevUrl?.search);
const newParams = new URLSearchParams(url?.search);
for (const param of notRefreshingParams) {
    oldParams.delete(param);
    newParams.delete(param);
}
const avoidUnnecessaryTempSiteReload =
    activeSite &&
    activeSite.metadata.storage === 'none' &&
    oldParams.toString() === newParams.toString();
```

## Testing instructions

**Test dismiss (no reload):**
1. Load `http://localhost:5400/?site-slug=test-123`
2. Wait for the missing site modal
3. Click "Keep using an Unsaved Playground"
4. Verify URL changes to `/` without WordPress reloading
5. WordPress should stay on the same instance (check the scope in the iframe URL stays the same)

**Test save (also no reload):**
1. Load `http://localhost:5400/?site-slug=test-456`  
2. Wait for the missing site modal
3. Click "Save Playground to browser storage"
4. Complete the save process
5. Verify WordPress doesn't reload during the save
6. Site title should change from "Unsaved Playground" to "Saved Playground"