### PR TITLE
Redirect unscoped WP URLs back to scoped WP URLs in service worker

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -101,7 +101,12 @@
 
 declare const self: ServiceWorkerGlobalScope;
 
-import { getURLScope, isURLScoped, removeURLScope } from '@php-wasm/scopes';
+import {
+	getURLScope,
+	isURLScoped,
+	removeURLScope,
+	setURLScope,
+} from '@php-wasm/scopes';
 import { applyRewriteRules } from '@php-wasm/universal';
 import {
 	awaitReply,
@@ -233,12 +238,23 @@ self.addEventListener('fetch', (event) => {
 	}
 
 	if (referrerUrl && isURLScoped(referrerUrl)) {
+		if (url.origin !== referrerUrl.origin) {
+			// Cross-origin requests can handled by the service worker when they
+			// are initiated from a page in the service worker's scope.
+			// If this request doesn't have the referrer scope's origin,
+			// let's not intercept it or send it to the scope's WordPress.
+			return;
+		}
+
 		const scope = getURLScope(referrerUrl)!;
-		return event.respondWith(
-			handleScopedRequest(event, scope).then((response) =>
-				rewriteCoopHeadersToDocumentIsolationPolicy(response, scope)
-			)
-		);
+
+		// Let's redirect to a scope URL so that no unscoped page is loaded
+		// while navigating around a scoped WordPress. Otherwise, clicking an
+		// unscoped link from an unscoped page will lose the scope entirely,
+		// and the service worker won't be able to match the request with
+		// the right WordPress instance.
+		const scopedRedirectTarget = setURLScope(event.request.url, scope);
+		return event.respondWith(Response.redirect(scopedRedirectTarget));
 	}
 
 	/**

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -239,7 +239,7 @@ self.addEventListener('fetch', (event) => {
 
 	if (referrerUrl && isURLScoped(referrerUrl)) {
 		if (url.origin !== referrerUrl.origin) {
-			// Cross-origin requests can handled by the service worker when they
+			// Cross-origin requests can be handled by the service worker when they
 			// are initiated from a page in the service worker's scope.
 			// If this request doesn't have the referrer scope's origin,
 			// let's not intercept it or send it to the scope's WordPress.


### PR DESCRIPTION
## Summary
- When the service worker intercepts a request from a scoped page (identified via the Referer header) but the request URL itself is unscoped, redirect it to the scoped version of the URL instead of directly handling it as a PHP request. This prevents scope loss when navigating around a scoped WordPress instance.
- Skip intercepting cross-origin requests initiated from scoped pages, letting them pass through to the network instead.

## Context

Previously, when a scoped WordPress page linked to an unscoped URL (e.g. a WordPress-generated link without the scope prefix), the service worker would directly handle it via `handleScopedRequest()`. This worked for that single request, but the resulting page would be loaded at an unscoped URL. Navigating from that unscoped page to another unscoped URL resulted in losing the scope entirely, and the service worker would no longer be able to match requests to the correct WordPress instance.

By redirecting to the scoped URL instead, the browser's address bar and subsequent navigations all stay within the scope.

## Test plan
- [ ] Load a scoped WordPress Playground instance
- [ ] Navigate to a WordPress link that doesn't include the scope prefix
- [ ] Verify the browser redirects to the scoped version of the URL
- [ ] Verify subsequent navigation continues to work within the scope
- [ ] Verify cross-origin requests from scoped pages are not intercepted