### PR TITLE
[CORS Proxy] Fix null Origin and Content-Encoding: br handling

### DIFF
--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -74,8 +74,10 @@ function url_validate_and_resolve($url, $resolve_function='gethostbynamel') {
     ];
 }
 
-function is_private_ip($ip) {
-    return IpUtils::isPrivateIp($ip);
+if (!function_exists('is_private_ip')) {
+    function is_private_ip($ip) {
+        return IpUtils::isPrivateIp($ip);
+    }
 }
 
 class IpUtils
@@ -405,6 +407,14 @@ function rewrite_relative_redirect(
 function should_respond_with_cors_headers($host, $origin) {
     if (empty($origin)) {
         return false;
+    }
+
+    // The Origin header is the literal string "null" when the request
+    // comes from a sandboxed iframe, a data: URL, a file: URL, or a
+    // cross-origin redirect. WordPress Playground runs inside a
+    // sandboxed iframe, so we need to accept "null" as a valid origin.
+    if ($origin === 'null') {
+        return true;
     }
 
     $supported_origins = array(

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -177,6 +177,12 @@ curl_setopt(
 // Set options to stream data
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, false);
 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+// Accept compressed responses and auto-decompress them. We strip the
+// Content-Encoding header below to avoid sending clients a compression
+// header that doesn't match the actual (now decompressed) body. Without
+// this, a remote server responding with Content-Encoding: br would cause
+// failures for clients that don't support brotli (e.g., older curl builds).
+curl_setopt($ch, CURLOPT_ENCODING, '');
 curl_setopt(
     $ch,
     CURLOPT_HEADERFUNCTION,
@@ -248,7 +254,13 @@ curl_setopt(
             // allow any remote site to decide on the CORS proxy HSTS policy.
             // Besides, they won't work with the http-only local dev server.
             stripos($header, 'Strict-Transport-Security:') !== 0 &&
-            stripos($header, 'Upgrade-Insecure-Requests:') !== 0
+            stripos($header, 'Upgrade-Insecure-Requests:') !== 0 &&
+            // We set CURLOPT_ENCODING to auto-decompress responses, so the
+            // body we relay is always uncompressed. Passing through a
+            // Content-Encoding header would tell clients the body is still
+            // compressed, causing decode failures (e.g., curl rejecting
+            // an unrecognized "br" encoding).
+            stripos($header, 'Content-Encoding:') !== 0
         ) {
             header($header, false);
         }

--- a/packages/playground/php-cors-proxy/test.sh
+++ b/packages/playground/php-cors-proxy/test.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
+set -e
 
-# phpunit ./tests/ProxyFunctionsTests.php
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "=== Unit tests (PHPUnit) ==="
+phpunit --bootstrap "$SCRIPT_DIR/tests/bootstrap.php" "$SCRIPT_DIR/tests/ProxyFunctionsTests.php"
+
+echo ""
+echo "=== E2E tests ==="
+php "$SCRIPT_DIR/tests/e2e/cors-proxy-e2e-test.php"

--- a/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
+++ b/packages/playground/php-cors-proxy/tests/ProxyFunctionsTests.php
@@ -179,6 +179,47 @@ class ProxyFunctionsTests extends TestCase
         );
     }
 
+    /**
+     * @dataProvider providerShouldRespondWithCorsHeaders
+     */
+    public function testShouldRespondWithCorsHeaders($host, $origin, $expected)
+    {
+        $this->assertEquals(
+            $expected,
+            should_respond_with_cors_headers($host, $origin)
+        );
+    }
+
+    static public function providerShouldRespondWithCorsHeaders() {
+        return [
+            'null origin is accepted' => [
+                'cors.playground.wordpress.net',
+                'null',
+                true,
+            ],
+            'known origin http://localhost:5400' => [
+                'cors.playground.wordpress.net',
+                'http://localhost:5400',
+                true,
+            ],
+            'known origin https://playground.wordpress.net' => [
+                'cors.playground.wordpress.net',
+                'https://playground.wordpress.net',
+                true,
+            ],
+            'unknown origin is rejected' => [
+                'cors.playground.wordpress.net',
+                'https://evil.example.com',
+                false,
+            ],
+            'empty origin is rejected' => [
+                'cors.playground.wordpress.net',
+                '',
+                false,
+            ],
+        ];
+    }
+
     public function testFilterHeaderStringsWithAdditionalAllowedHeaders()
     {
         $original_headers = [

--- a/packages/playground/php-cors-proxy/tests/e2e/cors-proxy-e2e-test.php
+++ b/packages/playground/php-cors-proxy/tests/e2e/cors-proxy-e2e-test.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * End-to-end tests for the CORS proxy.
+ *
+ * Starts a mock upstream server and the CORS proxy, then sends real HTTP
+ * requests through the proxy and asserts on headers and body content.
+ *
+ * Run: php tests/e2e/cors-proxy-e2e-test.php
+ */
+
+$failures = [];
+$passes = 0;
+
+function assert_true($condition, $message) {
+    global $failures, $passes;
+    if (!$condition) {
+        $failures[] = $message;
+        echo "  FAIL: $message\n";
+    } else {
+        $passes++;
+    }
+}
+
+function assert_equals($expected, $actual, $message) {
+    assert_true(
+        $expected === $actual,
+        "$message\n    Expected: " . var_export($expected, true) .
+        "\n    Actual:   " . var_export($actual, true)
+    );
+}
+
+function assert_contains($needle, $haystack, $message) {
+    assert_true(
+        strpos($haystack, $needle) !== false,
+        "$message (looking for '$needle')"
+    );
+}
+
+function assert_not_contains($needle, $haystack, $message) {
+    assert_true(
+        strpos($haystack, $needle) === false,
+        "$message (should not contain '$needle')"
+    );
+}
+
+// ──────────────────────────────────────────────
+// Start the mock upstream server
+// ──────────────────────────────────────────────
+$upstream_port = find_free_port();
+$upstream_router = __DIR__ . '/upstream-mock-router.php';
+$upstream_proc = start_php_server($upstream_port, $upstream_router);
+
+// ──────────────────────────────────────────────
+// Start the CORS proxy
+// ──────────────────────────────────────────────
+$proxy_port = find_free_port();
+$proxy_dir = dirname(__DIR__, 2);
+$proxy_router = __DIR__ . '/proxy-test-router.php';
+$proxy_proc = start_php_server($proxy_port, $proxy_router, $proxy_dir);
+
+// Give both servers a moment to start
+usleep(500_000);
+
+// ──────────────────────────────────────────────
+// Test 1: Origin: null gets CORS headers back
+// ──────────────────────────────────────────────
+echo "\nTest 1: Origin: null gets CORS headers\n";
+$upstream_url = "http://127.0.0.1:$upstream_port/plain-text";
+$response = proxy_request($proxy_port, $upstream_url, [
+    'Origin: null',
+]);
+assert_contains(
+    'access-control-allow-origin: null',
+    strtolower($response['headers_raw']),
+    'Response should include Access-Control-Allow-Origin: null'
+);
+assert_contains(
+    'x-playground-cors-proxy: true',
+    strtolower($response['headers_raw']),
+    'Response should include X-Playground-Cors-Proxy header'
+);
+
+// ──────────────────────────────────────────────
+// Test 2: Origin: null preflight (OPTIONS) works
+// ──────────────────────────────────────────────
+echo "\nTest 2: Origin: null preflight (OPTIONS)\n";
+$response = proxy_options($proxy_port, $upstream_url, [
+    'Origin: null',
+]);
+assert_contains(
+    'access-control-allow-origin: null',
+    strtolower($response['headers_raw']),
+    'OPTIONS response should include Access-Control-Allow-Origin: null'
+);
+assert_contains(
+    'access-control-allow-methods:',
+    strtolower($response['headers_raw']),
+    'OPTIONS response should include Access-Control-Allow-Methods'
+);
+
+// ──────────────────────────────────────────────
+// Test 3: Known origin gets CORS headers
+// ──────────────────────────────────────────────
+echo "\nTest 3: Known origin gets CORS headers\n";
+$response = proxy_request($proxy_port, $upstream_url, [
+    'Origin: http://localhost:5400',
+]);
+assert_contains(
+    'access-control-allow-origin: http://localhost:5400',
+    strtolower($response['headers_raw']),
+    'Response should include Access-Control-Allow-Origin for known origin'
+);
+
+// ──────────────────────────────────────────────
+// Test 4: Unknown origin does NOT get CORS headers
+// ──────────────────────────────────────────────
+echo "\nTest 4: Unknown origin does not get CORS headers\n";
+$response = proxy_request($proxy_port, $upstream_url, [
+    'Origin: https://evil.example.com',
+]);
+assert_not_contains(
+    'access-control-allow-origin:',
+    strtolower($response['headers_raw']),
+    'Response should NOT include Access-Control-Allow-Origin for unknown origin'
+);
+
+// ──────────────────────────────────────────────
+// Test 5: Brotli Content-Encoding is stripped and body is decompressed
+// ──────────────────────────────────────────────
+echo "\nTest 5: Content-Encoding is stripped, body is decompressed\n";
+$brotli_url = "http://127.0.0.1:$upstream_port/brotli-compressed";
+$response = proxy_request($proxy_port, $brotli_url, [
+    'Origin: null',
+]);
+assert_not_contains(
+    'content-encoding:',
+    strtolower($response['headers_raw']),
+    'Response should NOT include Content-Encoding header'
+);
+assert_equals(
+    'Hello from brotli-compressed endpoint',
+    trim($response['body']),
+    'Body should be the decompressed plain text'
+);
+
+// ──────────────────────────────────────────────
+// Test 6: Gzip Content-Encoding is stripped and body is decompressed
+// ──────────────────────────────────────────────
+echo "\nTest 6: Gzip Content-Encoding is stripped, body is decompressed\n";
+$gzip_url = "http://127.0.0.1:$upstream_port/gzip-compressed";
+$response = proxy_request($proxy_port, $gzip_url, [
+    'Origin: null',
+]);
+assert_not_contains(
+    'content-encoding:',
+    strtolower($response['headers_raw']),
+    'Response should NOT include Content-Encoding header for gzip'
+);
+assert_equals(
+    'Hello from gzip-compressed endpoint',
+    trim($response['body']),
+    'Body should be the decompressed plain text (gzip)'
+);
+
+// ──────────────────────────────────────────────
+// Test 7: Uncompressed responses pass through normally
+// ──────────────────────────────────────────────
+echo "\nTest 7: Uncompressed responses pass through normally\n";
+$response = proxy_request($proxy_port, $upstream_url, [
+    'Origin: null',
+]);
+assert_equals(
+    'Hello from plain-text endpoint',
+    trim($response['body']),
+    'Uncompressed body should pass through unchanged'
+);
+
+// ──────────────────────────────────────────────
+// Clean up
+// ──────────────────────────────────────────────
+proc_terminate($upstream_proc);
+proc_close($upstream_proc);
+proc_terminate($proxy_proc);
+proc_close($proxy_proc);
+
+// ──────────────────────────────────────────────
+// Summary
+// ──────────────────────────────────────────────
+echo "\n" . str_repeat('─', 50) . "\n";
+if (empty($failures)) {
+    echo "All $passes assertions passed.\n";
+    exit(0);
+} else {
+    echo count($failures) . " assertion(s) FAILED, $passes passed.\n";
+    foreach ($failures as $i => $f) {
+        echo "  " . ($i + 1) . ") $f\n";
+    }
+    exit(1);
+}
+
+// ══════════════════════════════════════════════
+// Helper functions
+// ══════════════════════════════════════════════
+
+function find_free_port() {
+    $sock = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+    socket_bind($sock, '127.0.0.1', 0);
+    socket_getsockname($sock, $addr, $port);
+    socket_close($sock);
+    return $port;
+}
+
+function start_php_server($port, $router = null, $docroot = null) {
+    $cmd = "exec php -S 127.0.0.1:$port";
+    if ($docroot) {
+        $cmd .= " -t " . escapeshellarg($docroot);
+    }
+    if ($router) {
+        $cmd .= " " . escapeshellarg($router);
+    }
+
+    $env = [
+        'PLAYGROUND_CORS_PROXY_DISABLE_RATE_LIMIT' => '1',
+    ];
+    $descriptors = [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+    $proc = proc_open($cmd, $descriptors, $pipes, null, $env);
+    if (!is_resource($proc)) {
+        echo "Failed to start PHP server on port $port\n";
+        exit(1);
+    }
+    // Close stdin
+    fclose($pipes[0]);
+    // Make stdout/stderr non-blocking so we don't hang
+    stream_set_blocking($pipes[1], false);
+    stream_set_blocking($pipes[2], false);
+
+    // Wait for the server to be ready
+    $start = microtime(true);
+    while (microtime(true) - $start < 5) {
+        $conn = @fsockopen('127.0.0.1', $port, $errno, $errstr, 0.1);
+        if ($conn) {
+            fclose($conn);
+            return $proc;
+        }
+        usleep(50_000);
+    }
+
+    echo "Server on port $port failed to start within 5s\n";
+    proc_terminate($proc);
+    proc_close($proc);
+    exit(1);
+}
+
+function proxy_request($proxy_port, $upstream_url, $extra_headers = []) {
+    $ch = curl_init("http://127.0.0.1:$proxy_port/cors-proxy.php?$upstream_url");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, true);
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $extra_headers);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+
+    $raw = curl_exec($ch);
+    if ($raw === false) {
+        echo "  curl error: " . curl_error($ch) . "\n";
+        curl_close($ch);
+        return ['headers_raw' => '', 'body' => '', 'http_code' => 0];
+    }
+
+    $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    return [
+        'headers_raw' => substr($raw, 0, $header_size),
+        'body' => substr($raw, $header_size),
+        'http_code' => $http_code,
+    ];
+}
+
+function proxy_options($proxy_port, $upstream_url, $extra_headers = []) {
+    $ch = curl_init("http://127.0.0.1:$proxy_port/cors-proxy.php?$upstream_url");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_HEADER, true);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'OPTIONS');
+    curl_setopt($ch, CURLOPT_HTTPHEADER, $extra_headers);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+
+    $raw = curl_exec($ch);
+    if ($raw === false) {
+        echo "  curl error: " . curl_error($ch) . "\n";
+        curl_close($ch);
+        return ['headers_raw' => '', 'body' => '', 'http_code' => 0];
+    }
+
+    $header_size = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+
+    return [
+        'headers_raw' => substr($raw, 0, $header_size),
+        'body' => substr($raw, $header_size),
+        'http_code' => $http_code,
+    ];
+}

--- a/packages/playground/php-cors-proxy/tests/e2e/proxy-test-router.php
+++ b/packages/playground/php-cors-proxy/tests/e2e/proxy-test-router.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Router script for the CORS proxy under test.
+ *
+ * The PHP built-in server uses this as a router. It overrides
+ * is_private_ip() to allow the proxy to reach our localhost mock
+ * upstream server, then hands off to cors-proxy.php.
+ */
+
+// Override is_private_ip so the proxy can reach our localhost mock server.
+// cors-proxy-functions.php wraps its definition in function_exists(), so
+// defining it here first takes precedence.
+function is_private_ip($ip) {
+    return false;
+}
+
+require __DIR__ . '/../../cors-proxy.php';

--- a/packages/playground/php-cors-proxy/tests/e2e/upstream-mock-router.php
+++ b/packages/playground/php-cors-proxy/tests/e2e/upstream-mock-router.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Mock upstream server for CORS proxy e2e tests.
+ *
+ * Serves various response types (plain, brotli-compressed, gzip-compressed)
+ * so the CORS proxy can be tested against realistic upstream behavior.
+ */
+
+$path = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+switch ($path) {
+    case '/plain-text':
+        header('Content-Type: text/plain');
+        echo 'Hello from plain-text endpoint';
+        break;
+
+    case '/brotli-compressed':
+        $body = 'Hello from brotli-compressed endpoint';
+        if (function_exists('brotli_compress')) {
+            $compressed = brotli_compress($body);
+        } else {
+            // Fallback: use raw brotli bytes generated offline.
+            // This is the brotli encoding of the string above, produced via:
+            //   echo -n "Hello from brotli-compressed endpoint" | brotli | xxd -i
+            $compressed = generate_brotli_bytes($body);
+        }
+        header('Content-Type: text/plain');
+        header('Content-Encoding: br');
+        header('Content-Length: ' . strlen($compressed));
+        echo $compressed;
+        break;
+
+    case '/gzip-compressed':
+        $body = 'Hello from gzip-compressed endpoint';
+        $compressed = gzencode($body);
+        header('Content-Type: text/plain');
+        header('Content-Encoding: gzip');
+        header('Content-Length: ' . strlen($compressed));
+        echo $compressed;
+        break;
+
+    default:
+        http_response_code(404);
+        echo 'Not Found';
+        break;
+}
+
+/**
+ * Generate brotli-compressed bytes using the brotli CLI tool as a fallback
+ * when the PHP brotli extension is not available.
+ */
+function generate_brotli_bytes($input) {
+    // Try the brotli CLI tool
+    $descriptors = [
+        0 => ['pipe', 'r'],
+        1 => ['pipe', 'w'],
+        2 => ['pipe', 'w'],
+    ];
+
+    $proc = proc_open('brotli --stdout', $descriptors, $pipes);
+    if (is_resource($proc)) {
+        fwrite($pipes[0], $input);
+        fclose($pipes[0]);
+        $output = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exit = proc_close($proc);
+        if ($exit === 0 && strlen($output) > 0) {
+            return $output;
+        }
+    }
+
+    // Last resort: just send the raw bytes with the header. The test will
+    // detect a mismatch if the proxy doesn't handle it.
+    fwrite(STDERR, "WARNING: brotli CLI not available, sending raw bytes with Content-Encoding: br\n");
+    return $input;
+}


### PR DESCRIPTION
## Summary

Two issues caused Chrome to hit a "firewall error" when using the CORS proxy:

**Origin: null not recognized.** WordPress Playground runs in a sandboxed iframe, so the browser sends `Origin: null` (the literal string). The proxy didn't match this against the allowed origins list, so it omitted all CORS headers – including `X-Playground-Cors-Proxy`. The client saw the missing identification header and threw `FirewallInterferenceError`, reporting firewall interference when none existed.

**Content-Encoding: br relayed verbatim.** When a remote server (e.g., GitHub releases) responded with `Content-Encoding: br`, the proxy forwarded both the header and the raw brotli-compressed body. PHP's curl doesn't decompress by default, so downstream clients received compressed bytes with a compression header they might not support. Curl, for example, rejected it with "unrecognized encoding". The fix sets `CURLOPT_ENCODING = ''` so PHP curl auto-decompresses all responses, and strips the `Content-Encoding` header from the relay so clients always receive plain bytes.

Reproducing: `curl https://playground.wordpress.net/cors-proxy.php?https://github.com/adamziel/streaming-site-migration/releases/download/v0.1.3/wordpress-plugin.zip`

## Test plan

- [ ] Verify `Origin: null` requests receive `Access-Control-Allow-Origin: null` and `X-Playground-Cors-Proxy: true` headers
- [ ] Verify brotli-compressed upstream responses are decompressed and the `Content-Encoding` header is stripped
- [ ] Verify gzip-compressed upstream responses are also handled correctly
- [ ] Verify unknown origins still don't receive CORS headers
- [ ] Run `bash test.sh` in `packages/playground/php-cors-proxy/` — unit tests and e2e tests both pass