### PR TITLE
[i18n] Add Bengali translation for about/index.md

### DIFF
--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/about/index.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/about/index.md
@@ -1,0 +1,163 @@
+---
+title: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড সম্পর্কে
+slug: /about
+description: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড-এর একটি সংক্ষিপ্ত বিবরণ, এটি কী, কেন এটি দরকারী এবং এটি কীভাবে আপনার ব্রাউজারে ওয়ার্ডপ্রেস চালায় তার ব্যাখ্যা।
+---
+
+<!--
+# About WordPress Playground
+-->
+
+# ওয়ার্ডপ্রেস প্লেগ্রাউন্ড সম্পর্কে
+
+<!--
+## What is WordPress Playground?
+-->
+
+## ওয়ার্ডপ্রেস প্লেগ্রাউন্ড কী?
+
+<!--
+**WordPress Playground is the platform that lets you run WordPress instantly on any device without a host**. It allows you to experiment and learn about WordPress without affecting your live website. It's a virtual sandbox where you can play around with different features, designs, and settings in a safe and controlled environment.
+-->
+
+**ওয়ার্ডপ্রেস প্লেগ্রাউন্ড এমন একটি প্ল্যাটফর্ম যা আপনাকে কোনো হোস্টিং ছাড়াই যেকোনো ডিভাইসে তাৎক্ষণিকভাবে ওয়ার্ডপ্রেস চালানোর সুবিধা দেয়।** এটি আপনাকে আপনার লাইভ ওয়েবসাইটকে প্রভাবিত না করেই ওয়ার্ডপ্রেস নিয়ে পরীক্ষা-নিরীক্ষা এবং শেখার সুযোগ করে দেয়। এটি একটি ভার্চুয়াল স্যান্ডবক্স যেখানে আপনি একটি নিরাপদ এবং নিয়ন্ত্রিত পরিবেশে বিভিন্ন ফিচার, ডিজাইন এবং সেটিংস নিয়ে কাজ করতে পারেন।
+
+<!--
+WordPress Playground is your place to build, test, and launch:
+-->
+
+আপনার তৈরি, পরীক্ষা এবং লঞ্চ করার জায়গা হলো ওয়ার্ডপ্রেস প্লেগ্রাউন্ড:
+
+<!--
+-   [Build](/about/build): WordPress Playground can help you to build products with WordPress. Use it from where you work best, whether that's in the browser, Node.js, mobile apps, VS Code, or elsewhere.
+-   [Test](/about/test): Upgrade your QA process with WordPress Playground. Quickly test your plugins or themes, experiment in a private sandbox, and create PRs from your WP Playground instance to any repo.
+-   [Launch](/about/launch): Use WordPress Playground to showcase your product, let users try it live, or launch it in the App Store with zero lead time.
+-->
+
+-   [তৈরি করুন (Build)](/about/build): ওয়ার্ডপ্রেস প্লেগ্রাউন্ড আপনাকে ওয়ার্ডপ্রেস দিয়ে পণ্য তৈরি করতে সাহায্য করতে পারে। আপনি ব্রাউজার, Node.js, মোবাইল অ্যাপস, VS Code বা অন্য যেকোনো জায়গা থেকে যেখানে আপনার কাজ করতে সুবিধা হয় সেখান থেকেই এটি ব্যবহার করতে পারেন।
+-   [পরীক্ষা করুন (Test)](/about/test): আপনার QA প্রক্রিয়াকে ওয়ার্ডপ্রেস প্লেগ্রাউন্ড-এর মাধ্যমে আরও উন্নত করুন। সহজেই আপনার প্লাগইন বা থিম পরীক্ষা করুন, একটি প্রাইভেট স্যান্ডবক্সে পরীক্ষা-নিরীক্ষা করুন এবং আপনার WP প্লেগ্রাউন্ড ইনস্ট্যান্স থেকে যেকোনো রেপোতে PR তৈরি করুন।
+-   [লঞ্চ করুন (Launch)](/about/launch): আপনার পণ্য প্রদর্শনের জন্য ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্যবহার করুন, ব্যবহারকারীদের এটি লাইভ ট্রায়াল দেওয়ার সুযোগ দিন, অথবা কোনো প্রকার বাড়তি সময় ছাড়াই অ্যাপ স্টোরে লঞ্চ করুন।
+
+<!--
+## Why WordPress Playground?
+-->
+
+## কেন ওয়ার্ডপ্রেস প্লেগ্রাউন্ড?
+
+<!--
+### Try themes and plugins on the fly
+-->
+
+### থিম এবং প্লাগইন সহজে ট্রাই করুন
+
+<!--
+With WordPress Playground, you can explore any [theme](https://developer.wordpress.org/themes/getting-started/what-is-a-theme/). You can choose from a wide range of themes and see how they look on your site. You can also modify the colors, fonts, layouts, and other visual elements to create a unique design.
+-->
+
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ড-এর মাধ্যমে আপনি যেকোনো [থিম](https://developer.wordpress.org/themes/getting-started/what-is-a-theme/) এক্সপ্লোর করতে পারেন। আপনি বিভিন্ন থিমের মধ্য থেকে বেছে নিতে পারেন এবং আপনার সাইটে সেগুলো কেমন দেখাবে তা দেখতে পারেন। একটি অনন্য ডিজাইন তৈরি করতে আপনি রঙ, ফন্ট, লেআউট এবং অন্যান্য ভিজ্যুয়াল উপাদানগুলোও পরিবর্তন করতে পারেন।
+
+<!--
+In addition to themes, you can experiment with plugins too. With WordPress Playground, you can install and test different plugins to see how they work and what they can do for your site. This allows you to explore and understand the capabilities of WordPress without worrying about breaking anything.
+-->
+
+থিম ছাড়াও আপনি প্লাগইন নিয়েও পরীক্ষা-নিরীক্ষা করতে পারেন। ওয়ার্ডপ্রেস প্লেগ্রাউন্ড-এর মাধ্যমে আপনি বিভিন্ন প্লাগইন ইনস্টল এবং পরীক্ষা করতে পারেন যাতে দেখা যায় সেগুলো কীভাবে কাজ করে এবং আপনার সাইটের জন্য কী করতে পারে। এটি আপনাকে কোনো কিছু ভেঙে যাওয়ার চিন্তা ছাড়াই ওয়ার্ডপ্রেস-এর ক্ষমতাগুলো বুঝতে সাহায্য করে।
+
+<!--
+### Create content on the go
+-->
+
+### যেকোনো জায়গায় কন্টেন্ট তৈরি করুন
+
+<!--
+Another great feature of WordPress Playground is the ability to create and edit content. You can write blog posts, create pages, and add media like images and videos to your site. This helps you understand how to organize and structure your content effectively.
+-->
+
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ড-এর আরেকটি চমৎকার ফিচার হলো কন্টেন্ট তৈরি এবং এডিট করার ক্ষমতা। আপনি ব্লগ পোস্ট লিখতে পারেন, পেজ তৈরি করতে পারেন এবং আপনার সাইটে ছবি ও ভিডিওর মতো মিডিয়া যোগ করতে পারেন। এটি আপনাকে আপনার কন্টেন্ট কীভাবে কার্যকরভাবে সংগঠিত এবং গঠন করতে হয় তা বুঝতে সাহায্য করে।
+
+<!--
+The content you create is limited to the Playground on your device and disappears once you leave it, so you are free to explore and play without risking breaking any actual site.
+-->
+
+আপনার তৈরি করা কন্টেন্ট শুধুমাত্র আপনার ডিভাইসের প্লেগ্রাউন্ডেই সীমাবদ্ধ থাকে এবং আপনি এটি ছেড়ে চলে গেলে তা মুছে যায়, তাই আপনি কোনো প্রকৃত সাইট নষ্ট করার ঝুঁকি ছাড়াই এক্সপ্লোর করতে পারেন।
+
+<!--
+But hey! You can also connect your Playground instance to a GitHub repo and create a PR to persist those changes.
+-->
+
+তবে একটু দাঁড়ান! আপনি আপনার প্লেগ্রাউন্ড ইনস্ট্যান্সকে একটি গিটহাব (GitHub) রেপোর সাথে কানেক্ট করতে পারেন এবং সেই পরিবর্তনগুলো স্থায়ী করতে একটি PR তৈরি করতে পারেন।
+
+<!--
+### It's super safe
+-->
+
+### এটি অত্যন্ত নিরাপদ
+
+<!--
+Overall, WordPress Playground provides a risk-free environment for beginners to learn and get hands-on experience with WordPress. It helps you to gain confidence and knowledge before making changes to your live website.
+-->
+
+সামগ্রিকভাবে, ওয়ার্ডপ্রেস প্লেগ্রাউন্ড নতুনদের জন্য ওয়ার্ডপ্রেস শেখার এবং সরাসরি অভিজ্ঞতা অর্জনের জন্য একটি ঝুঁকিমুক্ত পরিবেশ প্রদান করে। এটি আপনার লাইভ ওয়েবসাইটে পরিবর্তন করার আগে আপনাকে আত্মবিশ্বাস এবং জ্ঞান অর্জনে সাহায্য করে।
+
+<!--
+:::tip
+Check the [guides section](/guides) to learn more about how to leverage WordPress Playground to test your themes and plugins and create content on the fly.
+:::
+-->
+
+:::পরামর্শ
+আপনার থিম ও প্লাগইন পরীক্ষা করতে এবং সহজে কন্টেন্ট তৈরি করতে কীভাবে ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্যবহার করবেন সে সম্পর্কে আরও জানতে [গাইডস সেকশন](/guides) দেখুন।
+:::
+
+<!--
+## How does WordPress Playground work?
+-->
+
+## ওয়ার্ডপ্রেস প্লেগ্রাউন্ড কীভাবে কাজ করে?
+
+<!--
+When you first start using WordPress Playground, you'll be provided with a separate space where you can create and customise your own WordPress website. This space is completely isolated from your actual website.
+-->
+
+আপনি যখন প্রথমবার ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্যবহার শুরু করবেন, তখন আপনাকে একটি আলাদা জায়গা দেওয়া হবে যেখানে আপনি আপনার নিজস্ব ওয়ার্ডপ্রেস ওয়েবসাইট তৈরি এবং কাস্টমাইজ করতে পারবেন। এই জায়গাটি আপনার প্রকৃত ওয়েবসাইট থেকে সম্পূর্ণ আলাদা।
+
+<!--
+### Streamed, not served.
+-->
+
+### স্ট্রিমড (Streamed), সার্ভড (Served) নয়।
+
+<!--
+The WordPress you see when you open Playground in your browser is a WordPress that should function like any WordPress, with [a few limitations](/developers/limitations) and the important exception that it's not a permanent server with an internet address which will limit connections to some third-party services (automation, sharing, analysis, email, backups, etc.) in a persistent way.
+-->
+
+আপনি যখন ব্রাউজারে প্লেগ্রাউন্ড ওপেন করেন তখন যে ওয়ার্ডপ্রেস দেখতে পান, তা যেকোনো সাধারণ ওয়ার্ডপ্রেস-এর মতোই কাজ করে, তবে [কিছু সীমাবদ্ধতা](/developers/limitations) আছে। এছাড়া একটি গুরুত্বপূর্ণ বিষয় হলো যে এটি কোনো ইন্টারনেট অ্যাড্রেস সহ স্থায়ী সার্ভার নয়, যার ফলে এটি কিছু থার্ড-পার্টি সার্ভিস (অটোমেশন, শেয়ারিং, অ্যানালিসিস, ইমেইল, ব্যাকআপ ইত্যাদি) এর সাথে স্থায়ীভাবে কানেকশন সীমাবদ্ধ করতে পারে।
+
+<!--
+The loading screen and progress bar you see on Playground includes both the streaming of those foundational technologies to your browser and configuration steps from [WordPress Blueprints](/blueprints) (see [examples](/blueprints/examples)), so that a full server, WordPress software, Theme & Plugin solutions and configuration instructions can be streamed over-the-wire.
+-->
+
+প্লেগ্রাউন্ডে আপনি যে লোডিং স্ক্রিন এবং প্রগ্রেস বার দেখতে পান, তাতে আপনার ব্রাউজারে সেই মৌলিক প্রযুক্তিগুলোর স্ট্রিমিং এবং [ওয়ার্ডপ্রেস ব্লুপ্রিন্টস](/blueprints) (উদাহরণ দেখুন [examples](/blueprints/examples)) থেকে কনফিগারেশন ধাপগুলো অন্তর্ভুক্ত থাকে। এতে করে একটি সম্পূর্ণ সার্ভার, ওয়ার্ডপ্রেস সফটওয়্যার, থিম ও প্লাগইন সমাধান এবং কনফিগারেশন ইনস্ট্রাকশন অনলাইনে স্ট্রিম করা যায়।
+
+<!--
+## What makes Playground different from running WordPress on a web server or local desktop app?
+-->
+
+## ওয়েব সার্ভার বা লোকাল ডেস্কটপ অ্যাপে ওয়ার্ডপ্রেস চালানোর সাথে প্লেগ্রাউন্ডের পার্থক্য কী?
+
+<!--
+Web applications like WordPress have long relied on server technologies [to run logic](/developers/architecture/wasm-php-overview) and [store data](/developers/architecture/wordpress#sqlite).
+-->
+
+ওয়ার্ডপ্রেস-এর মতো ওয়েব অ্যাপ্লিকেশনগুলো লজিক চালানো [to run logic](/developers/architecture/wasm-php-overview) এবং ডেটা স্টোর করার [store data](/developers/architecture/wordpress#sqlite) জন্য অনেক আগে থেকেই সার্ভার প্রযুক্তির ওপর নির্ভরশীল।
+
+<!--
+Using those technologies has meant either running a web server connected to the internet or using those technologies in a desktop service or app (sometimes called a "WordPress local environment") that either leans on a virtual server with the technologies installed or the underlying technologies on the current device.
+-->
+
+এই প্রযুক্তিগুলো ব্যবহারের মানে ছিল হয় ইন্টারনেটের সাথে যুক্ত একটি ওয়েব সার্ভার চালানো, অথবা ডেস্কটপ সার্ভিস বা অ্যাপে (যাকে অনেক সময় "ওয়ার্ডপ্রেস লোকাল এনভায়রনমেন্ট" বলা হয়) এই প্রযুক্তিগুলো ব্যবহার করা। এগুলো হয় একটি ভার্চুয়াল সার্ভারের ওপর নির্ভর করে যেখানে প্রযুক্তিগুলো ইনস্টল করা থাকে অথবা বর্তমান ডিভাইসের অন্তর্নিহিত প্রযুক্তির ওপর।
+
+<!--
+Playground is a novel way to stream server technologies—including WordPress (and WP-CLI)—as files that can then run in the browser.
+-->
+
+প্লেগ্রাউন্ড হলো সার্ভার প্রযুক্তিগুলোকে—যার মধ্যে ওয়ার্ডপ্রেস (এয়ং WP-CLI) অন্তর্ভুক্ত—ফাইল হিসেবে স্ট্রিম করার একটি নতুন উপায়, যা ব্রাউজারের ভেতরেই চলতে পারে।


### PR DESCRIPTION
## What?

Added Bengali (bn) translation for the [about/index.md]

## Why?

To make WordPress Playground documentation accessible to Bengali-speaking users and provide an overview of the platform in their native language.

## How?

- Translated all content following the established translation format
- Original English text preserved in HTML comments for reviewer reference
- Technical terms (WordPress, Playground, GitHub, etc.) handled using standardized Bengali script while keeping original terms for clarity
- Markdown structure and links remain unchanged
- Code blocks remain unchanged