### PR TITLE
Remove unnecessary phpMyAdmin guard

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -944,12 +944,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			args.phpmyadmin = '/phpmyadmin';
 		}
 
-		if (args.skipSqliteSetup) {
-			throw new Error(
-				'--phpmyadmin requires SQLite. Cannot be used with --skip-sqlite-setup.'
-			);
-		}
-
 		// Set up path alias for phpMyAdmin.
 		args['pathAliases'] = [
 			{


### PR DESCRIPTION
## Motivation for the change, related issues

I propose to remove the unnecessary phpMyAdmin guard. Without that, it's impossible to run the Playground CLI with phpMyAdmin on a site which maintains the SQLite plugin itself.

## Implementation details

Just removed the guard.

## Testing Instructions (or ideally a Blueprint)
