### PR TITLE
[website] Refactor out an Overlay component from saved-playgrounds-overlay

### DIFF
--- a/packages/playground/website/src/components/overlay/index.tsx
+++ b/packages/playground/website/src/components/overlay/index.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState, ReactNode } from 'react';
+import { useCallback, useEffect } from 'react';
+import type { ReactNode } from 'react';
 import classNames from 'classnames';
 import {
 	__experimentalHStack as HStack,

--- a/packages/playground/website/src/components/overlay/index.tsx
+++ b/packages/playground/website/src/components/overlay/index.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useState, ReactNode } from 'react';
+import classNames from 'classnames';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	FlexItem,
+	Button,
+} from '@wordpress/components';
+import { close, arrowLeft } from '@wordpress/icons';
+import store from '../../lib/state/redux/store';
+import css from './style.module.css';
+
+function PlaygroundLogo() {
+	return (
+		<div className={css.logo}>
+			<svg
+				viewBox="0 0 124 124"
+				fill="none"
+				xmlns="http://www.w3.org/2000/svg"
+				className={css.logoIcon}
+			>
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M14.755 45.1665C12.0512 48.8962 10.6245 53.4789 10.3951 58.5153C10.358 59.3301 10.3522 60.1566 10.3774 60.9934C10.7191 72.3238 16.7432 85.5209 27.6103 96.388C44.2413 113.019 66.3294 118.307 78.8323 109.243C73.5732 108.004 68.2526 106.073 63.0136 103.496C61.6689 103.437 60.222 103.262 58.6713 102.952C56.0196 102.421 53.2158 101.511 50.3594 100.216C50.3593 100.216 50.3592 100.215 50.359 100.215C45.1354 97.8469 39.7361 94.1934 34.7704 89.2277C29.8052 84.2625 26.1519 78.8637 23.784 73.6406C23.7838 73.6405 23.7836 73.6405 23.7834 73.6404C22.4884 70.7839 21.5779 67.9798 21.0476 65.3279C20.7375 63.7776 20.5621 62.3309 20.5032 60.9865C17.9263 55.7471 15.9944 50.426 14.755 45.1665ZM4.33861 76.7002C4.71713 76.3217 5.11425 75.9686 5.52862 75.6407C6.7468 79.1965 8.35436 82.7444 10.3249 86.214C10.06 87.3833 10.0041 88.9848 10.4335 91.1319C11.2858 95.3936 13.9437 100.626 18.659 105.341C23.3743 110.056 28.6064 112.714 32.8681 113.567C35.0158 113.996 36.6176 113.94 37.787 113.675C41.2566 115.645 44.8043 117.252 48.36 118.47C48.0319 118.885 47.6786 119.283 47.2998 119.661C39.3909 127.57 23.3622 124.365 11.4988 112.501C-0.364596 100.638 -3.57033 84.6091 4.33861 76.7002ZM43.7198 80.2786C67.4466 104.005 99.5039 110.417 115.322 94.599C121.041 88.8798 123.854 81.0375 123.994 72.2337C124.239 56.6885 116.149 38.1454 101.001 22.9976C77.2746 -0.729192 45.2173 -7.14065 29.3994 8.67722C23.6725 14.4041 20.8595 22.2597 20.7271 31.078C20.4941 46.6158 28.5836 65.1423 43.7198 80.2786ZM77.1341 84.4888C77.5747 86.6917 77.7433 88.6853 77.6924 90.4738C68.7821 87.3724 59.3392 81.5782 50.88 73.119C42.4208 64.6598 36.6267 55.2171 33.5253 46.3068C35.3138 46.2559 37.3074 46.4245 39.5104 46.8651C47.0115 48.3653 55.7301 52.9069 63.4112 60.588C71.0923 68.2691 75.6339 76.9877 77.1341 84.4888ZM36.5596 15.8374C32.2725 20.1245 29.985 27.0976 31.1373 36.3235C43.2662 35.1444 58.3841 41.2404 70.5714 53.4278C82.7587 65.6151 88.8548 80.7329 87.6757 92.8617C96.9016 94.014 103.875 91.7265 108.162 87.4394C112.932 82.6694 115.226 74.5742 113.061 63.7503C110.913 53.0099 104.488 40.8048 93.8412 30.1578C83.1942 19.5108 70.9891 13.0857 60.2487 10.9376C49.4248 8.7728 41.3296 11.0674 36.5596 15.8374Z"
+					fill="#e5e6e6"
+				/>
+			</svg>
+			<span className={css.logoText}>Playground</span>
+		</div>
+	);
+}
+
+interface OverlayProps {
+	children: ReactNode;
+	onClose: () => void;
+	className?: string;
+}
+
+export function Overlay({ children, onClose, className }: OverlayProps) {
+	const handleKeyDown = useCallback(
+		(event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				const currentActiveModal = store.getState().ui.activeModal;
+				if (currentActiveModal) {
+					return;
+				}
+				onClose();
+			}
+		},
+		[onClose]
+	);
+
+	useEffect(() => {
+		document.addEventListener('keydown', handleKeyDown, true);
+		return () => {
+			document.removeEventListener('keydown', handleKeyDown, true);
+		};
+	}, [handleKeyDown]);
+
+	return (
+		<div className={classNames(css.overlay, className)}>
+			<VStack className={css.fullscreenContent} spacing={0}>
+				{children}
+			</VStack>
+		</div>
+	);
+}
+
+interface OverlayHeaderProps {
+	children?: ReactNode;
+	onClose: () => void;
+	onBack?: () => void;
+	title?: string;
+	showLogo?: boolean;
+}
+
+export function OverlayHeader({
+	children,
+	onClose,
+	onBack,
+	title,
+	showLogo = true,
+}: OverlayHeaderProps) {
+	return (
+		<HStack
+			className={css.header}
+			alignment="center"
+			justify="space-between"
+		>
+			{onBack ? (
+				<Button
+					icon={arrowLeft}
+					label="Back"
+					onClick={onBack}
+					className={css.backButton}
+				/>
+			) : (
+				<FlexItem className={css.headerSpacer} />
+			)}
+			{children || (
+				<>
+					{showLogo && <PlaygroundLogo />}
+					{title && <h1 className={css.headerTitle}>{title}</h1>}
+				</>
+			)}
+			<Button
+				icon={close}
+				label="Close"
+				onClick={onClose}
+				className={css.closeButton}
+			/>
+		</HStack>
+	);
+}
+
+interface OverlayBodyProps {
+	children: ReactNode;
+	className?: string;
+}
+
+export function OverlayBody({ children, className }: OverlayBodyProps) {
+	return <div className={classNames(css.body, className)}>{children}</div>;
+}
+
+interface OverlaySectionProps {
+	children: ReactNode;
+	title?: string;
+	description?: string;
+	className?: string;
+}
+
+export function OverlaySection({
+	children,
+	title,
+	description,
+	className,
+}: OverlaySectionProps) {
+	return (
+		<section className={classNames(css.section, className)}>
+			{title && <h2 className={css.sectionTitle}>{title}</h2>}
+			{description && (
+				<p className={css.sectionDescription}>{description}</p>
+			)}
+			{children}
+		</section>
+	);
+}
+
+export { css as overlayStyles };

