### PR TITLE
CLI: Add site editor performance benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"fix-asyncify": "node packages/php-wasm/node/bin/rebuild-while-asyncify-functions-missing.mjs",
 		"typecheck": "nx run-many --all --target=typecheck",
 		"prepare": "husky install",
+		"playground-cli:perf": "node --experimental-strip-types --experimental-transform-types --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts packages/playground/cli/perf/benchmark.ts",
 		"reset": "nx reset",
 		"local-package-repository": "./tools/scripts/local-package-repository.sh",
 		"recompile:php": "npm run recompile:php:web && npm run recompile:php:node",

--- a/packages/playground/cli/.eslintrc.json
+++ b/packages/playground/cli/.eslintrc.json
@@ -13,6 +13,12 @@
 		{
 			"files": ["*.js", "*.jsx"],
 			"rules": {}
+		},
+		{
+			"files": ["perf/**/*.ts"],
+			"rules": {
+				"no-console": 0
+			}
 		}
 	]
 }

--- a/packages/playground/cli/perf/artifacts/.gitignore
+++ b/packages/playground/cli/perf/artifacts/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!.gitignore

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -187,9 +187,16 @@ Options:
 		);
 		process.exit(1);
 	}
+	const rounds = parseInt(values.rounds as string, 10);
+	if (!Number.isInteger(rounds) || rounds < 1) {
+		console.error(
+			`Invalid --rounds: ${values.rounds}. Must be an integer >= 1.`
+		);
+		process.exit(1);
+	}
 
 	return {
-		rounds: parseInt(values.rounds as string, 10),
+		rounds,
 		mode,
 		withPlugins: values['with-plugins'] as boolean,
 		headed: values.headed as boolean,

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -155,6 +155,7 @@ async function main() {
 function getOptions(): Options {
 	const { values } = parseArgs({
 		options: {
+			help: { type: 'boolean', default: false },
 			rounds: { type: 'string', default: '3' },
 			mode: { type: 'string', default: 'unbuilt-jspi' },
 			'with-plugins': { type: 'boolean', default: false },
@@ -166,6 +167,23 @@ function getOptions(): Options {
 		strict: false,
 		allowPositionals: true,
 	});
+
+	if (values.help) {
+		console.log(`Usage: npx nx perf playground-cli [-- <options>]
+
+Measure WordPress site editor performance in a Playground CLI environment.
+
+Options:
+  --rounds=N         Number of benchmark rounds (default: 3)
+  --mode=<mode>      "unbuilt-jspi" or "built" (default: unbuilt-jspi)
+  --with-plugins     Also benchmark with a plugins blueprint
+  --headed           Run Chromium in headed mode (for debugging)
+  --port=<port>      Server port (default: 9876)
+  --wp=<version>     WordPress version (default: latest)
+  --php=<version>    PHP version (default: 8.2)
+  --help             Show this help message`);
+		process.exit(0);
+	}
 
 	const mode = values.mode as string;
 	if (mode !== 'unbuilt-jspi' && mode !== 'built') {

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -122,20 +122,16 @@ async function main() {
 				opts.headed
 			);
 
-			if (metrics) {
-				allResults.push({
-					environment: env.name,
-					metrics: {
-						serverStartup: activeHandle.startupMs,
-						...metrics,
-					},
-				});
-				console.log('  Done.');
-			} else {
-				console.log('  Failed — no successful rounds.');
-			}
+			allResults.push({
+				environment: env.name,
+				metrics: {
+					serverStartup: activeHandle.startupMs,
+					...metrics,
+				},
+			});
+			console.log('  Done.');
 		} catch (err) {
-			console.error(`  Error: ${err}`);
+			console.error(`  FAILED: ${err}`);
 		} finally {
 			if (activeHandle) {
 				console.log('  Stopping server...');
@@ -149,6 +145,12 @@ async function main() {
 	const savedPath = saveResults(allResults);
 	console.log(`\nResults saved to: ${savedPath}`);
 
+	if (allResults.length < environments.length) {
+		console.error(
+			`\n${environments.length - allResults.length} environment(s) failed.`
+		);
+		process.exit(1);
+	}
 	process.exit(0);
 }
 
@@ -174,7 +176,7 @@ function getOptions(): Options {
 Measure WordPress site editor performance in a Playground CLI environment.
 
 Options:
-  --rounds=N         Number of benchmark rounds (default: 3)
+  --rounds=N         Successful rounds required (default: 3, retries up to 2x)
   --mode=<mode>      "unbuilt-jspi" or "built" (default: unbuilt-jspi)
   --with-plugins     Also benchmark with a plugins blueprint
   --headed           Run Chromium in headed mode (for debugging)
@@ -324,15 +326,24 @@ async function runBenchmark(
 	url: string,
 	rounds: number,
 	headed: boolean
-): Promise<Record<string, number> | null> {
-	console.log(`  Running ${rounds} round${rounds > 1 ? 's' : ''}...`);
+): Promise<Record<string, number>> {
+	const maxAttempts = rounds * 2;
+	console.log(
+		`  Collecting ${rounds} successful round${rounds > 1 ? 's' : ''} (up to ${maxAttempts} attempts)...`
+	);
 
 	const allMeasurements: MeasurementResult[] = [];
+	let attempts = 0;
 
-	for (let round = 1; round <= rounds; round++) {
-		if (rounds > 1) {
-			console.log(`    Round ${round}/${rounds}...`);
-		}
+	while (allMeasurements.length < rounds && attempts < maxAttempts) {
+		attempts++;
+		const label =
+			`${allMeasurements.length + 1}/${rounds}` +
+			(attempts > allMeasurements.length + 1
+				? ` (attempt ${attempts}/${maxAttempts})`
+				: '');
+		console.log(`    Round ${label}...`);
+
 		try {
 			const result = await Promise.race([
 				measureSiteEditor({ url, headed }),
@@ -347,16 +358,19 @@ async function runBenchmark(
 				.join(', ');
 			console.log(`    ${parts}`);
 		} catch (err) {
-			console.warn(`    Round ${round} failed: ${err}`);
+			console.warn(`    Attempt ${attempts} failed: ${err}`);
 		}
 
-		if (round < rounds) {
+		if (allMeasurements.length < rounds) {
 			await sleep(1000);
 		}
 	}
 
-	if (allMeasurements.length === 0) {
-		return null;
+	if (allMeasurements.length < rounds) {
+		throw new Error(
+			`Only ${allMeasurements.length}/${rounds} rounds succeeded` +
+				` after ${maxAttempts} attempts`
+		);
 	}
 
 	const medians: Record<string, number> = {};

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -210,7 +210,7 @@ async function startServer(
 	opts: Options,
 	blueprintPath?: string
 ): Promise<ServerHandle> {
-	const { command, args } = buildNxCommand(opts, blueprintPath);
+	const { command, args } = buildCommand(opts, blueprintPath);
 
 	console.log(`  Starting CLI: ${command} ${args.join(' ')}`);
 
@@ -299,11 +299,10 @@ function killProcessesOnPort(url: string): void {
 	}
 }
 
-function buildNxCommand(
+function buildCommand(
 	opts: Options,
 	blueprintPath?: string
 ): { command: string; args: string[] } {
-	const nxTarget = opts.mode === 'built' ? 'start' : opts.mode;
 	const cliArgs = [
 		'server',
 		`--port=${opts.port}`,
@@ -316,9 +315,33 @@ function buildNxCommand(
 		cliArgs.push(`--blueprint=${blueprintPath}`);
 	}
 
+	const nodeFlags = [
+		'--experimental-strip-types',
+		'--experimental-transform-types',
+		'--disable-warning=ExperimentalWarning',
+		'--import',
+		'./packages/meta/src/node-es-module-loader/register.mts',
+	];
+
+	if (opts.mode === 'built') {
+		return {
+			command: process.execPath,
+			args: [
+				...nodeFlags,
+				'dist/packages/playground/cli/wp-playground.js',
+				...cliArgs,
+			],
+		};
+	}
+
 	return {
-		command: 'npx',
-		args: ['nx', nxTarget, 'playground-cli', '--', ...cliArgs],
+		command: process.execPath,
+		args: [
+			'--experimental-wasm-jspi',
+			...nodeFlags,
+			'./packages/playground/cli/src/cli.ts',
+			...cliArgs,
+		],
 	};
 }
 

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -262,7 +262,6 @@ function buildNxCommand(
 		`--wp=${opts.wp}`,
 		`--php=${opts.php}`,
 		'--login',
-		'--skip-browser',
 	];
 
 	if (blueprintPath) {

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -19,12 +19,11 @@
  *   --mode=<mode>     "unbuilt-jspi" (default) or "built"
  *   --with-plugins    Also run with the plugins blueprint
  *   --headed          Chromium in headed mode for debugging
- *   --port=<port>     Server port (default: 9876)
  *   --wp=<version>    WordPress version (default: latest)
  *   --php=<version>   PHP version (default: 8.2)
  */
 
-import { execSync, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import type { ChildProcess } from 'child_process';
 import fs from 'fs';
 import os from 'os';
@@ -38,7 +37,6 @@ interface Options {
 	mode: 'unbuilt-jspi' | 'built';
 	withPlugins: boolean;
 	headed: boolean;
-	port: number;
 	wp: string;
 	php: string;
 }
@@ -95,9 +93,6 @@ async function main() {
 			} catch {
 				// Already gone
 			}
-		}
-		if (activeHandle?.url) {
-			killProcessesOnPort(activeHandle.url);
 		}
 	};
 	process.on('SIGINT', () => {
@@ -162,7 +157,6 @@ function getOptions(): Options {
 			mode: { type: 'string', default: 'unbuilt-jspi' },
 			'with-plugins': { type: 'boolean', default: false },
 			headed: { type: 'boolean', default: false },
-			port: { type: 'string', default: '9876' },
 			wp: { type: 'string', default: 'latest' },
 			php: { type: 'string', default: '8.2' },
 		},
@@ -180,7 +174,6 @@ Options:
   --mode=<mode>      "unbuilt-jspi" or "built" (default: unbuilt-jspi)
   --with-plugins     Also benchmark with a plugins blueprint
   --headed           Run Chromium in headed mode (for debugging)
-  --port=<port>      Server port (default: 9876)
   --wp=<version>     WordPress version (default: latest)
   --php=<version>    PHP version (default: 8.2)
   --help             Show this help message`);
@@ -200,7 +193,6 @@ Options:
 		mode,
 		withPlugins: values['with-plugins'] as boolean,
 		headed: values.headed as boolean,
-		port: parseInt(values.port as string, 10),
 		wp: values.wp as string,
 		php: values.php as string,
 	};
@@ -227,24 +219,43 @@ async function startServer(
 	proc.stderr?.on('data', (data) => {
 		stderr += data.toString();
 	});
-	proc.stdout?.on('data', (data) => {
-		const line = data.toString().trim();
-		if (line) {
-			console.log(`  [cli] ${line}`);
-		}
-	});
 
-	const url = `http://127.0.0.1:${opts.port}`;
-	const ready = await waitForServer(url);
-	if (!ready) {
-		proc.kill('SIGKILL');
-		if (stderr) {
-			console.error(stderr.slice(0, 1000));
-		}
-		throw new Error(
-			`Playground CLI server failed to start on port ${opts.port}`
-		);
-	}
+	const url = await new Promise<string>((resolve, reject) => {
+		const readyPattern = /running on (https?:\/\/\S+)/i;
+		const timeoutId = setTimeout(() => {
+			reject(
+				new Error(
+					'Playground CLI server did not print a ready URL' +
+						(stderr ? `\nstderr: ${stderr.slice(0, 1000)}` : '')
+				)
+			);
+		}, 180_000);
+
+		proc.stdout?.on('data', (data) => {
+			const text = data.toString();
+			for (const line of text.split('\n')) {
+				const trimmed = line.trim();
+				if (trimmed) {
+					console.log(`  [cli] ${trimmed}`);
+				}
+			}
+			const match = text.match(readyPattern);
+			if (match) {
+				clearTimeout(timeoutId);
+				resolve(match[1]);
+			}
+		});
+
+		proc.on('exit', (code) => {
+			clearTimeout(timeoutId);
+			reject(
+				new Error(
+					`CLI exited with code ${code}` +
+						(stderr ? `\nstderr: ${stderr.slice(0, 1000)}` : '')
+				)
+			);
+		});
+	});
 
 	const startupMs = Date.now() - startTime;
 	console.log(`  Server ready at ${url}`);
@@ -252,50 +263,23 @@ async function startServer(
 }
 
 async function stopServer(handle: ServerHandle): Promise<void> {
-	// Kill the process group we spawned
-	if (handle.process.pid) {
-		try {
-			if (process.platform === 'win32') {
-				spawn('taskkill', [
-					'/F',
-					'/T',
-					'/PID',
-					String(handle.process.pid),
-				]);
-			} else {
-				process.kill(-handle.process.pid, 'SIGTERM');
-			}
-		} catch {
-			// Process may have already exited
-		}
-		await sleep(2000);
-		try {
-			process.kill(-handle.process.pid, 'SIGKILL');
-		} catch {
-			// Already gone
-		}
+	if (!handle.process.pid) {
+		return;
 	}
-	// Also kill anything still listening on the port — the actual
-	// CLI server is a grandchild of npx and may not share the
-	// same process group.
-	killProcessesOnPort(handle.url);
-}
-
-function killProcessesOnPort(url: string): void {
 	try {
-		const port = new URL(url).port;
 		if (process.platform === 'win32') {
-			execSync(
-				`for /f "tokens=5" %a in ('netstat -aon ^| find ":${port}"') do taskkill /F /PID %a`,
-				{ stdio: 'ignore' }
-			);
+			spawn('taskkill', ['/F', '/T', '/PID', String(handle.process.pid)]);
 		} else {
-			execSync(`lsof -ti:${port} | xargs kill -9 2>/dev/null || true`, {
-				stdio: 'ignore',
-			});
+			process.kill(-handle.process.pid, 'SIGTERM');
 		}
 	} catch {
-		// Nothing listening, that's fine
+		// Process may have already exited
+	}
+	await sleep(2000);
+	try {
+		process.kill(-handle.process.pid, 'SIGKILL');
+	} catch {
+		// Already gone
 	}
 }
 
@@ -305,7 +289,6 @@ function buildCommand(
 ): { command: string; args: string[] } {
 	const cliArgs = [
 		'server',
-		`--port=${opts.port}`,
 		`--wp=${opts.wp}`,
 		`--php=${opts.php}`,
 		'--login',
@@ -485,37 +468,6 @@ function formatDuration(ms: number): string {
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-async function waitForServer(
-	url: string,
-	timeoutMs = 180_000
-): Promise<boolean> {
-	const start = Date.now();
-	while (Date.now() - start < timeoutMs) {
-		try {
-			// Abort individual requests after 10s — the Express
-			// server accepts connections before WordPress finishes
-			// booting in WASM, so a single fetch can hang for
-			// minutes waiting for response headers.
-			const response = await fetch(url, {
-				signal: AbortSignal.timeout(10_000),
-				redirect: 'manual',
-			});
-			await response.body?.cancel();
-			if (
-				response.ok ||
-				response.status === 302 ||
-				response.status === 301
-			) {
-				return true;
-			}
-		} catch {
-			// Server not ready yet
-		}
-		await sleep(1000);
-	}
-	return false;
 }
 
 main().catch((err) => {

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -439,10 +439,13 @@ async function waitForServer(
 	const start = Date.now();
 	while (Date.now() - start < timeoutMs) {
 		try {
-			const response = await fetch(url);
-			// Consume the body to free the connection back to the
-			// pool — without this, undici's per-origin connection
-			// limit (~10) is exhausted and subsequent fetches hang.
+			// Abort individual requests after 10s — the Express
+			// server accepts connections before WordPress finishes
+			// booting in WASM, so a single fetch can hang for
+			// minutes waiting for response headers.
+			const response = await fetch(url, {
+				signal: AbortSignal.timeout(10_000),
+			});
 			await response.body?.cancel();
 			if (
 				response.ok ||

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -445,6 +445,7 @@ async function waitForServer(
 			// minutes waiting for response headers.
 			const response = await fetch(url, {
 				signal: AbortSignal.timeout(10_000),
+				redirect: 'manual',
 			});
 			await response.body?.cancel();
 			if (

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -33,10 +33,6 @@ import { parseArgs } from 'util';
 import { measureSiteEditor, METRIC_NAMES } from './measure-site-editor.ts';
 import type { MeasurementResult } from './measure-site-editor.ts';
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
 interface Options {
 	rounds: number;
 	mode: 'unbuilt-jspi' | 'built';
@@ -58,15 +54,7 @@ interface BenchmarkResult {
 	metrics: Record<string, number>;
 }
 
-// ---------------------------------------------------------------------------
-// Workspace root (four levels up from perf/)
-// ---------------------------------------------------------------------------
-
 const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../../..');
-
-// ---------------------------------------------------------------------------
-// Main (caller first, then callees)
-// ---------------------------------------------------------------------------
 
 async function main() {
 	const opts = getOptions();
@@ -161,10 +149,6 @@ async function main() {
 	process.exit(0);
 }
 
-// ---------------------------------------------------------------------------
-// Argument parsing
-// ---------------------------------------------------------------------------
-
 function getOptions(): Options {
 	const { values } = parseArgs({
 		options: {
@@ -198,10 +182,6 @@ function getOptions(): Options {
 		php: values.php as string,
 	};
 }
-
-// ---------------------------------------------------------------------------
-// CLI server management
-// ---------------------------------------------------------------------------
 
 async function startServer(
 	opts: Options,
@@ -295,10 +275,6 @@ function buildNxCommand(
 	};
 }
 
-// ---------------------------------------------------------------------------
-// Benchmark runner
-// ---------------------------------------------------------------------------
-
 async function runBenchmark(
 	url: string,
 	rounds: number,
@@ -350,10 +326,6 @@ async function runBenchmark(
 
 	return medians;
 }
-
-// ---------------------------------------------------------------------------
-// Results formatting and persistence
-// ---------------------------------------------------------------------------
 
 function printResultsTable(results: BenchmarkResult[]): void {
 	if (results.length === 0) {
@@ -415,10 +387,6 @@ function saveResults(results: BenchmarkResult[]): string {
 	return summaryPath;
 }
 
-// ---------------------------------------------------------------------------
-// Utility helpers
-// ---------------------------------------------------------------------------
-
 function median(values: number[]): number {
 	if (values.length === 0) return 0;
 	const sorted = [...values].sort((a, b) => a - b);
@@ -459,10 +427,6 @@ async function waitForServer(
 	}
 	return false;
 }
-
-// ---------------------------------------------------------------------------
-// Entry point
-// ---------------------------------------------------------------------------
 
 main().catch((err) => {
 	console.error('Benchmark failed:', err);

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -50,6 +50,7 @@ interface Options {
 interface ServerHandle {
 	process: ChildProcess;
 	url: string;
+	startupMs: number;
 }
 
 interface BenchmarkResult {
@@ -123,6 +124,7 @@ async function main() {
 
 		try {
 			activeHandle = await startServer(opts, env.blueprintPath);
+			console.log(`  Startup: ${formatDuration(activeHandle.startupMs)}`);
 			const metrics = await runBenchmark(
 				activeHandle.url,
 				opts.rounds,
@@ -132,7 +134,10 @@ async function main() {
 			if (metrics) {
 				allResults.push({
 					environment: env.name,
-					metrics,
+					metrics: {
+						serverStartup: activeHandle.startupMs,
+						...metrics,
+					},
 				});
 				console.log('  Done.');
 			} else {
@@ -206,6 +211,7 @@ async function startServer(
 
 	console.log(`  Starting CLI: ${command} ${args.join(' ')}`);
 
+	const startTime = Date.now();
 	const proc = spawn(command, args, {
 		cwd: WORKSPACE_ROOT,
 		stdio: ['ignore', 'pipe', 'pipe'],
@@ -237,8 +243,9 @@ async function startServer(
 		);
 	}
 
+	const startupMs = Date.now() - startTime;
 	console.log(`  Server ready at ${url}`);
-	return { process: proc, url };
+	return { process: proc, url, startupMs };
 }
 
 async function stopServer(handle: ServerHandle): Promise<void> {

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -1,0 +1,463 @@
+#!/usr/bin/env -S node --experimental-strip-types --experimental-transform-types --disable-warning=ExperimentalWarning
+/**
+ * Playground CLI — Site Editor Performance Benchmark
+ *
+ * Spawns the Playground CLI via Nx targets, launches headless
+ * Chromium to measure site-editor performance, and outputs results
+ * as JSON + a console table.
+ *
+ * Adapted from Automattic/studio's
+ * tools/benchmark-site-editor/.
+ *
+ * Usage:
+ *   npx nx perf playground-cli
+ *   npx nx perf playground-cli -- --rounds=3 --mode=built
+ *   npx nx perf playground-cli -- --with-plugins
+ *
+ * Options:
+ *   --rounds=N        Benchmark rounds (default: 3)
+ *   --mode=<mode>     "unbuilt-jspi" (default) or "built"
+ *   --with-plugins    Also run with the plugins blueprint
+ *   --headed          Chromium in headed mode for debugging
+ *   --port=<port>     Server port (default: 9876)
+ *   --wp=<version>    WordPress version (default: latest)
+ *   --php=<version>   PHP version (default: 8.2)
+ */
+
+import { spawn } from 'child_process';
+import type { ChildProcess } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parseArgs } from 'util';
+import { measureSiteEditor, METRIC_NAMES } from './measure-site-editor.ts';
+import type { MeasurementResult } from './measure-site-editor.ts';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface Options {
+	rounds: number;
+	mode: 'unbuilt-jspi' | 'built';
+	withPlugins: boolean;
+	headed: boolean;
+	port: number;
+	wp: string;
+	php: string;
+}
+
+interface ServerHandle {
+	process: ChildProcess;
+	url: string;
+}
+
+interface BenchmarkResult {
+	environment: string;
+	metrics: Record<string, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Workspace root (four levels up from perf/)
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_ROOT = path.resolve(import.meta.dirname, '../../../..');
+
+// ---------------------------------------------------------------------------
+// Main (caller first, then callees)
+// ---------------------------------------------------------------------------
+
+async function main() {
+	const opts = getOptions();
+
+	console.log('\n=== Playground CLI Site Editor Benchmark ===');
+	console.log(`Platform: ${os.platform()} ${os.arch()}`);
+	console.log(`Node: ${process.version}`);
+	console.log(`CPUs: ${os.cpus().length}`);
+	console.log(`Rounds: ${opts.rounds}`);
+	console.log(`Mode: ${opts.mode}`);
+	console.log(`WordPress: ${opts.wp}, PHP: ${opts.php}`);
+	console.log(`Date: ${new Date().toISOString()}`);
+	console.log('');
+
+	const environments: Array<{
+		name: string;
+		blueprintPath?: string;
+	}> = [{ name: 'bare' }];
+
+	if (opts.withPlugins) {
+		environments.push({
+			name: 'with-plugins',
+			blueprintPath: path.resolve(
+				import.meta.dirname,
+				'plugins-blueprint.json'
+			),
+		});
+	}
+
+	const allResults: BenchmarkResult[] = [];
+	let activeHandle: ServerHandle | undefined;
+
+	// Clean up spawned server on unexpected exit
+	const cleanup = () => {
+		if (activeHandle?.process.pid) {
+			try {
+				process.kill(-activeHandle.process.pid, 'SIGKILL');
+			} catch {
+				// Already gone
+			}
+		}
+	};
+	process.on('SIGINT', () => {
+		cleanup();
+		process.exit(130);
+	});
+	process.on('SIGTERM', () => {
+		cleanup();
+		process.exit(143);
+	});
+	process.on('exit', cleanup);
+
+	for (const env of environments) {
+		console.log(`\n--- ${env.name} ---`);
+
+		try {
+			activeHandle = await startServer(opts, env.blueprintPath);
+			const metrics = await runBenchmark(
+				activeHandle.url,
+				opts.rounds,
+				opts.headed
+			);
+
+			if (metrics) {
+				allResults.push({
+					environment: env.name,
+					metrics,
+				});
+				console.log('  Done.');
+			} else {
+				console.log('  Failed — no successful rounds.');
+			}
+		} catch (err) {
+			console.error(`  Error: ${err}`);
+		} finally {
+			if (activeHandle) {
+				console.log('  Stopping server...');
+				await stopServer(activeHandle);
+				activeHandle = undefined;
+			}
+		}
+	}
+
+	printResultsTable(allResults);
+	const savedPath = saveResults(allResults);
+	console.log(`\nResults saved to: ${savedPath}`);
+
+	process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function getOptions(): Options {
+	const { values } = parseArgs({
+		options: {
+			rounds: { type: 'string', default: '3' },
+			mode: { type: 'string', default: 'unbuilt-jspi' },
+			'with-plugins': { type: 'boolean', default: false },
+			headed: { type: 'boolean', default: false },
+			port: { type: 'string', default: '9876' },
+			wp: { type: 'string', default: 'latest' },
+			php: { type: 'string', default: '8.2' },
+		},
+		strict: false,
+		allowPositionals: true,
+	});
+
+	const mode = values.mode as string;
+	if (mode !== 'unbuilt-jspi' && mode !== 'built') {
+		console.error(
+			`Invalid --mode: ${mode}. Must be "unbuilt-jspi" or "built".`
+		);
+		process.exit(1);
+	}
+
+	return {
+		rounds: parseInt(values.rounds as string, 10),
+		mode,
+		withPlugins: values['with-plugins'] as boolean,
+		headed: values.headed as boolean,
+		port: parseInt(values.port as string, 10),
+		wp: values.wp as string,
+		php: values.php as string,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// CLI server management
+// ---------------------------------------------------------------------------
+
+async function startServer(
+	opts: Options,
+	blueprintPath?: string
+): Promise<ServerHandle> {
+	const { command, args } = buildNxCommand(opts, blueprintPath);
+
+	console.log(`  Starting CLI: ${command} ${args.join(' ')}`);
+
+	const proc = spawn(command, args, {
+		cwd: WORKSPACE_ROOT,
+		stdio: ['ignore', 'pipe', 'pipe'],
+		env: { ...process.env, FORCE_COLOR: '0' },
+		detached: process.platform !== 'win32',
+		shell: process.platform === 'win32',
+	});
+
+	let stderr = '';
+	proc.stderr?.on('data', (data) => {
+		stderr += data.toString();
+	});
+	proc.stdout?.on('data', (data) => {
+		const line = data.toString().trim();
+		if (line) {
+			console.log(`  [cli] ${line}`);
+		}
+	});
+
+	const url = `http://127.0.0.1:${opts.port}`;
+	const ready = await waitForServer(url);
+	if (!ready) {
+		proc.kill('SIGKILL');
+		if (stderr) {
+			console.error(stderr.slice(0, 1000));
+		}
+		throw new Error(
+			`Playground CLI server failed to start on port ${opts.port}`
+		);
+	}
+
+	console.log(`  Server ready at ${url}`);
+	return { process: proc, url };
+}
+
+async function stopServer(handle: ServerHandle): Promise<void> {
+	if (!handle.process.pid) {
+		return;
+	}
+	try {
+		if (process.platform === 'win32') {
+			spawn('taskkill', ['/F', '/T', '/PID', String(handle.process.pid)]);
+		} else {
+			process.kill(-handle.process.pid, 'SIGTERM');
+		}
+	} catch {
+		// Process may have already exited
+	}
+	// Wait for graceful shutdown
+	await sleep(3000);
+	// Force-kill any remaining processes
+	try {
+		process.kill(-handle.process.pid, 'SIGKILL');
+	} catch {
+		// Already gone
+	}
+}
+
+function buildNxCommand(
+	opts: Options,
+	blueprintPath?: string
+): { command: string; args: string[] } {
+	const nxTarget = opts.mode === 'built' ? 'start' : opts.mode;
+	const cliArgs = [
+		'server',
+		`--port=${opts.port}`,
+		`--wp=${opts.wp}`,
+		`--php=${opts.php}`,
+		'--login',
+		'--skip-browser',
+	];
+
+	if (blueprintPath) {
+		cliArgs.push(`--blueprint=${blueprintPath}`);
+	}
+
+	return {
+		command: 'npx',
+		args: ['nx', nxTarget, 'playground-cli', '--', ...cliArgs],
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark runner
+// ---------------------------------------------------------------------------
+
+async function runBenchmark(
+	url: string,
+	rounds: number,
+	headed: boolean
+): Promise<Record<string, number> | null> {
+	console.log(`  Running ${rounds} round${rounds > 1 ? 's' : ''}...`);
+
+	const allMeasurements: MeasurementResult[] = [];
+
+	for (let round = 1; round <= rounds; round++) {
+		if (rounds > 1) {
+			console.log(`    Round ${round}/${rounds}...`);
+		}
+		try {
+			const result = await Promise.race([
+				measureSiteEditor({ url, headed }),
+				sleep(600_000).then(() => {
+					throw new Error('Measurement timed out');
+				}),
+			]);
+			allMeasurements.push(result);
+
+			const parts = METRIC_NAMES.filter((m) => result[m] !== undefined)
+				.map((m) => `${m}=${formatDuration(result[m]!)}`)
+				.join(', ');
+			console.log(`    ${parts}`);
+		} catch (err) {
+			console.warn(`    Round ${round} failed: ${err}`);
+		}
+
+		if (round < rounds) {
+			await sleep(1000);
+		}
+	}
+
+	if (allMeasurements.length === 0) {
+		return null;
+	}
+
+	const medians: Record<string, number> = {};
+	for (const metric of METRIC_NAMES) {
+		const values = allMeasurements
+			.map((m) => m[metric])
+			.filter((v): v is number => v !== undefined);
+		if (values.length > 0) {
+			medians[metric] = median(values);
+		}
+	}
+
+	return medians;
+}
+
+// ---------------------------------------------------------------------------
+// Results formatting and persistence
+// ---------------------------------------------------------------------------
+
+function printResultsTable(results: BenchmarkResult[]): void {
+	if (results.length === 0) {
+		console.log('\nNo results to display.');
+		return;
+	}
+
+	const allMetrics = new Set<string>();
+	for (const r of results) {
+		Object.keys(r.metrics).forEach((k) => allMetrics.add(k));
+	}
+	const metrics = [...allMetrics].sort();
+
+	const metricColWidth = Math.max(20, ...metrics.map((m) => m.length + 2));
+	const envColWidth = Math.max(
+		12,
+		...results.map((r) => r.environment.length + 2)
+	);
+	const lineWidth = metricColWidth + envColWidth * results.length;
+
+	console.log('\n\nResults');
+	console.log('='.repeat(lineWidth));
+
+	const header =
+		'Metric'.padEnd(metricColWidth) +
+		results.map((r) => r.environment.padEnd(envColWidth)).join('');
+	console.log(header);
+	console.log('-'.repeat(lineWidth));
+
+	for (const metric of metrics) {
+		let row = metric.padEnd(metricColWidth);
+		for (const r of results) {
+			const value = r.metrics[metric];
+			row +=
+				value !== undefined
+					? formatDuration(value).padEnd(envColWidth)
+					: '\u2014'.padEnd(envColWidth);
+		}
+		console.log(row);
+	}
+
+	console.log('='.repeat(lineWidth));
+}
+
+function saveResults(results: BenchmarkResult[]): string {
+	const artifactsDir = path.resolve(import.meta.dirname, 'artifacts');
+	fs.mkdirSync(artifactsDir, { recursive: true });
+
+	const summaryPath = path.join(artifactsDir, `benchmark-${Date.now()}.json`);
+	const summary = {
+		date: new Date().toISOString(),
+		platform: os.platform(),
+		arch: os.arch(),
+		nodeVersion: process.version,
+		cpus: os.cpus().length,
+		results,
+	};
+	fs.writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+	return summaryPath;
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+function median(values: number[]): number {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	return sorted.length % 2 !== 0
+		? sorted[mid]
+		: (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms.toFixed(0)}ms`;
+	return `${(ms / 1000).toFixed(2)}s`;
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForServer(
+	url: string,
+	timeoutMs = 180_000
+): Promise<boolean> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		try {
+			const response = await fetch(url);
+			if (
+				response.ok ||
+				response.status === 302 ||
+				response.status === 301
+			) {
+				return true;
+			}
+		} catch {
+			// Server not ready yet
+		}
+		await sleep(1000);
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+main().catch((err) => {
+	console.error('Benchmark failed:', err);
+	process.exit(1);
+});

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -24,7 +24,7 @@
  *   --php=<version>   PHP version (default: 8.2)
  */
 
-import { spawn } from 'child_process';
+import { execSync, spawn } from 'child_process';
 import type { ChildProcess } from 'child_process';
 import fs from 'fs';
 import os from 'os';
@@ -95,6 +95,9 @@ async function main() {
 			} catch {
 				// Already gone
 			}
+		}
+		if (activeHandle?.url) {
+			killProcessesOnPort(activeHandle.url);
 		}
 	};
 	process.on('SIGINT', () => {
@@ -229,25 +232,50 @@ async function startServer(
 }
 
 async function stopServer(handle: ServerHandle): Promise<void> {
-	if (!handle.process.pid) {
-		return;
+	// Kill the process group we spawned
+	if (handle.process.pid) {
+		try {
+			if (process.platform === 'win32') {
+				spawn('taskkill', [
+					'/F',
+					'/T',
+					'/PID',
+					String(handle.process.pid),
+				]);
+			} else {
+				process.kill(-handle.process.pid, 'SIGTERM');
+			}
+		} catch {
+			// Process may have already exited
+		}
+		await sleep(2000);
+		try {
+			process.kill(-handle.process.pid, 'SIGKILL');
+		} catch {
+			// Already gone
+		}
 	}
+	// Also kill anything still listening on the port — the actual
+	// CLI server is a grandchild of npx and may not share the
+	// same process group.
+	killProcessesOnPort(handle.url);
+}
+
+function killProcessesOnPort(url: string): void {
 	try {
+		const port = new URL(url).port;
 		if (process.platform === 'win32') {
-			spawn('taskkill', ['/F', '/T', '/PID', String(handle.process.pid)]);
+			execSync(
+				`for /f "tokens=5" %a in ('netstat -aon ^| find ":${port}"') do taskkill /F /PID %a`,
+				{ stdio: 'ignore' }
+			);
 		} else {
-			process.kill(-handle.process.pid, 'SIGTERM');
+			execSync(`lsof -ti:${port} | xargs kill -9 2>/dev/null || true`, {
+				stdio: 'ignore',
+			});
 		}
 	} catch {
-		// Process may have already exited
-	}
-	// Wait for graceful shutdown
-	await sleep(3000);
-	// Force-kill any remaining processes
-	try {
-		process.kill(-handle.process.pid, 'SIGKILL');
-	} catch {
-		// Already gone
+		// Nothing listening, that's fine
 	}
 }
 
@@ -412,6 +440,10 @@ async function waitForServer(
 	while (Date.now() - start < timeoutMs) {
 		try {
 			const response = await fetch(url);
+			// Consume the body to free the connection back to the
+			// pool — without this, undici's per-origin connection
+			// limit (~10) is exhausted and subsequent fetches hang.
+			await response.body?.cancel();
 			if (
 				response.ok ||
 				response.status === 302 ||

--- a/packages/playground/cli/perf/benchmark.ts
+++ b/packages/playground/cli/perf/benchmark.ts
@@ -20,7 +20,7 @@
  *   --with-plugins    Also run with the plugins blueprint
  *   --headed          Chromium in headed mode for debugging
  *   --wp=<version>    WordPress version (default: latest)
- *   --php=<version>   PHP version (default: 8.2)
+ *   --php=<version>   PHP version (default: Current Playground recommended PHP version)
  */
 
 import { spawn } from 'child_process';
@@ -29,8 +29,12 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { parseArgs } from 'util';
-import { measureSiteEditor, METRIC_NAMES } from './measure-site-editor.ts';
-import type { MeasurementResult } from './measure-site-editor.ts';
+import {
+	measureSiteEditor,
+	METRIC_NAMES,
+	type MeasurementResult,
+} from './measure-site-editor';
+import { RecommendedPHPVersion } from '@wp-playground/common';
 
 interface Options {
 	rounds: number;
@@ -158,7 +162,7 @@ function getOptions(): Options {
 			'with-plugins': { type: 'boolean', default: false },
 			headed: { type: 'boolean', default: false },
 			wp: { type: 'string', default: 'latest' },
-			php: { type: 'string', default: '8.2' },
+			php: { type: 'string', default: RecommendedPHPVersion },
 		},
 		strict: false,
 		allowPositionals: true,
@@ -175,7 +179,7 @@ Options:
   --with-plugins     Also benchmark with a plugins blueprint
   --headed           Run Chromium in headed mode (for debugging)
   --wp=<version>     WordPress version (default: latest)
-  --php=<version>    PHP version (default: 8.2)
+  --php=<version>    PHP version (default: Current Playground recommended PHP version: ${RecommendedPHPVersion})
   --help             Show this help message`);
 		process.exit(0);
 	}

--- a/packages/playground/cli/perf/measure-site-editor.ts
+++ b/packages/playground/cli/perf/measure-site-editor.ts
@@ -167,21 +167,19 @@ export async function measureSiteEditor(
 		// Step 5: Save the template
 		const templateSaveStart = Date.now();
 
-		await page.getByRole('button', { name: 'Save' }).first().click();
+		const saveButton = page.getByRole('button', { name: 'Save' }).first();
+		await saveButton.click();
+		const saveButtonHandle = await saveButton.elementHandle();
 		await page.waitForFunction(
-			() => {
-				const btn = Array.from(
-					document.querySelectorAll('button')
-				).find(
-					(b) =>
-						b.textContent?.includes('Saved') ||
-						b
-							.getAttribute('aria-label')
-							?.toLowerCase()
-							.includes('saved')
-				);
-				return btn !== null;
+			(button: HTMLButtonElement | null) => {
+				if (!button) {
+					return false;
+				}
+				const text = button.textContent || '';
+				const aria = (button.getAttribute('aria-label') || '').toLowerCase();
+				return text.includes('Saved') || aria.includes('saved');
 			},
+			saveButtonHandle,
 			{ timeout: 30_000 }
 		);
 

--- a/packages/playground/cli/perf/measure-site-editor.ts
+++ b/packages/playground/cli/perf/measure-site-editor.ts
@@ -167,19 +167,15 @@ export async function measureSiteEditor(
 		// Step 5: Save the template
 		const templateSaveStart = Date.now();
 
-		const saveButton = page.getByRole('button', { name: 'Save' }).first();
+		const saveButton = page.getByRole('button', {
+			name: 'Save',
+			exact: true,
+		});
 		await saveButton.click();
-		const saveButtonHandle = await saveButton.elementHandle();
+		await saveButton.waitFor({ state: 'visible', timeout: 30_000 });
 		await page.waitForFunction(
-			(button: HTMLButtonElement | null) => {
-				if (!button) {
-					return false;
-				}
-				const text = button.textContent || '';
-				const aria = (button.getAttribute('aria-label') || '').toLowerCase();
-				return text.includes('Saved') || aria.includes('saved');
-			},
-			saveButtonHandle,
+			(btn) => btn?.getAttribute('aria-disabled') === 'true',
+			await saveButton.elementHandle(),
 			{ timeout: 30_000 }
 		);
 

--- a/packages/playground/cli/perf/measure-site-editor.ts
+++ b/packages/playground/cli/perf/measure-site-editor.ts
@@ -85,7 +85,7 @@ export async function measureSiteEditor(
 			timeout: 120_000,
 		});
 
-		const frame = findEditorCanvasFrame(page);
+		const frame = await findEditorCanvasFrame(page);
 		if (!frame) {
 			throw new Error('Editor canvas frame not found');
 		}
@@ -129,7 +129,7 @@ export async function measureSiteEditor(
 			timeout: 60_000,
 		});
 
-		const templateFrame = findEditorCanvasFrame(page);
+		const templateFrame = await findEditorCanvasFrame(page);
 		if (!templateFrame) {
 			throw new Error('Template editor frame not found');
 		}
@@ -195,8 +195,19 @@ export async function measureSiteEditor(
 	return result;
 }
 
-function findEditorCanvasFrame(page: Page): Frame | null {
-	return page.frame({ name: 'editor-canvas' });
+async function findEditorCanvasFrame(
+	page: Page,
+	timeoutMs = 30_000
+): Promise<Frame | null> {
+	const start = Date.now();
+	while (Date.now() - start < timeoutMs) {
+		const frame = page.frame({ name: 'editor-canvas' });
+		if (frame) {
+			return frame;
+		}
+		await page.waitForTimeout(200);
+	}
+	return null;
 }
 
 async function dismissWelcomeModal(page: Page): Promise<void> {

--- a/packages/playground/cli/perf/measure-site-editor.ts
+++ b/packages/playground/cli/perf/measure-site-editor.ts
@@ -12,10 +12,6 @@
 import { chromium } from '@playwright/test';
 import type { Page, Frame } from '@playwright/test';
 
-// ---------------------------------------------------------------------------
-// Metric names and types
-// ---------------------------------------------------------------------------
-
 export const METRIC_NAMES = [
 	'siteEditorLoad',
 	'templatesViewLoad',
@@ -36,10 +32,6 @@ export interface MeasureOptions {
 	/** Launch browser in headed mode for debugging. */
 	headed?: boolean;
 }
-
-// ---------------------------------------------------------------------------
-// Measurement (caller first, helpers below)
-// ---------------------------------------------------------------------------
 
 /**
  * Runs a single benchmark measurement pass against a Playground CLI
@@ -202,10 +194,6 @@ export async function measureSiteEditor(
 
 	return result;
 }
-
-// ---------------------------------------------------------------------------
-// Helpers (callees after caller)
-// ---------------------------------------------------------------------------
 
 function findEditorCanvasFrame(page: Page): Frame | null {
 	return page.frame({ name: 'editor-canvas' });

--- a/packages/playground/cli/perf/measure-site-editor.ts
+++ b/packages/playground/cli/perf/measure-site-editor.ts
@@ -1,0 +1,242 @@
+/**
+ * Site editor performance measurement module.
+ *
+ * Adapted from Automattic/studio's
+ * tools/benchmark-site-editor/measure-site-editor.ts.
+ *
+ * Runs a single benchmark pass against a Playground CLI WordPress
+ * site: launches Chromium, navigates through the site editor, and
+ * returns raw timing values for each metric.
+ */
+
+import { chromium } from '@playwright/test';
+import type { Page, Frame } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Metric names and types
+// ---------------------------------------------------------------------------
+
+export const METRIC_NAMES = [
+	'siteEditorLoad',
+	'templatesViewLoad',
+	'templateOpen',
+	'blockAdd',
+	'templateSave',
+] as const;
+
+export type MetricName = (typeof METRIC_NAMES)[number];
+
+/** One timing value per metric. A metric may be missing if that
+ *  step failed. */
+export type MeasurementResult = Partial<Record<MetricName, number>>;
+
+export interface MeasureOptions {
+	/** Base URL of the Playground CLI WordPress site. */
+	url: string;
+	/** Launch browser in headed mode for debugging. */
+	headed?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Measurement (caller first, helpers below)
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs a single benchmark measurement pass against a Playground CLI
+ * site.
+ *
+ * Launches a fresh Chromium browser, navigates to the site editor,
+ * performs the measurement steps, and returns timing results.  The
+ * browser is always closed, even on error.
+ */
+export async function measureSiteEditor(
+	options: MeasureOptions
+): Promise<MeasurementResult> {
+	let wpAdminUrl = options.url;
+	if (!wpAdminUrl.startsWith('http')) {
+		wpAdminUrl = `http://${wpAdminUrl}`;
+	}
+	wpAdminUrl = wpAdminUrl.replace(/\/$/, '');
+
+	const result: MeasurementResult = {};
+
+	const browser = await chromium.launch({
+		headless: !options.headed,
+	});
+	const context = await browser.newContext();
+	const page = await context.newPage();
+
+	try {
+		// Playground CLI auto-logs in as admin
+		await page.goto(`${wpAdminUrl}/wp-admin`, {
+			waitUntil: 'domcontentloaded',
+			timeout: 120_000,
+		});
+		await page
+			.waitForLoadState('networkidle', { timeout: 30_000 })
+			.catch(() => {});
+		await page.getByRole('link', { name: 'Appearance' }).waitFor({
+			state: 'visible',
+			timeout: 60_000,
+		});
+
+		// Step 1: Navigate to site editor
+		const siteEditorStart = Date.now();
+
+		await page.getByRole('link', { name: 'Appearance' }).click();
+		await page.locator('a[href="site-editor.php"]').click();
+
+		await dismissWelcomeModal(page);
+
+		await page.locator('iframe[name="editor-canvas"]').waitFor({
+			state: 'visible',
+			timeout: 120_000,
+		});
+
+		const frame = findEditorCanvasFrame(page);
+		if (!frame) {
+			throw new Error('Editor canvas frame not found');
+		}
+
+		await waitForBlocksRendered(frame);
+		result.siteEditorLoad = Date.now() - siteEditorStart;
+
+		// Step 2: Navigate to Templates view
+		const templatesViewStart = Date.now();
+
+		await page.getByRole('button', { name: 'Templates' }).click();
+		await page
+			.getByRole('heading', { name: 'Templates', level: 2 })
+			.waitFor({ timeout: 60_000 });
+		await page
+			.locator('.dataviews-view-grid-items.dataviews-view-grid')
+			.waitFor({ timeout: 60_000 });
+		const firstCard = page.locator('.dataviews-view-grid__card').first();
+		await firstCard.waitFor({
+			state: 'visible',
+			timeout: 60_000,
+		});
+		await firstCard
+			.getByRole('button')
+			.first()
+			.waitFor({ state: 'visible', timeout: 60_000 });
+
+		result.templatesViewLoad = Date.now() - templatesViewStart;
+
+		// Step 3: Open a template
+		const templateOpenStart = Date.now();
+
+		await page
+			.locator('.dataviews-view-grid__card')
+			.first()
+			.getByRole('button')
+			.first()
+			.click();
+		await page.locator('iframe[name="editor-canvas"]').waitFor({
+			state: 'visible',
+			timeout: 60_000,
+		});
+
+		const templateFrame = findEditorCanvasFrame(page);
+		if (!templateFrame) {
+			throw new Error('Template editor frame not found');
+		}
+
+		await waitForBlocksRendered(templateFrame);
+		result.templateOpen = Date.now() - templateOpenStart;
+
+		// Step 4: Add blocks
+		const blockAddStart = Date.now();
+
+		await page.keyboard.press('Escape');
+		await page.getByRole('button', { name: /Block Inserter/i }).click();
+
+		const searchInput = page.getByPlaceholder('Search');
+		await searchInput.fill('Paragraph');
+		await page
+			.getByRole('option', { name: 'Paragraph', exact: true })
+			.click();
+		await templateFrame.waitForSelector('p[data-block]', {
+			timeout: 15_000,
+		});
+
+		await searchInput.fill('Heading');
+		await page
+			.locator('.block-editor-block-types-list__item')
+			.filter({ hasText: /^Heading$/ })
+			.click();
+		await templateFrame.waitForSelector(
+			'h1[data-block], h2[data-block], h3[data-block]',
+			{ timeout: 15_000 }
+		);
+
+		result.blockAdd = Date.now() - blockAddStart;
+
+		// Step 5: Save the template
+		const templateSaveStart = Date.now();
+
+		await page.getByRole('button', { name: 'Save' }).first().click();
+		await page.waitForFunction(
+			() => {
+				const btn = Array.from(
+					document.querySelectorAll('button')
+				).find(
+					(b) =>
+						b.textContent?.includes('Saved') ||
+						b
+							.getAttribute('aria-label')
+							?.toLowerCase()
+							.includes('saved')
+				);
+				return btn !== null;
+			},
+			{ timeout: 30_000 }
+		);
+
+		result.templateSave = Date.now() - templateSaveStart;
+	} finally {
+		await page.close();
+		await context.close();
+		await browser.close();
+	}
+
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (callees after caller)
+// ---------------------------------------------------------------------------
+
+function findEditorCanvasFrame(page: Page): Frame | null {
+	return page.frame({ name: 'editor-canvas' });
+}
+
+async function dismissWelcomeModal(page: Page): Promise<void> {
+	const welcomeDialog = page.getByRole('dialog', {
+		name: /welcome to the site editor/i,
+	});
+	const isVisible = await welcomeDialog
+		.isVisible({ timeout: 5_000 })
+		.catch(() => false);
+	if (isVisible) {
+		await page.getByRole('button', { name: /get started/i }).click();
+		await welcomeDialog
+			.waitFor({ state: 'hidden', timeout: 5_000 })
+			.catch(() => {});
+	}
+}
+
+async function waitForBlocksRendered(frame: Frame): Promise<void> {
+	await frame.waitForLoadState('domcontentloaded');
+	await frame.waitForSelector('[data-block]', { timeout: 60_000 });
+	await frame.waitForFunction(
+		() => {
+			const blocks = document.querySelectorAll('[data-block]');
+			return (
+				blocks.length > 0 &&
+				Array.from(blocks).some((block) => block.clientHeight > 0)
+			);
+		},
+		{ timeout: 60_000 }
+	);
+}

--- a/packages/playground/cli/perf/plugins-blueprint.json
+++ b/packages/playground/cli/perf/plugins-blueprint.json
@@ -1,0 +1,75 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "woocommerce"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "jetpack"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "wp-super-cache"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "jetpack-boost"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "jetpack-protect"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "jetpack-social"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "jetpack-videopress"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "woocommerce-payments"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "contact-form-7"
+			}
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "coblocks"
+			}
+		}
+	]
+}

--- a/packages/playground/cli/perf/tsconfig.json
+++ b/packages/playground/cli/perf/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": "../../../../tsconfig.base.json",
+	"compilerOptions": {
+		"moduleResolution": "node",
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true
+	},
+	"files": [],
+	"include": ["./**/*.ts"]
+}

--- a/packages/playground/cli/project.json
+++ b/packages/playground/cli/project.json
@@ -149,6 +149,13 @@
 					"tsc -p packages/playground/cli/tsconfig.spec.json --noEmit"
 				]
 			}
+		},
+		"perf": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "node --experimental-strip-types --experimental-transform-types --disable-warning=ExperimentalWarning --import ./packages/meta/src/node-es-module-loader/register.mts packages/playground/cli/perf/benchmark.ts",
+				"tty": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add a Playwright-based site editor performance benchmark for the Playground CLI, adapted from [Studio's `tools/benchmark-site-editor/`](https://github.com/Automattic/studio/tree/trunk/tools/benchmark-site-editor)
- Measure 6 metrics: server startup time plus 5 site editor interaction metrics
- Support both `unbuilt-jspi` and `built` CLI modes via `--mode` flag, with configurable rounds and an optional plugins-loaded variant

## How it works

The benchmark spawns a Playground CLI server via Nx targets (`npx nx unbuilt-jspi playground-cli` or `npx nx start playground-cli`), then launches headless Chromium to navigate through the WordPress site editor and time each interaction. Results are aggregated using median across rounds and output as both a console table and a JSON artifact.

**Metrics measured:**
| Metric | Description |
|--------|-------------|
| `serverStartup` | Time from spawning the CLI process until the server responds to HTTP requests |
| `siteEditorLoad` | Time from clicking Appearance → Editor until blocks render in the editor canvas |
| `templatesViewLoad` | Time to open the Templates view and load the template grid |
| `templateOpen` | Time to open a specific template in the editor |
| `blockAdd` | Time to insert Paragraph + Heading blocks via the Block Inserter |
| `templateSave` | Time to save the template until "Saved" button appears |

**Usage:**
```bash
npx nx perf playground-cli
npx nx perf playground-cli -- --mode=built --rounds=5 --with-plugins
npx nx perf playground-cli -- --headed --rounds=1
```

## Test plan

- [x] Run `npx nx perf playground-cli -- --rounds=1` and verify it starts the CLI, runs measurements, prints a results table (including `serverStartup`), and saves a JSON artifact
- [ ] Run with `--mode=built` and verify it builds first, then benchmarks the built CLI
- [ ] Run with `--with-plugins` and verify both bare and with-plugins environments are benchmarked
- [x] Run with `--headed` and verify Chromium launches visibly for debugging
- [x] Verify `npx nx lint playground-cli` passes (no `no-console` errors from perf files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)