### PR TITLE
[Website] Fix Safari PWA cache failures by stripping Range headers

### DIFF
--- a/packages/playground/remote/src/lib/offline-mode-cache.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.ts
@@ -19,6 +19,13 @@ export async function cacheFirstFetch(request: Request): Promise<Response> {
 	}
 
 	/**
+	 * Strip the Range header if present. Safari sometimes adds Range headers
+	 * to requests, which results in 206 Partial Content responses that can't
+	 * be cached using .put() since they're incomplete responses.
+	 */
+	const requestWithoutRangeHeader = stripRangeHeader(request);
+
+	/**
 	 * Ensure the response is not coming from HTTP cache.
 	 *
 	 * We never want to put a stale asset in CacheStorage as
@@ -26,7 +33,7 @@ export async function cacheFirstFetch(request: Request): Promise<Response> {
 	 *
 	 * See service-worker.ts for more details.
 	 */
-	const response = await fetchFresh(request);
+	const response = await fetchFresh(requestWithoutRangeHeader);
 	if (response.ok) {
 		/**
 		 * Confirm the current service worker is still active
@@ -38,7 +45,7 @@ export async function cacheFirstFetch(request: Request): Promise<Response> {
 			// Intentionally do not await writing to the cache so the response
 			// promise can be returned immediately and observed for progress events.
 			// NOTE: This is a race condition for simultaneous requests for the same asset.
-			offlineModeCache.put(request, response.clone());
+			offlineModeCache.put(requestWithoutRangeHeader, response.clone());
 		}
 	}
 
@@ -177,6 +184,26 @@ export function shouldCacheUrl(url: URL) {
 	 * Allow only requests to the same hostname to be cached.
 	 */
 	return self.location.hostname === url.hostname;
+}
+
+/**
+ * Removes the Range header from a request if present.
+ *
+ * Safari sometimes adds Range headers which cause 206 Partial Content responses
+ * that can't be cached using Cache API's .put() method.
+ *
+ * @param request The original request
+ * @returns A new request without the Range header
+ */
+function stripRangeHeader(request: Request): Request {
+	if (!request.headers.has('range')) {
+		return request;
+	}
+
+	const headers = new Headers(request.headers);
+	headers.delete('range');
+
+	return new Request(request, { headers });
 }
 
 /**


### PR DESCRIPTION
## Summary

This is a potential fix for intermittent Safari PWA failures after deployments where the site displays a blank page until the cache is manually cleared.

Theory: Safari sometimes adds `Range` headers to asset requests, causing servers to return `206 Partial Content` responses. These partial responses fail when using `Cache.put()` because the Cache API requires complete responses.

## The Problem

After deploying playground.wordpress.net, Safari users sometimes experience:

- Blank page on reload, even though assets like `main.js` are accessible
- The files exist and load fine in new tabs
- Only clearing the cache and reloading fixes it
- Chrome and Firefox work fine with the same network-first caching strategy

## The Fix

Strip the `Range` header from requests before fetching in `cacheFirstFetch()`. This ensures:
- Servers return `200 OK` with complete responses instead of `206 Partial Content`
- Responses can be successfully cached with `Cache.put()`
- Consistent behavior across all browsers

## Important Note

This is a best-guess fix since the issue is not easily reproducible outside the deployed production environment. The Safari-specific behavior with Range headers in PWA contexts is well-documented, and this fix addresses that known issue. However, the root cause of the blank page problem may be more complex.

## Testing

The change is defensive and shouldn't affect normal operation:
- If no Range header is present, the request passes through unchanged
- If a Range header exists, a new request is created without it
- All other headers and request properties are preserved