### PR TITLE
[Exploration] Fix editor iframe loading by disabling DIP header rewriting

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -534,18 +534,19 @@ function emptyHtml(scope: string) {
 	};
 
 	/**
-	 * Only add Document-Isolation-Policy when the parent page also has cross-origin
-	 * isolation headers (COEP/COOP that were rewritten to Document-Isolation-Policy).
+	 * When the parent page is cross-origin isolated (via COEP/COOP),
+	 * the child iframe needs matching COEP headers. Without them:
+	 * - The browser may block the iframe (ERR_BLOCKED_BY_RESPONSE)
+	 * - The iframe loses its service worker controller because it
+	 *   ends up in a different browsing context group
 	 *
-	 * Without this header in empty.html, Gutenberg fails to populate the editor iframe
-	 * with the editor markup when the editor page is loaded with COOP/COEP headers set.
-	 *
-	 * However, adding this header unconditionally breaks REST API authentication because
-	 * `isolate-and-credentialless` causes cross-origin requests to be sent without
-	 * credentials (cookies), resulting in "Session expired" errors.
+	 * We always use COEP (never DIP) here because DIP would create
+	 * a new agent cluster, causing the browser to restart the
+	 * navigation outside the service worker's control.
 	 */
-	if (scopesWithCrossOriginIsolation.has(scope)) {
-		headers['Document-Isolation-Policy'] = 'isolate-and-credentialless';
+	const parentCoep = scopesWithCrossOriginIsolation.get(scope);
+	if (parentCoep) {
+		headers['Cross-Origin-Embedder-Policy'] = parentCoep;
 	}
 
 	return new Response(
@@ -628,11 +629,11 @@ async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {
 let browserSupportsDocumentIsolationPolicy: boolean | undefined;
 
 /**
- * Scopes that have cross-origin isolation enabled (COEP headers were rewritten to
- * Document-Isolation-Policy). This is used to determine whether empty.html should
- * also have Document-Isolation-Policy header.
+ * Scopes that have cross-origin isolation enabled via COEP headers.
+ * Stores the original COEP value so that empty.html can be served with
+ * matching headers regardless of whether Document-Isolation-Policy is supported.
  */
-const scopesWithCrossOriginIsolation = new Set<string>();
+const scopesWithCrossOriginIsolation = new Map<string, string>();
 
 self.addEventListener('message', (event) => {
 	if (event.data?.type === 'document-isolation-policy-support-check') {
@@ -659,26 +660,27 @@ function rewriteCoopHeadersToDocumentIsolationPolicy(
 	response: Response,
 	scope: string
 ): Response {
-	// If we don't know whether the browser supports Document-Isolation-Policy,
-	// or if it doesn't support it, return the original response unchanged.
-	if (!browserSupportsDocumentIsolationPolicy) {
-		return response;
-	}
-
-	// Check if the response has COEP or COOP headers that we should rewrite
-	if (
-		!response.headers.has('cross-origin-embedder-policy') &&
-		!response.headers.has('cross-origin-opener-policy')
-	) {
-		return response;
-	}
-
-	// Only rewrite if the response has COEP headers that indicate cross-origin isolation intent.
-	// COOP alone doesn't achieve cross-origin isolation, so we key off COEP.
+	// Only process responses that have COEP headers indicating cross-origin
+	// isolation intent. COOP alone doesn't achieve cross-origin isolation,
+	// so we key off COEP.
 	const coep = response.headers.get('cross-origin-embedder-policy');
 	if (!coep || (coep !== 'require-corp' && coep !== 'credentialless')) {
 		return response;
 	}
+
+	// Track that this scope uses cross-origin isolation, regardless of DIP
+	// support. This is needed so that emptyHtml() can serve matching headers.
+	scopesWithCrossOriginIsolation.set(scope, coep);
+
+	// Don't rewrite COEP/COOP to DIP. While DIP provides better
+	// cross-origin isolation semantics, it causes child iframes
+	// to lose their service worker controller. This breaks the
+	// Gutenberg editor iframe (empty.html) because sub-resource
+	// requests from the iframe bypass the service worker and 404.
+	//
+	// With COEP/COOP, same-origin child iframes keep their service
+	// worker controller and sub-resources load correctly.
+	return response;
 
 	/**
 	 * Map COEP value to the equivalent Document-Isolation-Policy value.
@@ -708,10 +710,6 @@ function rewriteCoopHeadersToDocumentIsolationPolicy(
 	newHeaders.delete('cross-origin-embedder-policy');
 	newHeaders.delete('cross-origin-opener-policy');
 	newHeaders.set('document-isolation-policy', documentIsolationPolicy);
-
-	// Track that this scope has cross-origin isolation enabled so that
-	// empty.html (the editor iframe) can also get the Document-Isolation-Policy header.
-	scopesWithCrossOriginIsolation.add(scope);
 
 	return new Response(response.body, {
 		status: response.status,


### PR DESCRIPTION
## Motivation for the change, related issues

This PR explores fixing the Gutenberg editor iframe loading in Playground when cross-origin isolation headers are in play. **This is an exploration, not intended to be merged as-is** — it's meant to document the problem, the interactions between DIP/COEP/COOP and service workers, and a working fix that can inform a proper solution.

When Gutenberg's client-side media processing experiment is enabled, WordPress sends `Cross-Origin-Embedder-Policy: credentialless` on wp-admin pages. Playground's service worker rewrites this to `Document-Isolation-Policy: isolate-and-credentialless` (DIP). This creates a new agent cluster, causing child iframes to lose their service worker controller — the browser restarts the navigation in a different browsing context group.

The result: the editor iframe (`/wp-includes/empty.html`, a synthetic page served by the service worker) gets a second request that bypasses the SW entirely, hits the dev server, and 404s. The block editor fails to load.

## Implementation details

All changes are in `packages/playground/remote/service-worker.ts`.

### 1. Disable DIP rewriting

`rewriteCoopHeadersToDocumentIsolationPolicy()` now records the COEP value in a `Map` but returns the response unchanged — no more rewriting COEP/COOP → DIP. The DIP code path is left in place (dead code after an early `return`) so it can be re-enabled later.

With plain COEP (no COOP), same-origin child iframes keep their service worker controller.

### 2. Serve matching COEP on empty.html

`emptyHtml()` now mirrors the parent page's COEP value (from the `scopesWithCrossOriginIsolation` map). Without this, the browser blocks the iframe with `ERR_BLOCKED_BY_RESPONSE` because a COEP parent requires children to also have COEP. We intentionally use COEP only — not COOP (which would swap browsing context groups) and not DIP (which would lose the SW controller).

### Trade-off

Without DIP, `crossOriginIsolated` is `false` on wp-admin pages, so `SharedArrayBuffer` isn't available. Gutenberg handles this gracefully — it falls back to server-side media processing. The DIP feature detection code is still in place and can be re-enabled when Chrome fixes the DIP + service worker interaction.

### Open questions

- Is disabling DIP entirely the right trade-off, or should we find a way to make DIP work with same-origin iframes?
- Should the dead DIP code path be removed or kept for future re-enablement?
- Does this affect any other cross-origin isolation consumers beyond Gutenberg's media processing?

## Testing Instructions

1. Run `npm run dev` to start the dev server
2. Open the Playground website with the Gutenberg plugin installed http://127.0.0.1:5400/website-server/?plugin=gutenberg&url=%2Fwp-admin%2Fpost-new.php
3. Confirm the block editor loads correctly (the iframe renders the editor canvas)
4. Try inserting an image block and uploading a file — confirm media upload works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
