### PR TITLE
[Docs] Update node supported version

### DIFF
--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -16,7 +16,7 @@ Playground CLI supports auto-mounting a directory with a plugin, theme, or WordP
 
 ## Requirements
 
-The Playground CLI requires Node.js 20.18 or higher, which is the recommended Long-Term Support (LTS) version. You can download it from the [Node.js website](https://nodejs.org/en/download).
+The Playground CLI requires Node.js 22.12 or higher, which is the recommended Long-Term Support (LTS) version. You can download it from the [Node.js website](https://nodejs.org/en/download).
 
 ## Quickstart
 

--- a/packages/docs/site/docs/main/contributing/contributor-day.md
+++ b/packages/docs/site/docs/main/contributing/contributor-day.md
@@ -18,10 +18,10 @@ We value diverse contributions across various areas, including community buildin
 
 This section outlines how you can contribute directly to the WordPress Playground project and its associated tools:
 
--   **Documentation:** Enhance our documentation by improving existing content, developing new guides, or translating materials into different languages.
--   **Blueprints:** Create plugin demos for plugins at the WordPress Plugin repository, or develop new Blueprints to enrich our project documentation.
--   **Testing the Playground Environment:** Engage in testing the WordPress Playground project itself. You can do this by carefully crafting new issues that describe problems you encounter and suggesting actionable solutions. Test our WordPress web instance (the playground.wordpress.net site), or explore the various applications powered by Playground. Test these tools, observe their functionality, and provide detailed feedback.
--   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
+- **Documentation:** Enhance our documentation by improving existing content, developing new guides, or translating materials into different languages.
+- **Blueprints:** Create plugin demos for plugins at the WordPress Plugin repository, or develop new Blueprints to enrich our project documentation.
+- **Testing the Playground Environment:** Engage in testing the WordPress Playground project itself. You can do this by carefully crafting new issues that describe problems you encounter and suggesting actionable solutions. Test our WordPress web instance (the playground.wordpress.net site), or explore the various applications powered by Playground. Test these tools, observe their functionality, and provide detailed feedback.
+- **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
 
 All feedback, including reported issues and test results, can be submitted through our GitHub repository.
 
@@ -56,7 +56,7 @@ The [Visual Studio Code Playground extension](https://marketplace.visualstudio.c
 
 #### Prerequisites
 
-`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven’t yet, [download and install](https://nodejs.org/en/download) both before you begin.
+`@wp-playground/cli` requires Node.js 22.12 or newer and NPM. If you haven’t yet, [download and install](https://nodejs.org/en/download) both before you begin.
 
 Depending on the Make WordPress team you contribute to, you may need a different Node.js version than the one you have installed. You can use Node Version Manager (NVM) to switch between versions. [Find the installation guide here](https://github.com/nvm-sh/nvm#installing-and-updating).
 
@@ -133,6 +133,6 @@ You can translate supported WordPress Plugins by loading the plugin you want to 
 
 Have a question or an idea for a new feature? Found a bug? Something’s not working as expected? We’re here to help:
 
--   During Contributor Day, you can reach us at the **Playground table**.
--   Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is the VS Code extension, NPM package, or the plugins, open an issue on the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
--   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+- During Contributor Day, you can reach us at the **Playground table**.
+- Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is the VS Code extension, NPM package, or the plugins, open an issue on the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
+- Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -53,10 +53,10 @@ This section outlines how you can contribute directly to the WordPress Playgroun
 -   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
 -->
 
--   **ডকুমেন্টেশন:** বিদ্যমান কনটেন্ট উন্নত করে, নতুন গাইড ডেভেলপ করে, অথবা বিভিন্ন ভাষায় ম্যাটেরিয়াল ট্রান্সলেট করে আমাদের ডকুমেন্টেশন সমৃদ্ধ করুন।
--   **ব্লুপ্রিন্ট:** ওয়ার্ডপ্রেস প্লাগইন রিপোজিটরির প্লাগইনগুলোর জন্য প্লাগইন ডেমো তৈরি করুন, অথবা আমাদের প্রজেক্ট ডকুমেন্টেশন সমৃদ্ধ করতে নতুন ব্লুপ্রিন্ট ডেভেলপ করুন।
--   **প্লেগ্রাউন্ড এনভায়রনমেন্ট টেস্টিং:** ওয়ার্ডপ্রেস প্লেগ্রাউন্ড প্রজেক্ট নিজেই টেস্ট করতে এনগেজ হন। আপনি সাবধানে নতুন ইস্যু তৈরি করে এটি করতে পারেন যা আপনার সম্মুখীন হওয়া সমস্যাগুলো বর্ণনা করে এবং অ্যাকশনেবল সমাধান সাজেস্ট করে। আমাদের ওয়ার্ডপ্রেস ওয়েব ইন্সট্যান্স (playground.wordpress.net সাইট) টেস্ট করুন, অথবা প্লেগ্রাউন্ড দ্বারা পাওয়ার্ড বিভিন্ন অ্যাপ্লিকেশন এক্সপ্লোর করুন। এই টুলস টেস্ট করুন, তাদের ফাংশনালিটি অবজার্ভ করুন এবং বিস্তারিত ফিডব্যাক প্রদান করুন।
--   **প্রোডাক্ট ফিডব্যাক:** প্লেগ্রাউন্ড এক্সপেরিয়েন্স উন্নত করার জন্য আপনার ইনসাইট অমূল্য। এর মধ্যে ওয়েব ইন্সট্যান্স, অ্যাপ্লিকেশন এবং যেকোনো সার্ভার-সাইড টুলসের উপর সাধারণ ফিডব্যাক অন্তর্ভুক্ত।
+- **ডকুমেন্টেশন:** বিদ্যমান কনটেন্ট উন্নত করে, নতুন গাইড ডেভেলপ করে, অথবা বিভিন্ন ভাষায় ম্যাটেরিয়াল ট্রান্সলেট করে আমাদের ডকুমেন্টেশন সমৃদ্ধ করুন।
+- **ব্লুপ্রিন্ট:** ওয়ার্ডপ্রেস প্লাগইন রিপোজিটরির প্লাগইনগুলোর জন্য প্লাগইন ডেমো তৈরি করুন, অথবা আমাদের প্রজেক্ট ডকুমেন্টেশন সমৃদ্ধ করতে নতুন ব্লুপ্রিন্ট ডেভেলপ করুন।
+- **প্লেগ্রাউন্ড এনভায়রনমেন্ট টেস্টিং:** ওয়ার্ডপ্রেস প্লেগ্রাউন্ড প্রজেক্ট নিজেই টেস্ট করতে এনগেজ হন। আপনি সাবধানে নতুন ইস্যু তৈরি করে এটি করতে পারেন যা আপনার সম্মুখীন হওয়া সমস্যাগুলো বর্ণনা করে এবং অ্যাকশনেবল সমাধান সাজেস্ট করে। আমাদের ওয়ার্ডপ্রেস ওয়েব ইন্সট্যান্স (playground.wordpress.net সাইট) টেস্ট করুন, অথবা প্লেগ্রাউন্ড দ্বারা পাওয়ার্ড বিভিন্ন অ্যাপ্লিকেশন এক্সপ্লোর করুন। এই টুলস টেস্ট করুন, তাদের ফাংশনালিটি অবজার্ভ করুন এবং বিস্তারিত ফিডব্যাক প্রদান করুন।
+- **প্রোডাক্ট ফিডব্যাক:** প্লেগ্রাউন্ড এক্সপেরিয়েন্স উন্নত করার জন্য আপনার ইনসাইট অমূল্য। এর মধ্যে ওয়েব ইন্সট্যান্স, অ্যাপ্লিকেশন এবং যেকোনো সার্ভার-সাইড টুলসের উপর সাধারণ ফিডব্যাক অন্তর্ভুক্ত।
 
 <!--
 All feedback, including reported issues and test results, can be submitted through our GitHub repository.
@@ -155,10 +155,10 @@ The [Visual Studio Code Playground extension](https://marketplace.visualstudio.c
 #### পূর্বশর্ত
 
 <!--
-`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
+`@wp-playground/cli` requires Node.js 22.12 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
 -->
 
-`@wp-playground/cli`-এর জন্য Node.js 20.18 বা নতুন এবং NPM প্রয়োজন। আপনি যদি এখনো না করে থাকেন, শুরু করার আগে উভয়ই [ডাউনলোড এবং ইন্সটল](https://nodejs.org/en/download) করুন।
+`@wp-playground/cli`-এর জন্য Node.js 22.12 বা নতুন এবং NPM প্রয়োজন। আপনি যদি এখনো না করে থাকেন, শুরু করার আগে উভয়ই [ডাউনলোড এবং ইন্সটল](https://nodejs.org/en/download) করুন।
 
 <!--
 Depending on the Make WordPress team you contribute to, you may need a different Node.js version than the one you have installed. You can use Node Version Manager (NVM) to switch between versions. [Find the installation guide here](https://github.com/nvm-sh/nvm#installing-and-updating).
@@ -324,6 +324,6 @@ Have a question or an idea for a new feature? Found a bug? Something's not worki
 -   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
 -->
 
--   কন্ট্রিবিউটর ডে-এর সময়, আপনি আমাদের **প্লেগ্রাউন্ড টেবিলে** পেতে পারেন।
--   [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড গিটহাব রিপোজিটরিতে](https://github.com/WordPress/wordpress-playground/issues/new) একটি ইস্যু ওপেন করুন। আপনার ফোকাস যদি VS Code এক্সটেনশন, NPM প্যাকেজ, অথবা প্লাগইন হয়, [প্লেগ্রাউন্ড টুলস রিপোজিটরিতে](https://github.com/WordPress/playground-tools/issues/new) একটি ইস্যু ওপেন করুন।
--   [**#playground** স্ল্যাক চ্যানেলে](https://wordpress.slack.com/archives/C04EWKGDJ0K) আপনার ফিডব্যাক শেয়ার করুন।
+- কন্ট্রিবিউটর ডে-এর সময়, আপনি আমাদের **প্লেগ্রাউন্ড টেবিলে** পেতে পারেন।
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড গিটহাব রিপোজিটরিতে](https://github.com/WordPress/wordpress-playground/issues/new) একটি ইস্যু ওপেন করুন। আপনার ফোকাস যদি VS Code এক্সটেনশন, NPM প্যাকেজ, অথবা প্লাগইন হয়, [প্লেগ্রাউন্ড টুলস রিপোজিটরিতে](https://github.com/WordPress/playground-tools/issues/new) একটি ইস্যু ওপেন করুন।
+- [**#playground** স্ল্যাক চ্যানেলে](https://wordpress.slack.com/archives/C04EWKGDJ0K) আপনার ফিডব্যাক শেয়ার করুন।

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -16,7 +16,7 @@ Playground CLI soporta el montaje automático de un directorio con un plugin, te
 
 ## Requisitos
 
-El Playground CLI requiere Node.js 20.18 o superior, que es la versión recomendada de Soporte a Largo Plazo (LTS). Puedes descargarlo desde el [sitio web de Node.js](https://nodejs.org/en/download).
+El Playground CLI requiere Node.js 22.12 o superior, que es la versión recomendada de Soporte a Largo Plazo (LTS). Puedes descargarlo desde el [sitio web de Node.js](https://nodejs.org/en/download).
 
 ## Inicio Rápido
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -205,11 +205,12 @@ npx @wp-playground/cli@latest server --auto-mount
 2. Luego, clona el repositorio bifurcado para descargar los archivos.
 3. Instala las dependencias necesarias y compila el código en modo de desarrollo.
 
-````bash
+```bash
 git clone git@github.com:WordPress/gutenberg.git
 cd gutenberg
 npm install
 npm run dev
+```
 
 <!--
 :::info
@@ -234,7 +235,7 @@ Abre una nueva pestaña en tu terminal, navega hasta el directorio de Gutenberg 
 ```bash
 cd gutenberg
 npx @wp-playground/cli@latest server --auto-mount
-````
+```
 
 <!--
 When you're ready, commit and push your changes to your forked repository on GitHub and open a Pull Request on the Gutenberg repository.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -53,10 +53,10 @@ Esta sección describe cómo puedes contribuir directamente al proyecto WordPres
 -   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
 -->
 
--   **Documentación:** Mejora nuestra documentación perfeccionando el contenido existente, desarrollando nuevas guías o traduciendo materiales a diferentes idiomas.
--   **Blueprints:** Crea demostraciones de plugins para los plugins del repositorio de plugins de WordPress o desarrolla nuevos Blueprints para enriquecer la documentación de nuestro proyecto.
--   **Pruebas del entorno Playground:** Participa en las pruebas del propio proyecto WordPress Playground. Puedes hacerlo elaborando cuidadosamente nuevas incidencias que describan los problemas que encuentres y sugiriendo soluciones viables. Prueba nuestra instancia web de WordPress (el sitio playground.wordpress.net) o explora las diversas aplicaciones que funcionan con Playground. Prueba estas herramientas, observa su funcionalidad y proporciona comentarios detallados.
--   **Comentarios sobre el producto:** Tus opiniones son muy valiosas para mejorar la experiencia de Playground. Esto incluye comentarios generales sobre la instancia web, la aplicación y cualquier herramienta del lado del servidor.
+- **Documentación:** Mejora nuestra documentación perfeccionando el contenido existente, desarrollando nuevas guías o traduciendo materiales a diferentes idiomas.
+- **Blueprints:** Crea demostraciones de plugins para los plugins del repositorio de plugins de WordPress o desarrolla nuevos Blueprints para enriquecer la documentación de nuestro proyecto.
+- **Pruebas del entorno Playground:** Participa en las pruebas del propio proyecto WordPress Playground. Puedes hacerlo elaborando cuidadosamente nuevas incidencias que describan los problemas que encuentres y sugiriendo soluciones viables. Prueba nuestra instancia web de WordPress (el sitio playground.wordpress.net) o explora las diversas aplicaciones que funcionan con Playground. Prueba estas herramientas, observa su funcionalidad y proporciona comentarios detallados.
+- **Comentarios sobre el producto:** Tus opiniones son muy valiosas para mejorar la experiencia de Playground. Esto incluye comentarios generales sobre la instancia web, la aplicación y cualquier herramienta del lado del servidor.
 
 <!--
 All feedback, including reported issues and test results, can be submitted through our GitHub repository.
@@ -155,10 +155,10 @@ La [extensión de Playground para Visual Studio Code](https://marketplace.visual
 #### Requisitos previos
 
 <!--
-`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
+`@wp-playground/cli` requires Node.js 22.12 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
 -->
 
-`@wp-playground/cli` requiere Node.js 20.18 o superior y NPM. Si aún no lo has hecho, [descarga e instala](https://nodejs.org/en/download) ambos antes de comenzar.
+`@wp-playground/cli` requiere Node.js 22.12 o superior y NPM. Si aún no lo has hecho, [descarga e instala](https://nodejs.org/en/download) ambos antes de comenzar.
 
 <!--
 Depending on the Make WordPress team you contribute to, you may need a different Node.js version than the one you have installed. You can use Node Version Manager (NVM) to switch between versions. [Find the installation guide here](https://github.com/nvm-sh/nvm#installing-and-updating).
@@ -205,7 +205,7 @@ npx @wp-playground/cli@latest server --auto-mount
 2. Luego, clona el repositorio bifurcado para descargar los archivos.
 3. Instala las dependencias necesarias y compila el código en modo de desarrollo.
 
-```bash
+````bash
 git clone git@github.com:WordPress/gutenberg.git
 cd gutenberg
 npm install
@@ -234,7 +234,7 @@ Abre una nueva pestaña en tu terminal, navega hasta el directorio de Gutenberg 
 ```bash
 cd gutenberg
 npx @wp-playground/cli@latest server --auto-mount
-```
+````
 
 <!--
 When you're ready, commit and push your changes to your forked repository on GitHub and open a Pull Request on the Gutenberg repository.
@@ -323,6 +323,6 @@ Have a question or an idea for a new feature? Found a bug? Something's not worki
 -   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
 -->
 
--   Durante el día del contribuidor, puedes encontrarnos en la **mesa de Playground**.
--   Abre una incidencia en el [repositorio de WordPress Playground en GitHub](https://github.com/WordPress/wordpress-playground/issues/new). Si te interesa la extensión de VS Code, el paquete NPM o los plugins, abre una incidencia en el [repositorio de Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
--   Comparte tus comentarios en el canal de Slack de [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+- Durante el día del contribuidor, puedes encontrarnos en la **mesa de Playground**.
+- Abre una incidencia en el [repositorio de WordPress Playground en GitHub](https://github.com/WordPress/wordpress-playground/issues/new). Si te interesa la extensión de VS Code, el paquete NPM o los plugins, abre una incidencia en el [repositorio de Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+- Comparte tus comentarios en el canal de Slack de [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -46,25 +46,25 @@ We value diverse contributions across different areas including community buildi
 This section outlines how you can directly contribute to the WordPress Playground project and its associated tools:
 -->
 
--   **દસ્તાવેજીકરણ:** હાલની સામગ્રીમાં સુધારો કરીને, નવી માર્ગદર્શિકાઓ વિકસાવીને અથવા વિવિધ ભાષાઓમાં સામગ્રીનો અનુવાદ કરીને અમારા દસ્તાવેજીકરણને વિસ્તૃત કરો.
+- **દસ્તાવેજીકરણ:** હાલની સામગ્રીમાં સુધારો કરીને, નવી માર્ગદર્શિકાઓ વિકસાવીને અથવા વિવિધ ભાષાઓમાં સામગ્રીનો અનુવાદ કરીને અમારા દસ્તાવેજીકરણને વિસ્તૃત કરો.
 
 <!--
 - **Documentation:** Expand our documentation by improving existing content, developing new guides, or translating content into different languages.
 -->
 
--   **બ્લુપ્રિન્ટ્સ:** વર્ડપ્રેસ પ્લગઇન રિપોઝીટરીમાં પ્લગઇન્સ માટે પ્લગઇન ડેમો બનાવો, અથવા અમારા પ્રોજેક્ટ દસ્તાવેજીકરણને સમૃદ્ધ બનાવવા માટે નવા બ્લુપ્રિન્ટ્સ વિકસાવો.
+- **બ્લુપ્રિન્ટ્સ:** વર્ડપ્રેસ પ્લગઇન રિપોઝીટરીમાં પ્લગઇન્સ માટે પ્લગઇન ડેમો બનાવો, અથવા અમારા પ્રોજેક્ટ દસ્તાવેજીકરણને સમૃદ્ધ બનાવવા માટે નવા બ્લુપ્રિન્ટ્સ વિકસાવો.
 
 <!--
 - **Blueprints:** Create plugin demos for plugins in the WordPress plugin repository, or develop new blueprints to enrich our project documentation.
 -->
 
--   **પ્લેગ્રાઉન્ડ પર્યાવરણનું પરીક્ષણ:** વર્ડપ્રેસ પ્લેગ્રાઉન્ડ પ્રોજેક્ટનું જ પરીક્ષણ કરવામાં જોડાઓ. તમે જે સમસ્યાઓનો સામનો કરો છો તેનું વર્ણન કરતી નવી સમસ્યાઓ કાળજીપૂર્વક બનાવીને અને કાર્યક્ષમ ઉકેલો સૂચવીને આ કરી શકો છો. અમારા વર્ડપ્રેસ વેબ ઇન્સ્ટન્સ (playground.wordpress.net સાઇટ) નું પરીક્ષણ કરો, અથવા પ્લેગ્રાઉન્ડ દ્વારા સંચાલિત વિવિધ એપ્લિકેશનોનું અન્વેષણ કરો. આ સાધનોનું પરીક્ષણ કરો, તેમની કાર્યક્ષમતાનું અવલોકન કરો અને વિગતવાર પ્રતિસાદ આપો.
+- **પ્લેગ્રાઉન્ડ પર્યાવરણનું પરીક્ષણ:** વર્ડપ્રેસ પ્લેગ્રાઉન્ડ પ્રોજેક્ટનું જ પરીક્ષણ કરવામાં જોડાઓ. તમે જે સમસ્યાઓનો સામનો કરો છો તેનું વર્ણન કરતી નવી સમસ્યાઓ કાળજીપૂર્વક બનાવીને અને કાર્યક્ષમ ઉકેલો સૂચવીને આ કરી શકો છો. અમારા વર્ડપ્રેસ વેબ ઇન્સ્ટન્સ (playground.wordpress.net સાઇટ) નું પરીક્ષણ કરો, અથવા પ્લેગ્રાઉન્ડ દ્વારા સંચાલિત વિવિધ એપ્લિકેશનોનું અન્વેષણ કરો. આ સાધનોનું પરીક્ષણ કરો, તેમની કાર્યક્ષમતાનું અવલોકન કરો અને વિગતવાર પ્રતિસાદ આપો.
 
 <!--
 - **Testing the Playground Environment:** Engage in testing the WordPress Playground project itself. You can do this by carefully creating new issues describing the problems you encounter and suggesting efficient solutions. Test our WordPress web instance (playground.wordpress.net site), or explore various applications powered by Playground. Test these tools, observe their functionality, and provide detailed feedback.
 -->
 
--   **ઉત્પાદન પ્રતિસાદ:** પ્લેગ્રાઉન્ડ અનુભવને સુધારવા માટે તમારી આંતરદૃષ્ટિ અમૂલ્ય છે. આમાં વેબ ઇન્સ્ટન્સ, એપ્લિકેશન અને કોઈપણ સર્વર-સાઇડ ટૂલ્સ પર સામાન્ય પ્રતિસાદ શામેલ છે.
+- **ઉત્પાદન પ્રતિસાદ:** પ્લેગ્રાઉન્ડ અનુભવને સુધારવા માટે તમારી આંતરદૃષ્ટિ અમૂલ્ય છે. આમાં વેબ ઇન્સ્ટન્સ, એપ્લિકેશન અને કોઈપણ સર્વર-સાઇડ ટૂલ્સ પર સામાન્ય પ્રતિસાદ શામેલ છે.
 
 <!--
 - **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, applications, and any server-side tools.
@@ -178,10 +178,10 @@ The [Visual Studio Code Playground Extension](https://marketplace.visualstudio.c
 #### Prerequisites
 -->
 
-`@wp-playground/cli` ને Node.js 20.18 અથવા નવા અને NPM ની જરૂર છે. જો તમે હજુ સુધી નથી કર્યું, તો શરૂ કરતા પહેલા બંને [ડાઉનલોડ અને ઇન્સ્ટોલ કરો](https://nodejs.org/en/download) કરો.
+`@wp-playground/cli` ને Node.js 22.12 અથવા નવા અને NPM ની જરૂર છે. જો તમે હજુ સુધી નથી કર્યું, તો શરૂ કરતા પહેલા બંને [ડાઉનલોડ અને ઇન્સ્ટોલ કરો](https://nodejs.org/en/download) કરો.
 
 <!--
-`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven't already, [download and install both](https://nodejs.org/en/download) before getting started.
+`@wp-playground/cli` requires Node.js 22.12 or newer and NPM. If you haven't already, [download and install both](https://nodejs.org/en/download) before getting started.
 -->
 
 તમે જે Make WordPress ટીમમાં યોગદાન આપો છો તેના આધારે, તમારે તમે ઇન્સ્ટોલ કરેલ કરતાં અલગ Node.js વર્ઝનની જરૂર પડી શકે છે. તમે વર્ઝન વચ્ચે સ્વિચ કરવા માટે Node Version Manager (NVM) નો ઉપયોગ કરી શકો છો. [ઇન્સ્ટોલેશન માર્ગદર્શિકા અહીં શોધો](https://github.com/nvm-sh/nvm#installing-and-updating).
@@ -369,19 +369,19 @@ You can translate supported WordPress plugins by loading the plugin you want to 
 Do you have any questions or ideas for new features? Found a bug? Something not working as expected? We're here to help:
 -->
 
--   કન્ટ્રિબ્યુટર ડે દરમિયાન, તમે **Playground ટેબલ** પર અમારો સંપર્ક કરી શકો છો.
+- કન્ટ્રિબ્યુટર ડે દરમિયાન, તમે **Playground ટેબલ** પર અમારો સંપર્ક કરી શકો છો.
 
 <!--
 - During Contributor Day, you can reach us at the **Playground table**.
 -->
 
--   [વર્ડપ્રેસ પ્લેગ્રાઉન્ડ ગિટહબ રીપોઝીટરી](https://github.com/WordPress/wordpress-playground/issues/new) પર એક મુદ્દો ખોલો. જો તમારું ધ્યાન VS કોડ એક્સટેન્શન, NPM પેકેજ અથવા પ્લગઇન્સ પર હોય, તો [પ્લેગ્રાઉન્ડ ટૂલ્સ રીપોઝીટરી](https://github.com/WordPress/playground-tools/issues/new) પર એક મુદ્દો ખોલો.
+- [વર્ડપ્રેસ પ્લેગ્રાઉન્ડ ગિટહબ રીપોઝીટરી](https://github.com/WordPress/wordpress-playground/issues/new) પર એક મુદ્દો ખોલો. જો તમારું ધ્યાન VS કોડ એક્સટેન્શન, NPM પેકેજ અથવા પ્લગઇન્સ પર હોય, તો [પ્લેગ્રાઉન્ડ ટૂલ્સ રીપોઝીટરી](https://github.com/WordPress/playground-tools/issues/new) પર એક મુદ્દો ખોલો.
 
 <!--
 - Open an issue on the [WordPress Playground GitHub repository](https://github.com/WordPress/wordpress-playground/issues/new). If your focus is on the VS Code extension, NPM package, or plugins, open an issue on the [Playground Tools repository](https://github.com/WordPress/playground-tools/issues/new).
 -->
 
--   [**#playground** સ્લેક ચેનલ](https://wordpress.slack.com/archives/C04EWKGDJ0K) પર તમારો પ્રતિસાદ શેર કરો.
+- [**#playground** સ્લેક ચેનલ](https://wordpress.slack.com/archives/C04EWKGDJ0K) પર તમારો પ્રતિસાદ શેર કરો.
 
 <!--
 - Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/it/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -45,10 +45,10 @@ All feedback, including reported issues and test results, can be submitted throu
 
 Questa sezione descrive come puoi contribuire direttamente al progetto WordPress Playground e ai suoi strumenti associati:
 
--   **Documentazione:** Migliora la nostra documentazione migliorando il contenuto esistente, sviluppando nuove guide o traducendo materiali in diverse lingue.
--   **Blueprints:** Crea demo di plugin per i plugin nel repository WordPress Plugin, o sviluppa nuovi Blueprints per arricchire la nostra documentazione del progetto.
--   **Testare l'ambiente Playground:** Impegnati nel testare il progetto WordPress Playground stesso. Puoi farlo creando attentamente nuove issue che descrivono i problemi che incontri e suggerendo soluzioni praticabili. Testa la nostra istanza web WordPress (il sito playground.wordpress.net), o esplora le varie applicazioni alimentate da Playground. Testa questi strumenti, osserva la loro funzionalità e fornisci feedback dettagliati.
--   **Feedback sul prodotto:** Le tue intuizioni sono preziose per migliorare l'esperienza Playground. Questo include feedback generale sull'istanza web, l'applicazione e qualsiasi strumento lato server.
+- **Documentazione:** Migliora la nostra documentazione migliorando il contenuto esistente, sviluppando nuove guide o traducendo materiali in diverse lingue.
+- **Blueprints:** Crea demo di plugin per i plugin nel repository WordPress Plugin, o sviluppa nuovi Blueprints per arricchire la nostra documentazione del progetto.
+- **Testare l'ambiente Playground:** Impegnati nel testare il progetto WordPress Playground stesso. Puoi farlo creando attentamente nuove issue che descrivono i problemi che incontri e suggerendo soluzioni praticabili. Testa la nostra istanza web WordPress (il sito playground.wordpress.net), o esplora le varie applicazioni alimentate da Playground. Testa questi strumenti, osserva la loro funzionalità e fornisci feedback dettagliati.
+- **Feedback sul prodotto:** Le tue intuizioni sono preziose per migliorare l'esperienza Playground. Questo include feedback generale sull'istanza web, l'applicazione e qualsiasi strumento lato server.
 
 Tutti i feedback, inclusi issue segnalate e risultati dei test, possono essere inviati tramite il nostro repository GitHub.
 
@@ -117,7 +117,7 @@ L'[estensione Visual Studio Code Playground](https://marketplace.visualstudio.co
 
 #### Prerequisites
 
-`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
+`@wp-playground/cli` requires Node.js 22.12 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
 
 Depending on the Make WordPress team you contribute to, you may need a different Node.js version than the one you have installed. You can use Node Version Manager (NVM) to switch between versions. [Find the installation guide here](https://github.com/nvm-sh/nvm#installing-and-updating).
 
@@ -137,7 +137,7 @@ npx @wp-playground/cli@latest server --auto-mount
 
 #### Prerequisiti
 
-`@wp-playground/cli` richiede Node.js 20.18 o più recente e NPM. Se non li hai ancora, [scarica e installa](https://nodejs.org/en/download) entrambi prima di iniziare.
+`@wp-playground/cli` richiede Node.js 22.12 o più recente e NPM. Se non li hai ancora, [scarica e installa](https://nodejs.org/en/download) entrambi prima di iniziare.
 
 A seconda del team Make WordPress a cui contribuisci, potresti aver bisogno di una versione Node.js diversa da quella che hai installato. Puoi usare Node Version Manager (NVM) per passare tra le versioni. [Trova la guida all'installazione qui](https://github.com/nvm-sh/nvm#installing-and-updating).
 
@@ -284,9 +284,9 @@ Puoi tradurre i plugin WordPress supportati caricando il plugin che vuoi tradurr
 
 Hai una domanda o un'idea per una nuova funzionalità? Hai trovato un bug? Qualcosa non funziona come previsto? Siamo qui per aiutare:
 
--   Durante il Contributor Day, puoi raggiungerci al **tavolo Playground**.
--   Apri una issue sul [repository GitHub WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se il tuo focus è l'estensione VS Code, il pacchetto NPM o i plugin, apri una issue sul [repository Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
--   Condividi il tuo feedback sul canale Slack [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+- Durante il Contributor Day, puoi raggiungerci al **tavolo Playground**.
+- Apri una issue sul [repository GitHub WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se il tuo focus è l'estensione VS Code, il pacchetto NPM o i plugin, apri una issue sul [repository Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+- Condividi il tuo feedback sul canale Slack [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).
 
 ## Chi può contribuire?
 
@@ -298,10 +298,10 @@ Valutiamo contributi diversificati in varie aree, inclusi community building, te
 
 Questa sezione descrive come puoi contribuire direttamente al progetto WordPress Playground e ai suoi strumenti associati:
 
--   **Documentazione:** Migliora la nostra documentazione migliorando il contenuto esistente, sviluppando nuove guide o traducendo materiali in diverse lingue.
--   **Blueprints:** Crea demo di plugin per i plugin nel repository WordPress Plugin, o sviluppa nuovi Blueprints per arricchire la nostra documentazione del progetto.
--   **Testare l'ambiente Playground:** Impegnati nel testare il progetto WordPress Playground stesso. Puoi farlo creando attentamente nuove issue che descrivono i problemi che incontri e suggerendo soluzioni praticabili. Testa la nostra istanza web WordPress (il sito playground.wordpress.net), o esplora le varie applicazioni alimentate da Playground. Testa questi strumenti, osserva la loro funzionalità e fornisci feedback dettagliati.
--   **Feedback sul prodotto:** Le tue intuizioni sono preziose per migliorare l'esperienza Playground. Questo include feedback generale sull'istanza web, l'applicazione e qualsiasi strumento lato server.
+- **Documentazione:** Migliora la nostra documentazione migliorando il contenuto esistente, sviluppando nuove guide o traducendo materiali in diverse lingue.
+- **Blueprints:** Crea demo di plugin per i plugin nel repository WordPress Plugin, o sviluppa nuovi Blueprints per arricchire la nostra documentazione del progetto.
+- **Testare l'ambiente Playground:** Impegnati nel testare il progetto WordPress Playground stesso. Puoi farlo creando attentamente nuove issue che descrivono i problemi che incontri e suggerendo soluzioni praticabili. Testa la nostra istanza web WordPress (il sito playground.wordpress.net), o esplora le varie applicazioni alimentate da Playground. Testa questi strumenti, osserva la loro funzionalità e fornisci feedback dettagliati.
+- **Feedback sul prodotto:** Le tue intuizioni sono preziose per migliorare l'esperienza Playground. Questo include feedback generale sull'istanza web, l'applicazione e qualsiasi strumento lato server.
 
 Tutti i feedback, inclusi issue segnalate e risultati dei test, possono essere inviati tramite il nostro repository GitHub.
 
@@ -336,7 +336,7 @@ L'[estensione Visual Studio Code Playground](https://marketplace.visualstudio.co
 
 #### Prerequisiti
 
-`@wp-playground/cli` richiede Node.js 20.18 o più recente e NPM. Se non li hai ancora, [scarica e installa](https://nodejs.org/en/download) entrambi prima di iniziare.
+`@wp-playground/cli` richiede Node.js 22.12 o più recente e NPM. Se non li hai ancora, [scarica e installa](https://nodejs.org/en/download) entrambi prima di iniziare.
 
 A seconda del team Make WordPress a cui contribuisci, potresti aver bisogno di una versione Node.js diversa da quella che hai installato. Puoi usare Node Version Manager (NVM) per passare tra le versioni. [Trova la guida all'installazione qui](https://github.com/nvm-sh/nvm#installing-and-updating).
 
@@ -413,6 +413,6 @@ Puoi tradurre i plugin WordPress supportati caricando il plugin che vuoi tradurr
 
 Hai una domanda o un'idea per una nuova funzionalità? Hai trovato un bug? Qualcosa non funziona come previsto? Siamo qui per aiutare:
 
--   Durante il Contributor Day, puoi raggiungerci al **tavolo Playground**.
--   Apri una issue sul [repository GitHub WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se il tuo focus è l'estensione VS Code, il pacchetto NPM o i plugin, apri una issue sul [repository Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
--   Condividi il tuo feedback sul canale Slack [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+- Durante il Contributor Day, puoi raggiungerci al **tavolo Playground**.
+- Apri una issue sul [repository GitHub WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se il tuo focus è l'estensione VS Code, il pacchetto NPM o i plugin, apri una issue sul [repository Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+- Condividi il tuo feedback sul canale Slack [**#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -22,9 +22,9 @@ Playground CLI supports auto-mounting a directory with a plugin, theme, or WordP
 **Key features:**
 -->
 
--   **クイックセットアップ**: わずか数秒でローカルの WordPress 環境をセットアップできます。
--   **柔軟性**: さまざまなシナリオに合わせて設定を調整できます。
--   **シンプルな環境**: 追加の設定は不要で、互換性のある Node バージョンをインストールするだけですぐに使用できます。
+- **クイックセットアップ**: わずか数秒でローカルの WordPress 環境をセットアップできます。
+- **柔軟性**: さまざまなシナリオに合わせて設定を調整できます。
+- **シンプルな環境**: 追加の設定は不要で、互換性のある Node バージョンをインストールするだけですぐに使用できます。
 
 <!--
 -   **Quick Setup**: Set up a local WordPress environment in seconds.
@@ -38,10 +38,10 @@ Playground CLI supports auto-mounting a directory with a plugin, theme, or WordP
 ## Requirements
 -->
 
-Playground CLI を使用するには、Node.js 20.18 以降が必要です。これは推奨される長期サポート (LTS) バージョンです。[Node.js ウェブサイト](https://nodejs.org/en/download) からダウンロードできます。
+Playground CLI を使用するには、Node.js 22.12 以降が必要です。これは推奨される長期サポート (LTS) バージョンです。[Node.js ウェブサイト](https://nodejs.org/en/download) からダウンロードできます。
 
 <!--
-The Playground CLI requires Node.js 20.18 or higher, which is the recommended Long-Term Support (LTS) version. You can download it from the [Node.js website](https://nodejs.org/en/download).
+The Playground CLI requires Node.js 22.12 or higher, which is the recommended Long-Term Support (LTS) version. You can download it from the [Node.js website](https://nodejs.org/en/download).
 -->
 
 ## クイックスタート
@@ -185,9 +185,9 @@ Playground CLI is simple, configurable, and unopinionated. You can set it up acc
 to your unique WordPress setup. With the Playground CLI, you can use the following top-level commands:
 -->
 
--   **`server`**: (デフォルト) ローカルの WordPress サーバーを起動します。
--   **`run-blueprint`**: Web サーバーを起動せずに Blueprint ファイルを実行します。
--   **`build-snapshot`**: Blueprint に基づいて WordPress サイトの ZIP スナップショットを構築します。
+- **`server`**: (デフォルト) ローカルの WordPress サーバーを起動します。
+- **`run-blueprint`**: Web サーバーを起動せずに Blueprint ファイルを実行します。
+- **`build-snapshot`**: Blueprint に基づいて WordPress サイトの ZIP スナップショットを構築します。
 
 <!--
 -   **`server`**: (Default) Starts a local WordPress server.
@@ -201,21 +201,21 @@ to your unique WordPress setup. With the Playground CLI, you can use the followi
 The `server` command supports the following optional arguments:
 -->
 
--   `--port=<port>`: サーバーが listen するポート番号。デフォルトは 9400 です。
--   `--outfile`: ビルド時にこの出力ファイルに書き込みます。
--   `--wp=<version>`: 使用する WordPress のバージョン。デフォルトは最新です。
--   `--auto-mount`: 現在のディレクトリ (プラグイン、テーマ、wp-content など) を自動的にマウントします。
--   `--mount=<mapping>`: ディレクトリを手動でマウントします (複数回使用可能)。形式: `"/host/path:/vfs/path"`。
--   `--mount-before-install`: WordPress をインストールする前に、ディレクトリを PHP ランタイムにマウントします (複数回使用可能)。形式: `"/host/path:/vfs/path"`。
--   `--mount-dir`: ディレクトリを PHP ランタイムにマウントします (複数回使用可能)。フォーマット: `"/host/path"` `"/vfs/path"`
--   `--mount-dir-before-install`: WordPress をインストールする前にディレクトリをマウントします（複数回使用可能）。フォーマット: `"/host/path"` `"/vfs/path"`
--   `--blueprint=<path>`: 実行する JSON ブループリント ファイルへのパス。
--   `--blueprint-may-read-adjacent-files`: 同意フラグ: ローカル ブループリント内の「バンドル」リソースが、ブループリント ファイルと同じディレクトリにあるファイルを読み取ることを許可します。
--   `--login`: ユーザーを管理者として自動的にログインします。
--   `--wordpress-install-mode <mode>`: WordPress の準備方法を制御します。既定値は `download-and-install` です。他のオプション: `install-from-existing-files` (マウント済みのファイルを使ってインストール)、`install-from-existing-files-if-needed` (既存サイトを検出した場合はセットアップを省略) 、`do-not-attempt-installing` (WordPress をダウンロードもインストールもしません)。
--   `--skip-sqlite-setup`: SQLite データベース統合をセットアップしません。
--   `--verbosity`: ログと進捗メッセージを出力します。選択肢は「quiet」、「normal」、「debug」です。デフォルトは「normal」です。
--   `--debug`: 起動中にエラーが発生した場合、PHP のエラーログを出力します。
+- `--port=<port>`: サーバーが listen するポート番号。デフォルトは 9400 です。
+- `--outfile`: ビルド時にこの出力ファイルに書き込みます。
+- `--wp=<version>`: 使用する WordPress のバージョン。デフォルトは最新です。
+- `--auto-mount`: 現在のディレクトリ (プラグイン、テーマ、wp-content など) を自動的にマウントします。
+- `--mount=<mapping>`: ディレクトリを手動でマウントします (複数回使用可能)。形式: `"/host/path:/vfs/path"`。
+- `--mount-before-install`: WordPress をインストールする前に、ディレクトリを PHP ランタイムにマウントします (複数回使用可能)。形式: `"/host/path:/vfs/path"`。
+- `--mount-dir`: ディレクトリを PHP ランタイムにマウントします (複数回使用可能)。フォーマット: `"/host/path"` `"/vfs/path"`
+- `--mount-dir-before-install`: WordPress をインストールする前にディレクトリをマウントします（複数回使用可能）。フォーマット: `"/host/path"` `"/vfs/path"`
+- `--blueprint=<path>`: 実行する JSON ブループリント ファイルへのパス。
+- `--blueprint-may-read-adjacent-files`: 同意フラグ: ローカル ブループリント内の「バンドル」リソースが、ブループリント ファイルと同じディレクトリにあるファイルを読み取ることを許可します。
+- `--login`: ユーザーを管理者として自動的にログインします。
+- `--wordpress-install-mode <mode>`: WordPress の準備方法を制御します。既定値は `download-and-install` です。他のオプション: `install-from-existing-files` (マウント済みのファイルを使ってインストール)、`install-from-existing-files-if-needed` (既存サイトを検出した場合はセットアップを省略) 、`do-not-attempt-installing` (WordPress をダウンロードもインストールもしません)。
+- `--skip-sqlite-setup`: SQLite データベース統合をセットアップしません。
+- `--verbosity`: ログと進捗メッセージを出力します。選択肢は「quiet」、「normal」、「debug」です。デフォルトは「normal」です。
+- `--debug`: 起動中にエラーが発生した場合、PHP のエラーログを出力します。
 
 <!--
 -   `--port=<port>`: The port number for the server to listen on. Defaults to 9400.

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -70,10 +70,10 @@ The [Visual Studio Code Playground extension](https://marketplace.visualstudio.c
 #### Prerequisites
 -->
 
-`@wp-playground/cli` には Node.js 20.18 以降と NPM が必要です。まだインストールしていない場合は、始める前に両方を[ダウンロードしてインストール](https://nodejs.org/en/download)してください。
+`@wp-playground/cli` には Node.js 22.12 以降と NPM が必要です。まだインストールしていない場合は、始める前に両方を[ダウンロードしてインストール](https://nodejs.org/en/download)してください。
 
 <!--
-`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven’t yet, [download and install](https://nodejs.org/en/download) both before you begin.
+`@wp-playground/cli` requires Node.js 22.12 or newer and NPM. If you haven’t yet, [download and install](https://nodejs.org/en/download) both before you begin.
 -->
 
 参加する Make WordPress チームによっては、インストール済みのものとは異なるバージョンの Node.js が必要になる場合があります。Node Version Manager（NVM）を使用してバージョンを切り替えることができます。[インストールガイドはこちら](https://github.com/nvm-sh/nvm#installing-and-updating)。
@@ -234,9 +234,9 @@ You can translate supported WordPress Plugins by loading the plugin you want to 
 Have a question or an idea for a new feature? Found a bug? Something’s not working as expected? We’re here to help:
 -->
 
--   コントリビューター デイ 中は、**Playground テーブル** でご連絡ください。
--   [WordPress Playground GitHub リポジトリ](https://github.com/WordPress/wordpress-playground/issues/new) で Issue を開いてください。VS Code 拡張機能、NPM パッケージ、またはプラグインに関する問題の場合は、[Playground Tools リポジトリ](https://github.com/WordPress/playground-tools/issues/new) で Issue を開いてください。
--   [**#playground** Slack チャンネル](https://wordpress.slack.com/archives/C04EWKGDJ0K) でフィードバックを共有してください。
+- コントリビューター デイ 中は、**Playground テーブル** でご連絡ください。
+- [WordPress Playground GitHub リポジトリ](https://github.com/WordPress/wordpress-playground/issues/new) で Issue を開いてください。VS Code 拡張機能、NPM パッケージ、またはプラグインに関する問題の場合は、[Playground Tools リポジトリ](https://github.com/WordPress/playground-tools/issues/new) で Issue を開いてください。
+- [**#playground** Slack チャンネル](https://wordpress.slack.com/archives/C04EWKGDJ0K) でフィードバックを共有してください。
 
 <!--
 -   During Contributor Day, you can reach us at the **Playground table**.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -29,9 +29,9 @@ O Playground CLI suporta auto-montagem de um diretório com um plugin, tema ou i
 
 ## Requisitos
 
-<!-- The Playground CLI requires Node.js 20.18 or higher, which is the recommended Long-Term Support (LTS) version. You can download it from the [Node.js website](https://nodejs.org/en/download). -->
+<!-- The Playground CLI requires Node.js 22.12 or higher, which is the recommended Long-Term Support (LTS) version. You can download it from the [Node.js website](https://nodejs.org/en/download). -->
 
-O Playground CLI requer Node.js 20.18 ou superior, que é a versão recomendada de Suporte de Longo Prazo (LTS). Você pode baixá-la no [site do Node.js](https://nodejs.org/en/download).
+O Playground CLI requer Node.js 22.12 ou superior, que é a versão recomendada de Suporte de Longo Prazo (LTS). Você pode baixá-la no [site do Node.js](https://nodejs.org/en/download).
 
 <!-- ## Quickstart -->
 
@@ -201,8 +201,8 @@ A localização do banco de dados depende do que você montar:
 
 - **Auto-montagem de wp-content ou WordPress completo**:
 
-    <!-- -   Database: `<your-local-project>/wp-content/database/.ht.sqlite` -->
-    <!-- -   ✅ **Persisted locally** in your project folder -->
+      <!-- -   Database: `<your-local-project>/wp-content/database/.ht.sqlite` -->
+      <!-- -   ✅ **Persisted locally** in your project folder -->
     - Banco de dados: `<seu-projeto-local>/wp-content/database/.ht.sqlite`
     - ✅ **Persistido localmente** na pasta do seu projeto
 
@@ -210,8 +210,8 @@ A localização do banco de dados depende do que você montar:
 
 - **Auto-montagem apenas de plugin/tema**:
 
-    <!-- -   Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite` -->
-    <!-- -   ⚠️ **Lost when server stops** (temp directories are cleaned up) -->
+      <!-- -   Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite` -->
+      <!-- -   ⚠️ **Lost when server stops** (temp directories are cleaned up) -->
     - Banco de dados: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
     - ⚠️ **Perdido quando o servidor para** (diretórios temporários são limpos)
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/contributing/contributor-day.md
@@ -53,10 +53,10 @@ Esta seção descreve como você pode contribuir diretamente com o projeto WordP
 -   **Product Feedback:** Your insights are invaluable for improving the Playground experience. This includes general feedback on the web instance, the application, and any server-side tools.
 -->
 
--   **Documentação:** Melhore nossa documentação aprimorando o conteúdo existente, desenvolvendo novos guias ou traduzindo materiais para diferentes idiomas.
--   **Blueprints:** Crie demonstrações de plugins para os plugins no repositório de Plugins do WordPress, ou desenvolva novos Blueprints para enriquecer nossa documentação do projeto.
--   **Testes do ambiente Playground:** Participe dos testes do próprio projeto WordPress Playground. Você pode fazer isso criando cuidadosamente novos issues que descrevam os problemas que você encontrou e sugerindo soluções práticas. Teste nossa instância web do WordPress (o site playground.wordpress.net), ou explore os vários aplicativos alimentados pelo Playground. Teste essas ferramentas, observe sua funcionalidade e forneça feedback detalhado.
--   **Feedback do produto:** Suas ideias são inestimáveis para melhorar a experiência do Playground. Isso inclui feedback geral sobre a instância web, o aplicativo e quaisquer ferramentas do lado do servidor.
+- **Documentação:** Melhore nossa documentação aprimorando o conteúdo existente, desenvolvendo novos guias ou traduzindo materiais para diferentes idiomas.
+- **Blueprints:** Crie demonstrações de plugins para os plugins no repositório de Plugins do WordPress, ou desenvolva novos Blueprints para enriquecer nossa documentação do projeto.
+- **Testes do ambiente Playground:** Participe dos testes do próprio projeto WordPress Playground. Você pode fazer isso criando cuidadosamente novos issues que descrevam os problemas que você encontrou e sugerindo soluções práticas. Teste nossa instância web do WordPress (o site playground.wordpress.net), ou explore os vários aplicativos alimentados pelo Playground. Teste essas ferramentas, observe sua funcionalidade e forneça feedback detalhado.
+- **Feedback do produto:** Suas ideias são inestimáveis para melhorar a experiência do Playground. Isso inclui feedback geral sobre a instância web, o aplicativo e quaisquer ferramentas do lado do servidor.
 
 <!--
 All feedback, including reported issues and test results, can be submitted through our GitHub repository.
@@ -155,10 +155,10 @@ A [extensão Playground para Visual Studio Code](https://marketplace.visualstudi
 #### Pré-requisitos
 
 <!--
-`@wp-playground/cli` requires Node.js 20.18 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
+`@wp-playground/cli` requires Node.js 22.12 or newer and NPM. If you haven't yet, [download and install](https://nodejs.org/en/download) both before you begin.
 -->
 
-`@wp-playground/cli` requer Node.js 20.18 ou mais recente e NPM. Se você ainda não fez isso, [baixe e instale](https://nodejs.org/en/download) ambos antes de começar.
+`@wp-playground/cli` requer Node.js 22.12 ou mais recente e NPM. Se você ainda não fez isso, [baixe e instale](https://nodejs.org/en/download) ambos antes de começar.
 
 <!--
 Depending on the Make WordPress team you contribute to, you may need a different Node.js version than the one you have installed. You can use Node Version Manager (NVM) to switch between versions. [Find the installation guide here](https://github.com/nvm-sh/nvm#installing-and-updating).
@@ -324,6 +324,6 @@ Tem uma pergunta ou uma ideia para um novo recurso? Encontrou um bug? Algo não 
 -   Share your feedback on the [**#playground** Slack channel](https://wordpress.slack.com/archives/C04EWKGDJ0K).
 -->
 
--   Durante o Dia do Contribuidor, você pode nos encontrar na **mesa do Playground**.
--   Abra um issue no [repositório GitHub do WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se seu foco é a extensão VS Code, pacote NPM ou os plugins, abra um issue no [repositório Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
--   Compartilhe seu feedback no [canal Slack **#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).
+- Durante o Dia do Contribuidor, você pode nos encontrar na **mesa do Playground**.
+- Abra um issue no [repositório GitHub do WordPress Playground](https://github.com/WordPress/wordpress-playground/issues/new). Se seu foco é a extensão VS Code, pacote NPM ou os plugins, abra um issue no [repositório Playground Tools](https://github.com/WordPress/playground-tools/issues/new).
+- Compartilhe seu feedback no [canal Slack **#playground**](https://wordpress.slack.com/archives/C04EWKGDJ0K).


### PR DESCRIPTION
This pull request updates the documentation for the Playground CLI and contributing guides across multiple languages to require Node.js version 22.12 or newer (previously 20.18 or newer). This ensures consistency and clarity about the minimum Node.js version needed for development and contribution.

**Documentation updates for Node.js version requirements:**

* Updated the required Node.js version for the Playground CLI from 20.18 to 22.12 in the main English documentation (`04-wp-playground-cli.md`) and its translations in Spanish, Japanese, and Brazilian Portuguese.
* Updated the Node.js version requirement in contributor guides for English, Bengali, Spanish, Gujarati, Italian, Japanese, and Brazilian Portuguese, ensuring all mention Node.js 22.12 or newer. 

**Minor formatting corrections:**

* Fixed code block formatting in the Spanish contributor guide for proper display of bash commands. 