### PR TITLE
Switch to a robust check for node env detection

### DIFF
--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -40,7 +40,10 @@ export function consumeAPI<APIType>(
 	setupTransferHandlers();
 
 	let endpoint;
-	const appearsToBeNodeEnvironment = import.meta.url.startsWith('file://');
+	const appearsToBeNodeEnvironment =
+		typeof process !== 'undefined' &&
+		typeof process.versions !== 'undefined' &&
+		typeof process.versions.node !== 'undefined';
 	if (appearsToBeNodeEnvironment) {
 		endpoint = nodeEndpoint(remote as NodeEndpoint);
 	} else {


### PR DESCRIPTION
## Motivation for the change, related issues

On Calypso, with the latest version of `@wp-playground/client` package, playground was not working because of calypso's webpack config, which sets `import.meta.url` to `file:///...` paths, which made playground think it was running in node env, resulting in a cross origin restriction. Debugging that led me to discover the brittle check for node env detection.

With this PR, the check is more reliable than URL-based detection and works across different runtimes like Electron and Bun.

## Implementation details

## Testing Instructions (or ideally a Blueprint)
