### PR TITLE
[Playground CLI] Use initialPlayground to build site snapshot instead of undefined playground

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -756,7 +756,7 @@ export async function runCLI(
 export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void>;
 export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	let loadBalancer: LoadBalancer;
-	let playground: RemoteAPI<PlaygroundCliWorker>;
+	let playground: RemoteAPI<PlaygroundCliWorker> | undefined;
 
 	const playgroundsToCleanUp: Map<
 		Worker,
@@ -1215,7 +1215,10 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					}
 
 					if (args.command === 'build-snapshot') {
-						await zipSite(playground, args.outfile as string);
+						await zipSite(
+							initialPlayground,
+							args.outfile as string
+						);
 						cliOutput.printStatus(`Exported to ${args.outfile}`);
 						await disposeCLI();
 						return;
@@ -1293,7 +1296,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					throw error;
 				}
 				let phpLogs = '';
-				if (await playground?.fileExists(errorLogPath)) {
+				if (playground && (await playground.fileExists(errorLogPath))) {
 					phpLogs = await playground.readFileAsText(errorLogPath);
 				}
 				await disposeCLI();

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -913,6 +913,31 @@ describe('start command', () => {
 	}, 120000);
 });
 
+describe('build-snapshot command', () => {
+	test('should create a zip file of the WordPress site', async () => {
+		const tmpDir = await mkdtemp(
+			path.join(tmpdir(), 'playground-test-snapshot-')
+		);
+		const zipPath = path.join(tmpDir, 'snapshot.zip');
+
+		try {
+			await runCLI({
+				command: 'build-snapshot',
+				outfile: zipPath,
+			});
+
+			expect(existsSync(zipPath)).toBe(true);
+			const stats = lstatSync(zipPath);
+			expect(stats.isFile()).toBe(true);
+			expect(stats.size).toBeGreaterThan(0);
+		} finally {
+			if (existsSync(tmpDir)) {
+				rmSync(tmpDir, { recursive: true, force: true });
+			}
+		}
+	}, 120000);
+});
+
 describe('other run-cli behaviors', () => {
 	describe('auto-login', () => {
 		test('should clear old auto-login cookie', async () => {


### PR DESCRIPTION
## Motivation for the change, related issues

The `build-snapshot` Playground CLI command failed to generate a zip with a `Cannot read properties of undefined (reading 'run')` while attempting to call `zipSite`.

The root cause was that the `playground` variable wasn't initialized at that time. To fix it, this PR uses `initialPlayground`, which is available at the time of calling `zipSite`.

To avoid similar errors in the future, the PR also updates the type of the `playground` variable to initially be` undefined`, so that Typescript can detect similar errors. It also adds a test that runs build-snapshot and checks if a non-empty file was created in the `outfile` path.

## Testing Instructions (or ideally a Blueprint)

- CI

### Manual testing

- Run `npx nx dev playground-cli server -- build-snapshot`
- Confirm that a site snapshot was created