### PR TITLE
[AI] Add Nx MCP plugin and workspace guidelines to AGENTS.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,5 +20,16 @@
 			"Bash(npm run deploy*)",
 			"Bash(npx nx publish*)"
 		]
+	},
+	"extraKnownMarketplaces": {
+		"nx-claude-plugins": {
+			"source": {
+				"source": "github",
+				"repo": "nrwl/nx-ai-agents-config"
+			}
+		}
+	},
+	"enabledPlugins": {
+		"nx@nx-claude-plugins": true
 	}
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,3 +294,27 @@ Located in `packages/nx-extensions/src/executors/`:
 - **WordPress major and beta versions**: Auto-refreshed via GitHub Actions
 - **SQLite integration**: WordPress uses SQLite by default (no MySQL required)
 - **Security**: Iframe-based isolation prevents untrusted code execution in parent window
+
+<!-- nx configuration start-->
+<!-- Leave the start & end comments to automatically receive updates. -->
+
+## General Guidelines for working with Nx
+
+- For navigating/exploring the workspace, invoke the `nx-workspace` skill first - it has patterns for querying projects, targets, and dependencies
+- When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
+- Prefix nx commands with the workspace's package manager (e.g., `pnpm nx build`, `npm exec nx test`) - avoids using globally installed CLI
+- You have access to the Nx MCP server and its tools, use them to help the user
+- For Nx plugin best practices, check `node_modules/@nx/<plugin>/PLUGIN.md`. Not all plugins have this file - proceed without it if unavailable.
+- NEVER guess CLI flags - always check nx_docs or `--help` first when unsure
+
+## Scaffolding & Generators
+
+- For scaffolding tasks (creating apps, libs, project structure, setup), ALWAYS invoke the `nx-generate` skill FIRST before exploring or calling MCP tools
+
+## When to use nx_docs
+
+- USE for: advanced config options, unfamiliar flags, migration guides, plugin configuration, edge cases
+- DON'T USE for: basic generator syntax (`nx g @nx/react:app`), standard commands, things you already know
+- The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
+
+<!-- nx configuration end-->


### PR DESCRIPTION
## Summary

Runs `npx nx configure-ai-agents` to:

- Configure the Nx Claude Code plugin marketplace and enable the `nx` plugin in `.claude/settings.json`
- Append Nx workspace guidelines to `AGENTS.md`, covering task running conventions, scaffolding, and `nx_docs` usage

## Test plan

- [ ] Verify `.claude/settings.json` is valid JSON and the Nx plugin loads correctly
- [ ] Confirm the Nx configuration section in `AGENTS.md` renders properly and doesn't conflict with existing content