### PR TITLE
[CLI] Optimization: Serve static files without occupying PHP workers

### DIFF
--- a/packages/php-wasm/universal/src/lib/fs-helpers.ts
+++ b/packages/php-wasm/universal/src/lib/fs-helpers.ts
@@ -49,68 +49,6 @@ export class FSHelpers {
 	}
 
 	/**
-	 * Reads a file from the PHP filesystem and returns it as a
-	 * ReadableStream, reading in chunks to avoid buffering the
-	 * entire file in memory at once.
-	 *
-	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file
-	 *   doesn't exist.
-	 * @param FS
-	 * @param path - The file path to read.
-	 * @param chunkSize - The size of each chunk in bytes.
-	 * @returns An object with the file size and a ReadableStream of
-	 *   the file contents.
-	 */
-	static streamFile(
-		FS: Emscripten.RootFS,
-		path: string,
-		chunkSize = 64 * 1024
-	): { fileSize: number; stream: ReadableStream<Uint8Array> } {
-		const stat = FS.stat(path);
-		const fileSize = stat.size;
-
-		// For NODEFS-backed files, use Node.js
-		// fs.createReadStream() for efficient streaming
-		// directly from the host filesystem.
-		const lookup = FS.lookupPath(path, { follow: true });
-		const isNodeFS = !('contents' in lookup.node);
-		if (isNodeFS) {
-			const hostPath = resolveNodeFSPath(lookup.node);
-			if (hostPath !== null) {
-				return {
-					fileSize,
-					stream: createNodeReadStream(hostPath),
-				};
-			}
-		}
-
-		// For MEMFS files (or if host path resolution
-		// failed), read in chunks via Emscripten's FS API.
-		const fsStream = FS.open(path, 'r');
-		let offset = 0;
-
-		const stream = new ReadableStream<Uint8Array>({
-			pull(controller) {
-				const bytesToRead = Math.min(chunkSize, fileSize - offset);
-				if (bytesToRead <= 0) {
-					FS.close(fsStream);
-					controller.close();
-					return;
-				}
-				const buf = new Uint8Array(bytesToRead);
-				FS.read(fsStream, buf, 0, bytesToRead, offset);
-				offset += bytesToRead;
-				controller.enqueue(buf);
-			},
-			cancel() {
-				FS.close(fsStream);
-			},
-		});
-
-		return { fileSize, stream };
-	}
-
-	/**
 	 * Overwrites data in a file in the PHP filesystem.
 	 * Creates a new file if one doesn't exist yet.
 	 *
@@ -414,9 +352,6 @@ FSHelpers.readFileAsText = rethrowFileSystemError('Could not read "{path}"')(
 FSHelpers.readFileAsBuffer = rethrowFileSystemError('Could not read "{path}"')(
 	FSHelpers.readFileAsBuffer
 );
-FSHelpers.streamFile = rethrowFileSystemError('Could not read "{path}"')(
-	FSHelpers.streamFile
-);
 FSHelpers.writeFile = rethrowFileSystemError('Could not write to "{path}"')(
 	FSHelpers.writeFile
 );
@@ -444,62 +379,3 @@ FSHelpers.fileExists = rethrowFileSystemError('Could not stat "{path}"')(
 FSHelpers.mkdir = rethrowFileSystemError('Could not create directory "{path}"')(
 	FSHelpers.mkdir
 );
-
-/**
- * Resolves the host filesystem path for a NODEFS-backed
- * Emscripten FS node. Uses the same algorithm as
- * Emscripten's internal NODEFS.realPath(): walk the node's
- * parent chain and prepend the mount's root option.
- *
- * Returns null if the mount doesn't have a root option
- * (i.e. it's not a NODEFS mount).
- */
-function resolveNodeFSPath(node: Emscripten.FS.FSNode): string | null {
-	const root = node.mount?.opts?.['root'];
-	if (typeof root !== 'string') {
-		return null;
-	}
-	const parts: string[] = [];
-	let current = node;
-	while (current.parent !== current) {
-		parts.push(current.name);
-		current = current.parent;
-	}
-	parts.push(root);
-	parts.reverse();
-	return parts.join('/');
-}
-
-/**
- * Creates a web ReadableStream backed by Node.js
- * fs.createReadStream(). The dynamic import of 'fs'
- * happens lazily inside the stream's start callback
- * so the function can return synchronously and the
- * module is only loaded in Node.js environments.
- */
-function createNodeReadStream(hostPath: string): ReadableStream<Uint8Array> {
-	let nodeStream: any;
-
-	return new ReadableStream<Uint8Array>({
-		async start(controller) {
-			// Dynamic module name prevents bundlers from
-			// resolving this import in browser builds.
-			const fsModule = 'fs';
-			const fs = await import(/* webpackIgnore: true */ fsModule);
-			nodeStream = fs.createReadStream(hostPath);
-
-			nodeStream.on('data', (chunk: Buffer) => {
-				controller.enqueue(new Uint8Array(chunk));
-			});
-			nodeStream.on('end', () => {
-				controller.close();
-			});
-			nodeStream.on('error', (err: Error) => {
-				controller.error(err);
-			});
-		},
-		cancel() {
-			nodeStream?.destroy();
-		},
-	});
-}

--- a/packages/php-wasm/universal/src/lib/fs-helpers.ts
+++ b/packages/php-wasm/universal/src/lib/fs-helpers.ts
@@ -49,6 +49,68 @@ export class FSHelpers {
 	}
 
 	/**
+	 * Reads a file from the PHP filesystem and returns it as a
+	 * ReadableStream, reading in chunks to avoid buffering the
+	 * entire file in memory at once.
+	 *
+	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file
+	 *   doesn't exist.
+	 * @param FS
+	 * @param path - The file path to read.
+	 * @param chunkSize - The size of each chunk in bytes.
+	 * @returns An object with the file size and a ReadableStream of
+	 *   the file contents.
+	 */
+	static streamFile(
+		FS: Emscripten.RootFS,
+		path: string,
+		chunkSize = 64 * 1024
+	): { fileSize: number; stream: ReadableStream<Uint8Array> } {
+		const stat = FS.stat(path);
+		const fileSize = stat.size;
+
+		// For NODEFS-backed files, use Node.js
+		// fs.createReadStream() for efficient streaming
+		// directly from the host filesystem.
+		const lookup = FS.lookupPath(path, { follow: true });
+		const isNodeFS = !('contents' in lookup.node);
+		if (isNodeFS) {
+			const hostPath = resolveNodeFSPath(lookup.node);
+			if (hostPath !== null) {
+				return {
+					fileSize,
+					stream: createNodeReadStream(hostPath),
+				};
+			}
+		}
+
+		// For MEMFS files (or if host path resolution
+		// failed), read in chunks via Emscripten's FS API.
+		const fsStream = FS.open(path, 'r');
+		let offset = 0;
+
+		const stream = new ReadableStream<Uint8Array>({
+			pull(controller) {
+				const bytesToRead = Math.min(chunkSize, fileSize - offset);
+				if (bytesToRead <= 0) {
+					FS.close(fsStream);
+					controller.close();
+					return;
+				}
+				const buf = new Uint8Array(bytesToRead);
+				FS.read(fsStream, buf, 0, bytesToRead, offset);
+				offset += bytesToRead;
+				controller.enqueue(buf);
+			},
+			cancel() {
+				FS.close(fsStream);
+			},
+		});
+
+		return { fileSize, stream };
+	}
+
+	/**
 	 * Overwrites data in a file in the PHP filesystem.
 	 * Creates a new file if one doesn't exist yet.
 	 *
@@ -352,6 +414,9 @@ FSHelpers.readFileAsText = rethrowFileSystemError('Could not read "{path}"')(
 FSHelpers.readFileAsBuffer = rethrowFileSystemError('Could not read "{path}"')(
 	FSHelpers.readFileAsBuffer
 );
+FSHelpers.streamFile = rethrowFileSystemError('Could not read "{path}"')(
+	FSHelpers.streamFile
+);
 FSHelpers.writeFile = rethrowFileSystemError('Could not write to "{path}"')(
 	FSHelpers.writeFile
 );
@@ -379,3 +444,62 @@ FSHelpers.fileExists = rethrowFileSystemError('Could not stat "{path}"')(
 FSHelpers.mkdir = rethrowFileSystemError('Could not create directory "{path}"')(
 	FSHelpers.mkdir
 );
+
+/**
+ * Resolves the host filesystem path for a NODEFS-backed
+ * Emscripten FS node. Uses the same algorithm as
+ * Emscripten's internal NODEFS.realPath(): walk the node's
+ * parent chain and prepend the mount's root option.
+ *
+ * Returns null if the mount doesn't have a root option
+ * (i.e. it's not a NODEFS mount).
+ */
+function resolveNodeFSPath(node: Emscripten.FS.FSNode): string | null {
+	const root = node.mount?.opts?.['root'];
+	if (typeof root !== 'string') {
+		return null;
+	}
+	const parts: string[] = [];
+	let current = node;
+	while (current.parent !== current) {
+		parts.push(current.name);
+		current = current.parent;
+	}
+	parts.push(root);
+	parts.reverse();
+	return parts.join('/');
+}
+
+/**
+ * Creates a web ReadableStream backed by Node.js
+ * fs.createReadStream(). The dynamic import of 'fs'
+ * happens lazily inside the stream's start callback
+ * so the function can return synchronously and the
+ * module is only loaded in Node.js environments.
+ */
+function createNodeReadStream(hostPath: string): ReadableStream<Uint8Array> {
+	let nodeStream: any;
+
+	return new ReadableStream<Uint8Array>({
+		async start(controller) {
+			// Dynamic module name prevents bundlers from
+			// resolving this import in browser builds.
+			const fsModule = 'fs';
+			const fs = await import(/* webpackIgnore: true */ fsModule);
+			nodeStream = fs.createReadStream(hostPath);
+
+			nodeStream.on('data', (chunk: Buffer) => {
+				controller.enqueue(new Uint8Array(chunk));
+			});
+			nodeStream.on('end', () => {
+				controller.close();
+			});
+			nodeStream.on('error', (err: Error) => {
+				controller.error(err);
+			});
+		},
+		cancel() {
+			nodeStream?.destroy();
+		},
+	});
+}

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -96,6 +96,12 @@ export type {
 	FileNotFoundAction,
 	CookieStore,
 } from './php-request-handler';
+export { RequestRouter } from './request-router';
+export type {
+	RouterFilesystem,
+	ResolvedRoute,
+	RequestRouterConfig,
+} from './request-router';
 export { rotatePHPRuntime } from './rotate-php-runtime';
 export { writeFiles } from './write-files';
 export type { FileTree } from './write-files';

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -81,6 +81,12 @@ export type {
 	FileNotFoundAction,
 	CookieStore,
 } from './php-request-handler';
+export { RequestRouter } from './request-router';
+export type {
+	RouterFilesystem,
+	ResolvedRoute,
+	RequestRouterConfig,
+} from './request-router';
 export { rotatePHPRuntime } from './rotate-php-runtime';
 export { writeFiles } from './write-files';
 export type { FileTree } from './write-files';

--- a/packages/php-wasm/universal/src/lib/php-request-handler.spec.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.spec.ts
@@ -20,6 +20,21 @@ function createMockPHP(filesystem: Map<string, 'file' | 'dir'>) {
 			}
 			throw new Error(`File not found: ${path}`);
 		}),
+		streamFile: vi.fn((path: string) => {
+			if (filesystem.get(path) === 'file') {
+				const bytes = new Uint8Array(Buffer.from(`Content of ${path}`));
+				return {
+					fileSize: bytes.byteLength,
+					stream: new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(bytes);
+							controller.close();
+						},
+					}),
+				};
+			}
+			throw new Error(`File not found: ${path}`);
+		}),
 		addEventListener: vi.fn(),
 		onMessage: vi.fn(() => Promise.resolve(() => {})),
 		dispatchEvent: vi.fn(),
@@ -264,14 +279,23 @@ describe('PHPRequestHandler', () => {
 				['/tools/phpmyadmin/styles.css', 'file'],
 			]);
 			const mockPHP = createMockPHP(filesystem);
