### PR TITLE
Update NPM packages with vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
 				"crc-32": "1.2.2",
 				"diff3": "0.0.4",
 				"express": "4.22.0",
-				"fast-xml-parser": "5.3.0",
+				"fast-xml-parser": "^5.3.4",
 				"file-saver": "^2.0.5",
 				"fs-extra": "11.1.1",
 				"ini": "4.1.2",
@@ -159,167 +159,58 @@
 				"fs-ext": "2.1.1"
 			}
 		},
-		"node_modules/@ai-sdk/gateway": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.27.tgz",
-			"integrity": "sha512-8hbezMsGa0crSt7/DKjkYL1UbbJJW/UFxTfhmf5qcIeYeeWG4dTNmm+DWbUdIsTaWvp59KC4eeC9gYXBbTHd7w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "2.0.1",
-				"@ai-sdk/provider-utils": "3.0.20",
-				"@vercel/oidc": "3.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
-		"node_modules/@ai-sdk/provider": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz",
-			"integrity": "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"json-schema": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@ai-sdk/provider-utils": {
-			"version": "3.0.20",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.20.tgz",
-			"integrity": "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "2.0.1",
-				"@standard-schema/spec": "^1.0.0",
-				"eventsource-parser": "^3.0.6"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
-		"node_modules/@ai-sdk/react": {
-			"version": "2.0.123",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-2.0.123.tgz",
-			"integrity": "sha512-exaEvHAsDdR0wgzF3l0BmC9U1nPLnkPK2CCnX3BP4RDj/PySZvPXjry3AOz1Ayb8KSPZgWklVRzxsQxrOYQJxA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider-utils": "3.0.20",
-				"ai": "5.0.121",
-				"swr": "^2.2.5",
-				"throttleit": "2.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1",
-				"zod": "^3.25.76 || ^4.1.8"
-			},
-			"peerDependenciesMeta": {
-				"zod": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@algolia/abtesting": {
-			"version": "1.12.3",
-			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.12.3.tgz",
-			"integrity": "sha512-0SpSdnME0RCS6UHSs9XD3ox4bMcCg1JTmjAJ3AU6rcTlX54CZOAEPc2as8uSghX6wfKGT0HWes4TeUpjJMg6FQ==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.13.0.tgz",
+			"integrity": "sha512-Zrqam12iorp3FjiKMXSTpedGYznZ3hTEOAr2oCxI8tbF8bS1kQHClyDYNq/eV0ewMNLyFkgZVWjaS+8spsOYiQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
-		"node_modules/@algolia/autocomplete-core": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.19.2.tgz",
-			"integrity": "sha512-mKv7RyuAzXvwmq+0XRK8HqZXt9iZ5Kkm2huLjgn5JoCPtDy+oh9yxUMfDDaVCw0oyzZ1isdJBc7l9nuCyyR7Nw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/autocomplete-plugin-algolia-insights": "1.19.2",
-				"@algolia/autocomplete-shared": "1.19.2"
-			}
-		},
-		"node_modules/@algolia/autocomplete-plugin-algolia-insights": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.19.2.tgz",
-			"integrity": "sha512-TjxbcC/r4vwmnZaPwrHtkXNeqvlpdyR+oR9Wi2XyfORkiGkLTVhX2j+O9SaCCINbKoDfc+c2PB8NjfOnz7+oKg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@algolia/autocomplete-shared": "1.19.2"
-			},
-			"peerDependencies": {
-				"search-insights": ">= 1 < 3"
-			}
-		},
-		"node_modules/@algolia/autocomplete-shared": {
-			"version": "1.19.2",
-			"resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.19.2.tgz",
-			"integrity": "sha512-jEazxZTVD2nLrC+wYlVHQgpBoBB5KPStrJxLzsIFl6Kqd1AlG9sIAGl39V5tECLpIQzB3Qa2T6ZPJ1ChkwMK/w==",
-			"dev": true,
-			"license": "MIT",
-			"peerDependencies": {
-				"@algolia/client-search": ">= 4.9.1 < 6",
-				"algoliasearch": ">= 4.9.1 < 6"
-			}
-		},
 		"node_modules/@algolia/client-abtesting": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.46.3.tgz",
-			"integrity": "sha512-i2C8sBcl3EKXuCd5nlGohW+pZ9pY3P3JKJ2OYqsbCPg6wURiR32hNDiDvDq7/dqJ7KWWwC2snxJhokZzGlckgQ==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.47.0.tgz",
+			"integrity": "sha512-aOpsdlgS9xTEvz47+nXmw8m0NtUiQbvGWNuSEb7fA46iPL5FxOmOUZkh8PREBJpZ0/H8fclSc7BMJCVr+Dn72w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-analytics": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.46.3.tgz",
-			"integrity": "sha512-uFmD7m3LOym1SAURHeiqupHT9jui+9HK0lAiIvm077gXEscOM5KKXM4rg/ICzQ3UDHLZEA0Lb5TglWsXnieE6w==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.47.0.tgz",
+			"integrity": "sha512-EcF4w7IvIk1sowrO7Pdy4Ako7x/S8+nuCgdk6En+u5jsaNQM4rTT09zjBPA+WQphXkA2mLrsMwge96rf6i7Mow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-common": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.46.3.tgz",
-			"integrity": "sha512-SN+yK840nXa+2+mF72hrDfGd8+B7eBjF8TK/8KoRMdjlAkO/P3o3vtpjKRKI/Sk4L8kYYkB/avW8l+cwR+O1Ew==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.47.0.tgz",
+			"integrity": "sha512-Wzg5Me2FqgRDj0lFuPWFK05UOWccSMsIBL2YqmTmaOzxVlLZ+oUqvKbsUSOE5ud8Fo1JU7JyiLmEXBtgDKzTwg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -327,64 +218,64 @@
 			}
 		},
 		"node_modules/@algolia/client-insights": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.46.3.tgz",
-			"integrity": "sha512-5ic1liG0VucNPi6gKCWh5bEUGWQfyEmVeXiNKS+rOSppg7B7nKH0PEEJOFXBbHmgK5aPfNNZINiKcyUoH4XsFA==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.47.0.tgz",
+			"integrity": "sha512-Ci+cn/FDIsDxSKMRBEiyKrqybblbk8xugo6ujDN1GSTv9RIZxwxqZYuHfdLnLEwLlX7GB8pqVyqrUSlRnR+sJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-personalization": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.46.3.tgz",
-			"integrity": "sha512-f4HNitgTip8tntKgluYBTc1LWSOkbNCdxZvRA3rRBZnEAYSvLe7jpE+AxRep6RY+prSWwMtyeCFhA/F1Um+TuQ==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.47.0.tgz",
+			"integrity": "sha512-gsLnHPZmWcX0T3IigkDL2imCNtsQ7dR5xfnwiFsb+uTHCuYQt+IwSNjsd8tok6HLGLzZrliSaXtB5mfGBtYZvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-query-suggestions": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.46.3.tgz",
-			"integrity": "sha512-/AaVqah2aYyJj7Cazu5QRkgcV3HF3lkBJo5TRkgqQ26xR4iHNRbLF2YsWJfJpJEFghlTF2HOCh7IgzaUCnM+8A==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.47.0.tgz",
+			"integrity": "sha512-PDOw0s8WSlR2fWFjPQldEpmm/gAoUgLigvC3k/jCSi/DzigdGX6RdC0Gh1RR1P8Cbk5KOWYDuL3TNzdYwkfDyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/client-search": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.46.3.tgz",
-			"integrity": "sha512-hfpCIukPuwkrlwsYfJEWdU5R5bduBHEq2uuPcqmgPgNq5MSjmiNIzRuzxGZZgiBKcre6gZT00DR7G1AFn//wiQ==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.47.0.tgz",
+			"integrity": "sha512-b5hlU69CuhnS2Rqgsz7uSW0t4VqrLMLTPbUpEl0QVz56rsSwr1Sugyogrjb493sWDA+XU1FU5m9eB8uH7MoI0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -398,87 +289,87 @@
 			"license": "MIT"
 		},
 		"node_modules/@algolia/ingestion": {
-			"version": "1.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.46.3.tgz",
-			"integrity": "sha512-ChVzNkCzAVxKozTnTgPWCG69WQLjzW7X6OqD91zUh8U38ZhPEX/t3qGhXs+M9ZNaHcJ7xToMB3jywNwONhpLGA==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.47.0.tgz",
+			"integrity": "sha512-WvwwXp5+LqIGISK3zHRApLT1xkuEk320/EGeD7uYy+K8WwDd5OjXnhjuXRhYr1685KnkvWkq1rQ/ihCJjOfHpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/monitoring": {
-			"version": "1.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.46.3.tgz",
-			"integrity": "sha512-MZa+Z5iPmVMxVAQ0aq4HpGsja5utSLEMcOuY01X8D46vvMrSPkP8DnlDFtu1PgJ0RwyIGqqx7v+ClFo6iRJ6bA==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.47.0.tgz",
+			"integrity": "sha512-j2EUFKAlzM0TE4GRfkDE3IDfkVeJdcbBANWzK16Tb3RHz87WuDfQ9oeEW6XiRE1/bEkq2xf4MvZesvSeQrZRDA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/recommend": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.46.3.tgz",
-			"integrity": "sha512-cr3atJRJBKgAKZl/Oxo4sig6Se0+ukbyIOOluPV5H+ZAXVcxuMoXQgwQ1M5UHPnCnEsZ4uBXhBmilRgUQpUegw==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.47.0.tgz",
+			"integrity": "sha512-+kTSE4aQ1ARj2feXyN+DMq0CIDHJwZw1kpxIunedkmpWUg8k3TzFwWsMCzJVkF2nu1UcFbl7xsIURz3Q3XwOXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/client-common": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-browser-xhr": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.46.3.tgz",
-			"integrity": "sha512-/Ku9GImJf2SKoRM2S3e03MjCVaWJCP5olih4k54DRhNDdmxBkd3nsWuUXvDElY3Ucw/arBYGs5SYz79SoS5APw==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.47.0.tgz",
+			"integrity": "sha512-Ja+zPoeSA2SDowPwCNRbm5Q2mzDvVV8oqxCQ4m6SNmbKmPlCfe30zPfrt9ho3kBHnsg37pGucwOedRIOIklCHw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3"
+				"@algolia/client-common": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-fetch": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.46.3.tgz",
-			"integrity": "sha512-Uw+SPy/zpfwbH1AxQaeOWvWVzPEcO0XbtLbbSz0HPcEIiBGWyfa9LUCxD5UferbDjrSQNVimmzl3FaWi4u8Ykw==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.47.0.tgz",
+			"integrity": "sha512-N6nOvLbaR4Ge+oVm7T4W/ea1PqcSbsHR4O58FJ31XtZjFPtOyxmnhgCmGCzP9hsJI6+x0yxJjkW5BMK/XI8OvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3"
+				"@algolia/client-common": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
 			}
 		},
 		"node_modules/@algolia/requester-node-http": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.46.3.tgz",
-			"integrity": "sha512-4No9iTjr1GZ0JWsFbQJj9aZBnmKyY1sTxOoEud9+SGe3U6iAulF0A0lI4cWi/F/Gcfg8V3jkaddcqSQKDnE45w==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.47.0.tgz",
+			"integrity": "sha512-z1oyLq5/UVkohVXNDEY70mJbT/sv/t6HYtCvCwNrOri6pxBJDomP9R83KOlwcat+xqBQEdJHjbrPh36f1avmZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/client-common": "5.46.3"
+				"@algolia/client-common": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -523,9 +414,9 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
-			"integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.28.5",
@@ -537,29 +428,29 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
-			"integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
-			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/generator": "^7.28.6",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
 				"@babel/helper-compilation-targets": "^7.28.6",
 				"@babel/helper-module-transforms": "^7.28.6",
 				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.28.6",
+				"@babel/parser": "^7.29.0",
 				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -585,13 +476,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
-			"integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
+			"integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -694,16 +585,16 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
-			"integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.6.tgz",
+			"integrity": "sha512-mOAsxeeKkUKayvZR3HeTYD/fICpCPLJrU5ZjelT/PA6WHtNDBOE436YiaEUvHN454bRM3CebhDsIpieCc4texA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"debug": "^4.4.1",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"debug": "^4.4.3",
 				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.22.10"
+				"resolve": "^1.22.11"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -904,12 +795,12 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
-			"integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.6"
+				"@babel/types": "^7.29.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -998,9 +889,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-decorators": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.28.6.tgz",
-			"integrity": "sha512-RVdFPPyY9fCRAX68haPmOk2iyKW8PKJFthmm8NeSI3paNxKWGZIn99+VbIf0FrtCpFnPgnpF/L48tadi617ULg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.0.tgz",
+			"integrity": "sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1338,14 +1229,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.6.tgz",
-			"integrity": "sha512-9knsChgsMzBV5Yh3kkhrZNxH3oCYAfMBkNNaVN4cP2RVlFPe8wYdwwcnOsAbkdDoV9UjFtOXWrWB52M8W4jNeA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+			"integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-remap-async-to-generator": "^7.27.1",
-				"@babel/traverse": "^7.28.6"
+				"@babel/traverse": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1517,9 +1408,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.28.6.tgz",
-			"integrity": "sha512-5suVoXjC14lUN6ZL9OLKIHCNVWCrqGqlmEp/ixdXjvgnEl/kauLvvMO/Xw9NyMc95Joj1AeLVPVMvibBgSoFlA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+			"integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
@@ -1719,15 +1610,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz",
-			"integrity": "sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+			"integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.28.3",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.5"
+				"@babel/traverse": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1753,13 +1644,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-			"integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+			"integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2056,9 +1947,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.6.tgz",
-			"integrity": "sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+			"integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.28.6"
@@ -2102,13 +1993,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-runtime": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.28.5.tgz",
-			"integrity": "sha512-20NUVgOrinudkIBzQ2bNxP08YpKprUkRTiRSd2/Z5GOdPImJGkoN4Z7IQe1T5AdyKI1i5L6RBmluqdSzvaq9/w==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.29.0.tgz",
+			"integrity": "sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"babel-plugin-polyfill-corejs2": "^0.4.14",
 				"babel-plugin-polyfill-corejs3": "^0.13.0",
 				"babel-plugin-polyfill-regenerator": "^0.6.5",
