### PR TITLE
[Personal-WP] Fix ?plugin= URL parameter not installing plugins

### DIFF
--- a/packages/playground/personal-wp/src/lib/personalwp/index.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/index.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Set up browser globals before any imports that might need them
+// @ts-ignore - minimal mock for testing
+global.location = {
+	origin: 'https://playground.wordpress.net',
+	href: 'https://playground.wordpress.net/',
+};
+// @ts-ignore - minimal mock for testing
+global.window = global.window || {};
+// @ts-ignore
+global.window.self = global.window;
+// @ts-ignore
+global.window.top = global.window;
+
+// Mock fetch for potential network requests
+global.fetch = vi.fn();
+
+// Now we can import the module
+const { resolveUrlParamsForExistingSite } = await import('./index');
+
+describe('resolveUrlParamsForExistingSite', () => {
+	it('returns null when no actionable URL params are present', async () => {
+		const url = new URL('https://playground.wordpress.net/');
+		const result = await resolveUrlParamsForExistingSite(url);
+		expect(result).toBeNull();
+	});
+
+	it('returns null for non-actionable params like ?mode=', async () => {
+		const url = new URL('https://playground.wordpress.net/?mode=seamless');
+		const result = await resolveUrlParamsForExistingSite(url);
+		expect(result).toBeNull();
+	});
+
+	it('returns blueprint with plugins property for ?plugin= param', async () => {
+		const url = new URL(
+			'https://playground.wordpress.net/?plugin=woocommerce'
+		);
+		const result = await resolveUrlParamsForExistingSite(url);
+
+		expect(result).not.toBeNull();
+		expect(result?.plugins).toEqual(['woocommerce']);
+	});
+
+	it('returns blueprint with multiple plugins for multiple ?plugin= params', async () => {
+		const url = new URL(
+			'https://playground.wordpress.net/?plugin=woocommerce&plugin=jetpack'
+		);
+		const result = await resolveUrlParamsForExistingSite(url);
+
+		expect(result).not.toBeNull();
+		expect(result?.plugins).toEqual(['woocommerce', 'jetpack']);
+	});
+
+	it('returns blueprint with installTheme steps for ?theme= param', async () => {
+		const url = new URL('https://playground.wordpress.net/?theme=flavor');
+		const result = await resolveUrlParamsForExistingSite(url);
+
+		expect(result).not.toBeNull();
+		expect(result?.steps).toBeDefined();
+
+		const themeStep = result?.steps?.find(
+			(step: any) => step?.step === 'installTheme'
+		);
+		expect(themeStep).toBeDefined();
+		expect((themeStep as any)?.themeData?.slug).toBe('flavor');
+	});
+
+	it('sets landingPage from ?url= param via applyQueryOverrides', async () => {
+		const url = new URL(
+			'https://playground.wordpress.net/?plugin=woocommerce&url=/wp-admin/plugins.php'
+		);
+		const result = await resolveUrlParamsForExistingSite(url);
+
+		expect(result).not.toBeNull();
+		expect(result?.landingPage).toBe('/wp-admin/plugins.php');
+	});
+
+	it('returns null for ?gutenberg-pr= (not supported for existing sites)', async () => {
+		const url = new URL(
+			'https://playground.wordpress.net/?gutenberg-pr=12345'
+		);
+		const result = await resolveUrlParamsForExistingSite(url);
+		expect(result).toBeNull();
+	});
+});

