### PR TITLE
Fix CORS proxy crash on PHP 8.5+ due to curl_close() deprecation notice

### DIFF
--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -274,8 +274,9 @@ if (!curl_exec($ch)) {
 } else {
     @$relay_http_code_and_initial_headers_if_not_already_sent();
 }
-// Close cURL session
-curl_close($ch);
+// Suppressed: curl_close() emits a deprecation notice in PHP 8.5+
+// that corrupts chunked responses when display_errors is on.
+@curl_close($ch);
 
 // Only send chunked transfer encoding footer if we're using chunked encoding.
 // We need to manually send the footer when running in the PHP built-in server


### PR DESCRIPTION
## Motivation for the change, related issues

PHP 8.5 deprecated curl_close(), and the deprecation notice was being printed into the chunked HTTP response body, corrupting chunk framing and causing Node's HTTP parser to fail with "Invalid character in chunk size". Suppress the notice with @ to support all PHP versions.

CORS proxy is launched by `php -S 127.0.0.1:5263` so uses native PHP on the machine. Mine is 8.5.3

## Implementation details

## Testing Instructions (or ideally a Blueprint)
