### PR TITLE
[WordPress Builds] Remove || true artifact in wordpress build

### DIFF
--- a/packages/playground/wordpress-builds/project.json
+++ b/packages/playground/wordpress-builds/project.json
@@ -87,7 +87,7 @@
 					"node --loader=./packages/meta/src/node-es-module-loader/loader.mts packages/playground/wordpress-builds/build/build.js --wp-version=latest-minus-2 --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public --force={args.force}",
 					"node --loader=./packages/meta/src/node-es-module-loader/loader.mts packages/playground/wordpress-builds/build/build.js --wp-version=latest-minus-1 --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public --force={args.force}",
 					"node --loader=./packages/meta/src/node-es-module-loader/loader.mts packages/playground/wordpress-builds/build/build.js --wp-version=latest --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public --force={args.force}",
-					"node --loader=./packages/meta/src/node-es-module-loader/loader.mts packages/playground/wordpress-builds/build/build.js --wp-version=beta --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public --force={args.force} || true"
+					"node --loader=./packages/meta/src/node-es-module-loader/loader.mts packages/playground/wordpress-builds/build/build.js --wp-version=beta --output-js=packages/playground/wordpress-builds/src/wordpress --output-assets=packages/playground/wordpress-builds/public --force={args.force}"
 				],
 				"parallel": false,
 				"force": false


### PR DESCRIPTION
## Motivation for the change, related issues

Follow-up on : https://github.com/WordPress/wordpress-playground/pull/3294

Three days ago, Wordpress 7.0 Beta 1 couldn't be updated during the `Refresh WordPress Major&Beta` job. Because the job runs the `unbuilt-jspi` target inside it, which crashed for the `beta` version since it needs Node 24 instead of 22 (fixed with the above pull request). 

But because of `|| true` the `unbuilt-jspi` crash didn't break the CI, making the `bundle-wordpress:major-and-beta` crash silently and we didn't realize something went wrong.

Removing `|| true` from `packages/playground/wordpress-builds/project.json` should fix the issue.

I assume the `|| true` was necessary before [this pull request](https://github.com/WordPress/wordpress-playground/pull/2376/changes). That pull request added the following check :

```
if (args.wpVersion === 'beta') {
	process.stdout.write('Skipping. We did not find a WP beta version.\n');
	process.exit(0);
}
```

## Implementation details

Remove the `|| true` artifact added in https://github.com/WordPress/wordpress-playground/pull/1343 

## Testing Instructions (or ideally a Blueprint)

CI