### PR TITLE
Update dependencies in package.json compatible with node 22.12

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # Without this, git is reporting that the files formatted in the
 # pre-commit hook are still modified after committing
 UPDATED_FILES=$(git diff-tree --no-commit-id --name-only -r HEAD)

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,3 @@
-#!/usr/bin/env sh
-# This, weirdly, breaks nx:
-# . "$(dirname -- "$0")/_/husky.sh"
-
 # Save the list of files that are staged for commit
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
 				"@types/fs-extra": "11.0.4",
 				"@types/ini": "4.1.0",
 				"@types/jest": "29.5.14",
-				"@types/node": "20.14.8",
+				"@types/node": "22.19.8",
 				"@types/pako": "1.0.4",
 				"@types/react": "18.3.1",
 				"@types/react-dom": "18.3.0",
@@ -123,7 +123,7 @@
 				"eslint-plugin-react": "7.37.5",
 				"eslint-plugin-react-hooks": "5.2.0",
 				"glob": "^9.3.0",
-				"husky": "8.0.3",
+				"husky": "9.1.7",
 				"jest": "29.7.0",
 				"jsdom": "22.1.0",
 				"jsonc-eslint-parser": "^2.1.0",
@@ -134,7 +134,7 @@
 				"prism-react-renderer": "^1.3.5",
 				"raw-loader": "^4.0.2",
 				"react-markdown": "^8.0.7",
-				"rimraf": "^4.4.0",
+				"rimraf": "5.0.10",
 				"rollup": "^4.34.6",
 				"sass": "1.71.1",
 				"tar-fs": "3.1.1",
@@ -143,7 +143,7 @@
 				"ts-node": "10.9.1",
 				"tslib": "^2.3.0",
 				"typedoc": "0.23.27",
-				"typescript": "5.4.5",
+				"typescript": "5.6.3",
 				"vite": "^5.0.0",
 				"vite-plugin-dts": "3.6.3",
 				"vite-tsconfig-paths": "4.2.0",
