### PR TITLE
[MCP] Add REST API authentication to request tool

### DIFF
--- a/packages/playground/mcp/e2e/mcp-tools.spec.ts
+++ b/packages/playground/mcp/e2e/mcp-tools.spec.ts
@@ -677,3 +677,153 @@ test('rejects WebSocket connections without a valid token', async ({
 
 	await rejected;
 });
+
+// -- REST API authentication tests --
+// These must run in order: CRUD while logged in, then logout,
+// then verify logged-out behavior.
+test.describe.serial('playground_request REST API auth', () => {
+	test('authenticated CRUD', async ({ mcpClient, siteId }) => {
+		// CREATE
+		const createResult = await mcpClient.callTool({
+			name: 'playground_request',
+			arguments: {
+				siteId,
+				url: '/wp-json/wp/v2/posts',
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					title: 'E2E REST Test',
+					content: 'Created via MCP',
+					status: 'publish',
+				}),
+			},
+		});
+		const created = JSON.parse(resultText(createResult));
+		expect(created.httpStatusCode).toBe(201);
+		const body = JSON.parse(created.text);
+		expect(body.title.raw).toBe('E2E REST Test');
+		const postId = body.id;
+
+		// READ
+		const readResult = await mcpClient.callTool({
+			name: 'playground_request',
+			arguments: { siteId, url: `/wp-json/wp/v2/posts/${postId}` },
+		});
+		const read = JSON.parse(resultText(readResult));
+		expect(read.httpStatusCode).toBe(200);
+		expect(JSON.parse(read.text).title.rendered).toBe('E2E REST Test');
+
+		// UPDATE
+		const updateResult = await mcpClient.callTool({
+			name: 'playground_request',
+			arguments: {
+				siteId,
+				url: `/wp-json/wp/v2/posts/${postId}`,
+				method: 'PUT',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ title: 'E2E REST Test Updated' }),
+			},
+		});
+		const updated = JSON.parse(resultText(updateResult));
+		expect(updated.httpStatusCode).toBe(200);
+		expect(JSON.parse(updated.text).title.raw).toBe(
+			'E2E REST Test Updated'
+		);
+
+		// DELETE
+		const deleteResult = await mcpClient.callTool({
+			name: 'playground_request',
+			arguments: {
+				siteId,
+				url: `/wp-json/wp/v2/posts/${postId}?force=true`,
+				method: 'DELETE',
+			},
+		});
+		const deleted = JSON.parse(resultText(deleteResult));
+		expect(deleted.httpStatusCode).toBe(200);
+		expect(JSON.parse(deleted.text).deleted).toBe(true);
+
+		// Verify gone
+		const goneResult = await mcpClient.callTool({
+			name: 'playground_request',
+			arguments: {
+				siteId,
+				url: `/wp-json/wp/v2/posts/${postId}`,
+			},
+		});
+		const gone = JSON.parse(resultText(goneResult));
+		expect(JSON.parse(gone.text).code).toBe('rest_post_invalid_id');
+	});
+
+	test('logged-out user cannot create posts', async ({
+		mcpClient,
+		siteId,
+	}) => {
+		// Log out first
+		const logoutEndpoint = '/wordpress/wp-content/mcp-logout.php';
+		const logoutPhp = `<?php
+require_once '/wordpress/wp-load.php';
+wp_logout();
+wp_set_current_user(0);
+echo json_encode(array('loggedOut' => true, 'user' => get_current_user_id()));
+`;
+		await mcpClient.callTool({
+			name: 'playground_write_file',
+			arguments: {
+				siteId,
+				path: logoutEndpoint,
+				contents: logoutPhp,
+			},
+		});
+		try {
+			const logoutResult = await mcpClient.callTool({
+				name: 'playground_request',
+				arguments: {
+					siteId,
+					url: '/wp-content/mcp-logout.php',
+					headers: {},
+				},
+			});
+			const logoutResp = JSON.parse(resultText(logoutResult));
+			expect(logoutResp.httpStatusCode).toBe(200);
+			const logoutBody = JSON.parse(logoutResp.text);
+			expect(logoutBody.loggedOut).toBe(true);
+			expect(logoutBody.user).toBe(0);
+		} finally {
+			await mcpClient.callTool({
+				name: 'playground_delete_file',
+				arguments: { siteId, path: logoutEndpoint },
+			});
+		}
+
+		const result = await mcpClient.callTool({
+			name: 'playground_request',
+			arguments: {
+				siteId,
+				url: '/wp-json/wp/v2/posts',
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					title: 'Should fail',
+					status: 'publish',
+				}),
+			},
+		});
+		const resp = JSON.parse(resultText(result));
+		expect(resp.httpStatusCode).toBe(401);
+	});
+
+	test('logged-out user can read public posts', async ({
+		mcpClient,
+		siteId,
+	}) => {
+		const result = await mcpClient.callTool({
+			name: 'playground_request',
+			arguments: { siteId, url: '/wp-json/wp/v2/posts' },
+		});
+		const resp = JSON.parse(resultText(result));
+		expect(resp.httpStatusCode).toBe(200);
+		const posts = JSON.parse(resp.text);
+		expect(Array.isArray(posts)).toBe(true);
+	});
+});

