### PR TITLE
[Playground CLI] Return a readable error and hint when given port is already in use

### DIFF
--- a/packages/playground/cli/src/cli-output.ts
+++ b/packages/playground/cli/src/cli-output.ts
@@ -286,14 +286,6 @@ export class CLIOutput {
 		this.writeStream.write(`${this.yellow('Warning:')} ${message}\n`);
 	}
 
-	printInfo(message: string, newLine = false): void {
-		if (this.isQuiet) return;
-
-		if (newLine) this.writeStream.write('\n');
-
-		this.writeStream.write(`${this.cyan('Info:')} ${message}\n`);
-	}
-
 	/**
 	 * Prints the phpMyAdmin URL when the --phpmyadmin flag is enabled.
 	 */

--- a/packages/playground/cli/src/cli-output.ts
+++ b/packages/playground/cli/src/cli-output.ts
@@ -286,6 +286,14 @@ export class CLIOutput {
 		this.writeStream.write(`${this.yellow('Warning:')} ${message}\n`);
 	}
 
+	printInfo(message: string, newLine = false): void {
+		if (this.isQuiet) return;
+
+		if (newLine) this.writeStream.write('\n');
+
+		this.writeStream.write(`${this.cyan('Info:')} ${message}\n`);
+	}
+
 	/**
 	 * Prints the phpMyAdmin URL when the --phpmyadmin flag is enabled.
 	 */

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -336,7 +336,8 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 
 		const serverOnlyOptions: Record<string, YargsOptions> = {
 			port: {
-				describe: 'Port to listen on when serving.',
+				describe:
+					'Port to listen on when serving. Defaults to 9400 when available.',
 				type: 'number',
 			},
 			'experimental-multi-worker': {
@@ -379,7 +380,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				default: 'latest',
 			},
 			port: {
-				describe: 'Port to listen on.',
+				describe: 'Port to listen on. Defaults to 9400 when available.',
 				type: 'number',
 			},
 			blueprint: {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -986,8 +986,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			: !(await isPortInUse(selectedPort))
 				? selectedPort
 				: 0,
-		onError: (error: NodeJS.ErrnoException) =>
-			cliOutput.printError(error.message),
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';
 			const serverUrl = `http://${host}:${port}`;
@@ -1528,6 +1526,9 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 			return response;
 		},
+	}).catch((error) => {
+		cliOutput.printError(error.message);
+		process.exit(1);
 	});
 
 	if (server && args.command === 'start' && !args.skipBrowser) {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -959,7 +959,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 		cliOutput.printConfig({
 			phpVersion: args.php || RecommendedPHPVersion,
 			wpVersion: args.wp || 'latest',
-			port: (args['port'] as number) || 9400,
+			port: args.port ?? 9400,
 			xdebug: !!args.xdebug,
 			intl: !!args.intl,
 			redis: !!args.redis,
@@ -973,8 +973,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 		});
 	}
 
-	const selectedPort =
-		args.command === 'server' ? ((args['port'] as number) ?? 9400) : 0;
+	const selectedPort = args.command === 'server' ? (args.port ?? 9400) : 0;
 
 	// Declare file lock manager outside scope of startServer
 	// so we can look at it when debugging request handling.
