### PR TITLE
[php-wasm-progress] Add a throttle of 500 milliseconds to the notify function

### DIFF
--- a/packages/php-wasm/progress/src/lib/emscripten-download-monitor.ts
+++ b/packages/php-wasm/progress/src/lib/emscripten-download-monitor.ts
@@ -155,8 +155,22 @@ export function cloneStreamMonitorProgress(
 	function notify(loaded: number, total: number, done: boolean) {
 		const now = performance.now();
 
-		// Time-based throttle to prevent progress event
-		// storms on small stream chunks (Safari and Firefox).
+		/*
+		 * This throttling exists to prevent severe UX degradation on mobile browsers,
+		 * particularly Safari. In some mobile environments, loading Playground
+		 * could take tens of seconds and appear frozen or blank, even though the boot
+		 * process eventually completed successfully.
+		 *
+		 * The issue was an excessive number of progress notifications directly tied
+		 * to how often php-wasm was able to read from a download's ReadableStream.
+		 * Each time we received a chunk from a readable stream, we sent a corresponding
+		 * progress notification. This appeared to work OK in Chrome and other browsers,
+		 * but we observed Safari's ReadableStream reading data in such small chunks
+		 * that we flooded the message channel with progress notifications.
+		 * This caused unnecessary main-thread pressure which impacted performance.
+		 *
+		 * To avoid this issue, we now throttle these progress notifications.
+		 */
 		if (!done && now - lastNotifyTime < 500) return;
 
 		lastNotifyTime = now;

--- a/packages/php-wasm/progress/src/lib/emscripten-download-monitor.ts
+++ b/packages/php-wasm/progress/src/lib/emscripten-download-monitor.ts
@@ -150,7 +150,17 @@ export function cloneStreamMonitorProgress(
 	total: number,
 	onProgress: (event: CustomEvent<DownloadProgress>) => void
 ): ReadableStream<Uint8Array> {
+	let lastNotifyTime = 0;
+
 	function notify(loaded: number, total: number) {
+		const now = performance.now();
+
+		// Time-based throttle to prevent progress event
+		// storms on small stream chunks (Safari and Firefox).
+		if (now - lastNotifyTime < 500) return;
+
+		lastNotifyTime = now;
+
 		onProgress(
 			new CustomEvent('progress', {
 				detail: {

--- a/packages/php-wasm/progress/src/lib/emscripten-download-monitor.ts
+++ b/packages/php-wasm/progress/src/lib/emscripten-download-monitor.ts
@@ -152,12 +152,12 @@ export function cloneStreamMonitorProgress(
 ): ReadableStream<Uint8Array> {
 	let lastNotifyTime = 0;
 
-	function notify(loaded: number, total: number) {
+	function notify(loaded: number, total: number, done: boolean) {
 		const now = performance.now();
 
 		// Time-based throttle to prevent progress event
 		// storms on small stream chunks (Safari and Firefox).
-		if (now - lastNotifyTime < 500) return;
+		if (!done && now - lastNotifyTime < 500) return;
 
 		lastNotifyTime = now;
 
@@ -186,11 +186,11 @@ export function cloneStreamMonitorProgress(
 						loaded += value.byteLength;
 					}
 					if (done) {
-						notify(loaded, loaded);
+						notify(loaded, loaded, done);
 						controller.close();
 						break;
 					} else {
-						notify(loaded, total);
+						notify(loaded, total, done);
 						controller.enqueue(value);
 					}
 				} catch (e) {

--- a/packages/php-wasm/progress/src/test/emscripten-download-monitor.spec.ts
+++ b/packages/php-wasm/progress/src/test/emscripten-download-monitor.spec.ts
@@ -1,0 +1,55 @@
+import { cloneStreamMonitorProgress } from '../lib/emscripten-download-monitor';
+
+function createChunkyStream(
+	chunks: number,
+	chunkSize: number
+): ReadableStream<Uint8Array> {
+	let emitted = 0;
+
+	return new ReadableStream({
+		pull(controller) {
+			if (emitted >= chunks) {
+				controller.close();
+				return;
+			}
+
+			emitted++;
+			controller.enqueue(new Uint8Array(chunkSize));
+		},
+	});
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('cloneStreamMonitorProgress throttling', () => {
+	it('throttles progress events for tiny ReadableStream chunks (Safari)', async () => {
+		let now = 0;
+
+		vi.spyOn(performance, 'now').mockImplementation(() => now);
+
+		const onProgress = vi.fn();
+
+		const stream = createChunkyStream(100, 10);
+
+		const monitored = cloneStreamMonitorProgress(stream, 1000, onProgress);
+
+		const reader = monitored.getReader();
+
+		while (true) {
+			const { done } = await reader.read();
+			if (done) break;
+
+			now += 10;
+		}
+
+		const lastEvent =
+			onProgress.mock.calls[onProgress.mock.calls.length - 1][0];
+
+		expect(onProgress).toHaveBeenCalled();
+		expect(onProgress.mock.calls.length).toBeLessThanOrEqual(3);
+		expect(lastEvent.detail.loaded).toBe(1000);
+		expect(lastEvent.detail.total).toBe(1000);
+	});
+});


### PR DESCRIPTION
## Motivation for the change, related issues

We received feedback reporting that loading the playground on mobile was extremely slow and impractical, taking more than 40 seconds to become usable. The affected user was on an iPhone, and we were able to identify Safari as the browser in use.

Based on this feedback, we started reproducing the issue on mobile devices. On Safari specifically, we observed that after WordPress finished booting successfully, the page would remain blank for roughly 30 seconds before the iframe content finally appeared.
 
The root cause was eventually identified as a very tight while-loop that was invoking the progress callback an extremely large number of times while processing small chunks of data on Safari. This resulted in excessive work on the main thread and a severe UX degradation during loading.

This problem was not initially detected in Chrome, as Chrome does not exhibit the same small-chunk behavior, which effectively masked the issue during development. Feedback from users on helped confirm that this was impacting real users in the wild.

This change introduces throttling to prevent this class of issue and to restore acceptable loading performance and user experience on mobile.

## Implementation details

- Add a throttle around the `notify` function in `cloneStreamMonitorProgress`. 

## Testing Instructions

🧪 `emscripten-download-monitor.spec.ts`

CI