### PR TITLE
Reduce Playground CLI target worker count to five

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -992,10 +992,11 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			// With HTTP 1.1, browsers typically support 6 parallel connections per domain. This is the
 			// upper limit to the number of workers we should run to optimize for performance. We also want
 			// to keep memory usage low by limiting the number of workers. Based on real world testing, five
-			// workers strikes a good balance. Keep at least two workers to preserve behavior that requires
-			// separate PHP processes (e.g. file locking tests and secondary-worker request handling).
+			// workers strikes a good balance. Keep at least three workers to preserve behavior that requires
+			// separate PHP processes (e.g. file locking tests and secondary-worker request handling) and to
+			// avoid two-worker deadlocks in lock coordination scenarios.
 			const targetWorkerCount = Math.max(
-				2,
+				3,
 				Math.min(5, cpus().length - 1)
 			);
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -992,10 +992,11 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			const serverUrl = `http://${host}:${port}`;
 			const siteUrl = args['site-url'] || serverUrl;
 
-			const targetWorkerCount = Math.max(
-				cpus().length - 1,
-				MINIMUM_WORKER_COUNT
-			);
+			// With HTTP 1.1, browsers typically support 6 parallel connections per domain. This is the
+			// upper limit to the number of workers we should run to optimize for performance. We also want
+			// to keep memory usage low by limiting the number of workers. Based on real world testing, five
+			// workers strikes a good balance.
+			const targetWorkerCount = Math.min(5, cpus().length - 1);
 
 			/*
 			 * Use a real temp dir as a target for the following Playground paths

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -48,7 +48,6 @@ import {
 	SupportedPHPVersions,
 	FileLockManagerInMemory,
 } from '@php-wasm/universal';
-import { cpus } from 'os';
 import type { MessagePort as NodeMessagePort } from 'worker_threads';
 import yargs, { type Argv, type Options as YargsOptions } from 'yargs';
 import { isValidWordPressSlug } from './is-valid-wordpress-slug';
@@ -989,16 +988,22 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			const serverUrl = `http://${host}:${port}`;
 			const siteUrl = args['site-url'] || serverUrl;
 
-			// With HTTP 1.1, browsers typically support 6 parallel connections per domain. This is the
-			// upper limit to the number of workers we should run to optimize for performance. We also want
-			// to keep memory usage low by limiting the number of workers. Based on real world testing, five
-			// workers strikes a good balance. Keep at least three workers to preserve behavior that requires
-			// separate PHP processes (e.g. file locking tests and secondary-worker request handling) and to
-			// avoid two-worker deadlocks in lock coordination scenarios.
-			const targetWorkerCount = Math.max(
-				3,
-				Math.min(5, cpus().length - 1)
-			);
+			/**
+			 * With HTTP 1.1, browsers typically support 6 parallel connections per domain.
+			 * > browsers open several connections to each domain,
+			 * > sending parallel requests. Default was once 2 to 3 connections,
+			 * > but this has now increased to a more common use of 6 parallel connections.
+			 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Connection_management_in_HTTP_1.x#domain_sharding
+			 *
+			 * While our HTTP server only supports HTTP 1.1 and while we are trying to limit the
+			 * memory requirements of multiple workers, let's hard-code the number of request-handling
+			 * workers to 6.
+			 *
+			 * Going higher than browsers' max concurrent requests seems pointless,
+			 * and going lower may increase the likelihood of deadlock due to workers
+			 * blocking and waiting for file locks.
+			 */
+			const targetWorkerCount = 6;
 
 			/*
 			 * Use a real temp dir as a target for the following Playground paths

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -992,8 +992,12 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			// With HTTP 1.1, browsers typically support 6 parallel connections per domain. This is the
 			// upper limit to the number of workers we should run to optimize for performance. We also want
 			// to keep memory usage low by limiting the number of workers. Based on real world testing, five
-			// workers strikes a good balance.
-			const targetWorkerCount = Math.min(5, cpus().length - 1);
+			// workers strikes a good balance. Keep at least two workers to preserve behavior that requires
+			// separate PHP processes (e.g. file locking tests and secondary-worker request handling).
+			const targetWorkerCount = Math.max(
+				2,
+				Math.min(5, cpus().length - 1)
+			);
 
 			/*
 			 * Use a real temp dir as a target for the following Playground paths

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -95,9 +95,6 @@ type LogVerbosity = (typeof LogVerbosity)[keyof typeof LogVerbosity]['name'];
 
 export type WorkerType = 'v1' | 'v2';
 
-// TODO: Consider creating more workers on demand if other workers blocked to avoid deadlock.
-const MINIMUM_WORKER_COUNT = 10;
-
 /**
  * Parse the CLI args and run the appropriate command.
  *


### PR DESCRIPTION
## Motivation for the change, related issues

Multi-worker support in Playground CLI (https://github.com/WordPress/wordpress-playground/pull/3150) is great, but it significantly increases memory usage. Through experimentation with @JanJakes, we found that five workers seem to yield the same loading times while reducing memory usage by ~1GB. This is because browsers limit the number of concurrent requests to a single domain (over HTTP 1.1 connections) to six at a time, [reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Connection_management_in_HTTP_1.x#domain_sharding).

Here are my results from testing this branch vs trunk. It shows a significant reduction in memory usage, but no significant change in load time. 


|  | Site Editor load time (avg, 5 runs) | Memory |
| --- | ----------------------------------- | ------ |
| This branch | 3,884s | 1,68GB |
| trunk | 3,928s | 2,59GB (peaking over 3GB) |


## Implementation details

Super simple change. We could also consider making this configurable or dynamic in some way, but I recommend we land this before the discussion drags on, as it would be very beneficial for Studio users by reducing memory use.

## Testing Instructions (or ideally a Blueprint)

1. Run the following command, where `PATH_TO_SITE` is the path to a WordPress site on disk

```
node --experimental-strip-types --experimental-transform-types --import ./packages/meta/src/node-es-module-loader/register.mts ./packages/playground/cli/src/cli.ts start --path PATH_TO_SITE
```

2. Open wp-admin
3. Navigate around wp-admin and ensure performance seems adequate compared to trunk