### PR TITLE
[i18n] Add Bengali translation for intro.md

### DIFF
--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/intro.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/intro.md
@@ -1,0 +1,210 @@
+---
+title: ভূমিকা
+slug: /
+id: introduction
+description: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ডকুমেন্টেশনে স্বাগতম! এই পেজটি ডকুমেন্টেশনের গঠন পরিচয় করিয়ে দেয় এবং আপনাকে সঠিক পথ খুঁজে পেতে সাহায্য করে।
+---
+
+<!--
+# WordPress Playground Docs
+-->
+
+# ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ডকস
+
+<!--
+:::info **Looking for the official Playground website?**
+
+WordPress Playground website moved to [wordpress.org/playground/](https://wordpress.org/playground/). The site you're at now hosts the documentation.
+
+:::
+-->
+
+:::তথ্য **অফিসিয়াল প্লেগ্রাউন্ড ওয়েবসাইট খুঁজছেন?**
+
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ওয়েবসাইট [wordpress.org/playground/](https://wordpress.org/playground/) এ স্থানান্তরিত হয়েছে। আপনি এখন যে সাইটে আছেন সেটি ডকুমেন্টেশন হোস্ট করে।
+
+:::
+
+<!--
+👋 Hi! Welcome to WordPress Playground documentation.
+-->
+
+👋 হ্যালো! ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ডকুমেন্টেশনে স্বাগতম।
+
+<!--
+Playground is an online tool to experiment and learn about WordPress. This site (Documentation) is where you will find all the information you need to start using Playground.
+-->
+
+প্লেগ্রাউন্ড হলো ওয়ার্ডপ্রেস নিয়ে পরীক্ষা-নিরীক্ষা এবং শেখার একটি অনলাইন টুল। এই সাইটে (ডকুমেন্টেশনে) আপনি প্লেগ্রাউন্ড ব্যবহার শুরু করার জন্য প্রয়োজনীয় সমস্ত তথ্য পাবেন।
+
+<!--
+<p class="docs-hubs">The WordPress Playground documentation is distributed across four separate hubs (subsites):</p>
+-->
+
+<p class="docs-hubs">ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ডকুমেন্টেশন চারটি পৃথক হাবে (সাবসাইট) বিতরণ করা হয়েছে:</p>
+
+<!--
+-   👉 [**Documentation**](/) (you're here) – Introduction to WP Playground, starter guides and your entry point to WP Playground Docs.
+-   [**Blueprints**](/blueprints) – Blueprints are JSON files for setting up your WordPress Playground instance. Learn about their possibilities from the Blueprints docs hub.
+-   [**Developers**](/developers) – WordPress Playground was created as a programmable tool. Discover all the things you can do with it from your code in the Developers docs hub.
+-   [**API Reference**](/api) – All the APIs exposed by WordPress Playground
+-->
+
+-   👉 [**ডকুমেন্টেশন**](/) (আপনি এখানে আছেন) – WP প্লেগ্রাউন্ড-এর ভূমিকা, স্টার্টার গাইড এবং WP প্লেগ্রাউন্ড ডকসে আপনার এন্ট্রি পয়েন্ট।
+-   [**ব্লুপ্রিন্ট**](/blueprints) – ব্লুপ্রিন্ট হলো আপনার ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ইনস্ট্যান্স সেটআপ করার জন্য JSON ফাইল। ব্লুপ্রিন্ট ডকস হাব থেকে এদের সম্ভাবনা সম্পর্কে জানুন।
+-   [**ডেভেলপার**](/developers) – ওয়ার্ডপ্রেস প্লেগ্রাউন্ড একটি প্রোগ্রামেবল টুল হিসেবে তৈরি করা হয়েছে। ডেভেলপার ডকস হাব থেকে আপনার কোড দিয়ে এটি দিয়ে কী কী করতে পারবেন তা জানুন।
+-   [**API রেফারেন্স**](/api) – ওয়ার্ডপ্রেস প্লেগ্রাউন্ড দ্বারা প্রকাশিত সমস্ত API
+
+<!--
+## Navigating this documentation hub
+-->
+
+## এই ডকুমেন্টেশন হাবে নেভিগেট করা
+
+<!--
+This docs hub is focused on starting with WordPress Playground and is divided into the following major sections.
+-->
+
+এই ডকস হাব ওয়ার্ডপ্রেস প্লেগ্রাউন্ড দিয়ে শুরু করার উপর ফোকাস করে এবং নিম্নলিখিত প্রধান সেকশনে বিভক্ত।
+
+<!--
+-   **[Quick Start Guide](/quick-start-guide)**: For those just starting out with WordPress Playground, this is where you can get up and running with WordPress Playground quickly to [start a new WordPress site](/quick-start-guide#start-a-new-wordpress-site) and [try a block/theme/plugin](/quick-start-guide#try-a-block-a-theme-or-a-plugin) or [test a specific WordPress/PHP version](/quick-start-guide#use-a-specific-wordpress-or-php-version).
+-->
+
+-   **[কুইক স্টার্ট গাইড](/quick-start-guide)**: যারা সবেমাত্র ওয়ার্ডপ্রেস প্লেগ্রাউন্ড দিয়ে শুরু করছেন, এখানে আপনি দ্রুত ওয়ার্ডপ্রেস প্লেগ্রাউন্ড চালু করে [একটি নতুন ওয়ার্ডপ্রেস সাইট শুরু করতে](/quick-start-guide#start-a-new-wordpress-site), [একটি ব্লক/থিম/প্লাগইন ট্রাই করতে](/quick-start-guide#try-a-block-a-theme-or-a-plugin) অথবা [একটি নির্দিষ্ট ওয়ার্ডপ্রেস/PHP সংস্করণ পরীক্ষা করতে](/quick-start-guide#use-a-specific-wordpress-or-php-version) পারবেন।
+
+<!--
+-   **[Playground web instance](/web-instance)**: Learn more about the Playground instance you get at https://playground.wordpress.net/
+-->
+
+-   **[প্লেগ্রাউন্ড ওয়েব ইনস্ট্যান্স](/web-instance)**: https://playground.wordpress.net/ এ আপনি যে প্লেগ্রাউন্ড ইনস্ট্যান্স পান সে সম্পর্কে আরও জানুন।
+
+<!--
+-   **[About Playground](/about)**: To learn about WordPress Playground, how safe it is, what you can do with and some of its current limitations, visit this section.
+
+    Discover how you can leverage WordPress Playground to [Build](./about/build), [Test](./about/test), and [Launch](./about/launch) your products.
+-->
+
+-   **[প্লেগ্রাউন্ড সম্পর্কে](/about)**: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড সম্পর্কে জানতে, এটি কতটা নিরাপদ, এটি দিয়ে কী করতে পারেন এবং এর বর্তমান কিছু সীমাবদ্ধতা সম্পর্কে জানতে এই সেকশনে যান।
+
+    আপনার পণ্য [তৈরি](./about/build), [পরীক্ষা](./about/test) এবং [লঞ্চ](./about/launch) করতে কীভাবে ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্যবহার করতে পারেন তা আবিষ্কার করুন।
+
+<!--
+-   **[Guides](/guides)**: Explore our comprehensive guides to master new skills, find step-by-step instructions, and unlock valuable insights. Dive in to learn and grow!
+-->
+
+-   **[গাইডস](/guides)**: নতুন দক্ষতা আয়ত্ত করতে, ধাপে ধাপে নির্দেশাবলী খুঁজে পেতে এবং মূল্যবান অন্তর্দৃষ্টি আনলক করতে আমাদের বিস্তৃত গাইডগুলো এক্সপ্লোর করুন। শিখতে এবং বাড়তে ডুব দিন!
+
+<!--
+-   **[Contributing](/contributing)**: WordPress Playground is an open-source project that welcomes all contributors—from code to design, documentation to triage. Learn here how to contribute.
+-->
+
+-   **[কন্ট্রিবিউটিং](/contributing)**: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড একটি ওপেন-সোর্স প্রজেক্ট যেখানে সব ধরনের কন্ট্রিবিউটরদের স্বাগত জানানো হয়—কোড থেকে ডিজাইন, ডকুমেন্টেশন থেকে ট্রায়াজ। এখানে কীভাবে কন্ট্রিবিউট করবেন তা শিখুন।
+
+<!--
+-   **[Links and resources](/resources)**: A nice compilation of useful links and resources related to WordPress Playground.
+-->
+
+-   **[লিংক এবং রিসোর্স](/resources)**: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড সম্পর্কিত দরকারী লিংক এবং রিসোর্সের একটি সুন্দর সংকলন।
+
+<!--
+## First steps
+-->
+
+## প্রথম পদক্ষেপ
+
+<!--
+Whether you're a developer, a non-technical user, or a contributor, these docs will guide you as you start your learning journey:
+-->
+
+আপনি একজন ডেভেলপার, নন-টেকনিক্যাল ইউজার, বা কন্ট্রিবিউটর যাই হোন না কেন, আপনার শেখার যাত্রা শুরু করার সময় এই ডকসগুলো আপনাকে গাইড করবে:
+
+<!--
+-   [Start using WordPress Playground](/quick-start-guide) in 5 minutes (and check out the [demo site](https://playground.wordpress.net/))
+-   [Get started for developing](/developers/build-your-first-app) with WordPress Playground
+-   Use Playground as a zero-setup [local development environment](/developers/local-development/)
+-   Read about the [limitations](/developers/limitations)
+-   [WordCamp Contributor Day](/contributing/contributor-day)
+-->
+
+-   ৫ মিনিটে [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্যবহার শুরু করুন](/quick-start-guide) (এবং [ডেমো সাইট](https://playground.wordpress.net/) দেখুন)
+-   ওয়ার্ডপ্রেস প্লেগ্রাউন্ড দিয়ে [ডেভেলপমেন্ট শুরু করুন](/developers/build-your-first-app)
+-   প্লেগ্রাউন্ডকে জিরো-সেটআপ [লোকাল ডেভেলপমেন্ট এনভায়রনমেন্ট](/developers/local-development/) হিসেবে ব্যবহার করুন
+-   [সীমাবদ্ধতাগুলো](/developers/limitations) সম্পর্কে পড়ুন
+-   [ওয়ার্ডক্যাম্প কন্ট্রিবিউটর ডে](/contributing/contributor-day)
+
+<!--
+:::tip
+Read [**Introduction to Playground: running WordPress in the browser**](https://developer.wordpress.org/news/2024/04/05/introduction-to-playground-running-wordpress-in-the-browser/) blog post in the [WordPress Developer Blog](https://developer.wordpress.org/news) for a great introduction to WordPress Playground
+:::
+-->
+
+:::পরামর্শ
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ড-এর একটি দুর্দান্ত ভূমিকার জন্য [ওয়ার্ডপ্রেস ডেভেলপার ব্লগে](https://developer.wordpress.org/news) [**প্লেগ্রাউন্ড পরিচিতি: ব্রাউজারে ওয়ার্ডপ্রেস চালানো**](https://developer.wordpress.org/news/2024/04/05/introduction-to-playground-running-wordpress-in-the-browser/) ব্লগ পোস্টটি পড়ুন
+:::
+
+<!--
+## Take a deep dive
+-->
+
+## গভীরে ডুব দিন
+
+<!--
+If you're a developer or tech user, you may want to check directly the APIs available:
+-->
+
+আপনি যদি ডেভেলপার বা টেক ইউজার হন, তাহলে আপনি সরাসরি উপলব্ধ API গুলো দেখতে চাইতে পারেন:
+
+import APIList from '@site/docs/\_fragments/\_api_list.mdx';
+
+<!--
+-   Read about [Playground APIs](/developers/apis/) and basic concepts
+-   Review [links and resources](/resources)
+-   Choose the right API for your app <APIList />
+-   Dive into the [architecture](/developers/architecture) and learn how it all works
+-->
+
+-   [প্লেগ্রাউন্ড API](/developers/apis/) এবং মৌলিক ধারণাগুলো সম্পর্কে পড়ুন
+-   [লিংক এবং রিসোর্স](/resources) রিভিউ করুন
+-   আপনার অ্যাপের জন্য সঠিক API বেছে নিন <APIList />
+-   [আর্কিটেকচারে](/developers/architecture) ডুব দিন এবং এটি কীভাবে কাজ করে তা শিখুন
+
+<!--
+## Get Involved
+-->
+
+## যুক্ত হোন
+
+<!--
+WordPress Playground is an open-source project and welcomes all contributors from code to design, and from documentation to triage. Don't worry, _you don't need to know WebAssembly_ to contribute!
+-->
+
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ড একটি ওপেন-সোর্স প্রজেক্ট এবং কোড থেকে ডিজাইন, ডকুমেন্টেশন থেকে ট্রায়াজ সব ধরনের কন্ট্রিবিউটরদের স্বাগত জানায়। চিন্তা করবেন না, _কন্ট্রিবিউট করতে আপনার WebAssembly জানার দরকার নেই!_
+
+<!--
+-   See the [Contributors Handbook](/contributing) for all the details on how you can contribute.
+-   Join us in the `#playground` channel in Slack (see the [WordPress Slack page](https://make.wordpress.org/chat/) for signup information)
+-->
+
+-   কীভাবে কন্ট্রিবিউট করতে পারেন তার সমস্ত বিবরণের জন্য [কন্ট্রিবিউটরস হ্যান্ডবুক](/contributing) দেখুন।
+-   স্ল্যাক-এ `#playground` চ্যানেলে আমাদের সাথে যোগ দিন (সাইনআপ তথ্যের জন্য [ওয়ার্ডপ্রেস স্ল্যাক পেজ](https://make.wordpress.org/chat/) দেখুন)
+
+<!--
+As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](https://make.wordpress.org/handbook/community-code-of-conduct/).
+-->
+
+সকল ওয়ার্ডপ্রেস প্রজেক্টের মতো, আমরা সবার জন্য একটি স্বাগত জানানোর পরিবেশ নিশ্চিত করতে চাই। এটি মাথায় রেখে, সমস্ত কন্ট্রিবিউটরদের আমাদের [কোড অব কন্ডাক্ট](https://make.wordpress.org/handbook/community-code-of-conduct/) অনুসরণ করতে হবে।
+
+<!--
+## License
+-->
+
+## লাইসেন্স
+
+<!--
+WordPress Playground is free software released under the terms of the GNU General Public License version 2 or (at your option) any later version. For a complete license, see [LICENSE.md](https://github.com/WordPress/wordpress-playground/blob/trunk/LICENSE).
+-->
+
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ড হলো GNU জেনারেল পাবলিক লাইসেন্স সংস্করণ ২ অথবা (আপনার পছন্দে) যেকোনো পরবর্তী সংস্করণের শর্তাবলীর অধীনে প্রকাশিত ফ্রি সফটওয়্যার। সম্পূর্ণ লাইসেন্সের জন্য, [LICENSE.md](https://github.com/WordPress/wordpress-playground/blob/trunk/LICENSE) দেখুন।
+
+<br/><br/><p align="center"><img src="https://s.w.org/style/images/codeispoetry.png?1" alt="Code is Poetry." /></p>


### PR DESCRIPTION
## What?

Added Bengali (bn) translation for the [intro.md]

## Why?

To make WordPress Playground documentation accessible to Bengali-speaking users and provide an overview of the platform in their native language.

## How?

- Translated all content following the established translation format
- Original English text preserved in HTML comments for reviewer reference
- Technical terms (WordPress, Playground, GitHub, etc.) handled using standardized Bengali script while keeping original terms for clarity
- Markdown structure and links remain unchanged
- Code blocks remain unchanged
