### PR TITLE
Allow web deploy from WP update workflow

### DIFF
--- a/.github/workflows/deploy-my-wordpress-net.yml
+++ b/.github/workflows/deploy-my-wordpress-net.yml
@@ -15,7 +15,7 @@ jobs:
         if: >
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
-                github.event_name == 'workflow_dispatch' ||
+                (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||
                 github.actor == 'adamziel' ||
                 github.actor == 'akirk' ||
                 github.actor == 'dmsnell' ||

--- a/.github/workflows/deploy-my-wordpress-net.yml
+++ b/.github/workflows/deploy-my-wordpress-net.yml
@@ -15,6 +15,7 @@ jobs:
         if: >
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
+                github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||
                 github.actor == 'akirk' ||
                 github.actor == 'dmsnell' ||

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -15,7 +15,7 @@ jobs:
         if: >
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
-                github.event_name == 'workflow_dispatch' ||
+                (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||
                 github.actor == 'adamziel' ||
                 github.actor == 'akirk' ||
                 github.actor == 'dmsnell' ||

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -15,6 +15,7 @@ jobs:
         if: >
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
+                github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||
                 github.actor == 'akirk' ||
                 github.actor == 'dmsnell' ||


### PR DESCRIPTION
## Motivation for the change, related issues

Today, whenever the WordPress update workflows try to deploy the website after an update, the website deploy workflow skips the run because the event name check fails.

## Implementation details

This PR adds `workflow_dispatch` to the list of events that can trigger the deploy workflows. This is how the WordPress update workflow attempts to trigger the deploys today.

## Testing Instructions (or ideally a Blueprint)

Observe whether the deploys happen automatically for the next WordPress release.
