### PR TITLE
[Website] Support streamed PHP responses in the service worker

### DIFF
--- a/packages/php-wasm/node/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/node/src/test/php-request-handler.spec.ts
@@ -343,7 +343,7 @@ describe.each(configsForRequestTests)(
 			expect(response).toEqual({
 				httpStatusCode: 301,
 				headers: {
-					Location: ['/folder/'],
+					location: ['/folder/'],
 				},
 				bytes: expect.any(Uint8Array),
 				errors: '',

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -294,7 +294,14 @@ function setupTransferHandlers() {
 		serialize(obj: StreamedPHPResponse): [any, Transferable[]] {
 			const supportsStreams = supportsTransferableStreams();
 			const exitCodePort = promiseToPort(obj.exitCode);
-			const headersStream = obj.getHeadersStream();
+
+			// The headers stream may already be consumed (e.g. by the
+			// cookie handler in PHPRequestHandler). If so, synthesize
+			// a fresh stream from the already-parsed header data.
+			const headersStream = obj.headersStreamConsumed
+				? headersToStream(obj.headers, obj.httpStatusCode)
+				: obj.getHeadersStream();
+
 			if (supportsStreams) {
 				const payload = {
 					__type: 'StreamedPHPResponse',
@@ -385,6 +392,37 @@ function supportsTransferableStreams(): boolean {
 		void _e;
 		return (_cachedSupportsTransferableStreams = false);
 	}
+}
+
+/**
+ * Synthesizes a headers ReadableStream from already-parsed header data.
+ * Used by the Comlink transfer handler when the original headers stream
+ * has already been consumed on the worker side.
+ */
+function headersToStream(
+	headersPromise: Promise<Record<string, string[]>>,
+	httpStatusCodePromise: Promise<number>
+): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		async start(controller) {
+			const [headers, httpStatusCode] = await Promise.all([
+				headersPromise,
+				httpStatusCodePromise,
+			]);
+			const headerLines: string[] = [];
+			for (const [name, values] of Object.entries(headers)) {
+				for (const value of values) {
+					headerLines.push(`${name}: ${value}`);
+				}
+			}
+			const json = JSON.stringify({
+				status: httpStatusCode,
+				headers: headerLines,
+			});
+			controller.enqueue(new TextEncoder().encode(json));
+			controller.close();
+		},
+	});
 }
 
 /**

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -360,21 +360,30 @@ function setupTransferHandlers() {
  * directly through postMessage (aka "transferable streams"). When false,
  * we must fall back to port-bridged streaming.
  */
-export function supportsTransferableStreams(): boolean {
+let _cachedSupportsTransferableStreams: boolean | undefined;
+function supportsTransferableStreams(): boolean {
+	if (_cachedSupportsTransferableStreams !== undefined) {
+		return _cachedSupportsTransferableStreams;
+	}
 	try {
-		if (typeof ReadableStream === 'undefined') return false;
+		if (typeof ReadableStream === 'undefined') {
+			return (_cachedSupportsTransferableStreams = false);
+		}
 		const { port1 } = new MessageChannel();
 		const rs = new ReadableStream();
-		port1.postMessage(rs as any);
+		// The stream must be in the transfer list — without it,
+		// postMessage tries to clone (which always fails for
+		// ReadableStream) instead of transferring.
+		port1.postMessage(rs, [rs as unknown as Transferable]);
 		try {
 			port1.close();
 		} catch (_e) {
 			void _e;
 		}
-		return true;
+		return (_cachedSupportsTransferableStreams = true);
 	} catch (_e) {
 		void _e;
-		return false;
+		return (_cachedSupportsTransferableStreams = false);
 	}
 }
 

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -55,7 +55,7 @@ export function consumeAPI<APIType>(
 	 * when `import.meta.url` started with `file://`. But this assumption breaks
 	 * with webpack which emits file URLs for `import.meta.url`.
 	 * https://webpack.js.org/api/module-variables/#importmetaurl
-	 * 
+	 *
 	 * We replaced this with a more explicit check for `process.versions.node`.
 	 * See https://github.com/WordPress/wordpress-playground/pull/3248
 	 */
@@ -360,7 +360,7 @@ function setupTransferHandlers() {
  * directly through postMessage (aka "transferable streams"). When false,
  * we must fall back to port-bridged streaming.
  */
-function supportsTransferableStreams(): boolean {
+export function supportsTransferableStreams(): boolean {
 	try {
 		if (typeof ReadableStream === 'undefined') return false;
 		const { port1 } = new MessageChannel();
@@ -389,7 +389,7 @@ function supportsTransferableStreams(): boolean {
  *   { t: 'close' }                 – end of stream
  *   { t: 'error', m: string }      – terminal error
  */
-function streamToPort(stream: ReadableStream<Uint8Array>): MessagePort {
+export function streamToPort(stream: ReadableStream<Uint8Array>): MessagePort {
 	const { port1, port2 } = new MessageChannel();
 	(async () => {
 		const reader = stream.getReader();
@@ -450,7 +450,7 @@ function streamToPort(stream: ReadableStream<Uint8Array>): MessagePort {
  * Reconstructs a ReadableStream from a MessagePort using the inverse of the
  * streamToPort protocol. Each message enqueues data, closes, or errors.
  */
-function portToStream(port: MessagePort): ReadableStream<Uint8Array> {
+export function portToStream(port: MessagePort): ReadableStream<Uint8Array> {
 	return new ReadableStream<Uint8Array>({
 		start(controller) {
 			const onMessage = (ev: MessageEvent) => {

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -363,29 +363,26 @@ function setupTransferHandlers() {
  */
 let _cachedSupportsTransferableStreams: boolean | undefined;
 function supportsTransferableStreams(): boolean {
-	if (_cachedSupportsTransferableStreams !== undefined) {
-		return _cachedSupportsTransferableStreams;
+	if (typeof ReadableStream === 'undefined') {
+		_cachedSupportsTransferableStreams = false;
 	}
-	try {
-		if (typeof ReadableStream === 'undefined') {
-			return (_cachedSupportsTransferableStreams = false);
-		}
-		const { port1 } = new MessageChannel();
-		const rs = new ReadableStream();
-		// The stream must be in the transfer list — without it,
-		// postMessage tries to clone (which always fails for
-		// ReadableStream) instead of transferring.
-		port1.postMessage(rs, [rs as unknown as Transferable]);
+	if (_cachedSupportsTransferableStreams === undefined) {
 		try {
-			port1.close();
+			const { port1 } = new MessageChannel();
+			const rs = new ReadableStream();
+			port1.postMessage(rs, [rs as unknown as Transferable]);
+			try {
+				port1.close();
+			} catch (_e) {
+				void _e;
+			}
+			_cachedSupportsTransferableStreams = true;
 		} catch (_e) {
 			void _e;
+			_cachedSupportsTransferableStreams = false;
 		}
-		return (_cachedSupportsTransferableStreams = true);
-	} catch (_e) {
-		void _e;
-		return (_cachedSupportsTransferableStreams = false);
 	}
+	return _cachedSupportsTransferableStreams;
 }
 
 /**

--- a/packages/php-wasm/universal/src/lib/api.ts
+++ b/packages/php-wasm/universal/src/lib/api.ts
@@ -294,13 +294,7 @@ function setupTransferHandlers() {
 		serialize(obj: StreamedPHPResponse): [any, Transferable[]] {
 			const supportsStreams = supportsTransferableStreams();
 			const exitCodePort = promiseToPort(obj.exitCode);
-
-			// The headers stream may already be consumed (e.g. by the
-			// cookie handler in PHPRequestHandler). If so, synthesize
-			// a fresh stream from the already-parsed header data.
-			const headersStream = obj.headersStreamConsumed
-				? headersToStream(obj.headers, obj.httpStatusCode)
-				: obj.getHeadersStream();
+			const headersStream = obj.getHeadersStream();
 
 			if (supportsStreams) {
 				const payload = {
@@ -392,37 +386,6 @@ function supportsTransferableStreams(): boolean {
 		void _e;
 		return (_cachedSupportsTransferableStreams = false);
 	}
-}
-
-/**
- * Synthesizes a headers ReadableStream from already-parsed header data.
- * Used by the Comlink transfer handler when the original headers stream
- * has already been consumed on the worker side.
- */
-function headersToStream(
-	headersPromise: Promise<Record<string, string[]>>,
-	httpStatusCodePromise: Promise<number>
-): ReadableStream<Uint8Array> {
-	return new ReadableStream<Uint8Array>({
-		async start(controller) {
-			const [headers, httpStatusCode] = await Promise.all([
-				headersPromise,
-				httpStatusCodePromise,
-			]);
-			const headerLines: string[] = [];
-			for (const [name, values] of Object.entries(headers)) {
-				for (const value of values) {
-					headerLines.push(`${name}: ${value}`);
-				}
-			}
-			const json = JSON.stringify({
-				status: httpStatusCode,
-				headers: headerLines,
-			});
-			controller.enqueue(new TextEncoder().encode(json));
-			controller.close();
-		},
-	});
 }
 
 /**

--- a/packages/php-wasm/universal/src/lib/php-request-handler.spec.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.spec.ts
@@ -137,7 +137,7 @@ describe('PHPRequestHandler', () => {
 
 			// Should redirect to add trailing slash
 			expect(response.httpStatusCode).toBe(301);
-			expect(response.headers['Location']).toEqual(['/phpmyadmin/']);
+			expect(response.headers['location']).toEqual(['/phpmyadmin/']);
 		});
 
 		it('should handle nested paths within an alias', async () => {

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -496,7 +496,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 				return StreamedPHPResponse.fromPHPResponse(
 					new PHPResponse(
 						301,
-						{ Location: [`${rewrittenRequestUrl.pathname}/`] },
+						{ location: [`${rewrittenRequestUrl.pathname}/`] },
 						new Uint8Array(0)
 					)
 				);

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -166,36 +166,20 @@ export class StreamedPHPResponse {
 	/**
 	 * Returns the raw headers stream for serialization purposes.
 	 * For parsed headers, use the `headers` property instead.
-	 *
-	 * If the original headers stream has already been consumed
-	 * (e.g. by the cookie handler in PHPRequestHandler), a fresh
-	 * stream is synthesized from the already-parsed header data.
-	 * This ensures the response can still be serialized via Comlink
-	 * even after the headers have been read on the worker side.
 	 */
 	getHeadersStream(): ReadableStream<Uint8Array> {
-		if (this.parsedHeaders) {
-			const parsedHeadersPromise = this.parsedHeaders;
-			return new ReadableStream<Uint8Array>({
-				async start(controller) {
-					const { headers, httpStatusCode } =
-						await parsedHeadersPromise;
-					const headerLines: string[] = [];
-					for (const [name, values] of Object.entries(headers)) {
-						for (const value of values) {
-							headerLines.push(`${name}: ${value}`);
-						}
-					}
-					const json = JSON.stringify({
-						status: httpStatusCode,
-						headers: headerLines,
-					});
-					controller.enqueue(new TextEncoder().encode(json));
-					controller.close();
-				},
-			});
-		}
 		return this.#headersStream;
+	}
+
+	/**
+	 * Whether the headers stream has already been consumed
+	 * (e.g. by the cookie handler in PHPRequestHandler).
+	 * When true, the serialization layer should use `headers`
+	 * and `httpStatusCode` to build a fresh stream instead of
+	 * transferring the original one.
+	 */
+	get headersStreamConsumed(): boolean {
+		return this.parsedHeaders !== null;
 	}
 
 	/**

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -49,17 +49,18 @@ const responseTexts: Record<number, string> = {
 
 export class StreamedPHPResponse {
 	/**
-	 * Headers stream reserved for serialization (Comlink transfer).
-	 * The constructor tees the incoming headers stream so that
-	 * getParsedHeaders() can consume one branch without locking
-	 * the stream that getHeadersStream() hands to the transport.
+	 * Headers stream that doesn't get locked when the consumer
+	 * reads the parsed headers. api.ts transfers the obj.getHeadersStream(),
+	 * and boot-playground-remote.ts copies the streamedResponse.headers.
+	 * Both streams must be readable when the StreamedPHPResponse is transferred
+	 * from the worker thread into the service worker.
 	 */
-	readonly #headersStream: ReadableStream<Uint8Array>;
+	readonly #rawHeadersStream: ReadableStream<Uint8Array>;
 
 	/**
 	 * Headers stream reserved for internal parsing.
 	 */
-	readonly #headersStreamForParsing: ReadableStream<Uint8Array>;
+	readonly #copiedHeadersStreamForParsing: ReadableStream<Uint8Array>;
 
 	/**
 	 * Response body. Contains the output from `echo`,
@@ -93,8 +94,8 @@ export class StreamedPHPResponse {
 		exitCode: Promise<number>
 	) {
 		const [forTransport, forParsing] = headers.tee();
-		this.#headersStream = forTransport;
-		this.#headersStreamForParsing = forParsing;
+		this.#rawHeadersStream = forTransport;
+		this.#copiedHeadersStreamForParsing = forParsing;
 		this.stdout = stdout;
 		this.stderr = stderr;
 		this.exitCode = exitCode;
@@ -169,7 +170,7 @@ export class StreamedPHPResponse {
 	 * For parsed headers, use the `headers` property instead.
 	 */
 	getHeadersStream(): ReadableStream<Uint8Array> {
-		return this.#headersStream;
+		return this.#rawHeadersStream;
 	}
 
 	/**
@@ -252,7 +253,7 @@ export class StreamedPHPResponse {
 	private async getParsedHeaders() {
 		if (!this.cachedParsedHeaders) {
 			this.cachedParsedHeaders = parseHeadersStream(
-				this.#headersStreamForParsing
+				this.#copiedHeadersStreamForParsing
 			);
 		}
 		return await this.cachedParsedHeaders;

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -49,9 +49,17 @@ const responseTexts: Record<number, string> = {
 
 export class StreamedPHPResponse {
 	/**
-	 * Response headers stream (internal).
+	 * Headers stream reserved for serialization (Comlink transfer).
+	 * The constructor tees the incoming headers stream so that
+	 * getParsedHeaders() can consume one branch without locking
+	 * the stream that getHeadersStream() hands to the transport.
 	 */
 	readonly #headersStream: ReadableStream<Uint8Array>;
+
+	/**
+	 * Headers stream reserved for internal parsing.
+	 */
+	readonly #headersStreamForParsing: ReadableStream<Uint8Array>;
 
 	/**
 	 * Response body. Contains the output from `echo`,
@@ -70,7 +78,7 @@ export class StreamedPHPResponse {
 	 */
 	readonly exitCode: Promise<number>;
 
-	private parsedHeaders: Promise<{
+	private cachedParsedHeaders: Promise<{
 		headers: Record<string, string[]>;
 		httpStatusCode: number;
 	}> | null = null;
@@ -84,7 +92,9 @@ export class StreamedPHPResponse {
 		stderr: ReadableStream<Uint8Array>,
 		exitCode: Promise<number>
 	) {
-		this.#headersStream = headers;
+		const [forTransport, forParsing] = headers.tee();
+		this.#headersStream = forTransport;
+		this.#headersStreamForParsing = forParsing;
 		this.stdout = stdout;
 		this.stderr = stderr;
 		this.exitCode = exitCode;
@@ -136,21 +146,12 @@ export class StreamedPHPResponse {
 			},
 		});
 
-		const streamed = new StreamedPHPResponse(
+		return new StreamedPHPResponse(
 			headersStream,
 			stdout,
 			stderr,
 			Promise.resolve(response.exitCode)
 		);
-
-		// Set pre-parsed headers as a fast-path for same-thread
-		// access (avoids re-parsing the stream we just created)
-		streamed.parsedHeaders = Promise.resolve({
-			headers: response.headers,
-			httpStatusCode: response.httpStatusCode,
-		});
-
-		return streamed;
 	}
 
 	/**
@@ -169,17 +170,6 @@ export class StreamedPHPResponse {
 	 */
 	getHeadersStream(): ReadableStream<Uint8Array> {
 		return this.#headersStream;
-	}
-
-	/**
-	 * Whether the headers stream has already been consumed
-	 * (e.g. by the cookie handler in PHPRequestHandler).
-	 * When true, the serialization layer should use `headers`
-	 * and `httpStatusCode` to build a fresh stream instead of
-	 * transferring the original one.
-	 */
-	get headersStreamConsumed(): boolean {
-		return this.parsedHeaders !== null;
 	}
 
 	/**
@@ -260,10 +250,12 @@ export class StreamedPHPResponse {
 	}
 
 	private async getParsedHeaders() {
-		if (!this.parsedHeaders) {
-			this.parsedHeaders = parseHeadersStream(this.#headersStream);
+		if (!this.cachedParsedHeaders) {
+			this.cachedParsedHeaders = parseHeadersStream(
+				this.#headersStreamForParsing
+			);
 		}
-		return await this.parsedHeaders;
+		return await this.cachedParsedHeaders;
 	}
 }
 

--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -166,8 +166,35 @@ export class StreamedPHPResponse {
 	/**
 	 * Returns the raw headers stream for serialization purposes.
 	 * For parsed headers, use the `headers` property instead.
+	 *
+	 * If the original headers stream has already been consumed
+	 * (e.g. by the cookie handler in PHPRequestHandler), a fresh
+	 * stream is synthesized from the already-parsed header data.
+	 * This ensures the response can still be serialized via Comlink
+	 * even after the headers have been read on the worker side.
 	 */
 	getHeadersStream(): ReadableStream<Uint8Array> {
+		if (this.parsedHeaders) {
+			const parsedHeadersPromise = this.parsedHeaders;
+			return new ReadableStream<Uint8Array>({
+				async start(controller) {
+					const { headers, httpStatusCode } =
+						await parsedHeadersPromise;
+					const headerLines: string[] = [];
+					for (const [name, values] of Object.entries(headers)) {
+						for (const value of values) {
+							headerLines.push(`${name}: ${value}`);
+						}
+					}
+					const json = JSON.stringify({
+						status: httpStatusCode,
+						headers: headerLines,
+					});
+					controller.enqueue(new TextEncoder().encode(json));
+					controller.close();
+				},
+			});
+		}
 		return this.#headersStream;
 	}
 

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -134,10 +134,12 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 		phpResponse.httpStatusCode
 	);
 
-	// Determine response body: prefer a streamed body (bridged via
-	// MessagePort) when available, fall back to the legacy buffered
-	// `bytes` payload for backwards compatibility with older
-	// main-thread code.
+	// The main thread streams the response body via a MessagePort bridge
+	// (using streamToPort/portToStream). We can't transfer ReadableStreams
+	// directly because ServiceWorker.postMessage() doesn't support
+	// transferable streams — only MessagePort transfers work on that channel.
+	// Falls back to the legacy buffered `bytes` payload for backwards
+	// compatibility with older main-thread code.
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
 		if (phpResponse.bodyPort) {

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -3,6 +3,7 @@ declare const self: ServiceWorkerGlobalScope;
 
 import { awaitReply, getNextRequestId } from './messaging';
 import { getURLScope, isURLScoped, setURLScope } from '@php-wasm/scopes';
+import { portToStream } from '@php-wasm/universal';
 
 export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 	let url = new URL(event.request.url);
@@ -132,7 +133,21 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 	const isNullBodyCode = [101, 103, 204, 205, 304].includes(
 		phpResponse.httpStatusCode
 	);
-	const responseBody = isNullBodyCode ? null : phpResponse.bytes;
+
+	// Determine response body: prefer a streamed body (bridged via
+	// MessagePort) when available, fall back to the legacy buffered
+	// `bytes` payload for backwards compatibility with older
+	// main-thread code.
+	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
+	if (!isNullBodyCode) {
+		if (phpResponse.bodyPort) {
+			responseBody = portToStream(phpResponse.bodyPort);
+		} else {
+			// Backwards compat: buffered response
+			responseBody = phpResponse.bytes;
+		}
+	}
+
 	return new Response(responseBody, {
 		headers: phpResponse.headers,
 		status: phpResponse.httpStatusCode,

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -134,24 +134,15 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 		phpResponse.httpStatusCode
 	);
 
-	// The main thread streams the response body via a MessagePort bridge
-	// (using streamToPort/portToStream). We can't transfer ReadableStreams
-	// directly because ServiceWorker.postMessage() doesn't support
-	// transferable streams — only MessagePort transfers work on that channel.
-	// Falls back to the legacy buffered `bytes` payload for backwards
-	// compatibility with older main-thread code.
-	// The main thread streams the response body via a MessagePort bridge
-	// (using streamToPort/portToStream). We can't transfer ReadableStreams
-	// directly because ServiceWorker.postMessage() silently drops the
-	// entire message when the transfer list contains a ReadableStream.
-	// Falls back to the legacy buffered `bytes` payload for backwards
-	// compatibility with older main-thread code.
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
 		if (phpResponse.bodyPort) {
+			// Reconstruct the body ReadableStream from the MessagePort.
+			// We couldn't just transfer it directly as this kind of transfer
+			// doesn't seem to be supported between the document and the service worker.
 			responseBody = portToStream(phpResponse.bodyPort);
 		} else {
-			// Backwards compat: buffered response
+			// Fallback: buffered response bytes
 			responseBody = phpResponse.bytes;
 		}
 	}

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -140,6 +140,12 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 	// transferable streams — only MessagePort transfers work on that channel.
 	// Falls back to the legacy buffered `bytes` payload for backwards
 	// compatibility with older main-thread code.
+	// The main thread streams the response body via a MessagePort bridge
+	// (using streamToPort/portToStream). We can't transfer ReadableStreams
+	// directly because ServiceWorker.postMessage() silently drops the
+	// entire message when the transfer list contains a ReadableStream.
+	// Falls back to the legacy buffered `bytes` payload for backwards
+	// compatibility with older main-thread code.
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
 		if (phpResponse.bodyPort) {

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -437,18 +437,25 @@ export async function bootPlaygroundRemote() {
 						// only covers the time until PHP outputs response
 						// headers. Body streaming happens after, with no
 						// timeout.
-						// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-						const streamedResponse = await (
-							phpWorkerApi.requestStreamed as Function
-						)(...args);
+						const streamedResponse =
+							await // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+							(phpWorkerApi.requestStreamed as Function)(...args);
 						const httpStatusCode =
 							await streamedResponse.httpStatusCode;
 						const headers = await streamedResponse.headers;
 
-						// Bridge the body stream via a MessagePort.
-						// We can't transfer a ReadableStream directly
-						// to a ServiceWorker — only MessagePort
-						// transfers are supported on that channel.
+						// We must bridge the body stream via a MessagePort.
+						// ServiceWorker.postMessage() silently drops the
+						// entire message when the transfer list contains a
+						// ReadableStream — the call succeeds and the stream
+						// detaches from the sender, but the message never
+						// arrives at the service worker. This affects all
+						// browsers. Service workers live in a different
+						// agent cluster than their clients, which limits
+						// what can be transferred on this channel.
+						// See https://github.com/whatwg/streams/issues/1063
+						// and the discussion in
+						// https://github.com/whatwg/streams/issues/276
 						const bodyPort = streamToPort(streamedResponse.stdout);
 						(event.source! as ServiceWorker).postMessage(
 							responseTo(event.data.requestId, {

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -431,31 +431,29 @@ export async function bootPlaygroundRemote() {
 						.method as keyof PlaygroundWorkerEndpoint;
 
 					if (method === 'request') {
-						// Stream the PHP response body through the
-						// service worker instead of buffering the entire
-						// response in memory. The 25s awaitReply timeout
-						// only covers the time until PHP outputs response
-						// headers. Body streaming happens after, with no
-						// timeout.
-						const streamedResponse =
-							await // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-							(phpWorkerApi.requestStreamed as Function)(...args);
+						const streamedResponse = await (
+							phpWorkerApi.requestStreamed as any
+						)(...args);
 						const httpStatusCode =
 							await streamedResponse.httpStatusCode;
 						const headers = await streamedResponse.headers;
 
-						// We must bridge the body stream via a MessagePort.
-						// ServiceWorker.postMessage() silently drops the
-						// entire message when the transfer list contains a
-						// ReadableStream — the call succeeds and the stream
-						// detaches from the sender, but the message never
-						// arrives at the service worker. This affects all
-						// browsers. Service workers live in a different
-						// agent cluster than their clients, which limits
-						// what can be transferred on this channel.
-						// See https://github.com/whatwg/streams/issues/1063
-						// and the discussion in
-						// https://github.com/whatwg/streams/issues/276
+						/**
+						 * ReadableStreams are transferable, but cannot be
+						 * transferred to the service worker.
+						 *
+						 * In Chrome, ServiceWorker.postMessage() silently drops the entire
+						 * message when the transfer list contains a ReadableStream.
+						 * The call succeeds and the stream detaches from the sender,
+						 * but the message never arrives at the service worker.
+						 *
+						 * To work around this, we bridge the body stream via a MessagePort.
+						 *
+						 * See:
+						 * * https://github.com/whatwg/streams/issues/1063
+						 * * https://github.com/whatwg/streams/issues/276
+						 * * https://groups.google.com/a/chromium.org/g/chromium-discuss/c/90Esr_dE6U4
+						 */
 						const bodyPort = streamToPort(streamedResponse.stdout);
 						(event.source! as ServiceWorker).postMessage(
 							responseTo(event.data.requestId, {

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -1,4 +1,5 @@
 import type { MessageListener } from '@php-wasm/universal';
+import { streamToPort } from '@php-wasm/universal';
 import type { SyncProgressCallback } from '@php-wasm/web';
 import {
 	spawnPHPWorkerThread,
@@ -311,7 +312,9 @@ export async function bootPlaygroundRemote() {
 			 *      the detailed context.
 			 */
 			const navigationComplete = new Promise<void>((resolve) => {
-				wpFrame.addEventListener('load', () => resolve(), { once: true });
+				wpFrame.addEventListener('load', () => resolve(), {
+					once: true,
+				});
 			});
 
 			// If the URL is the same, we need to force a reload
@@ -423,17 +426,42 @@ export async function bootPlaygroundRemote() {
 						return;
 					}
 
-					// Wait for the PHP API client to be set by bootPlaygroundRemote
 					const args = event.data.args || [];
 					const method = event.data
 						.method as keyof PlaygroundWorkerEndpoint;
-					// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-					const result = await (phpWorkerApi[method] as Function)(
-						...args
-					);
-					event.source!.postMessage(
-						responseTo(event.data.requestId, result)
-					);
+
+					if (method === 'request') {
+						// Stream the PHP response body through the
+						// service worker instead of buffering the entire
+						// response in memory. The 25s awaitReply timeout
+						// only covers the time until PHP outputs response
+						// headers. Body streaming happens after, with no
+						// timeout.
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+						const streamedResponse = await (
+							phpWorkerApi.requestStreamed as Function
+						)(...args);
+						const httpStatusCode =
+							await streamedResponse.httpStatusCode;
+						const headers = await streamedResponse.headers;
+						const bodyPort = streamToPort(streamedResponse.stdout);
+						(event.source! as ServiceWorker).postMessage(
+							responseTo(event.data.requestId, {
+								httpStatusCode,
+								headers,
+								bodyPort,
+							}),
+							[bodyPort]
+						);
+					} else {
+						// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+						const result = await (phpWorkerApi[method] as Function)(
+							...args
+						);
+						event.source!.postMessage(
+							responseTo(event.data.requestId, result)
+						);
+					}
 				}
 			);
 			sw.startMessages();

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -444,6 +444,11 @@ export async function bootPlaygroundRemote() {
 						const httpStatusCode =
 							await streamedResponse.httpStatusCode;
 						const headers = await streamedResponse.headers;
+
+						// Bridge the body stream via a MessagePort.
+						// We can't transfer a ReadableStream directly
+						// to a ServiceWorker — only MessagePort
+						// transfers are supported on that channel.
 						const bodyPort = streamToPort(streamedResponse.stdout);
 						(event.source! as ServiceWorker).postMessage(
 							responseTo(event.data.requestId, {


### PR DESCRIPTION
## Summary

The service worker used to buffer the entire PHP response in memory before sending it to the browser. When a long-running PHP task (such as a site import) exceeded the hard 25-second timeout on waiting for `postMessage()` response, the service worker assumed the response is not coming and communicated a network error. 

This PR streams the response body instead of buffering it. The main thread calls `requestStreamed()`, awaits just the response headers (fast, well within the 25s timeout), then bridges the body stream to the service worker via a MessagePort. The service worker constructs a streaming `Response` and returns it immediately — the body flows through as PHP produces it, with no timeout on the body.

The change also fixes a latent bug in `StreamedPHPResponse.getHeadersStream()`: the cookie handler in `PHPRequestHandler` consumes the headers stream before Comlink gets to serialize it, causing a "ReadableStream is locked" error. The fix synthesizes a fresh stream from already-parsed header data when the original has been consumed.

A backwards-compatible fallback checks for the legacy buffered `bytes` property, so older main-thread code continues to work.

## Test plan

- [ ] `npx nx build php-wasm-web-service-worker` and `npx nx build playground-remote` pass
- [ ] `npx nx test php-wasm-web-service-worker` and `npx nx test php-wasm-universal` pass
- [ ] `npm run dev` → open http://127.0.0.1:5400/website-server/ → WordPress front page loads
- [ ] Navigate to wp-admin → Dashboard loads with no console errors
- [ ] Load the streaming site importer blueprint → import should no longer fail after 25 seconds