### PR TITLE
WebRTC peer-to-peer sync transport + demo

### DIFF
--- a/packages/playground/sync/src/index.ts
+++ b/packages/playground/sync/src/index.ts
@@ -3,3 +3,10 @@ export * from './fs';
 export * from './transports';
 export * from './setup-playground-sync';
 export * from './middleware';
+export { SignalingClient } from './transports/signaling-client';
+export type { SignalingClientOptions } from './transports/signaling-client';
+export { WebRTCTransport } from './transports/webrtc-transport';
+export type {
+	WebRTCTransportOptions,
+	WebRTCTransportState,
+} from './transports/webrtc-transport';

--- a/packages/playground/sync/src/transports/message-chunking.spec.ts
+++ b/packages/playground/sync/src/transports/message-chunking.spec.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+	serializeEnvelope,
+	deserializeEnvelope,
+	chunkMessage,
+	MessageAssembler,
+} from './message-chunking';
+import type { TransportEnvelope } from '../transports';
+
+function makeEnvelope(
+	sqlCount = 1,
+	binaryData?: Uint8Array
+): TransportEnvelope {
+	return {
+		sql: Array.from({ length: sqlCount }, (_, i) => ({
+			type: 'sql' as const,
+			subtype: 'replay' as const,
+			query: `INSERT INTO wp_posts VALUES (${i})`,
+		})),
+		fs: binaryData
+			? [
+					{
+						operation: 'UPDATE_FILE' as const,
+						path: '/wordpress/wp-content/test.txt',
+						data: binaryData,
+						nodeType: 'file' as const,
+					},
+				]
+			: [],
+	};
+}
+
+describe('serializeEnvelope / deserializeEnvelope', () => {
+	it('should round-trip an envelope with no binary data', () => {
+		const envelope = makeEnvelope(2);
+		const serialized = serializeEnvelope(envelope);
+		const deserialized = deserializeEnvelope(serialized);
+		expect(deserialized).toEqual(envelope);
+	});
+
+	it('should round-trip an envelope with binary data', () => {
+		const data = new Uint8Array([1, 2, 3, 4, 5]);
+		const envelope = makeEnvelope(1, data);
+		const serialized = serializeEnvelope(envelope);
+		const deserialized = deserializeEnvelope(serialized);
+		expect(deserialized.fs).toHaveLength(1);
+		const fsOp = deserialized.fs[0] as { data: Uint8Array };
+		expect(fsOp.data).toBeInstanceOf(Uint8Array);
+		expect(Array.from(fsOp.data)).toEqual([1, 2, 3, 4, 5]);
+	});
+
+	it('should round-trip an envelope with large binary data', () => {
+		const data = new Uint8Array(100_000);
+		for (let i = 0; i < data.length; i++) {
+			data[i] = i % 256;
+		}
+		const envelope = makeEnvelope(1, data);
+		const serialized = serializeEnvelope(envelope);
+		const deserialized = deserializeEnvelope(serialized);
+		const fsOp = deserialized.fs[0] as { data: Uint8Array };
+		expect(fsOp.data).toBeInstanceOf(Uint8Array);
+		expect(fsOp.data.byteLength).toBe(100_000);
+		expect(fsOp.data[0]).toBe(0);
+		expect(fsOp.data[255]).toBe(255);
+		expect(fsOp.data[256]).toBe(0);
+	});
+
+	it('should handle empty envelope', () => {
+		const envelope: TransportEnvelope = { sql: [], fs: [] };
+		const serialized = serializeEnvelope(envelope);
+		const deserialized = deserializeEnvelope(serialized);
+		expect(deserialized).toEqual(envelope);
+	});
+});
+
+describe('chunkMessage', () => {
+	it('should produce a single chunk for small messages', () => {
+		const data = new Uint8Array([10, 20, 30]);
+		const chunks = chunkMessage(1, data);
+		expect(chunks).toHaveLength(1);
+		// 5 bytes header + 3 bytes payload
+		expect(chunks[0].byteLength).toBe(8);
+	});
+
+	it('should split large messages into multiple chunks', () => {
+		// Use a small maxChunkSize so we get multiple chunks
+		const data = new Uint8Array(100);
+		const chunks = chunkMessage(42, data, 30);
+		// maxPayload = 30 - 5 = 25, so 100/25 = 4 chunks
+		expect(chunks).toHaveLength(4);
+
+		// Only the last chunk should have the final flag
+		for (let i = 0; i < chunks.length - 1; i++) {
+			expect(chunks[i][0] & 0x01).toBe(0);
+		}
+		expect(chunks[chunks.length - 1][0] & 0x01).toBe(1);
+	});
+
+	it('should handle empty data', () => {
+		const data = new Uint8Array(0);
+		const chunks = chunkMessage(1, data);
+		expect(chunks).toHaveLength(1);
+		expect(chunks[0][0] & 0x01).toBe(1); // final flag set
+	});
+});
+
+describe('MessageAssembler', () => {
+	it('should assemble a single-chunk message', () => {
+		const assembler = new MessageAssembler();
+		const data = new Uint8Array([1, 2, 3]);
+		const chunks = chunkMessage(1, data);
+		const result = assembler.addChunk(chunks[0]);
+		expect(result).not.toBeNull();
+		expect(Array.from(result!)).toEqual([1, 2, 3]);
+	});
+
+	it('should assemble a multi-chunk message', () => {
+		const assembler = new MessageAssembler();
+		const data = new Uint8Array(100);
+		for (let i = 0; i < data.length; i++) {
+			data[i] = i % 256;
+		}
+		const chunks = chunkMessage(7, data, 30);
+		expect(chunks.length).toBeGreaterThan(1);
+
+		let result: Uint8Array | null = null;
+		for (const chunk of chunks) {
+			result = assembler.addChunk(chunk);
+		}
+		expect(result).not.toBeNull();
+		expect(Array.from(result!)).toEqual(Array.from(data));
+	});
+
+	it('should handle concurrent message IDs', () => {
+		const assembler = new MessageAssembler();
+		const dataA = new Uint8Array([10, 20, 30, 40, 50]);
+		const dataB = new Uint8Array([60, 70, 80, 90, 100]);
+
+		const chunksA = chunkMessage(1, dataA, 8); // 3 byte payload per chunk
+		const chunksB = chunkMessage(2, dataB, 8);
+
+		// Interleave chunks from both messages
+		let resultA: Uint8Array | null = null;
+		let resultB: Uint8Array | null = null;
+		const maxLen = Math.max(chunksA.length, chunksB.length);
+		for (let i = 0; i < maxLen; i++) {
+			if (i < chunksA.length) {
+				const r = assembler.addChunk(chunksA[i]);
+				if (r) resultA = r;
+			}
+			if (i < chunksB.length) {
+				const r = assembler.addChunk(chunksB[i]);
+				if (r) resultB = r;
+			}
+		}
+
+		expect(resultA).not.toBeNull();
+		expect(resultB).not.toBeNull();
+		expect(Array.from(resultA!)).toEqual([10, 20, 30, 40, 50]);
+		expect(Array.from(resultB!)).toEqual([60, 70, 80, 90, 100]);
+	});
+
+	it('should return null for intermediate chunks', () => {
+		const assembler = new MessageAssembler();
+		const data = new Uint8Array(100);
+		const chunks = chunkMessage(1, data, 30);
+		expect(chunks.length).toBeGreaterThan(1);
+
+		for (let i = 0; i < chunks.length - 1; i++) {
+			expect(assembler.addChunk(chunks[i])).toBeNull();
+		}
+		expect(assembler.addChunk(chunks[chunks.length - 1])).not.toBeNull();
+	});
+});
+
+describe('full round-trip: serialize → chunk → reassemble → deserialize', () => {
+	it('should round-trip a large envelope through chunking', () => {
+		const bigData = new Uint8Array(200_000);
+		for (let i = 0; i < bigData.length; i++) {
+			bigData[i] = i % 256;
+		}
+		const envelope = makeEnvelope(3, bigData);
+
+		const serialized = serializeEnvelope(envelope);
+		const chunks = chunkMessage(1, serialized);
+
+		const assembler = new MessageAssembler();
+		let assembled: Uint8Array | null = null;
+		for (const chunk of chunks) {
+			assembled = assembler.addChunk(chunk);
+		}
+		expect(assembled).not.toBeNull();
+
+		const deserialized = deserializeEnvelope(assembled!);
+		expect(deserialized.sql).toEqual(envelope.sql);
+		expect(deserialized.fs).toHaveLength(1);
+		const fsOp = deserialized.fs[0] as { data: Uint8Array };
+		expect(fsOp.data.byteLength).toBe(200_000);
+		expect(fsOp.data[0]).toBe(0);
+		expect(fsOp.data[255]).toBe(255);
+	});
+});

