### PR TITLE
Replace .blob() with .arrayBuffer() to avoid disk space errors

### DIFF
--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -200,7 +200,7 @@ export async function cloneRequest(
 	request: Request,
 	overrides: Record<string, any>
 ): Promise<Request> {
-	let body: Blob | ReadableStream | undefined;
+	let body: ArrayBuffer | ReadableStream | undefined;
 
 	if (['GET', 'HEAD'].includes(request.method) || 'body' in overrides) {
 		body = undefined;
@@ -210,8 +210,12 @@ export async function cloneRequest(
 		// that's still waiting for more data
 		body = request.body;
 	} else {
-		// Otherwise, we need to read the body as a blob
-		body = await request.blob();
+		// Otherwise, we need to read the body as an arrayBuffer.
+		// We don't use .blob() because it throws when the client is low
+		// on disk space (blobs tend to be stored as temporary files, array
+		// buffers tend to be stored in memory).
+		// see https://github.com/WordPress/wordpress-playground/issues/2769
+		body = await request.arrayBuffer();
 	}
 
 	return new Request(overrides['url'] || request.url, {
@@ -286,27 +290,32 @@ export function removeContentSecurityPolicyDirective(
 
 	// Parse based on the CSP spec:
 	// https://w3c.github.io/webappsec-csp/#parse-serialized-policy
-	return cspHeader
-		// "For each token returned by strictly splitting serialized
-		// on the U+003B SEMICOLON character (;):"
-		.split(';')
-		.filter((rawDirective: string) => {
-			// "Strip leading and trailing ASCII whitespace from token."
-			const trimmedDirective = rawDirective
-				.replace(leadingAsciiWhitespace, '')
-				.replace(trailingAsciiWhitespace, '');
+	return (
+		cspHeader
+			// "For each token returned by strictly splitting serialized
+			// on the U+003B SEMICOLON character (;):"
+			.split(';')
+			.filter((rawDirective: string) => {
+				// "Strip leading and trailing ASCII whitespace from token."
+				const trimmedDirective = rawDirective
+					.replace(leadingAsciiWhitespace, '')
+					.replace(trailingAsciiWhitespace, '');
 
-			// "Let directive name be the result of collecting a sequence
-			// of code points from token which are not ASCII whitespace."
-			const [directiveName] = trimmedDirective.split(
-				asciiWhitespace,
-				// The directive name is the first token.
-				1
-			);
+				// "Let directive name be the result of collecting a sequence
+				// of code points from token which are not ASCII whitespace."
+				const [directiveName] = trimmedDirective.split(
+					asciiWhitespace,
+					// The directive name is the first token.
+					1
+				);
 
-			// "Directive names are case-insensitive, that is:
-			// script-SRC 'none' and ScRiPt-sRc 'none' are equivalent."
-			return directiveName.toLowerCase() !== directiveToRemove.toLowerCase();
-		})
-		.join(';');
+				// "Directive names are case-insensitive, that is:
+				// script-SRC 'none' and ScRiPt-sRc 'none' are equivalent."
+				return (
+					directiveName.toLowerCase() !==
+					directiveToRemove.toLowerCase()
+				);
+			})
+			.join(';')
+	);
 }

--- a/packages/playground/blueprints/src/lib/steps/set-site-language.ts
+++ b/packages/playground/blueprints/src/lib/steps/set-site-language.ts
@@ -167,7 +167,7 @@ export const setSiteLanguage: StepHandler<SetSiteLanguageStep> = async (
 				await unzipFile(
 					playground,
 					new File(
-						[await response.blob()],
+						[await response.arrayBuffer()],
 						`${language}-${type}.zip`
 					),
 					destination

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -562,7 +562,7 @@ export abstract class FetchResource extends Resource<File> {
 					response.headers.get('content-disposition') || ''
 				) ||
 				encodeURIComponent(url);
-			return new File([await response.blob()], filename);
+			return new File([await response.arrayBuffer()], filename);
 		} catch (e) {
 			throw new ResourceDownloadError(
 				`Could not download "${url}".\n\n` +

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -161,11 +161,16 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				// Do not await the WordPress download or the sqlite integration download.
 				// Let bootWordPress start the PHP runtime download first, and then await
 				// all the ZIP files right before they're used.
+
+				// We use .arrayBuffer() and not .blob() here because blob() throws when the
+				// client is low on disk space. Blobs tend to be stored as temporary files,
+				// array buffers tend to be stored in memory.
+				// @see https://github.com/WordPress/wordpress-playground/issues/2769
 				wordPressZip: wordPressRequest
-					?.then((r) => r.blob())
+					?.then((r) => r.arrayBuffer())
 					.then((b) => new File([b], 'wp.zip')),
 				sqliteIntegrationPluginZip: sqliteIntegrationRequest
-					.then((r) => r.blob())
+					.then((r) => r.arrayBuffer())
 					.then((b) => new File([b], 'sqlite.zip')),
 				hooks: {
 					async beforeWordPressFiles(php: PHP) {

--- a/packages/playground/remote/src/lib/worker-utils.ts
+++ b/packages/playground/remote/src/lib/worker-utils.ts
@@ -99,7 +99,11 @@ export async function backfillStaticFilesRemovedFromMinifiedBuild(php: PHP) {
 		}
 		await unzipFile(
 			php,
-			new File([await response!.blob()], 'wordpress-static.zip'),
+			// We use .arrayBuffer() and not .blob() here because blob() throws when the
+			// client is low on disk space. Blobs tend to be stored as temporary files,
+			// array buffers tend to be stored in memory.
+			// @see https://github.com/WordPress/wordpress-playground/issues/2769
+			new File([await response!.arrayBuffer()], 'wordpress-static.zip'),
 			php.requestHandler!.documentRoot,
 			false
 		);

--- a/packages/playground/wordpress-builds/src/sqlite-database-integration/get-sqlite-driver-module.ts
+++ b/packages/playground/wordpress-builds/src/sqlite-database-integration/get-sqlite-driver-module.ts
@@ -20,7 +20,11 @@ export async function getSqliteDriverModule(
 		data = await readFile(path);
 	} else {
 		const response = await fetch(url);
-		data = await response.blob();
+		// We use .arrayBuffer() and not .blob() here because blob() throws when the
+		// client is low on disk space. Blobs tend to be stored as temporary files,
+		// array buffers tend to be stored in memory.
+		// @see https://github.com/WordPress/wordpress-playground/issues/2769
+		data = await response.arrayBuffer();
 	}
 	return new File([data], `sqlite-${pluginVersion}.zip`, {
 		type: 'application/zip',

--- a/packages/playground/wordpress-builds/src/wordpress/get-wordpress-module.ts
+++ b/packages/playground/wordpress-builds/src/wordpress/get-wordpress-module.ts
@@ -13,7 +13,11 @@ export async function getWordPressModule(wpVersion = '6.8'): Promise<File> {
 		data = await readFile(path);
 	} else {
 		const response = await fetch(url);
-		data = await response.blob();
+		// We use .arrayBuffer() and not .blob() here because blob() throws when the
+		// client is low on disk space. Blobs tend to be stored as temporary files,
+		// array buffers tend to be stored in memory.
+		// @see https://github.com/WordPress/wordpress-playground/issues/2769
+		data = await response.arrayBuffer();
 	}
 	return new File([data as any], `${wpVersion || 'wp'}.zip`, {
 		type: 'application/zip',


### PR DESCRIPTION
## Summary

When the client is low on disk space, calling `.blob()` on a Response can throw an error because blobs are typically stored as temporary files on disk. ArrayBuffers are stored in memory instead, which avoids this issue entirely.

This PR replaces all uses of `response.blob()` with `response.arrayBuffer()` throughout the codebase.

Fixes #2769

## Changes

Updated the following areas:
- **Service worker request cloning** (`web-service-worker/src/utils.ts`): Clone request bodies using arrayBuffer instead of blob
- **WordPress module downloads** (`wordpress-builds/src/wordpress/get-wordpress-module.ts`)
- **SQLite integration downloads** (`wordpress-builds/src/sqlite-database-integration/get-sqlite-driver-module.ts`)
- **Language pack downloads** (`blueprints/src/lib/steps/set-site-language.ts`)
- **Blueprint resource fetching** (`blueprints/src/lib/v1/resources.ts`)
- **Worker endpoint initialization** (`remote/src/lib/playground-worker-endpoint-blueprints-v1.ts`)
- **Static files backfill** (`remote/src/lib/worker-utils.ts`)

All locations now include a comment explaining why arrayBuffer is used instead of blob.

## Test plan

- [ ] Test Playground on a device with limited disk space
- [ ] Verify all file downloads work correctly
- [ ] Verify WordPress and plugin installations complete successfully
- [ ] Verify language pack installations work
- [ ] Test blueprint execution with various resource types

Fixes #2769