### PR TITLE
[MCP] Preserve MCP connection parameters when opening site in new tab

### DIFF
--- a/packages/playground/mcp/e2e/mcp-tools.spec.ts
+++ b/packages/playground/mcp/e2e/mcp-tools.spec.ts
@@ -171,7 +171,6 @@ test.afterEach(async ({ mcpClient, playgroundPage, browser }) => {
 
 test('lists all registered tools', async ({ mcpClient }) => {
 	const result = await mcpClient.listTools();
-	expect(result.tools).toHaveLength(17);
 	const names = result.tools.map((t) => t.name).sort();
 	expect(names).toEqual([
 		'playground_delete_directory',

--- a/packages/playground/mcp/e2e/mcp-tools.spec.ts
+++ b/packages/playground/mcp/e2e/mcp-tools.spec.ts
@@ -169,9 +169,9 @@ test.afterEach(async ({ mcpClient, playgroundPage, browser }) => {
 	}
 });
 
-test('lists all 16 registered tools', async ({ mcpClient }) => {
+test('lists all registered tools', async ({ mcpClient }) => {
 	const result = await mcpClient.listTools();
-	expect(result.tools).toHaveLength(16);
+	expect(result.tools).toHaveLength(17);
 	const names = result.tools.map((t) => t.name).sort();
 	expect(names).toEqual([
 		'playground_delete_directory',
@@ -180,6 +180,7 @@ test('lists all 16 registered tools', async ({ mcpClient }) => {
 		'playground_file_exists',
 		'playground_get_current_url',
 		'playground_get_site_info',
+		'playground_get_website_url',
 		'playground_list_files',
 		'playground_list_sites',
 		'playground_mkdir',

--- a/packages/playground/mcp/src/index.ts
+++ b/packages/playground/mcp/src/index.ts
@@ -15,7 +15,7 @@ async function main() {
 	const bridge = new PlaygroundBridge();
 	await bridge.startWebSocketServer(getPortFromArgs());
 	const port = bridge.getPort();
-	const server = createServer(port);
+	const server = createServer();
 	registerMcpServerTools(server, bridge, port);
 	const transport = new StdioServerTransport();
 	await server.connect(transport);

--- a/packages/playground/mcp/src/mcp-server.ts
+++ b/packages/playground/mcp/src/mcp-server.ts
@@ -10,7 +10,7 @@ try {
 	packageVersion = require('../package.json').version;
 }
 
-export function createServer(port: number): McpServer {
+export function createServer(): McpServer {
 	return new McpServer({
 		name: 'wordpress-playground',
 		version: packageVersion,

--- a/packages/playground/mcp/src/tools/register-mcp-server-tools.ts
+++ b/packages/playground/mcp/src/tools/register-mcp-server-tools.ts
@@ -83,7 +83,7 @@ export function registerMcpServerTools(
 	port: number
 ) {
 	const sendCommand = bridge.sendCommand.bind(bridge);
-	const siteToolDefinitions = getSiteToolDefinitions(port);
+	const siteToolDefinitions = getSiteToolDefinitions();
 	const url = playgroundUrl(port);
 
 	// -- Site management tools --

--- a/packages/playground/mcp/src/tools/tool-definitions.ts
+++ b/packages/playground/mcp/src/tools/tool-definitions.ts
@@ -386,10 +386,7 @@ export const toolDefinitions: Record<string, ToolDefinition> = {
 
 // -- Site management tool definitions --
 
-export function getSiteToolDefinitions(
-	port: number
-): Record<string, ToolDefinition> {
-	const url = playgroundUrl(port);
+export function getSiteToolDefinitions(): Record<string, ToolDefinition> {
 	return {
 		playground_list_sites: {
 			title: 'List Available Sites',


### PR DESCRIPTION
**Note** Most of the changes from this PR got pushed to `trunk` by Claude (it set `branch.add/mcp-server-improvements.merge=refs/heads/trunk`) and the best way to [see the changes is to open this link
](https://github.com/WordPress/wordpress-playground/compare/2b35eeb58af3d49970be08b80a10912e0a593152...add/mcp-server-improvements).

## What is this PR doing?                                                                                                                                                        
                                                                                                                                                                                   
Improves the WordPress Playground MCP server with a new `playground_get_website_url`                                                                                             
tool, better URL persistence, README improvements, and a fix that preserves MCP                                                                                                  
connection settings when opening sites in new tabs.                                                                                                                              
                                                                                                                                                                                 
## Motivation for the change, related issues                                                                                                                                     
                                                                                                                                                                                 
Without a dedicated tool to retrieve the Playground website URL, AI assistants had                                                                                               
no reliable way to tell users where to open Playground — they had to ask users to                                                                                                
open it manually. Additionally, opening a site in a new tab dropped the `mcp`,                                                                                                   
`mcp-port`, and `can-save` query parameters, breaking the MCP bridge connection in                                                                                               
the new tab.                                                                                                                                                                     
                                                                                                                                                                                 
## Implementation details                                                                                                                                                        
                                                                                                                                                                                 
- **`playground_get_website_url` tool** (`packages/playground/mcp/src/tools/`): New                                                                                              
  MCP tool that returns the URL of the running Playground website so AI assistants                                                                                             
  can share it directly. The README is updated to document this tool.                                                                                                            
                                                                                                                                                                                 
- **Persist MCP query params across navigation** (`packages/playground/website/src/lib/state/url/router.ts`):                                                                    
  Adds `mcp`, `mcp-port`, and `can-save` to the list of query parameters preserved                                                                                               
  across internal navigation, so MCP mode stays active when the router updates the URL.                                                                                          
                                                                                                                                                                                 
- **Open site in new tab with MCP params** (`packages/playground/mcp/src/bridge-client.ts`):                                                                                     
  When opening a site via `__open_site`, the `mcp=yes` and `mcp-port` params are                                                                                                 
  now appended to the new tab URL, so the MCP bridge reconnects automatically.                                                                                                   
                                                                                                                                                                                 
- **README included in build output** (`packages/playground/mcp/project.json`):                                                                                                  
  Adds a `build:README` target that copies `README.md` into the dist folder so it                                                                                                
  is bundled with the published npm package.                                                                                                                                     
                                                                                                                                                                                 
- **Security section in README**: Documents that the MCP bridge is local-only and                                                                                                
  advises connecting only to trusted Playground instances. Fixes `npx` invocation                                                                                                
  to include the `-y` flag for non-interactive install.                                                                                                                          
                                                                                                                                                                                   
## Testing Instructions                                                                                                                                                          
                                                                                                                                                                                 
1. Start the MCP server: `npx @wp-playground/mcp`                                                                                                                                
2. Open the Playground website at the URL the server provides.
3. Ask your AI assistant: _"What's the Playground website URL?"_ — it should return                                                                                              
   the URL without asking you to find it.                                                                                                                                        
4. Use `playground_open_site` to open a site in a new tab.                                                                                                                       
5. Confirm the new tab URL includes `mcp=yes` and `mcp-port=<port>` and that the                                                                                                 
   MCP bridge is still connected (AI can still execute PHP, list sites, etc.).                                                                                                   
6. Navigate between pages inside Playground and confirm `mcp`, `mcp-port`, and                                                                                                   
   `can-save` params are preserved in the URL.                          