### PR TITLE
[Personal-WP] Fix broadcast message loop in tab coordinator

### DIFF
--- a/packages/playground/personal-wp/src/lib/hooks/use-tab-tracking.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-tab-tracking.ts
@@ -48,6 +48,9 @@ export function useTabTracking(
 		}
 	}, [hasOwnWorker]);
 
+	const onWorkerLostRef = useRef(options.onWorkerLost);
+	onWorkerLostRef.current = options.onWorkerLost;
+
 	const checkWorkerLost = useCallback(() => {
 		if (
 			!hasOwnWorkerRef.current &&
@@ -55,9 +58,9 @@ export function useTabTracking(
 			!recentlyBecameDependentRef.current
 		) {
 			setWorkerLost(true);
-			options.onWorkerLost?.();
+			onWorkerLostRef.current?.();
 		}
-	}, [options]);
+	}, []);
 
 	useEffect(() => {
 		if (!activeSite || !tabInfo) {

--- a/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.ts
@@ -79,6 +79,7 @@ type TabCoordinatorMessage =
 const CHANNEL_NAME = 'playground-tab-coordinator';
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const PING_TIMEOUT_MS = 150;
+const MIN_CHECK_INTERVAL_MS = 1000;
 
 let channel: BroadcastChannel | null = null;
 let currentTabInfo: TabInfo | null = null;
@@ -87,6 +88,8 @@ let takeoverCallback: (() => void) | null = null;
 let backupRequestCallback: (() => Promise<boolean>) | null = null;
 let siteResetCallback: (() => void) | null = null;
 let beforeUnloadHandler: (() => void) | null = null;
+let isCheckingTabs = false;
+let lastCheckTime = 0;
 
 /**
  * Initialize the tab coordinator for a specific site.
@@ -168,6 +171,8 @@ export function destroyTabCoordinator(): void {
 	takeoverCallback = null;
 	backupRequestCallback = null;
 	siteResetCallback = null;
+	isCheckingTabs = false;
+	lastCheckTime = 0;
 }
 
 /**
@@ -185,8 +190,15 @@ export async function checkForExistingTabs(siteSlug: string): Promise<{
 		return { existingTabs: [], hasFreshTab: false, hasStaleTab: false };
 	}
 
-	const existingTabs: TabInfo[] = [];
+	// Safeguard: prevent concurrent checks and rate limit
 	const now = Date.now();
+	if (isCheckingTabs || now - lastCheckTime < MIN_CHECK_INTERVAL_MS) {
+		return { existingTabs: [], hasFreshTab: false, hasStaleTab: false };
+	}
+	isCheckingTabs = true;
+	lastCheckTime = now;
+
+	const existingTabs: TabInfo[] = [];
 
 	const pongHandler = (event: MessageEvent<TabCoordinatorMessage>) => {
 		const message = event.data;
@@ -212,13 +224,15 @@ export async function checkForExistingTabs(siteSlug: string): Promise<{
 
 	channel.removeEventListener('message', pongHandler);
 
+	const checkTime = Date.now();
 	const hasFreshTab = existingTabs.some(
-		(tab) => now - tab.createdAt < ONE_DAY_MS && !tab.isDependentMode
+		(tab) => checkTime - tab.createdAt < ONE_DAY_MS && !tab.isDependentMode
 	);
 	const hasStaleTab = existingTabs.some(
-		(tab) => now - tab.createdAt >= ONE_DAY_MS && !tab.isDependentMode
+		(tab) => checkTime - tab.createdAt >= ONE_DAY_MS && !tab.isDependentMode
 	);
 
+	isCheckingTabs = false;
 	return { existingTabs, hasFreshTab, hasStaleTab };
 }
 


### PR DESCRIPTION
## Motivation for the change, related issues

The tab coordinator was causing an infinite loop of broadcast messages, where `checkForExistingTabs` was being called repeatedly. This resulted in continuous `ping` messages being sent between BroadcastChannel instances, even within a single tab.

The issue had two contributing factors:
1. Multiple BroadcastChannel instances (one in `tab-coordinator.ts`, another in `useTabTracking` hook) could trigger each other
2. An unstable `useCallback` dependency in `useTabTracking` caused the effect to re-run on every render

## Implementation details

**tab-coordinator.ts:**
- Added mutex lock (`isCheckingTabs`) to prevent concurrent calls to `checkForExistingTabs`
- Added rate limiting (`lastCheckTime` + 1 second minimum interval) to prevent rapid successive calls
- Reset these guards in `destroyTabCoordinator` for proper cleanup

**use-tab-tracking.ts:**
- Fixed unstable `useCallback` dependency by storing `options.onWorkerLost` in a ref
- Changed `checkWorkerLost` callback to have empty dependencies `[]` instead of `[options]`

## Testing Instructions (or ideally a Blueprint)

1. Open Personal WordPress Playground
2. Open browser DevTools console
3. Paste this to monitor broadcast messages:
```javascript
const originalPostMessage = BroadcastChannel.prototype.postMessage;
BroadcastChannel.prototype.postMessage = function(message) {
  console.log('%c📤 SEND', 'color: #4CAF50; font-weight: bold', this.name, message);
  return originalPostMessage.call(this, message);
};
```
4. Verify that ping messages are NOT being sent continuously (should only see initial pings on load, then silence)
5. Open a second tab with the same site - verify tabs detect each other properly


cc @fellyph since you also observed this!