-			(
-				mockPHP.readFileAsBuffer as ReturnType<typeof vi.fn>
-			).mockImplementation((path: string) => {
-				if (path === '/tools/phpmyadmin/styles.css') {
-					return new Uint8Array(Buffer.from(cssContent));
+			(mockPHP.streamFile as ReturnType<typeof vi.fn>).mockImplementation(
+				(path: string) => {
+					if (path === '/tools/phpmyadmin/styles.css') {
+						const bytes = new Uint8Array(Buffer.from(cssContent));
+						return {
+							fileSize: bytes.byteLength,
+							stream: new ReadableStream<Uint8Array>({
+								start(controller) {
+									controller.enqueue(bytes);
+									controller.close();
+								},
+							}),
+						};
+					}
+					throw new Error(`File not found: ${path}`);
 				}
-				throw new Error(`File not found: ${path}`);
-			});
+			);
 
 			const handler = new PHPRequestHandler({
 				php: mockPHP,
@@ -383,14 +407,23 @@ describe('PHPRequestHandler', () => {
 				['/www/app.css', 'file'],
 			]);
 			const mockPHP = createMockPHP(filesystem);
-			(
-				mockPHP.readFileAsBuffer as ReturnType<typeof vi.fn>
-			).mockImplementation((path: string) => {
-				if (path === '/www/app.css') {
-					return new Uint8Array(Buffer.from(cssContent));
+			(mockPHP.streamFile as ReturnType<typeof vi.fn>).mockImplementation(
+				(path: string) => {
+					if (path === '/www/app.css') {
+						const bytes = new Uint8Array(Buffer.from(cssContent));
+						return {
+							fileSize: bytes.byteLength,
+							stream: new ReadableStream<Uint8Array>({
+								start(controller) {
+									controller.enqueue(bytes);
+									controller.close();
+								},
+							}),
+						};
+					}
+					throw new Error(`File not found: ${path}`);
 				}
-				throw new Error(`File not found: ${path}`);
-			});
+			);
 
 			const handler = new PHPRequestHandler({
 				php: mockPHP,

--- a/packages/php-wasm/universal/src/lib/php-request-handler.spec.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.spec.ts
@@ -20,21 +20,6 @@ function createMockPHP(filesystem: Map<string, 'file' | 'dir'>) {
 			}
 			throw new Error(`File not found: ${path}`);
 		}),
-		streamFile: vi.fn((path: string) => {
-			if (filesystem.get(path) === 'file') {
-				const bytes = new Uint8Array(Buffer.from(`Content of ${path}`));
-				return {
-					fileSize: bytes.byteLength,
-					stream: new ReadableStream<Uint8Array>({
-						start(controller) {
-							controller.enqueue(bytes);
-							controller.close();
-						},
-					}),
-				};
-			}
-			throw new Error(`File not found: ${path}`);
-		}),
 		addEventListener: vi.fn(),
 		onMessage: vi.fn(() => Promise.resolve(() => {})),
 		dispatchEvent: vi.fn(),
@@ -279,23 +264,14 @@ describe('PHPRequestHandler', () => {
 				['/tools/phpmyadmin/styles.css', 'file'],
 			]);
 			const mockPHP = createMockPHP(filesystem);
-			(mockPHP.streamFile as ReturnType<typeof vi.fn>).mockImplementation(
-				(path: string) => {
-					if (path === '/tools/phpmyadmin/styles.css') {
-						const bytes = new Uint8Array(Buffer.from(cssContent));
-						return {
-							fileSize: bytes.byteLength,
-							stream: new ReadableStream<Uint8Array>({
-								start(controller) {
-									controller.enqueue(bytes);
-									controller.close();
-								},
-							}),
-						};
-					}
-					throw new Error(`File not found: ${path}`);
+			(
+				mockPHP.readFileAsBuffer as ReturnType<typeof vi.fn>
+			).mockImplementation((path: string) => {
+				if (path === '/tools/phpmyadmin/styles.css') {
+					return new Uint8Array(Buffer.from(cssContent));
 				}
-			);
+				throw new Error(`File not found: ${path}`);
+			});
 
 			const handler = new PHPRequestHandler({
 				php: mockPHP,
@@ -407,23 +383,14 @@ describe('PHPRequestHandler', () => {
 				['/www/app.css', 'file'],
 			]);
 			const mockPHP = createMockPHP(filesystem);
-			(mockPHP.streamFile as ReturnType<typeof vi.fn>).mockImplementation(
-				(path: string) => {
-					if (path === '/www/app.css') {
-						const bytes = new Uint8Array(Buffer.from(cssContent));
-						return {
-							fileSize: bytes.byteLength,
-							stream: new ReadableStream<Uint8Array>({
-								start(controller) {
-									controller.enqueue(bytes);
-									controller.close();
-								},
-							}),
-						};
-					}
-					throw new Error(`File not found: ${path}`);
+			(
+				mockPHP.readFileAsBuffer as ReturnType<typeof vi.fn>
+			).mockImplementation((path: string) => {
+				if (path === '/www/app.css') {
+					return new Uint8Array(Buffer.from(cssContent));
 				}
-			);
+				throw new Error(`File not found: ${path}`);
+			});
 
 			const handler = new PHPRequestHandler({
 				php: mockPHP,

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -458,7 +458,9 @@ export class PHPRequestHandler implements AsyncDisposable {
 
 		switch (route.type) {
 			case 'static-file':
-				return this.#streamStaticFile(primaryPhp, route.fsPath);
+				return StreamedPHPResponse.fromPHPResponse(
+					this.#serveStaticFile(primaryPhp, route.fsPath)
+				);
 			case 'php': {
 				const isAbsolute = looksLikeAbsoluteUrl(request.url);
 				const originalRequestUrl = new URL(
@@ -538,54 +540,26 @@ export class PHPRequestHandler implements AsyncDisposable {
 	}
 
 	/**
-	 * Streams a static file from the PHP filesystem
-	 * without buffering it entirely in memory.
+	 * Serves a static file from the PHP filesystem.
 	 *
-	 * @param fsPath - Absolute path of the static file.
-	 * @returns A streamed response.
+	 * @param  fsPath - Absolute path of the static file to serve.
+	 * @returns The response.
 	 */
-	#streamStaticFile(php: PHP, fsPath: string): StreamedPHPResponse {
-		const { fileSize, stream: stdout } = php.streamFile(fsPath);
-
-		const headers: Record<string, string[]> = {
-			'content-length': [`${fileSize}`],
-			// @TODO: Infer the content-type from the file
-			// contents instead of the file path. The code
-			// below won't return the correct mime-type if
-			// the extension was tampered with.
-			'content-type': [inferMimeType(fsPath)],
-			'accept-ranges': ['bytes'],
-			'cache-control': ['public, max-age=0'],
-		};
-
-		const headerLines: string[] = [];
-		for (const [name, values] of Object.entries(headers)) {
-			for (const value of values) {
-				headerLines.push(`${name}: ${value}`);
-			}
-		}
-		const headersJson = JSON.stringify({
-			status: 200,
-			headers: headerLines,
-		});
-		const headersStream = new ReadableStream<Uint8Array>({
-			start(controller) {
-				controller.enqueue(new TextEncoder().encode(headersJson));
-				controller.close();
+	#serveStaticFile(php: PHP, fsPath: string): PHPResponse {
+		const arrayBuffer = php.readFileAsBuffer(fsPath);
+		return new PHPResponse(
+			200,
+			{
+				'content-length': [`${arrayBuffer.byteLength}`],
+				// @TODO: Infer the content-type from the
+				// arrayBuffer instead of the file path.
+				// The code below won't return the correct
+				// mime-type if the extension was tampered with.
+				'content-type': [inferMimeType(fsPath)],
+				'accept-ranges': ['bytes'],
+				'cache-control': ['public, max-age=0'],
 			},
-		});
-
-		const stderr = new ReadableStream<Uint8Array>({
-			start(controller) {
-				controller.close();
-			},
-		});
-
-		return new StreamedPHPResponse(
-			headersStream,
-			stdout,
-			stderr,
-			Promise.resolve(0)
+			arrayBuffer
 		);
 	}
 

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -722,7 +722,6 @@ export class PHPRequestHandler implements AsyncDisposable {
 			REMOTE_ADDR: '127.0.0.1',
 			DOCUMENT_ROOT: this.#DOCROOT,
 			HTTPS: this.#ABSOLUTE_URL.startsWith('https://') ? 'on' : '',
-			SERVER_PROTOCOL: 'HTTP/1.1',
 		};
 
 		/**

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -648,8 +648,7 @@ export class PHPRequestHandler implements AsyncDisposable {
 			$_SERVER: this.prepare_$_SERVER_superglobal(
 				originalRequestUrl,
 				rewrittenRequestUrl,
-				scriptPath,
-				request.protocolVersion
+				scriptPath
 			),
 			body,
 			scriptPath,
@@ -759,14 +758,13 @@ export class PHPRequestHandler implements AsyncDisposable {
 	private prepare_$_SERVER_superglobal(
 		originalRequestUrl: URL,
 		rewrittenRequestUrl: URL,
-		resolvedScriptPath: string,
-		protocolVersion?: string
+		resolvedScriptPath: string
 	): Record<string, string> {
 		const $_SERVER: Record<string, string> = {
 			REMOTE_ADDR: '127.0.0.1',
 			DOCUMENT_ROOT: this.#DOCROOT,
 			HTTPS: this.#ABSOLUTE_URL.startsWith('https://') ? 'on' : '',
-			SERVER_PROTOCOL: protocolVersion || 'HTTP/1.1',
+			SERVER_PROTOCOL: 'HTTP/1.1',
 		};
 
 		/**

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -1,10 +1,4 @@
-import { joinPaths } from '@php-wasm/util';
-import {
-	ensurePathPrefix,
-	toRelativeUrl,
-	removePathPrefix,
-	DEFAULT_BASE_URL,
-} from './urls';
+import { ensurePathPrefix, toRelativeUrl, DEFAULT_BASE_URL } from './urls';
 import type { PHP } from './php';
 import { normalizeHeaders } from './php';
 import { PHPResponse, StreamedPHPResponse } from './php-response';
@@ -211,8 +205,6 @@ export class PHPRequestHandler implements AsyncDisposable {
 	#PATHNAME: string;
 	#ABSOLUTE_URL: string;
 	#cookieStore: CookieStore | false;
-	#router: RequestRouter | undefined;
-	#routerFs: RouterFilesystem | undefined;
 	#pathAliases: PathAlias[];
 	rewriteRules: RewriteRule[];
 	/**
@@ -453,29 +445,20 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 */
 	async requestStreamed(request: PHPRequest): Promise<StreamedPHPResponse> {
 		const primaryPhp = await this.getPrimaryPhp();
-		const router = this.#getRouter(primaryPhp);
-		const route = router.resolve(request);
+		const route = this.#createRouter(primaryPhp).resolve(request);
 
 		switch (route.type) {
 			case 'static-file':
 				return StreamedPHPResponse.fromPHPResponse(
 					this.#serveStaticFile(primaryPhp, route.fsPath)
 				);
-			case 'php': {
-				const isAbsolute = looksLikeAbsoluteUrl(request.url);
-				const originalRequestUrl = new URL(
-					request.url.split('#')[0],
-					isAbsolute ? undefined : DEFAULT_BASE_URL
-				);
-				const rewrittenRequestUrl =
-					this.#applyRewriteRules(originalRequestUrl);
+			case 'php':
 				return await this.#spawnPHPAndDispatchRequest(
 					request,
-					originalRequestUrl,
-					rewrittenRequestUrl,
+					route.originalRequestUrl,
+					route.rewrittenRequestUrl,
 					route.fsPath
 				);
-			}
 			case 'redirect':
 				return StreamedPHPResponse.fromPHPResponse(
 					new PHPResponse(
@@ -492,51 +475,26 @@ export class PHPRequestHandler implements AsyncDisposable {
 	}
 
 	/**
-	 * Gets or creates the RequestRouter instance, lazily
-	 * initializing the filesystem wrapper on first use.
-	 */
-	#getRouter(php: PHP): RequestRouter {
-		if (!this.#router) {
-			this.#routerFs = {
-				isFile: (path: string) => php.isFile(path),
-				isDir: (path: string) => php.isDir(path),
-			};
-			this.#router = new RequestRouter({
-				documentRoot: this.#DOCROOT,
-				pathname: this.#PATHNAME,
-				rewriteRules: this.rewriteRules,
-				pathAliases: this.#pathAliases,
-				getFileNotFoundAction: this.getFileNotFoundAction,
-				fs: this.#routerFs,
-			});
-		}
-		return this.#router;
-	}
-
-	/**
-	 * Apply the rewrite rules to the original request URL.
+	 * Builds a RequestRouter for a single request.
 	 *
-	 * @param originalRequestUrl - The original request URL.
-	 * @returns The rewritten request URL.
+	 * A fresh router per request keeps the routing decisions in sync with
+	 * `rewriteRules` and `getFileNotFoundAction`, which are public and may
+	 * be reassigned between requests, and with the PHP instance backing the
+	 * filesystem lookups.
 	 */
-	#applyRewriteRules(originalRequestUrl: URL): URL {
-		const siteRelativePath = removePathPrefix(
-			decodeURIComponent(originalRequestUrl.pathname),
-			this.#PATHNAME
-		);
-		const rewrittenRequestPath = applyRewriteRules(
-			siteRelativePath,
-			this.rewriteRules
-		);
-		const rewrittenRequestUrl = new URL(
-			joinPaths(this.#PATHNAME, rewrittenRequestPath),
-			originalRequestUrl.toString()
-		);
-		// Merge the query string parameters from the original request URL.
-		for (const [key, value] of originalRequestUrl.searchParams.entries()) {
-			rewrittenRequestUrl.searchParams.append(key, value);
-		}
-		return rewrittenRequestUrl;
+	#createRouter(php: PHP): RequestRouter {
+		const fs: RouterFilesystem = {
+			isFile: (path: string) => php.isFile(path),
+			isDir: (path: string) => php.isDir(path),
+		};
+		return new RequestRouter({
+			documentRoot: this.#DOCROOT,
+			pathname: this.#PATHNAME,
+			rewriteRules: this.rewriteRules,
+			pathAliases: this.#pathAliases,
+			getFileNotFoundAction: (uri) => this.getFileNotFoundAction(uri),
+			fs,
+		});
 	}
 
 	/**
@@ -930,23 +888,4 @@ export function applyRewriteRules(path: string, rules: RewriteRule[]): string {
 		}
 	}
 	return path;
-}
-
-/**
- * Checks if the given URL looks like an absolute URL.
- *
- * @param url - The URL to check.
- * @returns `true` if the URL looks like an absolute URL, `false` otherwise.
- */
-function looksLikeAbsoluteUrl(url: string): boolean {
-	try {
-		// NOTE: We could just use URL.canParse() but are avoiding it here
-		// because we've seen users with older Safari versions that don't support it.
-		// Maybe Playground will break in other ways for them,
-		// but since this is an easy, low-risk change, let's give it a try.
-		new URL(url);
-		return true;
-	} catch {
-		return false;
-	}
 }

--- a/packages/php-wasm/universal/src/lib/php-request-handler.ts
+++ b/packages/php-wasm/universal/src/lib/php-request-handler.ts
@@ -1,4 +1,4 @@
-import { dirname, joinPaths } from '@php-wasm/util';
+import { joinPaths } from '@php-wasm/util';
 import {
 	ensurePathPrefix,
 	toRelativeUrl,
@@ -16,6 +16,8 @@ import type { PHPInstanceManager, AcquiredPHP } from './php-instance-manager';
 import { SinglePHPInstanceManager } from './single-php-instance-manager';
 import { HttpCookieStore } from './http-cookie-store';
 import mimeTypes from './mime-types.json';
+import { RequestRouter } from './request-router';
+import type { RouterFilesystem } from './request-router';
 
 export type RewriteRule = {
 	match: RegExp;
@@ -209,6 +211,8 @@ export class PHPRequestHandler implements AsyncDisposable {
 	#PATHNAME: string;
 	#ABSOLUTE_URL: string;
 	#cookieStore: CookieStore | false;
+	#router: RequestRouter | undefined;
+	#routerFs: RouterFilesystem | undefined;
 	#pathAliases: PathAlias[];
 	rewriteRules: RewriteRule[];
 	/**
@@ -448,150 +452,63 @@ export class PHPRequestHandler implements AsyncDisposable {
 	 * @returns A StreamedPHPResponse.
 	 */
 	async requestStreamed(request: PHPRequest): Promise<StreamedPHPResponse> {
-		const isAbsolute = looksLikeAbsoluteUrl(request.url);
-		const originalRequestUrl = new URL(
-			// Remove the hash part of the URL as it's not meant for the server.
-			request.url.split('#')[0],
-			isAbsolute ? undefined : DEFAULT_BASE_URL
-		);
-
-		const rewrittenRequestUrl = this.#applyRewriteRules(originalRequestUrl);
 		const primaryPhp = await this.getPrimaryPhp();
-		/**
-		 * Turn a URL such as `https://playground/scope:my-site/wp-admin/index.php`
-		 * into a site-relative path, such as `/wp-admin/index.php`.
-		 */
-		const siteRelativePath = removePathPrefix(
-			/**
-			 * URL.pathname returns a URL-encoded path. We need to decode it
-			 * before using it as a filesystem path.
-			 */
-			decodeURIComponent(rewrittenRequestUrl.pathname),
-			this.#PATHNAME
-		);
-		let fsPath = this.#resolveToFsPath(siteRelativePath);
-		if (primaryPhp.isDir(fsPath)) {
-			// Ensure directory URIs have a trailing slash. Otherwise,
-			// relative URIs in index.php or index.html files are relative
-			// to the next directory up.
-			//
-			// Example:
-			// For an index page served for URI "/settings", we naturally expect
-			// links to be relative to "/settings", but without the trailing
-			// slash, a relative link "edit.php" resolves to "/edit.php"
-			// rather than "/settings/edit.php".
-			//
-			// This treatment of relative links is correct behavior for the browser:
-			// https://www.rfc-editor.org/rfc/rfc3986#section-5.2.3
-			//
-			// But user intent for `/settings/index.php` is that its relative
-			// URIs are relative to `/settings/`. So we redirect to add a
-			// trailing slash to directory URIs to meet this expecatation.
-			//
-			// This behavior is also necessary for WordPress to function properly.
-			// Otherwise, when viewing the WP admin dashboard at `/wp-admin`,
-			// links to other admin pages like `edit.php` will incorrectly
-			// resolve to `/edit.php` rather than `/wp-admin/edit.php`.
-			if (!siteRelativePath.endsWith('/')) {
-				return StreamedPHPResponse.fromPHPResponse(
-					new PHPResponse(
-						301,
-						{ location: [`${rewrittenRequestUrl.pathname}/`] },
-						new Uint8Array(0)
-					)
+		const router = this.#getRouter(primaryPhp);
+		const route = router.resolve(request);
+
+		switch (route.type) {
+			case 'static-file':
+				return this.#streamStaticFile(primaryPhp, route.fsPath);
+			case 'php': {
+				const isAbsolute = looksLikeAbsoluteUrl(request.url);
+				const originalRequestUrl = new URL(
+					request.url.split('#')[0],
+					isAbsolute ? undefined : DEFAULT_BASE_URL
 				);
-			}
-
-			// We can only satisfy requests for directories with a default file
-			// so let's first resolve to a default path when available.
-			for (const possibleIndexFile of ['index.php', 'index.html']) {
-				const possibleIndexPath = joinPaths(fsPath, possibleIndexFile);
-				if (primaryPhp.isFile(possibleIndexPath)) {
-					fsPath = possibleIndexPath;
-
-					// Include the resolved index file in the final rewritten request URL.
-					rewrittenRequestUrl.pathname = joinPaths(
-						rewrittenRequestUrl.pathname,
-						possibleIndexFile
-					);
-					break;
-				}
-			}
-		}
-
-		if (!primaryPhp.isFile(fsPath)) {
-			/**
-			 * Try resolving a partial path.
-			 *
-			 * Example:
-			 *
-			 * – Request URL: /file.php/index.php
-			 * – Document Root: /var/www
-			 *
-			 * If /var/www/file.php/index.php does not exist, but /var/www/file.php does,
-			 * use /var/www/file.php. This is also what Apache and PHP Dev Server do.
-			 */
-			let pathToTry = siteRelativePath;
-			while (
-				pathToTry.startsWith('/') &&
-				pathToTry !== dirname(pathToTry)
-			) {
-				pathToTry = dirname(pathToTry);
-				const resolvedPathToTry = this.#resolveToFsPath(pathToTry);
-				if (
-					primaryPhp.isFile(resolvedPathToTry) &&
-					// Only run partial path resolution for PHP files.
-					resolvedPathToTry.endsWith('.php')
-				) {
-					fsPath = this.#resolveToFsPath(pathToTry);
-					break;
-				}
-			}
-		}
-
-		if (!primaryPhp.isFile(fsPath)) {
-			const fileNotFoundAction = this.getFileNotFoundAction(
-				rewrittenRequestUrl.pathname
-			);
-			switch (fileNotFoundAction.type) {
-				case 'response':
-					return StreamedPHPResponse.fromPHPResponse(
-						fileNotFoundAction.response
-					);
-				case 'internal-redirect':
-					fsPath = joinPaths(this.#DOCROOT, fileNotFoundAction.uri);
-					break;
-				case '404':
-					return StreamedPHPResponse.forHttpCode(404);
-				default:
-					throw new Error(
-						'Unsupported file-not-found action type: ' +
-							// Cast because TS asserts the remaining possibility is `never`
-							`'${
-								(fileNotFoundAction as FileNotFoundAction).type
-							}'`
-					);
-			}
-		}
-
-		// We need to confirm that the current target file exists because
-		// file-not-found fallback actions may redirect to non-existent files.
-		if (primaryPhp.isFile(fsPath)) {
-			if (fsPath.endsWith('.php')) {
+				const rewrittenRequestUrl =
+					this.#applyRewriteRules(originalRequestUrl);
 				return await this.#spawnPHPAndDispatchRequest(
 					request,
 					originalRequestUrl,
 					rewrittenRequestUrl,
-					fsPath
-				);
-			} else {
-				return StreamedPHPResponse.fromPHPResponse(
-					this.#serveStaticFile(primaryPhp, fsPath)
+					route.fsPath
 				);
 			}
-		} else {
-			return StreamedPHPResponse.forHttpCode(404);
+			case 'redirect':
+				return StreamedPHPResponse.fromPHPResponse(
+					new PHPResponse(
+						route.statusCode,
+						route.headers,
+						new Uint8Array(0)
+					)
+				);
+			case 'response':
+				return StreamedPHPResponse.fromPHPResponse(route.response);
+			case '404':
+				return StreamedPHPResponse.forHttpCode(404);
 		}
+	}
+
+	/**
+	 * Gets or creates the RequestRouter instance, lazily
+	 * initializing the filesystem wrapper on first use.
+	 */
+	#getRouter(php: PHP): RequestRouter {
+		if (!this.#router) {
+			this.#routerFs = {
+				isFile: (path: string) => php.isFile(path),
+				isDir: (path: string) => php.isDir(path),
+			};
+			this.#router = new RequestRouter({
+				documentRoot: this.#DOCROOT,
+				pathname: this.#PATHNAME,
+				rewriteRules: this.rewriteRules,
+				pathAliases: this.#pathAliases,
+				getFileNotFoundAction: this.getFileNotFoundAction,
+				fs: this.#routerFs,
+			});
+		}
+		return this.#router;
 	}
 
 	/**
@@ -621,50 +538,54 @@ export class PHPRequestHandler implements AsyncDisposable {
 	}
 
 	/**
-	 * Resolves a URL path to a filesystem path, checking path aliases first.
+	 * Streams a static file from the PHP filesystem
+	 * without buffering it entirely in memory.
 	 *
-	 * If the URL path matches a configured alias prefix, the alias's
-	 * filesystem path is used instead of the document root.
-	 *
-	 * @param urlPath - The URL path to resolve (e.g., '/phpmyadmin/index.php')
-	 * @returns The resolved filesystem path
+	 * @param fsPath - Absolute path of the static file.
+	 * @returns A streamed response.
 	 */
-	#resolveToFsPath(urlPath: string): string {
-		// Check if the URL path matches any alias
-		for (const alias of this.#pathAliases) {
-			if (
-				urlPath === alias.urlPrefix ||
-				urlPath.startsWith(alias.urlPrefix + '/')
-			) {
-				// Replace the URL prefix with the filesystem path
-				const relativePath = urlPath.slice(alias.urlPrefix.length);
-				return joinPaths(alias.fsPath, relativePath);
+	#streamStaticFile(php: PHP, fsPath: string): StreamedPHPResponse {
+		const { fileSize, stream: stdout } = php.streamFile(fsPath);
+
+		const headers: Record<string, string[]> = {
+			'content-length': [`${fileSize}`],
+			// @TODO: Infer the content-type from the file
+			// contents instead of the file path. The code
+			// below won't return the correct mime-type if
+			// the extension was tampered with.
+			'content-type': [inferMimeType(fsPath)],
+			'accept-ranges': ['bytes'],
+			'cache-control': ['public, max-age=0'],
+		};
+
+		const headerLines: string[] = [];
+		for (const [name, values] of Object.entries(headers)) {
+			for (const value of values) {
+				headerLines.push(`${name}: ${value}`);
 			}
 		}
-		// No alias matched, use the document root
-		return joinPaths(this.#DOCROOT, urlPath);
-	}
-
-	/**
-	 * Serves a static file from the PHP filesystem.
-	 *
-	 * @param  fsPath - Absolute path of the static file to serve.
-	 * @returns The response.
-	 */
-	#serveStaticFile(php: PHP, fsPath: string): PHPResponse {
-		const arrayBuffer = php.readFileAsBuffer(fsPath);
-		return new PHPResponse(
-			200,
-			{
-				'content-length': [`${arrayBuffer.byteLength}`],
-				// @TODO: Infer the content-type from the arrayBuffer instead of the
-				// file path. The code below won't return the correct mime-type if the
-				// extension was tampered with.
-				'content-type': [inferMimeType(fsPath)],
-				'accept-ranges': ['bytes'],
-				'cache-control': ['public, max-age=0'],
+		const headersJson = JSON.stringify({
+			status: 200,
+			headers: headerLines,
+		});
+		const headersStream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(headersJson));
+				controller.close();
 			},
-			arrayBuffer
+		});
+
+		const stderr = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.close();
+			},
+		});
+
+		return new StreamedPHPResponse(
+			headersStream,
+			stdout,
+			stderr,
+			Promise.resolve(0)
 		);
 	}
 
@@ -753,7 +674,8 @@ export class PHPRequestHandler implements AsyncDisposable {
 			$_SERVER: this.prepare_$_SERVER_superglobal(
 				originalRequestUrl,
 				rewrittenRequestUrl,
-				scriptPath
+				scriptPath,
+				request.protocolVersion
 			),
 			body,
 			scriptPath,
@@ -863,12 +785,14 @@ export class PHPRequestHandler implements AsyncDisposable {
 	private prepare_$_SERVER_superglobal(
 		originalRequestUrl: URL,
 		rewrittenRequestUrl: URL,
-		resolvedScriptPath: string
+		resolvedScriptPath: string,
+		protocolVersion?: string
 	): Record<string, string> {
 		const $_SERVER: Record<string, string> = {
 			REMOTE_ADDR: '127.0.0.1',
 			DOCUMENT_ROOT: this.#DOCROOT,
 			HTTPS: this.#ABSOLUTE_URL.startsWith('https://') ? 'on' : '',
+			SERVER_PROTOCOL: protocolVersion || 'HTTP/1.1',
 		};
 
 		/**

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1205,6 +1205,29 @@ export class PHP implements Disposable {
 	}
 
 	/**
+	 * Reads a file from the PHP filesystem and returns it as a
+	 * ReadableStream, reading in chunks to avoid buffering the
+	 * entire file in memory at once.
+	 *
+	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file
+	 *   doesn't exist.
+	 * @param path - The file path to read.
+	 * @param chunkSize - The size of each chunk in bytes.
+	 * @returns An object with the file size and a ReadableStream
+	 *   of the file contents.
+	 */
+	streamFile(
+		path: string,
+		chunkSize?: number
+	): { fileSize: number; stream: ReadableStream<Uint8Array> } {
+		return FSHelpers.streamFile(
+			this[__private__dont__use].FS,
+			path,
+			chunkSize
+		);
+	}
+
+	/**
 	 * Overwrites data in a file in the PHP filesystem.
 	 * Creates a new file if one doesn't exist yet.
 	 *

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1205,29 +1205,6 @@ export class PHP implements Disposable {
 	}
 
 	/**
-	 * Reads a file from the PHP filesystem and returns it as a
-	 * ReadableStream, reading in chunks to avoid buffering the
-	 * entire file in memory at once.
-	 *
-	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file
-	 *   doesn't exist.
-	 * @param path - The file path to read.
-	 * @param chunkSize - The size of each chunk in bytes.
-	 * @returns An object with the file size and a ReadableStream
-	 *   of the file contents.
-	 */
-	streamFile(
-		path: string,
-		chunkSize?: number
-	): { fileSize: number; stream: ReadableStream<Uint8Array> } {
-		return FSHelpers.streamFile(
-			this[__private__dont__use].FS,
-			path,
-			chunkSize
-		);
-	}
-
-	/**
 	 * Overwrites data in a file in the PHP filesystem.
 	 * Creates a new file if one doesn't exist yet.
 	 *

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1182,29 +1182,6 @@ export class PHP implements Disposable {
 	}
 
 	/**
-	 * Reads a file from the PHP filesystem and returns it as a
-	 * ReadableStream, reading in chunks to avoid buffering the
-	 * entire file in memory at once.
-	 *
-	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file
-	 *   doesn't exist.
-	 * @param path - The file path to read.
-	 * @param chunkSize - The size of each chunk in bytes.
-	 * @returns An object with the file size and a ReadableStream
-	 *   of the file contents.
-	 */
-	streamFile(
-		path: string,
-		chunkSize?: number
-	): { fileSize: number; stream: ReadableStream<Uint8Array> } {
-		return FSHelpers.streamFile(
-			this[__private__dont__use].FS,
-			path,
-			chunkSize
-		);
-	}
-
-	/**
 	 * Overwrites data in a file in the PHP filesystem.
 	 * Creates a new file if one doesn't exist yet.
 	 *

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1182,6 +1182,29 @@ export class PHP implements Disposable {
 	}
 
 	/**
+	 * Reads a file from the PHP filesystem and returns it as a
+	 * ReadableStream, reading in chunks to avoid buffering the
+	 * entire file in memory at once.
+	 *
+	 * @throws {@link @php-wasm/universal:ErrnoError} – If the file
+	 *   doesn't exist.
+	 * @param path - The file path to read.
+	 * @param chunkSize - The size of each chunk in bytes.
+	 * @returns An object with the file size and a ReadableStream
+	 *   of the file contents.
+	 */
+	streamFile(
+		path: string,
+		chunkSize?: number
+	): { fileSize: number; stream: ReadableStream<Uint8Array> } {
+		return FSHelpers.streamFile(
+			this[__private__dont__use].FS,
+			path,
+			chunkSize
+		);
+	}
+
+	/**
 	 * Overwrites data in a file in the PHP filesystem.
 	 * Creates a new file if one doesn't exist yet.
 	 *

--- a/packages/php-wasm/universal/src/lib/request-router.spec.ts
+++ b/packages/php-wasm/universal/src/lib/request-router.spec.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it } from 'vitest';
+import { RequestRouter } from './request-router';
+import type { RouterFilesystem, ResolvedRoute } from './request-router';
+import { PHPResponse } from './php-response';
+
+/**
+ * Creates a mock RouterFilesystem backed by a Map.
+ */
+function createMockFs(entries: Map<string, 'file' | 'dir'>): RouterFilesystem {
+	return {
+		isFile: (path: string) => entries.get(path) === 'file',
+		isDir: (path: string) => entries.get(path) === 'dir',
+	};
+}
+
+describe('RequestRouter', () => {
+	describe('static files', () => {
+		it('resolves a static file', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/style.css', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				fs,
+			});
+
+			const route = router.resolve({ url: '/style.css' });
+			expect(route).toEqual({
+				type: 'static-file',
+				fsPath: '/www/style.css',
+			});
+		});
+
+		it('resolves nested static files', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/assets/img/logo.png', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				fs,
+			});
+
+			const route = router.resolve({
+				url: '/assets/img/logo.png',
+			});
+			expect(route).toEqual({
+				type: 'static-file',
+				fsPath: '/www/assets/img/logo.png',
+			});
+		});
+	});
+
+	describe('PHP files', () => {
+		it('resolves a PHP file', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				fs,
+			});
+
+			const route = router.resolve({ url: '/index.php' });
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/www/index.php',
+			});
+		});
+
+		it('resolves partial path (PATH_INFO) to PHP file', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/file.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				fs,
+			});
+
+			const route = router.resolve({
+				url: '/file.php/extra/path',
+			});
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/www/file.php',
+			});
+		});
+	});
+
+	describe('directories', () => {
+		it('redirects dir without trailing slash', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/subdir', 'dir'],
+					['/www/subdir/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				fs,
+			});
+
+			const route = router.resolve({ url: '/subdir' });
+			expect(route).toEqual({
+				type: 'redirect',
+				statusCode: 301,
+				headers: { location: ['/subdir/'] },
+			});
+		});
+
+		it('resolves dir with trailing slash to index.php', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/subdir', 'dir'],
+					['/www/subdir/', 'dir'],
+					['/www/subdir/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				fs,
+			});
+
+			const route = router.resolve({ url: '/subdir/' });
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/www/subdir/index.php',
+			});
+		});
+
+		it('resolves dir with trailing slash to index.html', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/docs', 'dir'],
+					['/www/docs/', 'dir'],
+					['/www/docs/index.html', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				fs,
+			});
+
+			const route = router.resolve({ url: '/docs/' });
+			expect(route).toEqual({
+				type: 'static-file',
+				fsPath: '/www/docs/index.html',
+			});
+		});
+	});
+
+	describe('file not found', () => {
+		it('returns 404 by default', () => {
+			const fs = createMockFs(new Map([['/www', 'dir']]));
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				fs,
+			});
+
+			const route = router.resolve({ url: '/nonexistent.txt' });
+			expect(route).toEqual({ type: '404' });
+		});
+
+		it('handles internal-redirect action (WordPress fallback)', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				getFileNotFoundAction: () => ({
+					type: 'internal-redirect',
+					uri: '/index.php',
+				}),
+				fs,
+			});
+
+			const route = router.resolve({
+				url: '/pretty-permalink',
+			});
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/www/index.php',
+			});
+		});
+
+		it('handles response action', () => {
+			const customResponse = new PHPResponse(
+				403,
+				{ 'content-type': ['text/plain'] },
+				new Uint8Array(Buffer.from('Forbidden'))
+			);
+			const fs = createMockFs(new Map([['/www', 'dir']]));
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				getFileNotFoundAction: () => ({
+					type: 'response',
+					response: customResponse,
+				}),
+				fs,
+			});
+
+			const route = router.resolve({ url: '/secret' });
+			expect(route.type).toBe('response');
+			expect(
+				(route as Extract<ResolvedRoute, { type: 'response' }>).response
+			).toBe(customResponse);
+		});
+	});
+
+	describe('rewrite rules', () => {
+		it('applies rewrite rules before routing', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				rewriteRules: [
+					{
+						match: /^\/api\/(.*)$/,
+						replacement: '/index.php?route=$1',
+					},
+				],
+				getFileNotFoundAction: () => ({
+					type: 'internal-redirect',
+					uri: '/index.php',
+				}),
+				fs,
+			});
+
+			const route = router.resolve({ url: '/api/users' });
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/www/index.php',
+			});
+		});
+
+		it('WordPress multisite rewrite rule strips site prefix', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/wp-admin/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				rewriteRules: [
+					{
+						match: new RegExp(
+							`^(/[_0-9a-zA-Z-]+)?(/wp-(content|admin|includes).*)`
+						),
+						replacement: '$2',
+					},
+				],
+				fs,
+			});
+
+			const route = router.resolve({
+				url: '/mysite/wp-admin/index.php',
+			});
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/www/wp-admin/index.php',
+			});
+		});
+	});
+
+	describe('path aliases', () => {
+		it('resolves aliased paths', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/tools/phpmyadmin', 'dir'],
+					['/tools/phpmyadmin/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				pathAliases: [
+					{
+						urlPrefix: '/phpmyadmin',
+						fsPath: '/tools/phpmyadmin',
+					},
+				],
+				fs,
+			});
+
+			const route = router.resolve({
+				url: '/phpmyadmin/index.php',
+			});
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/tools/phpmyadmin/index.php',
+			});
+		});
+
+		it('falls back to document root for non-aliased paths', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/index.php', 'file'],
+					['/tools/phpmyadmin', 'dir'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				pathAliases: [
+					{
+						urlPrefix: '/phpmyadmin',
+						fsPath: '/tools/phpmyadmin',
+					},
+				],
+				fs,
+			});
+
+			const route = router.resolve({ url: '/index.php' });
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/www/index.php',
+			});
+		});
+
+		it('matches alias exactly at prefix boundary', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/phpmyadmin-extra', 'dir'],
+					['/www/phpmyadmin-extra/index.php', 'file'],
+					['/tools/phpmyadmin', 'dir'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				pathAliases: [
+					{
+						urlPrefix: '/phpmyadmin',
+						fsPath: '/tools/phpmyadmin',
+					},
+				],
+				fs,
+			});
+
+			const route = router.resolve({
+				url: '/phpmyadmin-extra/index.php',
+			});
+			// Should resolve in document root, not alias
+			expect(route).toEqual({
+				type: 'php',
+				fsPath: '/www/phpmyadmin-extra/index.php',
+			});
+		});
+	});
+
+	describe('URL pathname prefix', () => {
+		it('strips pathname prefix before resolving', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/style.css', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				pathname: '/scope:mysite',
+				fs,
+			});
+
+			const route = router.resolve({
+				url: '/scope:mysite/style.css',
+			});
+			expect(route).toEqual({
+				type: 'static-file',
+				fsPath: '/www/style.css',
+			});
+		});
+	});
+});