@@ -2289,12 +2180,12 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.6.tgz",
-			"integrity": "sha512-GaTI4nXDrs7l0qaJ6Rg06dtOXTBCG6TMDB44zbqofCIC4PqC7SEvmFFtpxzCDw9W5aJ7RKVshgXTLvLdBFV/qw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
+			"integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
+				"@babel/compat-data": "^7.29.0",
 				"@babel/helper-compilation-targets": "^7.28.6",
 				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
@@ -2308,7 +2199,7 @@
 				"@babel/plugin-syntax-import-attributes": "^7.28.6",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.27.1",
-				"@babel/plugin-transform-async-generator-functions": "^7.28.6",
+				"@babel/plugin-transform-async-generator-functions": "^7.29.0",
 				"@babel/plugin-transform-async-to-generator": "^7.28.6",
 				"@babel/plugin-transform-block-scoped-functions": "^7.27.1",
 				"@babel/plugin-transform-block-scoping": "^7.28.6",
@@ -2319,7 +2210,7 @@
 				"@babel/plugin-transform-destructuring": "^7.28.5",
 				"@babel/plugin-transform-dotall-regex": "^7.28.6",
 				"@babel/plugin-transform-duplicate-keys": "^7.27.1",
-				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.28.6",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
 				"@babel/plugin-transform-dynamic-import": "^7.27.1",
 				"@babel/plugin-transform-explicit-resource-management": "^7.28.6",
 				"@babel/plugin-transform-exponentiation-operator": "^7.28.6",
@@ -2332,9 +2223,9 @@
 				"@babel/plugin-transform-member-expression-literals": "^7.27.1",
 				"@babel/plugin-transform-modules-amd": "^7.27.1",
 				"@babel/plugin-transform-modules-commonjs": "^7.28.6",
-				"@babel/plugin-transform-modules-systemjs": "^7.28.5",
+				"@babel/plugin-transform-modules-systemjs": "^7.29.0",
 				"@babel/plugin-transform-modules-umd": "^7.27.1",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
 				"@babel/plugin-transform-new-target": "^7.27.1",
 				"@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
 				"@babel/plugin-transform-numeric-separator": "^7.28.6",
@@ -2346,7 +2237,7 @@
 				"@babel/plugin-transform-private-methods": "^7.28.6",
 				"@babel/plugin-transform-private-property-in-object": "^7.28.6",
 				"@babel/plugin-transform-property-literals": "^7.27.1",
-				"@babel/plugin-transform-regenerator": "^7.28.6",
+				"@babel/plugin-transform-regenerator": "^7.29.0",
 				"@babel/plugin-transform-regexp-modifiers": "^7.28.6",
 				"@babel/plugin-transform-reserved-words": "^7.27.1",
 				"@babel/plugin-transform-shorthand-properties": "^7.27.1",
@@ -2359,10 +2250,10 @@
 				"@babel/plugin-transform-unicode-regex": "^7.27.1",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.14",
-				"babel-plugin-polyfill-corejs3": "^0.13.0",
-				"babel-plugin-polyfill-regenerator": "^0.6.5",
-				"core-js-compat": "^3.43.0",
+				"babel-plugin-polyfill-corejs2": "^0.4.15",
+				"babel-plugin-polyfill-corejs3": "^0.14.0",
+				"babel-plugin-polyfill-regenerator": "^0.6.6",
+				"core-js-compat": "^3.48.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -2370,6 +2261,19 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "0.14.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.0.tgz",
+			"integrity": "sha512-AvDcMxJ34W4Wgy4KBIIePQTAOP1Ie2WFwkQp3dB7FQ/f0lI5+nM96zUnYEOE1P9sEg0es5VCP0HxiWu5fUHZAQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.6.6",
+				"core-js-compat": "^3.48.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/@babel/preset-env/node_modules/semver": {
@@ -2444,12 +2348,12 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
-			"integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.0.tgz",
+			"integrity": "sha512-TgUkdp71C9pIbBcHudc+gXZnihEDOjUAmXO1VO4HHGES7QLZcShR0stfKIxLSNIYx2fqhmJChOjm/wkF8wv4gA==",
 			"license": "MIT",
 			"dependencies": {
-				"core-js-pure": "^3.43.0"
+				"core-js-pure": "^3.48.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2470,17 +2374,17 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
-			"integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/generator": "^7.28.6",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.6",
+				"@babel/parser": "^7.29.0",
 				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.28.6",
+				"@babel/types": "^7.29.0",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -2488,9 +2392,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
-			"integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -2643,9 +2547,9 @@
 			}
 		},
 		"node_modules/@codemirror/lint": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
-			"integrity": "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==",
+			"version": "6.9.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.3.tgz",
+			"integrity": "sha512-y3YkYhdnhjDBAe0VIA0c4wVoFOvnp8CnAvfLqi0TqotIv92wIlAAP7HELOpLBsKwjAX6W92rSflA6an/2zBvXw==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -4132,9 +4036,9 @@
 			}
 		},
 		"node_modules/@docsearch/core": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.4.0.tgz",
-			"integrity": "sha512-kiwNo5KEndOnrf5Kq/e5+D9NBMCFgNsDoRpKQJ9o/xnSlheh6b8AXppMuuUVVdAUIhIfQFk/07VLjjk/fYyKmw==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.5.3.tgz",
+			"integrity": "sha512-x/P5+HVzv9ALtbuJIfpkF8Eyc5RE8YCsFcOgLrrtWa9Ui+53ggZA5seIAanCRORbS4+m982lu7rZmebSiuMIcw==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -4155,27 +4059,21 @@
 			}
 		},
 		"node_modules/@docsearch/css": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.4.0.tgz",
-			"integrity": "sha512-e9vPgtih6fkawakmYo0Y6V4BKBmDV7Ykudn7ADWXUs5b6pmtBRwDbpSG/WiaUG63G28OkJDEnsMvgIAnZgGwYw==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.5.3.tgz",
+			"integrity": "sha512-kUpHaxn0AgI3LQfyzTYkNUuaFY4uEz/Ym9/N/FvyDE+PzSgZsCyDH9jE49B6N6f1eLCm9Yp64J9wENd6vypdxA==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@docsearch/react": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.4.0.tgz",
-			"integrity": "sha512-z12zeg1mV7WD4Ag4pKSuGukETJLaucVFwszDXL/qLaEgRqxEaVacO9SR1qqnCXvZztlvz2rt7cMqryi/7sKfjA==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.5.3.tgz",
+			"integrity": "sha512-Hm3Lg/FD9HXV57WshhWOHOprbcObF5ptLzcjA5zdgJDzYOMwEN+AvY8heQ5YMTWyC6kW2d+Qk25AVlHnDWMSvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ai-sdk/react": "^2.0.30",
-				"@algolia/autocomplete-core": "1.19.2",
-				"@docsearch/core": "4.4.0",
-				"@docsearch/css": "4.4.0",
-				"ai": "^5.0.30",
-				"algoliasearch": "^5.28.0",
-				"marked": "^16.3.0",
-				"zod": "^4.1.8"
+				"@docsearch/core": "4.5.3",
+				"@docsearch/css": "4.5.3"
 			},
 			"peerDependencies": {
 				"@types/react": ">= 16.8.0 < 20.0.0",
@@ -6048,31 +5946,31 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-			"integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+			"integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/utils": "^0.2.10"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-			"integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+			"version": "1.7.5",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+			"integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.3",
+				"@floating-ui/core": "^1.7.4",
 				"@floating-ui/utils": "^0.2.10"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-			"integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+			"integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/dom": "^1.7.4"
+				"@floating-ui/dom": "^1.7.5"
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0",
@@ -6219,9 +6117,9 @@
 			}
 		},
 		"node_modules/@isaacs/brace-expansion": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+			"integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6229,53 +6127,6 @@
 			},
 			"engines": {
 				"node": "20 || >=22"
-			}
-		},
-		"node_modules/@isaacs/cliui": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^5.1.2",
-				"string-width-cjs": "npm:string-width@^4.2.0",
-				"strip-ansi": "^7.0.1",
-				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-				"wrap-ansi": "^8.1.0",
-				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-			"integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -6657,17 +6508,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/@jest/reporters/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/@jest/reporters/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -6683,41 +6523,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@jest/reporters/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/@jest/reporters/node_modules/supports-color": {
@@ -6997,9 +6802,9 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/buffers": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
-			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"version": "17.65.0",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.65.0.tgz",
+			"integrity": "sha512-eBrIXd0/Ld3p9lpDDlMaMn6IEfWqtHMD+z61u0JrIiPzsV1r7m6xDZFRxJyvIFTEO+SWdYF9EiQbXZGd8BzPfA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.0"
@@ -7029,13 +6834,13 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-core": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.2.tgz",
-			"integrity": "sha512-5s3t0Lj/gDgPhhXEdSe9yNDB07iMrpIXN9OV9FTiwlLKP3EBFhsbOhhMMVoWuSJkPxaaiOFUpZcyZcKi7mOmUQ==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.10.tgz",
+			"integrity": "sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-builtins": "4.56.2",
-				"@jsonjoy.com/fs-node-utils": "4.56.2",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
 				"thingies": "^2.5.0"
 			},
 			"engines": {
@@ -7050,14 +6855,14 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-fsa": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.2.tgz",
-			"integrity": "sha512-2lN4rdhcjFBf2Oji0rHR1aS+fW+GA0l9o9gXCMWFoC+YXqRO4N4xkSeJwm6a10SMuqlhoseCWRWlhaDYiNiI2A==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.10.tgz",
+			"integrity": "sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.2",
-				"@jsonjoy.com/fs-node-builtins": "4.56.2",
-				"@jsonjoy.com/fs-node-utils": "4.56.2",
+				"@jsonjoy.com/fs-core": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
 				"thingies": "^2.5.0"
 			},
 			"engines": {
@@ -7072,15 +6877,16 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.2.tgz",
-			"integrity": "sha512-Ws4cwm9UQY0noP/Ee2KpPf2zJJukJywjTIl3lBTH/AdH7r5n5CyGPLgySxpAa7/isV0WD02bYV+XKhslF/Dtbg==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.10.tgz",
+			"integrity": "sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.2",
-				"@jsonjoy.com/fs-node-builtins": "4.56.2",
-				"@jsonjoy.com/fs-node-utils": "4.56.2",
-				"@jsonjoy.com/fs-print": "4.56.2",
+				"@jsonjoy.com/fs-core": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-print": "4.56.10",
+				"@jsonjoy.com/fs-snapshot": "4.56.10",
 				"glob-to-regex.js": "^1.0.0",
 				"thingies": "^2.5.0"
 			},
@@ -7096,9 +6902,9 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-builtins": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.2.tgz",
-			"integrity": "sha512-TB8rFES/4lygIudoTHSGp2fjHe7R229VRQ4IQCMds6uTKhBKuDLZAqOUBiS3hosfxTVrB/JpDrr46MvCSjPzog==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.10.tgz",
+			"integrity": "sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.0"
@@ -7112,14 +6918,14 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-to-fsa": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.2.tgz",
-			"integrity": "sha512-Es62G93ychdl0VhQKVTIPq31QWabXveTEVJfi3gC/AIiehnXV3AMl38TWXLCS4fomBz5EaLqNhMkV7u/oW1p6g==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.10.tgz",
+			"integrity": "sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-fsa": "4.56.2",
-				"@jsonjoy.com/fs-node-builtins": "4.56.2",
-				"@jsonjoy.com/fs-node-utils": "4.56.2"
+				"@jsonjoy.com/fs-fsa": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -7133,12 +6939,12 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-node-utils": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.2.tgz",
-			"integrity": "sha512-CIUSlhbnws7b9f3Z2r963/lSA+VLPJlJcy8fqjQ9lk1Z1y6Ca9qj2CWXlABkvDZE7sDX+6PEdEU1PsXlfkZVbg==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.10.tgz",
+			"integrity": "sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-builtins": "4.56.2"
+				"@jsonjoy.com/fs-node-builtins": "4.56.10"
 			},
 			"engines": {
 				"node": ">=10.0"
@@ -7152,12 +6958,12 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-print": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.2.tgz",
-			"integrity": "sha512-7e4hmCrfERuqdNu1shsj140F4uS4h8orBULhlXQJ0F3sT4lnCuWe32rwxAa8xPutb99jKpHcsxM76TaFzFgQTA==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.10.tgz",
+			"integrity": "sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-utils": "4.56.2",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
 				"tree-dump": "^1.1.0"
 			},
 			"engines": {
@@ -7172,12 +6978,13 @@
 			}
 		},
 		"node_modules/@jsonjoy.com/fs-snapshot": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.2.tgz",
-			"integrity": "sha512-Qh0lc8Ujnb2b1D4RQ7CD+BOzqzw2aUpJPIK9SDv+y9LTy3lZ/ydPU7m6qBIH2ePhBKZuBIyVwxOWSvHRaasETQ==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.10.tgz",
+			"integrity": "sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-node-utils": "4.56.2",
+				"@jsonjoy.com/buffers": "^17.65.0",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
 				"@jsonjoy.com/json-pack": "^17.65.0",
 				"@jsonjoy.com/util": "^17.65.0"
 			},
@@ -7196,22 +7003,6 @@
 			"version": "17.65.0",
 			"resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.65.0.tgz",
 			"integrity": "sha512-Xrh7Fm/M0QAYpekSgmskdZYnFdSGnsxJ/tHaolA4bNwWdG9i65S8m83Meh7FOxyJyQAdo4d4J97NOomBLEfkDQ==",
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=10.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/streamich"
-			},
-			"peerDependencies": {
-				"tslib": "2"
-			}
-		},
-		"node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/buffers": {
-			"version": "17.65.0",
-			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.65.0.tgz",
-			"integrity": "sha512-eBrIXd0/Ld3p9lpDDlMaMn6IEfWqtHMD+z61u0JrIiPzsV1r7m6xDZFRxJyvIFTEO+SWdYF9EiQbXZGd8BzPfA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.0"
@@ -7331,6 +7122,22 @@
 				"tslib": "2"
 			}
 		},
