### PR TITLE
Fix wp-cli step failing on STDERR output with successful exit codes

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.spec.ts
@@ -42,6 +42,41 @@ describe('Blueprint step wpCLI', () => {
 		});
 		expect(result.text).toContain('Created post 4');
 	});
+
+	it('should succeed when there is STDERR output but exit code is 0', async () => {
+		await php.writeFile(
+			'/tmp/test-stderr.php',
+			`<?php
+			fwrite(STDERR, "PHP Deprecated: Case statements followed by a semicolon (;) are deprecated\\n");
+			echo "Command succeeded";
+			exit(0);
+			?>`
+		);
+
+		const result = await wpCLI(php, {
+			command: 'wp eval-file /tmp/test-stderr.php --no-color',
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.errors).toContain('PHP Deprecated');
+		expect(result.text).toContain('Command succeeded');
+	});
+
+	it('should fail when exit code is non-zero even with error message', async () => {
+		await php.writeFile(
+			'/tmp/test-failure.php',
+			`<?php
+			fwrite(STDERR, "Error: Command failed\\n");
+			exit(1);
+			?>`
+		);
+
+		await expect(
+			wpCLI(php, {
+				command: 'wp eval-file /tmp/test-failure.php --no-color',
+			})
+		).rejects.toThrow('Error: Command failed');
+	});
 });
 
 describe('splitShellCommand', () => {

--- a/packages/playground/blueprints/src/lib/steps/wp-cli.ts
+++ b/packages/playground/blueprints/src/lib/steps/wp-cli.ts
@@ -153,7 +153,7 @@ This will ensure your code works reliably regardless of the current working dire
 		scriptPath: joinPaths(documentRoot, 'run-cli.php'),
 	});
 
-	if (result.errors) {
+	if (result.exitCode !== 0) {
 		throw new Error(result.errors);
 	}
 


### PR DESCRIPTION
## Summary

The wp-cli step was checking for any STDERR output and treating it as a failure, even when the command succeeded with exit code 0. This caused issues with PHP deprecation warnings and notices that don't indicate actual failures.

For example, this deprecation warning would cause the step to fail even though the command succeeded:
```
PHP Deprecated: Case statements followed by a semicolon (;) are deprecated, use a colon (:) instead in phar:///tmp/wp-cli.phar/vendor/react/promise/src/functions.php on line 369
```

## Changes

- Fix `wp-cli.ts` to check `result.exitCode !== 0` instead of `result.errors`
- Commands can now produce warnings or deprecation notices in STDERR and still succeed, as long as the exit code is 0
- Add comprehensive tests to verify the fix

## Test plan

- [x] Run existing wp-cli tests (all pass)
- [x] Added test: step succeeds when STDERR has content but exit code is 0
- [x] Added test: step fails when exit code is non-zero regardless of error message
- [x] Verify in real usage that wp-cli commands with deprecation warnings no longer fail