### PR TITLE
More reliably relay blueprints to kapa

### DIFF
--- a/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
+++ b/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
@@ -69,6 +69,51 @@ function loadKapaScript(): Promise<void> {
 	});
 }
 
+function getBlueprintContext(): string {
+	const urlParams = new URLSearchParams(window.location.search);
+	const blueprintUrl = urlParams.get('blueprint-url');
+
+	// Hash-based blueprint: #eyJ...
+	if (window.location.hash.length > 1) {
+		try {
+			const base64 = window.location.hash.slice(1);
+			const json = atob(base64);
+			JSON.parse(json); // Validate it's valid JSON
+			return json;
+		} catch {
+			// Invalid base64 or JSON, ignore
+		}
+	}
+
+	// Data URL blueprint: ?blueprint-url=data:application/json;base64,...
+	if (blueprintUrl?.startsWith('data:')) {
+		try {
+			const base64Match = blueprintUrl.match(
+				/^data:application\/json;base64,(.+)$/
+			);
+			if (base64Match) {
+				const json = atob(base64Match[1]);
+				JSON.parse(json); // Validate it's valid JSON
+				return json;
+			}
+		} catch {
+			// Invalid base64 or JSON, ignore
+		}
+	}
+
+	// Remote URL blueprint: ?blueprint-url=https://...
+	if (blueprintUrl) {
+		return `Blueprint URL: ${blueprintUrl}`;
+	}
+
+	// Query param blueprint: ?plugin=foo&theme=bar
+	if (window.location.search.length > 1) {
+		return `URL query parameters: ${window.location.search}`;
+	}
+
+	return '';
+}
+
 export function useKapaAI() {
 	const hasSubmittedQuery = useRef(false);
 	const isEnabled = () => {
@@ -89,11 +134,10 @@ export function useKapaAI() {
 			if (hasSubmittedQuery.current) {
 				window.Kapa.open();
 			} else {
-				const urlParams = new URLSearchParams(window.location.search);
-				const hasExternalBlueprint = urlParams.has('blueprint-url');
-				const contextPrefix = hasExternalBlueprint
-					? ''
-					: `Given the URL query parameters ${window.location.search}, `;
+				const blueprintContext = getBlueprintContext();
+				const contextPrefix = blueprintContext
+					? `Given the following blueprint:\n${blueprintContext}\n\n`
+					: '';
 
 				window.Kapa.open({
 					mode: 'ai',


### PR DESCRIPTION
## Motivation for the change, related issues

When clicking "Troubleshoot with AI" in the error modal, the kapa.ai prompt was not providing useful context in several cases:

1. **Hash-based blueprints** (`#eyJ...`): The prompt showed "Given the URL query parameters , " with empty params
2. **Data URL blueprints** (`?blueprint-url=data:application/json;base64,...`): No blueprint context was included
3. **External URL blueprints**: No context was provided at all

This made it harder for the AI to provide relevant troubleshooting suggestions.

## Implementation details

Added a `getBlueprintContext()` function that extracts and decodes blueprint information from various URL formats:

- **Hash-based blueprints**: Decodes base64 from the URL hash and includes the full JSON
- **Data URL blueprints**: Decodes the base64-encoded JSON from data URLs
- **Remote URL blueprints**: Includes the blueprint URL for reference
- **Query param blueprints** (`?plugin=foo&theme=bar`): Includes the query parameters

The prompt now shows the actual blueprint content when available, giving kapa.ai better context for troubleshooting.

## Testing Instructions (or ideally a Blueprint)

1. Open a URL with a hash-based blueprint that crashes:
   ```
   https://playground.wordpress.net/#eyJzdGVwcyI6W3sic3RlcCI6InJ1blBIUCIsImNvZGUiOiI8P3BocCB0aHJvdyBuZXcgRXhjZXB0aW9uKCdUZXN0IGNyYXNoJyk7In1dfQ==
   ```
2. Click "Troubleshoot with AI" in the error modal
3. Verify the prompt includes the decoded blueprint JSON
4. Test with other blueprint formats (data URL, remote URL, query params)
