### PR TITLE
[Website] Add custom error message when artifact is expired

### DIFF
--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <head>
 	<title>WordPress PR Previewer</title>
 	<meta charset="utf-8" />
@@ -190,6 +190,8 @@
 					}
 				} else if (error === 'artifact_invalid') {
 					errorDiv.innerText = `The PR ${prNumber} requires a rebase before it can be previewed.`;
+				} else if (error === 'artifact_expired') {
+					errorDiv.innerText = `The PR ${prNumber} couldn't be previewed because the CI build artifact has expired. To load that pull request, the author or a maintainer should push a new commit, rebase, or rerun the CI job to trigger a fresh CI build.`;
 				} else {
 					errorDiv.innerText = `The PR ${prNumber} couldn't be previewed due to an unexpected error. Please try again later or fill an issue in the WordPress Playground repository.`;
 					// https://github.com/WordPress/wordpress-playground/issues/new

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -193,7 +193,7 @@
 				} else if (error === 'artifact_expired') {
 					errorDiv.innerText = `The PR ${prNumber} couldn't be previewed because the CI build artifact has expired. To load that pull request, the author or a maintainer should push a new commit, rebase, or rerun the CI job to trigger a fresh CI build.`;
 				} else {
-					errorDiv.innerText = `The PR ${prNumber} couldn't be previewed due to an unexpected error. Please try again later or fill an issue in the WordPress Playground repository.`;
+					errorDiv.innerText = `The PR ${prNumber} couldn't be previewed due to an unexpected error. Please try again later or file an issue in the WordPress Playground repository.`;
 					// https://github.com/WordPress/wordpress-playground/issues/new
 				}
 				submitting = false;

--- a/packages/playground/website/src/github/preview-pr/form.tsx
+++ b/packages/playground/website/src/github/preview-pr/form.tsx
@@ -167,7 +167,7 @@ export default function PreviewPRForm({
 					);
 				} else {
 					setError(
-						`The PR ${ref} couldn't be previewed due to an unexpected error. Please try again later or fill an issue in the WordPress Playground repository.`
+						`The PR ${ref} couldn't be previewed due to an unexpected error. Please try again later or file an issue in the WordPress Playground repository.`
 					);
 					// https://github.com/WordPress/wordpress-playground/issues/new
 				}

--- a/packages/playground/website/src/github/preview-pr/form.tsx
+++ b/packages/playground/website/src/github/preview-pr/form.tsx
@@ -161,6 +161,10 @@ export default function PreviewPRForm({
 					setError(
 						`The PR ${ref} requires a rebase before it can be previewed.`
 					);
+				} else if (error === 'artifact_expired') {
+					setError(
+						`The PR ${ref} couldn't be previewed because the CI build artifact has expired. To load that pull request, the author or a maintainer should push a new commit, rebase, or rerun the CI job to trigger a fresh CI build.`
+					);
 				} else {
 					setError(
 						`The PR ${ref} couldn't be previewed due to an unexpected error. Please try again later or fill an issue in the WordPress Playground repository.`


### PR DESCRIPTION
## Motivation for the change, related issues

A WordCamp Nice 2026 contributor asked why this was crashing : 

https://playground.wordpress.net/wordpress.html?pr=9026

I found out the CI build artifact for that pull request was expired. To load that pull request, the author or a maintainer should push a new commit, rebase or rerun the CI Job to trigger a fresh CI build. 


## Implementation details

- Added a new custom error message.

## Testing Instructions (or ideally a Blueprint)


1. `npm run dev`
2. Go to `http://localhost:5400/website-server/wordpress.html?pr=9026`

[On Playground](https://playground.wordpress.net/wordpress.html?pr=9026)

<img width="1917" height="1033" alt="remote-screenshot" src="https://github.com/user-attachments/assets/d8411c5e-a186-46d9-8c09-4b9c60a7c71a" />

[Locally](http://localhost:5400/website-server/wordpress.html?pr=9026)

<img width="1915" height="1036" alt="local-screenshot" src="https://github.com/user-attachments/assets/b0e2079d-34ab-46a7-b3a3-918ba57918c9" />