### PR TITLE
Fix Node.js version for WP rebuilds which require JSPI

### DIFF
--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -40,7 +40,9 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
-                  node-version: 22
+                  # The build uses JSPI which is supported in Node.js 23+.
+                  # Let's pick 24 as an LTS release.
+                  node-version: 24
             - name: 'Recompile WordPress'
               id: build
               shell: bash


### PR DESCRIPTION
## Motivation for the change, related issues

Recent changes to Node.js versions broke automated WP rebuilds. We would have noticed earlier, but the Nx target for beta contained an `|| true` expression which swallowed the error and made the CI job appear successful.

@mho22 discovered this and work on a fix for the silent failure.

This PR fixes the WP update and rebuilds job.

## Implementation details

The WP rebuild process relies on JSPI which is supported in Node.js 23+. This PR updates the build's Node.js version to 24.x because 24 is an LTS release.

## Testing Instructions (or ideally a Blueprint)

- Rerun the WordPress Major and Beta Update job after deploying this fix.
