### PR TITLE
Bump transitive dependency flatted from 3.4.1 to 3.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28477,9 +28477,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-			"integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},


### PR DESCRIPTION
## Summary

- Upgrades the transitive dependency `flatted` from 3.4.1 to 3.4.2 to resolve [Dependabot security alert #265](https://github.com/WordPress/wordpress-playground/security/dependabot/265)
- `flatted` is pulled in transitively via `eslint` → `flat-cache` and `@nx/react` → `log4js`, both of which use semver ranges (`^3.2.x`) that already allow 3.4.2
- Only the lockfile resolution changed — no direct dependency upgrades needed

## Test plan

- [x] Verify `npm ls flatted` shows 3.4.2
- [x] Verify CI passes (no functional changes, only lockfile update)


Made with [Cursor](https://cursor.com)