+		"node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
 		"node_modules/@jsonjoy.com/json-pointer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
@@ -7360,6 +7167,22 @@
 				"@jsonjoy.com/buffers": "^1.0.0",
 				"@jsonjoy.com/codegen": "^1.0.0"
 			},
+			"engines": {
+				"node": ">=10.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/streamich"
+			},
+			"peerDependencies": {
+				"tslib": "2"
+			}
+		},
+		"node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+			"integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.0"
 			},
@@ -7552,9 +7375,9 @@
 			}
 		},
 		"node_modules/@lezer/common": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.0.tgz",
-			"integrity": "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.1.tgz",
+			"integrity": "sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==",
 			"license": "MIT"
 		},
 		"node_modules/@lezer/css": {
@@ -7611,9 +7434,9 @@
 			}
 		},
 		"node_modules/@lezer/lr": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.7.tgz",
-			"integrity": "sha512-wNIFWdSUfX9Jc6ePMzxSPVgTVB4EOfDIwLQLWASyiUdHKaMsiilj9bYiGkGQCKVodd0x6bgQCV207PILGFCF9Q==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+			"integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.0.0"
@@ -7701,9 +7524,9 @@
 			}
 		},
 		"node_modules/@microsoft/api-extractor": {
-			"version": "7.55.2",
-			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.55.2.tgz",
-			"integrity": "sha512-1jlWO4qmgqYoVUcyh+oXYRztZde/pAi7cSVzBz/rc+S7CoVzDasy8QE13dx6sLG4VRo8SfkkLbFORR6tBw4uGQ==",
+			"version": "7.56.0",
+			"resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.56.0.tgz",
+			"integrity": "sha512-H0V69QG5jIb9Ayx35NVBv2lOgFSS3q+Eab2oyGEy0POL3ovYPST+rCNPbwYoczOZXNG8IKjWUmmAMxmDTsXlQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7712,8 +7535,8 @@
 				"@microsoft/tsdoc-config": "~0.18.0",
 				"@rushstack/node-core-library": "5.19.1",
 				"@rushstack/rig-package": "0.6.0",
-				"@rushstack/terminal": "0.19.5",
-				"@rushstack/ts-command-line": "5.1.5",
+				"@rushstack/terminal": "0.21.0",
+				"@rushstack/ts-command-line": "5.1.7",
 				"diff": "~8.0.2",
 				"lodash": "~4.17.15",
 				"minimatch": "10.0.3",
@@ -8376,52 +8199,6 @@
 			},
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-			}
-		},
-		"node_modules/@npmcli/move-file/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@npmcli/move-file/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@npmcli/move-file/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/@npmcli/move-file/node_modules/rimraf": {
@@ -10805,16 +10582,6 @@
 				"@octokit/openapi-types": "^24.2.0"
 			}
 		},
-		"node_modules/@opentelemetry/api": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
 		"node_modules/@parcel/watcher": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.0.4.tgz",
@@ -11314,17 +11081,6 @@
 			"resolved": "packages/php-wasm/xdebug-bridge",
 			"link": true
 		},
-		"node_modules/@pkgjs/parseargs": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-			"integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=14"
-			}
-		},
 		"node_modules/@playwright/test": {
 			"version": "1.55.1",
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
@@ -11389,9 +11145,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.12.1",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.12.1.tgz",
-			"integrity": "sha512-BwbTXpj+9QutoZLQvbttRg5x3l5468qaV2kufh+51yha1c53ep5dY4kTuZR35+3pAZxpfQerGJiQqg34ZNZ6uA==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
+			"integrity": "sha512-slT6XeTCAbdql61GVLlGU4x7XHI7kCZV5Um5uhE4zLX4ApgiiXc0UYFvVOKq06xcovzp7p+61l68oPi563ARKg==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -11980,13 +11736,6 @@
 				}
 			}
 		},
-		"node_modules/@rolldown/pluginutils": {
-			"version": "1.0.0-beta.53",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
-			"integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
@@ -12031,9 +11780,9 @@
 			}
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.2.tgz",
-			"integrity": "sha512-21J6xzayjy3O6NdnlO6aXi/urvSRjm6nCI6+nF6ra2YofKruGixN9kfT+dt55HVNwfDmpDHJcaS3JuP/boNnlA==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+			"integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
 			"cpu": [
 				"arm"
 			],
@@ -12045,9 +11794,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.2.tgz",
-			"integrity": "sha512-eXBg7ibkNUZ+sTwbFiDKou0BAckeV6kIigK7y5Ko4mB/5A1KLhuzEKovsmfvsL8mQorkoincMFGnQuIT92SKqA==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+			"integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
 			"cpu": [
 				"arm64"
 			],
@@ -12059,9 +11808,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.2.tgz",
-			"integrity": "sha512-UCbaTklREjrc5U47ypLulAgg4njaqfOVLU18VrCrI+6E5MQjuG0lSWaqLlAJwsD7NpFV249XgB0Bi37Zh5Sz4g==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+			"integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
 			"cpu": [
 				"arm64"
 			],
@@ -12073,9 +11822,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.2.tgz",
-			"integrity": "sha512-dP67MA0cCMHFT2g5XyjtpVOtp7y4UyUxN3dhLdt11at5cPKnSm4lY+EhwNvDXIMzAMIo2KU+mc9wxaAQJTn7sQ==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+			"integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
 			"cpu": [
 				"x64"
 			],
@@ -12087,9 +11836,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-arm64": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.2.tgz",
-			"integrity": "sha512-WDUPLUwfYV9G1yxNRJdXcvISW15mpvod1Wv3ok+Ws93w1HjIVmCIFxsG2DquO+3usMNCpJQ0wqO+3GhFdl6Fow==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+			"integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
 			"cpu": [
 				"arm64"
 			],
@@ -12101,9 +11850,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-freebsd-x64": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.2.tgz",
-			"integrity": "sha512-Ng95wtHVEulRwn7R0tMrlUuiLVL/HXA8Lt/MYVpy88+s5ikpntzZba1qEulTuPnPIZuOPcW9wNEiqvZxZmgmqQ==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+			"integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
 			"cpu": [
 				"x64"
 			],
@@ -12115,9 +11864,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.2.tgz",
-			"integrity": "sha512-AEXMESUDWWGqD6LwO/HkqCZgUE1VCJ1OhbvYGsfqX2Y6w5quSXuyoy/Fg3nRqiwro+cJYFxiw5v4kB2ZDLhxrw==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+			"integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
 			"cpu": [
 				"arm"
 			],
@@ -12129,9 +11878,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-musleabihf": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.2.tgz",
-			"integrity": "sha512-ZV7EljjBDwBBBSv570VWj0hiNTdHt9uGznDtznBB4Caj3ch5rgD4I2K1GQrtbvJ/QiB+663lLgOdcADMNVC29Q==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+			"integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
 			"cpu": [
 				"arm"
 			],
@@ -12143,9 +11892,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.2.tgz",
-			"integrity": "sha512-uvjwc8NtQVPAJtq4Tt7Q49FOodjfbf6NpqXyW/rjXoV+iZ3EJAHLNAnKT5UJBc6ffQVgmXTUL2ifYiLABlGFqA==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+			"integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
 			"cpu": [
 				"arm64"
 			],
@@ -12157,9 +11906,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.2.tgz",
-			"integrity": "sha512-s3KoWVNnye9mm/2WpOZ3JeUiediUVw6AvY/H7jNA6qgKA2V2aM25lMkVarTDfiicn/DLq3O0a81jncXszoyCFA==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+			"integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -12171,9 +11920,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-gnu": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.2.tgz",
-			"integrity": "sha512-gi21faacK+J8aVSyAUptML9VQN26JRxe484IbF+h3hpG+sNVoMXPduhREz2CcYr5my0NE3MjVvQ5bMKX71pfVA==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+			"integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
 			"cpu": [
 				"loong64"
 			],
@@ -12185,9 +11934,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-loong64-musl": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.2.tgz",
-			"integrity": "sha512-qSlWiXnVaS/ceqXNfnoFZh4IiCA0EwvCivivTGbEu1qv2o+WTHpn1zNmCTAoOG5QaVr2/yhCoLScQtc/7RxshA==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+			"integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
 			"cpu": [
 				"loong64"
 			],
@@ -12199,9 +11948,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-gnu": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.2.tgz",
-			"integrity": "sha512-rPyuLFNoF1B0+wolH277E780NUKf+KoEDb3OyoLbAO18BbeKi++YN6gC/zuJoPPDlQRL3fIxHxCxVEWiem2yXw==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+			"integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -12213,9 +11962,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-ppc64-musl": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.2.tgz",
-			"integrity": "sha512-g+0ZLMook31iWV4PvqKU0i9E78gaZgYpSrYPed/4Bu+nGTgfOPtfs1h11tSSRPXSjC5EzLTjV/1A7L2Vr8pJoQ==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+			"integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
 			"cpu": [
 				"ppc64"
 			],
@@ -12227,9 +11976,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.2.tgz",
-			"integrity": "sha512-i+sGeRGsjKZcQRh3BRfpLsM3LX3bi4AoEVqmGDyc50L6KfYsN45wVCSz70iQMwPWr3E5opSiLOwsC9WB4/1pqg==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+			"integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
 			"cpu": [
 				"riscv64"
 			],
@@ -12241,9 +11990,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-musl": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.2.tgz",
-			"integrity": "sha512-C1vLcKc4MfFV6I0aWsC7B2Y9QcsiEcvKkfxprwkPfLaN8hQf0/fKHwSF2lcYzA9g4imqnhic729VB9Fo70HO3Q==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+			"integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
 			"cpu": [
 				"riscv64"
 			],
@@ -12255,9 +12004,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-s390x-gnu": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.2.tgz",
-			"integrity": "sha512-68gHUK/howpQjh7g7hlD9DvTTt4sNLp1Bb+Yzw2Ki0xvscm2cOdCLZNJNhd2jW8lsTPrHAHuF751BygifW4bkQ==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+			"integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
 			"cpu": [
 				"s390x"
 			],
@@ -12269,9 +12018,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.2.tgz",
-			"integrity": "sha512-1e30XAuaBP1MAizaOBApsgeGZge2/Byd6wV4a8oa6jPdHELbRHBiw7wvo4dp7Ie2PE8TZT4pj9RLGZv9N4qwlw==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+			"integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
 			"cpu": [
 				"x64"
 			],
@@ -12283,9 +12032,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.2.tgz",
-			"integrity": "sha512-4BJucJBGbuGnH6q7kpPqGJGzZnYrpAzRd60HQSt3OpX/6/YVgSsJnNzR8Ot74io50SeVT4CtCWe/RYIAymFPwA==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+			"integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
 			"cpu": [
 				"x64"
 			],
@@ -12297,9 +12046,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openbsd-x64": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.2.tgz",
-			"integrity": "sha512-cT2MmXySMo58ENv8p6/O6wI/h/gLnD3D6JoajwXFZH6X9jz4hARqUhWpGuQhOgLNXscfZYRQMJvZDtWNzMAIDw==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+			"integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
 			"cpu": [
 				"x64"
 			],
@@ -12311,9 +12060,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-openharmony-arm64": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.2.tgz",
-			"integrity": "sha512-sZnyUgGkuzIXaK3jNMPmUIyJrxu/PjmATQrocpGA1WbCPX8H5tfGgRSuYtqBYAvLuIGp8SPRb1O4d1Fkb5fXaQ==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+			"integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -12325,9 +12074,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.2.tgz",
-			"integrity": "sha512-sDpFbenhmWjNcEbBcoTV0PWvW5rPJFvu+P7XoTY0YLGRupgLbFY0XPfwIbJOObzO7QgkRDANh65RjhPmgSaAjQ==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+			"integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -12339,9 +12088,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.2.tgz",
-			"integrity": "sha512-GvJ03TqqaweWCigtKQVBErw2bEhu1tyfNQbarwr94wCGnczA9HF8wqEe3U/Lfu6EdeNP0p6R+APeHVwEqVxpUQ==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+			"integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
 			"cpu": [
 				"ia32"
 			],
@@ -12353,9 +12102,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-gnu": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.2.tgz",
-			"integrity": "sha512-KvXsBvp13oZz9JGe5NYS7FNizLe99Ny+W8ETsuCyjXiKdiGrcz2/J/N8qxZ/RSwivqjQguug07NLHqrIHrqfYw==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+			"integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
 			"cpu": [
 				"x64"
 			],
@@ -12367,9 +12116,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.2.tgz",
-			"integrity": "sha512-xNO+fksQhsAckRtDSPWaMeT1uIM+JrDRXlerpnWNXhn1TdB3YZ6uKBMBTKP0eX9XtYEP978hHk1f8332i2AW8Q==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+			"integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
 			"cpu": [
 				"x64"
 			],
@@ -12525,9 +12274,9 @@
 			}
 		},
 		"node_modules/@rushstack/terminal": {
-			"version": "0.19.5",
-			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.19.5.tgz",
-			"integrity": "sha512-6k5tpdB88G0K7QrH/3yfKO84HK9ggftfUZ51p7fePyCE7+RLLHkWZbID9OFWbXuna+eeCFE7AkKnRMHMxNbz7Q==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.21.0.tgz",
+			"integrity": "sha512-cLaI4HwCNYmknM5ns4G+drqdEB6q3dCPV423+d3TZeBusYSSm09+nR7CnhzJMjJqeRcdMAaLnrA4M/3xDz4R3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12545,13 +12294,13 @@
 			}
 		},
 		"node_modules/@rushstack/ts-command-line": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.1.5.tgz",
