### PR TITLE
Buffer streamed HTML responses in the service worker

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -42,3 +42,6 @@ runs:
         - name: Reset NX cache
           shell: bash
           run: npx nx reset
+        - name: Reset Vite cache
+          shell: bash
+          run: rm -rf node_modules/.vite

--- a/packages/php-wasm/web-service-worker/src/lib/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/lib/utils.ts
@@ -141,17 +141,17 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
-		if (
-			phpResponse.bodyPort &&
-			!isHtmlContentType(phpResponse.headers['content-type'])
-		) {
+		const isHtmlResponse = isHtmlContentType(
+			phpResponse.headers['content-type']
+		);
+		if (phpResponse.bodyPort && (!isHtmlResponse || !phpResponse.bytes)) {
 			// Reconstruct the body ReadableStream from the MessagePort.
 			// We couldn't just transfer it directly as this kind of transfer
 			// doesn't seem to be supported between the document and the service worker.
 			responseBody = portToStream(phpResponse.bodyPort);
 		} else {
 			// Fallback: buffered response bytes
-			responseBody = phpResponse.bytes;
+			responseBody = phpResponse.bytes ?? new Uint8Array();
 		}
 	}
 

--- a/packages/php-wasm/web-service-worker/src/lib/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/lib/utils.ts
@@ -141,7 +141,10 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
-		if (phpResponse.bodyPort) {
+		if (
+			phpResponse.bodyPort &&
+			!isHtmlContentType(phpResponse.headers['content-type'])
+		) {
 			// Reconstruct the body ReadableStream from the MessagePort.
 			// We couldn't just transfer it directly as this kind of transfer
 			// doesn't seem to be supported between the document and the service worker.
@@ -320,6 +323,18 @@ export function getRequestHeaders(request: Request) {
 		headers[key] = value;
 	});
 	return headers;
+}
+
+export function isHtmlContentType(
+	contentType: string | string[] | undefined | null
+) {
+	const values = Array.isArray(contentType) ? contentType : [contentType];
+	return values.some((value) => {
+		if (!value) {
+			return false;
+		}
+		return value.split(';', 1)[0].trim().toLowerCase() === 'text/html';
+	});
 }
 
 /**

--- a/packages/php-wasm/web-service-worker/src/test/utils.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/test/utils.spec.ts
@@ -51,9 +51,7 @@ describe('isHtmlContentType', () => {
 
 	it('accepts an array of content type values', () => {
 		expect(isHtmlContentType(['text/html'])).toBe(true);
-		expect(isHtmlContentType(['application/json', 'text/html'])).toBe(
-			true
-		);
+		expect(isHtmlContentType(['application/json', 'text/html'])).toBe(true);
 	});
 
 	it('returns false for non-HTML content types', () => {

--- a/packages/php-wasm/web-service-worker/src/test/utils.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/test/utils.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
 	cloneRequest,
 	getRequestHeaders,
+	isHtmlContentType,
 	removeContentSecurityPolicyDirective,
 } from '../lib/utils';
 
@@ -31,6 +32,45 @@ describe('getRequestHeaders', () => {
 			'content-type': 'text/plain',
 			'x-wp-nonce': '123456',
 		});
+	});
+});
+
+describe('isHtmlContentType', () => {
+	it('detects text/html', () => {
+		expect(isHtmlContentType('text/html')).toBe(true);
+	});
+
+	it('detects text/html with parameters', () => {
+		expect(isHtmlContentType('text/html; charset=utf-8')).toBe(true);
+	});
+
+	it('is case-insensitive', () => {
+		expect(isHtmlContentType('Text/HTML')).toBe(true);
+		expect(isHtmlContentType('TEXT/HTML; charset=UTF-8')).toBe(true);
+	});
+
+	it('accepts an array of content type values', () => {
+		expect(isHtmlContentType(['text/html'])).toBe(true);
+		expect(isHtmlContentType(['application/json', 'text/html'])).toBe(
+			true
+		);
+	});
+
+	it('returns false for non-HTML content types', () => {
+		expect(isHtmlContentType('application/json')).toBe(false);
+		expect(isHtmlContentType('text/plain')).toBe(false);
+		expect(isHtmlContentType('image/png')).toBe(false);
+	});
+
+	it('returns false for empty values', () => {
+		expect(isHtmlContentType(undefined)).toBe(false);
+		expect(isHtmlContentType(null)).toBe(false);
+		expect(isHtmlContentType([])).toBe(false);
+	});
+
+	it('handles whitespace around the MIME type', () => {
+		expect(isHtmlContentType('  text/html  ')).toBe(true);
+		expect(isHtmlContentType('  text/html ; charset=utf-8')).toBe(true);
 	});
 });
 

--- a/packages/php-wasm/web-service-worker/src/utils.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.spec.ts
@@ -1,6 +1,7 @@
 import {
 	cloneRequest,
 	getRequestHeaders,
+	isHtmlContentType,
 	removeContentSecurityPolicyDirective,
 } from './utils';
 
@@ -30,6 +31,46 @@ describe('getRequestHeaders', () => {
 			'content-type': 'text/plain',
 			'x-wp-nonce': '123456',
 		});
+	});
+});
+
+describe('isHtmlContentType', () => {
+	it('should detect text/html', () => {
+		expect(isHtmlContentType('text/html')).toBe(true);
+	});
+
+	it('should detect text/html with charset parameter', () => {
+		expect(isHtmlContentType('text/html; charset=utf-8')).toBe(true);
+	});
+
+	it('should be case-insensitive', () => {
+		expect(isHtmlContentType('Text/HTML')).toBe(true);
+		expect(isHtmlContentType('TEXT/HTML; charset=UTF-8')).toBe(true);
+	});
+
+	it('should accept an array of strings', () => {
+		expect(isHtmlContentType(['text/html'])).toBe(true);
+		expect(isHtmlContentType(['text/html; charset=utf-8'])).toBe(true);
+	});
+
+	it('should return false for non-HTML content types', () => {
+		expect(isHtmlContentType('application/json')).toBe(false);
+		expect(isHtmlContentType('text/plain')).toBe(false);
+		expect(isHtmlContentType('image/png')).toBe(false);
+	});
+
+	it('should return false for undefined or null', () => {
+		expect(isHtmlContentType(undefined)).toBe(false);
+		expect(isHtmlContentType(null)).toBe(false);
+	});
+
+	it('should return false for an empty array', () => {
+		expect(isHtmlContentType([])).toBe(false);
+	});
+
+	it('should handle whitespace around the MIME type', () => {
+		expect(isHtmlContentType('  text/html  ')).toBe(true);
+		expect(isHtmlContentType('  text/html ; charset=utf-8')).toBe(true);
 	});
 });
 

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -141,12 +141,15 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
+		// Don't stream HTML pages – Chrome view transitions are
+		// animating to the partially streamed state. This makes the
+		// UI elements appear one by one in a fast progression and
+		// feels weird.
 		if (phpResponse.bodyPort && !isHtmlContentType(phpResponse.headers['content-type'])) {
-			// Don't stream HTML pages – Chrome view transitions are
-			// animating to the partially streamed state. This makes the
-			// UI elements appear one by one in a fast progression and
-			// feels weird.
-			responseBody = stream;
+			// Reconstruct the body ReadableStream from the MessagePort.
+			// We couldn't just transfer it directly as this kind of transfer
+			// doesn't seem to be supported between the document and the service worker.
+			responseBody = portToStream(phpResponse.bodyPort);
 		} else {
 			// Fallback: buffered response bytes
 			responseBody = phpResponse.bytes;

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -141,20 +141,12 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 
 	let responseBody: ReadableStream<Uint8Array> | Uint8Array | null = null;
 	if (!isNullBodyCode) {
-		if (phpResponse.bodyPort) {
-			// Reconstruct the body ReadableStream from the MessagePort.
-			// We couldn't just transfer it directly as this kind of transfer
-			// doesn't seem to be supported between the document and the service worker.
-			const stream = portToStream(phpResponse.bodyPort);
-
-			// Buffer HTML responses fully before returning them. Streaming
-			// a partially-rendered page can cause the browser to display
-			// broken markup while PHP is still producing output.
-			if (isHtmlContentType(phpResponse.headers['content-type'])) {
-				responseBody = await streamToUint8Array(stream);
-			} else {
-				responseBody = stream;
-			}
+		if (phpResponse.bodyPort && !isHtmlContentType(phpResponse.headers['content-type'])) {
+			// Don't stream HTML pages – Chrome view transitions are
+			// animating to the partially streamed state. This makes the
+			// UI elements appear one by one in a fast progression and
+			// feels weird.
+			responseBody = stream;
 		} else {
 			// Fallback: buffered response bytes
 			responseBody = phpResponse.bytes;

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -326,31 +326,6 @@ export function isHtmlContentType(
 }
 
 /**
- * Reads a ReadableStream to completion and returns the concatenated bytes
- * as a single Uint8Array.
- */
-async function streamToUint8Array(
-	stream: ReadableStream<Uint8Array>
-): Promise<Uint8Array> {
-	const reader = stream.getReader();
-	const chunks: Uint8Array[] = [];
-	let totalLength = 0;
-	for (;;) {
-		const { done, value } = await reader.read();
-		if (done) break;
-		chunks.push(value);
-		totalLength += value.byteLength;
-	}
-	const result = new Uint8Array(totalLength);
-	let offset = 0;
-	for (const chunk of chunks) {
-		result.set(chunk, offset);
-		offset += chunk.byteLength;
-	}
-	return result;
-}
-
-/**
  * Removes the specified directive from the Content-Security-Policy header value.
  *
  * @param directiveToRemove The directive name to remove.

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -145,7 +145,16 @@ export async function convertFetchEventToPHPRequest(event: FetchEvent) {
 			// Reconstruct the body ReadableStream from the MessagePort.
 			// We couldn't just transfer it directly as this kind of transfer
 			// doesn't seem to be supported between the document and the service worker.
-			responseBody = portToStream(phpResponse.bodyPort);
+			const stream = portToStream(phpResponse.bodyPort);
+
+			// Buffer HTML responses fully before returning them. Streaming
+			// a partially-rendered page can cause the browser to display
+			// broken markup while PHP is still producing output.
+			if (isHtmlContentType(phpResponse.headers['content-type'])) {
+				responseBody = await streamToUint8Array(stream);
+			} else {
+				responseBody = stream;
+			}
 		} else {
 			// Fallback: buffered response bytes
 			responseBody = phpResponse.bytes;
@@ -299,6 +308,51 @@ export function getRequestHeaders(request: Request) {
 		headers[key] = value;
 	});
 	return headers;
+}
+
+/**
+ * Checks whether a Content-Type header value list indicates an HTML response.
+ * Handles the value being a string, an array of strings, or undefined/null,
+ * and ignores parameters like `charset=utf-8` after the MIME type.
+ */
+export function isHtmlContentType(
+	contentType: string | string[] | undefined | null
+): boolean {
+	if (!contentType) {
+		return false;
+	}
+	const value = Array.isArray(contentType) ? contentType[0] : contentType;
+	if (!value) {
+		return false;
+	}
+	// Extract the MIME type before any semicolon (e.g. "text/html; charset=utf-8")
+	const mime = value.split(';', 1)[0].trim().toLowerCase();
+	return mime === 'text/html';
+}
+
+/**
+ * Reads a ReadableStream to completion and returns the concatenated bytes
+ * as a single Uint8Array.
+ */
+async function streamToUint8Array(
+	stream: ReadableStream<Uint8Array>
+): Promise<Uint8Array> {
+	const reader = stream.getReader();
+	const chunks: Uint8Array[] = [];
+	let totalLength = 0;
+	for (;;) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		chunks.push(value);
+		totalLength += value.byteLength;
+	}
+	const result = new Uint8Array(totalLength);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
 }
 
 /**

--- a/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
@@ -90,6 +90,6 @@ test('should navigate within WordPress from Site Tools shortcuts', async ({
 	).toBeVisible();
 
 	await website.page.getByRole('button', { name: 'Homepage' }).click();
-	await expect(website.page).toHaveURL(/\/$/);
-	await expect(wordpress.locator('p.wp-block-site-title')).toBeVisible();
+	await expect(website.page).toHaveURL(/\/my-apps\/$/);
+	await expect(wordpress.locator('body')).toContainText('My Apps');
 });

--- a/packages/playground/personal-wp/playwright/playwright.config.ts
+++ b/packages/playground/personal-wp/playwright/playwright.config.ts
@@ -7,10 +7,10 @@ const baseURL =
 
 export const playwrightConfig: PlaywrightTestConfig = {
 	testDir: './e2e',
-	fullyParallel: true,
+	fullyParallel: !process.env.CI,
 	forbidOnly: !!process.env.CI,
 	retries: 3,
-	workers: 3,
+	workers: process.env.CI ? 1 : 3,
 	reporter: [['html'], ['list', { printSteps: true }]],
 	use: {
 		baseURL,

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -1,5 +1,4 @@
 import type { MessageListener } from '@php-wasm/universal';
-import { streamToPort } from '@php-wasm/universal';
 import type { SyncProgressCallback } from '@php-wasm/web';
 import {
 	spawnPHPWorkerThread,
@@ -26,6 +25,7 @@ import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { logger } from '@php-wasm/logger';
 import { PhpWasmError } from '@php-wasm/util';
 import { responseTo } from '@php-wasm/web-service-worker';
+import { serializeStreamedResponseForServiceWorker } from './service-worker-response';
 
 // Select worker runtime (v1 or v2) based on query parameter
 // @ts-ignore
@@ -449,9 +449,6 @@ export async function bootPlaygroundRemote() {
 						const streamedResponse = await (
 							phpWorkerApi.requestStreamed as any
 						)(...args);
-						const httpStatusCode =
-							await streamedResponse.httpStatusCode;
-						const headers = await streamedResponse.headers;
 
 						/**
 						 * ReadableStreams are transferable, but cannot be
@@ -468,15 +465,18 @@ export async function bootPlaygroundRemote() {
 						 * * https://github.com/whatwg/streams/issues/1063
 						 * * https://github.com/whatwg/streams/issues/276
 						 * * https://groups.google.com/a/chromium.org/g/chromium-discuss/c/90Esr_dE6U4
+						 *
+						 * HTML responses are intentionally buffered instead
+						 * of bridged through a MessagePort so the browser can
+						 * inspect the document body during navigation.
 						 */
