### PR TITLE
Remove pre-parsed headers shortcut from StreamedPHPResponse

### DIFF
--- a/packages/php-wasm/universal/src/lib/php-response.ts
+++ b/packages/php-wasm/universal/src/lib/php-response.ts
@@ -70,7 +70,7 @@ export class StreamedPHPResponse {
 	 */
 	readonly exitCode: Promise<number>;
 
-	private parsedHeaders: Promise<{
+	private cachedParsedHeaders: Promise<{
 		headers: Record<string, string[]>;
 		httpStatusCode: number;
 	}> | null = null;
@@ -136,21 +136,12 @@ export class StreamedPHPResponse {
 			},
 		});
 
-		const streamed = new StreamedPHPResponse(
+		return new StreamedPHPResponse(
 			headersStream,
 			stdout,
 			stderr,
 			Promise.resolve(response.exitCode)
 		);
-
-		// Set pre-parsed headers as a fast-path for same-thread
-		// access (avoids re-parsing the stream we just created)
-		streamed.parsedHeaders = Promise.resolve({
-			headers: response.headers,
-			httpStatusCode: response.httpStatusCode,
-		});
-
-		return streamed;
 	}
 
 	/**
@@ -249,10 +240,10 @@ export class StreamedPHPResponse {
 	}
 
 	private async getParsedHeaders() {
-		if (!this.parsedHeaders) {
-			this.parsedHeaders = parseHeadersStream(this.#headersStream);
+		if (!this.cachedParsedHeaders) {
+			this.cachedParsedHeaders = parseHeadersStream(this.#headersStream);
 		}
-		return await this.parsedHeaders;
+		return await this.cachedParsedHeaders;
 	}
 }
 


### PR DESCRIPTION
## Summary

`StreamedPHPResponse.fromPHPResponse()` was pre-populating the internal `parsedHeaders` cache as a shortcut to avoid re-parsing headers it already had in hand. This created unnecessary coupling between the factory method and the class's internal caching mechanism, making the class harder to reason about and modify (it was a source of bugs in #3361).

Now `fromPHPResponse()` simply encodes headers into the stream and returns. `getParsedHeaders()` lazily parses on first access, the same code path used everywhere else.

## Test plan

- Existing unit tests pass (`npx nx test php-wasm-universal` — one pre-existing failure unrelated to this change)
- No functional change: headers are still parsed correctly, just through the stream round-trip instead of a shortcut