### PR TITLE
Use deploy keys instead of username/token for workflow pushes to trunk

### DIFF
--- a/.github/workflows/publish-devtools-extension.yml
+++ b/.github/workflows/publish-devtools-extension.yml
@@ -39,6 +39,7 @@ jobs:
                   ref: trunk
                   clean: true
                   fetch-depth: 1
+                  persist-credentials: true
                   ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
 

--- a/.github/workflows/publish-devtools-extension.yml
+++ b/.github/workflows/publish-devtools-extension.yml
@@ -40,7 +40,6 @@ jobs:
                   clean: true
                   fetch-depth: 1
                   persist-credentials: true
-                  ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
 
             - name: Configure git

--- a/.github/workflows/publish-devtools-extension.yml
+++ b/.github/workflows/publish-devtools-extension.yml
@@ -39,7 +39,7 @@ jobs:
                   ref: trunk
                   clean: true
                   fetch-depth: 1
-                  persist-credentials: true
+                  ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
 
             - name: Configure git

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -62,14 +62,13 @@ jobs:
               with:
                   ref: ${{ github.ref }}
                   clean: true
-                  persist-credentials: false
+                  ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
 
             - name: Configure git
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
-                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
 
             - name: Set up Node.js with OIDC
               uses: actions/setup-node@v4

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -62,6 +62,7 @@ jobs:
               with:
                   ref: ${{ github.ref }}
                   clean: true
+                  persist-credentials: true
                   ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
 

--- a/.github/workflows/publish-self-hosted-package-release.yml
+++ b/.github/workflows/publish-self-hosted-package-release.yml
@@ -41,13 +41,12 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
-                  persist-credentials: false
+                  ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
             - name: Config git user
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
-                  git remote set-url origin https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}
             - uses: ./.github/actions/prepare-playground
             # Version bump, release, tag a new version on GitHub
             - name: Bump package versions

--- a/.github/workflows/publish-self-hosted-package-release.yml
+++ b/.github/workflows/publish-self-hosted-package-release.yml
@@ -41,6 +41,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
+                  persist-credentials: true
                   ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
             - name: Config git user

--- a/.github/workflows/refresh-sqlite-integration.yml
+++ b/.github/workflows/refresh-sqlite-integration.yml
@@ -31,6 +31,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
+                  persist-credentials: true
                   ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
             - uses: ./.github/actions/prepare-playground

--- a/.github/workflows/refresh-sqlite-integration.yml
+++ b/.github/workflows/refresh-sqlite-integration.yml
@@ -31,7 +31,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
-                  persist-credentials: false
+                  ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
@@ -54,7 +54,6 @@ jobs:
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
-                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   git add -A
                   git commit -a -m "Refresh SQLite integration plugin"
                   git pull --rebase

--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -36,6 +36,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
+                  persist-credentials: true
                   ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
             - uses: ./.github/actions/prepare-playground

--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -36,7 +36,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
-                  persist-credentials: false
+                  ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
@@ -67,7 +67,6 @@ jobs:
                   sudo chown -R "$(whoami):$(id -gn)" packages/playground/wordpress-builds/public
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
-                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   git add -A
                   git commit -a -m "Recompile WordPress major and beta versions"
                   git pull --rebase

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -29,6 +29,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
+                  persist-credentials: true
                   ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
             - uses: ./.github/actions/prepare-playground

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -29,7 +29,7 @@ jobs:
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
                   clean: true
-                  persist-credentials: false
+                  ssh-key: ${{ secrets.DEPLOY_KEY }}
                   submodules: true
             - uses: ./.github/actions/prepare-playground
               with:
@@ -41,7 +41,6 @@ jobs:
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
-                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   git add -A
                   git commit -a -m "Refresh WordPress Nightly"
                   git pull --rebase

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -45,7 +45,7 @@ jobs:
                   submodules: recursive
                   ref: trunk
                   clean: true
-                  persist-credentials: false
+                  ssh-key: ${{ secrets.DEPLOY_KEY }}
             - name: 'Install bun (for the changelog)'
               run: |
                   curl -fsSL https://bun.sh/install | bash
@@ -63,7 +63,6 @@ jobs:
               run: |
                   git config --global user.name "deployment_bot"
                   git config --global user.email "deployment_bot@users.noreply.github.com"
-                  git remote set-url origin https://${{ secrets.GH_ACTOR }}:${{ secrets.GH_TOKEN }}@github.com/${{ github.repository }}
                   if [[ -n $(git status --porcelain CHANGELOG.md) ]]; then
                       git commit -m "chore: update changelog" \
                           CHANGELOG.md \

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -45,6 +45,7 @@ jobs:
                   submodules: recursive
                   ref: trunk
                   clean: true
+                  persist-credentials: true
                   ssh-key: ${{ secrets.DEPLOY_KEY }}
             - name: 'Install bun (for the changelog)'
               run: |


### PR DESCRIPTION
## Summary
- Switch all GitHub workflows that push to trunk from username/token
  authentication (`GH_ACTOR`/`GH_TOKEN` remote URL) to SSH deploy keys
- This enables stricter branch protection rules that require PRs before
  pushing to trunk, which helps avoid inadvertent pushes to trunk by AI
  agents

## Changes
- Replace `persist-credentials: false` with `ssh-key: ${{ secrets.DEPLOY_KEY }}`
  in checkout steps across 7 workflow files
- Remove manual `git remote set-url` lines that embedded credentials in
  the remote URL

## Affected workflows
- `refresh-wordpress-major-and-beta.yml`
- `refresh-wordpress-nightly.yml`
- `refresh-sqlite-integration.yml`
- `update-changelog.yml`
- `publish-npm-packages.yml`
- `publish-self-hosted-package-release.yml`

## Before merging
1. Generate an SSH key pair and add the public key as a repo deploy key
   (with write access)
2. Add the private key as a repo secret named `DEPLOY_KEY`
3. Re-enable the branch protection ruleset:
   https://github.com/WordPress/wordpress-playground/settings/rules/13447755