### PR TITLE
[Website] Disable WP Cron

### DIFF
--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -272,7 +272,7 @@ add_filter('wp_client_side_media_processing_enabled', '__return_false');
  */
 define('DISABLE_WP_CRON', true);
 if(str_ends_with($_SERVER['PHP_SELF'], '/wp-cron.php')) {
-	http_response_code(400);
+	http_response_code(503);
 	header('Content-Type: text/plain');
 	echo 'WP Cron is temporarily disabled in the Playground.';
 	exit;

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -264,13 +264,14 @@ add_action('init', function() {
 add_filter('wp_client_side_media_processing_enabled', '__return_false');
 
 /**
- * Disable the WP Cron. Around WordPress 7.0 beta 1, many wp-cron requests in
- * the Playground started taking the full 30 seconds to complete. Since we're
- * running PHP on a single worker, that blocks every other request from running
- * until WP Cron completes.
+ * Disable the WP Cron.
+ * 
+ * Around WordPress 7.0 beta 1, many wp-cron requests in the Playground started
+ * taking the full 30 seconds to complete. Since we're running PHP on a single
+ * worker, that blocks every other request from running until WP Cron completes.
  */
 define('DISABLE_WP_CRON', true);
-if(str_ends_with($_SERVER['REQUEST_URI'], '/wp-cron.php')) {
+if(str_ends_with($_SERVER['PHP_SELF'], '/wp-cron.php')) {
 	http_response_code(400);
 	header('Content-Type: text/plain');
 	echo 'WP Cron is temporarily disabled in the Playground.';

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -262,3 +262,17 @@ add_action('init', function() {
  * @TODO: Let's find a solution that doesn't require us to disable client side media processing.
  */
 add_filter('wp_client_side_media_processing_enabled', '__return_false');
+
+/**
+ * Disable the WP Cron. Around WordPress 7.0 beta 1, many wp-cron requests in
+ * the Playground started taking the full 30 seconds to complete. Since we're
+ * running PHP on a single worker, that blocks every other request from running
+ * until WP Cron completes.
+ */
+define('DISABLE_WP_CRON', true);
+if(str_ends_with($_SERVER['REQUEST_URI'], '/wp-cron.php')) {
+	http_response_code(400);
+	header('Content-Type: text/plain');
+	echo 'WP Cron is temporarily disabled in the Playground.';
+	exit;
+}


### PR DESCRIPTION
Disables WP Cron until Playground can limit its adverse UX effects.

Around WordPress 7.0 beta 1, many wp-cron requests in the Playground started taking the full 30 seconds to complete. Since we're running PHP on a single worker, that blocks every other request from running until WP Cron completes.

To re-enable WP Cron, we'll need to do one of the following:

* Set a hard time limit to 2 or 3 seconds for wp-cron.php
* Support a multi worker setup to run WP Cron without blocking other WordPress requests
* Identify the blocking long-running wp-cron operation and address it. I think I've seen a fetch() for a WordPress update, can we avoid fetching it in a fresh Playground running off WordPress trunk?

@brandonpayton 