### PR TITLE
Suppress Vite warning in dev env

### DIFF
--- a/packages/playground/personal-wp/index.html
+++ b/packages/playground/personal-wp/index.html
@@ -179,7 +179,7 @@
 								'_ts',
 								String(Date.now())
 							);
-							return import(moduleUrl.toString());
+							return import(/* @vite-ignore */ moduleUrl.toString());
 						}
 					} catch {
 						// Fall back to the original error

--- a/packages/playground/website/index.html
+++ b/packages/playground/website/index.html
@@ -179,7 +179,7 @@
 								'_ts',
 								String(Date.now())
 							);
-							return import(moduleUrl.toString());
+							return import(/* @vite-ignore */ moduleUrl.toString());
 						}
 					} catch {
 						// Fall back to the original error


### PR DESCRIPTION
## Motivation for the change, related issues
Dynamic import in Safari fallback causes vite to show a warning, which this PR fixes.

## Implementation details

## Testing Instructions (or ideally a Blueprint)
