### PR TITLE
Update SQLite database path

### DIFF
--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -165,11 +165,11 @@ Mount before WP install: /wordpress ->
 The database location depends on what you mount:
 
 - **Auto-mounting wp-content or full WordPress**:
-    - Database: `<your-local-project>/wp-content/database/.ht.sqlite`
+    - Database: `<your-local-project>/wp-content/database/.ht.sqlite.php`
     - ✅ **Persisted locally** in your project folder
 
 - **Auto-mounting plugin/theme only**:
-    - Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    - Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite.php`
     - ⚠️ **Lost when server stops** (temp directories are cleaned up)
 
 - **Custom mounts**: Database location follows your mount configuration
@@ -211,7 +211,7 @@ The `<path-hash>` is derived from your project directory path. This ensures isol
 The database location depends on your configuration:
 
 - **Default (automatic persistence)**:
-    - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite`
+    - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite.php`
     - **Persisted automatically** between sessions
 
 #### Resetting a persisted site

--- a/packages/docs/site/docs/main/quick-start-guide.md
+++ b/packages/docs/site/docs/main/quick-start-guide.md
@@ -70,7 +70,7 @@ To keep your WordPress Playground site for longer than a single browser session,
 
 The exported file contains the complete site you've built. You could host it on any server that supports PHP and SQLite. All WordPress core files, plugins, themes, and everything else you've added to your site are in there.
 
-The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
+The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite.php`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
 
 ## Restore a saved site
 

--- a/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/bn/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -155,10 +155,10 @@ The exported file contains the complete site you've built. You could host it on 
 এক্সপোর্ট করা ফাইলে আপনার তৈরি করা সম্পূর্ণ সাইটটি থাকে। আপনি এটিকে PHP এবং SQLite সাপোর্ট করে এমন যেকোনো সার্ভারে হোস্ট করতে পারেন। ওয়ার্ডপ্রেসের সমস্ত কোর ফাইল, প্লাগইন, থিম এবং আপনি আপনার সাইটে যা যা যোগ করেছেন তার সবকিছুই সেখানে থাকে।
 
 <!--
-The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
+The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite.php`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
 -->
 
-এক্সপোর্টের সাথে SQLite ডাটাবেস ফাইলটিও অন্তর্ভুক্ত থাকে, যা আপনি `wp-content/database/.ht.sqlite` ঠিকানায় পাবেন। মনে রাখবেন যে, ডট (.) দিয়ে শুরু হওয়া ফাইলগুলো সাধারণত অধিকাংশ অপারেটিং সিস্টেমে ডিফল্টভাবে লুকানো থাকে, তাই আপনার ফাইল ম্যানেজারে "Show hidden files" অপশনটি চালু করার প্রয়োজন হতে পারে।
+এক্সপোর্টের সাথে SQLite ডাটাবেস ফাইলটিও অন্তর্ভুক্ত থাকে, যা আপনি `wp-content/database/.ht.sqlite.php` ঠিকানায় পাবেন। মনে রাখবেন যে, ডট (.) দিয়ে শুরু হওয়া ফাইলগুলো সাধারণত অধিকাংশ অপারেটিং সিস্টেমে ডিফল্টভাবে লুকানো থাকে, তাই আপনার ফাইল ম্যানেজারে "Show hidden files" অপশনটি চালু করার প্রয়োজন হতে পারে।
 
 <!--
 ## Restore a saved site

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -323,11 +323,11 @@ Mount before WP install: /wordpress ->
 The database location depends on what you mount:
 
 - **Auto-mounting wp-content or full WordPress**:
-    - Database: `<your-local-project>/wp-content/database/.ht.sqlite`
+    - Database: `<your-local-project>/wp-content/database/.ht.sqlite.php`
     - ✅ **Persisted locally** in your project folder
 
 - **Auto-mounting plugin/theme only**:
-    - Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    - Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite.php`
     - ⚠️ **Lost when server stops** (temp directories are cleaned up)
 
 - **Custom mounts**: Database location follows your mount configuration
