### PR TITLE
Correct plugin directory reference in documentation

### DIFF
--- a/packages/docs/site/docs/main/guides/for-plugin-developers.md
+++ b/packages/docs/site/docs/main/guides/for-plugin-developers.md
@@ -16,7 +16,7 @@ Discover how to [Build](/about/build), [Test](/about/test), and [Launch](/about/
 
 ## Launching a Playground instance with a plugin
 
-### Plugin in the WordPress plugin directory
+### Plugin in the WordPress plugins directory
 
 With WordPress Playground, you can quickly launch a WordPress installation with almost any plugin available in the [WordPress Plugins Directory](https://wordpress.org/plugins/) installed and activated. All you need to do is to add the `plugin` [query parameter](/developers/apis/query-api) to the [Playground URL](https://playground.wordpress.net) and use the slug of the plugin from the WordPress directory as a value. For example: https://playground.wordpress.net/?plugin=create-block-theme
 

--- a/packages/docs/site/docs/main/guides/for-plugin-developers.md
+++ b/packages/docs/site/docs/main/guides/for-plugin-developers.md
@@ -16,7 +16,7 @@ Discover how to [Build](/about/build), [Test](/about/test), and [Launch](/about/
 
 ## Launching a Playground instance with a plugin
 
-### Plugin in the WordPress themes directory
+### Plugin in the WordPress plugin directory
 
 With WordPress Playground, you can quickly launch a WordPress installation with almost any plugin available in the [WordPress Plugins Directory](https://wordpress.org/plugins/) installed and activated. All you need to do is to add the `plugin` [query parameter](/developers/apis/query-api) to the [Playground URL](https://playground.wordpress.net) and use the slug of the plugin from the WordPress directory as a value. For example: https://playground.wordpress.net/?plugin=create-block-theme
 


### PR DESCRIPTION
https://wordpress.github.io/wordpress-playground/guides/for-plugin-developers/#plugin-in-a-github-repository
is talking about installing a plugin from the WordPress theme directory.