### PR TITLE
[Personal-WP] Port Safari fixes from website package

### DIFF
--- a/packages/playground/personal-wp/index.html
+++ b/packages/playground/personal-wp/index.html
@@ -132,7 +132,60 @@
 		</main>
 		<script type="module">
 			if (!shouldLazyLoadPlayground) {
-				import('./src/main');
+				/**
+				 * Safari sometimes fail to import this script after playground.wordpress.net
+				 * is deployed. The error message is:
+				 *
+				 * ```
+				 * TypeError: Importing a module script failed.
+				 * ```
+				 *
+				 * It is very difficult to debug as Safari does not provide a useful stack trace,
+				 * line numbers, or any further error details. After some hours of debugging, the
+				 * issue was narrowed down to this import() call.
+				 *
+				 * Somehow, when this import() runs, Safari does not even start a network request
+				 * to fetch this script. The Service Worker `fetch` event handler is also not called.
+				 * It just fails on sight. The root cause is unclear. Everything is fine CORS-wise,
+				 * Safari Memory cache seems unlikely since the "network" devtools tab does not display
+				 * any attempts to fetch this script.
+				 *
+				 * Manually clearing Safari cache and reloading the page seems to resolve the issue.
+				 * It's not good enough, but it proves this is related to Safari cache.
+				 *
+				 * Therefore, we're bypassing the cached import by adding a cache busting query parameter
+				 * if the original import fails.
+				 */
+				import('./src/main').catch((e) => {
+					console.error('Failed to load main module:', e);
+					try {
+						/**
+						 * I couldn't find another way of baking the actual module URL directly into the
+						 * built file. Basically we're creating a function that calls import(), stringifying it,
+						 * extracting the module URL from the string, and adding a cache busting query parameter
+						 * to that URL before finally importing it.
+						 */
+						const stringifiedImport = (() =>
+							import('./src/main')).toString();
+						const moduleUrlString = stringifiedImport.match(
+							/import\(\s*['"](.+?)['"]\s*\)/
+						)[1];
+						if (moduleUrlString) {
+							const moduleUrl = new URL(
+								moduleUrlString,
+								import.meta.url
+							);
+							moduleUrl.searchParams.set(
+								'_ts',
+								String(Date.now())
+							);
+							return import(moduleUrl.toString());
+						}
+					} catch {
+						// Fall back to the original error
+					}
+					throw e;
+				});
 			}
 		</script>
 	</body>


### PR DESCRIPTION
## Motivation for the change, related issues

Porting recent Safari-related fixes from the website package to personal-wp.

The following PRs were analyzed for porting:

| PR | Description | Status for personal-wp |
|---|---|---|
| #3200 | Strip Range headers in Safari (offline-mode-cache.ts) | Already covered - personal-wp uses the `remote` package |
| #3208 | Use `no-store` instead of `no-cache` (offline-mode-cache.ts) | Already covered - personal-wp uses the `remote` package |
| #3212 | Replace `.blob()` with `.arrayBuffer()` | Already covered - changes are in shared packages (`blueprints`, `wordpress-builds`, `php-wasm/web-service-worker`, `remote`) |
| #3216 | Retry `import()` when it fails in Safari | **Ported in this PR** |

Only #3216 required porting since it modifies `index.html` which is specific to each package.

## Implementation details

When the initial `import('./src/main')` fails, the code retries by:
1. Extracting the built module URL from a stringified import function
2. Adding a cache-busting `_ts` query parameter with the current timestamp
3. Attempting the import again with the cache-busted URL

This is the same approach used in the website package.

## Testing Instructions (or ideally a Blueprint)

1. Open personal-wp in Safari on iOS
2. Connect to a Mac via cable
3. Open devtools for that tab in Desktop Safari
4. Deploy this PR
5. Refresh the tab on iOS
6. Confirm the website reloads correctly
7. If you see "Failed to load main module" in the console followed by a successful retry, the fix is working