### PR TITLE
[i18n] Add Bengali translation for about/launch.md

### DIFF
--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/about/launch.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/about/launch.md
@@ -1,0 +1,105 @@
+---
+title: লঞ্চ
+slug: /about/launch
+description: প্লেগ্রাউন্ড ব্যবহার করে কীভাবে পণ্য লঞ্চ করবেন তা জানুন, ওয়েবসাইটে ইন্টারঅ্যাকটিভ ডেমো এম্বেড করা থেকে শুরু করে নেটিভ মোবাইল অ্যাপ তৈরি করা পর্যন্ত।
+---
+
+<!--
+# Launch
+-->
+
+# লঞ্চ
+
+<!--
+Reach your clients or customers faster. Showcase your product, let users try it live, or launch it in the App Store with zero lead time.
+-->
+
+আপনার ক্লায়েন্ট বা গ্রাহকদের কাছে দ্রুত পৌঁছান। আপনার পণ্য প্রদর্শন করুন, ব্যবহারকারীদের এটি লাইভ ট্রাই করতে দিন, অথবা লিড টাইম ছাড়াই অ্যাপ স্টোরে এটি লঞ্চ করুন।
+
+<!--
+## Embed interactive product demos on websites.
+-->
+
+## ওয়েবসাইটে ইন্টারঅ্যাকটিভ পণ্য ডেমো এম্বেড করুন।
+
+<!--
+Leverage [blueprints'](/blueprints) potential to create interactive demos of your plugins or themes. For example, you can provide a link to your users/clients to showcase how your custom plugin integrates with an adapted theme, demonstrating their combined functionality and appearance.
+-->
+
+আপনার প্লাগইন বা থিমের ইন্টারঅ্যাকটিভ ডেমো তৈরি করতে [ব্লুপ্রিন্টগুলোর](/blueprints) সম্ভাবনা কাজে লাগান। উদাহরণস্বরূপ, আপনি আপনার ব্যবহারকারী/ক্লায়েন্টদের একটি লিঙ্ক দিতে পারেন যেখানে আপনার কাস্টম প্লাগইনটি একটি অ্যাডাপ্টেড থিমের সাথে কীভাবে ইন্টিগ্রেট করে তা দেখানো হবে, এবং তাদের সম্মিলিত কার্যকারিতা ও চেহারা প্রদর্শন করা হবে।
+
+<!--
+Read more about this at [How to use WordPress Playground for interactive demos](https://developer.wordpress.org/news/2024/04/25/how-to-use-wordpress-playground-for-interactive-demos/)
+-->
+
+এ সম্পর্কে আরও পড়ুন [ইন্টারঅ্যাকটিভ ডেমোর জন্য ওয়ার্ডপ্রেস প্লেগ্রাউন্ড কীভাবে ব্যবহার করবেন](https://developer.wordpress.org/news/2024/04/25/how-to-use-wordpress-playground-for-interactive-demos/)-এ
+
+<!--
+Get inspiration about the type of interactive demos you can create at the [Blueprints Gallery](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md)
+-->
+
+[ব্লুপ্রিন্ট গ্যালারি](https://github.com/WordPress/blueprints/blob/trunk/GALLERY.md) থেকে আপনি কী ধরণের ইন্টারঅ্যাকটিভ ডেমো তৈরি করতে পারেন সে সম্পর্কে অনুপ্রেরণা নিন।
+
+<!--
+The [Blueprints builder](https://playground.wordpress.net/builder/builder.html) tool allows you edit your blueprint online and run it directly in a Playground instance.
+-->
+
+[ব্লুপ্রিন্ট বিল্ডার](https://playground.wordpress.net/builder/builder.html) টুলটি আপনাকে আপনার ব্লুপ্রিন্ট অনলাইনে এডিট করতে এবং সরাসরি একটি প্লেগ্রাউন্ড ইনস্ট্যান্সে চালাতে দেয়।
+
+<!--
+<iframe width="800" src="https://www.youtube.com/embed/lQzozsoJ3aY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+-->
+
+<iframe width="800" src="https://www.youtube.com/embed/lQzozsoJ3aY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<!--
+<p></p>
+-->
+
+<p></p>
+
+<!--
+Another handy tool to create a blueprint is the [WordPress Playground Step Library](https://akirk.github.io/playground-step-library/#) tool that provides a visual interface to drag or click the steps to create a blueprint for WordPress Playground. You can also [create your own steps](https://github.com/akirk/playground-step-library/#contributing)!
+-->
+
+ব্লুপ্রিন্ট তৈরির আরেকটি সুবিধাজনক টুল হলো [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড স্টেপ লাইব্রেরি](https://akirk.github.io/playground-step-library/#), যা ওয়ার্ডপ্রেস প্লেগ্রাউন্ডের জন্য ব্লুপ্রিন্ট তৈরি করতে ধাপগুলো ড্র্যাগ বা ক্লিক করার একটি ভিজ্যুয়াল ইন্টারফেস প্রদান করে। আপনি [আপনার নিজের ধাপগুলোও তৈরি করতে পারেন](https://github.com/akirk/playground-step-library/#contributing)!
+
+<!--
+## Embed demos in posts and pages with the WordPress Playground block
+-->
+
+## ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্লকের মাধ্যমে পোস্ট এবং পেজে ডেমো এম্বেড করুন
+
+<!--
+This [WordPress Playground block](https://wordpress.org/plugins/interactive-code-block/) allows you to embed WordPress Playground in your posts and pages. You can also include an interactive code editor to demonstrate and teach your readers how WordPress plugins are built.
+-->
+
+এই [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্লকটি](https://wordpress.org/plugins/interactive-code-block/) আপনাকে আপনার পোস্ট এবং পেজে ওয়ার্ডপ্রেস প্লেগ্রাউন্ড এম্বেড করতে দেয়। ওয়ার্ডপ্রেস প্লাগইনগুলো কীভাবে তৈরি হয় তা আপনার পাঠকদের দেখাতে এবং শেখাতে আপনি একটি ইন্টারঅ্যাকটিভ কোড এডিটরও অন্তর্ভুক্ত করতে পারেন।
+
+<!--
+With this block you have a straightforward and effective way to create live WordPress environments that can be embedded within your blog posts.
+-->
+
+এই ব্লকের মাধ্যমে আপনার কাছে লাইভ ওয়ার্ডপ্রেস পরিবেশ তৈরি করার একটি সহজ এবং কার্যকর উপায় আছে যা আপনার ব্লগ পোস্টের মধ্যে এম্বেড করা যেতে পারে।
+
+<!--
+:::info
+For any issues or questions about the WordPress Playground Block, please open a GitHub issue in the [playground-tools](https://github.com/WordPress/playground-tools) repository.
+:::
+-->
+
+:::তথ্য
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্লক সম্পর্কে যেকোনো সমস্যা বা প্রশ্নের জন্য, অনুগ্রহ করে [playground-tools](https://github.com/WordPress/playground-tools) রিপোজিটরিতে একটি গিটহাব ইস্যু খুলুন।
+:::
+
+<!--
+## Put a native app running WordPress in the App Store.
+-->
+
+## অ্যাপ স্টোরে ওয়ার্ডপ্রেস চালিত একটি নেটিভ অ্যাপ রাখুন।
+
+<!--
+Check the [How to ship a real WordPress site in a native iOS app via Playground?](../guides/wordpress-native-ios-app) guide for info on this use case
+-->
+
+এই ব্যবহারের ক্ষেত্রে তথ্যের জন্য [প্লেগ্রাউন্ডের মাধ্যমে একটি নেটিভ আইওএস অ্যাপে কীভাবে একটি আসল ওয়ার্ডপ্রেস সাইট শিপ করবেন?](../guides/wordpress-native-ios-app) গাইডটি দেখুন।


### PR DESCRIPTION
## What?

Added Bengali (bn) translation for the [about/launch.md]

## Why?

To make WordPress Playground documentation accessible to Bengali-speaking users and provide an overview of the platform in their native language.

## How?

- Translated all content following the established translation format
- Original English text preserved in HTML comments for reviewer reference
- Technical terms (WordPress, Playground, GitHub, etc.) handled using standardized Bengali script while keeping original terms for clarity
- Markdown structure and links remain unchanged
- Code blocks remain unchanged