@@ -346,11 +346,11 @@ Playground CLI automatically removes temp directories that are:
 La ubicación de la base de datos depende de lo que montes:
 
 - **Montaje automático de wp-content o WordPress completo**:
-    - Base de datos: `<tu-proyecto-local>/wp-content/database/.ht.sqlite`
+    - Base de datos: `<tu-proyecto-local>/wp-content/database/.ht.sqlite.php`
     - ✅ **Persistida localmente** en la carpeta de tu proyecto
 
 - **Solo montaje automático de plugin/tema**:
-    - Base de datos: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    - Base de datos: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite.php`
     - ⚠️ **Se pierde al detener el servidor** (los directorios temporales se eliminan)
 
 - **Montajes personalizados**: La ubicación de la base de datos sigue tu configuración de montaje
@@ -409,7 +409,7 @@ El `<path-hash>` se deriva de la ruta del directorio de tu proyecto. Así se aí
 The database location depends on your configuration:
 
 - **Default (automatic persistence)**:
-    - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite`
+    - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite.php`
     - **Persisted automatically** between sessions
 -->
 
@@ -421,7 +421,7 @@ The database location depends on your configuration:
 La ubicación de la base de datos depende de tu configuración:
 
 - **Por defecto (persistencia automática)**:
-    - Base de datos: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite`
+    - Base de datos: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite.php`
     - **Persistida automáticamente** entre sesiones
 
 <!--

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -153,10 +153,10 @@ The exported file contains the complete site you've built. You could host it on 
 El archivo exportado contiene el sitio completo que has construido. Podrías alojarlo en cualquier servidor que admita PHP y SQLite. Todos los archivos principales de WordPress, plugins, temas y todo lo demás que hayas agregado a tu sitio están allí.
 
 <!--
-The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
+The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite.php`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
 -->
 
-El archivo de base de datos SQLite también está incluido en la exportación, lo encontrarás en `wp-content/database/.ht.sqlite`. Ten en cuenta que los archivos que comienzan con un punto están ocultos por defecto en la mayoría de los sistemas operativos, por lo que es posible que necesites habilitar la opción "Mostrar archivos ocultos" en tu administrador de archivos.
+El archivo de base de datos SQLite también está incluido en la exportación, lo encontrarás en `wp-content/database/.ht.sqlite.php`. Ten en cuenta que los archivos que comienzan con un punto están ocultos por defecto en la mayoría de los sistemas operativos, por lo que es posible que necesites habilitar la opción "Mostrar archivos ocultos" en tu administrador de archivos.
 
 <!--
 ## Restore a saved site

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -117,9 +117,9 @@ Pour conserver votre site WordPress Playground au delà d’une seule session de
 
 Le fichier exporté contient la totalité du site que vous avez créé. Vous pouvez l’héberger sur n’importe quel serveur prenant en charge PHP et SQLite. Tous les fichiers de base WordPress, les extensions, les thèmes et tout ce que vous avez ajouté d’autre à votre site s’y trouvent.
 
-<!-- The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager. -->
+<!-- The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite.php`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager. -->
 
-Le fichier de base de données SQLite est également inclus dans l’export, vous le trouverez `wp-content/database/.ht.sqlite`. Gardez à l’esprit que les fichiers commençant par un point sont masqués par défaut sur la plupart des systèmes d’exploitation, vous devrez donc peut-être activer l’option « Afficher les fichiers masqués » dans votre gestionnaire de fichiers.
+Le fichier de base de données SQLite est également inclus dans l’export, vous le trouverez `wp-content/database/.ht.sqlite.php`. Gardez à l’esprit que les fichiers commençant par un point sont masqués par défaut sur la plupart des systèmes d’exploitation, vous devrez donc peut-être activer l’option « Afficher les fichiers masqués » dans votre gestionnaire de fichiers.
 
 <!-- ## Restore a saved site -->
 

--- a/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -123,9 +123,9 @@ https://playground.wordpress.net/?plugin=coblocks&plugin=friends&theme=pendant
 
 એક્સપોર્ટ કરેલી ફાઇલમાં તમે બનાવેલી સંપૂર્ણ સાઇટ સામેલ છે. તમે તેને કોઈપણ સર્વર પર હોસ્ટ કરી શકો છો જે PHP અને SQLite ને સપોર્ટ કરે છે. તમામ વર્ડપ્રેસ કોર ફાઇલો, પ્લગિન્સ, થીમ્સ અને તમે તમારી સાઇટમાં ઉમેરેલી બધી અન્ય વસ્તુઓ તેમાં સામેલ છે.
 
-<!-- The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager. -->
+<!-- The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite.php`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager. -->
 
