### PR TITLE
Removes the `.github/CODEOWNERS` file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/* @WordPress/playground-maintainers


### PR DESCRIPTION
## Motivation for the change, related issues

The CODEOWNERS file has two issues:

1. **Incomplete coverage** – The `/* @WordPress/playground-maintainers` pattern only matches files in the repository root, so PRs that only change files in subdirectories don't get automatic reviewer assignments.
2. **Can't be removed by automation** – When CODEOWNERS assigns a reviewer, GitHub prevents it from being removed programmatically, which breaks our reviewer removal automation.

## Implementation details

Deletes the CODEOWNERS file entirely. To restore automatic reviewer assignment, a repository admin should set up a branch protection rule that assigns the Playground Maintainers team as reviewers on all PRs.

## Testing Instructions

- Confirm `.github/CODEOWNERS` no longer exists after merge

