### PR TITLE
Fix progressive performance degradation in playground.run()

### DIFF
--- a/packages/php-wasm/universal/src/lib/comlink-sync.ts
+++ b/packages/php-wasm/universal/src/lib/comlink-sync.ts
@@ -392,9 +392,8 @@ export type ProxyOrClone<T> = T extends ProxyMarked ? Remote<T> : T;
 /**
  * Inverse of `ProxyOrClone<T>`.
  */
-export type UnproxyOrClone<T> = T extends RemoteObject<ProxyMarked>
-	? Local<T>
-	: T;
+export type UnproxyOrClone<T> =
+	T extends RemoteObject<ProxyMarked> ? Local<T> : T;
 
 /**
  * Takes the raw type of a remote object in the other thread and returns the type as it is visible
@@ -439,7 +438,7 @@ export type Remote<T> =
 					...args: {
 						[I in keyof TArguments]: UnproxyOrClone<TArguments[I]>;
 					}
-			  ) => Promisify<ProxyOrClone<Unpromisify<TReturn>>>
+				) => Promisify<ProxyOrClone<Unpromisify<TReturn>>>
 			: unknown) &
 		// Handle construct signature (if present)
 		// The return of construct signatures is always proxied (whether marked or not)
@@ -452,7 +451,7 @@ export type Remote<T> =
 							>;
 						}
 					): Promisify<Remote<TInstance>>;
-			  }
+				}
 			: unknown) &
 		// Include additional special comlink methods available on the proxy.
 		ProxyMethods;
@@ -478,8 +477,8 @@ export type Local<T> =
 					...args: {
 						[I in keyof TArguments]: ProxyOrClone<TArguments[I]>;
 					}
-			  ) => // The raw function could either be sync or async, but is always proxied automatically
-			  MaybePromise<UnproxyOrClone<Unpromisify<TReturn>>>
+				) => // The raw function could either be sync or async, but is always proxied automatically
+				MaybePromise<UnproxyOrClone<Unpromisify<TReturn>>>
 			: unknown) &
 		// Handle construct signature (if present)
 		// The return of construct signatures is always proxied (whether marked or not)
@@ -493,7 +492,7 @@ export type Local<T> =
 						}
 					): // The raw constructor could either be sync or async, but is always proxied automatically
 					MaybePromise<Local<Unpromisify<TInstance>>>;
-			  }
+				}
 			: unknown);
 
 const isObject = (val: unknown): val is object =>
@@ -806,12 +805,56 @@ function unregisterProxy(proxy: object) {
 	}
 }
 
+/**
+ * Cache for proxy objects keyed by endpoint and path.
+ *
+ * This prevents creating new proxy objects on every property access,
+ * which would otherwise accumulate in the FinalizationRegistry and
+ * cause progressive performance degradation over many calls.
+ *
+ * Using WeakMap ensures the cache is automatically cleaned up when
+ * the endpoint is garbage collected.
+ */
+const proxyCache = new WeakMap<Endpoint, Map<string, object>>();
+
+function getCachedProxy<T>(
+	ep: Endpoint,
+	pathKey: string
+): Remote<T> | undefined {
+	const cache = proxyCache.get(ep);
+	return cache?.get(pathKey) as Remote<T> | undefined;
+}
+
+function setCachedProxy(ep: Endpoint, pathKey: string, proxy: object): void {
+	let cache = proxyCache.get(ep);
+	if (!cache) {
+		cache = new Map();
+		proxyCache.set(ep, cache);
+	}
+	cache.set(pathKey, proxy);
+}
+
+function clearProxyCache(ep: Endpoint): void {
+	proxyCache.delete(ep);
+}
+
 function createProxy<T>(
 	ep: Endpoint,
 	pendingListeners: PendingListenersMap,
 	path: (string | number | symbol)[] = [],
 	target: object = function () {}
 ): Remote<T> {
+	// Check cache for existing proxy (only for string/number paths, not symbols)
+	const isCacheable = path.every((p) => typeof p !== 'symbol');
+	const pathKey = isCacheable ? path.join('\0') : '';
+
+	if (isCacheable) {
+		const cached = getCachedProxy<T>(ep, pathKey);
+		if (cached) {
+			return cached;
+		}
+	}
+
 	let isProxyReleased = false;
 	const proxy = new Proxy(target, {
 		get(_target, prop) {
@@ -819,6 +862,7 @@ function createProxy<T>(
 			if (prop === releaseProxy) {
 				return () => {
 					unregisterProxy(proxy);
+					clearProxyCache(ep);
 					releaseEndpoint(ep);
 					pendingListeners.clear();
 					isProxyReleased = true;
@@ -893,6 +937,12 @@ function createProxy<T>(
 			).then(fromWireValue);
 		},
 	});
+
+	// Cache the proxy before registering and returning
+	if (isCacheable) {
+		setCachedProxy(ep, pathKey, proxy);
+	}
+
 	registerProxy(proxy, ep);
 	return proxy as any;
 }

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -213,18 +213,23 @@ async function parseHeadersStream(
 async function streamToText(
 	stream: ReadableStream<Uint8Array>
 ): Promise<string> {
+	const decoderStream = new TextDecoderStream();
 	const reader = (stream as ReadableStream<BufferSource>)
-		.pipeThrough(new TextDecoderStream())
+		.pipeThrough(decoderStream)
 		.getReader();
 	const text: string[] = [];
-	while (true) {
-		const { done, value } = await reader.read();
-		if (done) {
-			return text.join('');
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				return text.join('');
+			}
+			if (value) {
+				text.push(value);
+			}
 		}
-		if (value) {
-			text.push(value);
-		}
+	} finally {
+		reader.releaseLock();
 	}
 }
 
@@ -234,24 +239,28 @@ async function streamToBytes(
 	const reader = stream.getReader();
 	const chunks: Uint8Array[] = [];
 
-	while (true) {
-		const { done, value } = await reader.read();
-		if (done) {
-			const totalLength = chunks.reduce(
-				(acc, chunk) => acc + chunk.byteLength,
-				0
-			);
-			const result = new Uint8Array(totalLength);
-			let offset = 0;
-			for (const chunk of chunks) {
-				result.set(chunk, offset);
-				offset += chunk.byteLength;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				const totalLength = chunks.reduce(
+					(acc, chunk) => acc + chunk.byteLength,
+					0
+				);
+				const result = new Uint8Array(totalLength);
+				let offset = 0;
+				for (const chunk of chunks) {
+					result.set(chunk, offset);
+					offset += chunk.byteLength;
+				}
+				return result;
 			}
-			return result;
+			if (value) {
+				chunks.push(value);
+			}
 		}
-		if (value) {
-			chunks.push(value);
-		}
+	} finally {
+		reader.releaseLock();
 	}
 }
 

--- a/packages/php-wasm/universal/src/lib/php-worker.ts
+++ b/packages/php-wasm/universal/src/lib/php-worker.ts
@@ -19,6 +19,16 @@ const _private = new WeakMap<
 	}
 >();
 
+/**
+ * Tracks PHP instances that have already had worker listeners registered.
+ *
+ * This prevents duplicate event listeners from being added when the same
+ * PHP instance is reused across multiple run() calls, which would otherwise
+ * cause progressive performance degradation as each event fires N times
+ * for N accumulated listeners.
+ */
+const registeredPHPInstances = new WeakSet<PHP>();
+
 export type LimitedPHPApi = Pick<
 	PHP,
 	| 'request'
@@ -343,6 +353,14 @@ export class PHPWorker implements LimitedPHPApi, AsyncDisposable {
 	}
 
 	protected registerWorkerListeners(php: PHP) {
+		// Prevent duplicate listener registration when the same PHP instance
+		// is reused across multiple run() calls. Without this check, listeners
+		// would accumulate and cause progressive performance degradation.
+		if (registeredPHPInstances.has(php)) {
+			return;
+		}
+		registeredPHPInstances.add(php);
+
 		php.addEventListener('*', async (event) => {
 			this.dispatchEvent(event);
 		});


### PR DESCRIPTION
## Motivation for the change, related issues

Repeated calls to `playground.run()` exhibited progressive performance degradation. The first batch of calls would execute in ~1ms, but after many calls the execution time would increase to 10-11ms — an 11.76x slowdown.

This affected browser-based usage where the same PHP instance is reused across requests via `SinglePHPInstanceManager`.

## Implementation details

Three sources of resource accumulation were identified and fixed:

**1. Comlink proxy accumulation** (`comlink-sync.ts`)

Each property access on a Comlink proxy created a new proxy object registered with `FinalizationRegistry`. These proxies accumulated over time. Fixed by adding a `WeakMap`-based cache that reuses existing proxies for the same endpoint and path combination.

**2. Stream reader cleanup** (`php-response.ts`)

The `streamToText()` and `streamToBytes()` functions didn't properly release reader locks in all code paths. Fixed by adding `try/finally` blocks with `reader.releaseLock()`.

**3. Worker listener accumulation** (`php-worker.ts`)

When using `SinglePHPInstanceManager`, the same PHP instance is reused across multiple `run()` calls. Previously, `registerWorkerListeners()` added new event listeners on every call, causing O(n) listener accumulation where each event fired N times for N calls. Fixed by tracking registered instances in a `WeakSet` to prevent duplicate registration.

## Testing Instructions (or ideally a Blueprint)

Run this in the browser console on the Playground website:

```javascript
(async () => {
    const playground = window.playground;
    
    // Warmup
    for (let i = 0; i < 5; i++) {
        await playground.run({ code: '<?php echo "warmup";' });
    }
    
    const times = [];
    for (let i = 0; i < 100; i++) {
        const start = performance.now();
        await playground.run({ code: '<?php echo "test";' });
        times.push(performance.now() - start);
    }
    
    const avg = (arr) => arr.reduce((a, b) => a + b, 0) / arr.length;
    const first10 = avg(times.slice(0, 10));
    const last10 = avg(times.slice(-10));
    
    console.log('First 10 avg:', first10.toFixed(2) + 'ms');
    console.log('Last 10 avg:', last10.toFixed(2) + 'ms');
    console.log('Ratio:', (last10 / first10).toFixed(2) + 'x');
})();
```

**Before:** Ratio ~11.76x (gets slower)
**After:** Ratio ~0.7x (gets faster due to JIT — no degradation)