### PR TITLE
[PHP] Add `cp` method to Universal PHP

### DIFF
--- a/packages/php-wasm/node/src/test/php-part-1.spec.ts
+++ b/packages/php-wasm/node/src/test/php-part-1.spec.ts
@@ -1607,6 +1607,154 @@ phpLoaderOptions.forEach((options) => {
 				expect(php.readFileAsText('/tmp/test.txt')).toEqual('contents');
 			});
 
+			it('cp() should copy a file', () => {
+				php.mkdir(testDirPath);
+				const file1 = testDirPath + '/1.txt';
+				const file2 = testDirPath + '/2.txt';
+
+				php.writeFile(file1, '1');
+				php.cp(file1, file2);
+
+				expect(php.fileExists(file1)).toEqual(true);
+				expect(php.fileExists(file2)).toEqual(true);
+				expect(php.readFileAsText(file2)).toEqual('1');
+			});
+
+			it('cp() should replace target file if it exists', () => {
+				php.mkdir(testDirPath);
+				const file1 = testDirPath + '/1.txt';
+				const file2 = testDirPath + '/2.txt';
+
+				php.writeFile(file1, '1');
+				php.writeFile(file2, '2');
+
+				php.cp(file1, file2);
+
+				expect(php.fileExists(file1)).toEqual(true);
+				expect(php.fileExists(file2)).toEqual(true);
+				expect(php.readFileAsText(file2)).toEqual('1');
+			});
+
+			it('cp() should recursively copy a directory', () => {
+				php.mkdir(testDirPath);
+				const sourceDir = testDirPath + '/dir1';
+				const targetDir = testDirPath + '/dir2';
+
+				php.mkdir(sourceDir);
+				php.writeFile(sourceDir + '/a.txt', 'A');
+				php.mkdir(sourceDir + '/nested');
+				php.writeFile(sourceDir + '/nested/b.txt', 'B');
+
+				php.cp(sourceDir, targetDir);
+
+				expect(php.fileExists(sourceDir + '/a.txt')).toEqual(true);
+				expect(php.fileExists(targetDir + '/a.txt')).toEqual(true);
+				expect(php.fileExists(targetDir + '/nested/b.txt')).toEqual(
+					true
+				);
+				expect(php.readFileAsText(targetDir + '/a.txt')).toEqual('A');
+				expect(php.readFileAsText(targetDir + '/nested/b.txt')).toEqual(
+					'B'
+				);
+			});
+
+			it('cp() should throw a useful error when source file does not exist', () => {
+				php.mkdir(testDirPath);
+				const file1 = testDirPath + '/1.txt';
+				const file2 = testDirPath + '/2.txt';
+
+				expect(() => {
+					php.cp(file1, file2);
+				}).toThrowError(
+					`Could not copy ${file1} to ${file2}: There is no such file or directory OR the parent directory does not exist.`
+				);
+			});
+
+			it('cp() should throw a useful error when target directory does not exist', () => {
+				php.mkdir(testDirPath);
+				const file1 = testDirPath + '/1.txt';
+				const file2 = testDirPath + '/nowhere/2.txt';
+
+				php.writeFile(file1, '1');
+
+				expect(() => {
+					php.cp(file1, file2);
+				}).toThrowError(
+					`Could not copy ${file1} to ${file2}: There is no such file or directory OR the parent directory does not exist.`
+				);
+			});
+
+			it('cp() should not allow copying a directory into itself', () => {
+				php.mkdir(testDirPath);
+				const dir = testDirPath + '/dir';
+
+				php.mkdir(dir);
+
+				expect(() => {
+					php.cp(dir, `${dir}/nested`);
+				}).toThrow(
+					`Could not copy ${dir} to ${dir}/nested: Invalid argument.`
+				);
+			});
+
+			it('cp() from NODEFS to MEMFS should work', () => {
+				mkdirSync(__dirname + '/test-data/mount-contents/copy-src', {
+					recursive: true,
+				});
+				writeFileSync(
+					__dirname + '/test-data/mount-contents/copy-src/test.txt',
+					'contents'
+				);
+
+				php.mount(
+					'/nodefs',
+					createNodeFsMountHandler(
+						__dirname + '/test-data/mount-contents'
+					)
+				);
+				php.cp('/nodefs/copy-src', '/tmp/copied-dir');
+
+				expect(php.fileExists('/tmp/copied-dir/test.txt')).toEqual(
+					true
+				);
+				expect(php.readFileAsText('/tmp/copied-dir/test.txt')).toEqual(
+					'contents'
+				);
+
+				rmSync(__dirname + '/test-data/mount-contents/copy-src', {
+					recursive: true,
+				});
+			});
+
+			it('cp() from NODEFS to MEMFS should work', () => {
+				mkdirSync(__dirname + '/test-data/mount-contents/copy-src', {
+					recursive: true,
+				});
+				writeFileSync(
+					__dirname + '/test-data/mount-contents/copy-src/test.txt',
+					'contents'
+				);
+
+				php.mount(
+					'/nodefs',
+					createNodeFsMountHandler(
+						__dirname + '/test-data/mount-contents'
+					)
+				);
+				php.cp('/nodefs/copy-src', '/tmp/copied-dir');
+
+				expect(php.fileExists('/tmp/copied-dir/test.txt')).toEqual(
+					true
+				);
+				expect(php.readFileAsText('/tmp/copied-dir/test.txt')).toEqual(
+					'contents'
+				);
+
+				rmSync(__dirname + '/test-data/mount-contents/copy-src', {
+					recursive: true,
+				});
+			});
+
 			it('mkdir() should create a directory', () => {
 				php.mkdir(testDirPath);
 				expect(php.fileExists(testDirPath)).toEqual(true);

--- a/packages/php-wasm/node/src/test/php-part-1.spec.ts
+++ b/packages/php-wasm/node/src/test/php-part-1.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@php-wasm/universal';
 import { createSpawnHandler, phpVar } from '@php-wasm/util';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import type { PHPLoaderOptions } from '..';
 import { loadNodeRuntime } from '..';
 import { createNodeFsMountHandler } from '../lib/node-fs-mount';
@@ -1698,61 +1698,89 @@ phpLoaderOptions.forEach((options) => {
 			});
 
 			it('cp() from NODEFS to MEMFS should work', () => {
-				mkdirSync(__dirname + '/test-data/mount-contents/copy-src', {
-					recursive: true,
-				});
-				writeFileSync(
-					__dirname + '/test-data/mount-contents/copy-src/test.txt',
-					'contents'
-				);
-
 				php.mount(
 					'/nodefs',
 					createNodeFsMountHandler(
 						__dirname + '/test-data/mount-contents'
 					)
 				);
-				php.cp('/nodefs/copy-src', '/tmp/copied-dir');
+				php.mkdir('/nodefs/tmp-dir-for-cp-test');
+				expect(
+					existsSync(
+						__dirname +
+							'/test-data/mount-contents/tmp-dir-for-cp-test'
+					)
+				).toEqual(true);
 
-				expect(php.fileExists('/tmp/copied-dir/test.txt')).toEqual(
-					true
-				);
-				expect(php.readFileAsText('/tmp/copied-dir/test.txt')).toEqual(
+				php.writeFile(
+					'/nodefs/tmp-dir-for-cp-test/test.txt',
 					'contents'
 				);
+				php.cp(
+					'/nodefs/tmp-dir-for-cp-test',
+					'/tmp/tmp-dir-for-cp-test'
+				);
+				expect(
+					existsSync(
+						__dirname +
+							'/test-data/mount-contents/tmp-dir-for-cp-test'
+					)
+				).toEqual(true);
+				expect(php.fileExists('/nodefs/tmp-dir-for-cp-test')).toEqual(
+					true
+				);
+				expect(php.fileExists('/tmp/tmp-dir-for-cp-test')).toEqual(
+					true
+				);
+				expect(
+					php.readFileAsText('/tmp/tmp-dir-for-cp-test/test.txt')
+				).toEqual('contents');
 
-				rmSync(__dirname + '/test-data/mount-contents/copy-src', {
-					recursive: true,
-				});
+				rmSync(
+					__dirname + '/test-data/mount-contents/tmp-dir-for-cp-test',
+					{
+						recursive: true,
+					}
+				);
 			});
 
-			it('cp() from NODEFS to MEMFS should work', () => {
-				mkdirSync(__dirname + '/test-data/mount-contents/copy-src', {
-					recursive: true,
-				});
-				writeFileSync(
-					__dirname + '/test-data/mount-contents/copy-src/test.txt',
-					'contents'
-				);
-
+			it('cp() from MEMFS to NODEFS should work', () => {
 				php.mount(
 					'/nodefs',
 					createNodeFsMountHandler(
 						__dirname + '/test-data/mount-contents'
 					)
 				);
-				php.cp('/nodefs/copy-src', '/tmp/copied-dir');
 
-				expect(php.fileExists('/tmp/copied-dir/test.txt')).toEqual(
+				php.mkdir('/tmp/tmp-dir-for-cp-test');
+				php.writeFile('/tmp/tmp-dir-for-cp-test/test.txt', 'contents');
+				php.cp(
+					'/tmp/tmp-dir-for-cp-test',
+					'/nodefs/tmp-dir-for-cp-test'
+				);
+				expect(php.fileExists('/tmp/tmp-dir-for-cp-test')).toEqual(
 					true
 				);
-				expect(php.readFileAsText('/tmp/copied-dir/test.txt')).toEqual(
-					'contents'
-				);
+				expect(
+					existsSync(
+						__dirname +
+							'/test-data/mount-contents/tmp-dir-for-cp-test'
+					)
+				).toEqual(true);
+				expect(
+					readFileSync(
+						__dirname +
+							'/test-data/mount-contents/tmp-dir-for-cp-test/test.txt',
+						'utf-8'
+					)
+				).toEqual('contents');
 
-				rmSync(__dirname + '/test-data/mount-contents/copy-src', {
-					recursive: true,
-				});
+				rmSync(
+					__dirname + '/test-data/mount-contents/tmp-dir-for-cp-test',
+					{
+						recursive: true,
+					}
+				);
 			});
 
 			it('mkdir() should create a directory', () => {

--- a/packages/php-wasm/universal/src/lib/fs-helpers.ts
+++ b/packages/php-wasm/universal/src/lib/fs-helpers.ts
@@ -305,23 +305,39 @@ export class FSHelpers {
 		fromPath: string,
 		toPath: string
 	) {
-		const fromNode = FS.lookupPath(fromPath).node;
-		if (FS.isDir(fromNode.mode)) {
-			FS.mkdirTree(toPath);
-			const filenames = FS.readdir(fromPath).filter(
-				(name: string) => name !== '.' && name !== '..'
-			);
-			for (const filename of filenames) {
-				FSHelpers.copyRecursive(
-					FS,
-					joinPaths(fromPath, filename),
-					joinPaths(toPath, filename)
+		try {
+			const fromNode = FS.lookupPath(fromPath).node;
+			if (FS.isDir(fromNode.mode)) {
+				// Prevent copying directory into itself
+				if (fromPath === toPath || toPath.startsWith(`${fromPath}/`))
+					throw new ErrnoError(28);
+				FS.mkdirTree(toPath);
+				const filenames = FS.readdir(fromPath).filter(
+					(name: string) => name !== '.' && name !== '..'
 				);
+				for (const filename of filenames) {
+					FSHelpers.copyRecursive(
+						FS,
+						joinPaths(fromPath, filename),
+						joinPaths(toPath, filename)
+					);
+				}
+			} else if (FS.isLink(fromNode.mode)) {
+				FS.symlink(FS.readlink(fromPath), toPath);
+			} else {
+				FS.writeFile(toPath, FS.readFile(fromPath));
 			}
-		} else if (FS.isLink(fromNode.mode)) {
-			FS.symlink(FS.readlink(fromPath), toPath);
-		} else {
-			FS.writeFile(toPath, FS.readFile(fromPath));
+		} catch (e) {
+			const errmsg = getEmscriptenFsError(e);
+			if (!errmsg) {
+				throw e;
+			}
+			throw new Error(
+				`Could not copy ${fromPath} to ${toPath}: ${errmsg}`,
+				{
+					cause: e,
+				}
+			);
 		}
 	}
 }
@@ -363,6 +379,3 @@ FSHelpers.fileExists = rethrowFileSystemError('Could not stat "{path}"')(
 FSHelpers.mkdir = rethrowFileSystemError('Could not create directory "{path}"')(
 	FSHelpers.mkdir
 );
-FSHelpers.copyRecursive = rethrowFileSystemError(
-	'Could not copy files from "{path}"'
-)(FSHelpers.copyRecursive);

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1228,6 +1228,23 @@ export class PHP implements Disposable {
 	}
 
 	/**
+	 * Copies a file or directory in the PHP filesystem to a
+	 * new location.
+	 *
+	 * @param oldPath The path to rename.
+	 * @param newPath The new path.
+	 */
+	cp(fromPath: string, toPath: string) {
+		const result = FSHelpers.copyRecursive(
+			this[__private__dont__use].FS,
+			fromPath,
+			toPath
+		);
+		this.dispatchEvent({ type: 'filesystem.write' });
+		return result;
+	}
+
+	/**
 	 * Removes a directory from the PHP filesystem.
 	 *
 	 * @param path The directory path to remove.

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1214,8 +1214,8 @@ export class PHP implements Disposable {
 	 * Moves a file or directory in the PHP filesystem to a
 	 * new location.
 	 *
-	 * @param oldPath The path to rename.
-	 * @param newPath The new path.
+	 * @param fromPath The path to rename.
+	 * @param toPath The new path.
 	 */
 	mv(fromPath: string, toPath: string) {
 		const result = FSHelpers.mv(
@@ -1231,8 +1231,8 @@ export class PHP implements Disposable {
 	 * Copies a file or directory in the PHP filesystem to a
 	 * new location.
 	 *
-	 * @param oldPath The path to rename.
-	 * @param newPath The new path.
+	 * @param fromPath The source path.
+	 * @param toPath The target path.
 	 */
 	cp(fromPath: string, toPath: string) {
 		const result = FSHelpers.copyRecursive(


### PR DESCRIPTION
## Motivation for the change, related issues

Based on [this issue](https://github.com/WordPress/wordpress-playground/issues/3112)

While playing with PHP.wasm, I found out it has a `mv` method, but no `cp` method.

## Implementation details

- Using directly `FSHelpers.copyRecursive` inside the `php.cp()` method
- Adding tests
- Keep consistency with the `mv()` when throwing errors
- Throws a new error when copyRecursive is recursively copying inside himself.

## Testing Instructions

CI 

or manually :

`cp.ts` : 

```typescript
import { PHP } from '@php-wasm/universal';
import { loadNodeRuntime } from "@php-wasm/node";

const php = new PHP(await loadNodeRuntime('8.5'));

php.mkdir('test');

php.chdir('test');

php.writeFile('foo', `<?php echo "File copied successfully";`);

php.cp('foo', 'bar');

const response = await php.runStream({scriptPath: 'bar'});

console.log(await response.stdoutText, php.listFiles('/test'));
```

Output :

```
> node cp.ts

File copied successfully [ 'foo', 'bar' ]
```