@@ -985,6 +984,9 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 	const server = await startServer({
 		port: selectedPort,
+		onError: (error: Error) => {
+			cliOutput.printError(error.message);
+		},
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';
 			const serverUrl = `http://${host}:${port}`;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -40,7 +40,7 @@ import {
 	parseDefineBoolArguments,
 	parseDefineNumberArguments,
 } from './defines';
-import { startServer } from './start-server';
+import { isPortInUse, startServer } from './start-server';
 import type { PlaygroundCliBlueprintV1Worker } from './blueprints-v1/worker-thread-v1';
 import type { PlaygroundCliBlueprintV2Worker } from './blueprints-v2/worker-thread-v2';
 /* eslint-disable no-console */
@@ -338,7 +338,6 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			port: {
 				describe: 'Port to listen on when serving.',
 				type: 'number',
-				default: 9400,
 			},
 			'experimental-multi-worker': {
 				deprecated:
@@ -382,7 +381,6 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			port: {
 				describe: 'Port to listen on.',
 				type: 'number',
-				default: 9400,
 			},
 			blueprint: {
 				describe:
@@ -983,17 +981,13 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	let isFirstRequest = true;
 
 	const server = await startServer({
-		port: selectedPort,
-		onError: (error: NodeJS.ErrnoException) => {
-			cliOutput.printError(error.message);
-			switch (error.code) {
-				case 'EADDRINUSE':
-					cliOutput.printInfo(
-						'Use the --port flag to specify a different port.',
-						true
-					);
-			}
-		},
+		port: args.port
+			? args.port
+			: !(await isPortInUse(selectedPort))
+				? selectedPort
+				: 0,
+		onError: (error: NodeJS.ErrnoException) =>
+			cliOutput.printError(error.message),
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';
 			const serverUrl = `http://${host}:${port}`;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -984,8 +984,15 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 	const server = await startServer({
 		port: selectedPort,
-		onError: (error: Error) => {
+		onError: (error: NodeJS.ErrnoException) => {
 			cliOutput.printError(error.message);
+			switch (error.code) {
+				case 'EADDRINUSE':
+					cliOutput.printInfo(
+						'Use the --port flag to specify a different port.',
+						true
+					);
+			}
 		},
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -18,6 +18,19 @@ export interface ServerOptions {
 	handleRequest: (request: PHPRequest) => Promise<StreamedPHPResponse>;
 }
 
+export function isPortInUse(port: number): Promise<boolean> {
+	return new Promise((resolve) => {
+		if (port === 0) return resolve(false);
+
+		const server = express().listen(port);
+
+		server.once('listening', () => server.close(() => resolve(false)));
+		server.once('error', (error: NodeJS.ErrnoException) =>
+			resolve(error.code === 'EADDRINUSE')
+		);
+	});
+}
+
 export async function startServer(
 	options: ServerOptions
 ): Promise<RunCLIServer | void> {

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -11,6 +11,7 @@ import { logger } from '@php-wasm/logger';
 export interface ServerOptions {
 	port: number;
 	onBind: (server: Server, port: number) => Promise<RunCLIServer | void>;
+	onError: (error: Error) => void;
 	/**
 	 * Handler for requests. Always returns StreamedPHPResponse.
 	 */
@@ -25,14 +26,16 @@ export async function startServer(
 	const server = await new Promise<
 		Server<typeof IncomingMessage, typeof ServerResponse>
 	>((resolve, reject) => {
-		const server = app.listen(options.port, () => {
-			const address = server.address();
-			if (address === null || typeof address === 'string') {
-				reject(new Error('Server address is not available'));
-			} else {
-				resolve(server);
-			}
-		});
+		const server = app
+			.listen(options.port, () => {
+				const address = server.address();
+				if (address === null || typeof address === 'string') {
+					reject(new Error('Server address is not available'));
+				} else {
+					resolve(server);
+				}
+			})
+			.once('error', (error) => options.onError(error));
 	});
 
 	app.use('/', async (req, res) => {

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -11,7 +11,7 @@ import { logger } from '@php-wasm/logger';
 export interface ServerOptions {
 	port: number;
 	onBind: (server: Server, port: number) => Promise<RunCLIServer | void>;
-	onError: (error: Error) => void;
+	onError: (error: NodeJS.ErrnoException) => void;
 	/**
 	 * Handler for requests. Always returns StreamedPHPResponse.
 	 */

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -11,7 +11,6 @@ import { logger } from '@php-wasm/logger';
 export interface ServerOptions {
 	port: number;
 	onBind: (server: Server, port: number) => Promise<RunCLIServer | void>;
-	onError: (error: NodeJS.ErrnoException) => void;
 	/**
 	 * Handler for requests. Always returns StreamedPHPResponse.
 	 */
@@ -48,7 +47,7 @@ export async function startServer(
 					resolve(server);
 				}
 			})
-			.once('error', (error) => options.onError(error));
+			.once('error', reject);
 	});
 
 	app.use('/', async (req, res) => {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1429,4 +1429,63 @@ describe('other run-cli behaviors', () => {
 			}
 		);
 	});
+
+	describe('port in use', () => {
+		test('should error when explicit port is already in use', async () => {
+			const stdoutMessages: string[] = [];
+			const mockStdout = vi
+				.spyOn(process.stdout, 'write')
+				.mockImplementation((chunk) => {
+					stdoutMessages.push(String(chunk));
+					return true;
+				});
+			const mockExit = vi
+				.spyOn(process, 'exit')
+				.mockImplementation(() => undefined as never);
+
+			const port = 12345;
+			const blockingServer = http.createServer();
+			await new Promise<void>((resolve) => {
+				blockingServer.listen(port, () => resolve());
+			});
+
+			try {
+				await runCLI({
+					command: 'server',
+					port,
+				});
+
+				expect(stdoutMessages.join('')).toContain(
+					`Error: listen EADDRINUSE: address already in use :::${port}`
+				);
+			} finally {
+				mockExit.mockRestore();
+				mockStdout.mockRestore();
+				blockingServer.close();
+			}
+		});
+
+		test('should use a random port when default port is already in use', async () => {
+			const port = 12345;
+			const blockingServer = http.createServer();
+			await new Promise<void>((resolve) => {
+				blockingServer.listen(port, () => resolve());
+			});
+
+			try {
+				await using cliServer = await runCLI({
+					command: 'server',
+					wordpressInstallMode: 'do-not-attempt-installing',
+					skipSqliteSetup: true,
+					blueprint: undefined,
+				});
+
+				const assignedPort = new URL(cliServer.serverUrl).port;
+				expect(Number(assignedPort)).not.toBe(port);
+				expect(Number(assignedPort)).toBeGreaterThan(0);
+			} finally {
+				blockingServer.close();
+			}
+		});
+	});
 });


### PR DESCRIPTION
## Motivation for the change, related issues

Based on [this issue](https://github.com/WordPress/wordpress-playground/issues/3237#issuecomment-3841685018)

The goal was to ignore stack traces, only print error messages in the CLI output style.

## Implementation details

Added a `onError` option in `ServerOptions` that will be called once a error happens in `app.listen(..)`.

## Testing Instructions

CLI

or

Run the following command in two separate terminals : 

```
node --no-warnings --loader=./packages/meta/src/node-es-module-loader/loader.mts ./packages/playground/cli/src/cli.ts server
```

```
WordPress Playground CLI

PHP 8.3  WordPress latest
Extensions intl

Running Blueprint 100%

Ready! WordPress is running on http://127.0.0.1:9400 (1 worker)
```
 
```
WordPress Playground CLI

PHP 8.3  WordPress latest
Extensions intl

Error: listen EADDRINUSE: address already in use :::9400
```


