### PR TITLE
Fix /wp-admin blank page when response crosses Comlink worker boundary

### DIFF
--- a/packages/php-wasm/universal/src/lib/php-response.spec.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.spec.ts
@@ -86,6 +86,93 @@ describe('StreamedPHPResponse', () => {
 			expect(await streamed.exitCode).toBe(1);
 			expect(await streamed.stdoutText).toBe('error output');
 		});
+
+		it('encodes headers into headersStream for cross-thread serialization', async () => {
+			const original = new PHPResponse(
+				301,
+				{ location: ['/wp-admin/'] },
+				new Uint8Array(0),
+				'',
+				0
+			);
+
+			const streamed = StreamedPHPResponse.fromPHPResponse(original);
+
+			// Simulate what Comlink's transfer handler does:
+			// it reads the raw headersStream and ignores parsedHeaders.
+			const rawStream = streamed.getHeadersStream();
+			const reader = rawStream
+				.pipeThrough(new TextDecoderStream())
+				.getReader();
+			let text = '';
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				text += value;
+			}
+
+			const parsed = JSON.parse(text);
+			expect(parsed.status).toBe(301);
+			expect(parsed.headers).toEqual(['location: /wp-admin/']);
+
+			// Reconstruct a StreamedPHPResponse from the raw stream
+			// as the Comlink deserializer would
+			const reconstructed = new StreamedPHPResponse(
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.enqueue(new TextEncoder().encode(text));
+						controller.close();
+					},
+				}),
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.close();
+					},
+				}),
+				new ReadableStream<Uint8Array>({
+					start(controller) {
+						controller.close();
+					},
+				}),
+				Promise.resolve(0)
+			);
+
+			expect(await reconstructed.httpStatusCode).toBe(301);
+			expect(await reconstructed.headers).toEqual({
+				location: ['/wp-admin/'],
+			});
+		});
+
+		it('encodes multi-value headers into headersStream', async () => {
+			const original = new PHPResponse(
+				200,
+				{
+					'set-cookie': ['a=1', 'b=2'],
+					'content-type': ['text/html'],
+				},
+				new Uint8Array(0),
+				'',
+				0
+			);
+
+			const streamed = StreamedPHPResponse.fromPHPResponse(original);
+			const rawStream = streamed.getHeadersStream();
+			const reader = rawStream
+				.pipeThrough(new TextDecoderStream())
+				.getReader();
+			let text = '';
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				text += value;
+			}
+
+			const parsed = JSON.parse(text);
+			expect(parsed.status).toBe(200);
+			expect(parsed.headers).toContain('set-cookie: a=1');
+			expect(parsed.headers).toContain('set-cookie: b=2');
+			expect(parsed.headers).toContain('content-type: text/html');
+		});
 	});
 
 	describe('forHttpCode()', () => {
@@ -357,8 +444,7 @@ describe('PHPResponse', () => {
 			);
 
 			const streamed = StreamedPHPResponse.fromPHPResponse(original);
-			const converted =
-				await PHPResponse.fromStreamedResponse(streamed);
+			const converted = await PHPResponse.fromStreamedResponse(streamed);
 
 			expect(converted.httpStatusCode).toBe(201);
 			expect(converted.headers).toEqual({

--- a/packages/php-wasm/universal/src/lib/php-response.spec.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.spec.ts
@@ -85,6 +85,7 @@ describe('StreamedPHPResponse', () => {
 			expect(await streamed.httpStatusCode).toBe(500);
 			expect(await streamed.exitCode).toBe(1);
 			expect(await streamed.stdoutText).toBe('error output');
+			expect(await streamed.stderrText).toBe('Fatal error on line 5');
 		});
 
 		it('encodes headers into headersStream for cross-thread serialization', async () => {
@@ -452,6 +453,7 @@ describe('PHPResponse', () => {
 				'x-custom': ['val1', 'val2'],
 			});
 			expect(converted.bytes).toEqual(body);
+			expect(converted.errors).toBe('some stderr');
 			expect(converted.exitCode).toBe(0);
 		});
 
@@ -471,7 +473,7 @@ describe('PHPResponse', () => {
 			expect(roundTripped.httpStatusCode).toBe(original.httpStatusCode);
 			expect(roundTripped.headers).toEqual(original.headers);
 			expect(roundTripped.bytes).toEqual(original.bytes);
-			expect(roundTripped.errors).toBe('');
+			expect(roundTripped.errors).toBe('error log entry');
 			expect(roundTripped.exitCode).toBe(original.exitCode);
 			expect(roundTripped.text).toBe(original.text);
 		});

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -103,23 +103,43 @@ export class StreamedPHPResponse {
 			},
 		});
 
-		// Create empty streams for headers and stderr (won't be used since
-		// we set parsedHeaders directly below)
-		const emptyStream = () =>
-			new ReadableStream<Uint8Array>({
-				start(controller) {
-					controller.close();
-				},
-			});
+		// Encode headers into the stream in the JSON format that
+		// parseHeadersStream expects. This is critical for when
+		// the response crosses a worker thread boundary via
+		// Comlink — only the raw headersStream is serialized,
+		// not the parsedHeaders property.
+		const headerLines: string[] = [];
+		for (const [name, values] of Object.entries(response.headers)) {
+			for (const value of values) {
+				headerLines.push(`${name}: ${value}`);
+			}
+		}
+		const headersJson = JSON.stringify({
+			status: response.httpStatusCode,
+			headers: headerLines,
+		});
+		const headersStream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(headersJson));
+				controller.close();
+			},
+		});
+
+		const emptyStream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.close();
+			},
+		});
 
 		const streamed = new StreamedPHPResponse(
-			emptyStream(),
+			headersStream,
 			stdout,
-			emptyStream(),
+			emptyStream,
 			Promise.resolve(response.exitCode)
 		);
 
