### PR TITLE
[PHPProcessManager] Spawn at most 2 PHP instances

### DIFF
--- a/packages/php-wasm/node/src/test/php-worker.spec.ts
+++ b/packages/php-wasm/node/src/test/php-worker.spec.ts
@@ -53,7 +53,7 @@ describe('PHP Worker', () => {
 
 	it('addEventListener() should add a listener for all PHP instances spawned by the worker', async () => {
 		const received: any[] = [];
-		worker.addEventListener('runtime.beforeExit', (event) => {
+		worker.addEventListener('request.end', (event) => {
 			received.push(event);
 		});
 		await worker.run({

--- a/packages/php-wasm/universal/src/lib/php-process-manager.ts
+++ b/packages/php-wasm/universal/src/lib/php-process-manager.ts
@@ -82,7 +82,7 @@ export class PHPProcessManager implements PHPInstanceManager {
 	private semaphore: Semaphore;
 
 	constructor(options?: ProcessManagerOptions) {
-		this.maxPhpInstances = options?.maxPhpInstances ?? 5;
+		this.maxPhpInstances = options?.maxPhpInstances ?? 2;
 		this.phpFactory = options?.phpFactory;
 		this.primaryPhp = options?.primaryPhp;
 		this.semaphore = new Semaphore({
@@ -140,7 +140,7 @@ export class PHPProcessManager implements PHPInstanceManager {
 	 *                                and the waiting timeout is exceeded.
 	 */
 	async acquirePHPInstance({
-		considerPrimary = false,
+		considerPrimary = true,
 	}: {
 		considerPrimary?: boolean;
 	} = {}): Promise<AcquiredPHP> {


### PR DESCRIPTION
## Motivation for the change, related issues

Makes `PHPProcessManager` only allocate up to 2 PHP runtimes to reduce the memory consumption on playground.wordpress.net.

## Background

Playground can take 3 gigs of memory or more. PHPProcessManager is a large part of it as it:

* Spawns up to 5 PHP runtimes to handle concurrent requests, each allocating 1GB of ram upfront.
* Doesn't reuse the "primary" PHP instance, that's a historical nuance from before we supported the automated `php.rotateRuntime()` machinery that recreates the PHP runtime once it's killed after a `php.cli()` call.

## Implementation details

This PR:

* Limits the number of runtimes to 2. This will break some use-cases, e.g. when an active request calls `proc_open()` and the child script also calls `proc_open()`. It's not ideal, but at least it replaces a large problem with a smaller problem. We'll need to follow-up on this PR to solve that smaller problem as well, e.g. with a smart runtime management strategy that doesn't optimistically go up to 3-4 gigs while also supporting nested processes when needed. 
* Flips the default value of `considerPrimary` to true to keep reusing the primary PHP instance for handling requests. We don't care if it crashes because its filesystem will remain intact, and that's the part that matters for other runtimes. Also, we'll automatically recover in a few milliseconds thanks to the automated `php.rotateRuntime()` machinery.

## Risks

Some places in the codebase make direct calls to `primaryPHP` without going through `acquirePHPInstance` first. There is no chance of conflicting async `php.run()` calls, as every PHP instance maintains its own internal semaphore.

However, this is opening a theoretical possibility of a deadlock where a `primaryPHP.run()` triggers a loopback request, the request handler calls `acquirePHPInstance`, receives the primary PHP instance, and tries to handle it with `php.run()`. The same goes for `primaryPHP.run()` triggering a `proc_open()` call that's handled via `primaryPHP.cli()`.

I didn't find any such code path in the codebase, so I think we're good. Still, I'm acknowledging this as a risk.

## Testing Instructions (or ideally a Blueprint)

Confirm all the CI tests pass – if the assumptions of this PR are invalid and it breaks something fundamental, we have enough tests that at least one would break.

cc @mho22 @JanJakes 
