### PR TITLE
[Blueprints] Define $_SERVER['HTTP_HOST'] in the enableMultisite step

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -1,3 +1,4 @@
+import { phpVar } from '@php-wasm/util';
 import type { StepHandler } from '.';
 import { defineWpConfigConsts } from './define-wp-config-consts';
 import { setSiteOptions } from './site-data';
@@ -68,7 +69,7 @@ export const enableMultisite: StepHandler<EnableMultisiteStep> = async (
 	const wpConfig = await playground.readFileAsText(wpConfigPath);
 	const newWpConfig = wpConfig.replace(
 		/^<\?php\s*/i,
-		`<?php\n$_SERVER['HTTP_HOST'] = '${url.hostname}';\n`
+		`<?php\n$_SERVER['HTTP_HOST'] = ${phpVar(url.hostname)};\n`
 	);
 	await playground.writeFile(wpConfigPath, newWpConfig);
 };

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -67,9 +67,12 @@ export const enableMultisite: StepHandler<EnableMultisiteStep> = async (
 	const docRoot = await playground.documentRoot;
 	const wpConfigPath = `${docRoot}/wp-config.php`;
 	const wpConfig = await playground.readFileAsText(wpConfigPath);
-	const newWpConfig = wpConfig.replace(
-		/^<\?php\s*/i,
-		`<?php\n$_SERVER['HTTP_HOST'] = ${phpVar(url.hostname)};\n`
-	);
+	let newWpConfig = wpConfig;
+	if (!wpConfig.includes("$_SERVER['HTTP_HOST']")) {
+		newWpConfig = wpConfig.replace(
+			/^<\?php\s*/i,
+			`<?php\n$_SERVER['HTTP_HOST'] = ${phpVar(url.hostname)};\n`
+		);
+	}
 	await playground.writeFile(wpConfigPath, newWpConfig);
 };

--- a/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
+++ b/packages/playground/blueprints/src/lib/steps/enable-multisite.ts
@@ -60,4 +60,15 @@ export const enableMultisite: StepHandler<EnableMultisiteStep> = async (
 	await wpCLI(playground, {
 		command: `wp core multisite-convert --base="${sitePath}"`,
 	});
+
+	// Set $_SERVER['HTTP_HOST'] in wp-config.php for multisite support.
+	// https://make.wordpress.org/cli/handbook/guides/common-issues/#php-notice-undefined-index-on-_server-superglobal
+	const docRoot = await playground.documentRoot;
+	const wpConfigPath = `${docRoot}/wp-config.php`;
+	const wpConfig = await playground.readFileAsText(wpConfigPath);
+	const newWpConfig = wpConfig.replace(
+		/^<\?php\s*/i,
+		`<?php\n$_SERVER['HTTP_HOST'] = '${url.hostname}';\n`
+	);
+	await playground.writeFile(wpConfigPath, newWpConfig);
 };


### PR DESCRIPTION
## Summary

When a multisite WordPress site is created via blueprints and then restarted, it fails with "Error connecting to the SQLite database." This happens because WordPress multisite needs `$_SERVER['HTTP_HOST']` during bootstrap to determine the current site, but it's not available when PHP runs without a request context.

## Changes

After `wp core multisite-convert` runs, we now add `$_SERVER['HTTP_HOST']` to the top of wp-config.php with the configured hostname. This follows the [WP-CLI recommendation](https://make.wordpress.org/cli/handbook/guides/common-issues/#php-notice-undefined-index-on-_server-superglobal) for handling missing `$_SERVER` variables.

## Test plan

**Prerequisites:**
- Add `127.0.0.1 playground.test` to `/etc/hosts`
- Multisite requires port 80, so commands use `sudo`

**1. Create the blueprint file at `/tmp/multisite-blueprint.json`:**
```json
{
  "preferredVersions": {
    "php": "8.3",
    "wp": "latest"
  },
  "login": true,
  "steps": [{ "step": "enableMultisite" }]
}
```

**2. Create a fresh directory and start a multisite site:**
```bash
mkdir -p /tmp/playground-multisite-test
sudo npx nx dev playground-cli server \
  --site-url=http://playground.test \
  --blueprint=/tmp/multisite-blueprint.json \
  --mount-before-install=/tmp/playground-multisite-test:/wordpress \
  --port=80
```

**3. Verify multisite is working at `http://playground.test/wp-admin/network/`**

**4. Stop the server (Ctrl+C)**

**5. Restart with existing files:**
```bash
sudo npx nx dev playground-cli server \
  --site-url=http://playground.test \
  --mount-before-install=/tmp/playground-multisite-test:/wordpress \
  --wordpress-install-mode=install-from-existing-files-if-needed \
  --port=80
```

**Expected results:**
- [ ] Without the fix (trunk): fails with "Error connecting to the SQLite database"
- [ ] With the fix: restarts successfully
- [ ] All existing tests pass (`npm test`)