### PR TITLE
[personal-wp] Fix backup status showing "Infinity days since backup"

### DIFF
--- a/packages/playground/personal-wp/src/components/browser-chrome/backup-status-indicator.tsx
+++ b/packages/playground/personal-wp/src/components/browser-chrome/backup-status-indicator.tsx
@@ -10,8 +10,7 @@ import {
 } from '../../lib/hooks/use-backup-constants';
 import { isSameDay } from '../../lib/utils/date';
 
-function getDaysSinceBackup(lastBackupTimestamp: number | undefined): number {
-	if (!lastBackupTimestamp) return Infinity;
+function getDaysSinceBackup(lastBackupTimestamp: number): number {
 	const now = Date.now();
 	return Math.floor((now - lastBackupTimestamp) / (1000 * 60 * 60 * 24));
 }
@@ -43,7 +42,6 @@ export function BackupStatusIndicator() {
 
 	const isTemporarySite = activeSite?.metadata.storage === 'none';
 	const lastBackupTimestamp = backupHistory[0]?.timestamp;
-	const daysSinceBackup = getDaysSinceBackup(lastBackupTimestamp);
 
 	// Hide for temporary sites
 	if (isTemporarySite) {
@@ -60,10 +58,17 @@ export function BackupStatusIndicator() {
 		return null;
 	}
 
-	// Hide if backed up today
-	if (lastBackupTimestamp && isSameDay(lastBackupTimestamp, Date.now())) {
+	// Hide if never backed up
+	if (!lastBackupTimestamp) {
 		return null;
 	}
+
+	// Hide if backed up today
+	if (isSameDay(lastBackupTimestamp, Date.now())) {
+		return null;
+	}
+
+	const daysSinceBackup = getDaysSinceBackup(lastBackupTimestamp);
 
 	const urgency = getBackupUrgency(daysSinceBackup);
 	const isWorking = isBackingUp || isRequestingRemote;


### PR DESCRIPTION
## Motivation for the change, related issues

In Personal WP, when a site has never been backed up, the backup status indicator displays "Infinity days since backup" instead of a meaningful message.

# Screenshot

<img width="528" height="86" alt="Capture d’écran 2026-01-28 à 11 01 24" src="https://github.com/user-attachments/assets/cc24ba2a-6d09-4c86-a45c-a1b29baa4963" />

## Implementation details

The indicator now hides entirely when a site has never been backed up. This is handled by an early return before computing the days since backup, which also allowed simplifying `getDaysSinceBackup` to always expect a valid timestamp.                                              


## Testing Instructions (or ideally a Blueprint)

1. Open Personal WP
2. Create a new site (with persistent storage)
3. Observe the backup status indicator is hidden instead of showing "Infinity days since backup"