### PR TITLE
Ignore `ERR_STREAM_PREMATURE_CLOSE` in CLI server

### DIFF
--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -97,7 +97,20 @@ async function handleStreamedResponse(
 
 	// Cast needed: Web ReadableStream and Node.js ReadableStream types differ
 	const nodeStream = Readable.fromWeb(streamedResponse.stdout as any);
-	await pipeline(nodeStream, res);
+	try {
+		await pipeline(nodeStream, res);
+	} catch (error: unknown) {
+		// Ignore "ERR_STREAM_PREMATURE_CLOSE". It means the client disconnected
+		// before the response finished (e.g. a redirect or mid-load navigation).
+		if (
+			error instanceof Error &&
+			'code' in error &&
+			error.code === 'ERR_STREAM_PREMATURE_CLOSE'
+		) {
+			return;
+		}
+		throw error;
+	}
 }
 
 const bufferRequestBody = async (req: Request): Promise<Uint8Array> =>

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -10,29 +10,40 @@ vi.mock('@php-wasm/logger', () => ({
 
 describe('startServer', () => {
 	it('does not log an error on client disconnect', async () => {
-		const response = new StreamedPHPResponse(
-			new ReadableStream({
-				start(controller) {
-					const json = JSON.stringify({
-						status: 200,
-						headers: ['content-type: text/plain'],
-					});
-					controller.enqueue(new TextEncoder().encode(json));
-					controller.close();
-				},
-			}),
-			new ReadableStream({
-				start(controller) {
-					controller.enqueue(new TextEncoder().encode('hello'));
-				},
-			}),
-			new ReadableStream({ start: (c) => c.close() }),
-			Promise.resolve(0)
-		);
+		const error = new Error('handler failure');
+		const handlers = [
+			// First request returns a streaming response.
+			async () =>
+				new StreamedPHPResponse(
+					new ReadableStream({
+						start(controller) {
+							const json = JSON.stringify({
+								status: 200,
+								headers: ['content-type: text/plain'],
+							});
+							controller.enqueue(new TextEncoder().encode(json));
+							controller.close();
+						},
+					}),
+					new ReadableStream({
+						start(controller) {
+							controller.enqueue(
+								new TextEncoder().encode('hello')
+							);
+						},
+					}),
+					new ReadableStream({ start: (c) => c.close() }),
+					Promise.resolve(0)
+				),
+			// Second request throws to verify error logging works.
+			async () => {
+				throw error;
+			},
+		];
 
 		const cliServer = await startServer({
 			port: 0,
-			handleRequest: async () => response,
+			handleRequest: () => handlers.shift()!(),
 			async onBind(server, port) {
 				return { server, port } as any;
 			},
@@ -40,6 +51,7 @@ describe('startServer', () => {
 		const { server, port } = cliServer as any;
 
 		try {
+			// First request: client disconnects mid-stream.
 			await new Promise<void>((resolve) => {
 				const req = http.get(`http://127.0.0.1:${port}/`, (res) => {
 					res.once('data', () => {
@@ -48,9 +60,17 @@ describe('startServer', () => {
 					});
 				});
 			});
-
 			await new Promise((r) => setTimeout(r, 200));
 			expect(logger.error).not.toHaveBeenCalled();
+
+			// Second request: handler throws to prove error logging works.
+			await new Promise<void>((resolve) => {
+				http.get(`http://127.0.0.1:${port}/`, (res) => {
+					res.resume();
+					res.on('end', () => resolve());
+				});
+			});
+			expect(logger.error).toHaveBeenCalledWith(error);
 		} finally {
 			server.close();
 		}

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -1,18 +1,33 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, type Mock } from 'vitest';
 import http from 'http';
+import { pipeline } from 'stream/promises';
 import { StreamedPHPResponse } from '@php-wasm/universal';
 import { startServer } from '../src/start-server';
 import { logger } from '@php-wasm/logger';
+import type StreamPromisesModule from 'stream/promises';
 
 vi.mock('@php-wasm/logger', () => ({
 	logger: { error: vi.fn() },
 }));
 
+vi.mock('stream/promises', async (importOriginal) => {
+	const actual = await importOriginal<typeof StreamPromisesModule>();
+	return { ...actual, pipeline: vi.fn(actual.pipeline) };
+});
+
 describe('startServer', () => {
 	it('does not log an error on client disconnect', async () => {
-		const error = new Error('handler failure');
-		const handlers = [
-			// First request returns a streaming response.
+		const expectedErrorBefore = new Error('handler failure before');
+		const expectedErrorAfter = new Error('handler failure after');
+
+		const repondersForHandleRequest = [
+			// Demonstrate logged error before the ignored error
+			// to confirm the logger was working beforehand.
+			async () => {
+				throw expectedErrorBefore;
+			},
+			// Provide a real streamed response so we can test what happens
+			// when the client disconnects mid-stream.
 			async () =>
 				new StreamedPHPResponse(
 					new ReadableStream({
@@ -35,15 +50,18 @@ describe('startServer', () => {
 					new ReadableStream({ start: (c) => c.close() }),
 					Promise.resolve(0)
 				),
-			// Second request throws to verify error logging works.
+			// Demonstrate logged error after the ignored error
+			// to confirm the logger was working afterward.
 			async () => {
-				throw error;
+				throw expectedErrorAfter;
 			},
 		];
 
 		const cliServer = await startServer({
 			port: 0,
-			handleRequest: () => handlers.shift()!(),
+			// Each time handleRequest is called,
+			// move on to the next responder in the list.
+			handleRequest: () => repondersForHandleRequest.shift()!(),
 			async onBind(server, port) {
 				return { server, port } as any;
 			},
@@ -51,7 +69,17 @@ describe('startServer', () => {
 		const { server, port } = cliServer as any;
 
 		try {
-			// First request: client disconnects mid-stream.
+			// Demonstrate that error logging is working before the client disconnect test.
+			await new Promise<void>((resolve) => {
+				http.get(`http://127.0.0.1:${port}/`, (res) => {
+					res.resume();
+					res.on('end', () => resolve());
+				});
+			});
+			expect(logger.error).toHaveBeenCalledWith(expectedErrorBefore);
+			(logger.error as Mock<typeof logger.error>).mockClear();
+
+			// Test what happens when the client disconnects mid-stream.
 			await new Promise<void>((resolve) => {
 				const req = http.get(`http://127.0.0.1:${port}/`, (res) => {
 					res.once('data', () => {
@@ -61,16 +89,32 @@ describe('startServer', () => {
 				});
 			});
 			await new Promise((r) => setTimeout(r, 200));
+
+			// Confirm the ERR_STREAM_PREMATURE_CLOSE error was
+			// actually produced by the pipeline call.
+			const pipelineMock = vi.mocked(pipeline);
+			expect(pipelineMock).toHaveBeenCalled();
+			const pipelineResult = pipelineMock.mock.results[0];
+			expect(pipelineResult.type).toBe('return');
+			const pipelineError = await (
+				pipelineResult.value as Promise<void>
+			).catch((e: Error) => e);
+			expect(pipelineError).toBeInstanceOf(Error);
+			expect((pipelineError as NodeJS.ErrnoException).code).toBe(
+				'ERR_STREAM_PREMATURE_CLOSE'
+			);
+
+			// Confirm the error was NOT logged.
 			expect(logger.error).not.toHaveBeenCalled();
 
-			// Second request: handler throws to prove error logging works.
+			// Demonstrate that error logging remains working after the client disconnect test.
 			await new Promise<void>((resolve) => {
 				http.get(`http://127.0.0.1:${port}/`, (res) => {
 					res.resume();
 					res.on('end', () => resolve());
 				});
 			});
-			expect(logger.error).toHaveBeenCalledWith(error);
+			expect(logger.error).toHaveBeenCalledWith(expectedErrorAfter);
 		} finally {
 			server.close();
 		}

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import http from 'http';
+import { StreamedPHPResponse } from '@php-wasm/universal';
+import { startServer } from '../src/start-server';
+import { logger } from '@php-wasm/logger';
+
+vi.mock('@php-wasm/logger', () => ({
+	logger: { error: vi.fn() },
+}));
+
+describe('startServer', () => {
+	it('does not log an error on client disconnect', async () => {
+		const response = new StreamedPHPResponse(
+			new ReadableStream({
+				start(controller) {
+					const json = JSON.stringify({
+						status: 200,
+						headers: ['content-type: text/plain'],
+					});
+					controller.enqueue(new TextEncoder().encode(json));
+					controller.close();
+				},
+			}),
+			new ReadableStream({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode('hello'));
+				},
+			}),
+			new ReadableStream({ start: (c) => c.close() }),
+			Promise.resolve(0)
+		);
+
+		const cliServer = await startServer({
+			port: 0,
+			handleRequest: async () => response,
+			async onBind(server, port) {
+				return { server, port } as any;
+			},
+		});
+		const { server, port } = cliServer as any;
+
+		try {
+			await new Promise<void>((resolve) => {
+				const req = http.get(`http://127.0.0.1:${port}/`, (res) => {
+					res.once('data', () => {
+						req.destroy();
+						resolve();
+					});
+				});
+			});
+
+			await new Promise((r) => setTimeout(r, 200));
+			expect(logger.error).not.toHaveBeenCalled();
+		} finally {
+			server.close();
+		}
+	});
+});


### PR DESCRIPTION
## Motivation for the change, related issues

The streaming response refactor in #3222 replaced buffered responses with `pipeline(Readable.fromWeb(stdout), res)`. When the browser disconnects before the response stream finishes — e.g. during a redirect or when the user clicks a link mid-load — Node.js throws `ERR_STREAM_PREMATURE_CLOSE`. This results in noisy error logs on every navigation in wp-admin:

```
Error [ERR_STREAM_PREMATURE_CLOSE]: Premature close
    at onclose (node:internal/streams/end-of-stream:171:30)
    at process.processTicksAndRejections (node:internal/process/task_queues:85:11)
```

## Implementation details

Wrap the `pipeline()` call in `handleStreamedResponse` with a try/catch that silently ignores `ERR_STREAM_PREMATURE_CLOSE` and re-throws any other error.

## Testing Instructions (or ideally a Blueprint)

1. Run `npx nx test-playground-cli playground-cli --testFile=start-server.spec.ts`
2. For manual verification:
   - `npx nx dev playground-cli start --login`
   - Click around in wp-admin — the `ERR_STREAM_PREMATURE_CLOSE` errors should no longer appear in the terminal