### PR TITLE
[i18n] Add Bengali translation for guides/playground-for-everyone.md

### DIFF
--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/guides/playground-for-everyone.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/guides/playground-for-everyone.md
@@ -1,0 +1,367 @@
+---
+title: সবার জন্য ওয়ার্ডপ্রেস প্লেগ্রাউন্ড
+slug: /guides/playground-for-everyone
+description: ওয়ার্ডপ্রেস প্লেগ্রাউন্ড কীভাবে নতুনদের, সাইটের মালিকদের এবং শিক্ষার্থীদের কোনো টেকনিক্যাল দক্ষতা ছাড়াই নিরাপদে ওয়ার্ডপ্রেস নিয়ে এক্সপেরিমেন্ট করতে সাহায্য করে তা জানুন।
+---
+
+<!--
+# WordPress Playground for Everyone
+-->
+
+# সবার জন্য ওয়ার্ডপ্রেস প্লেগ্রাউন্ড
+
+<!--
+**WordPress Playground lets you run WordPress instantly—no server, no setup, no risk.** It works in your browser at [playground.wordpress.net](https://playground.wordpress.net), and developers can also use it via CLI, Node.js, or embedded in their own apps. But you don't need to be technical to benefit from it.
+-->
+
+**ওয়ার্ডপ্রেস প্লেগ্রাউন্ড আপনাকে তাৎক্ষণিকভাবে ওয়ার্ডপ্রেস চালানোর সুযোগ দেয়—কোনো সার্ভার, কোনো সেটআপ বা ঝুঁকির প্রয়োজন নেই।** এটি আপনার ব্রাউজারে [playground.wordpress.net](https://playground.wordpress.net) লিঙ্কে কাজ করে এবং ডেভেলপাররা এটিকে CLI, Node.js বা তাদের নিজস্ব অ্যাপের ভেতরে এমবেড করেও ব্যবহার করতে পারেন। তবে এর সুবিধা নিতে আপনাকে টেকনিক্যাল বিশেষজ্ঞ হওয়ার প্রয়োজন নেই।
+
+<!--
+Watch this quick overview:
+-->
+
+এই সংক্ষিপ্ত ওভারভিউটি দেখুন:
+
+<iframe width="800" src="https://www.youtube.com/embed/8_rH2k-OQ8E" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<!--
+## Think of It Like a Car Simulator
+-->
+
+## এটিকে একটি কার সিমুলেটরের মতো মনে করুন
+
+<!--
+A car simulator gives you a steering wheel, pedals, and virtual streets. Practice driving, hit cones, make mistakes — nothing bad happens. No real car gets damaged. Want to try again? Just restart.
+-->
+
+একটি কার সিমুলেটর আপনাকে একটি স্টিয়ারিং হুইল, প্যাডেল এবং ভার্চুয়াল রাস্তা দেয়। ড্রাইভিং প্র্যাকটিস করুন, কোণে ধাক্কা দিন, ভুল করুন — কিছুই খারাপ হবে না। কোনো আসল গাড়ির ক্ষতি হবে না। আবার চেষ্টা করতে চান? শুধু রিস্টার্ট দিন।
+
+<!--
+WordPress Playground works the same way. It gives you a complete WordPress site to experiment with, but nothing you do affects any real website. Make changes, break things, learn from mistakes — then start fresh whenever you want.
+-->
+
+ওয়ার্ডপ্রেস প্লেগ্রাউন্ড একইভাবে কাজ করে। এটি আপনাকে এক্সপেরিমেন্ট করার জন্য একটি পূর্ণাঙ্গ ওয়ার্ডপ্রেস সাইট দেয়, কিন্তু আপনার করা কোনো কিছুই কোনো আসল ওয়েবসাইটকে প্রভাবিত করে না। পরিবর্তন করুন, জিনিসগুলো নষ্ট করুন, ভুল থেকে শিখুন — তারপর যখনই চান নতুন করে শুরু করুন।
+
+![WordPress Playground Landing Page](@site/static/img/guides/wordpress-playground-landing-page.webp)
+
+<!--
+## What Can You Do with Playground?
+-->
+
+## আপনি প্লেগ্রাউন্ড দিয়ে কী করতে পারেন?
+
+<!--
+When you visit [playground.wordpress.net](https://playground.wordpress.net), you get a WordPress site running entirely in your browser. You can:
+-->
+
+আপনি যখন [playground.wordpress.net](https://playground.wordpress.net) ভিজিট করবেন, তখন আপনি সম্পূর্ণ আপনার ব্রাউজারে চলা একটি ওয়ার্ডপ্রেস সাইট পাবেন। আপনি যা করতে পারেন:
+
+<!--
+- Install plugins and themes
+- Edit pages and create content
+- Change WordPress and PHP versions
+- Explore features you've never tried before
+-->
+
+- প্লাগইন এবং থিম ইনস্টল করা
+- পেজ এডিট করা এবং কন্টেন্ট তৈরি করা
+- ওয়ার্ডপ্রেস এবং PHP ভার্সন পরিবর্তন করা
+- আগে কখনও চেষ্টা করেননি এমন সব ফিচার এক্সপ্লোর করা
+
+<!--
+By default, WordPress Playground loads a landing page to introduce some of the features of Playground and where you can learn more about it. But you can also load a vanilla WordPress version without the landing page. At the Launching Playground panel, one option is to load a vanilla WordPress version.
+-->
+
+ডিফল্টভাবে, ওয়ার্ডপ্রেস প্লেগ্রাউন্ড কিছু ফিচারের সাথে পরিচিত করার জন্য একটি ল্যান্ডিং পেজ লোড করে এবং সেখান থেকে আপনি এর সম্পর্কে আরও জানতে পারেন। তবে আপনি ল্যান্ডিং পেজ ছাড়াই একদম ভ্যানিলা ওয়ার্ডপ্রেস ভার্সন লোড করতে পারেন। প্লেগ্রাউন্ড লঞ্চিং প্যানেলে, ভ্যানিলা ওয়ার্ডপ্রেস ভার্সন লোড করার একটি অপশন রয়েছে।
+
+<!--
+1. Open Launch WordPress Panel
+   ![Launch WordPress Panel](@site/static/img/about/open-playground-dashboard.webp)
+-->
+
+১. লঞ্চ ওয়ার্ডপ্রেস প্যানেল খুলুন
+   ![Launch WordPress Panel](@site/static/img/about/open-playground-dashboard.webp)
+
+<!--
+2. Select to load a Vanilla WordPress version
+   ![Launching Vanilla WordPress](@site/static/img/guides/launch-vanilla-wordpress.webp)
+-->
+
+২. একটি ভ্যানিলা ওয়ার্ডপ্রেস ভার্সন লোড করতে সিলেক্ট করুন
+   ![Launching Vanilla WordPress](@site/static/img/guides/launch-vanilla-wordpress.webp)
+
+<!--
+## If You're Learning WordPress
+-->
+
+## আপনি যদি ওয়ার্ডপ্রেস শিখছেন
+
+<!--
+Are you new to WordPress or trying to understand features like the Site Editor or the new features of the latest WordPress Release? Playground is your perfect practice space.
+-->
+
+আপনি কি ওয়ার্ডপ্রেসে নতুন অথবা সাইট এডিটর বা সর্বশেষ ওয়ার্ডপ্রেস রিলিজের নতুন ফিচারগুলো বোঝার চেষ্টা করছেন? প্লেগ্রাউন্ড আপনার জন্য একটি নিখুঁত প্র্যাকটিস স্পেস।
+
+<!--
+### Explore How Pages Are Built
+-->
+
+### পেজগুলো কীভাবে তৈরি হয়েছে তা এক্সপ্লোর করুন
+
+<!--
+Playground logs you in as an administrator, so you can edit any page. Click **Edit** for editing posts and **Edit Site** to update the website layout in the top toolbar to open the editor.
+-->
+
+প্লেগ্রাউন্ড আপনাকে অ্যাডমিনিস্ট্রেটর হিসেবে লগ ইন করায়, তাই আপনি যেকোনো পেজ এডিট করতে পারেন। পোস্ট এডিট করার জন্য **এডিট** এবং ওয়েবসাইটের লেআউট আপডেট করার জন্য উপরের টুলবারের **এডিট সাইট**-এ ক্লিক করে এডিটর খুলুন।
+
+![Editing WordPress websites](@site/static/img/guides/edit-sites-with-playground.webp)
+
+<!--
+Want to understand how a page layout was created? Open the **List View** (the three horizontal lines icon) to see every block that makes up the page.
+-->
+
+একটি পেজ লেআউট কীভাবে তৈরি হয়েছে তা বুঝতে চান? পেজটি যে ব্লকগুলো দিয়ে তৈরি তা দেখতে **লিস্ট ভিউ** (তিনটি সমান্তরাল রেখার আইকন) ওপেন করুন।
+
+![Site Editor List view](@site/static/img/guides/site-editor-list-view.webp)
+
+<!--
+You can inspect columns, headings, images, and buttons — and see exactly how they're arranged. This is a powerful way to learn by example.
+-->
+
+আপনি কলাম, হেডিং, ইমেজ এবং বাটনগুলো ইন্সপেক্ট করতে পারেন — এবং সেগুলো কীভাবে সাজানো হয়েছে তা দেখতে পারেন। উদাহরণ থেকে শেখার জন্য এটি একটি শক্তিশালী মাধ্যম।
+
+<!--
+#### Explore the Blueprint Library
+-->
+
+#### ব্লুপ্রিন্ট লাইব্রেরি এক্সপ্লোর করুন
+
+<!--
+At the Launch WordPress Playground panel, you will have access to the Blueprint Library, a set of more than 40 blueprints to inspire you and try different types of websites with WordPress Playground, Art Gallery, E-commerce, and Web Portfolio are some of the examples.
+-->
+
+প্লেগ্রাউন্ড লঞ্চ প্যানেলে আপনি ব্লুপ্রিন্ট লাইব্রেরিতে একসেস পাবেন। এটি ৪০টিরও বেশি ব্লুপ্রিন্টের একটি সেট যা আপনাকে অনুপ্রাণিত করবে এবং ওয়ার্ডপ্রেস প্লেগ্রাউন্ড ব্যবহার করে বিভিন্ন ধরণের ওয়েবসাইট যেমন আর্ট গ্যালারি, ই-কমার্স এবং ওয়েব পোর্টফলিও ট্রাই করতে দিবে।
+
+<!--
+1. Open the Blueprint gallery at the Playground Launch Panel
+   ![Open blueprint Gallery](@site/static/img/guides/open-blueprints-gallery.webp)
+-->
+
+১. প্লেগ্রাউন্ড লঞ্চ প্যানেলে ব্লুপ্রিন্ট গ্যালারি খুলুন
+   ![Open blueprint Gallery](@site/static/img/guides/open-blueprints-gallery.webp)
+
+<!--
+1. Navigate and select the Blueprint to launch at WordPress Playground
+   ![Open blueprint Gallery](@site/static/img/guides/list-of-blueprints.webp)
+-->
+
+২. ওয়ার্ডপ্রেস প্লেগ্রাউন্ডে লঞ্চ করার জন্য কাঙ্ক্ষিত ব্লুপ্রিন্টটি সিলেক্ট করুন
+   ![Open blueprint Gallery](@site/static/img/guides/list-of-blueprints.webp)
+
+<!--
+### Try New Features Safely
+-->
+
+### নতুন ফিচারগুলো নিরাপদে চেষ্টা করুন
+
+<!--
+When the WordPress team releases new features, you can test them in Playground before they affect your real site. Select any WordPress version from the settings panel to explore what's new — or what's coming next.
+-->
+
+যখন ওয়ার্ডপ্রেস টিম নতুন ফিচার রিলিজ করে, তখন আপনার আসল সাইটকে প্রভাবিত করার আগে আপনি প্লেগ্রাউন্ডে সেগুলো টেস্ট করতে পারেন। সেটিং প্যানেল থেকে যেকোনো ওয়ার্ডপ্রেস ভার্সন সিলেক্ট করে নতুন কী এসেছে — বা ভবিষ্যতে কী আসতে চলেছে তা এক্সপ্লোর করুন।
+
+<!--
+## If You Own a WordPress Site
+-->
+
+## আপনার যদি একটি ওয়ার্ডপ্রেস সাইট থাকে
+
+<!--
+Running a live website means every change risks breaking something. Playground lets you test before you commit.
+-->
+
+একটি লাইভ ওয়েবসাইট চালানো মানে হলো প্রতিটি পরিবর্তনের সাথেই কিছু নষ্ট হয়ে যাওয়ার ঝুঁকি থাকে। প্লেগ্রাউন্ড আপনাকে পরিবর্তনের আগে সেটি টেস্ট করার সুযোগ দেয়।
+
+<!--
+### Test Plugins Before Installing
+-->
+
+### ইনস্টল করার আগে প্লাগইনগুলো পরীক্ষা করুন
+
+<!--
+Curious about a new SEO plugin? Want to compare two contact form options? Install them in Playground first:
+-->
+
+একটি নতুন SEO প্লাগইন সম্পর্কে জানতে আগ্রহী? দুটি কন্টাক্ট ফর্মের তুলনা করতে চান? প্রথমে প্লেগ্রাউন্ডে সেগুলো ইনস্টল করুন:
+
+<!--
+1. Open [playground.wordpress.net](https://playground.wordpress.net)
+2. Go to **Plugins → Add New**
+3. Search for and install any plugin
+4. Test it thoroughly
+-->
+
+১. [playground.wordpress.net](https://playground.wordpress.net) ওপেন করুন
+২. **প্লাগইন → নতুন যুক্ত করুন**-এ যান
+৩. যেকোনো প্লাগইন সার্চ করে ইনস্টল করুন
+৪. এটি সব দিক থেকে পরীক্ষা করুন
+
+<!--
+Your real site stays untouched while you evaluate whether the plugin fits your needs.
+-->
+
+প্লাগইনটি আপনার প্রয়োজন মেটাবে কিনা তা যাচাই করার সময় আপনার আসল সাইটটি সুরক্ষিত থাকবে।
+
+![Installing Plugins](@site/static/img/guides/installing-plugins.webp)
+
+<!--
+### Preview Theme Changes
+-->
+
+### থিমের পরিবর্তনগুলোর প্রিভিউ দেখুন
+
+<!--
+Thinking about switching themes? Test your new theme in Playground to see how it handles your content — without disrupting your visitors.
+-->
+
+থিম পরিবর্তন করার কথা ভাবছেন? আপনার নতুন থিমটি প্লেগ্রাউন্ডে টেস্ট করুন এবং দেখুন এটি আপনার কন্টেন্টের সাথে কীভাবে কাজ করে — ভিজিটরদের কোনো অসুবিধা না করেই।
+
+<!--
+### Compare Options Side by Side
+-->
+
+### অপশনগুলো পাশাপাশি তুলনা করুন
+
+<!--
+Open multiple browser tabs with different Playground setups. Compare plugin A versus plugin B, or see how your content looks in different themes. Make informed decisions before touching your production site.
+-->
+
+বিভিন্ন প্লেগ্রাউন্ড সেটআপ সহ একাধিক ব্রাউজার ট্যাব খুলুন। প্লাগইন A বনাম প্লাগইন B তুলনা করুন, অথবা বিভিন্ন থিমে আপনার কন্টেন্ট কেমন দেখায় তা দেখুন। প্রোডাকশন সাইটে হাত দেওয়ার আগে সঠিকভাবে জেনে-বুঝে সিদ্ধান্ত নিন।
+
+<!--
+:::info Your Real Site Stays Safe
+Every Playground runs independently in your browser. Nothing syncs to any external server, and nothing affects your live WordPress installation.
+:::
+-->
+
+:::তথ্য আপনার আসল সাইটটি নিরাপদে থাকে
+প্রতিটি প্লেগ্রাউন্ড আপনার ব্রাউজারে স্বাধীনভাবে চলে। কোনো কিছুই কোনো বাইরের সার্ভারের সাথে সিঙ্ক হয় না এবং কোনো কিছুই আপনার লাইভ ওয়ার্ডপ্রেস সাইটকে প্রভাবিত করে না।
+:::
+
+<!--
+## If You Use WordPress Daily
+-->
+
+## আপনি যদি প্রতিদিন ওয়ার্ডপ্রেস ব্যবহার করেন
+
+<!--
+Even experienced WordPress users benefit from a safe testing environment.
+-->
+
+এমনকি অভিজ্ঞ ওয়ার্ডপ্রেস ব্যবহারকারীরাও একটি নিরাপদ টেস্টিং এনভায়রনমেন্ট থেকে উপকৃত হন।
+
+<!--
+### Make Design Experiments
+-->
+
+### ডিজাইন এক্সপেরিমেন্ট করুন
+
+<!--
+Want to try a different font size? Adjust spacing? Change colors? Load a Playground with the same theme that you are using in production and edit it freely:
+-->
+
+একটি ভিন্ন ফন্ট সাইজ চেষ্টা করতে চান? স্পেসিং সমন্বয় করতে চান? রঙ পরিবর্তন করতে চান? প্রোডাকশনে আপনি যে থিম ব্যবহার করছেন সেটি প্লেগ্রাউন্ডে লোড করুন এবং স্বাধীনভাবে এডিট করুন:
+
+<!--
+1. Open any page in the editor
+2. Select a block and modify its settings
+3. See the results immediately
+-->
+
+১. এডিটরে যেকোনো পেজ ওপেন করুন
+২. একটি ব্লক সিলেক্ট করুন এবং এর সেটিংস পরিবর্তন করুন
+৩. ফলাফল তাৎক্ষণিকভাবে দেখুন
+
+<!--
+If you like what you see, recreate those changes on your real site. If not, just close the tab — no cleanup required.
+-->
+
+আপনি যদি পরিবর্তনগুলো পছন্দ করেন, তবে সেগুলো আপনার আসল সাইটে প্রয়োগ করুন। আর না হলে, শুধু ট্যাবটি বন্ধ করে দিন — কোনো কিছু ক্লিন-আপ করার প্রয়োজন নেই।
+
+<!--
+## Yes, You Can Save Your Work
+-->
+
+## হ্যাঁ, আপনি আপনার কাজ সেভ করতে পারেন
+
+<!--
+**Playground doesn't have to be temporary.** You can save your progress and return to it later.
+-->
+
+**প্লেগ্রাউন্ডকে স্থায়ীও করা যায়।** আপনি আপনার অগ্রগতি সেভ করতে পারেন এবং পরে আবার সেখানে ফিরে আসতে পারেন।
+
+<!--
+### Save to Your Browser
+-->
+
+### আপনার ব্রাউজারে সেভ করুন
+
+<!--
+1. Now WordPress Playground teels you if your Playground instance is unsaved on the top right
+2. Click on **Save** (yellow button)
+3. Set the name of your instance
+-->
+
+১. আপনার প্লেগ্রাউন্ড ইনস্ট্যান্সটি সেভ করা না থাকলে ওয়ার্ডপ্রেস প্লেগ্রাউন্ড এখন আপনাকে ডানদিকের উপরে তা জানাবে
+২. **সেভ** (হলুদ বাটন)-এ ক্লিক করুন
+৩. আপনার ইনস্ট্যান্সের নাম সেট করুন
+
+![Saving Playgrounds](@site/static/img/guides/unsaved-playground-warning.webp)
+
+<!--
+Playground generates a unique link for your saved site. Bookmark it, and you can return to exactly where you left off.
+-->
+
+প্লেগ্রাউন্ড আপনার সেভ করা সাইটের জন্য একটি ইউনিক লিঙ্ক জেনারেট করে। এটি বুকমার্ক করে রাখুন এবং আপনি ঠিক যেখান থেকে শেষ করেছিলেন সেখান থেকেই আবার শুরু করতে পারবেন।
+
+<!--
+### Download as a ZIP File
+-->
+
+### ZIP ফাইল হিসেবে ডাউনলোড করুন
+
+<!--
+Need to move your work elsewhere? Choose **Download as .zip** to export your entire Playground — including plugins, themes, and content. You can restore it later or even host it on a real server.
+-->
+
+আপনার কাজ অন্য কোথাও নিতে চান? আপনার পুরো প্লেগ্রাউন্ডটি — যার মধ্যে প্লাগইন, থিম এবং কন্টেন্ট রয়েছে — এক্সপোর্ট করার জন্য **.zip হিসেবে ডাউনলোড করুন** বেছে নিন। আপনি এটি পরে রিস্টোর করতে পারেন অথবা এমনকি একটি আসল সার্ভারে হোস্ট করতে পারেন।
+
+<!--
+:::tip Keep Your Playground Link
+When you save to the browser, copy the unique URL it generates. That link is your way back to your saved work.
+:::
+-->
+
+:::পরামর্শ আপনার প্লেগ্রাউন্ড লিঙ্কটি সংরক্ষণ করুন
+আপনি যখন ব্রাউজারে সেভ করবেন, তখন এটি যে ইউনিক URL জেনারেট করবে তা কপি করে রাখুন। আপনার সেভ করা কাজে ফিরে আসার জন্য এই লিঙ্কটিই একমাত্র উপায়।
+:::
+
+<!--
+## Next Steps
+-->
+
+## পরবর্তী পদক্ষেপ
+
+<!--
+Now that you know Playground is for everyone, explore further:
+-->
+
+এখন যেহেতু আপনি জানেন প্লেগ্রাউন্ড সবার জন্য, তাই আরও এক্সপ্লোর করুন:
+
+<!--
+- [Quick Start Guide](/quick-start-guide) — A 5-minute walkthrough of Playground basics
+- [About WordPress Playground](/about) — Learn what you can build, test, and launch
+-->
+
+- [কুইক স্টার্ট গাইড](/quick-start-guide) — প্লেগ্রাউন্ডের মৌলিক বিষয়গুলোর ৫ মিনিটের একটি ওয়াকথ্রু
+- [ওয়ার্ডপ্রেস প্লেগ্রাউন্ড সম্পর্কে](/about) — আপনি কী কী তৈরি করতে, টেস্ট করতে এবং লঞ্চ করতে পারেন তা জানুন

--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/guides/playground-for-everyone.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/guides/playground-for-everyone.md
@@ -192,7 +192,7 @@ Running a live website means every change risks breaking something. Playground l
 Curious about a new SEO plugin? Want to compare two contact form options? Install them in Playground first:
 -->
 
-একটি নতুন SEO প্লাগইন সম্পর্কে জানতে আগ্রহী? দুটি কন্টাক্ট ফর্মের তুলনা করতে চান? প্রথমে প্লেগ্রাউন্ডে সেগুলো ইনস্টল করুন:
+একটি নতুন এসইও প্লাগইন সম্পর্কে জানতে আগ্রহী? দুটি কন্টাক্ট ফর্মের তুলনা করতে চান? প্রথমে প্লেগ্রাউন্ডে সেগুলো ইনস্টল করুন:
 
 <!--
 1. Open [playground.wordpress.net](https://playground.wordpress.net)


### PR DESCRIPTION
## What?

Added Bengali (bn) translation for the [guides/playground-for-everyone.md]

## Why?

To make WordPress Playground documentation accessible to Bengali-speaking users and provide an overview of the platform in their native language.

## How?

- Translated all content following the established translation format
- Original English text preserved in HTML comments for reviewer reference
- Technical terms (WordPress, Playground, GitHub, etc.) handled using standardized Bengali script while keeping original terms for clarity
- Markdown structure and links remain unchanged
- Code blocks remain unchanged
