### PR TITLE
[ xdebug ] Skip paths alongside path mappings in IDE configs 

### DIFF
--- a/packages/php-wasm/cli-util/src/lib/xdebug-path-mappings.ts
+++ b/packages/php-wasm/cli-util/src/lib/xdebug-path-mappings.ts
@@ -117,21 +117,22 @@ export type IDEConfig = {
 	 */
 	mounts?: Mount[];
 	/**
+	 * The paths to skip when debugging.
+	 */
+	pathSkippings?: string[];
+	/**
 	 * The IDE key to use for the debug configuration. Defaults to 'PHPWASMCLI'.
 	 */
 	ideKey?: string;
 };
 
-type PhpStormConfigMetaData = {
+type PhpStormWorkspaceConfigMetaData = {
 	name?: string;
 	version?: string;
 	host?: string;
 	use_path_mappings?: string;
 	'local-root'?: string;
 	'remote-root'?: string;
-	/**
-	 * The type of the server.
-	 */
 	type?: 'PhpRemoteDebugRunConfigurationType';
 	factoryName?: string;
 	filter_connections?: 'FILTER';
@@ -140,16 +141,30 @@ type PhpStormConfigMetaData = {
 	v?: string;
 };
 
-type PhpStormConfigNode = {
-	':@'?: PhpStormConfigMetaData;
-	project?: PhpStormConfigNode[];
-	component?: PhpStormConfigNode[];
-	servers?: PhpStormConfigNode[];
-	server?: PhpStormConfigNode[];
-	path_mappings?: PhpStormConfigNode[];
-	mapping?: PhpStormConfigNode[];
-	configuration?: PhpStormConfigNode[];
-	method?: PhpStormConfigNode[];
+type PhpStormWorkspaceConfigNode = {
+	':@'?: PhpStormWorkspaceConfigMetaData;
+	project?: PhpStormWorkspaceConfigNode[];
+	component?: PhpStormWorkspaceConfigNode[];
+	servers?: PhpStormWorkspaceConfigNode[];
+	server?: PhpStormWorkspaceConfigNode[];
+	path_mappings?: PhpStormWorkspaceConfigNode[];
+	mapping?: PhpStormWorkspaceConfigNode[];
+	configuration?: PhpStormWorkspaceConfigNode[];
+	method?: PhpStormWorkspaceConfigNode[];
+};
+
+type PhpStormPHPConfigMetaData = {
+	name?: string;
+	version?: string;
+	file?: string;
+};
+
+type PhpStormPHPConfigNode = {
+	':@'?: PhpStormPHPConfigMetaData;
+	project?: PhpStormPHPConfigNode[];
+	component?: PhpStormPHPConfigNode[];
+	skipped_files?: PhpStormPHPConfigNode[];
+	skipped_file?: PhpStormPHPConfigNode[];
 };
 
 type VSCodeConfigMetaData = {
@@ -162,6 +177,7 @@ type VSCodeConfigNode = {
 	request: string;
 	port: number;
 	pathMappings?: VSCodeConfigMetaData;
+	skipFiles?: string[];
 };
 
 const xmlParserOptions: X2jOptions = {
@@ -189,12 +205,12 @@ const jsoncParseOptions: JSONC.ParseOptions = {
 	allowTrailingComma: true,
 };
 
-export type PhpStormConfigOptions = {
+export type PhpStormWorkspaceConfigOptions = {
 	name: string;
 	host: string;
 	port: number;
 	projectDir: string;
-	mappings?: Mount[];
+	pathMappings?: Mount[];
 	ideKey: string;
 };
 
@@ -206,16 +222,16 @@ export type PhpStormConfigOptions = {
  * @returns Updated XML content
  * @throws Error if XML is invalid or configuration is incompatible
  */
-export function updatePhpStormConfig(
+export function updatePhpStormWorkspaceConfig(
 	xmlContent: string,
-	options: PhpStormConfigOptions
+	options: PhpStormWorkspaceConfigOptions
 ): string {
-	const { name, host, port, mappings, ideKey } = options;
+	const { name, host, port, pathMappings, ideKey } = options;
 
 	const xmlParser = new XMLParser(xmlParserOptions);
 
 	// Parse the XML
-	const config: PhpStormConfigNode[] = (() => {
+	const config: PhpStormWorkspaceConfigNode[] = (() => {
 		try {
 			return xmlParser.parse(xmlContent, true);
 		} catch {
@@ -224,7 +240,7 @@ export function updatePhpStormConfig(
 	})();
 
 	// Create the server element with path mappings
-	const serverElement: PhpStormConfigNode = {
+	const serverElement: PhpStormWorkspaceConfigNode = {
 		server: [{}],
 		':@': {
 			name,
@@ -236,20 +252,24 @@ export function updatePhpStormConfig(
 		},
 	};
 
-	if (mappings && mappings.length) {
-		serverElement.server![0].path_mappings = mappings.map((mapping) => ({
-			mapping: [],
-			':@': {
-				'local-root': `$PROJECT_DIR$/${toPosixPath(
-					path.relative(options.projectDir, mapping.hostPath)
-				)}`,
-				'remote-root': mapping.vfsPath,
-			},
-		}));
+	if (pathMappings && pathMappings.length) {
+		serverElement.server![0].path_mappings = pathMappings.map(
+			(pathMapping) => ({
+				mapping: [],
+				':@': {
+					'local-root': `$PROJECT_DIR$/${toPosixPath(
+						path.relative(options.projectDir, pathMapping.hostPath)
+					)}`,
+					'remote-root': pathMapping.vfsPath,
+				},
+			})
+		);
 	}
 
 	// Find or create project element
-	let projectElement = config?.find((c: PhpStormConfigNode) => !!c?.project);
+	let projectElement = config?.find(
+		(c: PhpStormWorkspaceConfigNode) => !!c?.project
+	);
 	if (projectElement) {
 		const projectVersion = projectElement[':@']?.version;
 		if (projectVersion === undefined) {
@@ -274,7 +294,7 @@ export function updatePhpStormConfig(
 
 	// Find or create PhpServers component
 	let componentElement = projectElement.project?.find(
-		(c: PhpStormConfigNode) =>
+		(c: PhpStormWorkspaceConfigNode) =>
 			!!c?.component && c?.[':@']?.name === 'PhpServers'
 	);
 	if (componentElement === undefined) {
@@ -292,7 +312,7 @@ export function updatePhpStormConfig(
 
 	// Find or create servers element
 	let serversElement = componentElement.component?.find(
-		(c: PhpStormConfigNode) => !!c?.servers
+		(c: PhpStormWorkspaceConfigNode) => !!c?.servers
 	);
 	if (serversElement === undefined) {
 		serversElement = { servers: [] };
@@ -306,7 +326,8 @@ export function updatePhpStormConfig(
 
 	// Check if server already exists
 	const serverElementIndex = serversElement.servers?.findIndex(
-		(c: PhpStormConfigNode) => !!c?.server && c?.[':@']?.name === name
+		(c: PhpStormWorkspaceConfigNode) =>
+			!!c?.server && c?.[':@']?.name === name
 	);
 
 	// Only add server if it doesn't exist
@@ -320,7 +341,7 @@ export function updatePhpStormConfig(
 
 	// Find or create RunManager component
 	let runManagerElement = projectElement.project?.find(
-		(c: PhpStormConfigNode) =>
+		(c: PhpStormWorkspaceConfigNode) =>
 			!!c?.component && c?.[':@']?.name === 'RunManager'
 	);
 	if (runManagerElement === undefined) {
@@ -339,13 +360,13 @@ export function updatePhpStormConfig(
 	// Check if run configuration already exists
 	const existingConfigIndex =
 		runManagerElement.component?.findIndex(
-			(c: PhpStormConfigNode) =>
+			(c: PhpStormWorkspaceConfigNode) =>
 				!!c?.configuration && c?.[':@']?.name === name
 		) ?? -1;
 
 	// Only add run configuration if it doesn't exist
 	if (existingConfigIndex < 0) {
-		const runConfigElement: PhpStormConfigNode = {
+		const runConfigElement: PhpStormWorkspaceConfigNode = {
 			configuration: [
 				{
 					method: [],
@@ -385,10 +406,146 @@ export function updatePhpStormConfig(
 	return xml;
 }
 
+export type PhpStormPHPConfigOptions = {
+	pathSkippings?: string[];
+};
+
+/**
+ * Pure function to update PhpStorm php.xml config with skipped files.
+ *
+ * @param xmlContent The original XML content of php.xml
+ * @param options Configuration options for skipped files
+ * @returns Updated XML content
+ * @throws Error if XML is invalid or configuration is incompatible
+ */
+export function updatePhpStormPHPConfig(
+	xmlContent: string,
+	options: PhpStormPHPConfigOptions
+): string {
+	const { pathSkippings } = options;
+
+	const xmlParser = new XMLParser(xmlParserOptions);
+
+	const config: PhpStormPHPConfigNode[] = (() => {
+		try {
+			return xmlParser.parse(xmlContent, true);
+		} catch {
+			throw new Error(
+				'PhpStorm PHP configuration file is not valid XML.'
+			);
+		}
+	})();
+
+	// Find or create project element
+	let projectElement = config?.find(
+		(c: PhpStormPHPConfigNode) => !!c?.project
+	);
+	if (projectElement) {
+		const projectVersion = projectElement[':@']?.version;
+		if (projectVersion === undefined) {
+			throw new Error(
+				'PhpStorm IDE integration only supports ' +
+					'<project version="4"> in php.xml, ' +
+					'but the <project> configuration has no version number.'
+			);
+		} else if (projectVersion !== '4') {
+			throw new Error(
+				'PhpStorm IDE integration only supports ' +
+					'<project version="4"> in php.xml, ' +
+					`but we found a <project> configuration ` +
+					`with version "${projectVersion}".`
+			);
+		}
+	}
+	if (projectElement === undefined) {
+		projectElement = {
+			project: [],
+			':@': { version: '4' },
+		};
+		config.push(projectElement);
+	}
+
+	// Find or create PhpStepFilterConfiguration component
+	let componentElement = projectElement.project?.find(
+		(c: PhpStormPHPConfigNode) =>
+			!!c?.component && c?.[':@']?.name === 'PhpStepFilterConfiguration'
+	);
+	if (componentElement === undefined) {
+		componentElement = {
+			component: [],
+			':@': { name: 'PhpStepFilterConfiguration' },
+		};
+
+		if (projectElement.project === undefined) {
+			projectElement.project = [];
+		}
+
+		projectElement.project.push(componentElement);
+	}
+
+	// Find or create skipped_files element
+	let skippedFilesElement = componentElement.component?.find(
+		(c: PhpStormPHPConfigNode) => !!c?.skipped_files
+	);
+	if (skippedFilesElement === undefined) {
+		skippedFilesElement = { skipped_files: [] };
+
+		if (componentElement.component === undefined) {
+			componentElement.component = [];
+		}
+
+		componentElement.component.push(skippedFilesElement);
+	}
+
+	// Add skipped files
+	if (pathSkippings && pathSkippings.length) {
+		for (const skippedPath of pathSkippings) {
+			const normalizedPath = skippedPath.endsWith('/')
+				? skippedPath.slice(0, -1)
+				: skippedPath;
+			const filePath = `$PROJECT_DIR$${normalizedPath}`;
+
+			// Check if already exists
+			const exists = skippedFilesElement.skipped_files?.some(
+				(c: PhpStormPHPConfigNode) =>
+					!!c?.skipped_file && c?.[':@']?.file === filePath
+			);
+
+			if (!exists) {
+				if (skippedFilesElement.skipped_files === undefined) {
+					skippedFilesElement.skipped_files = [];
+				}
+
+				skippedFilesElement.skipped_files.push({
+					skipped_file: [],
+					':@': { file: filePath },
+				});
+			}
+		}
+	}
+
+	// Build the updated XML
+	const xmlBuilder = new XMLBuilder(xmlBuilderOptions);
+	const xml = xmlBuilder.build(config);
+
+	// Validate the generated XML
+	try {
+		xmlParser.parse(xml, true);
+	} catch {
+		throw new Error(
+			'The resulting PhpStorm PHP configuration file ' +
+				'is not valid XML.'
+		);
+	}
+
+	return xml;
+}
+
 export type VSCodeConfigOptions = {
 	name: string;
 	workspaceDir: string;
-	mappings?: Mount[];
+	pathMappings?: Mount[];
+	pathSkippings?: string[];
 };
 
 /**
@@ -403,7 +560,7 @@ export function updateVSCodeConfig(
 	jsonContent: string,
 	options: VSCodeConfigOptions
 ): string {
-	const { name, mappings } = options;
+	const { name, pathMappings, pathSkippings } = options;
 
 	const errors: JSONC.ParseError[] = [];
 
@@ -445,13 +602,19 @@ export function updateVSCodeConfig(
 			port: 9003,
 		};
 
-		if (mappings && mappings.length) {
-			configuration.pathMappings = mappings.reduce((acc, mount) => {
+		if (pathMappings && pathMappings.length) {
+			configuration.pathMappings = pathMappings.reduce((acc, mount) => {
 				acc[mount.vfsPath] = `\${workspaceFolder}/${toPosixPath(
 					path.relative(options.workspaceDir, mount.hostPath)
 				)}`;
 				return acc;
 			}, {} as VSCodeConfigMetaData);
+		}
+
+		if (pathSkippings && pathSkippings.length) {
+			configuration.skipFiles = pathSkippings.map((skippedPath) =>
+				skippedPath.endsWith('/') ? `${skippedPath}**` : skippedPath
+			);
 		}
 
 		// Get the current length to append at the end
@@ -489,9 +652,10 @@ export async function addXdebugIDEConfig({
 	port,
 	cwd,
 	mounts,
+	pathSkippings,
 	ideKey = DEFAULT_IDE_KEY,
 }: IDEConfig) {
-	const mappings = mounts ? filterLocalMounts(cwd, mounts) : [];
+	const pathMappings = mounts ? filterLocalMounts(cwd, mounts) : [];
 	const modifiedConfig: Record<string, string> = {};
 
 	// PHPstorm
@@ -519,16 +683,47 @@ export async function addXdebugIDEConfig({
 
 		if (fs.existsSync(phpStormConfigFilePath)) {
 			const contents = fs.readFileSync(phpStormConfigFilePath, 'utf8');
-			const updatedXml = updatePhpStormConfig(contents, {
+			const updatedXml = updatePhpStormWorkspaceConfig(contents, {
 				name,
 				host,
 				port,
 				projectDir: cwd,
-				mappings,
+				pathMappings,
 				ideKey,
 			});
 			fs.writeFileSync(phpStormConfigFilePath, updatedXml);
 			modifiedConfig['phpstorm'] = phpStormRelativeConfigFilePath;
+		}
+
+		// PhpStorm php.xml (path skippings)
+		if (pathSkippings && pathSkippings.length) {
+			const phpStormRelativePHPConfigFilePath = '.idea/php.xml';
+			const phpStormPHPConfigFilePath = path.join(
+				cwd,
+				phpStormRelativePHPConfigFilePath
+			);
+
+			if (!fs.existsSync(phpStormPHPConfigFilePath)) {
+				if (fs.existsSync(path.dirname(phpStormPHPConfigFilePath))) {
+					fs.writeFileSync(
+						phpStormPHPConfigFilePath,
+						'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>'
+					);
+				}
+			}
+
+			if (fs.existsSync(phpStormPHPConfigFilePath)) {
+				const contents = fs.readFileSync(
+					phpStormPHPConfigFilePath,
+					'utf8'
+				);
+				const updatedXml = updatePhpStormPHPConfig(contents, {
+					pathSkippings,
+				});
+				fs.writeFileSync(phpStormPHPConfigFilePath, updatedXml);
+				modifiedConfig['phpstorm-php'] =
+					phpStormRelativePHPConfigFilePath;
+			}
 		}
 	}
 
@@ -560,7 +755,8 @@ export async function addXdebugIDEConfig({
 			const updatedJson = updateVSCodeConfig(content, {
 				name,
 				workspaceDir: cwd,
-				mappings,
+				pathMappings,
+				pathSkippings,
 			});
 
 			// Only write and track the file if changes were made
@@ -587,7 +783,7 @@ export async function clearXdebugIDEConfig(name: string, cwd: string) {
 		const contents = fs.readFileSync(phpStormConfigFilePath, 'utf8');
 		const xmlParser = new XMLParser(xmlParserOptions);
 		// NOTE: Using an IIFE so `config` can remain const.
-		const config: PhpStormConfigNode[] = (() => {
+		const config: PhpStormWorkspaceConfigNode[] = (() => {
 			try {
 				return xmlParser.parse(contents, true);
 			} catch {
@@ -598,17 +794,18 @@ export async function clearXdebugIDEConfig(name: string, cwd: string) {
 		})();
 
 		const projectElement = config.find(
-			(c: PhpStormConfigNode) => !!c?.project
+			(c: PhpStormWorkspaceConfigNode) => !!c?.project
 		);
 		const componentElement = projectElement?.project?.find(
-			(c: PhpStormConfigNode) =>
+			(c: PhpStormWorkspaceConfigNode) =>
 				!!c?.component && c?.[':@']?.name === 'PhpServers'
 		);
 		const serversElement = componentElement?.component?.find(
-			(c: PhpStormConfigNode) => !!c?.servers
+			(c: PhpStormWorkspaceConfigNode) => !!c?.servers
 		);
 		const serverElementIndex = serversElement?.servers?.findIndex(
-			(c: PhpStormConfigNode) => !!c?.server && c?.[':@']?.name === name
+			(c: PhpStormWorkspaceConfigNode) =>
+				!!c?.server && c?.[':@']?.name === name
 		);
 
 		if (serverElementIndex !== undefined && serverElementIndex >= 0) {
@@ -632,6 +829,56 @@ export async function clearXdebugIDEConfig(name: string, cwd: string) {
 				fs.unlinkSync(phpStormConfigFilePath);
 			} else {
 				fs.writeFileSync(phpStormConfigFilePath, xml);
+			}
+		}
+	}
+
+	// PhpStorm php.xml (path skippings)
+	const phpStormPHPConfigFilePath = path.join(cwd, '.idea/php.xml');
+	if (fs.existsSync(phpStormPHPConfigFilePath)) {
+		const contents = fs.readFileSync(phpStormPHPConfigFilePath, 'utf8');
+		const xmlParser = new XMLParser(xmlParserOptions);
+		const config: PhpStormPHPConfigNode[] = (() => {
+			try {
+				return xmlParser.parse(contents, true);
+			} catch {
+				throw new Error(
+					'PhpStorm PHP configuration file is not valid XML.'
+				);
+			}
+		})();
+
+		const projectElement = config.find(
+			(c: PhpStormPHPConfigNode) => !!c?.project
+		);
+		const componentIndex = projectElement?.project?.findIndex(
+			(c: PhpStormPHPConfigNode) =>
+				!!c?.component &&
+				c?.[':@']?.name === 'PhpStepFilterConfiguration'
+		);
+
+		if (componentIndex !== undefined && componentIndex >= 0) {
+			projectElement!.project!.splice(componentIndex, 1);
+
+			const xmlBuilder = new XMLBuilder(xmlBuilderOptions);
+			const xml = xmlBuilder.build(config);
+
+			try {
+				xmlParser.parse(xml, true);
+			} catch {
+				throw new Error(
+					'The resulting PhpStorm PHP configuration file ' +
+						'is not valid XML.'
+				);
+			}
+
+			if (
+				xml ===
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>'
+			) {
+				fs.unlinkSync(phpStormPHPConfigFilePath);
+			} else {
+				fs.writeFileSync(phpStormPHPConfigFilePath, xml);
 			}
 		}
 	}

--- a/packages/php-wasm/cli-util/src/lib/xdebug-path-mappings.ts
+++ b/packages/php-wasm/cli-util/src/lib/xdebug-path-mappings.ts
@@ -17,6 +17,13 @@ export interface XdebugOptions {
 }
 
 export const DEFAULT_IDE_KEY = 'PHPWASMCLI';
+export const DEFAULT_PATH_SKIPPINGS = [
+	'/dev/',
+	'/home/',
+	'/internal/',
+	'/request/',
+	'/proc/',
+];
 
 /**
  * Create a symlink to a tempory directory.

--- a/packages/php-wasm/cli-util/src/test/xdebug-path-mappings.spec.ts
+++ b/packages/php-wasm/cli-util/src/test/xdebug-path-mappings.spec.ts
@@ -1,9 +1,11 @@
 import {
 	DEFAULT_IDE_KEY,
 	makeXdebugConfig,
-	updatePhpStormConfig,
+	updatePhpStormWorkspaceConfig,
+	updatePhpStormPHPConfig,
 	updateVSCodeConfig,
-	type PhpStormConfigOptions,
+	type PhpStormWorkspaceConfigOptions,
+	type PhpStormPHPConfigOptions,
 	type VSCodeConfigOptions,
 } from '../lib/xdebug-path-mappings';
 import { XMLParser } from 'fast-xml-parser';
@@ -89,13 +91,13 @@ function expectJSONEquals(actualJSON: string, expectedJSON: string) {
 	expect(actual).toEqual(expected);
 }
 
-describe('updatePhpStormConfig', () => {
-	const defaultOptions: PhpStormConfigOptions = {
+describe('updatePhpStormWorkspaceConfig', () => {
+	const defaultOptions: PhpStormWorkspaceConfigOptions = {
 		name: 'Test Server',
 		host: 'localhost',
 		port: 8080,
 		projectDir: process.cwd(),
-		mappings: [
+		pathMappings: [
 			{
 				hostPath: './src',
 				vfsPath: '/var/www/html/src',
@@ -108,7 +110,7 @@ describe('updatePhpStormConfig', () => {
 		it('should add server and run configuration to minimal valid XML', () => {
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -134,7 +136,7 @@ describe('updatePhpStormConfig', () => {
 		it('should handle empty project element', () => {
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4"></project>';
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -164,7 +166,7 @@ describe('updatePhpStormConfig', () => {
 		<option name="someOption" value="someValue" />
 	</component>
 </project>`;
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -193,8 +195,11 @@ describe('updatePhpStormConfig', () => {
 		it('should not duplicate server if it already exists', () => {
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result1 = updatePhpStormConfig(xml, defaultOptions);
-			const result2 = updatePhpStormConfig(result1, defaultOptions);
+			const result1 = updatePhpStormWorkspaceConfig(xml, defaultOptions);
+			const result2 = updatePhpStormWorkspaceConfig(
+				result1,
+				defaultOptions
+			);
 
 			// Count server elements in PhpServers component - should only be 1
 			const serverMatches =
@@ -208,7 +213,7 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should handle no path mapping', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				name: 'Test Server',
 				host: 'localhost',
 				port: 8080,
@@ -218,7 +223,7 @@ describe('updatePhpStormConfig', () => {
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -239,9 +244,9 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should handle multiple path mappings', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: './src',
 						vfsPath: '/var/www/html/src',
@@ -259,7 +264,7 @@ describe('updatePhpStormConfig', () => {
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -285,9 +290,9 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should strip leading ./ from hostPath', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: './foo/bar',
 						vfsPath: '/var/www/html/foo/bar',
@@ -301,7 +306,7 @@ describe('updatePhpStormConfig', () => {
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -326,9 +331,9 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should make absolute hostPath relative to project directory', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: `${defaultOptions.projectDir}/foo/bar`,
 						vfsPath: '/var/www/html/foo/bar',
@@ -342,7 +347,7 @@ describe('updatePhpStormConfig', () => {
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -373,7 +378,7 @@ describe('updatePhpStormConfig', () => {
 		<servers></servers>
 	</component>
 </project>`;
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -403,7 +408,7 @@ describe('updatePhpStormConfig', () => {
 		<configuration name="Other Config" type="PHPUnitRunConfigurationType" />
 	</component>
 </project>`;
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -428,14 +433,14 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should use custom IDE key', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				...defaultOptions,
 				ideKey: 'CUSTOM_KEY',
 			};
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -459,7 +464,7 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should handle complex host and port combinations', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				...defaultOptions,
 				host: '192.168.1.100',
 				port: 3000,
@@ -467,7 +472,7 @@ describe('updatePhpStormConfig', () => {
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -496,7 +501,7 @@ describe('updatePhpStormConfig', () => {
 			const invalidXml = 'not valid xml';
 
 			expect(() => {
-				updatePhpStormConfig(invalidXml, defaultOptions);
+				updatePhpStormWorkspaceConfig(invalidXml, defaultOptions);
 			}).toThrow('PhpStorm configuration file is not valid XML.');
 		});
 
@@ -504,7 +509,7 @@ describe('updatePhpStormConfig', () => {
 			const malformedXml = '<?xml version="1.0"?><project><unclosed>';
 
 			expect(() => {
-				updatePhpStormConfig(malformedXml, defaultOptions);
+				updatePhpStormWorkspaceConfig(malformedXml, defaultOptions);
 			}).toThrow('PhpStorm configuration file is not valid XML.');
 		});
 
@@ -513,7 +518,7 @@ describe('updatePhpStormConfig', () => {
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project>\n</project>';
 
 			expect(() => {
-				updatePhpStormConfig(xml, defaultOptions);
+				updatePhpStormWorkspaceConfig(xml, defaultOptions);
 			}).toThrow(
 				'PhpStorm IDE integration only supports <project version="4"> in workspace.xml, ' +
 					'but the <project> configuration has no version number.'
@@ -525,7 +530,7 @@ describe('updatePhpStormConfig', () => {
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="5">\n</project>';
 
 			expect(() => {
-				updatePhpStormConfig(xml, defaultOptions);
+				updatePhpStormWorkspaceConfig(xml, defaultOptions);
 			}).toThrow(
 				'PhpStorm IDE integration only supports <project version="4"> in workspace.xml, ' +
 					'but we found a <project> configuration with version "5".'
@@ -533,14 +538,14 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should handle empty mappings array', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				...defaultOptions,
-				mappings: [],
+				pathMappings: [],
 			};
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -568,7 +573,7 @@ describe('updatePhpStormConfig', () => {
 <project version="4">
 	<!-- Another comment -->
 </project>`;
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <!-- This is a comment -->
@@ -600,7 +605,7 @@ describe('updatePhpStormConfig', () => {
 		<![CDATA[Some data]]>
 	</component>
 </project>`;
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -627,14 +632,14 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should handle special characters in server name', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				...defaultOptions,
 				name: 'Test & Server "With" Quotes',
 			};
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -658,9 +663,9 @@ describe('updatePhpStormConfig', () => {
 		});
 
 		it('should handle paths with special characters', () => {
-			const options: PhpStormConfigOptions = {
+			const options: PhpStormWorkspaceConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: './src/my-special-dir',
 						vfsPath: '/var/www/html/my-special-dir',
@@ -670,7 +675,7 @@ describe('updatePhpStormConfig', () => {
 
 			const xml =
 				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
-			const result = updatePhpStormConfig(xml, options);
+			const result = updatePhpStormWorkspaceConfig(xml, options);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -706,7 +711,7 @@ describe('updatePhpStormConfig', () => {
 		</servers>
 	</component>
 </project>`;
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
@@ -739,7 +744,7 @@ describe('updatePhpStormConfig', () => {
 <project version="4" foo="bar" baz="qux">
 	<component name="ExistingComponent" />
 </project>`;
-			const result = updatePhpStormConfig(xml, defaultOptions);
+			const result = updatePhpStormWorkspaceConfig(xml, defaultOptions);
 
 			const expected = `<?xml version="1.0" encoding="UTF-8"?>
 <project version="4" foo="bar" baz="qux">
@@ -765,11 +770,184 @@ describe('updatePhpStormConfig', () => {
 	});
 });
 
+describe('updatePhpStormPHPConfig', () => {
+	const defaultOptions: PhpStormPHPConfigOptions = {
+		pathSkippings: ['/dev/', '/home/', '/internal/'],
+	};
+
+	describe('valid configurations', () => {
+		it('should add skipped files to minimal valid XML', () => {
+			const xml =
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
+			const result = updatePhpStormPHPConfig(xml, defaultOptions);
+
+			const expected = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpStepFilterConfiguration">
+		<skipped_files>
+			<skipped_file file="$PROJECT_DIR$/dev"/>
+			<skipped_file file="$PROJECT_DIR$/home"/>
+			<skipped_file file="$PROJECT_DIR$/internal"/>
+		</skipped_files>
+	</component>
+</project>`;
+
+			expectXMLEquals(result, expected);
+		});
+
+		it('should handle empty project element', () => {
+			const xml =
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4"></project>';
+			const result = updatePhpStormPHPConfig(xml, defaultOptions);
+
+			const expected = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpStepFilterConfiguration">
+		<skipped_files>
+			<skipped_file file="$PROJECT_DIR$/dev"/>
+			<skipped_file file="$PROJECT_DIR$/home"/>
+			<skipped_file file="$PROJECT_DIR$/internal"/>
+		</skipped_files>
+	</component>
+</project>`;
+
+			expectXMLEquals(result, expected);
+		});
+
+		it('should preserve existing components', () => {
+			const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpInterpreters">
+		<interpreters/>
+	</component>
+</project>`;
+			const result = updatePhpStormPHPConfig(xml, defaultOptions);
+
+			const expected = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpInterpreters">
+		<interpreters/>
+	</component>
+	<component name="PhpStepFilterConfiguration">
+		<skipped_files>
+			<skipped_file file="$PROJECT_DIR$/dev"/>
+			<skipped_file file="$PROJECT_DIR$/home"/>
+			<skipped_file file="$PROJECT_DIR$/internal"/>
+		</skipped_files>
+	</component>
+</project>`;
+
+			expectXMLEquals(result, expected);
+		});
+
+		it('should not duplicate existing skipped files', () => {
+			const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpStepFilterConfiguration">
+		<skipped_files>
+			<skipped_file file="$PROJECT_DIR$/dev"/>
+		</skipped_files>
+	</component>
+</project>`;
+			const result = updatePhpStormPHPConfig(xml, defaultOptions);
+
+			const expected = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpStepFilterConfiguration">
+		<skipped_files>
+			<skipped_file file="$PROJECT_DIR$/dev"/>
+			<skipped_file file="$PROJECT_DIR$/home"/>
+			<skipped_file file="$PROJECT_DIR$/internal"/>
+		</skipped_files>
+	</component>
+</project>`;
+
+			expectXMLEquals(result, expected);
+		});
+
+		it('should strip trailing slash from directory paths', () => {
+			const xml =
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
+			const result = updatePhpStormPHPConfig(xml, {
+				pathSkippings: ['/dev/', '/foo.php'],
+			});
+
+			const expected = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpStepFilterConfiguration">
+		<skipped_files>
+			<skipped_file file="$PROJECT_DIR$/dev"/>
+			<skipped_file file="$PROJECT_DIR$/foo.php"/>
+		</skipped_files>
+	</component>
+</project>`;
+
+			expectXMLEquals(result, expected);
+		});
+
+		it('should handle empty pathSkippings', () => {
+			const xml =
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
+			const result = updatePhpStormPHPConfig(xml, {
+				pathSkippings: [],
+			});
+
+			const expected = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpStepFilterConfiguration">
+		<skipped_files/>
+	</component>
+</project>`;
+
+			expectXMLEquals(result, expected);
+		});
+
+		it('should handle undefined pathSkippings', () => {
+			const xml =
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="4">\n</project>';
+			const result = updatePhpStormPHPConfig(xml, {});
+
+			const expected = `<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+	<component name="PhpStepFilterConfiguration">
+		<skipped_files/>
+	</component>
+</project>`;
+
+			expectXMLEquals(result, expected);
+		});
+	});
+
+	describe('error handling', () => {
+		it('should throw for invalid XML', () => {
+			expect(() =>
+				updatePhpStormPHPConfig('not xml', defaultOptions)
+			).toThrow('PhpStorm PHP configuration file is not valid XML.');
+		});
+
+		it('should throw for project with wrong version', () => {
+			const xml =
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project version="3">\n</project>';
+			expect(() => updatePhpStormPHPConfig(xml, defaultOptions)).toThrow(
+				'version "3"'
+			);
+		});
+
+		it('should throw for project with no version', () => {
+			const xml =
+				'<?xml version="1.0" encoding="UTF-8"?>\n<project>\n</project>';
+			expect(() => updatePhpStormPHPConfig(xml, defaultOptions)).toThrow(
+				'no version number'
+			);
+		});
+	});
+});
+
 describe('updateVSCodeConfig', () => {
 	const defaultOptions: VSCodeConfigOptions = {
 		name: 'Test Configuration',
 		workspaceDir: process.cwd(),
-		mappings: [
+		pathMappings: [
 			{
 				hostPath: './src',
 				vfsPath: '/var/www/html/src',
@@ -783,17 +961,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -804,17 +982,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -825,17 +1003,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -843,35 +1021,35 @@ describe('updateVSCodeConfig', () => {
 
 		it('should preserve existing configurations', () => {
 			const json = `{
-    "configurations": [
-        {
-            "name": "Existing Config",
-            "type": "php",
-            "request": "launch",
-            "port": 9000
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Existing Config",
+			"type": "php",
+			"request": "launch",
+			"port": 9000
+		}
+	]
 }`;
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Existing Config",
-            "type": "php",
-            "request": "launch",
-            "port": 9000
-        },
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Existing Config",
+			"type": "php",
+			"request": "launch",
+			"port": 9000
+		},
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -904,7 +1082,7 @@ describe('updateVSCodeConfig', () => {
 			"request": "launch",
 			"port": 9003,
 		}
-    ]
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -913,7 +1091,7 @@ describe('updateVSCodeConfig', () => {
 		it('should handle multiple path mappings', () => {
 			const options: VSCodeConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: './src',
 						vfsPath: '/var/www/html/src',
@@ -933,20 +1111,105 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, options);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src",
-                "/var/www/html/tests": "\${workspaceFolder}/tests",
-                "/var/www/html/vendor": "\${workspaceFolder}/vendor"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src",
+				"/var/www/html/tests": "\${workspaceFolder}/tests",
+				"/var/www/html/vendor": "\${workspaceFolder}/vendor"
+			}
+		}
+	]
 }`;
+
+			expectJSONEquals(result, expected);
+		});
+
+		it('should add skipFiles for directory paths', () => {
+			const json = '{\n    "configurations": []\n}';
+			const result = updateVSCodeConfig(json, {
+				name: 'Test',
+				workspaceDir: process.cwd(),
+				pathSkippings: ['/dev/', '/home/', '/internal/'],
+			});
+
+			const expected = `{
+		"configurations": [
+			{
+				"name": "Test",
+				"type": "php",
+				"request": "launch",
+				"port": 9003,
+				"skipFiles": [
+					"/dev/**",
+					"/home/**",
+					"/internal/**"
+				]
+			}
+		]
+	}`;
+
+			expectJSONEquals(result, expected);
+		});
+
+		it('should not append ** to file paths', () => {
+			const json = '{\n    "configurations": []\n}';
+			const result = updateVSCodeConfig(json, {
+				name: 'Test',
+				workspaceDir: process.cwd(),
+				pathSkippings: ['/dev/', '/foo.php'],
+			});
+
+			const expected = `{
+		"configurations": [
+			{
+				"name": "Test",
+				"type": "php",
+				"request": "launch",
+				"port": 9003,
+				"skipFiles": [
+					"/dev/**",
+					"/foo.php"
+				]
+			}
+		]
+	}`;
+
+			expectJSONEquals(result, expected);
+		});
+
+		it('should include both skipFiles and pathMappings', () => {
+			const json = '{\n    "configurations": []\n}';
+			const result = updateVSCodeConfig(json, {
+				name: 'Test',
+				workspaceDir: process.cwd(),
+				pathMappings: [
+					{ hostPath: './src', vfsPath: '/var/www/html/src' },
+				],
+				pathSkippings: ['/dev/', '/home/'],
+			});
+
+			const expected = `{
+		"configurations": [
+			{
+				"name": "Test",
+				"type": "php",
+				"request": "launch",
+				"port": 9003,
+				"pathMappings": {
+					"/var/www/html/src": "\${workspaceFolder}/src"
+				},
+				"skipFiles": [
+					"/dev/**",
+					"/home/**"
+				]
+			}
+		]
+	}`;
 
 			expectJSONEquals(result, expected);
 		});
@@ -954,7 +1217,7 @@ describe('updateVSCodeConfig', () => {
 		it('should strip leading ./ from hostPath', () => {
 			const options: VSCodeConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: './foo/bar',
 						vfsPath: '/var/www/html/foo/bar',
@@ -970,18 +1233,18 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, options);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/foo/bar": "\${workspaceFolder}/foo/bar",
-                "/var/www/html/baz/qux": "\${workspaceFolder}/baz/qux"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/foo/bar": "\${workspaceFolder}/foo/bar",
+				"/var/www/html/baz/qux": "\${workspaceFolder}/baz/qux"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -990,7 +1253,7 @@ describe('updateVSCodeConfig', () => {
 		it('should make absolute hostPath relative to workspace folder', () => {
 			const options: VSCodeConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: `${defaultOptions.workspaceDir}/foo/bar`,
 						vfsPath: '/var/www/html/foo/bar',
@@ -1006,18 +1269,18 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, options);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/foo/bar": "\${workspaceFolder}/foo/bar",
-                "/var/www/html/baz/qux": "\${workspaceFolder}/baz/qux"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/foo/bar": "\${workspaceFolder}/foo/bar",
+				"/var/www/html/baz/qux": "\${workspaceFolder}/baz/qux"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1025,26 +1288,26 @@ describe('updateVSCodeConfig', () => {
 
 		it('should handle JSON with comments (JSONC)', () => {
 			const json = `{
-    // This is a comment
-    "configurations": [
-        // Another comment
-    ]
+	// This is a comment
+	"configurations": [
+		// Another comment
+	]
 }`;
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			// Comments are not preserved in output, so just check structure
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1052,32 +1315,32 @@ describe('updateVSCodeConfig', () => {
 
 		it('should handle JSON with trailing commas (JSONC)', () => {
 			const json = `{
-    "configurations": [
-        {
-            "name": "Existing Config",
-            "type": "php",
-        },
-    ],
+	"configurations": [
+		{
+			"name": "Existing Config",
+			"type": "php",
+		},
+	],
 }`;
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			// Trailing commas are normalized in output
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Existing Config",
-            "type": "php"
-        },
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Existing Config",
+			"type": "php"
+		},
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1085,26 +1348,26 @@ describe('updateVSCodeConfig', () => {
 
 		it('should preserve other properties in the JSON', () => {
 			const json = `{
-    "version": "0.2.0",
-    "configurations": [],
-    "compounds": []
+	"version": "0.2.0",
+	"configurations": [],
+	"compounds": []
 }`;
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ],
-    "compounds": []
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	],
+	"compounds": []
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1115,17 +1378,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1162,21 +1425,21 @@ describe('updateVSCodeConfig', () => {
 		it('should handle empty mappings array', () => {
 			const options: VSCodeConfigOptions = {
 				...defaultOptions,
-				mappings: [],
+				pathMappings: [],
 			};
 
 			const json = '{\n    "configurations": []\n}';
 			const result = updateVSCodeConfig(json, options);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1194,17 +1457,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, options);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test & Configuration \\"With\\" Quotes",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test & Configuration \\"With\\" Quotes",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1213,7 +1476,7 @@ describe('updateVSCodeConfig', () => {
 		it('should handle paths with special characters', () => {
 			const options: VSCodeConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: './src/my-special-dir',
 						vfsPath: '/var/www/html/my-special-dir',
@@ -1225,17 +1488,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, options);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/my-special-dir": "\${workspaceFolder}/src/my-special-dir"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/my-special-dir": "\${workspaceFolder}/src/my-special-dir"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1243,43 +1506,43 @@ describe('updateVSCodeConfig', () => {
 
 		it('should handle deeply nested existing structure', () => {
 			const json = `{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Existing Config",
-            "type": "php",
-            "request": "launch",
-            "port": 9000,
-            "pathMappings": {
-                "/var/www/html/existing": "\${workspaceFolder}/existing"
-            }
-        }
-    ]
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Existing Config",
+			"type": "php",
+			"request": "launch",
+			"port": 9000,
+			"pathMappings": {
+				"/var/www/html/existing": "\${workspaceFolder}/existing"
+			}
+		}
+	]
 }`;
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "Existing Config",
-            "type": "php",
-            "request": "launch",
-            "port": 9000,
-            "pathMappings": {
-                "/var/www/html/existing": "\${workspaceFolder}/existing"
-            }
-        },
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Existing Config",
+			"type": "php",
+			"request": "launch",
+			"port": 9000,
+			"pathMappings": {
+				"/var/www/html/existing": "\${workspaceFolder}/existing"
+			}
+		},
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1290,17 +1553,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1313,17 +1576,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, defaultOptions);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/src": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/src": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1332,7 +1595,7 @@ describe('updateVSCodeConfig', () => {
 		it('should handle mixed single and double quotes in paths', () => {
 			const options: VSCodeConfigOptions = {
 				...defaultOptions,
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: "./src/path-with-'single'-quotes",
 						vfsPath: '/var/www/html/path',
@@ -1344,17 +1607,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, options);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/path": "\${workspaceFolder}/src/path-with-'single'-quotes"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/path": "\${workspaceFolder}/src/path-with-'single'-quotes"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);
@@ -1392,7 +1655,7 @@ describe('updateVSCodeConfig', () => {
 			const options: VSCodeConfigOptions = {
 				...defaultOptions,
 				name: 'Test 🚀 Configuration',
-				mappings: [
+				pathMappings: [
 					{
 						hostPath: './src',
 						vfsPath: '/var/www/html/тест', // Cyrillic characters
@@ -1404,17 +1667,17 @@ describe('updateVSCodeConfig', () => {
 			const result = updateVSCodeConfig(json, options);
 
 			const expected = `{
-    "configurations": [
-        {
-            "name": "Test 🚀 Configuration",
-            "type": "php",
-            "request": "launch",
-            "port": 9003,
-            "pathMappings": {
-                "/var/www/html/тест": "\${workspaceFolder}/src"
-            }
-        }
-    ]
+	"configurations": [
+		{
+			"name": "Test 🚀 Configuration",
+			"type": "php",
+			"request": "launch",
+			"port": 9003,
+			"pathMappings": {
+				"/var/www/html/тест": "\${workspaceFolder}/src"
+			}
+		}
+	]
 }`;
 
 			expectJSONEquals(result, expected);

--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -170,6 +170,13 @@ ${process.argv[0]} ${process.execArgv.join(' ')} ${process.argv[1]}
 				port: 443,
 				ides: ides,
 				cwd: process.cwd(),
+				pathSkippings: [
+					'/dev/',
+					'/home/',
+					'/internal/',
+					'/request/',
+					'/proc/',
+				],
 			});
 
 			// Display IDE-specific instructions

--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -14,6 +14,7 @@ import {
 	makeXdebugConfig,
 	addXdebugIDEConfig,
 	clearXdebugIDEConfig,
+	DEFAULT_PATH_SKIPPINGS,
 } from '@php-wasm/cli-util';
 import { loadNodeRuntime, useHostFilesystem } from '@php-wasm/node';
 import {
@@ -135,13 +136,7 @@ ${process.argv[0]} ${process.execArgv.join(' ')} ${process.argv[1]}
 			withXdebug:
 				hasXdebugOption ??
 				makeXdebugConfig({
-					pathSkippings: [
-						'/dev/',
-						'/home/',
-						'/internal/',
-						'/request/',
-						'/proc/',
-					],
+					pathSkippings: [...DEFAULT_PATH_SKIPPINGS],
 				}),
 		})
 	);
@@ -170,13 +165,7 @@ ${process.argv[0]} ${process.execArgv.join(' ')} ${process.argv[1]}
 				port: 443,
 				ides: ides,
 				cwd: process.cwd(),
-				pathSkippings: [
-					'/dev/',
-					'/home/',
-					'/internal/',
-					'/request/',
-					'/proc/',
-				],
+				pathSkippings: [...DEFAULT_PATH_SKIPPINGS],
 			});
 
 			// Display IDE-specific instructions

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1109,6 +1109,13 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 									...(args['mount-before-install'] || []),
 									...(args.mount || []),
 								],
+								pathSkippings: [
+									'/dev/',
+									'/home/',
+									'/internal/',
+									'/request/',
+									'/proc/',
+								],
 								ideKey:
 									xdebugOptions.ideKey || 'WPPLAYGROUNDCLI',
 							});

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -71,6 +71,7 @@ import {
 	createTempDirSymlink,
 	removeTempDirSymlink,
 	makeXdebugConfig,
+	DEFAULT_PATH_SKIPPINGS,
 } from '@php-wasm/cli-util';
 import { createHash } from 'crypto';
 import { CLIOutput } from './cli-output';
@@ -1058,13 +1059,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 							...(args['mount-before-install'] || []),
 							...(args.mount || []),
 						],
-						pathSkippings: [
-							'/dev/',
-							'/home/',
-							'/internal/',
-							'/request/',
-							'/proc/',
-						],
+						pathSkippings: [...DEFAULT_PATH_SKIPPINGS],
 					});
 
 					console.log(bold(`Xdebug configured successfully`));
@@ -1109,13 +1104,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 									...(args['mount-before-install'] || []),
 									...(args.mount || []),
 								],
-								pathSkippings: [
-									'/dev/',
-									'/home/',
-									'/internal/',
-									'/request/',
-									'/proc/',
-								],
+								pathSkippings: [...DEFAULT_PATH_SKIPPINGS],
 								ideKey:
 									xdebugOptions.ideKey || 'WPPLAYGROUNDCLI',
 							});


### PR DESCRIPTION
## Motivation for the change, related issues

Follow-up on : https://github.com/WordPress/wordpress-playground/pull/3115

This pull request aims to provide a way to ignore paths from step debugging. This feature has been enabled internally in Xdebug 3.5 [ PHP 8.5 ] but for older PHP versions, only IDEs can somehow ignore paths.

## Implementation details

#### VSCode 

By adding a `skipFiles` property with an array of skipped paths :

`.vscode/launch.json`

```json
{
    "configurations": [
        {
            "name": "PHP.wasm CLI - Listen for Xdebug",
            "type": "php",
            "request": "launch",
            "port": 9003,
            "skipFiles": [
                "/php/foo.php",
                "/baz/**"
            ],
            "pathMappings": {
                "/": "${workspaceRoot}/",
            }
        }
    ]
}
```

#### PhpStorm :

By creating a new file named `php.xml` which will list skipped files.

`.idea/workspace.xml`

```
<servers>
      <server host="example.com:443" port="80" name="Listen for Xdebug" use_path_mappings="true">
        <path_mappings>
          <mapping local-root="$PROJECT_DIR$" remote-root="/" />
        </path_mappings>
      </server>
</servers>
```

`.idea/php.xml`

```
<component name="PhpStepFilterConfiguration">
    <skipped_files>
      <skipped_file file="$PROJECT_DIR$/php/foo.php" />
      <skipped_file file="$PROJECT_DIR$/baz" />
    </skipped_files>
</component>
```

## Testing Instructions

### Setup

Create the following PHP files in a test directory:

**`php/xdebug.php`**

```php
<?php

echo "In\n";

require_once __DIR__ . "/foo.php";

foo();

echo "Out\n";
```

**`php/foo.php`**

```php
<?php

require_once __DIR__ . "/../../proc/qux.php";

function foo() {
    echo "Foo\n";
    qux();
}
```

**`proc/qux.php`**

```php
<?php

require_once __DIR__ . "/../wordpress/php/bar.php";

function qux() {
    echo "Qux\n";
    bar();
}
```

**`php/bar.php`**

```php
<?php

function bar() {
    echo "Hello Xdebug World!\n";
}
```

### Steps (VSCode)

1. Make sure you have the **PHP Debug** extension installed in VSCode
2.  Run `npx nx dev playground-cli server --php=8.4 --xdebug --experimental-unsafe-ide-integration=vscode --skip-wordpress-install --mount=./php:/wordpress/php --mount=./proc:/proc`.
3. Navigate to `http://localhost:9400/php/xdebug.php` in the browser.
4. You should see this : `In Foo Qux Hello Xdebug World! Out`.
5. Verify that the **"WP Playground CLI - Listen for Xdebug"** configuration was created in `.vscode/launch.json` with default `skipFiles`.
5. Go to `Run` > `Start Debugging` and select **"WP Playground CLI - Listen for Xdebug"** in the Debug Console.
6. Add a breakpoint in `php/xdebug.php` on `foo()` on **line 7**
7. Reload the `http://localhost:9400/php/xdebug.php` page in the browser.
8. Witness the magic break.
9. **Step into** and confirm the debugger should enter `foo.php` normally.
10. **Step into** two times and confirm the debugger should **skip** `proc/qux.php` (since `/proc/**` is in the default `skipFiles`) and land directly in `php/bar.php`.
11. It still should display : `In Foo Qux Hello Xdebug World! Out` at the end of the step debugging.

or

CI

or

`npx nx test php-wasm-cli-util --testFile=xdebug-path-mappings.spec.ts`