-			"integrity": "sha512-YmrFTFUdHXblYSa+Xc9OO9FsL/XFcckZy0ycQ6q7VSBsVs5P0uD9vcges5Q9vctGlVdu27w+Ct6IuJ458V0cTQ==",
+			"version": "5.1.7",
+			"resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.1.7.tgz",
+			"integrity": "sha512-Ugwl6flarZcL2nqH5IXFYk3UR3mBVDsVFlCQW/Oaqidvdb/5Ota6b/Z3JXWIdqV3rOR2/JrYoAHanWF5rgenXA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@rushstack/terminal": "0.19.5",
+				"@rushstack/terminal": "0.21.0",
 				"@types/argparse": "1.0.38",
 				"argparse": "~1.0.9",
 				"string-argv": "~0.3.1"
@@ -12703,37 +12452,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/@sigstore/sign/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/@sigstore/sign/node_modules/glob/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/@sigstore/sign/node_modules/lru-cache": {
 			"version": "7.18.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -12769,22 +12487,6 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@sigstore/sign/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@sigstore/sign/node_modules/minipass": {
@@ -12889,9 +12591,9 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"license": "MIT"
 		},
 		"node_modules/@sindresorhus/is": {
@@ -12936,13 +12638,6 @@
 				"micromark-util-character": "^1.1.0",
 				"micromark-util-symbol": "^1.0.1"
 			}
-		},
-		"node_modules/@standard-schema/spec": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@svgr/babel-plugin-add-jsx-attribute": {
 			"version": "8.0.0",
@@ -13488,13 +13183,6 @@
 				"@types/ms": "*"
 			}
 		},
-		"node_modules/@types/diff": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
-			"integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/eslint": {
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -13669,9 +13357,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
 			"license": "MIT"
 		},
 		"node_modules/@types/http-errors": {
@@ -15163,17 +14851,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.1.tgz",
-			"integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.54.0.tgz",
+			"integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.53.1",
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/typescript-estree": "8.53.1",
-				"@typescript-eslint/visitor-keys": "8.53.1",
+				"@typescript-eslint/scope-manager": "8.54.0",
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/typescript-estree": "8.54.0",
+				"@typescript-eslint/visitor-keys": "8.54.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -15189,15 +14877,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.1.tgz",
-			"integrity": "sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
+			"integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/visitor-keys": "8.53.1"
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/visitor-keys": "8.54.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15208,14 +14896,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.1.tgz",
-			"integrity": "sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
+			"integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
+				"@typescript-eslint/types": "8.54.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -15241,14 +14929,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.1.tgz",
-			"integrity": "sha512-WYC4FB5Ra0xidsmlPb+1SsnaSKPmS3gsjIARwbEkHkoWloQmuzcfypljaJcR78uyLA1h8sHdWWPHSLDI+MtNog==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.54.0.tgz",
+			"integrity": "sha512-YPf+rvJ1s7MyiWM4uTRhE4DvBXrEV+d8oC3P9Y2eT7S+HBS0clybdMIPnhiATi9vZOYDc7OQ1L/i6ga6NFYK/g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.53.1",
-				"@typescript-eslint/types": "^8.53.1",
+				"@typescript-eslint/tsconfig-utils": "^8.54.0",
+				"@typescript-eslint/types": "^8.54.0",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -15295,9 +14983,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.1.tgz",
-			"integrity": "sha512-qfvLXS6F6b1y43pnf0pPbXJ+YoXIC7HKg0UGZ27uMIemKMKA6XH2DTxsEDdpdN29D+vHV07x/pnlPNVLhdhWiA==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz",
+			"integrity": "sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15312,15 +15000,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.1.tgz",
-			"integrity": "sha512-MOrdtNvyhy0rHyv0ENzub1d4wQYKb2NmIqG7qEqPWFW7Mpy2jzFC3pQ2yKDvirZB7jypm5uGjF2Qqs6OIqu47w==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.54.0.tgz",
+			"integrity": "sha512-hiLguxJWHjjwL6xMBwD903ciAwd7DmK30Y9Axs/etOkftC3ZNN9K44IuRD/EB08amu+Zw6W37x9RecLkOo3pMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/typescript-estree": "8.53.1",
-				"@typescript-eslint/utils": "8.53.1",
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/typescript-estree": "8.54.0",
+				"@typescript-eslint/utils": "8.54.0",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.4.0"
 			},
@@ -15337,9 +15025,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.1.tgz",
-			"integrity": "sha512-jr/swrr2aRmUAUjW5/zQHbMaui//vQlsZcJKijZf3M26bnmLj8LyZUpj8/Rd6uzaek06OWsqdofN/Thenm5O8A==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.54.0.tgz",
+			"integrity": "sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15351,16 +15039,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.1.tgz",
-			"integrity": "sha512-RGlVipGhQAG4GxV1s34O91cxQ/vWiHJTDHbXRr0li2q/BGg3RR/7NM8QDWgkEgrwQYCvmJV9ichIwyoKCQ+DTg==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.54.0.tgz",
+			"integrity": "sha512-BUwcskRaPvTk6fzVWgDPdUndLjB87KYDrN5EYGetnktoeAvPtO4ONHlAZDnj5VFnUANg0Sjm7j4usBlnoVMHwA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.53.1",
-				"@typescript-eslint/tsconfig-utils": "8.53.1",
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/visitor-keys": "8.53.1",
+				"@typescript-eslint/project-service": "8.54.0",
+				"@typescript-eslint/tsconfig-utils": "8.54.0",
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/visitor-keys": "8.54.0",
 				"debug": "^4.4.3",
 				"minimatch": "^9.0.5",
 				"semver": "^7.7.3",
@@ -15379,13 +15067,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.1.tgz",
-			"integrity": "sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
+			"integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
+				"@typescript-eslint/types": "8.54.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -15426,16 +15114,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.1.tgz",
-			"integrity": "sha512-c4bMvGVWW4hv6JmDUEG7fSYlWOl3II2I4ylt0NM+seinYQlZMQIaKaXIIVJWt9Ofh6whrpM+EdDQXKXjNovvrg==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.54.0.tgz",
+			"integrity": "sha512-9Cnda8GS57AQakvRyG0PTejJNlA2xhvyNtEVIMlDWOOeEyBkYWhGPnfrIAnqxLMTSTo6q8g12XVjjev5l1NvMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.53.1",
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/typescript-estree": "8.53.1"
+				"@typescript-eslint/scope-manager": "8.54.0",
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/typescript-estree": "8.54.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15450,14 +15138,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.1.tgz",
-			"integrity": "sha512-Lu23yw1uJMFY8cUeq7JlrizAgeQvWugNQzJp8C3x8Eo5Jw5Q2ykMdiiTB9vBVOOUBysMzmRRmUfwFrZuI2C4SQ==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.54.0.tgz",
+			"integrity": "sha512-27rYVQku26j/PbHYcVfRPonmOlVI6gihHtXFbTdB5sb6qA0wdAQAbyXFVarQ5t4HRojIz64IV90YtsjQSSGlQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/visitor-keys": "8.53.1"
+				"@typescript-eslint/types": "8.54.0",
+				"@typescript-eslint/visitor-keys": "8.54.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -15468,13 +15156,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.53.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.1.tgz",
-			"integrity": "sha512-oy+wV7xDKFPRyNggmXuZQSBzvoLnpmJs+GhzRhPjrxl2b/jIlyjVokzm47CZCDUdXKr2zd7ZLodPfOBpOPyPlg==",
+			"version": "8.54.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.54.0.tgz",
+			"integrity": "sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
+				"@typescript-eslint/types": "8.54.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -15618,16 +15306,6 @@
 			},
 			"peerDependencies": {
 				"react": ">= 16.8.0"
-			}
-		},
-		"node_modules/@vercel/oidc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-			"integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": ">= 20"
 			}
 		},
 		"node_modules/@vitejs/plugin-react": {
@@ -15836,9 +15514,9 @@
 			}
 		},
 		"node_modules/@vue/compiler-core/node_modules/entities": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.0.tgz",
-			"integrity": "sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+			"integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -16046,13 +15724,13 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.38.0.tgz",
-			"integrity": "sha512-/xmHkUxQ2W5lDLp1jNOYWu2j9lrMqnV7bjs8X3jCTJ1fG2G60f+AGB1N0Qrwxf6rIfMIllDYoT5Ve2kbz2LBHQ==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.39.0.tgz",
+			"integrity": "sha512-uFy3FIF6MOo67tTVC2SaNyBQbFafu+DRirt2/IUQlY7w2MOiXWPaQFi3Oyy81gc8TfsooSFBlK4lrujd7O4gEw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.38.0",
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/dom-ready": "^4.39.0",
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16060,13 +15738,13 @@
 			}
 		},
 		"node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -16080,14 +15758,14 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.38.0.tgz",
-			"integrity": "sha512-RISdjFjAoXWY9WcnHq05sqTAuKCcMwe+4y+hjZZLix0PUgeClQ2GxfO1iAIfPSI/SMcFqlSvkW5k7k2jixsudw==",
+			"version": "7.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.39.0.tgz",
+			"integrity": "sha512-H6ysbEgDYuIDhvRje1iTyC9r4bEOY9AT0fRmNEr6fSG/furznt4XNtoflzh4Q4DeaC2flTQ9hn46JgcmW3IXJA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0",
-				"@wordpress/url": "^4.38.0"
+				"@wordpress/i18n": "^6.12.0",
+				"@wordpress/url": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16095,14 +15773,14 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -16116,9 +15794,9 @@
 			}
 		},
 		"node_modules/@wordpress/autop": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.38.0.tgz",
-			"integrity": "sha512-lHXCrLxCpKqH7aTlKcwVsC3QbTQMYCfRFMk/S639+y2xxt+O7GhuySRdtW5vawIgbBqqdxRRrlipOCa59ckBSg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.39.0.tgz",
+			"integrity": "sha512-plqVet/sQD+AVZk4UXlgUUX7CwqGr6lkgn6SY7JlgYrxDq0BsYm1oZ+bHKOHuhSzO83F8P8A24IIHS5yVYnKzQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -16127,9 +15805,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.14.0.tgz",
-			"integrity": "sha512-0NoWb5+gVGUMZ8RiAE4g4dJ08ZdSMrWdnt/fp//BclezTdOLepZPzZ9O6nDWLVdlNgnYLhPwK/t5jxOow5WRoA==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.15.0.tgz",
+			"integrity": "sha512-AJ569cP6WqG0/RWx+x7MDNFxnCrZ5Pz1dHCLSE+7B0lLMXh3RGC1+Fj0YIZtUQ2ULLf2I3LRn6kuHdwyWNGiNA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -16138,9 +15816,9 @@
 			}
 		},
 		"node_modules/@wordpress/blob": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.38.0.tgz",
-			"integrity": "sha512-QF0uF5ZyPrUQsV0EpLESV+byOGIaTBp6NwKLnAJUlRXnhqADCzdGHzlqB+xYGoRi+fLroBLf3eK6eAfbWrfh2A==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.39.0.tgz",
+			"integrity": "sha512-TK3mevvKKidK/k6fROdEHF3n5tCAsnsvLRe2qasPYfhxVN1mBLFrYn506KqZgC42Xibd+fzDN3m9voldg0VeLQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -16212,13 +15890,13 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.38.0.tgz",
-			"integrity": "sha512-J00DFUe83KWyHFSi48yw7DWeKH7J50DlzXOFVDsTW5SygWggt7t1pVxLsIqk9NCBhJsf73Fnq/d4dkDLup1npg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+			"integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16226,14 +15904,14 @@
 			}
 		},
 		"node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -16257,9 +15935,9 @@
 			}
 		},
 		"node_modules/@wordpress/block-serialization-default-parser": {
-			"version": "5.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.38.0.tgz",
-			"integrity": "sha512-iHqqlvuPGIz9ycU4Kce/zgti7zvDC+9i1hG5RIiMWAOX1Fwor4CPy9R1jZMXR64cBnW+nntP4mK0+KJeKmusiw==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.39.0.tgz",
+			"integrity": "sha512-X2lFTu3Wq4QlKwA0YzTmzD3yX7dhi6lz+Xv+ki/qXpXUXGTS0H191uqgjDKGm7Y6qSVlgP1QTF26sAxRC56RwA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -16311,20 +15989,20 @@
 			}
 		},
 		"node_modules/@wordpress/commands": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.38.0.tgz",
-			"integrity": "sha512-fxpOc1BvoBA19saY4p0N2LLiPMGn9jibArzmSqRzHOW50qcKWCd6ao/htF6FpLk8qAn7dpzHecoZT4nOUDUv0g==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.39.0.tgz",
+			"integrity": "sha512-zNFvNyfv+/mLFa+kPcAtrdPscj2XT+9eVMzS9jN645hcFQZdep6YhSGkaK6jVw9Vu+qTsw04o31Q8PaWejI9Mw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.14.0",
-				"@wordpress/components": "^32.0.0",
-				"@wordpress/data": "^10.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/i18n": "^6.11.0",
-				"@wordpress/icons": "^11.5.0",
-				"@wordpress/keyboard-shortcuts": "^5.38.0",
-				"@wordpress/private-apis": "^1.38.0",
+				"@wordpress/base-styles": "^6.15.0",
+				"@wordpress/components": "^32.1.0",
+				"@wordpress/data": "^10.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/i18n": "^6.12.0",
+				"@wordpress/icons": "^11.6.0",
+				"@wordpress/keyboard-shortcuts": "^5.39.0",
+				"@wordpress/private-apis": "^1.39.0",
 				"clsx": "^2.1.1",
 				"cmdk": "^1.0.0"
 			},
