### PR TITLE
WIP: Fix Gutenberg site editor under Document-Isolation-Policy

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -412,10 +412,16 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 		unscopedUrl.pathname.endsWith('/block-editor/index.min.js')
 	) {
 		const script = await workerResponse.text();
-		const newScript = `${controlledIframe} ${script.replace(
-			/\(\s*"iframe",/,
-			'(__playground_ControlledIframe,'
-		)}`;
+		const newScript = `${controlledIframe} ${script
+			.replace(/\(\s*"iframe",/, '(__playground_ControlledIframe,')
+			// .replace(
+			// 	/"media-experiments\/disable-embed-previews",t/g,
+			// 	'"media-experiments/disable-embed-previews", function(){}'
+			// )
+			.replace(
+				/setAttribute\("src"/g,
+				'setAttribute("data-donotreplace"'
+			)}`;
 		return new Response(newScript, {
 			status: workerResponse.status,
 			statusText: workerResponse.statusText,
@@ -488,28 +494,29 @@ window.__playground_ControlledIframe = window.wp.element.forwardRef(function (pr
 			} catch(e) {
 				return '';
 			} finally {
-				URL.revokeObjectURL(url);
+				// URL.revokeObjectURL(url);
 			}
 		};
 		if (props.srcDoc) {
 			// WordPress <= 6.2 uses a srcDoc that only contains a doctype.
-			return '/wp-includes/empty.html';
+			return '../wp-includes/empty.html';
 		} else if (props.src && props.src.startsWith('blob:')) {
 			// WordPress 6.3 uses a blob URL with doctype and a list of static assets.
 			// Let's pass the document content to empty.html and render it there.
-			return '/wp-includes/empty.html#' + encodeURIComponent(__playground_readBlobAsText(props.src));
+			return '../wp-includes/empty.html#' + encodeURIComponent(__playground_readBlobAsText(props.src));
 		} else {
 			// WordPress >= 6.4 uses a plain HTTPS URL that needs no correction.
 			return props.src;
 		}
 	}, [props.src]);
+	const {crossorigin, ...restProps} = props;
 	return (
 		window.wp.element.createElement('iframe', {
-			...props,
+			...restProps,
 			ref: ref,
 			src: source,
 			// Make sure there's no srcDoc, as it would interfere with the src.
-			srcDoc: undefined
+			srcDoc: undefined,
 		})
 	)
 });`;
@@ -535,12 +542,17 @@ function emptyHtml(scope: string) {
 	 * `isolate-and-credentialless` causes cross-origin requests to be sent without
 	 * credentials (cookies), resulting in "Session expired" errors.
 	 */
-	if (scopesWithCrossOriginIsolation.has(scope)) {
-		headers['Document-Isolation-Policy'] = 'isolate-and-credentialless';
-	}
+	// if (scopesWithCrossOriginIsolation.has(scope)) {
+	headers['Document-Isolation-Policy'] = 'isolate-and-credentialless';
+	// }
 
 	return new Response(
-		'<!doctype html><script>const hash = window.location.hash.substring(1); if ( hash ) document.write(decodeURIComponent(hash))</script>',
+		`<!doctype html><script>
+			const hash = window.location.hash.substring(1);
+			if ( hash ) {
+				document.write(decodeURIComponent(hash))
+			}
+		</script>`,
 		{
 			status: 200,
 			headers,
@@ -656,7 +668,7 @@ function rewriteCoopHeadersToDocumentIsolationPolicy(
 	// If we don't know whether the browser supports Document-Isolation-Policy,
 	// or if it doesn't support it, return the original response unchanged.
 	if (!browserSupportsDocumentIsolationPolicy) {
-		return response;
+		// return response;
 	}
 
 	// Check if the response has COEP or COOP headers that we should rewrite
@@ -664,14 +676,14 @@ function rewriteCoopHeadersToDocumentIsolationPolicy(
 		!response.headers.has('cross-origin-embedder-policy') &&
 		!response.headers.has('cross-origin-opener-policy')
 	) {
-		return response;
+		// return response;
 	}
 
 	// Only rewrite if the response has COEP headers that indicate cross-origin isolation intent.
 	// COOP alone doesn't achieve cross-origin isolation, so we key off COEP.
 	const coep = response.headers.get('cross-origin-embedder-policy');
 	if (!coep || (coep !== 'require-corp' && coep !== 'credentialless')) {
-		return response;
+		// return response;
 	}
 
 	/**
@@ -701,11 +713,13 @@ function rewriteCoopHeadersToDocumentIsolationPolicy(
 	const newHeaders = new Headers(response.headers);
 	newHeaders.delete('cross-origin-embedder-policy');
 	newHeaders.delete('cross-origin-opener-policy');
+	// if (coep) {
 	newHeaders.set('document-isolation-policy', documentIsolationPolicy);
 
 	// Track that this scope has cross-origin isolation enabled so that
 	// empty.html (the editor iframe) can also get the Document-Isolation-Policy header.
 	scopesWithCrossOriginIsolation.add(scope);
+	// }
 
 	return new Response(response.body, {
 		status: response.status,

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -311,7 +311,9 @@ export async function bootPlaygroundRemote() {
 			 *      the detailed context.
 			 */
 			const navigationComplete = new Promise<void>((resolve) => {
-				wpFrame.addEventListener('load', () => resolve(), { once: true });
+				wpFrame.addEventListener('load', () => resolve(), {
+					once: true,
+				});
 			});
 
 			// If the URL is the same, we need to force a reload
@@ -564,6 +566,9 @@ function detectDocumentIsolationPolicySuport(): Promise<boolean> {
 		};
 
 		document.body.appendChild(testFrame);
+	}).then((result) => {
+		console.log('detectDocumentIsolationPolicySuport', result);
+		return result;
 	});
 }
 

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -261,4 +261,5 @@ add_action('init', function() {
  * This has something to do with our /wp-includes/empty.html workaround.
  * @TODO: Let's find a solution that doesn't require us to disable client side media processing.
  */
-add_filter('wp_client_side_media_processing_enabled', '__return_false');
+// add_filter('wp_client_side_media_processing_enabled', '__return_false');
+define( 'DISABLE_WP_CRON', true );

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -93,6 +93,10 @@ export default defineConfig(({ mode }) => {
 			port: remoteDevServerPort,
 			host: remoteDevServerHost,
 			allowedHosts: ['playground.test', 'playground-preview.test'],
+			headers: {
+				'X-Server-By': 'vite-remote',
+				'Document-Isolation-Policy': 'isolate-and-credentialless',
+			},
 			proxy: {
 				// Proxy CORS requests to the local PHP CORS proxy server.
 				// This avoids Private Network Access (PNA) restrictions in Chrome

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -40,10 +40,7 @@ const isDevcontainer = process.env.VITE_DEVCONTAINER === 'true';
 // a port that was published using the devcontainer "appPort" configuration.
 const serverHost = isDevcontainer ? '0.0.0.0' : websiteDevServerHost;
 
-async function setCodespacesPortPublic(
-	port: number,
-	codespaceName: string
-) {
+async function setCodespacesPortPublic(port: number, codespaceName: string) {
 	// eslint-disable-next-line no-console
 	console.log(`Publishing port ${port}...`);
 	const cmd = `gh codespace ports visibility ${port}:public -c ${codespaceName}`;
@@ -101,6 +98,10 @@ export default defineConfig(({ command, mode }) => {
 		server: {
 			port: websiteDevServerPort,
 			host: serverHost,
+			headers: {
+				'X-Served-By': 'vite',
+				'Document-Isolation-Policy': 'isolate-and-credentialless',
+			},
 			allowedHosts: [
 				'playground.test',
 				'playground-preview.test',
@@ -141,8 +142,7 @@ export default defineConfig(({ command, mode }) => {
 				? {
 						name: 'devcontainer-print-urls',
 						configureServer(server: ViteDevServer) {
-							const codespaceName =
-								process.env['CODESPACE_NAME'];
+							const codespaceName = process.env['CODESPACE_NAME'];
 							const codespacesDomain =
 								process.env[
 									'GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN'
@@ -160,13 +160,11 @@ export default defineConfig(({ command, mode }) => {
 							// Codespaces ports default to private, breaking CORS.
 							// Publish once the tunnel is ready.
 							if (codespaceName) {
-								server.httpServer?.once(
-									'listening',
-									() =>
-										setCodespacesPortPublic(
-											websiteDevServerPort,
-											codespaceName
-										)
+								server.httpServer?.once('listening', () =>
+									setCodespacesPortPublic(
+										websiteDevServerPort,
+										codespaceName
+									)
 								);
 							}
 						},


### PR DESCRIPTION
## Summary

Gutenberg 26.2 uses `SharedArrayBuffer` in the site editor. That requires cross-origin isolation. WordPress serves the editor frame with COEP/COOP headers. It's pretty difficult to do the same in Playground, so instead we rewrite those headers as `Document-Isolation-Policy`. However, DIP has subtle side effect that breaks how Gutenberg sets up its editor canvas. I think (?) it wasn't a problem at the time https://github.com/WordPress/wordpress-playground/pull/3028 was merged, but Gutenberg internals changed in https://github.com/WordPress/gutenberg/pull/74418 (and likely a few other PRs) so the situation needs to be re-evaluated now.

This is a WIP branch capturing the debugging so far.

## Why Playground can't use COEP/COOP

COEP/COOP require the **entire frame ancestry** to participate. To get `SharedArrayBuffer` inside the site editor iframe, headers must be set on:

- The site editor iframe itself
- The `remote.html` Playground frame above it
- The `playground.wordpress.net` host page above that
- **Any third-party page that embeds Playground**

That last point is the blocker. Playground is embedded on WordPress.org, in documentation, in tutorials. Those pages don't send COEP/COOP, and we can't make them.

Native WordPress doesn't have this problem — wp-admin does full-page reloads, so COEP/COOP only needs to cover the current page. In Playground, the top-level frame stays alive for the entire session.

Perhaps we could introduce a query param such as `?coop=1` or so and use a magic default value depending on whether Playground is loaded from an iframe, but that sounds fragile.

## The DIP problem

`Document-Isolation-Policy` isolates a single document without requiring parent cooperation. But it has a catch:

**When only the child frame has DIP but the parent doesn't:**
- `window.frameElement` becomes `null`
- Parent-to-child `contentDocument` access is blocked

Gutenberg's site editor calls `iframe.contentWindow.contentDocument` directly to set up the block editor canvas. When `contentDocument` is blocked, it crashes.

**When both parent and child have DIP:**
- `window.frameElement` is defined
- `contentDocument` access works

<img width="1661" height="2341" alt="dip-dual-parent-child" src="https://github.com/user-attachments/assets/5d77ed40-ba58-4f2c-ad14-8bb33a399833" />

## What this branch does

Serves `Document-Isolation-Policy: isolate-and-credentialless` on **all** HTML responses in Playground — from the service worker and from both Vite dev servers — so that the parent-child DIP requirement is satisfied.

To try it, go to http://localhost:5400/website-server/?wp=beta&url=%2Fwp-admin%2Fsite-editor.php#ewogICJwbHVnaW5zIjogW10sCiAgInN0ZXBzIjogW10sCiAgInByZWZlcnJlZFZlcnNpb25zIjogewogICAgInBocCI6ICI4LjMiLAogICAgIndwIjogImJldGEiCiAgfSwKICAiZmVhdHVyZXMiOiB7fSwKICAibG9naW4iOiB0cnVlLAogICJsYW5kaW5nUGFnZSI6ICIvd3AtYWRtaW4vc2l0ZS1lZGl0b3IucGhwIgp9

It has some very rough edges, e.g. all the blocks crash and I don't know why. Also, I'm not sure about the impact of this on Playgrounds embedded on sites without the `Document-Isolation-Policy` header. Also, it further complicates the Chrome vs FF/Safari maintenance split. Finally, I'm not sure if client-side media processing actually works in this PR. But I know SharedArrayBuffer is available in the right iframe, and that's already a lot. This PR is just a debugging exploration to understand the phenomenon. It's not meant for merging.

cc @brandonpayton @JanJakes @adamsilverstein @swissspidy 

related to https://github.com/WordPress/wordpress-playground/issues/2954