-		// Set pre-parsed headers to bypass header stream parsing
+		// Set pre-parsed headers as a fast-path for same-thread
+		// access (avoids re-parsing the stream we just created)
 		streamed.parsedHeaders = Promise.resolve({
 			headers: response.headers,
 			httpStatusCode: response.httpStatusCode,

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -125,8 +125,13 @@ export class StreamedPHPResponse {
 			},
 		});
 
-		const emptyStream = new ReadableStream<Uint8Array>({
+		const stderr = new ReadableStream<Uint8Array>({
 			start(controller) {
+				if (response.errors.length > 0) {
+					controller.enqueue(
+						new TextEncoder().encode(response.errors)
+					);
+				}
 				controller.close();
 			},
 		});
@@ -134,7 +139,7 @@ export class StreamedPHPResponse {
 		const streamed = new StreamedPHPResponse(
 			headersStream,
 			stdout,
-			emptyStream,
+			stderr,
 			Promise.resolve(response.exitCode)
 		);
 


### PR DESCRIPTION
## Motivation for the change, related issues

In Playground 3.1.2, navigating to `/wp-admin` (without trailing slash) in an incognito window shows a blank page instead of redirecting to the login page. This regression was introduced by the streaming response refactor (PR #3222).

## Implementation details

`StreamedPHPResponse.fromPHPResponse()` created an empty `headersStream` and relied on setting the `parsedHeaders` property directly. This worked on the same thread, but when the response crossed a Comlink worker boundary, the transfer handler only serialized the raw `headersStream` — the `parsedHeaders` property was lost.

On the receiving thread, the deserialized response had an empty `headersStream`. When headers were accessed, `parseHeadersStream` read the empty stream, `JSON.parse('')` failed, and the fallback returned `{ headers: {}, httpStatusCode: 200 }`. The 301 redirect became a 200 OK with no headers and an empty body.

The fix encodes headers into the `headersStream` using the JSON format that `parseHeadersStream` expects (`{ status, headers: ["Name: value", ...] }`), so headers survive Comlink serialization. The `parsedHeaders` fast-path is kept for same-thread access.

This affected all responses created via `fromPHPResponse()` or `forHttpCode()` that cross a worker boundary: directory trailing-slash 301 redirects, 404 responses, 502 responses, and static file responses.

## Testing Instructions (or ideally a Blueprint)

1. Run existing tests: `npx nx test php-wasm-universal --testFile=php-response.spec.ts`
2. Run request handler tests: `npx nx test php-wasm-universal --testFile=php-request-handler.spec.ts`

### Manual test
1. Apply this branch and run the updated package by running: `npx nx build php-wasm-universal`
2. Start the CLI by running: `npx nx dev playground-cli server --wp=6.8 --php=8.4 --login`
3. On a browser incognito window, navigate to `http://127.0.0.1:9400/wp-admin` (please ensure that there isn't a trailing slash `/` at the end)
4. Check that you can navigate to `wp-admin` successfully
5. You can repeat steps 2-3 on `trunk` and check that you see a blank page in trunk
