### PR TITLE
[Web] Fix bugs with running personal WP dev server

### DIFF
--- a/packages/playground/php-cors-proxy/cors-proxy-functions.php
+++ b/packages/playground/php-cors-proxy/cors-proxy-functions.php
@@ -433,6 +433,8 @@ function should_respond_with_cors_headers($host, $origin) {
         'http://127.0.0.1',
         'http://127.0.0.1:5400',
         'http://localhost:5400',
+        'http://127.0.0.1:5401',
+        'http://localhost:5401',
         'http://127.0.0.1:4400',
         'http://localhost:4400',
     );

--- a/packages/playground/php-cors-proxy/cors-proxy.php
+++ b/packages/playground/php-cors-proxy/cors-proxy.php
@@ -1,7 +1,7 @@
 <?php
 // Set error reporting
 error_reporting(E_ALL);
-ini_set('display_errors', 1);
+ini_set('display_errors', 0);
 
 define('MAX_REQUEST_SIZE', 1 * 1024 * 1024); // 1MB
 define('MAX_RESPONSE_SIZE', 100 * 1024 * 1024); // 100MB
@@ -124,7 +124,7 @@ function send_response_chunk($data) {
 /**
  * We need to manually chunk the response when running the PHP
  * dev server AND the transfer-encoding header is set to chunked.
- * 
+ *
  * Apache, Nginx, etc. will handle the chunking for us.
  */
 function should_send_as_chunked_response() {
@@ -228,11 +228,11 @@ curl_setopt(
 
         $len = strlen($header);
         $colonPos = strpos($header, ':');
-        
+
         if ($colonPos === false) {
             return $len;
         }
-        
+
         $name = strtolower(substr($header, 0, $colonPos));
         $value = trim(substr($header, $colonPos + 1));
 
@@ -349,7 +349,11 @@ if (!curl_exec($ch)) {
     @$relay_http_code_and_initial_headers_if_not_already_sent();
 }
 // Close cURL session
-curl_close($ch);
+if (version_compare(PHP_VERSION, '8.5', '<')) {
+    // curl_close is deprecated in PHP 8.5 and later.
+    // See https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.curl
+    curl_close($ch);
+}
 
 // Only send chunked transfer encoding footer if we're using chunked encoding.
 // We need to manually send the footer when running in the PHP built-in server

--- a/packages/playground/remote/src/lib/offline-mode-cache.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.ts
@@ -178,6 +178,8 @@ export function shouldCacheUrl(url: URL) {
 	if (
 		url.href.startsWith('http://127.0.0.1:5400/') ||
 		url.href.startsWith('http://localhost:5400/') ||
+		url.href.startsWith('http://127.0.0.1:5401/') ||
+		url.href.startsWith('http://localhost:5401/') ||
 		url.href.startsWith('https://playground.test/') ||
 		url.pathname.startsWith('/website-server/')
 	) {


### PR DESCRIPTION
## Motivation for the change, related issues

There are some places in Playground that do not properly acknowledge the personal-wp dev server origin of `http://127.0.0.1:5401`:
- Not excluded from offline asset caching
- Not allowed by default by the CORS proxy script

In addition, the local CORS proxy was not working for @zaerl and I, and @zaerl noticed that the CORS proxy output was being corrupted by an inline warning due to `curl_close()` being deprecated in PHP 8.5+.

## Implementation details

- Add `http://127.0.0.1:5401` to the relevant allow and exclude lists.
- Set `display_errors` to zero in cors-proxy.php
- Only call `curl_close()` when the PHP version is below 8.5

## Testing Instructions (or ideally a Blueprint)

- CI
- Run `npx nx dev playground-personal-wp` on a clean browser env and confirm it loads the Your WordPress welcome page.
