### PR TITLE
Fix: force x-safari scheme for Linkedin app

### DIFF
--- a/packages/playground/personal-wp/index.html
+++ b/packages/playground/personal-wp/index.html
@@ -170,7 +170,12 @@
 						navigator.share({ url: window.location.href });
 					});
 				} else {
-					safariLink.href = 'open-in-safari://';
+					safariLink.href =
+						'x-safari-https://' +
+						window.location.host +
+						window.location.pathname +
+						window.location.search +
+						window.location.hash;
 				}
 
 				document

--- a/packages/playground/personal-wp/index.html
+++ b/packages/playground/personal-wp/index.html
@@ -160,6 +160,7 @@
 				);
 
 				if (/Twitter for iPhone/i.test(ua)) {
+					// This is tested with the X mobile app.
 					safariLink.textContent = 'Share link';
 					safariLink.removeAttribute('href');
 					safariLink.addEventListener('click', function (e) {
@@ -167,6 +168,11 @@
 						navigator.share({ url: window.location.href });
 					});
 				} else {
+					// The `x-safari-http(s)://` scheme doesn't work in a WKWebView running in iOS simulator
+					// when running http://127.0.0.1:5400/website-server/, the `open-in-safari://` instead works,
+					// but not in other environments.
+					// This is tested with the Linkedin mobile app.
+					// TODO: test with other mobile apps.
 					safariLink.href =
 						'x-safari-https://' +
 						window.location.host +

--- a/packages/playground/personal-wp/index.html
+++ b/packages/playground/personal-wp/index.html
@@ -155,9 +155,6 @@
 					.getElementById('wkwebview-notice')
 					.classList.add('is-visible');
 
-				document.getElementById('wkwebview-safari-link').href =
-					'open-in-safari://';
-
 				let safariLink = document.getElementById(
 					'wkwebview-safari-link'
 				);

--- a/packages/playground/website/index.html
+++ b/packages/playground/website/index.html
@@ -166,6 +166,7 @@
 				);
 
 				if (/Twitter for iPhone/i.test(ua)) {
+					// This is tested with the X mobile app.
 					safariLink.textContent = 'Share link';
 					safariLink.removeAttribute('href');
 					safariLink.addEventListener('click', function (e) {
@@ -173,7 +174,17 @@
 						navigator.share({ url: window.location.href });
 					});
 				} else {
-					safariLink.href = 'open-in-safari://';
+					// The `x-safari-http(s)://` scheme doesn't work in a WKWebView running in iOS simulator
+					// when running http://127.0.0.1:5400/website-server/, the `open-in-safari://` instead works,
+					// but not in other environments.
+					// This is tested with the Linkedin mobile app.
+					// TODO: test with other mobile apps.
+					safariLink.href =
+						'x-safari-https://' +
+						window.location.host +
+						window.location.pathname +
+						window.location.search +
+						window.location.hash;
 				}
 
 				document


### PR DESCRIPTION
## Motivation for the change, related issues
The `x-safari-http(s)://` scheme doesn't work in a WKWebView running in iOS simulator when running http://127.0.0.1:5400/website-server/, the `open-in-safari://` instead works.

Forced the right scheme.

## Implementation details

## Testing Instructions (or ideally a Blueprint)
