### PR TITLE
CLI: serve static assets directly from the Express server

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -981,12 +981,17 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	let wordPressReady = false;
 	let isFirstRequest = true;
 
+	const existingSiteRootMount =
+		getMountForVfsPath(args['mount-before-install'] || [], '/wordpress') ||
+		getMountForVfsPath(args.mount || [], '/wordpress');
+
 	const server = await startServer({
 		port: args.port
 			? args.port
 			: !(await isPortInUse(selectedPort))
 				? selectedPort
 				: 0,
+		rootDir: existingSiteRootMount?.hostPath,
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';
 			const serverUrl = `http://${host}:${port}`;

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -10,6 +10,7 @@ import { logger } from '@php-wasm/logger';
 
 export interface ServerOptions {
 	port: number;
+	rootDir?: string;
 	onBind: (server: Server, port: number) => Promise<RunCLIServer | void>;
 	/**
 	 * Handler for requests. Always returns StreamedPHPResponse.
@@ -49,6 +50,18 @@ export async function startServer(
 			})
 			.once('error', reject);
 	});
+
+	if (options.rootDir) {
+		const staticMiddleware = express.static(options.rootDir, {
+			index: false,
+		});
+		app.use('/', (req, res, next) => {
+			if (req.path.endsWith('.php')) {
+				return next();
+			}
+			return staticMiddleware(req, res, next);
+		});
+	}
 
 	app.use('/', async (req, res) => {
 		try {


### PR DESCRIPTION
## Motivation for the change, related issues

Between Studio and Playground, we've been discussing performance a lot lately. This is an attempt at squeezing a little better performance out of Playground CLI's logic for serving static assets.

## Implementation details

This PR implements a change where static assets are served directly from the Express server in `packages/playground/cli/src/start-server.ts`. 

This change would probably have had a bigger effect prior to @brandonpayton's #3150, as it would have allowed static assets to be served in parallel, even if Playground only served a single PHP request at a time. Sadly, I didn't think of this earlier 🤷‍♂️

In any case, I did some simple performance testing for this PR by measuring the total load time for all resources in the Site Editor and wasn't able to detect a statistically significant performance improvement with this approach. So, is this still a good idea?

Conceptually, it makes sense to serve static assets higher up in the tree, IMO. It would also help us preserve performance if we decide to make the worker-count variable, for example, to reduce memory usage. I'll happily discuss the change further. Thoughts and feedback welcome!

## Testing Instructions (or ideally a Blueprint)

1. Run the following command, where `PATH_TO_SITE` is the path to a WordPress site on disk

```
node --experimental-strip-types --experimental-transform-types --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts start --path PATH_TO_SITE
```

2. Open wp-admin
3. Navigate around the wp-admin pages and ensure that they load as expected