### PR TITLE
Fix "Cannot read properties of undefined (reading 'data')" with nx

### DIFF
--- a/packages/nx-extensions/src/executors/package-json/executor.ts
+++ b/packages/nx-extensions/src/executors/package-json/executor.ts
@@ -23,16 +23,25 @@ export default async function* packageJsonExecutor(
 	options: PackageJsonExecutorSchema,
 	context: ExecutorContext
 ) {
+	// Ensure externalNodes exists to prevent "Cannot read properties of undefined"
+	// errors in NX's createPackageJson. This can happen when NX's native module
+	// doesn't track lockfiles (e.g., package-lock.json), causing the js plugin's
+	// createNodes to never populate externalNodes.
+	if (!context.projectGraph.externalNodes) {
+		context.projectGraph.externalNodes = {};
+	}
+
 	const helperDependencies = getHelperDependenciesFromProjectGraph(
 		context.root,
 		context.projectName,
 		context.projectGraph
-	);
+	).filter((dep) => dep.target in context.projectGraph.externalNodes);
 
 	const importHelpers = !!readTsConfig(options.tsConfig).options
 		.importHelpers;
 	const shouldAddHelperDependency =
 		importHelpers &&
+		HelperDependency.tsc in context.projectGraph.externalNodes &&
 		helperDependencies.every((dep) => dep.target !== HelperDependency.tsc);
 
 	if (shouldAddHelperDependency) {


### PR DESCRIPTION
### Motivation for the change, related issues                                                                                                 
                                                                                                                                          
Local builds fail with `Cannot read properties of undefined (reading 'data')` in NX's `create-package-json.js` when running `npm run build` or any `npx nx build <package>` that uses the `build:package-json` target.                   
                                                                                                                                          
Root cause: NX's native Rust module doesn't include `package-lock.json` in its file tracking (at least for me, locally), so the js plugin's lockfile glob never matches anything and `externalNodes` in the project graph stays empty. When our executor calls NX's `createPackageJson`, it tries to look up helper dependencies (like `npm:tslib`) in `externalNodes` and crashes.                                                                               
                                                                                                                                          
I am not quite sure why CI passes.
                      

```
   ✖  nx run php-wasm-node-polyfills:build:package-json
       NX  Falling back to ts-node for local typescript execution. This may be a little slower.
        - To fix this, ensure @swc-node/register and @swc/core have been installed
      vite v5.4.21 building for production...
      transforming...
      ✓ 4 modules transformed.
      rendering chunks...
      
      [vite:dts] Start generate declaration files...
      computing gzip size...
      ../../../dist/packages/php-wasm/node-polyfills/index.js  2.36 kB │ gzip: 1.03 kB │ map: 10.08 kB
      [vite:dts] Declaration files built in 239ms.
      
      ../../../dist/packages/php-wasm/node-polyfills/index.cjs  1.66 kB │ gzip: 0.83 kB │ map: 9.85 kB
      ✓ built in 283ms
      
       NX   Cannot read properties of undefined (reading 'data')
      
      Pass --verbose to see the stacktrace.
      
      

———————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————
   ✖  nx run php-wasm-logger:build:package-json
       NX  Falling back to ts-node for local typescript execution. This may be a little slower.
        - To fix this, ensure @swc-node/register and @swc/core have been installed
      vite v5.4.21 building for production...
      transforming...
      ✓ 10 modules transformed.
      rendering chunks...
      
      [vite:dts] Start generate declaration files...
      computing gzip size...
      ../../../dist/packages/php-wasm/logger/index.js  6.94 kB │ gzip: 2.35 kB │ map: 21.81 kB
      [vite:dts] Declaration files built in 295ms.
      
      ../../../dist/packages/php-wasm/logger/index.cjs  4.62 kB │ gzip: 1.96 kB │ map: 20.67 kB
      ✓ built in 379ms
      
       NX   Cannot read properties of undefined (reading 'data')
      
      Pass --verbose to see the stacktrace.

```
                                                                      
### Implementation details                                                                                                                    
                                                                                                                                          
- Ensure `externalNodes` exists by defaulting to an empty object if undefined
- Filter helper dependencies from `getHelperDependenciesFromProjectGraph` to only include ones that actually exist in `externalNodes` 
- Only add `tslib` helper dependency if it exists in `externalNodes`
                                                                                                                                          
Trade-off: When `externalNodes` is empty, generated `package.json` files won't include `tslib`. This should be fine since we use bundled builds  where helpers are inlined anyway.                                                                                                         
                                                                                                                                          
### Testing Instructions (or ideally a Blueprint)                                                                                             
                                                                                                                                          
`npx nx reset`
`npx nx build php-wasm-universal`
`npx nx build playground-client`
