### PR TITLE
[AI] Add shared Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+	"$schema": "https://json.schemastore.org/claude-code-settings.json",
+	"permissions": {
+		"allow": [
+			"Bash(npm run *)",
+			"Bash(npm test *)",
+			"Bash(npx nx *)",
+			"Bash(npx vitest *)",
+			"Bash(npx tsc *)",
+			"Bash(npx wp-playground *)",
+			"Bash(npx playwright *)",
+			"WebFetch(domain:blueprintlibrary.wordpress.com)",
+			"WebFetch(domain:playground.wordpress.net)",
+			"WebFetch(domain:public-api.wordpress.com)",
+			"WebFetch(domain:nx.dev)"
+		],
+		"deny": [
+			"Bash(npm run release*)",
+			"Bash(npm run deploy*)",
+			"Bash(npx nx publish*)"
+		]
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ rollup.d.ts
 node_modules
 /__interactive-code-batteries
 
+# AI tooling
+.claude/settings.local.json
+
 # IDEs and editors
 /.idea
 /.local


### PR DESCRIPTION
## Motivation for the change, related issues

Set up shared Claude Code permission rules so contributors using Claude Code get sensible defaults out of the box — common build/test/lint commands are auto-allowed, while publish/deploy/release commands require explicit approval.

Also gitignore `.claude/settings.local.json` so personal settings don't get committed.

## Implementation details

**`.claude/settings.json`** (shared, committed):
- Allow project-specific commands: `npm run`, `npm test`, `npx nx`, `npx vitest`, `npx tsc`, `npx wp-playground`, `npx playwright`
- Allow WebFetch for project domains: `blueprintlibrary.wordpress.com`, `playground.wordpress.net`, `public-api.wordpress.com`, `nx.dev`
- Deny `npm run release`, `npm run deploy`, `npx nx publish`

**`.gitignore`**:
- Added `.claude/settings.local.json` so contributors' personal settings (git/GitHub permissions, sandbox config, etc.) stay local

## Testing Instructions (or ideally a Blueprint)

No functional changes. Verify that the settings file is valid JSON and the permission rules make sense for the project.