--- a/packages/php-wasm/universal/src/lib/request-router.spec.ts
+++ b/packages/php-wasm/universal/src/lib/request-router.spec.ts
@@ -70,7 +70,7 @@ describe('RequestRouter', () => {
 			});
 
 			const route = router.resolve({ url: '/index.php' });
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/www/index.php',
 			});
@@ -91,7 +91,7 @@ describe('RequestRouter', () => {
 			const route = router.resolve({
 				url: '/file.php/extra/path',
 			});
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/www/file.php',
 			});
@@ -135,7 +135,7 @@ describe('RequestRouter', () => {
 			});
 
 			const route = router.resolve({ url: '/subdir/' });
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/www/subdir/index.php',
 			});
@@ -194,7 +194,7 @@ describe('RequestRouter', () => {
 			const route = router.resolve({
 				url: '/pretty-permalink',
 			});
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/www/index.php',
 			});
@@ -248,7 +248,7 @@ describe('RequestRouter', () => {
 			});
 
 			const route = router.resolve({ url: '/api/users' });
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/www/index.php',
 			});
@@ -277,7 +277,7 @@ describe('RequestRouter', () => {
 			const route = router.resolve({
 				url: '/mysite/wp-admin/index.php',
 			});
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/www/wp-admin/index.php',
 			});