--- a/packages/playground/mcp/src/tools/tool-definitions.ts
+++ b/packages/playground/mcp/src/tools/tool-definitions.ts
@@ -84,18 +84,31 @@ export const toolDefinitions: Record<string, ToolDefinition> = {
 		title: 'HTTP Request',
 		errorPrefix: 'Error making request',
 		description: `Make an HTTP request to the WordPress site
-			running in Playground. Requests are authenticated
-			automatically via the browser session's cookie
-			store.
+			running in Playground. REST API requests
+			(/wp-json/* or ?rest_route=) are automatically
+			authenticated with a valid nonce — no manual
+			auth needed.
 
-			Prefer playground_execute_php for reading WordPress
-			data (posts, options, plugin state) — it is faster
-			and returns only what you echo. Use this tool only
-			when the HTTP layer itself is what you are testing,
-			for example: verifying that a URL returns a 301
-			redirect, that a form submission sets a cookie, or
-			that a REST endpoint returns the correct status
-			code.
+			Tool selection guide:
+			1. Use this tool (playground_request) with the
+			   REST API for standard content CRUD — posts,
+			   pages, users, terms, comments, settings, etc.
+			   The REST API handles serialization, pagination,
+			   and field filtering for you.
+			2. Use playground_execute_php when the data you
+			   need is not exposed by the REST API (e.g.
+			   raw options, direct database queries, or
+			   custom table access).
+			3. Use this tool as a plain HTTP request (non-REST)
+			   when the HTTP layer itself matters: verifying
+			   redirects, status codes, cookies, or response
+			   headers.
+
+			The response JSON contains three fields:
+			- "text": the response body as a string
+			- "httpStatusCode": HTTP status code (200, 404…)
+			- "headers": response headers as key-value pairs
+			Check "httpStatusCode" to determine success.
 
 			Note: full HTML responses can be very large and may
 			fill the context window. To change the URL the user
@@ -126,7 +139,9 @@ export const toolDefinitions: Record<string, ToolDefinition> = {
 			{
 				name: 'headers',
 				type: 'object',
-				description: 'Request headers as key-value pairs',
+				description: `Request headers as string key-value
+					pairs, e.g. {"Content-Type":
+					"application/json"}`,
 				required: false,
 				additionalProperties: true,
 			},

--- a/packages/playground/mcp/src/tools/tool-executors.ts
+++ b/packages/playground/mcp/src/tools/tool-executors.ts
@@ -92,22 +92,64 @@ export const toolExecutors: Record<
 		client.run({ code: input['code'] as string }),
 
 	playground_request: async (client, input) => {
-		const options: {
-			url: string;
-			method: string;
-			headers?: Record<string, string>;
-			body?: string;
-		} = {
-			url: input['url'] as string,
-			method: (input['method'] as string) ?? 'GET',
+		const url = input['url'] as string;
+		const method = (input['method'] as string) ?? 'GET';
+		const headers = {
+			...((input['headers'] as Record<string, string>) ?? {}),
 		};
-		if (input['headers']) {
-			options.headers = input['headers'] as Record<string, string>;
+		const body = input['body'] as string | undefined;
+
+		try {
+			const parsedUrl = new URL(url, 'http://localhost');
+			const isRestApi =
+				url.includes('/wp-json/') ||
+				parsedUrl.searchParams.has('rest_route');
+
+			// Auto-set Content-Type for REST API JSON bodies.
+			if (
+				isRestApi &&
+				body &&
+				!Object.keys(headers).some(
+					(k) => k.toLowerCase() === 'content-type'
+				)
+			) {
+				headers['Content-Type'] = 'application/json';
+			}
+
+			const hasNonce = Object.keys(headers).some(
+				(k) => k.toLowerCase() === 'x-wp-nonce'
+			);
+
+			if (isRestApi && !hasNonce) {
+				// Generate the nonce via a temporary PHP file requested
+				// through request() — not run() — so that the cookie
+				// store is included and WordPress ties the nonce to
+				// the logged-in user.
+				const nonceId = Math.random().toString(36).slice(2, 10);
+				const noncePath = `/wordpress/wp-content/mcp-nonce-${nonceId}.php`;
+				const nonceUrl = `/wp-content/mcp-nonce-${nonceId}.php`;
+				const nonceCode =
+					"<?php require_once '/wordpress/wp-load.php'; echo wp_create_nonce('wp_rest');";
+				await client.writeFile(noncePath, nonceCode);
+				let nonce = '';
+				try {
+					const nonceResp = await client.request({
+						url: nonceUrl,
+						method: 'GET',
+					});
+					nonce = nonceResp.text.trim();
+				} finally {
+					await client.unlink(noncePath);
+				}
+				if (nonce && nonce !== '0') {
+					headers['X-WP-Nonce'] = nonce;
+				}
+			}
+		} catch {
+			// Nonce generation failed — proceed without it.
 		}
-		if (input['body']) {
-			options.body = input['body'] as string;
-		}
-		return await client.request(options);
+
+		return await client.request({ url, method, headers, body });
 	},
 
 	playground_navigate: async (client, input) => {


### PR DESCRIPTION
## Motivation for the change, related issues

Adds automatic REST API authentication (nonce injection) to the `playground_request` MCP tool. Previously, agents couldn't create, update, or delete posts via the REST API without manually handling nonces, which made the tool description actively discourage REST API usage in favor of `playground_execute_php`. Now REST API requests are automatically authenticated with a valid nonce tied to the logged-in user, making the REST API the recommended path for content CRUD.

## Implementation details

**Nonce injection** — When the request URL matches a REST API path (`/wp-json/*` or `?rest_route=`), the executor:
1. Creates a temporary PHP file that calls `wp_create_nonce('wp_rest')`
2. Fetches it via `client.request()` (so the browser cookie store is included, tying the nonce to the logged-in user)
3. Injects the nonce as an `X-WP-Nonce` header
4. Cleans up the temporary file

If nonce generation fails for any reason, the request proceeds without it (graceful degradation for logged-out users or non-WP sites).

**Auto Content-Type** — REST API requests with a body automatically get `Content-Type: application/json` if not already set.

**Updated tool description** — Rewritten to recommend the REST API as the primary tool for content CRUD, with `playground_execute_php` as a fallback for data not exposed by the REST API.

## Testing Instructions

- CI