### PR TITLE
[website] Switch error modal Kapa widget to hcaptcha

### DIFF
--- a/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
+++ b/packages/playground/website/src/components/site-error-modal/use-kapa-ai.ts
@@ -54,6 +54,7 @@ function loadKapaScript(): Promise<void> {
 		script.setAttribute('data-button-hide', 'true');
 		script.setAttribute('data-modal-z-index', '100001');
 		script.setAttribute('data-scale-factor', '1.3');
+		script.setAttribute('data-bot-protection-mechanism', 'hcaptcha');
 
 		script.onload = () => {
 			const checkKapa = setInterval(() => {


### PR DESCRIPTION
## Motivation for the change, related issues

Switches the bot protection mechanism to hcaptcha to match the docs site Kapa widget configuration.

## Implementation details

Adds `data-bot-protection-mechanism="hcaptcha"` attribute to the Kapa script in `use-kapa-ai.ts`.

## Testing Instructions (or ideally a Blueprint)

1. Visit the Playground website
2. Trigger an error that opens the error modal
3. Click the "Ask AI" button to open the Kapa widget
4. Verify the widget loads correctly with hcaptcha protection