### PR TITLE
[Website] Use `content-type: application/octet-stream` for CORS proxy requests

### DIFF
--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
@@ -245,6 +245,46 @@ describe('fetchWithCorsProxy', () => {
 		expect(await response.text()).toBe('proxied');
 	});
 
+	it('wraps multipart/form-data Content-Type when retrying via CORS proxy', async () => {
+		const corsProxyHeaders = new Headers();
+		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
+
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockRejectedValueOnce(new Error('CORS'))
+			.mockResolvedValueOnce(
+				new Response('proxied', { headers: corsProxyHeaders })
+			);
+
+		const boundary = '----WebKitFormBoundary7MA4YWxk';
+		const body = `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="data.json"\r\nContent-Type: application/json\r\n\r\n["/path/to/file"]\r\n--${boundary}--\r\n`;
+		const request = new Request('https://example.com/api', {
+			method: 'POST',
+			headers: {
+				'Content-Type': `multipart/form-data; boundary=${boundary}`,
+			},
+			body,
+		});
+
+		await fetchWithCorsProxy(
+			request,
+			undefined,
+			'https://proxy.test/?url='
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const proxyRequest = fetchMock.mock.calls[1][0] as Request;
+		// Content-Type should be wrapped to prevent PHP auto-parsing
+		expect(proxyRequest.headers.get('content-type')).toBe(
+			'application/octet-stream'
+		);
+		expect(proxyRequest.headers.get('x-cors-proxy-content-type')).toBe(
+			`multipart/form-data; boundary=${boundary}`
+		);
+		// The body should survive intact
+		expect(await new Response(proxyRequest.body).text()).toBe(body);
+	});
+
 	it('forwards init to duplexSafeFetch in the CORS proxy retry path', async () => {
 		const corsProxyHeaders = new Headers();
 		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
@@ -172,7 +172,7 @@ describe('fetchWithCorsProxy', () => {
 		);
 	});
 
-	it('does not buffer the request body for https:// URLs', async () => {
+	it('buffers the request body for https:// URLs too', async () => {
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
@@ -195,11 +195,13 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const sentRequest = fetchMock.mock.calls[0][0] as Request;
-		// The exact same Request object should reach fetch() –
-		// no cloning, no buffering, just a pass-through.
-		expect(sentRequest).toBe(request);
-		// Body was NOT consumed — no buffering happened.
-		expect(request.bodyUsed).toBe(false);
+		// The body was consumed to buffer it into an ArrayBuffer.
+		expect(request.bodyUsed).toBe(true);
+		// A new Request was built from the buffered body.
+		expect(sentRequest).not.toBe(request);
+		expect(await new Response(sentRequest.body).text()).toBe(
+			'streamed data'
+		);
 	});
 
 	it('buffers the request body when retrying via an http:// CORS proxy', async () => {

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
@@ -140,7 +140,7 @@ describe('fetchWithCorsProxy', () => {
 		expect(request.url).toBe('http://localhost:1234/v1/chat/completions');
 	});
 
-	it('buffers a streaming request body for http:// URLs', async () => {
+	it('passes request through to fetch for localhost http:// URLs', async () => {
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
@@ -162,17 +162,12 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const sentRequest = fetchMock.mock.calls[0][0] as Request;
-		// The original request's body was consumed to buffer it into
-		// an ArrayBuffer, so bodyUsed must be true.
-		expect(request.bodyUsed).toBe(true);
-		// A new Request was built from the buffered body.
-		expect(sentRequest).not.toBe(request);
-		expect(await new Response(sentRequest.body).text()).toBe(
-			'streamed data'
-		);
+		// Direct fetch — no buffering, same Request passed through.
+		expect(sentRequest).toBe(request);
+		expect(request.bodyUsed).toBe(false);
 	});
 
-	it('buffers the request body for https:// URLs too', async () => {
+	it('passes request through to fetch for https:// URLs without proxy', async () => {
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')
 			.mockResolvedValue(new Response('ok'));
@@ -195,13 +190,9 @@ describe('fetchWithCorsProxy', () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const sentRequest = fetchMock.mock.calls[0][0] as Request;
-		// The body was consumed to buffer it into an ArrayBuffer.
-		expect(request.bodyUsed).toBe(true);
-		// A new Request was built from the buffered body.
-		expect(sentRequest).not.toBe(request);
-		expect(await new Response(sentRequest.body).text()).toBe(
-			'streamed data'
-		);
+		// Direct fetch — no buffering, same Request passed through.
+		expect(sentRequest).toBe(request);
+		expect(request.bodyUsed).toBe(false);
 	});
 
 	it('buffers the request body when retrying via an http:// CORS proxy', async () => {

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -56,15 +56,15 @@ export async function fetchWithCorsProxy(
 
 	// Tee the request to avoid consuming the request body stream on the initial
 	// fetch() so that we can retry through the cors proxy.
-	const [request1, request2] = await teeRequest(requestObject);
+	const [directRequest, corsProxyRequest] = await teeRequest(requestObject);
 
 	try {
-		return await duplexSafeFetch(request1);
+		return await duplexSafeFetch(directRequest);
 	} catch {
 		// If the developer has explicitly allowed the request to pass the
 		// credentials headers with the X-Cors-Proxy-Allowed-Request-Headers header,
 		// then let's include those credentials in the fetch() request.
-		const headers = new Headers(request2.headers);
+		const headers = new Headers(corsProxyRequest.headers);
 		const corsProxyAllowedHeaders =
 			headers.get('x-cors-proxy-allowed-request-headers')?.split(',') ||
 			[];
@@ -86,16 +86,13 @@ export async function fetchWithCorsProxy(
 			headers.set('content-type', 'application/octet-stream');
 		}
 
-		const newRequest = await cloneRequest(request2, {
+		const newRequest = await cloneRequest(corsProxyRequest, {
 			url: `${corsProxyUrl}${requestObject.url}`,
 			headers,
 			...(requestIntendsToPassCredentials && { credentials: 'include' }),
 		});
 
-		// Don't pass `init` here – it was already folded into
-		// `requestObject` at the top of this function. Passing it again
-		// would let it override the proxy URL, wrapped headers, and
-		// buffered body we just prepared.
+		// Skip the `init`, it's already folded into `requestObject`.
 		const response = await duplexSafeFetch(newRequest);
 
 		// Check for firewall interference: if we got a response but it's

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -72,12 +72,41 @@ export async function fetchWithCorsProxy(
 			corsProxyAllowedHeaders.includes('authorization') ||
 			corsProxyAllowedHeaders.includes('cookie');
 
+		// Wrap multipart/form-data Content-Type to prevent the CORS
+		// proxy's PHP from auto-parsing the body. PHP consumes
+		// multipart/form-data bodies into $_POST/$_FILES, emptying
+		// php://input and making it impossible for the proxy to
+		// forward the raw body to the target server.
+		const contentType = headers.get('content-type');
+		if (
+			contentType &&
+			contentType.toLowerCase().includes('multipart/form-data')
+		) {
+			headers.set('x-cors-proxy-content-type', contentType);
+			headers.set('content-type', 'application/octet-stream');
+		}
+
+		// Buffer the request body before sending through the CORS proxy.
+		// The body arrives as a ReadableStream with duplex: 'half' from
+		// the TLS decryption layer. Production CORS proxies (behind CDNs,
+		// load balancers, or PHP's multipart parsing) may not correctly
+		// forward a half-duplex streaming body. Buffering it as an
+		// ArrayBuffer ensures the full body is sent as a single chunk.
+		// This is safe because the CORS proxy already caps requests at
+		// 1MB (MAX_REQUEST_SIZE).
+		let bufferedBody: ArrayBuffer | undefined;
+		if (request2.body) {
+			bufferedBody = await new Response(request2.body).arrayBuffer();
+		}
+
 		const newRequest = await cloneRequest(request2, {
 			url: `${corsProxyUrl}${requestObject.url}`,
+			body: bufferedBody,
+			headers,
 			...(requestIntendsToPassCredentials && { credentials: 'include' }),
 		});
 
-		const response = await duplexSafeFetch(newRequest, init);
+		const response = await duplexSafeFetch(newRequest);
 
 		// Check for firewall interference: if we got a response but it's
 		// missing the CORS proxy identification header, the response likely

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -87,36 +87,35 @@ export async function fetchWithCorsProxy(
 		}
 
 		/**
-		 * Buffer the cors proxy request body into an ArrayBuffer before calling fetch().
+		 * Buffer the cors proxy request body into an ArrayBuffer if talking to a `http://` URL.
 		 *
-		 * This is necessary, because Chrome only supports using a ReadableStream request body
-		 * when fetch() is called with the `duplex: 'half'` option. However, duplex connections
-		 * are problematic:
+		 * Streaming request bodies don't work with the local dev server, which uses http://
+		 * as a protocol. However, with a streamed request body, Chrome silently upgrades a
+		 * HTTP/1.1 request to HTTP/2. However, our HTTP/1.1-only local dev server still replies
+		 * with a HTTP/1.1 response. Chrome then treats the request as failed with an
+		 * ERR_ALPN_NEGOTIATION_FAILED error.
 		 *
-		 * 1. They don't work with the local dev server, which runs at a http:// URL.
-		 *    When the duplex option is set, Chrome silently upgrades a HTTP/1.1 request
-		 *    to HTTP/2. However, our HTTP/1.1-only local dev server still replies
-		 *    with a HTTP/1.1 response. Chrome then treats the request as failed with an
-		 *    ERR_ALPN_NEGOTIATION_FAILED error.
+		 * Inferring the HTTP version from the URL protocol is unreliable and will fail
+		 * if the CORS proxy is hosted on a `https://` URL that speaks HTTP < 2. This is
+		 * a recognized limitation of the CORS proxy feature. If you host it on an `https://` URL,
+		 * make sure to use HTTP/2.
 		 *
-		 * 2. They don't work with the official Playground CORS proxy at https://wordpress-playground-cors-proxy.net/.
-		 *    The server infrastructure just can't handle duplex POST requests. Something between
-		 *    the browser and the cors-proxy.php runtime buffers the entire body anyway. When
-		 *    it can't, it treats the request body as empty and fails with a 400 Bad Request error
-		 *    as 0 bytes were sent instead of the expected Content-Length. This can be true
-		 *    for any PHP-hosted script out there. An edge proxy, a load balancer, a reverse proxy
-		 *    may not support duplex POST requests either.
-		 *
-		 * We're already in the final `} catch {` block. We've already failed to send a direct
-		 * fetch with a streamed body. Maybe it was due to the duplex problem, maybe not, but
-		 * this is our last chance so let's maximize the probability of success. The entire request
-		 * body must have been produced by now anyway, since the prior fetch() had to send it,
-		 * so it's likely buffered somewhere in the browser's memory. We're just changing the
-		 * data type from ReadableStream to ArrayBuffer to make that explicit.
+		 * See: https://developer.chrome.com/docs/capabilities/web-apis/fetch-streaming-requests
 		 */
-		const body = corsProxyRequest.body
-			? await new Response(corsProxyRequest.body).arrayBuffer()
-			: undefined;
+
+		// In development, corsProxyUrl may be /cors-proxy/. We need to resolve the absolute URL
+		// to access the protocol.
+		const rootUrl = new URL(import.meta.url);
+		rootUrl.pathname = '';
+		rootUrl.search = '';
+		rootUrl.hash = '';
+		const corsProxyUrlObj = new URL(corsProxyUrl, rootUrl.toString());
+
+		let body: ArrayBuffer | ReadableStream<Uint8Array> | null =
+			corsProxyRequest.body;
+		if (body && new URL(corsProxyUrlObj).protocol === 'http:') {
+			body = await new Response(body).arrayBuffer();
+		}
 
 		const newRequest = await cloneRequest(corsProxyRequest, {
 			url: `${corsProxyUrl}${requestObject.url}`,

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -106,6 +106,10 @@ export async function fetchWithCorsProxy(
 			...(requestIntendsToPassCredentials && { credentials: 'include' }),
 		});
 
+		// Don't pass `init` here – it was already folded into
+		// `requestObject` at the top of this function. Passing it again
+		// would let it override the proxy URL, wrapped headers, and
+		// buffered body we just prepared.
 		const response = await duplexSafeFetch(newRequest);
 
 		// Check for firewall interference: if we got a response but it's

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -26,7 +26,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj.hostname === '[::1]' ||
 		requestUrlObj.hostname === '::1';
 	if (isLocalhost) {
-		return await duplexSafeFetch(requestObject);
+		return await fetch(requestObject);
 	}
 
 	if (requestUrlObj.protocol === 'http:') {
@@ -36,7 +36,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj = new URL(httpsUrl);
 	}
 	if (!corsProxyUrl) {
-		return await duplexSafeFetch(requestObject);
+		return await fetch(requestObject);
 	}
 
 	/**
@@ -51,7 +51,7 @@ export async function fetchWithCorsProxy(
 		requestUrlObj.port === playgroundUrlObj.port &&
 		requestUrlObj.pathname.startsWith(playgroundUrlObj.pathname)
 	) {
-		return await duplexSafeFetch(requestObject);
+		return await fetch(requestObject);
 	}
 
 	// Tee the request to avoid consuming the request body stream on the initial
@@ -59,7 +59,7 @@ export async function fetchWithCorsProxy(
 	const [directRequest, corsProxyRequest] = await teeRequest(requestObject);
 
 	try {
-		return await duplexSafeFetch(directRequest);
+		return await fetch(directRequest);
 	} catch {
 		// If the developer has explicitly allowed the request to pass the
 		// credentials headers with the X-Cors-Proxy-Allowed-Request-Headers header,
@@ -86,14 +86,47 @@ export async function fetchWithCorsProxy(
 			headers.set('content-type', 'application/octet-stream');
 		}
 
+		/**
+		 * Buffer the cors proxy request body into an ArrayBuffer before calling fetch().
+		 *
+		 * This is necessary, because Chrome only supports using a ReadableStream request body
+		 * when fetch() is called with the `duplex: 'half'` option. However, duplex connections
+		 * are problematic:
+		 *
+		 * 1. They don't work with the local dev server, which runs at a http:// URL.
+		 *    When the duplex option is set, Chrome silently upgrades a HTTP/1.1 request
+		 *    to HTTP/2. However, our HTTP/1.1-only local dev server still replies
+		 *    with a HTTP/1.1 response. Chrome then treats the request as failed with an
+		 *    ERR_ALPN_NEGOTIATION_FAILED error.
+		 *
+		 * 2. They don't work with the official Playground CORS proxy at https://wordpress-playground-cors-proxy.net/.
+		 *    The server infrastructure just can't handle duplex POST requests. Something between
+		 *    the browser and the cors-proxy.php runtime buffers the entire body anyway. When
+		 *    it can't, it treats the request body as empty and fails with a 400 Bad Request error
+		 *    as 0 bytes were sent instead of the expected Content-Length. This can be true
+		 *    for any PHP-hosted script out there. An edge proxy, a load balancer, a reverse proxy
+		 *    may not support duplex POST requests either.
+		 *
+		 * We're already in the final `} catch {` block. We've already failed to send a direct
+		 * fetch with a streamed body. Maybe it was due to the duplex problem, maybe not, but
+		 * this is our last chance so let's maximize the probability of success. The entire request
+		 * body must have been produced by now anyway, since the prior fetch() had to send it,
+		 * so it's likely buffered somewhere in the browser's memory. We're just changing the
+		 * data type from ReadableStream to ArrayBuffer to make that explicit.
+		 */
+		const body = corsProxyRequest.body
+			? await new Response(corsProxyRequest.body).arrayBuffer()
+			: undefined;
+
 		const newRequest = await cloneRequest(corsProxyRequest, {
 			url: `${corsProxyUrl}${requestObject.url}`,
 			headers,
+			body,
 			...(requestIntendsToPassCredentials && { credentials: 'include' }),
 		});
 
 		// Skip the `init`, it's already folded into `requestObject`.
-		const response = await duplexSafeFetch(newRequest);
+		const response = await fetch(newRequest);
 
 		// Check for firewall interference: if we got a response but it's
 		// missing the CORS proxy identification header, the response likely
@@ -108,41 +141,4 @@ export async function fetchWithCorsProxy(
 
 		return response;
 	}
-}
-
-/**
- * A version of fetch() that buffers streaming request bodies into an
- * ArrayBuffer before calling fetch().
- *
- * This is necessary for two reasons:
- *
- * 1. Chrome does not support using a ReadableStream request body
- *    with HTTP/1.1 requests. If we just always set `duplex: 'half'`,
- *    we'll get an ERR_ALPN_NEGOTIATION_FAILED error as Chrome will
- *    refuse to use duplex over HTTP/1.1 and will switch to HTTP/2.
- *    A HTTP/1.1-only server, however, will still reply with a HTTP/1.1
- *    response, causing that ALPN error.
- *
- * 2. Production CORS proxies (behind CDNs, load balancers, or PHP's
- *    multipart parsing) may not correctly forward a half-duplex
- *    streaming body. Buffering ensures the full body is sent as a
- *    single chunk.
- */
-async function duplexSafeFetch(
-	request: Request,
-	init?: RequestInit
-): Promise<Response> {
-	// Combine the base request and init into a single effective Request so that
-	// any overrides in init (including body) are taken into account before
-	// buffering.
-	let effectiveRequest = init ? new Request(request, init) : request;
-
-	if (effectiveRequest.body) {
-		const body = await new Response(effectiveRequest.body).arrayBuffer();
-		effectiveRequest = await cloneRequest(effectiveRequest, {
-			body,
-		});
-	}
-
-	return fetch(effectiveRequest);
 }

--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.ts
@@ -86,22 +86,8 @@ export async function fetchWithCorsProxy(
 			headers.set('content-type', 'application/octet-stream');
 		}
 
-		// Buffer the request body before sending through the CORS proxy.
-		// The body arrives as a ReadableStream with duplex: 'half' from
-		// the TLS decryption layer. Production CORS proxies (behind CDNs,
-		// load balancers, or PHP's multipart parsing) may not correctly
-		// forward a half-duplex streaming body. Buffering it as an
-		// ArrayBuffer ensures the full body is sent as a single chunk.
-		// This is safe because the CORS proxy already caps requests at
-		// 1MB (MAX_REQUEST_SIZE).
-		let bufferedBody: ArrayBuffer | undefined;
-		if (request2.body) {
-			bufferedBody = await new Response(request2.body).arrayBuffer();
-		}
-
 		const newRequest = await cloneRequest(request2, {
 			url: `${corsProxyUrl}${requestObject.url}`,
-			body: bufferedBody,
 			headers,
 			...(requestIntendsToPassCredentials && { credentials: 'include' }),
 		});
@@ -128,27 +114,22 @@ export async function fetchWithCorsProxy(
 }
 
 /**
- * A version of fetch() that buffers the request body for http:// requests.
+ * A version of fetch() that buffers streaming request bodies into an
+ * ArrayBuffer before calling fetch().
  *
- * Chrome does not support using a ReadableStream request body
- * with HTTP/1.1 requests. If we just always set `duplex: 'half'`,
- * we'll get an ERR_ALPN_NEGOTIATION_FAILED error as Chrome will
- * refuse to use duplex over HTTP/1.1 and will switch to HTTP/2.
- * A HTTP/1.1-only server, however, will still reply with a HTTP/1.1
- * response, causing that ALPN error.
+ * This is necessary for two reasons:
  *
- * We do not know upfront what kind of server we're talking to,
- * so we'll make a guess. Most servers do not support HTTP >= 2
- * without TLS, so we can assume that anything starting with `http://`
- * requires buffering the body stream. This solves the ALPN negotiation
- * problem on the local dev server.
+ * 1. Chrome does not support using a ReadableStream request body
+ *    with HTTP/1.1 requests. If we just always set `duplex: 'half'`,
+ *    we'll get an ERR_ALPN_NEGOTIATION_FAILED error as Chrome will
+ *    refuse to use duplex over HTTP/1.1 and will switch to HTTP/2.
+ *    A HTTP/1.1-only server, however, will still reply with a HTTP/1.1
+ *    response, causing that ALPN error.
  *
- * There will, inevitably, be some ancient HTTP/1.1+TLS servers on
- * the internet that will fall into the `duplex: half` trap. This
- * is not a big problem, though, since those requests will fail
- * and be retried over the CORS proxy which runs alongside Playground
- * and speaks either HTTP/1.1 in the local dev server or HTTP/2+ in
- * production.
+ * 2. Production CORS proxies (behind CDNs, load balancers, or PHP's
+ *    multipart parsing) may not correctly forward a half-duplex
+ *    streaming body. Buffering ensures the full body is sent as a
+ *    single chunk.
  */
 async function duplexSafeFetch(
 	request: Request,
@@ -156,20 +137,15 @@ async function duplexSafeFetch(
 ): Promise<Response> {
 	// Combine the base request and init into a single effective Request so that
 	// any overrides in init (including body) are taken into account before
-	// applying HTTP/1.1 streaming safeguards.
+	// buffering.
 	let effectiveRequest = init ? new Request(request, init) : request;
 
-	if (
-		new URL(effectiveRequest.url).protocol === 'http:' &&
-		effectiveRequest.body
-	) {
+	if (effectiveRequest.body) {
 		const body = await new Response(effectiveRequest.body).arrayBuffer();
 		effectiveRequest = await cloneRequest(effectiveRequest, {
 			body,
 		});
 	}
 
-	// Call fetch() with the fully prepared Request so the buffered body is
-	// guaranteed to be what is actually sent.
 	return fetch(effectiveRequest);
 }

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -216,8 +216,10 @@ export async function cloneRequest(
 ): Promise<Request> {
 	let body: ArrayBuffer | ReadableStream | undefined;
 
-	if (['GET', 'HEAD'].includes(request.method) || 'body' in overrides) {
+	if (['GET', 'HEAD'].includes(request.method)) {
 		body = undefined;
+	} else if ('body' in overrides) {
+		body = overrides['body'];
 	} else if (!request.bodyUsed && request.body) {
 		// If the body hasn't been consumed yet, we can reuse the stream directly
 		// This avoids the hang that occurs when trying to read from a stream
@@ -244,16 +246,14 @@ export async function cloneRequest(
 		redirect: request.redirect,
 		integrity: request.integrity,
 		/**
-		 * We're forced to infer the duplex value. We cannot read it directly in a
-		 * reliable way from the body type because of this issue:
+		 * Infer the duplex value in a way that's consistent across browsers. Web browsers
+		 * only support 'half' as of January 2026, but other values may be supported in the future.
+		 * Unfortunately, also as of January 2026, we cannot read the duplex value directly from the
+		 * request object:
 		 *
 		 * > Although duplex can be passed as an option when constructing a Request,
 		 * > it is not currently exposed as a readable property on the resulting Request
 		 * > object in all browsers.
-		 *
-		 * We could read it when it's available and infer it otherwise, but that would
-		 * just create more ways in which the code can execute. Let's just use the same
-		 * lowest common denominator in all browsers.
 		 *
 		 * See MDN: https://developer.mozilla.org/en-US/docs/Web/API/Request/duplex
 		 */

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -243,6 +243,20 @@ export async function cloneRequest(
 		cache: request.cache,
 		redirect: request.redirect,
 		integrity: request.integrity,
+		/**
+		 * We're forced to infer the duplex value. We cannot read it directly in a
+		 * reliable way from the body type because of this issue:
+		 *
+		 * > Although duplex can be passed as an option when constructing a Request,
+		 * > it is not currently exposed as a readable property on the resulting Request
+		 * > object in all browsers.
+		 *
+		 * We could read it when it's available and infer it otherwise, but that would
+		 * just create more ways in which the code can execute. Let's just use the same
+		 * lowest common denominator in all browsers.
+		 *
+		 * See MDN: https://developer.mozilla.org/en-US/docs/Web/API/Request/duplex
+		 */
 		...(body instanceof ReadableStream && { duplex: 'half' }),
 		...overrides,
 	});

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.spec.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.spec.ts
@@ -606,14 +606,19 @@ describe('TCPOverFetchWebsocket with CORS proxy', () => {
 				targetPath = '/';
 			}
 
-			// Forward to the local target server
+			// Forward to the local target server.
+			// Restore the original Content-Type if it was wrapped by
+			// fetchWithCorsProxy to prevent PHP from auto-parsing
+			// multipart/form-data bodies.
 			const targetReq = http.request(
 				`http://127.0.0.1:${targetPort}${targetPath}`,
 				{
 					method: 'POST',
 					headers: {
 						'content-type':
-							req.headers['content-type'] || 'text/plain',
+							req.headers['x-cors-proxy-content-type'] ||
+							req.headers['content-type'] ||
+							'text/plain',
 					},
 				},
 				(targetRes) => {

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -148,7 +148,10 @@ $allHeaders = getallheaders();
 $originalContentType = null;
 foreach ($allHeaders as $name => $value) {
     if (strcasecmp($name, 'X-Cors-Proxy-Content-Type') === 0) {
-        $originalContentType = $value;
+        // Reject values containing CR/LF to prevent header injection.
+        if (!preg_match('/[\r\n]/', $value)) {
+            $originalContentType = $value;
+        }
         break;
     }
 }
@@ -182,7 +185,7 @@ $curlHeaders = kv_headers_to_curl_format(
 // If Content-Type was wrapped, replace the placeholder
 // application/octet-stream with the original value so the target
 // server receives the correct Content-Type.
-if ($originalContentType) {
+if ($originalContentType !== null) {
     $curlHeaders = array_values(array_filter(
         $curlHeaders,
         fn($h) => stripos($h, 'Content-Type:') !== 0

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -22,7 +22,7 @@ if (should_respond_with_cors_headers($server_host, $origin)) {
     header('Access-Control-Allow-Origin: ' . $allow_origin);
     header('Access-Control-Allow-Credentials: true');
     header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
-    header('Access-Control-Allow-Headers: Accept, Authorization, Content-Type, git-protocol, wp_blog, wp_install, x-cors-proxy-allowed-request-headers');
+    header('Access-Control-Allow-Headers: Accept, Authorization, Content-Type, git-protocol, wp_blog, wp_install, x-cors-proxy-allowed-request-headers, x-cors-proxy-content-type');
     // Identify this response as coming from the legitimate CORS proxy.
     // Network firewalls may intercept requests and return error responses
     // without this header, allowing clients to detect interference.
@@ -138,13 +138,31 @@ curl_setopt($ch, CURLOPT_RESOLVE, [
     "$host:443:$resolvedIp"
 ]);
 
+$allHeaders = getallheaders();
+
+// If the browser wrapped Content-Type to prevent PHP from consuming
+// multipart/form-data bodies, extract the original value to restore
+// it for the outgoing request. PHP automatically parses
+// multipart/form-data into $_POST/$_FILES, emptying php://input and
+// making it impossible for the proxy to forward the raw body.
+$originalContentType = null;
+foreach ($allHeaders as $name => $value) {
+    if (strcasecmp($name, 'X-Cors-Proxy-Content-Type') === 0) {
+        $originalContentType = $value;
+        break;
+    }
+}
+
 $strictly_disallowed_headers = [
     // Cookies represent a relationship between the proxy server
     // and the client, so it is inappropriate to forward them.
     'Cookie',
     // Drop the incoming Host header because it identifies the
     // proxy server, not the target server.
-    'Host'
+    'Host',
+    // Internal header for Content-Type wrapping. Must not be
+    // forwarded to the target server.
+    'X-Cors-Proxy-Content-Type',
 ];
 $headers_requiring_opt_in = [
     // Allow Authorization header to be forwarded only if the client
@@ -155,11 +173,23 @@ $headers_requiring_opt_in = [
 ];
 $curlHeaders = kv_headers_to_curl_format(
     filter_headers_by_name(
-        getallheaders(),
+        $allHeaders,
         $strictly_disallowed_headers,
         $headers_requiring_opt_in,
     )
 );
+
+// If Content-Type was wrapped, replace the placeholder
+// application/octet-stream with the original value so the target
+// server receives the correct Content-Type.
+if ($originalContentType) {
+    $curlHeaders = array_values(array_filter(
+        $curlHeaders,
+        fn($h) => stripos($h, 'Content-Type:') !== 0
+    ));
+    $curlHeaders[] = 'Content-Type: ' . $originalContentType;
+}
+
 curl_setopt(
     $ch,
     CURLOPT_HTTPHEADER,


### PR DESCRIPTION
## Summary

When sending requests through the CORS proxy, PHP runtime automatically parses the `multipart/form-data` body into `$_POST`/`$_FILES`, emptying `php://input` and removing our ability to pass through the unchanged request body. 

This PR:

* Replaces the Content-type with `application/octet-stream`
* Sends the original Content-type via `X-Cors-Proxy-Content-Type`
* Adjusts the cors-proxy.php implementation to support is
* Simplifies the request body streaming and fetching. No more `duplexSafeFetch` function. We only buffer when sending to the local dev server's CORS proxy. It turns out that change was misguided and we can actually send streamed request bodies to the production CORS proxy.

### Deployment note

The Playground changes and the CORS proxy changes must be deployed at the same time.

## Test plan

- [ ] Run `npx nx test php-wasm-web-service-worker` — all tests pass including Content-Type wrapping and body buffering tests
- [ ] Run `npx nx test playground-php-cors-proxy` — CORS proxy tests pass
- [ ] Test site import through CORS proxy with a multipart/form-data POST body
- [ ] Verify GET requests through CORS proxy are unaffected
- [ ] Verify non-multipart POST requests through CORS proxy are unaffected