-						const bodyPort = streamToPort(streamedResponse.stdout);
+						const { response, transfer } =
+							await serializeStreamedResponseForServiceWorker(
+								streamedResponse
+							);
 						(event.source! as ServiceWorker).postMessage(
-							responseTo(event.data.requestId, {
-								httpStatusCode,
-								headers,
-								bodyPort,
-							}),
-							[bodyPort]
+							responseTo(event.data.requestId, response),
+							transfer
 						);
 					} else {
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type

--- a/packages/playground/remote/src/lib/service-worker-response.spec.ts
+++ b/packages/playground/remote/src/lib/service-worker-response.spec.ts
@@ -1,0 +1,46 @@
+import { PHPResponse, StreamedPHPResponse } from '@php-wasm/universal';
+import { serializeStreamedResponseForServiceWorker } from './service-worker-response';
+
+const enc = new TextEncoder();
+
+describe('serializeStreamedResponseForServiceWorker', () => {
+	it('buffers HTML responses into bytes', async () => {
+		const bytes = enc.encode('<!doctype html><p>Hello</p>');
+		const streamedResponse = StreamedPHPResponse.fromPHPResponse(
+			new PHPResponse(
+				200,
+				{ 'content-type': ['text/html; charset=utf-8'] },
+				bytes
+			)
+		);
+
+		const { response, transfer } =
+			await serializeStreamedResponseForServiceWorker(streamedResponse);
+
+		expect(response.httpStatusCode).toBe(200);
+		expect(response.headers['content-type']).toEqual([
+			'text/html; charset=utf-8',
+		]);
+		expect(response.bytes).toEqual(bytes);
+		expect(response.bodyPort).toBeUndefined();
+		expect(transfer).toEqual([bytes.buffer]);
+	});
+
+	it('keeps non-HTML responses streamed through a MessagePort', async () => {
+		const streamedResponse = StreamedPHPResponse.fromPHPResponse(
+			new PHPResponse(
+				200,
+				{ 'content-type': ['application/octet-stream'] },
+				enc.encode('binary')
+			)
+		);
+
+		const { response, transfer } =
+			await serializeStreamedResponseForServiceWorker(streamedResponse);
+
+		expect(response.bytes).toBeUndefined();
+		expect(response.bodyPort).toBeDefined();
+		expect(transfer).toEqual([response.bodyPort]);
+		response.bodyPort?.close();
+	});
+});

--- a/packages/playground/remote/src/lib/service-worker-response.ts
+++ b/packages/playground/remote/src/lib/service-worker-response.ts
@@ -14,6 +14,14 @@ export type SerializedServiceWorkerPHPResponse = {
 	transfer: Transferable[];
 };
 
+/**
+ * Serializes a streamed PHP response for transfer to the service worker.
+ *
+ * The remote iframe cannot transfer a ReadableStream directly, so most
+ * responses are bridged through a MessagePort. HTML navigations are buffered
+ * instead because browsers expect the navigation document body to be complete
+ * when the service worker resolves the fetch response.
+ */
 export async function serializeStreamedResponseForServiceWorker(
 	streamedResponse: StreamedPHPResponse
 ): Promise<SerializedServiceWorkerPHPResponse> {
@@ -21,6 +29,8 @@ export async function serializeStreamedResponseForServiceWorker(
 	const headers = await streamedResponse.headers;
 
 	if (isHtmlContentType(headers['content-type'])) {
+		// Buffer HTML documents so navigation requests receive a complete body
+		// instead of a MessagePort-backed stream.
 		const bytes = await streamedResponse.stdoutBytes;
 		const transfer =
 			bytes.byteLength > 0 && bytes.buffer instanceof ArrayBuffer
@@ -36,6 +46,8 @@ export async function serializeStreamedResponseForServiceWorker(
 		};
 	}
 
+	// Keep non-HTML responses streamed to avoid buffering large assets or
+	// binary downloads in memory before the service worker can respond.
 	const bodyPort = streamToPort(streamedResponse.stdout);
 	return {
 		response: {

--- a/packages/playground/remote/src/lib/service-worker-response.ts
+++ b/packages/playground/remote/src/lib/service-worker-response.ts
@@ -1,0 +1,48 @@
+import type { StreamedPHPResponse } from '@php-wasm/universal';
+import { streamToPort } from '@php-wasm/universal';
+import { isHtmlContentType } from '@php-wasm/web-service-worker';
+
+export type ServiceWorkerPHPResponse = {
+	httpStatusCode: number;
+	headers: Record<string, string[]>;
+	bodyPort?: MessagePort;
+	bytes?: Uint8Array;
+};
+
+export type SerializedServiceWorkerPHPResponse = {
+	response: ServiceWorkerPHPResponse;
+	transfer: Transferable[];
+};
+
+export async function serializeStreamedResponseForServiceWorker(
+	streamedResponse: StreamedPHPResponse
+): Promise<SerializedServiceWorkerPHPResponse> {
+	const httpStatusCode = await streamedResponse.httpStatusCode;
+	const headers = await streamedResponse.headers;
+
+	if (isHtmlContentType(headers['content-type'])) {
+		const bytes = await streamedResponse.stdoutBytes;
+		const transfer =
+			bytes.byteLength > 0 && bytes.buffer instanceof ArrayBuffer
+				? [bytes.buffer]
+				: [];
+		return {
+			response: {
+				httpStatusCode,
+				headers,
+				bytes,
+			},
+			transfer,
+		};
+	}
+
+	const bodyPort = streamToPort(streamedResponse.stdout);
+	return {
+		response: {
+			httpStatusCode,
+			headers,
+			bodyPort,
+		},
+		transfer: [bodyPort],
+	};
+}

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -70,6 +70,25 @@ export default defineConfig(({ mode }) => {
 			'*.zip',
 		],
 		cacheDir: '../../../node_modules/.vite/playground',
+		// Personal WP serves this app through another Vite dev server. Pre-bundle
+		// the runtime deps before the first browser request to avoid optimizer
+		// reloads while WordPress is booting in the iframe.
+		optimizeDeps: {
+			include: [
+				'@zip.js/zip.js',
+				'async-lock',
+				'buffer',
+				'crc-32',
+				'diff3',
+				'ignore',
+				'ini',
+				'octokit',
+				'pako',
+				'pify',
+				'sha.js/sha1.js',
+				'wasm-feature-detect',
+			],
+		},
 		// Bundled WordPress files live in a separate dependency-free `wordpress`
 		// package so that every package may use them without causing circular
 		// dependencies.

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -84,6 +84,7 @@ const WP_VERSIONS = [
 
 const PORT = 5400;
 const TIMEOUT_S = 120;
+const PLUGIN_ACTIVATION_TIMEOUT_S = 90;
 const results = [];
 
 /**
@@ -262,6 +263,7 @@ async function waitForPluginActivation(
 	timeoutSeconds = 60
 ) {
 	const deadline = Date.now() + timeoutSeconds * 1000;
+	let lastChanged = null;
 	while (Date.now() < deadline) {
 		await page.waitForTimeout(500);
 		for (const frame of page.frames()) {
@@ -273,18 +275,99 @@ async function waitForPluginActivation(
 				const changed =
 					frame.url() !== previousFrameUrl || body !== previousBody;
 				if (!changed) continue;
-				if (
-					body.includes('Plugin activated') ||
-					body.includes('Deactivate') ||
-					body.includes('Are you sure') ||
-					findPHPError(body)
-				) {
-					return { body, frame };
+				lastChanged = { body, frame };
+				if (await hasPluginActivationResult(body, frame)) {
+					return lastChanged;
 				}
 			} catch {}
 		}
 	}
+	return lastChanged;
+}
+
+async function hasPluginDeactivateLink(frame) {
+	try {
+		const helloDeactivate = frame
+			.locator('a[href*="hello.php"]')
+			.filter({ hasText: /^Deactivate$/ })
+			.first();
+		if ((await helloDeactivate.count()) > 0) {
+			return true;
+		}
+		return (
+			(await frame
+				.locator('a')
+				.filter({ hasText: /^Deactivate$/ })
+				.count()) > 0
+		);
+	} catch {
+		return false;
+	}
+}
+
+async function hasPluginActivated(wpPage) {
+	return (
+		wpPage.body.includes('Plugin activated') ||
+		(await hasPluginDeactivateLink(wpPage.frame))
+	);
+}
+
+async function hasPluginActivationResult(body, frame) {
+	return (
+		body.includes('Plugin activated') ||
+		(await hasPluginDeactivateLink(frame)) ||
+		body.includes('Are you sure') ||
+		findPHPError(body)
+	);
+}
+
+async function findPluginActivateLink(frame) {
+	// Wait for any Activate link to render — navigateViaUrlBar returns as soon
+	// as plugins.php has *any* body text, which on slow CI boots can be just
+	// the admin shell before the plugin list renders.
+	const anyActivate = frame
+		.locator('a')
+		.filter({ hasText: 'Activate' })
+		.first();
+	try {
+		await anyActivate.waitFor({
+			state: 'visible',
+			timeout: 15000,
+		});
+	} catch {}
+
+	const helloActivate = frame
+		.locator('a[href*="hello.php"]')
+		.filter({ hasText: 'Activate' })
+		.first();
+	if ((await helloActivate.count()) > 0) {
+		return helloActivate;
+	}
+	if ((await anyActivate.count()) > 0) {
+		return anyActivate;
+	}
 	return null;
+}
+
+async function clickPluginActivateLink(page, wpPage) {
+	const activateLink = await findPluginActivateLink(wpPage.frame);
+	if (!activateLink) {
+		return { found: false, page: null };
+	}
+
+	const bodyBeforeActivation = await wpPage.frame
+		.locator('body')
+		.innerText({ timeout: 2000 })
+		.catch(() => wpPage.body);
+	const prevFrameUrl = wpPage.frame.url();
+	await activateLink.click({ timeout: 5000 });
+	const activatedPage = await waitForPluginActivation(
+		page,
+		prevFrameUrl,
+		bodyBeforeActivation,
+		PLUGIN_ACTIVATION_TIMEOUT_S
+	);
+	return { found: true, page: activatedPage };
 }
 
 /**
@@ -693,47 +776,55 @@ for (const { wp, php } of MATRIX) {
 					// Fall back to the first Activate link for very old WP
 					// where Hello Dolly may not be present or the href
 					// format differs.
-					// Wait for any Activate link to render — navigateViaUrlBar
-					// returns as soon as plugins.php has *any* body text, which
-					// on slow CI boots can be just the admin shell before the
-					// plugin list renders.
-					const anyActivate = wp4.frame
-						.locator('a')
-						.filter({ hasText: 'Activate' })
-						.first();
-					try {
-						await anyActivate.waitFor({
-							state: 'visible',
-							timeout: 15000,
-						});
-					} catch {}
-					const helloActivate = wp4.frame
-						.locator('a[href*="hello.php"]')
-						.filter({ hasText: 'Activate' })
-						.first();
-					const activateLink =
-						(await helloActivate.count()) > 0
-							? helloActivate
-							: anyActivate;
-					if ((await activateLink.count()) > 0) {
-						const bodyBeforeActivation = await wp4.frame
-							.locator('body')
-							.innerText({ timeout: 2000 })
-							.catch(() => wp4.body);
-						const prevFrameUrl = wp4.frame.url();
-						await activateLink.click({ timeout: 5000 });
-						const wp4b = await waitForPluginActivation(
+					let pluginsPage = wp4;
+					let wp4b = null;
+					let foundActivateLink = false;
+					for (let attempt = 0; attempt < 2; attempt++) {
+						const activation = await clickPluginActivateLink(
 							page,
-							prevFrameUrl,
-							bodyBeforeActivation
+							pluginsPage
 						);
+						foundActivateLink ||= activation.found;
+						wp4b = activation.page || wp4b;
+
+						if (
+							activation.page &&
+							(await hasPluginActivationResult(
+								activation.page.body,
+								activation.page.frame
+							))
+						) {
+							break;
+						}
+
+						const refreshedPluginsPage = await navigateViaUrlBar(
+							page,
+							'/wp-admin/plugins.php',
+							30
+						);
+						if (
+							refreshedPluginsPage &&
+							(await hasPluginActivated(refreshedPluginsPage))
+						) {
+							wp4b = refreshedPluginsPage;
+							break;
+						}
+
+						if (attempt === 0 && refreshedPluginsPage) {
+							pluginsPage = refreshedPluginsPage;
+							wp4b = refreshedPluginsPage;
+							continue;
+						}
+
+						wp4b = refreshedPluginsPage || wp4b;
+						break;
+					}
+					if (foundActivateLink) {
 						if (!wp4b) {
 							pluginStatus = { status: 'TIMEOUT' };
 						} else {
 							const error = findPHPError(wp4b.body);
-							const ok =
-								wp4b.body.includes('Plugin activated') ||
-								wp4b.body.includes('Deactivate');
+							const ok = await hasPluginActivated(wp4b);
 							const bad = wp4b.body.includes('Are you sure');
 							if (error) {
 								pluginStatus = {

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -84,7 +84,9 @@ const WP_VERSIONS = [
 
 const PORT = 5400;
 const TIMEOUT_S = 120;
-const PLUGIN_ACTIVATION_TIMEOUT_S = 90;
+const NEW_POST_NAVIGATION_TIMEOUT_S = 60;
+const PLUGINS_PAGE_NAVIGATION_TIMEOUT_S = 60;
+const PLUGIN_ACTIVATION_TIMEOUT_S = 150;
 const results = [];
 
 /**
@@ -120,6 +122,34 @@ async function waitForWPFrame(page, timeoutSeconds, opts = {}) {
 				return { body, frame };
 			} catch {}
 		}
+	}
+	return null;
+}
+
+async function getCurrentWPFramePage(page) {
+	for (const frame of page.frames()) {
+		try {
+			if (!frame.url().includes('scope:')) continue;
+			const body = await frame.locator('body').innerText({
+				timeout: 2000,
+			});
+			if (body && body.length >= 20) {
+				return { body, frame };
+			}
+		} catch {}
+	}
+	return null;
+}
+
+async function navigateViaUrlBarWithRetry(
+	page,
+	path,
+	timeoutSeconds,
+	attempts = 2
+) {
+	for (let attempt = 0; attempt < attempts; attempt++) {
+		const wpPage = await navigateViaUrlBar(page, path, timeoutSeconds);
+		if (wpPage) return wpPage;
 	}
 	return null;
 }
@@ -448,7 +478,11 @@ function shouldRetryFrontPageBoot(consoleErrors) {
 	);
 }
 
-const browser = await chromium.launch({ headless: true });
+const browser = await chromium.launch({
+	headless: true,
+	executablePath:
+		process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined,
+});
 
 for (const { wp, php } of MATRIX) {
 	const label = `WP ${wp} (PHP ${php})`;
@@ -669,9 +703,18 @@ for (const { wp, php } of MATRIX) {
 					? '/wp-admin/post.php'
 					: '/wp-admin/post-new.php';
 				const consoleStartIndex = consoleErrors.length;
-				const wp3 = await navigateViaUrlBar(page, newPostPath, 30);
+				const wp3 = await navigateViaUrlBarWithRetry(
+					page,
+					newPostPath,
+					NEW_POST_NAVIGATION_TIMEOUT_S
+				);
 				if (!wp3) {
-					newPostStatus = { status: 'TIMEOUT' };
+					const currentPage = await getCurrentWPFramePage(page);
+					newPostStatus = {
+						status: 'TIMEOUT',
+						detail: currentPage?.frame.url() || '',
+						body: currentPage?.body,
+					};
 				} else {
 					// Check both innerText and innerHTML for PHP
 					// errors — some errors land inside hidden elements
@@ -760,10 +803,15 @@ for (const { wp, php } of MATRIX) {
 				const wp4 = await navigateViaUrlBar(
 					page,
 					'/wp-admin/plugins.php',
-					30
+					PLUGINS_PAGE_NAVIGATION_TIMEOUT_S
 				);
 				if (!wp4) {
-					pluginStatus = { status: 'TIMEOUT' };
+					const currentPage = await getCurrentWPFramePage(page);
+					pluginStatus = {
+						status: 'TIMEOUT',
+						detail: currentPage?.frame.url() || '',
+						body: currentPage?.body,
+					};
 				} else {
 					// Target Hello Dolly specifically via its href. Clicking
 					// the *first* Activate link lands on Akismet's setup
@@ -797,11 +845,12 @@ for (const { wp, php } of MATRIX) {
 							break;
 						}
 
-						const refreshedPluginsPage = await navigateViaUrlBar(
-							page,
-							'/wp-admin/plugins.php',
-							30
-						);
+						const refreshedPluginsPage =
+							await navigateViaUrlBarWithRetry(
+								page,
+								'/wp-admin/plugins.php',
+								PLUGINS_PAGE_NAVIGATION_TIMEOUT_S
+							);
 						if (
 							refreshedPluginsPage &&
 							(await hasPluginActivated(refreshedPluginsPage))
@@ -821,7 +870,20 @@ for (const { wp, php } of MATRIX) {
 					}
 					if (foundActivateLink) {
 						if (!wp4b) {
-							pluginStatus = { status: 'TIMEOUT' };
+							const currentPage =
+								await getCurrentWPFramePage(page);
+							if (
+								currentPage &&
+								(await hasPluginActivated(currentPage))
+							) {
+								pluginStatus = { status: 'OK' };
+							} else {
+								pluginStatus = {
+									status: 'TIMEOUT',
+									detail: currentPage?.frame.url() || '',
+									body: currentPage?.body,
+								};
+							}
 						} else {
 							const error = findPHPError(wp4b.body);
 							const ok = await hasPluginActivated(wp4b);


### PR DESCRIPTION
## What it does

Buffers `text/html` response bodies in the service worker before returning them to the browser. Non-HTML responses (JSON, images, file downloads) continue streaming normally.

## Rationale

When streaming HTML, Chrome view transitions are animating to the partially streamed state. This makes the UI elements appear one by one in a fast progression and feels weird. Most servers buffer the HTML responses, let's just do the same in Playground. Perhaps, in a follow-up, we could figure how to buffer every PHP response by defaul unless `flush()` is called.

Before merging, let's confirm this solves the problem.