### PR TITLE
[Website] Fix plugin-proxy artifact lookup for busy repos

### DIFF
--- a/packages/playground/website/public/plugin-proxy.php
+++ b/packages/playground/website/public/plugin-proxy.php
@@ -48,16 +48,31 @@ class PluginDownloader
 	private function streamArtifactFromBranch($organization, $repo, $branchName, $workflow_name, $artifact_name)
 	{
 		$branchName = urlencode($branchName);
-		$ciRuns = $this->gitHubRequest("https://api.github.com/repos/$organization/$repo/actions/runs?branch=$branchName")['body'];
-		if (!$ciRuns) {
+
+		$workflows = $this->gitHubRequest("https://api.github.com/repos/$organization/$repo/actions/workflows")['body'];
+		if (!$workflows || !$workflows->workflows) {
+			throw new ApiException('no_workflows_found');
+		}
+
+		$workflow_id = null;
+		foreach ($workflows->workflows as $workflow) {
+			if ($workflow->name === $workflow_name) {
+				$workflow_id = $workflow->id;
+				break;
+			}
+		}
+		if (!$workflow_id) {
+			throw new ApiException('workflow_not_found');
+		}
+
+		$ciRuns = $this->gitHubRequest("https://api.github.com/repos/$organization/$repo/actions/workflows/$workflow_id/runs?branch=$branchName")['body'];
+		if (!$ciRuns || !$ciRuns->workflow_runs) {
 			throw new ApiException('no_ci_runs');
 		}
 
 		$artifactsUrls = [];
 		foreach ($ciRuns->workflow_runs as $run) {
-			if ($run->name === $workflow_name) {
-				$artifactsUrls[] = $run->artifacts_url;
-			}
+			$artifactsUrls[] = $run->artifacts_url;
 		}
 		if (!$artifactsUrls) {
 			throw new ApiException('artifact_not_found');


### PR DESCRIPTION
## Motivation for the change, related issues

The plugin-proxy was failing with `artifact_not_found` when trying to fetch GitHub Actions artifacts from repositories with high workflow activity (e.g., Gutenberg).

For example, @getdave ran into this in his call for testing: https://make.wordpress.org/test/2026/01/27/call-for-testing-customizable-navigation-mobile-overlays/

Which uses this URL https://href.li/?https://playground.wordpress.net/?blueprint-url=https://gist.githubusercontent.com/getdave/6feb0e42612912a25cec599320e67766/raw/78004dc70b666b9c82c639c49340159a629788fe/blueprint-gutenberg-experiment.json&gutenberg-branch=trunk

The `gutenberg-branch=trunk` tries to fetch the build artifact using a URL like this:
```
https://playground.wordpress.net/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&branch=trunk
```

The issue: The proxy used the generic `/repos/{org}/{repo}/actions/runs?branch={branch}` endpoint which returns only 30 results by default. For repos like Gutenberg where "Props Bot" runs very frequently, it would dominate the first page of results, pushing the "Build Gutenberg Plugin Zip" workflow runs out of view.


## Implementation details

Changed the artifact lookup to:
1. First fetch all workflows from `/repos/{org}/{repo}/actions/workflows`
2. Find the workflow matching the requested name
3. Query that specific workflow's runs via `/repos/{org}/{repo}/actions/workflows/{workflow_id}/runs?branch={branch}`

This ensures we always find runs for the requested workflow regardless of how frequently other workflows run.

## Testing Instructions (or ideally a Blueprint)

Test the plugin proxy endpoint locally:

```bash
cd packages/playground/website/public
GITHUB_TOKEN=<your-token> php -S localhost:8080
```

Then verify the Gutenberg artifact can be fetched:
```bash
curl 'http://localhost:8080/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&branch=trunk&verify_only'
```

Should return HTTP 200 instead of the previous `{"error":"artifact_not_found"}`.