### PR TITLE
Move MountDevice type declaration to @wp-playground/storage

### DIFF
--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -5,7 +5,7 @@ import { logger } from '@php-wasm/logger';
 import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { normalizeFilesystemOperations } from '@php-wasm/fs-journal';
 import { journalFSEvents } from '@php-wasm/fs-journal';
-import type { MountDevice as _MountDevice } from '@wp-playground/storage';
+import type { MountDevice } from '@wp-playground/storage';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type * as pleaseLoadTypes from 'wicg-file-system-access';
 
@@ -28,7 +28,7 @@ declare global {
 }
 
 /** @deprecated Import MountDevice from '@wp-playground/storage' instead. */
-export type MountDevice = _MountDevice;
+export type { MountDevice };
 
 export interface MountOptions {
 	initialSync: {

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -5,6 +5,7 @@ import { logger } from '@php-wasm/logger';
 import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { normalizeFilesystemOperations } from '@php-wasm/fs-journal';
 import { journalFSEvents } from '@php-wasm/fs-journal';
+import type { MountDevice as _MountDevice } from '@wp-playground/storage';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type * as pleaseLoadTypes from 'wicg-file-system-access';
 
@@ -26,15 +27,8 @@ declare global {
 	}
 }
 
-export type MountDevice =
-	| {
-			type: 'opfs';
-			path: string;
-	  }
-	| {
-			type: 'local-fs';
-			handle: FileSystemDirectoryHandle;
-	  };
+/** @deprecated Import MountDevice from '@wp-playground/storage' instead. */
+export type MountDevice = _MountDevice;
 
 export interface MountOptions {
 	initialSync: {
@@ -260,9 +254,9 @@ async function overwriteOpfsFile(
 	const writer =
 		opfsFile.createWritable !== undefined
 			? // Google Chrome, Firefox, probably more browsers
-			  await opfsFile.createWritable()
+				await opfsFile.createWritable()
 			: // Safari
-			  await opfsFile.createSyncAccessHandle();
+				await opfsFile.createSyncAccessHandle();
 	try {
 		await writer.truncate(0);
 		await writer.write(buffer);

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-clients.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-clients.ts
@@ -1,6 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice, createEntityAdapter } from '@reduxjs/toolkit';
-import type { MountDevice, SyncProgress } from '@php-wasm/web';
+import type { SyncProgress } from '@php-wasm/web';
+import type { MountDevice } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
 
 export type OpfsSync =

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -3,11 +3,8 @@ import { journalFSEvents, replayFSJournal } from '@php-wasm/fs-journal';
 import type { EmscriptenDownloadMonitor } from '@php-wasm/progress';
 import { setURLScope } from '@php-wasm/scopes';
 import { joinPaths } from '@php-wasm/util';
-import type {
-	MountDevice,
-	SyncProgressCallback,
-	TCPOverFetchOptions,
-} from '@php-wasm/web';
+import type { SyncProgressCallback, TCPOverFetchOptions } from '@php-wasm/web';
+import type { MountDevice } from '@wp-playground/storage';
 import {
 	createDirectoryHandleMountHandler,
 	loadWebRuntime,

--- a/packages/playground/storage/src/lib/browser-fs.ts
+++ b/packages/playground/storage/src/lib/browser-fs.ts
@@ -1,6 +1,15 @@
-import type { MountDevice } from '@php-wasm/web';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type * as pleaseLoadTypes from 'wicg-file-system-access';
+
+export type MountDevice =
+	| {
+			type: 'opfs';
+			path: string;
+	  }
+	| {
+			type: 'local-fs';
+			handle: FileSystemDirectoryHandle;
+	  };
 
 export async function directoryHandleFromMountDevice(
 	device: MountDevice

--- a/packages/playground/website/src/lib/state/redux/slice-clients.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-clients.ts
@@ -1,6 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit';
 import { createSlice, createEntityAdapter } from '@reduxjs/toolkit';
-import type { MountDevice, SyncProgress } from '@php-wasm/web';
+import type { SyncProgress } from '@php-wasm/web';
+import type { MountDevice } from '@wp-playground/storage';
 import type { PlaygroundClient } from '@wp-playground/remote';
 
 export type OpfsSync =


### PR DESCRIPTION
## Motivation for the change, related issues
`@wp-playground/storage` depends on `@php-wasm/web` because of a single `MountDevice` type import in [packages/playground/storage/src/lib/browser-fs.ts](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/storage/src/lib/browser-fs.ts).

## Implementation details
`MountDevice` type export is moved to `@wp-playground/storage`. `@php-wasm/web` continue exporting it for backwards compatibility.

## Testing Instructions (or ideally a Blueprint)
Passing tests is enough.