@@ -307,7 +307,7 @@ describe('RequestRouter', () => {
 			const route = router.resolve({
 				url: '/phpmyadmin/index.php',
 			});
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/tools/phpmyadmin/index.php',
 			});
@@ -333,7 +333,7 @@ describe('RequestRouter', () => {
 			});
 
 			const route = router.resolve({ url: '/index.php' });
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/www/index.php',
 			});
@@ -363,7 +363,7 @@ describe('RequestRouter', () => {
 				url: '/phpmyadmin-extra/index.php',
 			});
 			// Should resolve in document root, not alias
-			expect(route).toEqual({
+			expect(route).toMatchObject({
 				type: 'php',
 				fsPath: '/www/phpmyadmin-extra/index.php',
 			});
@@ -391,6 +391,143 @@ describe('RequestRouter', () => {
 				type: 'static-file',
 				fsPath: '/www/style.css',
 			});
+		});
+	});
+
+	/**
+	 * PHPRequestHandler derives $_SERVER['PHP_SELF'] and the relative URI it
+	 * hands to PHP from `rewrittenRequestUrl`, so the router must report the
+	 * URL it actually resolved `fsPath` from — including the directory index
+	 * file it appended and the query string the rewrite rules produced.
+	 */
+	describe('rewritten request URL of PHP routes', () => {
+		function resolvePhpRoute(
+			router: RequestRouter,
+			url: string
+		): Extract<ResolvedRoute, { type: 'php' }> {
+			const route = router.resolve({ url });
+			if (route.type !== 'php') {
+				throw new Error(`Expected a PHP route, got '${route.type}'`);
+			}
+			return route;
+		}
+
+		it('appends the resolved index file for a directory request', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/subdir', 'dir'],
+					['/www/subdir/', 'dir'],
+					['/www/subdir/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({ documentRoot: '/www', fs });
+
+			const route = resolvePhpRoute(router, '/subdir/');
+			expect(route.rewrittenRequestUrl.pathname).toBe(
+				'/subdir/index.php'
+			);
+			expect(route.originalRequestUrl.pathname).toBe('/subdir/');
+		});
+
+		it('appends the resolved index file for the document root', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					// `/` resolves to the document root with a trailing slash.
+					['/www/', 'dir'],
+					['/www/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({ documentRoot: '/www', fs });
+
+			expect(
+				resolvePhpRoute(router, '/').rewrittenRequestUrl.pathname
+			).toBe('/index.php');
+		});
+
+		it('preserves the query string of a directory request', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/subdir', 'dir'],
+					['/www/subdir/', 'dir'],
+					['/www/subdir/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({ documentRoot: '/www', fs });
+
+			const route = resolvePhpRoute(router, '/subdir/?foo=bar');
+			expect(route.rewrittenRequestUrl.pathname).toBe(
+				'/subdir/index.php'
+			);
+			expect(route.rewrittenRequestUrl.search).toBe('?foo=bar');
+		});
+
+		it('reports the rewritten path and merged query string', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				rewriteRules: [
+					{
+						match: /^\/api\/(.*)$/,
+						replacement: '/index.php?route=$1',
+					},
+				],
+				fs,
+			});
+
+			const route = resolvePhpRoute(router, '/api/users?page=2');
+			expect(route.rewrittenRequestUrl.pathname).toBe('/index.php');
+			expect(route.rewrittenRequestUrl.searchParams.get('route')).toBe(
+				'users'
+			);
+			expect(route.rewrittenRequestUrl.searchParams.get('page')).toBe(
+				'2'
+			);
+			expect(route.originalRequestUrl.pathname).toBe('/api/users');
+		});
+
+		it('keeps the pathname prefix in the rewritten URL', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/wp-admin', 'dir'],
+					['/www/wp-admin/', 'dir'],
+					['/www/wp-admin/index.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({
+				documentRoot: '/www',
+				pathname: '/scope:mysite',
+				fs,
+			});
+
+			const route = resolvePhpRoute(router, '/scope:mysite/wp-admin/');
+			expect(route.rewrittenRequestUrl.pathname).toBe(
+				'/scope:mysite/wp-admin/index.php'
+			);
+		});
+
+		it('leaves the trailing path info of a partial path match', () => {
+			const fs = createMockFs(
+				new Map([
+					['/www', 'dir'],
+					['/www/file.php', 'file'],
+				])
+			);
+			const router = new RequestRouter({ documentRoot: '/www', fs });
+
+			const route = resolvePhpRoute(router, '/file.php/extra/path');
+			expect(route.fsPath).toBe('/www/file.php');
+			expect(route.rewrittenRequestUrl.pathname).toBe(
+				'/file.php/extra/path'
+			);
 		});
 	});
 });