@@ -16421,9 +16099,9 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/components": {
-			"version": "32.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.0.0.tgz",
-			"integrity": "sha512-Com5lFqJGK0dAHuG0zIU5GQoiI4k1K5nurjR+cBei6c1LvCZ3ZNGQmNt4JETudNYjKOUI0EsiPayMBr0pzfcSA==",
+			"version": "32.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+			"integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -16438,25 +16116,26 @@
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.38.0",
-				"@wordpress/base-styles": "^6.14.0",
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/date": "^5.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/dom": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/escape-html": "^3.38.0",
-				"@wordpress/hooks": "^4.38.0",
-				"@wordpress/html-entities": "^4.38.0",
-				"@wordpress/i18n": "^6.11.0",
-				"@wordpress/icons": "^11.5.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/keycodes": "^4.38.0",
-				"@wordpress/primitives": "^4.38.0",
-				"@wordpress/private-apis": "^1.38.0",
-				"@wordpress/rich-text": "^7.38.0",
-				"@wordpress/warning": "^3.38.0",
+				"@wordpress/a11y": "^4.39.0",
+				"@wordpress/base-styles": "^6.15.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/date": "^5.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/dom": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/escape-html": "^3.39.0",
+				"@wordpress/hooks": "^4.39.0",
+				"@wordpress/html-entities": "^4.39.0",
+				"@wordpress/i18n": "^6.12.0",
+				"@wordpress/icons": "^11.6.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/keycodes": "^4.39.0",
+				"@wordpress/primitives": "^4.39.0",
+				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/rich-text": "^7.39.0",
+				"@wordpress/warning": "^3.39.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -16486,19 +16165,19 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/data": {
-			"version": "10.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.38.0.tgz",
-			"integrity": "sha512-z+JftoaEotRp5K9O0j8XJJFAeSHl1PJU75C/KD5MG+7oth4FO6dI0juY5AMt8zlLsyuB+Q+zT4fkO+qxd+JF6w==",
+			"version": "10.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.39.0.tgz",
+			"integrity": "sha512-L04X/Vawzx6RgvvSQga8JhvPxr1A6seBrWJoRBBP7+1zdCV7nmmR8339yTEPRnCH6m70qb0xSwTByUmTzWYzLg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/priority-queue": "^3.38.0",
-				"@wordpress/private-apis": "^1.38.0",
-				"@wordpress/redux-routine": "^5.38.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/priority-queue": "^3.39.0",
+				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/redux-routine": "^5.39.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -16516,15 +16195,15 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -16536,14 +16215,14 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -16557,14 +16236,14 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
-			"version": "11.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.5.0.tgz",
-			"integrity": "sha512-dVsAARE7pN5P2bRbREYMJB5F5bxu6gTxNQZXcFA6PAPTn6CXJfEtrSUqNDzLa0AwMmrHszy9foIbdHvlSYleHQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/primitives": "^4.38.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16575,13 +16254,13 @@
 			}
 		},
 		"node_modules/@wordpress/commands/node_modules/@wordpress/keycodes": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.38.0.tgz",
-			"integrity": "sha512-J00DFUe83KWyHFSi48yw7DWeKH7J50DlzXOFVDsTW5SygWggt7t1pVxLsIqk9NCBhJsf73Fnq/d4dkDLup1npg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+			"integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16670,12 +16349,12 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/keycodes": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.38.0.tgz",
-			"integrity": "sha512-J00DFUe83KWyHFSi48yw7DWeKH7J50DlzXOFVDsTW5SygWggt7t1pVxLsIqk9NCBhJsf73Fnq/d4dkDLup1npg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+			"integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16683,13 +16362,13 @@
 			}
 		},
 		"node_modules/@wordpress/components/node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -16712,19 +16391,19 @@
 			}
 		},
 		"node_modules/@wordpress/compose": {
-			"version": "7.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.38.0.tgz",
-			"integrity": "sha512-qWQ+SBuMm1cduo6rT6auHrETux0sLkmanoOWAM1FMpx+1GH6G9CGeRcCjPTW0AeXpioDNGCRoLy3O+HbEDhC7A==",
+			"version": "7.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.39.0.tgz",
+			"integrity": "sha512-9VyaqEDojUEnXKVxNamamEyYrWuI9vc2r33iV7hAe+8W0ISujRAFXp/baDiSOlYAcsbauRD4yAkEXuM0C4Vyhg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/dom": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/keycodes": "^4.38.0",
-				"@wordpress/priority-queue": "^3.38.0",
-				"@wordpress/undo-manager": "^1.38.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/dom": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/keycodes": "^4.39.0",
+				"@wordpress/priority-queue": "^3.39.0",
+				"@wordpress/undo-manager": "^1.39.0",
 				"change-case": "^4.1.2",
 				"clipboard": "^2.0.11",
 				"mousetrap": "^1.6.5",
@@ -16758,14 +16437,14 @@
 			}
 		},
 		"node_modules/@wordpress/compose/node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -16777,13 +16456,13 @@
 			}
 		},
 		"node_modules/@wordpress/compose/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -16797,12 +16476,12 @@
 			}
 		},
 		"node_modules/@wordpress/compose/node_modules/@wordpress/keycodes": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.38.0.tgz",
-			"integrity": "sha512-J00DFUe83KWyHFSi48yw7DWeKH7J50DlzXOFVDsTW5SygWggt7t1pVxLsIqk9NCBhJsf73Fnq/d4dkDLup1npg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+			"integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17048,18 +16727,18 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/data": {
-			"version": "10.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.38.0.tgz",
-			"integrity": "sha512-z+JftoaEotRp5K9O0j8XJJFAeSHl1PJU75C/KD5MG+7oth4FO6dI0juY5AMt8zlLsyuB+Q+zT4fkO+qxd+JF6w==",
+			"version": "10.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.39.0.tgz",
+			"integrity": "sha512-L04X/Vawzx6RgvvSQga8JhvPxr1A6seBrWJoRBBP7+1zdCV7nmmR8339yTEPRnCH6m70qb0xSwTByUmTzWYzLg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/priority-queue": "^3.38.0",
-				"@wordpress/private-apis": "^1.38.0",
-				"@wordpress/redux-routine": "^5.38.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/priority-queue": "^3.39.0",
+				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/redux-routine": "^5.39.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -17077,14 +16756,14 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -17105,12 +16784,12 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "5.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.38.0.tgz",
-			"integrity": "sha512-WyXChgB3dHfOi/BQSx9yJol883XNABGH73fm7M0RnGUyhM6ueE5kYfgsNycWN5v5/ZP4deUe+heab+JE18ZQeg==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.39.0.tgz",
+			"integrity": "sha512-Wy8z+I0ZQjSTP/S4M9JqaDEUuucxGy70g+I8UCOFRgDFIO5v4hZVKo1uOH0NO5gGdlhmg4Scb9l9uzYVp8oqmg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.38.0",
+				"@wordpress/deprecated": "^4.39.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -17120,12 +16799,12 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.38.0.tgz",
-			"integrity": "sha512-pGw2VVGQwW6VXgAlsjQnPV/H2btQ9CIv/xLBvaPtWLAbWQsB9r4Fb7ZBTKPsMA16f8mzQxHyhd8y4NL6HhQUtw==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.39.0.tgz",
+			"integrity": "sha512-/vTXUsh2MGOuh8nhzgpBKIKsbgdtgjE2hFiCPw8rP4wwEbKUlxhNdtZdqkaumNtZywfHbRUBWO9xTpAVX17XfA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.38.0"
+				"@wordpress/hooks": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17133,12 +16812,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.38.0.tgz",
-			"integrity": "sha512-STaByZ7YYqlNxhb4e5JvyG7vy4twyszOpDk6IHKp/NVJUGntg12yrDvsAHfAWOxLef7Z0jgCdOC+6QXL4Pfksg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.39.0.tgz",
+			"integrity": "sha512-PCZVqTIV3V797rjWxZYoBJ+5g8girPZB0GzKZWxgsB6Y/+bS5OvBCJ70FgeZwO7oReo7ktXVNz/ZQMb5JsPosw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.38.0"
+				"@wordpress/deprecated": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17146,9 +16825,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.38.0.tgz",
-			"integrity": "sha512-HEH3NaLEQS5fk9Do7GpWQpYCl6q0ehoBE7AJhyARoZPDGo5Uuizv4asr0rXKYM0kD29rDoIHp2u7KDba/MH8gQ==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.39.0.tgz",
+			"integrity": "sha512-qHhRnlSK0E2GTMo1D2gOtcr9FW11HG8X8lZLkmf3N0zhjem+MP7G15jFB7wophpypL3plnBHMxiDD6qUHh9dSg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17176,9 +16855,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.38.0.tgz",
-			"integrity": "sha512-LItqIdFnn/JAVEzTtvDZGJfsdmzeIE4ryMjovHkJhRElzcQWKHuq806DMprL40NcvJbdn0YfJZSv+aeP+9Ah3g==",
+			"version": "3.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.39.0.tgz",
+			"integrity": "sha512-YhAmZYQsOnnfafMwInzy/M1AR77O59u4aaIVSqiQjvCLkY+BQABsU6AizDckCg57mF2SoDnARl6xQY/7FCwEmw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17186,9 +16865,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.38.0.tgz",
-			"integrity": "sha512-nrLo2semyTID4yIlu9/DSKVM9v61Mgrkyr+MNj7LgzlD3PuGjYNzXVh5+ngfgPoKVdhV3kzFhda+1PZ8SK8cYg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.39.0.tgz",
+			"integrity": "sha512-FTKdGF5jHHmC8GSO6/ATQqh1IFQeDwapRtlp7t4VaTGwZtX+uzawgq/7QDIhFi3cfg9hNsFF0CSFp/Ul3nEeUA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17196,9 +16875,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.38.0.tgz",
-			"integrity": "sha512-xe9OHCLft2jsxDhFPsPpzTTh4g/I5kXufDOj+og6+dC3Ut7ZmNjimm41rY9S+wfNYXJDonTiW51xSFq1NSl9yw==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.39.0.tgz",
+			"integrity": "sha512-gKpDo9vXxws4L03x6JYal8zrv+HjtQ4KMicpUdsHY8hhH5Asid2UGOBkCA1pQ1j9KVSWWj+3RsF0Ay1lem06Fw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17285,14 +16964,14 @@
 			}
 		},
 		"node_modules/@wordpress/icons/node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -17304,9 +16983,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.38.0.tgz",
-			"integrity": "sha512-KR2rAUI3ECN86+8VNS0kdlPwXL8exZQo5bNWG0DgUyY3ZlbzYYWXdvqL5zNr2USr93BjFYd87yE+lH9/TbZ6Lg==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.39.0.tgz",
+			"integrity": "sha512-v/yDkQj/VpdR8y4b0xNTeuFkfdU2AYf/0YABbry6GB6zG+mkPgi2+cglQ681V621korKOX6JRAsMQuRX6D2UNA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17314,15 +16993,15 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts": {
-			"version": "5.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.38.0.tgz",
-			"integrity": "sha512-40xh793ZYprBUmVuwqh9B6t0cPkw3nbKKSfIbwn5eyOiP7vPqwLY1hpWZ24Tdwl0jqO1w0kFC5Frmct4HF2Siw==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.39.0.tgz",
+			"integrity": "sha512-vTB9fTgsgWrCQbFQQCZqMWWTAj24ZhhfLvlN+JB3Vf417tWlRjd153XkTkEL3gu3UTWaCjwhtuyMVnEeV0Xwxw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/data": "^10.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/keycodes": "^4.38.0"
+				"@wordpress/data": "^10.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/keycodes": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17354,19 +17033,19 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
-			"version": "10.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.38.0.tgz",
-			"integrity": "sha512-z+JftoaEotRp5K9O0j8XJJFAeSHl1PJU75C/KD5MG+7oth4FO6dI0juY5AMt8zlLsyuB+Q+zT4fkO+qxd+JF6w==",
+			"version": "10.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.39.0.tgz",
+			"integrity": "sha512-L04X/Vawzx6RgvvSQga8JhvPxr1A6seBrWJoRBBP7+1zdCV7nmmR8339yTEPRnCH6m70qb0xSwTByUmTzWYzLg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/priority-queue": "^3.38.0",
-				"@wordpress/private-apis": "^1.38.0",
-				"@wordpress/redux-routine": "^5.38.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/priority-queue": "^3.39.0",
+				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/redux-routine": "^5.39.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -17384,15 +17063,15 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -17404,14 +17083,14 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -17425,13 +17104,13 @@
 			}
 		},
 		"node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/keycodes": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.38.0.tgz",
-			"integrity": "sha512-J00DFUe83KWyHFSi48yw7DWeKH7J50DlzXOFVDsTW5SygWggt7t1pVxLsIqk9NCBhJsf73Fnq/d4dkDLup1npg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+			"integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17503,22 +17182,22 @@
 			}
 		},
 		"node_modules/@wordpress/preferences": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.38.0.tgz",
-			"integrity": "sha512-gGh9pfqEuaAbLR5IgWaaWi8aJaraeIRZ8t4/Juc1p/n9KvhaNDAHDS2gFQT4Id59fXsoyle7LW0kxw7HGOFpxg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.39.0.tgz",
+			"integrity": "sha512-4rUwrdglMKxGrru5l/JTEKsv7/ncsVQFxMtlG+VmFV2f/x/WboDDz2VGQwRO2/bOTyOM4KZJpZxeJ7E1Lo2B0A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.38.0",
-				"@wordpress/base-styles": "^6.14.0",
-				"@wordpress/components": "^32.0.0",
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/data": "^10.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/i18n": "^6.11.0",
-				"@wordpress/icons": "^11.5.0",
-				"@wordpress/private-apis": "^1.38.0",
+				"@wordpress/a11y": "^4.39.0",
+				"@wordpress/base-styles": "^6.15.0",
+				"@wordpress/components": "^32.1.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/data": "^10.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/i18n": "^6.12.0",
+				"@wordpress/icons": "^11.6.0",
+				"@wordpress/private-apis": "^1.39.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -17614,9 +17293,9 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
-			"version": "32.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.0.0.tgz",
-			"integrity": "sha512-Com5lFqJGK0dAHuG0zIU5GQoiI4k1K5nurjR+cBei6c1LvCZ3ZNGQmNt4JETudNYjKOUI0EsiPayMBr0pzfcSA==",
+			"version": "32.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.1.0.tgz",
+			"integrity": "sha512-Q4dUTWhVqV4pgW3AX9DaAwC4qsG5xiU1x9zVjo8Tm/B275hSWjumqN+spEe97T1QWx7b2RBAWK/OKVaIjkePTw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -17631,25 +17310,26 @@
 				"@floating-ui/react-dom": "2.0.8",
 				"@types/gradient-parser": "1.1.0",
 				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.38.0",
