### PR TITLE
Fix CORS proxy for local development and PHP 8.5

### DIFF
--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -274,8 +274,6 @@ if (!curl_exec($ch)) {
 } else {
     @$relay_http_code_and_initial_headers_if_not_already_sent();
 }
-// Close cURL session
-curl_close($ch);
 
 // Only send chunked transfer encoding footer if we're using chunked encoding.
 // We need to manually send the footer when running in the PHP built-in server

--- a/packages/playground/remote/src/lib/offline-mode-cache.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.ts
@@ -11,11 +11,17 @@ const promisedOfflineModeCache = caches.open(LATEST_CACHE_NAME);
 
 export async function cacheFirstFetch(request: Request): Promise<Response> {
 	const offlineModeCache = await promisedOfflineModeCache;
-	const cachedResponse = await offlineModeCache.match(request, {
-		ignoreSearch: true,
-	});
-	if (cachedResponse) {
-		return cachedResponse;
+
+	// The Cache API only supports GET requests
+	const canCache = request.method === 'GET';
+
+	if (canCache) {
+		const cachedResponse = await offlineModeCache.match(request, {
+			ignoreSearch: true,
+		});
+		if (cachedResponse) {
+			return cachedResponse;
+		}
 	}
 
 	/**
@@ -27,7 +33,7 @@ export async function cacheFirstFetch(request: Request): Promise<Response> {
 	 * See service-worker.ts for more details.
 	 */
 	const response = await fetchFresh(request);
-	if (response.ok) {
+	if (response.ok && canCache) {
 		/**
 		 * Confirm the current service worker is still active
 		 * when the asset is fetched. Caching a stale request


### PR DESCRIPTION
## Motivation for the change, related issues

When running `npm run dev` with PHP 8.5, the Vite dev server logs errors like:
```
[vite] http proxy error: /cors-proxy.php?https://api.wordpress.org/plugins/update-check/1.1/
Error: Parse Error: Invalid character in chunk size
```

This happens because `curl_close()` is deprecated since PHP 8.5 and outputs a deprecation warning that corrupts the HTTP response body.

Additionally, the service worker's offline cache was throwing errors for POST requests because the Cache API doesn't support them.

## Implementation details

**CORS proxy fix:**
- Remove the deprecated `curl_close()` call - it has no effect since PHP 8.0 anyway

**Offline cache fix:**
- Skip caching for non-GET requests (Cache API only supports GET)

## Testing Instructions

1. Run `npm run dev`
2. Open the Playground in the browser
3. Verify no more "Parse Error: Invalid character in chunk size" errors in the terminal
4. Verify no "Failed to execute 'put' on 'Cache': Request method 'POST' is unsupported" errors in the console