### PR TITLE
[i18n] Update translations.md for multiple languages

### DIFF
--- a/packages/docs/site/docs/main/contributing/translations.md
+++ b/packages/docs/site/docs/main/contributing/translations.md
@@ -88,18 +88,18 @@ We recommend only adding a language to the switcher when a significant portion o
 
 As a guideline, a language should be made publicly available in the switcher only when the entire "Documentation" hub is translated, including these key sections:
 
--   [Quick Start Guide](https://wordpress.github.io/wordpress-playground/quick-start-guide)
--   [Playground web instance](https://wordpress.github.io/wordpress-playground/web-instance)
--   [About Playground](https://wordpress.github.io/wordpress-playground/about)
--   [Guides](https://wordpress.github.io/wordpress-playground/guides)
--   [Contributing](https://wordpress.github.io/wordpress-playground/contributing)
--   [Links and Resources](https://wordpress.github.io/wordpress-playground/resources)
+- [Quick Start Guide](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+- [Playground web instance](https://wordpress.github.io/wordpress-playground/web-instance)
+- [About Playground](https://wordpress.github.io/wordpress-playground/about)
+- [Guides](https://wordpress.github.io/wordpress-playground/guides)
+- [Contributing](https://wordpress.github.io/wordpress-playground/contributing)
+- [Links and Resources](https://wordpress.github.io/wordpress-playground/resources)
 
 All languages are available once the i18n setup for a language is complete and the correct file structure is in place under `i18n`.
 
--   https://wordpress.github.io/wordpress-playground/
--   https://wordpress.github.io/wordpress-playground/es/
--   https://wordpress.github.io/wordpress-playground/fr/
+- https://wordpress.github.io/wordpress-playground/
+- https://wordpress.github.io/wordpress-playground/es/
+- https://wordpress.github.io/wordpress-playground/fr/
 
 Assuming the `fr` language is the first language with the Documentation hub pages (Quick Start Guide, Playground web instance, About Playground, Guides,... ) completely translated to French, the `docusaurus.config.js` should look like this in that branch so `npm run build:docs` properly generate the `fr` subsite and only displays the french language in the `localeDropdown` language switcher.
 
@@ -138,17 +138,17 @@ Follow these steps to translate a page:
 2. **Create a New Translation Issue**: If no issue exists, please create a new one to track the translation progress for the language. You can model it after issue [#2202](https://github.com/WordPress/wordpress-playground/issues/2202) and use the markdown checklist below to track progress.
 3. **Translate the File**:
 
--   Check if you have the latest version of the documentation
--   Copy the original .md file from `packages/docs/site/docs/...` to the corresponding path in the language directory (e.g., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). It is crucial to replicate the original file structure.
--   Translate the content of the new file, keeping the original content commented out `<!-- English Content -->`.
--   The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
--   Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
+- Check if you have the latest version of the documentation
+- Copy the original .md file from `packages/docs/site/docs/...` to the corresponding path in the language directory (e.g., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). It is crucial to replicate the original file structure.
+- Translate the content of the new file, keeping the original content commented out `<!-- English Content -->`.
+- The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
+- Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
 
 4. **Create a pull request with your changes**
 
--   Add a prefix to the title `[i18n]` to help to identify the translations
--   Describe the pages that you translated
--   Request a review at `#playground` or `#polyglots` at `wordpress.slack.com`
+- Add a prefix to the title `[i18n]` to help to identify the translations
+- Describe the pages that you translated
+- Request a review at `#playground` or `#polyglots` at `wordpress.slack.com`
 
 :::info
 We highly recommend submitting pull requests with a small number of translated pages. This approach simplifies the review process and allows for a more gradual and manageable integration of your work.
@@ -165,95 +165,104 @@ You can use the following markdown in your tracking issue:
 <summary><h3>Main</h3></summary>
 
 - about
-  - [ ] build.md #2291
-  - [ ] index.md #2282
-  - [ ] launch.md #2292
-  - [ ] test.md #2302
+  - [ ] build.md
+  - [ ] index.md
+  - [ ] launch.md
+  - [ ] test.md
 - contributing
-  - [ ] code.md #2218
-  - [ ] coding-standards.md #2219
-  - [ ] contributor-day.md #2246
+  - [ ] code.md
+  - [ ] coding-standards.md
   - [ ] contributor-badge.md
-  - [ ] documentation.md #2271
-  - [ ] translations.md #2201
+  - [ ] contributor-day.md
+  - [ ] contributor-day-table-lead.md
+  - [ ] documentation.md
+  - [ ] index.md
+  - [ ] releases.md
+  - [ ] translations.md
 - guides
-  - [ ] for-plugin-developers.md #2210
-  - [ ] for-theme-developers.md #2211
-  - [ ] index.md #2209
-  - [ ] providing-content-for-your-demo.md #2213
-  - [ ] wordpress-native-ios-app.md #2214
-- [ ] intro.md #2198
-- [ ] quick-start-guide.md #2204
-- [ ] resources.md #2207
-- [ ] web-instance.md #2208
+  - [ ] for-plugin-developers.md
+  - [ ] for-theme-developers.md
+  - [ ] github-action-pr-preview.md
+  - [ ] index.md
+  - [ ] providing-content-for-your-demo.md
+  - [ ] wordpress-native-ios-app.md
+- [ ] changelog.md
+- [ ] intro.md
+- [ ] quick-start-guide.md
+- [ ] resources.md
+- [ ] web-instance.md
 
 </details>
 
 <details open>
 <summary><h3>Blueprints</h3></summary>
 
-- blueprints
-  - [ ] 01-index.md #2305
-  - [ ] 02-using-blueprints.md #2330
-  - [ ] 03-data-format.md #2340
-   - [ ] 04-resources.md #2352
-   - [ ] 05-steps-shorthands.md  #2386
-  - [ ] 05-steps.md  #2386
-  - [ ] 06-bundles.md #2438
-   - [ ] 07-json-api-and-function-api.md #2438
-   - [ ] 08-examples.md #2474
-   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
-   - [ ] intro.md #2489
-   - tutorial
-       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
-       - [ ] 02-how-to-load-run-blueprints.md #2526
-       - [ ] 03-build-your-first-blueprint.md
-       - [ ] index.md #2511
+- [ ] 01-index.md
+- [ ] 02-using-blueprints.md
+- [ ] 03-data-format.md
+- [ ] 04-resources.md
+- [ ] 05-steps.md
+- [ ] 05-steps-shorthands.md
+- [ ] 06-bundles.md
+- [ ] 07-json-api-and-function-api.md
+- [ ] 08-examples.md
+- [ ] 09-troubleshoot-and-debug-blueprints.md
+- [ ] intro.md
+- tutorial
+  - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md
+  - [ ] 02-how-to-load-run-blueprints.md
+  - [ ] 03-build-your-first-blueprint.md
+  - [ ] index.md
+
 </details>
 
 <details open>
 <summary><h3>Developers</h3></summary>
 
-- [ ] developers
-   - [ ] 03-build-an-app
-      - [ ] 01-index.md
-   - [ ] 05-local-development
-      - [ ] 01-wp-now.md
-      - [ ] 02-vscode-extension.md
-      - [ ] 03-php-wasm-node.md
-      - [ ] intro.md
-   - [ ] 06-apis
-      - [ ] 01-index.md
-      - [ ] javascript-api
-         - [ ] 01-index.md
-         - [ ] 02-index-html-vs-remote-html.md
-         - [ ] 03-playground-api-client.md
-         - [ ] 04-blueprint-json-in-api-client.md
-         - [ ] 05-blueprint-functions-in-api-client.md
-         - [ ] 06-mount-data.md
-      - [ ] query-api
-          - [ ] 01-index.md
-   - [ ] 23-architecture
-      - [ ] 01-index.md
-      - [ ] 02-wasm-php-overview.md
-      - [ ] 03-wasm-php-compiling.md
-      - [ ] 04-wasm-php-javascript-module.md
-      - [ ] 05-wasm-php-filesystem.md
-      - [ ] 07-wasm-asyncify.md
-      - [ ] 08-browser-concepts.md
-      - [ ] 09-browser-tab-orchestrates-execution.md
-      - [ ] 10-browser-iframe-rendering.md
-      - [ ] 11-browser-php-worker-threads.md
-      - [ ] 12-browser-service-workers.md
-      - [ ] 13-browser-scopes.md
-      - [ ] 14-browser-cross-process-communication.md
-      - [ ] 15-wordpress.md
-      - [ ] 16-wordpress-database.md
-      - [ ] 17-browser-wordpress.md
-      - [ ] 18-host-your-own-playground.md
-   - [ ] 24-limitations
-      - [ ] 01-index.md
-   - [ ] intro-devs.md
+- 03-build-an-app
+  - [ ] 01-index.md
+- 05-local-development
+  - [ ] 01-wp-now.md
+  - [ ] 02-vscode-extension.md
+  - [ ] 03-php-wasm-node.md
+  - [ ] 04-wp-playground-cli.md
+  - [ ] intro.md
+- 06-apis
+  - [ ] 01-index.md
+  - javascript-api
+    - [ ] 01-index.md
+    - [ ] 02-index-html-vs-remote-html.md
+    - [ ] 03-playground-api-client.md
+    - [ ] 04-blueprint-json-in-api-client.md
+    - [ ] 05-blueprint-functions-in-api-client.md
+    - [ ] 06-mount-data.md
+  - query-api
+    - [ ] 01-index.md
+- 07-xdebug
+  - [ ] 01-introduction.md
+  - [ ] 02-getting-started.md
+- 23-architecture
+  - [ ] 01-index.md
+  - [ ] 02-wasm-php-overview.md
+  - [ ] 03-wasm-php-compiling.md
+  - [ ] 04-wasm-php-javascript-module.md
+  - [ ] 05-wasm-php-filesystem.md
+  - [ ] 07-wasm-asyncify.md
+  - [ ] 08-browser-concepts.md
+  - [ ] 09-browser-tab-orchestrates-execution.md
+  - [ ] 10-browser-iframe-rendering.md
+  - [ ] 11-browser-php-worker-threads.md
+  - [ ] 12-browser-service-workers.md
+  - [ ] 13-browser-scopes.md
+  - [ ] 14-browser-cross-process-communication.md
+  - [ ] 15-wordpress.md
+  - [ ] 16-wordpress-database.md
+  - [ ] 17-browser-wordpress.md
+  - [ ] 18-host-your-own-playground.md
+- 24-limitations
+  - [ ] 01-index.md
+- [ ] intro-devs.md
+
 </details>
 ```
 
@@ -285,14 +294,12 @@ This guide will show you how to both update an existing translation and add a br
 #### Adding a New Translation
 
 1.  **Determine the correct file path.** The new file's path and name must mirror the original English file.
-
-    -   **English original:** `packages/docs/site/docs/main/contributing/documentation.md`
-    -   **French translation:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
+    - **English original:** `packages/docs/site/docs/main/contributing/documentation.md`
+    - **French translation:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
 
 2.  **Create the new file.** Navigate to the correct language folder (e.g., `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Click **Add file** > **Create new file**.
     ![Creating a new translation](@site/static/img/contributing/adding-file-github-ui.webp)
-
-    -   **Pro Tip:** In the filename box, you can create new folders by typing the folder name followed by a `/`. For example, typing `main/contributing/documentation.md` will create the `main` and `contributing` folders automatically.
+    - **Pro Tip:** In the filename box, you can create new folders by typing the folder name followed by a `/`. For example, typing `main/contributing/documentation.md` will create the `main` and `contributing` folders automatically.
 
 3.  **Fork the repository.** Just like before, GitHub will prompt you to **Fork this repository**. Click the button to create your personal copy.
 

--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -199,12 +199,12 @@ As a guideline, a language should be made publicly available in the switcher onl
 -   [Links and Resources](https://wordpress.github.io/wordpress-playground/resources)
 -->
 
--   [দ্রুত শুরু গাইড](https://wordpress.github.io/wordpress-playground/quick-start-guide)
--   [প্লেগ্রাউন্ড ওয়েব ইন্সট্যান্স](https://wordpress.github.io/wordpress-playground/web-instance)
--   [প্লেগ্রাউন্ড সম্পর্কে](https://wordpress.github.io/wordpress-playground/about)
--   [গাইড](https://wordpress.github.io/wordpress-playground/guides)
--   [কন্ট্রিবিউটিং](https://wordpress.github.io/wordpress-playground/contributing)
--   [লিঙ্ক এবং রিসোর্স](https://wordpress.github.io/wordpress-playground/resources)
+- [দ্রুত শুরু গাইড](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+- [প্লেগ্রাউন্ড ওয়েব ইন্সট্যান্স](https://wordpress.github.io/wordpress-playground/web-instance)
+- [প্লেগ্রাউন্ড সম্পর্কে](https://wordpress.github.io/wordpress-playground/about)
+- [গাইড](https://wordpress.github.io/wordpress-playground/guides)
+- [কন্ট্রিবিউটিং](https://wordpress.github.io/wordpress-playground/contributing)
+- [লিঙ্ক এবং রিসোর্স](https://wordpress.github.io/wordpress-playground/resources)
 
 <!--
 All languages are available once the i18n setup for a language is complete and the correct file structure is in place under `i18n`.
@@ -218,9 +218,9 @@ All languages are available once the i18n setup for a language is complete and t
 -   https://wordpress.github.io/wordpress-playground/fr/
 -->
 
--   https://wordpress.github.io/wordpress-playground/
--   https://wordpress.github.io/wordpress-playground/es/
--   https://wordpress.github.io/wordpress-playground/fr/
+- https://wordpress.github.io/wordpress-playground/
+- https://wordpress.github.io/wordpress-playground/es/
+- https://wordpress.github.io/wordpress-playground/fr/
 
 <!--
 Assuming the `fr` language is the first language with the Documentation hub pages (Quick Start Guide, Playground web instance, About Playground, Guides,... ) completely translated to French, the `docusaurus.config.js` should look like this in that branch so `npm run build:docs` properly generate the `fr` subsite and only displays the french language in the `localeDropdown` language switcher.
@@ -281,15 +281,16 @@ Follow these steps to translate a page:
 -   Check if you have the latest version of the documentation
 -   Copy the original .md file from `packages/docs/site/docs/...` to the corresponding path in the language directory (e.g., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). It is crucial to replicate the original file structure.
 -   Translate the content of the new file, keeping the original content commented out `<!-- English Content -->`.
--   The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
--   Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
--->
 
--   আপনার কাছে ডকুমেন্টেশনের সর্বশেষ ভার্সন আছে কিনা চেক করুন
--   মূল .md ফাইল `packages/docs/site/docs/...` থেকে ভাষা ডিরেক্টরিতে সংশ্লিষ্ট পাথে কপি করুন (যেমন, `packages/docs/site/i18n/<LANGUAGE_CODE>/...`)। মূল ফাইল স্ট্রাকচার রেপ্লিকেট করা অত্যন্ত গুরুত্বপূর্ণ।
--   নতুন ফাইলের কনটেন্ট অনুবাদ করুন, মূল কনটেন্ট কমেন্ট আউট রেখে `<!-- English Content -->`।
--   অ্যাসেটগুলো `packages/docs/site/static/img/`-তে তালিকাভুক্ত, শুধুমাত্র লোকালাইজড কনটেন্ট প্রয়োজন হলে অনুবাদ ফোল্ডারে অ্যাসেট রাখুন।
--   অনুবাদ রেডি হলে, ডক্স বিল্ড স্ক্রিপ্ট সঠিকভাবে চলছে কিনা চেক করুন `npm run build:docs`।
+- The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
+- Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
+  -->
+
+- আপনার কাছে ডকুমেন্টেশনের সর্বশেষ ভার্সন আছে কিনা চেক করুন
+- মূল .md ফাইল `packages/docs/site/docs/...` থেকে ভাষা ডিরেক্টরিতে সংশ্লিষ্ট পাথে কপি করুন (যেমন, `packages/docs/site/i18n/<LANGUAGE_CODE>/...`)। মূল ফাইল স্ট্রাকচার রেপ্লিকেট করা অত্যন্ত গুরুত্বপূর্ণ।
+- নতুন ফাইলের কনটেন্ট অনুবাদ করুন, মূল কনটেন্ট কমেন্ট আউট রেখে `<!-- English Content -->`।
+- অ্যাসেটগুলো `packages/docs/site/static/img/`-তে তালিকাভুক্ত, শুধুমাত্র লোকালাইজড কনটেন্ট প্রয়োজন হলে অনুবাদ ফোল্ডারে অ্যাসেট রাখুন।
+- অনুবাদ রেডি হলে, ডক্স বিল্ড স্ক্রিপ্ট সঠিকভাবে চলছে কিনা চেক করুন `npm run build:docs`।
 
 <!--
 4. **Create a pull request with your changes**
@@ -303,9 +304,9 @@ Follow these steps to translate a page:
 -   Request a review at `#playground` or `#polyglots` at `wordpress.slack.com`
 -->
 
--   অনুবাদ চিহ্নিত করতে সাহায্য করতে টাইটেলে `[i18n]` প্রিফিক্স যোগ করুন
--   আপনি যে পেজগুলো অনুবাদ করেছেন সেগুলো বর্ণনা করুন
--   `wordpress.slack.com`-এ `#playground` বা `#polyglots`-এ রিভিউ রিকোয়েস্ট করুন
+- অনুবাদ চিহ্নিত করতে সাহায্য করতে টাইটেলে `[i18n]` প্রিফিক্স যোগ করুন
+- আপনি যে পেজগুলো অনুবাদ করেছেন সেগুলো বর্ণনা করুন
+- `wordpress.slack.com`-এ `#playground` বা `#polyglots`-এ রিভিউ রিকোয়েস্ট করুন
 
 <!--
 :::info
@@ -336,95 +337,104 @@ You can use the following markdown in your tracking issue:
 <summary><h3>Main</h3></summary>
 
 - about
-  - [ ] build.md #2291
-  - [ ] index.md #2282
-  - [ ] launch.md #2292
-  - [ ] test.md #2302
+  - [ ] build.md
+  - [ ] index.md
+  - [ ] launch.md
+  - [ ] test.md
 - contributing
-  - [ ] code.md #2218
-  - [ ] coding-standards.md #2219
-  - [ ] contributor-day.md #2246
+  - [ ] code.md
+  - [ ] coding-standards.md
   - [ ] contributor-badge.md
-  - [ ] documentation.md #2271
-  - [ ] translations.md #2201
+  - [ ] contributor-day.md
+  - [ ] contributor-day-table-lead.md
+  - [ ] documentation.md
+  - [ ] index.md
+  - [ ] releases.md
+  - [ ] translations.md
 - guides
-  - [ ] for-plugin-developers.md #2210
-  - [ ] for-theme-developers.md #2211
-  - [ ] index.md #2209
-  - [ ] providing-content-for-your-demo.md #2213
-  - [ ] wordpress-native-ios-app.md #2214
-- [ ] intro.md #2198
-- [ ] quick-start-guide.md #2204
-- [ ] resources.md #2207
-- [ ] web-instance.md #2208
+  - [ ] for-plugin-developers.md
+  - [ ] for-theme-developers.md
+  - [ ] github-action-pr-preview.md
+  - [ ] index.md
+  - [ ] providing-content-for-your-demo.md
+  - [ ] wordpress-native-ios-app.md
+- [ ] changelog.md
+- [ ] intro.md
+- [ ] quick-start-guide.md
+- [ ] resources.md
+- [ ] web-instance.md
 
 </details>
 
 <details open>
 <summary><h3>Blueprints</h3></summary>
 
-- blueprints
-  - [ ] 01-index.md #2305
-  - [ ] 02-using-blueprints.md #2330
-  - [ ] 03-data-format.md #2340
-   - [ ] 04-resources.md #2352
-   - [ ] 05-steps-shorthands.md  #2386
-  - [ ] 05-steps.md  #2386
-  - [ ] 06-bundles.md #2438
-   - [ ] 07-json-api-and-function-api.md #2438
-   - [ ] 08-examples.md #2474
-   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
-   - [ ] intro.md #2489
-   - tutorial
-       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
-       - [ ] 02-how-to-load-run-blueprints.md #2526
-       - [ ] 03-build-your-first-blueprint.md
-       - [ ] index.md #2511
+- [ ] 01-index.md
+- [ ] 02-using-blueprints.md
+- [ ] 03-data-format.md
+- [ ] 04-resources.md
+- [ ] 05-steps.md
+- [ ] 05-steps-shorthands.md
+- [ ] 06-bundles.md
+- [ ] 07-json-api-and-function-api.md
+- [ ] 08-examples.md
+- [ ] 09-troubleshoot-and-debug-blueprints.md
+- [ ] intro.md
+- tutorial
+  - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md
+  - [ ] 02-how-to-load-run-blueprints.md
+  - [ ] 03-build-your-first-blueprint.md
+  - [ ] index.md
+
 </details>
 
 <details open>
 <summary><h3>Developers</h3></summary>
 
-- [ ] developers
-   - [ ] 03-build-an-app
-      - [ ] 01-index.md
-   - [ ] 05-local-development
-      - [ ] 01-wp-now.md
-      - [ ] 02-vscode-extension.md
-      - [ ] 03-php-wasm-node.md
-      - [ ] intro.md
-   - [ ] 06-apis
-      - [ ] 01-index.md
-      - [ ] javascript-api
-         - [ ] 01-index.md
-         - [ ] 02-index-html-vs-remote-html.md
-         - [ ] 03-playground-api-client.md
-         - [ ] 04-blueprint-json-in-api-client.md
-         - [ ] 05-blueprint-functions-in-api-client.md
-         - [ ] 06-mount-data.md
-      - [ ] query-api
-          - [ ] 01-index.md
-   - [ ] 23-architecture
-      - [ ] 01-index.md
-      - [ ] 02-wasm-php-overview.md
-      - [ ] 03-wasm-php-compiling.md
-      - [ ] 04-wasm-php-javascript-module.md
-      - [ ] 05-wasm-php-filesystem.md
-      - [ ] 07-wasm-asyncify.md
-      - [ ] 08-browser-concepts.md
-      - [ ] 09-browser-tab-orchestrates-execution.md
-      - [ ] 10-browser-iframe-rendering.md
-      - [ ] 11-browser-php-worker-threads.md
-      - [ ] 12-browser-service-workers.md
-      - [ ] 13-browser-scopes.md
-      - [ ] 14-browser-cross-process-communication.md
-      - [ ] 15-wordpress.md
-      - [ ] 16-wordpress-database.md
-      - [ ] 17-browser-wordpress.md
-      - [ ] 18-host-your-own-playground.md
-   - [ ] 24-limitations
-      - [ ] 01-index.md
-   - [ ] intro-devs.md
+- 03-build-an-app
+  - [ ] 01-index.md
+- 05-local-development
+  - [ ] 01-wp-now.md
+  - [ ] 02-vscode-extension.md
+  - [ ] 03-php-wasm-node.md
+  - [ ] 04-wp-playground-cli.md
+  - [ ] intro.md
+- 06-apis
+  - [ ] 01-index.md
+  - javascript-api
+    - [ ] 01-index.md
+    - [ ] 02-index-html-vs-remote-html.md
+    - [ ] 03-playground-api-client.md
+    - [ ] 04-blueprint-json-in-api-client.md
+    - [ ] 05-blueprint-functions-in-api-client.md
+    - [ ] 06-mount-data.md
+  - query-api
+    - [ ] 01-index.md
+- 07-xdebug
+  - [ ] 01-introduction.md
+  - [ ] 02-getting-started.md
+- 23-architecture
+  - [ ] 01-index.md
+  - [ ] 02-wasm-php-overview.md
+  - [ ] 03-wasm-php-compiling.md
+  - [ ] 04-wasm-php-javascript-module.md
+  - [ ] 05-wasm-php-filesystem.md
+  - [ ] 07-wasm-asyncify.md
+  - [ ] 08-browser-concepts.md
+  - [ ] 09-browser-tab-orchestrates-execution.md
+  - [ ] 10-browser-iframe-rendering.md
+  - [ ] 11-browser-php-worker-threads.md
+  - [ ] 12-browser-service-workers.md
+  - [ ] 13-browser-scopes.md
+  - [ ] 14-browser-cross-process-communication.md
+  - [ ] 15-wordpress.md
+  - [ ] 16-wordpress-database.md
+  - [ ] 17-browser-wordpress.md
+  - [ ] 18-host-your-own-playground.md
+- 24-limitations
+  - [ ] 01-index.md
+- [ ] intro-devs.md
+
 </details>
 ```
 
@@ -507,9 +517,8 @@ This guide will show you how to both update an existing translation and add a br
 -->
 
 1.  **সঠিক ফাইল পাথ নির্ধারণ করুন।** নতুন ফাইলের পাথ এবং নাম অবশ্যই মূল ইংরেজি ফাইলের মতো হতে হবে।
-
-    -   **ইংরেজি মূল:** `packages/docs/site/docs/main/contributing/documentation.md`
-    -   **ফ্রেঞ্চ অনুবাদ:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
+    - **ইংরেজি মূল:** `packages/docs/site/docs/main/contributing/documentation.md`
+    - **ফ্রেঞ্চ অনুবাদ:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
 
 <!--
 2.  **Create the new file.** Navigate to the correct language folder (e.g., `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Click **Add file** > **Create new file**.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -209,12 +209,12 @@ Como guía, un idioma solo debe estar públicamente disponible en el selector cu
 -   [Links and Resources](https://wordpress.github.io/wordpress-playground/resources)
 -->
 
--   [Guía de inicio rápido](https://wordpress.github.io/wordpress-playground/quick-start-guide)
--   [Instancia web de Playground](https://wordpress.github.io/wordpress-playground/web-instance)
--   [Acerca de Playground](https://wordpress.github.io/wordpress-playground/about)
--   [Guías](https://wordpress.github.io/wordpress-playground/guides)
--   [Contribuir](https://wordpress.github.io/wordpress-playground/contributing)
--   [Enlaces y Recursos](https://wordpress.github.io/wordpress-playground/resources)
+- [Guía de inicio rápido](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+- [Instancia web de Playground](https://wordpress.github.io/wordpress-playground/web-instance)
+- [Acerca de Playground](https://wordpress.github.io/wordpress-playground/about)
+- [Guías](https://wordpress.github.io/wordpress-playground/guides)
+- [Contribuir](https://wordpress.github.io/wordpress-playground/contributing)
+- [Enlaces y Recursos](https://wordpress.github.io/wordpress-playground/resources)
 
 <!--
 All languages are available once the i18n setup for a language is complete and the correct file structure is in place under `i18n`.
@@ -222,9 +222,9 @@ All languages are available once the i18n setup for a language is complete and t
 
 Todos los idiomas están disponibles una vez que la configuración de i18n para un idioma está completa y la estructura de archivos correcta está en su lugar bajo `i18n`.
 
--   https://wordpress.github.io/wordpress-playground/
--   https://wordpress.github.io/wordpress-playground/es/
--   https://wordpress.github.io/wordpress-playground/fr/
+- https://wordpress.github.io/wordpress-playground/
+- https://wordpress.github.io/wordpress-playground/es/
+- https://wordpress.github.io/wordpress-playground/fr/
 
 <!--
 Assuming the `fr` language is the first language with the Documentation hub pages (Quick Start Guide, Playground web instance, About Playground, Guides,... ) completely translated to French, the `docusaurus.config.js` should look like this in that branch so `npm run build:docs` properly generate the `fr` subsite and only displays the french language in the `localeDropdown` language switcher.
@@ -286,15 +286,15 @@ Sigue estos pasos para traducir una página:
 -   Copy the original .md file from `packages/docs/site/docs/...` to the corresponding path in the language directory (e.g., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). It is crucial to replicate the original file structure.
 -   Translate the content of the new file, keeping the original content commented out `<!-- English Content -->`.
 
--   The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
--   Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
-    -->
+- The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
+- Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
+  -->
 
--   Verifica que tengas la última versión de la documentación
--   Copia el archivo .md original de `packages/docs/site/docs/...` a la ruta correspondiente en el directorio del idioma (por ejemplo, `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). Es crucial replicar la estructura de archivos original.
--   Traduce el contenido del nuevo archivo, manteniendo el contenido original comentado `<!-- English Content -->`.
--   Los recursos están listados en `packages/docs/site/static/img/` solo coloca recursos dentro de la carpeta de traducción cuando requiera contenido localizado.
--   Una vez que las traducciones estén listas, verifica si el script de compilación de documentación se ejecuta correctamente `npm run build:docs`.
+- Verifica que tengas la última versión de la documentación
+- Copia el archivo .md original de `packages/docs/site/docs/...` a la ruta correspondiente en el directorio del idioma (por ejemplo, `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). Es crucial replicar la estructura de archivos original.
+- Traduce el contenido del nuevo archivo, manteniendo el contenido original comentado `<!-- English Content -->`.
+- Los recursos están listados en `packages/docs/site/static/img/` solo coloca recursos dentro de la carpeta de traducción cuando requiera contenido localizado.
+- Una vez que las traducciones estén listas, verifica si el script de compilación de documentación se ejecuta correctamente `npm run build:docs`.
 
 <!--
 4. **Create a pull request with your changes**
@@ -308,9 +308,9 @@ Sigue estos pasos para traducir una página:
 -   Request a review at `#playground` or `#polyglots` at `wordpress.slack.com`
 -->
 
--   Agrega un prefijo al título `[i18n]` para ayudar a identificar las traducciones
--   Describe las páginas que tradujiste
--   Solicita una revisión en `#playground` o `#polyglots` en `wordpress.slack.com`
+- Agrega un prefijo al título `[i18n]` para ayudar a identificar las traducciones
+- Describe las páginas que tradujiste
+- Solicita una revisión en `#playground` o `#polyglots` en `wordpress.slack.com`
 
 <!--
 :::info
@@ -342,95 +342,104 @@ Puedes usar el siguiente markdown en tu issue de seguimiento:
 <summary><h3>Main</h3></summary>
 
 - about
-  - [ ] build.md #2291
-  - [ ] index.md #2282
-  - [ ] launch.md #2292
-  - [ ] test.md #2302
+  - [ ] build.md
+  - [ ] index.md
+  - [ ] launch.md
+  - [ ] test.md
 - contributing
-  - [ ] code.md #2218
-  - [ ] coding-standards.md #2219
-  - [ ] contributor-day.md #2246
+  - [ ] code.md
+  - [ ] coding-standards.md
   - [ ] contributor-badge.md
-  - [ ] documentation.md #2271
-  - [ ] translations.md #2201
+  - [ ] contributor-day.md
+  - [ ] contributor-day-table-lead.md
+  - [ ] documentation.md
+  - [ ] index.md
+  - [ ] releases.md
+  - [ ] translations.md
 - guides
-  - [ ] for-plugin-developers.md #2210
-  - [ ] for-theme-developers.md #2211
-  - [ ] index.md #2209
-  - [ ] providing-content-for-your-demo.md #2213
-  - [ ] wordpress-native-ios-app.md #2214
-- [ ] intro.md #2198
-- [ ] quick-start-guide.md #2204
-- [ ] resources.md #2207
-- [ ] web-instance.md #2208
+  - [ ] for-plugin-developers.md
+  - [ ] for-theme-developers.md
+  - [ ] github-action-pr-preview.md
+  - [ ] index.md
+  - [ ] providing-content-for-your-demo.md
+  - [ ] wordpress-native-ios-app.md
+- [ ] changelog.md
+- [ ] intro.md
+- [ ] quick-start-guide.md
+- [ ] resources.md
+- [ ] web-instance.md
 
 </details>
 
 <details open>
 <summary><h3>Blueprints</h3></summary>
 
-- blueprints
-  - [ ] 01-index.md #2305
-  - [ ] 02-using-blueprints.md #2330
-  - [ ] 03-data-format.md #2340
-   - [ ] 04-resources.md #2352
-   - [ ] 05-steps-shorthands.md  #2386
-  - [ ] 05-steps.md  #2386
-  - [ ] 06-bundles.md #2438
-   - [ ] 07-json-api-and-function-api.md #2438
-   - [ ] 08-examples.md #2474
-   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
-   - [ ] intro.md #2489
-   - tutorial
-       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
-       - [ ] 02-how-to-load-run-blueprints.md #2526
-       - [ ] 03-build-your-first-blueprint.md
-       - [ ] index.md #2511
+- [ ] 01-index.md
+- [ ] 02-using-blueprints.md
+- [ ] 03-data-format.md
+- [ ] 04-resources.md
+- [ ] 05-steps.md
+- [ ] 05-steps-shorthands.md
+- [ ] 06-bundles.md
+- [ ] 07-json-api-and-function-api.md
+- [ ] 08-examples.md
+- [ ] 09-troubleshoot-and-debug-blueprints.md
+- [ ] intro.md
+- tutorial
+  - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md
+  - [ ] 02-how-to-load-run-blueprints.md
+  - [ ] 03-build-your-first-blueprint.md
+  - [ ] index.md
+
 </details>
 
 <details open>
 <summary><h3>Developers</h3></summary>
 
-- [ ] developers
-   - [ ] 03-build-an-app
-      - [ ] 01-index.md
-   - [ ] 05-local-development
-      - [ ] 01-wp-now.md
-      - [ ] 02-vscode-extension.md
-      - [ ] 03-php-wasm-node.md
-      - [ ] intro.md
-   - [ ] 06-apis
-      - [ ] 01-index.md
-      - [ ] javascript-api
-         - [ ] 01-index.md
-         - [ ] 02-index-html-vs-remote-html.md
-         - [ ] 03-playground-api-client.md
-         - [ ] 04-blueprint-json-in-api-client.md
-         - [ ] 05-blueprint-functions-in-api-client.md
-         - [ ] 06-mount-data.md
-      - [ ] query-api
-          - [ ] 01-index.md
-   - [ ] 23-architecture
-      - [ ] 01-index.md
-      - [ ] 02-wasm-php-overview.md
-      - [ ] 03-wasm-php-compiling.md
-      - [ ] 04-wasm-php-javascript-module.md
-      - [ ] 05-wasm-php-filesystem.md
-      - [ ] 07-wasm-asyncify.md
-      - [ ] 08-browser-concepts.md
-      - [ ] 09-browser-tab-orchestrates-execution.md
-      - [ ] 10-browser-iframe-rendering.md
-      - [ ] 11-browser-php-worker-threads.md
-      - [ ] 12-browser-service-workers.md
-      - [ ] 13-browser-scopes.md
-      - [ ] 14-browser-cross-process-communication.md
-      - [ ] 15-wordpress.md
-      - [ ] 16-wordpress-database.md
-      - [ ] 17-browser-wordpress.md
-      - [ ] 18-host-your-own-playground.md
-   - [ ] 24-limitations
-      - [ ] 01-index.md
-   - [ ] intro-devs.md
+- 03-build-an-app
+  - [ ] 01-index.md
+- 05-local-development
+  - [ ] 01-wp-now.md
+  - [ ] 02-vscode-extension.md
+  - [ ] 03-php-wasm-node.md
+  - [ ] 04-wp-playground-cli.md
+  - [ ] intro.md
+- 06-apis
+  - [ ] 01-index.md
+  - javascript-api
+    - [ ] 01-index.md
+    - [ ] 02-index-html-vs-remote-html.md
+    - [ ] 03-playground-api-client.md
+    - [ ] 04-blueprint-json-in-api-client.md
+    - [ ] 05-blueprint-functions-in-api-client.md
+    - [ ] 06-mount-data.md
+  - query-api
+    - [ ] 01-index.md
+- 07-xdebug
+  - [ ] 01-introduction.md
+  - [ ] 02-getting-started.md
+- 23-architecture
+  - [ ] 01-index.md
+  - [ ] 02-wasm-php-overview.md
+  - [ ] 03-wasm-php-compiling.md
+  - [ ] 04-wasm-php-javascript-module.md
+  - [ ] 05-wasm-php-filesystem.md
+  - [ ] 07-wasm-asyncify.md
+  - [ ] 08-browser-concepts.md
+  - [ ] 09-browser-tab-orchestrates-execution.md
+  - [ ] 10-browser-iframe-rendering.md
+  - [ ] 11-browser-php-worker-threads.md
+  - [ ] 12-browser-service-workers.md
+  - [ ] 13-browser-scopes.md
+  - [ ] 14-browser-cross-process-communication.md
+  - [ ] 15-wordpress.md
+  - [ ] 16-wordpress-database.md
+  - [ ] 17-browser-wordpress.md
+  - [ ] 18-host-your-own-playground.md
+- 24-limitations
+  - [ ] 01-index.md
+- [ ] intro-devs.md
+
 </details>
 ```
 -->
@@ -442,95 +451,104 @@ Puedes usar el siguiente markdown en tu issue de seguimiento:
 <summary><h3>Main</h3></summary>
 
 - about
-  - [ ] build.md #2291
-  - [ ] index.md #2282
-  - [ ] launch.md #2292
-  - [ ] test.md #2302
+  - [ ] build.md
+  - [ ] index.md
+  - [ ] launch.md
+  - [ ] test.md
 - contributing
-  - [ ] code.md #2218
-  - [ ] coding-standards.md #2219
-  - [ ] contributor-day.md #2246
+  - [ ] code.md
+  - [ ] coding-standards.md
   - [ ] contributor-badge.md
-  - [ ] documentation.md #2271
-  - [ ] translations.md #2201
+  - [ ] contributor-day.md
+  - [ ] contributor-day-table-lead.md
+  - [ ] documentation.md
+  - [ ] index.md
+  - [ ] releases.md
+  - [ ] translations.md
 - guides
-  - [ ] for-plugin-developers.md #2210
-  - [ ] for-theme-developers.md #2211
-  - [ ] index.md #2209
-  - [ ] providing-content-for-your-demo.md #2213
-  - [ ] wordpress-native-ios-app.md #2214
-- [ ] intro.md #2198
-- [ ] quick-start-guide.md #2204
-- [ ] resources.md #2207
-- [ ] web-instance.md #2208
+  - [ ] for-plugin-developers.md
+  - [ ] for-theme-developers.md
+  - [ ] github-action-pr-preview.md
+  - [ ] index.md
+  - [ ] providing-content-for-your-demo.md
+  - [ ] wordpress-native-ios-app.md
+- [ ] changelog.md
+- [ ] intro.md
+- [ ] quick-start-guide.md
+- [ ] resources.md
+- [ ] web-instance.md
 
 </details>
 
 <details open>
 <summary><h3>Blueprints</h3></summary>
 
-- blueprints
-  - [ ] 01-index.md #2305
-  - [ ] 02-using-blueprints.md #2330
-  - [ ] 03-data-format.md #2340
-   - [ ] 04-resources.md #2352
-   - [ ] 05-steps-shorthands.md  #2386
-  - [ ] 05-steps.md  #2386
-  - [ ] 06-bundles.md #2438
-   - [ ] 07-json-api-and-function-api.md #2438
-   - [ ] 08-examples.md #2474
-   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
-   - [ ] intro.md #2489
-   - tutorial
-       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
-       - [ ] 02-how-to-load-run-blueprints.md #2526
-       - [ ] 03-build-your-first-blueprint.md
-       - [ ] index.md #2511
+- [ ] 01-index.md
+- [ ] 02-using-blueprints.md
+- [ ] 03-data-format.md
+- [ ] 04-resources.md
+- [ ] 05-steps.md
+- [ ] 05-steps-shorthands.md
+- [ ] 06-bundles.md
+- [ ] 07-json-api-and-function-api.md
+- [ ] 08-examples.md
+- [ ] 09-troubleshoot-and-debug-blueprints.md
+- [ ] intro.md
+- tutorial
+  - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md
+  - [ ] 02-how-to-load-run-blueprints.md
+  - [ ] 03-build-your-first-blueprint.md
+  - [ ] index.md
+
 </details>
 
 <details open>
 <summary><h3>Developers</h3></summary>
 
-- [ ] developers
-   - [ ] 03-build-an-app
-      - [ ] 01-index.md
-   - [ ] 05-local-development
-      - [ ] 01-wp-now.md
-      - [ ] 02-vscode-extension.md
-      - [ ] 03-php-wasm-node.md
-      - [ ] intro.md
-   - [ ] 06-apis
-      - [ ] 01-index.md
-      - [ ] javascript-api
-         - [ ] 01-index.md
-         - [ ] 02-index-html-vs-remote-html.md
-         - [ ] 03-playground-api-client.md
-         - [ ] 04-blueprint-json-in-api-client.md
-         - [ ] 05-blueprint-functions-in-api-client.md
-         - [ ] 06-mount-data.md
-      - [ ] query-api
-          - [ ] 01-index.md
-   - [ ] 23-architecture
-      - [ ] 01-index.md
-      - [ ] 02-wasm-php-overview.md
-      - [ ] 03-wasm-php-compiling.md
-      - [ ] 04-wasm-php-javascript-module.md
-      - [ ] 05-wasm-php-filesystem.md
-      - [ ] 07-wasm-asyncify.md
-      - [ ] 08-browser-concepts.md
-      - [ ] 09-browser-tab-orchestrates-execution.md
-      - [ ] 10-browser-iframe-rendering.md
-      - [ ] 11-browser-php-worker-threads.md
-      - [ ] 12-browser-service-workers.md
-      - [ ] 13-browser-scopes.md
-      - [ ] 14-browser-cross-process-communication.md
-      - [ ] 15-wordpress.md
-      - [ ] 16-wordpress-database.md
-      - [ ] 17-browser-wordpress.md
-      - [ ] 18-host-your-own-playground.md
-   - [ ] 24-limitations
-      - [ ] 01-index.md
-   - [ ] intro-devs.md
+- 03-build-an-app
+  - [ ] 01-index.md
+- 05-local-development
+  - [ ] 01-wp-now.md
+  - [ ] 02-vscode-extension.md
+  - [ ] 03-php-wasm-node.md
+  - [ ] 04-wp-playground-cli.md
+  - [ ] intro.md
+- 06-apis
+  - [ ] 01-index.md
+  - javascript-api
+    - [ ] 01-index.md
+    - [ ] 02-index-html-vs-remote-html.md
+    - [ ] 03-playground-api-client.md
+    - [ ] 04-blueprint-json-in-api-client.md
+    - [ ] 05-blueprint-functions-in-api-client.md
+    - [ ] 06-mount-data.md
+  - query-api
+    - [ ] 01-index.md
+- 07-xdebug
+  - [ ] 01-introduction.md
+  - [ ] 02-getting-started.md
+- 23-architecture
+  - [ ] 01-index.md
+  - [ ] 02-wasm-php-overview.md
+  - [ ] 03-wasm-php-compiling.md
+  - [ ] 04-wasm-php-javascript-module.md
+  - [ ] 05-wasm-php-filesystem.md
+  - [ ] 07-wasm-asyncify.md
+  - [ ] 08-browser-concepts.md
+  - [ ] 09-browser-tab-orchestrates-execution.md
+  - [ ] 10-browser-iframe-rendering.md
+  - [ ] 11-browser-php-worker-threads.md
+  - [ ] 12-browser-service-workers.md
+  - [ ] 13-browser-scopes.md
+  - [ ] 14-browser-cross-process-communication.md
+  - [ ] 15-wordpress.md
+  - [ ] 16-wordpress-database.md
+  - [ ] 17-browser-wordpress.md
+  - [ ] 18-host-your-own-playground.md
+- 24-limitations
+  - [ ] 01-index.md
+- [ ] intro-devs.md
+
 </details>
 ```
 
@@ -614,9 +632,8 @@ Esta guía te mostrará cómo actualizar una traducción existente y agregar una
 -->
 
 1.  **Determina la ruta correcta del archivo.** La ruta y el nombre del nuevo archivo deben reflejar el archivo original en inglés.
-
-    -   **Original en inglés:** `packages/docs/site/docs/main/contributing/documentation.md`
-    -   **Traducción al francés:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
+    - **Original en inglés:** `packages/docs/site/docs/main/contributing/documentation.md`
+    - **Traducción al francés:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
 
 <!--
 2.  **Create the new file.** Navigate to the correct language folder (e.g., `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Click **Add file** > **Create new file**.
@@ -627,8 +644,7 @@ Esta guía te mostrará cómo actualizar una traducción existente y agregar una
 
 2.  **Crea el nuevo archivo.** Navega a la carpeta del idioma correcto (por ejemplo, `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Haz clic en **Add file** > **Create new file**.
     ![Creando una nueva traducción](@site/static/img/contributing/adding-file-github-ui.webp)
-
-    -   **Consejo profesional:** En el cuadro de nombre de archivo, puedes crear nuevas carpetas escribiendo el nombre de la carpeta seguido de un `/`. Por ejemplo, escribir `main/contributing/documentation.md` creará las carpetas `main` y `contributing` automáticamente.
+    - **Consejo profesional:** En el cuadro de nombre de archivo, puedes crear nuevas carpetas escribiendo el nombre de la carpeta seguido de un `/`. Por ejemplo, escribir `main/contributing/documentation.md` creará las carpetas `main` y `contributing` automáticamente.
 
 <!--
 3.  **Fork the repository.** Just like before, GitHub will prompt you to **Fork this repository**. Click the button to create your personal copy.

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -175,12 +175,12 @@ Nous recommandons d'ajouter une langue au sélecteur uniquement lorsqu'une parti
 
 À titre indicatif, une langue devrait être rendue publiquement disponible dans le sélecteur uniquement lorsque l'ensemble du hub "Documentation" est traduit, y compris ces sections clés :
 
--   [Guide de démarrage rapide](https://wordpress.github.io/wordpress-playground/quick-start-guide)
--   [Instance web Playground](https://wordpress.github.io/wordpress-playground/web-instance)
--   [À propos de Playground](https://wordpress.github.io/wordpress-playground/about)
--   [Guides](https://wordpress.github.io/wordpress-playground/guides)
--   [Contribuer](https://wordpress.github.io/wordpress-playground/contributing)
--   [Liens et ressources](https://wordpress.github.io/wordpress-playground/resources)
+- [Guide de démarrage rapide](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+- [Instance web Playground](https://wordpress.github.io/wordpress-playground/web-instance)
+- [À propos de Playground](https://wordpress.github.io/wordpress-playground/about)
+- [Guides](https://wordpress.github.io/wordpress-playground/guides)
+- [Contribuer](https://wordpress.github.io/wordpress-playground/contributing)
+- [Liens et ressources](https://wordpress.github.io/wordpress-playground/resources)
 
 <!--
 All languages are available once the i18n setup for a language is complete and the correct file structure is in place under `i18n`.
@@ -192,9 +192,9 @@ All languages are available once the i18n setup for a language is complete and t
 
 Toutes les langues sont disponibles une fois que la configuration i18n pour une langue est complète et que la structure de fichiers correcte est en place sous `i18n`.
 
--   https://wordpress.github.io/wordpress-playground/
--   https://wordpress.github.io/wordpress-playground/es/
--   https://wordpress.github.io/wordpress-playground/fr/
+- https://wordpress.github.io/wordpress-playground/
+- https://wordpress.github.io/wordpress-playground/es/
+- https://wordpress.github.io/wordpress-playground/fr/
 
 <!--
 Assuming the `fr` language is the first language with the Documentation hub pages (Quick Start Guide, Playground web instance, About Playground, Guides,... ) completely translated to French, the `docusaurus.config.js` should look like this in that branch so `npm run build:docs` properly generate the `fr` subsite and only displays the french language in the `localeDropdown` language switcher.
@@ -258,16 +258,16 @@ Suivez ces étapes pour traduire une page :
 2. **Créez une nouvelle issue de traduction** : Si aucune issue n’existe, veuillez en créer une nouvelle pour suivre les progrès de traduction pour la langue. Vous pouvez vous inspirer de l’issue [#2202](https://github.com/WordPress/wordpress-playground/issues/2202) et utiliser la liste de vérification en markdown ci-dessous pour suivre l’avancée.
 3. **Traduisez le fichier** :
 
--   Vérifiez si vous avez la dernière version de la documentation
--   Copiez le fichier .md original de `packages/docs/site/docs/...` vers le chemin correspondant dans le répertoire de langue (par exemple, `packages/docs/site/i18n/<CODE_LANGUE>/...`). Il est crucial de reproduire la structure de fichiers originale.
--   Traduisez le contenu du nouveau fichier, en gardant le contenu original commenté `<!-- Contenu anglais -->`.
--   Les ressources sont listées dans `packages/docs/site/static/img/`, ne placez les ressources dans le dossier de traduction que lorsqu'elles nécessitent du contenu localisé.
--   Une fois les traductions prêtes, vérifiez si le script de build de la documentation fonctionne correctement `npm run build:docs`.
+- Vérifiez si vous avez la dernière version de la documentation
+- Copiez le fichier .md original de `packages/docs/site/docs/...` vers le chemin correspondant dans le répertoire de langue (par exemple, `packages/docs/site/i18n/<CODE_LANGUE>/...`). Il est crucial de reproduire la structure de fichiers originale.
+- Traduisez le contenu du nouveau fichier, en gardant le contenu original commenté `<!-- Contenu anglais -->`.
+- Les ressources sont listées dans `packages/docs/site/static/img/`, ne placez les ressources dans le dossier de traduction que lorsqu'elles nécessitent du contenu localisé.
+- Une fois les traductions prêtes, vérifiez si le script de build de la documentation fonctionne correctement `npm run build:docs`.
 
 4. **Créez une pull request avec vos modifications**
 
--   Décrivez les pages que vous avez traduites
--   Demandez une révision sur `#playground` ou `#polyglots` sur `wordpress.slack.com`
+- Décrivez les pages que vous avez traduites
+- Demandez une révision sur `#playground` ou `#polyglots` sur `wordpress.slack.com`
 
 <!--
 :::info
@@ -295,93 +295,106 @@ Vous pouvez utiliser le markdown suivant dans votre issue de suivi:
 <details open>
 <summary><h3>Principal</h3></summary>
 
--   about
-    -   [ ] build.md #2291
-    -   [ ] index.md #2282
-    -   [ ] launch.md #2292
-    -   [ ] test.md #2302
--   contributing
-    -   [ ] code.md #2218
-    -   [ ] coding-standards.md #2219
-    -   [ ] contributor-day.md #2246
-    -   [ ] contributor-badge.md
-    -   [ ] documentation.md #2271
-    -   [ ] translations.md #2201
--   guides
-    -   [ ] for-plugin-developers.md #2210
-    -   [ ] for-theme-developers.md #2211
-    -   [ ] index.md #2209
-    -   [ ] providing-content-for-your-demo.md #2213
-    -   [ ] wordpress-native-ios-app.md #2214
--   [ ] intro.md #2198
--   [ ] quick-start-guide.md #2204
--   [ ] resources.md #2207
--   [ ] web-instance.md #2208
+- about
+    - [ ] build.md
+    - [ ] index.md
+    - [ ] launch.md
+    - [ ] test.md
+- contributing
+    - [ ] code.md
+    - [ ] coding-standards.md
+    - [ ] contributor-badge.md
+    - [ ] contributor-day.md
+    - [ ] contributor-day-table-lead.md
+    - [ ] documentation.md
+    - [ ] index.md
+    - [ ] releases.md
+    - [ ] translations.md
+- guides
+    - [ ] for-plugin-developers.md
+    - [ ] for-theme-developers.md
+    - [ ] github-action-pr-preview.md
+    - [ ] index.md
+    - [ ] providing-content-for-your-demo.md
+    - [ ] wordpress-native-ios-app.md
+- [ ] changelog.md
+- [ ] intro.md
+- [ ] quick-start-guide.md
+- [ ] resources.md
+- [ ] web-instance.md
 
 </details>
 
 <details open>
 <summary><h3>Blueprints</h3></summary>
 
--   blueprints
-    -   [ ] 01-index.md #2305
-    -   [ ] 02-using-blueprints.md #2330
-    -   [ ] 03-data-format.md #2340
-    -   [ ] 04-resources.md #2352
-    -   [ ] 05-steps-shorthands.md #2386
-    -   [ ] 05-steps.md #2386
-    -   [ ] 06-bundles.md #2438
-    -   [ ] 07-json-api-and-function-api.md #2438
-    -   [ ] 08-examples.md #2474
-    -   [ ] 09-troubleshoot-and-debug-blueprints.md #2474
-    -   [ ] intro.md #2489
-    -   tutorial - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511 - [ ] 02-how-to-load-run-blueprints.md #2526 - [ ] 03-build-your-first-blueprint.md - [ ] index.md #2511
-    </details>
+- [ ] 01-index.md
+- [ ] 02-using-blueprints.md
+- [ ] 03-data-format.md
+- [ ] 04-resources.md
+- [ ] 05-steps.md
+- [ ] 05-steps-shorthands.md
+- [ ] 06-bundles.md
+- [ ] 07-json-api-and-function-api.md
+- [ ] 08-examples.md
+- [ ] 09-troubleshoot-and-debug-blueprints.md
+- [ ] intro.md
+- tutorial
+    - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md
+    - [ ] 02-how-to-load-run-blueprints.md
+    - [ ] 03-build-your-first-blueprint.md
+    - [ ] index.md
+
+</details>
 
 <details open>
 <summary><h3>Développeurs</h3></summary>
 
--   [ ] developers
-    -   [ ] 03-build-an-app
-        -   [ ] 01-index.md
-    -   [ ] 05-local-development
-        -   [ ] 01-wp-now.md
-        -   [ ] 02-vscode-extension.md
-        -   [ ] 03-php-wasm-node.md
-        -   [ ] intro.md
-    -   [ ] 06-apis
-        -   [ ] 01-index.md
-        -   [ ] javascript-api
-            -   [ ] 01-index.md
-            -   [ ] 02-index-html-vs-remote-html.md
-            -   [ ] 03-playground-api-client.md
-            -   [ ] 04-blueprint-json-in-api-client.md
-            -   [ ] 05-blueprint-functions-in-api-client.md
-            -   [ ] 06-mount-data.md
-        -   [ ] query-api
-            -   [ ] 01-index.md
-    -   [ ] 23-architecture
-        -   [ ] 01-index.md
-        -   [ ] 02-wasm-php-overview.md
-        -   [ ] 03-wasm-php-compiling.md
-        -   [ ] 04-wasm-php-javascript-module.md
-        -   [ ] 05-wasm-php-filesystem.md
-        -   [ ] 07-wasm-asyncify.md
-        -   [ ] 08-browser-concepts.md
-        -   [ ] 09-browser-tab-orchestrates-execution.md
-        -   [ ] 10-browser-iframe-rendering.md
-        -   [ ] 11-browser-php-worker-threads.md
-        -   [ ] 12-browser-service-workers.md
-        -   [ ] 13-browser-scopes.md
-        -   [ ] 14-browser-cross-process-communication.md
-        -   [ ] 15-wordpress.md
-        -   [ ] 16-wordpress-database.md
-        -   [ ] 17-browser-wordpress.md
-        -   [ ] 18-host-your-own-playground.md
-    -   [ ] 24-limitations
-        -   [ ] 01-index.md
-    -   [ ] intro-devs.md
-    </details>
+- 03-build-an-app
+    - [ ] 01-index.md
+- 05-local-development
+    - [ ] 01-wp-now.md
+    - [ ] 02-vscode-extension.md
+    - [ ] 03-php-wasm-node.md
+    - [ ] 04-wp-playground-cli.md
+    - [ ] intro.md
+- 06-apis
+    - [ ] 01-index.md
+    - javascript-api
+        - [ ] 01-index.md
+        - [ ] 02-index-html-vs-remote-html.md
+        - [ ] 03-playground-api-client.md
+        - [ ] 04-blueprint-json-in-api-client.md
+        - [ ] 05-blueprint-functions-in-api-client.md
+        - [ ] 06-mount-data.md
+    - query-api
+        - [ ] 01-index.md
+- 07-xdebug
+    - [ ] 01-introduction.md
+    - [ ] 02-getting-started.md
+- 23-architecture
+    - [ ] 01-index.md
+    - [ ] 02-wasm-php-overview.md
+    - [ ] 03-wasm-php-compiling.md
+    - [ ] 04-wasm-php-javascript-module.md
+    - [ ] 05-wasm-php-filesystem.md
+    - [ ] 07-wasm-asyncify.md
+    - [ ] 08-browser-concepts.md
+    - [ ] 09-browser-tab-orchestrates-execution.md
+    - [ ] 10-browser-iframe-rendering.md
+    - [ ] 11-browser-php-worker-threads.md
+    - [ ] 12-browser-service-workers.md
+    - [ ] 13-browser-scopes.md
+    - [ ] 14-browser-cross-process-communication.md
+    - [ ] 15-wordpress.md
+    - [ ] 16-wordpress-database.md
+    - [ ] 17-browser-wordpress.md
+    - [ ] 18-host-your-own-playground.md
+- 24-limitations
+    - [ ] 01-index.md
+- [ ] intro-devs.md
+
+</details>
 ```
 
 <!--

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -238,18 +238,18 @@ Raccomandiamo di aggiungere una lingua al selettore solo quando una parte signif
 
 Come linea guida, una lingua dovrebbe essere resa pubblicamente disponibile nel selettore solo quando l'intero hub "Documentazione" è tradotto, inclusi questi capitoli chiave:
 
--   [Guida rapida](https://wordpress.github.io/wordpress-playground/quick-start-guide)
--   [Istanza web Playground](https://wordpress.github.io/wordpress-playground/web-instance)
--   [Informazioni su Playground](https://wordpress.github.io/wordpress-playground/about)
--   [Guide](https://wordpress.github.io/wordpress-playground/guides)
--   [Contribuire](https://wordpress.github.io/wordpress-playground/contributing)
--   [Link e risorse](https://wordpress.github.io/wordpress-playground/resources)
+- [Guida rapida](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+- [Istanza web Playground](https://wordpress.github.io/wordpress-playground/web-instance)
+- [Informazioni su Playground](https://wordpress.github.io/wordpress-playground/about)
+- [Guide](https://wordpress.github.io/wordpress-playground/guides)
+- [Contribuire](https://wordpress.github.io/wordpress-playground/contributing)
+- [Link e risorse](https://wordpress.github.io/wordpress-playground/resources)
 
 Tutte le lingue sono disponibili una volta che la configurazione i18n per una lingua è completa e la struttura dei file corretta è in posto sotto `i18n`.
 
--   https://wordpress.github.io/wordpress-playground/
--   https://wordpress.github.io/wordpress-playground/es/
--   https://wordpress.github.io/wordpress-playground/fr/
+- https://wordpress.github.io/wordpress-playground/
+- https://wordpress.github.io/wordpress-playground/es/
+- https://wordpress.github.io/wordpress-playground/fr/
 
 Assumendo che la lingua `fr` sia la prima lingua con le pagine dell'hub Documentazione (Guida rapida, Istanza web Playground, Informazioni su Playground, Guide,... ) completamente tradotte in francese, il `docusaurus.config.js` dovrebbe apparire così in quel branch così `npm run build:docs` genera correttamente il sottosito `fr` e mostra solo la lingua francese nel selettore della lingua `localeDropdown`.
 
@@ -293,14 +293,14 @@ Follow these steps to translate a page:
 -   Copy the original .md file from `packages/docs/site/docs/...` to the corresponding path in the language directory (e.g., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). It is crucial to replicate the original file structure.
 -   Translate the content of the new file, keeping the original content commented out `<!-- English Content -->`.
 
--   The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
--   Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
+- The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
+- Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
 
 4. **Create a pull request with your changes**
 
--   Add a prefix to the title `[i18n]` to help to identify the translations
--   Describe the pages that you translated
--   Request a review at `#playground` or `#polyglots` at `wordpress.slack.com`
+- Add a prefix to the title `[i18n]` to help to identify the translations
+- Describe the pages that you translated
+- Request a review at `#playground` or `#polyglots` at `wordpress.slack.com`
 
 :::info
 We highly recommend submitting pull requests with a small number of translated pages. This approach simplifies the review process and allows for a more gradual and manageable integration of your work.
@@ -315,17 +315,17 @@ Segui questi passaggi per tradurre una pagina:
 2. **Crea una nuova issue di traduzione**: Se non esiste una issue, per favore creane una nuova per tracciare i progressi della traduzione per la lingua. Puoi modellarla sull'issue [#2202](https://github.com/WordPress/wordpress-playground/issues/2202) e usare la checklist markdown qui sotto per tracciare i progressi.
 3. **Traduci il file**:
 
--   Controlla se hai l'ultima versione della documentazione
--   Copia il file .md originale da `packages/docs/site/docs/...` al percorso corrispondente nella directory della lingua (es., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). È cruciale replicare la struttura dei file originale.
--   Traduci il contenuto del nuovo file, mantenendo il contenuto originale commentato `<!-- Contenuto inglese -->`.
--   Le risorse sono elencate in `packages/docs/site/static/img/` posiziona le risorse dentro la cartella di traduzione solo quando richiede contenuto localizzato.
--   Una volta che le traduzioni sono pronte, controlla se lo script di build della documentazione funziona correttamente `npm run build:docs`.
+- Controlla se hai l'ultima versione della documentazione
+- Copia il file .md originale da `packages/docs/site/docs/...` al percorso corrispondente nella directory della lingua (es., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). È cruciale replicare la struttura dei file originale.
+- Traduci il contenuto del nuovo file, mantenendo il contenuto originale commentato `<!-- Contenuto inglese -->`.
+- Le risorse sono elencate in `packages/docs/site/static/img/` posiziona le risorse dentro la cartella di traduzione solo quando richiede contenuto localizzato.
+- Una volta che le traduzioni sono pronte, controlla se lo script di build della documentazione funziona correttamente `npm run build:docs`.
 
 4. **Crea una pull request con le tue modifiche**
 
--   Aggiungi un prefisso al titolo `[i18n]` per aiutare a identificare le traduzioni
--   Descrivi le pagine che hai tradotto
--   Richiedi una revisione su `#playground` o `#polyglots` su `wordpress.slack.com`
+- Aggiungi un prefisso al titolo `[i18n]` per aiutare a identificare le traduzioni
+- Descrivi le pagine che hai tradotto
+- Richiedi una revisione su `#playground` o `#polyglots` su `wordpress.slack.com`
 
 :::info
 Raccomandiamo fortemente di inviare pull request con un piccolo numero di pagine tradotte. Questo approccio semplifica il processo di revisione e permette un'integrazione più graduale e gestibile del tuo lavoro.
@@ -447,95 +447,104 @@ Puoi usare il seguente markdown nella tua issue di tracciamento:
 <summary><h3>Main</h3></summary>
 
 - about
-  - [ ] build.md #2291
-  - [ ] index.md #2282
-  - [ ] launch.md #2292
-  - [ ] test.md #2302
+  - [ ] build.md
+  - [ ] index.md
+  - [ ] launch.md
+  - [ ] test.md
 - contributing
-  - [ ] code.md #2218
-  - [ ] coding-standards.md #2219
-  - [ ] contributor-day.md #2246
+  - [ ] code.md
+  - [ ] coding-standards.md
   - [ ] contributor-badge.md
-  - [ ] documentation.md #2271
-  - [ ] translations.md #2201
+  - [ ] contributor-day.md
+  - [ ] contributor-day-table-lead.md
+  - [ ] documentation.md
+  - [ ] index.md
+  - [ ] releases.md
+  - [ ] translations.md
 - guides
-  - [ ] for-plugin-developers.md #2210
-  - [ ] for-theme-developers.md #2211
-  - [ ] index.md #2209
-  - [ ] providing-content-for-your-demo.md #2213
-  - [ ] wordpress-native-ios-app.md #2214
-- [ ] intro.md #2198
-- [ ] quick-start-guide.md #2204
-- [ ] resources.md #2207
-- [ ] web-instance.md #2208
+  - [ ] for-plugin-developers.md
+  - [ ] for-theme-developers.md
+  - [ ] github-action-pr-preview.md
+  - [ ] index.md
+  - [ ] providing-content-for-your-demo.md
+  - [ ] wordpress-native-ios-app.md
+- [ ] changelog.md
+- [ ] intro.md
+- [ ] quick-start-guide.md
+- [ ] resources.md
+- [ ] web-instance.md
 
 </details>
 
 <details open>
 <summary><h3>Blueprints</h3></summary>
 
-- blueprints
-  - [ ] 01-index.md #2305
-  - [ ] 02-using-blueprints.md #2330
-  - [ ] 03-data-format.md #2340
-   - [ ] 04-resources.md #2352
-   - [ ] 05-steps-shorthands.md  #2386
-  - [ ] 05-steps.md  #2386
-  - [ ] 06-bundles.md #2438
-   - [ ] 07-json-api-and-function-api.md #2438
-   - [ ] 08-examples.md #2474
-   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
-   - [ ] intro.md #2489
-   - tutorial
-       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
-       - [ ] 02-how-to-load-run-blueprints.md #2526
-       - [ ] 03-build-your-first-blueprint.md
-       - [ ] index.md #2511
+- [ ] 01-index.md
+- [ ] 02-using-blueprints.md
+- [ ] 03-data-format.md
+- [ ] 04-resources.md
+- [ ] 05-steps.md
+- [ ] 05-steps-shorthands.md
+- [ ] 06-bundles.md
+- [ ] 07-json-api-and-function-api.md
+- [ ] 08-examples.md
+- [ ] 09-troubleshoot-and-debug-blueprints.md
+- [ ] intro.md
+- tutorial
+  - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md
+  - [ ] 02-how-to-load-run-blueprints.md
+  - [ ] 03-build-your-first-blueprint.md
+  - [ ] index.md
+
 </details>
 
 <details open>
 <summary><h3>Developers</h3></summary>
 
-- [ ] developers
-   - [ ] 03-build-an-app
-      - [ ] 01-index.md
-   - [ ] 05-local-development
-      - [ ] 01-wp-now.md
-      - [ ] 02-vscode-extension.md
-      - [ ] 03-php-wasm-node.md
-      - [ ] intro.md
-   - [ ] 06-apis
-      - [ ] 01-index.md
-      - [ ] javascript-api
-         - [ ] 01-index.md
-         - [ ] 02-index-html-vs-remote-html.md
-         - [ ] 03-playground-api-client.md
-         - [ ] 04-blueprint-json-in-api-client.md
-         - [ ] 05-blueprint-functions-in-api-client.md
-         - [ ] 06-mount-data.md
-      - [ ] query-api
-          - [ ] 01-index.md
-   - [ ] 23-architecture
-      - [ ] 01-index.md
-      - [ ] 02-wasm-php-overview.md
-      - [ ] 03-wasm-php-compiling.md
-      - [ ] 04-wasm-php-javascript-module.md
-      - [ ] 05-wasm-php-filesystem.md
-      - [ ] 07-wasm-asyncify.md
-      - [ ] 08-browser-concepts.md
-      - [ ] 09-browser-tab-orchestrates-execution.md
-      - [ ] 10-browser-iframe-rendering.md
-      - [ ] 11-browser-php-worker-threads.md
-      - [ ] 12-browser-service-workers.md
-      - [ ] 13-browser-scopes.md
-      - [ ] 14-browser-cross-process-communication.md
-      - [ ] 15-wordpress.md
-      - [ ] 16-wordpress-database.md
-      - [ ] 17-browser-wordpress.md
-      - [ ] 18-host-your-own-playground.md
-   - [ ] 24-limitations
-      - [ ] 01-index.md
-   - [ ] intro-devs.md
+- 03-build-an-app
+  - [ ] 01-index.md
+- 05-local-development
+  - [ ] 01-wp-now.md
+  - [ ] 02-vscode-extension.md
+  - [ ] 03-php-wasm-node.md
+  - [ ] 04-wp-playground-cli.md
+  - [ ] intro.md
+- 06-apis
+  - [ ] 01-index.md
+  - javascript-api
+    - [ ] 01-index.md
+    - [ ] 02-index-html-vs-remote-html.md
+    - [ ] 03-playground-api-client.md
+    - [ ] 04-blueprint-json-in-api-client.md
+    - [ ] 05-blueprint-functions-in-api-client.md
+    - [ ] 06-mount-data.md
+  - query-api
+    - [ ] 01-index.md
+- 07-xdebug
+  - [ ] 01-introduction.md
+  - [ ] 02-getting-started.md
+- 23-architecture
+  - [ ] 01-index.md
+  - [ ] 02-wasm-php-overview.md
+  - [ ] 03-wasm-php-compiling.md
+  - [ ] 04-wasm-php-javascript-module.md
+  - [ ] 05-wasm-php-filesystem.md
+  - [ ] 07-wasm-asyncify.md
+  - [ ] 08-browser-concepts.md
+  - [ ] 09-browser-tab-orchestrates-execution.md
+  - [ ] 10-browser-iframe-rendering.md
+  - [ ] 11-browser-php-worker-threads.md
+  - [ ] 12-browser-service-workers.md
+  - [ ] 13-browser-scopes.md
+  - [ ] 14-browser-cross-process-communication.md
+  - [ ] 15-wordpress.md
+  - [ ] 16-wordpress-database.md
+  - [ ] 17-browser-wordpress.md
+  - [ ] 18-host-your-own-playground.md
+- 24-limitations
+  - [ ] 01-index.md
+- [ ] intro-devs.md
+
 </details>
 ```
 
@@ -629,14 +638,12 @@ Questa guida ti mostrerà come aggiornare una traduzione esistente e aggiungerne
 #### Aggiungere una nuova traduzione
 
 1.  **Determina il percorso del file corretto.** Il percorso e il nome del nuovo file devono rispecchiare il file inglese originale.
-
-    -   **Originale inglese:** `packages/docs/site/docs/main/contributing/documentation.md`
-    -   **Traduzione francese:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
+    - **Originale inglese:** `packages/docs/site/docs/main/contributing/documentation.md`
+    - **Traduzione francese:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
 
 2.  **Crea il nuovo file.** Naviga nella cartella della lingua corretta (es., `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Clicca **Add file** > **Create new file**.
     ![Creazione nuova traduzione](@site/static/img/contributing/adding-file-github-ui.webp)
-
-    -   **Suggerimento:** Nella casella del nome file, puoi creare nuove cartelle digitando il nome della cartella seguito da `/`. Per esempio, digitando `main/contributing/documentation.md` creerà automaticamente le cartelle `main` e `contributing`.
+    - **Suggerimento:** Nella casella del nome file, puoi creare nuove cartelle digitando il nome della cartella seguito da `/`. Per esempio, digitando `main/contributing/documentation.md` creerà automaticamente le cartelle `main` e `contributing`.
 
 3.  **Fai il fork del repository.** Proprio come prima, GitHub ti chiederà di **Fare il fork di questo repository**. Clicca il pulsante per creare la tua copia personale.
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/translations.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/translations.md
@@ -209,12 +209,12 @@ Como uma diretriz, um idioma deve ser tornado publicamente disponível no seleto
 -   [Links and Resources](https://wordpress.github.io/wordpress-playground/resources)
 -->
 
--   [Guia de Início Rápido](https://wordpress.github.io/wordpress-playground/quick-start-guide)
--   [Instância web do Playground](https://wordpress.github.io/wordpress-playground/web-instance)
--   [Sobre o Playground](https://wordpress.github.io/wordpress-playground/about)
--   [Guias](https://wordpress.github.io/wordpress-playground/guides)
--   [Contribuindo](https://wordpress.github.io/wordpress-playground/contributing)
--   [Links e Recursos](https://wordpress.github.io/wordpress-playground/resources)
+- [Guia de Início Rápido](https://wordpress.github.io/wordpress-playground/quick-start-guide)
+- [Instância web do Playground](https://wordpress.github.io/wordpress-playground/web-instance)
+- [Sobre o Playground](https://wordpress.github.io/wordpress-playground/about)
+- [Guias](https://wordpress.github.io/wordpress-playground/guides)
+- [Contribuindo](https://wordpress.github.io/wordpress-playground/contributing)
+- [Links e Recursos](https://wordpress.github.io/wordpress-playground/resources)
 
 <!--
 All languages are available once the i18n setup for a language is complete and the correct file structure is in place under `i18n`.
@@ -222,9 +222,9 @@ All languages are available once the i18n setup for a language is complete and t
 
 Todos os idiomas estão disponíveis assim que a configuração i18n para um idioma estiver completa e a estrutura de arquivos correta estiver em vigor sob `i18n`.
 
--   https://wordpress.github.io/wordpress-playground/
--   https://wordpress.github.io/wordpress-playground/es/
--   https://wordpress.github.io/wordpress-playground/fr/
+- https://wordpress.github.io/wordpress-playground/
+- https://wordpress.github.io/wordpress-playground/es/
+- https://wordpress.github.io/wordpress-playground/fr/
 
 <!--
 Assuming the `fr` language is the first language with the Documentation hub pages (Quick Start Guide, Playground web instance, About Playground, Guides,... ) completely translated to French, the `docusaurus.config.js` should look like this in that branch so `npm run build:docs` properly generate the `fr` subsite and only displays the french language in the `localeDropdown` language switcher.
@@ -286,15 +286,15 @@ Siga estes passos para traduzir uma página:
 -   Copy the original .md file from `packages/docs/site/docs/...` to the corresponding path in the language directory (e.g., `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). It is crucial to replicate the original file structure.
 -   Translate the content of the new file, keeping the original content commented out `<!-- English Content -->`.
 
--   The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
--   Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
-    -->
+- The assets are listed at `packages/docs/site/static/img/` only place assets inside the translation folder when it requires localized content.
+- Once the translations are ready, check if the docs build script is running properly `npm run build:docs`.
+  -->
 
--   Verifique se você tem a versão mais recente da documentação
--   Copie o arquivo .md original de `packages/docs/site/docs/...` para o caminho correspondente no diretório do idioma (por exemplo, `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). É crucial replicar a estrutura de arquivos original.
--   Traduza o conteúdo do novo arquivo, mantendo o conteúdo original comentado `<!-- English Content -->`.
--   Os recursos estão listados em `packages/docs/site/static/img/` apenas coloque recursos dentro da pasta de tradução quando necessitar de conteúdo localizado.
--   Assim que as traduções estiverem prontas, verifique se o script de compilação de documentação está sendo executado corretamente `npm run build:docs`.
+- Verifique se você tem a versão mais recente da documentação
+- Copie o arquivo .md original de `packages/docs/site/docs/...` para o caminho correspondente no diretório do idioma (por exemplo, `packages/docs/site/i18n/<LANGUAGE_CODE>/...`). É crucial replicar a estrutura de arquivos original.
+- Traduza o conteúdo do novo arquivo, mantendo o conteúdo original comentado `<!-- English Content -->`.
+- Os recursos estão listados em `packages/docs/site/static/img/` apenas coloque recursos dentro da pasta de tradução quando necessitar de conteúdo localizado.
+- Assim que as traduções estiverem prontas, verifique se o script de compilação de documentação está sendo executado corretamente `npm run build:docs`.
 
 <!--
 4. **Create a pull request with your changes**
@@ -308,9 +308,9 @@ Siga estes passos para traduzir uma página:
 -   Request a review at `#playground` or `#polyglots` at `wordpress.slack.com`
 -->
 
--   Adicione um prefixo ao título `[i18n]` para ajudar a identificar as traduções
--   Descreva as páginas que você traduziu
--   Solicite uma revisão em `#playground` ou `#polyglots` no `wordpress.slack.com`
+- Adicione um prefixo ao título `[i18n]` para ajudar a identificar as traduções
+- Descreva as páginas que você traduziu
+- Solicite uma revisão em `#playground` ou `#polyglots` no `wordpress.slack.com`
 
 <!--
 :::info
@@ -342,95 +342,104 @@ Você pode usar o seguinte markdown em sua issue de rastreamento:
 <summary><h3>Main</h3></summary>
 
 - about
-  - [ ] build.md #2291
-  - [ ] index.md #2282
-  - [ ] launch.md #2292
-  - [ ] test.md #2302
+  - [ ] build.md
+  - [ ] index.md
+  - [ ] launch.md
+  - [ ] test.md
 - contributing
-  - [ ] code.md #2218
-  - [ ] coding-standards.md #2219
-  - [ ] contributor-day.md #2246
+  - [ ] code.md
+  - [ ] coding-standards.md
   - [ ] contributor-badge.md
-  - [ ] documentation.md #2271
-  - [ ] translations.md #2201
+  - [ ] contributor-day.md
+  - [ ] contributor-day-table-lead.md
+  - [ ] documentation.md
+  - [ ] index.md
+  - [ ] releases.md
+  - [ ] translations.md
 - guides
-  - [ ] for-plugin-developers.md #2210
-  - [ ] for-theme-developers.md #2211
-  - [ ] index.md #2209
-  - [ ] providing-content-for-your-demo.md #2213
-  - [ ] wordpress-native-ios-app.md #2214
-- [ ] intro.md #2198
-- [ ] quick-start-guide.md #2204
-- [ ] resources.md #2207
-- [ ] web-instance.md #2208
+  - [ ] for-plugin-developers.md
+  - [ ] for-theme-developers.md
+  - [ ] github-action-pr-preview.md
+  - [ ] index.md
+  - [ ] providing-content-for-your-demo.md
+  - [ ] wordpress-native-ios-app.md
+- [ ] changelog.md
+- [ ] intro.md
+- [ ] quick-start-guide.md
+- [ ] resources.md
+- [ ] web-instance.md
 
 </details>
 
 <details open>
 <summary><h3>Blueprints</h3></summary>
 
-- blueprints
-  - [ ] 01-index.md #2305
-  - [ ] 02-using-blueprints.md #2330
-  - [ ] 03-data-format.md #2340
-   - [ ] 04-resources.md #2352
-   - [ ] 05-steps-shorthands.md  #2386
-  - [ ] 05-steps.md  #2386
-  - [ ] 06-bundles.md #2438
-   - [ ] 07-json-api-and-function-api.md #2438
-   - [ ] 08-examples.md #2474
-   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
-   - [ ] intro.md #2489
-   - tutorial
-       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
-       - [ ] 02-how-to-load-run-blueprints.md #2526
-       - [ ] 03-build-your-first-blueprint.md
-       - [ ] index.md #2511
+- [ ] 01-index.md
+- [ ] 02-using-blueprints.md
+- [ ] 03-data-format.md
+- [ ] 04-resources.md
+- [ ] 05-steps.md
+- [ ] 05-steps-shorthands.md
+- [ ] 06-bundles.md
+- [ ] 07-json-api-and-function-api.md
+- [ ] 08-examples.md
+- [ ] 09-troubleshoot-and-debug-blueprints.md
+- [ ] intro.md
+- tutorial
+  - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md
+  - [ ] 02-how-to-load-run-blueprints.md
+  - [ ] 03-build-your-first-blueprint.md
+  - [ ] index.md
+
 </details>
 
 <details open>
 <summary><h3>Developers</h3></summary>
 
-- [ ] developers
-   - [ ] 03-build-an-app
-      - [ ] 01-index.md
-   - [ ] 05-local-development
-      - [ ] 01-wp-now.md
-      - [ ] 02-vscode-extension.md
-      - [ ] 03-php-wasm-node.md
-      - [ ] intro.md
-   - [ ] 06-apis
-      - [ ] 01-index.md
-      - [ ] javascript-api
-         - [ ] 01-index.md
-         - [ ] 02-index-html-vs-remote-html.md
-         - [ ] 03-playground-api-client.md
-         - [ ] 04-blueprint-json-in-api-client.md
-         - [ ] 05-blueprint-functions-in-api-client.md
-         - [ ] 06-mount-data.md
-      - [ ] query-api
-          - [ ] 01-index.md
-   - [ ] 23-architecture
-      - [ ] 01-index.md
-      - [ ] 02-wasm-php-overview.md
-      - [ ] 03-wasm-php-compiling.md
-      - [ ] 04-wasm-php-javascript-module.md
-      - [ ] 05-wasm-php-filesystem.md
-      - [ ] 07-wasm-asyncify.md
-      - [ ] 08-browser-concepts.md
-      - [ ] 09-browser-tab-orchestrates-execution.md
-      - [ ] 10-browser-iframe-rendering.md
-      - [ ] 11-browser-php-worker-threads.md
-      - [ ] 12-browser-service-workers.md
-      - [ ] 13-browser-scopes.md
-      - [ ] 14-browser-cross-process-communication.md
-      - [ ] 15-wordpress.md
-      - [ ] 16-wordpress-database.md
-      - [ ] 17-browser-wordpress.md
-      - [ ] 18-host-your-own-playground.md
-   - [ ] 24-limitations
-      - [ ] 01-index.md
-   - [ ] intro-devs.md
+- 03-build-an-app
+  - [ ] 01-index.md
+- 05-local-development
+  - [ ] 01-wp-now.md
+  - [ ] 02-vscode-extension.md
+  - [ ] 03-php-wasm-node.md
+  - [ ] 04-wp-playground-cli.md
+  - [ ] intro.md
+- 06-apis
+  - [ ] 01-index.md
+  - javascript-api
+    - [ ] 01-index.md
+    - [ ] 02-index-html-vs-remote-html.md
+    - [ ] 03-playground-api-client.md
+    - [ ] 04-blueprint-json-in-api-client.md
+    - [ ] 05-blueprint-functions-in-api-client.md
+    - [ ] 06-mount-data.md
+  - query-api
+    - [ ] 01-index.md
+- 07-xdebug
+  - [ ] 01-introduction.md
+  - [ ] 02-getting-started.md
+- 23-architecture
+  - [ ] 01-index.md
+  - [ ] 02-wasm-php-overview.md
+  - [ ] 03-wasm-php-compiling.md
+  - [ ] 04-wasm-php-javascript-module.md
+  - [ ] 05-wasm-php-filesystem.md
+  - [ ] 07-wasm-asyncify.md
+  - [ ] 08-browser-concepts.md
+  - [ ] 09-browser-tab-orchestrates-execution.md
+  - [ ] 10-browser-iframe-rendering.md
+  - [ ] 11-browser-php-worker-threads.md
+  - [ ] 12-browser-service-workers.md
+  - [ ] 13-browser-scopes.md
+  - [ ] 14-browser-cross-process-communication.md
+  - [ ] 15-wordpress.md
+  - [ ] 16-wordpress-database.md
+  - [ ] 17-browser-wordpress.md
+  - [ ] 18-host-your-own-playground.md
+- 24-limitations
+  - [ ] 01-index.md
+- [ ] intro-devs.md
+
 </details>
 ```
 -->
@@ -442,95 +451,104 @@ Você pode usar o seguinte markdown em sua issue de rastreamento:
 <summary><h3>Main</h3></summary>
 
 - about
-  - [ ] build.md #2291
-  - [ ] index.md #2282
-  - [ ] launch.md #2292
-  - [ ] test.md #2302
+  - [ ] build.md
+  - [ ] index.md
+  - [ ] launch.md
+  - [ ] test.md
 - contributing
-  - [ ] code.md #2218
-  - [ ] coding-standards.md #2219
-  - [ ] contributor-day.md #2246
+  - [ ] code.md
+  - [ ] coding-standards.md
   - [ ] contributor-badge.md
-  - [ ] documentation.md #2271
-  - [ ] translations.md #2201
+  - [ ] contributor-day.md
+  - [ ] contributor-day-table-lead.md
+  - [ ] documentation.md
+  - [ ] index.md
+  - [ ] releases.md
+  - [ ] translations.md
 - guides
-  - [ ] for-plugin-developers.md #2210
-  - [ ] for-theme-developers.md #2211
-  - [ ] index.md #2209
-  - [ ] providing-content-for-your-demo.md #2213
-  - [ ] wordpress-native-ios-app.md #2214
-- [ ] intro.md #2198
-- [ ] quick-start-guide.md #2204
-- [ ] resources.md #2207
-- [ ] web-instance.md #2208
+  - [ ] for-plugin-developers.md
+  - [ ] for-theme-developers.md
+  - [ ] github-action-pr-preview.md
+  - [ ] index.md
+  - [ ] providing-content-for-your-demo.md
+  - [ ] wordpress-native-ios-app.md
+- [ ] changelog.md
+- [ ] intro.md
+- [ ] quick-start-guide.md
+- [ ] resources.md
+- [ ] web-instance.md
 
 </details>
 
 <details open>
 <summary><h3>Blueprints</h3></summary>
 
-- blueprints
-  - [ ] 01-index.md #2305
-  - [ ] 02-using-blueprints.md #2330
-  - [ ] 03-data-format.md #2340
-   - [ ] 04-resources.md #2352
-   - [ ] 05-steps-shorthands.md  #2386
-  - [ ] 05-steps.md  #2386
-  - [ ] 06-bundles.md #2438
-   - [ ] 07-json-api-and-function-api.md #2438
-   - [ ] 08-examples.md #2474
-   - [ ] 09-troubleshoot-and-debug-blueprints.md #2474
-   - [ ] intro.md #2489
-   - tutorial
-       - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md #2511
-       - [ ] 02-how-to-load-run-blueprints.md #2526
-       - [ ] 03-build-your-first-blueprint.md
-       - [ ] index.md #2511
+- [ ] 01-index.md
+- [ ] 02-using-blueprints.md
+- [ ] 03-data-format.md
+- [ ] 04-resources.md
+- [ ] 05-steps.md
+- [ ] 05-steps-shorthands.md
+- [ ] 06-bundles.md
+- [ ] 07-json-api-and-function-api.md
+- [ ] 08-examples.md
+- [ ] 09-troubleshoot-and-debug-blueprints.md
+- [ ] intro.md
+- tutorial
+  - [ ] 01-what-are-blueprints-what-you-can-do-with-them.md
+  - [ ] 02-how-to-load-run-blueprints.md
+  - [ ] 03-build-your-first-blueprint.md
+  - [ ] index.md
+
 </details>
 
 <details open>
 <summary><h3>Developers</h3></summary>
 
-- [ ] developers
-   - [ ] 03-build-an-app
-      - [ ] 01-index.md
-   - [ ] 05-local-development
-      - [ ] 01-wp-now.md
-      - [ ] 02-vscode-extension.md
-      - [ ] 03-php-wasm-node.md
-      - [ ] intro.md
-   - [ ] 06-apis
-      - [ ] 01-index.md
-      - [ ] javascript-api
-         - [ ] 01-index.md
-         - [ ] 02-index-html-vs-remote-html.md
-         - [ ] 03-playground-api-client.md
-         - [ ] 04-blueprint-json-in-api-client.md
-         - [ ] 05-blueprint-functions-in-api-client.md
-         - [ ] 06-mount-data.md
-      - [ ] query-api
-          - [ ] 01-index.md
-   - [ ] 23-architecture
-      - [ ] 01-index.md
-      - [ ] 02-wasm-php-overview.md
-      - [ ] 03-wasm-php-compiling.md
-      - [ ] 04-wasm-php-javascript-module.md
-      - [ ] 05-wasm-php-filesystem.md
-      - [ ] 07-wasm-asyncify.md
-      - [ ] 08-browser-concepts.md
-      - [ ] 09-browser-tab-orchestrates-execution.md
-      - [ ] 10-browser-iframe-rendering.md
-      - [ ] 11-browser-php-worker-threads.md
-      - [ ] 12-browser-service-workers.md
-      - [ ] 13-browser-scopes.md
-      - [ ] 14-browser-cross-process-communication.md
-      - [ ] 15-wordpress.md
-      - [ ] 16-wordpress-database.md
-      - [ ] 17-browser-wordpress.md
-      - [ ] 18-host-your-own-playground.md
-   - [ ] 24-limitations
-      - [ ] 01-index.md
-   - [ ] intro-devs.md
+- 03-build-an-app
+  - [ ] 01-index.md
+- 05-local-development
+  - [ ] 01-wp-now.md
+  - [ ] 02-vscode-extension.md
+  - [ ] 03-php-wasm-node.md
+  - [ ] 04-wp-playground-cli.md
+  - [ ] intro.md
+- 06-apis
+  - [ ] 01-index.md
+  - javascript-api
+    - [ ] 01-index.md
+    - [ ] 02-index-html-vs-remote-html.md
+    - [ ] 03-playground-api-client.md
+    - [ ] 04-blueprint-json-in-api-client.md
+    - [ ] 05-blueprint-functions-in-api-client.md
+    - [ ] 06-mount-data.md
+  - query-api
+    - [ ] 01-index.md
+- 07-xdebug
+  - [ ] 01-introduction.md
+  - [ ] 02-getting-started.md
+- 23-architecture
+  - [ ] 01-index.md
+  - [ ] 02-wasm-php-overview.md
+  - [ ] 03-wasm-php-compiling.md
+  - [ ] 04-wasm-php-javascript-module.md
+  - [ ] 05-wasm-php-filesystem.md
+  - [ ] 07-wasm-asyncify.md
+  - [ ] 08-browser-concepts.md
+  - [ ] 09-browser-tab-orchestrates-execution.md
+  - [ ] 10-browser-iframe-rendering.md
+  - [ ] 11-browser-php-worker-threads.md
+  - [ ] 12-browser-service-workers.md
+  - [ ] 13-browser-scopes.md
+  - [ ] 14-browser-cross-process-communication.md
+  - [ ] 15-wordpress.md
+  - [ ] 16-wordpress-database.md
+  - [ ] 17-browser-wordpress.md
+  - [ ] 18-host-your-own-playground.md
+- 24-limitations
+  - [ ] 01-index.md
+- [ ] intro-devs.md
+
 </details>
 ```
 
@@ -614,9 +632,8 @@ Este guia mostrará como atualizar uma tradução existente e adicionar uma nova
 -->
 
 1.  **Determine o caminho correto do arquivo.** O caminho e o nome do novo arquivo devem espelhar o arquivo original em inglês.
-
-    -   **Original em inglês:** `packages/docs/site/docs/main/contributing/documentation.md`
-    -   **Tradução em francês:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
+    - **Original em inglês:** `packages/docs/site/docs/main/contributing/documentation.md`
+    - **Tradução em francês:** `packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/contributing/documentation.md`
 
 <!--
 2.  **Create the new file.** Navigate to the correct language folder (e.g., `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Click **Add file** > **Create new file**.
@@ -627,8 +644,7 @@ Este guia mostrará como atualizar uma tradução existente e adicionar uma nova
 
 2.  **Crie o novo arquivo.** Navegue até a pasta de idioma correta (por exemplo, `/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/`). Clique em **Add file** > **Create new file**.
     ![Criando uma nova tradução](@site/static/img/contributing/adding-file-github-ui.webp)
-
-    -   **Dica profissional:** Na caixa de nome do arquivo, você pode criar novas pastas digitando o nome da pasta seguido por `/`. Por exemplo, digitar `main/contributing/documentation.md` criará as pastas `main` e `contributing` automaticamente.
+    - **Dica profissional:** Na caixa de nome do arquivo, você pode criar novas pastas digitando o nome da pasta seguido por `/`. Por exemplo, digitar `main/contributing/documentation.md` criará as pastas `main` e `contributing` automaticamente.
 
 <!--
 3.  **Fork the repository.** Just like before, GitHub will prompt you to **Fork this repository**. Click the button to create your personal copy.


### PR DESCRIPTION
## What?

Updated the translations.md file across various language directories (bn, es, fr, it, pt-BR) to remove issue numbers from the markdown checklist items.

## Why?

This change standardizes the format of the checklist items by removing unnecessary issue references, making the document cleaner and easier to read.

## How?

- Removed issue numbers from checklist items in the translations.md files for Bengali, Spanish, French, Italian, and Portuguese (Brazilian) translations.
- Ensured that the markdown structure remains intact for all languages.

