### PR TITLE
CLI: Auto-enable JSPI flags on Node.js 23+

### DIFF
--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -38,11 +38,24 @@ function reexecWithJspiIfNeeded(): boolean {
 				env: process.env,
 			}
 		);
-	} catch (error: any) {
-		// execFileSync throws on non-zero exit codes. Forward the exit code.
-		process.exit(error.status ?? 1);
+		process.exit(0);
+	} catch (error: unknown) {
+		if (
+			error instanceof Error &&
+			'status' in error &&
+			typeof (error as any).status === 'number'
+		) {
+			process.exit((error as any).status);
+		}
+		if (
+			error instanceof Error &&
+			'signal' in error &&
+			(error as any).signal
+		) {
+			process.kill(process.pid, (error as any).signal);
+		}
+		process.exit(1);
 	}
-	return true;
 }
 
 if (!reexecWithJspiIfNeeded()) {

--- a/packages/playground/cli/src/cli.ts
+++ b/packages/playground/cli/src/cli.ts
@@ -1,7 +1,54 @@
+import { execFileSync } from 'child_process';
 import { parseOptionsAndRunCLI } from './run-cli';
 
-// The CLI args are after the original command and the script name
-const args = process.argv.slice(2);
+/**
+ * Re-execute the current process with JSPI flags if the Node.js version
+ * supports them but they were not passed on the command line.
+ *
+ * JSPI (JavaScript Promise Integration) provides reliable async WASM
+ * operations. Without it, the CLI falls back to Asyncify which crashes
+ * on certain PHP functions like proc_open(). Node.js 23+ ships V8 with
+ * JSPI support but requires explicit flags to enable it.
+ */
+function reexecWithJspiIfNeeded(): boolean {
+	const majorVersion = parseInt(process.versions.node.split('.')[0], 10);
+	if (majorVersion < 23) {
+		return false;
+	}
 
-// Do not await this as top-level await is not supported in all environments.
-parseOptionsAndRunCLI(args);
+	const jspiFlags = [
+		'--experimental-wasm-jspi',
+		'--experimental-wasm-stack-switching',
+	];
+	const currentFlags = process.execArgv;
+	const missingFlags = jspiFlags.filter(
+		(flag) => !currentFlags.includes(flag)
+	);
+
+	if (missingFlags.length === 0) {
+		return false;
+	}
+
+	try {
+		execFileSync(
+			process.execPath,
+			[...currentFlags, ...missingFlags, ...process.argv.slice(1)],
+			{
+				stdio: 'inherit',
+				env: process.env,
+			}
+		);
+	} catch (error: any) {
+		// execFileSync throws on non-zero exit codes. Forward the exit code.
+		process.exit(error.status ?? 1);
+	}
+	return true;
+}
+
+if (!reexecWithJspiIfNeeded()) {
+	// The CLI args are after the original command and the script name
+	const args = process.argv.slice(2);
+
+	// Do not await this as top-level await is not supported in all environments.
+	parseOptionsAndRunCLI(args);
+}


### PR DESCRIPTION
I tried to see if the plugin-check plugin could be run against new plugin directory submissions from CLI via Playground, but the wp-cli blueprint step crashes on Asyncify builds because PHPCS uses `proc_open()` internally.

## Summary

When running on Node.js 23+, the CLI now automatically re-executes itself with `--experimental-wasm-jspi` and `--experimental-wasm-stack-switching` flags if they are not already present.

Without JSPI, the CLI falls back to the Asyncify WASM build which crashes with `RuntimeError: unreachable` when PHP code triggers `proc_open()` — for example when running `wp plugin check` via the `wp-cli` blueprint step, which internally invokes PHPCS. JSPI handles these async WASM operations correctly.

On Node.js < 23, the behavior is unchanged (Asyncify remains the only option).

### How it works

The entry point (`cli.ts`) checks:
1. Is Node.js version >= 23?
2. Are the JSPI flags already in `process.execArgv`?

If flags are missing, it re-executes the same command with the flags added to exec args using `execFileSync` with `stdio: 'inherit'`, then exits with the child's exit code (or re-raises the signal if the child was terminated by one).

### How I discovered this

While exploring using Playground CLI to run WordPress Plugin Check (PCP) before plugin submission, the `wp-cli` blueprint step consistently crashed:

```
Error: Error when executing the blueprint step #3: unreachable
    at php.wasm.wasm_sapi_handle_request (asyncify/php_8_5.js)
    at Object.doRewind (asyncify/php_8_5.js)
```

Running the same command with `node --experimental-wasm-jspi --experimental-wasm-stack-switching cli.js ...` worked perfectly — all 22 plugin_repo checks ran including `plugin_review_phpcs` (which uses `proc_open` internally for PHPCS).

The root cause: `npx @wp-playground/cli` spawns Node without JSPI flags, so `wasm-feature-detect` falls back to Asyncify, and Asyncify cannot handle the `proc_open` call chain.

## Test plan

- [ ] On Node.js 23+: `npx @wp-playground/cli@latest run-blueprint --blueprint=<blueprint-with-wp-cli-step>` should use JSPI (check for `jspi/php_*.js` in stack traces, not `asyncify/php_*.js`)
- [ ] On Node.js 22: behavior unchanged, still uses Asyncify
- [ ] `wp plugin check` via `wp-cli` blueprint step should complete without crashing
- [ ] Verify the re-exec doesn't cause issues with `--port`, `--mount`, or other flags

Ref: #1872