### PR TITLE
Add support for two other standard locations for SQLite plugin

### DIFF
--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -16,11 +16,10 @@ namespace Adminer;
 // The path varies depending on the environment (Playground, Studio, etc.).
 $sqlite_driver_locations = array(
 	'/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
-	'/wordpress/wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
-	'/wordpress/wp-content/plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	defined( 'WP_SQLITE_LOCATION' ) ? WP_SQLITE_LOCATION . '/wp-pdo-mysql-on-sqlite.php' : false,
 );
 foreach ($sqlite_driver_locations as $sqlite_driver_path) {
-	if (file_exists($sqlite_driver_path)) {
+	if ($sqlite_driver_path && file_exists($sqlite_driver_path)) {
 		require_once $sqlite_driver_path;
 		break;
 	}

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -24,6 +24,9 @@ foreach ($sqlite_driver_locations as $sqlite_driver_path) {
 		break;
 	}
 }
+if (!class_exists('WP_SQLite_Driver')) {
+	die('Error: Could not load the SQLite driver.');
+}
 
 use Throwable;
 use WP_SQLite_Driver;

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -12,8 +12,19 @@
 
 namespace Adminer;
 
-// Load the SQLite driver.
-require_once '/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
+// Load the SQLite driver from the first available location.
+// The path varies depending on the environment (Playground, Studio, etc.).
+$sqlite_driver_locations = array(
+	'/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	'/wordpress/wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	'/wordpress/wp-content/plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+);
+foreach ($sqlite_driver_locations as $sqlite_driver_path) {
+	if (file_exists($sqlite_driver_path)) {
+		require_once $sqlite_driver_path;
+		break;
+	}
+}
 
 use Throwable;
 use WP_SQLite_Driver;

--- a/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
+++ b/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
@@ -26,11 +26,10 @@ use WP_SQLite_Driver;
 // The path varies depending on the environment (Playground, Studio, etc.).
 $sqlite_driver_locations = array(
 	'/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
-	'/wordpress/wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
-	'/wordpress/wp-content/plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	defined( 'WP_SQLITE_LOCATION' ) ? WP_SQLITE_LOCATION . '/wp-pdo-mysql-on-sqlite.php' : false,
 );
 foreach ($sqlite_driver_locations as $sqlite_driver_path) {
-	if (file_exists($sqlite_driver_path)) {
+	if ($sqlite_driver_path && file_exists($sqlite_driver_path)) {
 		require_once $sqlite_driver_path;
 		break;
 	}

--- a/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
+++ b/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
@@ -22,8 +22,19 @@ use Throwable;
 use WP_SQLite_Connection;
 use WP_SQLite_Driver;
 
-// Load the SQLite driver.
-require_once '/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
+// Load the SQLite driver from the first available location.
+// The path varies depending on the environment (Playground, Studio, etc.).
+$sqlite_driver_locations = array(
+	'/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	'/wordpress/wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	'/wordpress/wp-content/plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+);
+foreach ($sqlite_driver_locations as $sqlite_driver_path) {
+	if (file_exists($sqlite_driver_path)) {
+		require_once $sqlite_driver_path;
+		break;
+	}
+}
 
 // Supress the following phpMyAdmin warning:
 //   "The mysqlnd extension is missing. Please check your PHP configuration."

--- a/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
+++ b/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
@@ -34,6 +34,9 @@ foreach ($sqlite_driver_locations as $sqlite_driver_path) {
 		break;
 	}
 }
+if (!class_exists('WP_SQLite_Driver')) {
+	die('Error: Could not load the SQLite driver.');
+}
 
 // Supress the following phpMyAdmin warning:
 //   "The mysqlnd extension is missing. Please check your PHP configuration."

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -16,11 +16,10 @@ namespace Adminer;
 // The path varies depending on the environment (Playground, Studio, etc.).
 $sqlite_driver_locations = array(
 	'/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
-	'/wordpress/wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
-	'/wordpress/wp-content/plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	defined( 'WP_SQLITE_LOCATION' ) ? WP_SQLITE_LOCATION . '/wp-pdo-mysql-on-sqlite.php' : false,
 );
 foreach ($sqlite_driver_locations as $sqlite_driver_path) {
-	if (file_exists($sqlite_driver_path)) {
+	if ($sqlite_driver_path && file_exists($sqlite_driver_path)) {
 		require_once $sqlite_driver_path;
 		break;
 	}

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -24,6 +24,9 @@ foreach ($sqlite_driver_locations as $sqlite_driver_path) {
 		break;
 	}
 }
+if (!class_exists('WP_SQLite_Driver')) {
+	die('Error: Could not load the SQLite driver.');
+}
 
 use Throwable;
 use WP_SQLite_Driver;

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -12,8 +12,19 @@
 
 namespace Adminer;
 
-// Load the SQLite driver.
-require_once '/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
+// Load the SQLite driver from the first available location.
+// The path varies depending on the environment (Playground, Studio, etc.).
+$sqlite_driver_locations = array(
+	'/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	'/wordpress/wp-content/mu-plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+	'/wordpress/wp-content/plugins/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php',
+);
+foreach ($sqlite_driver_locations as $sqlite_driver_path) {
+	if (file_exists($sqlite_driver_path)) {
+		require_once $sqlite_driver_path;
+		break;
+	}
+}
 
 use Throwable;
 use WP_SQLite_Driver;


### PR DESCRIPTION
## Motivation for the change, related issues

Currently, database admin tool patches included in Playground assume the internal path for the SQLite plugin. Playground also allows skipping SQLite setup, so user can manage their SQLite and keep it in `plugins/` or `mu-plugins`.

## Implementation details

I propose adding a fallback for two other paths.

## Testing Instructions (or ideally a Blueprint)

Test if phpMyAdmin still loads fine.