### PR TITLE
Add ashfame to workflow maintainers list

### DIFF
--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -21,7 +21,8 @@ jobs:
                 github.actor == 'zaerl' ||
                 github.actor == 'akirk' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         # Specify runner + deployment step

--- a/.github/workflows/deploy-my-wordpress-net.yml
+++ b/.github/workflows/deploy-my-wordpress-net.yml
@@ -22,7 +22,8 @@ jobs:
                 github.actor == 'brandonpayton' ||
                 github.actor == 'zaerl' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -22,7 +22,8 @@ jobs:
                 github.actor == 'brandonpayton' ||
                 github.actor == 'zaerl' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         # Specify runner + deployment step

--- a/.github/workflows/publish-devtools-extension.yml
+++ b/.github/workflows/publish-devtools-extension.yml
@@ -25,7 +25,8 @@ jobs:
                 github.actor == 'zaerl' ||
                 github.actor == 'ashfame' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -30,7 +30,8 @@ jobs:
               github.actor == 'brandonpayton' ||
               github.actor == 'zaerl' ||
               github.actor == 'janjakes' ||
-              github.actor == 'mho22'
+              github.actor == 'mho22' ||
+              github.actor == 'ashfame'
             )
 
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-self-hosted-package-release.yml
+++ b/.github/workflows/publish-self-hosted-package-release.yml
@@ -26,7 +26,8 @@ jobs:
                 github.actor == 'zaerl' ||
                 github.actor == 'ashfame' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         # Specify runner + deployment step

--- a/.github/workflows/refresh-sqlite-integration.yml
+++ b/.github/workflows/refresh-sqlite-integration.yml
@@ -17,7 +17,8 @@ jobs:
                 github.actor == 'brandonpayton' ||
                 github.actor == 'zaerl' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         runs-on: ubuntu-latest

--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -22,7 +22,8 @@ jobs:
                 github.actor == 'brandonpayton' ||
                 github.actor == 'zaerl' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         runs-on: ubuntu-latest

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -17,7 +17,8 @@ jobs:
                 github.actor == 'brandonpayton' ||
                 github.actor == 'zaerl' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         runs-on: ubuntu-latest

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -24,7 +24,8 @@ jobs:
                 github.actor == 'brandonpayton' ||
                 github.actor == 'zaerl' ||
                 github.actor == 'janjakes' ||
-                github.actor == 'mho22'
+                github.actor == 'mho22' ||
+                github.actor == 'ashfame'
             )
 
         # Specify runner + deployment step


### PR DESCRIPTION
## Summary

- Adds `ashfame` to the list of maintainers who can trigger deployment workflows
- Updates all 4 workflow files:
  - `deploy-website.yml` (Playground website)
  - `deploy-my-wordpress-net.yml` (my.wordpress.net)
  - `deploy-cors-proxy.yml` (CORS proxy)
  - `publish-npm-packages.yml` (NPM package releases)

## Test plan

- [ ] Verify workflow syntax is valid (CI should pass)
- [ ] After merge, verify ashfame can manually trigger the deployment workflows

Made with [Cursor](https://cursor.com)