### PR TITLE
Fix npm publish by adding glob as a devDependency

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -20,15 +20,15 @@ runs:
           id: cache-nodemodules
           uses: actions/cache@v4
           env:
-              cache-name: cache-node-modules
+              cache-name: cache-node-modules-v2
           with:
               # caching node_modules
               path: node_modules
               key: ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-build-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}
               restore-keys: |
-                  ${{ runner.os }}-build-${{ env.cache-name }}-
-                  ${{ runner.os }}-build-
-                  ${{ runner.os }}-
+                  ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-build-${{ env.cache-name }}-
+                  ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-build-
+                  ${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-
         - name: Install Dependencies
           shell: bash
           if: steps.cache-nodemodules.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,19 +31,21 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - name: test-unit-asyncify (1/7)
+                    - name: test-unit-asyncify (1/8)
                       target: test
-                    - name: test-unit-asyncify (2/7)
+                    - name: test-unit-asyncify (2/8)
                       target: test-group-1-asyncify
-                    - name: test-unit-asyncify (3/7)
-                      target: test-group-2-asyncify
-                    - name: test-unit-asyncify (4/7)
+                    - name: test-unit-asyncify (3/8)
+                      target: test-group-2a-asyncify
+                    - name: test-unit-asyncify (4/8)
+                      target: test-group-2b-asyncify
+                    - name: test-unit-asyncify (5/8)
                       target: test-group-3-asyncify
-                    - name: test-unit-asyncify (5/7)
+                    - name: test-unit-asyncify (6/8)
                       target: test-group-4-asyncify
-                    - name: test-unit-asyncify (6/7)
+                    - name: test-unit-asyncify (7/8)
                       target: test-group-5-asyncify
-                    - name: test-unit-asyncify (7/7)
+                    - name: test-unit-asyncify (8/8)
                       target: test-group-6-asyncify
         name: ${{ matrix.name }}
         services:
@@ -79,17 +81,19 @@ jobs:
             fail-fast: false
             matrix:
                 include:
-                    - name: test-unit-jspi (1/6)
+                    - name: test-unit-jspi (1/7)
                       target: test-group-1-jspi
-                    - name: test-unit-jspi (2/6)
-                      target: test-group-2-jspi
-                    - name: test-unit-jspi (3/6)
+                    - name: test-unit-jspi (2/7)
+                      target: test-group-2a-jspi
+                    - name: test-unit-jspi (3/7)
+                      target: test-group-2b-jspi
+                    - name: test-unit-jspi (4/7)
                       target: test-group-3-jspi
-                    - name: test-unit-jspi (4/6)
+                    - name: test-unit-jspi (5/7)
                       target: test-group-4-jspi
-                    - name: test-unit-jspi (5/6)
+                    - name: test-unit-jspi (6/7)
                       target: test-group-5-jspi
-                    - name: test-unit-jspi (6/6)
+                    - name: test-unit-jspi (7/7)
                       target: test-group-6-jspi
         name: ${{ matrix.name }}
         services:
@@ -396,6 +400,8 @@ jobs:
                     exit 1
                   fi
                   npx nx affected --target=build --parallel=3 --verbose
+            - name: Verify npm pack works (catches override conflicts before publish)
+              run: npm pack --dry-run --workspace=packages/php-wasm/logger
 
     # Deploy documentation job
     deploy_docs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -122,6 +122,7 @@
 				"eslint-plugin-playground-dev": "file:packages/meta/src/eslint-plugin-playground-dev",
 				"eslint-plugin-react": "7.37.5",
 				"eslint-plugin-react-hooks": "5.2.0",
+				"glob": "^9.3.0",
 				"husky": "8.0.3",
 				"jest": "29.7.0",
 				"jsdom": "22.1.0",
@@ -6518,6 +6519,16 @@
 				"node": "20 || >=22"
 			}
 		},
