### PR TITLE
[Docs] Update translations and configuration in docusaurus.config.js

### DIFF
--- a/packages/docs/site/docusaurus.config.js
+++ b/packages/docs/site/docusaurus.config.js
@@ -25,7 +25,12 @@ const config = {
 	projectName: 'wordpress-playground', // Usually your repo name.
 
 	onBrokenLinks: 'throw',
-	onBrokenMarkdownLinks: 'throw',
+
+	markdown: {
+		hooks: {
+			onBrokenMarkdownLinks: 'throw',
+		},
+	},
 
 	// Even if you don't use internalization, you can use this field to set useful
 	// metadata like HTML lang. For example, if your site is Chinese, you may want
@@ -44,7 +49,7 @@ const config = {
 				path: 'es',
 			},
 			fr: {
-				label: 'French',
+				label: 'Français',
 				path: 'fr',
 			},
 			ja: {
@@ -60,7 +65,7 @@ const config = {
 				path: 'tl',
 			},
 			gu: {
-				label: 'Gujarati',
+				label: 'ગુજરાતી',
 				path: 'gu',
 			},
 		},
@@ -115,9 +120,8 @@ const config = {
 						defaultSidebarItemsGenerator,
 						...args
 					}) {
-						const sidebarItems = await defaultSidebarItemsGenerator(
-							args
-						);
+						const sidebarItems =
+							await defaultSidebarItemsGenerator(args);
 						return flattenDirectoriesWithSingleFile(sidebarItems);
 					},
 				},


### PR DESCRIPTION
## What?

- Added a structured configuration for handling broken Markdown links.
- Updated language labels for French and Gujarati translations to their native scripts.

## Why?

To enhance the documentation's accessibility and improve the user experience for non-English speakers.

## How?

- Introduced a `markdown.hooks` configuration to manage broken links. Removing the warning: `[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.`
- Changed the French label from 'French' to 'Français'.
- Changed the Gujarati label from 'Gujarati' to 'ગુજરાતી'.