--- a/packages/playground/sync/src/transports/message-chunking.ts
+++ b/packages/playground/sync/src/transports/message-chunking.ts
@@ -1,0 +1,218 @@
+import type { TransportEnvelope } from '../transports';
+
+/**
+ * Binary serialization format for TransportEnvelope:
+ *
+ * [4 bytes: JSON length][JSON bytes][for each binary segment:
+ *   [4 bytes: segment length][segment bytes]]
+ *
+ * Uint8Array fields in the envelope are replaced with
+ * {"__binary__": <index>} placeholders in the JSON portion.
+ * The actual binary data is appended as length-prefixed segments.
+ */
+
+type JsonReplacer = (key: string, value: unknown) => unknown;
+
+export function serializeEnvelope(envelope: TransportEnvelope): Uint8Array {
+	const binaries: Uint8Array[] = [];
+
+	const replacer: JsonReplacer = (_key, value) => {
+		if (value instanceof Uint8Array) {
+			const index = binaries.length;
+			binaries.push(value);
+			return { __binary__: index };
+		}
+		return value;
+	};
+
+	const json = JSON.stringify(envelope, replacer);
+	const jsonBytes = new TextEncoder().encode(json);
+
+	// Calculate total size:
+	// 4 (json length) + jsonBytes + for each binary: 4 (length) + data
+	let totalSize = 4 + jsonBytes.byteLength;
+	for (const bin of binaries) {
+		totalSize += 4 + bin.byteLength;
+	}
+
+	const result = new Uint8Array(totalSize);
+	const view = new DataView(result.buffer);
+	let offset = 0;
+
+	// Write JSON length + data
+	view.setUint32(offset, jsonBytes.byteLength);
+	offset += 4;
+	result.set(jsonBytes, offset);
+	offset += jsonBytes.byteLength;
+
+	// Write each binary segment
+	for (const bin of binaries) {
+		view.setUint32(offset, bin.byteLength);
+		offset += 4;
+		result.set(bin, offset);
+		offset += bin.byteLength;
+	}
+
+	return result;
+}
+
+interface BinaryPlaceholder {
+	__binary__: number;
+}
+
+function isBinaryPlaceholder(value: unknown): value is BinaryPlaceholder {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'__binary__' in value &&
+		typeof (value as BinaryPlaceholder).__binary__ === 'number'
+	);
+}
+
+function restoreBinaries(obj: unknown, binaries: Uint8Array[]): unknown {
+	if (isBinaryPlaceholder(obj)) {
+		return binaries[obj.__binary__];
+	}
+	if (Array.isArray(obj)) {
+		return obj.map((item) => restoreBinaries(item, binaries));
+	}
+	if (typeof obj === 'object' && obj !== null) {
+		const result: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(obj)) {
+			result[key] = restoreBinaries(value, binaries);
+		}
+		return result;
+	}
+	return obj;
+}
+
+export function deserializeEnvelope(data: Uint8Array): TransportEnvelope {
+	const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+	let offset = 0;
+
+	// Read JSON
+	const jsonLength = view.getUint32(offset);
+	offset += 4;
+	const jsonBytes = data.subarray(offset, offset + jsonLength);
+	offset += jsonLength;
+	const json = new TextDecoder().decode(jsonBytes);
+	const parsed = JSON.parse(json);
+
+	// Read binary segments
+	const binaries: Uint8Array[] = [];
+	while (offset < data.byteLength) {
+		const segmentLength = view.getUint32(offset);
+		offset += 4;
+		binaries.push(data.slice(offset, offset + segmentLength));
+		offset += segmentLength;
+	}
+
+	return restoreBinaries(parsed, binaries) as TransportEnvelope;
+}
+
+/**
+ * Chunk header format:
+ * [1 byte: flags][4 bytes: messageId][payload]
+ *
+ * Flags byte:
+ *   bit 0: 1 = final chunk, 0 = more chunks follow
+ */
+const CHUNK_HEADER_SIZE = 5;
+const FLAG_FINAL = 0x01;
+
+export function chunkMessage(
+	messageId: number,
+	data: Uint8Array,
+	maxChunkSize = 48_000
+): Uint8Array[] {
+	const maxPayload = maxChunkSize - CHUNK_HEADER_SIZE;
+	if (maxPayload <= 0) {
+		throw new Error('maxChunkSize must be greater than header size');
+	}
+
+	const chunks: Uint8Array[] = [];
+	let offset = 0;
+
+	while (offset < data.byteLength) {
+		const remaining = data.byteLength - offset;
+		const payloadSize = Math.min(remaining, maxPayload);
+		const isFinal = offset + payloadSize >= data.byteLength;
+
+		const chunk = new Uint8Array(CHUNK_HEADER_SIZE + payloadSize);
+		const chunkView = new DataView(chunk.buffer);
+
+		chunkView.setUint8(0, isFinal ? FLAG_FINAL : 0);
+		chunkView.setUint32(1, messageId);
+		chunk.set(
+			data.subarray(offset, offset + payloadSize),
+			CHUNK_HEADER_SIZE
+		);
+
+		chunks.push(chunk);
+		offset += payloadSize;
+	}
+
+	// Handle empty data — produce a single final chunk with no payload
+	if (chunks.length === 0) {
+		const chunk = new Uint8Array(CHUNK_HEADER_SIZE);
+		const chunkView = new DataView(chunk.buffer);
+		chunkView.setUint8(0, FLAG_FINAL);
+		chunkView.setUint32(1, messageId);
+		chunks.push(chunk);
+	}
+
+	return chunks;
+}
+
+interface PendingMessage {
+	chunks: Uint8Array[];
+	totalSize: number;
+}
+
+export class MessageAssembler {
+	private pending = new Map<number, PendingMessage>();
+
+	/**
+	 * Feed a chunk into the assembler.
+	 * Returns the complete message if all chunks have arrived, or null.
+	 */
+	addChunk(chunk: Uint8Array): Uint8Array | null {
+		const view = new DataView(
+			chunk.buffer,
+			chunk.byteOffset,
+			chunk.byteLength
+		);
+		const flags = view.getUint8(0);
+		const messageId = view.getUint32(1);
+		const payload = chunk.subarray(CHUNK_HEADER_SIZE);
+
+		let pending = this.pending.get(messageId);
+		if (!pending) {
+			pending = { chunks: [], totalSize: 0 };
+			this.pending.set(messageId, pending);
+		}
+
+		pending.chunks.push(payload);
+		pending.totalSize += payload.byteLength;
+
+		if (flags & FLAG_FINAL) {
+			this.pending.delete(messageId);
+
+			// Fast path for single-chunk messages
+			if (pending.chunks.length === 1) {
+				return pending.chunks[0];
+			}
+
+			// Concatenate all chunks
+			const result = new Uint8Array(pending.totalSize);
+			let offset = 0;
+			for (const part of pending.chunks) {
+				result.set(part, offset);
+				offset += part.byteLength;
+			}
+			return result;
+		}
+
+		return null;
+	}
+}

