### PR TITLE
Correct error message formatting in resources.ts

### DIFF
--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -566,7 +566,7 @@ export abstract class FetchResource extends Resource<File> {
 		} catch (e) {
 			throw new ResourceDownloadError(
 				`Could not download "${url}".\n\n` +
-					`Confirm that the URL is correct, the server is reachable, and the file is` +
+					`Confirm that the URL is correct, the server is reachable, and the file is ` +
 					`actually served at that URL. Original error: \n ${e}`,
 				url,
 				{ cause: e }


### PR DESCRIPTION
Fix formatting of error message in resource download. See screenshot below:

![Screenshot 2026-03-10 at 10 57 02](https://github.com/user-attachments/assets/d6ab3766-449f-410c-82d4-d7257ac50b48)
