### PR TITLE
Fix Dependabot exclude paths to match dirs recursively

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
       schedule:
           interval: 'daily'
       exclude-paths:
-          - packages/playground/wordpress-builds/public
-          - isomorphic-git
+          - packages/playground/wordpress-builds/public/**
+          - isomorphic-git/**
       ignore:
           # Ignore all non-security updates - only allow security updates for high or critical vulnerabilities
           - dependency-name: '*'


### PR DESCRIPTION
## Motivation for the change, related issues

According to https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#exclude-paths-, the `exclude-paths` requires the use of glob patterns such as `**` to match directories recursively.

## Implementation details

## Testing Instructions (or ideally a Blueprint)