+		"node_modules/@isaacs/cliui": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+			"integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@isaacs/fs-minipass": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -8486,6 +8497,96 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@lerna/create/node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/@lerna/create/node_modules/rimraf/node_modules/glob": {
+			"version": "9.3.5",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+			"integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"minimatch": "^8.0.2",
+				"minipass": "^4.2.4",
+				"path-scurry": "^1.6.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@lerna/create/node_modules/rimraf/node_modules/lru-cache": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@lerna/create/node_modules/rimraf/node_modules/minimatch": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+			"integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@lerna/create/node_modules/rimraf/node_modules/minipass": {
+			"version": "4.2.8",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+			"integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@lerna/create/node_modules/rimraf/node_modules/path-scurry": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+			"integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^10.2.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@lerna/create/node_modules/rimraf/node_modules/path-scurry/node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
 			}
 		},
 		"node_modules/@lerna/create/node_modules/semver": {
@@ -10921,6 +11022,34 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
+		"node_modules/@npmcli/map-workspaces/node_modules/glob": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.2.tgz",
+			"integrity": "sha512-035InabNu/c1lW0tzPhAgapKctblppqsKKG9ZaNzbr+gXwWMjXoiyGSyB9sArzrjG7jY+zntRq5ZSUYemrnWVQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.1.2",
+				"minipass": "^7.1.2",
+				"path-scurry": "^2.0.0"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/lru-cache": {
+			"version": "11.2.6",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
 			"version": "10.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
@@ -10929,6 +11058,33 @@
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/brace-expansion": "^5.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/@npmcli/map-workspaces/node_modules/path-scurry": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+			"integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
 			},
 			"engines": {
 				"node": "20 || >=22"
@@ -11013,6 +11169,31 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
+		"node_modules/@npmcli/package-json/node_modules/glob": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+			"integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"foreground-child": "^3.3.1",
+				"jackspeak": "^4.1.1",
+				"minimatch": "^10.1.1",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^2.0.0"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/@npmcli/package-json/node_modules/hosted-git-info": {
 			"version": "9.0.2",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
@@ -11044,6 +11225,49 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/minimatch": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+			"integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/brace-expansion": "^5.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/minipass": {
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/@npmcli/package-json/node_modules/path-scurry": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+			"integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@npmcli/package-json/node_modules/proc-log": {
@@ -23039,6 +23263,24 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
+		"node_modules/cacache/node_modules/glob": {
+			"version": "13.0.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.2.tgz",
+			"integrity": "sha512-035InabNu/c1lW0tzPhAgapKctblppqsKKG9ZaNzbr+gXwWMjXoiyGSyB9sArzrjG7jY+zntRq5ZSUYemrnWVQ==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.1.2",
+				"minipass": "^7.1.2",
+				"path-scurry": "^2.0.0"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/cacache/node_modules/lru-cache": {
 			"version": "11.2.6",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
@@ -23047,6 +23289,22 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": "20 || >=22"
+			}
+		},
+		"node_modules/cacache/node_modules/minimatch": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+			"integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/brace-expansion": "^5.0.1"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/cacache/node_modules/minipass": {
@@ -23070,6 +23328,23 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cacache/node_modules/path-scurry": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+			"integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/cacache/node_modules/ssri": {
@@ -28303,6 +28578,36 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/foreground-child": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.6",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/foreground-child/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
 		"node_modules/forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -31493,6 +31798,22 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/jackspeak": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+			"integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^9.0.0"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/jake": {

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
 		"eslint-plugin-playground-dev": "file:packages/meta/src/eslint-plugin-playground-dev",
 		"eslint-plugin-react": "7.37.5",
 		"eslint-plugin-react-hooks": "5.2.0",
+		"glob": "^9.3.0",
 		"husky": "8.0.3",
 		"jest": "29.7.0",
 		"jsdom": "22.1.0",

--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -161,7 +161,7 @@
 				"testFiles": ["php-part-1.spec.ts"]
 			}
 		},
-		"test-group-2-asyncify": {
+		"test-group-2a-asyncify": {
 			"executor": "@nx/vite:test",
 			"outputs": ["{workspaceRoot}/coverage/packages/php-wasm/node"],
 			"options": {
@@ -169,14 +169,23 @@
 				"testFiles": [
 					"php-file-locking.spec.ts",
 					"file-lock-manager-for-node.spec.ts",
-					"php-imagick.spec.ts",
+					"php-imagick.spec.ts"
+				]
+			}
+		},
+		"test-group-2b-asyncify": {
+			"executor": "@nx/vite:test",
+			"outputs": ["{workspaceRoot}/coverage/packages/php-wasm/node"],
+			"options": {
+				"reportsDirectory": "../../../coverage/packages/php-wasm/node",
+				"testFiles": [
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
 					"php-fsockopen.spec.ts"
 				]
 			}
 		},
-		"test-group-2-jspi": {
+		"test-group-2a-jspi": {
 			"executor": "@nx/vite:test",
 			"outputs": ["{workspaceRoot}/coverage/packages/php-wasm/node"],
 			"options": {
@@ -185,7 +194,17 @@
 				"testFiles": [
 					"php-file-locking.spec.ts",
 					"file-lock-manager-for-node.spec.ts",
-					"php-imagick.spec.ts",
+					"php-imagick.spec.ts"
+				]
+			}
+		},
+		"test-group-2b-jspi": {
+			"executor": "@nx/vite:test",
+			"outputs": ["{workspaceRoot}/coverage/packages/php-wasm/node"],
+			"options": {
+				"configFile": "packages/php-wasm/node/vite.jspi.config.ts",
+				"reportsDirectory": "../../../coverage/packages/php-wasm/node",
+				"testFiles": [
 					"php-soap.spec.ts",
 					"php-image-extensions.spec.ts",
 					"php-fsockopen.spec.ts"


### PR DESCRIPTION
## Summary

The blanket `"glob": "^9.3.0"` override forces all transitive dependencies to use glob 9+, eliminating the glob 7.2.3 security vulnerability. However, `@npmcli/arborist`'s `assertRootOverrides` (which only runs during `npm pack`/`npm publish`, not during install or build) rejects overrides that change a dependency's resolved spec when the package isn't also a direct dependency of the project root.

Adding glob as a devDependency at the same version makes `edge.rawSpec` match `edge.spec`, satisfying arborist's check.

Also adds an `npm pack --dry-run` step to the CI build job so that override conflicts are caught before they reach the publish workflow.

## Test plan

- `npm pack --dry-run --workspace=packages/php-wasm/logger` succeeds locally
- `npm ls glob` shows no glob versions below 9
- CI build job includes the new npm pack verification step