### PR TITLE
[website] Fix broken e2e tests because of sqlite db integration update

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -33,6 +33,8 @@ require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-as
 require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php';
 require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-exception.php';
 require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php';
+require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-pdo-proxy-statement.php';
+require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-pdo-mysql-on-sqlite.php';
 
 use Throwable;
 use WP_SQLite_Driver;

--- a/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-extensions/DbiMysqli.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/phpmyadmin-extensions/DbiMysqli.php
@@ -43,6 +43,8 @@ require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-as
 require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php';
 require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-exception.php';
 require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php';
+require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-pdo-proxy-statement.php';
+require_once '/internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-pdo-mysql-on-sqlite.php';
 
 // Supress the following phpMyAdmin warning:
 //   "The mysqlnd extension is missing. Please check your PHP configuration."


### PR DESCRIPTION
## Motivation for the change, related issues

[The SQLite database integration plugin was refreshed on Jan 22](https://github.com/WordPress/wordpress-playground/commit/ed5e3a341e6d0800c2ea3bb1446aa4a0047541ce), introducing new classes (`WP_PDO_Proxy_Statement` and `WP_PDO_MySQL_On_SQLite`). The Adminer and phpMyAdmin extensions weren't updated to load these new files, causing both database tools to fail with:

```
Fatal error: Uncaught Error: Class "WP_PDO_Proxy_Statement" not found
```

This broke the e2e tests for "Database panel > should load and open Adminer" and "Database panel > should load and open phpMyAdmin".

## Implementation details

Added the missing `require_once` statements for the two new SQLite driver classes to both:
- `adminer-mysql-on-sqlite-driver.php`
- `DbiMysqli.php`

## Testing Instructions (or ideally a Blueprint)

1. Run `npx nx e2e playground-website` and verify the Database panel tests pass
2. Or manually: Open Playground → Database panel → Click "Open Adminer" or "Open phpMyAdmin" → Should load without errors
