### PR TITLE
[i18n] Add Bengali translation for resources.md

### DIFF
--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/resources.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/resources.md
@@ -1,0 +1,189 @@
+---
+title: লিংক এবং রিসোর্স
+slug: /resources
+description: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড সম্পর্কে আরও জানার জন্য অ্যাপ, টুল, নিবন্ধ এবং ভিডিওর একটি সংকলিত তালিকা।
+---
+
+<!--
+# Links and Resources
+-->
+
+# লিংক এবং রিসোর্স
+
+<!--
+:::tip
+
+There's a set of redirections in place to make it easier the access to some of the tools related to Playground:
+
+<ul id="list-resources-redirections">
+<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → Playground instance</li>
+<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → Playground Docs</li>
+<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → Playground Blueprints Builder</li>
+<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → Playground PR viewer for WordPress</li>
+<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → Playground PR viewer for Gutenberg</li>
+<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → Playground Proxy Service <em>(see <a href="/blueprints/steps/resources#urlreference">URLReference</a> for more info)</em></li>
+</ul>
+:::
+-->
+
+:::পরামর্শ
+
+প্লেগ্রাউন্ড সম্পর্কিত কিছু টুলে অ্যাক্সেস সহজ করার জন্য এখানে কিছু রিডাইরেকশন সেট করা আছে:
+
+<ul id="list-resources-redirections">
+<li><a href="https://playground.wordpress.net/"><strong>https://playground.wordpress.net/</strong></a> → প্লেগ্রাউন্ড ইনস্ট্যান্স</li>
+<li><a href="https://playground.wordpress.net/docs">https://playground.wordpress.net<strong>/docs</strong></a> → প্লেগ্রাউন্ড ডকস</li>
+<li><a href="https://playground.wordpress.net/builder">https://playground.wordpress.net<strong>/builder</strong></a> → প্লেগ্রাউন্ড ব্লুপ্রিন্ট বিল্ডার</li>
+<li><a href="https://playground.wordpress.net/wordpress">https://playground.wordpress.net<strong>/wordpress</strong></a> → ওয়ার্ডপ্রেসের জন্য প্লেগ্রাউন্ড PR ভিউয়ার</li>
+<li><a href="https://playground.wordpress.net/gutenberg">https://playground.wordpress.net<strong>/gutenberg</strong></a> → গুটেনবার্গের জন্য প্লেগ্রাউন্ড PR ভিউয়ার</li>
+<li><a href="https://playground.wordpress.net/proxy">https://playground.wordpress.net<strong>/proxy</strong></a> → প্লেগ্রাউন্ড প্রক্সি সার্ভিস <em>(আরও তথ্যের জন্য <a href="/blueprints/steps/resources#urlreference">URLReference</a> দেখুন)</em></li>
+</ul>
+:::
+
+<!--
+## Frequently sought links
+
+- [Demo](https://playground.wordpress.net/)
+- [GitHub Repository](https://github.com/WordPress/wordpress-playground)
+- [Documentation](https://wordpress.github.io/wordpress-playground/)
+- [Playground tools Repository](https://github.com/WordPress/playground-tools)
+-->
+
+## সরাসরি দরকারি লিংক
+
+- [ডেমো](https://playground.wordpress.net/)
+- [গিটহাব রিপোজিটরি](https://github.com/WordPress/wordpress-playground)
+- [ডকুমেন্টেশন](https://wordpress.github.io/wordpress-playground/)
+- [প্লেগ্রাউন্ড টুলস রিপোজিটরি](https://github.com/WordPress/playground-tools)
+
+<!--
+## Apps built with WordPress Playground
+
+- [Official demo](https://playground.wordpress.net/) and the [showcase](https://developer.wordpress.org/playground) app – install a theme, try out a plugin, create a few pages, export what you've built
+- [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – a CLI tool for instant WordPress dev environment
+- [WordPress Playground for VS Code](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+- Live Translations: [App](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [announcement](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [more details](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+- [Interactive code block](https://wordpress.org/plugins/interactive-code-block/) which powers the [HTML Tag Processor tutorial](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) and the [Playground JS API tutorial](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/)
+- [Gutenberg Pull Request previewer](https://playground.wordpress.net/gutenberg.html)
+- [Notifications plugin live demo](https://johnhooks.io/playground-experiment/)
+- [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+- [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – the first ever iOS app running WordPress on your phone
+- [Playground embedder](https://joost.blog/embedded-playground/) to embed Playground examples in WordPress.org documentation using shortcodes
+- [Plugin demos on wp.org](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – a user script that adds a "demo" tab to plugin pages on WordPress.org
+- [WordPress Pull Request previewer](https://playground.wordpress.net/wordpress.html)
+- [Synchronization between two Playgrounds](https://playground.wordpress.net/demos/sync.html)
+- [Time Travel](https://playground.wordpress.net/demos/time-traveling.html)
+- [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+- [PHP implementation of Blueprints](https://playground.wordpress.net/demos/php-blueprints.html)
+-->
+
+## ওয়ার্ডপ্রেস প্লেগ্রাউন্ড দিয়ে তৈরি অ্যাপ
+
+- [অফিসিয়াল ডেমো](https://playground.wordpress.net/) এবং [শোকেস](https://developer.wordpress.org/playground) অ্যাপ – একটি থিম ইনস্টল করুন, একটি প্লাগইন ব্যবহার করে দেখুন, কয়েকটি পেজ তৈরি করুন এবং আপনি যা তৈরি করেছেন তা এক্সপোর্ট করুন
+- [@wp-playground/cli](https://www.npmjs.com/package/@wp-playground/cli) – দ্রুত ওয়ার্ডপ্রেস ডেভেলপমেন্ট এনভায়রনমেন্টের জন্য একটি CLI টুল
+- [VS কোড-এর জন্য ওয়ার্ডপ্রেস প্লেগ্রাউন্ড](https://marketplace.visualstudio.com/items?itemName=WordPressPlayground.wordpress-playground)
+- লাইভ ট্রান্সলেশন: [অ্যাপ](https://translate.wordpress.org/projects/wp-plugins/friends/dev/pl/default/playground/), [ঘোষণা](https://make.wordpress.org/polyglots/2023/04/19/wp-translation-playground/), [আরও বিস্তারিত](https://make.wordpress.org/polyglots/2023/05/08/translate-live-updates-to-the-translation-playground/)
+- [ইন্টারেক্টিভ কোড ব্লক](https://wordpress.org/plugins/interactive-code-block/) যা [HTML ট্যাগ প্রসেসর টিউটোরিয়াল](https://adamadam.blog/2023/02/16/how-to-modify-html-in-a-php-wordpress-plugin-using-the-new-tag-processor-api/) এবং [প্লেগ্রাউন্ড JS API টিউটোরিয়ালকে](https://wordpress.github.io/wordpress-playground/developers/apis/javascript-api/) পরিচালনা করে
+- [গুটেনবার্গ পুল রিকোয়েস্ট প্রিভিউয়ার](https://playground.wordpress.net/gutenberg.html)
+- [নোটিফিকেশন প্লাগইন লাইভ ডেমো](https://johnhooks.io/playground-experiment/)
+- [GraphQL REPL](https://www.wpgraphql.com/2023/06/15/announcing-the-wpgraphql-repl)
+- [Blocknotes](https://twitter.com/adamzielin/status/1669478239771799552) – আপনার ফোনে ওয়ার্ডপ্রেস চালানো প্রথম iOS অ্যাপ
+- [প্লেগ্রাউন্ড এমবেডার](https://joost.blog/embedded-playground/) যা শর্টকোড ব্যবহার করে WordPress.org ডকুমেন্টেশনে প্লেগ্রাউন্ডের উদাহরণ এমবেড করতে পারে
+- [wp.org-এ প্লাগইন ডেমো](https://gist.github.com/adamziel/0fe3ffc1fb5202a907a87d055ee37135) – একটি ইউজার স্ক্রিপ্ট যা WordPress.org-এ প্লাগইন পেজগুলোতে একটি "demo" ট্যাব যুক্ত করে
+- [ওয়ার্ডপ্রেস পুল রিকোয়েস্ট প্রিভিউয়ার](https://playground.wordpress.net/wordpress.html)
+- [দুটি প্লেগ্রাউন্ডের মধ্যে সিনক্রোনাইজেশন](https://playground.wordpress.net/demos/sync.html)
+- [টাইম ট্রাভেল](https://playground.wordpress.net/demos/time-traveling.html)
+- [WP-CLI](https://playground.wordpress.net/demos/wp-cli.html)
+- [ব্লুপ্রিন্টের PHP ইমপ্লিমেন্টেশন](https://playground.wordpress.net/demos/php-blueprints.html)
+
+<!--
+## Reading materials
+
+- [Build in-browser WordPress experiences with WordPress Playground and WebAssembly](https://web.dev/wordpress-playground/)
+- [WordPress Playground on developer.wordpress.org](https://developer.wordpress.org/playground)
+- [In-Browser WordPress Tech Demos: WordPress Development with WordPress Playground](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+- [Initial announcement on make.wordpress.org](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+- [Hackernews discussion](https://news.ycombinator.com/item?id=32960560)
+-->
+
+## পড়ার উপকরণ
+
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড এবং WebAssembly ব্যবহার করে ব্রাউজারে ওয়ার্ডপ্রেস অভিজ্ঞতা তৈরি করুন](https://web.dev/wordpress-playground/)
+- [developer.wordpress.org-এ ওয়ার্ডপ্রেস প্লেগ্রাউন্ড](https://developer.wordpress.org/playground)
+- [ইন-ব্রাউজার ওয়ার্ডপ্রেস টেক ডেমো: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড দিয়ে ওয়ার্ডপ্রেস ডেভেলপমেন্ট](https://make.wordpress.org/core/2023/04/13/in-browser-wordpress-tech-demos-wordpress-development-with-wordpress-playground/)
+- [make.wordpress.org-এ প্রাথমিক ঘোষণা](https://make.wordpress.org/core/2022/09/23/client-side-webassembly-wordpress-with-no-server/)
+- [হ্যাকারনিউজ আলোচনা](https://news.ycombinator.com/item?id=32960560)
+
+<!--
+## Videos
+
+- Developer Hours Videos:
+    - [Americas Region (May 23,2023)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    - [APAC/EMEA Region (May 24,2023)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    - [Creating WordPress Playground Blueprints for Testing and Demos (May 28, 2024)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) by Birgit Pauli-Haack & Nick Diego
+    - [Developer Hours: Everything you need to know about WordPress Playground (Dec 17, 2024)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) by Nick Diego & Ryan Welcher
+- [Playground at State of the Word](https://youtu.be/VeigCZuxnfY?t=2912)
+- [Playground at WCEU 2023](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+- [Watch "WordPress Playground: the ultimate learning, testing, & teaching tool for WordPress"](https://www.youtube.com/watch?v=dN_LaenY8bI) by Anne McCarthy
+- [WordPress Playground for developers](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) by Berislav Grgicak and Jonathan Bossenger
+- [WordPress Playground Block code editor theme support](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) by Jonathan Bossenger
+- [WordPress Playground – use WordPress without a server at WCEU 2024](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) by Adam Zielinski
+- [Code, Test, Repeat: Accelerating Development with WordPress Playground at WordCamp Larissa 2024](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) by Uros Tasic
+- [Liberating data with WordPress Playground in a Browser Extension at WordCamp Netherlands 2024](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) by Alex Kirk
+- [Beyond the Playground: WordPress as a Tool and Product Builder at WCUS 2024](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) by Dennis Snell
+- [Create a demo with Playground at WC Asia 2025](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) by Birgit Pauli-Haack
+- [Dissecting WordPress Playground at WordCamp Nepal 2025](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) by Sakar Upadhyaya Khatiwada
+- [Building Automated Test with WordPress Playground at WCEU 2025](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/)by Berislav Grgicak
+- [From Zero to Demo: Mastering WordPress Playground Blueprints at WCEU 2025](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) by Birgit Pauli-Haack
+- [Playground at WordCamp Gliwice (in Polish)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) by Adam Zielinski
+- [WordPress Playground at WordCamp Wrocław 2024 (in Polish)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) by Adam Zielinski
+- [WordPress Playground at WordCamp Gdynia 2025 (in Polish)](https://wordpress.tv/2025/04/21/wordpress-playground/) by Magdalena Paciorek
+- [Discovering Playground, the demo tool(in Spanish)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) by Alex Cuadra
+- [WordPress Playground: Complete and functional WordPress installation(in Spanish)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) by Fernando García Rebolledo
+- [Playground: A throwaway WordPress within your browser at WordCamp Madrid 2025(in Spanish)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentow-de-tu-navegador/) by Álvaro Gómez Velasco
+- [Use WordPress with just a browser! WordPress Playground Tutorial: Basic usage of Playground (in Japanese)](https://www.youtube.com/watch?v=6s_B0WvJauU) by Shimomura Tomoki
+- [WordPress Playground: How to use Blueprints](https://www.youtube.com/watch?v=Vcao6uXguWg) by Shimomura Tomoki
+- [Streamlined Block Theme Development: Using WordPress Playground and GitHub for No-Code Version Control of Site Editor Changes](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) by Birgit Pauli-Haack
+- [Playground, la mejor herramienta jamás inventada para enseñar WordPress (in Spanish)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) by Nilo Vélez
+- [Testing Faster Than a Red Bull Pit Stop: WordPress Playground and WooCommerce Blueprints](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) by Daniel Dudzic
+- [Is WordPress playground only for developers?](https://wordpress.tv/2025/10/25/is-wordpress-playground-only-for-developers/) by Fellyph Cintra
+- [How to test the next WordPress release with WordPress Playground](https://wordpress.tv/2025/11/13/how-to-test-the-next-wordpress-release-with-wordpress-playground/) by Fellyph cintra
+- [Running WordPress directly from the JavaScript code with runCLI](https://wordpress.tv/2025/10/22/running-wordpress-directly-from-the-javascript-code-with-runcli/) by Fellyph Cintra
+- [WordPress Playground: The Path to Test Automation](https://wordpress.tv/2025/11/24/wordpress-playground-the-path-to-test-automation/) by Fellyph Cintra
+-->
+
+## ভিডিও
+
+- ডেভেলপার আওয়ার ভিডিও:
+    - [আমেরিকা অঞ্চল (২৩ মে, ২০২৩)](https://wordpress.tv/2023/05/23/developer-hours-wordpress-playground-americas/)
+    - [APAC/EMEA অঞ্চল (২৪ মে, ২০২৩)](https://wordpress.tv/2023/05/24/developer-hours-wordpress-playground-apac-emea/)
+    - [টেস্টিং এবং ডেমোর জন্য ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্লুপ্রিন্ট তৈরি করা (২৮ মে, ২০২৪)](https://wordpress.tv/2024/05/28/developer-hours-creating-wordpress-playground-blueprints-for-testing-and-demos/) - বিরজিত পাওলি-হ্যাক এবং নিক দিয়েগো
+    - [ডেভেলপার আওয়ার: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড সম্পর্কে আপনার যা জানা দরকার (১৭ ডিসেম্বর, ২০২৪)](https://wordpress.tv/2024/12/17/developer-hours-everything-you-need-to-know-about-wordpress-playground/) - নিক দিয়েগো এবং রায়ান ওয়েলচার
+- [State of the Word-এ প্লেগ্রাউন্ড](https://youtu.be/VeigCZuxnfY?t=2912)
+- [WCEU 2023-এ প্লেগ্রাউন্ড](https://www.youtube.com/watch?v=e-CwouzTGp4&t=26946s)
+- ["ওয়ার্ডপ্রেস প্লেগ্রাউন্ড: ওয়ার্ডপ্রেসের জন্য পরম শেখার, পরীক্ষা করার এবং শেখানোর টুল" দেখুন](https://www.youtube.com/watch?v=dN_LaenY8bI) - অ্যান ম্যাকার্থি
+- [ডেভেলপারদের জন্য ওয়ার্ডপ্রেস প্লেগ্রাউন্ড](https://wordpress.tv/2024/12/16/wordpress-playground-for-developers/) - বেরিস্লাভ গ্রগিক্যাক এবং জোনাথন বসেনজার
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্লক কোড এডিটর থিম সাপোর্ট](https://wordpress.tv/2024/10/05/wordpress-playground-block-code-editor-theme-support/) - জোনাথন বসেনজার
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড – WCEU 2024-এ সার্ভার ছাড়াই ওয়ার্ডপ্রেস ব্যবহার করুন](https://wordpress.tv/2024/07/03/wordpress-playground-use-wordpress-without-a-server/) - অ্যাডাম জেলিনস্কি
+- [কোড, টেস্ট, রিপিট: ওয়ার্ডক্যাম্প লরিসা ২০২৪-এ ওয়ার্ডপ্রেস প্লেগ্রাউন্ডের সাথে ডেভেলপমেন্ট ত্বরান্বিত করা](https://wordpress.tv/2024/12/13/code-test-repeat-accelerating-development-with-wordpress-playground/) - উরোস তাসিচ
+- [ওয়ার্ডক্যাম্প নেদারল্যান্ডস ২০২৪-এ একটি ব্রাউজার এক্সটেনশনে ওয়ার্ডপ্রেস প্লেগ্রাউন্ডের সাথে ডেটা লিবারেটিং](https://wordpress.tv/2024/12/24/liberating-data-with-wordpress-playground-in-a-browser-extension/) - অ্যালেক্স কার্ক
+- [প্লেগ্রাউন্ডের বাইরে: WCUS ২০২৪-এ একটি টুল এবং প্রোডাক্ট বিল্ডার হিসেবে ওয়ার্ডপ্রেস](https://wordpress.tv/2024/10/10/beyond-the-playground-wordpress-as-a-tool-and-product-builder/) - ডেনিস স্নেল
+- [WC এশিয়া ২০২৫-এ প্লেগ্রাউন্ড দিয়ে একটি ডেমো তৈরি করুন](https://wordpress.tv/2025/04/30/create-a-demo-with-playground/) - বিরজিত পাওলি-হ্যাক
+- [ওয়ার্ডক্যাম্প নেপাল ২০২৫-এ ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্যবচ্ছেদ করা](https://wordpress.tv/2025/04/30/dissecting-wordpress-playground/) - সাকার উপাধ্যায় খাতিওয়াদা
+- [WCEU ২০২৫-এ ওয়ার্ডপ্রেস প্লেগ্রাউন্ডের সাথে অটোমেটেড টেস্ট তৈরি করা](https://wordpress.tv/2025/06/07/building-automated-tests-with-wordpress-playground/) - বেরিস্লাভ গ্রগিক্যাক
+- [জিরো থেকে ডেমো: WCEU ২০২৫-এ ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্লুপ্রিন্ট আয়ত্ত করা](https://wordpress.tv/2025/06/07/from-zero-to-demo-mastering-wordpress-playground-blueprints/) - বিরজিত পাওলি-হ্যাক
+- [ওয়ার্ডক্যাম্প গ্লিওয়াইস-এ প্লেগ্রাউন্ড (পোলিশ ভাষায়)](https://www.youtube.com/watch?v=AUHklF9GdL8&list=PLiCne9CeL82_hGuJOAJlsc84WxVDSH-c9&index=4) - অ্যাডাম জেলিনস্কি
+- [ওয়ার্ডক্যাম্প রোক্লো ২০২৪-এ ওয়ার্ডপ্রেস প্লেগ্রাউন্ড (পোলিশ ভাষায়)](https://wordpress.tv/2024/12/02/wordpress-playground-przelom-w-wordpressie-2/) - অ্যাডাম জেলিনস্কি
+- [ওয়ার্ডক্যাম্প গদানিয়া ২০২৫-এ ওয়ার্ডপ্রেস প্লেগ্রাউন্ড (পোলিশ ভাষায়)](https://wordpress.tv/2025/04/21/wordpress-playground/) - ম্যাগডালেনা প্যাকিয়োরেকি
+- [প্লেগ্রাউন্ড আবিষ্কার, ডেমো টুল (স্প্যানিশ ভাষায়)](https://wordpress.tv/2024/08/09/descubriendo-playground-la-herramienta-para-hacer-demos/) - অ্যালেক্স কুয়াদ্রা
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড: সম্পূর্ণ এবং কার্যকর ওয়ার্ডপ্রেস ইনস্টলেশন (স্প্যানিশ ভাষায়)](https://wordpress.tv/2024/02/07/wordpress-playground-instalacion-completa-y-funcional-de-wordpress/) - ফার্নান্দো গার্সিয়া রেবোলেডো
+- [প্লেগ্রাউন্ড: ওয়ার্ডক্যাম্প মাদ্রিদ ২০২৫-এ আপনার ব্রাউজারের মধ্যে একটি ওয়ান-অফ ওয়ার্ডপ্রেস (স্প্যানিশ ভাষায়)](https://wordpress.tv/2025/03/09/playground-un-wordpress-de-usar-y-tirar-dentow-de-tu-navegador/) - আলভারো গোমেজ ভেলাস্কো
+- [শুধু একটি ব্রাউজার দিয়ে ওয়ার্ডপ্রেস ব্যবহার করুন! ওয়ার্ডপ্রেস প্লেগ্রাউন্ড টিউটোরিয়াল: প্লেগ্রাউন্ডের মৌলিক ব্যবহার (জাপানি ভাষায়)](https://www.youtube.com/watch?v=6s_B0WvJauU) - শিমোমুরা তোমোকি
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড: কীভাবে ব্লুপ্রিন্ট ব্যবহার করবেন](https://www.youtube.com/watch?v=Vcao6uXguWg) - শিমোমুরা তোমোকি
+- [স্ট্রিমলাইনড ব্লক থিম ডেভেলপমেন্ট: সাইট এডিটর পরিবর্তনের নো-কোড ভার্সন কন্ট্রোলের জন্য ওয়ার্ডপ্রেস প্লেগ্রাউন্ড এবং গিটহাব ব্যবহার করা](https://wordpress.tv/2025/09/30/streamlined-block-theme-development-using-wordpress-playground-and-github-for-no-code-version-contr/) - বিরজিত পাওলি-হ্যাক
+- [প্লেগ্রাউন্ড, ওয়ার্ডপ্রেস শেখানোর জন্য উদ্ভাবিত সেরা টুল (স্প্যানিশ ভাষায়)](https://wordpress.tv/2025/10/05/playground-la-mejor-herramienta-jamas-inventada-para-ensenar-wordpress/) - নিলো ভেলেজ
+- [রেড বুল পিট স্টপের চেয়ে দ্রুত টেস্টিং: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড এবং কমার্স ব্লুপ্রিন্ট](https://wordpress.tv/2025/09/30/testing-faster-than-a-red-bull-pit-stop-wordpress-playground-and-woocommerce-blueprints/) - ড্যানিয়েল ডুজিক
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড কি শুধু ডেভেলপারদের জন্য?](https://wordpress.tv/2025/10/25/is-wordpress-playground-only-for-developers/) - ফেলিপ সিন্ট্রা
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ডের সাথে পরবর্তী ওয়ার্ডপ্রেস রিলিজ কীভাবে পরীক্ষা করবেন](https://wordpress.tv/2025/11/13/how-to-test-the-next-wordpress-release-with-wordpress-playground/) - ফেলিপ সিন্ট্রা
+- [runCLI এর মাধ্যমে সরাসরি জাভাস্ক্রিপ্ট কোড থেকে ওয়ার্ডপ্রেস চালানো](https://wordpress.tv/2025/10/22/running-wordpress-directly-from-the-javascript-code-with-runcli/) - ফেলিপ সিন্ট্রা
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড: টেস্ট অটোমেশনের পথ](https://wordpress.tv/2025/11/24/wordpress-playground-the-path-to-test-automation/) - ফেলিপ সিন্ট্রা


### PR DESCRIPTION
## What?

Added Bengali (bn) translation for the [resources.md]

## Why?

To make WordPress Playground documentation accessible to Bengali-speaking users and provide an overview of the platform in their native language.

## How?

- Translated all content following the established translation format
- Original English text preserved in HTML comments for reviewer reference
- Technical terms (WordPress, Playground, GitHub, etc.) handled using standardized Bengali script while keeping original terms for clarity
- Markdown structure and links remain unchanged
- Code blocks remain unchanged

