### PR TITLE
[CLI]: Consider it a lint error for CLI to depend on large Playground web packages

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,12 @@
 								"notDependOnLibsWithTags": [
 									"scope:php-binaries"
 								]
+							},
+							{
+								"sourceTag": "scope:cli",
+								"notDependOnLibsWithTags": [
+									"scope:browser-only"
+								]
 							}
 						]
 					}

--- a/packages/php-wasm/cli/project.json
+++ b/packages/php-wasm/cli/project.json
@@ -3,7 +3,7 @@
 	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
 	"sourceRoot": "packages/php-wasm/cli/src",
 	"projectType": "library",
-	"tags": ["scope:php-wasm-public"],
+	"tags": ["scope:php-wasm-public", "scope:cli"],
 	"targets": {
 		"build": {
 			"executor": "nx:noop",

--- a/packages/php-wasm/web-builds/7-4/project.json
+++ b/packages/php-wasm/web-builds/7-4/project.json
@@ -57,5 +57,5 @@
 			"dependsOn": ["build"]
 		}
 	},
-	"tags": ["scope:php-binaries"]
+	"tags": ["scope:php-binaries", "scope:browser-only"]
 }

--- a/packages/php-wasm/web-builds/8-0/project.json
+++ b/packages/php-wasm/web-builds/8-0/project.json
@@ -57,5 +57,5 @@
 			"dependsOn": ["build"]
 		}
 	},
-	"tags": ["scope:php-binaries"]
+	"tags": ["scope:php-binaries", "scope:browser-only"]
 }

--- a/packages/php-wasm/web-builds/8-1/project.json
+++ b/packages/php-wasm/web-builds/8-1/project.json
@@ -57,5 +57,5 @@
 			"dependsOn": ["build"]
 		}
 	},
-	"tags": ["scope:php-binaries"]
+	"tags": ["scope:php-binaries", "scope:browser-only"]
 }

--- a/packages/php-wasm/web-builds/8-2/project.json
+++ b/packages/php-wasm/web-builds/8-2/project.json
@@ -57,5 +57,5 @@
 			"dependsOn": ["build"]
 		}
 	},
-	"tags": ["scope:php-binaries"]
+	"tags": ["scope:php-binaries", "scope:browser-only"]
 }

--- a/packages/php-wasm/web-builds/8-3/project.json
+++ b/packages/php-wasm/web-builds/8-3/project.json
@@ -57,5 +57,5 @@
 			"dependsOn": ["build"]
 		}
 	},
-	"tags": ["scope:php-binaries"]
+	"tags": ["scope:php-binaries", "scope:browser-only"]
 }

--- a/packages/php-wasm/web-builds/8-4/project.json
+++ b/packages/php-wasm/web-builds/8-4/project.json
@@ -57,5 +57,5 @@
 			"dependsOn": ["build"]
 		}
 	},
-	"tags": ["scope:php-binaries"]
+	"tags": ["scope:php-binaries", "scope:browser-only"]
 }

--- a/packages/php-wasm/web-builds/8-5/project.json
+++ b/packages/php-wasm/web-builds/8-5/project.json
@@ -57,5 +57,5 @@
 			"dependsOn": ["build"]
 		}
 	},
-	"tags": ["scope:php-binaries"]
+	"tags": ["scope:php-binaries", "scope:browser-only"]
 }

--- a/packages/php-wasm/web/project.json
+++ b/packages/php-wasm/web/project.json
@@ -3,7 +3,7 @@
 	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
 	"sourceRoot": "packages/php-wasm/web/src",
 	"projectType": "library",
-	"tags": ["scope:php-binaries"],
+	"tags": ["scope:php-binaries", "scope:browser-only"],
 	"implicitDependencies": ["php-wasm-compile"],
 	"targets": {
 		"build": {

--- a/packages/playground/cli/project.json
+++ b/packages/playground/cli/project.json
@@ -3,7 +3,7 @@
 	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
 	"sourceRoot": "packages/playground/cli/src",
 	"projectType": "library",
-	"tags": ["scope:php-wasm-public"],
+	"tags": ["scope:php-wasm-public", "scope:cli"],
 	"targets": {
 		"build": {
 			"executor": "nx:noop",

--- a/packages/playground/remote/project.json
+++ b/packages/playground/remote/project.json
@@ -3,7 +3,7 @@
 	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
 	"sourceRoot": "packages/playground/remote/src",
 	"projectType": "library",
-	"tags": [],
+	"tags": ["scope:browser-only"],
 	"targets": {
 		"build": {
 			"executor": "nx:noop",


### PR DESCRIPTION
## Summary

- Updates the `@nx/enforce-module-boundaries` to prevent `scope:cli` packages from depending on `scope:browser-only` packages
- Tags `@php-wasm/cli` and `@wp-playground/cli` with `scope:cli`
- Tags `@php-wasm/web`, all `@php-wasm/web-builds/*`, and `@wp-playground/remote` with `scope:browser-only`

## Motivation

Studio bundles the Playground CLI as a dependency. When browser-only packages (like `@php-wasm/web` or `@wp-playground/remote`) get pulled into the CLI's dependency graph, their large web-specific assets end up in Studio builds unnecessarily. This has happened before and is easy to miss in code review.

This lint rule catches these invalid dependencies at `nx lint` time, so browser-only packages can't sneak into CLI (and by extension, Studio) builds.

@fredrikekelund, this isn't much, but hopefully, it will help us avoid big mistakes that cause Studio builds to grab large, web-related Playground modules. 

## Test plan

- [x] `npx nx lint php-wasm-cli` passes (no violations on current code)
- [x] `npx nx lint playground-cli` passes
- [x] Manually verify that adding a `scope:browser-only` import to a `scope:cli` package triggers a lint error

🤖 Generated with [Claude Code](https://claude.com/claude-code)