### PR TITLE
[Playground CLI] Support overriding WP_DEBUG using define-bool and define-number

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -656,7 +656,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		>;
 		const defineNumber = (args['define-number'] || {}) as Record<
 			string,
-			boolean
+			number
 		>;
 		const hasDebugDefine = (name: string) => {
 			return name in define || name in defineBool || name in defineNumber;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -661,13 +661,13 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		const hasDebugDefine = (name: string) => {
 			return name in define || name in defineBool || name in defineNumber;
 		};
-		if ( !hasDebugDefine('WP_DEBUG') ) {
+		if (!hasDebugDefine('WP_DEBUG')) {
 			define['WP_DEBUG'] = 'true';
 		}
-		if ( !hasDebugDefine('WP_DEBUG_LOG') ) {
+		if (!hasDebugDefine('WP_DEBUG_LOG')) {
 			define['WP_DEBUG_LOG'] = 'true';
 		}
-		if ( !hasDebugDefine('WP_DEBUG_DISPLAY') ) {
+		if (!hasDebugDefine('WP_DEBUG_DISPLAY')) {
 			define['WP_DEBUG_DISPLAY'] = 'false';
 		}
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -650,14 +650,25 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		}
 
 		const define = (args['define'] || {}) as Record<string, string>;
-		if (
-			!('WP_DEBUG' in define) &&
-			!('WP_DEBUG_LOG' in define) &&
-			!('WP_DEBUG_DISPLAY' in define)
-		) {
+		const defineBool = (args['define-bool'] || {}) as Record<
+			string,
+			boolean
+		>;
+		const defineNumber = (args['define-number'] || {}) as Record<
+			string,
+			boolean
+		>;
+		const hasDebugDefine = (name: string) => {
+			return name in define || name in defineBool || name in defineNumber;
+		};
+		if ( !hasDebugDefine('WP_DEBUG') ) {
 			define['WP_DEBUG'] = 'true';
+		}
+		if ( !hasDebugDefine('WP_DEBUG_LOG') ) {
 			define['WP_DEBUG_LOG'] = 'true';
-			define['WP_DEBUG_DISPLAY'] = 'true';
+		}
+		if ( !hasDebugDefine('WP_DEBUG_DISPLAY') ) {
+			define['WP_DEBUG_DISPLAY'] = 'false';
 		}
 
 		const cliArgs = {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1664,6 +1664,110 @@ describe('other run-cli behaviors', () => {
 		);
 	});
 
+	describe('WP_DEBUG constants', () => {
+		async function getConstants(cliArgs: string[]) {
+			const exitSpy = vi
+				.spyOn(process, 'exit')
+				.mockImplementation((() => {}) as any);
+			try {
+				await using cliResult = await parseOptionsAndRunCLI([
+					'server',
+					'--wordpress-install-mode=do-not-attempt-installing',
+					'--skip-sqlite-setup',
+					'--verbosity=quiet',
+					'--port=0',
+					...cliArgs,
+				]);
+				const cliServer = cliResult[internalsKeyForTesting].cliServer;
+				await cliServer.playground.writeFile(
+					'/wordpress/check-consts.php',
+					`<?php
+					echo json_encode([
+						'WP_DEBUG' => defined('WP_DEBUG') ? WP_DEBUG : '__UNDEFINED__',
+						'WP_DEBUG_LOG' => defined('WP_DEBUG_LOG') ? WP_DEBUG_LOG : '__UNDEFINED__',
+						'WP_DEBUG_DISPLAY' => defined('WP_DEBUG_DISPLAY') ? WP_DEBUG_DISPLAY : '__UNDEFINED__',
+					]);
+					`
+				);
+				const response = await fetch(
+					new URL('/check-consts.php', cliServer.serverUrl)
+				);
+				return JSON.parse(await response.text());
+			} finally {
+				exitSpy.mockRestore();
+			}
+		}
+
+		test('should override WP_DEBUG constants via --define-bool', async () => {
+			// Confirm default values before confirming they can be overridden.
+			const defaultConstantss = await getConstants([]);
+			expect(defaultConstantss.WP_DEBUG).toBe('true');
+			expect(defaultConstantss.WP_DEBUG_LOG).toBe('true');
+			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe('false');
+
+			const constants = await getConstants([
+				'--define-bool',
+				'WP_DEBUG',
+				'false',
+				'--define-bool',
+				'WP_DEBUG_LOG',
+				'false',
+				'--define-bool',
+				'WP_DEBUG_DISPLAY',
+				'true',
+			]);
+			expect(constants.WP_DEBUG).toBe(false);
+			expect(constants.WP_DEBUG_LOG).toBe(false);
+			expect(constants.WP_DEBUG_DISPLAY).toBe(true);
+		});
+
+		test('should override WP_DEBUG constants via --define-bool', async () => {
+			// Confirm default values before confirming they can be overridden.
+			const defaultConstantss = await getConstants([]);
+			expect(defaultConstantss.WP_DEBUG).toBe('true');
+			expect(defaultConstantss.WP_DEBUG_LOG).toBe('true');
+			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe('false');
+
+			const constants = await getConstants([
+				'--define-number',
+				'WP_DEBUG',
+				'0',
+				'--define-number',
+				'WP_DEBUG_LOG',
+				'0',
+				'--define-number',
+				'WP_DEBUG_DISPLAY',
+				'0',
+			]);
+			expect(constants.WP_DEBUG).toBe(false);
+			expect(constants.WP_DEBUG_LOG).toBe(false);
+			expect(constants.WP_DEBUG_DISPLAY).toBe(true);
+		});
+
+		test('should override WP_DEBUG constants via --define', async () => {
+			// Confirm default values before confirming they can be overridden.
+			const defaultConstantss = await getConstants([]);
+			expect(defaultConstantss.WP_DEBUG).toBe('true');
+			expect(defaultConstantss.WP_DEBUG_LOG).toBe('true');
+			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe('false');
+
+			const constants = await getConstants([
+				'--define',
+				'WP_DEBUG',
+				'false',
+				'--define',
+				'WP_DEBUG_LOG',
+				'false',
+				'--define',
+				'WP_DEBUG_DISPLAY',
+				'true',
+			]);
+			expect(constants.WP_DEBUG).toBe('false');
+			expect(constants.WP_DEBUG_LOG).toBe('false');
+			expect(constants.WP_DEBUG_DISPLAY).toBe('true');
+		});
+	});
+
 	describe('port in use', () => {
 		test('should error when explicit port is already in use', async () => {
 			const stdoutMessages: string[] = [];

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1721,7 +1721,7 @@ describe('other run-cli behaviors', () => {
 			expect(constants.WP_DEBUG_DISPLAY).toBe(true);
 		});
 
-		test('should override WP_DEBUG constants via --define-bool', async () => {
+		test('should override WP_DEBUG constants via --define-number', async () => {
 			// Confirm default values before confirming they can be overridden.
 			const defaultConstantss = await getConstants([]);
 			expect(defaultConstantss.WP_DEBUG).toBe('true');
@@ -1737,11 +1737,11 @@ describe('other run-cli behaviors', () => {
 				'0',
 				'--define-number',
 				'WP_DEBUG_DISPLAY',
-				'0',
+				'1',
 			]);
-			expect(constants.WP_DEBUG).toBe(false);
-			expect(constants.WP_DEBUG_LOG).toBe(false);
-			expect(constants.WP_DEBUG_DISPLAY).toBe(true);
+			expect(constants.WP_DEBUG).toBe(0);
+			expect(constants.WP_DEBUG_LOG).toBe(0);
+			expect(constants.WP_DEBUG_DISPLAY).toBe(1);
 		});
 
 		test('should override WP_DEBUG constants via --define', async () => {


### PR DESCRIPTION
## Motivation for the change, related issues

PR #3128 added `--define-bool` and `--define-number` CLI flags alongside the existing `--define` flag. However, the logic that sets default WP_DEBUG constants only checks the `--define` map, meaning a user running `--define-bool WP_DEBUG false` would still get the default `WP_DEBUG=true` injected via `--define`, effectively overriding their intent.

Additionally, `WP_DEBUG_DISPLAY` was defaulting to `true`, which is noisy for most CLI usage — this changes it to `false`.

## Implementation details

- Checks all three define maps (`define`, `define-bool`, `define-number`) before injecting WP_DEBUG defaults, using a `hasDebugDefine()` helper
- Checks each debug constant (`WP_DEBUG`, `WP_DEBUG_LOG`, `WP_DEBUG_DISPLAY`) independently rather than as an all-or-nothing group — users can now override just one without losing defaults for the others
- Changes the default for `WP_DEBUG_DISPLAY` from `true` to `false`

## Testing Instructions

1. Run `npx nx dev playground-cli server --define-bool WP_DEBUG_DISPLAY true`
2. Confirm WP_DEBUG_DISPLAY is `true` 
3. Run `npx nx dev playground-cli server` (no flags)
4. Confirm WP_DEBUG and WP_DEBUG_LOG default to `true`, and WP_DEBUG_DISPLAY defaults to `false`