--- a/packages/php-wasm/universal/src/lib/request-router.ts
+++ b/packages/php-wasm/universal/src/lib/request-router.ts
@@ -1,0 +1,212 @@
+import { dirname, joinPaths } from '@php-wasm/util';
+import { removePathPrefix } from './urls';
+import type { PHPResponse } from './php-response';
+import type { PHPRequest } from './universal-php';
+import type {
+	RewriteRule,
+	PathAlias,
+	FileNotFoundGetActionCallback,
+	FileNotFoundAction,
+} from './php-request-handler';
+import { applyRewriteRules } from './php-request-handler';
+
+/**
+ * Minimal filesystem interface for routing decisions.
+ * Implementations can back this with a WASM filesystem,
+ * host filesystem, or any other source.
+ */
+export interface RouterFilesystem {
+	isFile(path: string): boolean;
+	isDir(path: string): boolean;
+}
+
+export type ResolvedRoute =
+	| { type: 'static-file'; fsPath: string }
+	| { type: 'php'; fsPath: string }
+	| {
+			type: 'redirect';
+			statusCode: number;
+			headers: Record<string, string[]>;
+	  }
+	| { type: '404' }
+	| { type: 'response'; response: PHPResponse };
+
+export interface RequestRouterConfig {
+	documentRoot: string;
+	/**
+	 * URL path prefix (e.g., '/scope:xxx'). Stripped from
+	 * request URLs before filesystem resolution.
+	 */
+	pathname?: string;
+	rewriteRules?: RewriteRule[];
+	pathAliases?: PathAlias[];
+	getFileNotFoundAction?: FileNotFoundGetActionCallback;
+	fs: RouterFilesystem;
+}
+
+/**
+ * A pure routing engine that resolves a request URL to a routing
+ * decision. Has no PHP dependency — only needs a filesystem
+ * abstraction for isFile/isDir checks.
+ *
+ * This class encapsulates the routing logic previously embedded in
+ * PHPRequestHandler.requestStreamed(), making it reusable on the
+ * main thread (e.g., the CLI can create a router backed by the
+ * host filesystem to serve static files without a worker round-trip).
+ */
+export class RequestRouter {
+	#documentRoot: string;
+	#pathname: string;
+	#rewriteRules: RewriteRule[];
+	#pathAliases: PathAlias[];
+	#getFileNotFoundAction: FileNotFoundGetActionCallback;
+	#fs: RouterFilesystem;
+
+	constructor(config: RequestRouterConfig) {
+		this.#documentRoot = config.documentRoot;
+		this.#pathname = config.pathname ?? '';
+		this.#rewriteRules = config.rewriteRules ?? [];
+		this.#pathAliases = config.pathAliases ?? [];
+		this.#getFileNotFoundAction =
+			config.getFileNotFoundAction ?? (() => ({ type: '404' }));
+		this.#fs = config.fs;
+	}
+
+	resolve(request: PHPRequest): ResolvedRoute {
+		const isAbsolute = looksLikeAbsoluteUrl(request.url);
+		const originalRequestUrl = new URL(
+			request.url.split('#')[0],
+			isAbsolute ? undefined : 'http://example.com'
+		);
+
+		const rewrittenRequestUrl = this.#applyRewriteRules(originalRequestUrl);
+
+		const siteRelativePath = removePathPrefix(
+			decodeURIComponent(rewrittenRequestUrl.pathname),
+			this.#pathname
+		);
+		let fsPath = this.#resolveToFsPath(siteRelativePath);
+
+		if (this.#fs.isDir(fsPath)) {
+			if (!siteRelativePath.endsWith('/')) {
+				return {
+					type: 'redirect',
+					statusCode: 301,
+					headers: {
+						location: [`${rewrittenRequestUrl.pathname}/`],
+					},
+				};
+			}
+
+			for (const possibleIndexFile of ['index.php', 'index.html']) {
+				const possibleIndexPath = joinPaths(fsPath, possibleIndexFile);
+				if (this.#fs.isFile(possibleIndexPath)) {
+					fsPath = possibleIndexPath;
+					rewrittenRequestUrl.pathname = joinPaths(
+						rewrittenRequestUrl.pathname,
+						possibleIndexFile
+					);
+					break;
+				}
+			}
+		}
+
+		if (!this.#fs.isFile(fsPath)) {
+			// Try resolving a partial path (e.g., /file.php/path-info)
+			let pathToTry = siteRelativePath;
+			while (
+				pathToTry.startsWith('/') &&
+				pathToTry !== dirname(pathToTry)
+			) {
+				pathToTry = dirname(pathToTry);
+				const resolvedPathToTry = this.#resolveToFsPath(pathToTry);
+				if (
+					this.#fs.isFile(resolvedPathToTry) &&
+					resolvedPathToTry.endsWith('.php')
+				) {
+					fsPath = this.#resolveToFsPath(pathToTry);
+					break;
+				}
+			}
+		}
+
+		if (!this.#fs.isFile(fsPath)) {
+			const fileNotFoundAction = this.#getFileNotFoundAction(
+				rewrittenRequestUrl.pathname
+			);
+			switch (fileNotFoundAction.type) {
+				case 'response':
+					return {
+						type: 'response',
+						response: fileNotFoundAction.response,
+					};
+				case 'internal-redirect':
+					fsPath = joinPaths(
+						this.#documentRoot,
+						fileNotFoundAction.uri
+					);
+					break;
+				case '404':
+					return { type: '404' };
+				default:
+					throw new Error(
+						'Unsupported file-not-found action type: ' +
+							`'${
+								(fileNotFoundAction as FileNotFoundAction).type
+							}'`
+					);
+			}
+		}
+
+		if (this.#fs.isFile(fsPath)) {
+			if (fsPath.endsWith('.php')) {
+				return { type: 'php', fsPath };
+			} else {
+				return { type: 'static-file', fsPath };
+			}
+		}
+
+		return { type: '404' };
+	}
+
+	#applyRewriteRules(originalRequestUrl: URL): URL {
+		const siteRelativePath = removePathPrefix(
+			decodeURIComponent(originalRequestUrl.pathname),
+			this.#pathname
+		);
+		const rewrittenRequestPath = applyRewriteRules(
+			siteRelativePath,
+			this.#rewriteRules
+		);
+		const rewrittenRequestUrl = new URL(
+			joinPaths(this.#pathname, rewrittenRequestPath),
+			originalRequestUrl.toString()
+		);
+		for (const [key, value] of originalRequestUrl.searchParams.entries()) {
+			rewrittenRequestUrl.searchParams.append(key, value);
+		}
+		return rewrittenRequestUrl;
+	}
+
+	#resolveToFsPath(urlPath: string): string {
+		for (const alias of this.#pathAliases) {
+			if (
+				urlPath === alias.urlPrefix ||
+				urlPath.startsWith(alias.urlPrefix + '/')
+			) {
+				const relativePath = urlPath.slice(alias.urlPrefix.length);
+				return joinPaths(alias.fsPath, relativePath);
+			}
+		}
+		return joinPaths(this.#documentRoot, urlPath);
+	}
+}
+
+function looksLikeAbsoluteUrl(url: string): boolean {
+	try {
+		new URL(url);
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/packages/php-wasm/universal/src/lib/request-router.ts
+++ b/packages/php-wasm/universal/src/lib/request-router.ts
@@ -1,5 +1,5 @@
 import { dirname, joinPaths } from '@php-wasm/util';
-import { removePathPrefix } from './urls';
+import { DEFAULT_BASE_URL, removePathPrefix } from './urls';
 import type { PHPResponse } from './php-response';
 import type { PHPRequest } from './universal-php';
 import type {
@@ -22,7 +22,21 @@ export interface RouterFilesystem {
 
 export type ResolvedRoute =
 	| { type: 'static-file'; fsPath: string }
-	| { type: 'php'; fsPath: string }
+	| {
+			type: 'php';
+			fsPath: string;
+			/**
+			 * The request URL as it arrived, minus the hash.
+			 */
+			originalRequestUrl: URL;
+			/**
+			 * The request URL after the rewrite rules and the directory
+			 * index resolution have been applied. PHP superglobals such as
+			 * PHP_SELF and QUERY_STRING are derived from this URL, so it
+			 * must be the URL the router actually resolved `fsPath` from.
+			 */
+			rewrittenRequestUrl: URL;
+	  }
 	| {
 			type: 'redirect';
 			statusCode: number;
@@ -75,8 +89,9 @@ export class RequestRouter {
 	resolve(request: PHPRequest): ResolvedRoute {
 		const isAbsolute = looksLikeAbsoluteUrl(request.url);
 		const originalRequestUrl = new URL(
+			// Remove the hash part of the URL as it's not meant for the server.
 			request.url.split('#')[0],
-			isAbsolute ? undefined : 'http://example.com'
+			isAbsolute ? undefined : DEFAULT_BASE_URL
 		);
 
 		const rewrittenRequestUrl = this.#applyRewriteRules(originalRequestUrl);
@@ -160,7 +175,12 @@ export class RequestRouter {
 
 		if (this.#fs.isFile(fsPath)) {
 			if (fsPath.endsWith('.php')) {
-				return { type: 'php', fsPath };
+				return {
+					type: 'php',
+					fsPath,
+					originalRequestUrl,
+					rewrittenRequestUrl,
+				};
 			} else {
 				return { type: 'static-file', fsPath };
 			}
@@ -202,8 +222,18 @@ export class RequestRouter {
 	}
 }
 
+/**
+ * Checks if the given URL looks like an absolute URL.
+ *
+ * @param url - The URL to check.
+ * @returns `true` if the URL looks like an absolute URL, `false` otherwise.
+ */
 function looksLikeAbsoluteUrl(url: string): boolean {
 	try {
+		// NOTE: We could just use URL.canParse() but are avoiding it here
+		// because we've seen users with older Safari versions that don't support it.
+		// Maybe Playground will break in other ways for them,
+		// but since this is an easy, low-risk change, let's give it a try.
 		new URL(url);
 		return true;
 	} catch {

--- a/packages/php-wasm/universal/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/universal/src/test/php-request-handler.spec.ts
@@ -19,21 +19,6 @@ function createMockPHP(filesystem: Map<string, 'file' | 'dir'>) {
 			}
 			throw new Error(`File not found: ${path}`);
 		}),
-		streamFile: vi.fn((path: string) => {
-			if (filesystem.get(path) === 'file') {
-				const bytes = new Uint8Array(Buffer.from(`Content of ${path}`));
-				return {
-					fileSize: bytes.byteLength,
-					stream: new ReadableStream<Uint8Array>({
-						start(controller) {
-							controller.enqueue(bytes);
-							controller.close();
-						},
-					}),
-				};
-			}
-			throw new Error(`File not found: ${path}`);
-		}),
 		addEventListener: vi.fn(),
 		onMessage: vi.fn(() => Promise.resolve(() => {})),
 		dispatchEvent: vi.fn(),
@@ -278,23 +263,14 @@ describe('PHPRequestHandler', () => {
 				['/tools/phpmyadmin/styles.css', 'file'],
 			]);
 			const mockPHP = createMockPHP(filesystem);
-			(mockPHP.streamFile as ReturnType<typeof vi.fn>).mockImplementation(
-				(path: string) => {
-					if (path === '/tools/phpmyadmin/styles.css') {
-						const bytes = new Uint8Array(Buffer.from(cssContent));
-						return {
-							fileSize: bytes.byteLength,
-							stream: new ReadableStream<Uint8Array>({
-								start(controller) {
-									controller.enqueue(bytes);
-									controller.close();
-								},
-							}),
-						};
-					}
-					throw new Error(`File not found: ${path}`);
+			(
+				mockPHP.readFileAsBuffer as ReturnType<typeof vi.fn>
+			).mockImplementation((path: string) => {
+				if (path === '/tools/phpmyadmin/styles.css') {
+					return new Uint8Array(Buffer.from(cssContent));
 				}
-			);
+				throw new Error(`File not found: ${path}`);
+			});
 
 			const handler = new PHPRequestHandler({
 				php: mockPHP,
@@ -406,23 +382,14 @@ describe('PHPRequestHandler', () => {
 				['/www/app.css', 'file'],
 			]);
 			const mockPHP = createMockPHP(filesystem);
-			(mockPHP.streamFile as ReturnType<typeof vi.fn>).mockImplementation(
-				(path: string) => {
-					if (path === '/www/app.css') {
-						const bytes = new Uint8Array(Buffer.from(cssContent));
-						return {
-							fileSize: bytes.byteLength,
-							stream: new ReadableStream<Uint8Array>({
-								start(controller) {
-									controller.enqueue(bytes);
-									controller.close();
-								},
-							}),
-						};
-					}
-					throw new Error(`File not found: ${path}`);
+			(
+				mockPHP.readFileAsBuffer as ReturnType<typeof vi.fn>
+			).mockImplementation((path: string) => {
+				if (path === '/www/app.css') {
+					return new Uint8Array(Buffer.from(cssContent));
 				}
-			);
+				throw new Error(`File not found: ${path}`);
+			});
 
 			const handler = new PHPRequestHandler({
 				php: mockPHP,

--- a/packages/php-wasm/universal/src/test/php-request-handler.spec.ts
+++ b/packages/php-wasm/universal/src/test/php-request-handler.spec.ts
@@ -19,6 +19,21 @@ function createMockPHP(filesystem: Map<string, 'file' | 'dir'>) {
 			}
 			throw new Error(`File not found: ${path}`);
 		}),
+		streamFile: vi.fn((path: string) => {
+			if (filesystem.get(path) === 'file') {
+				const bytes = new Uint8Array(Buffer.from(`Content of ${path}`));
+				return {
+					fileSize: bytes.byteLength,
+					stream: new ReadableStream<Uint8Array>({
+						start(controller) {
+							controller.enqueue(bytes);
+							controller.close();
+						},
+					}),
+				};
+			}
+			throw new Error(`File not found: ${path}`);
+		}),
 		addEventListener: vi.fn(),
 		onMessage: vi.fn(() => Promise.resolve(() => {})),
 		dispatchEvent: vi.fn(),
@@ -263,14 +278,23 @@ describe('PHPRequestHandler', () => {
 				['/tools/phpmyadmin/styles.css', 'file'],
 			]);
 			const mockPHP = createMockPHP(filesystem);
-			(
-				mockPHP.readFileAsBuffer as ReturnType<typeof vi.fn>
-			).mockImplementation((path: string) => {
-				if (path === '/tools/phpmyadmin/styles.css') {
-					return new Uint8Array(Buffer.from(cssContent));
+			(mockPHP.streamFile as ReturnType<typeof vi.fn>).mockImplementation(
+				(path: string) => {
+					if (path === '/tools/phpmyadmin/styles.css') {
+						const bytes = new Uint8Array(Buffer.from(cssContent));
+						return {
+							fileSize: bytes.byteLength,
+							stream: new ReadableStream<Uint8Array>({
+								start(controller) {
+									controller.enqueue(bytes);
+									controller.close();
+								},
+							}),
+						};
+					}
+					throw new Error(`File not found: ${path}`);
 				}
-				throw new Error(`File not found: ${path}`);
-			});
+			);
 
 			const handler = new PHPRequestHandler({
 				php: mockPHP,
@@ -382,14 +406,23 @@ describe('PHPRequestHandler', () => {
 				['/www/app.css', 'file'],
 			]);
 			const mockPHP = createMockPHP(filesystem);
-			(
-				mockPHP.readFileAsBuffer as ReturnType<typeof vi.fn>
-			).mockImplementation((path: string) => {
-				if (path === '/www/app.css') {
-					return new Uint8Array(Buffer.from(cssContent));
+			(mockPHP.streamFile as ReturnType<typeof vi.fn>).mockImplementation(
+				(path: string) => {
+					if (path === '/www/app.css') {
+						const bytes = new Uint8Array(Buffer.from(cssContent));
+						return {
+							fileSize: bytes.byteLength,
+							stream: new ReadableStream<Uint8Array>({
+								start(controller) {
+									controller.enqueue(bytes);
+									controller.close();
+								},
+							}),
+						};
+					}
+					throw new Error(`File not found: ${path}`);
 				}
-				throw new Error(`File not found: ${path}`);
-			});
+			);
 
 			const handler = new PHPRequestHandler({
 				php: mockPHP,

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -81,8 +81,7 @@ import {
 } from './temp-dir';
 import {
 	type WordPressInstallMode,
-	wordPressRewriteRules,
-	getFileNotFoundActionForWordPress,
+	getWordPressRoutingConfig,
 } from '@wp-playground/wordpress';
 import {
 	type Mount,
@@ -2025,11 +2024,10 @@ function createMainThreadRouter(
 		},
 	};
 
+	// Built from the same config as the worker's PHPRequestHandler, so both
+	// resolve a request URL to the same file.
 	const router = new RequestRouter({
-		documentRoot: '/wordpress',
-		rewriteRules: wordPressRewriteRules,
-		pathAliases,
-		getFileNotFoundAction: getFileNotFoundActionForWordPress,
+		...getWordPressRoutingConfig({ pathAliases }),
 		fs: hostFs,
 	});
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -40,6 +40,7 @@ import fs, {
 	createReadStream,
 } from 'fs';
 import type { Server } from 'http';
+import { Readable } from 'stream';
 import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
 // @ts-ignore
 import {
@@ -1494,11 +1495,10 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			];
 
 			let handler: BlueprintsV1Handler | BlueprintsV2Handler;
-			const useBlueprintsV2Handler =
-				await shouldUseBlueprintsV2Handler(
-					args,
-					hasExplicitBlueprintsV2Mode
-				);
+			const useBlueprintsV2Handler = await shouldUseBlueprintsV2Handler(
+				args,
+				hasExplicitBlueprintsV2Mode
+			);
 			if (useBlueprintsV2Handler) {
 				validateAndNormalizeBlueprintsV2Args(
 					args,
@@ -1822,36 +1822,25 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					new PHPResponse(302, headers, new Uint8Array())
 				);
 			}
-			// Main-thread routing: resolve the request against the
-			// host filesystem to serve static files without a worker
-			// round-trip.
+			// Main-thread routing: serve static files straight from the
+			// host filesystem so they don't occupy a PHP worker.
+			//
+			// Only a `static-file` route is handled here, and only when the
+			// file is really present on the host. Every other outcome —
+			// PHP scripts, redirects, 404s, file-not-found fallbacks — is
+			// left to the worker, which owns the authoritative filesystem
+			// and request handler configuration. Answering those here would
+			// mean duplicating the worker's routing policy against a
+			// filesystem view that only covers the mounted directories.
 			if (mainThreadRouter && mapVfsToHost) {
 				const route = mainThreadRouter.resolve(request);
-				switch (route.type) {
-					case 'static-file': {
-						const hostPath = mapVfsToHost(route.fsPath);
-						if (hostPath) {
-							return serveStaticFileFromHost(hostPath);
-						}
-						break;
+				if (route.type === 'static-file') {
+					const hostPath = mapVfsToHost(route.fsPath);
+					const response =
+						hostPath && serveStaticFileFromHost(hostPath);
+					if (response) {
+						return response;
 					}
-					case 'redirect':
-						return StreamedPHPResponse.fromPHPResponse(
-							new PHPResponse(
-								route.statusCode,
-								route.headers,
-								new Uint8Array(0)
-							)
-						);
-					case 'response':
-						return StreamedPHPResponse.fromPHPResponse(
-							route.response
-						);
-					case '404':
-						return StreamedPHPResponse.forHttpCode(404);
-					case 'php':
-						// Fall through to the worker pool below.
-						break;
 				}
 			}
 
@@ -1990,11 +1979,17 @@ function createMainThreadRouter(
 	router: RequestRouter;
 	mapVfsToHost: (vfsPath: string) => string | undefined;
 } {
-	// Sort mounts longest-prefix-first so the most specific
-	// mount wins when multiple mounts overlap.
-	const sortedMounts = [...mounts].sort(
-		(a, b) => b.vfsPath.length - a.vfsPath.length
-	);
+	// Sort mounts longest-prefix-first so the most specific mount wins when
+	// multiple mounts overlap. Two mounts of the same VFS path are broken by
+	// mount order, so the last one applied wins — as it does in the VFS.
+	const sortedMounts = mounts
+		.map((mount, order) => ({ mount, order }))
+		.sort(
+			(a, b) =>
+				b.mount.vfsPath.length - a.mount.vfsPath.length ||
+				b.order - a.order
+		)
+		.map(({ mount }) => mount);
 
 	function mapVfsToHost(vfsPath: string): string | undefined {
 		for (const mount of sortedMounts) {
@@ -2045,14 +2040,26 @@ function createMainThreadRouter(
  * Serves a static file from the host filesystem as a
  * StreamedPHPResponse, using Node.js streams to avoid
  * buffering the entire file in memory.
+ *
+ * Returns `undefined` when the file cannot be stat'ed, which happens when
+ * it is removed between the router's `isFile()` check and this call. The
+ * caller then falls back to the PHP worker.
  */
-function serveStaticFileFromHost(hostPath: string): StreamedPHPResponse {
-	const stat = statSync(hostPath);
+function serveStaticFileFromHost(
+	hostPath: string
+): StreamedPHPResponse | undefined {
+	let size: number;
+	try {
+		size = statSync(hostPath).size;
+	} catch {
+		return undefined;
+	}
+
 	const headersJson = JSON.stringify({
 		status: 200,
 		headers: [
 			`content-type: ${inferMimeType(hostPath)}`,
-			`content-length: ${stat.size}`,
+			`content-length: ${size}`,
 			'accept-ranges: bytes',
 			'cache-control: public, max-age=0',
 		],
@@ -2065,23 +2072,11 @@ function serveStaticFileFromHost(hostPath: string): StreamedPHPResponse {
 		},
 	});
 
-	const fileStream = createReadStream(hostPath);
-	const stdout = new ReadableStream<Uint8Array>({
-		start(controller) {
-			fileStream.on('data', (chunk: Buffer) => {
-				controller.enqueue(new Uint8Array(chunk));
-			});
-			fileStream.on('end', () => {
-				controller.close();
-			});
-			fileStream.on('error', (err) => {
-				controller.error(err);
-			});
-		},
-		cancel() {
-			fileStream.destroy();
-		},
-	});
+	// Readable.toWeb() propagates backpressure to the file stream, so a
+	// large file is not read into memory faster than it is sent out.
+	const stdout = Readable.toWeb(
+		createReadStream(hostPath)
+	) as ReadableStream<Uint8Array>;
 
 	const stderr = new ReadableStream<Uint8Array>({
 		start(controller) {

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -16,7 +16,10 @@ import {
 	exposeSyncAPI,
 	printDebugDetails,
 	describeError,
+	RequestRouter,
+	inferMimeType,
 } from '@php-wasm/universal';
+import type { RouterFilesystem } from '@php-wasm/universal';
 import type {
 	BlueprintBundle,
 	BlueprintV1Declaration,
@@ -28,7 +31,14 @@ import {
 	runBlueprintV1Steps,
 } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import fs, { existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
+import fs, {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	createReadStream,
+} from 'fs';
 import type { Server } from 'http';
 import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
 // @ts-ignore
@@ -68,7 +78,11 @@ import {
 	cleanupStalePlaygroundTempDirs,
 	createPlaygroundCliTempDir,
 } from './temp-dir';
-import { type WordPressInstallMode } from '@wp-playground/wordpress';
+import {
+	type WordPressInstallMode,
+	wordPressRewriteRules,
+	getFileNotFoundActionForWordPress,
+} from '@wp-playground/wordpress';
 import {
 	type Mount,
 	addXdebugIDEConfig,
@@ -1113,6 +1127,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 	let wordPressReady = false;
 	let isFirstRequest = true;
+	let mainThreadRouter: RequestRouter | undefined;
+	let mapVfsToHost: ((vfsPath: string) => string | undefined) | undefined;
 
 	const server = await startServer({
 		port: args.port
@@ -1468,6 +1484,15 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				});
 			}
 
+			// Build the mount table (VFS path → host path) so the
+			// main-thread router can map VFS paths to host disk.
+			// Post-install mounts override pre-install mounts for
+			// the same VFS prefix.
+			const allMounts = [
+				...(args['mount-before-install'] || []),
+				...(args['mount'] || []),
+			];
+
 			let handler: BlueprintsV1Handler | BlueprintsV2Handler;
 			const useBlueprintsV2Handler =
 				await shouldUseBlueprintsV2Handler(
@@ -1635,6 +1660,16 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 					wordPressReady = true;
 
+					// Create main-thread router backed by the
+					// host filesystem so static files can be served
+					// without a worker round-trip.
+					const routerResult = createMainThreadRouter(
+						allMounts,
+						args['pathAliases'] || []
+					);
+					mainThreadRouter = routerResult.router;
+					mapVfsToHost = routerResult.mapVfsToHost;
+
 					if (useBlueprintsV2Handler) {
 						const compiledInputBlueprint =
 							await handler.compileInputBlueprint(
@@ -1787,6 +1822,39 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					new PHPResponse(302, headers, new Uint8Array())
 				);
 			}
+			// Main-thread routing: resolve the request against the
+			// host filesystem to serve static files without a worker
+			// round-trip.
+			if (mainThreadRouter && mapVfsToHost) {
+				const route = mainThreadRouter.resolve(request);
+				switch (route.type) {
+					case 'static-file': {
+						const hostPath = mapVfsToHost(route.fsPath);
+						if (hostPath) {
+							return serveStaticFileFromHost(hostPath);
+						}
+						break;
+					}
+					case 'redirect':
+						return StreamedPHPResponse.fromPHPResponse(
+							new PHPResponse(
+								route.statusCode,
+								route.headers,
+								new Uint8Array(0)
+							)
+						);
+					case 'response':
+						return StreamedPHPResponse.fromPHPResponse(
+							route.response
+						);
+					case '404':
+						return StreamedPHPResponse.forHttpCode(404);
+					case 'php':
+						// Fall through to the worker pool below.
+						break;
+				}
+			}
+
 			if (cookieStore) {
 				request = {
 					...request,
@@ -1802,8 +1870,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				};
 			}
 
-			// TODO: Explore switching to a worker thread method to adopt an entire HTTP connection
-			// It might be more efficient to let the worker respond directly
 			const response = await playgroundPool.requestStreamed(request);
 
 			if (cookieStore) {
@@ -1907,6 +1973,128 @@ function validateAndNormalizeBlueprintsV2Args(
 	if (args.wordpressInstallMode === 'do-not-attempt-installing') {
 		args.mode = 'mount-only';
 	}
+}
+
+/**
+ * Creates a RequestRouter backed by the host filesystem for
+ * main-thread static file serving.
+ *
+ * The router maps VFS paths (e.g. /wordpress/wp-content/style.css)
+ * to host paths via the CLI's mount table, allowing static files to
+ * be served directly from disk without a worker round-trip.
+ */
+function createMainThreadRouter(
+	mounts: Mount[],
+	pathAliases: PathAlias[]
+): {
+	router: RequestRouter;
+	mapVfsToHost: (vfsPath: string) => string | undefined;
+} {
+	// Sort mounts longest-prefix-first so the most specific
+	// mount wins when multiple mounts overlap.
+	const sortedMounts = [...mounts].sort(
+		(a, b) => b.vfsPath.length - a.vfsPath.length
+	);
+
+	function mapVfsToHost(vfsPath: string): string | undefined {
+		for (const mount of sortedMounts) {
+			if (
+				vfsPath === mount.vfsPath ||
+				vfsPath.startsWith(mount.vfsPath + '/')
+			) {
+				const relativePath = vfsPath.slice(mount.vfsPath.length);
+				return path.join(mount.hostPath, relativePath);
+			}
+		}
+		return undefined;
+	}
+
+	const hostFs: RouterFilesystem = {
+		isFile(vfsPath: string): boolean {
+			const hostPath = mapVfsToHost(vfsPath);
+			if (!hostPath) return false;
+			try {
+				return statSync(hostPath).isFile();
+			} catch {
+				return false;
+			}
+		},
+		isDir(vfsPath: string): boolean {
+			const hostPath = mapVfsToHost(vfsPath);
+			if (!hostPath) return false;
+			try {
+				return statSync(hostPath).isDirectory();
+			} catch {
+				return false;
+			}
+		},
+	};
+
+	const router = new RequestRouter({
+		documentRoot: '/wordpress',
+		rewriteRules: wordPressRewriteRules,
+		pathAliases,
+		getFileNotFoundAction: getFileNotFoundActionForWordPress,
+		fs: hostFs,
+	});
+
+	return { router, mapVfsToHost };
+}
+
+/**
+ * Serves a static file from the host filesystem as a
+ * StreamedPHPResponse, using Node.js streams to avoid
+ * buffering the entire file in memory.
+ */
+function serveStaticFileFromHost(hostPath: string): StreamedPHPResponse {
+	const stat = statSync(hostPath);
+	const headersJson = JSON.stringify({
+		status: 200,
+		headers: [
+			`content-type: ${inferMimeType(hostPath)}`,
+			`content-length: ${stat.size}`,
+			'accept-ranges: bytes',
+			'cache-control: public, max-age=0',
+		],
+	});
+
+	const headersStream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(headersJson));
+			controller.close();
+		},
+	});
+
+	const fileStream = createReadStream(hostPath);
+	const stdout = new ReadableStream<Uint8Array>({
+		start(controller) {
+			fileStream.on('data', (chunk: Buffer) => {
+				controller.enqueue(new Uint8Array(chunk));
+			});
+			fileStream.on('end', () => {
+				controller.close();
+			});
+			fileStream.on('error', (err) => {
+				controller.error(err);
+			});
+		},
+		cancel() {
+			fileStream.destroy();
+		},
+	});
+
+	const stderr = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.close();
+		},
+	});
+
+	return new StreamedPHPResponse(
+		headersStream,
+		stdout,
+		stderr,
+		Promise.resolve(0)
+	);
 }
 
 /**

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -15,7 +15,10 @@ import {
 	exposeAPI,
 	exposeSyncAPI,
 	printDebugDetails,
+	RequestRouter,
+	inferMimeType,
 } from '@php-wasm/universal';
+import type { RouterFilesystem } from '@php-wasm/universal';
 import type {
 	BlueprintBundle,
 	BlueprintV1Declaration,
@@ -26,7 +29,14 @@ import {
 	runBlueprintV1Steps,
 } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import fs, { existsSync, mkdirSync, readdirSync, rmdirSync } from 'fs';
+import fs, {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	rmdirSync,
+	statSync,
+	createReadStream,
+} from 'fs';
 import type { Server } from 'http';
 import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
 // @ts-ignore
@@ -63,7 +73,11 @@ import {
 	cleanupStalePlaygroundTempDirs,
 	createPlaygroundCliTempDir,
 } from './temp-dir';
-import { type WordPressInstallMode } from '@wp-playground/wordpress';
+import {
+	type WordPressInstallMode,
+	wordPressRewriteRules,
+	getFileNotFoundActionForWordPress,
+} from '@wp-playground/wordpress';
 import {
 	type Mount,
 	addXdebugIDEConfig,
@@ -986,6 +1000,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 	let wordPressReady = false;
 	let isFirstRequest = true;
+	let mainThreadRouter: RequestRouter | undefined;
+	let mapVfsToHost: ((vfsPath: string) => string | undefined) | undefined;
 
 	const server = await startServer({
 		port: args.port
@@ -1292,6 +1308,15 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				}
 			}
 
+			// Build the mount table (VFS path → host path) so the
+			// main-thread router can map VFS paths to host disk.
+			// Post-install mounts override pre-install mounts for
+			// the same VFS prefix.
+			const allMounts = [
+				...(args['mount-before-install'] || []),
+				...(args['mount'] || []),
+			];
+
 			let handler: BlueprintsV1Handler | BlueprintsV2Handler;
 			if (args['experimental-blueprints-v2-runner']) {
 				handler = new BlueprintsV2Handler(args, {
@@ -1452,6 +1477,16 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 					wordPressReady = true;
 
+					// Create main-thread router backed by the
+					// host filesystem so static files can be served
+					// without a worker round-trip.
+					const routerResult = createMainThreadRouter(
+						allMounts,
+						args['pathAliases'] || []
+					);
+					mainThreadRouter = routerResult.router;
+					mapVfsToHost = routerResult.mapVfsToHost;
+
 					if (!args['experimental-blueprints-v2-runner']) {
 						const compiledBlueprint = await (
 							handler as BlueprintsV1Handler
@@ -1595,6 +1630,39 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					new PHPResponse(302, headers, new Uint8Array())
 				);
 			}
+			// Main-thread routing: resolve the request against the
+			// host filesystem to serve static files without a worker
+			// round-trip.
+			if (mainThreadRouter && mapVfsToHost) {
+				const route = mainThreadRouter.resolve(request);
+				switch (route.type) {
+					case 'static-file': {
+						const hostPath = mapVfsToHost(route.fsPath);
+						if (hostPath) {
+							return serveStaticFileFromHost(hostPath);
+						}
+						break;
+					}
+					case 'redirect':
+						return StreamedPHPResponse.fromPHPResponse(
+							new PHPResponse(
+								route.statusCode,
+								route.headers,
+								new Uint8Array(0)
+							)
+						);
+					case 'response':
+						return StreamedPHPResponse.fromPHPResponse(
+							route.response
+						);
+					case '404':
+						return StreamedPHPResponse.forHttpCode(404);
+					case 'php':
+						// Fall through to the worker pool below.
+						break;
+				}
+			}
+
 			if (cookieStore) {
 				request = {
 					...request,
@@ -1610,8 +1678,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				};
 			}
 
-			// TODO: Explore switching to a worker thread method to adopt an entire HTTP connection
-			// It might be more efficient to let the worker respond directly
 			const response = await playgroundPool.requestStreamed(request);
 
 			if (cookieStore) {
@@ -1634,6 +1700,128 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 		openInBrowser(server.serverUrl);
 	}
 	return server;
+}
+
+/**
+ * Creates a RequestRouter backed by the host filesystem for
+ * main-thread static file serving.
+ *
+ * The router maps VFS paths (e.g. /wordpress/wp-content/style.css)
+ * to host paths via the CLI's mount table, allowing static files to
+ * be served directly from disk without a worker round-trip.
+ */
+function createMainThreadRouter(
+	mounts: Mount[],
+	pathAliases: PathAlias[]
+): {
+	router: RequestRouter;
+	mapVfsToHost: (vfsPath: string) => string | undefined;
+} {
+	// Sort mounts longest-prefix-first so the most specific
+	// mount wins when multiple mounts overlap.
+	const sortedMounts = [...mounts].sort(
+		(a, b) => b.vfsPath.length - a.vfsPath.length
+	);
+
+	function mapVfsToHost(vfsPath: string): string | undefined {
+		for (const mount of sortedMounts) {
+			if (
+				vfsPath === mount.vfsPath ||
+				vfsPath.startsWith(mount.vfsPath + '/')
+			) {
+				const relativePath = vfsPath.slice(mount.vfsPath.length);
+				return path.join(mount.hostPath, relativePath);
+			}
+		}
+		return undefined;
+	}
+
+	const hostFs: RouterFilesystem = {
+		isFile(vfsPath: string): boolean {
+			const hostPath = mapVfsToHost(vfsPath);
+			if (!hostPath) return false;
+			try {
+				return statSync(hostPath).isFile();
+			} catch {
+				return false;
+			}
+		},
+		isDir(vfsPath: string): boolean {
+			const hostPath = mapVfsToHost(vfsPath);
+			if (!hostPath) return false;
+			try {
+				return statSync(hostPath).isDirectory();
+			} catch {
+				return false;
+			}
+		},
+	};
+
+	const router = new RequestRouter({
+		documentRoot: '/wordpress',
+		rewriteRules: wordPressRewriteRules,
+		pathAliases,
+		getFileNotFoundAction: getFileNotFoundActionForWordPress,
+		fs: hostFs,
+	});
+
+	return { router, mapVfsToHost };
+}
+
+/**
+ * Serves a static file from the host filesystem as a
+ * StreamedPHPResponse, using Node.js streams to avoid
+ * buffering the entire file in memory.
+ */
+function serveStaticFileFromHost(hostPath: string): StreamedPHPResponse {
+	const stat = statSync(hostPath);
+	const headersJson = JSON.stringify({
+		status: 200,
+		headers: [
+			`content-type: ${inferMimeType(hostPath)}`,
+			`content-length: ${stat.size}`,
+			'accept-ranges: bytes',
+			'cache-control: public, max-age=0',
+		],
+	});
+
+	const headersStream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(headersJson));
+			controller.close();
+		},
+	});
+
+	const fileStream = createReadStream(hostPath);
+	const stdout = new ReadableStream<Uint8Array>({
+		start(controller) {
+			fileStream.on('data', (chunk: Buffer) => {
+				controller.enqueue(new Uint8Array(chunk));
+			});
+			fileStream.on('end', () => {
+				controller.close();
+			});
+			fileStream.on('error', (err) => {
+				controller.error(err);
+			});
+		},
+		cancel() {
+			fileStream.destroy();
+		},
+	});
+
+	const stderr = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.close();
+		},
+	});
+
+	return new StreamedPHPResponse(
+		headersStream,
+		stdout,
+		stderr,
+		Promise.resolve(0)
+	);
 }
 
 /**

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -482,12 +482,8 @@ export async function bootRequestHandler(options: BootRequestHandlerOptions) {
 	}
 
 	const requestHandler: PHPRequestHandler = new PHPRequestHandler({
-		documentRoot: options.documentRoot || '/wordpress',
+		...getWordPressRoutingConfig(options),
 		absoluteUrl: options.siteUrl,
-		rewriteRules: wordPressRewriteRules,
-		pathAliases: options.pathAliases,
-		getFileNotFoundAction:
-			options.getFileNotFoundAction ?? getFileNotFoundActionForWordPress,
 		cookieStore: options.cookieStore,
 
 		/**
@@ -633,6 +629,38 @@ async function installWordPress(php: PHP) {
 	if (defaultedToPrettyPermalinks.text !== '1') {
 		logger.warn('Failed to default to pretty permalinks after WP install.');
 	}
+}
+
+/**
+ * The inputs a request router needs to resolve a request URL to a file in a
+ * WordPress installation.
+ */
+export type WordPressRoutingOptions = {
+	documentRoot?: string;
+	pathAliases?: PathAlias[];
+	getFileNotFoundAction?: FileNotFoundGetActionCallback;
+};
+
+/**
+ * Builds the routing configuration for a WordPress site.
+ *
+ * Every router resolving requests for the same site must be built from this
+ * function. `bootWordPress()` uses it for the `PHPRequestHandler` running in
+ * the worker, and the Playground CLI uses it for the `RequestRouter` that
+ * serves static files from the main thread. Should the two disagree on the
+ * document root, the rewrite rules or the file-not-found action, the same
+ * request could resolve to a different file depending on which one saw it.
+ */
+export function getWordPressRoutingConfig(
+	options: WordPressRoutingOptions = {}
+) {
+	return {
+		documentRoot: options.documentRoot || '/wordpress',
+		rewriteRules: wordPressRewriteRules,
+		pathAliases: options.pathAliases ?? [],
+		getFileNotFoundAction:
+			options.getFileNotFoundAction ?? getFileNotFoundActionForWordPress,
+	};
 }
 
 export function getFileNotFoundActionForWordPress(

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -18,7 +18,9 @@ export {
 	bootWordPressAndRequestHandler,
 	bootRequestHandler,
 	getFileNotFoundActionForWordPress,
+	getWordPressRoutingConfig,
 } from './boot';
+export type { WordPressRoutingOptions } from './boot';
 export * from './streaming-tar-extract';
 export type {
 	PhpIniOptions,


### PR DESCRIPTION
## Summary

- Extracts routing logic from `PHPRequestHandler` into a standalone `RequestRouter` class that resolves request URLs to routing decisions without any PHP dependency.
- The CLI creates its own `RequestRouter` on the main thread, backed by the host filesystem, and serves static files straight from disk instead of occupying a PHP worker.

Note: @fredrikekelund proposed this earlier, but we did not pursue it because the perf tests didn't seem to show clear gains and because there were concerns about skipping php-wasm request routing. This PR addresses the routing concerns and reliably improves site editor loading.

## How it works

`RequestRouter` is a pure routing engine. It takes a `RouterFilesystem` abstraction (`isFile`/`isDir`) and resolves a request through rewrite rules, path aliases, directory index resolution, and file-not-found fallbacks — the same logic previously buried inside `PHPRequestHandler.requestStreamed()`. It returns a `ResolvedRoute` describing what should happen, and for PHP routes it also reports the original and rewritten request URLs it resolved the script path from.

`PHPRequestHandler` now uses `RequestRouter` internally. This is a refactor of existing logic with no behavior change for non-CLI consumers.

In the CLI, a second router is wired to the host filesystem via the mount table. **It only ever short-circuits a `static-file` route whose file genuinely exists on the host.** PHP scripts, redirects, 404s, and file-not-found fallbacks all fall through to the worker pool, which owns the authoritative filesystem and the request handler configuration. That boundary matters: the main thread can only see the mounted directories, so it must not be the one making negative or fallback decisions.

Both routers are built from `getWordPressRoutingConfig()`, so the main thread and the worker cannot disagree about the document root, the rewrite rules, or the file-not-found action. If they drifted, the same URL could resolve to a different file depending on which router saw it.

## Performance

The mechanism is easy to demonstrate directly. With all 6 PHP workers blocked on a `sleep(6)` script:

| Request | Latency |
|---|---|
| `/wp-includes/css/dashicons.min.css` (static, main thread) | **1.4 ms** |
| `/` (PHP, queued behind the workers) | 5.5 s |

On `trunk` the static request would queue behind the workers too.

End-to-end numbers, 10 rounds, sequential, medians, two runs:

| Metric | trunk | this branch | Run 1 Δ | Run 2 Δ |
|--------|-------|----------------|---------|---------|
| siteEditorLoad | 1.98s / 2.07s | 1.62s / 1.83s | **-18.2%** | **-11.6%** |
| templatesViewLoad | 123ms / 126ms | 125ms / 122ms | +1.6% | -3.2% |
| templateOpen | 1.97s / 2.00s | 1.94s / 1.94s | -1.5% | -3.0% |
| blockAdd | 1.39s / 1.56s | 1.58s / 1.57s | +13.7% | +0.6% |
| templateSave | 857ms / 860ms | 842ms / 843ms | -1.8% | -2.0% |
| serverStartup | 5.49s / 6.18s | 5.87s / 6.18s | +6.9% | 0.0% |

`siteEditorLoad` is the main signal — static files served from the main thread free up PHP workers for the heavy initial PHP requests. Other metrics are within noise.

These end-to-end numbers were measured before the routing fixes below. Those fixes only changed which routes short-circuit on the main thread (static files still do; redirects and 404s no longer do), and redirects and 404s are rare, so the hot path is unchanged. Still worth re-measuring before merge.

## Key files

| File | Change |
|------|--------|
| `packages/php-wasm/universal/src/lib/request-router.ts` | **New** — `RequestRouter`, `RouterFilesystem`, `ResolvedRoute` |
| `packages/php-wasm/universal/src/lib/request-router.spec.ts` | **New** — 22 tests covering all routing scenarios |
| `packages/php-wasm/universal/src/lib/php-request-handler.ts` | Refactored to use `RequestRouter` internally |
| `packages/playground/wordpress/src/boot.ts` | **New** `getWordPressRoutingConfig()` — one routing config for both routers |
| `packages/playground/cli/src/run-cli.ts` | Main-thread router + host FS static file serving |

## Routing correctness

Three defects were found and fixed while reviewing the extraction:

1. **`PHP_SELF` lost the resolved directory index.** `RequestRouter` resolved `/wp-admin/` to `/wp-admin/index.php` but only updated its own copy of the rewritten URL; `PHPRequestHandler` discarded that copy and recomputed the URL from the original request. `$_SERVER['PHP_SELF']`, `SCRIPT_NAME`, and the relative URI handed to PHP all came out as `/wp-admin/`. The `php` route now carries the URLs it actually resolved from. This was the cause of the 14 failures in `test-group-3-{asyncify,jspi}`.

2. **The CLI answered `404`, `redirect`, and `response` routes on the main thread**, duplicating the worker's routing policy against a filesystem view that only covers mounted directories. A server started with no WordPress installed answered 404 before the request handler ever ran. The main thread now only serves static files it can prove exist on disk.

3. **`serveStaticFileFromHost()` ignored backpressure**, enqueuing every `data` event into the `ReadableStream` and buffering whole files in memory — the opposite of what its comment claimed. It now uses `Readable.toWeb()`, and returns `undefined` if the file disappears between the router's `isFile()` check and the read, so the request falls back to the worker instead of throwing.

The router is also rebuilt per request, so it stays in sync with `rewriteRules` and `getFileNotFoundAction`, which are public and reassignable.

## Test plan

- [x] `npx nx test php-wasm-universal` — passes, including 22 `RequestRouter` tests (6 of them regression tests for the `PHP_SELF` bug above)
- [x] `npx nx run php-wasm-node:test-group-3-asyncify` and `:test-group-3-jspi` — 2511 pass
- [x] `npx nx run playground-cli:test-playground-cli` — 167 pass
- [x] `npx nx run-many -t lint typecheck -p php-wasm-universal playground-cli playground-wordpress`
- [x] Manual: `npx nx dev playground-cli server` — WordPress loads, `/wp-admin` 301s, missing files 404, static assets stream byte-exact (verified against a 20 MB binary), and `PHP_SELF` is correct for directory indexes
- [ ] `npx nx perf playground-cli -- --rounds=3` — re-measure after the fixes

## Notes for reviewers

- **New public API.** `@php-wasm/universal` now exports `RequestRouter`, `RouterFilesystem`, `ResolvedRoute`, and `RequestRouterConfig`; `@wp-playground/wordpress` exports `getWordPressRoutingConfig()`. Additive, not breaking.
- **Split out separately:** an earlier revision of this branch also set `$_SERVER['SERVER_PROTOCOL'] = 'HTTP/1.1'`. That is a real fix — the `/* SERVER_PROTOCOL */` block in `php_wasm.c` actually registers `SERVER_PORT`, so the SAPI never sets `SERVER_PROTOCOL` and `wp_get_server_protocol()` falls back to `HTTP/1.0` — but it is unrelated to static file serving and should land on its own.
- **Known gap:** static responses advertise `accept-ranges: bytes` but ignore `Range`. This matches the behavior of the php-wasm static file path it replaces, so it is not a regression, but it matters more now that the CLI serves large media straight from disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