-SQLite ડેટાબેસ ફાઇલ પણ એક્સપોર્ટમાં સામેલ છે, તમે તેને `wp-content/database/.ht.sqlite` માં શોધી શકો છો. ધ્યાનમાં રાખો કે ડોટ (.) થી શરૂ થતી ફાઇલો મોટાભાગની ઓપરેટિંગ સિસ્ટમમાં ડિફૉલ્ટ મુજબ છુપાયેલી હોય છે, તેથી તમને તમારા ફાઇલ મેનેજરમાં "Show hidden files" વિકલ્પ સક્રિય કરવાની જરૂર પડી શકે છે.
+SQLite ડેટાબેસ ફાઇલ પણ એક્સપોર્ટમાં સામેલ છે, તમે તેને `wp-content/database/.ht.sqlite.php` માં શોધી શકો છો. ધ્યાનમાં રાખો કે ડોટ (.) થી શરૂ થતી ફાઇલો મોટાભાગની ઓપરેટિંગ સિસ્ટમમાં ડિફૉલ્ટ મુજબ છુપાયેલી હોય છે, તેથી તમને તમારા ફાઇલ મેનેજરમાં "Show hidden files" વિકલ્પ સક્રિય કરવાની જરૂર પડી શકે છે.
 
 <!-- ## Restore a saved site -->
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -322,11 +322,11 @@ Mount before WP install: /wordpress ->
 The database location depends on what you mount:
 
 - **Auto-mounting wp-content or full WordPress**:
-    - Database: `<your-local-project>/wp-content/database/.ht.sqlite`
+    - Database: `<your-local-project>/wp-content/database/.ht.sqlite.php`
     - ✅ **Persisted locally** in your project folder
 
 - **Auto-mounting plugin/theme only**:
-    - Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    - Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite.php`
     - ⚠️ **Lost when server stops** (temp directories are cleaned up)
 
 - **Custom mounts**: Database location follows your mount configuration
@@ -345,11 +345,11 @@ Playground CLI automatically removes temp directories that are:
 マウント内容によってデータベースの場所が変わります:
 
 - **wp-content または WordPress 全体の自動マウント**:
-    - データベース: `<プロジェクト>/wp-content/database/.ht.sqlite`
+    - データベース: `<プロジェクト>/wp-content/database/.ht.sqlite.php`
     - ✅ プロジェクトフォルダに **ローカル永続化**
 
 - **プラグイン/テーマのみ自動マウント**:
-    - データベース: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    - データベース: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite.php`
     - ⚠️ サーバー停止時に **削除**（一時ディレクトリはクリーンアップされる）
 
 - **カスタムマウント**: マウント設定に従う
@@ -407,7 +407,7 @@ The `<path-hash>` is derived from your project directory path. This ensures isol
 The database location depends on your configuration:
 
 - **Default (automatic persistence)**:
-    - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite`
+    - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite.php`
     - **Persisted automatically** between sessions
 -->
 
@@ -419,7 +419,7 @@ The database location depends on your configuration:
 データベースの場所は設定により異なります:
 
 - **デフォルト（自動永続化）**:
-    - データベース: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite`
+    - データベース: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite.php`
     - セッション間で **自動永続化**
 
 <!--

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -174,10 +174,10 @@ To keep your WordPress Playground site for longer than a single browser session,
 The exported file contains the complete site you've built. You could host it on any server that supports PHP and SQLite. All WordPress core files, plugins, themes, and everything else you've added to your site are in there.
  -->
 
