### PR TITLE
Create GitHub Release on every npm publish

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -21,7 +21,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  ref: trunk
+                  ref: ${{ github.event.workflow_run.head_sha }}
 
             - name: Read version from lerna.json
               id: version

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -37,8 +37,12 @@ jobs:
                   # Extract the section between this version's heading and the next version heading.
                   # The changelog uses "## [vX.Y.Z]" headings.
                   CHANGELOG=$(awk -v ver="$VERSION" '
-                      # When we hit the heading for this version, start capturing from the next line.
-                      $0 == "## [v" ver "]" {
+                      # When we hit the heading for this version, start capturing
+                      # from the next line. The heading format is:
+                      #   ## [vX.Y.Z] (YYYY-MM-DD)
+                      # so we match the prefix "## [vX.Y.Z]" and allow anything
+                      # after the closing bracket (like the date).
+                      index($0, "## [v" ver "]") == 1 {
                           found = 1
                           next
                       }

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -2,7 +2,7 @@ name: Publish GitHub Release
 
 on:
     workflow_run:
-        workflows: [Update CHANGELOG.md]
+        workflows: [Release NPM packages]
         types:
             - completed
 
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
     create-release:
-        # Only create a release when the changelog update succeeded on trunk
+        # Only create a release after a successful npm publish on trunk
         if: >
             github.event.workflow_run.conclusion == 'success' &&
             github.event.workflow_run.head_branch == 'trunk'
@@ -74,4 +74,4 @@ jobs:
                   gh release create "$TAG" \
                       --title "WordPress Playground $TAG" \
                       --notes-file /tmp/release-body.md \
-                      --verify-tag
+                      --target trunk

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -1,0 +1,77 @@
+name: Publish GitHub Release
+
+on:
+    workflow_run:
+        workflows: [Update CHANGELOG.md]
+        types:
+            - completed
+
+permissions:
+    contents: write
+
+jobs:
+    create-release:
+        # Only create a release when the changelog update succeeded on trunk
+        if: >
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.head_branch == 'trunk'
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: trunk
+
+            - name: Read version from lerna.json
+              id: version
+              run: |
+                  VERSION=$(jq -r '.version' lerna.json)
+                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+                  echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+            - name: Extract changelog for this version
+              id: changelog
+              run: |
+                  VERSION="${{ steps.version.outputs.version }}"
+                  # Extract the section between this version's heading and the next version heading.
+                  # The changelog uses "## [vX.Y.Z]" headings.
+                  CHANGELOG=$(awk "/^## \\[v${VERSION}\\]/{found=1; next} /^## \\[v[0-9]/{if(found) exit} found" CHANGELOG.md)
+
+                  if [ -z "$CHANGELOG" ]; then
+                      CHANGELOG="No changelog entries for this release."
+                  fi
+
+                  # Write to file to avoid escaping issues
+                  {
+                      echo "$CHANGELOG"
+                      echo ""
+                      echo "---"
+                      echo ""
+                      echo "**Install via npm:**"
+                      echo ""
+                      echo '```'
+                      echo "npm install @wp-playground/client@${VERSION}"
+                      echo '```'
+                      echo ""
+                      echo "Or browse all packages on [npm](https://www.npmjs.com/search?q=%40wp-playground)."
+                      echo ""
+                      echo "> **Stay up to date:** Click **Watch → Custom → Releases** at the top of this repository to get notified of new releases."
+                  } > /tmp/release-body.md
+
+            - name: Create GitHub Release
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  TAG="${{ steps.version.outputs.tag }}"
+
+                  # Check if this release already exists
+                  if gh release view "$TAG" &>/dev/null; then
+                      echo "Release $TAG already exists, skipping."
+                      exit 0
+                  fi
+
+                  gh release create "$TAG" \
+                      --title "WordPress Playground $TAG" \
+                      --notes-file /tmp/release-body.md \
+                      --verify-tag

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -36,8 +36,21 @@ jobs:
                   VERSION="${{ steps.version.outputs.version }}"
                   # Extract the section between this version's heading and the next version heading.
                   # The changelog uses "## [vX.Y.Z]" headings.
-                  CHANGELOG=$(awk "/^## \\[v${VERSION}\\]/{found=1; next} /^## \\[v[0-9]/{if(found) exit} found" CHANGELOG.md)
+                  CHANGELOG=$(awk -v ver="$VERSION" '
+                      # When we hit the heading for this version, start capturing from the next line.
+                      $0 == "## [v" ver "]" {
+                          found = 1
+                          next
+                      }
 
+                      # When we hit the next version heading after starting, stop.
+                      /^## \[v[0-9]/ {
+                          if (found) exit
+                      }
+
+                      # While in the section for this version, print lines.
+                      found
+                  ' CHANGELOG.md)
                   if [ -z "$CHANGELOG" ]; then
                       CHANGELOG="No changelog entries for this release."
                   fi


### PR DESCRIPTION
## What it does

Creates a GitHub Release automatically after every npm publish. The release has no binary assets – just the changelog for that version, an `npm install` command, and a note about subscribing to releases via **Watch → Custom → Releases**.

## Rationale

People who depend on WordPress Playground don't have an easy way to know when a new version ships. GitHub Releases are the standard mechanism for this – they show up in the repo's release feed and anyone watching releases gets notified.

## Implementation

New workflow `.github/workflows/publish-github-release.yml` that:

1. Triggers via `workflow_run` after the **Release NPM packages** workflow succeeds on `trunk`
2. Reads the version from `lerna.json`
3. Extracts the matching section from `CHANGELOG.md` using `awk`
4. Calls `gh release create` with `--target trunk`
5. Skips gracefully if the release already exists

Triggering directly off the npm release workflow (instead of the changelog workflow) ensures we only create a GitHub Release when packages actually ship to npm — not when the changelog updates for other reasons like self-hosted releases.

## Testing instructions

- After the next npm publish on trunk, verify a GitHub Release appears at https://github.com/WordPress/wordpress-playground/releases
- Confirm the release title is `WordPress Playground vX.Y.Z`, the body has the changelog and npm link, and there are no attached assets