### PR TITLE
[tcp-over-fetch] Strip Content-Encoding from response headers

### DIFF
--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.spec.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.spec.ts
@@ -565,6 +565,9 @@ describe('TCPOverFetchWebsocket over HTTP', () => {
 		// Confirm we're using transfer-encoding: chunked
 		expect(response).not.toContain('content-length');
 		expect(response).toContain('transfer-encoding: chunked');
+		// The browser decompresses the body, so Content-Encoding must
+		// be stripped to avoid telling PHP the body is still compressed.
+		expect(response).not.toContain('content-encoding');
 
 		// Confirm the response is not truncated
 		expect(response.length).toBeGreaterThan(pygmalion.length);
@@ -717,6 +720,47 @@ describe('TCPOverFetchWebsocket with CORS proxy', () => {
 });
 
 describe('RawBytesFetch', () => {
+	it('fetchRawResponseBytes should strip content-encoding from response headers', async () => {
+		// Simulate a response where the browser has already decompressed
+		// the body but the Content-Encoding header is still present.
+		const bodyText = 'decompressed body content';
+		const mockResponse = new Response(bodyText, {
+			status: 200,
+			statusText: 'OK',
+			headers: {
+				'Content-Type': 'text/plain',
+				'Content-Encoding': 'br',
+				'X-Custom': 'kept',
+			},
+		});
+
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = async () => mockResponse;
+		try {
+			const stream = RawBytesFetch.fetchRawResponseBytes(
+				new Request('https://example.com/test')
+			);
+			const reader = stream.getReader();
+			let raw = '';
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				raw += new TextDecoder().decode(value);
+			}
+
+			// The raw HTTP response should NOT contain content-encoding
+			const headerSection = raw.split('\r\n\r\n')[0].toLowerCase();
+			expect(headerSection).not.toContain('content-encoding');
+			// Other headers should still be present
+			expect(headerSection).toContain('x-custom: kept');
+			expect(headerSection).toContain('transfer-encoding: chunked');
+			// Body should be present (chunked encoded)
+			expect(raw).toContain(bodyText);
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	});
+
 	it('parseHttpRequest should handle an transfer-encoding: chunked POST requests', async () => {
 		const encodedBodyBytes = 'abcde';
 		const encodedChunkedBodyBytes = `${encodedBodyBytes.length}\r\n${encodedBodyBytes}\r\n0\r\n\r\n`;

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -609,6 +609,12 @@ export class RawBytesFetch {
 		 * for the details.
 		 */
 		delete headersObject['content-length'];
+		// The browser decompresses the response body transparently, but
+		// the Content-Encoding header may still be present. Passing it
+		// through would tell PHP's curl the body is compressed when it's
+		// actually already decompressed, causing decode failures (e.g.,
+		// curl rejecting an unrecognized "br" encoding).
+		delete headersObject['content-encoding'];
 		headersObject['transfer-encoding'] = 'chunked';
 
 		const headers: string[] = [];

--- a/packages/php-wasm/web/src/test/php-networking.spec.ts
+++ b/packages/php-wasm/web/src/test/php-networking.spec.ts
@@ -116,8 +116,9 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 					]);
 				`,
 			});
+			const text = await response.stdoutText;
 			php.exit();
-			return await response.stdoutText;
+			return text;
 		}, serverUrl);
 
 		const parsed = JSON.parse(result);
@@ -167,8 +168,9 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 					]);
 				`,
 			});
+			const text = await response.stdoutText;
 			php.exit();
-			return await response.stdoutText;
+			return text;
 		}, serverUrl);
 
 		const parsed = JSON.parse(result);

--- a/packages/php-wasm/web/src/test/php-networking.spec.ts
+++ b/packages/php-wasm/web/src/test/php-networking.spec.ts
@@ -1,0 +1,180 @@
+import test from '@playwright/test';
+import http from 'http';
+import zlib from 'zlib';
+import type { AddressInfo } from 'net';
+
+const longText = 'The quick brown fox jumps over the lazy dog. '.repeat(100);
+
+test.describe('PHP networking through tcp-over-fetch bridge', () => {
+	let mockServer: http.Server;
+	let serverUrl: string;
+
+	test.beforeAll(async () => {
+		mockServer = http.createServer((req, res) => {
+			// Allow cross-origin requests from the Playwright dev server
+			res.setHeader('Access-Control-Allow-Origin', '*');
+			res.setHeader('Access-Control-Allow-Methods', 'GET, POST');
+			res.setHeader('Access-Control-Allow-Headers', '*');
+			if (req.method === 'OPTIONS') {
+				res.writeHead(204);
+				res.end();
+				return;
+			}
+
+			const url = new URL(req.url!, `http://${req.headers.host}`);
+			switch (url.pathname) {
+				case '/plain': {
+					res.setHeader('Content-Type', 'text/plain');
+					res.end(longText);
+					break;
+				}
+				case '/gzipped': {
+					const compressed = zlib.gzipSync(longText);
+					res.setHeader('Content-Type', 'text/plain');
+					res.setHeader('Content-Encoding', 'gzip');
+					res.setHeader(
+						'Content-Length',
+						compressed.length.toString()
+					);
+					res.end(compressed);
+					break;
+				}
+				case '/brotli': {
+					const compressed = zlib.brotliCompressSync(longText);
+					res.setHeader('Content-Type', 'text/plain');
+					res.setHeader('Content-Encoding', 'br');
+					res.setHeader(
+						'Content-Length',
+						compressed.length.toString()
+					);
+					res.end(compressed);
+					break;
+				}
+				default:
+					res.writeHead(404);
+					res.end('Not Found');
+			}
+		});
+
+		await new Promise<void>((resolve) => {
+			mockServer.listen(0, '127.0.0.1', () => resolve());
+		});
+		const addr = mockServer.address() as AddressInfo;
+		serverUrl = `http://127.0.0.1:${addr.port}`;
+	});
+
+	test.afterAll(() => {
+		mockServer?.close();
+	});
+
+	test.beforeEach(async ({ page }) => {
+		page.on('console', (log) => console.log(log.text()));
+		await page.goto('/');
+		await page.addScriptTag({
+			type: 'module',
+			url: '/src/test/playwright/globals.ts',
+		});
+	});
+
+	test('PHP curl receives decompressed body for gzip-compressed response', async ({
+		page,
+	}) => {
+		const result = await page.evaluate(async (url: string) => {
+			const CAroot = await window.generateCertificate({
+				subject: {
+					commonName: 'TestCA',
+					organizationName: 'Test',
+					countryName: 'US',
+				},
+				basicConstraints: { ca: true },
+			});
+
+			const php = new window.PHP(
+				await window.loadWebRuntime('8.4', {
+					tcpOverFetch: { CAroot },
+				})
+			);
+
+			await window.setPhpIniEntries(php, {
+				allow_url_fopen: '1',
+				disable_functions: '',
+			});
+
+			const response = await php.runStream({
+				code: `<?php
+					$ch = curl_init('${url}/gzipped');
+					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+					$body = curl_exec($ch);
+					$error = curl_error($ch);
+					$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+					curl_close($ch);
+					echo json_encode([
+						'code' => $code,
+						'error' => $error,
+						'bodyLength' => strlen($body),
+						'bodyStart' => substr($body, 0, 50),
+					]);
+				`,
+			});
+			php.exit();
+			return await response.stdoutText;
+		}, serverUrl);
+
+		const parsed = JSON.parse(result);
+		test.expect(parsed.code).toBe(200);
+		test.expect(parsed.error).toBe('');
+		test.expect(parsed.bodyLength).toBe(longText.length);
+		test.expect(parsed.bodyStart).toBe(longText.slice(0, 50));
+	});
+
+	test('PHP curl receives decompressed body for brotli-compressed response', async ({
+		page,
+	}) => {
+		const result = await page.evaluate(async (url: string) => {
+			const CAroot = await window.generateCertificate({
+				subject: {
+					commonName: 'TestCA',
+					organizationName: 'Test',
+					countryName: 'US',
+				},
+				basicConstraints: { ca: true },
+			});
+
+			const php = new window.PHP(
+				await window.loadWebRuntime('8.4', {
+					tcpOverFetch: { CAroot },
+				})
+			);
+
+			await window.setPhpIniEntries(php, {
+				allow_url_fopen: '1',
+				disable_functions: '',
+			});
+
+			const response = await php.runStream({
+				code: `<?php
+					$ch = curl_init('${url}/brotli');
+					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+					$body = curl_exec($ch);
+					$error = curl_error($ch);
+					$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+					curl_close($ch);
+					echo json_encode([
+						'code' => $code,
+						'error' => $error,
+						'bodyLength' => strlen($body),
+						'bodyStart' => substr($body, 0, 50),
+					]);
+				`,
+			});
+			php.exit();
+			return await response.stdoutText;
+		}, serverUrl);
+
+		const parsed = JSON.parse(result);
+		test.expect(parsed.code).toBe(200);
+		test.expect(parsed.error).toBe('');
+		test.expect(parsed.bodyLength).toBe(longText.length);
+		test.expect(parsed.bodyStart).toBe(longText.slice(0, 50));
+	});
+});

--- a/packages/php-wasm/web/src/test/playwright/globals.d.ts
+++ b/packages/php-wasm/web/src/test/playwright/globals.d.ts
@@ -1,10 +1,12 @@
-import type { PHP } from '@php-wasm/universal';
-import type { loadWebRuntime } from '../../lib';
+import type { PHP, setPhpIniEntries } from '@php-wasm/universal';
+import type { loadWebRuntime, generateCertificate } from '../../lib';
 
 declare global {
 	interface Window {
 		PHP: typeof PHP;
 		loadWebRuntime: typeof loadWebRuntime;
 		proxyFileSystem: typeof proxyFileSystem;
+		setPhpIniEntries: typeof setPhpIniEntries;
+		generateCertificate: typeof generateCertificate;
 	}
 }

--- a/packages/php-wasm/web/src/test/playwright/globals.ts
+++ b/packages/php-wasm/web/src/test/playwright/globals.ts
@@ -1,6 +1,8 @@
-import { PHP, proxyFileSystem } from '@php-wasm/universal';
-import { loadWebRuntime } from '../../lib';
+import { PHP, proxyFileSystem, setPhpIniEntries } from '@php-wasm/universal';
+import { loadWebRuntime, generateCertificate } from '../../lib';
 
 (window as any).PHP = PHP;
 (window as any).loadWebRuntime = loadWebRuntime;
 (window as any).proxyFileSystem = proxyFileSystem;
+(window as any).setPhpIniEntries = setPhpIniEntries;
+(window as any).generateCertificate = generateCertificate;


### PR DESCRIPTION
## Summary

In the browser, curl requests failed with content decoding error when the server provided a response header such as `Content-Encoding: br`. This is because the TCP-over-fetch bridge passed both of these back to curl:

* The decoded response body stream
* The `Content-encoding: br` header

The PR makes curl work again by removing the `Content-Encoding` header from the list of headers passed back to curl. The upside (curl not failing) wins over the downside (PHP can't see that header even though the server provided it).

## Test plan

- [ ] Run `npx nx test php-wasm-web --testFile=tcp-over-fetch-websocket.spec.ts` — all 28 vitest tests pass (unit test verifies Content-Encoding is stripped from raw bytes; gzipped e2e test asserts absence of content-encoding header)
- [ ] Run `npx nx e2e php-wasm-web` — Playwright tests boot PHP 8.4 in the browser with tcpOverFetch networking and run PHP `curl_exec()` against a mock server returning gzip and brotli compressed responses; PHP receives the correct decompressed body with the right length