### PR TITLE
[personal-wp] Skip CORS proxy for localhost requests

### DIFF
--- a/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.spec.ts
@@ -88,4 +88,55 @@ describe('fetchWithCorsProxy', () => {
 		expect(response.status).toBe(200);
 		expect(await response.text()).toBe('proxied');
 	});
+
+	it('never proxies localhost requests even if direct fetch fails', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockRejectedValue(new Error('connection refused'));
+
+		await expect(
+			fetchWithCorsProxy(
+				'http://localhost:8080/api',
+				undefined,
+				'https://proxy.test/?url='
+			)
+		).rejects.toThrow('connection refused');
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const request = fetchMock.mock.calls[0][0] as Request;
+		expect(request.url).toBe('http://localhost:8080/api');
+	});
+
+	it('never proxies 127.0.0.1 requests', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response('ok'));
+
+		await fetchWithCorsProxy(
+			'http://127.0.0.1:3000/endpoint',
+			undefined,
+			'https://proxy.test/?url='
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const request = fetchMock.mock.calls[0][0] as Request;
+		expect(request.url).toBe('http://127.0.0.1:3000/endpoint');
+	});
+
+	it('does not upgrade localhost HTTP to HTTPS when corsProxyUrl is configured', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response('ok'));
+
+		await fetchWithCorsProxy(
+			'http://localhost:1234/v1/chat/completions',
+			undefined,
+			'https://proxy.test/?url='
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const request = fetchMock.mock.calls[0][0] as Request;
+		// Should stay as http, not upgraded to https
+		expect(request.url).toBe('http://localhost:1234/v1/chat/completions');
+	});
 });

