### PR TITLE
[Web] Avoid cross-origin policy errors in editor

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -251,3 +251,14 @@ add_action('init', function() {
 	$prefs['core']['enableChoosePatternModal'] = false;
 	update_user_meta($user_id, 'wp_persisted_preferences', $prefs);
 });
+
+/**
+ * ¡TEMPORARY WORKAROUND!
+ * On 2026-02-26, with Gutenberg v22.6.0 and above, the site editor and post
+ * editor fail to load. This appears related the `cross-origin-embedder-policy: credentialless`
+ * header which is added when client side media is enabled by default.
+ *
+ * This has something to do with our /wp-includes/empty.html workaround.
+ * @TODO: Let's find a solution that doesn't require us to disable client side media processing.
+ */
+add_filter('wp_client_side_media_processing_enabled', '__return_false');


### PR DESCRIPTION
## Motivation for the change, related issues

When using Gutenberg v22.6.0 or WordPress 7.0 beta, the site and post editors fail to load when the `cross-origin-embedder-policy: credentialless` header is sent for the editor parent document.

## Implementation details

We don't yet know why this is an issue for Playground, and we'll be looking into it. But in the meantime, disabling client-side media processing avoids the issue:
```
add_filter('wp_client_side_media_processing_enabled', '__return_false');
```

## Testing Instructions (or ideally a Blueprint)

- CI
- Load Playground with the latest Gutenberg plugin and make sure the site and post editors load completely.