### PR TITLE
[WordPress Builds] Fix semver crash on two-part WordPress versions

### DIFF
--- a/packages/playground/wordpress-builds/build/build.js
+++ b/packages/playground/wordpress-builds/build/build.js
@@ -76,8 +76,8 @@ const latestVersions = wpVersions.reduce((versionAccumulator, wpVersion) => {
 		versionAccumulator.push(wpVersion);
 	} else if (
 		semver.gt(
-			wpVersion.version,
-			versionAccumulator[currentVersionIndex].version
+			semver.coerce(wpVersion.version),
+			semver.coerce(versionAccumulator[currentVersionIndex].version)
 		)
 	) {
 		versionAccumulator[currentVersionIndex] = wpVersion;


### PR DESCRIPTION
## Motivation for the change, related issues

Based on Refresh WordPress Major&Beta [CI crash](https://github.com/WordPress/wordpress-playground/actions/runs/22333417674/job/64620603805)

The WordPress version API sometimes returns versions like 6.9 (two-part, no patch number). semver.gt() requires valid semver strings (three parts), so the build script crashes with `TypeError: Invalid Version: 6.9` when comparing these versions.

e.g. [link](https://api.wordpress.org/core/version-check/1.7/?channel=beta)
```json
{
    "response": "autoupdate",
    "download": "https://downloads.w.org/release/wordpress-6.9.zip",
    "locale": "en_US",
    "packages": {
        "full": "https://downloads.w.org/release/wordpress-6.9.zip",
        "no_content": "https://downloads.w.org/release/wordpress-6.9-no-content.zip",
        "new_bundled": "https://downloads.w.org/release/wordpress-6.9-new-bundled.zip",
        "partial": false,
        "rollback": false
    },
    "current": "6.9",
    "version": "6.9",
    "php_version": "7.2.24",
    "mysql_version": "5.5.5",
    "new_bundled": "6.7",
    "partial_version": false,
    "new_files": true
},
 ```

## Implementation details

Wrap both arguments to `semver.gt()` with `semver.coerce()`, which converts partial versions like `6.9` into valid semver `6.9.0` before comparison.

## Testing Instructions (or ideally a Blueprint)

CI or

```
node --loader=./packages/meta/src/node-es-module-loader/loader.mts \
    packages/playground/wordpress-builds/build/build.js \
    --wp-version=latest-minus-3 \
    --output-js=packages/playground/wordpress-builds/src/wordpress \
    --output-assets=packages/playground/wordpress-builds/public \
    --force=false
```

 - Before: TypeError: Invalid Version: 6.9
 - After: The requested version was latest-minus-3, but its latest release (6.6.4) is already downloaded