### PR TITLE
[Website] Improve OAuth flow for private GitHub repositories

### DIFF
--- a/packages/playground/website/src/components/github-private-repo-auth-modal/index.tsx
+++ b/packages/playground/website/src/components/github-private-repo-auth-modal/index.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@wordpress/components';
 import { GitHubIcon } from '../../github/github';
 import css from '../../github/github-oauth-guard/style.module.css';
 import { staticAnalyzeGitHubURL } from '../../github/analyze-github-url';
+import { buildOAuthRedirectUrl } from '../../github/git-auth-helpers';
 
 const OAUTH_FLOW_URL = 'oauth.php?redirect=1';
 
@@ -19,11 +20,8 @@ export function GitHubPrivateRepoAuthModal() {
 	const { owner, repo } = staticAnalyzeGitHubURL(repoUrl);
 	const displayRepoName = owner && repo ? `${owner}/${repo}` : repoUrl;
 
-	const redirectUrl = new URL(window.location.href);
-	redirectUrl.searchParams.delete('modal');
-
 	const urlParams = new URLSearchParams();
-	urlParams.set('redirect_uri', redirectUrl.toString());
+	urlParams.set('redirect_uri', buildOAuthRedirectUrl());
 	const oauthUrl = `${OAUTH_FLOW_URL}&${urlParams.toString()}`;
 
 	return (

--- a/packages/playground/website/src/github/git-auth-helpers.ts
+++ b/packages/playground/website/src/github/git-auth-helpers.ts
@@ -1,4 +1,5 @@
 import { oAuthState } from './state';
+import { encodeStringAsBase64 } from '../lib/base64';
 
 function isGitHubUrl(url: string): boolean {
 	try {
@@ -17,9 +18,11 @@ export function shouldShowGitHubAuthModal(url: string | undefined): boolean {
 export function createGitAuthHeaders(): (
 	url: string
 ) => Record<string, string> {
-	const token = oAuthState.value.token;
-
 	return (url: string): Record<string, string> => {
+		// Get token at call time, not at creation time, so that we pick up
+		// the token after it's acquired via the OAuth flow.
+		const token = oAuthState.value.token;
+
 		if (!token || !isGitHubUrl(url)) {
 			return {};
 		}
@@ -39,4 +42,30 @@ export function createGitAuthHeaders(): (
 			'X-Cors-Proxy-Allowed-Request-Headers': 'Authorization',
 		};
 	};
+}
+
+/**
+ * Build the OAuth redirect URL, converting any URL fragment blueprint to a
+ * data URI query parameter so it survives the OAuth round-trip.
+ *
+ * URL fragments are not sent to servers in HTTP requests, so they would be
+ * lost during the OAuth redirect flow.
+ */
+export function buildOAuthRedirectUrl(): string {
+	const redirectUrl = new URL(window.location.href);
+	redirectUrl.searchParams.delete('code');
+	redirectUrl.searchParams.delete('modal');
+
+	if (redirectUrl.hash && !redirectUrl.searchParams.has('blueprint-url')) {
+		const fragment = decodeURIComponent(redirectUrl.hash.substring(1));
+		if (fragment.startsWith('{')) {
+			const dataUri =
+				'data:application/json;base64,' +
+				encodeStringAsBase64(fragment);
+			redirectUrl.searchParams.set('blueprint-url', dataUri);
+			redirectUrl.hash = '';
+		}
+	}
+
+	return redirectUrl.toString();
 }

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -236,6 +236,8 @@ export function bootSiteClient(
 					})
 				);
 			}
+			// Don't continue to client setup after an error
+			return;
 		}
 
 		if (signal.aborted || !playground) {


### PR DESCRIPTION
## Motivation for the change, related issues

When using blueprints that reference private GitHub repositories, the OAuth authentication flow has several issues:

1. **Hash blueprints are lost**: URL fragments (e.g., `#{"steps":...}`) are not sent to servers in HTTP requests, so they're lost during the OAuth redirect to GitHub and back.

2. **Token not used after OAuth**: The `createGitAuthHeaders()` function captured the OAuth token at creation time, but the token is only available after the OAuth redirect completes. It still works here because the page reloads after OAuth, and the token is acquired before boot starts on the fresh page. The bug would only show when we remove the blueprint parameters as we do in `personal-wp`.

> 1. User loads page with private repo blueprint                                                                                              
> 2. Boot fails with GitAuthenticationError (no token)                                                                                        
> 3. Auth modal shown, user authenticates                                                                                                     
> 4. GitHub redirects back with ?code=...                                                                                                     
> 5. Page loads fresh - acquireOAuthTokenIfNeeded() runs at module import time                                                                
> 6. Token is exchanged and stored before React renders                                                                                       
> 7. Boot starts, createGitAuthHeaders() is called - token already exists                                                                     
> 8. Blueprint succeeds                                                                                                                       

3. **Client setup runs after errors**: When `startPlaygroundWeb` throws an error (e.g., `GitAuthenticationError`), the catch block handles it but execution continues to run client setup code, which shouldn't happen for failed boots.

## Implementation details

1. **Add `buildOAuthRedirectUrl()`**: Converts URL fragment blueprints to `blueprint-url` query parameters before the OAuth redirect, preserving the blueprint through the round-trip.

2. **Fix token capture timing**: Move token retrieval inside the returned function so it's captured at call time, not creation time.

3. **Add early return in catch block**: Prevent client setup code from running after boot errors.

## Testing Instructions (or ideally a Blueprint)

1. Navigate to the Playground with a hash blueprint referencing a private GitHub repo:
   ```
   https://playground.wordpress.net/#{"steps":[{"step":"installPlugin","pluginData":{"resource":"url","url":"https://github.com/user/private-repo/archive/refs/heads/main.zip"}}]}
   ```
2. Observe the GitHub auth modal appears
3. Click "Connect your GitHub account" and complete the OAuth flow
5. After redirect, verify the blueprint is preserved and applied with authentication