### PR TITLE
[personal-wp] Ask before applying blueprints to your site

### DIFF
--- a/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/index.tsx
+++ b/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/index.tsx
@@ -1,15 +1,20 @@
+import { useState } from 'react';
 import { Button } from '@wordpress/components';
 import { Modal } from '../modal';
 import css from './style.module.css';
 import { useAppDispatch, useAppSelector } from '../../lib/state/redux/store';
 import {
-	clearPendingBlueprintConfirmation,
+	rejectPendingBlueprint,
 	confirmPendingBlueprint,
 } from '../../lib/state/redux/slice-ui';
 import type {
 	BlueprintWarning,
 	WarningSeverity,
 } from '../../lib/blueprint-confirmation';
+import type {
+	StepDefinition,
+	BlueprintV1Declaration,
+} from '@wp-playground/blueprints';
 
 const severityLabels: Record<WarningSeverity, string> = {
 	danger: 'High risk',
@@ -62,6 +67,354 @@ function WarningGroup({
 	);
 }
 
+function truncate(str: string, max: number): string {
+	if (str.length <= max) return str;
+	return str.slice(0, max) + '...';
+}
+
+function getResourceInfo(resource: unknown): string {
+	if (!resource || typeof resource !== 'object') {
+		return '';
+	}
+	const r = resource as Record<string, unknown>;
+
+	if (r.resource === 'wordpress.org/plugins' && r.slug) {
+		return `wordpress.org: ${r.slug}`;
+	}
+	if (r.resource === 'wordpress.org/themes' && r.slug) {
+		return `wordpress.org: ${r.slug}`;
+	}
+	if (r.resource === 'url' && r.url) {
+		return truncate(String(r.url), 60);
+	}
+	if (r.url) {
+		return truncate(String(r.url), 60);
+	}
+	if (r.slug) {
+		return String(r.slug);
+	}
+	if (r.resource === 'literal') {
+		return 'inline content';
+	}
+	return '';
+}
+
+function getStepSummary(step: StepDefinition): string {
+	if (typeof step === 'string') {
+		return step;
+	}
+	if (!step || typeof step !== 'object') {
+		return 'Unknown step';
+	}
+
+	const s = step as Record<string, unknown>;
+	const stepType = s.step as string;
+
+	switch (stepType) {
+		case 'installPlugin': {
+			const info =
+				getResourceInfo(s.pluginData) ||
+				getResourceInfo(s.pluginZipFile);
+			return info || 'Install plugin';
+		}
+		case 'installTheme': {
+			const info =
+				getResourceInfo(s.themeData) || getResourceInfo(s.themeZipFile);
+			return info || 'Install theme';
+		}
+		case 'activatePlugin':
+			return s.pluginPath ? String(s.pluginPath) : 'Activate plugin';
+		case 'activateTheme':
+			return s.themeFolderName
+				? String(s.themeFolderName)
+				: 'Activate theme';
+		case 'login':
+			return s.username ? `as ${s.username}` : 'as admin';
+		case 'runPHP':
+		case 'runPHPWithOptions': {
+			const code = (s.code as string) || '';
+			const clean = code
+				.replace(/^<\?php\s*/i, '')
+				.replace(/\s+/g, ' ')
+				.trim();
+			return truncate(clean, 80) || 'Execute PHP code';
+		}
+		case 'wp-cli': {
+			const cmd = s.command;
+			if (Array.isArray(cmd)) return `wp ${cmd.join(' ')}`;
+			if (typeof cmd === 'string') return `wp ${truncate(cmd, 60)}`;
+			return 'Execute command';
+		}
+		case 'writeFile':
+			return s.path ? String(s.path) : 'Write file';
+		case 'mkdir':
+			return s.path ? String(s.path) : 'Create directory';
+		case 'rm':
+			return s.path ? String(s.path) : 'Delete file';
+		case 'rmdir':
+			return s.path ? String(s.path) : 'Delete directory';
+		case 'cp':
+			return `${s.fromPath || '?'} → ${s.toPath || '?'}`;
+		case 'mv':
+			return `${s.fromPath || '?'} → ${s.toPath || '?'}`;
+		case 'request': {
+			const method = s.method || 'GET';
+			const url = s.url ? truncate(String(s.url), 50) : 'unknown URL';
+			return `${method} ${url}`;
+		}
+		case 'setSiteOptions': {
+			const options = s.options as Record<string, unknown> | undefined;
+			if (options && typeof options === 'object') {
+				const keys = Object.keys(options);
+				return keys.length > 0 ? keys.join(', ') : 'Update options';
+			}
+			return 'Update options';
+		}
+		case 'defineWpConfigConsts': {
+			const consts = s.consts as Record<string, unknown> | undefined;
+			if (consts && typeof consts === 'object') {
+				const keys = Object.keys(consts);
+				return keys.length > 0 ? keys.join(', ') : 'Set constants';
+			}
+			return 'Set constants';
+		}
+		case 'importWxr': {
+			const info = getResourceInfo(s.file);
+			return info || 'Import XML content';
+		}
+		case 'importWordPressFiles': {
+			const info = getResourceInfo(s.wordPressFilesZip);
+			return info || 'Import files';
+		}
+		case 'enableMultisite':
+			return 'Enable WordPress multisite';
+		case 'runSql': {
+			const sql = s.sql as string | undefined;
+			if (sql) return truncate(sql.replace(/\s+/g, ' '), 60);
+			return 'Execute query';
+		}
+		case 'unzip': {
+			const to = s.extractToPath ? ` to ${s.extractToPath}` : '';
+			return `Extract archive${to}`;
+		}
+		case 'setPhpIniEntry':
+			return s.key ? `${s.key} = ${s.value}` : 'Set PHP ini';
+		case 'resetData':
+			return 'Reset WordPress data';
+		case 'setSiteLanguage':
+			return s.language ? String(s.language) : 'Set language';
+		default:
+			return stepType || 'Unknown step';
+	}
+}
+
+interface BlueprintMeta {
+	title?: string;
+	description?: string;
+	author?: string;
+}
+
+interface BlueprintOverviewProps {
+	steps: StepDefinition[];
+	landingPage?: string;
+	plugins?: string[];
+	themes?: string[];
+	warnings?: BlueprintWarning[];
+}
+
+function getStepSeverity(
+	stepIndex: number,
+	warnings: BlueprintWarning[]
+): WarningSeverity | null {
+	const stepWarnings = warnings.filter((w) => w.stepIndex === stepIndex);
+	if (stepWarnings.some((w) => w.severity === 'danger')) return 'danger';
+	if (stepWarnings.some((w) => w.severity === 'warning')) return 'warning';
+	if (stepWarnings.some((w) => w.severity === 'info')) return 'info';
+	return null;
+}
+
+function SeverityIcon({ severity }: { severity: WarningSeverity }) {
+	if (severity === 'danger') {
+		return (
+			<span className={css['severity-icon']} title="High risk">
+				⚠
+			</span>
+		);
+	}
+	if (severity === 'warning') {
+		return (
+			<span className={css['severity-icon']} title="Caution">
+				⚠
+			</span>
+		);
+	}
+	return (
+		<span className={css['severity-icon']} title="Info">
+			ℹ
+		</span>
+	);
+}
+
+function BlueprintOverview({
+	steps,
+	landingPage,
+	plugins,
+	themes,
+	warnings = [],
+}: BlueprintOverviewProps) {
+	const hasSteps = steps && steps.length > 0;
+	const hasPlugins = plugins && plugins.length > 0;
+	const hasThemes = themes && themes.length > 0;
+	const hasContent = hasSteps || landingPage || hasPlugins || hasThemes;
+
+	if (!hasContent) {
+		return <p className={css.noSteps}>No actions in this blueprint.</p>;
+	}
+
+	return (
+		<div className={css.blueprintOverview}>
+			{hasPlugins && (
+				<div className={css.blueprintProperty}>
+					<span className={css.stepType}>plugins</span>
+					<span className={css.stepSummary}>
+						{plugins.join(', ')}
+					</span>
+				</div>
+			)}
+			{hasThemes && (
+				<div className={css.blueprintProperty}>
+					<span className={css.stepType}>themes</span>
+					<span className={css.stepSummary}>{themes.join(', ')}</span>
+				</div>
+			)}
+			{landingPage && (
+				<div className={css.blueprintProperty}>
+					<span className={css.stepType}>landingPage</span>
+					<span className={css.stepSummary}>{landingPage}</span>
+				</div>
+			)}
+			{hasSteps && (
+				<>
+					<h4
+						className={`${css.stepsHeading} ${!hasPlugins && !hasThemes && !landingPage ? css.stepsHeadingFirst : ''}`}
+					>
+						Steps
+					</h4>
+					<ol className={css.stepsTree}>
+						{steps.map((step, index) => {
+							if (!step) return null;
+							const stepObj =
+								typeof step === 'object'
+									? (step as Record<string, unknown>)
+									: null;
+							const stepType = stepObj?.step as
+								| string
+								| undefined;
+							const severity = getStepSeverity(index, warnings);
+
+							return (
+								<li
+									key={index}
+									className={`${css.stepItem} ${severity ? css[`step-severity-${severity}`] : ''}`}
+								>
+									{severity && (
+										<SeverityIcon severity={severity} />
+									)}
+									<span className={css.stepType}>
+										{stepType || 'step'}
+									</span>
+									<span className={css.stepSummary}>
+										{getStepSummary(step)}
+									</span>
+								</li>
+							);
+						})}
+					</ol>
+				</>
+			)}
+		</div>
+	);
+}
+
+function BlueprintContents({
+	blueprint,
+	warnings = [],
+}: {
+	blueprint: BlueprintV1Declaration;
+	warnings?: BlueprintWarning[];
+}) {
+	const [showRaw, setShowRaw] = useState(false);
+	const blueprintJson = JSON.stringify(blueprint, null, 2);
+	const meta = blueprint.meta as BlueprintMeta | undefined;
+
+	return (
+		<div className={css.blueprintContents}>
+			{meta && (meta.title || meta.description || meta.author) && (
+				<div className={css.blueprintMeta}>
+					<div className={css.metaHeader}>
+						{meta.title && (
+							<h3 className={css.metaTitle}>{meta.title}</h3>
+						)}
+						{meta.author && (
+							<span className={css.metaAuthor}>
+								by {meta.author}
+							</span>
+						)}
+					</div>
+					{meta.description && (
+						<p className={css.metaDescription}>
+							{meta.description}
+						</p>
+					)}
+				</div>
+			)}
+			<div
+				className={`${css.blueprintPanel} ${showRaw ? css.blueprintPanelJson : ''}`}
+			>
+				{showRaw ? (
+					<pre className={css.blueprintCode}>{blueprintJson}</pre>
+				) : (
+					<BlueprintOverview
+						steps={(blueprint.steps as StepDefinition[]) || []}
+						landingPage={
+							blueprint.landingPage as string | undefined
+						}
+						plugins={blueprint.plugins as string[] | undefined}
+						themes={undefined}
+						warnings={warnings}
+					/>
+				)}
+			</div>
+			<div className={css.blueprintFooter}>
+				<div className={css.viewTabs}>
+					<button
+						type="button"
+						className={`${css.viewTab} ${!showRaw ? css.viewTabActive : ''}`}
+						onClick={() => setShowRaw(false)}
+					>
+						Overview
+					</button>
+					<button
+						type="button"
+						className={`${css.viewTab} ${showRaw ? css.viewTabActive : ''}`}
+						onClick={() => setShowRaw(true)}
+					>
+						JSON
+					</button>
+				</div>
+				<a
+					href="https://wordpress.github.io/wordpress-playground/blueprints/"
+					target="_blank"
+					rel="noopener noreferrer"
+					className={css.docsLink}
+				>
+					What is a blueprint?
+				</a>
+			</div>
+		</div>
+	);
+}
+
 export function BlueprintConfirmationModal() {
 	const dispatch = useAppDispatch();
 	const pendingConfirmation = useAppSelector(
@@ -81,7 +434,7 @@ export function BlueprintConfirmationModal() {
 	const infoWarnings = warnings.filter((w) => w.severity === 'info');
 
 	const handleCancel = () => {
-		dispatch(clearPendingBlueprintConfirmation());
+		dispatch(rejectPendingBlueprint());
 	};
 
 	const handleConfirm = () => {
@@ -104,9 +457,6 @@ export function BlueprintConfirmationModal() {
 	} else if (blueprint.source.type === 'inline-string') {
 		isInlineBlueprint = true;
 	}
-
-	// Format blueprint JSON for display
-	const blueprintJson = JSON.stringify(blueprint.blueprint, null, 2);
 
 	const hasDanger = dangerWarnings.length > 0;
 
@@ -132,14 +482,12 @@ export function BlueprintConfirmationModal() {
 					)}
 
 					{isInlineBlueprint && (
-						<details className={css.blueprintDetails}>
-							<summary className={css.blueprintSummary}>
-								View blueprint contents
-							</summary>
-							<pre className={css.blueprintCode}>
-								{blueprintJson}
-							</pre>
-						</details>
+						<BlueprintContents
+							blueprint={
+								blueprint.blueprint as BlueprintV1Declaration
+							}
+							warnings={warnings}
+						/>
 					)}
 
 					<div className={css.warningsContainer}>
@@ -152,13 +500,6 @@ export function BlueprintConfirmationModal() {
 							warnings={warningWarnings}
 						/>
 						<WarningGroup severity="info" warnings={infoWarnings} />
-
-						{warnings.length === 0 && (
-							<p className={css.noWarnings}>
-								This blueprint does not contain any recognized
-								operations.
-							</p>
-						)}
 					</div>
 				</div>
 

--- a/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/index.tsx
+++ b/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/index.tsx
@@ -1,0 +1,143 @@
+import { Button } from '@wordpress/components';
+import { Modal } from '../modal';
+import css from './style.module.css';
+import { useAppDispatch, useAppSelector } from '../../lib/state/redux/store';
+import {
+	clearPendingBlueprintConfirmation,
+	confirmPendingBlueprint,
+} from '../../lib/state/redux/slice-ui';
+import type { BlueprintWarning, WarningSeverity } from '../../lib/blueprint-confirmation';
+
+const severityLabels: Record<WarningSeverity, string> = {
+	danger: 'High risk',
+	warning: 'Caution',
+	info: 'Info',
+};
+
+const severityDescriptions: Record<WarningSeverity, string> = {
+	danger: 'These operations could compromise your site',
+	warning: 'These operations will modify your site',
+	info: 'These operations are generally safe',
+};
+
+function WarningGroup({
+	severity,
+	warnings,
+}: {
+	severity: WarningSeverity;
+	warnings: BlueprintWarning[];
+}) {
+	if (warnings.length === 0) {
+		return null;
+	}
+
+	return (
+		<div className={`${css.warningGroup} ${css[`severity-${severity}`]}`}>
+			<div className={css.warningGroupHeader}>
+				<span className={`${css.severityBadge} ${css[`badge-${severity}`]}`}>
+					{severityLabels[severity]}
+				</span>
+				<span className={css.severityDescription}>
+					{severityDescriptions[severity]}
+				</span>
+			</div>
+			<ul className={css.warningList}>
+				{warnings.map((warning, index) => (
+					<li key={index} className={css.warningItem}>
+						<span className={css.warningTitle}>{warning.title}</span>
+						<span className={css.warningDescription}>
+							{warning.description}
+						</span>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
+export function BlueprintConfirmationModal() {
+	const dispatch = useAppDispatch();
+	const pendingConfirmation = useAppSelector(
+		(state) => state.ui.pendingBlueprintConfirmation
+	);
+
+	if (!pendingConfirmation) {
+		return null;
+	}
+
+	const { analysisResult, blueprint } = pendingConfirmation;
+	const { warnings } = analysisResult;
+
+	// Group warnings by severity
+	const dangerWarnings = warnings.filter((w) => w.severity === 'danger');
+	const warningWarnings = warnings.filter((w) => w.severity === 'warning');
+	const infoWarnings = warnings.filter((w) => w.severity === 'info');
+
+	const handleCancel = () => {
+		dispatch(clearPendingBlueprintConfirmation());
+	};
+
+	const handleConfirm = () => {
+		dispatch(confirmPendingBlueprint());
+	};
+
+	// Get source URL for display
+	let sourceUrl = '';
+	if (
+		blueprint.source.type === 'remote-url' ||
+		blueprint.source.type === 'personal-blueprint'
+	) {
+		sourceUrl = blueprint.source.url;
+	}
+
+	const hasDanger = dangerWarnings.length > 0;
+
+	return (
+		<Modal
+			title="Apply Blueprint?"
+			onRequestClose={handleCancel}
+			className={css.confirmationModal}
+		>
+			<div className={css.modalContent}>
+				<div className={css.modalBody}>
+					<p className={css.leadText}>
+						An external blueprint wants to modify your WordPress installation.
+						Please review the following actions before proceeding.
+					</p>
+
+					{sourceUrl && (
+						<div className={css.sourceInfo}>
+							<span className={css.sourceLabel}>Source:</span>
+							<code className={css.sourceUrl}>{sourceUrl}</code>
+						</div>
+					)}
+
+					<div className={css.warningsContainer}>
+						<WarningGroup severity="danger" warnings={dangerWarnings} />
+						<WarningGroup severity="warning" warnings={warningWarnings} />
+						<WarningGroup severity="info" warnings={infoWarnings} />
+
+						{warnings.length === 0 && (
+							<p className={css.noWarnings}>
+								This blueprint does not contain any recognized operations.
+							</p>
+						)}
+					</div>
+				</div>
+
+				<div className={css.modalFooter}>
+					<Button variant="secondary" onClick={handleCancel}>
+						Cancel
+					</Button>
+					<Button
+						variant="primary"
+						onClick={handleConfirm}
+						className={hasDanger ? css.dangerButton : ''}
+					>
+						{hasDanger ? 'Apply Anyway' : 'Apply Blueprint'}
+					</Button>
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/index.tsx
+++ b/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/index.tsx
@@ -6,7 +6,10 @@ import {
 	clearPendingBlueprintConfirmation,
 	confirmPendingBlueprint,
 } from '../../lib/state/redux/slice-ui';
-import type { BlueprintWarning, WarningSeverity } from '../../lib/blueprint-confirmation';
+import type {
+	BlueprintWarning,
+	WarningSeverity,
+} from '../../lib/blueprint-confirmation';
 
 const severityLabels: Record<WarningSeverity, string> = {
 	danger: 'High risk',
@@ -34,7 +37,9 @@ function WarningGroup({
 	return (
 		<div className={`${css.warningGroup} ${css[`severity-${severity}`]}`}>
 			<div className={css.warningGroupHeader}>
-				<span className={`${css.severityBadge} ${css[`badge-${severity}`]}`}>
+				<span
+					className={`${css.severityBadge} ${css[`badge-${severity}`]}`}
+				>
 					{severityLabels[severity]}
 				</span>
 				<span className={css.severityDescription}>
@@ -44,7 +49,9 @@ function WarningGroup({
 			<ul className={css.warningList}>
 				{warnings.map((warning, index) => (
 					<li key={index} className={css.warningItem}>
-						<span className={css.warningTitle}>{warning.title}</span>
+						<span className={css.warningTitle}>
+							{warning.title}
+						</span>
 						<span className={css.warningDescription}>
 							{warning.description}
 						</span>
@@ -81,14 +88,25 @@ export function BlueprintConfirmationModal() {
 		dispatch(confirmPendingBlueprint());
 	};
 
-	// Get source URL for display
+	// Get source URL for display (only for remote URLs, not data: URLs)
 	let sourceUrl = '';
+	let isInlineBlueprint = false;
 	if (
 		blueprint.source.type === 'remote-url' ||
 		blueprint.source.type === 'personal-blueprint'
 	) {
-		sourceUrl = blueprint.source.url;
+		const url = blueprint.source.url;
+		if (url.startsWith('data:')) {
+			isInlineBlueprint = true;
+		} else {
+			sourceUrl = url;
+		}
+	} else if (blueprint.source.type === 'inline-string') {
+		isInlineBlueprint = true;
 	}
+
+	// Format blueprint JSON for display
+	const blueprintJson = JSON.stringify(blueprint.blueprint, null, 2);
 
 	const hasDanger = dangerWarnings.length > 0;
 
@@ -101,25 +119,44 @@ export function BlueprintConfirmationModal() {
 			<div className={css.modalContent}>
 				<div className={css.modalBody}>
 					<p className={css.leadText}>
-						An external blueprint wants to modify your WordPress installation.
-						Please review the following actions before proceeding.
+						An external blueprint wants to modify your WordPress
+						installation. Please review the following actions before
+						proceeding.
 					</p>
 
 					{sourceUrl && (
 						<div className={css.sourceInfo}>
 							<span className={css.sourceLabel}>Source:</span>
-							<code className={css.sourceUrl}>{sourceUrl}</code>
+							<span className={css.sourceUrl}>{sourceUrl}</span>
 						</div>
 					)}
 
+					{isInlineBlueprint && (
+						<details className={css.blueprintDetails}>
+							<summary className={css.blueprintSummary}>
+								View blueprint contents
+							</summary>
+							<pre className={css.blueprintCode}>
+								{blueprintJson}
+							</pre>
+						</details>
+					)}
+
 					<div className={css.warningsContainer}>
-						<WarningGroup severity="danger" warnings={dangerWarnings} />
-						<WarningGroup severity="warning" warnings={warningWarnings} />
+						<WarningGroup
+							severity="danger"
+							warnings={dangerWarnings}
+						/>
+						<WarningGroup
+							severity="warning"
+							warnings={warningWarnings}
+						/>
 						<WarningGroup severity="info" warnings={infoWarnings} />
 
 						{warnings.length === 0 && (
 							<p className={css.noWarnings}>
-								This blueprint does not contain any recognized operations.
+								This blueprint does not contain any recognized
+								operations.
 							</p>
 						)}
 					</div>

--- a/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/style.module.css
+++ b/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/style.module.css
@@ -71,11 +71,47 @@
 }
 
 .source-url {
-	font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+	font-family:
+		'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 	font-size: 0.8125rem;
 	word-break: break-all;
 	color: #1d2327;
 	background: transparent;
+}
+
+.blueprint-details {
+	background: #f6f7f7;
+	border-radius: 8px;
+	border: 1px solid #dcdcde;
+}
+
+.blueprint-summary {
+	padding: 0.75rem;
+	cursor: pointer;
+	font-size: 0.875rem;
+	font-weight: 500;
+	color: #1d2327;
+	user-select: none;
+}
+
+.blueprint-summary:hover {
+	color: #0073aa;
+}
+
+.blueprint-code {
+	margin: 0;
+	padding: 0.75rem;
+	padding-top: 0;
+	font-family:
+		'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+	font-size: 0.75rem;
+	line-height: 1.5;
+	overflow-x: auto;
+	max-height: 200px;
+	overflow-y: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+	color: #1d2327;
 }
 
 .warnings-container {

--- a/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/style.module.css
+++ b/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/style.module.css
@@ -1,0 +1,253 @@
+.confirmation-modal {
+	width: min(600px, calc(100vw - 32px));
+	max-width: none;
+	max-height: 85dvh;
+}
+
+.confirmation-modal :global(.components-modal__content) {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	font-size: 15px;
+	padding: 0 24px 20px;
+	padding-top: 0;
+}
+
+.confirmation-modal :global(.components-modal__header) {
+	padding-top: 20px;
+	padding-bottom: 16px;
+	padding-left: 24px;
+	padding-right: 24px;
+	margin: 0;
+}
+
+.confirmation-modal :global(.components-modal__header-heading) {
+	font-size: 20px;
+	line-height: 1.3;
+}
+
+.modal-content {
+	display: flex;
+	flex-direction: column;
+	width: 100%;
+	height: 100%;
+}
+
+.modal-body {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	overflow-y: auto;
+	padding-right: 0.25rem;
+	min-height: 0;
+	padding-top: 4px;
+	padding-bottom: 16px;
+}
+
+.lead-text {
+	font-size: 1rem;
+	line-height: 1.5;
+	color: #1d2327;
+	margin: 0;
+}
+
+.source-info {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	background: #f6f7f7;
+	border-radius: 8px;
+	padding: 0.75rem;
+	border: 1px solid #dcdcde;
+}
+
+.source-label {
+	font-size: 0.75rem;
+	font-weight: 600;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	color: #6c7781;
+}
+
+.source-url {
+	font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+	font-size: 0.8125rem;
+	word-break: break-all;
+	color: #1d2327;
+	background: transparent;
+}
+
+.warnings-container {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+}
+
+.warning-group {
+	border-radius: 10px;
+	padding: 0.875rem;
+	border: 1px solid;
+}
+
+.severity-danger {
+	background: #fef2f2;
+	border-color: #fecaca;
+}
+
+.severity-warning {
+	background: #fffbeb;
+	border-color: #fde68a;
+}
+
+.severity-info {
+	background: #f0f9ff;
+	border-color: #bae6fd;
+}
+
+.warning-group-header {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+
+.severity-badge {
+	display: inline-flex;
+	align-items: center;
+	flex-shrink: 0;
+	white-space: nowrap;
+	font-size: 0.6875rem;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	font-weight: 600;
+	padding: 0.25rem 0.625rem;
+	border-radius: 999px;
+	line-height: 1;
+}
+
+.badge-danger {
+	background: #fee2e2;
+	color: #991b1b;
+}
+
+.badge-warning {
+	background: #fef3c7;
+	color: #92400e;
+}
+
+.badge-info {
+	background: #e0f2fe;
+	color: #075985;
+}
+
+.severity-description {
+	font-size: 0.8125rem;
+	color: #6c7781;
+}
+
+.warning-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.warning-item {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	padding-left: 0.5rem;
+	border-left: 2px solid currentColor;
+}
+
+.severity-danger .warning-item {
+	border-color: #f87171;
+}
+
+.severity-warning .warning-item {
+	border-color: #fbbf24;
+}
+
+.severity-info .warning-item {
+	border-color: #38bdf8;
+}
+
+.warning-title {
+	font-weight: 600;
+	font-size: 0.9375rem;
+	color: #1d2327;
+}
+
+.warning-description {
+	font-size: 0.8125rem;
+	color: #50575e;
+	line-height: 1.4;
+	word-break: break-word;
+}
+
+.no-warnings {
+	color: #6c7781;
+	font-style: italic;
+	margin: 0;
+}
+
+.modal-footer {
+	flex-shrink: 0;
+	display: flex;
+	gap: 0.75rem;
+	padding-top: 16px;
+	margin-top: 4px;
+	border-top: 1px solid #dcdcde;
+	justify-content: flex-end;
+}
+
+.danger-button {
+	background: #dc2626 !important;
+	border-color: #dc2626 !important;
+}
+
+.danger-button:hover {
+	background: #b91c1c !important;
+	border-color: #b91c1c !important;
+}
+
+.danger-button:focus {
+	box-shadow: 0 0 0 2px #fecaca !important;
+}
+
+@media (max-width: 768px) {
+	.confirmation-modal {
+		max-width: none;
+		max-height: none;
+		margin: 0;
+		width: 100dvw;
+		height: 100dvh;
+	}
+
+	.confirmation-modal :global(.components-modal__content) {
+		font-size: 14px;
+		padding: 18px 20px;
+		padding-top: 0;
+	}
+
+	.confirmation-modal :global(.components-modal__header) {
+		padding-bottom: 14px;
+		padding-left: 20px;
+		padding-right: 20px;
+	}
+
+	.confirmation-modal :global(.components-modal__header-heading) {
+		font-size: 18px;
+	}
+
+	.lead-text {
+		font-size: 0.9375rem;
+	}
+
+	.modal-footer {
+		padding-top: 14px;
+	}
+}

--- a/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/style.module.css
+++ b/packages/playground/personal-wp/src/components/blueprint-confirmation-modal/style.module.css
@@ -4,6 +4,12 @@
 	max-height: 85dvh;
 }
 
+.confirmation-modal:focus,
+.confirmation-modal:focus-visible {
+	outline: none !important;
+	box-shadow: none !important;
+}
+
 .confirmation-modal :global(.components-modal__content) {
 	display: flex;
 	flex-direction: column;
@@ -79,39 +85,223 @@
 	background: transparent;
 }
 
-.blueprint-details {
-	background: #f6f7f7;
-	border-radius: 8px;
-	border: 1px solid #dcdcde;
+.blueprint-contents {
+	overflow: hidden;
 }
 
-.blueprint-summary {
-	padding: 0.75rem;
-	cursor: pointer;
-	font-size: 0.875rem;
-	font-weight: 500;
+.blueprint-meta {
+	margin-bottom: 0.75rem;
+}
+
+.meta-header {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+}
+
+.meta-title {
+	margin: 0;
+	font-size: 1rem;
+	font-weight: 600;
 	color: #1d2327;
-	user-select: none;
 }
 
-.blueprint-summary:hover {
+.meta-description {
+	margin: 0.25rem 0 0;
+	font-size: 0.875rem;
+	color: #50575e;
+	line-height: 1.4;
+}
+
+.meta-author {
+	font-size: 0.75rem;
+	color: #6c7781;
+}
+
+.blueprint-footer {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+}
+
+.docs-link {
+	font-size: 0.75rem;
 	color: #0073aa;
+	text-decoration: none;
+	padding-top: 0.5rem;
+}
+
+.docs-link:hover {
+	text-decoration: underline;
+}
+
+.view-tabs {
+	display: flex;
+}
+
+.view-tab {
+	padding: 0.5rem 0.875rem;
+	font-size: 0.75rem;
+	font-weight: 500;
+	border: 1px solid transparent;
+	border-top: none;
+	border-radius: 0 0 4px 4px;
+	background: transparent;
+	color: #50575e;
+	cursor: pointer;
+	margin-top: -1px;
+}
+
+.view-tab:hover {
+	color: #1d2327;
+}
+
+.view-tab:focus,
+.view-tab:focus-visible {
+	outline: none;
+	box-shadow: none;
+}
+
+.view-tab-active {
+	background: #fff;
+	color: #1d2327;
+	border-color: #dcdcde;
+	border-top: 1px solid #fff;
+}
+
+.blueprint-panel {
+	background: #fff;
+	height: 220px;
+	overflow-y: auto;
+	border: 1px solid #dcdcde;
+	border-radius: 8px 8px 8px 0;
+}
+
+.blueprint-panel-json {
+	border-radius: 8px;
 }
 
 .blueprint-code {
 	margin: 0;
 	padding: 0.75rem;
-	padding-top: 0;
 	font-family:
 		'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
 	font-size: 0.75rem;
 	line-height: 1.5;
-	overflow-x: auto;
-	max-height: 200px;
-	overflow-y: auto;
 	white-space: pre-wrap;
 	word-break: break-word;
 	color: #1d2327;
+}
+
+.blueprint-overview {
+	padding: 0.75rem;
+}
+
+.blueprint-property {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	padding: 0.375rem 0;
+}
+
+.steps-heading {
+	margin: 0;
+	margin-top: 0.75rem;
+	padding-top: 0.75rem;
+	border-top: 1px solid #e2e4e7;
+	font-size: 0.6875rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	color: #6c7781;
+}
+
+.steps-heading-first {
+	margin-top: 0;
+	padding-top: 0;
+	border-top: none;
+}
+
+.steps-tree {
+	margin: 0;
+	margin-top: 0.5rem;
+	padding: 0;
+	list-style: none;
+	counter-reset: step-counter;
+}
+
+.step-item {
+	display: flex;
+	align-items: baseline;
+	gap: 0.5rem;
+	padding: 0.375rem 0;
+	border-bottom: 1px solid #e2e4e7;
+	counter-increment: step-counter;
+}
+
+.step-item:last-child {
+	border-bottom: none;
+}
+
+.severity-icon {
+	flex-shrink: 0;
+	font-size: 0.875rem;
+	line-height: 1;
+}
+
+.step-severity-danger .severity-icon {
+	color: #dc2626;
+}
+
+.step-severity-warning .severity-icon {
+	color: #d97706;
+}
+
+.step-severity-info .severity-icon {
+	color: #0284c7;
+}
+
+.step-item::before {
+	content: counter(step-counter);
+	flex-shrink: 0;
+	width: 1.25rem;
+	height: 1.25rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #e2e4e7;
+	border-radius: 50%;
+	font-size: 0.6875rem;
+	font-weight: 600;
+	color: #50575e;
+}
+
+.step-type {
+	flex-shrink: 0;
+	font-family:
+		'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: #0073aa;
+	background: #e5f5fa;
+	padding: 0.125rem 0.375rem;
+	border-radius: 3px;
+}
+
+.step-summary {
+	font-size: 0.8125rem;
+	color: #50575e;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.no-steps {
+	margin: 0;
+	padding: 0.75rem;
+	padding-top: 0;
+	color: #6c7781;
+	font-style: italic;
 }
 
 .warnings-container {

--- a/packages/playground/personal-wp/src/components/layout/index.tsx
+++ b/packages/playground/personal-wp/src/components/layout/index.tsx
@@ -12,6 +12,7 @@ import {
 	PlaygroundViewport,
 } from '../playground-viewport';
 import { MissingSiteModal } from '../missing-site-modal';
+import { BlueprintConfirmationModal } from '../blueprint-confirmation-modal';
 import { modalSlugs } from '../../lib/state/redux/slice-ui';
 import { SiteManager } from '../site-manager';
 import { useAutoBackup } from '../../lib/hooks/use-auto-backup';
@@ -67,6 +68,14 @@ function Modals() {
 	const currentModal = useAppSelector(
 		(state: PlaygroundReduxState) => state.ui.activeModal
 	);
+	const pendingBlueprintConfirmation = useAppSelector(
+		(state: PlaygroundReduxState) => state.ui.pendingBlueprintConfirmation
+	);
+
+	// Blueprint confirmation modal takes priority
+	if (pendingBlueprintConfirmation) {
+		return <BlueprintConfirmationModal />;
+	}
 
 	if (currentModal === modalSlugs.LOG) {
 		return <LogModal />;

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -46,6 +46,7 @@ export const JustViewport = function JustViewport({
 }) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const site = useAppSelector((state) => selectSiteBySlug(state, siteSlug))!;
+	const bootTrigger = useAppSelector((state) => state.ui.bootTrigger);
 
 	const dispatch = useAppDispatch();
 	const runtimeConfigString = JSON.stringify(
@@ -71,7 +72,7 @@ export const JustViewport = function JustViewport({
 			dispatch(removeClientInfo(siteSlug));
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [siteSlug, iframeRef, runtimeConfigString]);
+	}, [siteSlug, iframeRef, runtimeConfigString, bootTrigger]);
 
 	const error = useAppSelector(selectActiveSiteError);
 	const errorDetails = useAppSelector(selectActiveSiteErrorDetails);

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.spec.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import { analyzeBlueprint } from './analyzer';
+import type { RuleContext, BlueprintRule } from './types';
+
+describe('analyzeBlueprint', () => {
+	describe('trusted sources', () => {
+		it('does not require confirmation for trusted sources', () => {
+			const context: RuleContext = {
+				blueprint: {
+					steps: [{ step: 'runPHP', code: '<?php echo "hello";' }],
+				},
+				source: {
+					type: 'remote-url',
+					url: 'https://raw.githubusercontent.com/WordPress/blueprints/my-wordpress/app.json',
+				},
+			};
+
+			const result = analyzeBlueprint(context);
+
+			expect(result.requiresConfirmation).toBe(false);
+			expect(result.isTrustedSource).toBe(true);
+		});
+
+		it('still collects warnings for trusted sources', () => {
+			const context: RuleContext = {
+				blueprint: {
+					steps: [{ step: 'runPHP', code: '<?php echo "hello";' }],
+				},
+				source: {
+					type: 'remote-url',
+					url: 'https://raw.githubusercontent.com/WordPress/blueprints/main/app.json',
+				},
+			};
+
+			const result = analyzeBlueprint(context);
+
+			expect(result.isTrustedSource).toBe(true);
+			expect(result.warnings.length).toBeGreaterThan(0);
+		});
+
+		it('does not require confirmation for type: none', () => {
+			const context: RuleContext = {
+				blueprint: {
+					steps: [
+						{
+							step: 'installPlugin',
+							pluginData: {
+								resource: 'wordpress.org/plugins',
+								slug: 'hello-dolly',
+							},
+						},
+					],
+				},
+				source: { type: 'none' },
+			};
+
+			const result = analyzeBlueprint(context);
+
+			expect(result.requiresConfirmation).toBe(false);
+			expect(result.isTrustedSource).toBe(true);
+		});
+	});
+
+	describe('untrusted sources', () => {
+		it('requires confirmation for external URLs', () => {
+			const context: RuleContext = {
+				blueprint: {
+					steps: [{ step: 'runPHP', code: '<?php echo "hello";' }],
+				},
+				source: {
+					type: 'remote-url',
+					url: 'https://untrusted.com/blueprint.json',
+				},
+			};
+
+			const result = analyzeBlueprint(context);
+
+			expect(result.requiresConfirmation).toBe(true);
+			expect(result.isTrustedSource).toBe(false);
+		});
+
+		it('requires confirmation for inline-string (hash fragments)', () => {
+			const context: RuleContext = {
+				blueprint: {
+					steps: [{ step: 'login' }],
+				},
+				source: { type: 'inline-string' },
+			};
+
+			const result = analyzeBlueprint(context);
+
+			expect(result.requiresConfirmation).toBe(true);
+			expect(result.isTrustedSource).toBe(false);
+		});
+
+		it('requires confirmation for data: URLs', () => {
+			const context: RuleContext = {
+				blueprint: {
+					steps: [{ step: 'login' }],
+				},
+				source: {
+					type: 'remote-url',
+					url: 'data:application/json;base64,eyJzdGVwcyI6W119',
+				},
+			};
+
+			const result = analyzeBlueprint(context);
+
+			expect(result.requiresConfirmation).toBe(true);
+			expect(result.isTrustedSource).toBe(false);
+		});
+	});
+
+	describe('warning sorting', () => {
+		it('sorts warnings by severity: danger > warning > info', () => {
+			const context: RuleContext = {
+				blueprint: {
+					steps: [
+						{
+							step: 'installPlugin',
+							pluginData: {
+								resource: 'wordpress.org/plugins',
+								slug: 'hello',
+							},
+						},
+						{ step: 'runPHP', code: '<?php echo 1;' },
+						{ step: 'request', url: 'https://example.com' },
+					],
+				},
+				source: {
+					type: 'remote-url',
+					url: 'https://untrusted.com/bp.json',
+				},
+			};
+
+			const result = analyzeBlueprint(context);
+
+			const severities = result.warnings.map((w) => w.severity);
+			const dangerIndex = severities.indexOf('danger');
+			const warningIndex = severities.indexOf('warning');
+			const infoIndex = severities.indexOf('info');
+
+			if (dangerIndex !== -1 && warningIndex !== -1) {
+				expect(dangerIndex).toBeLessThan(warningIndex);
+			}
+			if (warningIndex !== -1 && infoIndex !== -1) {
+				expect(warningIndex).toBeLessThan(infoIndex);
+			}
+		});
+	});
+
+	describe('custom rules', () => {
+		it('accepts custom rules instead of defaults', () => {
+			const customRule: BlueprintRule = {
+				name: 'custom-rule',
+				analyze: () => [
+					{
+						severity: 'info',
+						title: 'Custom warning',
+						description: 'From custom rule',
+					},
+				],
+			};
+
+			const context: RuleContext = {
+				blueprint: {
+					steps: [{ step: 'runPHP', code: '<?php echo 1;' }],
+				},
+				source: {
+					type: 'remote-url',
+					url: 'https://untrusted.com/bp.json',
+				},
+			};
+
+			const result = analyzeBlueprint(context, [customRule]);
+
+			expect(result.warnings).toHaveLength(1);
+			expect(result.warnings[0].title).toBe('Custom warning');
+		});
+
+		it('returns empty warnings when no rules match', () => {
+			const context: RuleContext = {
+				blueprint: {
+					steps: [{ step: 'login' }],
+				},
+				source: {
+					type: 'remote-url',
+					url: 'https://untrusted.com/bp.json',
+				},
+			};
+
+			const result = analyzeBlueprint(context, []);
+
+			expect(result.warnings).toHaveLength(0);
+			expect(result.requiresConfirmation).toBe(true);
+		});
+	});
+
+	describe('empty blueprints', () => {
+		it('handles blueprints with no steps', () => {
+			const context: RuleContext = {
+				blueprint: {},
+				source: {
+					type: 'remote-url',
+					url: 'https://untrusted.com/bp.json',
+				},
+			};
+
+			const result = analyzeBlueprint(context);
+
+			expect(result.warnings).toHaveLength(0);
+			expect(result.requiresConfirmation).toBe(true);
+		});
+
+		it('handles blueprints with empty steps array', () => {
+			const context: RuleContext = {
+				blueprint: { steps: [] },
+				source: {
+					type: 'remote-url',
+					url: 'https://untrusted.com/bp.json',
+				},
+			};
+
+			const result = analyzeBlueprint(context);
+
+			expect(result.warnings).toHaveLength(0);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.spec.ts
@@ -124,7 +124,10 @@ describe('analyzeBlueprint', () => {
 							},
 						},
 						{ step: 'runPHP', code: '<?php echo 1;' },
-						{ step: 'request', url: 'https://example.com' },
+						{
+							step: 'request',
+							request: { url: 'https://example.com' },
+						},
 					],
 				},
 				source: {

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.ts
@@ -1,0 +1,78 @@
+import type {
+	AnalysisResult,
+	BlueprintRule,
+	BlueprintWarning,
+	RuleContext,
+} from './types';
+import { isTrustedSource } from './trusted-sources';
+import {
+	externalPluginSourceRule,
+	externalThemeSourceRule,
+	runPhpRule,
+	filesystemOperationsRule,
+	wpCliRule,
+	requestRule,
+} from './rules';
+
+/**
+ * Default set of rules to analyze blueprints.
+ */
+const defaultRules: BlueprintRule[] = [
+	externalPluginSourceRule,
+	externalThemeSourceRule,
+	runPhpRule,
+	filesystemOperationsRule,
+	wpCliRule,
+	requestRule,
+];
+
+/**
+ * Sort warnings by severity (danger > warning > info).
+ */
+function sortWarningsBySeverity(warnings: BlueprintWarning[]): BlueprintWarning[] {
+	const severityOrder = { danger: 0, warning: 1, info: 2 };
+	return [...warnings].sort(
+		(a, b) => severityOrder[a.severity] - severityOrder[b.severity]
+	);
+}
+
+/**
+ * Analyze a blueprint to determine if it requires user confirmation.
+ *
+ * The analysis:
+ * 1. Checks if the source is trusted (bypasses confirmation if so)
+ * 2. Runs all rules to collect warnings
+ * 3. Determines if confirmation is needed based on trust status
+ *
+ * Confirmation is required for ALL non-trusted blueprints when WordPress
+ * is installed, regardless of warning severity. This ensures users always
+ * know what's being applied to their persistent installation.
+ *
+ * @param context - The blueprint and source to analyze
+ * @param rules - Optional custom rules (defaults to all built-in rules)
+ * @returns Analysis result with warnings and confirmation requirement
+ */
+export function analyzeBlueprint(
+	context: RuleContext,
+	rules: BlueprintRule[] = defaultRules
+): AnalysisResult {
+	const trustedSource = isTrustedSource(context.source);
+
+	// Collect warnings from all rules
+	const warnings: BlueprintWarning[] = [];
+	for (const rule of rules) {
+		const ruleWarnings = rule.analyze(context);
+		warnings.push(...ruleWarnings);
+	}
+
+	// Sort warnings by severity (danger first, then warning, then info)
+	const sortedWarnings = sortWarningsBySeverity(warnings);
+
+	return {
+		// Require confirmation for all non-trusted sources
+		// The actual check for "is WordPress installed" happens at the integration point
+		requiresConfirmation: !trustedSource,
+		warnings: sortedWarnings,
+		isTrustedSource: trustedSource,
+	};
+}

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/index.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/index.ts
@@ -1,0 +1,17 @@
+export { analyzeBlueprint } from './analyzer';
+export { isTrustedSource } from './trusted-sources';
+export type {
+	AnalysisResult,
+	BlueprintRule,
+	BlueprintWarning,
+	RuleContext,
+	WarningSeverity,
+} from './types';
+export {
+	externalPluginSourceRule,
+	externalThemeSourceRule,
+	runPhpRule,
+	filesystemOperationsRule,
+	wpCliRule,
+	requestRule,
+} from './rules';

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/analyzer.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/analyzer.spec.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { analyzePhpCode, groupFindingsBySeverity } from './analyzer';
+
+describe('analyzePhpCode', () => {
+	describe('dangerous function detection', () => {
+		it('detects code execution functions as danger', () => {
+			// Testing security detection - these are patterns we want to catch
+			const findings = analyzePhpCode('<?php eval($code);');
+			expect(
+				findings.some(
+					(f) => f.severity === 'danger' && f.name === 'eval'
+				)
+			).toBe(true);
+		});
+
+		it('detects shell functions as danger', () => {
+			const findings = analyzePhpCode('<?php system("ls");');
+			expect(
+				findings.some(
+					(f) => f.severity === 'danger' && f.name === 'system'
+				)
+			).toBe(true);
+		});
+
+		it('detects network functions as danger', () => {
+			const findings = analyzePhpCode('<?php fsockopen("evil.com", 80);');
+			expect(
+				findings.some(
+					(f) => f.severity === 'danger' && f.name === 'fsockopen'
+				)
+			).toBe(true);
+		});
+	});
+
+	describe('warning function detection', () => {
+		it('detects file operations as warning', () => {
+			const findings = analyzePhpCode(
+				'<?php file_get_contents("http://example.com");'
+			);
+			expect(
+				findings.some(
+					(f) =>
+						f.severity === 'warning' &&
+						f.name === 'file_get_contents'
+				)
+			).toBe(true);
+		});
+
+		it('detects base64_decode as warning (obfuscation)', () => {
+			const findings = analyzePhpCode('<?php base64_decode($data);');
+			expect(
+				findings.some(
+					(f) =>
+						f.severity === 'warning' && f.name === 'base64_decode'
+				)
+			).toBe(true);
+		});
+
+		it('detects WordPress user functions as warning', () => {
+			const findings = analyzePhpCode('<?php wp_insert_user($userdata);');
+			expect(
+				findings.some(
+					(f) =>
+						f.severity === 'warning' && f.name === 'wp_insert_user'
+				)
+			).toBe(true);
+		});
+	});
+
+	describe('info function detection', () => {
+		it('detects phpinfo as info', () => {
+			const findings = analyzePhpCode('<?php phpinfo();');
+			expect(
+				findings.some(
+					(f) => f.severity === 'info' && f.name === 'phpinfo'
+				)
+			).toBe(true);
+		});
+
+		it('detects WordPress option functions as info', () => {
+			const findings = analyzePhpCode(
+				'<?php update_option("key", "value");'
+			);
+			expect(
+				findings.some(
+					(f) => f.severity === 'info' && f.name === 'update_option'
+				)
+			).toBe(true);
+		});
+	});
+
+	describe('superglobal detection', () => {
+		it('detects $_GET access', () => {
+			const findings = analyzePhpCode('<?php $x = $_GET["param"];');
+			expect(
+				findings.some(
+					(f) => f.type === 'superglobal' && f.name === '$_GET'
+				)
+			).toBe(true);
+		});
+
+		it('detects $_POST access', () => {
+			const findings = analyzePhpCode('<?php $x = $_POST["data"];');
+			expect(
+				findings.some(
+					(f) => f.type === 'superglobal' && f.name === '$_POST'
+				)
+			).toBe(true);
+		});
+
+		it('detects $_REQUEST access', () => {
+			const findings = analyzePhpCode('<?php $x = $_REQUEST["input"];');
+			expect(
+				findings.some(
+					(f) => f.type === 'superglobal' && f.name === '$_REQUEST'
+				)
+			).toBe(true);
+		});
+
+		it('detects $_COOKIE access', () => {
+			const findings = analyzePhpCode('<?php $x = $_COOKIE["session"];');
+			expect(
+				findings.some(
+					(f) => f.type === 'superglobal' && f.name === '$_COOKIE'
+				)
+			).toBe(true);
+		});
+	});
+
+	describe('variable function detection', () => {
+		it('detects variable function calls', () => {
+			const findings = analyzePhpCode(
+				'<?php $func = "system"; $func("ls");'
+			);
+			expect(findings.some((f) => f.type === 'variable_function')).toBe(
+				true
+			);
+		});
+
+		it('detects array-based variable function calls', () => {
+			const findings = analyzePhpCode('<?php $funcs["cmd"]("ls");');
+			expect(findings.some((f) => f.type === 'variable_function')).toBe(
+				true
+			);
+		});
+	});
+
+	describe('backtick detection', () => {
+		it('detects backtick shell execution', () => {
+			const findings = analyzePhpCode('<?php $output = `whoami`;');
+			expect(findings.some((f) => f.type === 'backtick_exec')).toBe(true);
+		});
+	});
+
+	describe('safe code', () => {
+		it('returns empty for safe code', () => {
+			const findings = analyzePhpCode('<?php echo "Hello World";');
+			expect(findings).toHaveLength(0);
+		});
+
+		it('returns empty for simple variable assignments', () => {
+			const findings = analyzePhpCode('<?php $x = 1; $y = $x + 2;');
+			expect(findings).toHaveLength(0);
+		});
+
+		it('returns empty for safe string operations', () => {
+			const findings = analyzePhpCode(
+				'<?php $name = strtolower($input);'
+			);
+			expect(findings).toHaveLength(0);
+		});
+	});
+
+	describe('line numbers', () => {
+		it('reports correct line numbers', () => {
+			const code = '<?php\n$x = 1;\neval($code);';
+			const findings = analyzePhpCode(code);
+			const evalFinding = findings.find((f) => f.name === 'eval');
+			expect(evalFinding?.line).toBe(3);
+		});
+	});
+
+	describe('multiple findings', () => {
+		it('detects multiple issues in same code', () => {
+			const code = '<?php eval($_GET["cmd"]); system($x);';
+			const findings = analyzePhpCode(code);
+			expect(findings.length).toBeGreaterThanOrEqual(3); // eval, $_GET, system
+		});
+	});
+
+	describe('groupFindingsBySeverity', () => {
+		it('groups findings correctly', () => {
+			const code = '<?php eval($x); file_get_contents($url); phpinfo();';
+			const findings = analyzePhpCode(code);
+			const grouped = groupFindingsBySeverity(findings);
+
+			expect(grouped.danger.some((f) => f.name === 'eval')).toBe(true);
+			expect(
+				grouped.warning.some((f) => f.name === 'file_get_contents')
+			).toBe(true);
+			expect(grouped.info.some((f) => f.name === 'phpinfo')).toBe(true);
+		});
+	});
+
+	describe('case sensitivity', () => {
+		it('detects functions regardless of case', () => {
+			const findings = analyzePhpCode('<?php EVAL($code); System("ls");');
+			expect(findings.some((f) => f.name.toLowerCase() === 'eval')).toBe(
+				true
+			);
+			expect(
+				findings.some((f) => f.name.toLowerCase() === 'system')
+			).toBe(true);
+		});
+	});
+
+	describe('comments are ignored', () => {
+		it('does not flag functions in comments', () => {
+			const findings = analyzePhpCode('<?php // eval($code); is bad');
+			expect(findings.some((f) => f.name === 'eval')).toBe(false);
+		});
+
+		it('does not flag functions in block comments', () => {
+			const findings = analyzePhpCode(
+				'<?php /* system("ls"); */ echo 1;'
+			);
+			expect(findings.some((f) => f.name === 'system')).toBe(false);
+		});
+	});
+
+	describe('strings are not function calls', () => {
+		it('does not flag function names in strings', () => {
+			const findings = analyzePhpCode('<?php $msg = "do not eval this";');
+			expect(
+				findings.some(
+					(f) => f.type === 'function_call' && f.name === 'eval'
+				)
+			).toBe(false);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/analyzer.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/analyzer.ts
@@ -1,0 +1,346 @@
+/**
+ * PHP code analyzer using the simple tokenizer.
+ *
+ * Analyzes tokenized PHP code to detect:
+ * - Dangerous function calls
+ * - Variable function calls (dynamic execution)
+ * - Superglobal access (user input)
+ * - Backtick shell execution
+ * - Suspicious string patterns
+ */
+
+import { tokenize, filterSignificantTokens, type Token } from './tokenizer';
+import type { WarningSeverity } from '../types';
+
+export interface PhpFinding {
+	type:
+		| 'function_call'
+		| 'variable_function'
+		| 'superglobal'
+		| 'backtick_exec'
+		| 'suspicious_string';
+	severity: WarningSeverity;
+	name: string;
+	description: string;
+	line: number;
+}
+
+/**
+ * Dangerous functions categorized by severity.
+ */
+const DANGEROUS_FUNCTIONS: Record<
+	string,
+	{ severity: WarningSeverity; description: string }
+> = {
+	// Danger: Code/command execution
+	eval: { severity: 'danger', description: 'Executes arbitrary PHP code' },
+	assert: {
+		severity: 'danger',
+		description: 'Can execute code when passed a string',
+	},
+	create_function: {
+		severity: 'danger',
+		description: 'Creates function from string (deprecated)',
+	},
+	exec: { severity: 'danger', description: 'Executes shell command' },
+	shell_exec: { severity: 'danger', description: 'Executes shell command' },
+	system: { severity: 'danger', description: 'Executes shell command' },
+	passthru: { severity: 'danger', description: 'Executes shell command' },
+	popen: { severity: 'danger', description: 'Opens process' },
+	proc_open: {
+		severity: 'danger',
+		description: 'Opens process with full control',
+	},
+	pcntl_exec: { severity: 'danger', description: 'Replaces current process' },
+
+	// Danger: Network (data exfiltration)
+	curl_exec: { severity: 'danger', description: 'Executes cURL request' },
+	fsockopen: { severity: 'danger', description: 'Opens network socket' },
+	pfsockopen: { severity: 'danger', description: 'Opens persistent socket' },
+	stream_socket_client: {
+		severity: 'danger',
+		description: 'Opens socket connection',
+	},
+
+	// Warning: Network (could be legitimate)
+	file_get_contents: {
+		severity: 'warning',
+		description: 'Reads file or URL',
+	},
+	curl_init: { severity: 'warning', description: 'Initializes cURL session' },
+	wp_remote_get: {
+		severity: 'warning',
+		description: 'Makes HTTP GET request',
+	},
+	wp_remote_post: {
+		severity: 'warning',
+		description: 'Makes HTTP POST request',
+	},
+	wp_remote_request: {
+		severity: 'warning',
+		description: 'Makes HTTP request',
+	},
+
+	// Warning: File writes
+	file_put_contents: { severity: 'warning', description: 'Writes to file' },
+	fwrite: { severity: 'warning', description: 'Writes to file' },
+	fputs: { severity: 'warning', description: 'Writes to file' },
+
+	// Warning: Dynamic execution
+	call_user_func: {
+		severity: 'warning',
+		description: 'Calls function dynamically',
+	},
+	call_user_func_array: {
+		severity: 'warning',
+		description: 'Calls function dynamically',
+	},
+	preg_replace_callback: {
+		severity: 'warning',
+		description: 'Executes callback on matches',
+	},
+
+	// Warning: Encoding (often used for obfuscation)
+	base64_decode: {
+		severity: 'warning',
+		description: 'Decodes base64 (often hides malicious code)',
+	},
+	gzinflate: { severity: 'warning', description: 'Decompresses data' },
+	gzuncompress: { severity: 'warning', description: 'Decompresses data' },
+	gzdecode: { severity: 'warning', description: 'Decodes gzip data' },
+	str_rot13: {
+		severity: 'warning',
+		description: 'ROT13 encoding (often obfuscation)',
+	},
+
+	// Warning: WordPress user management
+	wp_insert_user: {
+		severity: 'warning',
+		description: 'Creates WordPress user',
+	},
+	wp_create_user: {
+		severity: 'warning',
+		description: 'Creates WordPress user',
+	},
+	wp_set_password: {
+		severity: 'warning',
+		description: 'Changes user password',
+	},
+
+	// Warning: Database
+	mysqli_query: {
+		severity: 'warning',
+		description: 'Executes database query',
+	},
+
+	// Info: Information disclosure
+	phpinfo: { severity: 'info', description: 'Displays PHP configuration' },
+	getenv: { severity: 'info', description: 'Gets environment variable' },
+	get_defined_vars: {
+		severity: 'info',
+		description: 'Gets all defined variables',
+	},
+
+	// Info: WordPress options
+	update_option: {
+		severity: 'info',
+		description: 'Updates WordPress option',
+	},
+	add_option: { severity: 'info', description: 'Adds WordPress option' },
+	delete_option: {
+		severity: 'info',
+		description: 'Deletes WordPress option',
+	},
+};
+
+/**
+ * Superglobals that indicate user input.
+ */
+const SUPERGLOBALS = [
+	'$_GET',
+	'$_POST',
+	'$_REQUEST',
+	'$_COOKIE',
+	'$_FILES',
+	'$_SERVER',
+];
+
+/**
+ * Analyze PHP code for security concerns.
+ */
+export function analyzePhpCode(code: string): PhpFinding[] {
+	const tokens = tokenize(code);
+	const significant = filterSignificantTokens(tokens);
+	const findings: PhpFinding[] = [];
+
+	for (let i = 0; i < significant.length; i++) {
+		const token = significant[i];
+		const next = significant[i + 1];
+
+		// Check for function calls: identifier followed by (
+		if (token.type === 'T_STRING' && next?.type === 'T_OPEN_PAREN') {
+			const funcName = token.value.toLowerCase();
+			const funcInfo = DANGEROUS_FUNCTIONS[funcName];
+
+			if (funcInfo) {
+				findings.push({
+					type: 'function_call',
+					severity: funcInfo.severity,
+					name: token.value,
+					description: funcInfo.description,
+					line: token.line,
+				});
+			}
+		}
+
+		// Check for variable function calls: $var(...) or $var[...](...)
+		if (token.type === 'T_VARIABLE') {
+			const callIndex = findFunctionCallAfterVariable(significant, i);
+			if (callIndex !== -1) {
+				findings.push({
+					type: 'variable_function',
+					severity: 'danger',
+					name: token.value,
+					description:
+						'Calls function via variable (potential code execution)',
+					line: token.line,
+				});
+			}
+		}
+
+		// Check for superglobal access
+		if (token.type === 'T_VARIABLE' && SUPERGLOBALS.includes(token.value)) {
+			findings.push({
+				type: 'superglobal',
+				severity: 'warning',
+				name: token.value,
+				description: `Accesses user input via ${token.value}`,
+				line: token.line,
+			});
+		}
+
+		// Check for backtick shell execution
+		if (token.type === 'T_BACKTICK_STRING') {
+			findings.push({
+				type: 'backtick_exec',
+				severity: 'danger',
+				name: 'backtick operator',
+				description: 'Executes shell command via backticks',
+				line: token.line,
+			});
+		}
+
+		// Check string literals for suspicious patterns
+		if (token.type === 'T_CONSTANT_STRING') {
+			const stringFindings = analyzeString(token.value, token.line);
+			findings.push(...stringFindings);
+		}
+	}
+
+	return deduplicateFindings(findings);
+}
+
+/**
+ * Look ahead from a variable to see if it's used as a function call.
+ * Handles patterns like: $var(), $var[0](), $obj->$method()
+ */
+function findFunctionCallAfterVariable(
+	tokens: Token[],
+	startIndex: number
+): number {
+	let i = startIndex + 1;
+	let bracketDepth = 0;
+
+	while (i < tokens.length) {
+		const token = tokens[i];
+
+		if (token.type === 'T_OPEN_BRACKET') {
+			bracketDepth++;
+		} else if (token.type === 'T_CLOSE_BRACKET') {
+			bracketDepth--;
+		} else if (token.type === 'T_OPEN_PAREN' && bracketDepth === 0) {
+			return i;
+		} else if (
+			bracketDepth === 0 &&
+			token.type !== 'T_WHITESPACE' &&
+			token.type !== 'T_OPEN_BRACKET' &&
+			token.type !== 'T_CLOSE_BRACKET'
+		) {
+			// Hit something else, not a function call
+			break;
+		}
+
+		i++;
+	}
+
+	return -1;
+}
+
+/**
+ * Analyze a string literal for suspicious content.
+ */
+function analyzeString(value: string, line: number): PhpFinding[] {
+	const findings: PhpFinding[] = [];
+
+	// Remove quotes
+	const content = value.slice(1, -1);
+
+	// Check for URLs to PHP files
+	if (/https?:\/\/[^\s'"]+\.php/i.test(content)) {
+		findings.push({
+			type: 'suspicious_string',
+			severity: 'warning',
+			name: 'URL to PHP file',
+			description: 'Contains URL pointing to PHP file',
+			line,
+		});
+	}
+
+	// Check for base64 that decodes to PHP
+	if (/^[A-Za-z0-9+/=]{50,}$/.test(content)) {
+		try {
+			const decoded = atob(content);
+			if (decoded.includes('<?php') || decoded.includes('eval')) {
+				findings.push({
+					type: 'suspicious_string',
+					severity: 'danger',
+					name: 'Encoded PHP code',
+					description: 'Contains base64-encoded PHP code',
+					line,
+				});
+			}
+		} catch {
+			// Not valid base64, ignore
+		}
+	}
+
+	return findings;
+}
+
+/**
+ * Remove duplicate findings (same type, name, and line).
+ */
+function deduplicateFindings(findings: PhpFinding[]): PhpFinding[] {
+	const seen = new Set<string>();
+	return findings.filter((f) => {
+		const key = `${f.type}:${f.name}:${f.line}`;
+		if (seen.has(key)) {
+			return false;
+		}
+		seen.add(key);
+		return true;
+	});
+}
+
+/**
+ * Group findings by severity.
+ */
+export function groupFindingsBySeverity(
+	findings: PhpFinding[]
+): Record<WarningSeverity, PhpFinding[]> {
+	return {
+		danger: findings.filter((f) => f.severity === 'danger'),
+		warning: findings.filter((f) => f.severity === 'warning'),
+		info: findings.filter((f) => f.severity === 'info'),
+	};
+}

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/analyzer.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/analyzer.ts
@@ -260,12 +260,7 @@ function findFunctionCallAfterVariable(
 			bracketDepth--;
 		} else if (token.type === 'T_OPEN_PAREN' && bracketDepth === 0) {
 			return i;
-		} else if (
-			bracketDepth === 0 &&
-			token.type !== 'T_WHITESPACE' &&
-			token.type !== 'T_OPEN_BRACKET' &&
-			token.type !== 'T_CLOSE_BRACKET'
-		) {
+		} else if (bracketDepth === 0) {
 			// Hit something else, not a function call
 			break;
 		}

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/tokenizer.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/tokenizer.spec.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest';
+import { tokenize, filterSignificantTokens } from './tokenizer';
+
+describe('tokenize', () => {
+	describe('PHP tags', () => {
+		it('tokenizes <?php open tag', () => {
+			const tokens = tokenize('<?php echo 1;');
+			expect(tokens[0]).toMatchObject({
+				type: 'T_OPEN_TAG',
+				value: '<?php',
+			});
+		});
+
+		it('tokenizes <?= short echo tag', () => {
+			const tokens = tokenize('<?= $var ?>');
+			expect(tokens[0]).toMatchObject({
+				type: 'T_OPEN_TAG',
+				value: '<?=',
+			});
+		});
+
+		it('tokenizes ?> close tag', () => {
+			const tokens = tokenize('<?php echo 1; ?>');
+			const closeTag = tokens.find((t) => t.type === 'T_CLOSE_TAG');
+			expect(closeTag?.value).toBe('?>');
+		});
+	});
+
+	describe('variables', () => {
+		it('tokenizes simple variables', () => {
+			const tokens = tokenize('<?php $foo');
+			const varToken = tokens.find((t) => t.type === 'T_VARIABLE');
+			expect(varToken?.value).toBe('$foo');
+		});
+
+		it('tokenizes superglobals', () => {
+			const tokens = tokenize('<?php $_GET["x"]');
+			const varToken = tokens.find((t) => t.type === 'T_VARIABLE');
+			expect(varToken?.value).toBe('$_GET');
+		});
+
+		it('tokenizes variables with underscores and numbers', () => {
+			const tokens = tokenize('<?php $my_var_123');
+			const varToken = tokens.find((t) => t.type === 'T_VARIABLE');
+			expect(varToken?.value).toBe('$my_var_123');
+		});
+	});
+
+	describe('strings', () => {
+		it('tokenizes single-quoted strings', () => {
+			const tokens = tokenize("<?php 'hello world'");
+			const strToken = tokens.find((t) => t.type === 'T_CONSTANT_STRING');
+			expect(strToken?.value).toBe("'hello world'");
+		});
+
+		it('tokenizes double-quoted strings', () => {
+			const tokens = tokenize('<?php "hello world"');
+			const strToken = tokens.find((t) => t.type === 'T_CONSTANT_STRING');
+			expect(strToken?.value).toBe('"hello world"');
+		});
+
+		it('handles escaped quotes in strings', () => {
+			const tokens = tokenize("<?php 'it\\'s fine'");
+			const strToken = tokens.find((t) => t.type === 'T_CONSTANT_STRING');
+			expect(strToken?.value).toBe("'it\\'s fine'");
+		});
+	});
+
+	describe('backtick strings (shell execution)', () => {
+		it('tokenizes backtick strings', () => {
+			const tokens = tokenize('<?php `ls -la`');
+			const btToken = tokens.find((t) => t.type === 'T_BACKTICK_STRING');
+			expect(btToken?.value).toBe('`ls -la`');
+		});
+	});
+
+	describe('identifiers (function names)', () => {
+		it('tokenizes function names', () => {
+			const tokens = tokenize('<?php strtolower($str)');
+			const significant = filterSignificantTokens(tokens);
+			expect(significant[1]).toMatchObject({
+				type: 'T_STRING',
+				value: 'strtolower',
+			});
+		});
+
+		it('tokenizes namespaced identifiers', () => {
+			const tokens = tokenize('<?php Some\\Namespace\\func()');
+			const strings = tokens.filter((t) => t.type === 'T_STRING');
+			expect(strings.map((t) => t.value)).toContain('Some');
+			expect(strings.map((t) => t.value)).toContain('Namespace');
+			expect(strings.map((t) => t.value)).toContain('func');
+		});
+	});
+
+	describe('comments', () => {
+		it('tokenizes single-line // comments', () => {
+			const tokens = tokenize('<?php // this is a comment\n$x = 1;');
+			const comment = tokens.find((t) => t.type === 'T_COMMENT');
+			expect(comment?.value).toBe('// this is a comment');
+		});
+
+		it('tokenizes single-line # comments', () => {
+			const tokens = tokenize('<?php # hash comment\n$x = 1;');
+			const comment = tokens.find((t) => t.type === 'T_COMMENT');
+			expect(comment?.value).toBe('# hash comment');
+		});
+
+		it('tokenizes multi-line comments', () => {
+			const tokens = tokenize('<?php /* multi\nline */ $x');
+			const comment = tokens.find((t) => t.type === 'T_COMMENT');
+			expect(comment?.value).toBe('/* multi\nline */');
+		});
+	});
+
+	describe('operators and punctuation', () => {
+		it('tokenizes parentheses', () => {
+			const tokens = tokenize('<?php func()');
+			expect(tokens.some((t) => t.type === 'T_OPEN_PAREN')).toBe(true);
+			expect(tokens.some((t) => t.type === 'T_CLOSE_PAREN')).toBe(true);
+		});
+
+		it('tokenizes brackets', () => {
+			const tokens = tokenize('<?php $arr[0]');
+			expect(tokens.some((t) => t.type === 'T_OPEN_BRACKET')).toBe(true);
+			expect(tokens.some((t) => t.type === 'T_CLOSE_BRACKET')).toBe(true);
+		});
+
+		it('tokenizes arrow operator', () => {
+			const tokens = tokenize('<?php $obj->method()');
+			expect(tokens.some((t) => t.type === 'T_ARROW')).toBe(true);
+		});
+
+		it('tokenizes double colon', () => {
+			const tokens = tokenize('<?php Class::method()');
+			expect(tokens.some((t) => t.type === 'T_DOUBLE_COLON')).toBe(true);
+		});
+
+		it('tokenizes double arrow', () => {
+			const tokens = tokenize('<?php ["key" => "value"]');
+			expect(tokens.some((t) => t.type === 'T_DOUBLE_ARROW')).toBe(true);
+		});
+	});
+
+	describe('line tracking', () => {
+		it('tracks line numbers correctly', () => {
+			const code = '<?php\n$line2 = 1;\n$line3 = 2;';
+			const tokens = tokenize(code);
+			const line2Var = tokens.find((t) => t.value === '$line2');
+			const line3Var = tokens.find((t) => t.value === '$line3');
+			expect(line2Var?.line).toBe(2);
+			expect(line3Var?.line).toBe(3);
+		});
+	});
+
+	describe('filterSignificantTokens', () => {
+		it('removes whitespace and comments', () => {
+			const tokens = tokenize('<?php /* comment */ $x = 1; // end');
+			const significant = filterSignificantTokens(tokens);
+			expect(significant.every((t) => t.type !== 'T_WHITESPACE')).toBe(
+				true
+			);
+			expect(significant.every((t) => t.type !== 'T_COMMENT')).toBe(true);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/tokenizer.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/tokenizer.ts
@@ -1,0 +1,241 @@
+/**
+ * Simple PHP tokenizer for security analysis.
+ *
+ * This is not a full PHP parser - it's designed to identify potentially
+ * dangerous patterns like function calls, variable usage, and string literals.
+ */
+
+export type TokenType =
+	| 'T_OPEN_TAG'
+	| 'T_CLOSE_TAG'
+	| 'T_VARIABLE'
+	| 'T_STRING' // identifiers, function names
+	| 'T_CONSTANT_STRING' // 'string' or "string"
+	| 'T_NUMBER'
+	| 'T_WHITESPACE'
+	| 'T_COMMENT'
+	| 'T_OPERATOR'
+	| 'T_SEMICOLON'
+	| 'T_OPEN_PAREN'
+	| 'T_CLOSE_PAREN'
+	| 'T_OPEN_BRACKET'
+	| 'T_CLOSE_BRACKET'
+	| 'T_OPEN_BRACE'
+	| 'T_CLOSE_BRACE'
+	| 'T_COMMA'
+	| 'T_DOUBLE_COLON'
+	| 'T_ARROW'
+	| 'T_DOUBLE_ARROW'
+	| 'T_BACKTICK_STRING'
+	| 'T_UNKNOWN';
+
+export interface Token {
+	type: TokenType;
+	value: string;
+	line: number;
+	column: number;
+}
+
+/**
+ * Tokenize PHP code into a stream of tokens.
+ */
+export function tokenize(code: string): Token[] {
+	const tokens: Token[] = [];
+	let pos = 0;
+	let line = 1;
+	let column = 1;
+
+	const updatePosition = (consumed: string) => {
+		for (const char of consumed) {
+			if (char === '\n') {
+				line++;
+				column = 1;
+			} else {
+				column++;
+			}
+		}
+		pos += consumed.length;
+	};
+
+	const addToken = (type: TokenType, value: string) => {
+		tokens.push({ type, value, line, column });
+		updatePosition(value);
+	};
+
+	const peek = (offset = 0): string => code[pos + offset] || '';
+	const remaining = (): string => code.slice(pos);
+
+	while (pos < code.length) {
+		const char = peek();
+		const rest = remaining();
+
+		// PHP open tags
+		if (rest.startsWith('<?php')) {
+			addToken('T_OPEN_TAG', '<?php');
+			continue;
+		}
+		if (rest.startsWith('<?=')) {
+			addToken('T_OPEN_TAG', '<?=');
+			continue;
+		}
+		if (rest.startsWith('<?')) {
+			addToken('T_OPEN_TAG', '<?');
+			continue;
+		}
+		if (rest.startsWith('?>')) {
+			addToken('T_CLOSE_TAG', '?>');
+			continue;
+		}
+
+		// Whitespace
+		const wsMatch = rest.match(/^[\s]+/);
+		if (wsMatch) {
+			addToken('T_WHITESPACE', wsMatch[0]);
+			continue;
+		}
+
+		// Comments
+		if (rest.startsWith('//') || rest.startsWith('#')) {
+			const endOfLine = rest.indexOf('\n');
+			const comment = endOfLine === -1 ? rest : rest.slice(0, endOfLine);
+			addToken('T_COMMENT', comment);
+			continue;
+		}
+		if (rest.startsWith('/*')) {
+			const endComment = rest.indexOf('*/');
+			const comment =
+				endComment === -1 ? rest : rest.slice(0, endComment + 2);
+			addToken('T_COMMENT', comment);
+			continue;
+		}
+
+		// Backtick strings (shell execution)
+		if (char === '`') {
+			let str = '`';
+			let i = 1;
+			while (pos + i < code.length && code[pos + i] !== '`') {
+				if (code[pos + i] === '\\' && pos + i + 1 < code.length) {
+					str += code[pos + i] + code[pos + i + 1];
+					i += 2;
+				} else {
+					str += code[pos + i];
+					i++;
+				}
+			}
+			if (pos + i < code.length) {
+				str += '`';
+			}
+			addToken('T_BACKTICK_STRING', str);
+			continue;
+		}
+
+		// Strings
+		if (char === '"' || char === "'") {
+			const quote = char;
+			let str = quote;
+			let i = 1;
+			while (pos + i < code.length && code[pos + i] !== quote) {
+				if (code[pos + i] === '\\' && pos + i + 1 < code.length) {
+					str += code[pos + i] + code[pos + i + 1];
+					i += 2;
+				} else {
+					str += code[pos + i];
+					i++;
+				}
+			}
+			if (pos + i < code.length) {
+				str += quote;
+			}
+			addToken('T_CONSTANT_STRING', str);
+			continue;
+		}
+
+		// Variables
+		if (char === '$') {
+			const varMatch = rest.match(
+				/^\$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/
+			);
+			if (varMatch) {
+				addToken('T_VARIABLE', varMatch[0]);
+				continue;
+			}
+		}
+
+		// Numbers
+		const numMatch = rest.match(
+			/^(?:0x[0-9a-fA-F]+|0b[01]+|0[0-7]+|\d+\.?\d*(?:e[+-]?\d+)?)/i
+		);
+		if (numMatch) {
+			addToken('T_NUMBER', numMatch[0]);
+			continue;
+		}
+
+		// Multi-character operators
+		if (rest.startsWith('::')) {
+			addToken('T_DOUBLE_COLON', '::');
+			continue;
+		}
+		if (rest.startsWith('->')) {
+			addToken('T_ARROW', '->');
+			continue;
+		}
+		if (rest.startsWith('=>')) {
+			addToken('T_DOUBLE_ARROW', '=>');
+			continue;
+		}
+
+		// Identifiers (function names, keywords, etc.)
+		const idMatch = rest.match(/^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*/);
+		if (idMatch) {
+			addToken('T_STRING', idMatch[0]);
+			continue;
+		}
+
+		// Single character tokens
+		switch (char) {
+			case '(':
+				addToken('T_OPEN_PAREN', char);
+				break;
+			case ')':
+				addToken('T_CLOSE_PAREN', char);
+				break;
+			case '[':
+				addToken('T_OPEN_BRACKET', char);
+				break;
+			case ']':
+				addToken('T_CLOSE_BRACKET', char);
+				break;
+			case '{':
+				addToken('T_OPEN_BRACE', char);
+				break;
+			case '}':
+				addToken('T_CLOSE_BRACE', char);
+				break;
+			case ';':
+				addToken('T_SEMICOLON', char);
+				break;
+			case ',':
+				addToken('T_COMMA', char);
+				break;
+			default:
+				// Operators and other characters
+				const opMatch = rest.match(/^[+\-*\/%&|^~<>=!?.@:\\]+/);
+				if (opMatch) {
+					addToken('T_OPERATOR', opMatch[0]);
+				} else {
+					addToken('T_UNKNOWN', char);
+				}
+		}
+	}
+
+	return tokens;
+}
+
+/**
+ * Filter out whitespace and comment tokens.
+ */
+export function filterSignificantTokens(tokens: Token[]): Token[] {
+	return tokens.filter(
+		(t) => t.type !== 'T_WHITESPACE' && t.type !== 'T_COMMENT'
+	);
+}

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/tokenizer.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/php-analyzer/tokenizer.ts
@@ -217,14 +217,15 @@ export function tokenize(code: string): Token[] {
 			case ',':
 				addToken('T_COMMA', char);
 				break;
-			default:
+			default: {
 				// Operators and other characters
-				const opMatch = rest.match(/^[+\-*\/%&|^~<>=!?.@:\\]+/);
+				const opMatch = rest.match(/^[+\-*/%&|^~<>=!?.@:\\]+/);
 				if (opMatch) {
 					addToken('T_OPERATOR', opMatch[0]);
 				} else {
 					addToken('T_UNKNOWN', char);
 				}
+			}
 		}
 	}
 

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-plugin-source.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-plugin-source.spec.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { externalPluginSourceRule } from './external-plugin-source';
 import type { RuleContext } from '../types';
 
-const createContext = (steps: unknown[]): RuleContext => ({
-	blueprint: { steps },
-	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
-});
+// Type assertion allows testing edge cases with malformed/incomplete step data
+const createContext = (steps: unknown[]): RuleContext =>
+	({
+		blueprint: { steps },
+		source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+	}) as RuleContext;
 
 describe('externalPluginSourceRule', () => {
 	describe('wordpress.org plugins', () => {

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-plugin-source.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-plugin-source.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { externalPluginSourceRule } from './external-plugin-source';
+import type { RuleContext } from '../types';
+
+const createContext = (steps: unknown[]): RuleContext => ({
+	blueprint: { steps },
+	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+});
+
+describe('externalPluginSourceRule', () => {
+	describe('wordpress.org plugins', () => {
+		it('returns info severity for wordpress.org plugins', () => {
+			const context = createContext([
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'wordpress.org/plugins',
+						slug: 'hello-dolly',
+					},
+				},
+			]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('info');
+			expect(warnings[0].title).toBe('Install plugin "hello-dolly"');
+			expect(warnings[0].description).toContain('WordPress.org');
+		});
+
+		it('includes step index in warning', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'wordpress.org/plugins',
+						slug: 'woocommerce',
+					},
+				},
+			]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings[0].stepIndex).toBe(1);
+		});
+	});
+
+	describe('external URL plugins', () => {
+		it('returns warning severity for URL resource', () => {
+			const context = createContext([
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'url',
+						url: 'https://example.com/plugin.zip',
+					},
+				},
+			]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Install plugin from external URL');
+			expect(warnings[0].description).toContain(
+				'https://example.com/plugin.zip'
+			);
+		});
+	});
+
+	describe('embedded plugins', () => {
+		it('returns warning severity for vfs resource', () => {
+			const context = createContext([
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'vfs',
+						path: '/tmp/plugin.zip',
+					},
+				},
+			]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Install embedded plugin');
+		});
+
+		it('returns warning severity for literal resource', () => {
+			const context = createContext([
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'literal',
+						contents: 'base64-encoded-plugin-data',
+					},
+				},
+			]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Install embedded plugin');
+		});
+	});
+
+	describe('multiple plugins', () => {
+		it('returns warnings for all installPlugin steps', () => {
+			const context = createContext([
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'wordpress.org/plugins',
+						slug: 'woocommerce',
+					},
+				},
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'url',
+						url: 'https://example.com/custom.zip',
+					},
+				},
+			]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(2);
+			expect(warnings[0].severity).toBe('info');
+			expect(warnings[1].severity).toBe('warning');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('ignores non-installPlugin steps', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'runPHP', code: '<?php echo 1;' },
+				{
+					step: 'installTheme',
+					themeData: { resource: 'url', url: 'x' },
+				},
+			]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles missing pluginData', () => {
+			const context = createContext([{ step: 'installPlugin' }]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles null steps in array', () => {
+			const context = createContext([
+				null,
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'wordpress.org/plugins',
+						slug: 'test',
+					},
+				},
+			]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+		});
+
+		it('handles empty steps array', () => {
+			const context = createContext([]);
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles undefined steps', () => {
+			const context: RuleContext = {
+				blueprint: {},
+				source: {
+					type: 'remote-url',
+					url: 'https://example.com/bp.json',
+				},
+			};
+
+			const warnings = externalPluginSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-plugin-source.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-plugin-source.ts
@@ -1,0 +1,63 @@
+import type { BlueprintRule, BlueprintWarning } from '../types';
+
+/**
+ * Analyzes installPlugin steps for external plugin sources.
+ *
+ * - WordPress.org plugins: info severity (safe, official source)
+ * - External URLs: warning severity (untrusted source)
+ */
+export const externalPluginSourceRule: BlueprintRule = {
+	name: 'external-plugin-source',
+	analyze: (context) => {
+		const warnings: BlueprintWarning[] = [];
+		const steps = context.blueprint.steps || [];
+
+		steps.forEach((step, index) => {
+			if (!step || typeof step !== 'object') {
+				return;
+			}
+
+			const stepObj = step as Record<string, unknown>;
+			if (stepObj.step !== 'installPlugin') {
+				return;
+			}
+
+			const pluginData = stepObj.pluginData as
+				| Record<string, unknown>
+				| undefined;
+			if (!pluginData) {
+				return;
+			}
+
+			const resource = pluginData.resource as string | undefined;
+			const slug = pluginData.slug as string | undefined;
+			const url = pluginData.url as string | undefined;
+
+			if (resource === 'wordpress.org/plugins' && slug) {
+				warnings.push({
+					severity: 'info',
+					title: `Install plugin "${slug}"`,
+					description: `Installs the "${slug}" plugin from WordPress.org`,
+					stepIndex: index,
+				});
+			} else if (resource === 'url' && url) {
+				warnings.push({
+					severity: 'warning',
+					title: 'Install plugin from external URL',
+					description: `Installs a plugin from: ${url}`,
+					stepIndex: index,
+				});
+			} else if (resource === 'vfs' || resource === 'literal') {
+				warnings.push({
+					severity: 'warning',
+					title: 'Install embedded plugin',
+					description:
+						'Installs a plugin embedded in the blueprint',
+					stepIndex: index,
+				});
+			}
+		});
+
+		return warnings;
+	},
+};

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-theme-source.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-theme-source.spec.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { externalThemeSourceRule } from './external-theme-source';
 import type { RuleContext } from '../types';
 
-const createContext = (steps: unknown[]): RuleContext => ({
-	blueprint: { steps },
-	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
-});
+// Type assertion allows testing edge cases with malformed/incomplete step data
+const createContext = (steps: unknown[]): RuleContext =>
+	({
+		blueprint: { steps },
+		source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+	}) as RuleContext;
 
 describe('externalThemeSourceRule', () => {
 	describe('wordpress.org themes', () => {

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-theme-source.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-theme-source.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { externalThemeSourceRule } from './external-theme-source';
+import type { RuleContext } from '../types';
+
+const createContext = (steps: unknown[]): RuleContext => ({
+	blueprint: { steps },
+	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+});
+
+describe('externalThemeSourceRule', () => {
+	describe('wordpress.org themes', () => {
+		it('returns info severity for wordpress.org themes', () => {
+			const context = createContext([
+				{
+					step: 'installTheme',
+					themeData: {
+						resource: 'wordpress.org/themes',
+						slug: 'twentytwentyfour',
+					},
+				},
+			]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('info');
+			expect(warnings[0].title).toBe('Install theme "twentytwentyfour"');
+			expect(warnings[0].description).toContain('WordPress.org');
+		});
+
+		it('includes step index in warning', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{
+					step: 'installTheme',
+					themeData: {
+						resource: 'wordpress.org/themes',
+						slug: 'astra',
+					},
+				},
+			]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings[0].stepIndex).toBe(1);
+		});
+	});
+
+	describe('external URL themes', () => {
+		it('returns warning severity for URL resource', () => {
+			const context = createContext([
+				{
+					step: 'installTheme',
+					themeData: {
+						resource: 'url',
+						url: 'https://example.com/theme.zip',
+					},
+				},
+			]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Install theme from external URL');
+			expect(warnings[0].description).toContain(
+				'https://example.com/theme.zip'
+			);
+		});
+	});
+
+	describe('embedded themes', () => {
+		it('returns warning severity for vfs resource', () => {
+			const context = createContext([
+				{
+					step: 'installTheme',
+					themeData: {
+						resource: 'vfs',
+						path: '/tmp/theme.zip',
+					},
+				},
+			]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Install embedded theme');
+		});
+
+		it('returns warning severity for literal resource', () => {
+			const context = createContext([
+				{
+					step: 'installTheme',
+					themeData: {
+						resource: 'literal',
+						contents: 'base64-encoded-theme-data',
+					},
+				},
+			]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Install embedded theme');
+		});
+	});
+
+	describe('multiple themes', () => {
+		it('returns warnings for all installTheme steps', () => {
+			const context = createContext([
+				{
+					step: 'installTheme',
+					themeData: {
+						resource: 'wordpress.org/themes',
+						slug: 'twentytwentyfour',
+					},
+				},
+				{
+					step: 'installTheme',
+					themeData: {
+						resource: 'url',
+						url: 'https://example.com/custom-theme.zip',
+					},
+				},
+			]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(2);
+			expect(warnings[0].severity).toBe('info');
+			expect(warnings[1].severity).toBe('warning');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('ignores non-installTheme steps', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'runPHP', code: '<?php echo 1;' },
+				{
+					step: 'installPlugin',
+					pluginData: { resource: 'url', url: 'x' },
+				},
+			]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles missing themeData', () => {
+			const context = createContext([{ step: 'installTheme' }]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles null steps in array', () => {
+			const context = createContext([
+				null,
+				{
+					step: 'installTheme',
+					themeData: {
+						resource: 'wordpress.org/themes',
+						slug: 'test',
+					},
+				},
+			]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+		});
+
+		it('handles empty steps array', () => {
+			const context = createContext([]);
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles undefined steps', () => {
+			const context: RuleContext = {
+				blueprint: {},
+				source: {
+					type: 'remote-url',
+					url: 'https://example.com/bp.json',
+				},
+			};
+
+			const warnings = externalThemeSourceRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-theme-source.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/external-theme-source.ts
@@ -1,0 +1,62 @@
+import type { BlueprintRule, BlueprintWarning } from '../types';
+
+/**
+ * Analyzes installTheme steps for external theme sources.
+ *
+ * - WordPress.org themes: info severity (safe, official source)
+ * - External URLs: warning severity (untrusted source)
+ */
+export const externalThemeSourceRule: BlueprintRule = {
+	name: 'external-theme-source',
+	analyze: (context) => {
+		const warnings: BlueprintWarning[] = [];
+		const steps = context.blueprint.steps || [];
+
+		steps.forEach((step, index) => {
+			if (!step || typeof step !== 'object') {
+				return;
+			}
+
+			const stepObj = step as Record<string, unknown>;
+			if (stepObj.step !== 'installTheme') {
+				return;
+			}
+
+			const themeData = stepObj.themeData as
+				| Record<string, unknown>
+				| undefined;
+			if (!themeData) {
+				return;
+			}
+
+			const resource = themeData.resource as string | undefined;
+			const slug = themeData.slug as string | undefined;
+			const url = themeData.url as string | undefined;
+
+			if (resource === 'wordpress.org/themes' && slug) {
+				warnings.push({
+					severity: 'info',
+					title: `Install theme "${slug}"`,
+					description: `Installs the "${slug}" theme from WordPress.org`,
+					stepIndex: index,
+				});
+			} else if (resource === 'url' && url) {
+				warnings.push({
+					severity: 'warning',
+					title: 'Install theme from external URL',
+					description: `Installs a theme from: ${url}`,
+					stepIndex: index,
+				});
+			} else if (resource === 'vfs' || resource === 'literal') {
+				warnings.push({
+					severity: 'warning',
+					title: 'Install embedded theme',
+					description: 'Installs a theme embedded in the blueprint',
+					stepIndex: index,
+				});
+			}
+		});
+
+		return warnings;
+	},
+};

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/file-patterns.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/file-patterns.ts
@@ -88,7 +88,7 @@ export const FILE_CONTENT_PATTERNS: FileContentPattern[] = [
 	// PHP code injection
 	{
 		name: 'php-tag',
-		pattern: /<\?php|\<\?=/i,
+		pattern: /<\?php|<\?=/i,
 		severity: 'danger',
 		description: 'Contains PHP code',
 	},

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/file-patterns.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/file-patterns.ts
@@ -1,0 +1,225 @@
+import type { WarningSeverity } from '../types';
+
+/**
+ * Sensitive paths that warrant danger severity when modified.
+ */
+export const SENSITIVE_PATHS = [
+	'/wp-config.php',
+	'/wp-includes/',
+	'/wp-admin/',
+	'/.htaccess',
+	'/wp-content/db.php',
+	'/wp-content/object-cache.php',
+	'/wp-content/advanced-cache.php',
+	'/wp-content/sunrise.php',
+	'/wp-content/mu-plugins/',
+];
+
+/**
+ * Paths where writing PHP files is particularly suspicious.
+ */
+export const EXECUTABLE_SENSITIVE_PATHS = [
+	'/wp-content/uploads/', // PHP in uploads is a classic backdoor location
+	'/wp-content/cache/',
+	'/wp-content/upgrade/',
+];
+
+/**
+ * Check if a path is sensitive and warrants danger severity.
+ */
+export function isSensitivePath(path: string): boolean {
+	const normalizedPath = normalizePath(path);
+	return SENSITIVE_PATHS.some(
+		(sensitive) =>
+			normalizedPath === sensitive || normalizedPath.startsWith(sensitive)
+	);
+}
+
+/**
+ * Check if path is in a location where executable files are suspicious.
+ */
+export function isExecutableSensitivePath(path: string): boolean {
+	const normalizedPath = normalizePath(path);
+	return EXECUTABLE_SENSITIVE_PATHS.some((sensitive) =>
+		normalizedPath.startsWith(sensitive)
+	);
+}
+
+/**
+ * Check if a file is a PHP file based on extension.
+ */
+export function isPhpFile(path: string): boolean {
+	const normalizedPath = path.toLowerCase();
+	return (
+		normalizedPath.endsWith('.php') ||
+		normalizedPath.endsWith('.phtml') ||
+		normalizedPath.endsWith('.php5') ||
+		normalizedPath.endsWith('.php7') ||
+		normalizedPath.endsWith('.phar')
+	);
+}
+
+/**
+ * Normalize a path for comparison.
+ */
+export function normalizePath(path: string): string {
+	let normalized = path;
+	if (!normalized.startsWith('/')) {
+		normalized = '/' + normalized;
+	}
+	// Remove /wordpress prefix if present (common in Playground)
+	if (normalized.startsWith('/wordpress/')) {
+		normalized = normalized.substring('/wordpress'.length);
+	}
+	return normalized;
+}
+
+export interface FileContentPattern {
+	name: string;
+	pattern: RegExp;
+	severity: WarningSeverity;
+	description: string;
+}
+
+/**
+ * Patterns to detect in file content being written.
+ */
+export const FILE_CONTENT_PATTERNS: FileContentPattern[] = [
+	// PHP code injection
+	{
+		name: 'php-tag',
+		pattern: /<\?php|\<\?=/i,
+		severity: 'danger',
+		description: 'Contains PHP code',
+	},
+	{
+		name: 'php-short-tag',
+		pattern: /<\?\s+/,
+		severity: 'warning',
+		description: 'May contain PHP short tags',
+	},
+
+	// Backdoor signatures
+	{
+		name: 'eval-base64',
+		pattern: /eval\s*\(\s*base64_decode/i,
+		severity: 'danger',
+		description: 'Contains obfuscated code execution (eval + base64)',
+	},
+	{
+		name: 'webshell-signature',
+		pattern:
+			/\$_(GET|POST|REQUEST|COOKIE)\s*\[\s*['"][^'"]+['"]\s*\]\s*\(/i,
+		severity: 'danger',
+		description: 'Contains webshell-like code pattern',
+	},
+	{
+		name: 'shell-exec-pattern',
+		pattern:
+			/(shell_exec|system|passthru|exec)\s*\(\s*\$_(GET|POST|REQUEST)/i,
+		severity: 'danger',
+		description: 'Contains remote command execution pattern',
+	},
+
+	// Suspicious patterns
+	{
+		name: 'hidden-admin',
+		pattern: /wp_insert_user|wp_create_user.*administrator/i,
+		severity: 'danger',
+		description: 'Creates WordPress admin user',
+	},
+	{
+		name: 'disable-security',
+		pattern: /remove_filter\s*\(\s*['"]authenticate/i,
+		severity: 'danger',
+		description: 'Disables authentication filters',
+	},
+];
+
+/**
+ * Analyze file content for suspicious patterns.
+ */
+export function analyzeFileContent(content: string): Array<{
+	pattern: FileContentPattern;
+	match: string;
+}> {
+	const findings: Array<{ pattern: FileContentPattern; match: string }> = [];
+
+	for (const pattern of FILE_CONTENT_PATTERNS) {
+		const match = content.match(pattern.pattern);
+		if (match) {
+			findings.push({
+				pattern,
+				match: match[0],
+			});
+		}
+	}
+
+	return findings;
+}
+
+export interface FileWriteAnalysis {
+	severity: WarningSeverity;
+	title: string;
+	reasons: string[];
+}
+
+/**
+ * Analyze a file write operation for security concerns.
+ */
+export function analyzeFileWrite(
+	path: string,
+	content?: string
+): FileWriteAnalysis {
+	const normalizedPath = normalizePath(path);
+	const reasons: string[] = [];
+	let severity: WarningSeverity = 'info';
+	let title = 'Write file';
+
+	// Check path sensitivity
+	if (isSensitivePath(normalizedPath)) {
+		severity = 'danger';
+		title = 'Write to sensitive location';
+		reasons.push(`Writing to sensitive path: ${normalizedPath}`);
+	}
+
+	// Check for PHP files
+	if (isPhpFile(normalizedPath)) {
+		if (isExecutableSensitivePath(normalizedPath)) {
+			severity = 'danger';
+			title = 'Write PHP file to suspicious location';
+			reasons.push(
+				`Writing PHP file to ${normalizedPath} (uploads/cache dirs should not contain PHP)`
+			);
+		} else if (severity !== 'danger') {
+			severity = 'warning';
+			title = 'Write PHP file';
+			reasons.push('Writing executable PHP file');
+		}
+	}
+
+	// Analyze content if available
+	if (content) {
+		const contentFindings = analyzeFileContent(content);
+
+		for (const finding of contentFindings) {
+			if (finding.pattern.severity === 'danger') {
+				severity = 'danger';
+				title = 'Write file with dangerous content';
+			} else if (
+				finding.pattern.severity === 'warning' &&
+				severity !== 'danger'
+			) {
+				severity = 'warning';
+			}
+			reasons.push(finding.pattern.description);
+		}
+	}
+
+	// Default reason if none found
+	if (reasons.length === 0) {
+		reasons.push(`Writes to: ${normalizedPath}`);
+	}
+
+	return { severity, title, reasons };
+}

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.spec.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { filesystemOperationsRule } from './filesystem-operations';
 import type { RuleContext } from '../types';
 
-const createContext = (steps: unknown[]): RuleContext => ({
-	blueprint: { steps },
-	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
-});
+// Type assertion allows testing edge cases with malformed/incomplete step data
+const createContext = (steps: unknown[]): RuleContext =>
+	({
+		blueprint: { steps },
+		source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+	}) as RuleContext;
 
 describe('filesystemOperationsRule', () => {
 	describe('writeFile', () => {

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.spec.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect } from 'vitest';
+import { filesystemOperationsRule } from './filesystem-operations';
+import type { RuleContext } from '../types';
+
+const createContext = (steps: unknown[]): RuleContext => ({
+	blueprint: { steps },
+	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+});
+
+describe('filesystemOperationsRule', () => {
+	describe('writeFile', () => {
+		it('returns info severity for normal paths without dangerous content', () => {
+			const context = createContext([
+				{
+					step: 'writeFile',
+					path: '/wp-content/test.txt',
+					data: 'content',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('info');
+			expect(warnings[0].title).toBe('Write file');
+		});
+
+		it('returns danger severity for wp-config.php', () => {
+			const context = createContext([
+				{ step: 'writeFile', path: '/wp-config.php', data: 'content' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+			expect(warnings[0].title).toBe('Write to sensitive location');
+		});
+
+		it('returns danger severity for wp-includes paths', () => {
+			const context = createContext([
+				{
+					step: 'writeFile',
+					path: '/wp-includes/malicious.php',
+					data: 'content',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+		});
+
+		it('returns danger severity for wp-admin paths', () => {
+			const context = createContext([
+				{
+					step: 'writeFile',
+					path: '/wp-admin/custom.php',
+					data: 'content',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+		});
+
+		it('returns danger severity for .htaccess', () => {
+			const context = createContext([
+				{ step: 'writeFile', path: '/.htaccess', data: 'content' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+		});
+
+		it('returns danger severity for db.php drop-in', () => {
+			const context = createContext([
+				{
+					step: 'writeFile',
+					path: '/wp-content/db.php',
+					data: 'content',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+		});
+	});
+
+	describe('rm (delete file)', () => {
+		it('returns warning severity for normal paths', () => {
+			const context = createContext([
+				{ step: 'rm', path: '/wp-content/uploads/image.jpg' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Delete file');
+		});
+
+		it('returns danger severity for sensitive paths', () => {
+			const context = createContext([
+				{ step: 'rm', path: '/wp-config.php' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+			expect(warnings[0].title).toBe('Delete sensitive file');
+		});
+	});
+
+	describe('rmdir (delete directory)', () => {
+		it('returns warning severity for normal paths', () => {
+			const context = createContext([
+				{ step: 'rmdir', path: '/wp-content/uploads/2024' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Delete directory');
+		});
+
+		it('returns danger severity for wp-includes', () => {
+			const context = createContext([
+				{ step: 'rmdir', path: '/wp-includes/' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+			expect(warnings[0].title).toBe('Delete sensitive directory');
+		});
+	});
+
+	describe('mkdir', () => {
+		it('returns info severity for mkdir (always safe)', () => {
+			const context = createContext([
+				{ step: 'mkdir', path: '/wp-content/custom-folder' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('info');
+			expect(warnings[0].title).toBe('Create directory');
+		});
+	});
+
+	describe('mv (move)', () => {
+		it('returns warning severity for normal paths', () => {
+			const context = createContext([
+				{
+					step: 'mv',
+					fromPath: '/wp-content/old.txt',
+					toPath: '/wp-content/new.txt',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Move file');
+		});
+
+		it('returns danger severity when moving to sensitive path', () => {
+			const context = createContext([
+				{
+					step: 'mv',
+					fromPath: '/tmp/malicious.php',
+					toPath: '/wp-includes/hack.php',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+			expect(warnings[0].title).toBe('Move sensitive file');
+		});
+
+		it('returns danger severity when moving from sensitive path', () => {
+			const context = createContext([
+				{
+					step: 'mv',
+					fromPath: '/wp-config.php',
+					toPath: '/tmp/backup.php',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+		});
+	});
+
+	describe('cp (copy)', () => {
+		it('returns info severity for normal paths', () => {
+			const context = createContext([
+				{
+					step: 'cp',
+					fromPath: '/wp-content/file.txt',
+					toPath: '/wp-content/backup.txt',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('info');
+			expect(warnings[0].title).toBe('Copy file');
+		});
+
+		it('returns danger severity when copying to sensitive path', () => {
+			const context = createContext([
+				{
+					step: 'cp',
+					fromPath: '/tmp/evil.php',
+					toPath: '/wp-includes/evil.php',
+				},
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+			expect(warnings[0].title).toBe('Copy to sensitive location');
+		});
+	});
+
+	describe('path normalization', () => {
+		it('handles paths without leading slash', () => {
+			const context = createContext([
+				{ step: 'writeFile', path: 'wp-config.php', data: 'content' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings[0].severity).toBe('danger');
+		});
+	});
+
+	describe('multiple operations', () => {
+		it('returns warnings for all filesystem steps', () => {
+			const context = createContext([
+				{ step: 'writeFile', path: '/test.txt', data: 'x' },
+				{ step: 'rm', path: '/old.txt' },
+				{ step: 'mkdir', path: '/new-folder' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings).toHaveLength(3);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('ignores non-filesystem steps', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'runPHP', code: '<?php echo 1;' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles missing path property', () => {
+			const context = createContext([
+				{ step: 'writeFile', data: 'content' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].description).toContain('Writes to:');
+		});
+
+		it('handles null steps', () => {
+			const context = createContext([
+				null,
+				{ step: 'writeFile', path: '/test.txt', data: 'x' },
+			]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+		});
+
+		it('handles empty steps array', () => {
+			const context = createContext([]);
+
+			const warnings = filesystemOperationsRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.ts
@@ -9,7 +9,6 @@ import {
 	isExecutableSensitivePath,
 	normalizePath,
 	analyzeFileWrite,
-	analyzeFileContent,
 } from './file-patterns';
 
 /**

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.ts
@@ -1,0 +1,135 @@
+import type { BlueprintRule, BlueprintWarning, WarningSeverity } from '../types';
+
+/**
+ * Sensitive paths that warrant danger severity when modified.
+ */
+const SENSITIVE_PATHS = [
+	'/wp-config.php',
+	'/wp-includes/',
+	'/wp-admin/',
+	'/.htaccess',
+	'/wp-content/db.php',
+	'/wp-content/object-cache.php',
+	'/wp-content/advanced-cache.php',
+];
+
+/**
+ * Check if a path is sensitive and warrants danger severity.
+ */
+function isSensitivePath(path: string): boolean {
+	const normalizedPath = path.startsWith('/') ? path : '/' + path;
+	return SENSITIVE_PATHS.some(
+		(sensitive) =>
+			normalizedPath === sensitive ||
+			normalizedPath.startsWith(sensitive)
+	);
+}
+
+/**
+ * Analyzes filesystem operation steps like writeFile, rm, mkdir, etc.
+ *
+ * - Normal paths: warning severity
+ * - Sensitive paths (wp-config.php, wp-includes, etc.): danger severity
+ */
+export const filesystemOperationsRule: BlueprintRule = {
+	name: 'filesystem-operations',
+	analyze: (context) => {
+		const warnings: BlueprintWarning[] = [];
+		const steps = context.blueprint.steps || [];
+
+		const filesystemSteps = [
+			'writeFile',
+			'rm',
+			'rmdir',
+			'mkdir',
+			'mv',
+			'cp',
+		];
+
+		steps.forEach((step, index) => {
+			if (!step || typeof step !== 'object') {
+				return;
+			}
+
+			const stepObj = step as Record<string, unknown>;
+			const stepName = stepObj.step as string;
+
+			if (!filesystemSteps.includes(stepName)) {
+				return;
+			}
+
+			const path = (stepObj.path as string) || '';
+			const fromPath = (stepObj.fromPath as string) || '';
+			const toPath = (stepObj.toPath as string) || '';
+
+			const affectedPaths = [path, fromPath, toPath].filter(Boolean);
+			const hasSensitivePath = affectedPaths.some(isSensitivePath);
+			const severity: WarningSeverity = hasSensitivePath
+				? 'danger'
+				: 'warning';
+
+			switch (stepName) {
+				case 'writeFile':
+					warnings.push({
+						severity,
+						title: hasSensitivePath
+							? 'Write to sensitive file'
+							: 'Write file',
+						description: `Writes to: ${path}`,
+						stepIndex: index,
+					});
+					break;
+				case 'rm':
+					warnings.push({
+						severity,
+						title: hasSensitivePath
+							? 'Delete sensitive file'
+							: 'Delete file',
+						description: `Deletes: ${path}`,
+						stepIndex: index,
+					});
+					break;
+				case 'rmdir':
+					warnings.push({
+						severity,
+						title: hasSensitivePath
+							? 'Delete sensitive directory'
+							: 'Delete directory',
+						description: `Deletes directory: ${path}`,
+						stepIndex: index,
+					});
+					break;
+				case 'mkdir':
+					warnings.push({
+						severity: 'info',
+						title: 'Create directory',
+						description: `Creates directory: ${path}`,
+						stepIndex: index,
+					});
+					break;
+				case 'mv':
+					warnings.push({
+						severity,
+						title: hasSensitivePath
+							? 'Move sensitive file'
+							: 'Move file',
+						description: `Moves from ${fromPath} to ${toPath}`,
+						stepIndex: index,
+					});
+					break;
+				case 'cp':
+					warnings.push({
+						severity: hasSensitivePath ? severity : 'info',
+						title: hasSensitivePath
+							? 'Copy to sensitive location'
+							: 'Copy file',
+						description: `Copies from ${fromPath} to ${toPath}`,
+						stepIndex: index,
+					});
+					break;
+			}
+		});
+
+		return warnings;
+	},
+};

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/filesystem-operations.ts
@@ -1,50 +1,52 @@
-import type { BlueprintRule, BlueprintWarning, WarningSeverity } from '../types';
+import type {
+	BlueprintRule,
+	BlueprintWarning,
+	WarningSeverity,
+} from '../types';
+import {
+	isSensitivePath,
+	isPhpFile,
+	isExecutableSensitivePath,
+	normalizePath,
+	analyzeFileWrite,
+	analyzeFileContent,
+} from './file-patterns';
 
 /**
- * Sensitive paths that warrant danger severity when modified.
+ * Extract string content from various data formats used in blueprints.
  */
-const SENSITIVE_PATHS = [
-	'/wp-config.php',
-	'/wp-includes/',
-	'/wp-admin/',
-	'/.htaccess',
-	'/wp-content/db.php',
-	'/wp-content/object-cache.php',
-	'/wp-content/advanced-cache.php',
-];
-
-/**
- * Check if a path is sensitive and warrants danger severity.
- */
-function isSensitivePath(path: string): boolean {
-	const normalizedPath = path.startsWith('/') ? path : '/' + path;
-	return SENSITIVE_PATHS.some(
-		(sensitive) =>
-			normalizedPath === sensitive ||
-			normalizedPath.startsWith(sensitive)
-	);
+function extractContent(data: unknown): string | undefined {
+	if (typeof data === 'string') {
+		return data;
+	}
+	if (data && typeof data === 'object') {
+		const dataObj = data as Record<string, unknown>;
+		// Handle { resource: 'literal', contents: '...' }
+		if (dataObj.contents && typeof dataObj.contents === 'string') {
+			return dataObj.contents;
+		}
+		// Handle base64 encoded content
+		if (dataObj.resource === 'literal' && dataObj.contents) {
+			return String(dataObj.contents);
+		}
+	}
+	return undefined;
 }
 
 /**
  * Analyzes filesystem operation steps like writeFile, rm, mkdir, etc.
  *
- * - Normal paths: warning severity
- * - Sensitive paths (wp-config.php, wp-includes, etc.): danger severity
+ * Performs detailed analysis:
+ * - Checks if target paths are sensitive (wp-config, wp-includes, etc.)
+ * - Detects PHP files being written to suspicious locations (uploads, cache)
+ * - Analyzes file content for malicious patterns (backdoors, webshells)
+ * - Detects obfuscated code and dangerous functions
  */
 export const filesystemOperationsRule: BlueprintRule = {
 	name: 'filesystem-operations',
 	analyze: (context) => {
 		const warnings: BlueprintWarning[] = [];
 		const steps = context.blueprint.steps || [];
-
-		const filesystemSteps = [
-			'writeFile',
-			'rm',
-			'rmdir',
-			'mkdir',
-			'mv',
-			'cp',
-		];
 
 		steps.forEach((step, index) => {
 			if (!step || typeof step !== 'object') {
@@ -54,79 +56,171 @@ export const filesystemOperationsRule: BlueprintRule = {
 			const stepObj = step as Record<string, unknown>;
 			const stepName = stepObj.step as string;
 
-			if (!filesystemSteps.includes(stepName)) {
+			// Handle writeFile with content analysis
+			if (stepName === 'writeFile') {
+				const path = (stepObj.path as string) || '';
+				const content = extractContent(stepObj.data);
+
+				const analysis = analyzeFileWrite(path, content);
+				warnings.push({
+					severity: analysis.severity,
+					title: analysis.title,
+					description: analysis.reasons.join('\n• '),
+					stepIndex: index,
+				});
 				return;
 			}
 
-			const path = (stepObj.path as string) || '';
-			const fromPath = (stepObj.fromPath as string) || '';
-			const toPath = (stepObj.toPath as string) || '';
+			// Handle writeFiles (multiple files)
+			if (stepName === 'writeFiles') {
+				const files = stepObj.files as
+					| Record<string, unknown>
+					| undefined;
+				if (files && typeof files === 'object') {
+					for (const [filePath, fileData] of Object.entries(files)) {
+						const content = extractContent(fileData);
+						const analysis = analyzeFileWrite(filePath, content);
+						warnings.push({
+							severity: analysis.severity,
+							title: analysis.title,
+							description: analysis.reasons.join('\n• '),
+							stepIndex: index,
+						});
+					}
+				}
+				return;
+			}
 
-			const affectedPaths = [path, fromPath, toPath].filter(Boolean);
-			const hasSensitivePath = affectedPaths.some(isSensitivePath);
-			const severity: WarningSeverity = hasSensitivePath
-				? 'danger'
-				: 'warning';
+			// Handle delete operations
+			if (stepName === 'rm') {
+				const path = (stepObj.path as string) || '';
+				const normalizedPath = normalizePath(path);
+				const sensitive = isSensitivePath(normalizedPath);
 
-			switch (stepName) {
-				case 'writeFile':
-					warnings.push({
-						severity,
-						title: hasSensitivePath
-							? 'Write to sensitive file'
-							: 'Write file',
-						description: `Writes to: ${path}`,
-						stepIndex: index,
-					});
-					break;
-				case 'rm':
-					warnings.push({
-						severity,
-						title: hasSensitivePath
-							? 'Delete sensitive file'
-							: 'Delete file',
-						description: `Deletes: ${path}`,
-						stepIndex: index,
-					});
-					break;
-				case 'rmdir':
-					warnings.push({
-						severity,
-						title: hasSensitivePath
-							? 'Delete sensitive directory'
-							: 'Delete directory',
-						description: `Deletes directory: ${path}`,
-						stepIndex: index,
-					});
-					break;
-				case 'mkdir':
-					warnings.push({
-						severity: 'info',
-						title: 'Create directory',
-						description: `Creates directory: ${path}`,
-						stepIndex: index,
-					});
-					break;
-				case 'mv':
-					warnings.push({
-						severity,
-						title: hasSensitivePath
-							? 'Move sensitive file'
-							: 'Move file',
-						description: `Moves from ${fromPath} to ${toPath}`,
-						stepIndex: index,
-					});
-					break;
-				case 'cp':
-					warnings.push({
-						severity: hasSensitivePath ? severity : 'info',
-						title: hasSensitivePath
-							? 'Copy to sensitive location'
-							: 'Copy file',
-						description: `Copies from ${fromPath} to ${toPath}`,
-						stepIndex: index,
-					});
-					break;
+				warnings.push({
+					severity: sensitive ? 'danger' : 'warning',
+					title: sensitive ? 'Delete sensitive file' : 'Delete file',
+					description: `Deletes: ${normalizedPath}`,
+					stepIndex: index,
+				});
+				return;
+			}
+
+			if (stepName === 'rmdir') {
+				const path = (stepObj.path as string) || '';
+				const normalizedPath = normalizePath(path);
+				const sensitive = isSensitivePath(normalizedPath);
+
+				warnings.push({
+					severity: sensitive ? 'danger' : 'warning',
+					title: sensitive
+						? 'Delete sensitive directory'
+						: 'Delete directory',
+					description: `Deletes directory: ${normalizedPath}`,
+					stepIndex: index,
+				});
+				return;
+			}
+
+			// Handle mkdir
+			if (stepName === 'mkdir') {
+				const path = (stepObj.path as string) || '';
+				warnings.push({
+					severity: 'info',
+					title: 'Create directory',
+					description: `Creates directory: ${normalizePath(path)}`,
+					stepIndex: index,
+				});
+				return;
+			}
+
+			// Handle move operations
+			if (stepName === 'mv') {
+				const fromPath = normalizePath(
+					(stepObj.fromPath as string) || ''
+				);
+				const toPath = normalizePath((stepObj.toPath as string) || '');
+				const hasSensitive =
+					isSensitivePath(fromPath) || isSensitivePath(toPath);
+				const movingPhpToSensitive =
+					isPhpFile(toPath) && isExecutableSensitivePath(toPath);
+
+				let severity: WarningSeverity = 'warning';
+				let title = 'Move file';
+
+				if (movingPhpToSensitive) {
+					severity = 'danger';
+					title = 'Move PHP file to suspicious location';
+				} else if (hasSensitive) {
+					severity = 'danger';
+					title = 'Move sensitive file';
+				}
+
+				warnings.push({
+					severity,
+					title,
+					description: `Moves from ${fromPath} to ${toPath}`,
+					stepIndex: index,
+				});
+				return;
+			}
+
+			// Handle copy operations
+			if (stepName === 'cp') {
+				const fromPath = normalizePath(
+					(stepObj.fromPath as string) || ''
+				);
+				const toPath = normalizePath((stepObj.toPath as string) || '');
+				const hasSensitive =
+					isSensitivePath(fromPath) || isSensitivePath(toPath);
+				const copyingPhpToSensitive =
+					isPhpFile(toPath) && isExecutableSensitivePath(toPath);
+
+				let severity: WarningSeverity = 'info';
+				let title = 'Copy file';
+
+				if (copyingPhpToSensitive) {
+					severity = 'danger';
+					title = 'Copy PHP file to suspicious location';
+				} else if (hasSensitive) {
+					severity = 'danger';
+					title = 'Copy to sensitive location';
+				}
+
+				warnings.push({
+					severity,
+					title,
+					description: `Copies from ${fromPath} to ${toPath}`,
+					stepIndex: index,
+				});
+				return;
+			}
+
+			// Handle unzip - could extract PHP files anywhere
+			if (stepName === 'unzip') {
+				const extractTo = normalizePath(
+					(stepObj.extractToPath as string) || ''
+				);
+				const sensitive = isSensitivePath(extractTo);
+				const phpSuspicious = isExecutableSensitivePath(extractTo);
+
+				let severity: WarningSeverity = 'warning';
+				let title = 'Extract archive';
+
+				if (sensitive) {
+					severity = 'danger';
+					title = 'Extract archive to sensitive location';
+				} else if (phpSuspicious) {
+					severity = 'warning';
+					title = 'Extract archive (may contain PHP)';
+				}
+
+				warnings.push({
+					severity,
+					title,
+					description: `Extracts archive to: ${extractTo}`,
+					stepIndex: index,
+				});
 			}
 		});
 

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/index.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/index.ts
@@ -1,0 +1,6 @@
+export { externalPluginSourceRule } from './external-plugin-source';
+export { externalThemeSourceRule } from './external-theme-source';
+export { runPhpRule } from './run-php';
+export { filesystemOperationsRule } from './filesystem-operations';
+export { wpCliRule } from './wp-cli';
+export { requestRule } from './request';

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/request.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/request.spec.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { requestRule } from './request';
 import type { RuleContext } from '../types';
 
-const createContext = (steps: unknown[]): RuleContext => ({
-	blueprint: { steps },
-	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
-});
+// Type assertion allows testing edge cases with malformed/incomplete step data
+const createContext = (steps: unknown[]): RuleContext =>
+	({
+		blueprint: { steps },
+		source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+	}) as RuleContext;
 
 describe('requestRule', () => {
 	describe('request step', () => {

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/request.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/request.spec.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import { requestRule } from './request';
+import type { RuleContext } from '../types';
+
+const createContext = (steps: unknown[]): RuleContext => ({
+	blueprint: { steps },
+	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+});
+
+describe('requestRule', () => {
+	describe('request step', () => {
+		it('returns warning severity for request steps', () => {
+			const context = createContext([
+				{ step: 'request', url: 'https://api.example.com/data' },
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Make HTTP request');
+		});
+
+		it('includes URL in description', () => {
+			const context = createContext([
+				{ step: 'request', url: 'https://api.example.com/endpoint' },
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings[0].description).toContain(
+				'https://api.example.com/endpoint'
+			);
+		});
+
+		it('includes method in description when specified', () => {
+			const context = createContext([
+				{
+					step: 'request',
+					url: 'https://api.example.com/data',
+					method: 'POST',
+				},
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings[0].description).toContain('POST');
+		});
+
+		it('defaults to GET method when not specified', () => {
+			const context = createContext([
+				{ step: 'request', url: 'https://api.example.com/data' },
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings[0].description).toContain('GET');
+		});
+
+		it('handles nested request object format', () => {
+			const context = createContext([
+				{
+					step: 'request',
+					request: {
+						url: 'https://api.example.com/nested',
+						method: 'PUT',
+					},
+				},
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings[0].description).toContain(
+				'https://api.example.com/nested'
+			);
+			expect(warnings[0].description).toContain('PUT');
+		});
+
+		it('truncates long URLs', () => {
+			const longUrl = 'https://api.example.com/' + 'x'.repeat(100);
+			const context = createContext([{ step: 'request', url: longUrl }]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings[0].description.length).toBeLessThan(longUrl.length);
+			expect(warnings[0].description).toContain('...');
+		});
+
+		it('includes step index', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'request', url: 'https://api.example.com/data' },
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings[0].stepIndex).toBe(1);
+		});
+	});
+
+	describe('multiple request steps', () => {
+		it('returns warnings for all request steps', () => {
+			const context = createContext([
+				{ step: 'request', url: 'https://api1.example.com' },
+				{ step: 'login' },
+				{
+					step: 'request',
+					url: 'https://api2.example.com',
+					method: 'POST',
+				},
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings).toHaveLength(2);
+			expect(warnings[0].stepIndex).toBe(0);
+			expect(warnings[1].stepIndex).toBe(2);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('ignores non-request steps', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'runPHP', code: '<?php echo 1;' },
+				{ step: 'installPlugin', pluginData: {} },
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles missing URL property', () => {
+			const context = createContext([
+				{ step: 'request', method: 'POST' },
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].description).toContain('HTTP');
+		});
+
+		it('handles null steps in array', () => {
+			const context = createContext([
+				null,
+				{ step: 'request', url: 'https://api.example.com' },
+			]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+		});
+
+		it('handles empty steps array', () => {
+			const context = createContext([]);
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles undefined steps', () => {
+			const context: RuleContext = {
+				blueprint: {},
+				source: {
+					type: 'remote-url',
+					url: 'https://example.com/bp.json',
+				},
+			};
+
+			const warnings = requestRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/request.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/request.ts
@@ -1,0 +1,51 @@
+import type { BlueprintRule, BlueprintWarning } from '../types';
+
+/**
+ * Analyzes request steps that make HTTP requests.
+ *
+ * HTTP requests can send data to external servers or fetch potentially
+ * malicious content. Always returns warning severity.
+ */
+export const requestRule: BlueprintRule = {
+	name: 'request',
+	analyze: (context) => {
+		const warnings: BlueprintWarning[] = [];
+		const steps = context.blueprint.steps || [];
+
+		steps.forEach((step, index) => {
+			if (!step || typeof step !== 'object') {
+				return;
+			}
+
+			const stepObj = step as Record<string, unknown>;
+			if (stepObj.step !== 'request') {
+				return;
+			}
+
+			const request = stepObj.request as Record<string, unknown> | undefined;
+			const url = (request?.url as string) || (stepObj.url as string) || '';
+			const method =
+				(request?.method as string) ||
+				(stepObj.method as string) ||
+				'GET';
+
+			let description: string;
+			if (url) {
+				const urlPreview =
+					url.length > 60 ? url.substring(0, 60) + '...' : url;
+				description = `Makes ${method} request to: ${urlPreview}`;
+			} else {
+				description = `Makes an HTTP ${method} request`;
+			}
+
+			warnings.push({
+				severity: 'warning',
+				title: 'Make HTTP request',
+				description,
+				stepIndex: index,
+			});
+		});
+
+		return warnings;
+	},
+};

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/run-php.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/run-php.spec.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { runPhpRule } from './run-php';
 import type { RuleContext } from '../types';
 
-const createContext = (steps: unknown[]): RuleContext => ({
-	blueprint: { steps },
-	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
-});
+// Type assertion allows testing edge cases with malformed/incomplete step data
+const createContext = (steps: unknown[]): RuleContext =>
+	({
+		blueprint: { steps },
+		source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+	}) as RuleContext;
 
 describe('runPhpRule', () => {
 	describe('safe PHP code', () => {

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/run-php.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/run-php.spec.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import { runPhpRule } from './run-php';
+import type { RuleContext } from '../types';
+
+const createContext = (steps: unknown[]): RuleContext => ({
+	blueprint: { steps },
+	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+});
+
+describe('runPhpRule', () => {
+	describe('safe PHP code', () => {
+		it('returns warning severity for simple PHP code without dangerous patterns', () => {
+			const context = createContext([
+				{ step: 'runPHP', code: '<?php echo "hello";' },
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Execute PHP code');
+		});
+
+		it('includes code preview in description', () => {
+			const context = createContext([
+				{ step: 'runPHP', code: '<?php echo "test";' },
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings[0].description).toContain('<?php echo "test";');
+		});
+
+		it('truncates long code in description', () => {
+			const longCode = '<?php ' + 'x'.repeat(200);
+			const context = createContext([{ step: 'runPHP', code: longCode }]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings[0].description.length).toBeLessThan(
+				longCode.length
+			);
+			expect(warnings[0].description).toContain('...');
+		});
+	});
+
+	describe('dangerous PHP code', () => {
+		it('returns danger severity for code with dangerous functions', () => {
+			const context = createContext([
+				{ step: 'runPHP', code: '<?php system("ls");' },
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			const dangerWarning = warnings.find((w) => w.severity === 'danger');
+			expect(dangerWarning).toBeDefined();
+			expect(dangerWarning?.title).toBe(
+				'PHP code with dangerous operations'
+			);
+		});
+
+		it('returns warning severity for superglobal access', () => {
+			const context = createContext([
+				{
+					step: 'runPHPWithOptions',
+					code: '<?php echo $_GET["test"];',
+				},
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			const warningLevel = warnings.find((w) => w.severity === 'warning');
+			expect(warningLevel).toBeDefined();
+		});
+
+		it('detects backtick shell execution', () => {
+			const context = createContext([
+				{ step: 'runPHP', code: '<?php $out = `whoami`;' },
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			const dangerWarning = warnings.find((w) => w.severity === 'danger');
+			expect(dangerWarning).toBeDefined();
+		});
+	});
+
+	describe('multiple PHP steps', () => {
+		it('returns warnings for all PHP steps', () => {
+			const context = createContext([
+				{ step: 'runPHP', code: '<?php echo 1;' },
+				{ step: 'login' },
+				{ step: 'runPHPWithOptions', code: '<?php echo 2;' },
+				{ step: 'runPHP', code: '<?php echo 3;' },
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings).toHaveLength(3);
+			expect(warnings[0].stepIndex).toBe(0);
+			expect(warnings[1].stepIndex).toBe(2);
+			expect(warnings[2].stepIndex).toBe(3);
+		});
+	});
+
+	describe('step index tracking', () => {
+		it('includes step index', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'runPHP', code: '<?php echo 1;' },
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings[0].stepIndex).toBe(1);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('ignores non-PHP steps', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'installPlugin', pluginData: {} },
+				{ step: 'writeFile', path: '/test.txt', data: 'content' },
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles missing code property', () => {
+			const context = createContext([{ step: 'runPHP' }]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].description).toContain('PHP code');
+		});
+
+		it('handles null steps in array', () => {
+			const context = createContext([
+				null,
+				{ step: 'runPHP', code: '<?php echo 1;' },
+			]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+		});
+
+		it('handles empty steps array', () => {
+			const context = createContext([]);
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles undefined steps', () => {
+			const context: RuleContext = {
+				blueprint: {},
+				source: {
+					type: 'remote-url',
+					url: 'https://example.com/bp.json',
+				},
+			};
+
+			const warnings = runPhpRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/run-php.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/run-php.ts
@@ -1,0 +1,45 @@
+import type { BlueprintRule, BlueprintWarning } from '../types';
+
+/**
+ * Analyzes runPHP and runPHPWithOptions steps.
+ *
+ * These steps can execute arbitrary PHP code, which is a high-risk operation.
+ * Always returns danger severity.
+ */
+export const runPhpRule: BlueprintRule = {
+	name: 'run-php',
+	analyze: (context) => {
+		const warnings: BlueprintWarning[] = [];
+		const steps = context.blueprint.steps || [];
+
+		steps.forEach((step, index) => {
+			if (!step || typeof step !== 'object') {
+				return;
+			}
+
+			const stepObj = step as Record<string, unknown>;
+			if (
+				stepObj.step !== 'runPHP' &&
+				stepObj.step !== 'runPHPWithOptions'
+			) {
+				return;
+			}
+
+			const code = stepObj.code as string | undefined;
+			const codePreview = code
+				? code.length > 100
+					? code.substring(0, 100) + '...'
+					: code
+				: 'PHP code';
+
+			warnings.push({
+				severity: 'danger',
+				title: 'Execute custom PHP code',
+				description: `Runs arbitrary PHP code: ${codePreview}`,
+				stepIndex: index,
+			});
+		});
+
+		return warnings;
+	},
+};

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/run-php.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/run-php.ts
@@ -1,10 +1,18 @@
 import type { BlueprintRule, BlueprintWarning } from '../types';
+import {
+	analyzePhpCode,
+	groupFindingsBySeverity,
+} from '../php-analyzer/analyzer';
 
 /**
  * Analyzes runPHP and runPHPWithOptions steps.
  *
- * These steps can execute arbitrary PHP code, which is a high-risk operation.
- * Always returns danger severity.
+ * Uses a tokenizer-based PHP analyzer to detect:
+ * - Dangerous function calls (eval, exec, curl, etc.)
+ * - Variable function calls (dynamic code execution)
+ * - Superglobal access (user input handling)
+ * - Backtick shell execution
+ * - Suspicious string patterns
  */
 export const runPhpRule: BlueprintRule = {
 	name: 'run-php',
@@ -26,18 +34,75 @@ export const runPhpRule: BlueprintRule = {
 			}
 
 			const code = stepObj.code as string | undefined;
-			const codePreview = code
-				? code.length > 100
-					? code.substring(0, 100) + '...'
-					: code
-				: 'PHP code';
+			if (!code) {
+				warnings.push({
+					severity: 'warning',
+					title: 'Execute PHP code',
+					description:
+						'Runs PHP code (code not available for analysis)',
+					stepIndex: index,
+				});
+				return;
+			}
 
-			warnings.push({
-				severity: 'danger',
-				title: 'Execute custom PHP code',
-				description: `Runs arbitrary PHP code: ${codePreview}`,
-				stepIndex: index,
-			});
+			// Analyze the PHP code using tokenizer
+			const findings = analyzePhpCode(code);
+			const grouped = groupFindingsBySeverity(findings);
+
+			// Create warnings for each severity level
+			if (grouped.danger.length > 0) {
+				const descriptions = grouped.danger
+					.map(
+						(f) => `• ${f.description} (${f.name}, line ${f.line})`
+					)
+					.join('\n');
+				warnings.push({
+					severity: 'danger',
+					title: 'PHP code with dangerous operations',
+					description: descriptions,
+					stepIndex: index,
+				});
+			}
+
+			if (grouped.warning.length > 0) {
+				const descriptions = grouped.warning
+					.map(
+						(f) => `• ${f.description} (${f.name}, line ${f.line})`
+					)
+					.join('\n');
+				warnings.push({
+					severity: 'warning',
+					title: 'PHP code with risky operations',
+					description: descriptions,
+					stepIndex: index,
+				});
+			}
+
+			if (grouped.info.length > 0) {
+				const descriptions = grouped.info
+					.map(
+						(f) => `• ${f.description} (${f.name}, line ${f.line})`
+					)
+					.join('\n');
+				warnings.push({
+					severity: 'info',
+					title: 'PHP code operations',
+					description: descriptions,
+					stepIndex: index,
+				});
+			}
+
+			// If no specific findings, still note that arbitrary code is being run
+			if (findings.length === 0) {
+				const codePreview =
+					code.length > 100 ? code.substring(0, 100) + '...' : code;
+				warnings.push({
+					severity: 'warning',
+					title: 'Execute PHP code',
+					description: `Runs PHP code: ${codePreview}`,
+					stepIndex: index,
+				});
+			}
 		});
 
 		return warnings;

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/wp-cli.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/wp-cli.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { wpCliRule } from './wp-cli';
+import type { RuleContext } from '../types';
+
+const createContext = (steps: unknown[]): RuleContext => ({
+	blueprint: { steps },
+	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+});
+
+describe('wpCliRule', () => {
+	describe('wp-cli step', () => {
+		it('returns warning severity for wp-cli commands', () => {
+			const context = createContext([
+				{ step: 'wp-cli', command: 'plugin list' },
+			]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].severity).toBe('warning');
+			expect(warnings[0].title).toBe('Run WP-CLI command');
+		});
+
+		it('includes command in description (string format)', () => {
+			const context = createContext([
+				{
+					step: 'wp-cli',
+					command: 'option update siteurl "https://example.com"',
+				},
+			]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings[0].description).toContain(
+				'wp option update siteurl'
+			);
+		});
+
+		it('includes command in description (array format)', () => {
+			const context = createContext([
+				{
+					step: 'wp-cli',
+					command: ['user', 'create', 'admin', 'admin@example.com'],
+				},
+			]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings[0].description).toContain('wp user create admin');
+		});
+
+		it('truncates long commands', () => {
+			const longCommand =
+				'option update very_long_option_name ' + 'x'.repeat(100);
+			const context = createContext([
+				{ step: 'wp-cli', command: longCommand },
+			]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings[0].description.length).toBeLessThan(
+				longCommand.length + 20
+			);
+			expect(warnings[0].description).toContain('...');
+		});
+
+		it('includes step index', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'wp-cli', command: 'cache flush' },
+			]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings[0].stepIndex).toBe(1);
+		});
+	});
+
+	describe('multiple wp-cli steps', () => {
+		it('returns warnings for all wp-cli steps', () => {
+			const context = createContext([
+				{ step: 'wp-cli', command: 'plugin activate woocommerce' },
+				{ step: 'login' },
+				{ step: 'wp-cli', command: 'rewrite flush' },
+			]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings).toHaveLength(2);
+			expect(warnings[0].stepIndex).toBe(0);
+			expect(warnings[1].stepIndex).toBe(2);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('ignores non-wp-cli steps', () => {
+			const context = createContext([
+				{ step: 'login' },
+				{ step: 'runPHP', code: '<?php echo 1;' },
+				{ step: 'installPlugin', pluginData: {} },
+			]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles missing command property', () => {
+			const context = createContext([{ step: 'wp-cli' }]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+			expect(warnings[0].description).toContain('WP-CLI command');
+		});
+
+		it('handles null steps in array', () => {
+			const context = createContext([
+				null,
+				{ step: 'wp-cli', command: 'cache flush' },
+			]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings).toHaveLength(1);
+		});
+
+		it('handles empty steps array', () => {
+			const context = createContext([]);
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+
+		it('handles undefined steps', () => {
+			const context: RuleContext = {
+				blueprint: {},
+				source: {
+					type: 'remote-url',
+					url: 'https://example.com/bp.json',
+				},
+			};
+
+			const warnings = wpCliRule.analyze(context);
+
+			expect(warnings).toHaveLength(0);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/wp-cli.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/wp-cli.spec.ts
@@ -2,10 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { wpCliRule } from './wp-cli';
 import type { RuleContext } from '../types';
 
-const createContext = (steps: unknown[]): RuleContext => ({
-	blueprint: { steps },
-	source: { type: 'remote-url', url: 'https://example.com/bp.json' },
-});
+// Type assertion allows testing edge cases with malformed/incomplete step data
+const createContext = (steps: unknown[]): RuleContext =>
+	({
+		blueprint: { steps },
+		source: { type: 'remote-url', url: 'https://example.com/bp.json' },
+	}) as RuleContext;
 
 describe('wpCliRule', () => {
 	describe('wp-cli step', () => {

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/wp-cli.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/rules/wp-cli.ts
@@ -1,0 +1,45 @@
+import type { BlueprintRule, BlueprintWarning } from '../types';
+
+/**
+ * Analyzes wp-cli steps.
+ *
+ * WP-CLI commands can perform various administrative operations.
+ * Always returns warning severity as these can modify site settings.
+ */
+export const wpCliRule: BlueprintRule = {
+	name: 'wp-cli',
+	analyze: (context) => {
+		const warnings: BlueprintWarning[] = [];
+		const steps = context.blueprint.steps || [];
+
+		steps.forEach((step, index) => {
+			if (!step || typeof step !== 'object') {
+				return;
+			}
+
+			const stepObj = step as Record<string, unknown>;
+			if (stepObj.step !== 'wp-cli') {
+				return;
+			}
+
+			const command = stepObj.command as string | string[] | undefined;
+			const commandStr = Array.isArray(command)
+				? command.join(' ')
+				: command || 'WP-CLI command';
+
+			const commandPreview =
+				commandStr.length > 80
+					? commandStr.substring(0, 80) + '...'
+					: commandStr;
+
+			warnings.push({
+				severity: 'warning',
+				title: 'Run WP-CLI command',
+				description: `Executes: wp ${commandPreview}`,
+				stepIndex: index,
+			});
+		});
+
+		return warnings;
+	},
+};

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/trusted-sources.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/trusted-sources.spec.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { isTrustedSource } from './trusted-sources';
+import type { BlueprintSource } from '../state/url/resolve-blueprint-from-url';
+
+describe('isTrustedSource', () => {
+	describe('trusted sources', () => {
+		it('trusts type: none (query param blueprints like ?plugin=friends)', () => {
+			const source: BlueprintSource = { type: 'none' };
+			expect(isTrustedSource(source)).toBe(true);
+		});
+
+		it('trusts official WordPress blueprints repository', () => {
+			const source: BlueprintSource = {
+				type: 'remote-url',
+				url: 'https://raw.githubusercontent.com/WordPress/blueprints/my-wordpress/apps/woocommerce.json',
+			};
+			expect(isTrustedSource(source)).toBe(true);
+		});
+
+		it('trusts WordPress blueprints repo root', () => {
+			const source: BlueprintSource = {
+				type: 'remote-url',
+				url: 'https://raw.githubusercontent.com/WordPress/blueprints/main/blueprint.json',
+			};
+			expect(isTrustedSource(source)).toBe(true);
+		});
+
+		it('trusts wordpress.org plugin API', () => {
+			const source: BlueprintSource = {
+				type: 'remote-url',
+				url: 'https://wordpress.org/plugins/wp-json/plugins/v1/plugin/woocommerce',
+			};
+			expect(isTrustedSource(source)).toBe(true);
+		});
+
+		it('trusts personal-blueprint type from trusted URLs', () => {
+			const source: BlueprintSource = {
+				type: 'personal-blueprint',
+				url: 'https://raw.githubusercontent.com/WordPress/blueprints/my-wordpress/test.json',
+			};
+			expect(isTrustedSource(source)).toBe(true);
+		});
+	});
+
+	describe('untrusted sources', () => {
+		it('does not trust data: URLs (can contain arbitrary content)', () => {
+			const source: BlueprintSource = {
+				type: 'remote-url',
+				url: 'data:application/json;base64,eyJzdGVwcyI6W119',
+			};
+			expect(isTrustedSource(source)).toBe(false);
+		});
+
+		it('does not trust inline-string type (hash fragments)', () => {
+			const source: BlueprintSource = { type: 'inline-string' };
+			expect(isTrustedSource(source)).toBe(false);
+		});
+
+		it('does not trust last-autosave type', () => {
+			const source: BlueprintSource = { type: 'last-autosave' };
+			expect(isTrustedSource(source)).toBe(false);
+		});
+
+		it('does not trust opfs-site type', () => {
+			const source: BlueprintSource = { type: 'opfs-site' };
+			expect(isTrustedSource(source)).toBe(false);
+		});
+
+		it('does not trust arbitrary external URLs', () => {
+			const source: BlueprintSource = {
+				type: 'remote-url',
+				url: 'https://example.com/malicious-blueprint.json',
+			};
+			expect(isTrustedSource(source)).toBe(false);
+		});
+
+		it('does not trust other GitHub repositories', () => {
+			const source: BlueprintSource = {
+				type: 'remote-url',
+				url: 'https://raw.githubusercontent.com/someone/their-repo/main/blueprint.json',
+			};
+			expect(isTrustedSource(source)).toBe(false);
+		});
+
+		it('does not trust URLs that look similar but are not exact prefix matches', () => {
+			const source: BlueprintSource = {
+				type: 'remote-url',
+				url: 'https://raw.githubusercontent.com/WordPress/blueprints-fake/main/bp.json',
+			};
+			expect(isTrustedSource(source)).toBe(false);
+		});
+
+		it('does not trust personal-blueprint type from untrusted URLs', () => {
+			const source: BlueprintSource = {
+				type: 'personal-blueprint',
+				url: 'https://untrusted.com/blueprint.json',
+			};
+			expect(isTrustedSource(source)).toBe(false);
+		});
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/trusted-sources.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/trusted-sources.ts
@@ -5,12 +5,13 @@ import type { BlueprintSource } from '../state/url/resolve-blueprint-from-url';
  *
  * - Official WordPress blueprints repo
  * - WordPress.org plugin API
- * - Data URLs (internal blueprints from menu overlay)
+ *
+ * Note: data:application/json;base64, URLs are NOT trusted as they can contain
+ * arbitrary blueprint content, similar to inline hash fragments.
  */
 const TRUSTED_URL_PREFIXES = [
 	'https://raw.githubusercontent.com/WordPress/blueprints/',
 	'https://wordpress.org/plugins/wp-json/plugins/v1/plugin',
-	'data:application/json;base64,',
 ];
 
 /**
@@ -19,7 +20,10 @@ const TRUSTED_URL_PREFIXES = [
  * Trusted sources include:
  * - `type: 'none'` - Query param blueprints like `?plugin=friends` (resolves to wordpress.org)
  * - Remote URLs from trusted prefixes (official blueprints repo, wordpress.org)
- * - Data URLs (internal blueprints from menu overlay)
+ *
+ * NOT trusted (requires confirmation):
+ * - data: URLs (can contain arbitrary content, like inline hash fragments)
+ * - Any other external URLs
  *
  * @param source - The blueprint source to check
  * @returns true if the source is trusted

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/trusted-sources.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/trusted-sources.ts
@@ -1,0 +1,39 @@
+import type { BlueprintSource } from '../state/url/resolve-blueprint-from-url';
+
+/**
+ * URL prefixes that are considered trusted and bypass confirmation.
+ *
+ * - Official WordPress blueprints repo
+ * - WordPress.org plugin API
+ * - Data URLs (internal blueprints from menu overlay)
+ */
+const TRUSTED_URL_PREFIXES = [
+	'https://raw.githubusercontent.com/WordPress/blueprints/',
+	'https://wordpress.org/plugins/wp-json/plugins/v1/plugin',
+	'data:application/json;base64,',
+];
+
+/**
+ * Check if a blueprint source is trusted and should bypass confirmation.
+ *
+ * Trusted sources include:
+ * - `type: 'none'` - Query param blueprints like `?plugin=friends` (resolves to wordpress.org)
+ * - Remote URLs from trusted prefixes (official blueprints repo, wordpress.org)
+ * - Data URLs (internal blueprints from menu overlay)
+ *
+ * @param source - The blueprint source to check
+ * @returns true if the source is trusted
+ */
+export function isTrustedSource(source: BlueprintSource): boolean {
+	if (source.type === 'none') {
+		return true;
+	}
+
+	if (source.type === 'remote-url' || source.type === 'personal-blueprint') {
+		return TRUSTED_URL_PREFIXES.some((prefix) =>
+			source.url.startsWith(prefix)
+		);
+	}
+
+	return false;
+}

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/types.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/types.ts
@@ -1,0 +1,27 @@
+import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
+import type { BlueprintSource } from '../state/url/resolve-blueprint-from-url';
+
+export type WarningSeverity = 'info' | 'warning' | 'danger';
+
+export interface BlueprintWarning {
+	severity: WarningSeverity;
+	title: string;
+	description: string;
+	stepIndex?: number;
+}
+
+export interface RuleContext {
+	blueprint: BlueprintV1Declaration;
+	source: BlueprintSource;
+}
+
+export interface BlueprintRule {
+	name: string;
+	analyze: (context: RuleContext) => BlueprintWarning[];
+}
+
+export interface AnalysisResult {
+	requiresConfirmation: boolean;
+	warnings: BlueprintWarning[];
+	isTrustedSource: boolean;
+}

--- a/packages/playground/personal-wp/src/lib/personalwp/index.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/index.ts
@@ -1,6 +1,7 @@
 import type { BlueprintV1Declaration } from '@wp-playground/client';
 import {
 	type ResolvedBlueprint,
+	type BlueprintSource,
 	resolveBlueprintFromURL,
 } from '../state/url/resolve-blueprint-from-url';
 import {
@@ -91,6 +92,11 @@ function hasActionableUrlParams(url: URL): boolean {
 	return ACTIONABLE_URL_PARAMS.some((param) => url.searchParams.has(param));
 }
 
+export interface ResolvedUrlBlueprint {
+	blueprint: BlueprintV1Declaration;
+	source: BlueprintSource;
+}
+
 /**
  * Resolves URL params as a blueprint to apply to an existing personal site.
  * Returns null if there are no actionable URL params.
@@ -101,7 +107,7 @@ function hasActionableUrlParams(url: URL): boolean {
  */
 export async function resolveUrlParamsForExistingSite(
 	url: URL
-): Promise<BlueprintV1Declaration | null> {
+): Promise<ResolvedUrlBlueprint | null> {
 	if (!hasActionableUrlParams(url)) {
 		return null;
 	}
@@ -112,7 +118,10 @@ export async function resolveUrlParamsForExistingSite(
 		const blueprint = isBlueprintBundle(resolved.blueprint)
 			? await getBlueprintDeclaration(resolved.blueprint)
 			: (resolved.blueprint as BlueprintV1Declaration);
-		return blueprint;
+		return {
+			blueprint,
+			source: resolved.source,
+		};
 	} catch (e) {
 		logger.error('Error resolving URL blueprint for existing site:', e);
 		return null;

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -22,7 +22,12 @@ import { setupPostMessageRelay } from '@php-wasm/web';
 import { startPlaygroundWeb } from '@wp-playground/client';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import { getRemoteUrl } from '../../config';
-import { setActiveSiteError } from './slice-ui';
+import {
+	setActiveSiteError,
+	setPendingBlueprintConfirmation,
+	clearConfirmedBlueprintSource,
+} from './slice-ui';
+import { analyzeBlueprint } from '../../blueprint-confirmation';
 import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import {
 	selectSiteBySlug,
@@ -360,8 +365,46 @@ export function bootSiteClient(
 				landingPage: urlParamLandingPage || site.metadata.lastUrl,
 			};
 
-			// Merge URL blueprint (e.g., ?plugin=friends) into boot blueprint
+			// Check if URL blueprint requires user confirmation
 			if (hasUrlBlueprint) {
+				// Check if this blueprint source was already confirmed by the user
+				const confirmedSourceUrl =
+					getState().ui.confirmedBlueprintSourceUrl;
+				const currentSourceUrl =
+					urlBlueprint.source.type === 'remote-url' ||
+					urlBlueprint.source.type === 'personal-blueprint'
+						? urlBlueprint.source.url
+						: null;
+				const isAlreadyConfirmed =
+					confirmedSourceUrl &&
+					currentSourceUrl &&
+					confirmedSourceUrl === currentSourceUrl;
+
+				if (!isAlreadyConfirmed) {
+					const analysisResult = analyzeBlueprint({
+						blueprint:
+							urlBlueprint.blueprint as BlueprintV1Declaration,
+						source: urlBlueprint.source,
+					});
+
+					if (analysisResult.requiresConfirmation) {
+						dispatch(
+							setPendingBlueprintConfirmation({
+								blueprint: urlBlueprint,
+								analysisResult,
+							})
+						);
+						// Wait for user confirmation before proceeding
+						return;
+					}
+				}
+
+				// Clear the confirmed source URL after using it
+				if (isAlreadyConfirmed) {
+					dispatch(clearConfirmedBlueprintSource());
+				}
+
+				// Merge URL blueprint (e.g., ?plugin=friends) into boot blueprint
 				const resolved = urlBlueprint.blueprint;
 				const current = blueprint as BlueprintV1Declaration;
 				blueprint = {

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -26,6 +26,7 @@ import {
 	setActiveSiteError,
 	setPendingBlueprintConfirmation,
 	clearConfirmedBlueprintSource,
+	clearRejectedBlueprintUrl,
 } from './slice-ui';
 import { analyzeBlueprint } from '../../blueprint-confirmation';
 import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
@@ -76,8 +77,21 @@ export function bootSiteClient(
 
 		// Check for URL blueprint from redux (set when URL has params like ?plugin=friends)
 		const urlBlueprint = selectBlueprintResolvedFromUrl(getState());
-		const hasUrlBlueprint =
+		let hasUrlBlueprint =
 			urlBlueprint && urlBlueprint.targetSiteSlug === site.slug;
+
+		// If the user rejected the blueprint confirmation, skip the URL blueprint
+		// and clear the URL params
+		if (getState().ui.rejectedBlueprintUrl) {
+			hasUrlBlueprint = false;
+			dispatch(setBlueprintResolvedFromUrl(null));
+			dispatch(clearRejectedBlueprintUrl());
+			// Clear URL search params and hash
+			const cleanUrl = new URL(window.location.href);
+			cleanUrl.search = '';
+			cleanUrl.hash = '';
+			window.history.replaceState({}, '', cleanUrl.toString());
+		}
 
 		let mountDescriptor = undefined;
 		if (site.metadata.storage === 'opfs') {
@@ -366,7 +380,7 @@ export function bootSiteClient(
 			};
 
 			// Check if URL blueprint requires user confirmation
-			if (hasUrlBlueprint) {
+			if (hasUrlBlueprint && urlBlueprint) {
 				// Check if this blueprint source was already confirmed by the user
 				const confirmedSourceUrl =
 					getState().ui.confirmedBlueprintSourceUrl;

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
@@ -22,6 +22,7 @@ import {
 	type ResolvedBlueprint,
 	applyQueryOverrides,
 } from '../url/resolve-blueprint-from-url';
+import type { ResolvedUrlBlueprint } from '../../personalwp';
 import { logger } from '@php-wasm/logger';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
@@ -62,6 +63,7 @@ const sitesAdapter = createEntityAdapter<SiteInfo, string>({
 export interface BlueprintResolvedFromUrl {
 	targetSiteSlug: string;
 	blueprint: BlueprintV1Declaration;
+	source: BlueprintSource;
 }
 
 // Define the initial state using the adapter and include the loading state
@@ -368,14 +370,16 @@ export function setTemporarySiteSpec(
 			if (existingDefaultSite) {
 				// Check if there are actionable URL params that should be applied
 				// to the existing site (e.g., ?plugin=friends, ?blueprint-url=...)
-				const blueprint = await resolveUrlParamsForExistingSite(
-					playgroundUrlWithQueryApiArgs
-				);
-				if (blueprint) {
+				const resolvedUrlBlueprint =
+					await resolveUrlParamsForExistingSite(
+						playgroundUrlWithQueryApiArgs
+					);
+				if (resolvedUrlBlueprint) {
 					dispatch(
 						sitesSlice.actions.setBlueprintResolvedFromUrl({
 							targetSiteSlug: existingDefaultSite.slug,
-							blueprint,
+							blueprint: resolvedUrlBlueprint.blueprint,
+							source: resolvedUrlBlueprint.source,
 						})
 					);
 				}

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
@@ -22,7 +22,6 @@ import {
 	type ResolvedBlueprint,
 	applyQueryOverrides,
 } from '../url/resolve-blueprint-from-url';
-import type { ResolvedUrlBlueprint } from '../../personalwp';
 import { logger } from '@php-wasm/logger';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
@@ -163,6 +163,11 @@ export interface UIState {
 	 */
 	confirmedBlueprintSourceUrl: string | null;
 	/**
+	 * Whether the user rejected the blueprint confirmation.
+	 * Used to boot without the blueprint and clear URL params.
+	 */
+	rejectedBlueprintUrl: boolean;
+	/**
 	 * Counter that increments to trigger a site re-boot.
 	 * Used after blueprint confirmation.
 	 */
@@ -208,6 +213,7 @@ const initialState: UIState = {
 	siteManagerSection: 'site-details',
 	pendingBlueprintConfirmation: null,
 	confirmedBlueprintSourceUrl: null,
+	rejectedBlueprintUrl: false,
 	bootTrigger: 0,
 };
 
@@ -310,6 +316,15 @@ const uiSlice = createSlice({
 			state.pendingBlueprintConfirmation = null;
 			state.bootTrigger += 1;
 		},
+		rejectPendingBlueprint: (state) => {
+			// Clear the pending state and trigger re-boot without the blueprint
+			state.pendingBlueprintConfirmation = null;
+			state.rejectedBlueprintUrl = true;
+			state.bootTrigger += 1;
+		},
+		clearRejectedBlueprintUrl: (state) => {
+			state.rejectedBlueprintUrl = false;
+		},
 		clearConfirmedBlueprintSource: (state) => {
 			state.confirmedBlueprintSourceUrl = null;
 		},
@@ -361,7 +376,9 @@ export const {
 	setPendingBlueprintConfirmation,
 	clearPendingBlueprintConfirmation,
 	confirmPendingBlueprint,
+	rejectPendingBlueprint,
 	clearConfirmedBlueprintSource,
+	clearRejectedBlueprintUrl,
 } = uiSlice.actions;
 
 export default uiSlice.reducer;

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
@@ -1,6 +1,8 @@
 import type { PayloadAction, Middleware } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { BlueprintStepExecutionError } from '@wp-playground/blueprints';
+import type { AnalysisResult } from '../../blueprint-confirmation';
+import type { ResolvedBlueprint } from '../url/resolve-blueprint-from-url';
 
 export type SiteError =
 	| 'directory-handle-not-found-in-indexeddb'
@@ -137,6 +139,11 @@ const serializeSiteErrorDetails = (
 	}
 };
 
+export interface PendingBlueprintConfirmation {
+	blueprint: ResolvedBlueprint;
+	analysisResult: AnalysisResult;
+}
+
 export interface UIState {
 	activeSite?: {
 		slug: string;
@@ -149,6 +156,17 @@ export interface UIState {
 	offline: boolean;
 	siteManagerIsOpen: boolean;
 	siteManagerSection: SiteManagerSection;
+	pendingBlueprintConfirmation: PendingBlueprintConfirmation | null;
+	/**
+	 * URL of a blueprint source that was confirmed by the user.
+	 * Used to skip the confirmation dialog on re-boot.
+	 */
+	confirmedBlueprintSourceUrl: string | null;
+	/**
+	 * Counter that increments to trigger a site re-boot.
+	 * Used after blueprint confirmation.
+	 */
+	bootTrigger: number;
 }
 
 const query = new URL(document.location.href).searchParams;
@@ -188,6 +206,9 @@ const initialState: UIState = {
 		// quite a confusing experience.
 		!isMobile,
 	siteManagerSection: 'site-details',
+	pendingBlueprintConfirmation: null,
+	confirmedBlueprintSourceUrl: null,
+	bootTrigger: 0,
 };
 
 const uiSlice = createSlice({
@@ -264,6 +285,34 @@ const uiSlice = createSlice({
 		) => {
 			state.siteSlugToRename = action.payload;
 		},
+		setPendingBlueprintConfirmation: (
+			state,
+			action: PayloadAction<PendingBlueprintConfirmation | null>
+		) => {
+			state.pendingBlueprintConfirmation = action.payload;
+		},
+		clearPendingBlueprintConfirmation: (state) => {
+			state.pendingBlueprintConfirmation = null;
+		},
+		confirmPendingBlueprint: (state) => {
+			// Store the confirmed source URL so the next boot skips confirmation
+			const pending = state.pendingBlueprintConfirmation;
+			if (pending) {
+				const source = pending.blueprint.source;
+				if (
+					source.type === 'remote-url' ||
+					source.type === 'personal-blueprint'
+				) {
+					state.confirmedBlueprintSourceUrl = source.url;
+				}
+			}
+			// Clear the pending state and trigger re-boot
+			state.pendingBlueprintConfirmation = null;
+			state.bootTrigger += 1;
+		},
+		clearConfirmedBlueprintSource: (state) => {
+			state.confirmedBlueprintSourceUrl = null;
+		},
 	},
 });
 
@@ -309,6 +358,10 @@ export const {
 	setSiteManagerOpen,
 	setSiteManagerSection,
 	setSiteSlugToRename,
+	setPendingBlueprintConfirmation,
+	clearPendingBlueprintConfirmation,
+	confirmPendingBlueprint,
+	clearConfirmedBlueprintSource,
 } = uiSlice.actions;
 
 export default uiSlice.reducer;


### PR DESCRIPTION
## Motivation for the change, related issues

Adds a security confirmation system for blueprints applied to persistent WordPress installations. When a user has an existing WordPress site and tries to apply an external blueprint, they should be warned about what the blueprint will do before it executes.

## Screenshots
<img width="659" height="639" alt="Screenshot 2026-01-27 at 12 21 32" src="https://github.com/user-attachments/assets/f60bc2c7-176b-44ff-a675-601d0d8b4658" />

<img width="644" height="581" alt="Screenshot 2026-01-27 at 12 24 14" src="https://github.com/user-attachments/assets/06e5169d-dcb0-4955-b0f8-6ef620b2ef89" />


### Security Concerns Addressed

1. **Destructive blueprints** - Malicious blueprints could delete files or corrupt the installation
2. **Data exfiltration** - Plugins installed via blueprint could send WordPress data to third-party servers
3. **Arbitrary code execution** - `runPHP` steps can execute any PHP code

### Trust Model

Blueprints from these sources bypass confirmation:
- `https://raw.githubusercontent.com/WordPress/blueprints/` - Official blueprints repo
- `https://wordpress.org/plugins/wp-json/plugins/v1/plugin` - WordPress.org plugin API
- `?plugin=friends` style query params (type: 'none') - Resolves to wordpress.org

**Not trusted** (requires confirmation):
- `data:application/json;base64,...` URLs - Can contain arbitrary content
- Inline hash fragments `#{...}`
- Any other external URLs

## Implementation details

### Architecture

```
Blueprint JSON → isTrustedSource() → [trusted: skip] or [untrusted: analyze]
                                              ↓
                                    Run analysis rules
                                              ↓
                                    Show confirmation modal
```

### Rule-based Analysis System

| Rule | Analyzes | Severity |
|------|----------|----------|
| `run-php` | `runPHP`, `runPHPWithOptions` steps | Varies by content |
| `filesystem-operations` | `writeFile`, `rm`, `mkdir`, etc. | info/warning/danger |
| `external-plugin-source` | `installPlugin` steps | info for wordpress.org, warning for external |
| `external-theme-source` | `installTheme` steps | info for wordpress.org, warning for external |
| `wp-cli` | `wp-cli` steps | warning |
| `request` | HTTP request steps | warning |

### PHP Tokenizer (TypeScript)

Custom synchronous tokenizer that parses PHP code:
- Identifies function calls, variables, strings, backticks, comments
- Tracks line numbers for detailed error reporting
- No external dependencies or async php-wasm needed

### PHP Code Analysis

Detects dangerous patterns:
- **Danger**: `eval`, `system`, `exec`, `shell_exec`, `curl_exec`, `fsockopen`, variable function calls (`$func()`)
- **Warning**: `file_get_contents`, `base64_decode`, `wp_remote_get`, `wp_insert_user`, superglobals (`$_GET`, `$_POST`)
- **Info**: `phpinfo`, `update_option`, `getenv`

### File Content Analysis

Analyzes `writeFile` step content:
- Detects PHP code injection patterns
- Flags webshell signatures
- Warns about PHP files in suspicious locations (uploads, cache dirs)
- Checks for backdoor patterns (`eval(base64_decode(...))`)

### Test Coverage

152 unit tests covering:
- Tokenizer: 22 tests
- PHP Analyzer: 25 tests  
- All 6 rules with edge cases
- Trusted source detection: 13 tests

## Testing Instructions (or ideally a Blueprint)

Run the test suite:
```bash
npx nx test playground-personal-wp --testFile=blueprint-confirmation
```

Manual testing:
1. Start personal-wp with an existing WordPress installation
2. Apply an untrusted blueprint URL
3. Verify confirmation modal appears with detailed warnings
4. Test trusted sources bypass confirmation (install app from menu)