-				"@wordpress/base-styles": "^6.14.0",
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/date": "^5.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/dom": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/escape-html": "^3.38.0",
-				"@wordpress/hooks": "^4.38.0",
-				"@wordpress/html-entities": "^4.38.0",
-				"@wordpress/i18n": "^6.11.0",
-				"@wordpress/icons": "^11.5.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/keycodes": "^4.38.0",
-				"@wordpress/primitives": "^4.38.0",
-				"@wordpress/private-apis": "^1.38.0",
-				"@wordpress/rich-text": "^7.38.0",
-				"@wordpress/warning": "^3.38.0",
+				"@wordpress/a11y": "^4.39.0",
+				"@wordpress/base-styles": "^6.15.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/date": "^5.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/dom": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/escape-html": "^3.39.0",
+				"@wordpress/hooks": "^4.39.0",
+				"@wordpress/html-entities": "^4.39.0",
+				"@wordpress/i18n": "^6.12.0",
+				"@wordpress/icons": "^11.6.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/keycodes": "^4.39.0",
+				"@wordpress/primitives": "^4.39.0",
+				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/rich-text": "^7.39.0",
+				"@wordpress/warning": "^3.39.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
 				"colord": "^2.7.0",
@@ -17679,19 +17359,19 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/data": {
-			"version": "10.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.38.0.tgz",
-			"integrity": "sha512-z+JftoaEotRp5K9O0j8XJJFAeSHl1PJU75C/KD5MG+7oth4FO6dI0juY5AMt8zlLsyuB+Q+zT4fkO+qxd+JF6w==",
+			"version": "10.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.39.0.tgz",
+			"integrity": "sha512-L04X/Vawzx6RgvvSQga8JhvPxr1A6seBrWJoRBBP7+1zdCV7nmmR8339yTEPRnCH6m70qb0xSwTByUmTzWYzLg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/priority-queue": "^3.38.0",
-				"@wordpress/private-apis": "^1.38.0",
-				"@wordpress/redux-routine": "^5.38.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/priority-queue": "^3.39.0",
+				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/redux-routine": "^5.39.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -17709,15 +17389,15 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -17729,14 +17409,14 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -17750,14 +17430,14 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
-			"version": "11.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.5.0.tgz",
-			"integrity": "sha512-dVsAARE7pN5P2bRbREYMJB5F5bxu6gTxNQZXcFA6PAPTn6CXJfEtrSUqNDzLa0AwMmrHszy9foIbdHvlSYleHQ==",
+			"version": "11.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.6.0.tgz",
+			"integrity": "sha512-X3Tp3ARJWRokFOTJ1SJQef3J+bykyZHuHL6NSaMnEtbQzs7Tre+3HEghP5S5K/AGnLr+RvpGnwEN0uNy53uIiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/primitives": "^4.38.0"
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/primitives": "^4.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17768,13 +17448,13 @@
 			}
 		},
 		"node_modules/@wordpress/preferences/node_modules/@wordpress/keycodes": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.38.0.tgz",
-			"integrity": "sha512-J00DFUe83KWyHFSi48yw7DWeKH7J50DlzXOFVDsTW5SygWggt7t1pVxLsIqk9NCBhJsf73Fnq/d4dkDLup1npg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+			"integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -17801,12 +17481,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.38.0.tgz",
-			"integrity": "sha512-mba5ua+9xifdfXqMDpFupcowJN/DTcQJaQ0cISFtEhe9jmMVc63yFUlaDgqphGUA1ydhItp8u7Kx4m3GxB5BQQ==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.39.0.tgz",
+			"integrity": "sha512-RV9s+KzyuS8p0YKczLecmhFAtOHIWkCToHyDSmRf8N3XOy4id/T0+B5SJ2nMZJleG1oYINf5lrVcccqP2VmFJg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.38.0",
+				"@wordpress/element": "^6.39.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -17837,14 +17517,14 @@
 			}
 		},
 		"node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -17865,9 +17545,9 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.38.0.tgz",
-			"integrity": "sha512-REUN3SNVKEskpiib/XDzXMNZIOH7R/w2k4tDwo0r83Fz/Z+Uwbft9dirnrP7J/l3SRRGAEKteYYa+OXPZ8Ryaw==",
+			"version": "3.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.39.0.tgz",
+			"integrity": "sha512-IyiB5y55dIYJZnC5Vl3v2cKuRDR1hYSEA++fijpD4AJZTu+2bhtdN9PnmFE9T25WGzWqnfJEdBSHPglby9MhRA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -17878,9 +17558,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.38.0.tgz",
-			"integrity": "sha512-6Hj9x3xJb64Xu/p2M4XA9fGeY2omTly2bb+Kayaa55eEZi6iXlcIhvv7UAdKhJ2PF9hfuENccgqhG7OrvaEEJg==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.39.0.tgz",
+			"integrity": "sha512-ssMAzKtjPV/T1IEFWNSVeaecKG3mhRHYHPMy2Ajh7V8RpOCyYBOZ48kZGyOwd25uzQX5k634tmfW27qJ/SMVQA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -17888,9 +17568,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.38.0.tgz",
-			"integrity": "sha512-UC7XpM2s3SVINieWDuEgGdoNLFe6fFuljXaI4/2CZOu4iM6kPruv4K/XWImsnV41cfcL08egHd9r4RUdhrdscw==",
+			"version": "5.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.39.0.tgz",
+			"integrity": "sha512-XvAn9I/rfVWpv9KSKLc24mYqfVHJ4o9PiwcHQb6FyJyeVvCbrHpTFN1iAaXSsBSTCs6mMVKNuZFZv7Sg7c++bg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"is-plain-object": "^5.0.0",
@@ -17906,20 +17586,20 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.38.0.tgz",
-			"integrity": "sha512-PffqVNJqpnhJn8zRm1ap/aWsBqjNcteyRmx277WwPvzHkvYY3OF/SH9R6UOhGRTNPlhKCWkWvvhEw+DpPtqdKQ==",
+			"version": "7.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.39.0.tgz",
+			"integrity": "sha512-4wpQyyaZ9vmInRk0oiBpPFmLtGn6w+ejrQvaCeDeOAeA+IYdEvrTMEbGp7NhYZ9llZvEqEQ8/yNcoAczE4DLSg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.38.0",
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/data": "^10.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/dom": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/escape-html": "^3.38.0",
-				"@wordpress/i18n": "^6.11.0",
-				"@wordpress/keycodes": "^4.38.0",
+				"@wordpress/a11y": "^4.39.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/data": "^10.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/dom": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/escape-html": "^3.39.0",
+				"@wordpress/i18n": "^6.12.0",
+				"@wordpress/keycodes": "^4.39.0",
 				"colord": "2.9.3",
 				"memize": "^2.1.0"
 			},
@@ -17951,18 +17631,18 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
-			"version": "10.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.38.0.tgz",
-			"integrity": "sha512-z+JftoaEotRp5K9O0j8XJJFAeSHl1PJU75C/KD5MG+7oth4FO6dI0juY5AMt8zlLsyuB+Q+zT4fkO+qxd+JF6w==",
+			"version": "10.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.39.0.tgz",
+			"integrity": "sha512-L04X/Vawzx6RgvvSQga8JhvPxr1A6seBrWJoRBBP7+1zdCV7nmmR8339yTEPRnCH6m70qb0xSwTByUmTzWYzLg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.38.0",
-				"@wordpress/deprecated": "^4.38.0",
-				"@wordpress/element": "^6.38.0",
-				"@wordpress/is-shallow-equal": "^5.38.0",
-				"@wordpress/priority-queue": "^3.38.0",
-				"@wordpress/private-apis": "^1.38.0",
-				"@wordpress/redux-routine": "^5.38.0",
+				"@wordpress/compose": "^7.39.0",
+				"@wordpress/deprecated": "^4.39.0",
+				"@wordpress/element": "^6.39.0",
+				"@wordpress/is-shallow-equal": "^5.39.0",
+				"@wordpress/priority-queue": "^3.39.0",
+				"@wordpress/private-apis": "^1.39.0",
+				"@wordpress/redux-routine": "^5.39.0",
 				"deepmerge": "^4.3.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
@@ -17980,14 +17660,14 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-			"version": "6.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
-			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
+			"version": "6.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.39.0.tgz",
+			"integrity": "sha512-yVEjTddIVEsYjwRCY1pEzav/dGVH9S1xfwYwRyGsUGOQw5hXtIVnTbCIfQ2t3OCOGgSIYEh2ZmsSt0eTxZvtBw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.38.0",
+				"@wordpress/escape-html": "^3.39.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -17999,13 +17679,13 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.11.0.tgz",
-			"integrity": "sha512-JOJk1LtKACxnQ8MQEJAOSdJxUaYupxXzk3CPGWRzhxPHQ9xWH8LS0NqGppUebcah4s4uu26vqACiZvTt93N4eA==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.12.0.tgz",
+			"integrity": "sha512-KMleg8p/HtnoX1d/WoRDI51VTZsA4RGNUvBYn+Cc3avaeeNKROb91+viMcOc8NHuLplEzl7zH9/mrOSs9aY3rg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.38.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -18019,12 +17699,12 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/keycodes": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.38.0.tgz",
-			"integrity": "sha512-J00DFUe83KWyHFSi48yw7DWeKH7J50DlzXOFVDsTW5SygWggt7t1pVxLsIqk9NCBhJsf73Fnq/d4dkDLup1npg==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.39.0.tgz",
+			"integrity": "sha512-RN7Py7vvvmBOGuRM8X4hHOvXXG57jWDW9pIXUnVGc33EvTrwtnr16f8Xt4nKWs8L/UNUdrrAtA2HAeqRkdxr+A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.11.0"
+				"@wordpress/i18n": "^6.12.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18032,9 +17712,9 @@
 			}
 		},
 		"node_modules/@wordpress/shortcode": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.38.0.tgz",
-			"integrity": "sha512-A9qDn1AgZcVe3U1M3Y90K1Ucfh3yY5oA+RexPler8EQy59Hz5vtFcNd6gCWs85MhyD4We9qlrqJ9t3Fg65tNiw==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.39.0.tgz",
+			"integrity": "sha512-2aDAwkwFbheyDqdL4cqWcbByC4FgJ1c+t0hKDz4yX1KeeXlB5VYEdT2gXU9GGA4nQaQ3ZvlCFowQL3BYcarnCw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -18046,9 +17726,9 @@
 			}
 		},
 		"node_modules/@wordpress/style-engine": {
-			"version": "2.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.38.0.tgz",
-			"integrity": "sha512-GQ8GjHyNPpsOS0gjsPnx+Rt9rvMqXGaanY7+PguTtsrlJAQ+G35smracAz7OYVjZ8wOWDhEl6PRfn1elP/P6cA==",
+			"version": "2.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.39.0.tgz",
+			"integrity": "sha512-UhQ8rzIfdWYV0uITZOWl1G1HI+9ay679Ig+9W7qcGjp8Okwl4XyMF+B7f1jtqjbAhq45spzUgPs1d3+F4aiWYA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -18060,19 +17740,17 @@
 			}
 		},
 		"node_modules/@wordpress/sync": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.38.0.tgz",
-			"integrity": "sha512-KCEIQgsk/tyRSl786K5/lYxida+OsQNwW0pUHcBJJzI/+J75dRxpqBxfb1cB2hMG4a0TQZ80S7VoFN7yD4nDOA==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.39.0.tgz",
+			"integrity": "sha512-oYNxhMaNf2ZYOIuPmxkBgFNvqiSnnT8uTHrFgim09aN2fxA8Mu1G86EBokqHfAXBfx/NTiYOLbCy4bhGsjdbQg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/diff": "7.0.2",
-				"@wordpress/hooks": "^4.38.0",
-				"@wordpress/undo-manager": "^1.38.0",
-				"@wordpress/url": "^4.38.0",
+				"@wordpress/api-fetch": "^7.39.0",
+				"@wordpress/hooks": "^4.39.0",
 				"diff": "4.0.2",
 				"fast-deep-equal": "3.1.3",
-				"lib0": "^0.2.42",
+				"lib0": "0.2.85",
 				"y-protocols": "^1.0.5",
 				"yjs": "~13.6.6"
 			},