--- a/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web/src/lib/fetch-with-cors-proxy.ts
@@ -15,6 +15,20 @@ export async function fetchWithCorsProxy(
 	let requestUrlObj = playgroundUrlObj
 		? new URL(requestObject.url, playgroundUrlObj)
 		: new URL(requestObject.url);
+
+	/**
+	 * Never proxy localhost requests. The remote proxy cannot reach the user's
+	 * localhost, so we must fetch directly to access local APIs.
+	 */
+	const isLocalhost =
+		requestUrlObj.hostname === 'localhost' ||
+		requestUrlObj.hostname === '127.0.0.1' ||
+		requestUrlObj.hostname === '[::1]' ||
+		requestUrlObj.hostname === '::1';
+	if (isLocalhost) {
+		return await fetch(requestObject);
+	}
+
 	if (requestUrlObj.protocol === 'http:') {
 		requestUrlObj.protocol = 'https:';
 		const httpsUrl = requestUrlObj.toString();

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.spec.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.spec.ts
@@ -2,10 +2,15 @@ import {
 	TCPOverFetchWebsocket,
 	RawBytesFetch,
 } from './tcp-over-fetch-websocket';
-import express from 'express';
+import express, { type Express } from 'express';
+import http from 'http';
 import https from 'https';
+import tls from 'tls';
+import { Duplex } from 'stream';
 import type { AddressInfo } from 'net';
 import zlib from 'zlib';
+import { generateCertificate as generateCACertificate } from './tls/certificates';
+import type { GeneratedCertificate } from './tls/certificates';
 import {
 	generateCertificate,
 	cleanupCertificate,
@@ -61,10 +66,89 @@ destructive results fifty years hence. He was, I believe, not in the
 least an ill-natured man: very much the opposite, I should say; but he
 would not suffer fools gladly.`;
 
+function createTestApp(): Express {
+	const app = express();
+
+	// Set up all routes BEFORE creating the server
+	app.get('/simple', (req, res) => {
+		res.send('Hello, World!');
+	});
+
+	app.get('/slow', (req, res) => {
+		setTimeout(() => {
+			res.send('Slow response');
+		}, 1000);
+	});
+
+	app.get('/stream', (req, res) => {
+		res.flushHeaders();
+		res.write('Part 1');
+		setTimeout(() => {
+			res.write('Part 2');
+			res.end();
+		}, 1500);
+	});
+
+	app.get('/headers', (req, res) => {
+		res.set('X-Custom-Header', 'TestValue');
+		res.send('OK');
+	});
+
+	app.get('/gzipped', (req, res) => {
+		const gzip = zlib.createGzip();
+		gzip.write(pygmalion);
+		gzip.end();
+
+		const gzippedChunks: Uint8Array[] = [];
+		gzip.on('data', (chunk) => {
+			gzippedChunks.push(chunk);
+		});
+		gzip.on('end', () => {
+			const length = gzippedChunks.reduce(
+				(acc, chunk) => acc + chunk.length,
+				0
+			);
+			res.setHeader('Content-Encoding', 'gzip');
+			res.setHeader('Content-Length', length.toString());
+			for (const chunk of gzippedChunks) {
+				res.write(chunk);
+			}
+			res.end();
+		});
+	});
+
+	app.post('/echo', (req, res) => {
+		// Set appropriate headers
+		res.setHeader(
+			'Content-Type',
+			req.headers['content-type'] || 'text/plain'
+		);
+		res.setHeader('Transfer-Encoding', 'chunked');
+		// Create readable stream from request body
+		const stream = req;
+
+		// Pipe the input stream directly to the response
+		stream.pipe(res);
+
+		// Handle errors
+		stream.on('error', (error) => {
+			console.error('Stream error:', error);
+			res.status(500).end();
+		});
+	});
+
+	app.get('/error', (req, res) => {
+		res.status(500).send('Internal Server Error');
+	});
+
+	return app;
+}
+
 describe('TCPOverFetchWebsocket', () => {
 	let server: https.Server;
 	let host: string;
 	let port: number;
+	let CAroot: GeneratedCertificate;
 	let originalRejectUnauthorized: string | undefined;
 
 	beforeAll(async () => {
@@ -73,81 +157,18 @@ describe('TCPOverFetchWebsocket', () => {
 			process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
 		process.env['NODE_TLS_REJECT_UNAUTHORIZED'] = '0';
 
-		const app = express();
-
-		// Set up all routes BEFORE creating the server
-		app.get('/simple', (req, res) => {
-			res.send('Hello, World!');
+		CAroot = await generateCACertificate({
+			subject: {
+				countryName: 'US',
+				organizationName: 'Test CA',
+				commonName: 'test-ca.local',
+			},
+			basicConstraints: {
+				ca: true,
+			},
 		});
 
-		app.get('/slow', (req, res) => {
-			setTimeout(() => {
-				res.send('Slow response');
-			}, 1000);
-		});
-
-		app.get('/stream', (req, res) => {
-			res.flushHeaders();
-			res.write('Part 1');
-			setTimeout(() => {
-				res.write('Part 2');
-				res.end();
-			}, 1500);
-		});
-
-		app.get('/headers', (req, res) => {
-			res.set('X-Custom-Header', 'TestValue');
-			res.send('OK');
-		});
-
-		app.get('/gzipped', (req, res) => {
-			const gzip = zlib.createGzip();
-			gzip.write(pygmalion);
-			gzip.end();
-
-			const gzippedChunks: Uint8Array[] = [];
-			gzip.on('data', (chunk) => {
-				gzippedChunks.push(chunk);
-			});
-			gzip.on('end', () => {
-				const length = gzippedChunks.reduce(
-					(acc, chunk) => acc + chunk.length,
-					0
-				);
-				res.setHeader('Content-Encoding', 'gzip');
-				res.setHeader('Content-Length', length.toString());
-				for (const chunk of gzippedChunks) {
-					res.write(chunk);
-				}
-				res.end();
-			});
-		});
-
-		app.post('/echo', (req, res) => {
-			// Set appropriate headers
-			res.setHeader(
-				'Content-Type',
-				req.headers['content-type'] || 'text/plain'
-			);
-			res.setHeader('Transfer-Encoding', 'chunked');
-			// Create readable stream from request body
-			const stream = req;
-
-			// Pipe the input stream directly to the response
-			stream.pipe(res);
-
-			// Handle errors
-			stream.on('error', (error) => {
-				console.error('Stream error:', error);
-				res.status(500).end();
-			});
-		});
-
-		app.get('/error', (req, res) => {
-			res.status(500).send('Internal Server Error');
-		});
-
-		// Now create and start the HTTPS server
+		const app = createTestApp();
 		const { cert, key } = await generateCertificate();
 		server = https.createServer({ cert, key }, app);
 
@@ -157,7 +178,7 @@ describe('TCPOverFetchWebsocket', () => {
 		});
 
 		const address = server.address() as AddressInfo;
-		host = `127.0.0.1`;
+		host = '127.0.0.1';
 		port = address.port;
 	});
 
@@ -171,6 +192,92 @@ describe('TCPOverFetchWebsocket', () => {
 		} else {
 			delete process.env['NODE_TLS_REJECT_UNAUTHORIZED'];
 		}
+	});
+
+	it('should handle a simple HTTPS request via TLS path', async () => {
+		const socket = new TCPOverFetchWebsocket(
+			`ws://playground.internal/?host=${host}&port=443`,
+			[],
+			{ CAroot, outputType: 'stream' }
+		);
+
+		const duplexStream = new Duplex({
+			read() {},
+			write(chunk, encoding, callback) {
+				socket.send(chunk);
+				callback();
+			},
+		});
+
+		const reader = socket.clientDownstream.readable.getReader();
+		(async () => {
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) {
+						duplexStream.push(null);
+						break;
+					}
+					duplexStream.push(value);
+				}
+			} catch {
+				duplexStream.destroy();
+			}
+		})();
+
+		const crypto = await import('crypto');
+		const tlsSocket = tls.connect({
+			socket: duplexStream,
+			rejectUnauthorized: false,
+			secureOptions:
+				crypto.constants.SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION,
+		});
+
+		const response = await new Promise<string>((resolve, reject) => {
+			let data = '';
+
+			tlsSocket.on('secureConnect', () => {
+				const request = `GET /simple HTTP/1.1\r\nHost: ${host}:${port}\r\n\r\n`;
+				tlsSocket.write(request);
+			});
+
+			tlsSocket.on('data', (chunk) => {
+				data += chunk.toString();
+				if (data.includes('Hello, World!')) {
+					tlsSocket.end();
+					resolve(data);
+				}
+			});
+
+			tlsSocket.on('error', reject);
+			tlsSocket.on('end', () => resolve(data));
+		});
+
+		expect(response).toContain('HTTP/1.1 200 OK');
+		expect(response).toContain('Hello, World!');
+	});
+});
+
+describe('TCPOverFetchWebsocket over HTTP', () => {
+	let server: http.Server;
+	let host: string;
+	let port: number;
+
+	beforeAll(async () => {
+		const app = createTestApp();
+		server = http.createServer(app);
+
+		await new Promise<void>((resolve) => {
+			server.listen(0, () => resolve());
+		});
+
+		const address = server.address() as AddressInfo;
+		host = `127.0.0.1`;
+		port = address.port;
+	});
+
+	afterAll(() => {
+		server.close();
 	});
 
 	it('should handle a simple HTTP request', async () => {

--- a/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
+++ b/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
@@ -1,6 +1,8 @@
 import { concatUint8Arrays } from '@php-wasm/util';
 
 import { ServerNameExtension } from '../extensions/0_server_name';
+import { ECPointFormatsExtension } from '../extensions/11_ec_point_formats';
+import { RenegotiationInfoExtension } from '../extensions/65281_renegotiation_info';
 import { CipherSuitesNames } from '../cipher-suites';
 import { CipherSuites } from '../cipher-suites';
 import { parseClientHelloExtensions } from '../extensions/parse-extensions';
@@ -29,7 +31,9 @@ import {
 	CompressionMethod,
 	HandshakeType,
 	ContentTypes,
+	AlertLevels,
 	AlertLevelNames,
+	AlertDescriptions,
 	AlertDescriptionNames,
 	ECCurveTypes,
 	ECNamedCurves,
@@ -480,9 +484,8 @@ export class TLS_1_2_Connection {
 		let accumulatedPayload: false | Uint8Array = false;
 		do {
 			record = await this.readNextTLSRecord(requestedType);
-			accumulatedPayload = await this.accumulateUntilMessageIsComplete(
-				record
-			);
+			accumulatedPayload =
+				await this.accumulateUntilMessageIsComplete(record);
 		} while (accumulatedPayload === false);
 
 		const message = TLSDecoder.TLSMessage(
@@ -529,23 +532,32 @@ export class TLS_1_2_Connection {
 			} as TLSRecord;
 
 			if (record.type === ContentTypes.Alert) {
-				const severity = AlertLevelNames[record.fragment[0]];
-				const description = AlertDescriptionNames[record.fragment[1]];
-				/**
-				 * @TODO: Handle TLS warnings, e.g. this one:
-				 *
-				 * close_notify
-				 *     Either party may initiate a close by sending a close_notify alert.
-				 *     Any data received after a closure alert is ignored.
-				 *
-				 *     Unless some other fatal alert has been transmitted, each party is
-				 *     required to send a close_notify alert before closing the write side
-				 *     of the connection.  The other party MUST respond with a close_notify
-				 *     alert of its own and close down the connection immediately,
-				 *     discarding any pending writes.
-				 */
+				const level = record.fragment[0];
+				const descriptionCode = record.fragment[1];
+				const severity = AlertLevelNames[level];
+				const description = AlertDescriptionNames[descriptionCode];
+
+				if (
+					level === AlertLevels.Warning &&
+					descriptionCode === AlertDescriptions.CloseNotify
+				) {
+					/**
+					 * close_notify
+					 *     Either party may initiate a close by sending a close_notify alert.
+					 *     Any data received after a closure alert is ignored.
+					 *
+					 *     Unless some other fatal alert has been transmitted, each party is
+					 *     required to send a close_notify alert before closing the write side
+					 *     of the connection.  The other party MUST respond with a close_notify
+					 *     alert of its own and close down the connection immediately,
+					 *     discarding any pending writes.
+					 */
+					throw new TLSConnectionClosed(
+						'TLS connection closed by peer (CloseNotify)'
+					);
+				}
 				throw new Error(
-					`TLS non-warning alert received: ${severity} ${description}`
+					`TLS alert received: ${severity} ${description}`
 				);
 			}
 
@@ -1163,9 +1175,24 @@ class MessageEncoder {
 						 * (extended) server hello.  The "extension_data" field of this extension
 						 * SHALL be empty.
 						 *
-						 * Source: dfile:///Users/cloudnik/Library/Application%20Support/Dash/User%20Contributed/RFCs/RFCs.docset/Contents/Resources/Documents/rfc6066.html#section-3
+						 * Source: https://datatracker.ietf.org/doc/html/rfc6066#section-3
 						 */
 						return ServerNameExtension.encodeForClient();
+					case 'ec_point_formats':
+						/**
+						 * RFC 4492: If the server understands the Supported Point Formats
+						 * Extension, it MUST include it in the ServerHello.
+						 */
+						return ECPointFormatsExtension.encodeForClient(
+							'uncompressed'
+						);
+					case 'renegotiation_info':
+						/**
+						 * RFC 5746: The server MUST include a "renegotiation_info" extension
+						 * in its ServerHello if the client included one in the ClientHello.
+						 * For initial connections, the renegotiated_connection field is empty.
+						 */
+						return RenegotiationInfoExtension.encodeForClient();
 				}
 				return undefined;
 			})

--- a/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
+++ b/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
@@ -1180,8 +1180,13 @@ class MessageEncoder {
 						return ServerNameExtension.encodeForClient();
 					case 'ec_point_formats':
 						/**
-						 * RFC 4492: If the server understands the Supported Point Formats
-						 * Extension, it MUST include it in the ServerHello.
+						 * RFC 4492 Section 5.2: When a client sends ec_point_formats and
+						 * the server selects an ECC cipher suite, the server responds with
+						 * its supported point formats. A server that cannot satisfy these
+						 * requirements MUST NOT choose an ECC cipher suite.
+						 *
+						 * Since we always use an ECC cipher suite (ECDHE_RSA_WITH_AES_128_GCM_SHA256)
+						 * and only support uncompressed points, we must respond accordingly.
 						 */
 						return ECPointFormatsExtension.encodeForClient(
 							'uncompressed'

--- a/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
+++ b/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
@@ -1193,9 +1193,13 @@ class MessageEncoder {
 						);
 					case 'renegotiation_info':
 						/**
-						 * RFC 5746: The server MUST include a "renegotiation_info" extension
-						 * in its ServerHello if the client included one in the ClientHello.
-						 * For initial connections, the renegotiated_connection field is empty.
+						 * RFC 5746: The renegotiation_info extension prevents MITM attacks
+						 * during TLS renegotiation. The server MUST include it in ServerHello
+						 * if the client sent it in ClientHello.
+						 *
+						 * For initial connections (not renegotiations), both sides send an
+						 * empty renegotiated_connection field. Since this implementation
+						 * doesn't support renegotiation, that's all we need to handle.
 						 */
 						return RenegotiationInfoExtension.encodeForClient();
 				}

--- a/packages/php-wasm/web/src/lib/tls/extensions/65281_renegotiation_info.ts
+++ b/packages/php-wasm/web/src/lib/tls/extensions/65281_renegotiation_info.ts
@@ -1,0 +1,45 @@
+/**
+ * Renegotiation Info Extension (RFC 5746)
+ * https://datatracker.ietf.org/doc/html/rfc5746
+ *
+ * This extension is used to prevent MITM attacks during TLS renegotiation.
+ * For initial connections (not renegotiations), the client sends an empty
+ * renegotiated_connection field, and the server responds with the same.
+ *
+ * struct {
+ *    opaque renegotiated_connection<0..255>;
+ * } RenegotiationInfo;
+ */
+
+import { ExtensionTypes } from './types';
+
+export type RenegotiationInfo = {
+	renegotiatedConnection: Uint8Array;
+};
+
+export const RenegotiationInfoExtension = {
+	decodeFromClient(data: Uint8Array): RenegotiationInfo {
+		// First byte is the length of the renegotiated_connection field
+		const length = data[0] ?? 0;
+		return {
+			renegotiatedConnection: data.slice(1, 1 + length),
+		};
+	},
+
+	/**
+	 * For an initial connection (not a renegotiation), the server responds
+	 * with an empty renegotiated_connection field.
+	 */
+	encodeForClient(): Uint8Array {
+		const extensionType = ExtensionTypes.renegotiation_info;
+		// Extension data: 1 byte length (0) for empty renegotiated_connection
+		const extensionData = new Uint8Array([0]);
+		return new Uint8Array([
+			(extensionType >> 8) & 0xff,
+			extensionType & 0xff,
+			0,
+			extensionData.length,
+			...extensionData,
+		]);
+	},
+};

--- a/packages/php-wasm/web/src/lib/tls/extensions/parse-extensions.ts
+++ b/packages/php-wasm/web/src/lib/tls/extensions/parse-extensions.ts
@@ -11,6 +11,8 @@ import type { ParsedECPointFormats } from './11_ec_point_formats';
 import { ECPointFormatsExtension } from './11_ec_point_formats';
 import type { SignatureAlgorithms } from './13_signature_algorithms';
 import { SignatureAlgorithmsExtension } from './13_signature_algorithms';
+import type { RenegotiationInfo } from './65281_renegotiation_info';
+import { RenegotiationInfoExtension } from './65281_renegotiation_info';
 import { ExtensionNames } from './types';
 
 export const TLSExtensionsHandlers = {
@@ -18,6 +20,7 @@ export const TLSExtensionsHandlers = {
 	signature_algorithms: SignatureAlgorithmsExtension,
 	supported_groups: SupportedGroupsExtension,
 	ec_point_formats: ECPointFormatsExtension,
+	renegotiation_info: RenegotiationInfoExtension,
 } as const;
 
 export type SupportedTLSExtension = keyof typeof TLSExtensionsHandlers;
@@ -41,6 +44,11 @@ export type ParsedExtension =
 	| {
 			type: 'supported_groups';
 			data: ParsedSupportedGroups;
+			raw: Uint8Array;
+	  }
+	| {
+			type: 'renegotiation_info';
+			data: RenegotiationInfo;
 			raw: Uint8Array;
 	  };
 

--- a/packages/php-wasm/web/src/lib/tls/extensions/types.ts
+++ b/packages/php-wasm/web/src/lib/tls/extensions/types.ts
@@ -56,6 +56,7 @@ export const ExtensionTypes = {
 	key_share: 51,
 	transparency_info: 52,
 	connection_id: 54,
+	renegotiation_info: 65281,
 } as const;
 
 import { flipObject } from '../utils';


### PR DESCRIPTION
## Motivation for the change, related issues

Enable access to local APIs from WordPress Playground. Previously, localhost requests would be upgraded to HTTPS and could fall through to the CORS proxy retry logic, which would fail since the remote proxy cannot reach the user's localhost.

## Implementation details

- Check for localhost early in `fetchWithCorsProxy` and return direct fetch immediately
- Skip HTTP→HTTPS upgrade for localhost (local APIs typically run on HTTP)
- Skip CORS proxy for localhost requests
- Fixed `tcp-over-fetch-websocket.ts` to construct HTTPS URLs (was incorrectly relying on the HTTP→HTTPS upgrade)

## Testing Instructions (or ideally a Blueprint)

1. Run a local API server (e.g., Ollama on port 11434, LM Studio on port 1234, or Beeper on port 23373)
2. From Playground, make a fetch request to `http://localhost:11434/api/...`
3. Verify the request reaches the local server directly via HTTP without being proxied or upgraded to HTTPS