### PR TITLE
[CLI] Eliminate duplicate Playground CLI Ready message

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1423,9 +1423,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				cliOutput.finishProgress();
 				cliOutput.printReady(serverUrl, targetWorkerCount);
 
-				cliOutput.finishProgress();
-				cliOutput.printReady(serverUrl, targetWorkerCount);
-
 				if (args.phpmyadmin) {
 					const phpMyAdminPath = path.join(
 						args.phpmyadmin as string,


### PR DESCRIPTION
## Motivation for the change, related issues

After merging the Playground CLI multi-worker PR, there is a duplicate Ready message when starting a server:
```

Ready! WordPress is running on http://127.0.0.1:9400 (13 workers)

Ready! WordPress is running on http://127.0.0.1:9400 (13 workers)

```

## Implementation details

This PR removes the duplicate ready logic.

## Testing Instructions (or ideally a Blueprint)

- CI
