### PR TITLE
[Web] Fix blank preview in WP site editor

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -487,8 +487,6 @@ window.__playground_ControlledIframe = window.wp.element.forwardRef(function (pr
 				return xhr.responseText;
 			} catch(e) {
 				return '';
-			} finally {
-				URL.revokeObjectURL(url);
 			}
 		};
 		if (props.srcDoc) {


### PR DESCRIPTION
## Motivation for the change, related issues

The preview pane is blanking during use of the WP site editor.

### Background

When iframe documents are created via the iframe.srcDoc property, requests in the context of that iframe are not sent to the service worker. This causes issues with loading the WP block editor in Playground because the editor relies upon iframe.srcDoc.

To work around this issue, we patch editor scripts so we can intercept the srcDoc setting and set iframe.src instead. This allows the Playground service worker to handle all requests from that iframe.

### Cause

Today, with the latest Gutenberg plugin, the site editor preview begins blanking after the first use. The reason appears to be that our editor workaround is proactively revoking a blob URL that the latest Gutenberg is attempting to reuse. Subsequent uses of the blob URL fail.

<img width="1101" height="578" alt="Screenshot 2026-03-02 at 6 31 21 PM" src="https://github.com/user-attachments/assets/0cf8024e-f812-488a-b8d5-b163dd73dbae" />

Thanks to @annezazu for reporting this!

## Implementation details

This PR adjusts our workaround to stop revoking the blob URL. It is up to the creator (Gutenberg) to handle cleanup, and it does so [via a finalization registry based on the resolved editor assets](https://github.com/WordPress/gutenberg/blob/5044b36b18e9a919633001ee5dae74d4ff76b111/packages/block-editor/src/components/iframe/index.js#L143).

## Testing Instructions (or ideally a Blueprint)

- CI
- Manual testing