### PR TITLE
Update CLAUDE.md with Node.js version guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,7 +203,7 @@ npx nx e2e playground-website
 The Playground CLI (`@wp-playground/cli`) can be run directly from source:
 
 ```bash
-nvm use 23
+nvm use
 npx nx dev playground-cli server --wp=6.8 --php=8.4 --auto-mount
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
-<!--                                                                      
-MAINTENANCE: Update this file when:                                       
-- Adding/removing npm scripts in package.json                             
-- Changing the monorepo structure (new packages, major refactors)         
-- Modifying build/test workflows                                          
-- Adding new architectural patterns or conventions                        
-- Updating Node.js/npm version requirements                               
+<!--
+MAINTENANCE: Update this file when:
+- Adding/removing npm scripts in package.json
+- Changing the monorepo structure (new packages, major refactors)
+- Modifying build/test workflows
+- Adding new architectural patterns or conventions
+- Updating Node.js/npm version requirements
 -->
 
 # CLAUDE.md
@@ -203,6 +203,7 @@ npx nx e2e playground-website
 The Playground CLI (`@wp-playground/cli`) can be run directly from source:
 
 ```bash
+nvm use 23
 npx nx dev playground-cli server --wp=6.8 --php=8.4 --auto-mount
 ```
 
@@ -261,7 +262,7 @@ Located in `packages/nx-extensions/src/executors/`:
 
 ## Node.js Version
 
-Requires Node.js >= 20.18.3 (LTS). Uses npm workspaces and packageManager field set to `npm@10.9.2`.
+Review the package.json file for the required Node.js version. At the time of writing, it's Node.js >= 20.18.3 (LTS) and npm >= `npm@10.9.2`.
 
 ## Documentation
 


### PR DESCRIPTION
This PR updates the CLAUDE.md documentation to make it more maintainable and clearer for developers.

## Changes

**Node.js version section**: Instead of hardcoding the specific version requirements, the documentation now points developers to check package.json. This reduces duplication and ensures the documentation stays accurate as versions change.

**CLI development example**: Added the `nvm use 23` command before the CLI server command to show developers the complete workflow for setting up their environment.

These changes make the documentation more maintainable and help developers follow the correct setup process.