--- a/packages/playground/sync/src/transports/signaling-client.spec.ts
+++ b/packages/playground/sync/src/transports/signaling-client.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SignalingClient } from './signaling-client';
+
+describe('SignalingClient', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	function jsonResponse(data: unknown, status = 200) {
+		return Promise.resolve({
+			ok: status >= 200 && status < 300,
+			status,
+			json: () => Promise.resolve(data),
+		});
+	}
+
+	it('createRoom sends POST and returns room_code', async () => {
+		fetchMock.mockReturnValue(jsonResponse({ room_code: 'ABC123' }));
+		const client = new SignalingClient({
+			baseUrl: 'https://example.com/signaling.php',
+		});
+		const code = await client.createRoom();
+		expect(code).toBe('ABC123');
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://example.com/signaling.php?action=create',
+			{ method: 'POST' }
+		);
+	});
+
+	it('sendOffer sends POST with SDP body', async () => {
+		fetchMock.mockReturnValue(jsonResponse({ ok: true }));
+		const client = new SignalingClient({
+			baseUrl: 'https://example.com/signaling.php',
+		});
+		await client.sendOffer('ROOM1', 'v=0\r\n...');
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://example.com/signaling.php?action=offer&room=ROOM1',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ sdp: 'v=0\r\n...' }),
+			}
+		);
+	});
+
+	it('sendAnswer sends POST with SDP body', async () => {
+		fetchMock.mockReturnValue(jsonResponse({ ok: true }));
+		const client = new SignalingClient({
+			baseUrl: 'https://example.com/signaling.php',
+		});
+		await client.sendAnswer('ROOM1', 'v=0\r\nanswer...');
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://example.com/signaling.php?action=answer&room=ROOM1',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ sdp: 'v=0\r\nanswer...' }),
+			}
+		);
+	});
+
+	it('pollForOffer resolves when offer appears', async () => {
+		fetchMock
+			.mockReturnValueOnce(jsonResponse({ offer: null }))
+			.mockReturnValueOnce(jsonResponse({ offer: 'sdp-offer-data' }));
+		const client = new SignalingClient({
+			baseUrl: 'https://example.com/signaling.php',
+			pollIntervalMs: 10,
+		});
+		const offer = await client.pollForOffer('ROOM1');
+		expect(offer).toBe('sdp-offer-data');
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		// Verify URL includes role=answerer
+		expect(fetchMock.mock.calls[0][0]).toContain('role=answerer');
+	});
+
+	it('pollForAnswer resolves when answer appears', async () => {
+		fetchMock
+			.mockReturnValueOnce(jsonResponse({ answer: null }))
+			.mockReturnValueOnce(jsonResponse({ answer: 'sdp-answer-data' }));
+		const client = new SignalingClient({
+			baseUrl: 'https://example.com/signaling.php',
+			pollIntervalMs: 10,
+		});
+		const answer = await client.pollForAnswer('ROOM1');
+		expect(answer).toBe('sdp-answer-data');
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock.mock.calls[0][0]).toContain('role=offerer');
+	});
+
+	it('pollForOffer rejects on AbortSignal', async () => {
+		fetchMock.mockReturnValue(jsonResponse({ offer: null }));
+		const client = new SignalingClient({
+			baseUrl: 'https://example.com/signaling.php',
+			pollIntervalMs: 50,
+		});
+		const controller = new AbortController();
+		const promise = client.pollForOffer('ROOM1', controller.signal);
+		// Abort during the poll interval wait
+		setTimeout(() => controller.abort(), 10);
+		await expect(promise).rejects.toThrow();
+	});
+
+	it('throws on non-ok response for createRoom', async () => {
+		fetchMock.mockReturnValue(jsonResponse({}, 500));
+		const client = new SignalingClient({
+			baseUrl: 'https://example.com/signaling.php',
+		});
+		await expect(client.createRoom()).rejects.toThrow(
+			'Failed to create room: 500'
+		);
+	});
+
+	it('strips trailing slash from baseUrl', async () => {
+		fetchMock.mockReturnValue(jsonResponse({ room_code: 'X' }));
+		const client = new SignalingClient({
+			baseUrl: 'https://example.com/signaling.php/',
+		});
+		await client.createRoom();
+		expect(fetchMock.mock.calls[0][0]).toBe(
+			'https://example.com/signaling.php?action=create'
+		);
+	});
+});

--- a/packages/playground/sync/src/transports/signaling-client.ts
+++ b/packages/playground/sync/src/transports/signaling-client.ts
@@ -1,0 +1,96 @@
+export interface SignalingClientOptions {
+	baseUrl: string;
+	pollIntervalMs?: number;
+}
+
+export class SignalingClient {
+	private baseUrl: string;
+	private pollIntervalMs: number;
+
+	constructor(options: SignalingClientOptions) {
+		this.baseUrl = options.baseUrl.replace(/\/$/, '');
+		this.pollIntervalMs = options.pollIntervalMs ?? 1500;
+	}
+
+	async createRoom(): Promise<string> {
+		const response = await fetch(`${this.baseUrl}?action=create`, {
+			method: 'POST',
+		});
+		if (!response.ok) {
+			throw new Error(`Failed to create room: ${response.status}`);
+		}
+		const data = await response.json();
+		return data.room_code;
+	}
+
+	async sendOffer(room: string, sdp: string): Promise<void> {
+		const response = await fetch(
+			`${this.baseUrl}?action=offer&room=${encodeURIComponent(room)}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ sdp }),
+			}
+		);
+		if (!response.ok) {
+			throw new Error(`Failed to send offer: ${response.status}`);
+		}
+	}
+
+	async sendAnswer(room: string, sdp: string): Promise<void> {
+		const response = await fetch(
+			`${this.baseUrl}?action=answer&room=${encodeURIComponent(room)}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ sdp }),
+			}
+		);
+		if (!response.ok) {
+			throw new Error(`Failed to send answer: ${response.status}`);
+		}
+	}
+
+	async pollForOffer(room: string, signal?: AbortSignal): Promise<string> {
+		return this.poll(room, 'answerer', 'offer', signal);
+	}
+
+	async pollForAnswer(room: string, signal?: AbortSignal): Promise<string> {
+		return this.poll(room, 'offerer', 'answer', signal);
+	}
+
+	private async poll(
+		room: string,
+		role: string,
+		field: string,
+		signal?: AbortSignal
+	): Promise<string> {
+		while (true) {
+			signal?.throwIfAborted();
+
+			const response = await fetch(
+				`${this.baseUrl}?action=poll&room=${encodeURIComponent(room)}&role=${encodeURIComponent(role)}`,
+				{ signal }
+			);
+			if (!response.ok) {
+				throw new Error(`Poll failed: ${response.status}`);
+			}
+			const data = await response.json();
+			if (data[field]) {
+				return data[field];
+			}
+
+			await new Promise<void>((resolve, reject) => {
+				const timer = setTimeout(resolve, this.pollIntervalMs);
+				signal?.addEventListener(
+					'abort',
+					() => {
+						clearTimeout(timer);
+						reject(signal.reason);
+					},
+					{ once: true }
+				);
+			});
+		}
+	}
+}

