### PR TITLE
[docs] Adding playwright guide

### DIFF
--- a/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
@@ -464,7 +464,7 @@ for (const { php, wp } of versionMatrix) {
 }
 ```
 
-The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.0–8.4, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`.
+The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.4–8.5, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`. For type-safe PHP version values, use the `SupportedPHPVersion` type from `@php-wasm/universal`.
 
 ## Running tests in CI/CD
 

--- a/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
@@ -14,7 +14,7 @@ This guide assumes familiarity with WordPress plugin or theme development. For a
 ## Prerequisites
 
 - **Node.js 20+** and up
-- A WordPress plugin or theme to test
+- A WordPress plugin/theme or an entire WordPress site to test
 - **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
 
 ## Project setup
@@ -59,13 +59,13 @@ export default defineConfig({
 WordPress Playground needs more time to start than a typical web app. The 120-second test timeout and 30-second assertion timeout account for WordPress boot time and page loads. Setting `workers: 1` prevents port conflicts when multiple tests share a Playground server.
 
 :::tip[Using baseURL with dynamic ports]
-The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `port: 9400` in the `runCLI` options to lock the port:
+By default, Playground will sign the port `9400`. If you want to select a different port, pass `port: [NEW_PORT_NUMBER]` in the `runCLI` options to select a different port:
 
 ```typescript
-const cli = await runCLI({ command: "server", port: 9400, blueprint });
+const cli = await runCLI({ command: "server", port: 9500, blueprint });
 ```
 
-Then add `baseURL: "http://localhost:9400"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
+Then add `baseURL: "http://localhost:9500"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
 :::
 
 :::tip
@@ -272,7 +272,7 @@ const cli = await runCLI({
 });
 ```
 
-This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files reflect immediately.
+This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files are reflected immediately. The user can set the `autoMount` property to identify plugins and themes, but the `mount` property will provide more control to the user to set different folders in the project.
 
 #### Setting options and creating content
 

