### PR TITLE
[Personal-WP] Improve recovery mode and add direct OPFS file browser access

### DIFF
--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -31,7 +31,7 @@ export class BlueprintsV1Handler {
 			scope,
 			shouldInstallWordPress,
 			sqliteDriverVersion,
-			skipWordPressInstallCheck,
+			wordpressInstallMode,
 			onClientConnected,
 		} = this.options;
 		const executionProgress = progressTracker!.stage(0.5);
@@ -57,7 +57,7 @@ export class BlueprintsV1Handler {
 			sapiName,
 			scope: scope ?? Math.random().toFixed(16),
 			shouldInstallWordPress,
-			skipWordPressInstallCheck,
+			wordpressInstallMode,
 			phpVersion: runtimeConfiguration.phpVersion,
 			wpVersion: runtimeConfiguration.wpVersion,
 			withIntl: runtimeConfiguration.intl,

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -31,6 +31,7 @@ export class BlueprintsV1Handler {
 			scope,
 			shouldInstallWordPress,
 			sqliteDriverVersion,
+			skipWordPressInstallCheck,
 			onClientConnected,
 		} = this.options;
 		const executionProgress = progressTracker!.stage(0.5);
@@ -56,6 +57,7 @@ export class BlueprintsV1Handler {
 			sapiName,
 			scope: scope ?? Math.random().toFixed(16),
 			shouldInstallWordPress,
+			skipWordPressInstallCheck,
 			phpVersion: runtimeConfiguration.phpVersion,
 			wpVersion: runtimeConfiguration.wpVersion,
 			withIntl: runtimeConfiguration.intl,

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -16,6 +16,7 @@ export type {
 	RmDirOptions,
 	RuntimeType,
 } from '@php-wasm/universal';
+export type { WordPressInstallMode } from '@wp-playground/wordpress';
 export {
 	setPhpIniEntries,
 	SupportedPHPVersions,
@@ -30,6 +31,7 @@ import type {
 	BlueprintV1Declaration,
 	OnStepCompleted,
 } from '@wp-playground/blueprints';
+import type { WordPressInstallMode } from '@wp-playground/wordpress';
 import { ProgressTracker } from '@php-wasm/progress';
 import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
 import { additionalRemoteOrigins } from './additional-remote-origins';
@@ -96,10 +98,10 @@ export interface StartPlaygroundOptions {
 	 */
 	sqliteDriverVersion?: string;
 	/**
-	 * When true, skip the isWordPressInstalled() check that loads WordPress.
-	 * Used for recovery mode when WordPress crashes due to a plugin error.
+	 * How to handle WordPress installation.
+	 * Defaults to 'install-from-existing-files-if-needed'.
 	 */
-	skipWordPressInstallCheck?: boolean;
+	wordpressInstallMode?: WordPressInstallMode;
 }
 
 /**

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -95,6 +95,11 @@ export interface StartPlaygroundOptions {
 	 * Defaults to the latest development version.
 	 */
 	sqliteDriverVersion?: string;
+	/**
+	 * When true, skip the isWordPressInstalled() check that loads WordPress.
+	 * Used for recovery mode when WordPress crashes due to a plugin error.
+	 */
+	skipWordPressInstallCheck?: boolean;
 }
 
 /**

--- a/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-file-browser/index.tsx
@@ -1,10 +1,15 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
 import { usePlaygroundClient } from '../../../lib/use-playground-client';
-import type { AsyncWritableFilesystem } from '@wp-playground/storage';
+import {
+	type AsyncWritableFilesystem,
+	OpfsFilesystemBackend,
+	EventedFilesystem,
+} from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import { PlaygroundFileEditor } from '@wp-playground/components';
 import { logger } from '@php-wasm/logger';
+import { getDirectoryPathForSlug } from '../../../lib/state/opfs/opfs-site-storage';
 
 export function SiteFileBrowser({
 	site,
@@ -16,11 +21,13 @@ export function SiteFileBrowser({
 	documentRoot: string;
 }) {
 	const client = usePlaygroundClient(site.slug);
-	const filesystem = useFilesystem(client);
+	const filesystem = useFilesystem(client, site);
 	const clientRef = useRef<PlaygroundClient | null>(client);
+	const filesystemRef = useRef<AsyncWritableFilesystem | null>(filesystem);
 
-	// Keep clientRef in sync
+	// Keep refs in sync
 	clientRef.current = client;
+	filesystemRef.current = filesystem;
 
 	// Handle filesystem changes - flush pending saves to the old filesystem
 	const handleBeforeFilesystemChange = useCallback(
@@ -36,13 +43,20 @@ export function SiteFileBrowser({
 		[]
 	);
 
-	// Custom save handler that writes directly to the client
+	// Custom save handler that writes to either the client or OPFS directly
 	const handleSaveFile = useCallback(
 		async (path: string, content: string) => {
-			if (!clientRef.current) {
-				throw new Error('No client available');
+			// Prefer the client if available (keeps memfs and OPFS in sync)
+			if (clientRef.current) {
+				await clientRef.current.writeFile(path, content);
+				return;
 			}
-			await clientRef.current.writeFile(path, content);
+			// Fall back to direct OPFS filesystem
+			if (filesystemRef.current) {
+				await filesystemRef.current.writeFile(path, content);
+				return;
+			}
+			throw new Error('No filesystem available');
 		},
 		[]
 	);
@@ -109,13 +123,54 @@ class ClientFilesystemWrapper
 	}
 }
 
+/**
+ * Hook that provides a filesystem for the file browser.
+ * Prefers the PlaygroundClient when available, but falls back to direct OPFS
+ * access when the client is unavailable (e.g., when Playground crashed).
+ */
 function useFilesystem(
-	client: PlaygroundClient | null
+	client: PlaygroundClient | null,
+	site: SiteInfo
 ): AsyncWritableFilesystem | null {
-	return useMemo(() => {
-		if (!client) {
-			return null;
+	const [opfsFilesystem, setOpfsFilesystem] =
+		useState<AsyncWritableFilesystem | null>(null);
+
+	useEffect(() => {
+		// If we have a client, we don't need direct OPFS access
+		if (client) {
+			setOpfsFilesystem(null);
+			return;
 		}
-		return new ClientFilesystemWrapper(client);
-	}, [client]);
+
+		// If site uses OPFS storage and no client is available, access OPFS directly.
+		// This allows file browsing/editing even when Playground crashed.
+		if (site.metadata.storage === 'opfs') {
+			let cancelled = false;
+			const opfsPath = getDirectoryPathForSlug(site.slug);
+			OpfsFilesystemBackend.fromPath(opfsPath)
+				.then((backend) => {
+					if (cancelled) return;
+					setOpfsFilesystem(new EventedFilesystem(backend));
+				})
+				.catch((err) => {
+					if (cancelled) return;
+					logger.error('Failed to access OPFS directly:', err);
+					setOpfsFilesystem(null);
+				});
+			return () => {
+				cancelled = true;
+			};
+		} else {
+			setOpfsFilesystem(null);
+		}
+	}, [client, site.slug, site.metadata.storage]);
+
+	return useMemo(() => {
+		// Prefer client-based filesystem when available
+		if (client) {
+			return new ClientFilesystemWrapper(client);
+		}
+		// Fall back to direct OPFS access
+		return opfsFilesystem;
+	}, [client, opfsFilesystem]);
 }

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -64,8 +64,11 @@ export function SiteInfoPanel({
 		return 'files';
 	});
 
-	// Resolve documentRoot from playground client
-	const [documentRoot, setDocumentRoot] = useState<string | null>(null);
+	// Resolve documentRoot from playground client, or use fallback for direct OPFS access
+	// Initialize to "/" for OPFS sites so the file browser can render immediately
+	const [documentRoot, setDocumentRoot] = useState<string | null>(
+		site.metadata.storage === 'opfs' ? '/' : null
+	);
 
 	// Save the tab when it changes
 	const handleTabSelect = (tabName: string) => {
@@ -77,17 +80,21 @@ export function SiteInfoPanel({
 	);
 	const playground = clientInfo?.client;
 
-	// Resolve documentRoot from playground
+	// Resolve documentRoot from playground, or use fallback for direct OPFS access
 	useEffect(() => {
-		if (!playground) {
+		if (playground) {
+			void playground.documentRoot.then((root) => {
+				setDocumentRoot(root);
+			});
+		} else if (site.metadata.storage === 'opfs') {
+			// When accessing OPFS directly (no client), the root is "/".
+			// This also handles the case where playground becomes null after being set
+			// (e.g., site crashes mid-session), resetting documentRoot for direct OPFS access.
+			setDocumentRoot('/');
+		} else {
 			setDocumentRoot(null);
-			return;
 		}
-
-		void playground.documentRoot.then((root) => {
-			setDocumentRoot(root);
-		});
-	}, [playground]);
+	}, [playground, site.metadata.storage]);
 
 	function navigateTo(path: string) {
 		if (siteViewHidden) {

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -172,8 +172,9 @@ export function bootSiteClient(
 		}
 
 		// Check if we're in recovery mode (Health Check troubleshooting).
-		// If so, skip the isWordPressInstalled() check that loads WordPress
-		// to prevent crashes from broken plugins.
+		// Recovery mode uses 'do-not-attempt-installing' to skip the
+		// isWordPressInstalled() check that would load WordPress and crash
+		// due to a broken plugin.
 		const urlBlueprintLandingPage = hasUrlBlueprint
 			? urlBlueprint.blueprint.landingPage
 			: undefined;
@@ -193,9 +194,11 @@ export function bootSiteClient(
 					new URLSearchParams(window.location.search).get(
 						'experimental-blueprints-v2-runner'
 					) === 'yes',
-				// Skip the WordPress install check in recovery mode to avoid
+				// In recovery mode, skip the WordPress install check to avoid
 				// loading WordPress before blueprint steps run.
-				skipWordPressInstallCheck: isRecoveryMode,
+				wordpressInstallMode: isRecoveryMode
+					? 'do-not-attempt-installing'
+					: undefined,
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playgroundClient) => {

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -171,6 +171,16 @@ export function bootSiteClient(
 			blueprint = site.metadata.originalBlueprint;
 		}
 
+		// Check if we're in recovery mode (Health Check troubleshooting).
+		// If so, skip the isWordPressInstalled() check that loads WordPress
+		// to prevent crashes from broken plugins.
+		const urlBlueprintLandingPage = hasUrlBlueprint
+			? urlBlueprint.blueprint.landingPage
+			: undefined;
+		const isRecoveryMode = urlBlueprintLandingPage?.includes(
+			'health-check-disable-plugin-hash'
+		);
+
 		let playground: PlaygroundClient | undefined = undefined;
 		try {
 			await startPlaygroundWeb({
@@ -183,6 +193,9 @@ export function bootSiteClient(
 					new URLSearchParams(window.location.search).get(
 						'experimental-blueprints-v2-runner'
 					) === 'yes',
+				// Skip the WordPress install check in recovery mode to avoid
+				// loading WordPress before blueprint steps run.
+				skipWordPressInstallCheck: isRecoveryMode,
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playgroundClient) => {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -42,6 +42,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 		withIntl = false,
 		withNetworking = true,
 		shouldInstallWordPress = true,
+		skipWordPressInstallCheck = false,
 		corsProxyUrl,
 	}: WorkerBootOptions) {
 		if (this.booted) {
@@ -157,7 +158,11 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				// saves around 600ms during the boot on a macbook pro so it's worth it.
 				// @TODO: Deprecate the `shouldInstallWordPress` semantics entirely and get the client
 				//        and the Playground website to pass `wordpressInstallMode` directly.
-				wordpressInstallMode: 'install-from-existing-files-if-needed',
+				// When skipWordPressInstallCheck is true (recovery mode), skip the isWordPressInstalled()
+				// check that loads WordPress and crashes due to a broken plugin.
+				wordpressInstallMode: skipWordPressInstallCheck
+					? 'do-not-attempt-installing'
+					: 'install-from-existing-files-if-needed',
 				// Do not await the WordPress download or the sqlite integration download.
 				// Let bootWordPress start the PHP runtime download first, and then await
 				// all the ZIP files right before they're used.

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -42,7 +42,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 		withIntl = false,
 		withNetworking = true,
 		shouldInstallWordPress = true,
-		skipWordPressInstallCheck = false,
+		wordpressInstallMode = 'install-from-existing-files-if-needed',
 		corsProxyUrl,
 	}: WorkerBootOptions) {
 		if (this.booted) {
@@ -158,11 +158,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				// saves around 600ms during the boot on a macbook pro so it's worth it.
 				// @TODO: Deprecate the `shouldInstallWordPress` semantics entirely and get the client
 				//        and the Playground website to pass `wordpressInstallMode` directly.
-				// When skipWordPressInstallCheck is true (recovery mode), skip the isWordPressInstalled()
-				// check that loads WordPress and crashes due to a broken plugin.
-				wordpressInstallMode: skipWordPressInstallCheck
-					? 'do-not-attempt-installing'
-					: 'install-from-existing-files-if-needed',
+				wordpressInstallMode,
 				// Do not await the WordPress download or the sqlite integration download.
 				// Let bootWordPress start the PHP runtime download first, and then await
 				// all the ZIP files right before they're used.

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -38,6 +38,7 @@ import {
 } from '@php-wasm/universal';
 import { certificateToPEM, generateCertificate } from '@php-wasm/web';
 import type { BlueprintDeclaration } from '@wp-playground/blueprints';
+import type { WordPressInstallMode } from '@wp-playground/wordpress';
 import {
 	bootRequestHandler,
 	getFileNotFoundActionForWordPress,
@@ -71,10 +72,10 @@ export type WorkerBootOptions = {
 	/** Blueprint v2 declaration to run in the worker when experimental mode is on */
 	blueprint?: BlueprintDeclaration;
 	/**
-	 * When true, skip the isWordPressInstalled() check that loads WordPress.
-	 * Used for recovery mode when WordPress crashes due to a plugin error.
+	 * How to handle WordPress installation.
+	 * Defaults to 'install-from-existing-files-if-needed'.
 	 */
-	skipWordPressInstallCheck?: boolean;
+	wordpressInstallMode?: WordPressInstallMode;
 };
 
 /** @inheritDoc PHPClient */

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -70,6 +70,11 @@ export type WorkerBootOptions = {
 	experimentalBlueprintsV2Runner?: boolean;
 	/** Blueprint v2 declaration to run in the worker when experimental mode is on */
 	blueprint?: BlueprintDeclaration;
+	/**
+	 * When true, skip the isWordPressInstalled() check that loads WordPress.
+	 * Used for recovery mode when WordPress crashes due to a plugin error.
+	 */
+	skipWordPressInstallCheck?: boolean;
 };
 
 /** @inheritDoc PHPClient */


### PR DESCRIPTION
## Motivation for the change, related issues

When a site crashes due to a broken plugin, recovery mode was failing because WordPress would boot and crash before the recovery blueprint could install the mu-plugins needed to disable the broken plugin. Additionally, when a site is crashed, users couldn't browse or edit files to manually fix issues.

I had this implemented in my https://github.com/akirk/wordpress-playground/ fork but missed to migrate it here.

## Implementation details

1. **wordpressInstallMode for recovery**: In recovery mode, pass `wordpressInstallMode: 'do-not-attempt-installing'` to prevent WordPress from booting before blueprint steps run. This allows the recovery blueprint to install mu-plugins even when a broken plugin would crash WordPress on boot.

2. **Direct OPFS file browser access**: When PlaygroundClient is unavailable (site crashed), the file browser now falls back to accessing OPFS directly via `OpfsFilesystemBackend`. This allows browsing and editing files without needing WordPress to boot.

## Testing Instructions (or ideally a Blueprint)

1. Create a persistent site and activate a plugin that causes a fatal error
2. Observe the site crashes on boot
3. Click the recovery button in the menu
4. Verify the recovery blueprint succeeds and enters troubleshooting mode
5. Verify the file browser shows files even before the site fully boots
6. Verify you can edit and save files via the file browser