-SQLite データベースファイルもエクスポートに含まれており、`wp-content/database/.ht.sqlite`にあります。ドットで始まるファイルは、ほとんどのオペレーティングシステムでデフォルトで非表示になっているため、ファイルマネージャーで「隠しファイルを表示する」オプションを有効にする必要がある場合があります。
+SQLite データベースファイルもエクスポートに含まれており、`wp-content/database/.ht.sqlite.php`にあります。ドットで始まるファイルは、ほとんどのオペレーティングシステムでデフォルトで非表示になっているため、ファイルマネージャーで「隠しファイルを表示する」オプションを有効にする必要がある場合があります。
 
 <!--
-The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
+The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite.php`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
  -->
 
 ## 保存したサイトを復元する

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/05-local-development/04-wp-playground-cli.md
@@ -323,11 +323,11 @@ Mount before WP install: /wordpress ->
 The database location depends on what you mount:
 
 - **Auto-mounting wp-content or full WordPress**:
-    - Database: `<your-local-project>/wp-content/database/.ht.sqlite`
+    - Database: `<your-local-project>/wp-content/database/.ht.sqlite.php`
     - ✅ **Persisted locally** in your project folder
 
 - **Auto-mounting plugin/theme only**:
-    - Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    - Database: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite.php`
     - ⚠️ **Lost when server stops** (temp directories are cleaned up)
 
 - **Custom mounts**: Database location follows your mount configuration
@@ -346,11 +346,11 @@ Playground CLI automatically removes temp directories that are:
 A localização do banco depende do que você monta:
 
 - **Montagem automática de wp-content ou WordPress completo**:
-    - Banco: `<seu-projeto-local>/wp-content/database/.ht.sqlite`
+    - Banco: `<seu-projeto-local>/wp-content/database/.ht.sqlite.php`
     - ✅ **Persistido localmente** na pasta do seu projeto
 
 - **Montagem automática só de plugin/tema**:
-    - Banco: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite`
+    - Banco: `<OS-TEMP-DIR>/playground-<id>/wordpress/wp-content/database/.ht.sqlite.php`
     - ⚠️ **Perdido quando o servidor para** (diretórios temporários são removidos)
 
 - **Montagens customizadas**: A localização do banco segue sua configuração de montagem
@@ -409,7 +409,7 @@ O `<path-hash>` é derivado do caminho do diretório do seu projeto. Isso garant
 The database location depends on your configuration:
 
 - **Default (automatic persistence)**:
-    - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite`
+    - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite.php`
     - **Persisted automatically** between sessions
 -->
 
@@ -421,7 +421,7 @@ The database location depends on your configuration:
 A localização do banco depende da sua configuração:
 
 - **Padrão (persistência automática)**:
-    - Banco: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite`
+    - Banco: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite.php`
     - **Persistido automaticamente** entre sessões
 
 <!--

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -159,10 +159,10 @@ The exported file contains the complete site you've built. You could host it on 
 O arquivo exportado contém o site completo que você criou. Você pode hospedá-lo em qualquer servidor compatível com PHP e SQLite. Todos os arquivos principais do WordPress, plugins, temas e tudo o mais que você adicionou ao seu site estarão lá.
 
 <!--
-The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
+The SQLite database file is also included in the export, you'll find it `wp-content/database/.ht.sqlite.php`. Keep in mind that files starting with a dot are hidden by default on most operating systems so you might need to enable the "Show hidden files" option in your file manager.
 -->
 
-O arquivo de banco de dados SQLite também está incluído na exportação. Você o encontrará em `wp-content/database/.ht.sqlite`. Lembre-se de que arquivos que começam com um ponto ficam ocultos por padrão na maioria dos sistemas operacionais, portanto, pode ser necessário habilitar a opção "Mostrar arquivos ocultos" no seu gerenciador de arquivos.
+O arquivo de banco de dados SQLite também está incluído na exportação. Você o encontrará em `wp-content/database/.ht.sqlite.php`. Lembre-se de que arquivos que começam com um ponto ficam ocultos por padrão na maioria dos sistemas operacionais, portanto, pode ser necessário habilitar a opção "Mostrar arquivos ocultos" no seu gerenciador de arquivos.
 
 <!--
 ## Restore a saved site

--- a/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
+++ b/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/quick-start-guide.md
@@ -68,7 +68,7 @@ Para hindi mawala ang iyong site pagkatapos ng single browser session, i-export 
 
 ![Export button](@site/static/img/site-manager/export-zip-file.webp)
 
-Ang na-export na file ay naglalaman ng buong site na iyong binuo, kasama ang database (`wp-content/database/.ht.sqlite`). Tandaan na ang mga nak начин ng tuldok ay nakatago, kaya maaaring kailangan mong i-enable ang "Show hidden files."
+Ang na-export na file ay naglalaman ng buong site na iyong binuo, kasama ang database (`wp-content/database/.ht.sqlite.php`). Tandaan na ang mga nak начин ng tuldok ay nakatago, kaya maaaring kailangan mong i-enable ang "Show hidden files."
 
 ## I-restore ang na-save na site
 

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -96,7 +96,7 @@ if (!defined('Adminer\DRIVER')) {
 		public $driver;
 
 		function attach($server, $username, $password) {
-			$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite');
+			$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite.php');
 			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$this->driver = new WP_SQLite_Driver(
 				new WP_SQLite_Connection(array('pdo' => $pdo)),

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/download-button.tsx
@@ -2,7 +2,7 @@ import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
 
-const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
+const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite.php';
 
 async function downloadDatabase(playground: PlaygroundClient): Promise<void> {
 	const fileExists = await playground.fileExists(DATABASE_PATH);

--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/index.tsx
@@ -6,7 +6,7 @@ import { AdminerButton } from './adminer-button';
 import { PhpMyAdminButton } from './phpmyadmin-button';
 import css from './style.module.css';
 
-const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
+const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite.php';
 
 export function SiteDatabasePanel({
 	playground,

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -551,7 +551,7 @@ export async function playgroundAvailableInOpfs(
 		/**
 		 * Assume it's a Playground directory if these files exist:
 		 * - wp-config.php
-		 * - wp-content/database/.ht.sqlite
+		 * - wp-content/database/.ht.sqlite.php
 		 */
 		await dirHandle.getFileHandle('wp-config.php', { create: false });
 		const wpContent = await dirHandle.getDirectoryHandle('wp-content', {
@@ -560,7 +560,7 @@ export async function playgroundAvailableInOpfs(
 		const database = await wpContent.getDirectoryHandle('database', {
 			create: false,
 		});
-		await database.getFileHandle('.ht.sqlite', { create: false });
+		await database.getFileHandle('.ht.sqlite.php', { create: false });
 	} catch {
 		return false;
 	}

--- a/packages/playground/sync/src/fs.ts
+++ b/packages/playground/sync/src/fs.ts
@@ -9,8 +9,8 @@ export async function journalFSOperations(
 		'/wordpress/wp-content',
 		async (entry: FilesystemOperation) => {
 			if (
-				entry.path.endsWith('/.ht.sqlite') ||
-				entry.path.endsWith('/.ht.sqlite-journal')
+				entry.path.endsWith('/.ht.sqlite.php') ||
+				entry.path.endsWith('/.ht.sqlite.php-journal')
 			) {
 				return;
 			}

--- a/packages/playground/sync/src/fs.ts
+++ b/packages/playground/sync/src/fs.ts
@@ -10,7 +10,9 @@ export async function journalFSOperations(
 		async (entry: FilesystemOperation) => {
 			if (
 				entry.path.endsWith('/.ht.sqlite.php') ||
-				entry.path.endsWith('/.ht.sqlite.php-journal')
+				entry.path.endsWith('/.ht.sqlite.php-journal') ||
+				entry.path.endsWith('/.ht.sqlite') ||
+				entry.path.endsWith('/.ht.sqlite-journal')
 			) {
 				return;
 			}

--- a/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
+++ b/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
@@ -253,7 +253,7 @@ class DbiMysqli implements DbiExtension {
 	private $last_error_number = 0;
 
     public function connect($user, $password, array $server) {
-		$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite');
+		$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite.php');
 		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->driver = new WP_SQLite_Driver(
 			new WP_SQLite_Connection(array('pdo' => $pdo)),

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -396,7 +396,9 @@ test.describe('Database panel', () => {
 	test('should display database info', async ({ website }) => {
 		await expect(website.page.getByText('Path:')).toBeVisible();
 		await expect(
-			website.page.getByText('/wordpress/wp-content/database/.ht.sqlite')
+			website.page.getByText(
+				'/wordpress/wp-content/database/.ht.sqlite.php'
+			)
 		).toBeVisible();
 		await expect(website.page.getByText('Size:')).toBeVisible();
 	});

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -96,7 +96,7 @@ if (!defined('Adminer\DRIVER')) {
 		public $driver;
 
 		function attach($server, $username, $password) {
-			$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite');
+			$pdo = new PDO('sqlite:/wordpress/wp-content/database/.ht.sqlite.php');
 			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$this->driver = new WP_SQLite_Driver(
 				new WP_SQLite_Connection(array('pdo' => $pdo)),

--- a/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/download-button.tsx
@@ -2,7 +2,7 @@ import { Button, Icon, Flex, FlexItem } from '@wordpress/components';
 import { download } from '@wordpress/icons';
 import type { PlaygroundClient } from '@wp-playground/client';
 
-const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
+const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite.php';
 
 async function downloadDatabase(playground: PlaygroundClient): Promise<void> {
 	const fileExists = await playground.fileExists(DATABASE_PATH);

--- a/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/index.tsx
@@ -6,7 +6,7 @@ import { AdminerButton } from './adminer-button';
 import { PhpMyAdminButton } from './phpmyadmin-button';
 import css from './style.module.css';
 
-const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite';
+const DATABASE_PATH = '/wordpress/wp-content/database/.ht.sqlite.php';
 
 export function SiteDatabasePanel({
 	playground,

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -315,7 +315,7 @@ export async function playgroundAvailableInOpfs(
 		/**
 		 * Assume it's a Playground directory if these files exist:
 		 * - wp-config.php
-		 * - wp-content/database/.ht.sqlite
+		 * - wp-content/database/.ht.sqlite.php
 		 */
 		await dirHandle.getFileHandle('wp-config.php', { create: false });
 		const wpContent = await dirHandle.getDirectoryHandle('wp-content', {
@@ -324,7 +324,7 @@ export async function playgroundAvailableInOpfs(
 		const database = await wpContent.getDirectoryHandle('database', {
 			create: false,
 		});
-		await database.getFileHandle('.ht.sqlite', { create: false });
+		await database.getFileHandle('.ht.sqlite.php', { create: false });
 	} catch {
 		return false;
 	}

--- a/packages/playground/wordpress-builds/public/wp-6.3/wordpress-remote-asset-paths
+++ b/packages/playground/wordpress-builds/public/wp-6.3/wordpress-remote-asset-paths
@@ -1640,7 +1640,7 @@ wp-includes/fonts/dashicons.woff
 wp-includes/fonts/dashicons.eot
 wp-includes/fonts/dashicons.svg
 wp-includes/theme-i18n.json
-wp-content/database/.ht.sqlite
+wp-content/database/.ht.sqlite.php
 wp-content/database/.htaccess
 wp-content/themes/twentytwentythree/theme.json
 wp-content/themes/twentytwentythree/style.css

--- a/packages/playground/wordpress/src/test/database.spec.ts
+++ b/packages/playground/wordpress/src/test/database.spec.ts
@@ -58,7 +58,7 @@ describe('Test database', () => {
 				siteUrl: 'http://playground-domain/',
 				wordPressZip: await getWordPressModule(),
 				sqliteIntegrationPluginZip: await getSqliteDriverModule(),
-				dataSqlPath: '/wordpress/wp-content/database/.ht.sqlite',
+				dataSqlPath: '/wordpress/wp-content/database/.ht.sqlite.php',
 			});
 
 			const loadedWordPressVersion =


### PR DESCRIPTION
Update all references to the SQLite database path from `.ht.sqlite` to `.ht.sqlite.php`, matching the latest SQLite integration plugin version.