@@ -152,8 +152,8 @@
 				"xterm-addon-fit": "0.8.0"
 			},
 			"engines": {
-				"node": ">=20.18.3",
-				"npm": ">=10.1.0"
+				"node": ">=22.12.0",
+				"npm": ">=10.9.0"
 			},
 			"optionalDependencies": {
 				"fs-ext": "2.1.1"
@@ -13812,12 +13812,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "20.14.8",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
-			"integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+			"version": "22.19.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
+			"integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~5.26.4"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -27449,16 +27449,16 @@
 			}
 		},
 		"node_modules/husky": {
-			"version": "8.0.3",
-			"resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-			"integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+			"version": "9.1.7",
+			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+			"integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
-				"husky": "lib/bin.js"
+				"husky": "bin.js"
 			},
 			"engines": {
-				"node": ">=14"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/typicode"
@@ -31651,6 +31651,71 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/lerna/node_modules/rimraf": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+			"integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^9.2.0"
+			},
+			"bin": {
+				"rimraf": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/lerna/node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/lerna/node_modules/rimraf/node_modules/glob": {
+			"version": "9.3.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+			"integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"minimatch": "^8.0.2",
+				"minipass": "^4.2.4",
+				"path-scurry": "^1.6.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/lerna/node_modules/rimraf/node_modules/minimatch": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+			"integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/lerna/node_modules/semver": {
@@ -42948,22 +43013,67 @@
 			"license": "MIT"
 		},
 		"node_modules/rimraf": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
-			"integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
+			"integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"glob": "^9.2.0"
+				"glob": "^10.3.7"
 			},
 			"bin": {
-				"rimraf": "dist/cjs/src/bin.js"
-			},
-			"engines": {
-				"node": ">=14"
+				"rimraf": "dist/esm/bin.mjs"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+			"integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "9.0.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/rollup": {
@@ -46999,9 +47109,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-			"integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+			"version": "5.6.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -47046,9 +47156,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "5.26.5",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"license": "MIT"
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"test": "node --expose-gc node_modules/nx/bin/nx run-many --all --target=test",
 		"fix-asyncify": "node packages/php-wasm/node/bin/rebuild-while-asyncify-functions-missing.mjs",
 		"typecheck": "nx run-many --all --target=typecheck",
-		"prepare": "husky install",
+		"prepare": "husky",
 		"reset": "nx reset",
 		"local-package-repository": "./tools/scripts/local-package-repository.sh",
 		"recompile:php": "npm run recompile:php:web && npm run recompile:php:node",
@@ -142,7 +142,7 @@
 		"@types/fs-extra": "11.0.4",
 		"@types/ini": "4.1.0",
 		"@types/jest": "29.5.14",
-		"@types/node": "20.14.8",
+		"@types/node": "22.19.8",
 		"@types/pako": "1.0.4",
 		"@types/react": "18.3.1",
 		"@types/react-dom": "18.3.0",
@@ -178,7 +178,7 @@
 		"eslint-plugin-react": "7.37.5",
 		"eslint-plugin-react-hooks": "5.2.0",
 		"glob": "^9.3.0",
-		"husky": "8.0.3",
+		"husky": "9.1.7",
 		"jest": "29.7.0",
 		"jsdom": "22.1.0",
 		"jsonc-eslint-parser": "^2.1.0",
@@ -189,7 +189,7 @@
 		"prism-react-renderer": "^1.3.5",
 		"raw-loader": "^4.0.2",
 		"react-markdown": "^8.0.7",
-		"rimraf": "^4.4.0",
+		"rimraf": "5.0.10",
 		"rollup": "^4.34.6",
 		"sass": "1.71.1",
 		"tar-fs": "3.1.1",
@@ -198,7 +198,7 @@
 		"ts-node": "10.9.1",
 		"tslib": "^2.3.0",
 		"typedoc": "0.23.27",
-		"typescript": "5.4.5",
+		"typescript": "5.6.3",
 		"vite": "^5.0.0",
 		"vite-plugin-dts": "3.6.3",
 		"vite-tsconfig-paths": "4.2.0",
@@ -210,7 +210,7 @@
 		"rollup": "^4.34.6",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
-		"typescript": "5.4.5",
+		"typescript": "5.6.3",
 		"@playwright/test": "1.55.1",
 		"ws": "8.18.3",
 		"tmp": "0.2.5",
@@ -224,8 +224,8 @@
 		"packages/playground/*"
 	],
 	"engines": {
-		"node": ">=20.18.3",
-		"npm": ">=10.1.0"
+		"node": ">=22.12.0",
+		"npm": ">=10.9.0"
 	},
 	"optionalDependencies": {
 		"fs-ext": "2.1.1"


### PR DESCRIPTION
This pull request updates dependencies and configurations for Husky, Node.js, TypeScript, and several other development tools. The main focus is on upgrading packages to their latest versions and adjusting configuration files to be compatible with these updates.

**Dependency Upgrades:**

* Upgraded `husky` from version 8.0.3 to 9.1.7 in `package.json` to ensure compatibility with newer Node.js versions and improve pre-commit hook management.
* Updated `@types/node` from 20.14.8 to 22.19.8, and `typescript` from 5.4.5 to 5.6.3 in `package.json`, aligning type definitions and the TypeScript compiler with the latest Node.js and language features. 
* Changed the required Node.js and npm versions in `package.json` engines to `node >=22.12.0` and `npm >=10.9.0` to support the upgraded dependencies.
* Updated `rimraf` to version 5.0.10 for improved file removal reliability.

**Husky Configuration Changes:**

* Modified the `prepare` script in `package.json` to use `husky` directly instead of `husky install`, reflecting changes in Husky's setup process for version 9+.
* Removed shebang lines from `.husky/pre-commit` and `.husky/post-commit` scripts, likely to prevent execution issues and ensure compatibility with Husky v9. 