### PR TITLE
Clarify Document-Isolation-Policy comments in service worker

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -577,15 +577,18 @@ async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {
  * usual way of achieving cross-origin isolation is via the Cross-Origin-Embedder-Policy (COEP)
  * and Cross-Origin-Resource-Policy (CORP) headers.
  *
- * However, COEP/COOP are viral-ish. Once a part of a site sets them, the rest of the site must
- * follow. This breaks external embeds, like YouTube videos, that don't set the necessary headers.
- * Serving them by default on the entire playground.wordpress.net site would break existing
- * WordPress features.
+ * However, COEP/COOP are viral-ish. To access SharedArrayBuffer in the site editor frame,
+ * the entire chain of parent frames must have them set. This includes the two iframes on
+ * playground.wordpress.net and also any site where Playground is embedded. This would break
+ * embedding Playground on other sites that don't set COEP/COOP headers.
  *
- * Gutenberg only uses them in the block editor iframe and only when the
- * client-side media processing experiment is enabled. This is fine for native WordPress, where
- * navigating between wp-admin pages triggers a full page reload, but it's problematic in
- * Playground, where the top-level page remains open the entire time you use WordPress.
+ * Relying on COEP/COOP headers is fine in native WordPress, but problematic in Playground:
+ *
+ * * WordPress can use the COEP/COOP headers in wp-admin as every navigation triggers a full
+ *   page reload and wp-admin rarely gets embedded in iframes on other pages.
+ * * Playground can't easily trigger a full page reload on every navigation – that would destroy
+ *   the current Playground instance. Also, Playground often gets embedded in iframes on other
+ *   pages.
  *
  * ## Document-Isolation-Policy
  *
@@ -606,7 +609,6 @@ async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {
  * Playground rewrites the COEP/COOP headers to Document-Isolation-Policy in the supporting
  * browsers. The support is decided using feature detection. As more browsers implement the
  * specification, they'll automatically start receiving the new header and a better experience.
- *
  *
  * @see boot-playground-remote.ts for the other part of the feature detection logic.
  * @see https://github.com/WordPress/wordpress-playground/issues/2954
@@ -639,8 +641,9 @@ self.addEventListener('message', (event) => {
  * - Removes Cross-Origin-Opener-Policy (COOP) header
  * - Adds Document-Isolation-Policy: isolate-and-credentialless
  *
- * This enables cross-origin isolation (for SharedArrayBuffer) without breaking
- * external embeds like YouTube videos that don't set COEP/COOP headers.
+ * This enables cross-origin isolation (for SharedArrayBuffer) without serving
+ * the entire playground.wordpress.net site with COEP/COOP headers (which would
+ * break embedding it on other sites).
  *
  * @param response The response to potentially modify
  * @param scope The scope of the request, used to track which scopes have cross-origin isolation


### PR DESCRIPTION
## Summary

The comments in the service worker explaining why Playground uses `Document-Isolation-Policy` instead of `COEP/COOP` headers were misleading. They suggested the problem was about "viral-ish" headers breaking YouTube embeds, but that's only part of the story. This PR rewrites them to explain the actual constraint.

## The nuance

Playground needs `SharedArrayBuffer` for the PHP WASM runtime. To get `SharedArrayBuffer`, the browser requires cross-origin isolation. There are two ways to achieve it:

1. **COEP/COOP headers** — the traditional approach
2. **Document-Isolation-Policy** — a newer Chrome-only header

The old comments said COEP/COOP are "viral-ish" and break external embeds. That's true but incomplete. The real constraint is architectural:

**COEP/COOP require the entire frame ancestry to participate.** To get `SharedArrayBuffer` inside the site editor iframe, the COEP/COOP headers must be set on:
- The site editor iframe itself
- The `remote.html` Playground frame above it
- The `playground.wordpress.net` website frame above that
- Any page that embeds Playground

That last point is the killer. Playground is routinely embedded in third-party sites (documentation, tutorials, WordPress.org). Those embedding pages don't set COEP/COOP headers, and we can't ask them to.

In native WordPress this isn't a problem — wp-admin pages do full reloads on every navigation, so COEP/COOP headers only affect the current page. In Playground, the top-level frame stays alive the entire session. Setting COEP/COOP on it would propagate the requirement upward to whatever embeds Playground.

**Document-Isolation-Policy solves this by isolating a single document** without requiring the parent chain to cooperate. It's the only viable path for Playground.

### But it's not free either

While debugging Gutenberg 26.2's `SharedArrayBuffer` usage in the site editor, I found that `Document-Isolation-Policy` introduces its own compatibility challenge:

**When only the child frame has DIP (but the parent doesn't), `window.frameElement` becomes `null` and parent-to-child `contentDocument` access is blocked.** Gutenberg's site editor directly manipulates `iframe.contentWindow.contentDocument` to set up the block editor canvas — this breaks under DIP when the parent document isn't also isolated.

<!-- TODO: embed dip-no-parent-isolation.png here – page 3 of the debugging PDF -->

When *both* parent and child have DIP, `window.frameElement` is defined and `contentDocument` access works:

<!-- TODO: embed dip-dual-parent-child.png here – page 4 of the debugging PDF -->

This is a solvable constraint in Playground (we control the service worker for all frames), but it highlights why the comments needed to be precise about what's actually going on. The previous "breaks embeds" explanation could lead someone to think COEP/COOP would work if we just handled embed resources — it won't, because the frame ancestry requirement is the fundamental blocker.

## What this PR changes

Comment-only change. No behavior changes. The debugging notes above are context for *why* precision matters in these comments — the DIP/COEP/COOP interaction is subtle enough that future contributors need accurate mental models.

## Test plan

- [x] Read the updated comments in `service-worker.ts` and verify they accurately describe the constraints
- [x] No functional changes to verify

cc @brandonpayton