### PR TITLE
[personal-wp] Add multi-tab coordination

### DIFF
--- a/packages/playground/personal-wp/src/components/address-bar/index.tsx
+++ b/packages/playground/personal-wp/src/components/address-bar/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Icon, MenuItem, NavigableMenu, Popover } from '@wordpress/components';
 import { home, wordpress, layout, pin } from '@wordpress/icons';
+import { WorkerStatusIndicator } from './worker-status-indicator';
 import css from './style.module.css';
 
 /**
@@ -69,9 +70,14 @@ const quickNavItems: QuickNavItem[] = [
 interface AddressBarProps {
 	url?: string;
 	onUpdate?: (url: string) => void;
+	onOpenOverlay?: () => void;
 }
 
-export default function AddressBar({ url, onUpdate }: AddressBarProps) {
+export default function AddressBar({
+	url,
+	onUpdate,
+	onOpenOverlay,
+}: AddressBarProps) {
 	const inputRef = useRef<HTMLInputElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const menuRef = useRef<HTMLDivElement>(null);
@@ -226,6 +232,7 @@ export default function AddressBar({ url, onUpdate }: AddressBarProps) {
 					aria-label='URL to visit in the WordPress site, like "/wp-admin"'
 					autoComplete="off"
 				/>
+				<WorkerStatusIndicator onOpenOverlay={onOpenOverlay} />
 				{isOpen && (
 					<Popover
 						placement="bottom-start"

--- a/packages/playground/personal-wp/src/components/address-bar/worker-status-indicator.module.css
+++ b/packages/playground/personal-wp/src/components/address-bar/worker-status-indicator.module.css
@@ -1,0 +1,53 @@
+.badge {
+	position: absolute;
+	right: 8px;
+	top: 50%;
+	transform: translateY(-50%);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding: 2px 6px;
+	font-size: 11px;
+	font-weight: 600;
+	color: #8c8f94;
+	background: rgba(140, 143, 148, 0.15);
+	border-radius: 4px;
+	cursor: help;
+	transition: all 0.15s ease;
+	text-transform: uppercase;
+	letter-spacing: 0.3px;
+}
+
+.badge:hover {
+	color: #fff;
+	background: rgba(255, 255, 255, 0.15);
+}
+
+.workerLost {
+	color: #dc2626;
+	background: rgba(220, 38, 38, 0.15);
+	cursor: pointer;
+}
+
+.workerLost:hover {
+	color: #ef4444;
+	background: rgba(239, 68, 68, 0.2);
+}
+
+.reloadText {
+	transition: opacity 0.15s ease;
+}
+
+.reloadIcon {
+	position: absolute;
+	opacity: 0;
+	transition: opacity 0.15s ease;
+}
+
+.workerLost:hover .reloadText {
+	opacity: 0;
+}
+
+.workerLost:hover .reloadIcon {
+	opacity: 1;
+}

--- a/packages/playground/personal-wp/src/components/address-bar/worker-status-indicator.tsx
+++ b/packages/playground/personal-wp/src/components/address-bar/worker-status-indicator.tsx
@@ -1,0 +1,61 @@
+import {
+	useAppSelector,
+	getActiveClientInfo,
+} from '../../lib/state/redux/store';
+import { useTabTracking } from '../../lib/hooks/use-tab-tracking';
+import css from './worker-status-indicator.module.css';
+
+interface WorkerStatusIndicatorProps {
+	onOpenOverlay?: () => void;
+}
+
+export function WorkerStatusIndicator({
+	onOpenOverlay,
+}: WorkerStatusIndicatorProps) {
+	const clientInfo = useAppSelector(getActiveClientInfo);
+
+	const hasOwnWorker = !!clientInfo && !clientInfo.isDependentMode;
+	const { otherTabs, workerLost } = useTabTracking(hasOwnWorker);
+
+	const otherTabCount = otherTabs.length;
+
+	if (otherTabCount === 0 && !workerLost) {
+		return null;
+	}
+
+	if (workerLost) {
+		return (
+			<div
+				className={`${css.badge} ${css.workerLost}`}
+				title="Worker connection lost. Click to reload."
+				onClick={() => window.location.reload()}
+			>
+				<span className={css.reloadText}>Reload required</span>
+				<svg
+					className={css.reloadIcon}
+					width="12"
+					height="12"
+					viewBox="0 0 16 16"
+					fill="currentColor"
+				>
+					<path d="M13.65 2.35C12.2 0.9 10.21 0 8 0 3.58 0 0.01 3.58 0.01 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L9 7h7V0l-2.35 2.35z" />
+				</svg>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className={css.badge}
+			title={
+				hasOwnWorker
+					? `This tab has its own worker (${otherTabCount} other tab${otherTabCount === 1 ? '' : 's'})`
+					: `This tab depends on another tab's worker (${otherTabCount} other tab${otherTabCount === 1 ? '' : 's'})`
+			}
+			onClick={onOpenOverlay}
+			style={{ cursor: onOpenOverlay ? 'pointer' : 'default' }}
+		>
+			{hasOwnWorker ? 'Main' : 'Dependent'}
+		</div>
+	);
+}

--- a/packages/playground/personal-wp/src/components/backup-reminder/index.tsx
+++ b/packages/playground/personal-wp/src/components/backup-reminder/index.tsx
@@ -26,7 +26,7 @@ export function BackupReminder() {
 	const playground = usePlaygroundClient();
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
-	const { performBackup, isBackingUp } = useBackup();
+	const { performBackup, isBackingUp, isRequestingRemote } = useBackup();
 	const [isImporting, setIsImporting] = useState(false);
 	const [showHistory, setShowHistory] = useState(false);
 	const importInputRef = useRef<HTMLInputElement>(null);
@@ -157,10 +157,19 @@ export function BackupReminder() {
 					<button
 						className={css.backupButton}
 						onClick={performBackup}
-						disabled={!playground || isBackingUp || isImporting}
+						disabled={
+							!playground ||
+							isBackingUp ||
+							isRequestingRemote ||
+							isImporting
+						}
 						type="button"
 					>
-						{isBackingUp ? 'Backing up...' : 'Download backup'}
+						{isRequestingRemote
+							? 'Requesting...'
+							: isBackingUp
+								? 'Backing up...'
+								: 'Download backup'}
 					</button>
 					<select
 						className={css.autoBackupSelect}
@@ -176,7 +185,12 @@ export function BackupReminder() {
 					<button
 						className={css.importButton}
 						onClick={handleImportClick}
-						disabled={!playground || isBackingUp || isImporting}
+						disabled={
+							!playground ||
+							isBackingUp ||
+							isRequestingRemote ||
+							isImporting
+						}
 						type="button"
 					>
 						<Icon icon={upload} size={16} />

--- a/packages/playground/personal-wp/src/components/browser-chrome/backup-status-indicator.tsx
+++ b/packages/playground/personal-wp/src/components/browser-chrome/backup-status-indicator.tsx
@@ -32,7 +32,8 @@ function getBackupUrgency(days: number): BackupUrgency {
 
 export function BackupStatusIndicator() {
 	const activeSite = useActiveSite();
-	const { performBackup, isBackingUp } = useBackup();
+	const { performBackup, isBackingUp, isRequestingRemote, isDependentMode } =
+		useBackup();
 
 	const {
 		whenCreated,
@@ -65,12 +66,15 @@ export function BackupStatusIndicator() {
 	}
 
 	const urgency = getBackupUrgency(daysSinceBackup);
-	const isWorking = isBackingUp;
-	const buttonText = isBackingUp
-		? 'Backing up...'
-		: formatDaysSinceBackup(daysSinceBackup);
-	const tooltipText =
-		'Your Playground is stored in this browser. Browser data can be cleared unexpectedly. Click to download a backup.';
+	const isWorking = isBackingUp || isRequestingRemote;
+	const buttonText = isRequestingRemote
+		? 'Requesting...'
+		: isBackingUp
+			? 'Backing up...'
+			: formatDaysSinceBackup(daysSinceBackup);
+	const tooltipText = isDependentMode
+		? 'Click to request a backup from the main tab. Your Playground is stored in this browser and may be cleared unexpectedly.'
+		: 'Your Playground is stored in this browser. Browser data can be cleared unexpectedly. Click to download a backup.';
 
 	return (
 		<div className={classNames(css.indicator, css[urgency])}>

--- a/packages/playground/personal-wp/src/components/browser-chrome/index.tsx
+++ b/packages/playground/personal-wp/src/components/browser-chrome/index.tsx
@@ -83,6 +83,7 @@ export default function BrowserChrome({ className }: BrowserChromeProps) {
 							onUpdate={(newUrl) =>
 								clientInfo?.client.goTo(newUrl)
 							}
+							onOpenOverlay={() => setIsMenuOverlayOpen(true)}
 						/>
 					</div>
 

--- a/packages/playground/personal-wp/src/components/menu-overlay/index.tsx
+++ b/packages/playground/personal-wp/src/components/menu-overlay/index.tsx
@@ -4,6 +4,8 @@ import { Icon } from '@wordpress/icons';
 import { logger } from '@php-wasm/logger';
 import { useActiveSite } from '../../lib/state/redux/store';
 import { opfsSiteStorage } from '../../lib/state/opfs/opfs-site-storage';
+import { broadcastSiteReset } from '../../lib/state/redux/tab-coordinator';
+import { useBackup } from '../../lib/hooks/use-backup';
 import {
 	Overlay,
 	OverlayHeader,
@@ -16,6 +18,7 @@ import {
 	healthCheckRecoveryBlueprint,
 } from '../../lib/health-check-recovery';
 import { BackupReminder } from '../backup-reminder';
+import { TabInfoWindow } from '../tab-info-window';
 
 interface MenuOverlayProps {
 	onClose: () => void;
@@ -23,6 +26,7 @@ interface MenuOverlayProps {
 
 export function MenuOverlay({ onClose }: MenuOverlayProps) {
 	const activeSite = useActiveSite();
+	const { isDependentMode } = useBackup();
 
 	const [showDeleteButton, setShowDeleteButton] = useState(false);
 	const [isDeleting, setIsDeleting] = useState(false);
@@ -47,6 +51,7 @@ export function MenuOverlay({ onClose }: MenuOverlayProps) {
 
 		setIsDeleting(true);
 		try {
+			broadcastSiteReset(activeSite.slug);
 			await opfsSiteStorage?.delete(activeSite.slug);
 			window.location.href =
 				window.location.origin + window.location.pathname;
@@ -61,6 +66,7 @@ export function MenuOverlay({ onClose }: MenuOverlayProps) {
 		<Overlay onClose={onClose}>
 			<OverlayHeader onClose={onClose} />
 			<OverlayBody>
+				<TabInfoWindow />
 				<OverlaySection
 					title="Personal Playground"
 					description="Your WordPress data is stored in your browser and will persist across sessions."
@@ -94,31 +100,42 @@ export function MenuOverlay({ onClose }: MenuOverlayProps) {
 					</OverlaySection>
 
 					<OverlaySection title="Start over">
-						<p>
-							If you want to start over,{' '}
-							<button
-								className={css.textButton}
-								onClick={() =>
-									setShowDeleteButton(!showDeleteButton)
-								}
-							>
-								you can reset this WordPress
-							</button>
-							.
-						</p>
-						{showDeleteButton && (
-							<button
-								className={css.dangerButton}
-								onClick={handleStartOver}
-								disabled={isDeleting}
-							>
-								<Icon icon={trash} size={20} />
-								<span>
-									{isDeleting
-										? 'Deleting...'
-										: 'Delete everything'}
-								</span>
-							</button>
+						{isDependentMode ? (
+							<p>
+								To reset this WordPress, use the main tab that
+								has the active connection.
+							</p>
+						) : (
+							<>
+								<p>
+									If you want to start over,{' '}
+									<button
+										className={css.textButton}
+										onClick={() =>
+											setShowDeleteButton(
+												!showDeleteButton
+											)
+										}
+									>
+										you can reset this WordPress
+									</button>
+									.
+								</p>
+								{showDeleteButton && (
+									<button
+										className={css.dangerButton}
+										onClick={handleStartOver}
+										disabled={isDeleting}
+									>
+										<Icon icon={trash} size={20} />
+										<span>
+											{isDeleting
+												? 'Deleting...'
+												: 'Delete everything'}
+										</span>
+									</button>
+								)}
+							</>
 						)}
 					</OverlaySection>
 				</div>

--- a/packages/playground/personal-wp/src/components/tab-info-window/index.tsx
+++ b/packages/playground/personal-wp/src/components/tab-info-window/index.tsx
@@ -1,0 +1,140 @@
+import { useState, useEffect } from 'react';
+import {
+	useAppSelector,
+	getActiveClientInfo,
+} from '../../lib/state/redux/store';
+import { useTabTracking } from '../../lib/hooks/use-tab-tracking';
+import css from './style.module.css';
+
+function formatLoadTime(timestamp: number): string {
+	const now = Date.now();
+	const diffMs = now - timestamp;
+	const diffSeconds = Math.floor(diffMs / 1000);
+
+	if (diffSeconds < 60) {
+		return `${diffSeconds} secs ago`;
+	} else if (diffSeconds < 3600) {
+		const diffMinutes = Math.floor(diffSeconds / 60);
+		return `${diffMinutes} mins ago`;
+	} else if (diffSeconds < 86400) {
+		const diffHours = Math.floor(diffSeconds / 3600);
+		return `${diffHours} hrs ago`;
+	} else {
+		const diffDays = Math.floor(diffSeconds / 86400);
+		return `${diffDays} days ago`;
+	}
+}
+
+export function TabInfoWindow() {
+	const clientInfo = useAppSelector(getActiveClientInfo);
+	const [loadTime, setLoadTime] = useState<Date | null>(null);
+	const [isExpanded, setIsExpanded] = useState(false);
+	const [, setTick] = useState(0);
+
+	const hasOwnWorker = !!clientInfo && !clientInfo.isDependentMode;
+	const { tabInfo, otherTabs } = useTabTracking(hasOwnWorker);
+
+	useEffect(() => {
+		if (tabInfo) {
+			setLoadTime(new Date(tabInfo.createdAt));
+		}
+	}, [tabInfo]);
+
+	useEffect(() => {
+		const interval = setInterval(() => {
+			setTick((t) => t + 1);
+		}, 1000);
+		return () => clearInterval(interval);
+	}, []);
+
+	if (!tabInfo || !loadTime) {
+		return null;
+	}
+
+	const sortedOtherTabs = [...otherTabs].sort(
+		(a, b) => b.createdAt - a.createdAt
+	);
+
+	const oldestTabId =
+		sortedOtherTabs.length > 0
+			? sortedOtherTabs[sortedOtherTabs.length - 1].tabId
+			: null;
+
+	const workerTabId = hasOwnWorker ? tabInfo.tabId : oldestTabId;
+
+	return (
+		<div className={css.tabInfoWindow}>
+			<div className={css.infoRow}>
+				<span className={css.label}>WordPress loaded:</span>
+				<span
+					className={css.timeValue}
+					title={loadTime.toLocaleString()}
+				>
+					{formatLoadTime(tabInfo.createdAt)}
+				</span>
+			</div>
+			{otherTabs.length > 0 && (
+				<>
+					<div className={css.accordionSection}>
+						<div
+							className={`${css.infoRow} ${css.clickable}`}
+							onClick={() => setIsExpanded(!isExpanded)}
+						>
+							<span className={css.label}>Other tabs:</span>
+							<span className={css.value}>
+								{otherTabs.length}
+								<span className={css.expandIcon}>
+									{isExpanded ? ' ▼' : ' ▶'}
+								</span>
+							</span>
+						</div>
+						{isExpanded && (
+							<div className={css.tabList}>
+								{sortedOtherTabs.map((tab) => {
+									const isWorkerTab =
+										tab.tabId === workerTabId;
+									return (
+										<div
+											key={tab.tabId}
+											className={css.tabItem}
+										>
+											<span
+												className={css.tabTime}
+												title={new Date(
+													tab.createdAt
+												).toLocaleString()}
+											>
+												{formatLoadTime(tab.createdAt)}
+											</span>
+											{isWorkerTab && (
+												<span
+													className={css.workerBadge}
+													title="This tab has the active worker"
+												>
+													Worker
+												</span>
+											)}
+										</div>
+									);
+								})}
+							</div>
+						)}
+					</div>
+					<div
+						className={css.infoRow}
+						title={
+							hasOwnWorker
+								? 'This tab has its own PHP worker'
+								: 'This tab is reusing a worker from another tab (dependent mode)'
+						}
+					>
+						<span className={css.label}>Worker:</span>
+						<span className={css.value}>
+							{hasOwnWorker ? 'Own' : 'Shared'}
+						</span>
+					</div>
+				</>
+			)}
+		</div>
+	);
+}

--- a/packages/playground/personal-wp/src/components/tab-info-window/style.module.css
+++ b/packages/playground/personal-wp/src/components/tab-info-window/style.module.css
@@ -1,0 +1,103 @@
+.tabInfoWindow {
+	position: absolute;
+	top: 36px;
+	right: 30px;
+	background: #2c3338;
+	border: 1px solid #3c4349;
+	border-radius: 8px;
+	padding: 16px;
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	font-size: 13px;
+	color: #9ca3af;
+	min-width: 200px;
+	max-width: 280px;
+	z-index: 1;
+}
+
+.infoRow {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	gap: 16px;
+}
+
+.clickable {
+	cursor: pointer;
+	transition: background-color 0.15s ease;
+	padding: 4px 8px;
+	margin: -4px -8px;
+	border-radius: 4px;
+}
+
+.clickable:hover {
+	background-color: rgba(255, 255, 255, 0.05);
+}
+
+.label {
+	color: #6b7280;
+	font-weight: 500;
+}
+
+.value {
+	color: #fff;
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+}
+
+.timeValue {
+	color: #fff;
+	font-weight: 500;
+	font-variant-numeric: tabular-nums;
+	min-width: 85px;
+	text-align: right;
+}
+
+.expandIcon {
+	font-size: 10px;
+	opacity: 0.7;
+}
+
+.accordionSection {
+	display: flex;
+	flex-direction: column;
+}
+
+.tabList {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+	margin-top: 8px;
+	padding-left: 8px;
+}
+
+.tabItem {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 4px 0;
+}
+
+.tabTime {
+	color: #9ca3af;
+	font-size: 12px;
+	font-variant-numeric: tabular-nums;
+}
+
+.workerBadge {
+	font-size: 10px;
+	font-weight: 600;
+	color: #3858e9;
+	padding: 2px 4px;
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+}
+
+@media (max-width: 768px) {
+	.tabInfoWindow {
+		position: static;
+		max-width: 100%;
+		margin-bottom: 24px;
+	}
+}

--- a/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-backup.ts
@@ -1,10 +1,17 @@
-import { useState, useCallback } from 'react';
-import { usePlaygroundClient } from '../use-playground-client';
+import { useState, useCallback, useEffect } from 'react';
+import {
+	usePlaygroundClient,
+	usePlaygroundClientInfo,
+} from '../use-playground-client';
 import { useActiveSite, useAppDispatch } from '../state/redux/store';
 import { updateSiteMetadata } from '../state/redux/slice-sites';
 import { zipWpContent } from '@wp-playground/client';
 import { logger } from '@php-wasm/logger';
 import saveAs from 'file-saver';
+import {
+	setBackupRequestCallback,
+	requestRemoteBackup,
+} from '../state/redux/tab-coordinator';
 
 function sanitizeForFilename(name: string): string {
 	return name
@@ -43,11 +50,27 @@ async function getWordPressSiteName(
 
 export function useBackup() {
 	const playground = usePlaygroundClient();
+	const clientInfo = usePlaygroundClientInfo();
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
 	const [isBackingUp, setIsBackingUp] = useState(false);
+	const [isRequestingRemote, setIsRequestingRemote] = useState(false);
+
+	const isMainMode = clientInfo && !clientInfo.isDependentMode;
+	const isDependentMode = clientInfo?.isDependentMode ?? false;
 
 	const performBackup = useCallback(async (): Promise<boolean> => {
+		// In dependent mode, request backup from the main tab
+		if (isDependentMode && activeSite) {
+			if (isRequestingRemote) return false;
+			setIsRequestingRemote(true);
+			try {
+				return await requestRemoteBackup(activeSite.slug);
+			} finally {
+				setIsRequestingRemote(false);
+			}
+		}
+
 		if (!playground || !activeSite || isBackingUp) {
 			return false;
 		}
@@ -89,11 +112,30 @@ export function useBackup() {
 		} finally {
 			setIsBackingUp(false);
 		}
-	}, [playground, activeSite, isBackingUp, dispatch]);
+	}, [
+		playground,
+		activeSite,
+		isBackingUp,
+		isRequestingRemote,
+		isDependentMode,
+		dispatch,
+	]);
+
+	// Register this tab as the backup handler when in main mode
+	useEffect(() => {
+		if (isMainMode && playground && activeSite) {
+			setBackupRequestCallback(performBackup);
+			return () => {
+				setBackupRequestCallback(null);
+			};
+		}
+	}, [isMainMode, playground, activeSite, performBackup]);
 
 	return {
 		performBackup,
 		isBackingUp,
+		isRequestingRemote,
+		isDependentMode,
 		canBackup: !!playground && !!activeSite,
 	};
 }

--- a/packages/playground/personal-wp/src/lib/hooks/use-tab-tracking.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-tab-tracking.ts
@@ -1,0 +1,149 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useActiveSite } from '../state/redux/store';
+import {
+	getCurrentTabInfo,
+	checkForExistingTabs,
+	type TabInfo,
+} from '../state/redux/tab-coordinator';
+
+interface UseTabTrackingOptions {
+	onWorkerLost?: () => void;
+}
+
+interface UseTabTrackingResult {
+	tabInfo: TabInfo | null;
+	otherTabs: TabInfo[];
+	workerLost: boolean;
+}
+
+export function useTabTracking(
+	hasOwnWorker: boolean,
+	options: UseTabTrackingOptions = {}
+): UseTabTrackingResult {
+	const activeSite = useActiveSite();
+	const [tabInfo, setTabInfo] = useState<TabInfo | null>(null);
+	const [otherTabs, setOtherTabs] = useState<TabInfo[]>([]);
+	const [workerLost, setWorkerLost] = useState(false);
+	const knownTabsRef = useRef<Map<string, TabInfo>>(new Map());
+	const recentlyBecameDependentRef = useRef(false);
+	const hasOwnWorkerRef = useRef(hasOwnWorker);
+
+	hasOwnWorkerRef.current = hasOwnWorker;
+
+	useEffect(() => {
+		const currentTab = getCurrentTabInfo();
+		if (currentTab) {
+			setTabInfo(currentTab);
+		}
+	}, [activeSite]);
+
+	useEffect(() => {
+		if (!hasOwnWorker) {
+			recentlyBecameDependentRef.current = true;
+			setWorkerLost(false);
+			const timer = setTimeout(() => {
+				recentlyBecameDependentRef.current = false;
+			}, 5000);
+			return () => clearTimeout(timer);
+		}
+	}, [hasOwnWorker]);
+
+	const checkWorkerLost = useCallback(() => {
+		if (
+			!hasOwnWorkerRef.current &&
+			knownTabsRef.current.size === 0 &&
+			!recentlyBecameDependentRef.current
+		) {
+			setWorkerLost(true);
+			options.onWorkerLost?.();
+		}
+	}, [options]);
+
+	useEffect(() => {
+		if (!activeSite || !tabInfo) {
+			return;
+		}
+
+		const siteSlug = activeSite.slug;
+		let isActive = true;
+		const knownTabs = knownTabsRef.current;
+
+		async function checkTabs() {
+			try {
+				const { existingTabs } = await checkForExistingTabs(siteSlug);
+				if (!isActive) return;
+
+				knownTabs.clear();
+				existingTabs.forEach((tab) => knownTabs.set(tab.tabId, tab));
+				setOtherTabs(Array.from(knownTabs.values()));
+				checkWorkerLost();
+			} catch {
+				// Failed to check for existing tabs - continue without error
+			}
+		}
+
+		checkTabs();
+
+		let channel: BroadcastChannel | null = null;
+		try {
+			channel = new BroadcastChannel('playground-tab-coordinator');
+
+			const handleMessage = (event: MessageEvent) => {
+				const message = event.data;
+
+				if (
+					message.type === 'ping' &&
+					message.siteSlug === siteSlug &&
+					message.tabId !== tabInfo.tabId
+				) {
+					const pingTabInfo: TabInfo = {
+						tabId: message.tabId,
+						siteSlug: message.siteSlug,
+						createdAt: Date.now(),
+					};
+					knownTabs.set(message.tabId, pingTabInfo);
+					setOtherTabs(Array.from(knownTabs.values()));
+				} else if (message.type === 'pong' && message.tabInfo) {
+					const otherTabId = message.tabInfo.tabId;
+					if (otherTabId !== tabInfo.tabId) {
+						knownTabs.set(otherTabId, message.tabInfo);
+						setOtherTabs(Array.from(knownTabs.values()));
+					}
+				} else if (
+					message.type === 'tab-closing' &&
+					message.tabId !== tabInfo.tabId
+				) {
+					knownTabs.delete(message.tabId);
+					setOtherTabs(Array.from(knownTabs.values()));
+					checkWorkerLost();
+				}
+			};
+
+			channel.addEventListener('message', handleMessage);
+
+			const refreshInterval = setInterval(checkTabs, 60000);
+
+			return () => {
+				isActive = false;
+				if (channel) {
+					channel.removeEventListener('message', handleMessage);
+					channel.close();
+				}
+				clearInterval(refreshInterval);
+			};
+		} catch {
+			// BroadcastChannel not supported - use polling fallback
+			const fallbackInterval = setInterval(checkTabs, 60000);
+			return () => {
+				isActive = false;
+				clearInterval(fallbackInterval);
+			};
+		}
+	}, [activeSite, tabInfo, checkWorkerLost]);
+
+	return {
+		tabInfo,
+		otherTabs,
+		workerLost,
+	};
+}

--- a/packages/playground/personal-wp/src/lib/hooks/use-takeover.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-takeover.ts
@@ -1,0 +1,136 @@
+import { useCallback, useState, useEffect } from 'react';
+import { usePlaygroundClientInfo } from '../use-playground-client';
+import { useActiveSite } from '../state/redux/store';
+import {
+	requestTakeover,
+	requestRemoteBackup,
+} from '../state/redux/tab-coordinator';
+
+const PENDING_ACTION_KEY = 'playground-pending-takeover-action';
+
+export type PendingAction = 'import' | null;
+
+/**
+ * Store a pending action to execute after takeover + reload
+ */
+export function setPendingAction(action: PendingAction): void {
+	if (action) {
+		sessionStorage.setItem(PENDING_ACTION_KEY, action);
+	} else {
+		sessionStorage.removeItem(PENDING_ACTION_KEY);
+	}
+}
+
+/**
+ * Get and clear the pending action (if any)
+ */
+export function consumePendingAction(): PendingAction {
+	const action = sessionStorage.getItem(PENDING_ACTION_KEY) as PendingAction;
+	if (action) {
+		sessionStorage.removeItem(PENDING_ACTION_KEY);
+	}
+	return action;
+}
+
+/**
+ * Hook to request taking over as the main tab from a dependent tab.
+ * After successful takeover, the page will reload and boot as main.
+ *
+ * @param pendingAction - Optional action to execute after reload (e.g., 'backup')
+ */
+export function useTakeover() {
+	const clientInfo = usePlaygroundClientInfo();
+	const activeSite = useActiveSite();
+	const [isTakingOver, setIsTakingOver] = useState(false);
+
+	const isDependentMode = clientInfo?.isDependentMode ?? false;
+
+	const performTakeover = useCallback(
+		async (pendingAction?: PendingAction): Promise<boolean> => {
+			if (!activeSite || !isDependentMode || isTakingOver) {
+				return false;
+			}
+
+			setIsTakingOver(true);
+			try {
+				if (pendingAction) {
+					setPendingAction(pendingAction);
+				}
+
+				const acknowledged = await requestTakeover(activeSite.slug);
+
+				if (acknowledged) {
+					window.location.reload();
+					return true;
+				}
+
+				window.location.reload();
+				return true;
+			} finally {
+				setIsTakingOver(false);
+			}
+		},
+		[activeSite, isDependentMode, isTakingOver]
+	);
+
+	return {
+		performTakeover,
+		isTakingOver,
+		isDependentMode,
+		canTakeover: isDependentMode && !!activeSite,
+	};
+}
+
+/**
+ * Hook to check for and execute pending actions after takeover + reload.
+ * Currently only handles 'import' action to open the backup overlay.
+ */
+export function usePendingTakeoverAction(onImport: () => void) {
+	const clientInfo = usePlaygroundClientInfo();
+	const isMainMode = clientInfo && !clientInfo.isDependentMode;
+
+	useEffect(() => {
+		if (!isMainMode) return;
+
+		const pendingAction = consumePendingAction();
+		if (pendingAction === 'import') {
+			const timer = setTimeout(() => {
+				onImport();
+			}, 500);
+			return () => clearTimeout(timer);
+		}
+	}, [isMainMode, onImport]);
+}
+
+/**
+ * Hook to request a backup from the main tab when in dependent mode.
+ * The backup file will be downloaded in the main tab.
+ */
+export function useRemoteBackup() {
+	const clientInfo = usePlaygroundClientInfo();
+	const activeSite = useActiveSite();
+	const [isRequestingBackup, setIsRequestingBackup] = useState(false);
+
+	const isDependentMode = clientInfo?.isDependentMode ?? false;
+
+	const requestBackup = useCallback(async (): Promise<boolean> => {
+		if (!activeSite || !isDependentMode || isRequestingBackup) {
+			return false;
+		}
+
+		setIsRequestingBackup(true);
+		try {
+			const success = await requestRemoteBackup(activeSite.slug);
+			return success;
+		} finally {
+			setIsRequestingBackup(false);
+		}
+	}, [activeSite, isDependentMode, isRequestingBackup]);
+
+	return {
+		requestBackup,
+		isRequestingBackup,
+		isDependentMode,
+		canRequestBackup: isDependentMode && !!activeSite,
+	};
+}

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -8,6 +8,7 @@ import {
 	addClientInfo,
 	removeClientInfo,
 	updateClientInfo,
+	selectClientInfoBySiteSlug,
 } from './slice-clients';
 import { logBlueprintEvents, logTrackingEvent } from '../../tracking';
 import {
@@ -32,6 +33,13 @@ import {
 // @ts-ignore
 import { corsProxyUrl } from 'virtual:cors-proxy-url';
 import { findFirewallErrorInCauseChain } from './error-utils';
+import {
+	initTabCoordinator,
+	checkForExistingTabs,
+	requestStaleTabsShutdown,
+	setDependentMode,
+	requestTakeover,
+} from './tab-coordinator';
 
 export interface BootSiteClientOptions {
 	signal: AbortSignal;
@@ -129,6 +137,221 @@ export function bootSiteClient(
 		}
 
 		logTrackingEvent('load');
+
+		// Initialize tab coordinator for multi-tab detection
+		// Only for persistent sites - temporary sites don't need coordination
+		if (site.metadata.storage !== 'none') {
+			initTabCoordinator(
+				site.slug,
+				(reason) => {
+					dispatch(
+						setActiveSiteError({
+							error: 'tab-superseded',
+							details: new Error(reason),
+						})
+					);
+				},
+				() => {
+					// This callback is called when another tab requests to take over as main
+					// We switch to dependent mode without showing an error
+					const remoteUrl = getRemoteUrl();
+					const scopedSiteUrl = `/scope:${encodeURIComponent(site.slug)}/`;
+
+					const dependentModeClient = {
+						goTo: async (path: string) => {
+							const newUrl = new URL(
+								scopedSiteUrl + path.replace(/^\//, ''),
+								remoteUrl
+							);
+							iframe.src = newUrl.toString();
+						},
+						getCurrentURL: async () => {
+							try {
+								const iframeUrl = new URL(
+									iframe.contentWindow?.location?.href || ''
+								);
+								return iframeUrl.pathname.replace(
+									new RegExp(
+										`^${scopedSiteUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`
+									),
+									'/'
+								);
+							} catch {
+								return '/';
+							}
+						},
+					} as PlaygroundClient;
+
+					dispatch(
+						updateClientInfo({
+							siteSlug: site.slug,
+							changes: {
+								client: dependentModeClient,
+								isDependentMode: true,
+								opfsMountDescriptor: undefined,
+							},
+						})
+					);
+
+					setDependentMode(true);
+
+					logger.info(
+						'Switched to dependent mode - another tab has taken over as main'
+					);
+				},
+				undefined,
+				() => {
+					// Site was reset by another tab - reload to start fresh
+					window.location.href =
+						window.location.origin + window.location.pathname;
+				}
+			);
+
+			const { existingTabs, hasFreshTab, hasStaleTab } =
+				await checkForExistingTabs(site.slug);
+
+			if (hasStaleTab) {
+				requestStaleTabsShutdown(existingTabs);
+			}
+
+			if (hasFreshTab) {
+				const urlParams = new URLSearchParams(window.location.search);
+				const hasBlueprintUrl = !!urlParams.get('blueprint-url');
+				const pendingBlueprintForCheck =
+					selectBlueprintResolvedFromUrl(getState());
+				const hasPendingBlueprintForSite =
+					pendingBlueprintForCheck &&
+					pendingBlueprintForCheck.targetSiteSlug === site.slug;
+				const needsMainMode =
+					hasBlueprintUrl || hasPendingBlueprintForSite;
+
+				if (needsMainMode) {
+					await requestTakeover(site.slug);
+				} else {
+					const existingClient = selectClientInfoBySiteSlug(
+						getState(),
+						site.slug
+					);
+					if (existingClient?.isDependentMode) {
+						return;
+					}
+
+					const remoteUrl = getRemoteUrl();
+					const scopedSiteUrl = `/scope:${encodeURIComponent(site.slug)}/`;
+					const scopedUrl = new URL(scopedSiteUrl, remoteUrl);
+
+					const dependentUrlParams = new URLSearchParams(
+						window.location.search
+					);
+					const landingPage =
+						dependentUrlParams.get('url') ||
+						site.metadata.lastUrl ||
+						'/wp-admin/';
+					scopedUrl.pathname += landingPage.replace(/^\//, '');
+					iframe.src = scopedUrl.toString();
+
+					const dependentModeClient = {
+						goTo: async (path: string) => {
+							const newUrl = new URL(
+								scopedSiteUrl + path.replace(/^\//, ''),
+								remoteUrl
+							);
+							iframe.src = newUrl.toString();
+						},
+						getCurrentURL: async () => {
+							try {
+								const iframeUrl = new URL(
+									iframe.contentWindow?.location?.href || ''
+								);
+								return iframeUrl.pathname.replace(
+									new RegExp(
+										`^${scopedSiteUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`
+									),
+									'/'
+								);
+							} catch {
+								return '/';
+							}
+						},
+					} as PlaygroundClient;
+
+					dispatch(
+						addClientInfo({
+							siteSlug: site.slug,
+							url: landingPage,
+							client: dependentModeClient,
+							opfsMountDescriptor: undefined,
+							isDependentMode: true,
+						})
+					);
+
+					const handleIframeNavigation = () => {
+						try {
+							const iframeHref =
+								iframe.contentWindow?.location?.href;
+							if (iframeHref) {
+								const iframeUrl = new URL(iframeHref);
+								const path = iframeUrl.pathname.replace(
+									new RegExp(
+										`^${scopedSiteUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`
+									),
+									'/'
+								);
+								dispatch(
+									updateClientInfo({
+										siteSlug: site.slug,
+										changes: { url: path },
+									})
+								);
+							}
+						} catch {
+							// Cross-origin access denied
+						}
+					};
+
+					iframe.addEventListener('load', handleIframeNavigation);
+
+					signal.onabort = () => {
+						iframe.removeEventListener(
+							'load',
+							handleIframeNavigation
+						);
+						dispatch(removeClientInfo(site.slug));
+					};
+
+					const now = Date.now();
+					const lastAccess = site.metadata.lastAccessDate;
+					const isNewDay =
+						lastAccess &&
+						new Date(lastAccess).toDateString() !==
+							new Date(now).toDateString();
+
+					const changes: {
+						lastAccessDate: number;
+						daysUsedSinceLastBackup?: number;
+					} = {
+						lastAccessDate: now,
+					};
+
+					if (isNewDay) {
+						changes.daysUsedSinceLastBackup =
+							(site.metadata.daysUsedSinceLastBackup || 0) + 1;
+					}
+
+					dispatch(
+						updateSiteMetadata({
+							slug: site.slug,
+							changes,
+						})
+					);
+
+					logger.info(
+						'Playground running in dependent mode - reusing existing service worker from another tab'
+					);
+					return;
+				}
+			}
+		}
 
 		let blueprint: Blueprint;
 		if (isWordPressInstalled) {

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -319,29 +319,12 @@ export function bootSiteClient(
 						dispatch(removeClientInfo(site.slug));
 					};
 
-					const now = Date.now();
-					const lastAccess = site.metadata.lastAccessDate;
-					const isNewDay =
-						lastAccess &&
-						new Date(lastAccess).toDateString() !==
-							new Date(now).toDateString();
-
-					const changes: {
-						lastAccessDate: number;
-						daysUsedSinceLastBackup?: number;
-					} = {
-						lastAccessDate: now,
-					};
-
-					if (isNewDay) {
-						changes.daysUsedSinceLastBackup =
-							(site.metadata.daysUsedSinceLastBackup || 0) + 1;
-					}
-
 					dispatch(
 						updateSiteMetadata({
 							slug: site.slug,
-							changes,
+							changes: {
+								lastAccessDate: Date.now(),
+							},
 						})
 					);
 

--- a/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.spec.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.spec.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	initCrossTabSync,
+	destroyCrossTabSync,
+	broadcastMetadataUpdate,
+	isFromBroadcast,
+} from './cross-tab-sync';
+import { sitesSlice } from './slice-sites';
+
+// Mock slice-sites to avoid browser dependencies from slice-ui
+vi.mock('./slice-sites', () => ({
+	sitesSlice: {
+		actions: {
+			updateSiteMetadata: vi.fn((payload) => ({
+				type: 'sites/updateSiteMetadata',
+				payload,
+			})),
+		},
+	},
+}));
+
+type MessageHandler = (event: MessageEvent) => void;
+
+class MockBroadcastChannel {
+	static instances: MockBroadcastChannel[] = [];
+	name: string;
+	onmessage: MessageHandler | null = null;
+	closed = false;
+
+	constructor(name: string) {
+		this.name = name;
+		MockBroadcastChannel.instances.push(this);
+	}
+
+	postMessage(data: unknown): void {
+		if (this.closed) return;
+
+		const event = { data } as MessageEvent;
+		for (const instance of MockBroadcastChannel.instances) {
+			if (
+				instance !== this &&
+				instance.name === this.name &&
+				!instance.closed
+			) {
+				if (instance.onmessage) {
+					instance.onmessage(event);
+				}
+			}
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+		const index = MockBroadcastChannel.instances.indexOf(this);
+		if (index !== -1) {
+			MockBroadcastChannel.instances.splice(index, 1);
+		}
+	}
+
+	static reset(): void {
+		MockBroadcastChannel.instances = [];
+	}
+}
+
+describe('cross-tab-sync', () => {
+	let mockDispatch: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		MockBroadcastChannel.reset();
+		vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
+		vi.stubGlobal('crypto', {
+			randomUUID: () =>
+				`test-uuid-${Math.random().toString(36).slice(2)}`,
+		});
+		mockDispatch = vi.fn();
+		destroyCrossTabSync();
+	});
+
+	afterEach(() => {
+		destroyCrossTabSync();
+		MockBroadcastChannel.reset();
+		vi.unstubAllGlobals();
+	});
+
+	describe('initCrossTabSync', () => {
+		it('creates a BroadcastChannel', () => {
+			initCrossTabSync(mockDispatch);
+			expect(MockBroadcastChannel.instances).toHaveLength(1);
+			expect(MockBroadcastChannel.instances[0].name).toBe(
+				'playground-site-metadata-sync'
+			);
+		});
+
+		it('does not create duplicate channels on multiple calls', () => {
+			initCrossTabSync(mockDispatch);
+			initCrossTabSync(mockDispatch);
+			expect(MockBroadcastChannel.instances).toHaveLength(1);
+		});
+	});
+
+	describe('destroyCrossTabSync', () => {
+		it('closes the channel', () => {
+			initCrossTabSync(mockDispatch);
+			expect(MockBroadcastChannel.instances).toHaveLength(1);
+
+			destroyCrossTabSync();
+			expect(MockBroadcastChannel.instances).toHaveLength(0);
+		});
+
+		it('does not throw when not initialized', () => {
+			expect(() => destroyCrossTabSync()).not.toThrow();
+		});
+	});
+
+	describe('broadcastMetadataUpdate', () => {
+		it('broadcasts syncable fields', () => {
+			initCrossTabSync(mockDispatch);
+
+			const messages: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-site-metadata-sync'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				messages.push(event.data);
+			};
+
+			broadcastMetadataUpdate('my-site', {
+				backupHistory: [{ timestamp: 123, filename: 'backup-123.zip' }],
+				daysUsedSinceLastBackup: 5,
+				lastAccessDate: 999,
+			});
+
+			expect(messages).toHaveLength(1);
+			const message = messages[0] as {
+				type: string;
+				slug: string;
+				changes: Record<string, unknown>;
+				senderId: string;
+			};
+			expect(message.type).toBe('metadata-update');
+			expect(message.slug).toBe('my-site');
+			expect(message.changes).toEqual({
+				backupHistory: [{ timestamp: 123, filename: 'backup-123.zip' }],
+				daysUsedSinceLastBackup: 5,
+				lastAccessDate: 999,
+			});
+			expect(message.senderId).toBeTruthy();
+
+			otherChannel.close();
+		});
+
+		it('filters out non-syncable fields', () => {
+			initCrossTabSync(mockDispatch);
+
+			const messages: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-site-metadata-sync'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				messages.push(event.data);
+			};
+
+			broadcastMetadataUpdate('my-site', {
+				backupHistory: [{ timestamp: 123, filename: 'backup-123.zip' }],
+				name: 'should-not-sync',
+				storage: 'opfs',
+				lastUrl: '/wp-admin/',
+			} as Record<string, unknown>);
+
+			expect(messages).toHaveLength(1);
+			const message = messages[0] as {
+				changes: Record<string, unknown>;
+			};
+			expect(message.changes).toEqual({
+				backupHistory: [{ timestamp: 123, filename: 'backup-123.zip' }],
+			});
+			expect(message.changes).not.toHaveProperty('name');
+			expect(message.changes).not.toHaveProperty('storage');
+			expect(message.changes).not.toHaveProperty('lastUrl');
+
+			otherChannel.close();
+		});
+
+		it('does not broadcast when no syncable fields', () => {
+			initCrossTabSync(mockDispatch);
+
+			const messages: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-site-metadata-sync'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				messages.push(event.data);
+			};
+
+			broadcastMetadataUpdate('my-site', {
+				name: 'not-syncable',
+				lastUrl: '/wp-admin/',
+			} as Record<string, unknown>);
+
+			expect(messages).toHaveLength(0);
+
+			otherChannel.close();
+		});
+
+		it('does not broadcast when not initialized', () => {
+			const messages: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-site-metadata-sync'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				messages.push(event.data);
+			};
+
+			broadcastMetadataUpdate('my-site', {
+				backupHistory: [],
+			});
+
+			expect(messages).toHaveLength(0);
+
+			otherChannel.close();
+		});
+	});
+
+	describe('receiving metadata updates', () => {
+		it('dispatches updateSiteMetadata action when receiving updates', () => {
+			initCrossTabSync(mockDispatch);
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-site-metadata-sync'
+			);
+			otherChannel.postMessage({
+				type: 'metadata-update',
+				slug: 'my-site',
+				changes: {
+					backupHistory: [
+						{ timestamp: 456, filename: 'backup-456.zip' },
+					],
+				},
+				senderId: 'other-sender',
+			});
+
+			expect(mockDispatch).toHaveBeenCalledWith(
+				sitesSlice.actions.updateSiteMetadata({
+					slug: 'my-site',
+					metadata: {
+						backupHistory: [
+							{ timestamp: 456, filename: 'backup-456.zip' },
+						],
+					},
+				})
+			);
+
+			otherChannel.close();
+		});
+
+		it('ignores messages from self', () => {
+			initCrossTabSync(mockDispatch);
+
+			broadcastMetadataUpdate('my-site', {
+				backupHistory: [],
+			});
+
+			expect(mockDispatch).not.toHaveBeenCalled();
+		});
+
+		it('does not dispatch when dispatch is not set', () => {
+			destroyCrossTabSync();
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-site-metadata-sync'
+			);
+
+			initCrossTabSync(mockDispatch);
+			destroyCrossTabSync();
+
+			otherChannel.postMessage({
+				type: 'metadata-update',
+				slug: 'my-site',
+				changes: { backupHistory: [] },
+				senderId: 'other-sender',
+			});
+
+			expect(mockDispatch).not.toHaveBeenCalled();
+
+			otherChannel.close();
+		});
+	});
+
+	describe('isFromBroadcast', () => {
+		it('returns false normally', () => {
+			initCrossTabSync(mockDispatch as never);
+			expect(isFromBroadcast()).toBe(false);
+		});
+
+		it('returns true while processing broadcast', () => {
+			let wasFromBroadcast = false;
+			const trackingDispatch = vi.fn(() => {
+				wasFromBroadcast = isFromBroadcast();
+			});
+
+			initCrossTabSync(trackingDispatch as never);
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-site-metadata-sync'
+			);
+			otherChannel.postMessage({
+				type: 'metadata-update',
+				slug: 'my-site',
+				changes: { backupHistory: [] },
+				senderId: 'other-sender',
+			});
+
+			expect(wasFromBroadcast).toBe(true);
+			expect(isFromBroadcast()).toBe(false);
+
+			otherChannel.close();
+		});
+	});
+
+	describe('loop prevention', () => {
+		it('does not re-broadcast while processing incoming broadcast', () => {
+			const messages: unknown[] = [];
+
+			const rebroadcastingDispatch = vi.fn(() => {
+				broadcastMetadataUpdate('my-site', {
+					daysUsedSinceLastBackup: 10,
+				});
+			});
+
+			initCrossTabSync(rebroadcastingDispatch as never);
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-site-metadata-sync'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				messages.push(event.data);
+			};
+
+			otherChannel.postMessage({
+				type: 'metadata-update',
+				slug: 'my-site',
+				changes: { backupHistory: [] },
+				senderId: 'other-sender',
+			});
+
+			expect(rebroadcastingDispatch).toHaveBeenCalled();
+			expect(messages).toHaveLength(0);
+
+			otherChannel.close();
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.spec.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.spec.ts
@@ -126,7 +126,6 @@ describe('cross-tab-sync', () => {
 
 			broadcastMetadataUpdate('my-site', {
 				backupHistory: [{ timestamp: 123, filename: 'backup-123.zip' }],
-				daysUsedSinceLastBackup: 5,
 				lastAccessDate: 999,
 			});
 
@@ -141,7 +140,6 @@ describe('cross-tab-sync', () => {
 			expect(message.slug).toBe('my-site');
 			expect(message.changes).toEqual({
 				backupHistory: [{ timestamp: 123, filename: 'backup-123.zip' }],
-				daysUsedSinceLastBackup: 5,
 				lastAccessDate: 999,
 			});
 			expect(message.senderId).toBeTruthy();
@@ -323,7 +321,7 @@ describe('cross-tab-sync', () => {
 
 			const rebroadcastingDispatch = vi.fn(() => {
 				broadcastMetadataUpdate('my-site', {
-					daysUsedSinceLastBackup: 10,
+					lastAccessDate: Date.now(),
 				});
 			});
 

--- a/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.ts
@@ -90,7 +90,6 @@ function filterSyncableChanges(
 ): Partial<SiteMetadata> {
 	const syncableFields: (keyof SiteMetadata)[] = [
 		'backupHistory',
-		'daysUsedSinceLastBackup',
 		'lastAccessDate',
 	];
 

--- a/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.ts
@@ -1,0 +1,138 @@
+import type { SiteMetadata } from './slice-sites';
+import type { PlaygroundDispatch } from './store';
+import { sitesSlice } from './slice-sites';
+
+/**
+ * Cross-tab synchronization for site metadata using BroadcastChannel.
+ *
+ * This module ensures that metadata changes (like backup history, days used since
+ * last backup) are synchronized across all tabs that have the same site open.
+ */
+
+type MetadataUpdateMessage = {
+	type: 'metadata-update';
+	slug: string;
+	changes: Partial<SiteMetadata>;
+	senderId: string;
+};
+
+type CrossTabMessage = MetadataUpdateMessage;
+
+const CHANNEL_NAME = 'playground-site-metadata-sync';
+
+let channel: BroadcastChannel | null = null;
+let dispatch: PlaygroundDispatch | null = null;
+let senderId: string | null = null;
+
+let isProcessingBroadcast = false;
+
+/**
+ * Initialize the cross-tab sync system.
+ * Should be called once during app initialization.
+ */
+export function initCrossTabSync(storeDispatch: PlaygroundDispatch): void {
+	if (channel) {
+		return;
+	}
+
+	dispatch = storeDispatch;
+	senderId = crypto.randomUUID();
+
+	try {
+		channel = new BroadcastChannel(CHANNEL_NAME);
+		channel.onmessage = handleMessage;
+	} catch {
+		// BroadcastChannel not supported
+	}
+}
+
+/**
+ * Clean up the cross-tab sync system.
+ */
+export function destroyCrossTabSync(): void {
+	if (channel) {
+		channel.close();
+		channel = null;
+	}
+	dispatch = null;
+	senderId = null;
+}
+
+/**
+ * Broadcast a metadata update to other tabs.
+ * Called from updateSiteMetadata after the local update is applied.
+ */
+export function broadcastMetadataUpdate(
+	slug: string,
+	changes: Partial<SiteMetadata>
+): void {
+	if (!channel || !senderId || isProcessingBroadcast) {
+		return;
+	}
+
+	const syncableChanges = filterSyncableChanges(changes);
+	if (Object.keys(syncableChanges).length === 0) {
+		return;
+	}
+
+	const message: MetadataUpdateMessage = {
+		type: 'metadata-update',
+		slug,
+		changes: syncableChanges,
+		senderId,
+	};
+
+	channel.postMessage(message);
+}
+
+function filterSyncableChanges(
+	changes: Partial<SiteMetadata>
+): Partial<SiteMetadata> {
+	const syncableFields: (keyof SiteMetadata)[] = [
+		'backupHistory',
+		'daysUsedSinceLastBackup',
+		'lastAccessDate',
+	];
+
+	const filtered: Partial<SiteMetadata> = {};
+	for (const field of syncableFields) {
+		if (field in changes) {
+			(filtered as Record<string, unknown>)[field] = changes[field];
+		}
+	}
+	return filtered;
+}
+
+function handleMessage(event: MessageEvent<CrossTabMessage>): void {
+	if (!dispatch || !senderId) {
+		return;
+	}
+
+	const message = event.data;
+
+	if (message.senderId === senderId) {
+		return;
+	}
+
+	if (message.type === 'metadata-update') {
+		isProcessingBroadcast = true;
+		try {
+			dispatch(
+				sitesSlice.actions.updateSiteMetadata({
+					slug: message.slug,
+					metadata: message.changes,
+				})
+			);
+		} finally {
+			isProcessingBroadcast = false;
+		}
+	}
+}
+
+/**
+ * Check if we're currently processing a broadcast.
+ * Useful for preventing re-broadcasts in middleware or thunks.
+ */
+export function isFromBroadcast(): boolean {
+	return isProcessingBroadcast;
+}

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-clients.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-clients.ts
@@ -21,6 +21,7 @@ export interface ClientInfo {
 		mountpoint: string;
 	};
 	opfsSync?: OpfsSync;
+	isDependentMode?: boolean;
 }
 
 // Create an entity adapter for ClientInfo

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
@@ -551,6 +551,11 @@ export interface SiteMetadata {
 		| 'every-2-days'
 		| 'weekly'
 		| 'ignore';
+
+	/**
+	 * Timestamp of the last time this site was accessed.
+	 */
+	lastAccessDate?: number;
 }
 
 export const { setOPFSSitesLoadingState, setBlueprintResolvedFromUrl } =

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
@@ -13,7 +13,8 @@ export type SiteError =
 	| 'blueprint-fetch-failed'
 	| 'blueprint-filesystem-required'
 	| 'blueprint-validation-failed'
-	| 'network-firewall-interference';
+	| 'network-firewall-interference'
+	| 'tab-superseded';
 
 export type SiteManagerSection = 'sidebar' | 'site-details' | 'blueprints';
 

--- a/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.spec.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.spec.ts
@@ -1,0 +1,678 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+	initTabCoordinator,
+	destroyTabCoordinator,
+	getCurrentTabInfo,
+	isTabStale,
+	setDependentMode,
+	checkForExistingTabs,
+	requestStaleTabsShutdown,
+	requestTakeover,
+	requestRemoteBackup,
+	broadcastSiteReset,
+	setBackupRequestCallback,
+	type TabInfo,
+} from './tab-coordinator';
+
+type MessageHandler = (event: MessageEvent) => void;
+
+class MockBroadcastChannel {
+	static instances: MockBroadcastChannel[] = [];
+	name: string;
+	onmessage: MessageHandler | null = null;
+	private listeners: Map<string, MessageHandler[]> = new Map();
+	closed = false;
+
+	constructor(name: string) {
+		this.name = name;
+		MockBroadcastChannel.instances.push(this);
+	}
+
+	postMessage(data: unknown): void {
+		if (this.closed) return;
+
+		const event = { data } as MessageEvent;
+		for (const instance of MockBroadcastChannel.instances) {
+			if (
+				instance !== this &&
+				instance.name === this.name &&
+				!instance.closed
+			) {
+				if (instance.onmessage) {
+					instance.onmessage(event);
+				}
+				const listeners = instance.listeners.get('message') || [];
+				for (const listener of listeners) {
+					listener(event);
+				}
+			}
+		}
+	}
+
+	addEventListener(type: string, handler: MessageHandler): void {
+		if (!this.listeners.has(type)) {
+			this.listeners.set(type, []);
+		}
+		this.listeners.get(type)!.push(handler);
+	}
+
+	removeEventListener(type: string, handler: MessageHandler): void {
+		const handlers = this.listeners.get(type);
+		if (handlers) {
+			const index = handlers.indexOf(handler);
+			if (index !== -1) {
+				handlers.splice(index, 1);
+			}
+		}
+	}
+
+	close(): void {
+		this.closed = true;
+		const index = MockBroadcastChannel.instances.indexOf(this);
+		if (index !== -1) {
+			MockBroadcastChannel.instances.splice(index, 1);
+		}
+	}
+
+	static reset(): void {
+		MockBroadcastChannel.instances = [];
+	}
+}
+
+describe('tab-coordinator', () => {
+	beforeEach(() => {
+		MockBroadcastChannel.reset();
+		vi.stubGlobal('BroadcastChannel', MockBroadcastChannel);
+		vi.stubGlobal('crypto', {
+			randomUUID: () =>
+				`test-uuid-${Math.random().toString(36).slice(2)}`,
+		});
+		destroyTabCoordinator();
+	});
+
+	afterEach(() => {
+		destroyTabCoordinator();
+		MockBroadcastChannel.reset();
+		vi.unstubAllGlobals();
+	});
+
+	describe('isTabStale', () => {
+		it('returns false for tabs created just now', () => {
+			const tabInfo: TabInfo = {
+				tabId: 'test-tab',
+				createdAt: Date.now(),
+				siteSlug: 'test-site',
+			};
+			expect(isTabStale(tabInfo)).toBe(false);
+		});
+
+		it('returns false for tabs created 23 hours ago', () => {
+			const twentyThreeHoursAgo = Date.now() - 23 * 60 * 60 * 1000;
+			const tabInfo: TabInfo = {
+				tabId: 'test-tab',
+				createdAt: twentyThreeHoursAgo,
+				siteSlug: 'test-site',
+			};
+			expect(isTabStale(tabInfo)).toBe(false);
+		});
+
+		it('returns true for tabs created exactly 24 hours ago', () => {
+			const oneDayAgo = Date.now() - 24 * 60 * 60 * 1000;
+			const tabInfo: TabInfo = {
+				tabId: 'test-tab',
+				createdAt: oneDayAgo,
+				siteSlug: 'test-site',
+			};
+			expect(isTabStale(tabInfo)).toBe(true);
+		});
+
+		it('returns true for tabs created more than 24 hours ago', () => {
+			const twoDaysAgo = Date.now() - 48 * 60 * 60 * 1000;
+			const tabInfo: TabInfo = {
+				tabId: 'test-tab',
+				createdAt: twoDaysAgo,
+				siteSlug: 'test-site',
+			};
+			expect(isTabStale(tabInfo)).toBe(true);
+		});
+	});
+
+	describe('initTabCoordinator', () => {
+		it('creates tab info with correct site slug', () => {
+			const tabInfo = initTabCoordinator('my-site');
+			expect(tabInfo.siteSlug).toBe('my-site');
+		});
+
+		it('creates tab info with current timestamp', () => {
+			const before = Date.now();
+			const tabInfo = initTabCoordinator('my-site');
+			const after = Date.now();
+			expect(tabInfo.createdAt).toBeGreaterThanOrEqual(before);
+			expect(tabInfo.createdAt).toBeLessThanOrEqual(after);
+		});
+
+		it('creates tab info with unique tab ID', () => {
+			const tabInfo = initTabCoordinator('my-site');
+			expect(tabInfo.tabId).toBeTruthy();
+			expect(typeof tabInfo.tabId).toBe('string');
+		});
+
+		it('returns same tab info when called twice with same site', () => {
+			const tabInfo1 = initTabCoordinator('my-site');
+			const tabInfo2 = initTabCoordinator('my-site');
+			expect(tabInfo1).toBe(tabInfo2);
+		});
+
+		it('creates new tab info when switching sites', () => {
+			const tabInfo1 = initTabCoordinator('site-a');
+			destroyTabCoordinator();
+			const tabInfo2 = initTabCoordinator('site-b');
+			expect(tabInfo1.tabId).not.toBe(tabInfo2.tabId);
+			expect(tabInfo2.siteSlug).toBe('site-b');
+		});
+	});
+
+	describe('getCurrentTabInfo', () => {
+		it('returns null before initialization', () => {
+			expect(getCurrentTabInfo()).toBeNull();
+		});
+
+		it('returns tab info after initialization', () => {
+			initTabCoordinator('my-site');
+			const tabInfo = getCurrentTabInfo();
+			expect(tabInfo).not.toBeNull();
+			expect(tabInfo!.siteSlug).toBe('my-site');
+		});
+
+		it('returns null after destroy', () => {
+			initTabCoordinator('my-site');
+			destroyTabCoordinator();
+			expect(getCurrentTabInfo()).toBeNull();
+		});
+	});
+
+	describe('setDependentMode', () => {
+		it('sets isDependentMode on current tab info', () => {
+			initTabCoordinator('my-site');
+			setDependentMode(true);
+			expect(getCurrentTabInfo()!.isDependentMode).toBe(true);
+		});
+
+		it('can toggle dependent mode off', () => {
+			initTabCoordinator('my-site');
+			setDependentMode(true);
+			setDependentMode(false);
+			expect(getCurrentTabInfo()!.isDependentMode).toBe(false);
+		});
+
+		it('does nothing if not initialized', () => {
+			expect(() => setDependentMode(true)).not.toThrow();
+		});
+	});
+
+	describe('checkForExistingTabs', () => {
+		it('returns empty when no other tabs exist', async () => {
+			initTabCoordinator('my-site');
+			const result = await checkForExistingTabs('my-site');
+			expect(result.existingTabs).toHaveLength(0);
+			expect(result.hasFreshTab).toBe(false);
+			expect(result.hasStaleTab).toBe(false);
+		});
+
+		it('returns empty when not initialized', async () => {
+			const result = await checkForExistingTabs('my-site');
+			expect(result.existingTabs).toHaveLength(0);
+		});
+
+		it('detects fresh tabs from other instances', async () => {
+			initTabCoordinator('my-site');
+
+			destroyTabCoordinator();
+			initTabCoordinator('my-site');
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				if (event.data.type === 'ping') {
+					otherChannel.postMessage({
+						type: 'pong',
+						tabInfo: {
+							tabId: 'other-tab',
+							createdAt: Date.now(),
+							siteSlug: 'my-site',
+						},
+					});
+				}
+			};
+
+			const result = await checkForExistingTabs('my-site');
+			expect(result.existingTabs).toHaveLength(1);
+			expect(result.hasFreshTab).toBe(true);
+			expect(result.hasStaleTab).toBe(false);
+
+			otherChannel.close();
+		});
+
+		it('detects stale tabs', async () => {
+			initTabCoordinator('my-site');
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			const twoDaysAgo = Date.now() - 48 * 60 * 60 * 1000;
+			otherChannel.onmessage = (event: MessageEvent) => {
+				if (event.data.type === 'ping') {
+					otherChannel.postMessage({
+						type: 'pong',
+						tabInfo: {
+							tabId: 'stale-tab',
+							createdAt: twoDaysAgo,
+							siteSlug: 'my-site',
+						},
+					});
+				}
+			};
+
+			const result = await checkForExistingTabs('my-site');
+			expect(result.existingTabs).toHaveLength(1);
+			expect(result.hasFreshTab).toBe(false);
+			expect(result.hasStaleTab).toBe(true);
+
+			otherChannel.close();
+		});
+
+		it('ignores tabs for different sites', async () => {
+			initTabCoordinator('my-site');
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				if (event.data.type === 'ping') {
+					otherChannel.postMessage({
+						type: 'pong',
+						tabInfo: {
+							tabId: 'other-tab',
+							createdAt: Date.now(),
+							siteSlug: 'different-site',
+						},
+					});
+				}
+			};
+
+			const result = await checkForExistingTabs('my-site');
+			expect(result.existingTabs).toHaveLength(0);
+
+			otherChannel.close();
+		});
+
+		it('ignores dependent mode tabs when checking for fresh tabs', async () => {
+			initTabCoordinator('my-site');
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				if (event.data.type === 'ping') {
+					otherChannel.postMessage({
+						type: 'pong',
+						tabInfo: {
+							tabId: 'dependent-tab',
+							createdAt: Date.now(),
+							siteSlug: 'my-site',
+							isDependentMode: true,
+						},
+					});
+				}
+			};
+
+			const result = await checkForExistingTabs('my-site');
+			expect(result.existingTabs).toHaveLength(1);
+			expect(result.hasFreshTab).toBe(false);
+
+			otherChannel.close();
+		});
+	});
+
+	describe('requestStaleTabsShutdown', () => {
+		it('requests shutdown only for stale tabs', () => {
+			initTabCoordinator('my-site');
+
+			const shutdownRequests: string[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				if (event.data.type === 'shutdown-request') {
+					shutdownRequests.push(event.data.targetTabId);
+				}
+			};
+
+			const now = Date.now();
+			const tabs: TabInfo[] = [
+				{ tabId: 'fresh-tab', createdAt: now, siteSlug: 'my-site' },
+				{
+					tabId: 'stale-tab',
+					createdAt: now - 25 * 60 * 60 * 1000,
+					siteSlug: 'my-site',
+				},
+			];
+
+			requestStaleTabsShutdown(tabs);
+
+			expect(shutdownRequests).toHaveLength(1);
+			expect(shutdownRequests[0]).toBe('stale-tab');
+
+			otherChannel.close();
+		});
+	});
+
+	describe('message handling', () => {
+		it('responds to ping with pong for same site', () => {
+			initTabCoordinator('my-site');
+			const tabInfo = getCurrentTabInfo()!;
+
+			const responses: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				responses.push(event.data);
+			};
+
+			otherChannel.postMessage({
+				type: 'ping',
+				tabId: 'other-tab',
+				siteSlug: 'my-site',
+			});
+
+			expect(responses).toHaveLength(1);
+			expect(responses[0]).toEqual({
+				type: 'pong',
+				tabInfo,
+			});
+
+			otherChannel.close();
+		});
+
+		it('does not respond to ping for different site', () => {
+			initTabCoordinator('my-site');
+
+			const responses: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				responses.push(event.data);
+			};
+
+			otherChannel.postMessage({
+				type: 'ping',
+				tabId: 'other-tab',
+				siteSlug: 'different-site',
+			});
+
+			expect(responses).toHaveLength(0);
+
+			otherChannel.close();
+		});
+
+		it('calls shutdown callback when shutdown requested', () => {
+			const shutdownCallback = vi.fn();
+			const tabInfo = initTabCoordinator('my-site', shutdownCallback);
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.postMessage({
+				type: 'shutdown-request',
+				targetTabId: tabInfo.tabId,
+				reason: 'stale',
+			});
+
+			expect(shutdownCallback).toHaveBeenCalledWith(
+				'This tab has been open for over a day and a newer tab was opened.'
+			);
+
+			otherChannel.close();
+		});
+
+		it('calls takeover callback and sends acknowledgment', () => {
+			const takeoverCallback = vi.fn();
+			const tabInfo = initTabCoordinator(
+				'my-site',
+				undefined,
+				takeoverCallback
+			);
+
+			const responses: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				responses.push(event.data);
+			};
+
+			otherChannel.postMessage({
+				type: 'takeover-request',
+				requestingTabId: 'new-tab',
+				siteSlug: 'my-site',
+			});
+
+			expect(takeoverCallback).toHaveBeenCalled();
+			expect(responses).toHaveLength(1);
+			expect(responses[0]).toEqual({
+				type: 'takeover-acknowledged',
+				previousMainTabId: tabInfo.tabId,
+				targetTabId: 'new-tab',
+				siteSlug: 'my-site',
+			});
+
+			otherChannel.close();
+		});
+
+		it('does not respond to takeover request in dependent mode', () => {
+			const takeoverCallback = vi.fn();
+			initTabCoordinator('my-site', undefined, takeoverCallback);
+			setDependentMode(true);
+
+			const responses: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				responses.push(event.data);
+			};
+
+			otherChannel.postMessage({
+				type: 'takeover-request',
+				requestingTabId: 'new-tab',
+				siteSlug: 'my-site',
+			});
+
+			expect(takeoverCallback).not.toHaveBeenCalled();
+			expect(responses).toHaveLength(0);
+
+			otherChannel.close();
+		});
+
+		it('calls site reset callback when site-reset received', () => {
+			const siteResetCallback = vi.fn();
+			initTabCoordinator(
+				'my-site',
+				undefined,
+				undefined,
+				undefined,
+				siteResetCallback
+			);
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.postMessage({
+				type: 'site-reset',
+				siteSlug: 'my-site',
+			});
+
+			expect(siteResetCallback).toHaveBeenCalled();
+
+			otherChannel.close();
+		});
+	});
+
+	describe('requestTakeover', () => {
+		it('returns false when not initialized', async () => {
+			const result = await requestTakeover('my-site');
+			expect(result).toBe(false);
+		});
+
+		it('resolves to true when acknowledged', async () => {
+			const tabInfo = initTabCoordinator('my-site');
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				if (event.data.type === 'takeover-request') {
+					otherChannel.postMessage({
+						type: 'takeover-acknowledged',
+						previousMainTabId: 'old-main',
+						targetTabId: tabInfo.tabId,
+						siteSlug: 'my-site',
+					});
+				}
+			};
+
+			const result = await requestTakeover('my-site', 100);
+			expect(result).toBe(true);
+
+			otherChannel.close();
+		});
+
+		it('resolves to false on timeout', async () => {
+			initTabCoordinator('my-site');
+
+			const result = await requestTakeover('my-site', 50);
+			expect(result).toBe(false);
+		});
+	});
+
+	describe('requestRemoteBackup', () => {
+		it('returns false when not initialized', async () => {
+			const result = await requestRemoteBackup('my-site');
+			expect(result).toBe(false);
+		});
+
+		it('resolves to true when backup succeeds', async () => {
+			const tabInfo = initTabCoordinator('my-site');
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				if (event.data.type === 'backup-request') {
+					otherChannel.postMessage({
+						type: 'backup-completed',
+						targetTabId: tabInfo.tabId,
+						siteSlug: 'my-site',
+						success: true,
+					});
+				}
+			};
+
+			const result = await requestRemoteBackup('my-site', 100);
+			expect(result).toBe(true);
+
+			otherChannel.close();
+		});
+
+		it('resolves to false when backup fails', async () => {
+			const tabInfo = initTabCoordinator('my-site');
+
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				if (event.data.type === 'backup-request') {
+					otherChannel.postMessage({
+						type: 'backup-completed',
+						targetTabId: tabInfo.tabId,
+						siteSlug: 'my-site',
+						success: false,
+					});
+				}
+			};
+
+			const result = await requestRemoteBackup('my-site', 100);
+			expect(result).toBe(false);
+
+			otherChannel.close();
+		});
+
+		it('handles backup request and calls callback', async () => {
+			const backupCallback = vi.fn().mockResolvedValue(true);
+			initTabCoordinator('my-site');
+			setBackupRequestCallback(backupCallback);
+
+			const responses: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				responses.push(event.data);
+			};
+
+			otherChannel.postMessage({
+				type: 'backup-request',
+				requestingTabId: 'requester-tab',
+				siteSlug: 'my-site',
+			});
+
+			await vi.waitFor(() => {
+				expect(backupCallback).toHaveBeenCalled();
+			});
+
+			await vi.waitFor(() => {
+				expect(responses).toHaveLength(1);
+			});
+
+			expect(responses[0]).toEqual({
+				type: 'backup-completed',
+				targetTabId: 'requester-tab',
+				siteSlug: 'my-site',
+				success: true,
+			});
+
+			otherChannel.close();
+		});
+	});
+
+	describe('broadcastSiteReset', () => {
+		it('broadcasts site-reset message', () => {
+			initTabCoordinator('my-site');
+
+			const messages: unknown[] = [];
+			const otherChannel = new MockBroadcastChannel(
+				'playground-tab-coordinator'
+			);
+			otherChannel.onmessage = (event: MessageEvent) => {
+				messages.push(event.data);
+			};
+
+			broadcastSiteReset('my-site');
+
+			expect(messages).toHaveLength(1);
+			expect(messages[0]).toEqual({
+				type: 'site-reset',
+				siteSlug: 'my-site',
+			});
+
+			otherChannel.close();
+		});
+
+		it('does nothing when not initialized', () => {
+			expect(() => broadcastSiteReset('my-site')).not.toThrow();
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.ts
@@ -88,23 +88,6 @@ let backupRequestCallback: (() => Promise<boolean>) | null = null;
 let siteResetCallback: (() => void) | null = null;
 let beforeUnloadHandler: (() => void) | null = null;
 
-// Clean up on Vite HMR to prevent duplicate listeners
-if (
-	typeof import.meta !== 'undefined' &&
-	(import.meta as unknown as { hot?: { dispose: (cb: () => void) => void } })
-		.hot
-) {
-	(
-		import.meta as unknown as { hot: { dispose: (cb: () => void) => void } }
-	).hot.dispose(() => {
-		if (channel) {
-			channel.close();
-			channel = null;
-		}
-		currentTabInfo = null;
-	});
-}
-
 /**
  * Initialize the tab coordinator for a specific site.
  *
@@ -245,7 +228,7 @@ export async function checkForExistingTabs(siteSlug: string): Promise<{
  * @param targetTabId - The tab ID to shut down
  * @param reason - Why the tab should shut down
  */
-export function requestTabShutdown(
+function requestTabShutdown(
 	targetTabId: string,
 	reason: 'stale' | 'superseded'
 ): void {

--- a/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.ts
@@ -1,0 +1,513 @@
+/**
+ * Tab Coordinator
+ *
+ * Manages coordination between multiple browser tabs accessing the same
+ * WordPress Playground site. Handles:
+ *
+ * 1. Detection of existing tabs with active PHP workers
+ * 2. Age-based decisions (tabs > 1 day old should yield to newer tabs)
+ * 3. Graceful shutdown of stale tabs
+ * 4. Signaling when a new tab can reuse an existing service worker
+ */
+
+export type TabInfo = {
+	tabId: string;
+	createdAt: number;
+	siteSlug: string;
+	isReady?: boolean;
+	isDependentMode?: boolean;
+};
+
+type PingMessage = {
+	type: 'ping';
+	tabId: string;
+	siteSlug: string;
+};
+
+type PongMessage = {
+	type: 'pong';
+	tabInfo: TabInfo;
+};
+
+type ShutdownRequestMessage = {
+	type: 'shutdown-request';
+	targetTabId: string;
+	reason: 'stale' | 'superseded';
+};
+
+type TakeoverRequestMessage = {
+	type: 'takeover-request';
+	requestingTabId: string;
+	siteSlug: string;
+};
+
+type TakeoverAcknowledgedMessage = {
+	type: 'takeover-acknowledged';
+	previousMainTabId: string;
+	targetTabId: string;
+	siteSlug: string;
+};
+
+type BackupRequestMessage = {
+	type: 'backup-request';
+	requestingTabId: string;
+	siteSlug: string;
+};
+
+type BackupCompletedMessage = {
+	type: 'backup-completed';
+	targetTabId: string;
+	siteSlug: string;
+	success: boolean;
+};
+
+type SiteResetMessage = {
+	type: 'site-reset';
+	siteSlug: string;
+};
+
+type TabCoordinatorMessage =
+	| PingMessage
+	| PongMessage
+	| ShutdownRequestMessage
+	| TakeoverRequestMessage
+	| TakeoverAcknowledgedMessage
+	| BackupRequestMessage
+	| BackupCompletedMessage
+	| SiteResetMessage;
+
+const CHANNEL_NAME = 'playground-tab-coordinator';
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const PING_TIMEOUT_MS = 150;
+
+let channel: BroadcastChannel | null = null;
+let currentTabInfo: TabInfo | null = null;
+let shutdownCallback: ((reason: string) => void) | null = null;
+let takeoverCallback: (() => void) | null = null;
+let backupRequestCallback: (() => Promise<boolean>) | null = null;
+let siteResetCallback: (() => void) | null = null;
+let beforeUnloadHandler: (() => void) | null = null;
+
+// Clean up on Vite HMR to prevent duplicate listeners
+if (
+	typeof import.meta !== 'undefined' &&
+	(import.meta as unknown as { hot?: { dispose: (cb: () => void) => void } })
+		.hot
+) {
+	(
+		import.meta as unknown as { hot: { dispose: (cb: () => void) => void } }
+	).hot.dispose(() => {
+		if (channel) {
+			channel.close();
+			channel = null;
+		}
+		currentTabInfo = null;
+	});
+}
+
+/**
+ * Initialize the tab coordinator for a specific site.
+ *
+ * @param siteSlug - The slug of the site being loaded
+ * @param onShutdownRequested - Callback when this tab should shut down
+ * @param onTakeoverRequested - Callback when another tab requests to become main
+ * @param onBackupRequested - Callback when another tab requests a backup (main tab only)
+ * @param onSiteReset - Callback when another tab has reset/deleted the site
+ * @returns TabInfo for the current tab
+ */
+export function initTabCoordinator(
+	siteSlug: string,
+	onShutdownRequested?: (reason: string) => void,
+	onTakeoverRequested?: () => void,
+	onBackupRequested?: () => Promise<boolean>,
+	onSiteReset?: () => void
+): TabInfo {
+	if (currentTabInfo && currentTabInfo.siteSlug === siteSlug) {
+		return currentTabInfo;
+	}
+
+	// Clean up existing if switching sites
+	if (channel) {
+		channel.close();
+	}
+	if (beforeUnloadHandler && typeof window !== 'undefined') {
+		window.removeEventListener('beforeunload', beforeUnloadHandler);
+		beforeUnloadHandler = null;
+	}
+
+	currentTabInfo = {
+		tabId: crypto.randomUUID(),
+		createdAt: Date.now(),
+		siteSlug,
+	};
+
+	shutdownCallback = onShutdownRequested || null;
+	takeoverCallback = onTakeoverRequested || null;
+	backupRequestCallback = onBackupRequested || null;
+	siteResetCallback = onSiteReset || null;
+
+	try {
+		channel = new BroadcastChannel(CHANNEL_NAME);
+		channel.onmessage = handleMessage;
+
+		beforeUnloadHandler = () => {
+			if (channel) {
+				channel.postMessage({
+					type: 'tab-closing',
+					tabId: currentTabInfo?.tabId,
+				});
+				channel.close();
+				channel = null;
+			}
+		};
+		window.addEventListener('beforeunload', beforeUnloadHandler);
+	} catch {
+		// BroadcastChannel not supported
+	}
+
+	return currentTabInfo;
+}
+
+/**
+ * Clean up the tab coordinator.
+ */
+export function destroyTabCoordinator(): void {
+	if (channel) {
+		channel.close();
+		channel = null;
+	}
+	if (beforeUnloadHandler && typeof window !== 'undefined') {
+		window.removeEventListener('beforeunload', beforeUnloadHandler);
+		beforeUnloadHandler = null;
+	}
+	currentTabInfo = null;
+	shutdownCallback = null;
+	takeoverCallback = null;
+	backupRequestCallback = null;
+	siteResetCallback = null;
+}
+
+/**
+ * Check for existing tabs running the same site.
+ *
+ * @param siteSlug - The site to check for
+ * @returns Promise resolving to info about existing tabs (if any)
+ */
+export async function checkForExistingTabs(siteSlug: string): Promise<{
+	existingTabs: TabInfo[];
+	hasFreshTab: boolean;
+	hasStaleTab: boolean;
+}> {
+	if (!channel || !currentTabInfo) {
+		return { existingTabs: [], hasFreshTab: false, hasStaleTab: false };
+	}
+
+	const existingTabs: TabInfo[] = [];
+	const now = Date.now();
+
+	const pongHandler = (event: MessageEvent<TabCoordinatorMessage>) => {
+		const message = event.data;
+		if (
+			message.type === 'pong' &&
+			message.tabInfo.siteSlug === siteSlug &&
+			message.tabInfo.tabId !== currentTabInfo?.tabId
+		) {
+			existingTabs.push(message.tabInfo);
+		}
+	};
+
+	channel.addEventListener('message', pongHandler);
+
+	const pingMessage: PingMessage = {
+		type: 'ping',
+		tabId: currentTabInfo.tabId,
+		siteSlug,
+	};
+	channel.postMessage(pingMessage);
+
+	await new Promise((resolve) => setTimeout(resolve, PING_TIMEOUT_MS));
+
+	channel.removeEventListener('message', pongHandler);
+
+	const hasFreshTab = existingTabs.some(
+		(tab) => now - tab.createdAt < ONE_DAY_MS && !tab.isDependentMode
+	);
+	const hasStaleTab = existingTabs.some(
+		(tab) => now - tab.createdAt >= ONE_DAY_MS && !tab.isDependentMode
+	);
+
+	return { existingTabs, hasFreshTab, hasStaleTab };
+}
+
+/**
+ * Request a specific tab to shut down.
+ *
+ * @param targetTabId - The tab ID to shut down
+ * @param reason - Why the tab should shut down
+ */
+export function requestTabShutdown(
+	targetTabId: string,
+	reason: 'stale' | 'superseded'
+): void {
+	if (!channel) {
+		return;
+	}
+
+	const message: ShutdownRequestMessage = {
+		type: 'shutdown-request',
+		targetTabId,
+		reason,
+	};
+	channel.postMessage(message);
+}
+
+/**
+ * Request all stale tabs for a site to shut down.
+ *
+ * @param tabs - List of tabs to check
+ */
+export function requestStaleTabsShutdown(tabs: TabInfo[]): void {
+	const now = Date.now();
+	for (const tab of tabs) {
+		if (now - tab.createdAt >= ONE_DAY_MS) {
+			requestTabShutdown(tab.tabId, 'stale');
+		}
+	}
+}
+
+/**
+ * Get the current tab's info.
+ */
+export function getCurrentTabInfo(): TabInfo | null {
+	return currentTabInfo;
+}
+
+/**
+ * Check if a tab is considered stale (older than 1 day).
+ */
+export function isTabStale(tabInfo: TabInfo): boolean {
+	return Date.now() - tabInfo.createdAt >= ONE_DAY_MS;
+}
+
+/**
+ * Mark the current tab as being in dependent mode.
+ * This means it's using another tab's worker and shouldn't claim main status.
+ */
+export function setDependentMode(isDependentMode: boolean): void {
+	if (currentTabInfo) {
+		currentTabInfo.isDependentMode = isDependentMode;
+	}
+}
+
+/**
+ * Set the callback for handling backup requests from other tabs.
+ * This is separate from initTabCoordinator because the backup function
+ * may not be available at initialization time.
+ */
+export function setBackupRequestCallback(
+	callback: (() => Promise<boolean>) | null
+): void {
+	backupRequestCallback = callback;
+}
+
+/**
+ * Request to take over as the main tab from another tab.
+ * Sends a takeover-request and waits for acknowledgment.
+ *
+ * @param siteSlug - The site to take over
+ * @param timeoutMs - How long to wait for acknowledgment (default 2000ms)
+ * @returns Promise that resolves to true if takeover was acknowledged, false otherwise
+ */
+export async function requestTakeover(
+	siteSlug: string,
+	timeoutMs = 2000
+): Promise<boolean> {
+	if (!channel || !currentTabInfo) {
+		return false;
+	}
+
+	const tabId = currentTabInfo.tabId;
+	const currentChannel = channel;
+
+	return new Promise((resolve) => {
+		let resolved = false;
+
+		const ackHandler = (event: MessageEvent<TabCoordinatorMessage>) => {
+			const message = event.data;
+			if (
+				message.type === 'takeover-acknowledged' &&
+				message.siteSlug === siteSlug &&
+				message.targetTabId === tabId
+			) {
+				resolved = true;
+				currentChannel.removeEventListener('message', ackHandler);
+				resolve(true);
+			}
+		};
+
+		currentChannel.addEventListener('message', ackHandler);
+
+		const requestMessage: TakeoverRequestMessage = {
+			type: 'takeover-request',
+			requestingTabId: tabId,
+			siteSlug,
+		};
+		currentChannel.postMessage(requestMessage);
+
+		setTimeout(() => {
+			if (!resolved) {
+				currentChannel.removeEventListener('message', ackHandler);
+				resolve(false);
+			}
+		}, timeoutMs);
+	});
+}
+
+/**
+ * Request a backup from the main tab (for dependent tabs).
+ * Sends a backup-request and waits for completion.
+ *
+ * @param siteSlug - The site to backup
+ * @param timeoutMs - How long to wait for completion (default 30000ms)
+ * @returns Promise that resolves to true if backup succeeded, false otherwise
+ */
+export async function requestRemoteBackup(
+	siteSlug: string,
+	timeoutMs = 30000
+): Promise<boolean> {
+	if (!channel || !currentTabInfo) {
+		return false;
+	}
+
+	const tabId = currentTabInfo.tabId;
+	const currentChannel = channel;
+
+	return new Promise((resolve) => {
+		let resolved = false;
+
+		const completedHandler = (
+			event: MessageEvent<TabCoordinatorMessage>
+		) => {
+			const message = event.data;
+			if (
+				message.type === 'backup-completed' &&
+				message.siteSlug === siteSlug &&
+				message.targetTabId === tabId
+			) {
+				resolved = true;
+				currentChannel.removeEventListener('message', completedHandler);
+				resolve(message.success);
+			}
+		};
+
+		currentChannel.addEventListener('message', completedHandler);
+
+		const requestMessage: BackupRequestMessage = {
+			type: 'backup-request',
+			requestingTabId: tabId,
+			siteSlug,
+		};
+		currentChannel.postMessage(requestMessage);
+
+		setTimeout(() => {
+			if (!resolved) {
+				currentChannel.removeEventListener('message', completedHandler);
+				resolve(false);
+			}
+		}, timeoutMs);
+	});
+}
+
+/**
+ * Broadcast that a site is being reset/deleted.
+ * This notifies other tabs to reload since the site data is being deleted.
+ *
+ * @param siteSlug - The site being reset
+ */
+export function broadcastSiteReset(siteSlug: string): void {
+	if (!channel) {
+		return;
+	}
+
+	const message: SiteResetMessage = {
+		type: 'site-reset',
+		siteSlug,
+	};
+	channel.postMessage(message);
+}
+
+function handleMessage(event: MessageEvent<TabCoordinatorMessage>): void {
+	if (!currentTabInfo || !channel) {
+		return;
+	}
+
+	const message = event.data;
+
+	switch (message.type) {
+		case 'ping':
+			if (message.siteSlug === currentTabInfo.siteSlug) {
+				const pongMessage: PongMessage = {
+					type: 'pong',
+					tabInfo: currentTabInfo,
+				};
+				channel.postMessage(pongMessage);
+			}
+			break;
+
+		case 'shutdown-request':
+			if (message.targetTabId === currentTabInfo.tabId) {
+				const reason =
+					message.reason === 'stale'
+						? 'This tab has been open for over a day and a newer tab was opened.'
+						: 'A newer tab has taken over this session.';
+				shutdownCallback?.(reason);
+			}
+			break;
+
+		case 'takeover-request':
+			if (
+				message.siteSlug === currentTabInfo.siteSlug &&
+				!currentTabInfo.isDependentMode
+			) {
+				takeoverCallback?.();
+				const ackMessage: TakeoverAcknowledgedMessage = {
+					type: 'takeover-acknowledged',
+					previousMainTabId: currentTabInfo.tabId,
+					targetTabId: message.requestingTabId,
+					siteSlug: message.siteSlug,
+				};
+				channel.postMessage(ackMessage);
+			}
+			break;
+
+		case 'takeover-acknowledged':
+			break;
+
+		case 'backup-request':
+			if (
+				message.siteSlug === currentTabInfo.siteSlug &&
+				!currentTabInfo.isDependentMode &&
+				backupRequestCallback
+			) {
+				backupRequestCallback().then((success) => {
+					const completedMessage: BackupCompletedMessage = {
+						type: 'backup-completed',
+						targetTabId: message.requestingTabId,
+						siteSlug: message.siteSlug,
+						success,
+					};
+					channel?.postMessage(completedMessage);
+				});
+			}
+			break;
+
+		case 'backup-completed':
+			break;
+
+		case 'site-reset':
+			if (message.siteSlug === currentTabInfo.siteSlug) {
+				siteResetCallback?.();
+			}
+			break;
+	}
+}


### PR DESCRIPTION
Based on #3162.

## Motivation for the change, related issues

When users open the same persistent site in multiple browser tabs, OPFS (Origin Private File System) conflicts can occur because each tab tries to access the same storage. This PR adds a coordination system so only one tab owns the PHP worker while other tabs operate in "dependent mode".

## Screenshots

<img width="1034" height="208" alt="Screenshot 2026-01-22 at 05 02 39" src="https://github.com/user-attachments/assets/d71332df-310b-44b9-8adc-c34ec92157e9" />

<img width="1034" height="208" alt="Screenshot 2026-01-22 at 05 02 43" src="https://github.com/user-attachments/assets/481852f4-ba41-433c-a0c7-cd4b9dc0699a" />

<img width="1306" height="456" alt="Screenshot 2026-01-22 at 05 02 54" src="https://github.com/user-attachments/assets/4b667300-e9ca-454c-8ade-616400edc20f" />

<img width="1288" height="444" alt="Screenshot 2026-01-22 at 05 03 03" src="https://github.com/user-attachments/assets/b453b62c-bef4-4df1-8139-d1f95e405dd1" />

<img width="1288" height="508" alt="Screenshot 2026-01-22 at 05 03 08" src="https://github.com/user-attachments/assets/00c545ee-67cb-4db6-b045-ff3ac602a08e" />

<img width="1292" height="502" alt="Screenshot 2026-01-22 at 05 03 14" src="https://github.com/user-attachments/assets/c9f77c61-ce28-4037-bf07-2f1d017e3e44" />

## Implementation details

- **Tab Coordinator** (`tab-coordinator.ts`): Uses BroadcastChannel API for cross-tab communication with ping/pong discovery, takeover requests, and backup delegation
- **Boot Logic** (`boot-site-client.ts`): Checks for existing tabs before booting; yields to fresh main tabs or becomes dependent if one exists
- **Dependent Mode**: Tabs without their own worker use the main tab's service worker URL and delegate operations like backup
- **UI Indicators**: 
  - `WorkerStatusIndicator` in address bar shows "Main" or "Dependent" badge
  - `TabInfoWindow` in overlay shows WordPress boot time and connected tabs
- **Edge Cases**:
  - Main tab reload: Dependent tabs report `isDependentMode: true` in pong, so reloading main correctly re-establishes as main
  - Backup from dependent: Cross-tab messaging delegates backup request to main tab
  - Main tab closes: Dependent tabs show "Reload required" indicator

## Testing Instructions (or ideally a Blueprint)

1. Open a persistent site in Tab 1 → should boot normally
2. Open the same site in Tab 2 → should show "Dependent" badge, Tab 1 shows "Main"
3. Click badge to open overlay → shows boot time and other tabs count
4. In Tab 2 overlay, click Backup → download triggers (handled by main tab)
5. Reload Tab 1 → should re-establish as main (not become dependent)
6. Close Tab 1 → Tab 2 shows "Reload required"