--- a/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
@@ -59,7 +59,7 @@ export default defineConfig({
 WordPress Playground needs more time to start than a typical web app. The 120-second test timeout and 30-second assertion timeout account for WordPress boot time and page loads. Setting `workers: 1` prevents port conflicts when multiple tests share a Playground server.
 
 :::tip[Using baseURL with dynamic ports]
-The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `--port=9400` to lock the port:
+The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `port: 9400` in the `runCLI` options to lock the port:
 
 ```typescript
 const cli = await runCLI({ command: "server", port: 9400, blueprint });

--- a/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
@@ -1,0 +1,584 @@
+---
+title: E2E Testing with Playwright and WordPress Playground
+slug: /guides/e2e-testing-with-playwright
+description: Set up end-to-end tests for WordPress plugins and themes using Playwright and the Playground CLI.
+sidebar_class_name: navbar-build-item
+---
+
+End-to-end testing verifies that your WordPress plugin or theme works correctly from a user's perspective — clicking buttons, filling forms, and navigating pages in a real browser. This guide shows how to combine [Playwright](https://playwright.dev/) with the [WordPress Playground CLI](/developers/local-development/wp-playground-cli) to write reliable E2E tests without Docker, databases, or manual setup.
+
+:::info
+This guide assumes familiarity with WordPress plugin or theme development. For an introduction to using Playground in your development workflow, see [WordPress Playground for Plugin Developers](/guides/for-plugin-developers). For Blueprint configuration details, see [Blueprints Getting Started](/blueprints/getting-started).
+:::
+
+## Prerequisites
+
+- **Node.js 20+** and np
+- A WordPress plugin or theme to test
+- **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
+
+## Project setup
+
+### Install dependencies
+
+From your plugin or theme root directory:
+
+```bash
+npm init -y
+npm install --save-dev @playwright/test @wp-playground/cli
+npx playwright install chromium
+```
+
+This installs Playwright as the test runner, the Playground CLI for creating WordPress instances, and the Chromium browser for test execution.
+
+### Configure Playwright
+
+Create a `playwright.config.ts` file in your project root:
+
+```typescript
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "html",
+  timeout: 120_000,
+  expect: {
+    timeout: 30_000,
+  },
+  use: {
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+});
+```
+
+WordPress Playground needs more time to start than a typical web app. The 120-second test timeout and 30-second assertion timeout account for WordPress boot time and page loads. Setting `workers: 1` prevents port conflicts when multiple tests share a Playground server.
+
+:::tip[Using baseURL with dynamic ports]
+The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `--port=9400` to lock the port:
+
+```typescript
+const cli = await runCLI({ command: "server", port: 9400, blueprint });
+```
+
+Then add `baseURL: "http://localhost:9400"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
+:::
+
+:::tip
+The WordPress Playground project uses even longer timeouts (300s test, 60s assertion) for its own tests. Start with the values above and increase if your CI environment is slower.
+:::
+
+### First test file
+
+Create `tests/e2e/plugin.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { runCLI } from "@wp-playground/cli";
+
+let cli: Awaited<ReturnType<typeof runCLI>>;
+
+test.beforeAll(async () => {
+  cli = await runCLI({
+    command: "server",
+    blueprint: {
+      preferredVersions: { php: "8.3", wp: "latest" },
+      login: true,
+    },
+  });
+});
+
+test.afterAll(async () => {
+  await cli?.server?.close();
+});
+
+test("WordPress dashboard loads", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/wp-admin/`);
+  // WordPress core admin elements lack ARIA roles — CSS selectors are acceptable here
+  await expect(page.locator("#wpbody-content")).toBeVisible();
+  await expect(page).toHaveTitle(/Dashboard/);
+});
+```
+
+Run the test:
+
+```bash
+npx playwright test
+```
+
+## Choosing locators
+
+Playwright provides several ways to find elements on the page. Prefer locators that reflect how users see the page, falling back to CSS selectors only when necessary.
+
+**Locator priority** (most to least preferred):
+
+1. `page.getByRole()` — buttons, headings, links, form controls
+2. `page.getByLabel()` — form inputs with associated labels
+3. `page.getByText()` — visible text content
+4. `page.getByTestId()` — elements with `data-testid` attributes you add to your plugin
+5. `page.locator()` — CSS or XPath selectors as a last resort
+
+### WordPress-specific guidance
+
+In the WordPress admin, some core elements (admin bar, meta boxes) rely on IDs and CSS classes rather than ARIA roles. However, many elements work well with semantic locators. This means:
+
+- **Use semantic locators** for buttons, headings, links, form fields, and admin menu items — WordPress renders standard `<button>`, `<input>`, `<a>`, and `<h1>` elements that `getByRole` and `getByLabel` can find.
+- **Use `data-testid`** for your own plugin markup — you control the HTML, so add testable attributes.
+- **Use CSS selectors** for WordPress core layout elements like `#wpadminbar` or `#wpbody-content` — these lack ARIA alternatives.
+
+### Same element, three approaches
+
+```typescript
+// ✅ Preferred: semantic locator (works because WP renders a real <button>)
+await page.getByRole("button", { name: "Save Changes" }).click();
+
+// ⚠️ Acceptable: test ID you added to your plugin markup
+await page.getByTestId("save-settings").click();
+
+// ❌ Avoid: brittle CSS selector tied to WordPress markup
+await page.locator("#submit").click();
+```
+
+:::tip[Generate locators automatically]
+Run `npx playwright codegen localhost:9400/wp-admin/` to open a browser and record interactions. Playwright generates locator code as you click, helping you discover which semantic locators work for each element.
+:::
+
+## Auto-waiting and web-first assertions
+
+Playwright locators wait automatically for elements to appear, become visible, and become actionable. You do not need manual `waitForSelector` calls in most cases.
+
+### Web-first assertions
+
+Web-first assertions auto-retry until the condition passes or the timeout expires. Always prefer them over manual checks:
+
+```typescript
+// ✅ Web-first assertion (auto-retries until visible or timeout)
+await expect(page.getByText("Settings saved")).toBeVisible();
+
+// ❌ Manual check (no retry — flaky if the element appears after a delay)
+expect(await page.getByText("Settings saved").isVisible()).toBe(true);
+```
+
+### Soft assertions
+
+Use `expect.soft()` to check multiple things on one page without stopping at the first failure. All failures appear in the test report:
+
+```typescript
+await expect.soft(page.getByLabel("API Key")).toHaveValue("test-key-123");
+await expect.soft(page.getByText("Settings saved")).toBeVisible();
+await expect.soft(page.getByRole("heading", { level: 1 })).toContainText("Settings");
+```
+
+## Writing tests
+
+### Starting a Playground server
+
+The `runCLI` function starts a local Playground server and returns an object with `serverUrl` (the URL string) and `server` (the HTTP server instance). Pass a Blueprint to configure the WordPress instance:
+
+```typescript
+const cli = await runCLI({
+  command: "server",
+  blueprint: {
+    preferredVersions: { php: "8.3", wp: "latest" },
+    login: true,
+    steps: [
+      {
+        step: "installPlugin",
+        pluginData: {
+          resource: "wordpress.org/plugins",
+          slug: "woocommerce",
+        },
+      },
+    ],
+  },
+});
+```
+
+#### Server lifecycle: shared vs. per-test
+
+**Shared server (`beforeAll`/`afterAll`)** — one Playground instance serves all tests in a describe block. Faster, but tests can affect each other:
+
+```typescript
+test.describe("Plugin settings", () => {
+  test.beforeAll(async () => {
+    cli = await runCLI({ command: "server", blueprint });
+  });
+  test.afterAll(async () => {
+    await cli?.server?.close();
+  });
+  // Tests share the same WordPress instance
+});
+```
+
+**Per-test server (`beforeEach`/`afterEach`)** — each test gets a fresh instance. Slower, but fully isolated:
+
+```typescript
+test.beforeEach(async () => {
+  cli = await runCLI({ command: "server", blueprint });
+});
+test.afterEach(async () => {
+  await cli?.server?.close();
+});
+```
+
+Use shared servers when tests only read state (checking pages render). Use per-test servers when tests modify state (creating posts, changing settings).
+
+### Using Blueprints as test fixtures
+
+Blueprints define the WordPress state each test scenario needs. Here are common patterns:
+
+#### Installing a plugin from wordpress.org
+
+```typescript
+const blueprint = {
+  preferredVersions: { php: "8.3", wp: "latest" },
+  login: true,
+  steps: [
+    {
+      step: "installPlugin",
+      pluginData: {
+        resource: "wordpress.org/plugins",
+        slug: "contact-form-7",
+      },
+    },
+  ],
+};
+```
+
+#### Installing a local plugin
+
+Mount your local plugin directory into the Playground instance:
+
+```typescript
+const cli = await runCLI({
+  command: "server",
+  mount: {
+    "./": "/wordpress/wp-content/plugins/my-plugin",
+  },
+  blueprint: {
+    preferredVersions: { php: "8.3", wp: "latest" },
+    login: true,
+    steps: [
+      {
+        step: "activatePlugin",
+        pluginPath: "my-plugin/my-plugin.php",
+      },
+    ],
+  },
+});
+```
+
+This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files reflect immediately.
+
+#### Setting options and creating content
+
+```typescript
+const blueprint = {
+  login: true,
+  steps: [
+    {
+      step: "setSiteOptions",
+      options: {
+        blogname: "Test Site",
+        permalink_structure: "/%postname%/",
+      },
+    },
+    {
+      step: "runPHP",
+      code: `<?php
+        require '/wordpress/wp-load.php';
+        wp_insert_post([
+          'post_title' => 'Test Post',
+          'post_content' => '<!-- wp:paragraph --><p>Hello World</p><!-- /wp:paragraph -->',
+          'post_status' => 'publish',
+        ]);
+      `,
+    },
+  ],
+};
+```
+
+:::tip
+Use the [Playground Step Library](https://akirk.github.io/playground-step-library/) or [Pootle Playground](https://pootleplayground.com/) to prototype your Blueprint configuration visually before adding it to your test code.
+:::
+
+### Testing WordPress admin pages
+
+Navigate to admin pages and interact with the WordPress UI:
+
+```typescript
+test("plugin settings page saves options", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/wp-admin/options-general.php?page=my-plugin`);
+
+  await page.getByLabel("API Key").fill("test-key-123");
+  await page.getByRole("button", { name: "Save Changes" }).click();
+
+  await expect(page.getByText("Settings saved")).toBeVisible();
+  await expect(page.getByLabel("API Key")).toHaveValue("test-key-123");
+});
+```
+
+#### Handling common admin UI elements
+
+```typescript
+// Dismiss WordPress admin notices (WP adds aria-label to dismiss buttons)
+await page.getByRole("button", { name: "Dismiss this notice" }).first().click();
+
+// Wait for admin bar to load — no ARIA role available, use locator
+await page.locator("#wpadminbar").waitFor();
+
+// Navigate via admin menu
+await page.getByRole("link", { name: "My Plugin" }).first().click();
+```
+
+### Testing the front end
+
+```typescript
+test("plugin shortcode renders on front end", async ({ page }) => {
+  // Navigate to a page with the shortcode
+  await page.goto(`${cli.serverUrl}/?p=2`);
+
+  // Recommend: add data-testid="my-plugin-widget" to your plugin markup
+  await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
+  await expect(page.getByTestId("my-plugin-widget")).toContainText(
+    "Expected content"
+  );
+  // Or use CSS if you don't control the markup:
+  // await expect(page.locator(".my-plugin-widget")).toBeVisible();
+});
+
+test("theme displays post correctly", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/test-post/`);
+
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Test Post");
+  await expect(page.getByText("Hello World", { exact: true })).toBeVisible();
+});
+```
+
+## Page Object Model pattern
+
+The Page Object Model (POM) wraps page interactions into reusable classes. This reduces duplication and makes tests easier to maintain when your plugin UI changes.
+
+```typescript
+// tests/e2e/pages/plugin-settings.ts
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class PluginSettingsPage {
+  readonly page: Page;
+  readonly apiKeyInput: Locator;
+  readonly saveButton: Locator;
+  readonly successNotice: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.apiKeyInput = page.getByLabel("API Key");
+    this.saveButton = page.getByRole("button", { name: "Save Changes" });
+    this.successNotice = page.getByText("Settings saved");
+  }
+
+  async goto(baseUrl: string) {
+    await this.page.goto(
+      `${baseUrl}/wp-admin/options-general.php?page=my-plugin`
+    );
+  }
+
+  async setApiKey(key: string) {
+    await this.apiKeyInput.fill(key);
+    await this.saveButton.click();
+  }
+
+  async expectSaved() {
+    await expect(this.successNotice).toBeVisible();
+  }
+}
+```
+
+Use the POM in tests:
+
+```typescript
+import { PluginSettingsPage } from "./pages/plugin-settings";
+
+test("save plugin settings", async ({ page }) => {
+  const settings = new PluginSettingsPage(page);
+  await settings.goto(cli.serverUrl);
+  await settings.setApiKey("test-key-123");
+  await settings.expectSaved();
+});
+```
+
+The Playground project uses this pattern with a `WebsitePage` class that provides methods like `goto()`, `wordpress()`, and `getSiteTitle()` — encapsulating navigation and WordPress-specific interactions.
+
+## Testing across PHP and WordPress versions
+
+Parameterized tests cover multiple version combinations without duplicating test code:
+
+```typescript
+const versionMatrix = [
+  { php: "8.1", wp: "6.5" },
+  { php: "8.2", wp: "6.7" },
+  { php: "8.3", wp: "latest" },
+];
+
+for (const { php, wp } of versionMatrix) {
+  test.describe(`PHP ${php} + WP ${wp}`, () => {
+    let versionCli: Awaited<ReturnType<typeof runCLI>>;
+
+    test.beforeAll(async () => {
+      versionCli = await runCLI({
+        command: "server",
+        blueprint: {
+          preferredVersions: { php, wp },
+          login: true,
+          steps: [
+            {
+              step: "activatePlugin",
+              pluginPath: "my-plugin/my-plugin.php",
+            },
+          ],
+        },
+      });
+    });
+
+    test("admin page loads without errors", async ({ page }) => {
+      await page.goto(
+        `${versionCli.serverUrl}/wp-admin/options-general.php?page=my-plugin`
+      );
+      // WordPress core elements use CSS selectors — no ARIA roles available
+      await expect(page.locator(".error")).not.toBeVisible();
+      await expect(page.locator("#wpbody-content")).toBeVisible();
+    });
+
+    test("front-end output renders", async ({ page }) => {
+      await page.goto(versionCli.serverUrl);
+      await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
+    });
+
+    test.afterAll(async () => {
+      await versionCli?.server?.close();
+    });
+  });
+}
+```
+
+The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.0–8.4, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`.
+
+## Running tests in CI/CD
+
+### GitHub Actions
+
+Create `.github/workflows/e2e-tests.yml`:
+
+```yaml
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+```
+
+This workflow installs dependencies, downloads Chromium, runs the tests, and uploads the HTML report as an artifact. The `--with-deps` flag installs system libraries Chromium needs on Ubuntu.
+
+:::tip[Sharding for faster CI]
+Split tests across multiple CI jobs with Playwright's built-in sharding:
+
+```bash
+npx playwright test --shard=1/3
+npx playwright test --shard=2/3
+npx playwright test --shard=3/3
+```
+
+Create three parallel jobs in your workflow matrix, each running a different shard. This reduces total CI time proportionally.
+:::
+
+:::info
+For manual PR testing alongside automated E2E tests, see [Adding PR Preview Buttons with GitHub Actions](/guides/github-action-pr-preview).
+:::
+
+## Troubleshooting
+
+**Timeout errors** — Increase `timeout` in `playwright.config.ts`. WordPress boot time varies by environment. CI runners often need 120–180 seconds.
+
+**Port conflicts** — Let Playground auto-assign ports. Do not hardcode port numbers in your configuration. The `serverUrl` property returns the correct URL.
+
+**Browser not found** — Run `npx playwright install chromium` to download the browser binary. On CI, add `--with-deps` for system libraries.
+
+**WordPress not loading** — Check your Blueprint syntax against the [Blueprint schema](https://playground.wordpress.net/blueprint-schema.json). Invalid steps fail silently in some cases.
+
+**Tests pass locally but fail in CI** — CI runners have less memory and CPU. Increase timeouts, reduce parallel workers, and ensure `workers: 1` in the config.
+
+## Debugging tests
+
+When a test fails, Playwright provides several tools to investigate:
+
+**Playwright Inspector** — step through tests interactively with a built-in debugger:
+
+```bash
+npx playwright test --debug
+```
+
+**Trace viewer** — inspect a timeline of actions, DOM snapshots, and network requests from a failed test. The `trace: "on-first-retry"` setting in the config above captures traces automatically:
+
+```bash
+npx playwright show-trace test-results/plugin-spec-ts/trace.zip
+```
+
+**UI mode** — run tests in a visual interface where you can watch, filter, and re-run them:
+
+```bash
+npx playwright test --ui
+```
+
+**Screenshot on failure** — the `screenshot: "only-on-failure"` setting in the config saves a screenshot whenever a test fails. Find screenshots in the `test-results/` directory.
+
+:::tip
+Combine `--debug` with a specific test file to focus your investigation: `npx playwright test tests/e2e/settings.spec.ts --debug`
+:::
+
+## Next steps
+
+- [WordPress Playground CLI documentation](/developers/local-development/wp-playground-cli) — full CLI reference
+- [Playwright documentation](https://playwright.dev/docs/intro) — test writing guide and API reference
+- [Blueprints reference](/blueprints/steps) — all available Blueprint steps
+- [Adding PR Preview Buttons](/guides/github-action-pr-preview) — combine automated tests with manual PR previews

--- a/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/docs/main/guides/e2e-testing-with-playwright.md
@@ -13,7 +13,7 @@ This guide assumes familiarity with WordPress plugin or theme development. For a
 
 ## Prerequisites
 
-- **Node.js 20+** and np
+- **Node.js 20+** and up
 - A WordPress plugin or theme to test
 - **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
 

--- a/packages/docs/site/docs/main/guides/index.md
+++ b/packages/docs/site/docs/main/guides/index.md
@@ -40,3 +40,7 @@ Automate WordPress Playground workflows with Claude Code. Learn how to install t
 ## [Programmatic Usage of Playground CLI](/guides/programmatic-playground-cli)
 
 Learn how to use the `runCLI` function to control WordPress Playground programmatically from JavaScript/TypeScript for automation, end-to-end testing, and CI/CD pipelines.
+
+## [E2E Testing with Playwright and WordPress Playground](/guides/e2e-testing-with-playwright)
+
+Set up automated end-to-end tests for your WordPress plugins and themes using Playwright and the WordPress Playground CLI.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -94,7 +94,7 @@ export default defineConfig({
 WordPress Playground needs more time to start than a typical web app. The 120-second test timeout and 30-second assertion timeout account for WordPress boot time and page loads. Setting `workers: 1` prevents port conflicts when multiple tests share a Playground server.
 -->
 
-WordPress Playground necesita más tiempo para iniciarse que una aplicación web típica. El timeout de prueba de 120 segundos y el timeout de aserción de 30 segundos tienen en cuenta el tiempo de arranque de WordPress y la carga de páginas. Configurar `workers: 1` evita conflictos de puertos cuando varios pruebas comparten un servidor Playground.
+WordPress Playground necesita más tiempo para iniciarse que una aplicación web típica. El timeout de prueba de 120 segundos y el timeout de aserción de 30 segundos tienen en cuenta el tiempo de arranque de WordPress y la carga de páginas. Configurar `workers: 1` evita conflictos de puertos cuando varias pruebas comparten un servidor Playground.
 
 <!--
 :::tip[Using baseURL with dynamic ports]

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -649,7 +649,7 @@ for (const { php, wp } of versionMatrix) {
 ```
 
 <!--
-The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.0–8.4, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`.
+The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.4–8.5, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`. For type-safe PHP version values, use the `SupportedPHPVersion` type from `@php-wasm/universal`.
 
 ## Running tests in CI/CD
 
@@ -658,7 +658,7 @@ The `preferredVersions` property in the Blueprint controls which PHP and WordPre
 Create `.github/workflows/e2e-tests.yml`:
 -->
 
-La propiedad `preferredVersions` en el Blueprint controla qué versiones de PHP y WordPress usa la instancia Playground. Rangos soportados: PHP 7.0–8.4, WordPress 6.3–6.8+, además de `latest`, `nightly` y `beta`.
+La propiedad `preferredVersions` en el Blueprint controla qué versiones de PHP y WordPress usa la instancia Playground. Rangos soportados: PHP 7.4–8.5, WordPress 6.3–6.8+, además de `latest`, `nightly` y `beta`. Para valores de versión PHP con seguridad de tipos, usa el tipo `SupportedPHPVersion` de `@php-wasm/universal`.
 
 ## Ejecutar pruebas en CI/CD
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -24,15 +24,15 @@ Esta guía asume familiaridad con el desarrollo de plugins o temas WordPress. Pa
 <!--
 ## Prerequisites
 
-- **Node.js 20+** and npm
-- A WordPress plugin or theme to test
+- **Node.js 20+** and up
+- A WordPress plugin/theme or an entire WordPress site to test
 - **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
 -->
 
 ## Requisitos previos
 
-- **Node.js 20+** y npm
-- Un plugin o tema WordPress para probar
+- **Node.js 20+** y superior
+- Un plugin/tema WordPress o un sitio WordPress completo para probar
 - **Recomendado:** habilita la regla ESLint `@typescript-eslint/no-floating-promises` para detectar `await` faltante en llamadas asíncronas de Playwright
 
 <!--
@@ -98,24 +98,24 @@ WordPress Playground necesita más tiempo para iniciarse que una aplicación web
 
 <!--
 :::tip[Using baseURL with dynamic ports]
-The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `--port=9400` to lock the port:
+By default, Playground will sign the port `9400`. If you want to select a different port, pass `port: [NEW_PORT_NUMBER]` in the `runCLI` options to select a different port:
 
 ```typescript
-const cli = await runCLI({ command: "server", port: 9400, blueprint });
+const cli = await runCLI({ command: "server", port: 9500, blueprint });
 ```
 
-Then add `baseURL: "http://localhost:9400"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
+Then add `baseURL: "http://localhost:9500"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
 :::
 -->
 
 :::tip[Usar baseURL con puertos dinámicos]
-La función `runCLI` asigna un puerto aleatorio cada vez. Si quieres un `baseURL` estable en tu configuración de Playwright, pasa `--port=9400` para fijar el puerto:
+Por defecto, Playground usará el puerto `9400`. Si quieres seleccionar un puerto diferente, pasa `port: [NUEVO_NÚMERO_DE_PUERTO]` en las opciones de `runCLI` para seleccionar un puerto diferente:
 
 ```typescript
-const cli = await runCLI({ command: "server", port: 9400, blueprint });
+const cli = await runCLI({ command: "server", port: 9500, blueprint });
 ```
 
-Luego añade `baseURL: "http://localhost:9400"` a la sección `use` anterior. Nota que `testMatch` tiene por defecto `**/*.spec.ts` — personalízalo si tus archivos de prueba usan un patrón de nombres diferente.
+Luego añade `baseURL: "http://localhost:9500"` a la sección `use` anterior. Nota que `testMatch` tiene por defecto `**/*.spec.ts` — personalízalo si tus archivos de prueba usan un patrón de nombres diferente.
 :::
 
 <!--
@@ -440,12 +440,12 @@ const cli = await runCLI({
 ```
 
 <!--
-This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files reflect immediately.
+This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files are reflected immediately. The user can set the `autoMount` property to identify plugins and themes, but the `mount` property will provide more control to the user to set different folders in the project.
 
 #### Setting options and creating content
 -->
 
-Esto mapea tu directorio actual al path del plugin dentro de WordPress, luego activa el plugin. Los cambios en tus archivos locales se reflejan inmediatamente.
+Esto mapea tu directorio actual al path del plugin dentro de WordPress, luego activa el plugin. Los cambios en tus archivos locales se reflejan inmediatamente. El usuario puede configurar la propiedad `autoMount` para identificar plugins y temas, pero la propiedad `mount` proporcionará más control al usuario para establecer diferentes carpetas en el proyecto.
 
 #### Configurar opciones y crear contenido
 
@@ -543,12 +543,16 @@ await page.getByRole("link", { name: "My Plugin" }).first().click();
 
 ```typescript
 test("plugin shortcode renders on front end", async ({ page }) => {
+  // Navigate to a page with the shortcode
   await page.goto(`${cli.serverUrl}/?p=2`);
 
+  // Recommend: add data-testid="my-plugin-widget" to your plugin markup
   await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
   await expect(page.getByTestId("my-plugin-widget")).toContainText(
     "Expected content"
   );
+  // Or use CSS if you don't control the markup:
+  // await expect(page.locator(".my-plugin-widget")).toBeVisible();
 });
 
 test("theme displays post correctly", async ({ page }) => {
@@ -643,7 +647,41 @@ const versionMatrix = [
 
 for (const { php, wp } of versionMatrix) {
   test.describe(`PHP ${php} + WP ${wp}`, () => {
-    // ... test setup and assertions
+    let versionCli: Awaited<ReturnType<typeof runCLI>>;
+
+    test.beforeAll(async () => {
+      versionCli = await runCLI({
+        command: "server",
+        blueprint: {
+          preferredVersions: { php, wp },
+          login: true,
+          steps: [
+            {
+              step: "activatePlugin",
+              pluginPath: "my-plugin/my-plugin.php",
+            },
+          ],
+        },
+      });
+    });
+
+    test("admin page loads without errors", async ({ page }) => {
+      await page.goto(
+        `${versionCli.serverUrl}/wp-admin/options-general.php?page=my-plugin`
+      );
+      // WordPress core elements use CSS selectors — no ARIA roles available
+      await expect(page.locator(".error")).not.toBeVisible();
+      await expect(page.locator("#wpbody-content")).toBeVisible();
+    });
+
+    test("front-end output renders", async ({ page }) => {
+      await page.goto(versionCli.serverUrl);
+      await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
+    });
+
+    test.afterAll(async () => {
+      await versionCli?.server?.close();
+    });
   });
 }
 ```
@@ -730,10 +768,6 @@ npx playwright test --shard=2/3
 npx playwright test --shard=3/3
 ```
 
-<!--
-Create three parallel jobs in your workflow matrix, each running a different shard. This reduces total CI time proportionally.
-:::
--->
 
 Crea tres jobs paralelos en la matriz de tu workflow, cada uno ejecutando un fragmento diferente. Esto reduce el tiempo total de CI proporcionalmente.
 :::

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -1,0 +1,849 @@
+---
+title: Pruebas E2E con Playwright y WordPress Playground
+slug: /guides/e2e-testing-with-playwright
+description: Configura pruebas de extremo a extremo para plugins y temas WordPress usando Playwright y la CLI de Playground.
+sidebar_class_name: navbar-build-item
+---
+
+<!--
+End-to-end testing verifies that your WordPress plugin or theme works correctly from a user's perspective — clicking buttons, filling forms, and navigating pages in a real browser. This guide shows how to combine [Playwright](https://playwright.dev/) with the [WordPress Playground CLI](/developers/local-development/wp-playground-cli) to write reliable E2E tests without Docker, databases, or manual setup.
+-->
+
+Las pruebas de extremo a extremo verifican que tu plugin o tema WordPress funciona correctamente desde la perspectiva del usuario: haciendo clic en botones, completando formularios y navegando por páginas en un navegador real. Esta guía muestra cómo combinar [Playwright](https://playwright.dev/) con la [CLI de WordPress Playground](/developers/local-development/wp-playground-cli) para escribir pruebas E2E fiables sin Docker, bases de datos ni configuración manual.
+
+<!--
+:::info
+This guide assumes familiarity with WordPress plugin or theme development. For an introduction to using Playground in your development workflow, see [WordPress Playground for Plugin Developers](/guides/for-plugin-developers). For Blueprint configuration details, see [Blueprints Getting Started](/blueprints/getting-started).
+:::
+-->
+
+:::info
+Esta guía asume familiaridad con el desarrollo de plugins o temas WordPress. Para una introducción al uso de Playground en tu flujo de desarrollo, consulta [WordPress Playground para desarrolladores de plugins](/guides/for-plugin-developers). Para detalles de configuración de Blueprint, consulta [Introducción a Blueprints](/blueprints/getting-started).
+:::
+
+<!--
+## Prerequisites
+
+- **Node.js 20+** and npm
+- A WordPress plugin or theme to test
+- **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
+-->
+
+## Requisitos previos
+
+- **Node.js 20+** y npm
+- Un plugin o tema WordPress para probar
+- **Recomendado:** habilita la regla ESLint `@typescript-eslint/no-floating-promises` para detectar `await` faltante en llamadas asíncronas de Playwright
+
+<!--
+## Project setup
+
+### Install dependencies
+
+From your plugin or theme root directory:
+-->
+
+## Configuración del proyecto
+
+### Instalar dependencias
+
+Desde el directorio raíz de tu plugin o tema:
+
+```bash
+npm init -y
+npm install --save-dev @playwright/test @wp-playground/cli
+npx playwright install chromium
+```
+
+<!--
+This installs Playwright as the test runner, the Playground CLI for creating WordPress instances, and the Chromium browser for test execution.
+
+### Configure Playwright
+
+Create a `playwright.config.ts` file in your project root:
+-->
+
+Esto instala Playwright como ejecutor de pruebas, la CLI de Playground para crear instancias de WordPress y el navegador Chromium para la ejecución de pruebas.
+
+### Configurar Playwright
+
+Crea un archivo `playwright.config.ts` en la raíz de tu proyecto:
+
+```typescript
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "html",
+  timeout: 120_000,
+  expect: {
+    timeout: 30_000,
+  },
+  use: {
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+});
+```
+
+<!--
+WordPress Playground needs more time to start than a typical web app. The 120-second test timeout and 30-second assertion timeout account for WordPress boot time and page loads. Setting `workers: 1` prevents port conflicts when multiple tests share a Playground server.
+-->
+
+WordPress Playground necesita más tiempo para iniciarse que una aplicación web típica. El timeout de prueba de 120 segundos y el timeout de aserción de 30 segundos tienen en cuenta el tiempo de arranque de WordPress y la carga de páginas. Configurar `workers: 1` evita conflictos de puertos cuando varios pruebas comparten un servidor Playground.
+
+<!--
+:::tip[Using baseURL with dynamic ports]
+The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `--port=9400` to lock the port:
+
+```typescript
+const cli = await runCLI({ command: "server", port: 9400, blueprint });
+```
+
+Then add `baseURL: "http://localhost:9400"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
+:::
+-->
+
+:::tip[Usar baseURL con puertos dinámicos]
+La función `runCLI` asigna un puerto aleatorio cada vez. Si quieres un `baseURL` estable en tu configuración de Playwright, pasa `--port=9400` para fijar el puerto:
+
+```typescript
+const cli = await runCLI({ command: "server", port: 9400, blueprint });
+```
+
+Luego añade `baseURL: "http://localhost:9400"` a la sección `use` anterior. Nota que `testMatch` tiene por defecto `**/*.spec.ts` — personalízalo si tus archivos de prueba usan un patrón de nombres diferente.
+:::
+
+<!--
+:::tip
+The WordPress Playground project uses even longer timeouts (300s test, 60s assertion) for its own tests. Start with the values above and increase if your CI environment is slower.
+:::
+-->
+
+:::tip
+El proyecto WordPress Playground usa timeouts aún mayores (300s de prueba, 60s de aserción) para sus propias pruebas. Empieza con los valores anteriores y aumenta si tu entorno CI es más lento.
+:::
+
+<!--
+### First test file
+
+Create `tests/e2e/plugin.spec.ts`:
+-->
+
+### Primer archivo de prueba
+
+Crea `tests/e2e/plugin.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { runCLI } from "@wp-playground/cli";
+
+let cli: Awaited<ReturnType<typeof runCLI>>;
+
+test.beforeAll(async () => {
+  cli = await runCLI({
+    command: "server",
+    blueprint: {
+      preferredVersions: { php: "8.3", wp: "latest" },
+      login: true,
+    },
+  });
+});
+
+test.afterAll(async () => {
+  await cli?.server?.close();
+});
+
+test("WordPress dashboard loads", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/wp-admin/`);
+  // WordPress core admin elements lack ARIA roles — CSS selectors are acceptable here
+  await expect(page.locator("#wpbody-content")).toBeVisible();
+  await expect(page).toHaveTitle(/Dashboard/);
+});
+```
+
+<!--
+Run the test:
+
+```bash
+npx playwright test
+```
+-->
+
+Ejecuta la prueba:
+
+```bash
+npx playwright test
+```
+
+<!--
+## Choosing locators
+
+Playwright provides several ways to find elements on the page. Prefer locators that reflect how users see the page, falling back to CSS selectors only when necessary.
+
+**Locator priority** (most to least preferred):
+
+1. `page.getByRole()` — buttons, headings, links, form controls
+2. `page.getByLabel()` — form inputs with associated labels
+3. `page.getByText()` — visible text content
+4. `page.getByTestId()` — elements with `data-testid` attributes you add to your plugin
+5. `page.locator()` — CSS or XPath selectors as a last resort
+-->
+
+## Elegir localizadores
+
+Playwright ofrece varias formas de encontrar elementos en la página. Prefiere localizadores que reflejen cómo los usuarios ven la página, usando selectores CSS solo cuando sea necesario.
+
+**Prioridad de localizadores** (de más a menos preferido):
+
+1. `page.getByRole()` — botones, encabezados, enlaces, controles de formulario
+2. `page.getByLabel()` — inputs de formulario con etiquetas asociadas
+3. `page.getByText()` — contenido de texto visible
+4. `page.getByTestId()` — elementos con atributos `data-testid` que añades a tu plugin
+5. `page.locator()` — selectores CSS o XPath como último recurso
+
+<!--
+### WordPress-specific guidance
+
+In the WordPress admin, some core elements (admin bar, meta boxes) rely on IDs and CSS classes rather than ARIA roles. However, many elements work well with semantic locators. This means:
+
+- **Use semantic locators** for buttons, headings, links, form fields, and admin menu items — WordPress renders standard `<button>`, `<input>`, `<a>`, and `<h1>` elements that `getByRole` and `getByLabel` can find.
+- **Use `data-testid`** for your own plugin markup — you control the HTML, so add testable attributes.
+- **Use CSS selectors** for WordPress core layout elements like `#wpadminbar` or `#wpbody-content` — these lack ARIA alternatives.
+-->
+
+### Orientación específica para WordPress
+
+En el admin de WordPress, algunos elementos principales (barra de administración, meta boxes) usan IDs y clases CSS en lugar de roles ARIA. Sin embargo, muchos elementos funcionan bien con localizadores semánticos. Esto significa:
+
+- **Usa localizadores semánticos** para botones, encabezados, enlaces, campos de formulario e ítems del menú admin — WordPress renderiza elementos estándar `<button>`, `<input>`, `<a>` y `<h1>` que `getByRole` y `getByLabel` pueden encontrar.
+- **Usa `data-testid`** para el markup de tu propio plugin — controlas el HTML, así que añade atributos testeables.
+- **Usa selectores CSS** para elementos de layout principales de WordPress como `#wpadminbar` o `#wpbody-content` — estos no tienen alternativas ARIA.
+
+<!--
+### Same element, three approaches
+
+```typescript
+// ✅ Preferred: semantic locator (works because WP renders a real <button>)
+await page.getByRole("button", { name: "Save Changes" }).click();
+
+// ⚠️ Acceptable: test ID you added to your plugin markup
+await page.getByTestId("save-settings").click();
+
+// ❌ Avoid: brittle CSS selector tied to WordPress markup
+await page.locator("#submit").click();
+```
+-->
+
+### Mismo elemento, tres enfoques
+
+```typescript
+// ✅ Preferido: localizador semántico (funciona porque WP renderiza un <button> real)
+await page.getByRole("button", { name: "Guardar cambios" }).click();
+
+// ⚠️ Aceptable: ID de prueba que añadiste al markup de tu plugin
+await page.getByTestId("save-settings").click();
+
+// ❌ Evitar: selector CSS frágil ligado al markup de WordPress
+await page.locator("#submit").click();
+```
+
+<!--
+:::tip[Generate locators automatically]
+Run `npx playwright codegen localhost:9400/wp-admin/` to open a browser and record interactions. Playwright generates locator code as you click, helping you discover which semantic locators work for each element.
+:::
+-->
+
+:::tip[Generar localizadores automáticamente]
+Ejecuta `npx playwright codegen localhost:9400/wp-admin/` para abrir un navegador y grabar interacciones. Playwright genera código de localizador mientras haces clic, ayudándote a descubrir qué localizadores semánticos funcionan para cada elemento.
+:::
+
+<!--
+## Auto-waiting and web-first assertions
+
+Playwright locators wait automatically for elements to appear, become visible, and become actionable. You do not need manual `waitForSelector` calls in most cases.
+
+### Web-first assertions
+
+Web-first assertions auto-retry until the condition passes or the timeout expires. Always prefer them over manual checks:
+-->
+
+## Autoespera y aserciones web-first
+
+Los localizadores de Playwright esperan automáticamente a que los elementos aparezcan, sean visibles y accionables. En la mayoría de casos no necesitas llamadas manuales a `waitForSelector`.
+
+### Aserciones web-first
+
+Las aserciones web-first reintentan automáticamente hasta que se cumpla la condición o expire el timeout. Siempre prefiérelas a las comprobaciones manuales:
+
+```typescript
+// ✅ Aserción web-first (reintenta hasta visible o timeout)
+await expect(page.getByText("Configuración guardada")).toBeVisible();
+
+// ❌ Comprobación manual (sin retry — inestable si el elemento aparece con retraso)
+expect(await page.getByText("Configuración guardada").isVisible()).toBe(true);
+```
+
+<!--
+### Soft assertions
+
+Use `expect.soft()` to check multiple things on one page without stopping at the first failure. All failures appear in the test report:
+-->
+
+### Aserciones suaves
+
+Usa `expect.soft()` para comprobar varias cosas en una página sin parar en el primer fallo. Todos los fallos aparecen en el informe de pruebas:
+
+```typescript
+await expect.soft(page.getByLabel("API Key")).toHaveValue("test-key-123");
+await expect.soft(page.getByText("Settings saved")).toBeVisible();
+await expect.soft(page.getByRole("heading", { level: 1 })).toContainText("Settings");
+```
+
+<!--
+## Writing tests
+
+### Starting a Playground server
+
+The `runCLI` function starts a local Playground server and returns an object with `serverUrl` (the URL string) and `server` (the HTTP server instance). Pass a Blueprint to configure the WordPress instance:
+-->
+
+## Escribir pruebas
+
+### Iniciar un servidor Playground
+
+La función `runCLI` inicia un servidor Playground local y devuelve un objeto con `serverUrl` (la cadena URL) y `server` (la instancia del servidor HTTP). Pasa un Blueprint para configurar la instancia de WordPress:
+
+```typescript
+const cli = await runCLI({
+  command: "server",
+  blueprint: {
+    preferredVersions: { php: "8.3", wp: "latest" },
+    login: true,
+    steps: [
+      {
+        step: "installPlugin",
+        pluginData: {
+          resource: "wordpress.org/plugins",
+          slug: "woocommerce",
+        },
+      },
+    ],
+  },
+});
+```
+
+<!--
+#### Server lifecycle: shared vs. per-test
+
+**Shared server (`beforeAll`/`afterAll`)** — one Playground instance serves all tests in a describe block. Faster, but tests can affect each other:
+-->
+
+#### Ciclo de vida del servidor: compartido vs. por prueba
+
+**Servidor compartido (`beforeAll`/`afterAll`)** — una instancia Playground sirve todas las pruebas en un bloque describe. Más rápido, pero las pruebas pueden afectarse entre sí:
+
+```typescript
+test.describe("Plugin settings", () => {
+  test.beforeAll(async () => {
+    cli = await runCLI({ command: "server", blueprint });
+  });
+  test.afterAll(async () => {
+    await cli?.server?.close();
+  });
+  // Tests share the same WordPress instance
+});
+```
+
+<!--
+**Per-test server (`beforeEach`/`afterEach`)** — each test gets a fresh instance. Slower, but fully isolated:
+-->
+
+**Servidor por prueba (`beforeEach`/`afterEach`)** — cada prueba obtiene una instancia nueva. Más lento, pero totalmente aislado:
+
+```typescript
+test.beforeEach(async () => {
+  cli = await runCLI({ command: "server", blueprint });
+});
+test.afterEach(async () => {
+  await cli?.server?.close();
+});
+```
+
+<!--
+Use shared servers when tests only read state (checking pages render). Use per-test servers when tests modify state (creating posts, changing settings).
+
+### Using Blueprints as test fixtures
+
+Blueprints define the WordPress state each test scenario needs. Here are common patterns:
+-->
+
+Usa servidores compartidos cuando las pruebas solo leen estado (comprobando renderizado de páginas). Usa servidores por prueba cuando las pruebas modifican estado (creando entradas, cambiando configuración).
+
+### Usar Blueprints como fixtures de prueba
+
+Los Blueprints definen el estado de WordPress que cada escenario de prueba necesita. Aquí tienes patrones comunes:
+
+<!--
+#### Installing a plugin from wordpress.org
+-->
+
+#### Instalar un plugin desde wordpress.org
+
+```typescript
+const blueprint = {
+  preferredVersions: { php: "8.3", wp: "latest" },
+  login: true,
+  steps: [
+    {
+      step: "installPlugin",
+      pluginData: {
+        resource: "wordpress.org/plugins",
+        slug: "contact-form-7",
+      },
+    },
+  ],
+};
+```
+
+<!--
+#### Installing a local plugin
+
+Mount your local plugin directory into the Playground instance:
+-->
+
+#### Instalar un plugin local
+
+Monta el directorio de tu plugin local en la instancia Playground:
+
+```typescript
+const cli = await runCLI({
+  command: "server",
+  mount: {
+    "./": "/wordpress/wp-content/plugins/my-plugin",
+  },
+  blueprint: {
+    preferredVersions: { php: "8.3", wp: "latest" },
+    login: true,
+    steps: [
+      {
+        step: "activatePlugin",
+        pluginPath: "my-plugin/my-plugin.php",
+      },
+    ],
+  },
+});
+```
+
+<!--
+This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files reflect immediately.
+
+#### Setting options and creating content
+-->
+
+Esto mapea tu directorio actual al path del plugin dentro de WordPress, luego activa el plugin. Los cambios en tus archivos locales se reflejan inmediatamente.
+
+#### Configurar opciones y crear contenido
+
+```typescript
+const blueprint = {
+  login: true,
+  steps: [
+    {
+      step: "setSiteOptions",
+      options: {
+        blogname: "Test Site",
+        permalink_structure: "/%postname%/",
+      },
+    },
+    {
+      step: "runPHP",
+      code: `<?php
+        require '/wordpress/wp-load.php';
+        wp_insert_post([
+          'post_title' => 'Test Post',
+          'post_content' => '<!-- wp:paragraph --><p>Hello World</p><!-- /wp:paragraph -->',
+          'post_status' => 'publish',
+        ]);
+      `,
+    },
+  ],
+};
+```
+
+<!--
+:::tip
+Use the [Playground Step Library](https://akirk.github.io/playground-step-library/) or [Pootle Playground](https://pootleplayground.com/) to prototype your Blueprint configuration visually before adding it to your test code.
+:::
+-->
+
+:::tip
+Usa la [Playground Step Library](https://akirk.github.io/playground-step-library/) o [Pootle Playground](https://pootleplayground.com/) para prototipar tu configuración de Blueprint visualmente antes de añadirla a tu código de prueba.
+:::
+
+<!--
+### Testing WordPress admin pages
+
+Navigate to admin pages and interact with the WordPress UI:
+-->
+
+### Probar páginas del admin de WordPress
+
+Navega a las páginas del admin e interactúa con la interfaz de WordPress:
+
+```typescript
+test("plugin settings page saves options", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/wp-admin/options-general.php?page=my-plugin`);
+
+  await page.getByLabel("API Key").fill("test-key-123");
+  await page.getByRole("button", { name: "Guardar cambios" }).click();
+
+  await expect(page.getByText("Configuración guardada")).toBeVisible();
+  await expect(page.getByLabel("API Key")).toHaveValue("test-key-123");
+});
+```
+
+<!--
+#### Handling common admin UI elements
+
+```typescript
+// Dismiss WordPress admin notices (WP adds aria-label to dismiss buttons)
+await page.getByRole("button", { name: "Dismiss this notice" }).first().click();
+
+// Wait for admin bar to load — no ARIA role available, use locator
+await page.locator("#wpadminbar").waitFor();
+
+// Navigate via admin menu
+await page.getByRole("link", { name: "My Plugin" }).first().click();
+```
+-->
+
+#### Manejar elementos comunes de la UI del admin
+
+```typescript
+// Descartar avisos del admin de WordPress (WP añade aria-label a los botones descartar)
+await page.getByRole("button", { name: "Dismiss this notice" }).first().click();
+
+// Esperar carga de la barra admin — no hay rol ARIA disponible, usar locator
+await page.locator("#wpadminbar").waitFor();
+
+// Navegar por el menú admin
+await page.getByRole("link", { name: "My Plugin" }).first().click();
+```
+
+<!--
+### Testing the front end
+-->
+
+### Probar el front-end
+
+```typescript
+test("plugin shortcode renders on front end", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/?p=2`);
+
+  await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
+  await expect(page.getByTestId("my-plugin-widget")).toContainText(
+    "Expected content"
+  );
+});
+
+test("theme displays post correctly", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/test-post/`);
+
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Test Post");
+  await expect(page.getByText("Hello World", { exact: true })).toBeVisible();
+});
+```
+
+<!--
+## Page Object Model pattern
+
+The Page Object Model (POM) wraps page interactions into reusable classes. This reduces duplication and makes tests easier to maintain when your plugin UI changes.
+-->
+
+## Patrón Page Object Model
+
+El Page Object Model (POM) encapsula las interacciones de página en clases reutilizables. Esto reduce duplicación y facilita el mantenimiento de las pruebas cuando cambia la UI de tu plugin.
+
+```typescript
+// tests/e2e/pages/plugin-settings.ts
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class PluginSettingsPage {
+  readonly page: Page;
+  readonly apiKeyInput: Locator;
+  readonly saveButton: Locator;
+  readonly successNotice: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.apiKeyInput = page.getByLabel("API Key");
+    this.saveButton = page.getByRole("button", { name: "Guardar cambios" });
+    this.successNotice = page.getByText("Configuración guardada");
+  }
+
+  async goto(baseUrl: string) {
+    await this.page.goto(
+      `${baseUrl}/wp-admin/options-general.php?page=my-plugin`
+    );
+  }
+
+  async setApiKey(key: string) {
+    await this.apiKeyInput.fill(key);
+    await this.saveButton.click();
+  }
+
+  async expectSaved() {
+    await expect(this.successNotice).toBeVisible();
+  }
+}
+```
+
+<!--
+Use the POM in tests:
+-->
+
+Usa el POM en las pruebas:
+
+```typescript
+import { PluginSettingsPage } from "./pages/plugin-settings";
+
+test("save plugin settings", async ({ page }) => {
+  const settings = new PluginSettingsPage(page);
+  await settings.goto(cli.serverUrl);
+  await settings.setApiKey("test-key-123");
+  await settings.expectSaved();
+});
+```
+
+<!--
+The Playground project uses this pattern with a `WebsitePage` class that provides methods like `goto()`, `wordpress()`, and `getSiteTitle()` — encapsulating navigation and WordPress-specific interactions.
+
+## Testing across PHP and WordPress versions
+
+Parameterized tests cover multiple version combinations without duplicating test code:
+-->
+
+El proyecto Playground usa este patrón con la clase `WebsitePage` que proporciona métodos como `goto()`, `wordpress()` y `getSiteTitle()` — encapsulando navegación e interacciones específicas de WordPress.
+
+## Probar en diferentes versiones de PHP y WordPress
+
+Las pruebas parametrizadas cubren múltiples combinaciones de versiones sin duplicar código de prueba:
+
+```typescript
+const versionMatrix = [
+  { php: "8.1", wp: "6.5" },
+  { php: "8.2", wp: "6.7" },
+  { php: "8.3", wp: "latest" },
+];
+
+for (const { php, wp } of versionMatrix) {
+  test.describe(`PHP ${php} + WP ${wp}`, () => {
+    // ... test setup and assertions
+  });
+}
+```
+
+<!--
+The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.0–8.4, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`.
+
+## Running tests in CI/CD
+
+### GitHub Actions
+
+Create `.github/workflows/e2e-tests.yml`:
+-->
+
+La propiedad `preferredVersions` en el Blueprint controla qué versiones de PHP y WordPress usa la instancia Playground. Rangos soportados: PHP 7.0–8.4, WordPress 6.3–6.8+, además de `latest`, `nightly` y `beta`.
+
+## Ejecutar pruebas en CI/CD
+
+### GitHub Actions
+
+Crea `.github/workflows/e2e-tests.yml`:
+
+```yaml
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+```
+
+<!--
+This workflow installs dependencies, downloads Chromium, runs the tests, and uploads the HTML report as an artifact. The `--with-deps` flag installs system libraries Chromium needs on Ubuntu.
+
+:::tip[Sharding for faster CI]
+Split tests across multiple CI jobs with Playwright's built-in sharding:
+-->
+
+Este workflow instala dependencias, descarga Chromium, ejecuta las pruebas y sube el informe HTML como artefacto. La opción `--with-deps` instala las bibliotecas del sistema que Chromium necesita en Ubuntu.
+
+:::tip[Fragmentación para CI más rápido]
+Divide las pruebas en múltiples jobs de CI con la fragmentación incorporada de Playwright:
+
+```bash
+npx playwright test --shard=1/3
+npx playwright test --shard=2/3
+npx playwright test --shard=3/3
+```
+
+<!--
+Create three parallel jobs in your workflow matrix, each running a different shard. This reduces total CI time proportionally.
+:::
+-->
+
+Crea tres jobs paralelos en la matriz de tu workflow, cada uno ejecutando un fragmento diferente. Esto reduce el tiempo total de CI proporcionalmente.
+:::
+
+<!--
+:::info
+For manual PR testing alongside automated E2E tests, see [Adding PR Preview Buttons with GitHub Actions](/guides/github-action-pr-preview).
+:::
+-->
+
+:::info
+Para pruebas manuales de PR junto con pruebas E2E automatizadas, consulta [Añadir botones de vista previa de PR con GitHub Actions](/guides/github-action-pr-preview).
+:::
+
+<!--
+## Troubleshooting
+
+**Timeout errors** — Increase `timeout` in `playwright.config.ts`. WordPress boot time varies by environment. CI runners often need 120–180 seconds.
+
+**Port conflicts** — Let Playground auto-assign ports. Do not hardcode port numbers in your configuration. The `serverUrl` property returns the correct URL.
+
+**Browser not found** — Run `npx playwright install chromium` to download the browser binary. On CI, add `--with-deps` for system libraries.
+
+**WordPress not loading** — Check your Blueprint syntax against the [Blueprint schema](https://playground.wordpress.net/blueprint-schema.json). Invalid steps fail silently in some cases.
+
+**Tests pass locally but fail in CI** — CI runners have less memory and CPU. Increase timeouts, reduce parallel workers, and ensure `workers: 1` in the config.
+
+## Debugging tests
+
+When a test fails, Playwright provides several tools to investigate:
+-->
+
+## Solución de problemas
+
+**Errores de timeout** — Aumenta el `timeout` en `playwright.config.ts`. El tiempo de arranque de WordPress varía según el entorno. Los runners de CI suelen necesitar 120–180 segundos.
+
+**Conflictos de puertos** — Deja que Playground asigne puertos automáticamente. No codifiques números de puerto en tu configuración. La propiedad `serverUrl` devuelve la URL correcta.
+
+**Navegador no encontrado** — Ejecuta `npx playwright install chromium` para descargar el binario del navegador. En CI, añade `--with-deps` para bibliotecas del sistema.
+
+**WordPress no carga** — Comprueba la sintaxis de tu Blueprint con el [esquema Blueprint](https://playground.wordpress.net/blueprint-schema.json). Los pasos inválidos fallan silenciosamente en algunos casos.
+
+**Las pruebas pasan localmente pero fallan en CI** — Los runners de CI tienen menos memoria y CPU. Aumenta timeouts, reduce workers paralelos y asegúrate de `workers: 1` en la config.
+
+## Depurar pruebas
+
+Cuando una prueba falla, Playwright ofrece varias herramientas para investigar:
+
+<!--
+**Playwright Inspector** — step through tests interactively with a built-in debugger:
+
+```bash
+npx playwright test --debug
+```
+
+**Trace viewer** — inspect a timeline of actions, DOM snapshots, and network requests from a failed test. The `trace: "on-first-retry"` setting in the config above captures traces automatically:
+
+```bash
+npx playwright show-trace test-results/plugin-spec-ts/trace.zip
+```
+
+**UI mode** — run tests in a visual interface where you can watch, filter, and re-run them:
+
+```bash
+npx playwright test --ui
+```
+
+**Screenshot on failure** — the `screenshot: "only-on-failure"` setting in the config saves a screenshot whenever a test fails. Find screenshots in the `test-results/` directory.
+-->
+
+**Playwright Inspector** — recorre las pruebas interactivamente con un depurador incorporado:
+
+```bash
+npx playwright test --debug
+```
+
+**Visor de traces** — inspecciona una línea temporal de acciones, snapshots del DOM y solicitudes de red de una prueba fallida. La configuración `trace: "on-first-retry"` en el config anterior captura traces automáticamente:
+
+```bash
+npx playwright show-trace test-results/plugin-spec-ts/trace.zip
+```
+
+**Modo UI** — ejecuta las pruebas en una interfaz visual donde puedes ver, filtrar y reejecutarlas:
+
+```bash
+npx playwright test --ui
+```
+
+**Screenshot en fallo** — la configuración `screenshot: "only-on-failure"` en el config guarda un screenshot cada vez que una prueba falla. Encuentra los screenshots en el directorio `test-results/`.
+
+<!--
+:::tip
+Combine `--debug` with a specific test file to focus your investigation: `npx playwright test tests/e2e/settings.spec.ts --debug`
+:::
+
+## Next steps
+
+- [WordPress Playground CLI documentation](/developers/local-development/wp-playground-cli) — full CLI reference
+- [Playwright documentation](https://playwright.dev/docs/intro) — test writing guide and API reference
+- [Blueprints reference](/blueprints/steps) — all available Blueprint steps
+- [Adding PR Preview Buttons](/guides/github-action-pr-preview) — combine automated tests with manual PR previews
+-->
+
+:::tip
+Combina `--debug` con un archivo de prueba específico para centrar tu investigación: `npx playwright test tests/e2e/settings.spec.ts --debug`
+:::
+
+## Próximos pasos
+
+- [Documentación de WordPress Playground CLI](/developers/local-development/wp-playground-cli) — referencia completa de la CLI
+- [Documentación de Playwright](https://playwright.dev/docs/intro) — guía de escritura de pruebas y referencia de API
+- [Referencia de Blueprints](/blueprints/steps) — todos los pasos de Blueprint disponibles
+- [Añadir botones de vista previa de PR](/guides/github-action-pr-preview) — combina pruebas automatizadas con vistas previas manuales de PR

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -1,0 +1,849 @@
+---
+title: Tests E2E avec Playwright et WordPress Playground
+slug: /guides/e2e-testing-with-playwright
+description: Configurez des tests de bout en bout pour vos plugins et thèmes WordPress avec Playwright et la CLI Playground.
+sidebar_class_name: navbar-build-item
+---
+
+<!--
+End-to-end testing verifies that your WordPress plugin or theme works correctly from a user's perspective — clicking buttons, filling forms, and navigating pages in a real browser. This guide shows how to combine [Playwright](https://playwright.dev/) with the [WordPress Playground CLI](/developers/local-development/wp-playground-cli) to write reliable E2E tests without Docker, databases, or manual setup.
+-->
+
+Les tests de bout en bout vérifient que votre plugin ou thème WordPress fonctionne correctement du point de vue de l'utilisateur — cliquer sur des boutons, remplir des formulaires et naviguer sur les pages dans un véritable navigateur. Ce guide montre comment combiner [Playwright](https://playwright.dev/) avec la [CLI WordPress Playground](/developers/local-development/wp-playground-cli) pour écrire des tests E2E fiables sans Docker, bases de données ou configuration manuelle.
+
+<!--
+:::info
+This guide assumes familiarity with WordPress plugin or theme development. For an introduction to using Playground in your development workflow, see [WordPress Playground for Plugin Developers](/guides/for-plugin-developers). For Blueprint configuration details, see [Blueprints Getting Started](/blueprints/getting-started).
+:::
+-->
+
+:::info
+Ce guide suppose une familiarité avec le développement de plugins ou thèmes WordPress. Pour une introduction à l'utilisation de Playground dans votre flux de développement, consultez [WordPress Playground pour développeurs de plugins](/guides/for-plugin-developers). Pour les détails de configuration des Blueprints, voir [Démarrage avec Blueprints](/blueprints/getting-started).
+:::
+
+<!--
+## Prerequisites
+
+- **Node.js 20+** and npm
+- A WordPress plugin or theme to test
+- **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
+-->
+
+## Prérequis
+
+- **Node.js 20+** et npm
+- Un plugin ou thème WordPress à tester
+- **Recommandé :** activez la règle ESLint `@typescript-eslint/no-floating-promises` pour détecter les `await` manquants dans les appels asynchrones Playwright
+
+<!--
+## Project setup
+
+### Install dependencies
+
+From your plugin or theme root directory:
+-->
+
+## Configuration du projet
+
+### Installer les dépendances
+
+Depuis le répertoire racine de votre plugin ou thème :
+
+```bash
+npm init -y
+npm install --save-dev @playwright/test @wp-playground/cli
+npx playwright install chromium
+```
+
+<!--
+This installs Playwright as the test runner, the Playground CLI for creating WordPress instances, and the Chromium browser for test execution.
+
+### Configure Playwright
+
+Create a `playwright.config.ts` file in your project root:
+-->
+
+Cela installe Playwright comme exécuteur de tests, la CLI Playground pour créer des instances WordPress et le navigateur Chromium pour l'exécution des tests.
+
+### Configurer Playwright
+
+Créez un fichier `playwright.config.ts` à la racine de votre projet :
+
+```typescript
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "html",
+  timeout: 120_000,
+  expect: {
+    timeout: 30_000,
+  },
+  use: {
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+});
+```
+
+<!--
+WordPress Playground needs more time to start than a typical web app. The 120-second test timeout and 30-second assertion timeout account for WordPress boot time and page loads. Setting `workers: 1` prevents port conflicts when multiple tests share a Playground server.
+-->
+
+WordPress Playground a besoin de plus de temps pour démarrer qu'une application web typique. Le délai d'attente des tests de 120 secondes et le délai d'assertion de 30 secondes tiennent compte du temps de démarrage de WordPress et du chargement des pages. La valeur `workers: 1` évite les conflits de ports lorsque plusieurs tests partagent un serveur Playground.
+
+<!--
+:::tip[Using baseURL with dynamic ports]
+The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `--port=9400` to lock the port:
+
+```typescript
+const cli = await runCLI({ command: "server", port: 9400, blueprint });
+```
+
+Then add `baseURL: "http://localhost:9400"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
+:::
+-->
+
+:::tip[Utiliser baseURL avec des ports dynamiques]
+La fonction `runCLI` attribue un port aléatoire à chaque fois. Pour une `baseURL` stable dans votre configuration Playwright, passez `--port=9400` pour fixer le port :
+
+```typescript
+const cli = await runCLI({ command: "server", port: 9400, blueprint });
+```
+
+Puis ajoutez `baseURL: "http://localhost:9400"` à la section `use` ci-dessus. Notez que `testMatch` utilise par défaut `**/*.spec.ts` — personnalisez-le si vos fichiers de test utilisent un autre schéma de nommage.
+:::
+
+<!--
+:::tip
+The WordPress Playground project uses even longer timeouts (300s test, 60s assertion) for its own tests. Start with the values above and increase if your CI environment is slower.
+:::
+-->
+
+:::tip
+Le projet WordPress Playground utilise des délais encore plus longs (300s pour les tests, 60s pour les assertions) pour ses propres tests. Commencez avec les valeurs ci-dessus et augmentez-les si votre environnement CI est plus lent.
+:::
+
+<!--
+### First test file
+
+Create `tests/e2e/plugin.spec.ts`:
+-->
+
+### Premier fichier de test
+
+Créez `tests/e2e/plugin.spec.ts` :
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { runCLI } from "@wp-playground/cli";
+
+let cli: Awaited<ReturnType<typeof runCLI>>;
+
+test.beforeAll(async () => {
+  cli = await runCLI({
+    command: "server",
+    blueprint: {
+      preferredVersions: { php: "8.3", wp: "latest" },
+      login: true,
+    },
+  });
+});
+
+test.afterAll(async () => {
+  await cli?.server?.close();
+});
+
+test("WordPress dashboard loads", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/wp-admin/`);
+  // WordPress core admin elements lack ARIA roles — CSS selectors are acceptable here
+  await expect(page.locator("#wpbody-content")).toBeVisible();
+  await expect(page).toHaveTitle(/Dashboard/);
+});
+```
+
+<!--
+Run the test:
+
+```bash
+npx playwright test
+```
+-->
+
+Exécutez le test :
+
+```bash
+npx playwright test
+```
+
+<!--
+## Choosing locators
+
+Playwright provides several ways to find elements on the page. Prefer locators that reflect how users see the page, falling back to CSS selectors only when necessary.
+
+**Locator priority** (most to least preferred):
+
+1. `page.getByRole()` — buttons, headings, links, form controls
+2. `page.getByLabel()` — form inputs with associated labels
+3. `page.getByText()` — visible text content
+4. `page.getByTestId()` — elements with `data-testid` attributes you add to your plugin
+5. `page.locator()` — CSS or XPath selectors as a last resort
+-->
+
+## Choisir les localisateurs
+
+Playwright offre plusieurs façons de trouver les éléments sur la page. Préférez les localisateurs qui reflètent la façon dont les utilisateurs voient la page, en utilisant les sélecteurs CSS uniquement en dernier recours.
+
+**Priorité des localisateurs** (du plus au moins préféré) :
+
+1. `page.getByRole()` — boutons, titres, liens, contrôles de formulaire
+2. `page.getByLabel()` — champs de formulaire avec étiquettes associées
+3. `page.getByText()` — contenu texte visible
+4. `page.getByTestId()` — éléments avec attributs `data-testid` que vous ajoutez à votre plugin
+5. `page.locator()` — sélecteurs CSS ou XPath en dernier recours
+
+<!--
+### WordPress-specific guidance
+
+In the WordPress admin, some core elements (admin bar, meta boxes) rely on IDs and CSS classes rather than ARIA roles. However, many elements work well with semantic locators. This means:
+
+- **Use semantic locators** for buttons, headings, links, form fields, and admin menu items — WordPress renders standard `<button>`, `<input>`, `<a>`, and `<h1>` elements that `getByRole` and `getByLabel` can find.
+- **Use `data-testid`** for your own plugin markup — you control the HTML, so add testable attributes.
+- **Use CSS selectors** for WordPress core layout elements like `#wpadminbar` or `#wpbody-content` — these lack ARIA alternatives.
+-->
+
+### Conseils spécifiques à WordPress
+
+Dans l'admin WordPress, certains éléments principaux (barre d'administration, meta boxes) utilisent des ID et classes CSS plutôt que des rôles ARIA. Cependant, de nombreux éléments fonctionnent bien avec des localisateurs sémantiques. Cela signifie :
+
+- **Utilisez des localisateurs sémantiques** pour les boutons, titres, liens, champs de formulaire et éléments du menu admin — WordPress rend des éléments standards `<button>`, `<input>`, `<a>` et `<h1>` que `getByRole` et `getByLabel` peuvent trouver.
+- **Utilisez `data-testid`** pour le markup de votre propre plugin — vous contrôlez le HTML, ajoutez donc des attributs testables.
+- **Utilisez des sélecteurs CSS** pour les éléments de mise en page principaux de WordPress comme `#wpadminbar` ou `#wpbody-content` — ils n'ont pas d'alternatives ARIA.
+
+<!--
+### Same element, three approaches
+
+```typescript
+// ✅ Preferred: semantic locator (works because WP renders a real <button>)
+await page.getByRole("button", { name: "Save Changes" }).click();
+
+// ⚠️ Acceptable: test ID you added to your plugin markup
+await page.getByTestId("save-settings").click();
+
+// ❌ Avoid: brittle CSS selector tied to WordPress markup
+await page.locator("#submit").click();
+```
+-->
+
+### Même élément, trois approches
+
+```typescript
+// ✅ Préféré : localisateur sémantique (fonctionne car WP rend un vrai <button>)
+await page.getByRole("button", { name: "Enregistrer les modifications" }).click();
+
+// ⚠️ Acceptable : ID de test que vous avez ajouté au markup de votre plugin
+await page.getByTestId("save-settings").click();
+
+// ❌ À éviter : sélecteur CSS fragile lié au markup WordPress
+await page.locator("#submit").click();
+```
+
+<!--
+:::tip[Generate locators automatically]
+Run `npx playwright codegen localhost:9400/wp-admin/` to open a browser and record interactions. Playwright generates locator code as you click, helping you discover which semantic locators work for each element.
+:::
+-->
+
+:::tip[Générer les localisateurs automatiquement]
+Exécutez `npx playwright codegen localhost:9400/wp-admin/` pour ouvrir un navigateur et enregistrer les interactions. Playwright génère le code des localisateurs pendant que vous cliquez, vous aidant à découvrir quels localisateurs sémantiques fonctionnent pour chaque élément.
+:::
+
+<!--
+## Auto-waiting and web-first assertions
+
+Playwright locators wait automatically for elements to appear, become visible, and become actionable. You do not need manual `waitForSelector` calls in most cases.
+
+### Web-first assertions
+
+Web-first assertions auto-retry until the condition passes or the timeout expires. Always prefer them over manual checks:
+-->
+
+## Auto-attente et assertions web-first
+
+Les localisateurs Playwright attendent automatiquement que les éléments apparaissent, deviennent visibles et actionnables. Dans la plupart des cas, vous n'avez pas besoin d'appels manuels à `waitForSelector`.
+
+### Assertions web-first
+
+Les assertions web-first réessaient automatiquement jusqu'à ce que la condition soit remplie ou que le délai expire. Préférez-les toujours aux vérifications manuelles :
+
+```typescript
+// ✅ Assertion web-first (réessaie jusqu'à visible ou timeout)
+await expect(page.getByText("Paramètres enregistrés")).toBeVisible();
+
+// ❌ Vérification manuelle (sans retry — instable si l'élément apparaît en retard)
+expect(await page.getByText("Paramètres enregistrés").isVisible()).toBe(true);
+```
+
+<!--
+### Soft assertions
+
+Use `expect.soft()` to check multiple things on one page without stopping at the first failure. All failures appear in the test report:
+-->
+
+### Assertions molles
+
+Utilisez `expect.soft()` pour vérifier plusieurs éléments sur une page sans s'arrêter au premier échec. Tous les échecs apparaissent dans le rapport de test :
+
+```typescript
+await expect.soft(page.getByLabel("API Key")).toHaveValue("test-key-123");
+await expect.soft(page.getByText("Settings saved")).toBeVisible();
+await expect.soft(page.getByRole("heading", { level: 1 })).toContainText("Settings");
+```
+
+<!--
+## Writing tests
+
+### Starting a Playground server
+
+The `runCLI` function starts a local Playground server and returns an object with `serverUrl` (the URL string) and `server` (the HTTP server instance). Pass a Blueprint to configure the WordPress instance:
+-->
+
+## Écrire des tests
+
+### Démarrer un serveur Playground
+
+La fonction `runCLI` démarre un serveur Playground local et retourne un objet avec `serverUrl` (la chaîne URL) et `server` (l'instance du serveur HTTP). Passez un Blueprint pour configurer l'instance WordPress :
+
+```typescript
+const cli = await runCLI({
+  command: "server",
+  blueprint: {
+    preferredVersions: { php: "8.3", wp: "latest" },
+    login: true,
+    steps: [
+      {
+        step: "installPlugin",
+        pluginData: {
+          resource: "wordpress.org/plugins",
+          slug: "woocommerce",
+        },
+      },
+    ],
+  },
+});
+```
+
+<!--
+#### Server lifecycle: shared vs. per-test
+
+**Shared server (`beforeAll`/`afterAll`)** — one Playground instance serves all tests in a describe block. Faster, but tests can affect each other:
+-->
+
+#### Cycle de vie du serveur : partagé vs. par test
+
+**Serveur partagé (`beforeAll`/`afterAll`)** — une instance Playground sert tous les tests d'un bloc describe. Plus rapide, mais les tests peuvent s'influencer mutuellement :
+
+```typescript
+test.describe("Plugin settings", () => {
+  test.beforeAll(async () => {
+    cli = await runCLI({ command: "server", blueprint });
+  });
+  test.afterAll(async () => {
+    await cli?.server?.close();
+  });
+  // Tests share the same WordPress instance
+});
+```
+
+<!--
+**Per-test server (`beforeEach`/`afterEach`)** — each test gets a fresh instance. Slower, but fully isolated:
+-->
+
+**Serveur par test (`beforeEach`/`afterEach`)** — chaque test obtient une instance fraîche. Plus lent, mais entièrement isolé :
+
+```typescript
+test.beforeEach(async () => {
+  cli = await runCLI({ command: "server", blueprint });
+});
+test.afterEach(async () => {
+  await cli?.server?.close();
+});
+```
+
+<!--
+Use shared servers when tests only read state (checking pages render). Use per-test servers when tests modify state (creating posts, changing settings).
+
+### Using Blueprints as test fixtures
+
+Blueprints define the WordPress state each test scenario needs. Here are common patterns:
+-->
+
+Utilisez des serveurs partagés lorsque les tests ne font que lire l'état (vérification du rendu des pages). Utilisez des serveurs par test lorsque les tests modifient l'état (création d'articles, modification des paramètres).
+
+### Utiliser les Blueprints comme fixtures de test
+
+Les Blueprints définissent l'état WordPress nécessaire à chaque scénario de test. Voici les modèles courants :
+
+<!--
+#### Installing a plugin from wordpress.org
+-->
+
+#### Installer un plugin depuis wordpress.org
+
+```typescript
+const blueprint = {
+  preferredVersions: { php: "8.3", wp: "latest" },
+  login: true,
+  steps: [
+    {
+      step: "installPlugin",
+      pluginData: {
+        resource: "wordpress.org/plugins",
+        slug: "contact-form-7",
+      },
+    },
+  ],
+};
+```
+
+<!--
+#### Installing a local plugin
+
+Mount your local plugin directory into the Playground instance:
+-->
+
+#### Installer un plugin local
+
+Montez le répertoire de votre plugin local dans l'instance Playground :
+
+```typescript
+const cli = await runCLI({
+  command: "server",
+  mount: {
+    "./": "/wordpress/wp-content/plugins/my-plugin",
+  },
+  blueprint: {
+    preferredVersions: { php: "8.3", wp: "latest" },
+    login: true,
+    steps: [
+      {
+        step: "activatePlugin",
+        pluginPath: "my-plugin/my-plugin.php",
+      },
+    ],
+  },
+});
+```
+
+<!--
+This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files reflect immediately.
+
+#### Setting options and creating content
+-->
+
+Cela mappe votre répertoire actuel au chemin du plugin dans WordPress, puis active le plugin. Les modifications de vos fichiers locaux se reflètent immédiatement.
+
+#### Définir les options et créer du contenu
+
+```typescript
+const blueprint = {
+  login: true,
+  steps: [
+    {
+      step: "setSiteOptions",
+      options: {
+        blogname: "Test Site",
+        permalink_structure: "/%postname%/",
+      },
+    },
+    {
+      step: "runPHP",
+      code: `<?php
+        require '/wordpress/wp-load.php';
+        wp_insert_post([
+          'post_title' => 'Test Post',
+          'post_content' => '<!-- wp:paragraph --><p>Hello World</p><!-- /wp:paragraph -->',
+          'post_status' => 'publish',
+        ]);
+      `,
+    },
+  ],
+};
+```
+
+<!--
+:::tip
+Use the [Playground Step Library](https://akirk.github.io/playground-step-library/) or [Pootle Playground](https://pootleplayground.com/) to prototype your Blueprint configuration visually before adding it to your test code.
+:::
+-->
+
+:::tip
+Utilisez la [Playground Step Library](https://akirk.github.io/playground-step-library/) ou [Pootle Playground](https://pootleplayground.com/) pour prototyper votre configuration Blueprint visuellement avant de l'ajouter à votre code de test.
+:::
+
+<!--
+### Testing WordPress admin pages
+
+Navigate to admin pages and interact with the WordPress UI:
+-->
+
+### Tester les pages d'administration WordPress
+
+Naviguez vers les pages d'administration et interagissez avec l'interface WordPress :
+
+```typescript
+test("plugin settings page saves options", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/wp-admin/options-general.php?page=my-plugin`);
+
+  await page.getByLabel("API Key").fill("test-key-123");
+  await page.getByRole("button", { name: "Enregistrer les modifications" }).click();
+
+  await expect(page.getByText("Paramètres enregistrés")).toBeVisible();
+  await expect(page.getByLabel("API Key")).toHaveValue("test-key-123");
+});
+```
+
+<!--
+#### Handling common admin UI elements
+
+```typescript
+// Dismiss WordPress admin notices (WP adds aria-label to dismiss buttons)
+await page.getByRole("button", { name: "Dismiss this notice" }).first().click();
+
+// Wait for admin bar to load — no ARIA role available, use locator
+await page.locator("#wpadminbar").waitFor();
+
+// Navigate via admin menu
+await page.getByRole("link", { name: "My Plugin" }).first().click();
+```
+-->
+
+#### Gérer les éléments courants de l'interface d'administration
+
+```typescript
+// Fermer les notifications admin WordPress (WP ajoute aria-label aux boutons de fermeture)
+await page.getByRole("button", { name: "Dismiss this notice" }).first().click();
+
+// Attendre le chargement de la barre admin — pas de rôle ARIA disponible, utiliser locator
+await page.locator("#wpadminbar").waitFor();
+
+// Naviguer via le menu admin
+await page.getByRole("link", { name: "My Plugin" }).first().click();
+```
+
+<!--
+### Testing the front end
+-->
+
+### Tester le front-end
+
+```typescript
+test("plugin shortcode renders on front end", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/?p=2`);
+
+  await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
+  await expect(page.getByTestId("my-plugin-widget")).toContainText(
+    "Expected content"
+  );
+});
+
+test("theme displays post correctly", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/test-post/`);
+
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Test Post");
+  await expect(page.getByText("Hello World", { exact: true })).toBeVisible();
+});
+```
+
+<!--
+## Page Object Model pattern
+
+The Page Object Model (POM) wraps page interactions into reusable classes. This reduces duplication and makes tests easier to maintain when your plugin UI changes.
+-->
+
+## Modèle Page Object Model
+
+Le Page Object Model (POM) encapsule les interactions avec les pages dans des classes réutilisables. Cela réduit la duplication et facilite la maintenance des tests lorsque l'interface de votre plugin change.
+
+```typescript
+// tests/e2e/pages/plugin-settings.ts
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class PluginSettingsPage {
+  readonly page: Page;
+  readonly apiKeyInput: Locator;
+  readonly saveButton: Locator;
+  readonly successNotice: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.apiKeyInput = page.getByLabel("API Key");
+    this.saveButton = page.getByRole("button", { name: "Enregistrer les modifications" });
+    this.successNotice = page.getByText("Paramètres enregistrés");
+  }
+
+  async goto(baseUrl: string) {
+    await this.page.goto(
+      `${baseUrl}/wp-admin/options-general.php?page=my-plugin`
+    );
+  }
+
+  async setApiKey(key: string) {
+    await this.apiKeyInput.fill(key);
+    await this.saveButton.click();
+  }
+
+  async expectSaved() {
+    await expect(this.successNotice).toBeVisible();
+  }
+}
+```
+
+<!--
+Use the POM in tests:
+-->
+
+Utilisez le POM dans les tests :
+
+```typescript
+import { PluginSettingsPage } from "./pages/plugin-settings";
+
+test("save plugin settings", async ({ page }) => {
+  const settings = new PluginSettingsPage(page);
+  await settings.goto(cli.serverUrl);
+  await settings.setApiKey("test-key-123");
+  await settings.expectSaved();
+});
+```
+
+<!--
+The Playground project uses this pattern with a `WebsitePage` class that provides methods like `goto()`, `wordpress()`, and `getSiteTitle()` — encapsulating navigation and WordPress-specific interactions.
+
+## Testing across PHP and WordPress versions
+
+Parameterized tests cover multiple version combinations without duplicating test code:
+-->
+
+Le projet Playground utilise ce modèle avec une classe `WebsitePage` qui fournit des méthodes comme `goto()`, `wordpress()` et `getSiteTitle()` — encapsulant la navigation et les interactions spécifiques à WordPress.
+
+## Tester sur différentes versions de PHP et WordPress
+
+Les tests paramétrés couvrent plusieurs combinaisons de versions sans dupliquer le code de test :
+
+```typescript
+const versionMatrix = [
+  { php: "8.1", wp: "6.5" },
+  { php: "8.2", wp: "6.7" },
+  { php: "8.3", wp: "latest" },
+];
+
+for (const { php, wp } of versionMatrix) {
+  test.describe(`PHP ${php} + WP ${wp}`, () => {
+    // ... test setup and assertions
+  });
+}
+```
+
+<!--
+The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.0–8.4, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`.
+
+## Running tests in CI/CD
+
+### GitHub Actions
+
+Create `.github/workflows/e2e-tests.yml`:
+-->
+
+La propriété `preferredVersions` dans le Blueprint contrôle les versions PHP et WordPress utilisées par l'instance Playground. Plages prises en charge : PHP 7.0–8.4, WordPress 6.3–6.8+, ainsi que `latest`, `nightly` et `beta`.
+
+## Exécuter les tests en CI/CD
+
+### GitHub Actions
+
+Créez `.github/workflows/e2e-tests.yml` :
+
+```yaml
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+```
+
+<!--
+This workflow installs dependencies, downloads Chromium, runs the tests, and uploads the HTML report as an artifact. The `--with-deps` flag installs system libraries Chromium needs on Ubuntu.
+
+:::tip[Sharding for faster CI]
+Split tests across multiple CI jobs with Playwright's built-in sharding:
+-->
+
+Ce workflow installe les dépendances, télécharge Chromium, exécute les tests et télécharge le rapport HTML comme artefact. L'option `--with-deps` installe les bibliothèques système nécessaires à Chromium sur Ubuntu.
+
+:::tip[Fragmenter pour un CI plus rapide]
+Répartissez les tests sur plusieurs jobs CI avec la fragmentation intégrée de Playwright :
+
+```bash
+npx playwright test --shard=1/3
+npx playwright test --shard=2/3
+npx playwright test --shard=3/3
+```
+
+<!--
+Create three parallel jobs in your workflow matrix, each running a different shard. This reduces total CI time proportionally.
+:::
+-->
+
+Créez trois jobs parallèles dans la matrice de votre workflow, chacun exécutant un fragment différent. Cela réduit proportionnellement le temps total de CI.
+:::
+
+<!--
+:::info
+For manual PR testing alongside automated E2E tests, see [Adding PR Preview Buttons with GitHub Actions](/guides/github-action-pr-preview).
+:::
+-->
+
+:::info
+Pour les tests manuels des PR en complément des tests E2E automatisés, voir [Ajouter des boutons d'aperçu PR avec GitHub Actions](/guides/github-action-pr-preview).
+:::
+
+<!--
+## Troubleshooting
+
+**Timeout errors** — Increase `timeout` in `playwright.config.ts`. WordPress boot time varies by environment. CI runners often need 120–180 seconds.
+
+**Port conflicts** — Let Playground auto-assign ports. Do not hardcode port numbers in your configuration. The `serverUrl` property returns the correct URL.
+
+**Browser not found** — Run `npx playwright install chromium` to download the browser binary. On CI, add `--with-deps` for system libraries.
+
+**WordPress not loading** — Check your Blueprint syntax against the [Blueprint schema](https://playground.wordpress.net/blueprint-schema.json). Invalid steps fail silently in some cases.
+
+**Tests pass locally but fail in CI** — CI runners have less memory and CPU. Increase timeouts, reduce parallel workers, and ensure `workers: 1` in the config.
+
+## Debugging tests
+
+When a test fails, Playwright provides several tools to investigate:
+-->
+
+## Dépannage
+
+**Erreurs de timeout** — Augmentez `timeout` dans `playwright.config.ts`. Le temps de démarrage de WordPress varie selon l'environnement. Les runners CI ont souvent besoin de 120–180 secondes.
+
+**Conflits de ports** — Laissez Playground attribuer les ports automatiquement. Ne codez pas en dur les numéros de port dans votre configuration. La propriété `serverUrl` retourne la bonne URL.
+
+**Navigateur non trouvé** — Exécutez `npx playwright install chromium` pour télécharger le binaire du navigateur. Sur CI, ajoutez `--with-deps` pour les bibliothèques système.
+
+**WordPress ne charge pas** — Vérifiez la syntaxe de votre Blueprint par rapport au [schéma Blueprint](https://playground.wordpress.net/blueprint-schema.json). Les étapes invalides échouent silencieusement dans certains cas.
+
+**Les tests passent en local mais échouent en CI** — Les runners CI ont moins de mémoire et de CPU. Augmentez les timeouts, réduisez les workers parallèles et assurez-vous que `workers: 1` est dans la config.
+
+## Déboguer les tests
+
+Lorsqu'un test échoue, Playwright fournit plusieurs outils pour investiguer :
+
+<!--
+**Playwright Inspector** — step through tests interactively with a built-in debugger:
+
+```bash
+npx playwright test --debug
+```
+
+**Trace viewer** — inspect a timeline of actions, DOM snapshots, and network requests from a failed test. The `trace: "on-first-retry"` setting in the config above captures traces automatically:
+
+```bash
+npx playwright show-trace test-results/plugin-spec-ts/trace.zip
+```
+
+**UI mode** — run tests in a visual interface where you can watch, filter, and re-run them:
+
+```bash
+npx playwright test --ui
+```
+
+**Screenshot on failure** — the `screenshot: "only-on-failure"` setting in the config saves a screenshot whenever a test fails. Find screenshots in the `test-results/` directory.
+-->
+
+**Playwright Inspector** — parcourez les tests de manière interactive avec un débogueur intégré :
+
+```bash
+npx playwright test --debug
+```
+
+**Visualiseur de traces** — examinez une chronologie des actions, des snapshots DOM et des requêtes réseau d'un test échoué. La configuration `trace: "on-first-retry"` ci-dessus capture automatiquement les traces :
+
+```bash
+npx playwright show-trace test-results/plugin-spec-ts/trace.zip
+```
+
+**Mode UI** — exécutez les tests dans une interface visuelle où vous pouvez regarder, filtrer et relancer les tests :
+
+```bash
+npx playwright test --ui
+```
+
+**Capture d'écran en cas d'échec** — la configuration `screenshot: "only-on-failure"` dans le config sauvegarde une capture d'écran à chaque échec de test. Trouvez les captures dans le répertoire `test-results/`.
+
+<!--
+:::tip
+Combine `--debug` with a specific test file to focus your investigation: `npx playwright test tests/e2e/settings.spec.ts --debug`
+:::
+
+## Next steps
+
+- [WordPress Playground CLI documentation](/developers/local-development/wp-playground-cli) — full CLI reference
+- [Playwright documentation](https://playwright.dev/docs/intro) — test writing guide and API reference
+- [Blueprints reference](/blueprints/steps) — all available Blueprint steps
+- [Adding PR Preview Buttons](/guides/github-action-pr-preview) — combine automated tests with manual PR previews
+-->
+
+:::tip
+Combinez `--debug` avec un fichier de test spécifique pour concentrer votre investigation : `npx playwright test tests/e2e/settings.spec.ts --debug`
+:::
+
+## Prochaines étapes
+
+- [Documentation de la CLI WordPress Playground](/developers/local-development/wp-playground-cli) — référence complète de la CLI
+- [Documentation Playwright](https://playwright.dev/docs/intro) — guide d'écriture de tests et référence API
+- [Référence Blueprints](/blueprints/steps) — toutes les étapes Blueprint disponibles
+- [Ajouter des boutons d'aperçu PR](/guides/github-action-pr-preview) — combinez les tests automatisés avec les aperçus PR manuels

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -9,7 +9,7 @@ sidebar_class_name: navbar-build-item
 End-to-end testing verifies that your WordPress plugin or theme works correctly from a user's perspective — clicking buttons, filling forms, and navigating pages in a real browser. This guide shows how to combine [Playwright](https://playwright.dev/) with the [WordPress Playground CLI](/developers/local-development/wp-playground-cli) to write reliable E2E tests without Docker, databases, or manual setup.
 -->
 
-Les tests de bout en bout vérifient que votre plugin ou thème WordPress fonctionne correctement du point de vue de l'utilisateur — cliquer sur des boutons, remplir des formulaires et naviguer sur les pages dans un véritable navigateur. Ce guide montre comment combiner [Playwright](https://playwright.dev/) avec la [CLI WordPress Playground](/developers/local-development/wp-playground-cli) pour écrire des tests E2E fiables sans Docker, bases de données ou configuration manuelle.
+Les tests de bout en bout vérifient que votre extension ou thème WordPress fonctionne correctement du point de vue de l'utilisateur — cliquer sur des boutons, remplir des formulaires et naviguer sur les pages dans un véritable navigateur. Ce guide montre comment combiner [Playwright](https://playwright.dev/) avec la [CLI WordPress Playground](/developers/local-development/wp-playground-cli) pour écrire des tests E2E fiables sans Docker, bases de données ou configuration manuelle.
 
 <!--
 :::info
@@ -18,7 +18,7 @@ This guide assumes familiarity with WordPress plugin or theme development. For a
 -->
 
 :::info
-Ce guide suppose une familiarité avec le développement de plugins ou thèmes WordPress. Pour une introduction à l'utilisation de Playground dans votre flux de développement, consultez [WordPress Playground pour développeurs de plugins](/guides/for-plugin-developers). Pour les détails de configuration des Blueprints, voir [Démarrage avec Blueprints](/blueprints/getting-started).
+Ce guide suppose une familiarité avec le développement d’extensions ou de thèmes WordPress. Pour une introduction à l'utilisation de Playground dans votre flux de développement, consultez [WordPress Playground pour développeurs de plugins](/guides/for-plugin-developers). Pour les détails de configuration des Blueprints, voir [Démarrage avec Blueprints](/blueprints/getting-started).
 :::
 
 <!--
@@ -32,7 +32,7 @@ Ce guide suppose une familiarité avec le développement de plugins ou thèmes W
 ## Prérequis
 
 - **Node.js 20+** et supérieur
-- Un plugin/thème WordPress ou un site WordPress complet à tester
+- Une extension/thème WordPress ou un site WordPress complet à tester
 - **Recommandé :** activez la règle ESLint `@typescript-eslint/no-floating-promises` pour détecter les `await` manquants dans les appels asynchrones Playwright
 
 <!--
@@ -47,7 +47,7 @@ From your plugin or theme root directory:
 
 ### Installer les dépendances
 
-Depuis le répertoire racine de votre plugin ou thème :
+Depuis le répertoire racine de votre extension ou thème :
 
 ```bash
 npm init -y
@@ -198,7 +198,7 @@ Playwright provides several ways to find elements on the page. Prefer locators t
 
 Playwright offre plusieurs façons de trouver les éléments sur la page. Préférez les localisateurs qui reflètent la façon dont les utilisateurs voient la page, en utilisant les sélecteurs CSS uniquement en dernier recours.
 
-**Priorité des localisateurs** (du plus au moins préféré) :
+**Priorité des localisateurs** (du plus au moins recommandé) :
 
 1. `page.getByRole()` — boutons, titres, liens, contrôles de formulaire
 2. `page.getByLabel()` — champs de formulaire avec étiquettes associées
@@ -272,16 +272,16 @@ Playwright locators wait automatically for elements to appear, become visible, a
 Web-first assertions auto-retry until the condition passes or the timeout expires. Always prefer them over manual checks:
 -->
 
-## Auto-attente et assertions web-first
+## Auto-attente et assertions orientée web
 
 Les localisateurs Playwright attendent automatiquement que les éléments apparaissent, deviennent visibles et actionnables. Dans la plupart des cas, vous n'avez pas besoin d'appels manuels à `waitForSelector`.
 
-### Assertions web-first
+### Assertions orientée web
 
-Les assertions web-first réessaient automatiquement jusqu'à ce que la condition soit remplie ou que le délai expire. Préférez-les toujours aux vérifications manuelles :
+Les assertions orientée web réessaient automatiquement jusqu'à ce que la condition soit remplie ou que le délai expire. Préférez-les toujours aux vérifications manuelles :
 
 ```typescript
-// ✅ Assertion web-first (réessaie jusqu'à visible ou timeout)
+// ✅ Assertion orientée web (réessaie jusqu'à visible ou timeout)
 await expect(page.getByText("Paramètres enregistrés")).toBeVisible();
 
 // ❌ Vérification manuelle (sans retry — instable si l'élément apparaît en retard)
@@ -801,7 +801,7 @@ When a test fails, Playwright provides several tools to investigate:
 
 ## Dépannage
 
-**Erreurs de timeout** — Augmentez `timeout` dans `playwright.config.ts`. Le temps de démarrage de WordPress varie selon l'environnement. Les runners CI ont souvent besoin de 120–180 secondes.
+**Erreurs de timeout** — Augmentez `timeout` dans `playwright.config.ts`. Le temps de démarrage de WordPress varie selon l'environnement. Les exécuteurs CI ont souvent besoin de 120–180 secondes.
 
 **Conflits de ports** — Laissez Playground attribuer les ports automatiquement. Ne codez pas en dur les numéros de port dans votre configuration. La propriété `serverUrl` retourne la bonne URL.
 
@@ -809,7 +809,7 @@ When a test fails, Playwright provides several tools to investigate:
 
 **WordPress ne charge pas** — Vérifiez la syntaxe de votre Blueprint par rapport au [schéma Blueprint](https://playground.wordpress.net/blueprint-schema.json). Les étapes invalides échouent silencieusement dans certains cas.
 
-**Les tests passent en local mais échouent en CI** — Les runners CI ont moins de mémoire et de CPU. Augmentez les timeouts, réduisez les workers parallèles et assurez-vous que `workers: 1` est dans la config.
+**Les tests passent en local mais échouent en CI** — Les exécuteurs CI ont moins de mémoire et de CPU. Augmentez les délais d'expiration, réduisez les processus parallèles et assurez-vous que `workers: 1` est dans la config.
 
 ## Déboguer les tests
 
@@ -855,7 +855,7 @@ npx playwright show-trace test-results/plugin-spec-ts/trace.zip
 npx playwright test --ui
 ```
 
-**Capture d'écran en cas d'échec** — la configuration `screenshot: "only-on-failure"` dans le config sauvegarde une capture d'écran à chaque échec de test. Trouvez les captures dans le répertoire `test-results/`.
+**Capture d'écran en cas d'échec** — la configuration `screenshot: "only-on-failure"` dans le configuration sauvegarde une capture d'écran à chaque échec de test. Trouvez les captures dans le répertoire `test-results/`.
 
 <!--
 :::tip

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -294,7 +294,7 @@ expect(await page.getByText("Paramètres enregistrés").isVisible()).toBe(true);
 Use `expect.soft()` to check multiple things on one page without stopping at the first failure. All failures appear in the test report:
 -->
 
-### Assertions molles
+### Assertions souples
 
 Utilisez `expect.soft()` pour vérifier plusieurs éléments sur une page sans s'arrêter au premier échec. Tous les échecs apparaissent dans le rapport de test :
 

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -24,15 +24,15 @@ Ce guide suppose une familiarité avec le développement de plugins ou thèmes W
 <!--
 ## Prerequisites
 
-- **Node.js 20+** and npm
-- A WordPress plugin or theme to test
+- **Node.js 20+** and up
+- A WordPress plugin/theme or an entire WordPress site to test
 - **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
 -->
 
 ## Prérequis
 
-- **Node.js 20+** et npm
-- Un plugin ou thème WordPress à tester
+- **Node.js 20+** et supérieur
+- Un plugin/thème WordPress ou un site WordPress complet à tester
 - **Recommandé :** activez la règle ESLint `@typescript-eslint/no-floating-promises` pour détecter les `await` manquants dans les appels asynchrones Playwright
 
 <!--
@@ -98,24 +98,24 @@ WordPress Playground a besoin de plus de temps pour démarrer qu'une application
 
 <!--
 :::tip[Using baseURL with dynamic ports]
-The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `--port=9400` to lock the port:
+By default, Playground will sign the port `9400`. If you want to select a different port, pass `port: [NEW_PORT_NUMBER]` in the `runCLI` options to select a different port:
 
 ```typescript
-const cli = await runCLI({ command: "server", port: 9400, blueprint });
+const cli = await runCLI({ command: "server", port: 9500, blueprint });
 ```
 
-Then add `baseURL: "http://localhost:9400"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
+Then add `baseURL: "http://localhost:9500"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
 :::
 -->
 
 :::tip[Utiliser baseURL avec des ports dynamiques]
-La fonction `runCLI` attribue un port aléatoire à chaque fois. Pour une `baseURL` stable dans votre configuration Playwright, passez `--port=9400` pour fixer le port :
+Par défaut, Playground utilisera le port `9400`. Si vous souhaitez sélectionner un port différent, passez `port: [NOUVEAU_NUMÉRO_DE_PORT]` dans les options de `runCLI` pour sélectionner un port différent :
 
 ```typescript
-const cli = await runCLI({ command: "server", port: 9400, blueprint });
+const cli = await runCLI({ command: "server", port: 9500, blueprint });
 ```
 
-Puis ajoutez `baseURL: "http://localhost:9400"` à la section `use` ci-dessus. Notez que `testMatch` utilise par défaut `**/*.spec.ts` — personnalisez-le si vos fichiers de test utilisent un autre schéma de nommage.
+Puis ajoutez `baseURL: "http://localhost:9500"` à la section `use` ci-dessus. Notez que `testMatch` utilise par défaut `**/*.spec.ts` — personnalisez-le si vos fichiers de test utilisent un autre schéma de nommage.
 :::
 
 <!--
@@ -440,12 +440,12 @@ const cli = await runCLI({
 ```
 
 <!--
-This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files reflect immediately.
+This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files are reflected immediately. The user can set the `autoMount` property to identify plugins and themes, but the `mount` property will provide more control to the user to set different folders in the project.
 
 #### Setting options and creating content
 -->
 
-Cela mappe votre répertoire actuel au chemin du plugin dans WordPress, puis active le plugin. Les modifications de vos fichiers locaux se reflètent immédiatement.
+Cela mappe votre répertoire actuel au chemin du plugin dans WordPress, puis active le plugin. Les modifications de vos fichiers locaux se reflètent immédiatement. L'utilisateur peut configurer la propriété `autoMount` pour identifier les plugins et thèmes, mais la propriété `mount` offrira plus de contrôle à l'utilisateur pour définir différents dossiers dans le projet.
 
 #### Définir les options et créer du contenu
 
@@ -543,12 +543,16 @@ await page.getByRole("link", { name: "My Plugin" }).first().click();
 
 ```typescript
 test("plugin shortcode renders on front end", async ({ page }) => {
+  // Navigate to a page with the shortcode
   await page.goto(`${cli.serverUrl}/?p=2`);
 
+  // Recommend: add data-testid="my-plugin-widget" to your plugin markup
   await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
   await expect(page.getByTestId("my-plugin-widget")).toContainText(
     "Expected content"
   );
+  // Or use CSS if you don't control the markup:
+  // await expect(page.locator(".my-plugin-widget")).toBeVisible();
 });
 
 test("theme displays post correctly", async ({ page }) => {
@@ -643,7 +647,41 @@ const versionMatrix = [
 
 for (const { php, wp } of versionMatrix) {
   test.describe(`PHP ${php} + WP ${wp}`, () => {
-    // ... test setup and assertions
+    let versionCli: Awaited<ReturnType<typeof runCLI>>;
+
+    test.beforeAll(async () => {
+      versionCli = await runCLI({
+        command: "server",
+        blueprint: {
+          preferredVersions: { php, wp },
+          login: true,
+          steps: [
+            {
+              step: "activatePlugin",
+              pluginPath: "my-plugin/my-plugin.php",
+            },
+          ],
+        },
+      });
+    });
+
+    test("admin page loads without errors", async ({ page }) => {
+      await page.goto(
+        `${versionCli.serverUrl}/wp-admin/options-general.php?page=my-plugin`
+      );
+      // WordPress core elements use CSS selectors — no ARIA roles available
+      await expect(page.locator(".error")).not.toBeVisible();
+      await expect(page.locator("#wpbody-content")).toBeVisible();
+    });
+
+    test("front-end output renders", async ({ page }) => {
+      await page.goto(versionCli.serverUrl);
+      await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
+    });
+
+    test.afterAll(async () => {
+      await versionCli?.server?.close();
+    });
   });
 }
 ```
@@ -729,11 +767,6 @@ npx playwright test --shard=1/3
 npx playwright test --shard=2/3
 npx playwright test --shard=3/3
 ```
-
-<!--
-Create three parallel jobs in your workflow matrix, each running a different shard. This reduces total CI time proportionally.
-:::
--->
 
 Créez trois jobs parallèles dans la matrice de votre workflow, chacun exécutant un fragment différent. Cela réduit proportionnellement le temps total de CI.
 :::

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -649,7 +649,7 @@ for (const { php, wp } of versionMatrix) {
 ```
 
 <!--
-The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.0–8.4, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`.
+The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.4–8.5, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`. For type-safe PHP version values, use the `SupportedPHPVersion` type from `@php-wasm/universal`.
 
 ## Running tests in CI/CD
 
@@ -658,7 +658,7 @@ The `preferredVersions` property in the Blueprint controls which PHP and WordPre
 Create `.github/workflows/e2e-tests.yml`:
 -->
 
-La propriété `preferredVersions` dans le Blueprint contrôle les versions PHP et WordPress utilisées par l'instance Playground. Plages prises en charge : PHP 7.0–8.4, WordPress 6.3–6.8+, ainsi que `latest`, `nightly` et `beta`.
+La propriété `preferredVersions` dans le Blueprint contrôle les versions PHP et WordPress utilisées par l'instance Playground. Plages prises en charge : PHP 7.4–8.5, WordPress 6.3–6.8+, ainsi que `latest`, `nightly` et `beta`. Pour des valeurs de version PHP typées, utilisez le type `SupportedPHPVersion` de `@php-wasm/universal`.
 
 ## Exécuter les tests en CI/CD
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -247,9 +247,11 @@ await page.locator("#submit").click();
 
 ### Mesmo elemento, três abordagens
 
+> Observação: o WordPress Playground usa a interface de administração em inglês por padrão, então os textos dos botões (como "Save Changes") aparecem em inglês.
+
 ```typescript
 // ✅ Preferido: localizador semântico (funciona porque o WP renderiza um <button> real)
-await page.getByRole("button", { name: "Salvar alterações" }).click();
+await page.getByRole("button", { name: "Save Changes" }).click();
 
 // ⚠️ Aceitável: ID de teste que você adicionou à marcação do seu plugin
 await page.getByTestId("save-settings").click();

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -24,15 +24,15 @@ Este guia pressupõe familiaridade com desenvolvimento de plugins ou temas WordP
 <!--
 ## Prerequisites
 
-- **Node.js 20+** and npm
-- A WordPress plugin or theme to test
+- **Node.js 20+** and up
+- A WordPress plugin/theme or an entire WordPress site to test
 - **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
 -->
 
 ## Pré-requisitos
 
-- **Node.js 20+** e npm
-- Um plugin ou tema WordPress para testar
+- **Node.js 20+** e superior
+- Um plugin/tema WordPress ou um site WordPress completo para testar
 - **Recomendado:** habilite a regra ESLint `@typescript-eslint/no-floating-promises` para detectar `await` ausente em chamadas assíncronas do Playwright
 
 <!--
@@ -104,24 +104,24 @@ O WordPress Playground precisa de mais tempo para iniciar do que uma aplicação
 
 <!--
 :::tip[Using baseURL with dynamic ports]
-The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `--port=9400` to lock the port:
+By default, Playground will sign the port `9400`. If you want to select a different port, pass `port: [NEW_PORT_NUMBER]` in the `runCLI` options to select a different port:
 
 ```typescript
-const cli = await runCLI({ command: "server", port: 9400, blueprint });
+const cli = await runCLI({ command: "server", port: 9500, blueprint });
 ```
 
-Then add `baseURL: "http://localhost:9400"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
+Then add `baseURL: "http://localhost:9500"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
 :::
 -->
 
 :::tip[Usando baseURL com portas dinâmicas]
-A função `runCLI` atribui uma porta aleatória a cada vez. Se você quiser um `baseURL` estável na sua configuração do Playwright, passe `--port=9400` para fixar a porta:
+Por padrão, o Playground usará a porta `9400`. Se você quiser selecionar uma porta diferente, passe `port: [NOVO_NÚMERO_DE_PORTA]` nas opções do `runCLI` para selecionar uma porta diferente:
 
 ```typescript
-const cli = await runCLI({ command: "server", port: 9400, blueprint });
+const cli = await runCLI({ command: "server", port: 9500, blueprint });
 ```
 
-Em seguida, adicione `baseURL: "http://localhost:9400"` na seção `use` acima. Observe que `testMatch` tem como padrão `**/*.spec.ts` — personalize se seus arquivos de teste usarem um padrão de nomenclatura diferente.
+Em seguida, adicione `baseURL: "http://localhost:9500"` na seção `use` acima. Observe que `testMatch` tem como padrão `**/*.spec.ts` — personalize se seus arquivos de teste usarem um padrão de nomenclatura diferente.
 :::
 
 <!--
@@ -454,12 +454,12 @@ const cli = await runCLI({
 ```
 
 <!--
-This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files reflect immediately.
+This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files are reflected immediately. The user can set the `autoMount` property to identify plugins and themes, but the `mount` property will provide more control to the user to set different folders in the project.
 
 #### Setting options and creating content
 -->
 
-Isso mapeia seu diretório atual para o caminho do plugin dentro do WordPress e, em seguida, ativa o plugin. As alterações nos seus arquivos locais refletem imediatamente.
+Isso mapeia seu diretório atual para o caminho do plugin dentro do WordPress e, em seguida, ativa o plugin. As alterações nos seus arquivos locais refletem imediatamente. O usuário pode configurar a propriedade `autoMount` para identificar plugins e temas, mas a propriedade `mount` proporcionará mais controle ao usuário para definir diferentes pastas no projeto.
 
 #### Definindo opções e criando conteúdo
 
@@ -557,12 +557,16 @@ await page.getByRole("link", { name: "My Plugin" }).first().click();
 
 ```typescript
 test("plugin shortcode renders on front end", async ({ page }) => {
+  // Navigate to a page with the shortcode
   await page.goto(`${cli.serverUrl}/?p=2`);
 
+  // Recommend: add data-testid="my-plugin-widget" to your plugin markup
   await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
   await expect(page.getByTestId("my-plugin-widget")).toContainText(
     "Expected content"
   );
+  // Or use CSS if you don't control the markup:
+  // await expect(page.locator(".my-plugin-widget")).toBeVisible();
 });
 
 test("theme displays post correctly", async ({ page }) => {
@@ -657,7 +661,41 @@ const versionMatrix = [
 
 for (const { php, wp } of versionMatrix) {
   test.describe(`PHP ${php} + WP ${wp}`, () => {
-    // ... test setup and assertions
+    let versionCli: Awaited<ReturnType<typeof runCLI>>;
+
+    test.beforeAll(async () => {
+      versionCli = await runCLI({
+        command: "server",
+        blueprint: {
+          preferredVersions: { php, wp },
+          login: true,
+          steps: [
+            {
+              step: "activatePlugin",
+              pluginPath: "my-plugin/my-plugin.php",
+            },
+          ],
+        },
+      });
+    });
+
+    test("admin page loads without errors", async ({ page }) => {
+      await page.goto(
+        `${versionCli.serverUrl}/wp-admin/options-general.php?page=my-plugin`
+      );
+      // WordPress core elements use CSS selectors — no ARIA roles available
+      await expect(page.locator(".error")).not.toBeVisible();
+      await expect(page.locator("#wpbody-content")).toBeVisible();
+    });
+
+    test("front-end output renders", async ({ page }) => {
+      await page.goto(versionCli.serverUrl);
+      await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
+    });
+
+    test.afterAll(async () => {
+      await versionCli?.server?.close();
+    });
   });
 }
 ```
@@ -743,11 +781,6 @@ npx playwright test --shard=1/3
 npx playwright test --shard=2/3
 npx playwright test --shard=3/3
 ```
-
-<!--
-Create three parallel jobs in your workflow matrix, each running a different shard. This reduces total CI time proportionally.
-:::
--->
 
 Crie três jobs paralelos na matriz do seu workflow, cada um executando um fragmento diferente. Isso reduz o tempo total de CI proporcionalmente.
 :::

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -1,0 +1,861 @@
+---
+title: Testes E2E com Playwright e WordPress Playground
+slug: /guides/e2e-testing-with-playwright
+description: Configure testes de ponta a ponta para plugins e temas WordPress usando Playwright e o Playground CLI.
+sidebar_class_name: navbar-build-item
+---
+
+<!--
+End-to-end testing verifies that your WordPress plugin or theme works correctly from a user's perspective — clicking buttons, filling forms, and navigating pages in a real browser. This guide shows how to combine [Playwright](https://playwright.dev/) with the [WordPress Playground CLI](/developers/local-development/wp-playground-cli) to write reliable E2E tests without Docker, databases, or manual setup.
+-->
+
+Testes de ponta a ponta verificam se seu plugin ou tema WordPress funciona corretamente da perspectiva do usuário — clicando em botões, preenchendo formulários e navegando em páginas em um navegador real. Este guia mostra como combinar [Playwright](https://playwright.dev/) com o [WordPress Playground CLI](/developers/local-development/wp-playground-cli) para escrever testes E2E confiáveis sem Docker, bancos de dados ou configuração manual.
+
+<!--
+:::info
+This guide assumes familiarity with WordPress plugin or theme development. For an introduction to using Playground in your development workflow, see [WordPress Playground for Plugin Developers](/guides/for-plugin-developers). For Blueprint configuration details, see [Blueprints Getting Started](/blueprints/getting-started).
+:::
+-->
+
+:::info
+Este guia pressupõe familiaridade com desenvolvimento de plugins ou temas WordPress. Para uma introdução ao uso do Playground no seu fluxo de desenvolvimento, consulte [WordPress Playground para Desenvolvedores de Plugins](/guides/for-plugin-developers). Para detalhes de configuração do Blueprint, consulte [Introdução aos Blueprints](/blueprints/getting-started).
+:::
+
+<!--
+## Prerequisites
+
+- **Node.js 20+** and npm
+- A WordPress plugin or theme to test
+- **Recommended:** enable the `@typescript-eslint/no-floating-promises` ESLint rule to catch missing `await` on async Playwright calls
+-->
+
+## Pré-requisitos
+
+- **Node.js 20+** e npm
+- Um plugin ou tema WordPress para testar
+- **Recomendado:** habilite a regra ESLint `@typescript-eslint/no-floating-promises` para detectar `await` ausente em chamadas assíncronas do Playwright
+
+<!--
+## Project setup
+
+### Install dependencies
+
+From your plugin or theme root directory:
+
+```bash
+npm init -y
+npm install --save-dev @playwright/test @wp-playground/cli
+npx playwright install chromium
+```
+
+This installs Playwright as the test runner, the Playground CLI for creating WordPress instances, and the Chromium browser for test execution.
+-->
+
+## Configuração do projeto
+
+### Instalar dependências
+
+A partir do diretório raiz do seu plugin ou tema:
+
+```bash
+npm init -y
+npm install --save-dev @playwright/test @wp-playground/cli
+npx playwright install chromium
+```
+
+Isso instala o Playwright como executor de testes, o Playground CLI para criar instâncias do WordPress e o navegador Chromium para execução dos testes.
+
+<!--
+### Configure Playwright
+
+Create a `playwright.config.ts` file in your project root:
+-->
+
+### Configurar o Playwright
+
+Crie um arquivo `playwright.config.ts` na raiz do seu projeto:
+
+```typescript
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: "html",
+  timeout: 120_000,
+  expect: {
+    timeout: 30_000,
+  },
+  use: {
+    screenshot: "only-on-failure",
+    trace: "on-first-retry",
+  },
+});
+```
+
+<!--
+WordPress Playground needs more time to start than a typical web app. The 120-second test timeout and 30-second assertion timeout account for WordPress boot time and page loads. Setting `workers: 1` prevents port conflicts when multiple tests share a Playground server.
+-->
+
+O WordPress Playground precisa de mais tempo para iniciar do que uma aplicação web típica. O timeout de teste de 120 segundos e o timeout de asserção de 30 segundos consideram o tempo de inicialização do WordPress e o carregamento das páginas. Definir `workers: 1` evita conflitos de porta quando vários testes compartilham um servidor Playground.
+
+<!--
+:::tip[Using baseURL with dynamic ports]
+The `runCLI` function assigns a random port each time. If you want a stable `baseURL` in your Playwright config, pass `--port=9400` to lock the port:
+
+```typescript
+const cli = await runCLI({ command: "server", port: 9400, blueprint });
+```
+
+Then add `baseURL: "http://localhost:9400"` to the `use` section above. Note that `testMatch` defaults to `**/*.spec.ts` — customize it if your test files use a different naming pattern.
+:::
+-->
+
+:::tip[Usando baseURL com portas dinâmicas]
+A função `runCLI` atribui uma porta aleatória a cada vez. Se você quiser um `baseURL` estável na sua configuração do Playwright, passe `--port=9400` para fixar a porta:
+
+```typescript
+const cli = await runCLI({ command: "server", port: 9400, blueprint });
+```
+
+Em seguida, adicione `baseURL: "http://localhost:9400"` na seção `use` acima. Observe que `testMatch` tem como padrão `**/*.spec.ts` — personalize se seus arquivos de teste usarem um padrão de nomenclatura diferente.
+:::
+
+<!--
+:::tip
+The WordPress Playground project uses even longer timeouts (300s test, 60s assertion) for its own tests. Start with the values above and increase if your CI environment is slower.
+:::
+-->
+
+:::tip
+O projeto WordPress Playground usa timeouts ainda maiores (300s de teste, 60s de asserção) para seus próprios testes. Comece com os valores acima e aumente se seu ambiente de CI for mais lento.
+:::
+
+<!--
+### First test file
+
+Create `tests/e2e/plugin.spec.ts`:
+-->
+
+### Primeiro arquivo de teste
+
+Crie `tests/e2e/plugin.spec.ts`:
+
+```typescript
+import { test, expect } from "@playwright/test";
+import { runCLI } from "@wp-playground/cli";
+
+let cli: Awaited<ReturnType<typeof runCLI>>;
+
+test.beforeAll(async () => {
+  cli = await runCLI({
+    command: "server",
+    blueprint: {
+      preferredVersions: { php: "8.3", wp: "latest" },
+      login: true,
+    },
+  });
+});
+
+test.afterAll(async () => {
+  await cli?.server?.close();
+});
+
+test("WordPress dashboard loads", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/wp-admin/`);
+  // WordPress core admin elements lack ARIA roles — CSS selectors are acceptable here
+  await expect(page.locator("#wpbody-content")).toBeVisible();
+  await expect(page).toHaveTitle(/Dashboard/);
+});
+```
+
+<!--
+Run the test:
+
+```bash
+npx playwright test
+```
+-->
+
+Execute o teste:
+
+```bash
+npx playwright test
+```
+
+<!--
+## Choosing locators
+
+Playwright provides several ways to find elements on the page. Prefer locators that reflect how users see the page, falling back to CSS selectors only when necessary.
+
+**Locator priority** (most to least preferred):
+
+1. `page.getByRole()` — buttons, headings, links, form controls
+2. `page.getByLabel()` — form inputs with associated labels
+3. `page.getByText()` — visible text content
+4. `page.getByTestId()` — elements with `data-testid` attributes you add to your plugin
+5. `page.locator()` — CSS or XPath selectors as a last resort
+-->
+
+## Escolhendo localizadores
+
+O Playwright oferece várias formas de encontrar elementos na página. Prefira localizadores que reflitam como os usuários veem a página, usando seletores CSS apenas quando necessário.
+
+**Prioridade de localizadores** (do mais ao menos preferido):
+
+1. `page.getByRole()` — botões, títulos, links, controles de formulário
+2. `page.getByLabel()` — inputs de formulário com rótulos associados
+3. `page.getByText()` — conteúdo de texto visível
+4. `page.getByTestId()` — elementos com atributos `data-testid` que você adiciona ao seu plugin
+5. `page.locator()` — seletores CSS ou XPath como último recurso
+
+<!--
+### WordPress-specific guidance
+
+In the WordPress admin, some core elements (admin bar, meta boxes) rely on IDs and CSS classes rather than ARIA roles. However, many elements work well with semantic locators. This means:
+
+- **Use semantic locators** for buttons, headings, links, form fields, and admin menu items — WordPress renders standard `<button>`, `<input>`, `<a>`, and `<h1>` elements that `getByRole` and `getByLabel` can find.
+- **Use `data-testid`** for your own plugin markup — you control the HTML, so add testable attributes.
+- **Use CSS selectors** for WordPress core layout elements like `#wpadminbar` or `#wpbody-content` — these lack ARIA alternatives.
+-->
+
+### Orientação específica para WordPress
+
+No admin do WordPress, alguns elementos principais (barra de administração, meta boxes) usam IDs e classes CSS em vez de funções ARIA. Porém, muitos elementos funcionam bem com localizadores semânticos. Isso significa:
+
+- **Use localizadores semânticos** para botões, títulos, links, campos de formulário e itens do menu admin — o WordPress renderiza elementos padrão `<button>`, `<input>`, `<a>` e `<h1>` que `getByRole` e `getByLabel` podem encontrar.
+- **Use `data-testid`** para a marcação do seu próprio plugin — você controla o HTML, então adicione atributos testáveis.
+- **Use seletores CSS** para elementos de layout principais do WordPress como `#wpadminbar` ou `#wpbody-content` — estes não têm alternativas ARIA.
+
+<!--
+### Same element, three approaches
+
+```typescript
+// ✅ Preferred: semantic locator (works because WP renders a real <button>)
+await page.getByRole("button", { name: "Save Changes" }).click();
+
+// ⚠️ Acceptable: test ID you added to your plugin markup
+await page.getByTestId("save-settings").click();
+
+// ❌ Avoid: brittle CSS selector tied to WordPress markup
+await page.locator("#submit").click();
+```
+-->
+
+### Mesmo elemento, três abordagens
+
+```typescript
+// ✅ Preferido: localizador semântico (funciona porque o WP renderiza um <button> real)
+await page.getByRole("button", { name: "Salvar alterações" }).click();
+
+// ⚠️ Aceitável: ID de teste que você adicionou à marcação do seu plugin
+await page.getByTestId("save-settings").click();
+
+// ❌ Evite: seletor CSS frágil vinculado à marcação do WordPress
+await page.locator("#submit").click();
+```
+
+<!--
+:::tip[Generate locators automatically]
+Run `npx playwright codegen localhost:9400/wp-admin/` to open a browser and record interactions. Playwright generates locator code as you click, helping you discover which semantic locators work for each element.
+:::
+-->
+
+:::tip[Gerar localizadores automaticamente]
+Execute `npx playwright codegen localhost:9400/wp-admin/` para abrir um navegador e gravar interações. O Playwright gera código de localizador conforme você clica, ajudando a descobrir quais localizadores semânticos funcionam para cada elemento.
+:::
+
+<!--
+## Auto-waiting and web-first assertions
+
+Playwright locators wait automatically for elements to appear, become visible, and become actionable. You do not need manual `waitForSelector` calls in most cases.
+
+### Web-first assertions
+
+Web-first assertions auto-retry until the condition passes or the timeout expires. Always prefer them over manual checks:
+
+```typescript
+// ✅ Web-first assertion (auto-retries until visible or timeout)
+await expect(page.getByText("Settings saved")).toBeVisible();
+
+// ❌ Manual check (no retry — flaky if the element appears after a delay)
+expect(await page.getByText("Settings saved").isVisible()).toBe(true);
+```
+
+### Soft assertions
+
+Use `expect.soft()` to check multiple things on one page without stopping at the first failure. All failures appear in the test report:
+-->
+
+## Auto-espera e asserções web-first
+
+Os localizadores do Playwright esperam automaticamente que os elementos apareçam, fiquem visíveis e acionáveis. Na maioria dos casos, você não precisa de chamadas manuais a `waitForSelector`.
+
+### Asserções web-first
+
+Asserções web-first repetem automaticamente até a condição ser atendida ou o timeout expirar. Sempre prefira-as em vez de verificações manuais:
+
+```typescript
+// ✅ Asserção web-first (repete automaticamente até visível ou timeout)
+await expect(page.getByText("Configurações salvas")).toBeVisible();
+
+// ❌ Verificação manual (sem retry — instável se o elemento aparecer com atraso)
+expect(await page.getByText("Configurações salvas").isVisible()).toBe(true);
+```
+
+### Asserções suaves
+
+Use `expect.soft()` para verificar várias coisas em uma página sem parar no primeiro erro. Todas as falhas aparecem no relatório de teste:
+
+```typescript
+await expect.soft(page.getByLabel("API Key")).toHaveValue("test-key-123");
+await expect.soft(page.getByText("Settings saved")).toBeVisible();
+await expect.soft(page.getByRole("heading", { level: 1 })).toContainText("Settings");
+```
+
+<!--
+## Writing tests
+
+### Starting a Playground server
+
+The `runCLI` function starts a local Playground server and returns an object with `serverUrl` (the URL string) and `server` (the HTTP server instance). Pass a Blueprint to configure the WordPress instance:
+-->
+
+## Escrevendo testes
+
+### Iniciando um servidor Playground
+
+A função `runCLI` inicia um servidor Playground local e retorna um objeto com `serverUrl` (a string da URL) e `server` (a instância do servidor HTTP). Passe um Blueprint para configurar a instância do WordPress:
+
+```typescript
+const cli = await runCLI({
+  command: "server",
+  blueprint: {
+    preferredVersions: { php: "8.3", wp: "latest" },
+    login: true,
+    steps: [
+      {
+        step: "installPlugin",
+        pluginData: {
+          resource: "wordpress.org/plugins",
+          slug: "woocommerce",
+        },
+      },
+    ],
+  },
+});
+```
+
+<!--
+#### Server lifecycle: shared vs. per-test
+
+**Shared server (`beforeAll`/`afterAll`)** — one Playground instance serves all tests in a describe block. Faster, but tests can affect each other:
+-->
+
+#### Ciclo de vida do servidor: compartilhado vs. por teste
+
+**Servidor compartilhado (`beforeAll`/`afterAll`)** — uma instância Playground serve todos os testes em um bloco describe. Mais rápido, mas os testes podem afetar uns aos outros:
+
+```typescript
+test.describe("Plugin settings", () => {
+  test.beforeAll(async () => {
+    cli = await runCLI({ command: "server", blueprint });
+  });
+  test.afterAll(async () => {
+    await cli?.server?.close();
+  });
+  // Tests share the same WordPress instance
+});
+```
+
+<!--
+**Per-test server (`beforeEach`/`afterEach`)** — each test gets a fresh instance. Slower, but fully isolated:
+-->
+
+**Servidor por teste (`beforeEach`/`afterEach`)** — cada teste recebe uma instância nova. Mais lento, mas totalmente isolado:
+
+```typescript
+test.beforeEach(async () => {
+  cli = await runCLI({ command: "server", blueprint });
+});
+test.afterEach(async () => {
+  await cli?.server?.close();
+});
+```
+
+<!--
+Use shared servers when tests only read state (checking pages render). Use per-test servers when tests modify state (creating posts, changing settings).
+
+### Using Blueprints as test fixtures
+
+Blueprints define the WordPress state each test scenario needs. Here are common patterns:
+-->
+
+Use servidores compartilhados quando os testes apenas leem o estado (verificando renderização de páginas). Use servidores por teste quando os testes modificam o estado (criando posts, alterando configurações).
+
+### Usando Blueprints como fixtures de teste
+
+Blueprints definem o estado do WordPress que cada cenário de teste precisa. Aqui estão padrões comuns:
+
+<!--
+#### Installing a plugin from wordpress.org
+-->
+
+#### Instalando um plugin do wordpress.org
+
+```typescript
+const blueprint = {
+  preferredVersions: { php: "8.3", wp: "latest" },
+  login: true,
+  steps: [
+    {
+      step: "installPlugin",
+      pluginData: {
+        resource: "wordpress.org/plugins",
+        slug: "contact-form-7",
+      },
+    },
+  ],
+};
+```
+
+<!--
+#### Installing a local plugin
+
+Mount your local plugin directory into the Playground instance:
+-->
+
+#### Instalando um plugin local
+
+Monte o diretório do seu plugin local na instância do Playground:
+
+```typescript
+const cli = await runCLI({
+  command: "server",
+  mount: {
+    "./": "/wordpress/wp-content/plugins/my-plugin",
+  },
+  blueprint: {
+    preferredVersions: { php: "8.3", wp: "latest" },
+    login: true,
+    steps: [
+      {
+        step: "activatePlugin",
+        pluginPath: "my-plugin/my-plugin.php",
+      },
+    ],
+  },
+});
+```
+
+<!--
+This maps your current directory to the plugin path inside WordPress, then activates the plugin. Changes to your local files reflect immediately.
+
+#### Setting options and creating content
+-->
+
+Isso mapeia seu diretório atual para o caminho do plugin dentro do WordPress e, em seguida, ativa o plugin. As alterações nos seus arquivos locais refletem imediatamente.
+
+#### Definindo opções e criando conteúdo
+
+```typescript
+const blueprint = {
+  login: true,
+  steps: [
+    {
+      step: "setSiteOptions",
+      options: {
+        blogname: "Test Site",
+        permalink_structure: "/%postname%/",
+      },
+    },
+    {
+      step: "runPHP",
+      code: `<?php
+        require '/wordpress/wp-load.php';
+        wp_insert_post([
+          'post_title' => 'Test Post',
+          'post_content' => '<!-- wp:paragraph --><p>Hello World</p><!-- /wp:paragraph -->',
+          'post_status' => 'publish',
+        ]);
+      `,
+    },
+  ],
+};
+```
+
+<!--
+:::tip
+Use the [Playground Step Library](https://akirk.github.io/playground-step-library/) or [Pootle Playground](https://pootleplayground.com/) to prototype your Blueprint configuration visually before adding it to your test code.
+:::
+-->
+
+:::tip
+Use a [Playground Step Library](https://akirk.github.io/playground-step-library/) ou o [Pootle Playground](https://pootleplayground.com/) para prototipar sua configuração de Blueprint visualmente antes de adicioná-la ao seu código de teste.
+:::
+
+<!--
+### Testing WordPress admin pages
+
+Navigate to admin pages and interact with the WordPress UI:
+-->
+
+### Testando páginas do admin do WordPress
+
+Navegue até as páginas do admin e interaja com a interface do WordPress:
+
+```typescript
+test("plugin settings page saves options", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/wp-admin/options-general.php?page=my-plugin`);
+
+  await page.getByLabel("API Key").fill("test-key-123");
+  await page.getByRole("button", { name: "Save Changes" }).click();
+
+  await expect(page.getByText("Settings saved")).toBeVisible();
+  await expect(page.getByLabel("API Key")).toHaveValue("test-key-123");
+});
+```
+
+<!--
+#### Handling common admin UI elements
+
+```typescript
+// Dismiss WordPress admin notices (WP adds aria-label to dismiss buttons)
+await page.getByRole("button", { name: "Dismiss this notice" }).first().click();
+
+// Wait for admin bar to load — no ARIA role available, use locator
+await page.locator("#wpadminbar").waitFor();
+
+// Navigate via admin menu
+await page.getByRole("link", { name: "My Plugin" }).first().click();
+```
+-->
+
+#### Lidando com elementos comuns da UI do admin
+
+```typescript
+// Dispensar avisos do admin do WordPress (o WP adiciona aria-label aos botões de dispensar)
+await page.getByRole("button", { name: "Dismiss this notice" }).first().click();
+
+// Aguardar o carregamento da barra admin — sem função ARIA disponível, use locator
+await page.locator("#wpadminbar").waitFor();
+
+// Navegar pelo menu admin
+await page.getByRole("link", { name: "My Plugin" }).first().click();
+```
+
+<!--
+### Testing the front end
+-->
+
+### Testando o front-end
+
+```typescript
+test("plugin shortcode renders on front end", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/?p=2`);
+
+  await expect(page.getByTestId("my-plugin-widget")).toBeVisible();
+  await expect(page.getByTestId("my-plugin-widget")).toContainText(
+    "Expected content"
+  );
+});
+
+test("theme displays post correctly", async ({ page }) => {
+  await page.goto(`${cli.serverUrl}/test-post/`);
+
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("Test Post");
+  await expect(page.getByText("Hello World", { exact: true })).toBeVisible();
+});
+```
+
+<!--
+## Page Object Model pattern
+
+The Page Object Model (POM) wraps page interactions into reusable classes. This reduces duplication and makes tests easier to maintain when your plugin UI changes.
+-->
+
+## Padrão Page Object Model
+
+O Page Object Model (POM) encapsula as interações da página em classes reutilizáveis. Isso reduz duplicação e facilita a manutenção dos testes quando a UI do seu plugin muda.
+
+```typescript
+// tests/e2e/pages/plugin-settings.ts
+import { type Page, type Locator, expect } from "@playwright/test";
+
+export class PluginSettingsPage {
+  readonly page: Page;
+  readonly apiKeyInput: Locator;
+  readonly saveButton: Locator;
+  readonly successNotice: Locator;
+
+  constructor(page: Page) {
+    this.page = page;
+    this.apiKeyInput = page.getByLabel("API Key");
+    this.saveButton = page.getByRole("button", { name: "Save Changes" });
+    this.successNotice = page.getByText("Settings saved");
+  }
+
+  async goto(baseUrl: string) {
+    await this.page.goto(
+      `${baseUrl}/wp-admin/options-general.php?page=my-plugin`
+    );
+  }
+
+  async setApiKey(key: string) {
+    await this.apiKeyInput.fill(key);
+    await this.saveButton.click();
+  }
+
+  async expectSaved() {
+    await expect(this.successNotice).toBeVisible();
+  }
+}
+```
+
+<!--
+Use the POM in tests:
+-->
+
+Use o POM nos testes:
+
+```typescript
+import { PluginSettingsPage } from "./pages/plugin-settings";
+
+test("save plugin settings", async ({ page }) => {
+  const settings = new PluginSettingsPage(page);
+  await settings.goto(cli.serverUrl);
+  await settings.setApiKey("test-key-123");
+  await settings.expectSaved();
+});
+```
+
+<!--
+The Playground project uses this pattern with a `WebsitePage` class that provides methods like `goto()`, `wordpress()`, and `getSiteTitle()` — encapsulating navigation and WordPress-specific interactions.
+
+## Testing across PHP and WordPress versions
+
+Parameterized tests cover multiple version combinations without duplicating test code:
+-->
+
+O projeto Playground usa esse padrão com a classe `WebsitePage` que fornece métodos como `goto()`, `wordpress()` e `getSiteTitle()` — encapsulando navegação e interações específicas do WordPress.
+
+## Testando em diferentes versões de PHP e WordPress
+
+Testes parametrizados cobrem múltiplas combinações de versões sem duplicar código de teste:
+
+```typescript
+const versionMatrix = [
+  { php: "8.1", wp: "6.5" },
+  { php: "8.2", wp: "6.7" },
+  { php: "8.3", wp: "latest" },
+];
+
+for (const { php, wp } of versionMatrix) {
+  test.describe(`PHP ${php} + WP ${wp}`, () => {
+    // ... test setup and assertions
+  });
+}
+```
+
+<!--
+The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.0–8.4, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`.
+
+## Running tests in CI/CD
+
+### GitHub Actions
+
+Create `.github/workflows/e2e-tests.yml`:
+-->
+
+A propriedade `preferredVersions` no Blueprint controla quais versões de PHP e WordPress a instância Playground usa. Intervalos suportados: PHP 7.0–8.4, WordPress 6.3–6.8+, além de `latest`, `nightly` e `beta`.
+
+## Executando testes em CI/CD
+
+### GitHub Actions
+
+Crie `.github/workflows/e2e-tests.yml`:
+
+```yaml
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --with-deps
+
+      - name: Run E2E tests
+        run: npx playwright test
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+```
+
+<!--
+This workflow installs dependencies, downloads Chromium, runs the tests, and uploads the HTML report as an artifact. The `--with-deps` flag installs system libraries Chromium needs on Ubuntu.
+
+:::tip[Sharding for faster CI]
+Split tests across multiple CI jobs with Playwright's built-in sharding:
+-->
+
+Este workflow instala dependências, baixa o Chromium, executa os testes e faz upload do relatório HTML como artefato. A flag `--with-deps` instala as bibliotecas do sistema que o Chromium precisa no Ubuntu.
+
+:::tip[Fragmentação para CI mais rápido]
+Divida os testes em vários jobs de CI com a fragmentação integrada do Playwright:
+
+```bash
+npx playwright test --shard=1/3
+npx playwright test --shard=2/3
+npx playwright test --shard=3/3
+```
+
+<!--
+Create three parallel jobs in your workflow matrix, each running a different shard. This reduces total CI time proportionally.
+:::
+-->
+
+Crie três jobs paralelos na matriz do seu workflow, cada um executando um fragmento diferente. Isso reduz o tempo total de CI proporcionalmente.
+:::
+
+<!--
+:::info
+For manual PR testing alongside automated E2E tests, see [Adding PR Preview Buttons with GitHub Actions](/guides/github-action-pr-preview).
+:::
+-->
+
+:::info
+Para testes manuais de PR junto com testes E2E automatizados, consulte [Adicionando botões de preview de PR com GitHub Actions](/guides/github-action-pr-preview).
+:::
+
+<!--
+## Troubleshooting
+
+**Timeout errors** — Increase `timeout` in `playwright.config.ts`. WordPress boot time varies by environment. CI runners often need 120–180 seconds.
+
+**Port conflicts** — Let Playground auto-assign ports. Do not hardcode port numbers in your configuration. The `serverUrl` property returns the correct URL.
+
+**Browser not found** — Run `npx playwright install chromium` to download the browser binary. On CI, add `--with-deps` for system libraries.
+
+**WordPress not loading** — Check your Blueprint syntax against the [Blueprint schema](https://playground.wordpress.net/blueprint-schema.json). Invalid steps fail silently in some cases.
+
+**Tests pass locally but fail in CI** — CI runners have less memory and CPU. Increase timeouts, reduce parallel workers, and ensure `workers: 1` in the config.
+
+## Debugging tests
+
+When a test fails, Playwright provides several tools to investigate:
+-->
+
+## Solução de problemas
+
+**Erros de timeout** — Aumente o `timeout` no `playwright.config.ts`. O tempo de inicialização do WordPress varia conforme o ambiente. Runners de CI frequentemente precisam de 120–180 segundos.
+
+**Conflitos de porta** — Deixe o Playground atribuir portas automaticamente. Não codifique números de porta na sua configuração. A propriedade `serverUrl` retorna a URL correta.
+
+**Navegador não encontrado** — Execute `npx playwright install chromium` para baixar o binário do navegador. No CI, adicione `--with-deps` para bibliotecas do sistema.
+
+**WordPress não carrega** — Verifique a sintaxe do seu Blueprint com o [esquema Blueprint](https://playground.wordpress.net/blueprint-schema.json). Passos inválidos podem falhar silenciosamente em alguns casos.
+
+**Testes passam localmente mas falham no CI** — Runners de CI têm menos memória e CPU. Aumente os timeouts, reduza workers paralelos e garanta `workers: 1` na config.
+
+## Depurando testes
+
+Quando um teste falha, o Playwright oferece várias ferramentas para investigar:
+
+<!--
+**Playwright Inspector** — step through tests interactively with a built-in debugger:
+
+```bash
+npx playwright test --debug
+```
+
+**Trace viewer** — inspect a timeline of actions, DOM snapshots, and network requests from a failed test. The `trace: "on-first-retry"` setting in the config above captures traces automatically:
+
+```bash
+npx playwright show-trace test-results/plugin-spec-ts/trace.zip
+```
+
+**UI mode** — run tests in a visual interface where you can watch, filter, and re-run them:
+
+```bash
+npx playwright test --ui
+```
+
+**Screenshot on failure** — the `screenshot: "only-on-failure"` setting in the config saves a screenshot whenever a test fails. Find screenshots in the `test-results/` directory.
+-->
+
+**Playwright Inspector** — percorra os testes interativamente com um depurador integrado:
+
+```bash
+npx playwright test --debug
+```
+
+**Visualizador de trace** — inspecione uma linha do tempo de ações, capturas de DOM e requisições de rede de um teste que falhou. A configuração `trace: "on-first-retry"` no config acima captura traces automaticamente:
+
+```bash
+npx playwright show-trace test-results/plugin-spec-ts/trace.zip
+```
+
+**Modo UI** — execute os testes em uma interface visual onde você pode assistir, filtrar e reexecutá-los:
+
+```bash
+npx playwright test --ui
+```
+
+**Screenshot em caso de falha** — a configuração `screenshot: "only-on-failure"` no config salva um screenshot sempre que um teste falha. Encontre os screenshots no diretório `test-results/`.
+
+<!--
+:::tip
+Combine `--debug` with a specific test file to focus your investigation: `npx playwright test tests/e2e/settings.spec.ts --debug`
+:::
+
+## Next steps
+
+- [WordPress Playground CLI documentation](/developers/local-development/wp-playground-cli) — full CLI reference
+- [Playwright documentation](https://playwright.dev/docs/intro) — test writing guide and API reference
+- [Blueprints reference](/blueprints/steps) — all available Blueprint steps
+- [Adding PR Preview Buttons](/guides/github-action-pr-preview) — combine automated tests with manual PR previews
+-->
+
+:::tip
+Combine `--debug` com um arquivo de teste específico para focar sua investigação: `npx playwright test tests/e2e/settings.spec.ts --debug`
+:::
+
+## Próximos passos
+
+- [Documentação do WordPress Playground CLI](/developers/local-development/wp-playground-cli) — referência completa da CLI
+- [Documentação do Playwright](https://playwright.dev/docs/intro) — guia de escrita de testes e referência da API
+- [Referência de Blueprints](/blueprints/steps) — todos os passos de Blueprint disponíveis
+- [Adicionando botões de preview de PR](/guides/github-action-pr-preview) — combine testes automatizados com previews manuais de PR

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/e2e-testing-with-playwright.md
@@ -663,7 +663,7 @@ for (const { php, wp } of versionMatrix) {
 ```
 
 <!--
-The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.0–8.4, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`.
+The `preferredVersions` property in the Blueprint controls which PHP and WordPress versions the Playground instance uses. Supported ranges: PHP 7.4–8.5, WordPress 6.3–6.8+, plus `latest`, `nightly`, and `beta`. For type-safe PHP version values, use the `SupportedPHPVersion` type from `@php-wasm/universal`.
 
 ## Running tests in CI/CD
 
@@ -672,7 +672,7 @@ The `preferredVersions` property in the Blueprint controls which PHP and WordPre
 Create `.github/workflows/e2e-tests.yml`:
 -->
 
-A propriedade `preferredVersions` no Blueprint controla quais versões de PHP e WordPress a instância Playground usa. Intervalos suportados: PHP 7.0–8.4, WordPress 6.3–6.8+, além de `latest`, `nightly` e `beta`.
+A propriedade `preferredVersions` no Blueprint controla quais versões de PHP e WordPress a instância Playground usa. Intervalos suportados: PHP 7.4–8.5, WordPress 6.3–6.8+, além de `latest`, `nightly` e `beta`. Para valores de versão PHP com segurança de tipos, use o tipo `SupportedPHPVersion` de `@php-wasm/universal`.
 
 ## Executando testes em CI/CD
 

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -52,6 +52,7 @@ const sidebars = {
 						'main/guides/github-action-pr-preview',
 						'main/guides/playground-for-everyone',
 						'main/guides/programmatic-playground-cli',
+						'main/guides/e2e-testing-with-playwright',
 					],
 				},
 				{


### PR DESCRIPTION
This pull request adds documentation and sidebar navigation for a new guide on end-to-end (E2E) testing with Playwright and WordPress Playground. The main focus is to help users set up automated E2E tests for their WordPress plugins and themes using Playwright.

**Documentation updates:**

* Added a new guide, "E2E Testing with Playwright and WordPress Playground," to the guides index, providing instructions for setting up automated E2E tests.

**Navigation updates:**

* Included the new E2E testing guide in the documentation sidebar to ensure it's easily discoverable.
