### PR TITLE
[personal-wp] Add Health Check recovery

### DIFF
--- a/packages/playground/personal-wp/src/components/menu-overlay/index.tsx
+++ b/packages/playground/personal-wp/src/components/menu-overlay/index.tsx
@@ -11,6 +11,10 @@ import {
 	OverlaySection,
 } from '../overlay';
 import css from './style.module.css';
+import {
+	getBlueprintUrl,
+	healthCheckRecoveryBlueprint,
+} from '../../lib/health-check-recovery';
 
 interface MenuOverlayProps {
 	onClose: () => void;
@@ -21,6 +25,7 @@ export function MenuOverlay({ onClose }: MenuOverlayProps) {
 
 	const [showDeleteButton, setShowDeleteButton] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
+	const [showRecoveryButton, setShowRecoveryButton] = useState(false);
 
 	async function handleStartOver() {
 		if (!activeSite || activeSite.metadata.storage === 'none') {
@@ -107,6 +112,29 @@ export function MenuOverlay({ onClose }: MenuOverlayProps) {
 						)}
 					</OverlaySection>
 				</div>
+
+				<OverlaySection title="Recovery">
+					<p>
+						If WordPress crashed,{' '}
+						<button
+							className={css.textButton}
+							onClick={() =>
+								setShowRecoveryButton(!showRecoveryButton)
+							}
+						>
+							you can troubleshoot
+						</button>
+						.
+					</p>
+					{showRecoveryButton && (
+						<a
+							href={getBlueprintUrl(healthCheckRecoveryBlueprint)}
+							className={css.primaryButton}
+						>
+							Install Health Check &amp; Troubleshoot
+						</a>
+					)}
+				</OverlaySection>
 			</OverlayBody>
 		</Overlay>
 	);

--- a/packages/playground/personal-wp/src/lib/health-check-recovery.ts
+++ b/packages/playground/personal-wp/src/lib/health-check-recovery.ts
@@ -1,0 +1,80 @@
+import type { Blueprint } from '@wp-playground/blueprints';
+import { encodeStringAsBase64 } from './base64';
+
+//
+// The Health Check MU-plugin requires a database option 'health-check-disable-plugin-hash'
+// that matches: cookieValue + md5(REMOTE_ADDR). We add an earlier MU-plugin (alphabetically)
+// that uses pre_option filter to return the expected hash, bypassing the database check.
+export const healthCheckRecoveryBlueprint: Blueprint = {
+	steps: [
+		{
+			step: 'installPlugin',
+			pluginData: {
+				resource: 'wordpress.org/plugins',
+				slug: 'health-check',
+			},
+			options: {
+				activate: false,
+			},
+		},
+		{
+			step: 'mkdir',
+			path: '/wordpress/wp-content/mu-plugins',
+		},
+		{
+			step: 'cp',
+			fromPath:
+				'/wordpress/wp-content/plugins/health-check/mu-plugin/health-check-troubleshooting-mode.php',
+			toPath: '/wordpress/wp-content/mu-plugins/health-check-troubleshooting-mode.php',
+		},
+		{
+			// Add an MU-plugin that loads before health-check (alphabetically: "0" < "h")
+			// to provide the expected hash via pre_option filter
+			step: 'writeFile',
+			path: '/wordpress/wp-content/mu-plugins/0-health-check-hash-bypass.php',
+			data: `<?php
+// Bypass Health Check hash verification by setting both the GET param and option.
+// Self-delete when user disables troubleshooting mode via Health Check UI.
+if (isset($_GET['health-check-disable-troubleshooting'])) {
+    unlink(__FILE__);
+} else {
+    $_GET['health-check-disable-plugin-hash'] = 'playground-recovery';
+    add_filter('pre_option_health-check-disable-plugin-hash', function() {
+        return 'playground-recovery';
+    });
+    // Don't try to switch to a default theme
+    add_filter('pre_option_health-check-default-theme', function() {
+        return 'no';
+    });
+    // Add admin notice with guidance
+    add_action('admin_notices', function() {
+        ?>
+        <div class="notice notice-warning">
+            <p><strong>Troubleshooting Mode Active</strong></p>
+            <p>All plugins have been disabled. You can now activate them one by one to find the problematic one.</p>
+            <p>Once fixed, disable troubleshooting mode via <a href="<?php echo admin_url('site-health.php?tab=troubleshoot'); ?>">Site Health &rarr; Troubleshoot</a>.</p>
+        </div>
+        <?php
+    });
+}
+`,
+		},
+		{
+			step: 'login',
+		},
+	],
+	landingPage:
+		'/wp-admin/plugins.php?health-check-disable-plugin-hash=playground-recovery',
+};
+
+export function getBlueprintUrl(blueprint: Blueprint): string {
+	const url = new URL(window.location.href);
+	url.hash = '';
+	const jsonStr = JSON.stringify(blueprint);
+	const encoded = encodeStringAsBase64(jsonStr);
+	url.searchParams.set(
+		'blueprint-url',
+		`data:application/json;base64,${encoded}`
+	);
+	return url.toString();
+}


### PR DESCRIPTION
Based on #3155.

## Motivation for the change, related issues

When a plugin breaks a Personal Playground WordPress site, users need a way to recover. This adds a Health Check recovery option that enables troubleshooting mode, disabling all plugins so users can identify the problematic one.

## Screenshots
<img width="2120" height="1086" alt="Screenshot 2026-01-22 at 04 30 53" src="https://github.com/user-attachments/assets/3935f3b6-5d84-41b1-8703-5f551b201da2" />

<img width="2202" height="1140" alt="Screenshot 2026-01-22 at 04 31 30" src="https://github.com/user-attachments/assets/75925f8d-658f-4ccf-ba69-3cb3c225f373" />

## Implementation details

- `health-check-recovery.ts`: Blueprint that installs Health Check plugin and an MU-plugin to bypass hash verification, enabling troubleshooting mode
- `getBlueprintUrl()`: Encodes blueprints as base64 data URLs for easy sharing
- Recovery section in `PersistentPlaygroundOverlay` with expandable "Install Health Check & Troubleshoot" button

## Testing Instructions (or ideally a Blueprint)

1. Run `npm run dev` and visit http://127.0.0.1:5401
2. Open the menu (grid icon) and scroll to "Recovery" section
3. Click "you can troubleshoot" to reveal the recovery button
4. Click "Install Health Check & Troubleshoot"
5. Verify it installs Health Check and lands on plugins page in troubleshooting mode
