### PR TITLE
[Website] Disable pattern picker modal to prevent iOS Safari OOM crashes

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -236,3 +236,18 @@ if (defined('USE_FETCH_FOR_REQUESTS') && USE_FETCH_FOR_REQUESTS) {
 		return [ 'Dummy' ];
 	});
 }
+
+/**
+ * Disable the pattern picker modal to prevent iOS Safari memory crashes.
+ * @see https://github.com/WordPress/gutenberg/issues/75019
+ */
+add_action('init', function() {
+	if (defined('PLAYGROUND_ALLOW_PATTERN_PICKER') && PLAYGROUND_ALLOW_PATTERN_PICKER) return;
+	$user_id = get_current_user_id();
+	if (!$user_id) return;
+
+	$prefs = get_user_meta($user_id, 'wp_persisted_preferences', true) ?: [];
+	if (!isset($prefs['core'])) $prefs['core'] = [];
+	$prefs['core']['enableChoosePatternModal'] = false;
+	update_user_meta($user_id, 'wp_persisted_preferences', $prefs);
+});


### PR DESCRIPTION
The pattern picker modal that appears when creating new pages causes memory crashes on iOS Safari. This is especially problematic in Playground where memory is already constrained by running an entire WordPress and PHP stack in WebAssembly.

When users visit the page editor for the first time, Gutenberg shows a modal with pattern previews. Each preview includes images and rendered HTML that consumes significant memory. On iOS Safari, this pushes memory usage over the edge and triggers crashes.

This change sets the user preference to disable the modal by default. Users can still access all patterns through the inserter and other UI elements - they just won't see the modal on page load. The preference is stored in the database the same way it would be if a user manually disabled it through the preferences UI.

<img width="2550" height="1856" alt="CleanShot 2026-01-30 at 17 23 31@2x" src="https://github.com/user-attachments/assets/7b482695-f201-43bd-97a9-bcab2188f080" />

## Testing the Modal

If you need to test the modal behavior, use this Blueprint:

https://playground.wordpress.net/#ewogICJsYW5kaW5nUGFnZSI6ICIvd3AtYWRtaW4vcG9zdC1uZXcucGhwP3Bvc3RfdHlwZT1wYWdlIiwKICAibG9naW4iOiB0cnVlLAogICJzdGVwcyI6IFsKICAgIHsKICAgICAgInN0ZXAiOiAiZGVmaW5lV3BDb25maWdDb25zdHMiLAogICAgICAiY29uc3RzIjogewogICAgICAgICJQTEFZR1JPVU5EX0FMTE9XX1BBVFRFUk5fUElDS0VSIjogdHJ1ZQogICAgICB9LAogICAgICAibWV0aG9kIjogImRlZmluZS1iZWZvcmUtcnVuIgogICAgfQogIF0KfQ==

(^ it applies the following Blueprint:)

```json
{
  "landingPage": "/wp-admin/post-new.php?post_type=page",
  "login": true,
  "steps": [
    {
      "step": "defineWpConfigConsts",
      "consts": {
        "PLAYGROUND_ALLOW_PATTERN_PICKER": true
      },
      "method": "define-before-run"
    }
  ]
}
```

Works around https://github.com/WordPress/gutenberg/issues/75019 until Gutenberg uses less memory in that modal.