--- a/packages/playground/personal-wp/src/lib/personalwp/index.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/index.ts
@@ -2,6 +2,7 @@ import type { BlueprintV1Declaration } from '@wp-playground/client';
 import {
 	type ResolvedBlueprint,
 	resolveBlueprintFromURL,
+	applyQueryOverrides,
 } from '../state/url/resolve-blueprint-from-url';
 import {
 	getBlueprintDeclaration,
@@ -79,9 +80,6 @@ const ACTIONABLE_URL_PARAMS = [
 	'import-site',
 	'import-wxr',
 	'import-content',
-	'gutenberg-pr',
-	'gutenberg-branch',
-	'core-pr',
 ];
 
 /**
@@ -109,9 +107,14 @@ export async function resolveUrlParamsForExistingSite(
 	try {
 		const resolved = await resolveBlueprintFromURL(url, undefined);
 		// Extract the blueprint declaration from the bundle if needed
-		const blueprint = isBlueprintBundle(resolved.blueprint)
+		let blueprint = isBlueprintBundle(resolved.blueprint)
 			? await getBlueprintDeclaration(resolved.blueprint)
 			: (resolved.blueprint as BlueprintV1Declaration);
+		// Apply query overrides (e.g., ?url= for landing page, ?login=, etc.)
+		blueprint = (await applyQueryOverrides(
+			blueprint,
+			url.searchParams
+		)) as BlueprintV1Declaration;
 		return blueprint;
 	} catch (e) {
 		logger.error('Error resolving URL blueprint for existing site:', e);

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -366,6 +366,9 @@ export function bootSiteClient(
 				const current = blueprint as BlueprintV1Declaration;
 				blueprint = {
 					...blueprint,
+					...(resolved.plugins?.length
+						? { plugins: resolved.plugins }
+						: {}),
 					landingPage: resolved.landingPage || current.landingPage,
 					steps: [
 						...(current.steps || []),


### PR DESCRIPTION
## Motivation for the change, related issues

When visiting a Personal WordPress site with `?plugin=abc`, the plugin was not being installed. The URL parameter would simply disappear without the plugin being added to the site. Similarly, `?url=` for setting the landing page was not working.

## Supported URL Parameters for Existing Sites

The following URL parameters can be used to modify an existing Personal WordPress site:

| Parameter | Description | Example |
|-----------|-------------|---------|
| `plugin` | Install plugin(s) from wordpress.org | `?plugin=woocommerce&plugin=jetpack` |
| `theme` | Install and activate a theme from wordpress.org | `?theme=flavor` |
| `url` | Set the landing page after blueprint executes | `?url=/wp-admin/plugins.php` |
| `blueprint-url` | Apply a full blueprint from a URL | `?blueprint-url=https://...` |
| `import-site` | Import a site from a ZIP file URL | `?import-site=https://...` |
| `import-wxr` | Import content from a WXR file URL | `?import-wxr=https://...` |

**Not supported for existing sites:** `gutenberg-pr`, `gutenberg-branch`, `core-pr` (these are meant for fresh temporary installs)

## Implementation details

**Issue 1: Plugins property lost during merge**

In `boot-site-client.ts` where URL blueprints are merged into the boot blueprint, the merge only preserved `steps` and `landingPage`, but ignored the `plugins` shorthand property.

**Issue 2: Query overrides not applied for existing sites**

The `applyQueryOverrides` function (which handles `?url=`, `?language=`, etc.) was not being called in `resolveUrlParamsForExistingSite`.

**Changes:**
- Pass through `plugins` property in `boot-site-client.ts` merge (when present)
- Call `applyQueryOverrides` in `resolveUrlParamsForExistingSite` to handle query parameters
- Remove `gutenberg-pr`, `gutenberg-branch`, `core-pr` from actionable params for existing sites
- Add unit tests for `resolveUrlParamsForExistingSite`

## Testing Instructions (or ideally a Blueprint)

1. Open Personal WordPress Playground with an existing site
2. Test plugin installation: Navigate to `?plugin=friends`
   - Verify the plugin is installed
3. Test theme installation: Navigate to `?theme=flavor`
   - Verify the theme is installed and activated
4. Test landing page: Navigate to `?plugin=friends&url=/wp-admin/options-general.php`
   - Verify you land on the General Settings page after the plugin installs
5. Run unit tests: `npx nx test playground-personal-wp --testFile=index.spec.ts`