### PR TITLE
[AI] Add path manipulation guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Version-specific builds: `@php-wasm/web-7-4` through `@php-wasm/web-8-5` (and co
     - `scope:independent-from-php-binaries` packages cannot depend on `scope:php-binaries`
 - **Function ordering:** First caller, then callee. When function A calls function B, write first A, then B.
 - **Method ordering:** First public, then protected, then private. Respect **Function ordering** as well.
+- **Path manipulation**: Never use ad-hoc string operations for file paths. Use the POSIX path utilities from `@php-wasm/util` (`joinPaths`, `dirname`, `basename`, `normalizePath`, etc.) instead of Node.js `path` (which can produce Windows-style paths). If the package you're modifying has its own `paths.ts`, prefer that; otherwise import from `@php-wasm/util`. New path helpers should be co-located with the existing `paths.ts` in the relevant package, with tests.
 
 ### Testing
 


### PR DESCRIPTION
## Summary
- Adds a **Path manipulation** rule to the Code Style section of `AGENTS.md`
- Directs agents to use the POSIX path utilities from `@php-wasm/util` (`joinPaths`, `dirname`, `basename`, `normalizePath`, etc.) instead of ad-hoc string operations or Node.js `path` (which can produce Windows-style paths)
- Advises preferring a package's local `paths.ts` when available, otherwise importing from `@php-wasm/util`, and co-locating new helpers with tests

Follow up to #3223 (Adam suggested it)

Made with [Cursor](https://cursor.com)