--- a/packages/playground/website/src/components/overlay/style.module.css
+++ b/packages/playground/website/src/components/overlay/style.module.css
@@ -1,0 +1,137 @@
+.overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: #1e2327;
+	z-index: 100;
+	display: flex;
+	flex-direction: column;
+	overflow-y: auto;
+	animation: fadeIn 0.15s ease-out;
+}
+
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+
+.fullscreenContent {
+	width: 100%;
+	min-height: 100%;
+	display: flex;
+	flex-direction: column;
+	max-width: 1200px;
+	margin: 0 auto;
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 20px 32px;
+	border-bottom: 1px solid #2c3338;
+	flex-shrink: 0;
+}
+
+.headerSpacer {
+	width: 40px;
+}
+
+.headerTitle {
+	font-size: clamp(18px, 2vw, 22px);
+	font-weight: 600;
+	color: #fff !important;
+	margin: 0;
+}
+
+.logo {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.logoIcon {
+	width: 32px;
+	height: 32px;
+}
+
+.logoIcon path {
+	fill: #3858e9;
+}
+
+.logoText {
+	font-size: clamp(18px, 2vw, 22px);
+	font-weight: 600;
+	color: #fff;
+}
+
+.closeButton {
+	color: #949494 !important;
+	padding: 4px !important;
+}
+
+.closeButton:hover {
+	color: #fff !important;
+}
+
+.backButton {
+	color: #949494 !important;
+	padding: 4px !important;
+}
+
+.backButton:hover {
+	color: #fff !important;
+}
+
+.body {
+	position: relative;
+	padding: 32px;
+	flex: 1;
+}
+
+.section {
+	margin-bottom: 32px;
+	width: 100%;
+}
+
+.body > .section:last-child {
+	margin-bottom: 0;
+	padding-bottom: 32px;
+}
+
+.sectionTitle {
+	margin: 0 0 16px 0 !important;
+	font-size: clamp(18px, 2vw, 22px) !important;
+	font-weight: 600 !important;
+	color: #fff !important;
+}
+
+.sectionDescription {
+	margin: 0 0 12px 0;
+	font-size: clamp(13px, 1.3vw, 14px);
+	color: #6b7280;
+	line-height: 1.5;
+}
+
+.section p {
+	color: #9ca3af;
+	margin: 0;
+	font-size: clamp(14px, 1.4vw, 15px);
+	line-height: 1.5;
+}
+
+@media (max-width: 640px) {
+	.header {
+		padding: 16px 20px;
+	}
+
+	.body {
+		padding: 20px;
+	}
+}

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -1,20 +1,16 @@
 import css from './style.module.css';
 import classNames from 'classnames';
 import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-	FlexItem,
 	Spinner,
-	Button,
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
-import { close, arrowLeft, moreVertical, upload, link } from '@wordpress/icons';
+import { moreVertical, upload, link } from '@wordpress/icons';
 import { Icon } from '@wordpress/icons';
 import { GitHubIcon } from '../../github/github';
 import { useDispatch } from 'react-redux';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { usePlaygroundClient } from '../../lib/use-playground-client';
 import { importWordPressFiles } from '@wp-playground/client';
 import { logger } from '@php-wasm/logger';
@@ -24,7 +20,6 @@ import {
 	useAppDispatch,
 	useAppSelector,
 } from '../../lib/state/redux/store';
-import store from '../../lib/state/redux/store';
 import type { PlaygroundDispatch } from '../../lib/state/redux/store';
 import type { SiteLogo, SiteInfo } from '../../lib/state/redux/slice-sites';
 import {
@@ -42,6 +37,12 @@ import {
 import { WordPressIcon } from '@wp-playground/components';
 import useFetch from '../../lib/hooks/use-fetch';
 import { PlaygroundRoute, redirectTo } from '../../lib/state/url/router';
+import {
+	Overlay,
+	OverlayHeader,
+	OverlayBody,
+	OverlaySection,
+} from '../overlay';
 
 type BlueprintsIndexEntry = {
 	title: string;
@@ -57,9 +58,6 @@ interface SavedPlaygroundsOverlayProps {
 	onClose: () => void;
 }
 
-type ViewMode = 'main' | 'blueprints';
-
-// Pull Request icon from GitHub Octicons (https://github.com/primer/octicons)
 function PullRequestIcon() {
 	return (
 		<svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
@@ -68,33 +66,11 @@ function PullRequestIcon() {
 	);
 }
 
-// 3x3 grid icon from Bootstrap Icons (grid-3x3-gap-fill)
 function GridIcon({ size = 20 }: { size?: number }) {
 	return (
 		<svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
 			<path d="M1 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V2zM1 7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V7zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V7zM1 12a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2z" />
 		</svg>
-	);
-}
-
-function PlaygroundLogo() {
-	return (
-		<div className={css.logo}>
-			<svg
-				viewBox="0 0 124 124"
-				fill="none"
-				xmlns="http://www.w3.org/2000/svg"
-				className={css.logoIcon}
-			>
-				<path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M14.755 45.1665C12.0512 48.8962 10.6245 53.4789 10.3951 58.5153C10.358 59.3301 10.3522 60.1566 10.3774 60.9934C10.7191 72.3238 16.7432 85.5209 27.6103 96.388C44.2413 113.019 66.3294 118.307 78.8323 109.243C73.5732 108.004 68.2526 106.073 63.0136 103.496C61.6689 103.437 60.222 103.262 58.6713 102.952C56.0196 102.421 53.2158 101.511 50.3594 100.216C50.3593 100.216 50.3592 100.215 50.359 100.215C45.1354 97.8469 39.7361 94.1934 34.7704 89.2277C29.8052 84.2625 26.1519 78.8637 23.784 73.6406C23.7838 73.6405 23.7836 73.6405 23.7834 73.6404C22.4884 70.7839 21.5779 67.9798 21.0476 65.3279C20.7375 63.7776 20.5621 62.3309 20.5032 60.9865C17.9263 55.7471 15.9944 50.426 14.755 45.1665ZM4.33861 76.7002C4.71713 76.3217 5.11425 75.9686 5.52862 75.6407C6.7468 79.1965 8.35436 82.7444 10.3249 86.214C10.06 87.3833 10.0041 88.9848 10.4335 91.1319C11.2858 95.3936 13.9437 100.626 18.659 105.341C23.3743 110.056 28.6064 112.714 32.8681 113.567C35.0158 113.996 36.6176 113.94 37.787 113.675C41.2566 115.645 44.8043 117.252 48.36 118.47C48.0319 118.885 47.6786 119.283 47.2998 119.661C39.3909 127.57 23.3622 124.365 11.4988 112.501C-0.364596 100.638 -3.57033 84.6091 4.33861 76.7002ZM43.7198 80.2786C67.4466 104.005 99.5039 110.417 115.322 94.599C121.041 88.8798 123.854 81.0375 123.994 72.2337C124.239 56.6885 116.149 38.1454 101.001 22.9976C77.2746 -0.729192 45.2173 -7.14065 29.3994 8.67722C23.6725 14.4041 20.8595 22.2597 20.7271 31.078C20.4941 46.6158 28.5836 65.1423 43.7198 80.2786ZM77.1341 84.4888C77.5747 86.6917 77.7433 88.6853 77.6924 90.4738C68.7821 87.3724 59.3392 81.5782 50.88 73.119C42.4208 64.6598 36.6267 55.2171 33.5253 46.3068C35.3138 46.2559 37.3074 46.4245 39.5104 46.8651C47.0115 48.3653 55.7301 52.9069 63.4112 60.588C71.0923 68.2691 75.6339 76.9877 77.1341 84.4888ZM36.5596 15.8374C32.2725 20.1245 29.985 27.0976 31.1373 36.3235C43.2662 35.1444 58.3841 41.2404 70.5714 53.4278C82.7587 65.6151 88.8548 80.7329 87.6757 92.8617C96.9016 94.014 103.875 91.7265 108.162 87.4394C112.932 82.6694 115.226 74.5742 113.061 63.7503C110.913 53.0099 104.488 40.8048 93.8412 30.1578C83.1942 19.5108 70.9891 13.0857 60.2487 10.9376C49.4248 8.7728 41.3296 11.0674 36.5596 15.8374Z"
-					fill="#e5e6e6"
-				/>
-			</svg>
-			<span className={css.logoText}>Playground</span>
-		</div>
 	);
 }
 
@@ -112,25 +88,13 @@ export function SavedPlaygroundsOverlay({
 	const playground = usePlaygroundClient();
 	const zipFileInputRef = useRef<HTMLInputElement>(null);
 
-	const [viewMode, setViewMode] = useState<ViewMode>('main');
+	const [viewMode, setViewMode] = useState<'main' | 'blueprints'>('main');
 	const [searchQuery, setSearchQuery] = useState('');
 	const [selectedTag, setSelectedTag] = useState<string | null>(null);
-	const [isClosing, setIsClosing] = useState(false);
 	const [pendingZipFile, setPendingZipFile] = useState<File | null>(null);
 
-	const closeWithFade = (callback?: () => void) => {
-		setIsClosing(true);
-		setTimeout(() => {
-			if (callback) {
-				callback();
-			}
-			onClose();
-		}, 200); // Match the fadeOut animation duration
-	};
-
-	// Ensure we import into a temporary site, not a saved site.
-	// This effect handles the actual import once we're on a temporary site.
 	const isTemporarySite = activeSite?.metadata.storage === 'none';
+
 	useEffect(() => {
 		if (!pendingZipFile || !isTemporarySite || !playground) {
 			return;
@@ -141,8 +105,6 @@ export function SavedPlaygroundsOverlay({
 				await importWordPressFiles(playground, {
 					wordPressFilesZip: pendingZipFile,
 				});
-				// TODO: Do not prefetch update checks at this stage, it delays
-				//       refreshing the page.
 				setTimeout(async () => {
 					await playground.goTo('/');
 				}, 200);
@@ -155,10 +117,8 @@ export function SavedPlaygroundsOverlay({
 				alert(
 					'Unable to import file. Is it a valid WordPress Playground export?'
 				);
-				return;
 			} finally {
 				setPendingZipFile(null);
-				// Reset the input so the same file can be selected again
 				if (zipFileInputRef.current) {
 					zipFileInputRef.current.value = '';
 				}
@@ -169,16 +129,8 @@ export function SavedPlaygroundsOverlay({
 
 	function switchToTemporarySite() {
 		if (temporarySite) {
-			// Switch to existing temporary site, then import will happen via effect
 			dispatch(setActiveSite(temporarySite.slug));
 		} else {
-			// No temporary site exists, create one with a pushState-driven
-			// redirect that will trigger the temporary site route and create
-			// a new temporary site for us.
-			//
-			// Note it might take a moment so we won't call importWordPressFiles()
-			// right away. Instead, we've stored the pendingZipFile in state, and
-			// the effect above will handle the import once the temporary site loads.
 			redirectTo(PlaygroundRoute.newTemporarySite());
 		}
 	}
@@ -187,8 +139,6 @@ export function SavedPlaygroundsOverlay({
 		const file = e.target.files?.[0];
 		if (!file) return;
 
-		// Always import into a temporary site, never into a saved site.
-		// If we're on a saved site, switch to/create a temporary one first.
 		if (!isTemporarySite) {
 			setPendingZipFile(file);
 			switchToTemporarySite();
@@ -204,8 +154,6 @@ export function SavedPlaygroundsOverlay({
 
 		try {
 			await importWordPressFiles(playground, { wordPressFilesZip: file });
-			// TODO: Do not prefetch update checks at this stage, it delays
-			//       refreshing the page.
 			setTimeout(async () => {
 				await playground.goTo('/');
 			}, 200);
@@ -220,7 +168,6 @@ export function SavedPlaygroundsOverlay({
 			);
 		}
 
-		// Reset the input so the same file can be selected again
 		if (zipFileInputRef.current) {
 			zipFileInputRef.current.value = '';
 		}
@@ -243,7 +190,6 @@ export function SavedPlaygroundsOverlay({
 
 	const previewBlueprints = allBlueprints.slice(0, 5);
 
-	// Extract all unique tags and sort by popularity (number of blueprints), then alphabetically
 	const tagCounts = new Map<string, number>();
 	allBlueprints.forEach((b) => {
 		(b.categories || []).forEach((tag) => {
@@ -258,7 +204,6 @@ export function SavedPlaygroundsOverlay({
 			return 0;
 		});
 
-	// Filter blueprints based on search and tag
 	const filteredBlueprints = allBlueprints.filter((blueprint) => {
 		const query = searchQuery.toLowerCase();
 		const matchesSearch =
@@ -278,45 +223,18 @@ export function SavedPlaygroundsOverlay({
 		return matchesSearch && matchesTag;
 	});
 
-	// Handle Escape key
-	const handleKeyDown = useCallback(
-		(event: KeyboardEvent) => {
-			if (event.key === 'Escape') {
-				// Check current state at event time (not from closure)
-				const currentActiveModal = store.getState().ui.activeModal;
-				// If a sub-modal is open, let it handle the Escape key
-				if (currentActiveModal) {
-					return;
-				}
-				// Close the entire overlay (whether in main or blueprints view)
-				onClose();
-			}
-		},
-		[onClose]
-	);
-
-	useEffect(() => {
-		// Use capture phase so we can check modal state before modal handlers clear it
-		document.addEventListener('keydown', handleKeyDown, true);
-		return () => {
-			document.removeEventListener('keydown', handleKeyDown, true);
-		};
-	}, [handleKeyDown]);
-
 	const onSiteClick = (slug: string) => {
 		dispatch(setActiveSite(slug));
 		dispatch(setSiteManagerSection('site-details'));
-		closeWithFade();
+		onClose();
 	};
 
 	const onTemporaryPlaygroundClick = () => {
 		if (temporarySite) {
-			// Switch to existing temporary playground
 			dispatch(setActiveSite(temporarySite.slug));
 			dispatch(setSiteManagerSection('site-details'));
-			closeWithFade();
+			onClose();
 		} else {
-			// Create a new temporary playground
 			createVanillaSite();
 		}
 	};
@@ -325,40 +243,21 @@ export function SavedPlaygroundsOverlay({
 		return `data:${logo.mime};base64,${logo.data}`;
 	};
 
-	const handleDeleteSite = async (site: SiteInfo, onClose: () => void) => {
+	const handleDeleteSite = async (site: SiteInfo, closeMenu: () => void) => {
 		const proceed = window.confirm(
 			`Are you sure you want to delete the site '${site.metadata.name}'?`
 		);
 		if (proceed) {
 			await dispatch(removeSite(site.slug));
-			onClose();
+			closeMenu();
 		}
 	};
 
-	const handleRenameSite = (site: SiteInfo, onClose: () => void) => {
+	const handleRenameSite = (site: SiteInfo, closeMenu: () => void) => {
 		dispatch(setSiteSlugToRename(site.slug));
 		modalDispatch(setActiveModal(modalSlugs.RENAME_SITE));
-		onClose();
+		closeMenu();
 	};
-
-	// const handleDownloadSite = async (
-	// 	siteSlug: string,
-	// 	onClose: () => void
-	// ) => {
-	// 	const clientInfo = selectClientInfoBySiteSlug(
-	// 		{ clients: store.getState().clients },
-	// 		siteSlug
-	// 	);
-	// 	const playground = clientInfo?.client;
-	// 	if (!playground) {
-	// 		return;
-	// 	}
-	// 	const bytes = await zipWpContent(playground, {
-	// 		selfContained: true,
-	// 	});
-	// 	saveAs(new File([bytes], 'wordpress-playground.zip'));
-	// 	onClose();
-	// };
 
 	function previewBlueprint(blueprintPath: BlueprintsIndexEntry['path']) {
 		dispatch(setSiteManagerOpen(false));
@@ -373,13 +272,13 @@ export function SavedPlaygroundsOverlay({
 				},
 			})
 		);
-		closeWithFade();
+		onClose();
 	}
 
 	function createVanillaSite() {
 		dispatch(setSiteManagerOpen(false));
 		redirectTo(PlaygroundRoute.newTemporarySite());
-		closeWithFade();
+		onClose();
 	}
 
 	const creationOptions = [
@@ -442,105 +341,90 @@ export function SavedPlaygroundsOverlay({
 
 	if (viewMode === 'blueprints') {
 		return (
-			<div
-				className={classNames(css.overlay, {
-					[css.overlayClosing]: isClosing,
-				})}
-			>
-				<div className={css.fullscreenContent}>
-					<div className={css.header}>
-						<Button
-							icon={arrowLeft}
-							label="Back"
-							onClick={() => {
-								setViewMode('main');
-								setSearchQuery('');
-								setSelectedTag(null);
-							}}
-							className={css.backButton}
-						/>
-						<h1 className={css.headerTitle}>Blueprints</h1>
-						<Button
-							icon={close}
-							label="Close"
-							onClick={onClose}
-							className={css.closeButton}
-						/>
-					</div>
-
-					<div className={css.filtersBar}>
-						<div className={css.tagsContainer}>
+			<Overlay onClose={onClose}>
+				<OverlayHeader
+					onClose={onClose}
+					onBack={() => {
+						setViewMode('main');
+						setSearchQuery('');
+						setSelectedTag(null);
+					}}
+					title="Blueprints"
+					showLogo={false}
+				/>
+				<div className={css.filtersBar}>
+					<div className={css.tagsContainer}>
+						<button
+							className={classNames(css.tagButton, {
+								[css.tagButtonActive]: selectedTag === null,
+							})}
+							onClick={() => setSelectedTag(null)}
+						>
+							All
+						</button>
+						<button
+							className={classNames(css.tagButton, {
+								[css.tagButtonActive]:
+									selectedTag === 'Featured',
+							})}
+							onClick={() =>
+								setSelectedTag(
+									selectedTag === 'Featured'
+										? null
+										: 'Featured'
+								)
+							}
+						>
+							Featured
+						</button>
+						{allTags.slice(0, 8).map((tag) => (
 							<button
+								key={tag}
 								className={classNames(css.tagButton, {
-									[css.tagButtonActive]: selectedTag === null,
-								})}
-								onClick={() => setSelectedTag(null)}
-							>
-								All
-							</button>
-							<button
-								className={classNames(css.tagButton, {
-									[css.tagButtonActive]:
-										selectedTag === 'Featured',
+									[css.tagButtonActive]: selectedTag === tag,
 								})}
 								onClick={() =>
 									setSelectedTag(
-										selectedTag === 'Featured'
-											? null
-											: 'Featured'
+										selectedTag === tag ? null : tag
 									)
 								}
 							>
-								Featured
+								{tag}
 							</button>
-							{allTags.slice(0, 8).map((tag) => (
-								<button
-									key={tag}
-									className={classNames(css.tagButton, {
-										[css.tagButtonActive]:
-											selectedTag === tag,
-									})}
-									onClick={() =>
-										setSelectedTag(
-											selectedTag === tag ? null : tag
-										)
-									}
-								>
-									{tag}
-								</button>
-							))}
-						</div>
-						<div className={css.searchWrapper}>
-							<div className={css.searchIcon}>
-								<svg
-									width="18"
-									height="18"
-									viewBox="0 0 24 24"
-									fill="none"
-									stroke="currentColor"
-									strokeWidth="2"
-								>
-									<circle cx="11" cy="11" r="8" />
-									<path d="m21 21-4.35-4.35" />
-								</svg>
-							</div>
-							<input
-								type="text"
-								value={searchQuery}
-								onChange={(e) => setSearchQuery(e.target.value)}
-								placeholder="Search Blueprints"
-								className={css.searchField}
-								autoFocus
-							/>
-						</div>
+						))}
 					</div>
-
-					<div className={css.body}>
-						<h2 className={css.sectionTitle}>
-							{selectedTag || searchQuery
+					<div className={css.searchWrapper}>
+						<div className={css.searchIcon}>
+							<svg
+								width="18"
+								height="18"
+								viewBox="0 0 24 24"
+								fill="none"
+								stroke="currentColor"
+								strokeWidth="2"
+							>
+								<circle cx="11" cy="11" r="8" />
+								<path d="m21 21-4.35-4.35" />
+							</svg>
+						</div>
+						<input
+							type="text"
+							value={searchQuery}
+							onChange={(e) => setSearchQuery(e.target.value)}
+							placeholder="Search Blueprints"
+							className={css.searchField}
+							autoFocus
+						/>
+					</div>
+				</div>
+				<OverlayBody>
+					<OverlaySection
+						title={
+							selectedTag || searchQuery
 								? `Showing ${filteredBlueprints.length} of ${allBlueprints.length} blueprints`
-								: `Showing all ${filteredBlueprints.length} blueprints`}
-						</h2>
+								: `Showing all ${filteredBlueprints.length} blueprints`
+						}
+					>
 						{blueprintsLoading ? (
 							<div className={css.loadingContainer}>
 								<Spinner />
@@ -621,18 +505,14 @@ export function SavedPlaygroundsOverlay({
 								))}
 							</div>
 						)}
-					</div>
-				</div>
-			</div>
+					</OverlaySection>
+				</OverlayBody>
+			</Overlay>
 		);
 	}
 
 	return (
-		<div
-			className={classNames(css.overlay, {
-				[css.overlayClosing]: isClosing,
-			})}
-		>
+		<Overlay onClose={onClose}>
 			<input
 				type="file"
 				ref={zipFileInputRef}
@@ -640,297 +520,226 @@ export function SavedPlaygroundsOverlay({
 				accept=".zip,application/zip"
 				style={{ display: 'none' }}
 			/>
-			<VStack className={css.fullscreenContent} spacing={0}>
-				<HStack
-					className={css.header}
-					alignment="center"
-					justify="space-between"
-				>
-					<FlexItem className={css.headerSpacer} />
-					<PlaygroundLogo />
-					<Button
-						icon={close}
-						label="Close"
-						onClick={onClose}
-						className={css.closeButton}
-					/>
-				</HStack>
+			<OverlayHeader onClose={onClose} />
+			<OverlayBody>
+				<OverlaySection title="Start a new Playground">
+					<div className={css.creationRow}>
+						{creationOptions.map((option) => (
+							<button
+								key={option.id}
+								className={css.creationButton}
+								onClick={option.onClick}
+								disabled={option.disabled}
+							>
+								<span className={css.creationIcon}>
+									{'iconComponent' in option ? (
+										option.iconComponent
+									) : (
+										<Icon icon={option.icon} size={24} />
+									)}
+								</span>
+								<span className={css.creationTitle}>
+									{option.title}
+								</span>
+							</button>
+						))}
+					</div>
+				</OverlaySection>
 
-				<div className={css.body}>
-					{/* Start a new Playground */}
-					<section className={css.section}>
-						<h2 className={css.sectionTitle}>
-							Start a new Playground
-						</h2>
-						<div className={css.creationRow}>
-							{creationOptions.map((option) => (
+				<OverlaySection title="Start from a Blueprint">
+					{blueprintsLoading ? (
+						<div className={css.loadingContainer}>
+							<Spinner />
+						</div>
+					) : blueprintsError ? (
+						<p className={css.emptyMessage}>
+							Unable to load blueprints. Check your connection.
+						</p>
+					) : (
+						<div className={css.blueprintsRow}>
+							{previewBlueprints.map((blueprint) => (
 								<button
-									key={option.id}
-									className={css.creationButton}
-									onClick={option.onClick}
-									disabled={option.disabled}
+									key={blueprint.path}
+									className={css.blueprintPreviewCard}
+									onClick={() =>
+										previewBlueprint(blueprint.path)
+									}
 								>
-									<span className={css.creationIcon}>
-										{'iconComponent' in option ? (
-											option.iconComponent
-										) : (
-											<Icon
-												icon={option.icon}
-												size={24}
+									<div
+										className={
+											css.blueprintPreviewThumbnail
+										}
+									>
+										{blueprint.screenshot_url ? (
+											<img
+												src={blueprint.screenshot_url}
+												alt=""
+												loading="lazy"
 											/>
+										) : (
+											<div
+												className={
+													css.blueprintPlaceholder
+												}
+											>
+												<WordPressIcon />
+											</div>
 										)}
-									</span>
-									<span className={css.creationTitle}>
-										{option.title}
+									</div>
+									<span className={css.blueprintPreviewTitle}>
+										{blueprint.title}
 									</span>
 								</button>
 							))}
+							<button
+								className={css.blueprintPreviewCard}
+								onClick={() => setViewMode('blueprints')}
+							>
+								<div
+									className={classNames(
+										css.blueprintPreviewThumbnail,
+										css.viewAllThumbnail
+									)}
+								>
+									<GridIcon size={50} />
+								</div>
+								<span className={css.blueprintPreviewTitle}>
+									View all {allBlueprints.length} blueprints
+								</span>
+							</button>
 						</div>
-					</section>
+					)}
+				</OverlaySection>
 
-					{/* Start from a Blueprint */}
-					<section className={css.section}>
-						<div className={css.sectionHeader}>
-							<h2 className={css.sectionTitle}>
-								Start from a Blueprint
-							</h2>
+				<OverlaySection title="Your Playgrounds">
+					<div className={css.sitesList}>
+						<div
+							className={classNames(css.siteRow, {
+								[css.siteRowSelected]:
+									temporarySite?.slug === activeSite?.slug,
+							})}
+						>
+							<button
+								className={css.siteRowContent}
+								onClick={onTemporaryPlaygroundClick}
+							>
+								<div className={css.siteRowLogo}>
+									{temporarySite?.metadata.logo ? (
+										<img
+											src={getLogoDataURL(
+												temporarySite.metadata.logo
+											)}
+											alt=""
+										/>
+									) : (
+										<WordPressIcon />
+									)}
+								</div>
+								<div className={css.siteRowInfo}>
+									<span className={css.siteRowName}>
+										Unsaved Playground
+									</span>
+									<span className={css.siteRowDate}>
+										Not saved to browser storage
+									</span>
+								</div>
+							</button>
 						</div>
-						{blueprintsLoading ? (
-							<div className={css.loadingContainer}>
-								<Spinner />
-							</div>
-						) : blueprintsError ? (
-							<p className={css.emptyMessage}>
-								Unable to load blueprints. Check your
-								connection.
-							</p>
-						) : (
-							<div className={css.blueprintsRow}>
-								{previewBlueprints.map((blueprint) => (
+						{storedSites.map((site) => {
+							const isSelected = site.slug === activeSite?.slug;
+							return (
+								<div
+									key={site.slug}
+									className={classNames(css.siteRow, {
+										[css.siteRowSelected]: isSelected,
+									})}
+								>
 									<button
-										key={blueprint.path}
-										className={css.blueprintPreviewCard}
-										onClick={() =>
-											previewBlueprint(blueprint.path)
-										}
+										className={css.siteRowContent}
+										onClick={() => onSiteClick(site.slug)}
 									>
-										<div
-											className={
-												css.blueprintPreviewThumbnail
-											}
-										>
-											{blueprint.screenshot_url ? (
+										<div className={css.siteRowLogo}>
+											{site.metadata.logo ? (
 												<img
-													src={
-														blueprint.screenshot_url
-													}
+													src={getLogoDataURL(
+														site.metadata.logo
+													)}
 													alt=""
-													loading="lazy"
 												/>
 											) : (
-												<div
-													className={
-														css.blueprintPlaceholder
-													}
-												>
-													<WordPressIcon />
-												</div>
+												<WordPressIcon />
 											)}
 										</div>
-										<span
-											className={
-												css.blueprintPreviewTitle
-											}
-										>
-											{blueprint.title}
-										</span>
-									</button>
-								))}
-								<button
-									className={css.blueprintPreviewCard}
-									onClick={() => setViewMode('blueprints')}
-								>
-									<div
-										className={classNames(
-											css.blueprintPreviewThumbnail,
-											css.viewAllThumbnail
-										)}
-									>
-										<GridIcon size={50} />
-									</div>
-									<span className={css.blueprintPreviewTitle}>
-										View all {allBlueprints.length}{' '}
-										blueprints
-									</span>
-								</button>
-							</div>
-						)}
-					</section>
-
-					{/* Your Playgrounds */}
-					<section className={css.section}>
-						<h2 className={css.sectionTitle}>Your Playgrounds</h2>
-						<div className={css.sitesList}>
-							{/* Temporary Playground - always shown at top */}
-							<div
-								className={classNames(css.siteRow, {
-									[css.siteRowSelected]:
-										temporarySite?.slug ===
-										activeSite?.slug,
-								})}
-							>
-								<button
-									className={css.siteRowContent}
-									onClick={onTemporaryPlaygroundClick}
-								>
-									<div className={css.siteRowLogo}>
-										{temporarySite?.metadata.logo ? (
-											<img
-												src={getLogoDataURL(
-													temporarySite.metadata.logo
-												)}
-												alt=""
-											/>
-										) : (
-											<WordPressIcon />
-										)}
-									</div>
-									<div className={css.siteRowInfo}>
-										<span className={css.siteRowName}>
-											Unsaved Playground
-										</span>
-										<span className={css.siteRowDate}>
-											Not saved to browser storage
-										</span>
-									</div>
-								</button>
-							</div>
-							{storedSites.map((site) => {
-								const isSelected =
-									site.slug === activeSite?.slug;
-								// const hasClient = Boolean(
-								// 	selectClientInfoBySiteSlug(
-								// 		{
-								// 			clients:
-								// 				store.getState().clients,
-								// 		},
-								// 		site.slug
-								// 	)?.client
-								// );
-								return (
-									<div
-										key={site.slug}
-										className={classNames(css.siteRow, {
-											[css.siteRowSelected]: isSelected,
-										})}
-									>
-										<button
-											className={css.siteRowContent}
-											onClick={() =>
-												onSiteClick(site.slug)
-											}
-										>
-											<div className={css.siteRowLogo}>
-												{site.metadata.logo ? (
-													<img
-														src={getLogoDataURL(
-															site.metadata.logo
-														)}
-														alt=""
-													/>
-												) : (
-													<WordPressIcon />
-												)}
-											</div>
-											<div className={css.siteRowInfo}>
+										<div className={css.siteRowInfo}>
+											<span className={css.siteRowName}>
+												{site.metadata.name}
+											</span>
+											{site.metadata.whenCreated && (
 												<span
-													className={css.siteRowName}
+													className={css.siteRowDate}
 												>
-													{site.metadata.name}
+													Created{' '}
+													{new Date(
+														site.metadata
+															.whenCreated
+													).toLocaleDateString(
+														undefined,
+														{
+															year: 'numeric',
+															month: 'short',
+															day: 'numeric',
+														}
+													)}
 												</span>
-												{site.metadata.whenCreated && (
-													<span
-														className={
-															css.siteRowDate
+											)}
+										</div>
+									</button>
+									<DropdownMenu
+										icon={moreVertical}
+										label="Site actions"
+										className={css.siteRowMenu}
+										popoverProps={{
+											placement: 'bottom-end',
+										}}
+									>
+										{({ onClose: closeMenu }) => (
+											<>
+												<MenuGroup>
+													<MenuItem
+														onClick={() =>
+															handleRenameSite(
+																site,
+																closeMenu
+															)
 														}
 													>
-														Created{' '}
-														{new Date(
-															site.metadata
-																.whenCreated
-														).toLocaleDateString(
-															undefined,
-															{
-																year: 'numeric',
-																month: 'short',
-																day: 'numeric',
-															}
-														)}
-													</span>
-												)}
-											</div>
-										</button>
-										<DropdownMenu
-											icon={moreVertical}
-											label="Site actions"
-											className={css.siteRowMenu}
-											popoverProps={{
-												placement: 'bottom-end',
-											}}
-										>
-											{({ onClose: closeMenu }) => (
-												<>
-													<MenuGroup>
-														<MenuItem
-															onClick={() =>
-																handleRenameSite(
-																	site,
-																	closeMenu
-																)
-															}
-														>
-															Rename
-														</MenuItem>
-														{/* @TODO: Add download as .zip functionality for non-loaded sites */}
-														{/* <MenuItem
-																onClick={() =>
-																	handleDownloadSite(
-																		site.slug,
-																		closeMenu
-																	)
-																}
-																disabled={
-																	!hasClient
-																}
-															>
-																Download as .zip
-															</MenuItem> */}
-													</MenuGroup>
-													<MenuGroup>
-														<MenuItem
-															className={
-																css.dangerMenuItem
-															}
-															onClick={() =>
-																handleDeleteSite(
-																	site,
-																	closeMenu
-																)
-															}
-														>
-															Delete
-														</MenuItem>
-													</MenuGroup>
-												</>
-											)}
-										</DropdownMenu>
-									</div>
-								);
-							})}
-						</div>
-					</section>
-				</div>
-			</VStack>
-		</div>
+														Rename
+													</MenuItem>
+												</MenuGroup>
+												<MenuGroup>
+													<MenuItem
+														className={
+															css.dangerMenuItem
+														}
+														onClick={() =>
+															handleDeleteSite(
+																site,
+																closeMenu
+															)
+														}
+													>
+														Delete
+													</MenuItem>
+												</MenuGroup>
+											</>
+										)}
+									</DropdownMenu>
+								</div>
+							);
+						})}
+					</div>
+				</OverlaySection>
+			</OverlayBody>
+		</Overlay>
 	);
 }

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -1,108 +1,3 @@
-.overlay {
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background: #1e2327;
-	z-index: 100;
-	display: flex;
-	flex-direction: column;
-	overflow-y: auto;
-	animation: fadeIn 0.15s ease-out;
-}
-
-.overlayClosing {
-	animation: fadeOut 0.2s ease-out forwards;
-}
-
-@keyframes fadeIn {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
-}
-
-@keyframes fadeOut {
-	from {
-		opacity: 1;
-	}
-	to {
-		opacity: 0;
-	}
-}
-
-.fullscreenContent {
-	width: 100%;
-	min-height: 100%;
-	display: flex;
-	flex-direction: column;
-	max-width: 1200px;
-	margin: 0 auto;
-}
-
-.header {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	padding: 20px 32px;
-	border-bottom: 1px solid #2c3338;
-	flex-shrink: 0;
-}
-
-.headerSpacer {
-	width: 40px;
-}
-
-.headerTitle {
-	font-size: clamp(18px, 2vw, 22px);
-	font-weight: 600;
-	color: #fff !important;
-	margin: 0;
-}
-
-/* Logo styles */
-.logo {
-	display: flex;
-	align-items: center;
-	gap: 10px;
-}
-
-.logoIcon {
-	width: 32px;
-	height: 32px;
-}
-
-.logoIcon path {
-	fill: #3858e9;
-}
-
-.logoText {
-	font-size: clamp(18px, 2vw, 22px);
-	font-weight: 600;
-	color: #fff;
-}
-
-.closeButton {
-	color: #949494 !important;
-	padding: 4px !important;
-}
-
-.closeButton:hover {
-	color: #fff !important;
-}
-
-.backButton {
-	color: #949494 !important;
-	padding: 4px !important;
-}
-
-.backButton:hover {
-	color: #fff !important;
-}
-
 /* Filters bar for blueprints gallery */
 .filtersBar {
 	display: flex;
@@ -170,53 +65,6 @@
 	background: #3858e9;
 	border-color: #3858e9;
 	color: #fff;
-}
-
-.body {
-	padding: 32px;
-	flex: 1;
-}
-
-.section {
-	margin-bottom: 32px;
-	width: 100%;
-}
-
-.section:last-child {
-	margin-bottom: 0;
-	padding-bottom: 32px;
-}
-
-.sectionHeader {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	margin-bottom: 16px;
-}
-
-.sectionHeader .sectionTitle {
-	margin-bottom: 0 !important;
-}
-
-.sectionTitle {
-	margin: 0 0 16px 0 !important;
-	font-size: clamp(18px, 2vw, 22px) !important;
-	font-weight: 600 !important;
-	color: #fff !important;
-}
-
-.viewAllLink {
-	background: none;
-	border: none;
-	color: #3858e9;
-	font-size: clamp(14px, 1.4vw, 15px);
-	font-weight: 500;
-	cursor: pointer;
-	padding: 0;
-}
-
-.viewAllLink:hover {
-	text-decoration: underline;
 }
 
 .emptyMessage {
@@ -555,13 +403,6 @@
 	line-height: 1.4;
 }
 
-.blueprintMeta {
-	font-size: clamp(12px, 1.2vw, 13px);
-	color: #6b7280 !important;
-	margin: 0;
-	margin-top: 4px;
-}
-
 .blueprintTags {
 	display: flex;
 	flex-wrap: wrap;
@@ -639,16 +480,8 @@
 }
 
 @media (max-width: 640px) {
-	.header {
-		padding: 16px 20px;
-	}
-
 	.filtersBar {
 		padding: 16px 20px;
-	}
-
-	.body {
-		padding: 20px;
 	}
 
 	.creationRow {


### PR DESCRIPTION
## Motivation for the change, related issues

This PR extracts shared overlay components from the `saved-playgrounds-overlay` to enable reuse across different overlay implementations. This is preparatory work for the persistent deployment feature, which will introduce a new overlay with similar structure but different content.

## Implementation details

Creates a new `components/overlay/` module with reusable primitives:

- **`Overlay`** - Base container with escape key handling and fade-in animation
- **`OverlayHeader`** - Header with optional logo, title, back button, and close button
- **`OverlayBody`** - Scrollable body container
- **`OverlaySection`** - Section with optional title and description

The `saved-playgrounds-overlay` is refactored to use these new components, reducing code duplication and making the overlay structure consistent.

**Changes:**
- New: `components/overlay/index.tsx` and `style.module.css`
- Modified: `saved-playgrounds-overlay/index.tsx` - now uses shared overlay components
- Modified: `saved-playgrounds-overlay/style.module.css` - removed styles that moved to shared overlay

This is a pure refactor with no functional changes.

## Testing Instructions (or ideally a Blueprint)

1. Open the Playground website
2. Click the Playground logo/menu to open the site manager overlay
3. Verify the overlay displays correctly with:
   - Logo and close button in the header
   - "Start a new Playground" section
   - "Start from a Blueprint" section with preview cards
   - "Your Playgrounds" section with site list
4. Click "View all X blueprints" to enter the blueprints gallery view
5. Verify the back button and title appear correctly
6. Test escape key closes the overlay
7. Test that sub-modals (like "WordPress PR") still work correctly
