### PR TITLE
Fix: ignore ERR_STREAM_UNABLE_TO_PIPE in CLI server

### DIFF
--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -112,12 +112,15 @@ async function handleStreamedResponse(
 	try {
 		await pipeline(nodeStream, res);
 	} catch (error: unknown) {
-		// Ignore "ERR_STREAM_PREMATURE_CLOSE". It means the client disconnected
-		// before the response finished (e.g. a redirect or mid-load navigation).
+		// Ignore client-disconnect errors. These occur when the browser
+		// navigates away or refreshes before the response finishes:
+		// - ERR_STREAM_PREMATURE_CLOSE: stream was open but closed early
+		// - ERR_STREAM_UNABLE_TO_PIPE: stream was already destroyed
 		if (
 			error instanceof Error &&
 			'code' in error &&
-			error.code === 'ERR_STREAM_PREMATURE_CLOSE'
+			(error.code === 'ERR_STREAM_PREMATURE_CLOSE' ||
+				error.code === 'ERR_STREAM_UNABLE_TO_PIPE')
 		) {
 			return;
 		}
@@ -136,10 +139,7 @@ const bufferRequestBody = async (req: Request): Promise<Uint8Array> =>
 		});
 	});
 
-async function setCodespacesPortPublic(
-	port: number,
-	codespaceName: string
-) {
+async function setCodespacesPortPublic(port: number, codespaceName: string) {
 	logger.log(`Publishing port ${port}...`);
 	const cmd = `gh codespace ports visibility ${port}:public -c ${codespaceName}`;
 	for (let i = 0; i < 10; i++) {

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -16,7 +16,93 @@ vi.mock('stream/promises', async (importOriginal) => {
 });
 
 describe('startServer', () => {
-	it('does not log an error on client disconnect', async () => {
+	it('does not log an error when piping to a destroyed stream (ERR_STREAM_UNABLE_TO_PIPE)', async () => {
+		const pipelineMock = vi.mocked(pipeline);
+		pipelineMock.mockClear();
+		(logger.error as Mock<typeof logger.error>).mockClear();
+
+		// Use a deferred promise to control when headers resolve,
+		// so the client can disconnect before pipeline() is called.
+		let resolveHeaders!: () => void;
+
+		const repondersForHandleRequest = [
+			async () =>
+				new StreamedPHPResponse(
+					new ReadableStream({
+						async start(controller) {
+							await new Promise<void>((r) => {
+								resolveHeaders = r;
+							});
+							const json = JSON.stringify({
+								status: 200,
+								headers: ['content-type: text/plain'],
+							});
+							controller.enqueue(new TextEncoder().encode(json));
+							controller.close();
+						},
+					}),
+					new ReadableStream({
+						start(controller) {
+							controller.enqueue(
+								new TextEncoder().encode('hello')
+							);
+							controller.close();
+						},
+					}),
+					new ReadableStream({ start: (c) => c.close() }),
+					Promise.resolve(0)
+				),
+		];
+
+		const cliServer = await startServer({
+			port: 0,
+			handleRequest: () => repondersForHandleRequest.shift()!(),
+			async onBind(server, port) {
+				return { server, port } as any;
+			},
+		});
+		const { server, port } = cliServer as any;
+
+		try {
+			// Send a request, then destroy it before headers resolve.
+			// This simulates a browser refresh while the server is
+			// still waiting on PHP to produce response headers.
+			const req = http.get(`http://127.0.0.1:${port}/`);
+			req.on('error', () => {});
+			await new Promise((r) => setTimeout(r, 100));
+			req.destroy();
+			await new Promise((r) => setTimeout(r, 200));
+
+			// Now resolve headers – pipeline() will try to pipe to
+			// the already-destroyed response stream.
+			resolveHeaders();
+			await new Promise((r) => setTimeout(r, 200));
+
+			// Confirm the ERR_STREAM_UNABLE_TO_PIPE error was
+			// actually produced by the pipeline call.
+			expect(pipelineMock).toHaveBeenCalled();
+			const pipelineResult = pipelineMock.mock.results[0];
+			expect(pipelineResult.type).toBe('return');
+			const pipelineError = await (
+				pipelineResult.value as Promise<void>
+			).catch((e: Error) => e);
+			expect(pipelineError).toBeInstanceOf(Error);
+			expect((pipelineError as NodeJS.ErrnoException).code).toBe(
+				'ERR_STREAM_UNABLE_TO_PIPE'
+			);
+
+			// Confirm the error was NOT logged.
+			expect(logger.error).not.toHaveBeenCalled();
+		} finally {
+			server.close();
+		}
+	});
+
+	it('does not log an error on client disconnect (ERR_STREAM_PREMATURE_CLOSE)', async () => {
+		const pipelineMock = vi.mocked(pipeline);
+		pipelineMock.mockClear();
+		(logger.error as Mock<typeof logger.error>).mockClear();
+
 		const expectedErrorBefore = new Error('handler failure before');
 		const expectedErrorAfter = new Error('handler failure after');
 

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -21,12 +21,19 @@ describe('startServer', () => {
 		pipelineMock.mockClear();
 		(logger.error as Mock<typeof logger.error>).mockClear();
 
+		const expectedErrorBefore = new Error('handler failure before');
+		const expectedErrorAfter = new Error('handler failure after');
 		const unableToPipeError = Object.assign(
 			new Error('Cannot pipe to a closed or destroyed stream'),
 			{ code: 'ERR_STREAM_UNABLE_TO_PIPE' }
 		);
 
 		const repondersForHandleRequest = [
+			// Demonstrate logged error before the ignored error
+			// to confirm the logger was working beforehand.
+			async () => {
+				throw expectedErrorBefore;
+			},
 			async () =>
 				new StreamedPHPResponse(
 					new ReadableStream({
@@ -50,6 +57,11 @@ describe('startServer', () => {
 					new ReadableStream({ start: (c) => c.close() }),
 					Promise.resolve(0)
 				),
+			// Demonstrate logged error after the ignored error
+			// to confirm the logger was working afterward.
+			async () => {
+				throw expectedErrorAfter;
+			},
 		];
 
 		// Mock pipeline to reject with ERR_STREAM_UNABLE_TO_PIPE,
@@ -67,6 +79,16 @@ describe('startServer', () => {
 		const { server, port } = cliServer as any;
 
 		try {
+			// Demonstrate that error logging is working before the test.
+			await new Promise<void>((resolve) => {
+				http.get(`http://127.0.0.1:${port}/`, (res) => {
+					res.resume();
+					res.on('end', () => resolve());
+				});
+			});
+			expect(logger.error).toHaveBeenCalledWith(expectedErrorBefore);
+			(logger.error as Mock<typeof logger.error>).mockClear();
+
 			// Make a request. The mocked pipeline will reject, so the
 			// response won't complete – ignore the client-side error.
 			const req = http.get(`http://127.0.0.1:${port}/`);
@@ -89,6 +111,15 @@ describe('startServer', () => {
 
 			// Confirm the error was NOT logged.
 			expect(logger.error).not.toHaveBeenCalled();
+
+			// Demonstrate that error logging remains working after the test.
+			await new Promise<void>((resolve) => {
+				http.get(`http://127.0.0.1:${port}/`, (res) => {
+					res.resume();
+					res.on('end', () => resolve());
+				});
+			});
+			expect(logger.error).toHaveBeenCalledWith(expectedErrorAfter);
 		} finally {
 			server.close();
 		}

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -21,18 +21,16 @@ describe('startServer', () => {
 		pipelineMock.mockClear();
 		(logger.error as Mock<typeof logger.error>).mockClear();
 
-		// Use a deferred promise to control when headers resolve,
-		// so the client can disconnect before pipeline() is called.
-		let resolveHeaders!: () => void;
+		const unableToPipeError = Object.assign(
+			new Error('Cannot pipe to a closed or destroyed stream'),
+			{ code: 'ERR_STREAM_UNABLE_TO_PIPE' }
+		);
 
 		const repondersForHandleRequest = [
 			async () =>
 				new StreamedPHPResponse(
 					new ReadableStream({
-						async start(controller) {
-							await new Promise<void>((r) => {
-								resolveHeaders = r;
-							});
+						start(controller) {
 							const json = JSON.stringify({
 								status: 200,
 								headers: ['content-type: text/plain'],
@@ -54,6 +52,11 @@ describe('startServer', () => {
 				),
 		];
 
+		// Mock pipeline to reject with ERR_STREAM_UNABLE_TO_PIPE,
+		// simulating what happens when the response stream is already
+		// destroyed before pipeline() is called.
+		pipelineMock.mockRejectedValueOnce(unableToPipeError);
+
 		const cliServer = await startServer({
 			port: 0,
 			handleRequest: () => repondersForHandleRequest.shift()!(),
@@ -64,32 +67,12 @@ describe('startServer', () => {
 		const { server, port } = cliServer as any;
 
 		try {
-			// Send a request, then destroy it before headers resolve.
-			// This simulates a browser refresh while the server is
-			// still waiting on PHP to produce response headers.
+			// Make a request. The mocked pipeline will reject, so the
+			// response won't complete – ignore the client-side error.
 			const req = http.get(`http://127.0.0.1:${port}/`);
 			req.on('error', () => {});
-			await new Promise((r) => setTimeout(r, 100));
+			await new Promise((r) => setTimeout(r, 200));
 			req.destroy();
-			await new Promise((r) => setTimeout(r, 200));
-
-			// Now resolve headers – pipeline() will try to pipe to
-			// the already-destroyed response stream.
-			resolveHeaders();
-			await new Promise((r) => setTimeout(r, 200));
-
-			// Confirm the ERR_STREAM_UNABLE_TO_PIPE error was
-			// actually produced by the pipeline call.
-			expect(pipelineMock).toHaveBeenCalled();
-			const pipelineResult = pipelineMock.mock.results[0];
-			expect(pipelineResult.type).toBe('return');
-			const pipelineError = await (
-				pipelineResult.value as Promise<void>
-			).catch((e: Error) => e);
-			expect(pipelineError).toBeInstanceOf(Error);
-			expect((pipelineError as NodeJS.ErrnoException).code).toBe(
-				'ERR_STREAM_UNABLE_TO_PIPE'
-			);
 
 			// Confirm the error was NOT logged.
 			expect(logger.error).not.toHaveBeenCalled();

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -74,6 +74,19 @@ describe('startServer', () => {
 			await new Promise((r) => setTimeout(r, 200));
 			req.destroy();
 
+			// Confirm the ERR_STREAM_UNABLE_TO_PIPE error was
+			// actually produced by the pipeline call.
+			expect(pipelineMock).toHaveBeenCalled();
+			const pipelineResult = pipelineMock.mock.results[0];
+			expect(pipelineResult.type).toBe('return');
+			const pipelineError = await (
+				pipelineResult.value as Promise<void>
+			).catch((e: Error) => e);
+			expect(pipelineError).toBeInstanceOf(Error);
+			expect((pipelineError as NodeJS.ErrnoException).code).toBe(
+				'ERR_STREAM_UNABLE_TO_PIPE'
+			);
+
 			// Confirm the error was NOT logged.
 			expect(logger.error).not.toHaveBeenCalled();
 		} finally {


### PR DESCRIPTION
## Summary
- Silences `ERR_STREAM_UNABLE_TO_PIPE` errors in the CLI server's streamed response handler, alongside the already-ignored `ERR_STREAM_PREMATURE_CLOSE`
- Both are benign client-disconnect errors that occur when the browser navigates away or refreshes while the server is still streaming a response
- The only difference is timing: `PREMATURE_CLOSE` fires when the stream closes mid-pipe, while `UNABLE_TO_PIPE` fires when the stream is already destroyed before piping begins

## Test plan
- [ ] Start CLI server (`npx nx dev playground-cli server`)
- [ ] Load a page in the browser and refresh mid-load — no error should be logged