### PR TITLE
HTTP/2 support in Playground CLI

### DIFF
--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -753,7 +753,8 @@ export class PHPRequestHandler implements AsyncDisposable {
 			$_SERVER: this.prepare_$_SERVER_superglobal(
 				originalRequestUrl,
 				rewrittenRequestUrl,
-				scriptPath
+				scriptPath,
+				request.protocolVersion
 			),
 			body,
 			scriptPath,
@@ -863,12 +864,14 @@ export class PHPRequestHandler implements AsyncDisposable {
 	private prepare_$_SERVER_superglobal(
 		originalRequestUrl: URL,
 		rewrittenRequestUrl: URL,
-		resolvedScriptPath: string
+		resolvedScriptPath: string,
+		protocolVersion?: string
 	): Record<string, string> {
 		const $_SERVER: Record<string, string> = {
 			REMOTE_ADDR: '127.0.0.1',
 			DOCUMENT_ROOT: this.#DOCROOT,
 			HTTPS: this.#ABSOLUTE_URL.startsWith('https://') ? 'on' : '',
+			SERVER_PROTOCOL: protocolVersion || 'HTTP/1.1',
 		};
 
 		/**

--- a/packages/php-wasm/universal/src/lib/universal-php.ts
+++ b/packages/php-wasm/universal/src/lib/universal-php.ts
@@ -115,6 +115,13 @@ export interface PHPRequest {
 	 * and sent with a `multipart/form-data` header.
 	 */
 	body?: string | Uint8Array | Record<string, string | Uint8Array | File>;
+
+	/**
+	 * HTTP protocol version string for $_SERVER['SERVER_PROTOCOL'].
+	 * Examples: 'HTTP/1.0', 'HTTP/1.1', 'HTTP/2.0'.
+	 * Default: 'HTTP/1.1'.
+	 */
+	protocolVersion?: string;
 }
 
 export interface PHPRunOptions {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1053,10 +1053,30 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			const serverUrl = `${scheme}://${host}:${port}`;
 			const siteUrl = args['site-url'] || serverUrl;
 
-			const targetWorkerCount = computeWorkerCount(
-				args['min-workers'] as number,
-				args['max-workers'] as number
-			);
+			/**
+			 * With HTTP/1.1, browsers typically support 6 parallel
+			 * connections per domain.
+			 * > browsers open several connections to each domain,
+			 * > sending parallel requests. Default was once 2 to 3
+			 * > connections, but this has now increased to a more
+			 * > common use of 6 parallel connections.
+			 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Connection_management_in_HTTP_1.x#domain_sharding
+			 *
+			 * Going higher than browsers' max concurrent requests
+			 * seems pointless, and going lower may increase the
+			 * likelihood of deadlock due to workers blocking and
+			 * waiting for file locks.
+			 *
+			 * With HTTP/2, multiplexing removes the per-domain
+			 * connection limit, so we size the pool based on
+			 * available system memory instead.
+			 */
+			const targetWorkerCount = useHttp2
+				? computeWorkerCount(
+						args['min-workers'] as number,
+						args['max-workers'] as number
+					)
+				: 6;
 
 			/*
 			 * Use a real temp dir as a target for the following Playground paths

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -41,7 +41,7 @@ import {
 	parseDefineNumberArguments,
 } from './defines';
 import { isPortInUse, startServer } from './start-server';
-import { resolveTlsCertificates } from './tls';
+import { resolveTlsCertificate } from './tls';
 import type { PlaygroundCliBlueprintV1Worker } from './blueprints-v1/worker-thread-v1';
 import type { PlaygroundCliBlueprintV2Worker } from './blueprints-v2/worker-thread-v2';
 import type { XdebugOptions } from '@php-wasm/node';
@@ -1025,8 +1025,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	let isFirstRequest = true;
 
 	const useHttp2 = !!args.http2;
-	const tlsCertificates = useHttp2
-		? resolveTlsCertificates({
+	const tlsCertificate = useHttp2
+		? resolveTlsCertificate({
 				sslCert: args['ssl-cert'] as string | undefined,
 				sslKey: args['ssl-key'] as string | undefined,
 			})
@@ -1039,7 +1039,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				? selectedPort
 				: 0,
 		http2: useHttp2,
-		tlsCertificates,
+		tlsCertificate,
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';
 			const scheme = useHttp2 ? 'https' : 'http';
@@ -1921,7 +1921,9 @@ function computeWorkerCount(minWorkers: number, maxWorkers: number): number {
 		(freeMemory * 0.5) / ESTIMATED_WORKER_MEMORY_BYTES
 	);
 	const count = Math.max(minWorkers, Math.min(memoryBased, maxWorkers));
-	logger.log(`Worker count: ${count} (free memory: ${Math.round(freeMemory / 1024 / 1024)}MB)`);
+	logger.log(
+		`Worker count: ${count} (free memory: ${Math.round(freeMemory / 1024 / 1024)}MB)`
+	);
 	return count;
 }
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -41,6 +41,7 @@ import {
 	parseDefineNumberArguments,
 } from './defines';
 import { isPortInUse, startServer } from './start-server';
+import { resolveTlsCertificates } from './tls';
 import type { PlaygroundCliBlueprintV1Worker } from './blueprints-v1/worker-thread-v1';
 import type { PlaygroundCliBlueprintV2Worker } from './blueprints-v2/worker-thread-v2';
 import type { XdebugOptions } from '@php-wasm/node';
@@ -340,6 +341,35 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					'Port to listen on when serving. Defaults to 9400 when available.',
 				type: 'number',
 			},
+			http2: {
+				describe:
+					'Enable HTTP/2 with TLS. Requires HTTPS certificates ' +
+					'(auto-provisioned via mkcert or self-signed if not supplied).',
+				type: 'boolean',
+				default: false,
+			},
+			'ssl-cert': {
+				describe:
+					'Path to a TLS certificate file (PEM format). Used with --http2.',
+				type: 'string',
+			},
+			'ssl-key': {
+				describe:
+					'Path to a TLS private key file (PEM format). Used with --http2.',
+				type: 'string',
+			},
+			'min-workers': {
+				describe:
+					'Minimum number of PHP worker threads. Defaults to 2.',
+				type: 'number',
+				default: 2,
+			},
+			'max-workers': {
+				describe:
+					'Maximum number of PHP worker threads. Defaults to 12.',
+				type: 'number',
+				default: 12,
+			},
 			'experimental-multi-worker': {
 				deprecated:
 					'This option is not needed. Multiple workers are always used.',
@@ -436,6 +466,13 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				type: 'boolean',
 				default: false,
 			},
+			// HTTP/2 and TLS
+			http2: serverOnlyOptions['http2'],
+			'ssl-cert': serverOnlyOptions['ssl-cert'],
+			'ssl-key': serverOnlyOptions['ssl-key'],
+			// Worker pool
+			'min-workers': serverOnlyOptions['min-workers'],
+			'max-workers': serverOnlyOptions['max-workers'],
 			// Define constants
 			define: sharedOptions['define'],
 			'define-bool': sharedOptions['define-bool'],
@@ -987,15 +1024,26 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	let wordPressReady = false;
 	let isFirstRequest = true;
 
+	const useHttp2 = !!args.http2;
+	const tlsCertificates = useHttp2
+		? resolveTlsCertificates({
+				sslCert: args['ssl-cert'] as string | undefined,
+				sslKey: args['ssl-key'] as string | undefined,
+			})
+		: undefined;
+
 	const server = await startServer({
 		port: args.port
 			? args.port
 			: !(await isPortInUse(selectedPort))
 				? selectedPort
 				: 0,
+		http2: useHttp2,
+		tlsCertificates,
 		onBind: async (server: Server, port: number) => {
 			const host = '127.0.0.1';
-			const serverUrl = `http://${host}:${port}`;
+			const scheme = useHttp2 ? 'https' : 'http';
+			const serverUrl = `${scheme}://${host}:${port}`;
 			const siteUrl = args['site-url'] || serverUrl;
 
 			/**

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -358,17 +358,11 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 					'Path to a TLS private key file (PEM format). Used with --http2.',
 				type: 'string',
 			},
-			'min-workers': {
+			workers: {
 				describe:
-					'Minimum number of PHP worker threads. Defaults to 2.',
+					'Number of PHP worker threads to spawn. Defaults to 6.',
 				type: 'number',
-				default: 2,
-			},
-			'max-workers': {
-				describe:
-					'Maximum number of PHP worker threads. Defaults to 12.',
-				type: 'number',
-				default: 12,
+				default: 6,
 			},
 			'experimental-multi-worker': {
 				deprecated:
@@ -471,8 +465,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			'ssl-cert': serverOnlyOptions['ssl-cert'],
 			'ssl-key': serverOnlyOptions['ssl-key'],
 			// Worker pool
-			'min-workers': serverOnlyOptions['min-workers'],
-			'max-workers': serverOnlyOptions['max-workers'],
+			workers: serverOnlyOptions['workers'],
 			// Define constants
 			define: sharedOptions['define'],
 			'define-bool': sharedOptions['define-bool'],
@@ -854,8 +847,7 @@ export interface RunCLIArgs {
 	http2?: boolean;
 	'ssl-cert'?: string;
 	'ssl-key'?: string;
-	'min-workers'?: number;
-	'max-workers'?: number;
+	workers?: number;
 
 	// --------- Start command args -----------
 	path?: string;
@@ -1072,12 +1064,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			 * connection limit, so we size the pool based on
 			 * available system memory instead.
 			 */
-			const targetWorkerCount = useHttp2
-				? computeWorkerCount(
-						args['min-workers'] as number,
-						args['max-workers'] as number
-					)
-				: 6;
+			const targetWorkerCount = (args.workers as number) ?? 6;
+			warnIfInsufficientMemoryForWorkers(targetWorkerCount);
 
 			/*
 			 * Use a real temp dir as a target for the following Playground paths
@@ -1937,25 +1925,29 @@ function openInBrowser(url: string): void {
 export const ESTIMATED_WORKER_MEMORY_BYTES = 100 * 1024 * 1024; // ~100MB per worker
 
 /**
- * Determines the number of PHP worker threads to spawn based on
- * available system memory, clamped to [minWorkers, maxWorkers].
+ * Logs a warning when selected worker count appears too high for
+ * currently free system memory.
  *
- * Uses 50% of free memory as the budget for workers so the system
+ * Uses 50% of free memory as the recommended worker budget so the system
  * has headroom for the OS, browser, and other processes.
  */
-export function computeWorkerCount(
-	minWorkers: number,
-	maxWorkers: number
-): number {
+export function warnIfInsufficientMemoryForWorkers(workerCount: number): void {
 	const freeMemory = os.freemem();
-	const memoryBased = Math.floor(
+	const recommendedByMemory = Math.floor(
 		(freeMemory * 0.5) / ESTIMATED_WORKER_MEMORY_BYTES
 	);
-	const count = Math.max(minWorkers, Math.min(memoryBased, maxWorkers));
-	logger.log(
-		`Worker count: ${count} (free memory: ${Math.round(freeMemory / 1024 / 1024)}MB)`
-	);
-	return count;
+	const freeMemoryMb = Math.round(freeMemory / 1024 / 1024);
+	if (workerCount > recommendedByMemory) {
+		logger.warn(
+			`Selected workers (${workerCount}) may exceed available free memory budget ` +
+				`(free memory: ${freeMemoryMb}MB, recommended max: ${recommendedByMemory}). ` +
+				'Continuing with requested worker count.'
+		);
+	} else {
+		logger.log(
+			`Worker count: ${workerCount} (free memory: ${freeMemoryMb}MB)`
+		);
+	}
 }
 
 async function zipSite(

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -850,6 +850,13 @@ export interface RunCLIArgs {
 	'truncate-new-site-directory'?: boolean;
 	allow?: string;
 
+	// --------- Server command args -----------
+	http2?: boolean;
+	'ssl-cert'?: string;
+	'ssl-key'?: string;
+	'min-workers'?: number;
+	'max-workers'?: number;
+
 	// --------- Start command args -----------
 	path?: string;
 	skipBrowser?: boolean;

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1046,22 +1046,10 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			const serverUrl = `${scheme}://${host}:${port}`;
 			const siteUrl = args['site-url'] || serverUrl;
 
-			/**
-			 * With HTTP 1.1, browsers typically support 6 parallel connections per domain.
-			 * > browsers open several connections to each domain,
-			 * > sending parallel requests. Default was once 2 to 3 connections,
-			 * > but this has now increased to a more common use of 6 parallel connections.
-			 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Connection_management_in_HTTP_1.x#domain_sharding
-			 *
-			 * While our HTTP server only supports HTTP 1.1 and while we are trying to limit the
-			 * memory requirements of multiple workers, let's hard-code the number of request-handling
-			 * workers to 6.
-			 *
-			 * Going higher than browsers' max concurrent requests seems pointless,
-			 * and going lower may increase the likelihood of deadlock due to workers
-			 * blocking and waiting for file locks.
-			 */
-			const targetWorkerCount = 6;
+			const targetWorkerCount = computeWorkerCount(
+				args['min-workers'] as number,
+				args['max-workers'] as number
+			);
 
 			/*
 			 * Use a real temp dir as a target for the following Playground paths
@@ -1916,6 +1904,25 @@ function openInBrowser(url: string): void {
 			logger.debug(`Could not open browser: ${error.message}`);
 		}
 	});
+}
+
+const ESTIMATED_WORKER_MEMORY_BYTES = 100 * 1024 * 1024; // ~100MB per worker
+
+/**
+ * Determines the number of PHP worker threads to spawn based on
+ * available system memory, clamped to [minWorkers, maxWorkers].
+ *
+ * Uses 50% of free memory as the budget for workers so the system
+ * has headroom for the OS, browser, and other processes.
+ */
+function computeWorkerCount(minWorkers: number, maxWorkers: number): number {
+	const freeMemory = os.freemem();
+	const memoryBased = Math.floor(
+		(freeMemory * 0.5) / ESTIMATED_WORKER_MEMORY_BYTES
+	);
+	const count = Math.max(minWorkers, Math.min(memoryBased, maxWorkers));
+	logger.log(`Worker count: ${count} (free memory: ${Math.round(freeMemory / 1024 / 1024)}MB)`);
+	return count;
 }
 
 async function zipSite(

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1036,6 +1036,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 		? resolveTlsCertificate({
 				sslCert: args['ssl-cert'] as string | undefined,
 				sslKey: args['ssl-key'] as string | undefined,
+				debug: args.verbosity === 'debug',
 			})
 		: undefined;
 
@@ -1933,7 +1934,7 @@ function openInBrowser(url: string): void {
 	});
 }
 
-const ESTIMATED_WORKER_MEMORY_BYTES = 100 * 1024 * 1024; // ~100MB per worker
+export const ESTIMATED_WORKER_MEMORY_BYTES = 100 * 1024 * 1024; // ~100MB per worker
 
 /**
  * Determines the number of PHP worker threads to spawn based on
@@ -1942,7 +1943,10 @@ const ESTIMATED_WORKER_MEMORY_BYTES = 100 * 1024 * 1024; // ~100MB per worker
  * Uses 50% of free memory as the budget for workers so the system
  * has headroom for the OS, browser, and other processes.
  */
-function computeWorkerCount(minWorkers: number, maxWorkers: number): number {
+export function computeWorkerCount(
+	minWorkers: number,
+	maxWorkers: number
+): number {
 	const freeMemory = os.freemem();
 	const memoryBased = Math.floor(
 		(freeMemory * 0.5) / ESTIMATED_WORKER_MEMORY_BYTES

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -77,11 +77,15 @@ function createRequestListener(
 ): RequestListener {
 	return async (req, res) => {
 		try {
+			const httpVersion = (req as any).httpVersion;
 			const phpRequest: PHPRequest = {
 				url: req.url ?? '/',
 				headers: parseHeaders(req.headers),
 				method: (req.method ?? 'GET') as any,
 				body: await bufferRequestBody(req),
+				protocolVersion: httpVersion
+					? `HTTP/${httpVersion}`
+					: undefined,
 			};
 
 			const response = await handleRequest(phpRequest);

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -1,7 +1,6 @@
 import { exec as execCb } from 'child_process';
 import { promisify } from 'util';
 import type { PHPRequest, StreamedPHPResponse } from '@php-wasm/universal';
-import type { Request, Response } from 'express';
 import express from 'express';
 import type { IncomingMessage, Server, ServerResponse } from 'http';
 import type { AddressInfo } from 'net';
@@ -9,6 +8,8 @@ import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
 import type { RunCLIServer } from './run-cli';
 import { logger } from '@php-wasm/logger';
+import http2 from 'http2';
+import type { TlsCertificates } from './tls';
 
 const exec = promisify(execCb);
 
@@ -19,6 +20,8 @@ export interface ServerOptions {
 	 * Handler for requests. Always returns StreamedPHPResponse.
 	 */
 	handleRequest: (request: PHPRequest) => Promise<StreamedPHPResponse>;
+	http2?: boolean;
+	tlsCertificates?: TlsCertificates;
 }
 
 export function isPortInUse(port: number): Promise<boolean> {
@@ -37,6 +40,66 @@ export function isPortInUse(port: number): Promise<boolean> {
 export async function startServer(
 	options: ServerOptions
 ): Promise<RunCLIServer | void> {
+	const requestListener = createRequestListener(options.handleRequest);
+
+	// TODO: Remove Express path when HTTP/2 becomes the default
+	const server = options.http2
+		? await startHttp2Server(options, requestListener)
+		: await startExpressServer(options, requestListener);
+
+	const address = server.address();
+	const port = (address! as AddressInfo).port;
+
+	// Codespaces ports default to private, breaking CORS.
+	// Publish once the tunnel is ready.
+	const codespaceName = process.env['CODESPACE_NAME'];
+	if (codespaceName) {
+		setCodespacesPortPublic(port, codespaceName);
+	}
+
+	return await options.onBind(server, port);
+}
+
+type RequestListener = (
+	req: { url?: string; method?: string; headers: Record<string, any> } & {
+		on: (event: string, cb: (...args: any[]) => void) => void;
+	},
+	res: {
+		statusCode: number;
+		headersSent: boolean;
+		setHeader: (name: string, value: string) => void;
+		end: (data?: string) => void;
+	} & NodeJS.WritableStream
+) => Promise<void>;
+
+function createRequestListener(
+	handleRequest: ServerOptions['handleRequest']
+): RequestListener {
+	return async (req, res) => {
+		try {
+			const phpRequest: PHPRequest = {
+				url: req.url ?? '/',
+				headers: parseHeaders(req.headers),
+				method: (req.method ?? 'GET') as any,
+				body: await bufferRequestBody(req),
+			};
+
+			const response = await handleRequest(phpRequest);
+			await handleStreamedResponse(response, res as any);
+		} catch (error) {
+			logger.error(error);
+			if (!res.headersSent) {
+				res.statusCode = 500;
+				res.end('Internal Server Error');
+			}
+		}
+	};
+}
+
+async function startExpressServer(
+	options: ServerOptions,
+	requestListener: RequestListener
+): Promise<Server<typeof IncomingMessage, typeof ServerResponse>> {
 	const app = express();
 
 	const server = await new Promise<
@@ -54,37 +117,48 @@ export async function startServer(
 			.once('error', reject);
 	});
 
-	app.use('/', async (req, res) => {
-		try {
-			const phpRequest: PHPRequest = {
-				url: req.url,
-				headers: parseHeaders(req),
-				method: req.method as any,
-				body: await bufferRequestBody(req),
-			};
-
-			const response = await options.handleRequest(phpRequest);
-			await handleStreamedResponse(response, res);
-		} catch (error) {
-			logger.error(error);
-			if (!res.headersSent) {
-				res.statusCode = 500;
-				res.end('Internal Server Error');
-			}
-		}
+	app.use('/', (req, res) => {
+		requestListener(req, res);
 	});
 
-	const address = server.address();
-	const port = (address! as AddressInfo).port;
+	return server;
+}
 
-	// Codespaces ports default to private, breaking CORS.
-	// Publish once the tunnel is ready.
-	const codespaceName = process.env['CODESPACE_NAME'];
-	if (codespaceName) {
-		setCodespacesPortPublic(port, codespaceName);
+async function startHttp2Server(
+	options: ServerOptions,
+	requestListener: RequestListener
+): Promise<Server> {
+	if (!options.tlsCertificates) {
+		throw new Error('TLS certificates are required for HTTP/2.');
 	}
 
-	return await options.onBind(server, port);
+	const server = await new Promise<http2.Http2SecureServer>(
+		(resolve, reject) => {
+			const h2Server = http2.createSecureServer(
+				{
+					key: options.tlsCertificates!.key,
+					cert: options.tlsCertificates!.cert,
+					allowHTTP1: true,
+				},
+				(req, res) => {
+					requestListener(req, res);
+				}
+			);
+
+			h2Server
+				.listen(options.port, () => {
+					const address = h2Server.address();
+					if (address === null || typeof address === 'string') {
+						reject(new Error('Server address is not available'));
+					} else {
+						resolve(h2Server);
+					}
+				})
+				.once('error', reject);
+		}
+	);
+
+	return server as unknown as Server;
 }
 
 /**
@@ -93,7 +167,7 @@ export async function startServer(
  */
 async function handleStreamedResponse(
 	streamedResponse: StreamedPHPResponse,
-	res: Response
+	res: { statusCode: number; setHeader(name: string, value: string): void } & NodeJS.WritableStream
 ): Promise<void> {
 	// Wait for headers to be available
 	const [headers, httpStatusCode] = await Promise.all([
@@ -128,10 +202,12 @@ async function handleStreamedResponse(
 	}
 }
 
-const bufferRequestBody = async (req: Request): Promise<Uint8Array> =>
+const bufferRequestBody = async (
+	req: { on(event: string, cb: (...args: any[]) => void): void }
+): Promise<Uint8Array> =>
 	await new Promise((resolve) => {
 		const body: Uint8Array[] = [];
-		req.on('data', (chunk) => {
+		req.on('data', (chunk: Buffer) => {
 			body.push(chunk);
 		});
 		req.on('end', () => {
@@ -152,12 +228,21 @@ async function setCodespacesPortPublic(port: number, codespaceName: string) {
 	}
 }
 
-const parseHeaders = (req: Request): Record<string, string> => {
+/**
+ * Parses headers from an HTTP request object into a flat record.
+ * Filters out HTTP/2 pseudo-headers (keys starting with `:`) since
+ * PHP doesn't understand them.
+ */
+const parseHeaders = (
+	headers: Record<string, any>
+): Record<string, string> => {
 	const requestHeaders: Record<string, string> = {};
-	if (req.rawHeaders && req.rawHeaders.length) {
-		for (let i = 0; i < req.rawHeaders.length; i += 2) {
-			requestHeaders[req.rawHeaders[i].toLowerCase()] =
-				req.rawHeaders[i + 1];
+	for (const [key, value] of Object.entries(headers)) {
+		if (key.startsWith(':')) {
+			continue;
+		}
+		if (value !== undefined) {
+			requestHeaders[key.toLowerCase()] = String(value);
 		}
 	}
 	return requestHeaders;

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -67,8 +67,7 @@ type RequestListener = (
 	res: {
 		statusCode: number;
 		headersSent: boolean;
-		setHeader: (name: string, value: string) => void;
-		end: (data?: string) => void;
+		setHeader: (name: string, value: string | string[]) => void;
 	} & NodeJS.WritableStream
 ) => Promise<void>;
 
@@ -173,7 +172,7 @@ async function handleStreamedResponse(
 	streamedResponse: StreamedPHPResponse,
 	res: {
 		statusCode: number;
-		setHeader(name: string, value: string): void;
+		setHeader(name: string, value: string | string[]): void;
 	} & NodeJS.WritableStream
 ): Promise<void> {
 	// Wait for headers to be available

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -135,6 +135,8 @@ async function startHttp2Server(
 		throw new Error('TLS certificate is required for HTTP/2.');
 	}
 
+	const activeSessions = new Set<http2.Http2Session>();
+
 	const server = await new Promise<http2.Http2SecureServer>(
 		(resolve, reject) => {
 			const h2Server = http2.createSecureServer(
@@ -148,6 +150,11 @@ async function startHttp2Server(
 				}
 			);
 
+			h2Server.on('session', (session) => {
+				activeSessions.add(session);
+				session.on('close', () => activeSessions.delete(session));
+			});
+
 			h2Server
 				.listen(options.port, () => {
 					const address = h2Server.address();
@@ -160,6 +167,16 @@ async function startHttp2Server(
 				.once('error', reject);
 		}
 	);
+
+	// Http2SecureServer doesn't have closeAllConnections() (only
+	// http.Server does). Provide one so the shutdown code in run-cli.ts
+	// can force-close long-lived HTTP/2 sessions the same way it does
+	// for HTTP/1.1 connections.
+	(server as any).closeAllConnections = () => {
+		for (const session of activeSessions) {
+			session.destroy();
+		}
+	};
 
 	return server as unknown as Server;
 }

--- a/packages/playground/cli/src/start-server.ts
+++ b/packages/playground/cli/src/start-server.ts
@@ -9,7 +9,7 @@ import { pipeline } from 'stream/promises';
 import type { RunCLIServer } from './run-cli';
 import { logger } from '@php-wasm/logger';
 import http2 from 'http2';
-import type { TlsCertificates } from './tls';
+import type { TlsCertificate } from './tls';
 
 const exec = promisify(execCb);
 
@@ -21,7 +21,7 @@ export interface ServerOptions {
 	 */
 	handleRequest: (request: PHPRequest) => Promise<StreamedPHPResponse>;
 	http2?: boolean;
-	tlsCertificates?: TlsCertificates;
+	tlsCertificate?: TlsCertificate;
 }
 
 export function isPortInUse(port: number): Promise<boolean> {
@@ -132,16 +132,16 @@ async function startHttp2Server(
 	options: ServerOptions,
 	requestListener: RequestListener
 ): Promise<Server> {
-	if (!options.tlsCertificates) {
-		throw new Error('TLS certificates are required for HTTP/2.');
+	if (!options.tlsCertificate) {
+		throw new Error('TLS certificate is required for HTTP/2.');
 	}
 
 	const server = await new Promise<http2.Http2SecureServer>(
 		(resolve, reject) => {
 			const h2Server = http2.createSecureServer(
 				{
-					key: options.tlsCertificates!.key,
-					cert: options.tlsCertificates!.cert,
+					key: options.tlsCertificate!.key,
+					cert: options.tlsCertificate!.cert,
 					allowHTTP1: true,
 				},
 				(req, res) => {
@@ -171,7 +171,10 @@ async function startHttp2Server(
  */
 async function handleStreamedResponse(
 	streamedResponse: StreamedPHPResponse,
-	res: { statusCode: number; setHeader(name: string, value: string): void } & NodeJS.WritableStream
+	res: {
+		statusCode: number;
+		setHeader(name: string, value: string): void;
+	} & NodeJS.WritableStream
 ): Promise<void> {
 	// Wait for headers to be available
 	const [headers, httpStatusCode] = await Promise.all([
@@ -206,9 +209,9 @@ async function handleStreamedResponse(
 	}
 }
 
-const bufferRequestBody = async (
-	req: { on(event: string, cb: (...args: any[]) => void): void }
-): Promise<Uint8Array> =>
+const bufferRequestBody = async (req: {
+	on(event: string, cb: (...args: any[]) => void): void;
+}): Promise<Uint8Array> =>
 	await new Promise((resolve) => {
 		const body: Uint8Array[] = [];
 		req.on('data', (chunk: Buffer) => {
@@ -237,9 +240,7 @@ async function setCodespacesPortPublic(port: number, codespaceName: string) {
  * Filters out HTTP/2 pseudo-headers (keys starting with `:`) since
  * PHP doesn't understand them.
  */
-const parseHeaders = (
-	headers: Record<string, any>
-): Record<string, string> => {
+const parseHeaders = (headers: Record<string, any>): Record<string, string> => {
 	const requestHeaders: Record<string, string> = {};
 	for (const [key, value] of Object.entries(headers)) {
 		if (key.startsWith(':')) {

--- a/packages/playground/cli/src/tls.ts
+++ b/packages/playground/cli/src/tls.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { logger } from '@php-wasm/logger';
 
-export interface TlsCertificates {
+export interface TlsCertificate {
 	key: string;
 	cert: string;
 }
@@ -16,7 +16,7 @@ export interface TlsCertificates {
  * The certificate is valid for localhost and 127.0.0.1, expires in
  * 30 days, and is intended for local development only.
  */
-export function generateSelfSignedCert(): TlsCertificates {
+export function generateSelfSignedCert(): TlsCertificate {
 	const tempDir = mkdtempSync(join(tmpdir(), 'playground-tls-'));
 	const keyPath = join(tempDir, 'key.pem');
 	const certPath = join(tempDir, 'cert.pem');
@@ -104,7 +104,7 @@ export function getMkcertCaRoot(): string | null {
  * Generates a locally-trusted TLS certificate using mkcert.
  * Requires mkcert to be installed with its CA root set up.
  */
-export function generateMkcertCert(): TlsCertificates {
+export function generateMkcertCert(): TlsCertificate {
 	const tempDir = mkdtempSync(join(tmpdir(), 'playground-tls-'));
 	const keyPath = join(tempDir, 'key.pem');
 	const certPath = join(tempDir, 'cert.pem');
@@ -142,10 +142,10 @@ export function generateMkcertCert(): TlsCertificates {
  * 2. mkcert (if installed with trusted CA)
  * 3. Self-signed fallback
  */
-export function resolveTlsCertificates(options: {
+export function resolveTlsCertificate(options: {
 	sslCert?: string;
 	sslKey?: string;
-}): TlsCertificates {
+}): TlsCertificate {
 	if (options.sslCert && options.sslKey) {
 		logger.log('Using user-supplied TLS certificates.');
 		return {

--- a/packages/playground/cli/src/tls.ts
+++ b/packages/playground/cli/src/tls.ts
@@ -4,6 +4,12 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { logger } from '@php-wasm/logger';
 
+// Flip to true to surface openssl/mkcert output for debugging
+const DEBUG_CERT_GENERATION = false;
+const CERT_STDIO: ('pipe' | 'inherit')[] = DEBUG_CERT_GENERATION
+	? ['inherit', 'inherit', 'inherit']
+	: ['pipe', 'pipe', 'pipe'];
+
 export interface TlsCertificate {
 	key: string;
 	cert: string;
@@ -50,7 +56,7 @@ subjectAltName = DNS:localhost,IP:127.0.0.1
 			'30',
 			'-config',
 			confPath,
-		]);
+		], { stdio: CERT_STDIO });
 		return {
 			key: readFileSync(keyPath, 'utf8'),
 			cert: readFileSync(certPath, 'utf8'),
@@ -117,7 +123,7 @@ export function generateMkcertCert(): TlsCertificate {
 			certPath,
 			'localhost',
 			'127.0.0.1',
-		]);
+		], { stdio: CERT_STDIO });
 		return {
 			key: readFileSync(keyPath, 'utf8'),
 			cert: readFileSync(certPath, 'utf8'),
@@ -147,7 +153,7 @@ export function resolveTlsCertificate(options: {
 	sslKey?: string;
 }): TlsCertificate {
 	if (options.sslCert && options.sslKey) {
-		logger.log('Using user-supplied TLS certificates.');
+		logger.log('TLS: using provided certificates');
 		return {
 			key: readFileSync(options.sslKey, 'utf8'),
 			cert: readFileSync(options.sslCert, 'utf8'),
@@ -156,13 +162,13 @@ export function resolveTlsCertificate(options: {
 
 	const caRoot = getMkcertCaRoot();
 	if (caRoot) {
-		logger.log('Using mkcert for locally-trusted TLS certificates.');
+		logger.log('TLS: using mkcert (locally-trusted)');
 		return generateMkcertCert();
 	}
 
-	logger.log('Generating self-signed TLS certificate for HTTPS.');
 	logger.log(
-		'Tip: Install mkcert (https://github.com/FiloSottile/mkcert) for warning-free HTTPS.'
+		'TLS: using self-signed certificate' +
+			' (install mkcert for warning-free HTTPS)'
 	);
 	return generateSelfSignedCert();
 }

--- a/packages/playground/cli/src/tls.ts
+++ b/packages/playground/cli/src/tls.ts
@@ -4,11 +4,9 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { logger } from '@php-wasm/logger';
 
-// Flip to true to surface openssl/mkcert output for debugging
-const DEBUG_CERT_GENERATION = false;
-const CERT_STDIO: ('pipe' | 'inherit')[] = DEBUG_CERT_GENERATION
-	? ['inherit', 'inherit', 'inherit']
-	: ['pipe', 'pipe', 'pipe'];
+function certStdio(debug: boolean): ('pipe' | 'inherit')[] {
+	return debug ? ['inherit', 'inherit', 'inherit'] : ['pipe', 'pipe', 'pipe'];
+}
 
 export interface TlsCertificate {
 	key: string;
@@ -22,7 +20,7 @@ export interface TlsCertificate {
  * The certificate is valid for localhost and 127.0.0.1, expires in
  * 30 days, and is intended for local development only.
  */
-export function generateSelfSignedCert(): TlsCertificate {
+export function generateSelfSignedCert(debug = false): TlsCertificate {
 	const tempDir = mkdtempSync(join(tmpdir(), 'playground-tls-'));
 	const keyPath = join(tempDir, 'key.pem');
 	const certPath = join(tempDir, 'cert.pem');
@@ -42,21 +40,25 @@ subjectAltName = DNS:localhost,IP:127.0.0.1
 
 	try {
 		writeFileSync(confPath, opensslConf);
-		execFileSync('openssl', [
-			'req',
-			'-x509',
-			'-newkey',
-			'rsa:2048',
-			'-nodes',
-			'-keyout',
-			keyPath,
-			'-out',
-			certPath,
-			'-days',
-			'30',
-			'-config',
-			confPath,
-		], { stdio: CERT_STDIO });
+		execFileSync(
+			'openssl',
+			[
+				'req',
+				'-x509',
+				'-newkey',
+				'rsa:2048',
+				'-nodes',
+				'-keyout',
+				keyPath,
+				'-out',
+				certPath,
+				'-days',
+				'30',
+				'-config',
+				confPath,
+			],
+			{ stdio: certStdio(debug) }
+		);
 		return {
 			key: readFileSync(keyPath, 'utf8'),
 			cert: readFileSync(certPath, 'utf8'),
@@ -110,20 +112,24 @@ export function getMkcertCaRoot(): string | null {
  * Generates a locally-trusted TLS certificate using mkcert.
  * Requires mkcert to be installed with its CA root set up.
  */
-export function generateMkcertCert(): TlsCertificate {
+export function generateMkcertCert(debug = false): TlsCertificate {
 	const tempDir = mkdtempSync(join(tmpdir(), 'playground-tls-'));
 	const keyPath = join(tempDir, 'key.pem');
 	const certPath = join(tempDir, 'cert.pem');
 
 	try {
-		execFileSync('mkcert', [
-			'-key-file',
-			keyPath,
-			'-cert-file',
-			certPath,
-			'localhost',
-			'127.0.0.1',
-		], { stdio: CERT_STDIO });
+		execFileSync(
+			'mkcert',
+			[
+				'-key-file',
+				keyPath,
+				'-cert-file',
+				certPath,
+				'localhost',
+				'127.0.0.1',
+			],
+			{ stdio: certStdio(debug) }
+		);
 		return {
 			key: readFileSync(keyPath, 'utf8'),
 			cert: readFileSync(certPath, 'utf8'),
@@ -151,6 +157,7 @@ export function generateMkcertCert(): TlsCertificate {
 export function resolveTlsCertificate(options: {
 	sslCert?: string;
 	sslKey?: string;
+	debug?: boolean;
 }): TlsCertificate {
 	if (options.sslCert && options.sslKey) {
 		logger.log('TLS: using provided certificates');
@@ -160,15 +167,16 @@ export function resolveTlsCertificate(options: {
 		};
 	}
 
+	const debug = !!options.debug;
 	const caRoot = getMkcertCaRoot();
 	if (caRoot) {
 		logger.log('TLS: using mkcert (locally-trusted)');
-		return generateMkcertCert();
+		return generateMkcertCert(debug);
 	}
 
 	logger.log(
 		'TLS: using self-signed certificate' +
 			' (install mkcert for warning-free HTTPS)'
 	);
-	return generateSelfSignedCert();
+	return generateSelfSignedCert(debug);
 }

--- a/packages/playground/cli/src/tls.ts
+++ b/packages/playground/cli/src/tls.ts
@@ -1,0 +1,168 @@
+import { execSync, execFileSync } from 'child_process';
+import { readFileSync, writeFileSync, unlinkSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { logger } from '@php-wasm/logger';
+
+export interface TlsCertificates {
+	key: string;
+	cert: string;
+}
+
+/**
+ * Generates an ephemeral self-signed TLS certificate and private key
+ * using the system's OpenSSL (or LibreSSL) installation.
+ *
+ * The certificate is valid for localhost and 127.0.0.1, expires in
+ * 30 days, and is intended for local development only.
+ */
+export function generateSelfSignedCert(): TlsCertificates {
+	const tempDir = mkdtempSync(join(tmpdir(), 'playground-tls-'));
+	const keyPath = join(tempDir, 'key.pem');
+	const certPath = join(tempDir, 'cert.pem');
+	const confPath = join(tempDir, 'openssl.cnf');
+
+	const opensslConf = `[req]
+distinguished_name = req_dn
+x509_extensions = v3_req
+prompt = no
+
+[req_dn]
+CN = localhost
+
+[v3_req]
+subjectAltName = DNS:localhost,IP:127.0.0.1
+`;
+
+	try {
+		writeFileSync(confPath, opensslConf);
+		execFileSync('openssl', [
+			'req',
+			'-x509',
+			'-newkey',
+			'rsa:2048',
+			'-nodes',
+			'-keyout',
+			keyPath,
+			'-out',
+			certPath,
+			'-days',
+			'30',
+			'-config',
+			confPath,
+		]);
+		return {
+			key: readFileSync(keyPath, 'utf8'),
+			cert: readFileSync(certPath, 'utf8'),
+		};
+	} finally {
+		try {
+			unlinkSync(keyPath);
+		} catch {
+			// ignore
+		}
+		try {
+			unlinkSync(certPath);
+		} catch {
+			// ignore
+		}
+		try {
+			unlinkSync(confPath);
+		} catch {
+			// ignore
+		}
+	}
+}
+
+/**
+ * Checks whether mkcert is installed and has a trusted CA root.
+ * Returns the CA root path if available, or null if mkcert is not
+ * usable.
+ */
+export function getMkcertCaRoot(): string | null {
+	try {
+		const caRoot = execSync('mkcert -CAROOT', {
+			stdio: ['pipe', 'pipe', 'pipe'],
+		})
+			.toString()
+			.trim();
+		if (!caRoot) {
+			return null;
+		}
+		try {
+			readFileSync(join(caRoot, 'rootCA.pem'));
+			return caRoot;
+		} catch {
+			return null;
+		}
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Generates a locally-trusted TLS certificate using mkcert.
+ * Requires mkcert to be installed with its CA root set up.
+ */
+export function generateMkcertCert(): TlsCertificates {
+	const tempDir = mkdtempSync(join(tmpdir(), 'playground-tls-'));
+	const keyPath = join(tempDir, 'key.pem');
+	const certPath = join(tempDir, 'cert.pem');
+
+	try {
+		execFileSync('mkcert', [
+			'-key-file',
+			keyPath,
+			'-cert-file',
+			certPath,
+			'localhost',
+			'127.0.0.1',
+		]);
+		return {
+			key: readFileSync(keyPath, 'utf8'),
+			cert: readFileSync(certPath, 'utf8'),
+		};
+	} finally {
+		try {
+			unlinkSync(keyPath);
+		} catch {
+			// ignore
+		}
+		try {
+			unlinkSync(certPath);
+		} catch {
+			// ignore
+		}
+	}
+}
+
+/**
+ * Resolves TLS certificates using a priority chain:
+ * 1. User-supplied certs (--ssl-cert / --ssl-key)
+ * 2. mkcert (if installed with trusted CA)
+ * 3. Self-signed fallback
+ */
+export function resolveTlsCertificates(options: {
+	sslCert?: string;
+	sslKey?: string;
+}): TlsCertificates {
+	if (options.sslCert && options.sslKey) {
+		logger.log('Using user-supplied TLS certificates.');
+		return {
+			key: readFileSync(options.sslKey, 'utf8'),
+			cert: readFileSync(options.sslCert, 'utf8'),
+		};
+	}
+
+	const caRoot = getMkcertCaRoot();
+	if (caRoot) {
+		logger.log('Using mkcert for locally-trusted TLS certificates.');
+		return generateMkcertCert();
+	}
+
+	logger.log('Generating self-signed TLS certificate for HTTPS.');
+	logger.log(
+		'Tip: Install mkcert (https://github.com/FiloSottile/mkcert) for warning-free HTTPS.'
+	);
+	return generateSelfSignedCert();
+}

--- a/packages/playground/cli/tests/compute-worker-count.spec.ts
+++ b/packages/playground/cli/tests/compute-worker-count.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import os from 'os';
+import {
+	computeWorkerCount,
+	ESTIMATED_WORKER_MEMORY_BYTES,
+} from '../src/run-cli';
+
+vi.mock('@php-wasm/logger', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@php-wasm/logger')>();
+	return {
+		...actual,
+		logger: { log: vi.fn(), error: vi.fn(), debug: vi.fn() },
+	};
+});
+
+describe('computeWorkerCount', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns minWorkers when free memory is very low', () => {
+		vi.spyOn(os, 'freemem').mockReturnValue(50 * 1024 * 1024); // 50MB
+		expect(computeWorkerCount(2, 12)).toBe(2);
+	});
+
+	it('returns maxWorkers when free memory is very high', () => {
+		vi.spyOn(os, 'freemem').mockReturnValue(100 * 1024 * 1024 * 1024); // 100GB
+		expect(computeWorkerCount(2, 12)).toBe(12);
+	});
+
+	it('returns memory-based count when between min and max', () => {
+		// 800MB free -> 400MB budget -> 4 workers
+		vi.spyOn(os, 'freemem').mockReturnValue(800 * 1024 * 1024);
+		expect(computeWorkerCount(2, 12)).toBe(4);
+	});
+
+	it('clamps to minWorkers even when memory suggests fewer', () => {
+		// 300MB free -> 150MB budget -> 1 worker, but min is 4
+		vi.spyOn(os, 'freemem').mockReturnValue(300 * 1024 * 1024);
+		expect(computeWorkerCount(4, 8)).toBe(4);
+	});
+
+	it('clamps to maxWorkers even when memory suggests more', () => {
+		// 4GB free -> 2GB budget -> 20 workers, but max is 8
+		vi.spyOn(os, 'freemem').mockReturnValue(4 * 1024 * 1024 * 1024);
+		expect(computeWorkerCount(2, 8)).toBe(8);
+	});
+
+	it('uses 50% of free memory divided by estimated worker size', () => {
+		const freeMem = 1200 * 1024 * 1024; // 1200MB
+		vi.spyOn(os, 'freemem').mockReturnValue(freeMem);
+		const expected = Math.floor(
+			(freeMem * 0.5) / ESTIMATED_WORKER_MEMORY_BYTES
+		);
+		expect(computeWorkerCount(1, 100)).toBe(expected);
+		expect(expected).toBe(6);
+	});
+});

--- a/packages/playground/cli/tests/compute-worker-count.spec.ts
+++ b/packages/playground/cli/tests/compute-worker-count.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import type * as PhpWasmLoggerModule from '@php-wasm/logger';
+import { logger } from '@php-wasm/logger';
 import os from 'os';
 import {
-	computeWorkerCount,
+	warnIfInsufficientMemoryForWorkers,
 	ESTIMATED_WORKER_MEMORY_BYTES,
 } from '../src/run-cli';
 
@@ -10,50 +11,43 @@ vi.mock('@php-wasm/logger', async (importOriginal) => {
 	const actual = await importOriginal<typeof PhpWasmLoggerModule>();
 	return {
 		...actual,
-		logger: { log: vi.fn(), error: vi.fn(), debug: vi.fn() },
+		logger: { log: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 	};
 });
 
-describe('computeWorkerCount', () => {
+describe('warnIfInsufficientMemoryForWorkers', () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 
-	it('returns minWorkers when free memory is very low', () => {
+	it('logs a warning when selected workers exceed memory-based recommendation', () => {
 		vi.spyOn(os, 'freemem').mockReturnValue(50 * 1024 * 1024); // 50MB
-		expect(computeWorkerCount(2, 12)).toBe(2);
+		const warnSpy = vi.spyOn(logger, 'warn');
+		warnIfInsufficientMemoryForWorkers(2);
+		expect(warnSpy).toHaveBeenCalledTimes(1);
 	});
 
-	it('returns maxWorkers when free memory is very high', () => {
-		vi.spyOn(os, 'freemem').mockReturnValue(100 * 1024 * 1024 * 1024); // 100GB
-		expect(computeWorkerCount(2, 12)).toBe(12);
-	});
-
-	it('returns memory-based count when between min and max', () => {
-		// 800MB free -> 400MB budget -> 4 workers
+	it('logs an info message when selected workers fit memory budget', () => {
+		// 800MB free -> 400MB budget -> 4 workers recommended
 		vi.spyOn(os, 'freemem').mockReturnValue(800 * 1024 * 1024);
-		expect(computeWorkerCount(2, 12)).toBe(4);
-	});
-
-	it('clamps to minWorkers even when memory suggests fewer', () => {
-		// 300MB free -> 150MB budget -> 1 worker, but min is 4
-		vi.spyOn(os, 'freemem').mockReturnValue(300 * 1024 * 1024);
-		expect(computeWorkerCount(4, 8)).toBe(4);
-	});
-
-	it('clamps to maxWorkers even when memory suggests more', () => {
-		// 4GB free -> 2GB budget -> 20 workers, but max is 8
-		vi.spyOn(os, 'freemem').mockReturnValue(4 * 1024 * 1024 * 1024);
-		expect(computeWorkerCount(2, 8)).toBe(8);
+		const logSpy = vi.spyOn(logger, 'log');
+		warnIfInsufficientMemoryForWorkers(4);
+		expect(logSpy).toHaveBeenCalledTimes(1);
 	});
 
 	it('uses 50% of free memory divided by estimated worker size', () => {
-		const freeMem = 1200 * 1024 * 1024; // 1200MB
-		vi.spyOn(os, 'freemem').mockReturnValue(freeMem);
-		const expected = Math.floor(
-			(freeMem * 0.5) / ESTIMATED_WORKER_MEMORY_BYTES
+		const freeMemory = 1200 * 1024 * 1024; // 1200MB
+		vi.spyOn(os, 'freemem').mockReturnValue(freeMemory);
+		const expectedRecommendation = Math.floor(
+			(freeMemory * 0.5) / ESTIMATED_WORKER_MEMORY_BYTES
 		);
-		expect(computeWorkerCount(1, 100)).toBe(expected);
-		expect(expected).toBe(6);
+		const warnSpy = vi.spyOn(logger, 'warn');
+		warnIfInsufficientMemoryForWorkers(expectedRecommendation + 1);
+		expect(warnSpy).toHaveBeenCalledWith(
+			expect.stringContaining(
+				`recommended max: ${expectedRecommendation}`
+			)
+		);
+		expect(expectedRecommendation).toBe(6);
 	});
 });

--- a/packages/playground/cli/tests/compute-worker-count.spec.ts
+++ b/packages/playground/cli/tests/compute-worker-count.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import type * as PhpWasmLoggerModule from '@php-wasm/logger';
 import os from 'os';
 import {
 	computeWorkerCount,
@@ -6,7 +7,7 @@ import {
 } from '../src/run-cli';
 
 vi.mock('@php-wasm/logger', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('@php-wasm/logger')>();
+	const actual = await importOriginal<typeof PhpWasmLoggerModule>();
 	return {
 		...actual,
 		logger: { log: vi.fn(), error: vi.fn(), debug: vi.fn() },

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1758,8 +1758,7 @@ describe(
 			await using cliServer = await runCLI({
 				command: 'server',
 				http2: true,
-				'min-workers': 2,
-				'max-workers': 4,
+				workers: 4,
 				wordpressInstallMode: 'do-not-attempt-installing',
 				skipSqliteSetup: true,
 				blueprint: undefined,

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 import os from 'node:os';
 import http from 'node:http';
+import http2 from 'node:http2';
+import https from 'node:https';
 import {
 	runCLI,
 	parseOptionsAndRunCLI,
@@ -1723,3 +1725,106 @@ describe('other run-cli behaviors', () => {
 		});
 	});
 });
+
+describe(
+	'HTTP/2 integration',
+	() => {
+		function h2Get(url: string): Promise<{ status: number; body: string }> {
+			const parsed = new URL(url);
+			return new Promise((resolve, reject) => {
+				const client = http2.connect(parsed.origin, {
+					rejectUnauthorized: false,
+				});
+				client.on('error', reject);
+				const req = client.request({ ':path': parsed.pathname });
+				let body = '';
+				let status = 0;
+				req.on('response', (headers) => {
+					status = headers[':status'] as number;
+				});
+				req.on('data', (chunk: Buffer) => {
+					body += chunk.toString();
+				});
+				req.on('end', () => {
+					client.close();
+					resolve({ status, body });
+				});
+				req.on('error', reject);
+				req.end();
+			});
+		}
+
+		test('serves over HTTPS, reports correct SERVER_PROTOCOL for h2 and h1, and filters pseudo-headers', async () => {
+			await using cliServer = await runCLI({
+				command: 'server',
+				http2: true,
+				'min-workers': 2,
+				'max-workers': 4,
+				wordpressInstallMode: 'do-not-attempt-installing',
+				skipSqliteSetup: true,
+				blueprint: undefined,
+			});
+
+			// serverUrl uses https:// scheme with --http2
+			expect(cliServer.serverUrl).toMatch(/^https:\/\//);
+
+			// Consume the auto-login 302 redirect on the first request
+			await h2Get(new URL('/', cliServer.serverUrl).href);
+
+			// Write test PHP files
+			await cliServer.playground.writeFile(
+				'/wordpress/protocol.php',
+				'<?php echo $_SERVER["SERVER_PROTOCOL"]; ?>'
+			);
+			await cliServer.playground.writeFile(
+				'/wordpress/headers.php',
+				`<?php
+			header('Content-Type: application/json');
+			$pseudo = array_filter(
+				$_SERVER,
+				fn($k) => str_starts_with($k, 'HTTP_:'),
+				ARRAY_FILTER_USE_KEY
+			);
+			echo json_encode($pseudo);
+			?>`
+			);
+
+			// $_SERVER['SERVER_PROTOCOL'] reports HTTP/2.0 for h2 requests
+			const h2Result = await h2Get(
+				new URL('/protocol.php', cliServer.serverUrl).href
+			);
+			expect(h2Result.status).toBe(200);
+			expect(h2Result.body).toBe('HTTP/2.0');
+
+			// $_SERVER['SERVER_PROTOCOL'] reports HTTP/1.1 for h1 fallback
+			const h1Body = await new Promise<string>((resolve, reject) => {
+				const req = https.get(
+					new URL('/protocol.php', cliServer.serverUrl).href,
+					{ rejectUnauthorized: false },
+					(res) => {
+						let data = '';
+						res.on('data', (chunk: Buffer) => {
+							data += chunk.toString();
+						});
+						res.on('end', () => resolve(data));
+					}
+				);
+				req.on('error', reject);
+			});
+			expect(h1Body).toBe('HTTP/1.1');
+
+			// No HTTP/2 pseudo-headers leak into $_SERVER
+			const headersResult = await h2Get(
+				new URL('/headers.php', cliServer.serverUrl).href
+			);
+			expect(headersResult.status).toBe(200);
+			const pseudoHeaders = JSON.parse(headersResult.body);
+			expect(
+				Array.isArray(pseudoHeaders)
+					? pseudoHeaders.length
+					: Object.keys(pseudoHeaders).length
+			).toBe(0);
+		});
+	},
+	60_000 * 5
+);

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -354,9 +354,9 @@ describe('startServer with HTTP/2', () => {
 		try {
 			await h2Request(port, '/test');
 			expect(capturedRequest).toBeDefined();
-			const pseudoHeaders = Object.keys(capturedRequest!.headers).filter(
-				(k) => k.startsWith(':')
-			);
+			const pseudoHeaders = Object.keys(
+				capturedRequest!.headers ?? {}
+			).filter((k) => k.startsWith(':'));
 			expect(pseudoHeaders).toHaveLength(0);
 		} finally {
 			server.close();
@@ -402,7 +402,7 @@ describe('startServer with HTTP/2', () => {
 			});
 			expect(capturedRequest).toBeDefined();
 			// Pseudo-headers must not leak through to PHP
-			const headerKeys = Object.keys(capturedRequest!.headers);
+			const headerKeys = Object.keys(capturedRequest!.headers ?? {});
 			expect(headerKeys.filter((k) => k.startsWith(':'))).toHaveLength(0);
 		} finally {
 			server.close();

--- a/packages/playground/cli/tests/start-server.spec.ts
+++ b/packages/playground/cli/tests/start-server.spec.ts
@@ -1,19 +1,46 @@
-import { describe, it, expect, vi, type Mock } from 'vitest';
+import { describe, it, expect, vi, beforeAll, type Mock } from 'vitest';
 import http from 'http';
+import https from 'https';
+import http2 from 'http2';
 import { pipeline } from 'stream/promises';
+import type { PHPRequest } from '@php-wasm/universal';
 import { StreamedPHPResponse } from '@php-wasm/universal';
 import { startServer } from '../src/start-server';
+import { generateSelfSignedCert, type TlsCertificate } from '../src/tls';
 import { logger } from '@php-wasm/logger';
 import type StreamPromisesModule from 'stream/promises';
 
 vi.mock('@php-wasm/logger', () => ({
-	logger: { error: vi.fn() },
+	logger: { log: vi.fn(), error: vi.fn() },
 }));
 
 vi.mock('stream/promises', async (importOriginal) => {
 	const actual = await importOriginal<typeof StreamPromisesModule>();
 	return { ...actual, pipeline: vi.fn(actual.pipeline) };
 });
+
+function makeOkResponse(body: string): StreamedPHPResponse {
+	return new StreamedPHPResponse(
+		new ReadableStream({
+			start(controller) {
+				const json = JSON.stringify({
+					status: 200,
+					headers: ['content-type: text/plain'],
+				});
+				controller.enqueue(new TextEncoder().encode(json));
+				controller.close();
+			},
+		}),
+		new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(body));
+				controller.close();
+			},
+		}),
+		new ReadableStream({ start: (c) => c.close() }),
+		Promise.resolve(0)
+	);
+}
 
 describe('startServer', () => {
 	it('does not log an error when piping to a destroyed stream (ERR_STREAM_UNABLE_TO_PIPE)', async () => {
@@ -231,5 +258,200 @@ describe('startServer', () => {
 		} finally {
 			server.close();
 		}
+	});
+});
+
+describe('startServer with HTTP/2', () => {
+	let tlsCert: TlsCertificate;
+
+	beforeAll(() => {
+		tlsCert = generateSelfSignedCert();
+	});
+
+	function h2Request(
+		port: number,
+		path: string
+	): Promise<{ status: number; body: string }> {
+		return new Promise((resolve, reject) => {
+			const client = http2.connect(`https://127.0.0.1:${port}`, {
+				rejectUnauthorized: false,
+			});
+			client.on('error', reject);
+			const req = client.request({ ':path': path });
+			let body = '';
+			let status = 0;
+			req.on('response', (headers) => {
+				status = headers[':status'] as number;
+			});
+			req.on('data', (chunk: Buffer) => {
+				body += chunk.toString();
+			});
+			req.on('end', () => {
+				client.close();
+				resolve({ status, body });
+			});
+			req.on('error', reject);
+			req.end();
+		});
+	}
+
+	function startH2Server(
+		handleRequest: (request: PHPRequest) => Promise<StreamedPHPResponse>
+	) {
+		return startServer({
+			port: 0,
+			http2: true,
+			tlsCertificate: tlsCert,
+			handleRequest,
+			async onBind(server, port) {
+				return { server, port } as any;
+			},
+		});
+	}
+
+	it('starts and responds to HTTP/2 requests', async () => {
+		const cliServer = await startH2Server(async () =>
+			makeOkResponse('h2 works')
+		);
+		const { server, port } = cliServer as any;
+
+		try {
+			const { status, body } = await h2Request(port, '/');
+			expect(status).toBe(200);
+			expect(body).toBe('h2 works');
+		} finally {
+			server.close();
+			(server as any).closeAllConnections();
+		}
+	});
+
+	it('passes protocolVersion HTTP/2.0 to handleRequest', async () => {
+		let capturedRequest: PHPRequest | undefined;
+		const cliServer = await startH2Server(async (req) => {
+			capturedRequest = req;
+			return makeOkResponse('ok');
+		});
+		const { server, port } = cliServer as any;
+
+		try {
+			await h2Request(port, '/test');
+			expect(capturedRequest).toBeDefined();
+			expect(capturedRequest!.protocolVersion).toBe('HTTP/2.0');
+		} finally {
+			server.close();
+			(server as any).closeAllConnections();
+		}
+	});
+
+	it('filters HTTP/2 pseudo-headers from request', async () => {
+		let capturedRequest: PHPRequest | undefined;
+		const cliServer = await startH2Server(async (req) => {
+			capturedRequest = req;
+			return makeOkResponse('ok');
+		});
+		const { server, port } = cliServer as any;
+
+		try {
+			await h2Request(port, '/test');
+			expect(capturedRequest).toBeDefined();
+			const pseudoHeaders = Object.keys(capturedRequest!.headers).filter(
+				(k) => k.startsWith(':')
+			);
+			expect(pseudoHeaders).toHaveLength(0);
+		} finally {
+			server.close();
+			(server as any).closeAllConnections();
+		}
+	});
+
+	it('includes host header with no pseudo-headers leaking', async () => {
+		let capturedRequest: PHPRequest | undefined;
+		const cliServer = await startServer({
+			port: 0,
+			http2: true,
+			tlsCertificate: tlsCert,
+			handleRequest: async (req) => {
+				capturedRequest = req;
+				return makeOkResponse('ok');
+			},
+			async onBind(server, port) {
+				return { server, port } as any;
+			},
+		});
+		const { server, port } = cliServer as any;
+
+		try {
+			// Send a request with an explicit host-like header
+			await new Promise<void>((resolve, reject) => {
+				const client = http2.connect(`https://127.0.0.1:${port}`, {
+					rejectUnauthorized: false,
+				});
+				client.on('error', reject);
+				const req = client.request({
+					':path': '/',
+					':method': 'GET',
+				});
+				req.on('response', () => {});
+				req.on('data', () => {});
+				req.on('end', () => {
+					client.close();
+					resolve();
+				});
+				req.on('error', reject);
+				req.end();
+			});
+			expect(capturedRequest).toBeDefined();
+			// Pseudo-headers must not leak through to PHP
+			const headerKeys = Object.keys(capturedRequest!.headers);
+			expect(headerKeys.filter((k) => k.startsWith(':'))).toHaveLength(0);
+		} finally {
+			server.close();
+			(server as any).closeAllConnections();
+		}
+	});
+
+	it('supports HTTP/1.1 fallback via allowHTTP1', async () => {
+		let capturedRequest: PHPRequest | undefined;
+		const cliServer = await startH2Server(async (req) => {
+			capturedRequest = req;
+			return makeOkResponse('h1 fallback');
+		});
+		const { server, port } = cliServer as any;
+
+		try {
+			const body = await new Promise<string>((resolve, reject) => {
+				const req = https.get(
+					`https://127.0.0.1:${port}/`,
+					{ rejectUnauthorized: false },
+					(res) => {
+						let data = '';
+						res.on('data', (chunk: Buffer) => {
+							data += chunk.toString();
+						});
+						res.on('end', () => resolve(data));
+					}
+				);
+				req.on('error', reject);
+			});
+			expect(body).toBe('h1 fallback');
+			expect(capturedRequest).toBeDefined();
+			expect(capturedRequest!.protocolVersion).toBe('HTTP/1.1');
+		} finally {
+			server.close();
+			(server as any).closeAllConnections();
+		}
+	});
+
+	it('throws when HTTP/2 is requested without TLS certificate', async () => {
+		await expect(
+			startServer({
+				port: 0,
+				http2: true,
+				handleRequest: async () => makeOkResponse('nope'),
+				async onBind(server, port) {
+					return { server, port } as any;
+				},
+			})
+		).rejects.toThrow('TLS certificate is required for HTTP/2.');
 	});
 });

--- a/packages/playground/cli/tests/tls.spec.ts
+++ b/packages/playground/cli/tests/tls.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
+import type * as ChildProcessModule from 'child_process';
 import { X509Certificate } from 'crypto';
 import { writeFileSync, mkdtempSync } from 'fs';
 import { join } from 'path';
@@ -42,8 +43,7 @@ describe('getMkcertCaRoot', () => {
 	it('returns null when mkcert is not installed', async () => {
 		vi.resetModules();
 		vi.doMock('child_process', async (importOriginal) => {
-			const actual =
-				await importOriginal<typeof import('child_process')>();
+			const actual = await importOriginal<typeof ChildProcessModule>();
 			return {
 				...actual,
 				execSync: (cmd: string, ...args: any[]) => {
@@ -82,8 +82,7 @@ describe('resolveTlsCertificate', () => {
 	it('falls back to self-signed cert when no user certs and no mkcert', async () => {
 		vi.resetModules();
 		vi.doMock('child_process', async (importOriginal) => {
-			const actual =
-				await importOriginal<typeof import('child_process')>();
+			const actual = await importOriginal<typeof ChildProcessModule>();
 			return {
 				...actual,
 				execSync: (cmd: string, ...args: any[]) => {

--- a/packages/playground/cli/tests/tls.spec.ts
+++ b/packages/playground/cli/tests/tls.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { X509Certificate } from 'crypto';
+import { writeFileSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+	generateSelfSignedCert,
+	resolveTlsCertificate,
+	type TlsCertificate,
+} from '../src/tls';
+
+vi.mock('@php-wasm/logger', () => ({
+	logger: { log: vi.fn(), error: vi.fn() },
+}));
+
+describe('generateSelfSignedCert', () => {
+	let cert: TlsCertificate;
+
+	beforeAll(() => {
+		cert = generateSelfSignedCert();
+	});
+
+	it('returns valid PEM key and cert', () => {
+		expect(cert.key).toContain('-----BEGIN PRIVATE KEY-----');
+		expect(cert.cert).toContain('-----BEGIN CERTIFICATE-----');
+	});
+
+	it('cert covers localhost and 127.0.0.1', () => {
+		const x509 = new X509Certificate(cert.cert);
+		const san = x509.subjectAltName ?? '';
+		expect(san).toContain('DNS:localhost');
+		expect(san).toContain('IP Address:127.0.0.1');
+	});
+
+	it('cert has CN=localhost', () => {
+		const x509 = new X509Certificate(cert.cert);
+		expect(x509.subject).toContain('CN=localhost');
+	});
+});
+
+describe('getMkcertCaRoot', () => {
+	it('returns null when mkcert is not installed', async () => {
+		vi.resetModules();
+		vi.doMock('child_process', async (importOriginal) => {
+			const actual =
+				await importOriginal<typeof import('child_process')>();
+			return {
+				...actual,
+				execSync: (cmd: string, ...args: any[]) => {
+					if (typeof cmd === 'string' && cmd.includes('mkcert')) {
+						throw new Error('command not found: mkcert');
+					}
+					return actual.execSync(cmd, ...args);
+				},
+			};
+		});
+
+		const { getMkcertCaRoot } = await import('../src/tls');
+		const result = getMkcertCaRoot();
+		expect(result).toBeNull();
+		vi.doUnmock('child_process');
+	});
+});
+
+describe('resolveTlsCertificate', () => {
+	it('reads user-supplied cert and key files', () => {
+		const tempDir = mkdtempSync(join(tmpdir(), 'tls-test-'));
+		const cert = generateSelfSignedCert();
+		const certPath = join(tempDir, 'cert.pem');
+		const keyPath = join(tempDir, 'key.pem');
+		writeFileSync(certPath, cert.cert);
+		writeFileSync(keyPath, cert.key);
+
+		const result = resolveTlsCertificate({
+			sslCert: certPath,
+			sslKey: keyPath,
+		});
+		expect(result.cert).toBe(cert.cert);
+		expect(result.key).toBe(cert.key);
+	});
+
+	it('falls back to self-signed cert when no user certs and no mkcert', async () => {
+		vi.resetModules();
+		vi.doMock('child_process', async (importOriginal) => {
+			const actual =
+				await importOriginal<typeof import('child_process')>();
+			return {
+				...actual,
+				execSync: (cmd: string, ...args: any[]) => {
+					if (typeof cmd === 'string' && cmd.includes('mkcert')) {
+						throw new Error('command not found: mkcert');
+					}
+					return actual.execSync(cmd, ...args);
+				},
+			};
+		});
+
+		const { resolveTlsCertificate: freshResolve } =
+			await import('../src/tls');
+		const result = freshResolve({});
+		expect(result.key).toContain('-----BEGIN PRIVATE KEY-----');
+		expect(result.cert).toContain('-----BEGIN CERTIFICATE-----');
+		vi.doUnmock('child_process');
+	});
+});


### PR DESCRIPTION
## Motivation for the change, related issues

The Playground CLI currently serves WordPress over HTTP/1.1, which limits browser connections to 6 parallel TCP connections per origin. HTTP/2 multiplexes all requests over a single TLS connection, eliminating head-of-line blocking and improving page load performance — especially for asset-heavy WordPress pages.

## Implementation details

### TLS certificate provisioning (`tls.ts`)
- Smart fallback chain: user-supplied certs (`--ssl-cert` / `--ssl-key`) > mkcert (if installed with trusted CA) > self-signed fallback with tip message
- mkcert detection via `mkcert -CAROOT` and CA root validation
- Self-signed certs generated via OpenSSL, valid for localhost/127.0.0.1, 30-day expiry
- All temp files cleaned up after cert generation

### HTTP/2 server (`start-server.ts`)
- Opt-in via `--http2` flag; default HTTP/1.1 Express path is unchanged
- Uses Node.js native `http2.createSecureServer()` with `allowHTTP1: true` for backward compatibility
- Shared `RequestListener` abstraction works with both Express and HTTP/2 request/response types
- HTTP/2 pseudo-headers (`:method`, `:path`, `:scheme`, `:authority`) filtered out in `parseHeaders()` so they don't leak into PHP's `$_SERVER`

### `SERVER_PROTOCOL` plumbing
- `req.httpVersion` (set by Node.js for both HTTP/1.1 and HTTP/2) is read and passed through as `protocolVersion` on `PHPRequest`
- `PHPRequestHandler` forwards it as `$_SERVER['SERVER_PROTOCOL']` to PHP
- PHP correctly reports `HTTP/2.0` for h2 requests and `HTTP/1.1` for h1 requests — no C SAPI changes needed

### Worker pool sizing (`run-cli.ts`)
- Worker count is explicit: `--workers` (default **6**). The CLI spawns exactly that many PHP worker threads; it does not auto-scale based on memory.
- Free memory is checked at startup using the heuristic ~100MB per worker and 50% of `os.freemem()` as a budget. If the chosen worker count looks high relative to free RAM, the CLI logs a **warning** and continues with the requested count.

### New CLI flags
- `--http2` — enable HTTP/2 with TLS
- `--ssl-cert` / `--ssl-key` — supply custom TLS certificates
- `--workers` — number of PHP worker threads (default 6)

## Testing Instructions (or ideally a Blueprint)

Start the CLI with HTTP/2 enabled:
```bash
npx nx dev playground-cli server --http2
```

### 1. Protocol negotiation (Chrome DevTools)
Open the Network tab, enable the "Protocol" column. Load `https://localhost:9400/`. Requests should show `h2`.

### 2. Multiplexing
In the Network tab Waterfall, requests should fire concurrently over a single connection — no 6-connection staircase pattern.

### 3. HTTP/1.1 fallback
```bash
curl -k --http1.1 https://localhost:9400/
```
Should return a valid response (confirms `allowHTTP1: true` works).

### 4. HTTP/2 via curl
```bash
curl -k --http2 -v https://localhost:9400/
```
Look for `ALPN: server accepted h2` and `< HTTP/2 200`.

### 5. `$_SERVER['SERVER_PROTOCOL']` correctness
Create a blueprint (`test-bp.json`):
```json
{
  "steps": [
    {
      "step": "writeFile",
      "path": "/wordpress/server-info.php",
      "data": "<?php header('Content-Type: application/json'); echo json_encode(['SERVER_PROTOCOL' => $_SERVER['SERVER_PROTOCOL'], 'HTTP_headers' => array_filter($_SERVER, fn($k) => str_starts_with($k, 'HTTP_'), ARRAY_FILTER_USE_KEY)], JSON_PRETTY_PRINT);"
    }
  ]
}
```
```bash
npx nx dev playground-cli server --http2 --blueprint=test-bp.json

curl -ks --http2 https://localhost:9400/server-info.php | jq .SERVER_PROTOCOL
# → "HTTP/2.0"

curl -ks --http1.1 https://localhost:9400/server-info.php | jq .SERVER_PROTOCOL
# → "HTTP/1.1"
```

### 6. No pseudo-header leakage
```bash
curl -ks --http2 https://localhost:9400/server-info.php | jq .HTTP_headers
```
Should only contain normal headers (`HTTP_HOST`, `HTTP_ACCEPT`, etc.) — no `HTTP_:METHOD`, `HTTP_:PATH`, etc.

### 7. TLS cert fallback chain
- With `--http2 --ssl-cert=... --ssl-key=...` → logs "TLS: using provided certificates"
- With `--http2` and mkcert installed → logs "TLS: using mkcert (locally-trusted)"
- With `--http2` and no mkcert → logs "TLS: using self-signed certificate (install mkcert for warning-free HTTPS)"; browser shows cert warning

```bash
# Create a cert (using mkcert here, but OpenSSL would also do)
mkcert -key-file /tmp/test-key.pem -cert-file /tmp/test-cert.pem localhost 127.0.0.1

# Test by supplying certificate
npx nx dev playground-cli server --http2 --ssl-cert=/tmp/test-cert.pem --ssl-key=/tmp/test-key.pem
# Test by relying on mkcert
npx nx dev playground-cli server --http2
# Test auto generation of certificate by moving mkcert out of path temporarily
PATH=$(echo "$PATH" | tr ':' '\n' | grep -v "$(dirname $(which mkcert))" | tr '\n' ':') npx nx dev playground-cli server --http2
```

### Results
All 7 tests verified and passing.
