### PR TITLE
Use Node.js 22 in refresh workflows to fix .mts loader errors

### DIFF
--- a/.github/workflows/refresh-sqlite-integration.yml
+++ b/.github/workflows/refresh-sqlite-integration.yml
@@ -35,7 +35,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
-                  node-version: 20
+                  node-version: 22
             - name: 'Refresh the SQLite bundle'
               shell: bash
               run: npx nx bundle-sqlite-database playground-wordpress-builds

--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -40,7 +40,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
-                  node-version: 20
+                  node-version: 22
             - name: 'Recompile WordPress'
               id: build
               shell: bash

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -33,7 +33,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
-                  node-version: 20
+                  node-version: 22
             - name: 'Recompile WordPress'
               shell: bash
               run: npx nx bundle-wordpress:nightly playground-wordpress-builds


### PR DESCRIPTION
## Summary
- Bumps Node.js from 20 to 22 in the three refresh workflows (`refresh-wordpress-major-and-beta`, `refresh-sqlite-integration`, `refresh-wordpress-nightly`)
- Node.js 20.20.0 does not support `.mts` files as `--loader` arguments, causing `ERR_UNKNOWN_FILE_EXTENSION` errors
- Node.js 22 is the lowest major version with native TypeScript/`.mts` support

## Failing CI runs
- [Refresh WordPress Major&Beta](https://github.com/WordPress/wordpress-playground/actions/runs/21967488700/job/63460931335)
- [Refresh SQLite plugin](https://github.com/WordPress/wordpress-playground/actions/runs/21967500743/job/63460969582)
- [Refresh WordPress Nightly](https://github.com/WordPress/wordpress-playground/actions/runs/21967503750/job/63460978762)

## Test plan
- [ ] Verify the three refresh workflows pass with Node.js 22