--- a/packages/playground/sync/src/transports/webrtc-transport.spec.ts
+++ b/packages/playground/sync/src/transports/webrtc-transport.spec.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WebRTCTransport } from './webrtc-transport';
+import type { WebRTCTransportState } from './webrtc-transport';
+import type { SignalingClient } from './signaling-client';
+import type { TransportEnvelope } from '../transports';
+
+// --- Mocks ---
+
+class MockDataChannel {
+	readyState = 'connecting';
+	binaryType = 'blob';
+	ordered = true;
+	private listeners = new Map<
+		string,
+		Set<EventListenerOrEventListenerObject>
+	>();
+
+	addEventListener(
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: { once?: boolean }
+	) {
+		if (!this.listeners.has(type)) {
+			this.listeners.set(type, new Set());
+		}
+		if (options?.once) {
+			const original = listener;
+			const wrapper = ((event: Event) => {
+				this.listeners.get(type)?.delete(wrapper);
+				if (typeof original === 'function') {
+					original(event);
+				} else {
+					original.handleEvent(event);
+				}
+			}) as EventListener;
+			this.listeners.get(type)!.add(wrapper);
+		} else {
+			this.listeners.get(type)!.add(listener);
+		}
+	}
+
+	removeEventListener(
+		type: string,
+		listener: EventListenerOrEventListenerObject
+	) {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	send = vi.fn();
+	close = vi.fn();
+
+	// Test helpers
+	emit(type: string, event?: unknown) {
+		for (const listener of this.listeners.get(type) ?? []) {
+			if (typeof listener === 'function') {
+				listener(event as Event);
+			} else {
+				listener.handleEvent(event as Event);
+			}
+		}
+	}
+
+	simulateOpen() {
+		this.readyState = 'open';
+		this.emit('open');
+	}
+}
+
+class MockPeerConnection {
+	connectionState = 'new';
+	iceGatheringState = 'new';
+	localDescription: { type: string; sdp: string } | null = null;
+	private listeners = new Map<
+		string,
+		Set<EventListenerOrEventListenerObject>
+	>();
+	createdChannel: MockDataChannel | null = null;
+
+	addEventListener(
+		type: string,
+		listener: EventListenerOrEventListenerObject,
+		options?: { once?: boolean }
+	) {
+		if (!this.listeners.has(type)) {
+			this.listeners.set(type, new Set());
+		}
+		if (options?.once) {
+			const original = listener;
+			const wrapper = ((event: Event) => {
+				this.listeners.get(type)?.delete(wrapper);
+				if (typeof original === 'function') {
+					original(event);
+				} else {
+					original.handleEvent(event);
+				}
+			}) as EventListener;
+			this.listeners.get(type)!.add(wrapper);
+		} else {
+			this.listeners.get(type)!.add(listener);
+		}
+	}
+
+	removeEventListener(
+		type: string,
+		listener: EventListenerOrEventListenerObject
+	) {
+		this.listeners.get(type)?.delete(listener);
+	}
+
+	createDataChannel(_label: string, _options?: unknown) {
+		this.createdChannel = new MockDataChannel();
+		return this.createdChannel;
+	}
+
+	async createOffer() {
+		return { type: 'offer', sdp: 'mock-offer-sdp' };
+	}
+
+	async createAnswer() {
+		return { type: 'answer', sdp: 'mock-answer-sdp' };
+	}
+
+	async setLocalDescription(desc: { type: string; sdp: string }) {
+		this.localDescription = desc;
+		// Simulate ICE gathering completing immediately
+		this.iceGatheringState = 'complete';
+		this.emit('icegatheringstatechange');
+	}
+
+	async setRemoteDescription(_desc: { type: string; sdp: string }) {
+		// no-op for mock
+	}
+
+	close = vi.fn();
+
+	// Test helpers
+	emit(type: string, event?: unknown) {
+		for (const listener of this.listeners.get(type) ?? []) {
+			if (typeof listener === 'function') {
+				listener(event as Event);
+			} else {
+				listener.handleEvent(event as Event);
+			}
+		}
+	}
+
+	simulateDataChannelEvent(channel: MockDataChannel) {
+		this.emit('datachannel', { channel });
+	}
+}
+
+function createMockSignalingClient(
+	overrides: Partial<SignalingClient> = {}
+): SignalingClient {
+	return {
+		createRoom: vi.fn().mockResolvedValue('TEST01'),
+		sendOffer: vi.fn().mockResolvedValue(undefined),
+		sendAnswer: vi.fn().mockResolvedValue(undefined),
+		pollForOffer: vi.fn().mockResolvedValue('remote-offer-sdp'),
+		pollForAnswer: vi.fn().mockResolvedValue('remote-answer-sdp'),
+		...overrides,
+	} as unknown as SignalingClient;
+}
+
+describe('WebRTCTransport', () => {
+	let originalRTCPeerConnection: typeof globalThis.RTCPeerConnection;
+	let lastMockPC: MockPeerConnection;
+
+	beforeEach(() => {
+		originalRTCPeerConnection = globalThis.RTCPeerConnection;
+		(globalThis as unknown as Record<string, unknown>).RTCPeerConnection =
+			vi.fn().mockImplementation(() => {
+				lastMockPC = new MockPeerConnection();
+				return lastMockPC;
+			});
+	});
+
+	afterEach(() => {
+		(globalThis as unknown as Record<string, unknown>).RTCPeerConnection =
+			originalRTCPeerConnection;
+		vi.restoreAllMocks();
+	});
+
+	describe('offerer flow', () => {
+		it('should create offer, send via signaling, poll for answer', async () => {
+			const signaling = createMockSignalingClient();
+			const states: WebRTCTransportState[] = [];
+			const transport = new WebRTCTransport({
+				signalingClient: signaling,
+				role: 'offerer',
+				roomCode: 'ROOM1',
+				onStateChange: (s) => states.push(s),
+			});
+
+			await transport.connect();
+
+			expect(signaling.sendOffer).toHaveBeenCalledWith(
+				'ROOM1',
+				'mock-offer-sdp'
+			);
+			expect(signaling.pollForAnswer).toHaveBeenCalledWith('ROOM1');
+			expect(states).toContain('signaling');
+			expect(states).toContain('connecting');
+		});
+
+		it('should flush queued messages when DataChannel opens', async () => {
+			const signaling = createMockSignalingClient();
+			const transport = new WebRTCTransport({
+				signalingClient: signaling,
+				role: 'offerer',
+				roomCode: 'ROOM1',
+			});
+
+			await transport.connect();
+
+			const envelope: TransportEnvelope = {
+				sql: [
+					{
+						type: 'sql',
+						subtype: 'replay',
+						query: 'INSERT INTO test VALUES (1)',
+					},
+				],
+				fs: [],
+			};
+
+			// Queue a message before the channel opens
+			transport.sendChanges(envelope);
+
+			const dc = lastMockPC.createdChannel!;
+			expect(dc.send).not.toHaveBeenCalled();
+
+			// Open the channel — queue should flush
+			dc.simulateOpen();
+			expect(dc.send).toHaveBeenCalled();
+		});
+	});
+
+	describe('answerer flow', () => {
+		it('should poll for offer, create answer, send via signaling', async () => {
+			const signaling = createMockSignalingClient();
+			const states: WebRTCTransportState[] = [];
+			const transport = new WebRTCTransport({
+				signalingClient: signaling,
+				role: 'answerer',
+				roomCode: 'ROOM1',
+				onStateChange: (s) => states.push(s),
+			});
+
+			// The answerer flow will call pollForOffer, then
+			// setRemoteDescription, then wait for datachannel event.
+			// We need to simulate the PC emitting the datachannel event.
+			const connectPromise = transport.connect();
+
+			// Wait a tick for the async operations to proceed
+			await new Promise((r) => setTimeout(r, 0));
+
+			// Simulate the peer connection delivering a data channel
+			const remoteDC = new MockDataChannel();
+			lastMockPC.simulateDataChannelEvent(remoteDC);
+
+			await connectPromise;
+
+			expect(signaling.pollForOffer).toHaveBeenCalledWith('ROOM1');
+			expect(signaling.sendAnswer).toHaveBeenCalledWith(
+				'ROOM1',
+				'mock-answer-sdp'
+			);
+			expect(states).toContain('signaling');
+			expect(states).toContain('connecting');
+		});
+	});
+
+	describe('message handling', () => {
+		it('should deliver received messages via onChangesReceived', async () => {
+			const signaling = createMockSignalingClient();
+			const transport = new WebRTCTransport({
+				signalingClient: signaling,
+				role: 'offerer',
+				roomCode: 'ROOM1',
+			});
+
+			const received: TransportEnvelope[] = [];
+			transport.onChangesReceived((env) => received.push(env));
+
+			await transport.connect();
+			const dc = lastMockPC.createdChannel!;
+			dc.simulateOpen();
+
+			// Simulate the other side sending a message
+			// We need to create valid chunked data
+			const { serializeEnvelope, chunkMessage } =
+				await import('./message-chunking');
+			const envelope: TransportEnvelope = {
+				sql: [
+					{
+						type: 'sql',
+						subtype: 'replay',
+						query: 'SELECT 1',
+					},
+				],
+				fs: [],
+			};
+			const serialized = serializeEnvelope(envelope);
+			const chunks = chunkMessage(0, serialized);
+
+			for (const chunk of chunks) {
+				dc.emit('message', { data: chunk.buffer });
+			}
+
+			expect(received).toHaveLength(1);
+			expect(received[0].sql[0]).toEqual(envelope.sql[0]);
+		});
+	});
+
+	describe('state transitions', () => {
+		it('should report disconnected on close', async () => {
+			const signaling = createMockSignalingClient();
+			const states: WebRTCTransportState[] = [];
+			const transport = new WebRTCTransport({
+				signalingClient: signaling,
+				role: 'offerer',
+				roomCode: 'ROOM1',
+				onStateChange: (s) => states.push(s),
+			});
+
+			await transport.connect();
+			transport.close();
+			expect(states).toContain('disconnected');
+		});
+
+		it('should report failed on PC connection failure', async () => {
+			const signaling = createMockSignalingClient();
+			const states: WebRTCTransportState[] = [];
+			const transport = new WebRTCTransport({
+				signalingClient: signaling,
+				role: 'offerer',
+				roomCode: 'ROOM1',
+				onStateChange: (s) => states.push(s),
+			});
+
+			await transport.connect();
+			lastMockPC.connectionState = 'failed';
+			lastMockPC.emit('connectionstatechange');
+			expect(states).toContain('failed');
+		});
+	});
+});

--- a/packages/playground/sync/src/transports/webrtc-transport.ts
+++ b/packages/playground/sync/src/transports/webrtc-transport.ts
@@ -1,0 +1,228 @@
+import { logger } from '@php-wasm/logger';
+import type { SignalingClient } from './signaling-client';
+import type {
+	PlaygroundSyncTransport,
+	TransportEnvelope,
+	ChangesCallback,
+} from '../transports';
+import {
+	serializeEnvelope,
+	deserializeEnvelope,
+	chunkMessage,
+	MessageAssembler,
+} from './message-chunking';
+
+export type WebRTCTransportState =
+	| 'new'
+	| 'signaling'
+	| 'connecting'
+	| 'connected'
+	| 'disconnected'
+	| 'failed';
+
+export interface WebRTCTransportOptions {
+	signalingClient: SignalingClient;
+	role: 'offerer' | 'answerer';
+	roomCode: string;
+	iceServers?: RTCIceServer[];
+	onStateChange?: (state: WebRTCTransportState) => void;
+}
+
+const ICE_GATHERING_TIMEOUT_MS = 10_000;
+
+const DEFAULT_ICE_SERVERS: RTCIceServer[] = [
+	{ urls: 'stun:stun.l.google.com:19302' },
+	{ urls: 'stun:stun1.l.google.com:19302' },
+];
+
+export class WebRTCTransport implements PlaygroundSyncTransport {
+	private signalingClient: SignalingClient;
+	private role: 'offerer' | 'answerer';
+	private roomCode: string;
+	private iceServers: RTCIceServer[];
+	private onStateChange?: (state: WebRTCTransportState) => void;
+
+	private pc: RTCPeerConnection | null = null;
+	private dataChannel: RTCDataChannel | null = null;
+	private changesCallback: ChangesCallback | null = null;
+	private sendQueue: Uint8Array[] = [];
+	private messageId = 0;
+	private assembler = new MessageAssembler();
+	private state: WebRTCTransportState = 'new';
+
+	constructor(options: WebRTCTransportOptions) {
+		this.signalingClient = options.signalingClient;
+		this.role = options.role;
+		this.roomCode = options.roomCode;
+		this.iceServers = options.iceServers ?? DEFAULT_ICE_SERVERS;
+		this.onStateChange = options.onStateChange;
+	}
+
+	async connect(): Promise<void> {
+		this.setState('signaling');
+
+		this.pc = new RTCPeerConnection({
+			iceServers: this.iceServers,
+		});
+
+		this.pc.addEventListener('connectionstatechange', () => {
+			switch (this.pc?.connectionState) {
+				case 'connected':
+					this.setState('connected');
+					break;
+				case 'disconnected':
+					this.setState('disconnected');
+					break;
+				case 'failed':
+					this.setState('failed');
+					break;
+			}
+		});
+
+		if (this.role === 'offerer') {
+			await this.connectAsOfferer();
+		} else {
+			await this.connectAsAnswerer();
+		}
+	}
+
+	sendChanges(envelope: TransportEnvelope): void {
+		const serialized = serializeEnvelope(envelope);
+		const chunks = chunkMessage(this.messageId++, serialized);
+
+		if (this.dataChannel && this.dataChannel.readyState === 'open') {
+			for (const chunk of chunks) {
+				this.dataChannel.send(chunk);
+			}
+		} else {
+			this.sendQueue.push(...chunks);
+		}
+	}
+
+	onChangesReceived(fn: ChangesCallback): void {
+		this.changesCallback = fn;
+	}
+
+	close(): void {
+		this.dataChannel?.close();
+		this.pc?.close();
+		this.dataChannel = null;
+		this.pc = null;
+		this.setState('disconnected');
+	}
+
+	private async connectAsOfferer(): Promise<void> {
+		const dc = this.pc!.createDataChannel('sync', {
+			ordered: true,
+		});
+		this.setupDataChannel(dc);
+
+		const offer = await this.pc!.createOffer();
+		await this.pc!.setLocalDescription(offer);
+		await this.waitForIceGathering();
+
+		await this.signalingClient.sendOffer(
+			this.roomCode,
+			this.pc!.localDescription!.sdp
+		);
+
+		this.setState('connecting');
+		const answerSdp = await this.signalingClient.pollForAnswer(
+			this.roomCode
+		);
+		await this.pc!.setRemoteDescription({
+			type: 'answer',
+			sdp: answerSdp,
+		});
+	}
+
+	private async connectAsAnswerer(): Promise<void> {
+		this.setState('connecting');
+
+		const offerSdp = await this.signalingClient.pollForOffer(this.roomCode);
+
+		await this.pc!.setRemoteDescription({
+			type: 'offer',
+			sdp: offerSdp,
+		});
+
+		this.pc!.addEventListener(
+			'datachannel',
+			(event) => {
+				this.setupDataChannel(event.channel);
+			},
+			{ once: true }
+		);
+
+		const answer = await this.pc!.createAnswer();
+		await this.pc!.setLocalDescription(answer);
+		await this.waitForIceGathering();
+
+		await this.signalingClient.sendAnswer(
+			this.roomCode,
+			this.pc!.localDescription!.sdp
+		);
+	}
+
+	private setupDataChannel(dc: RTCDataChannel): void {
+		dc.binaryType = 'arraybuffer';
+		this.dataChannel = dc;
+
+		dc.addEventListener('open', () => {
+			this.setState('connected');
+			this.flushQueue();
+		});
+
+		dc.addEventListener('message', (event) => {
+			const data = new Uint8Array(event.data as ArrayBuffer);
+			const assembled = this.assembler.addChunk(data);
+			if (assembled && this.changesCallback) {
+				const envelope = deserializeEnvelope(assembled);
+				this.changesCallback(envelope);
+			}
+		});
+
+		dc.addEventListener('close', () => {
+			this.setState('disconnected');
+		});
+	}
+
+	private flushQueue(): void {
+		if (!this.dataChannel || this.dataChannel.readyState !== 'open') {
+			return;
+		}
+		for (const chunk of this.sendQueue) {
+			this.dataChannel.send(chunk);
+		}
+		this.sendQueue = [];
+	}
+
+	private waitForIceGathering(): Promise<void> {
+		return new Promise<void>((resolve) => {
+			if (this.pc!.iceGatheringState === 'complete') {
+				resolve();
+				return;
+			}
+			const timer = setTimeout(() => {
+				logger.warn(
+					`[WebRTC:${this.role}] ICE gathering` +
+						` timed out after ${ICE_GATHERING_TIMEOUT_MS}ms`
+				);
+				resolve();
+			}, ICE_GATHERING_TIMEOUT_MS);
+			this.pc!.addEventListener('icegatheringstatechange', () => {
+				if (this.pc!.iceGatheringState === 'complete') {
+					clearTimeout(timer);
+					resolve();
+				}
+			});
+		});
+	}
+
+	private setState(state: WebRTCTransportState): void {
+		if (this.state !== state) {
+			this.state = state;
+			this.onStateChange?.(state);
+		}
+	}
+}

--- a/packages/playground/sync/src/transports/webrtc-transport.ts
+++ b/packages/playground/sync/src/transports/webrtc-transport.ts
@@ -45,6 +45,7 @@ export class WebRTCTransport implements PlaygroundSyncTransport {
 	private pc: RTCPeerConnection | null = null;
 	private dataChannel: RTCDataChannel | null = null;
 	private changesCallback: ChangesCallback | null = null;
+	private receiveQueue: TransportEnvelope[] = [];
 	private sendQueue: Uint8Array[] = [];
 	private messageId = 0;
 	private assembler = new MessageAssembler();
@@ -101,6 +102,10 @@ export class WebRTCTransport implements PlaygroundSyncTransport {
 
 	onChangesReceived(fn: ChangesCallback): void {
 		this.changesCallback = fn;
+		for (const envelope of this.receiveQueue) {
+			fn(envelope);
+		}
+		this.receiveQueue = [];
 	}
 
 	close(): void {
@@ -176,9 +181,13 @@ export class WebRTCTransport implements PlaygroundSyncTransport {
 		dc.addEventListener('message', (event) => {
 			const data = new Uint8Array(event.data as ArrayBuffer);
 			const assembled = this.assembler.addChunk(data);
-			if (assembled && this.changesCallback) {
+			if (assembled) {
 				const envelope = deserializeEnvelope(assembled);
-				this.changesCallback(envelope);
+				if (this.changesCallback) {
+					this.changesCallback(envelope);
+				} else {
+					this.receiveQueue.push(envelope);
+				}
 			}
 		});
 

--- a/packages/playground/website/demos/webrtc-sync.html
+++ b/packages/playground/website/demos/webrtc-sync.html
@@ -1,0 +1,250 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<title>Playground WebRTC Sync</title>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<style>
+			* {
+				box-sizing: border-box;
+				margin: 0;
+				padding: 0;
+			}
+			body {
+				font-family:
+					-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+					sans-serif;
+				display: flex;
+				flex-direction: column;
+				height: 100dvh;
+			}
+			#controls {
+				display: flex;
+				align-items: center;
+				gap: 12px;
+				padding: 8px 12px;
+				background: #1e1e1e;
+				color: #fff;
+				font-size: 14px;
+			}
+			#controls button {
+				padding: 6px 14px;
+				border: none;
+				border-radius: 4px;
+				background: #3858e9;
+				color: #fff;
+				cursor: pointer;
+				font-size: 14px;
+			}
+			#controls button:hover {
+				background: #2a45c0;
+			}
+			#controls button:disabled {
+				opacity: 0.5;
+				cursor: not-allowed;
+			}
+			#controls input {
+				padding: 6px 10px;
+				border: 1px solid #555;
+				border-radius: 4px;
+				background: #2d2d2d;
+				color: #fff;
+				font-size: 14px;
+				width: 100px;
+				text-transform: uppercase;
+				letter-spacing: 2px;
+				text-align: center;
+			}
+			#room-code {
+				font-weight: bold;
+				font-size: 16px;
+				letter-spacing: 3px;
+				color: #7ee787;
+			}
+			#status {
+				margin-left: auto;
+			}
+			.status-dot {
+				display: inline-block;
+				width: 8px;
+				height: 8px;
+				border-radius: 50%;
+				margin-right: 6px;
+			}
+			.status-dot.new {
+				background: #888;
+			}
+			.status-dot.signaling {
+				background: #f0ad4e;
+			}
+			.status-dot.connecting {
+				background: #f0ad4e;
+			}
+			.status-dot.connected {
+				background: #7ee787;
+			}
+			.status-dot.syncing {
+				background: #58a6ff;
+			}
+			.status-dot.ready {
+				background: #7ee787;
+			}
+			.status-dot.disconnected {
+				background: #f85149;
+			}
+			.status-dot.failed {
+				background: #f85149;
+			}
+			#content {
+				flex: 1;
+				position: relative;
+			}
+			iframe {
+				width: 100%;
+				height: 100%;
+				border: 0;
+			}
+			#overlay {
+				position: absolute;
+				inset: 0;
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				background: #f6f6f6;
+				color: #333;
+				gap: 16px;
+				z-index: 10;
+			}
+			#overlay.hidden {
+				display: none;
+			}
+			.spinner {
+				width: 32px;
+				height: 32px;
+				border: 3px solid #ddd;
+				border-top-color: #3858e9;
+				border-radius: 50%;
+				animation: spin 0.8s linear infinite;
+			}
+			@keyframes spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			#overlay-status {
+				font-size: 16px;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="controls">
+			<button id="create-btn">Create Room</button>
+			<span>or</span>
+			<input id="room-input" placeholder="CODE" maxlength="6" />
+			<button id="join-btn">Join</button>
+			<span id="room-code"></span>
+			<span id="status">
+				<span class="status-dot new"></span>
+				Not connected
+			</span>
+		</div>
+		<div id="content">
+			<div id="overlay" class="hidden">
+				<div class="spinner"></div>
+				<div id="overlay-status"></div>
+			</div>
+			<iframe id="wp"></iframe>
+		</div>
+		<script type="module">
+			import {
+				createRoom,
+				connectAndSync,
+				SignalingClient,
+			} from './webrtc-sync.ts';
+
+			const createBtn = document.getElementById('create-btn');
+			const joinBtn = document.getElementById('join-btn');
+			const roomInput = document.getElementById('room-input');
+			const roomCodeEl = document.getElementById('room-code');
+			const statusEl = document.getElementById('status');
+			const iframe = document.getElementById('wp');
+			const overlay = document.getElementById('overlay');
+			const overlayStatus = document.getElementById('overlay-status');
+
+			const signalingUrl = new URL(
+				'/signaling.php',
+				window.location.origin
+			).toString();
+
+			const STATE_LABELS = {
+				new: 'Not connected',
+				signaling: 'Signaling...',
+				connecting: 'Connecting...',
+				connected: 'Connected',
+				syncing: 'Syncing...',
+				ready: 'Connected',
+				disconnected: 'Disconnected',
+				failed: 'Failed',
+			};
+
+			function setStatus(state) {
+				const label = STATE_LABELS[state] || state;
+				statusEl.innerHTML = `<span class="status-dot ${state}"></span>${label}`;
+			}
+
+			function disableControls() {
+				createBtn.disabled = true;
+				joinBtn.disabled = true;
+				roomInput.disabled = true;
+			}
+
+			function showOverlay(text) {
+				overlay.classList.remove('hidden');
+				iframe.style.visibility = 'hidden';
+				overlayStatus.textContent = text;
+			}
+
+			function hideOverlay() {
+				overlay.classList.add('hidden');
+				iframe.style.visibility = 'visible';
+			}
+
+			createBtn.addEventListener('click', async () => {
+				disableControls();
+				setStatus('signaling');
+
+				const signalingClient = new SignalingClient({
+					baseUrl: signalingUrl,
+				});
+				const roomCode = await createRoom(signalingClient);
+				roomCodeEl.textContent = roomCode;
+
+				await connectAndSync(iframe, 'offerer', roomCode, (state) => {
+					setStatus(state);
+				});
+			});
+
+			joinBtn.addEventListener('click', async () => {
+				const code = roomInput.value.trim().toUpperCase();
+				if (!code) return;
+				disableControls();
+
+				showOverlay('Booting WordPress...');
+				setStatus('connecting');
+
+				await connectAndSync(iframe, 'answerer', code, (state) => {
+					setStatus(state);
+
+					if (state === 'connected') {
+						showOverlay('Syncing...');
+					} else if (state === 'syncing') {
+						showOverlay('Syncing...');
+					} else if (state === 'ready') {
+						hideOverlay();
+					}
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/packages/playground/website/demos/webrtc-sync.ts
+++ b/packages/playground/website/demos/webrtc-sync.ts
@@ -1,0 +1,115 @@
+import { startPlaygroundWeb } from '@wp-playground/client';
+import { login } from '@wp-playground/blueprints';
+import {
+	setupPlaygroundSync,
+	SignalingClient,
+	WebRTCTransport,
+	loggerMiddleware,
+} from '@wp-playground/sync';
+import type { WebRTCTransportState, SyncMiddleware } from '@wp-playground/sync';
+import { getRemoteUrl } from '../src/lib/config';
+
+const SIGNALING_URL = new URL(
+	'/signaling.php',
+	window.location.origin
+).toString();
+
+export type DemoState = WebRTCTransportState | 'syncing' | 'ready';
+
+/**
+ * Create a signaling room and return the code immediately.
+ * WordPress boot + WebRTC connection happen separately.
+ */
+export async function createRoom(
+	signalingClient: SignalingClient
+): Promise<string> {
+	return signalingClient.createRoom();
+}
+
+/**
+ * Boot WordPress, set up sync, then establish the WebRTC connection.
+ *
+ * For the answerer, the iframe stays hidden until the first sync
+ * message is received and applied, then navigates to '/' to render
+ * the synced content.  The caller receives 'ready' via onStateChange
+ * when it's safe to show the iframe.
+ */
+export async function connectAndSync(
+	iframe: HTMLIFrameElement,
+	role: 'offerer' | 'answerer',
+	roomCode: string,
+	onStateChange: (state: DemoState) => void
+): Promise<void> {
+	const signalingClient = new SignalingClient({
+		baseUrl: SIGNALING_URL,
+	});
+
+	const transport = new WebRTCTransport({
+		signalingClient,
+		role,
+		roomCode,
+		onStateChange,
+	});
+
+	// Each peer needs a distinct autoincrement offset so that new
+	// rows created independently on each side never collide.
+	const autoincrementOffset =
+		role === 'offerer' ? 1_234_500_001 : 1_543_200_001;
+
+	// Start the WebRTC connection in parallel with WordPress boot.
+	// The transport queues messages until the DataChannel opens,
+	// so it's safe to wire up sync before the connection completes.
+	const connectPromise = transport.connect();
+
+	const middlewares: SyncMiddleware[] = [loggerMiddleware(role)];
+
+	// For the answerer, detect when the first sync message arrives.
+	let resolveFirstSync: (() => void) | undefined;
+	let firstSyncPromise: Promise<void> | undefined;
+	if (role === 'answerer') {
+		firstSyncPromise = new Promise<void>((resolve) => {
+			resolveFirstSync = resolve;
+		});
+		let isFirst = true;
+		middlewares.push({
+			beforeSend: (e) => e,
+			afterReceive: (e) => {
+				if (isFirst) {
+					isFirst = false;
+					resolveFirstSync!();
+				}
+				return e;
+			},
+		});
+	}
+
+	const playground = await startPlaygroundWeb({
+		iframe,
+		remoteUrl: getRemoteUrl().toString(),
+		sqliteDriverVersion: 'v2.1.16',
+	});
+
+	await setupPlaygroundSync(playground, {
+		autoincrementOffset,
+		transport,
+		middlewares,
+	});
+
+	await login(playground, { username: 'admin', password: 'password' });
+
+	if (role === 'offerer') {
+		await playground.goTo('/');
+		onStateChange('ready');
+	}
+
+	await connectPromise;
+
+	if (firstSyncPromise) {
+		onStateChange('syncing');
+		await firstSyncPromise;
+		await playground.goTo('/');
+		onStateChange('ready');
+	}
+}
+
+export { SignalingClient };

--- a/packages/playground/website/public/signaling.php
+++ b/packages/playground/website/public/signaling.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * WebRTC signaling endpoint for WordPress Playground P2P sync.
+ *
+ * Stores and retrieves SDP offers/answers using MySQL so that two
+ * browser tabs can establish a direct WebRTC connection.
+ *
+ * API (all via query params on signaling.php):
+ *
+ *   POST ?action=create                → {"room_code": "A7K3M2"}
+ *   POST ?action=offer&room=X   body: {"sdp": "..."}  → {"ok": true}
+ *   POST ?action=answer&room=X  body: {"sdp": "..."}  → {"ok": true}
+ *   GET  ?action=poll&room=X&role=offerer|answerer     → {"answer":"..."} or {"offer":"..."}
+ */
+
+// Disable error display in production.
+error_reporting(0);
+ini_set('display_errors', '0');
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: https://playground.wordpress.net');
+header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+$MAX_SDP_SIZE = 64 * 1024; // 64 KB
+
+/**
+ * Send a JSON response and terminate.
+ */
+function respond($data, $status = 200) {
+    http_response_code($status);
+    die(json_encode($data));
+}
+
+/**
+ * Get a PDO connection using environment variables.
+ */
+function get_db() {
+    static $pdo = null;
+    if ($pdo !== null) {
+        return $pdo;
+    }
+
+    $host = getenv('DB_HOST') ?: 'localhost';
+    $user = getenv('DB_USER');
+    $pass = getenv('DB_PASS');
+    $name = getenv('DB_NAME');
+
+    if (!$user || !$name) {
+        respond(['error' => 'Database not configured'], 500);
+    }
+
+    $dsn = "mysql:host=$host;dbname=$name;charset=utf8mb4";
+    $pdo = new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+
+    return $pdo;
+}
+
+/**
+ * Ensure the signaling table exists.
+ */
+function ensure_table() {
+    $db = get_db();
+    $db->exec("
+        CREATE TABLE IF NOT EXISTS playground_signaling_rooms (
+            room_code VARCHAR(12) PRIMARY KEY,
+            offer TEXT DEFAULT NULL,
+            answer TEXT DEFAULT NULL,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        )
+    ");
+}
+
+/**
+ * Generate a 6-character alphanumeric room code (uppercase).
+ */
+function generate_room_code() {
+    $chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+    $code = '';
+    for ($i = 0; $i < 6; $i++) {
+        $code .= $chars[random_int(0, strlen($chars) - 1)];
+    }
+    return $code;
+}
+
+/**
+ * Delete rooms older than 10 minutes.
+ */
+function cleanup_expired_rooms() {
+    $db = get_db();
+    $db->exec(
+        "DELETE FROM playground_signaling_rooms
+         WHERE created_at < DATE_SUB(NOW(), INTERVAL 10 MINUTE)"
+    );
+}
+
+// --- Main logic ---
+
+ensure_table();
+
+$action = $_GET['action'] ?? '';
+
+if ($action === 'create' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    cleanup_expired_rooms();
+
+    // Try a few times in case of code collision.
+    for ($attempt = 0; $attempt < 5; $attempt++) {
+        $code = generate_room_code();
+        $stmt = get_db()->prepare(
+            "INSERT IGNORE INTO playground_signaling_rooms (room_code)
+             VALUES (:code)"
+        );
+        $stmt->execute([':code' => $code]);
+        if ($stmt->rowCount() > 0) {
+            respond(['room_code' => $code]);
+        }
+    }
+    respond(['error' => 'Failed to create room'], 500);
+}
+
+// All other actions require a room parameter.
+$room = $_GET['room'] ?? '';
+if (!$room) {
+    respond(['error' => 'Missing room parameter'], 400);
+}
+
+// Validate room exists.
+$stmt = get_db()->prepare(
+    "SELECT room_code FROM playground_signaling_rooms
+     WHERE room_code = :code"
+);
+$stmt->execute([':code' => $room]);
+if (!$stmt->fetch()) {
+    respond(['error' => 'Room not found'], 404);
+}
+
+if ($action === 'offer' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $body = file_get_contents('php://input');
+    if (strlen($body) > $MAX_SDP_SIZE) {
+        respond(['error' => 'SDP payload too large'], 400);
+    }
+    $data = json_decode($body, true);
+    $sdp = $data['sdp'] ?? '';
+    if (!is_string($sdp) || $sdp === '') {
+        respond(['error' => 'Missing sdp'], 400);
+    }
+
+    $stmt = get_db()->prepare(
+        "UPDATE playground_signaling_rooms
+         SET offer = :sdp WHERE room_code = :code"
+    );
+    $stmt->execute([':sdp' => $sdp, ':code' => $room]);
+    respond(['ok' => true]);
+}
+
+if ($action === 'answer' && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    $body = file_get_contents('php://input');
+    if (strlen($body) > $MAX_SDP_SIZE) {
+        respond(['error' => 'SDP payload too large'], 400);
+    }
+    $data = json_decode($body, true);
+    $sdp = $data['sdp'] ?? '';
+    if (!is_string($sdp) || $sdp === '') {
+        respond(['error' => 'Missing sdp'], 400);
+    }
+
+    $stmt = get_db()->prepare(
+        "UPDATE playground_signaling_rooms
+         SET answer = :sdp WHERE room_code = :code"
+    );
+    $stmt->execute([':sdp' => $sdp, ':code' => $room]);
+    respond(['ok' => true]);
+}
+
+if ($action === 'poll' && $_SERVER['REQUEST_METHOD'] === 'GET') {
+    $role = $_GET['role'] ?? '';
+    $stmt = get_db()->prepare(
+        "SELECT offer, answer FROM playground_signaling_rooms
+         WHERE room_code = :code"
+    );
+    $stmt->execute([':code' => $room]);
+    $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if ($role === 'offerer') {
+        respond(['answer' => $row['answer']]);
+    } elseif ($role === 'answerer') {
+        respond(['offer' => $row['offer']]);
+    } else {
+        respond(['error' => 'Invalid role'], 400);
+    }
+}
+
+respond(['error' => 'Invalid action'], 400);

--- a/packages/playground/website/tsconfig.app.json
+++ b/packages/playground/website/tsconfig.app.json
@@ -32,6 +32,7 @@
 		"demos/terminal.ts",
 		"demos/terminal-component.tsx",
 		"demos/php-blueprints.ts",
+		"demos/webrtc-sync.ts",
 		"./cypress.config.ts",
 		"../components/src/icons.tsx"
 	]

--- a/packages/playground/website/vite.config.ts
+++ b/packages/playground/website/vite.config.ts
@@ -17,6 +17,8 @@ import {
 } from '../build-config';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { oAuthMiddleware } from './vite.oauth';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { signalingMiddleware } from './vite.signaling';
 import { exec as execCb } from 'node:child_process';
 import { promisify } from 'node:util';
 import { fileURLToPath } from 'node:url';
@@ -41,10 +43,7 @@ const isDevcontainer = process.env.VITE_DEVCONTAINER === 'true';
 // a port that was published using the devcontainer "appPort" configuration.
 const serverHost = isDevcontainer ? '0.0.0.0' : websiteDevServerHost;
 
-async function setCodespacesPortPublic(
-	port: number,
-	codespaceName: string
-) {
+async function setCodespacesPortPublic(port: number, codespaceName: string) {
 	// eslint-disable-next-line no-console
 	console.log(`Publishing port ${port}...`);
 	const cmd = `gh codespace ports visibility ${port}:public -c ${codespaceName}`;
@@ -142,8 +141,7 @@ export default defineConfig(({ command, mode }) => {
 				? {
 						name: 'devcontainer-print-urls',
 						configureServer(server: ViteDevServer) {
-							const codespaceName =
-								process.env['CODESPACE_NAME'];
+							const codespaceName = process.env['CODESPACE_NAME'];
 							const codespacesDomain =
 								process.env[
 									'GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN'
@@ -161,13 +159,11 @@ export default defineConfig(({ command, mode }) => {
 							// Codespaces ports default to private, breaking CORS.
 							// Publish once the tunnel is ready.
 							if (codespaceName) {
-								server.httpServer?.once(
-									'listening',
-									() =>
-										setCodespacesPortPublic(
-											websiteDevServerPort,
-											codespaceName
-										)
+								server.httpServer?.once('listening', () =>
+									setCodespacesPortPublic(
+										websiteDevServerPort,
+										codespaceName
+									)
 								);
 							}
 						},
@@ -194,6 +190,7 @@ export default defineConfig(({ command, mode }) => {
 				name: 'configure-server',
 				configureServer(server: ViteDevServer) {
 					server.middlewares.use(oAuthMiddleware);
+					server.middlewares.use(signalingMiddleware);
 				},
 			},
 			/**
@@ -305,6 +302,9 @@ export default defineConfig(({ command, mode }) => {
 					),
 					'time-traveling.html': fileURLToPath(
 						new URL('./demos/time-traveling.html', import.meta.url)
+					),
+					'webrtc-sync.html': fileURLToPath(
+						new URL('./demos/webrtc-sync.html', import.meta.url)
 					),
 					'builder/builder.html': fileURLToPath(
 						new URL('./builder/builder.html', import.meta.url)

--- a/packages/playground/website/vite.signaling.ts
+++ b/packages/playground/website/vite.signaling.ts
@@ -1,0 +1,136 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+
+interface Room {
+	offer: string | null;
+	answer: string | null;
+	createdAt: number;
+}
+
+const rooms = new Map<string, Room>();
+const ROOM_EXPIRY_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_SDP_SIZE = 64 * 1024; // 64KB
+
+function generateRoomCode(): string {
+	const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+	let code = '';
+	for (let i = 0; i < 6; i++) {
+		code += chars[Math.floor(Math.random() * chars.length)];
+	}
+	return code;
+}
+
+function cleanupExpiredRooms() {
+	const now = Date.now();
+	for (const [code, room] of rooms) {
+		if (now - room.createdAt > ROOM_EXPIRY_MS) {
+			rooms.delete(code);
+		}
+	}
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+	return new Promise((resolve, reject) => {
+		let body = '';
+		req.on('data', (chunk: Buffer) => {
+			body += chunk.toString();
+			if (body.length > MAX_SDP_SIZE) {
+				reject(new Error('Body too large'));
+			}
+		});
+		req.on('end', () => resolve(body));
+		req.on('error', reject);
+	});
+}
+
+function jsonResponse(res: ServerResponse, status: number, data: unknown) {
+	res.writeHead(status, {
+		'Content-Type': 'application/json',
+		'Access-Control-Allow-Origin': '*',
+		'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+		'Access-Control-Allow-Headers': 'Content-Type',
+	});
+	res.end(JSON.stringify(data));
+}
+
+export const signalingMiddleware = async (
+	req: IncomingMessage,
+	res: ServerResponse,
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+	next: Function
+) => {
+	if (!req.url?.startsWith('/signaling.php')) {
+		next();
+		return;
+	}
+
+	// Handle CORS preflight
+	if (req.method === 'OPTIONS') {
+		jsonResponse(res, 204, '');
+		return;
+	}
+
+	const query = new URL(req.url, 'http://example.com').searchParams;
+	const action = query.get('action');
+
+	if (action === 'create' && req.method === 'POST') {
+		cleanupExpiredRooms();
+		const roomCode = generateRoomCode();
+		rooms.set(roomCode, {
+			offer: null,
+			answer: null,
+			createdAt: Date.now(),
+		});
+		jsonResponse(res, 200, { room_code: roomCode });
+		return;
+	}
+
+	const roomCode = query.get('room');
+	if (!roomCode) {
+		jsonResponse(res, 400, { error: 'Missing room parameter' });
+		return;
+	}
+
+	const room = rooms.get(roomCode);
+	if (!room) {
+		jsonResponse(res, 404, { error: 'Room not found' });
+		return;
+	}
+
+	if (action === 'offer' && req.method === 'POST') {
+		const body = await readBody(req);
+		const { sdp } = JSON.parse(body);
+		if (!sdp || typeof sdp !== 'string') {
+			jsonResponse(res, 400, { error: 'Missing sdp' });
+			return;
+		}
+		room.offer = sdp;
+		jsonResponse(res, 200, { ok: true });
+		return;
+	}
+
+	if (action === 'answer' && req.method === 'POST') {
+		const body = await readBody(req);
+		const { sdp } = JSON.parse(body);
+		if (!sdp || typeof sdp !== 'string') {
+			jsonResponse(res, 400, { error: 'Missing sdp' });
+			return;
+		}
+		room.answer = sdp;
+		jsonResponse(res, 200, { ok: true });
+		return;
+	}
+
+	if (action === 'poll' && req.method === 'GET') {
+		const role = query.get('role');
+		if (role === 'offerer') {
+			jsonResponse(res, 200, { answer: room.answer });
+		} else if (role === 'answerer') {
+			jsonResponse(res, 200, { offer: room.offer });
+		} else {
+			jsonResponse(res, 400, { error: 'Invalid role' });
+		}
+		return;
+	}
+
+	jsonResponse(res, 400, { error: 'Invalid action' });
+};


### PR DESCRIPTION
## Summary

- Adds a WebRTC-based `PlaygroundSyncTransport` that enables cross-device WordPress Playground sync over peer-to-peer DataChannels
- Adds a lightweight signaling server (PHP for production, Vite middleware for dev) that brokers the initial WebRTC handshake via room codes
- Adds a demo page at `/demos/webrtc-sync.html` where two browsers can sync a WordPress instance in real time

## How it works

**Signaling:** One peer creates a 6-character room code. The other peer joins with that code. SDP offers/answers are exchanged via HTTP polling through the signaling server. Rooms auto-expire after 10 minutes.

**Connection:** Uses vanilla ICE (all candidates gathered before signaling) to keep the signaling protocol simple — no candidate relay needed. Once the WebRTC DataChannel opens, sync messages flow peer-to-peer with no server involvement.

**Message transport:** Large `TransportEnvelope` payloads (which can contain file data as `Uint8Array`) are serialized into a binary format and chunked to stay within the DataChannel's ~64KB message limit. A `MessageAssembler` on the receiving end reconstructs complete messages from chunks.

**Answerer UX:** The joining peer sees a status overlay ("Booting WordPress...", "Syncing...") instead of the iframe. WordPress boots in the background, and the iframe is only revealed after the first sync message has been received and applied — so the user sees the synced content immediately rather than a stale default site.

## New files

| File | Purpose |
|------|---------|
| `sync/src/transports/message-chunking.ts` | Binary serialization + chunking for DataChannel messages |
| `sync/src/transports/signaling-client.ts` | HTTP client for the signaling server (create room, exchange SDP) |
| `sync/src/transports/webrtc-transport.ts` | `WebRTCTransport` implementing `PlaygroundSyncTransport` |
| `website/vite.signaling.ts` | In-memory signaling server for dev mode (Vite middleware) |
| `website/public/signaling.php` | MySQL-backed signaling server for production |
| `website/demos/webrtc-sync.html` + `.ts` | Demo page |
| `*.spec.ts` (3 files) | 26 unit tests covering chunking, signaling client, and transport |

## Test plan

- [ ] `npx nx test playground-sync` — 26 new tests pass (pre-existing `sql.spec.ts` failures are unrelated)
- [ ] Dev mode: `npm run dev`, open `/website-server/demos/webrtc-sync.html` in two tabs, create room in one, join in the other, verify sync
- [ ] Cross-browser: test between Chrome and Firefox on the same machine

## Limitations (V1)

- No automatic reconnection — if the connection drops, users create a new room
- Two peers only (no multi-party)
- Production PHP endpoint requires MySQL; not yet deployed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)