@@ -18081,10 +17759,20 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/sync/node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/@wordpress/token-list": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.38.0.tgz",
-			"integrity": "sha512-SYe5bRWTODb2WD990FRUK70Yt48voiVcIpClYl2Ge37r1dfvJmIXPBJVkoEN4h9QrS1NkMscFv38RQqMVCV7+Q==",
+			"version": "3.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.39.0.tgz",
+			"integrity": "sha512-p8lVv2wPJ76CqGnwRCeQcho6MPDlBdcdyCmAtgrIe5BGS19Tvp+EpsSkfvKrFa9JkAWtOSmAiKVqIHW/LqkujA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -18093,12 +17781,12 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.38.0.tgz",
-			"integrity": "sha512-5dwOkqVWXikDqiYIPP0dNYMYpVQVP5ov8+nwksLJkrjruzqbeSL9L8n7khs0UAyw1bpsxtagb61JdY+ddunbKw==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.39.0.tgz",
+			"integrity": "sha512-LcCqVZk3K6tltAuUB1gXyo7lAbS48WP/RsRLrm4GBchY+kQwUT+kme30zCrRfsEJJaYCtfcGo1POIgda/HwHpw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.38.0"
+				"@wordpress/is-shallow-equal": "^5.39.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18106,9 +17794,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.38.0.tgz",
-			"integrity": "sha512-Pzt5QvX3+7Co++X3wZxOGeVvSzjslYejt2R/ZHp2T9qxHCuiAVWnEttOSeAxziwjiPeiOclrbfOVTUvPqK0Ftw==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.39.0.tgz",
+			"integrity": "sha512-pWOtqLcApB1EZnD2am/vMHxkCLgHzpysUypP8N8jz+USdLyOKy7vaY3v94+HAL1M9HBoT9VpllWEg+LxsO/eqQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -18120,9 +17808,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.38.0.tgz",
-			"integrity": "sha512-4eHJoNC/Ofrp+hOIf/2KqSoyIZLFIoyAhfTBrFxq3bGKNFJlOEHAJ3+tGiy77Ja93uQzrSWctZsH1CpSRYKkng==",
+			"version": "3.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.39.0.tgz",
+			"integrity": "sha512-NV2WoU4XxTqZU/3k2D5m5cHIw/uM2dlDgW5u1U5fmFIYLGg43WWMlSHQEu6F4tm7fqFt7k4qwT/FymucqHYp7Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -18130,9 +17818,9 @@
 			}
 		},
 		"node_modules/@wordpress/wordcount": {
-			"version": "4.38.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.38.0.tgz",
-			"integrity": "sha512-uXYnZsV6WMSidWfeFsZWk2IMaQfpnzWL6VucBhVMk4CpcU/vuoO1PbvJ6sD9q6zacfCr4cwJ+WxVCT7seroa2Q==",
+			"version": "4.39.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.39.0.tgz",
+			"integrity": "sha512-W8lY9zNeIL+afa7KvOwwFeA62IsJBhPJBmf71hPpInXBx+zBUlzFd8lTXiLbxCNLX665ABfrjs47RS1l7ZZLlQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -18430,25 +18118,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/ai": {
-			"version": "5.0.121",
-			"resolved": "https://registry.npmjs.org/ai/-/ai-5.0.121.tgz",
-			"integrity": "sha512-3iYPdARKGLryC/7OA9RgBUaym1gynvWS7UPy8NwoRNCKP52lshldtHB5xcEfVviw7liWH2zJlW9yEzsDglcIEQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/gateway": "2.0.27",
-				"@ai-sdk/provider": "2.0.1",
-				"@ai-sdk/provider-utils": "3.0.20",
-				"@opentelemetry/api": "1.9.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "8.12.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -18510,26 +18179,26 @@
 			}
 		},
 		"node_modules/algoliasearch": {
-			"version": "5.46.3",
-			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.46.3.tgz",
-			"integrity": "sha512-n/NdPglzmkcNYZfIT3Fo8pnDR/lKiK1kZ1Yaa315UoLyHymADhWw15+bzN5gBxrCA8KyeNu0JJD6mLtTov43lQ==",
+			"version": "5.47.0",
+			"resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.47.0.tgz",
+			"integrity": "sha512-AGtz2U7zOV4DlsuYV84tLp2tBbA7RPtLA44jbVH4TTpDcc1dIWmULjHSsunlhscbzDydnjuFlNhflR3nV4VJaQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@algolia/abtesting": "1.12.3",
-				"@algolia/client-abtesting": "5.46.3",
-				"@algolia/client-analytics": "5.46.3",
-				"@algolia/client-common": "5.46.3",
-				"@algolia/client-insights": "5.46.3",
-				"@algolia/client-personalization": "5.46.3",
-				"@algolia/client-query-suggestions": "5.46.3",
-				"@algolia/client-search": "5.46.3",
-				"@algolia/ingestion": "1.46.3",
-				"@algolia/monitoring": "1.46.3",
-				"@algolia/recommend": "5.46.3",
-				"@algolia/requester-browser-xhr": "5.46.3",
-				"@algolia/requester-fetch": "5.46.3",
-				"@algolia/requester-node-http": "5.46.3"
+				"@algolia/abtesting": "1.13.0",
+				"@algolia/client-abtesting": "5.47.0",
+				"@algolia/client-analytics": "5.47.0",
+				"@algolia/client-common": "5.47.0",
+				"@algolia/client-insights": "5.47.0",
+				"@algolia/client-personalization": "5.47.0",
+				"@algolia/client-query-suggestions": "5.47.0",
+				"@algolia/client-search": "5.47.0",
+				"@algolia/ingestion": "1.47.0",
+				"@algolia/monitoring": "1.47.0",
+				"@algolia/recommend": "5.47.0",
+				"@algolia/requester-browser-xhr": "5.47.0",
+				"@algolia/requester-fetch": "5.47.0",
+				"@algolia/requester-node-http": "5.47.0"
 			},
 			"engines": {
 				"node": ">= 14.0.0"
@@ -19067,9 +18736,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.23",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.23.tgz",
-			"integrity": "sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==",
+			"version": "10.4.24",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
+			"integrity": "sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -19087,7 +18756,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.1",
-				"caniuse-lite": "^1.0.30001760",
+				"caniuse-lite": "^1.0.30001766",
 				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
@@ -19152,9 +18821,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-			"integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
+			"integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19372,13 +19041,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.14",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
-			"integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.15.tgz",
+			"integrity": "sha512-hR3GwrRwHUfYwGfrisXPIDP3JcYfBrW7wKE7+Au6wDYl7fm/ka1NEII6kORzxNU556JjfidZeBsO10kYvtV1aw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.27.7",
-				"@babel/helper-define-polyfill-provider": "^0.6.5",
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-define-polyfill-provider": "^0.6.6",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -19408,12 +19077,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
-			"integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
+			"version": "0.6.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.6.tgz",
+			"integrity": "sha512-hYm+XLYRMvupxiQzrvXUj7YyvFFVfv5gI0R71AJzudg1g2AI2vyCPPIFEBjk162/wFzti3inBHo7isWFuEVS/A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.5"
+				"@babel/helper-define-polyfill-provider": "^0.6.6"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -19505,9 +19174,9 @@
 			}
 		},
 		"node_modules/bare-fs": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
-			"integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+			"version": "4.5.3",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
+			"integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -19608,9 +19277,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.15",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.15.tgz",
-			"integrity": "sha512-kX8h7K2srmDyYnXRIppo4AH/wYgzWVCs+eKr3RusRSQ5PvRYoEFmR/I0PbdTjKFAoKqp5+kbxnNTFO9jOfSVJg==",
+			"version": "2.9.19",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+			"integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.js"
@@ -20093,27 +19762,6 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/cacache/node_modules/glob": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^5.0.1",
-				"once": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/cacache/node_modules/lru-cache": {
 			"version": "7.18.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -20122,19 +19770,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/cacache/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/cacache/node_modules/minipass": {
@@ -20165,52 +19800,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/cacache/node_modules/rimraf/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/cacache/node_modules/rimraf/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/cacache/node_modules/rimraf/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/cacache/node_modules/yallist": {
@@ -20412,9 +20001,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001765",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001765.tgz",
-			"integrity": "sha512-LWcNtSyZrakjECqmpP4qdg0MMGdN368D7X8XvvAqOcqMv0RxnlqVKZl2V6/mBR68oYMxOZPLw/gO7DuisMHUvQ==",
+			"version": "1.0.30001767",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
+			"integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -20668,9 +20257,9 @@
 			}
 		},
 		"node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -21670,9 +21259,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-			"integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -21681,12 +21270,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
-			"integrity": "sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
+			"integrity": "sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.0"
+				"browserslist": "^4.28.1"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -21694,9 +21283,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
-			"integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
+			"integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -22148,9 +21737,9 @@
 			}
 		},
 		"node_modules/cssdb": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.7.0.tgz",
-			"integrity": "sha512-UxiWVpV953ENHqAKjKRPZHNDfRo3uOymvO5Ef7MFCWlenaohkYj7PTO7WCBdjZm8z/aDZd6rXyUIlwZ0AjyFSg==",
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.7.1.tgz",
+			"integrity": "sha512-+F6LKx48RrdGOtE4DT5jz7Uo+VeyKXpK797FAevIkzjV8bMHz6xTO5F7gNDcRCHmPgD5jj2g6QCsY9zmVrh38A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -22807,9 +22396,9 @@
 			}
 		},
 		"node_modules/default-browser": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.4.0.tgz",
-			"integrity": "sha512-XDuvSq38Hr1MdN47EDvYtx3U0MTqpCEn+F6ft8z2vYDzMrvQhVp0ui9oQdqW3MvK3vqUETglt1tVGgjLuJ5izg==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+			"integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
 			"license": "MIT",
 			"dependencies": {
 				"bundle-name": "^4.1.0",
@@ -23030,9 +22619,9 @@
 			}
 		},
 		"node_modules/diff": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+			"integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -23119,19 +22708,6 @@
 				"@docusaurus/mdx-loader": "^3.5.0",
 				"react": ">=18.0.0",
 				"typescript": "^5.0.0"
-			}
-		},
-		"node_modules/docusaurus-plugin-typedoc-api/node_modules/marked": {
-			"version": "9.1.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
-			"integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"marked": "bin/marked.js"
-			},
-			"engines": {
-				"node": ">= 16"
 			}
 		},
 		"node_modules/docusaurus-plugin-typedoc-api/node_modules/typedoc": {
@@ -23419,9 +22995,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.267",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-			"integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+			"version": "1.5.286",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
+			"integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
 			"license": "ISC"
 		},
 		"node_modules/emittery": {
@@ -23509,13 +23085,13 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.4",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-			"integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+			"version": "5.19.0",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
+			"integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.0"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -24774,16 +24350,6 @@
 				"bare-events": "^2.7.0"
 			}
 		},
-		"node_modules/eventsource-parser": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-			"integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -25062,9 +24628,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.0.tgz",
-			"integrity": "sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+			"integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
 			"funding": [
 				{
 					"type": "github",
@@ -25451,36 +25017,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/foreground-child": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"cross-spawn": "^7.0.6",
-				"signal-exit": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/foreground-child/node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/forever-agent": {
@@ -26181,6 +25717,7 @@
 			"version": "9.3.5",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
 			"integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -27697,18 +27234,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -28937,22 +28462,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/jackspeak": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-			"integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0",
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			},
-			"optionalDependencies": {
-				"@pkgjs/parseargs": "^0.11.0"
-			}
-		},
 		"node_modules/jake": {
 			"version": "10.9.4",
 			"resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
@@ -29285,17 +28794,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/jest-config/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/jest-config/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -29327,41 +28825,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/jest-config/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/jest-config/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/jest-config/node_modules/supports-color": {
@@ -29996,17 +29459,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/jest-runtime/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
 		"node_modules/jest-runtime/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -30022,41 +29474,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/jest-runtime/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/jest-runtime/node_modules/supports-color": {
@@ -30724,7 +30141,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
 			"integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
-			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -31359,25 +30775,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/lerna/node_modules/glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/lerna/node_modules/hosted-git-info": {
 			"version": "3.0.8",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
@@ -31814,16 +31211,15 @@
 			}
 		},
 		"node_modules/lib0": {
-			"version": "0.2.117",
-			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
-			"integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+			"version": "0.2.85",
+			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.85.tgz",
+			"integrity": "sha512-vtAhVttLXCu3ps2OIsTz8CdKYKdcMo7ds1MNBIcSXz6vrY8sxASqpTi4vmsAIn7xjWvyT7haKcWW6woP6jebjQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"isomorphic.js": "^0.2.4"
 			},
 			"bin": {
-				"0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
 				"0gentesthtml": "bin/gentesthtml.js",
 				"0serve": "bin/0serve.js"
 			},
@@ -32188,9 +31584,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.clonedeepwith": {
@@ -32664,16 +32060,16 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "16.4.2",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-			"integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+			"version": "9.1.6",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+			"integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"
 			},
 			"engines": {
-				"node": ">= 20"
+				"node": ">= 16"
 			}
 		},
 		"node_modules/marked-smartypants": {
@@ -33194,19 +32590,19 @@
 			}
 		},
 		"node_modules/memfs": {
-			"version": "4.56.2",
-			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.2.tgz",
-			"integrity": "sha512-AEbdVTy4TZiugbnfA7d1z9IvwpHlaGh9Vlb/iteHDtUU/WhOKAwgbhy1f8dnX1SMbeKLIXdXf3lVWb55PuBQQw==",
+			"version": "4.56.10",
+			"resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.10.tgz",
+			"integrity": "sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@jsonjoy.com/fs-core": "4.56.2",
-				"@jsonjoy.com/fs-fsa": "4.56.2",
-				"@jsonjoy.com/fs-node": "4.56.2",
-				"@jsonjoy.com/fs-node-builtins": "4.56.2",
-				"@jsonjoy.com/fs-node-to-fsa": "4.56.2",
-				"@jsonjoy.com/fs-node-utils": "4.56.2",
-				"@jsonjoy.com/fs-print": "4.56.2",
-				"@jsonjoy.com/fs-snapshot": "^4.56.2",
+				"@jsonjoy.com/fs-core": "4.56.10",
+				"@jsonjoy.com/fs-fsa": "4.56.10",
+				"@jsonjoy.com/fs-node": "4.56.10",
+				"@jsonjoy.com/fs-node-builtins": "4.56.10",
+				"@jsonjoy.com/fs-node-to-fsa": "4.56.10",
+				"@jsonjoy.com/fs-node-utils": "4.56.10",
+				"@jsonjoy.com/fs-print": "4.56.10",
+				"@jsonjoy.com/fs-snapshot": "4.56.10",
 				"@jsonjoy.com/json-pack": "^1.11.0",
 				"@jsonjoy.com/util": "^1.9.0",
 				"glob-to-regex.js": "^1.0.1",
@@ -35766,9 +35162,9 @@
 			}
 		},
 		"node_modules/nan": {
-			"version": "2.24.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
-			"integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==",
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.25.0.tgz",
+			"integrity": "sha512-0M90Ag7Xn5KMLLZ7zliPWP3rT90P6PN+IzVFS0VqmnPktBk3700xUVv8Ikm9EUaUE5SDWdp/BIxdENzVznpm1g==",
 			"license": "MIT",
 			"optional": true
 		},
@@ -35946,52 +35342,6 @@
 				"node-gyp-build": "bin.js",
 				"node-gyp-build-optional": "optional.js",
 				"node-gyp-build-test": "build-test.js"
-			}
-		},
-		"node_modules/node-gyp/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/node-gyp/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/node-gyp/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/node-gyp/node_modules/rimraf": {
@@ -36191,40 +35541,6 @@
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
 		},
