### PR TITLE
Load SQLite for phpMyAdmin and Adminer using WP configuration

### DIFF
--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -13,7 +13,13 @@
 namespace Adminer;
 
 // Load the SQLite driver.
-require_once '/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
+global $wp_env;
+$wp_env = require '/internal/shared/wp-env.php';
+if ($wp_env['db']['type'] === 'sqlite') {
+	require_once $wp_env['db']['driver_path'];
+} else {
+	die('Error: Unsupported database type: ' . $wp_env['db']['type']);
+}
 
 use Throwable;
 use WP_SQLite_Driver;
@@ -96,7 +102,8 @@ if (!defined('Adminer\DRIVER')) {
 		public $driver;
 
 		function attach($server, $username, $password) {
-			$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite');
+			global $wp_env;
+			$pdo = new PDO('sqlite:' . $wp_env['db']['path']);
 			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$this->driver = new WP_SQLite_Driver(
 				new WP_SQLite_Connection(array('pdo' => $pdo)),

--- a/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
+++ b/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
@@ -23,7 +23,13 @@ use WP_SQLite_Connection;
 use WP_SQLite_Driver;
 
 // Load the SQLite driver.
-require_once '/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
+global $wp_env;
+$wp_env = require '/internal/shared/wp-env.php';
+if ($wp_env['db']['type'] === 'sqlite') {
+	require_once $wp_env['db']['driver_path'];
+} else {
+	die('Error: Unsupported database type: ' . $wp_env['db']['type']);
+}
 
 // Supress the following phpMyAdmin warning:
 //   "The mysqlnd extension is missing. Please check your PHP configuration."
@@ -253,7 +259,8 @@ class DbiMysqli implements DbiExtension {
 	private $last_error_number = 0;
 
     public function connect($user, $password, array $server) {
-		$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite');
+		global $wp_env;
+		$pdo = new PDO('sqlite:' . $wp_env['db']['path']);
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->driver = new WP_SQLite_Driver(
 			new WP_SQLite_Connection(array('pdo' => $pdo)),

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -13,7 +13,13 @@
 namespace Adminer;
 
 // Load the SQLite driver.
-require_once '/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php';
+global $wp_env;
+$wp_env = require '/internal/shared/wp-env.php';
+if ($wp_env['db']['type'] === 'sqlite') {
+	require_once $wp_env['db']['driver_path'];
+} else {
+	die('Error: Unsupported database type: ' . $wp_env['db']['type']);
+}
 
 use Throwable;
 use WP_SQLite_Driver;
@@ -96,7 +102,8 @@ if (!defined('Adminer\DRIVER')) {
 		public $driver;
 
 		function attach($server, $username, $password) {
-			$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite');
+			global $wp_env;
+			$pdo = new PDO('sqlite:' . $wp_env['db']['path']);
 			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$this->driver = new WP_SQLite_Driver(
 				new WP_SQLite_Connection(array('pdo' => $pdo)),

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -261,6 +261,31 @@ export async function setupPlatformLevelMuPlugins(php: UniversalPHP) {
 	await php.writeFile(
 		'/internal/shared/mu-plugins/0-playground.php',
 		`<?php
+
+		// Save WordPress environment information to a file.
+		add_action('wp_loaded', function() {
+			if (defined('DB_ENGINE') && DB_ENGINE === 'sqlite') {
+				$db_info = array(
+					'type' => 'sqlite',
+					'path' => FQDB,
+					'driver_path' => defined('WP_MYSQL_ON_SQLITE_LOADER_PATH')
+						? WP_MYSQL_ON_SQLITE_LOADER_PATH
+						: dirname(SQLITE_MAIN_FILE) . '/wp-pdo-mysql-on-sqlite.php',
+				);
+			} else {
+				$db_info = array(
+					'type' => 'mysql',
+					// TODO: Save MySQL connection config.
+				);
+			}
+			$wp_env = array('db' => $db_info);
+			$wp_env_php = sprintf('<?php return %s;', var_export($wp_env, true));
+			$wp_env_file = '/internal/shared/wp-env.php';
+			if (!file_exists($wp_env_file) || file_get_contents($wp_env_file) !== $wp_env_php ) {
+				file_put_contents($wp_env_file, $wp_env_php);
+			}
+		});
+
         // Needed because gethostbyname( 'wordpress.org' ) returns
         // a private network IP address for some reason.
         add_filter( 'allowed_redirect_hosts', function( $deprecated = '' ) {


### PR DESCRIPTION
## Motivation for the change, related issues

The phpMyAdmin and Adminer integration previously hardcoded the SQLite-related paths:
  -  `/internal/shared/sqlite-database-integration/wp-pdo-mysql-on-sqlite.php`
  - `/wordpress/wp-content/database/.ht.sqlite`

This was not universal for situations when the paths differ from the defaults. This PR implements loading these paths from WordPress configuration.

## Implementation details

- A mu-plugin (`0-playground.php`) now writes the database configuration (type, path, driver path) to `/internal/shared/wp-env.php`.
- The phpMyAdmin and Adminer integration read this file at runtime instead of using hardcoded paths.
- For the internally preloaded SQLite integration, the `SQLITE_MAIN_FILE` constant is set to the actual plugin path instead of a dummy `'1'` value, so the driver path can be derived from it.

## Testing Instructions (or ideally a Blueprint)

- `npx nx dev playground-website` -> verify that phpMyAdmin and Adminer work.
- `npx nx dev playground-cli server --phpmyadmin` -> verify that Adminer works.