### PR TITLE
[Website] Fix 404 when loading /wp-includes/empty.html

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -491,11 +491,15 @@ window.__playground_ControlledIframe = window.wp.element.forwardRef(function (pr
 				URL.revokeObjectURL(url);
 			}
 		};
-		const siteUrl = document.location.href.substring(0, document.location.href.indexOf('/wp-admin/'));
 		/**
 		 * Different WordPress versions use different ways of loading the editor iframe. Let's handle
 		 * all possible scenarios.
+		 *
+		 * Derive the site URL from ajaxurl, which WordPress always sets in the admin to
+		 * {siteUrl}/wp-admin/admin-ajax.php.
 		 */
+		const ajaxUrl = new URL(window.ajaxurl, document.location.href);
+		const siteUrl = ajaxUrl.origin + ajaxUrl.pathname.substring(0, ajaxUrl.pathname.length - '/wp-admin/admin-ajax.php'.length);
 		if (props.srcDoc) {
 			// WordPress <= 6.2 uses a srcDoc that only contains a doctype.
 			return siteUrl + '/wp-includes/empty.html';

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -491,15 +491,20 @@ window.__playground_ControlledIframe = window.wp.element.forwardRef(function (pr
 				URL.revokeObjectURL(url);
 			}
 		};
+		const siteUrl = document.location.href.substring(0, document.location.href.indexOf('/wp-admin/'));
+		/**
+		 * Different WordPress versions use different ways of loading the editor iframe. Let's handle
+		 * all possible scenarios.
+		 */
 		if (props.srcDoc) {
 			// WordPress <= 6.2 uses a srcDoc that only contains a doctype.
-			return '/wp-includes/empty.html';
+			return siteUrl + '/wp-includes/empty.html';
 		} else if (props.src && props.src.startsWith('blob:')) {
-			// WordPress 6.3 uses a blob URL with doctype and a list of static assets.
+			// WordPress 6.3 and 7.0+ use a blob URL with doctype and a list of static assets.
 			// Let's pass the document content to empty.html and render it there.
-			return '/wp-includes/empty.html#' + encodeURIComponent(__playground_readBlobAsText(props.src));
+			return siteUrl + '/wp-includes/empty.html#' + encodeURIComponent(__playground_readBlobAsText(props.src));
 		} else {
-			// WordPress >= 6.4 uses a plain HTTPS URL that needs no correction.
+			// WordPress 6.4 – 6.9 uses a plain HTTPS URL that needs no correction.
 			return props.src;
 		}
 	}, [props.src]);


### PR DESCRIPTION
## What it does

Fixes the Gutenberg block editor iframe trying to load a non-existent `/wp-includes/empty.html` file in Gutenberg 22.6.0+. With this PR, it now uses a scoped URL such as `/scope:kind-noisy-road/wp-includes/empty.html`

## Rationale

Playground patches Gutenberg's editor iframe to replace the site editor source with the `empty.html` file to allow the service worker to control that iframe. In the recent Gutenberg version, the iframe src changed to a `blob:` URL which wasn't handled entirely correctly, that is the shoehorned `<iframe src="">` was pointing to `/wp-includes/empty.html` instead of the scoped version of that URL. This used to work a year or two ago, because the referrer header's scope played a role in the path resolution, but something must have changed either in how that header is delivered or in how the service worker treats it. In any case, the `/wp-includes/empty.html` path always yielded a 404 response. 

Related:

* https://github.com/WordPress/gutenberg/issues/75941


## Implementation

The `ControlledIframe` patch now prepends the current site URL to the `empty.html` path. The "current site URL" is defined as "everything before the first `/wp-admin`". This is naive and may break self-hosting Playground under a URL containing a `/wp-admin/` segment – let's try to tweak it.

## Testing instructions

1. `npm run dev`
2. Open Playground, install the latest Gutenberg plugin (or a WordPress nightly that uses blob: URLs for the editor iframe)
3. Open the block editor (post or site editor)
4. Confirm the editor iframe loads correctly and is not blank
5. Try inserting blocks, confirm assets (CSS, JS, fonts) load inside the iframe