-		"node_modules/npm-packlist/node_modules/glob": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^5.0.1",
-				"once": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm-packlist/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/npm-pick-manifest": {
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-8.0.2.tgz",
@@ -36379,37 +35695,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/npm-registry-fetch/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/npm-registry-fetch/node_modules/glob/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/npm-registry-fetch/node_modules/hosted-git-info": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.3.tgz",
@@ -36458,22 +35743,6 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/npm-registry-fetch/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/npm-registry-fetch/node_modules/minipass": {
@@ -37759,13 +37028,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/package-json-from-dist": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-			"dev": true,
-			"license": "BlueOak-1.0.0"
-		},
 		"node_modules/pacote": {
 			"version": "15.2.0",
 			"resolved": "https://registry.npmjs.org/pacote/-/pacote-15.2.0.tgz",
@@ -37869,37 +37131,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/pacote/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/pacote/node_modules/glob/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/pacote/node_modules/hosted-git-info": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.3.tgz",
@@ -37934,22 +37165,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/pacote/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/pacote/node_modules/minipass": {
@@ -38235,16 +37450,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-is-inside": {
@@ -40114,9 +39319,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
-			"integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
+			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -41887,27 +41092,6 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/read-package-json/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/read-package-json/node_modules/hosted-git-info": {
 			"version": "6.1.3",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.3.tgz",
@@ -41939,32 +41123,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
-			}
-		},
-		"node_modules/read-package-json/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/read-package-json/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/read-package-json/node_modules/normalize-package-data": {
@@ -42754,16 +41912,6 @@
 				"throttleit": "^1.0.0"
 			}
 		},
-		"node_modules/request-progress/node_modules/throttleit": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
-			"integrity": "sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/requestidlecallback": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
@@ -42967,9 +42115,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.55.2",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.2.tgz",
-			"integrity": "sha512-PggGy4dhwx5qaW+CKBilA/98Ql9keyfnb7lh4SR6shQ91QQQi1ORJ1v4UinkdP2i87OBs9AQFooQylcrrRfIcg==",
+			"version": "4.57.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+			"integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -42983,31 +42131,31 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.55.2",
-				"@rollup/rollup-android-arm64": "4.55.2",
-				"@rollup/rollup-darwin-arm64": "4.55.2",
-				"@rollup/rollup-darwin-x64": "4.55.2",
-				"@rollup/rollup-freebsd-arm64": "4.55.2",
-				"@rollup/rollup-freebsd-x64": "4.55.2",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.55.2",
-				"@rollup/rollup-linux-arm-musleabihf": "4.55.2",
-				"@rollup/rollup-linux-arm64-gnu": "4.55.2",
-				"@rollup/rollup-linux-arm64-musl": "4.55.2",
-				"@rollup/rollup-linux-loong64-gnu": "4.55.2",
-				"@rollup/rollup-linux-loong64-musl": "4.55.2",
-				"@rollup/rollup-linux-ppc64-gnu": "4.55.2",
-				"@rollup/rollup-linux-ppc64-musl": "4.55.2",
-				"@rollup/rollup-linux-riscv64-gnu": "4.55.2",
-				"@rollup/rollup-linux-riscv64-musl": "4.55.2",
-				"@rollup/rollup-linux-s390x-gnu": "4.55.2",
-				"@rollup/rollup-linux-x64-gnu": "4.55.2",
-				"@rollup/rollup-linux-x64-musl": "4.55.2",
-				"@rollup/rollup-openbsd-x64": "4.55.2",
-				"@rollup/rollup-openharmony-arm64": "4.55.2",
-				"@rollup/rollup-win32-arm64-msvc": "4.55.2",
-				"@rollup/rollup-win32-ia32-msvc": "4.55.2",
-				"@rollup/rollup-win32-x64-gnu": "4.55.2",
-				"@rollup/rollup-win32-x64-msvc": "4.55.2",
+				"@rollup/rollup-android-arm-eabi": "4.57.1",
+				"@rollup/rollup-android-arm64": "4.57.1",
+				"@rollup/rollup-darwin-arm64": "4.57.1",
+				"@rollup/rollup-darwin-x64": "4.57.1",
+				"@rollup/rollup-freebsd-arm64": "4.57.1",
+				"@rollup/rollup-freebsd-x64": "4.57.1",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+				"@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+				"@rollup/rollup-linux-arm64-gnu": "4.57.1",
+				"@rollup/rollup-linux-arm64-musl": "4.57.1",
+				"@rollup/rollup-linux-loong64-gnu": "4.57.1",
+				"@rollup/rollup-linux-loong64-musl": "4.57.1",
+				"@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+				"@rollup/rollup-linux-ppc64-musl": "4.57.1",
+				"@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+				"@rollup/rollup-linux-riscv64-musl": "4.57.1",
+				"@rollup/rollup-linux-s390x-gnu": "4.57.1",
+				"@rollup/rollup-linux-x64-gnu": "4.57.1",
+				"@rollup/rollup-linux-x64-musl": "4.57.1",
+				"@rollup/rollup-openbsd-x64": "4.57.1",
+				"@rollup/rollup-openharmony-arm64": "4.57.1",
+				"@rollup/rollup-win32-arm64-msvc": "4.57.1",
+				"@rollup/rollup-win32-ia32-msvc": "4.57.1",
+				"@rollup/rollup-win32-x64-gnu": "4.57.1",
+				"@rollup/rollup-win32-x64-msvc": "4.57.1",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -43276,14 +42424,6 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
-		"node_modules/search-insights": {
-			"version": "2.17.3",
-			"resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
-			"integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/section-matter": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
@@ -43507,21 +42647,25 @@
 			}
 		},
 		"node_modules/serve-index": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-			"integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
+			"integrity": "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==",
 			"license": "MIT",
 			"dependencies": {
-				"accepts": "~1.3.4",
+				"accepts": "~1.3.8",
 				"batch": "0.6.1",
 				"debug": "2.6.9",
 				"escape-html": "~1.0.3",
-				"http-errors": "~1.6.2",
-				"mime-types": "~2.1.17",
-				"parseurl": "~1.3.2"
+				"http-errors": "~1.8.0",
+				"mime-types": "~2.1.35",
+				"parseurl": "~1.3.3"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/serve-index/node_modules/debug": {
@@ -43543,37 +42687,26 @@
 			}
 		},
 		"node_modules/serve-index/node_modules/http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
 			"license": "MIT",
 			"dependencies": {
 				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.6"
 			}
-		},
-		"node_modules/serve-index/node_modules/inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-			"license": "ISC"
 		},
 		"node_modules/serve-index/node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
-		},
-		"node_modules/serve-index/node_modules/setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-			"license": "ISC"
 		},
 		"node_modules/serve-index/node_modules/statuses": {
 			"version": "1.5.0",
@@ -44182,37 +43315,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/sigstore/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/sigstore/node_modules/glob/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/sigstore/node_modules/lru-cache": {
 			"version": "7.18.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -44248,22 +43350,6 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/sigstore/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/sigstore/node_modules/minipass": {
@@ -45043,29 +44129,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/string-width-cjs": {
-			"name": "string-width",
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/string-width/node_modules/ansi-regex": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -45247,20 +44310,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi-cjs": {
-			"name": "strip-ansi",
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -45523,20 +44572,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/swr": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/swr/-/swr-2.3.8.tgz",
-			"integrity": "sha512-gaCPRVoMq8WGDcWj9p4YWzCMPHzE0WNl6W8ADIx9c3JBEIdMkJGMzW+uzXvxHMltwcYACr9jP+32H8/hgwMR7w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"dequal": "^2.0.3",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"peerDependencies": {
-				"react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
 		"node_modules/symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -45570,7 +44605,7 @@
 			"version": "6.1.11",
 			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
 			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
-			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
+			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -45803,28 +44838,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"node_modules/test-exclude/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/test-exclude/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -45913,14 +44926,11 @@
 			}
 		},
 		"node_modules/throttleit": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
-			"integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.1.tgz",
+			"integrity": "sha512-vDZpf9Chs9mAdfY046mcPt8fg5QSZr37hEH4TXYBnDF+izxgrbRGUAAaBvIk/fJm9aOFCGFd1EsNg5AZCbnQCQ==",
 			"dev": true,
 			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
@@ -46365,40 +45375,6 @@
 				"node": "^12.20.0 || >=14"
 			}
 		},
-		"node_modules/ts-json-schema-generator/node_modules/glob": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-			"integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^5.0.1",
-				"once": "^1.3.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/ts-json-schema-generator/node_modules/minimatch": {
-			"version": "5.1.6",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/ts-node": {
 			"version": "10.9.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
@@ -46615,37 +45591,6 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/tuf-js/node_modules/glob": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/tuf-js/node_modules/glob/node_modules/minipass": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/tuf-js/node_modules/lru-cache": {
 			"version": "7.18.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -46681,22 +45626,6 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/tuf-js/node_modules/minimatch": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/tuf-js/node_modules/minipass": {
@@ -47248,9 +46177,9 @@
 			}
 		},
 		"node_modules/unist-util-visit": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-			"integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+			"integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/unist": "^3.0.0",
@@ -47693,9 +46622,9 @@
 			}
 		},
 		"node_modules/uvu/node_modules/diff": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-			"integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+			"integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -48587,9 +47516,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.104.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-			"integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+			"version": "5.105.0",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.0.tgz",
+			"integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
@@ -48602,7 +47531,7 @@
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.4",
+				"enhanced-resolve": "^5.19.0",
 				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
@@ -48615,7 +47544,7 @@
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
 				"terser-webpack-plugin": "^5.3.16",
-				"watchpack": "^2.4.4",
+				"watchpack": "^2.5.1",
 				"webpack-sources": "^3.3.3"
 			},
 			"bin": {
@@ -49376,63 +48305,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/wrap-ansi-cjs": {
-			"name": "wrap-ansi",
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/wrap-ansi-cjs/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/wrap-ansi/node_modules/ansi-regex": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -49846,6 +48718,28 @@
 				"url": "https://github.com/sponsors/dmonad"
 			}
 		},
+		"node_modules/yjs/node_modules/lib0": {
+			"version": "0.2.117",
+			"resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+			"integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"isomorphic.js": "^0.2.4"
+			},
+			"bin": {
+				"0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+				"0gentesthtml": "bin/gentesthtml.js",
+				"0serve": "bin/0serve.js"
+			},
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"type": "GitHub Sponsors ❤",
+				"url": "https://github.com/sponsors/dmonad"
+			}
+		},
 		"node_modules/ylru": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
@@ -49877,16 +48771,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/zod": {
-			"version": "4.3.5",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-			"integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
-			"dev": true,
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/zwitch": {
@@ -50256,8 +49140,6 @@
 		},
 		"packages/playground/devtools-extension/node_modules/@vitejs/plugin-react": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
-			"integrity": "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -50320,6 +49202,8 @@
 		},
 		"packages/playground/storage/node_modules/pify": {
 			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -50355,12 +49239,12 @@
 			}
 		},
 		"packages/playground/website-extras/node_modules/@wordpress/i18n": {
-			"version": "6.10.0",
+			"version": "6.12.0",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.37.0",
+				"@wordpress/hooks": "^4.39.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,6 @@
 				"eslint-plugin-playground-dev": "file:packages/meta/src/eslint-plugin-playground-dev",
 				"eslint-plugin-react": "7.37.5",
 				"eslint-plugin-react-hooks": "5.2.0",
-				"glob": "^9.3.0",
 				"husky": "8.0.3",
 				"jest": "29.7.0",
 				"jsdom": "22.1.0",
@@ -11735,6 +11734,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-beta.53",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.53.tgz",
+			"integrity": "sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@rollup/pluginutils": {
 			"version": "5.3.0",
@@ -49140,6 +49146,8 @@
 		},
 		"packages/playground/devtools-extension/node_modules/@vitejs/plugin-react": {
 			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.2.tgz",
+			"integrity": "sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -49202,8 +49210,6 @@
 		},
 		"packages/playground/storage/node_modules/pify": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"

--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
 		"eslint-plugin-playground-dev": "file:packages/meta/src/eslint-plugin-playground-dev",
 		"eslint-plugin-react": "7.37.5",
 		"eslint-plugin-react-hooks": "5.2.0",
-		"glob": "^9.3.0",
 		"husky": "8.0.3",
 		"jest": "29.7.0",
 		"jsdom": "22.1.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
 		"crc-32": "1.2.2",
 		"diff3": "0.0.4",
 		"express": "4.22.0",
-		"fast-xml-parser": "5.3.0",
+		"fast-xml-parser": "^5.3.4",
 		"file-saver": "^2.0.5",
 		"fs-extra": "11.1.1",
 		"ini": "4.1.2",
@@ -214,7 +214,9 @@
 		"@playwright/test": "1.55.1",
 		"ws": "8.18.3",
 		"tmp": "0.2.5",
-		"form-data": "^4.0.4"
+		"form-data": "^4.0.4",
+		"lodash": "^4.17.23",
+		"glob": "^9.3.0"
 	},
 	"workspaces": [
 		"packages/nx-extensions",


### PR DESCRIPTION
## Motivation for the change, related issues

Dependabot currently lists 13 vulnerability alerts. 

- `lodash` needs to be `^4.17.23`
- `fast-xml-parser` needs to be `^5.3.4`
- `tar` needs to be `^7.5.7`

For `lodash` and `fast-xml-parser` modifying the `package.json` file did the trick. I also overrode `glob` to fix the warnings from the terminal.

Upgrading `tar` is more complicated since it is a transitive dependency used by `lerna`. And even the latest version of `lerna` doesn't use the `7.5.7` version of `tar`. But a pull request for `lerna` is pending : 

https://github.com/lerna/lerna/pull/4265

This will mean, upgrading `lerna` from `7.1.3` to `9.0.4`. For the record, we had some issues in the past when upgrading `lerna`.

## Implementation details

Upgrading `fast-xml-parser` and overriding `lodash` and `glob`.

## Testing Instructions

CI