### PR TITLE
Fix phpMyAdmin and Adminer crash on PHP 8.5

### DIFF
--- a/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/personal-wp/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -24,8 +24,6 @@ if ($wp_env['db']['type'] === 'sqlite') {
 use Throwable;
 use WP_SQLite_Driver;
 use WP_SQLite_Connection;
-use PDO;
-
 SqlDriver::$drivers = array("server" => "MySQL / MariaDB") + SqlDriver::$drivers;
 
 if (!defined('Adminer\DRIVER')) {
@@ -103,10 +101,8 @@ if (!defined('Adminer\DRIVER')) {
 
 		function attach($server, $username, $password) {
 			global $wp_env;
-			$pdo = new PDO('sqlite:' . $wp_env['db']['path']);
-			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$this->driver = new WP_SQLite_Driver(
-				new WP_SQLite_Connection(array('pdo' => $pdo)),
+				new WP_SQLite_Connection(array('path' => $wp_env['db']['path'])),
 				'wordpress'
 			);
 			return $this;

--- a/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
+++ b/packages/playground/tools/src/phpmyadmin/DbiMysqli.php
@@ -15,7 +15,6 @@ namespace PhpMyAdmin\Dbal;
 use Closure;
 use Exception;
 use Generator;
-use PDO;
 use PhpMyAdmin\FieldMetadata;
 use PhpMyAdmin\Query\Utilities;
 use Throwable;
@@ -260,10 +259,8 @@ class DbiMysqli implements DbiExtension {
 
     public function connect($user, $password, array $server) {
 		global $wp_env;
-		$pdo = new PDO('sqlite:' . $wp_env['db']['path']);
-		$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         $this->driver = new WP_SQLite_Driver(
-			new WP_SQLite_Connection(array('pdo' => $pdo)),
+			new WP_SQLite_Connection(array('path' => $wp_env['db']['path'])),
 			'wordpress'
 		);
 		return $this->driver;

--- a/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
+++ b/packages/playground/website/src/components/site-manager/site-database-panel/adminer-extensions/adminer-mysql-on-sqlite-driver.php
@@ -24,8 +24,6 @@ if ($wp_env['db']['type'] === 'sqlite') {
 use Throwable;
 use WP_SQLite_Driver;
 use WP_SQLite_Connection;
-use PDO;
-
 SqlDriver::$drivers = array("server" => "MySQL / MariaDB") + SqlDriver::$drivers;
 
 if (!defined('Adminer\DRIVER')) {
@@ -103,10 +101,8 @@ if (!defined('Adminer\DRIVER')) {
 
 		function attach($server, $username, $password) {
 			global $wp_env;
-			$pdo = new PDO('sqlite:' . $wp_env['db']['path']);
-			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 			$this->driver = new WP_SQLite_Driver(
-				new WP_SQLite_Connection(array('pdo' => $pdo)),
+				new WP_SQLite_Connection(array('path' => $wp_env['db']['path'])),
 				'wordpress'
 			);
 			return $this;


### PR DESCRIPTION
## Summary
- phpMyAdmin and Adminer crashed on PHP 8.5 because they created a plain `PDO` instance and passed it to `WP_SQLite_Connection`. The SQLite plugin calls `PDO::sqliteCreateFunction()`, which is deprecated in PHP 8.5.
- The plugin already checks for `PDO\SQLite` to use the new API, but the check failed because a plain `PDO` was passed.
- Fixed by passing the database path to `WP_SQLite_Connection` instead of a pre-built `PDO` object. Its constructor already selects the correct `PDO` class.

## Test plan
- [x] Run `npm nx dev playground-website` and open http://127.0.0.1:5400/website-server/
- [x] Change PHP to 8.5
- [x] Open phpMyAdmin — verify it loads without errors
- [x] Open Adminer — verify it loads without errors

Fixes #3443