### PR TITLE
[tcp-over-fetch] Buffer request body for non-HTTPS fetches

### DIFF
--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
@@ -144,6 +144,10 @@ describe('fetchWithCorsProxy', () => {
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
+		// Spy on the exact method duplexSafeFetch uses to buffer:
+		// new Response(body).arrayBuffer(). If it was called, the body
+		// was read into an ArrayBuffer and re-attached to a new Request.
+		const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
 
 		const body = new ReadableStream({
 			start(controller) {
@@ -162,10 +166,12 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const sentRequest = fetchMock.mock.calls[0][0] as Request;
-		// The body should have been re-created (buffered), not the
-		// original ReadableStream.
-		expect(sentRequest.body).not.toBe(body);
-		// The body content should be preserved.
+
+		// The body was buffered via Response.arrayBuffer().
+		expect(arrayBufferSpy).toHaveBeenCalledTimes(1);
+		// The request was re-created from the buffered body.
+		expect(sentRequest).not.toBe(request);
+		// The buffered content should be faithfully re-attached.
 		expect(await new Response(sentRequest.body).text()).toBe(
 			'streamed data'
 		);
@@ -175,6 +181,7 @@ describe('fetchWithCorsProxy', () => {
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
+		const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
 
 		const body = new ReadableStream({
 			start(controller) {
@@ -194,7 +201,10 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const sentRequest = fetchMock.mock.calls[0][0] as Request;
-		// For HTTPS the request should pass through without buffering.
+		// No buffering should have occurred for https://.
+		expect(arrayBufferSpy).not.toHaveBeenCalled();
+		// The exact same Request object should reach fetch() –
+		// no cloning, no buffering, just a pass-through.
 		expect(sentRequest).toBe(request);
 	});
 
@@ -208,6 +218,7 @@ describe('fetchWithCorsProxy', () => {
 			.mockResolvedValueOnce(
 				new Response('proxied', { headers: corsProxyHeaders })
 			);
+		const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
 
 		const body = new ReadableStream({
 			start(controller) {
@@ -229,12 +240,16 @@ describe('fetchWithCorsProxy', () => {
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
-		// The second call is the CORS-proxy retry to an http:// URL,
-		// so the body must have been buffered.
+		// The first call (direct https://) should NOT trigger buffering.
+		// The second call (http:// CORS proxy) should.
+		expect(arrayBufferSpy).toHaveBeenCalledTimes(1);
+
 		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
 		expect(proxyRequest.url).toBe(
 			'http://localhost:5400/cors-proxy/?url=https://example.com/api'
 		);
+		// The buffered content should survive the tee → clone → buffer
+		// pipeline intact.
 		expect(await new Response(proxyRequest.body).text()).toBe(
 			'upload payload'
 		);
@@ -251,16 +266,20 @@ describe('fetchWithCorsProxy', () => {
 			.mockResolvedValueOnce(
 				new Response('proxied', { headers: corsProxyHeaders })
 			);
+		const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
 
 		// When input is a string, init builds the initial Request and
 		// is also forwarded to duplexSafeFetch in the retry path.
-		await fetchWithCorsProxy(
+		const response = await fetchWithCorsProxy(
 			'https://example.com/api',
 			{ method: 'POST', body: 'form data' },
 			'http://localhost:5400/cors-proxy/?url='
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
+		// The http:// CORS proxy URL triggers buffering.
+		expect(arrayBufferSpy).toHaveBeenCalledTimes(1);
+
 		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
 		expect(proxyRequest.url).toBe(
 			'http://localhost:5400/cors-proxy/?url=https://example.com/api'
@@ -268,5 +287,6 @@ describe('fetchWithCorsProxy', () => {
 		// The body from init should survive the tee → clone → buffer
 		// pipeline.
 		expect(await new Response(proxyRequest.body).text()).toBe('form data');
+		expect(await response.text()).toBe('proxied');
 	});
 });

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
@@ -2,50 +2,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCorsProxy } from './fetch-with-cors-proxy';
 import { FirewallInterferenceError } from './firewall-interference-error';
 
-/**
- * Intercepts the Request constructor to record whether each
- * Request was built with a ReadableStream body ('stream') or a
- * buffered body like ArrayBuffer/string ('buffer').
- *
- * This lets tests assert the body *type* that reached the final
- * fetch() call — the actual property that matters for the
- * HTTP/1.1 duplex problem.
- */
-function trackRequestBodies() {
-	const bodyTypeByRequest = new WeakMap<Request, string>();
-	const OriginalRequest = globalThis.Request;
-	globalThis.Request = new Proxy(OriginalRequest, {
-		construct(target, args, newTarget) {
-			const instance = Reflect.construct(target, args, newTarget);
-			const [, init] = args;
-			if (init?.body !== undefined && init.body !== null) {
-				bodyTypeByRequest.set(
-					instance,
-					init.body instanceof ReadableStream ? 'stream' : 'buffer'
-				);
-			}
-			return instance;
-		},
-	}) as typeof Request;
-	return {
-		bodyTypeOf(request: Request): string | undefined {
-			return bodyTypeByRequest.get(request);
-		},
-		restore() {
-			globalThis.Request = OriginalRequest;
-		},
-	};
-}
-
 describe('fetchWithCorsProxy', () => {
-	let requestTracker: ReturnType<typeof trackRequestBodies> | null = null;
-
 	afterEach(() => {
 		vi.restoreAllMocks();
-		if (requestTracker) {
-			requestTracker.restore();
-			requestTracker = null;
-		}
 	});
 
 	it('upgrades plain HTTP requests to HTTPS before fetching directly', async () => {
@@ -182,7 +141,6 @@ describe('fetchWithCorsProxy', () => {
 	});
 
 	it('buffers a streaming request body for http:// URLs', async () => {
-		requestTracker = trackRequestBodies();
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
@@ -204,17 +162,17 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const sentRequest = fetchMock.mock.calls[0][0] as Request;
-		// The body passed to the Request constructor must have been a
-		// buffer (ArrayBuffer), not a ReadableStream. That is the
-		// whole point of duplexSafeFetch — avoid duplex: 'half'.
-		expect(requestTracker.bodyTypeOf(sentRequest)).toBe('buffer');
+		// The original request's body was consumed to buffer it into
+		// an ArrayBuffer, so bodyUsed must be true.
+		expect(request.bodyUsed).toBe(true);
+		// A new Request was built from the buffered body.
+		expect(sentRequest).not.toBe(request);
 		expect(await new Response(sentRequest.body).text()).toBe(
 			'streamed data'
 		);
 	});
 
 	it('does not buffer the request body for https:// URLs', async () => {
-		requestTracker = trackRequestBodies();
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
@@ -240,12 +198,11 @@ describe('fetchWithCorsProxy', () => {
 		// The exact same Request object should reach fetch() –
 		// no cloning, no buffering, just a pass-through.
 		expect(sentRequest).toBe(request);
-		// Confirm the body type is still a stream, not a buffer.
-		expect(requestTracker.bodyTypeOf(sentRequest)).toBe('stream');
+		// Body was NOT consumed — no buffering happened.
+		expect(request.bodyUsed).toBe(false);
 	});
 
 	it('buffers the request body when retrying via an http:// CORS proxy', async () => {
-		requestTracker = trackRequestBodies();
 		const corsProxyHeaders = new Headers();
 		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
 
@@ -276,15 +233,12 @@ describe('fetchWithCorsProxy', () => {
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
-		// The first call (direct https://) keeps the stream body.
-		const directRequest = fetchMock.mock.calls[0][0] as Request;
-		expect(requestTracker.bodyTypeOf(directRequest)).toBe('stream');
-		// The second call (http:// CORS proxy) must buffer the body.
 		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
-		expect(requestTracker.bodyTypeOf(proxyRequest)).toBe('buffer');
 		expect(proxyRequest.url).toBe(
 			'http://localhost:5400/cors-proxy/?url=https://example.com/api'
 		);
+		// The buffered content should survive the tee → clone → buffer
+		// pipeline intact.
 		expect(await new Response(proxyRequest.body).text()).toBe(
 			'upload payload'
 		);
@@ -292,7 +246,6 @@ describe('fetchWithCorsProxy', () => {
 	});
 
 	it('forwards init to duplexSafeFetch in the CORS proxy retry path', async () => {
-		requestTracker = trackRequestBodies();
 		const corsProxyHeaders = new Headers();
 		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
 
@@ -312,9 +265,7 @@ describe('fetchWithCorsProxy', () => {
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
-		// The http:// CORS proxy URL triggers buffering.
 		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
-		expect(requestTracker.bodyTypeOf(proxyRequest)).toBe('buffer');
 		expect(proxyRequest.url).toBe(
 			'http://localhost:5400/cors-proxy/?url=https://example.com/api'
 		);

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
@@ -139,4 +139,134 @@ describe('fetchWithCorsProxy', () => {
 		// Should stay as http, not upgraded to https
 		expect(request.url).toBe('http://localhost:1234/v1/chat/completions');
 	});
+
+	it('buffers a streaming request body for http:// URLs', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response('ok'));
+
+		const body = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('streamed data'));
+				controller.close();
+			},
+		});
+		const request = new Request('http://localhost:8080/api', {
+			method: 'POST',
+			body,
+			// @ts-expect-error duplex is required for streaming bodies
+			duplex: 'half',
+		});
+
+		await fetchWithCorsProxy(request);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const sentRequest = fetchMock.mock.calls[0][0] as Request;
+		// The body should have been re-created (buffered), not the
+		// original ReadableStream.
+		expect(sentRequest.body).not.toBe(body);
+		// The body content should be preserved.
+		expect(await new Response(sentRequest.body).text()).toBe(
+			'streamed data'
+		);
+	});
+
+	it('does not buffer the request body for https:// URLs', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue(new Response('ok'));
+
+		const body = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('streamed data'));
+				controller.close();
+			},
+		});
+		const request = new Request('https://example.com/api', {
+			method: 'POST',
+			body,
+			// @ts-expect-error duplex is required for streaming bodies
+			duplex: 'half',
+		});
+
+		// No corsProxyUrl → direct fetch, no tee/clone involved.
+		await fetchWithCorsProxy(request);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const sentRequest = fetchMock.mock.calls[0][0] as Request;
+		// For HTTPS the request should pass through without buffering.
+		expect(sentRequest).toBe(request);
+	});
+
+	it('buffers the request body when retrying via an http:// CORS proxy', async () => {
+		const corsProxyHeaders = new Headers();
+		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
+
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockRejectedValueOnce(new Error('CORS'))
+			.mockResolvedValueOnce(
+				new Response('proxied', { headers: corsProxyHeaders })
+			);
+
+		const body = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('upload payload'));
+				controller.close();
+			},
+		});
+		const request = new Request('https://example.com/api', {
+			method: 'POST',
+			body,
+			// @ts-expect-error duplex is required for streaming bodies
+			duplex: 'half',
+		});
+
+		const response = await fetchWithCorsProxy(
+			request,
+			undefined,
+			'http://localhost:5400/cors-proxy/?url='
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		// The second call is the CORS-proxy retry to an http:// URL,
+		// so the body must have been buffered.
+		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
+		expect(proxyRequest.url).toBe(
+			'http://localhost:5400/cors-proxy/?url=https://example.com/api'
+		);
+		expect(await new Response(proxyRequest.body).text()).toBe(
+			'upload payload'
+		);
+		expect(await response.text()).toBe('proxied');
+	});
+
+	it('forwards init to duplexSafeFetch in the CORS proxy retry path', async () => {
+		const corsProxyHeaders = new Headers();
+		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
+
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockRejectedValueOnce(new Error('CORS'))
+			.mockResolvedValueOnce(
+				new Response('proxied', { headers: corsProxyHeaders })
+			);
+
+		// When input is a string, init builds the initial Request and
+		// is also forwarded to duplexSafeFetch in the retry path.
+		await fetchWithCorsProxy(
+			'https://example.com/api',
+			{ method: 'POST', body: 'form data' },
+			'http://localhost:5400/cors-proxy/?url='
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
+		expect(proxyRequest.url).toBe(
+			'http://localhost:5400/cors-proxy/?url=https://example.com/api'
+		);
+		// The body from init should survive the tee → clone → buffer
+		// pipeline.
+		expect(await new Response(proxyRequest.body).text()).toBe('form data');
+	});
 });

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
@@ -2,9 +2,50 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fetchWithCorsProxy } from './fetch-with-cors-proxy';
 import { FirewallInterferenceError } from './firewall-interference-error';
 
+/**
+ * Intercepts the Request constructor to record whether each
+ * Request was built with a ReadableStream body ('stream') or a
+ * buffered body like ArrayBuffer/string ('buffer').
+ *
+ * This lets tests assert the body *type* that reached the final
+ * fetch() call — the actual property that matters for the
+ * HTTP/1.1 duplex problem.
+ */
+function trackRequestBodies() {
+	const bodyTypeByRequest = new WeakMap<Request, string>();
+	const OriginalRequest = globalThis.Request;
+	globalThis.Request = new Proxy(OriginalRequest, {
+		construct(target, args, newTarget) {
+			const instance = Reflect.construct(target, args, newTarget);
+			const [, init] = args;
+			if (init?.body !== undefined && init.body !== null) {
+				bodyTypeByRequest.set(
+					instance,
+					init.body instanceof ReadableStream ? 'stream' : 'buffer'
+				);
+			}
+			return instance;
+		},
+	}) as typeof Request;
+	return {
+		bodyTypeOf(request: Request): string | undefined {
+			return bodyTypeByRequest.get(request);
+		},
+		restore() {
+			globalThis.Request = OriginalRequest;
+		},
+	};
+}
+
 describe('fetchWithCorsProxy', () => {
+	let requestTracker: ReturnType<typeof trackRequestBodies> | null = null;
+
 	afterEach(() => {
 		vi.restoreAllMocks();
+		if (requestTracker) {
+			requestTracker.restore();
+			requestTracker = null;
+		}
 	});
 
 	it('upgrades plain HTTP requests to HTTPS before fetching directly', async () => {
@@ -141,13 +182,10 @@ describe('fetchWithCorsProxy', () => {
 	});
 
 	it('buffers a streaming request body for http:// URLs', async () => {
+		requestTracker = trackRequestBodies();
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
-		// Spy on the exact method duplexSafeFetch uses to buffer:
-		// new Response(body).arrayBuffer(). If it was called, the body
-		// was read into an ArrayBuffer and re-attached to a new Request.
-		const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
 
 		const body = new ReadableStream({
 			start(controller) {
@@ -166,22 +204,20 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const sentRequest = fetchMock.mock.calls[0][0] as Request;
-
-		// The body was buffered via Response.arrayBuffer().
-		expect(arrayBufferSpy).toHaveBeenCalledTimes(1);
-		// The request was re-created from the buffered body.
-		expect(sentRequest).not.toBe(request);
-		// The buffered content should be faithfully re-attached.
+		// The body passed to the Request constructor must have been a
+		// buffer (ArrayBuffer), not a ReadableStream. That is the
+		// whole point of duplexSafeFetch — avoid duplex: 'half'.
+		expect(requestTracker.bodyTypeOf(sentRequest)).toBe('buffer');
 		expect(await new Response(sentRequest.body).text()).toBe(
 			'streamed data'
 		);
 	});
 
 	it('does not buffer the request body for https:// URLs', async () => {
+		requestTracker = trackRequestBodies();
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
-		const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
 
 		const body = new ReadableStream({
 			start(controller) {
@@ -201,14 +237,15 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const sentRequest = fetchMock.mock.calls[0][0] as Request;
-		// No buffering should have occurred for https://.
-		expect(arrayBufferSpy).not.toHaveBeenCalled();
 		// The exact same Request object should reach fetch() –
 		// no cloning, no buffering, just a pass-through.
 		expect(sentRequest).toBe(request);
+		// Confirm the body type is still a stream, not a buffer.
+		expect(requestTracker.bodyTypeOf(sentRequest)).toBe('stream');
 	});
 
 	it('buffers the request body when retrying via an http:// CORS proxy', async () => {
+		requestTracker = trackRequestBodies();
 		const corsProxyHeaders = new Headers();
 		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
 
@@ -218,7 +255,6 @@ describe('fetchWithCorsProxy', () => {
 			.mockResolvedValueOnce(
 				new Response('proxied', { headers: corsProxyHeaders })
 			);
-		const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
 
 		const body = new ReadableStream({
 			start(controller) {
@@ -240,16 +276,15 @@ describe('fetchWithCorsProxy', () => {
 		);
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
-		// The first call (direct https://) should NOT trigger buffering.
-		// The second call (http:// CORS proxy) should.
-		expect(arrayBufferSpy).toHaveBeenCalledTimes(1);
-
+		// The first call (direct https://) keeps the stream body.
+		const directRequest = fetchMock.mock.calls[0][0] as Request;
+		expect(requestTracker.bodyTypeOf(directRequest)).toBe('stream');
+		// The second call (http:// CORS proxy) must buffer the body.
 		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
+		expect(requestTracker.bodyTypeOf(proxyRequest)).toBe('buffer');
 		expect(proxyRequest.url).toBe(
 			'http://localhost:5400/cors-proxy/?url=https://example.com/api'
 		);
-		// The buffered content should survive the tee → clone → buffer
-		// pipeline intact.
 		expect(await new Response(proxyRequest.body).text()).toBe(
 			'upload payload'
 		);
@@ -257,6 +292,7 @@ describe('fetchWithCorsProxy', () => {
 	});
 
 	it('forwards init to duplexSafeFetch in the CORS proxy retry path', async () => {
+		requestTracker = trackRequestBodies();
 		const corsProxyHeaders = new Headers();
 		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
 
@@ -266,7 +302,6 @@ describe('fetchWithCorsProxy', () => {
 			.mockResolvedValueOnce(
 				new Response('proxied', { headers: corsProxyHeaders })
 			);
-		const arrayBufferSpy = vi.spyOn(Response.prototype, 'arrayBuffer');
 
 		// When input is a string, init builds the initial Request and
 		// is also forwarded to duplexSafeFetch in the retry path.
@@ -278,9 +313,8 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		// The http:// CORS proxy URL triggers buffering.
-		expect(arrayBufferSpy).toHaveBeenCalledTimes(1);
-
 		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
+		expect(requestTracker.bodyTypeOf(proxyRequest)).toBe('buffer');
 		expect(proxyRequest.url).toBe(
 			'http://localhost:5400/cors-proxy/?url=https://example.com/api'
 		);

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -14,11 +14,22 @@ async function httpSafeFetch(
 	request: Request,
 	init?: RequestInit
 ): Promise<Response> {
-	if (new URL(request.url).protocol === 'http:' && request.body) {
-		const body = await new Response(request.body).arrayBuffer();
-		request = await cloneRequest(request, { body });
+	// Combine the base request and init into a single effective Request so that
+	// any overrides in init (including body) are taken into account before
+	// applying HTTP/1.1 streaming safeguards.
+	let effectiveRequest = init ? new Request(request, init) : request;
+
+	if (
+		new URL(effectiveRequest.url).protocol === 'http:' &&
+		effectiveRequest.body
+	) {
+		const body = await new Response(effectiveRequest.body).arrayBuffer();
+		effectiveRequest = await cloneRequest(effectiveRequest, { body });
 	}
-	return fetch(request, init);
+
+	// Call fetch() with the fully prepared Request so the buffered body is
+	// guaranteed to be what is actually sent.
+	return fetch(effectiveRequest);
 }
 
 export async function fetchWithCorsProxy(

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -3,6 +3,24 @@ import { FirewallInterferenceError } from './firewall-interference-error';
 
 const CORS_PROXY_HEADER = 'X-Playground-Cors-Proxy';
 
+/**
+ * Chrome cannot use a streaming request body (`duplex: 'half'`) with
+ * HTTP/1.1 servers – it requires HTTP/2 and fails with
+ * ERR_ALPN_NEGOTIATION_FAILED otherwise. This wrapper buffers the
+ * request body when the target URL is `http://` so `fetch()` sends
+ * it as a regular, non-streaming request.
+ */
+async function httpSafeFetch(
+	request: Request,
+	init?: RequestInit
+): Promise<Response> {
+	if (new URL(request.url).protocol === 'http:' && request.body) {
+		const body = await new Response(request.body).arrayBuffer();
+		request = await cloneRequest(request, { body });
+	}
+	return fetch(request, init);
+}
+
 export async function fetchWithCorsProxy(
 	input: RequestInfo,
 	init?: RequestInit,
@@ -26,7 +44,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj.hostname === '[::1]' ||
 		requestUrlObj.hostname === '::1';
 	if (isLocalhost) {
-		return await fetch(requestObject);
+		return await httpSafeFetch(requestObject);
 	}
 
 	if (requestUrlObj.protocol === 'http:') {
@@ -36,7 +54,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj = new URL(httpsUrl);
 	}
 	if (!corsProxyUrl) {
-		return await fetch(requestObject);
+		return await httpSafeFetch(requestObject);
 	}
 
 	/**
@@ -51,7 +69,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj.port === playgroundUrlObj.port &&
 		requestUrlObj.pathname.startsWith(playgroundUrlObj.pathname)
 	) {
-		return await fetch(requestObject);
+		return await httpSafeFetch(requestObject);
 	}
 
 	// Tee the request to avoid consuming the request body stream on the initial
@@ -59,7 +77,7 @@ export async function fetchWithCorsProxy(
 	const [request1, request2] = await teeRequest(requestObject);
 
 	try {
-		return await fetch(request1);
+		return await httpSafeFetch(request1);
 	} catch {
 		// If the developer has explicitly allowed the request to pass the
 		// credentials headers with the X-Cors-Proxy-Allowed-Request-Headers header,
@@ -77,7 +95,7 @@ export async function fetchWithCorsProxy(
 			...(requestIntendsToPassCredentials && { credentials: 'include' }),
 		});
 
-		const response = await fetch(newRequest, init);
+		const response = await httpSafeFetch(newRequest, init);
 
 		// Check for firewall interference: if we got a response but it's
 		// missing the CORS proxy identification header, the response likely

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -4,13 +4,29 @@ import { FirewallInterferenceError } from './firewall-interference-error';
 const CORS_PROXY_HEADER = 'X-Playground-Cors-Proxy';
 
 /**
- * Chrome cannot use a streaming request body (`duplex: 'half'`) with
- * HTTP/1.1 servers – it requires HTTP/2 and fails with
- * ERR_ALPN_NEGOTIATION_FAILED otherwise. This wrapper buffers the
- * request body when the target URL is `http://` so `fetch()` sends
- * it as a regular, non-streaming request.
+ * A version of fetch() that buffers the request body for http:// requests.
+ *
+ * Chrome does not support using a ReadableStream request body
+ * with HTTP/1.1 requests. If we just always set `duplex: 'half'`,
+ * we'll get an ERR_ALPN_NEGOTIATION_FAILED error as Chrome will
+ * refuse to use duplex over HTTP/1.1 and will switch to HTTP/2.
+ * A HTTP/1.1-only server, however, will still reply with a HTTP/1.1
+ * response, causing that ALPN error.
+ *
+ * We do not know upfront what kind of server we're talking to,
+ * so we'll make a guess. Most servers do not support HTTP >= 2
+ * without TLS, so we can assume that anything starting with `http://`
+ * requires buffering the body stream. This solves the ALPN negotiation
+ * problem on the local dev server.
+ *
+ * There will, inevitably, be some ancient HTTP/1.1+TLS servers on
+ * the internet that will fall into the `duplex: half` trap. This
+ * is not a big problem, though, since those requests will fail
+ * and be retried over the CORS proxy which runs alongside Playground
+ * and speaks either HTTP/1.1 in the local dev server or HTTP/2+ in
+ * production.
  */
-async function httpSafeFetch(
+async function duplexSafeFetch(
 	request: Request,
 	init?: RequestInit
 ): Promise<Response> {
@@ -24,7 +40,9 @@ async function httpSafeFetch(
 		effectiveRequest.body
 	) {
 		const body = await new Response(effectiveRequest.body).arrayBuffer();
-		effectiveRequest = await cloneRequest(effectiveRequest, { body });
+		effectiveRequest = await cloneRequest(effectiveRequest, {
+			body,
+		});
 	}
 
 	// Call fetch() with the fully prepared Request so the buffered body is
@@ -55,7 +73,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj.hostname === '[::1]' ||
 		requestUrlObj.hostname === '::1';
 	if (isLocalhost) {
-		return await httpSafeFetch(requestObject);
+		return await duplexSafeFetch(requestObject);
 	}
 
 	if (requestUrlObj.protocol === 'http:') {
@@ -65,7 +83,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj = new URL(httpsUrl);
 	}
 	if (!corsProxyUrl) {
-		return await httpSafeFetch(requestObject);
+		return await duplexSafeFetch(requestObject);
 	}
 
 	/**
@@ -80,7 +98,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj.port === playgroundUrlObj.port &&
 		requestUrlObj.pathname.startsWith(playgroundUrlObj.pathname)
 	) {
-		return await httpSafeFetch(requestObject);
+		return await duplexSafeFetch(requestObject);
 	}
 
 	// Tee the request to avoid consuming the request body stream on the initial
@@ -88,7 +106,7 @@ export async function fetchWithCorsProxy(
 	const [request1, request2] = await teeRequest(requestObject);
 
 	try {
-		return await httpSafeFetch(request1);
+		return await duplexSafeFetch(request1);
 	} catch {
 		// If the developer has explicitly allowed the request to pass the
 		// credentials headers with the X-Cors-Proxy-Allowed-Request-Headers header,
@@ -106,7 +124,7 @@ export async function fetchWithCorsProxy(
 			...(requestIntendsToPassCredentials && { credentials: 'include' }),
 		});
 
-		const response = await httpSafeFetch(newRequest, init);
+		const response = await duplexSafeFetch(newRequest, init);
 
 		// Check for firewall interference: if we got a response but it's
 		// missing the CORS proxy identification header, the response likely

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -3,53 +3,6 @@ import { FirewallInterferenceError } from './firewall-interference-error';
 
 const CORS_PROXY_HEADER = 'X-Playground-Cors-Proxy';
 
-/**
- * A version of fetch() that buffers the request body for http:// requests.
- *
- * Chrome does not support using a ReadableStream request body
- * with HTTP/1.1 requests. If we just always set `duplex: 'half'`,
- * we'll get an ERR_ALPN_NEGOTIATION_FAILED error as Chrome will
- * refuse to use duplex over HTTP/1.1 and will switch to HTTP/2.
- * A HTTP/1.1-only server, however, will still reply with a HTTP/1.1
- * response, causing that ALPN error.
- *
- * We do not know upfront what kind of server we're talking to,
- * so we'll make a guess. Most servers do not support HTTP >= 2
- * without TLS, so we can assume that anything starting with `http://`
- * requires buffering the body stream. This solves the ALPN negotiation
- * problem on the local dev server.
- *
- * There will, inevitably, be some ancient HTTP/1.1+TLS servers on
- * the internet that will fall into the `duplex: half` trap. This
- * is not a big problem, though, since those requests will fail
- * and be retried over the CORS proxy which runs alongside Playground
- * and speaks either HTTP/1.1 in the local dev server or HTTP/2+ in
- * production.
- */
-async function duplexSafeFetch(
-	request: Request,
-	init?: RequestInit
-): Promise<Response> {
-	// Combine the base request and init into a single effective Request so that
-	// any overrides in init (including body) are taken into account before
-	// applying HTTP/1.1 streaming safeguards.
-	let effectiveRequest = init ? new Request(request, init) : request;
-
-	if (
-		new URL(effectiveRequest.url).protocol === 'http:' &&
-		effectiveRequest.body
-	) {
-		const body = await new Response(effectiveRequest.body).arrayBuffer();
-		effectiveRequest = await cloneRequest(effectiveRequest, {
-			body,
-		});
-	}
-
-	// Call fetch() with the fully prepared Request so the buffered body is
-	// guaranteed to be what is actually sent.
-	return fetch(effectiveRequest);
-}
-
 export async function fetchWithCorsProxy(
 	input: RequestInfo,
 	init?: RequestInit,
@@ -139,4 +92,51 @@ export async function fetchWithCorsProxy(
 
 		return response;
 	}
+}
+
+/**
+ * A version of fetch() that buffers the request body for http:// requests.
+ *
+ * Chrome does not support using a ReadableStream request body
+ * with HTTP/1.1 requests. If we just always set `duplex: 'half'`,
+ * we'll get an ERR_ALPN_NEGOTIATION_FAILED error as Chrome will
+ * refuse to use duplex over HTTP/1.1 and will switch to HTTP/2.
+ * A HTTP/1.1-only server, however, will still reply with a HTTP/1.1
+ * response, causing that ALPN error.
+ *
+ * We do not know upfront what kind of server we're talking to,
+ * so we'll make a guess. Most servers do not support HTTP >= 2
+ * without TLS, so we can assume that anything starting with `http://`
+ * requires buffering the body stream. This solves the ALPN negotiation
+ * problem on the local dev server.
+ *
+ * There will, inevitably, be some ancient HTTP/1.1+TLS servers on
+ * the internet that will fall into the `duplex: half` trap. This
+ * is not a big problem, though, since those requests will fail
+ * and be retried over the CORS proxy which runs alongside Playground
+ * and speaks either HTTP/1.1 in the local dev server or HTTP/2+ in
+ * production.
+ */
+async function duplexSafeFetch(
+	request: Request,
+	init?: RequestInit
+): Promise<Response> {
+	// Combine the base request and init into a single effective Request so that
+	// any overrides in init (including body) are taken into account before
+	// applying HTTP/1.1 streaming safeguards.
+	let effectiveRequest = init ? new Request(request, init) : request;
+
+	if (
+		new URL(effectiveRequest.url).protocol === 'http:' &&
+		effectiveRequest.body
+	) {
+		const body = await new Response(effectiveRequest.body).arrayBuffer();
+		effectiveRequest = await cloneRequest(effectiveRequest, {
+			body,
+		});
+	}
+
+	// Call fetch() with the fully prepared Request so the buffered body is
+	// guaranteed to be what is actually sent.
+	return fetch(effectiveRequest);
 }

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -229,7 +229,7 @@ export async function cloneRequest(
 		cache: request.cache,
 		redirect: request.redirect,
 		integrity: request.integrity,
-		...(body && { duplex: 'half' }),
+		...(body instanceof ReadableStream && { duplex: 'half' }),
 		...overrides,
 	});
 }

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -323,47 +323,22 @@ export class TCPOverFetchWebsocket {
 			this.CAroot.certificate,
 		]);
 
-		await this.parseRequestAndFetch(
-			tlsConnection.serverEnd.upstream.readable,
-			tlsConnection.serverEnd.downstream.writable,
-			'https'
-		);
-	}
-
-	async fetchOverHTTP() {
-		await this.parseRequestAndFetch(
-			this.clientUpstream.readable,
-			this.clientDownstream.writable,
-			'http'
-		);
-	}
-
-	/**
-	 * Parses a raw HTTP request from the given byte stream, handles
-	 * the `Expect: 100-continue` handshake, and pipes the fetch()
-	 * response to the given writable stream.
-	 */
-	async parseRequestAndFetch(
-		requestBytesStream: ReadableStream<Uint8Array>,
-		responseWritable: WritableStream<Uint8Array>,
-		protocol: 'http' | 'https'
-	) {
+		// Connect the TLS server end to the fetch() request
 		const { request, expectsContinue } =
 			await RawBytesFetch.parseHttpRequest(
-				requestBytesStream,
+				tlsConnection.serverEnd.upstream.readable,
 				this.host,
-				protocol
+				'https'
 			);
 		// When PHP's curl sends "Expect: 100-continue" (e.g. for CurlFile
 		// uploads with bodies > 1024 bytes), it pauses after sending the
 		// headers and waits for a "100 Continue" response before sending
-		// the body. We must send that response back to unblock curl,
-		// otherwise the body stream will never arrive and we'll deadlock.
-		//
-		// IMPORTANT: This must happen BEFORE fetchRawResponseBytes, otherwise
-		// curl won't send the body and we'll deadlock.
+		// the body. We must send that response back through the TLS tunnel
+		// to unblock curl, otherwise the body stream will never arrive
+		// and we'll deadlock.
 		if (expectsContinue) {
-			const writer = responseWritable.getWriter();
+			const writer =
+				tlsConnection.serverEnd.downstream.writable.getWriter();
 			await writer.write(
 				new TextEncoder().encode('HTTP/1.1 100 Continue\r\n\r\n')
 			);
@@ -373,7 +348,42 @@ export class TCPOverFetchWebsocket {
 			await RawBytesFetch.fetchRawResponseBytes(
 				request,
 				this.corsProxyUrl
-			).pipeTo(responseWritable);
+			).pipeTo(tlsConnection.serverEnd.downstream.writable);
+		} catch {
+			// Ignore errors from fetch()
+			// They are handled in the constructor
+			// via this.clientDownstream.readable.pipeTo()
+			// and if we let the failures they would be logged
+			// as an unhandled promise rejection.
+		}
+	}
+
+	async fetchOverHTTP() {
+		// Connect this WebSocket's client end to the fetch() request
+		const { request, expectsContinue } =
+			await RawBytesFetch.parseHttpRequest(
+				this.clientUpstream.readable,
+				this.host,
+				'http'
+			);
+		// When PHP's curl sends "Expect: 100-continue" (e.g. for CurlFile
+		// uploads with bodies > 1024 bytes), it pauses after sending the
+		// headers and waits for a "100 Continue" response before sending
+		// the body. We must send that response back to unblock curl,
+		// otherwise the body stream will never arrive and we'll deadlock.
+		if (expectsContinue) {
+			const writer = this.clientDownstream.writable.getWriter();
+			await writer.write(
+				new TextEncoder().encode('HTTP/1.1 100 Continue\r\n\r\n')
+			);
+			writer.releaseLock();
+		}
+
+		try {
+			await RawBytesFetch.fetchRawResponseBytes(
+				request,
+				this.corsProxyUrl
+			).pipeTo(this.clientDownstream.writable);
 		} catch {
 			// Ignore errors from fetch()
 			// They are handled in the constructor

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -323,22 +323,47 @@ export class TCPOverFetchWebsocket {
 			this.CAroot.certificate,
 		]);
 
-		// Connect the TLS server end to the fetch() request
+		await this.parseRequestAndFetch(
+			tlsConnection.serverEnd.upstream.readable,
+			tlsConnection.serverEnd.downstream.writable,
+			'https'
+		);
+	}
+
+	async fetchOverHTTP() {
+		await this.parseRequestAndFetch(
+			this.clientUpstream.readable,
+			this.clientDownstream.writable,
+			'http'
+		);
+	}
+
+	/**
+	 * Parses a raw HTTP request from the given byte stream, handles
+	 * the `Expect: 100-continue` handshake, and pipes the fetch()
+	 * response to the given writable stream.
+	 */
+	async parseRequestAndFetch(
+		requestBytesStream: ReadableStream<Uint8Array>,
+		responseWritable: WritableStream<Uint8Array>,
+		protocol: 'http' | 'https'
+	) {
 		const { request, expectsContinue } =
 			await RawBytesFetch.parseHttpRequest(
-				tlsConnection.serverEnd.upstream.readable,
+				requestBytesStream,
 				this.host,
-				'https'
+				protocol
 			);
 		// When PHP's curl sends "Expect: 100-continue" (e.g. for CurlFile
 		// uploads with bodies > 1024 bytes), it pauses after sending the
 		// headers and waits for a "100 Continue" response before sending
-		// the body. We must send that response back through the TLS tunnel
-		// to unblock curl, otherwise the body stream will never arrive
-		// and we'll deadlock.
+		// the body. We must send that response back to unblock curl,
+		// otherwise the body stream will never arrive and we'll deadlock.
+		//
+		// IMPORTANT: This must happen BEFORE fetchRawResponseBytes, otherwise
+		// curl won't send the body and we'll deadlock.
 		if (expectsContinue) {
-			const writer =
-				tlsConnection.serverEnd.downstream.writable.getWriter();
+			const writer = responseWritable.getWriter();
 			await writer.write(
 				new TextEncoder().encode('HTTP/1.1 100 Continue\r\n\r\n')
 			);
@@ -348,75 +373,7 @@ export class TCPOverFetchWebsocket {
 			await RawBytesFetch.fetchRawResponseBytes(
 				request,
 				this.corsProxyUrl
-			).pipeTo(tlsConnection.serverEnd.downstream.writable);
-		} catch {
-			// Ignore errors from fetch()
-			// They are handled in the constructor
-			// via this.clientDownstream.readable.pipeTo()
-			// and if we let the failures they would be logged
-			// as an unhandled promise rejection.
-		}
-	}
-
-	async fetchOverHTTP() {
-		// Connect this WebSocket's client end to the fetch() request
-		const { request, expectsContinue, needsBodyBuffering } =
-			await RawBytesFetch.parseHttpRequest(
-				this.clientUpstream.readable,
-				this.host,
-				'http'
-			);
-		// When PHP's curl sends "Expect: 100-continue" (e.g. for CurlFile
-		// uploads with bodies > 1024 bytes), it pauses after sending the
-		// headers and waits for a "100 Continue" response before sending
-		// the body. We must send that response back to unblock curl,
-		// otherwise the body stream will never arrive and we'll deadlock.
-		if (expectsContinue) {
-			const writer = this.clientDownstream.writable.getWriter();
-			await writer.write(
-				new TextEncoder().encode('HTTP/1.1 100 Continue\r\n\r\n')
-			);
-			writer.releaseLock();
-		}
-		/**
-		 * Chrome does not support using a ReadableStream request body
-		 * with HTTP/1.1 requests. If we just always set `duplex: 'half'`,
-		 * we'll get an ERR_ALPN_NEGOTIATION_FAILED error as Chrome will
-		 * refuse to use duplex over HTTP/1.1 and will switch to HTTP/2.
-		 * A HTTP/1.1-only server, however, will still reply with a HTTP/1.1
-		 * response, causing that ALPN error.
-		 *
-		 * We do not know upfront what kind of server we're talking to,
-		 * so we'll make a guess. Most servers do not support HTTP >= 2
-		 * without TLS, so we can assume that anything starting with `http://`
-		 * requires buffering the body stream. This solves the ALPN negotiation
-		 * problem on the local dev server.
-		 *
-		 * There will, inevitably, be some ancient HTTP/1.1+TLS servers on
-		 * the internet that will fall into the `duplex: half` trap. This
-		 * is not a big problem, though, since those requests will fail
-		 * and be retried over the CORS proxy which runs alongside Playground
-		 * and speaks either HTTP/1.1 in the local dev server or HTTP/2+ in
-		 * production.
-		 *
-		 * IMPORTANT: Body buffering must happen AFTER the 100 Continue
-		 * response is sent (above), otherwise curl won't send the body
-		 * and we'll deadlock.
-		 */
-		let bufferedRequest = request;
-		if (needsBodyBuffering && request.body) {
-			const body = await new Response(request.body).arrayBuffer();
-			bufferedRequest = new Request(request.url, {
-				method: request.method,
-				headers: request.headers,
-				body,
-			});
-		}
-		try {
-			await RawBytesFetch.fetchRawResponseBytes(
-				bufferedRequest,
-				this.corsProxyUrl
-			).pipeTo(this.clientDownstream.writable);
+			).pipeTo(responseWritable);
 		} catch {
 			// Ignore errors from fetch()
 			// They are handled in the constructor
@@ -775,7 +732,6 @@ export class RawBytesFetch {
 		return {
 			request,
 			expectsContinue: parsedHeaders.expectsContinue,
-			needsBodyBuffering: protocol === 'http',
 		};
 	}
 


### PR DESCRIPTION
## Summary

HTTPS requests from PHP (e.g. curl to `https://example.com`) go through the TLS code path in tcp-over-fetch, which decrypts the traffic and runs a `fetch()`. When the direct fetch fails due to CORS, `fetchWithCorsProxy` retries through the CORS proxy. On the local dev server, that proxy is `http://localhost` — and Chrome refuses to stream request bodies over HTTP/1.1 (`ERR_ALPN_NEGOTIATION_FAILED`).

The body buffering logic was previously scattered in `tcp-over-fetch-websocket.ts` and only covered the `http://` protocol path, missing the TLS-via-HTTP-CORS-proxy case entirely. This PR moves all buffering decisions into a single `httpSafeFetch()` wrapper inside `fetchWithCorsProxy`. Every `fetch()` call in that function now goes through the wrapper, which buffers the request body whenever the target URL is `http://`. This handles all cases uniformly: direct requests, localhost, same-origin playground URLs, and CORS proxy fallbacks.

As a bonus, the duplicated request-parsing logic between `fetchOverTLS` and `fetchOverHTTP` is consolidated into a shared `parseRequestAndFetch` helper.

## Test plan

- [ ] Existing tests pass (`npx nx test php-wasm-web --testFile=tcp-over-fetch-websocket.spec.ts` and `npx nx test php-wasm-web-service-worker --testFile=fetch-with-cors-proxy.spec.ts`)
- [ ] Run local dev server (`npm run dev`), use a Blueprint that does a curl HTTPS request (e.g. installing a plugin from wordpress.org), confirm it succeeds
- [ ] Verify CURLFile uploads still work on the local dev server