### PR TITLE
Expose pathAliases and rewriteRules from runCLI

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -195,6 +195,7 @@ export class BlueprintsV1Handler {
 			withXdebug: !!this.args.xdebug,
 			nativeInternalDirPath,
 			pathAliases: this.args.pathAliases,
+			rewriteRules: this.args.rewriteRules,
 		});
 		await playground.isReady();
 		return playground;

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -1,7 +1,11 @@
 import type { FileLockManager } from '@php-wasm/universal';
 import { loadNodeRuntime } from '@php-wasm/node';
 import { EmscriptenDownloadMonitor } from '@php-wasm/progress';
-import type { PathAlias, SupportedPHPVersion } from '@php-wasm/universal';
+import type {
+	PathAlias,
+	RewriteRule,
+	SupportedPHPVersion,
+} from '@php-wasm/universal';
 import {
 	PHPWorker,
 	releaseApiProxy,
@@ -52,6 +56,7 @@ interface WorkerBootRequestHandlerOptions {
 	withMemcached?: boolean;
 	withXdebug?: boolean;
 	pathAliases?: PathAlias[];
+	rewriteRules?: RewriteRule[];
 }
 
 /**
@@ -181,6 +186,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 				sapiName: 'cli',
 				cookieStore: false,
 				pathAliases: options.pathAliases,
+				rewriteRules: options.rewriteRules,
 				spawnHandler: () =>
 					sandboxedSpawnHandlerFactory(() => {
 						let effectiveOptions = options;

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -11,6 +11,7 @@ import type {
 	PathAlias,
 	PHP,
 	FileTree,
+	RewriteRule,
 	RemoteAPI,
 	SupportedPHPVersion,
 	SpawnHandler,
@@ -173,6 +174,7 @@ export type SecondaryWorkerBootArgs = {
 	withMemcached?: boolean;
 	withXdebug?: boolean;
 	pathAliases?: PathAlias[];
+	rewriteRules?: RewriteRule[];
 	mountsBeforeWpInstall?: Array<Mount>;
 	mountsAfterWpInstall?: Array<Mount>;
 };
@@ -456,6 +458,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 		withMemcached,
 		withXdebug,
 		pathAliases,
+		rewriteRules,
 		onPHPInstanceCreated,
 		spawnHandler,
 	}: WorkerBootRequestHandlerOptions) {
@@ -502,6 +505,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 				constants,
 				phpIniEntries,
 				pathAliases,
+				rewriteRules,
 				cookieStore: false,
 				spawnHandler,
 			});
@@ -566,6 +570,7 @@ async function createPHPWorker(
 		nativeInternalDirPath,
 		withXdebug,
 		pathAliases,
+		rewriteRules,
 		mountsBeforeWpInstall,
 		mountsAfterWpInstall,
 	}: // NOTE: We explicitly remove processId from the options
@@ -592,6 +597,7 @@ async function createPHPWorker(
 		nativeInternalDirPath,
 		withXdebug,
 		pathAliases,
+		rewriteRules,
 		mountsBeforeWpInstall,
 		mountsAfterWpInstall,
 	});

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -5,6 +5,7 @@ import {
 	type Pooled,
 	type PHPRequest,
 	type PathAlias,
+	type RewriteRule,
 	type RemoteAPI,
 	type SupportedPHPVersion,
 } from '@php-wasm/universal';
@@ -767,6 +768,7 @@ export interface RunCLIArgs {
 	wp?: string;
 	autoMount?: string;
 	pathAliases?: PathAlias[];
+	rewriteRules?: RewriteRule[];
 	experimentalTrace?: boolean;
 	internalCookieStore?: boolean;
 	'additional-blueprint-steps'?: any[];

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -5,6 +5,7 @@ import type {
 	FileTree,
 	PathAlias,
 	PHPWorker,
+	RewriteRule,
 	SpawnHandler,
 	Remote,
 } from '@php-wasm/universal';
@@ -116,6 +117,13 @@ export interface BootRequestHandlerOptions {
 	 * ```
 	 */
 	pathAliases?: PathAlias[];
+
+	/**
+	 * Additional rewrite rules to apply on top of the default WordPress
+	 * rewrite rules.  Each rule maps a regex pattern to a replacement
+	 * path, similar to Apache/Nginx rewrite directives.
+	 */
+	rewriteRules?: RewriteRule[];
 
 	/**
 	 * The CookieStore instance to use.
@@ -493,7 +501,10 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 	const requestHandler: PHPRequestHandler = new PHPRequestHandler({
 		documentRoot: options.documentRoot || '/wordpress',
 		absoluteUrl: options.siteUrl,
-		rewriteRules: wordPressRewriteRules,
+		rewriteRules: [
+			...wordPressRewriteRules,
+			...(options.rewriteRules || []),
+		],
 		pathAliases: options.pathAliases,
 		getFileNotFoundAction:
 			options.getFileNotFoundAction ?? getFileNotFoundActionForWordPress,


### PR DESCRIPTION
## Summary

When importing a site into Studio via [streaming-site-migration](https://github.com/adamziel/streaming-site-migration/), the recreated remote host directory structure may not have a `wp-admin` directory directly in the document root. Custom rewrite rules let the caller remap URL paths to the actual filesystem layout so WordPress still boots correctly.

`pathAliases` was already threaded through `RunCLIArgs` but `rewriteRules` was hardcoded to the default WordPress set inside `bootRequestHandler()`. This change adds `rewriteRules` to `RunCLIArgs` and `BootRequestHandlerOptions`, and appends any caller-provided rules after the built-in WordPress rewrite rules.

## Test plan

- Confirm existing CLI tests pass
- Call `runCLI()` programmatically with custom `rewriteRules` and verify they take effect