### PR TITLE
[AI] Symlink .claude/skills to .agents/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## Summary

- Adds a symlink at `.claude/skills` pointing to `.agents/skills` so Claude Code automatically discovers skills defined in the shared `.agents/skills/` directory.

## Test plan

- [ ] Verify the symlink resolves correctly: `ls -la .claude/skills` should point to `../.agents/skills`
- [ ] Verify skills are accessible through the symlink: `ls .claude/skills/` should list `playground-website-debugging`