### PR TITLE
[Docs] Removing heading IDs to make docs compatible to migrate to org

### DIFF
--- a/packages/docs/site/docs/developers/23-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/docs/developers/23-architecture/18-host-your-own-playground.md
@@ -2,23 +2,23 @@
 slug: /developers/architecture/host-your-own-playground
 ---
 
-# Host your own Playground {#host-your-own-playground}
+# Host your own Playground
 
 You can host the Playground on your own domain instead of `playground.wordpress.net`.
 
 This is useful for having full control over its content and behavior, as well as removing dependency on a third-party server. It can provide a more customized user experience, for example: a playground with preinstalled plugins and themes, default site settings, or demo content.
 
-## Before you start {#before-you-start}
+## Before you start
 
 Self-hosting Playground gives you full control, but requires understanding a few key concepts:
 
-### What to expect {#what-to-expect}
+### What to expect
 
 - **Initial setup complexity**: Building and deploying Playground involves multiple steps. Allow time for troubleshooting during your first deployment.
 - **Static file hosting**: Playground is primarily static files (HTML, JS, WASM) with minimal server-side requirements.
 - **Browser-based execution**: All WordPress processing happens in the user's browser via WebAssembly—your server only delivers files.
 
-### Performance considerations {#performance-considerations}
+### Performance considerations
 
 Loading times depend on several factors:
 
@@ -29,7 +29,7 @@ Loading times depend on several factors:
 | **Browser**       | Chrome/Edge perform best; Safari uses fallback mechanisms           | Test across browsers                        |
 | **Device**        | Mobile devices load slower than desktop                             | Warn mobile users about longer load times   |
 
-### Browser compatibility {#browser-compatibility}
+### Browser compatibility
 
 Playground works across modern browsers, but with some differences:
 
@@ -42,7 +42,7 @@ Playground works across modern browsers, but with some differences:
 
 **Technical note**: Safari uses MessagePorts instead of SharedArrayBuffer for streaming responses. This fallback works reliably but adds slight overhead compared to Chrome/Edge.
 
-## Usage {#usage}
+## Usage
 
 A self-hosted Playground can be embedded as an iframe.
 
@@ -61,7 +61,7 @@ const client = await startPlaygroundWeb({
 });
 ```
 
-## Static assets {#static-assets}
+## Static assets
 
 There are several ways to get the static assets necessary to host the Playground.
 
@@ -71,7 +71,7 @@ In order of convenience and ease:
 - Fork the repository and build with GitHub Action
 - Build locally
 
-### Download pre-built package {#download-pre-built-package}
+### Download pre-built package
 
 To host the Playground as is, without making changes, you can download the built artifact from [the latest successful GitHub Action](https://github.com/WordPress/wordpress-playground/actions/workflows/deploy-website.yml?query=is%3Asuccess).
 
@@ -79,13 +79,13 @@ To host the Playground as is, without making changes, you can download the built
 - In the section **Artifacts** at the bottom of the page, click `playground-website`.
 - It's a zip package with the same files deployed to the public site.
 
-### Fork the repository and build with GitHub Action {#fork-repository-and-build-with-github-actions}
+### Fork the repository and build with GitHub Action
 
 To customize the Playground, you can [fork the Git repository](https://github.com/WordPress/wordpress-playground/fork).
 
 Build it from the fork's GitHub page by going to: **Actions -> Deploy Playground website -> Run workflow**.
 
-### Build locally {#build-locally}
+### Build locally
 
 The most flexible and customizable method is to build the site locally.
 
@@ -116,7 +116,7 @@ dist/packages/playground/wasm-wordpress-net
 
 The entire service of the Playground consists of the content of this folder.
 
-## Summary of included files {#summary-of-included-files}
+## Summary of included files
 
 The static assets include:
 
@@ -133,7 +133,7 @@ It is a static site, except for these dynamic aspects.
 
 For these to work, you need a server environment with Apache and PHP installed.
 
-## NGINX configuration {#nginx-configuration}
+## NGINX configuration
 
 As an alternative to Apache, here is an example of using NGINX to serve the Playground.
 
@@ -163,7 +163,7 @@ You may need to adjust the above according to server specifics, particularly how
 
 [Caddy web server](https://caddyserver.com) doesn't require any special config to work.
 
-## Customize bundled data {#customize-bundled-data}
+## Customize bundled data
 
 The file `wp.zip` is a bundle of all the files for the virtual file system in Playground. There's a data file for each available WordPress version.
 
@@ -179,7 +179,7 @@ npm run rebuild:wordpress-builds
 
 To rebuild the website to include the custom WordPress builds, follow the instructions [here](#build-locally).
 
-### Install plugins {#install-plugins}
+### Install plugins
 
 Here's an example of installing plugins for the data bundle.
 
@@ -209,7 +209,7 @@ COPY ./build-assets/*.zip /root/
 
 Then put the plugin zip files in `build-assets`. In this case, you may want to add their paths to `.gitignore`.
 
-### Import content {#import-content}
+### Import content
 
 Here's an example of importing content.
 
@@ -224,7 +224,7 @@ RUN cd wordpress ; \
 
 This assumes that you have put a WXR export file named `content.xml` in the folder `build-assets`. You can add its path to `.gitignore`.
 
-## Production deployment checklist {#production-deployment-checklist}
+## Production deployment checklist
 
 Before going live, verify your self-hosted Playground meets these requirements:
 

--- a/packages/docs/site/docs/developers/24-limitations/01-index.md
+++ b/packages/docs/site/docs/developers/24-limitations/01-index.md
@@ -9,9 +9,9 @@ WordPress Playground is under active development and has some limitations you sh
 
 You can track the status of these issues on the [Playground Project board](https://github.com/orgs/WordPress/projects/180).
 
-## In the browser {#in-the-browser}
+## In the browser
 
-### Temporary by design {#temporary-by-design}
+### Temporary by design
 
 Playground creates fresh WordPress instances on each page load. Refreshing the browser page discards all database changes, uploads, and modifications.
 
@@ -44,7 +44,7 @@ The dedicated refresh button inside Playground only reloads WordPress content—
 </figure>
 </blockquote>
 
-### Browser support {#browser-support}
+### Browser support
 
 WordPress Playground is designed to work across all major desktop and mobile browsers. This includes:
 
@@ -53,7 +53,7 @@ WordPress Playground is designed to work across all major desktop and mobile bro
 
 Playground leverages modern web technologies and should function consistently across these browser environments. However, some advanced features may have varying levels of support depending on the specific browser and its version.
 
-### Performance expectations {#performance-expectations}
+### Performance expectations
 
 Loading times vary based on what Playground needs to set up:
 
@@ -77,14 +77,14 @@ Loading times vary based on what Playground needs to set up:
 <strong>Note:</strong> Opera Mini support is not currently confirmed.
 </blockquote>
 
-## When developing with Playground {#when-developing-with-playground}
+## When developing with Playground
 
-### Iframe quirks {#iframe-quirks}
+### Iframe quirks
 
 Playground renders WordPress in an [`iframe`](/developers/architecture/browser-iframe-rendering) so clicking links with `target="_top"` will reload the page you’re working on.
 Also, JavaScript popups originating in the `iframe` may not always display.
 
-### Run WordPress PHP functions {#run-wordpress-php-functions}
+### Run WordPress PHP functions
 
 Playground supports running PHP code in Blueprints using the [`runPHP` step](/blueprints/steps#RunPHPStep). To run WordPress-specific PHP functions, you’d need to first require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php):
 
@@ -95,6 +95,6 @@ Playground supports running PHP code in Blueprints using the [`runPHP` step](/
 }
 ```
 
-### Using WP-CLI {#using-wp-cli}
+### Using WP-CLI
 
 You can execute `wp-cli` commands via the Blueprints [`wp-cli`](/blueprints/steps#WPCLIStep) step. However, since Playground runs in the browser, it doesn't support the [full array](https://developer.wordpress.org/cli/commands/) of available commands. While there is no definite list of supported commands, experimenting in [the online demo](https://playground.wordpress.net/demos/wp-cli.html) will help you assess what's possible.

--- a/packages/docs/site/docs/main/guides/agent-skill-wp-playground.md
+++ b/packages/docs/site/docs/main/guides/agent-skill-wp-playground.md
@@ -4,13 +4,13 @@ slug: /guides/agent-skill-wp-playground
 description: Install and use the wp-playground agent skill to automate WordPress Playground workflows with your coding agent.
 ---
 
-# Using the WordPress Playground Agent Skill {#using-wordpress-playground-agent-skill}
+# Using the WordPress Playground Agent Skill
 
 Want an AI assistant that already knows how to spin up WordPress instances, run Blueprints, and debug plugins? The **wp-playground** agent skill teaches coding agents the WordPress Playground CLI and browser workflows. You describe what you need in plain language. The agent handles the commands.
 
 Your coding agent reads the skill reference — a document with CLI flags, procedures, and troubleshooting steps — before responding. This ensures Playground commands run correctly.
 
-## Prerequisites {#prerequisites}
+## Prerequisites
 
 Before installing the skill, confirm you have:
 
@@ -21,9 +21,9 @@ Before installing the skill, confirm you have:
 
 You also need a coding agent that supports agent skills: Antigravity, Claude Code, Codex, Copilot, Cursor, or Gemini CLI. Make sure your CLI or IDE runs the latest version. Output quality depends on your chosen model.
 
-## Installation {#installation}
+## Installation
 
-### 1. Install via terminal {#install-via-terminal}
+### 1. Install via terminal
 
 Install the skill using the `npx skills` CLI:
 
@@ -31,7 +31,7 @@ Install the skill using the `npx skills` CLI:
 npx skills add wordpress/agent-skills --skill wp-playground
 ```
 
-### 2. Install manually {#install-manually}
+### 2. Install manually
 
 ```bash
 # Clone agent-skills
@@ -75,7 +75,7 @@ claude /skills
 gemini /skills list
 ```
 
-## Use the skill in the terminal {#use-the-skill-in-the-terminal}
+## Use the skill in the terminal
 
 With the skill installed, describe your WordPress environment to your coding agent. The agent builds the Blueprint, runs the CLI commands, and starts the server.
 
@@ -87,7 +87,7 @@ Open your coding agent in the terminal and type your request:
 
 The agent reads the skill reference, detects your project layout, and runs `server --auto-mount`. The instance starts at `http://localhost:9400`.
 
-### Generating content on the fly {#generating-content-on-the-fly}
+### Generating content on the fly
 
 Need sample data for testing or a demo? Describe the content structure you want:
 
@@ -113,7 +113,7 @@ More examples:
 
 Each prompt produces a complete Blueprint that runs locally, handling user creation, role assignment, post generation, and taxonomy setup through Blueprint steps.
 
-### Version compatibility testing {#version-compatibility-testing}
+### Version compatibility testing
 
 Does your plugin work on older PHP versions? Ask directly:
 
@@ -134,7 +134,7 @@ The agent adds `--wp` and `--php` flags to match your request. Common combinatio
 | Upcoming release  | "Run the WordPress nightly build"                           |
 | Legacy PHP        | "Start WordPress with PHP 7.4"                              |
 
-### Complex scenarios {#complex-scenarios}
+### Complex scenarios
 
 Combine multiple requirements in a single prompt:
 
@@ -150,7 +150,7 @@ Combine multiple requirements in a single prompt:
 
 The agent breaks these into the right sequence of Blueprint steps and CLI flags. Each request produces a fully configured, running instance.
 
-## How the skill works {#how-the-skill-works}
+## How the skill works
 
 The wp-playground skill is a set of Markdown files that your coding agent loads into its context when your request matches Playground-related patterns. The skill includes:
 
@@ -161,7 +161,7 @@ The wp-playground skill is a set of Markdown files that your coding agent loads 
 
 Your coding agent reads these files before generating commands, ensuring correct flags and warning you about common pitfalls.
 
-## Next steps {#next-steps}
+## Next steps
 
 - [WordPress Playground for Plugin Developers](/guides/for-plugin-developers) — Showcase and develop plugins with Playground
 - [WordPress Playground for Theme Developers](/guides/for-theme-developers) — Build and demo themes using Playground

--- a/packages/docs/site/docs/main/web-instance.md
+++ b/packages/docs/site/docs/main/web-instance.md
@@ -4,7 +4,7 @@ slug: /web-instance
 description: A detailed guide to the web interface at playground.wordpress.net, covering the toolbar, settings, and instance manager.
 ---
 
-# WordPress Playground web instance {#wordpress-playground-web-instance}
+# WordPress Playground web instance
 
 [https://playground.wordpress.net/](https://playground.wordpress.net/) lets developers run WordPress in a browser without a server. This environment makes testing plugins, themes, and features quick and easy.
 
@@ -20,7 +20,7 @@ The Playground website includes toolbars that customize your instance and provid
 
 ![Playground Toolbar Snapshot](@site/static/img/about/playground-toolbar.webp)
 
-## Customize Playground {#customize-playground}
+## Customize Playground
 
 On the toolbar, you'll find:
 
@@ -28,7 +28,7 @@ On the toolbar, you'll find:
 - **Playground Dashboard**: This panel lets you manage WordPress Playground instances, save and export them, edit files from your WordPress instance, and create new Blueprints.
 - **Playground Launch Panel**: The Launch Panel shows all the ways to launch a WordPress Playground instance.
 
-### Playground Settings {#playground-settings}
+### Playground Settings
 
 ![snapshot of customize Playground window at Playground instance](@site/static/img/about/playground-settings-panel.webp)
 
@@ -40,7 +40,7 @@ The **Playground Settings Panel** includes these [Query API options](/developers
 - `multisite`: Enables WordPress multisite support.
 - `networking`: Enables network access to the WordPress Plugin Directory and WordPress APIs.
 
-## Playground Manager {#playground-manager}
+## Playground Manager
 
 ![Playground settings panel allow users to save export and edit the WordPress directly](@site/static/img/about/playground-dashboard.webp)
 
@@ -56,20 +56,20 @@ This panel lets you manage Playground instances and provides access to the follo
 
 Click "Save" to create an instance and list it in the Playground Launch Panel. The Playground Dashboard also offers export and download options through the Additional actions menu:
 
-### Additional actions menu {#additional-actions-menu}
+### Additional actions menu
 
 ![Additional actions Menu](@site/static/img/about/additional-options-playground-dashboard.webp)
 
 - **Export Pull Request to GitHub**: Export WordPress plugins, themes, and entire wp-content directories as pull requests to any public GitHub repository. Watch a [demo of this feature](https://www.youtube.com/watch?v=gKrij8V3nK0&t=2488s).
 - **Download as .zip**: Creates a `.zip` file with the setup of the Playground instance, including any themes or plugins installed. This `.zip` excludes content and database changes.
 
-### Blueprint Editor {#blueprint-editor}
+### Blueprint Editor
 
 ![Blueprint editor WordPress Playground](@site/static/img/about/playground-blueprint-editor.webp)
 
 The Blueprint editor provides the ability to manage multiple Blueprints and to validate code.
 
-### Launch Playground Panel {#launch-playground-panel}
+### Launch Playground Panel
 
 ![Playground Launch Panel](@site/static/img/dashboard/import-playground.webp)
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/23-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/23-architecture/18-host-your-own-playground.md
@@ -2,9 +2,9 @@
 slug: /developers/architecture/host-your-own-playground
 ---
 
-<!-- # Host your own Playground {#host-your-own-playground} -->
+<!-- # Host your own Playground -->
 
-# Hospeda tu propio Playground {#host-your-own-playground}
+# Hospeda tu propio Playground
 
 <!-- You can host the Playground on your own domain instead of `playground.wordpress.net`. -->
 
@@ -14,17 +14,17 @@ Puedes hospedar el Playground en tu propio dominio en lugar de `playground.wordp
 
 Esto es útil para tener control total sobre su contenido y comportamiento, así como eliminar la dependencia de un servidor de terceros. Puede proporcionar una experiencia de usuario más personalizada, por ejemplo: un playground con plugins y temas preinstalados, configuraciones predeterminadas del sitio o contenido de demostración.
 
-<!-- ## Before you start {#before-you-start} -->
+<!-- ## Before you start -->
 
-## Antes de comenzar {#before-you-start}
+## Antes de comenzar
 
 <!-- Self-hosting Playground gives you full control, but requires understanding a few key concepts: -->
 
 Hospedar Playground por tu cuenta te da control total, pero requiere entender algunos conceptos clave:
 
-<!-- ### What to expect {#what-to-expect} -->
+<!-- ### What to expect -->
 
-### Qué esperar {#what-to-expect}
+### Qué esperar
 
 <!-- - **Initial setup complexity**: Building and deploying Playground involves multiple steps. Allow time for troubleshooting during your first deployment. -->
 <!-- - **Static file hosting**: Playground is primarily static files (HTML, JS, WASM) with minimal server-side requirements. -->
@@ -34,9 +34,9 @@ Hospedar Playground por tu cuenta te da control total, pero requiere entender al
 - **Alojamiento de archivos estáticos**: Playground es principalmente archivos estáticos (HTML, JS, WASM) con requisitos mínimos del lado del servidor.
 - **Ejecución basada en navegador**: Todo el procesamiento de WordPress ocurre en el navegador del usuario vía WebAssembly—tu servidor solo entrega archivos.
 
-<!-- ### Performance considerations {#performance-considerations} -->
+<!-- ### Performance considerations -->
 
-### Consideraciones de rendimiento {#performance-considerations}
+### Consideraciones de rendimiento
 
 <!-- Loading times depend on several factors: -->
 
@@ -56,9 +56,9 @@ Los tiempos de carga dependen de varios factores:
 | **Navegador**         | Chrome/Edge tienen mejor rendimiento; Safari usa mecanismos de respaldo   | Prueba en diferentes navegadores                              |
 | **Dispositivo**       | Los dispositivos móviles cargan más lento que escritorio                  | Advierte a usuarios móviles sobre tiempos de carga más largos |
 
-<!-- ### Browser compatibility {#browser-compatibility} -->
+<!-- ### Browser compatibility -->
 
-### Compatibilidad con navegadores {#browser-compatibility}
+### Compatibilidad con navegadores
 
 <!-- Playground works across modern browsers, but with some differences: -->
 
@@ -82,9 +82,9 @@ Playground funciona en navegadores modernos, pero con algunas diferencias:
 
 **Nota técnica**: Safari usa MessagePorts en lugar de SharedArrayBuffer para respuestas en streaming. Este mecanismo de respaldo funciona de manera confiable pero añade una ligera sobrecarga comparado con Chrome/Edge.
 
-<!-- ## Usage {#usage} -->
+<!-- ## Usage -->
 
-## Uso {#usage}
+## Uso
 
 <!-- A self-hosted Playground can be embedded as an iframe. -->
 
@@ -107,9 +107,9 @@ const client = await startPlaygroundWeb({
 });
 ```
 
-<!-- ## Static assets {#static-assets} -->
+<!-- ## Static assets -->
 
-## Recursos estáticos {#static-assets}
+## Recursos estáticos
 
 <!-- There are several ways to get the static assets necessary to host the Playground. -->
 
@@ -127,9 +127,9 @@ En orden de conveniencia y facilidad:
 - Hacer fork del repositorio y construir con GitHub Action
 - Construir localmente
 
-<!-- ### Download pre-built package {#download-pre-built-package} -->
+<!-- ### Download pre-built package -->
 
-### Descargar paquete pre-construido {#download-pre-built-package}
+### Descargar paquete pre-construido
 
 <!-- To host the Playground as is, without making changes, you can download the built artifact from [the latest successful GitHub Action](https://github.com/WordPress/wordpress-playground/actions/workflows/deploy-website.yml?query=is%3Asuccess). -->
 
@@ -143,9 +143,9 @@ Para hospedar el Playground tal como está, sin hacer cambios, puedes descargar 
 - En la sección **Artifacts** en la parte inferior de la página, haz clic en `playground-website`.
 - Es un paquete zip con los mismos archivos desplegados en el sitio público.
 
-<!-- ### Fork the repository and build with GitHub Action {#fork-repository-and-build-with-github-actions} -->
+<!-- ### Fork the repository and build with GitHub Action -->
 
-### Hacer fork del repositorio y construir con GitHub Action {#fork-repository-and-build-with-github-actions}
+### Hacer fork del repositorio y construir con GitHub Action
 
 <!-- To customize the Playground, you can [fork the Git repository](https://github.com/WordPress/wordpress-playground/fork). -->
 
@@ -155,9 +155,9 @@ Para personalizar el Playground, puedes [hacer fork del repositorio Git](https:/
 
 Constrúyelo desde la página de GitHub de tu fork yendo a: **Actions -> Deploy Playground website -> Run workflow**.
 
-<!-- ### Build locally {#build-locally} -->
+<!-- ### Build locally -->
 
-### Construir localmente {#build-locally}
+### Construir localmente
 
 <!-- The most flexible and customizable method is to build the site locally. -->
 
@@ -200,9 +200,9 @@ dist/packages/playground/wasm-wordpress-net
 
 El servicio completo del Playground consiste en el contenido de esta carpeta.
 
-<!-- ## Summary of included files {#summary-of-included-files} -->
+<!-- ## Summary of included files -->
 
-## Resumen de archivos incluidos {#summary-of-included-files}
+## Resumen de archivos incluidos
 
 <!-- The static assets include: -->
 
@@ -234,9 +234,9 @@ Es un sitio estático, excepto por estos aspectos dinámicos.
 
 Para que estos funcionen, necesitas un entorno de servidor con Apache y PHP instalados.
 
-<!-- ## NGINX configuration {#nginx-configuration} -->
+<!-- ## NGINX configuration -->
 
-## Configuración de NGINX {#nginx-configuration}
+## Configuración de NGINX
 
 <!-- As an alternative to Apache, here is an example of using NGINX to serve the Playground. -->
 
@@ -278,9 +278,9 @@ Puede que necesites ajustar lo anterior según las especificaciones del servidor
 
 [El servidor web Caddy](https://caddyserver.com) no requiere ninguna configuración especial para funcionar.
 
-<!-- ## Customize bundled data {#customize-bundled-data} -->
+<!-- ## Customize bundled data -->
 
-## Personalizar datos empaquetados {#customize-bundled-data}
+## Personalizar datos empaquetados
 
 <!-- The file `wp.zip` is a bundle of all the files for the virtual file system in Playground. There's a data file for each available WordPress version. -->
 
@@ -306,9 +306,9 @@ npm run rebuild:wordpress-builds
 
 Para reconstruir el sitio web para incluir los builds personalizados de WordPress, sigue las instrucciones [aquí](#build-locally).
 
-<!-- ### Install plugins {#install-plugins} -->
+<!-- ### Install plugins -->
 
-### Instalar plugins {#install-plugins}
+### Instalar plugins
 
 <!-- Here's an example of installing plugins for the data bundle. -->
 
@@ -348,9 +348,9 @@ COPY ./build-assets/*.zip /root/
 
 Luego coloca los archivos zip de plugins en `build-assets`. En este caso, puede que quieras añadir sus rutas a `.gitignore`.
 
-<!-- ### Import content {#import-content} -->
+<!-- ### Import content -->
 
-### Importar contenido {#import-content}
+### Importar contenido
 
 <!-- Here's an example of importing content. -->
 
@@ -369,9 +369,9 @@ RUN cd wordpress ; \
 
 Esto asume que has puesto un archivo de exportación WXR llamado `content.xml` en la carpeta `build-assets`. Puedes añadir su ruta a `.gitignore`.
 
-<!-- ## Production deployment checklist {#production-deployment-checklist} -->
+<!-- ## Production deployment checklist -->
 
-## Lista de verificación para despliegue en producción {#production-deployment-checklist}
+## Lista de verificación para despliegue en producción
 
 <!-- Before going live, verify your self-hosted Playground meets these requirements: -->
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/24-limitations/01-index.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/developers/24-limitations/01-index.md
@@ -16,13 +16,13 @@ WordPress Playground está en desarrollo activo y tiene algunas limitaciones que
 
 Puedes seguir el estado de estos problemas en el [tablero del proyecto Playground](https://github.com/orgs/WordPress/projects/180).
 
-<!-- ## In the browser {#in-the-browser} -->
+<!-- ## In the browser -->
 
-## En el navegador {#in-the-browser}
+## En el navegador
 
-<!-- ### Temporary by design {#temporary-by-design} -->
+<!-- ### Temporary by design -->
 
-### Temporal por diseño {#temporary-by-design}
+### Temporal por diseño
 
 <!-- Playground creates fresh WordPress instances on each page load. Refreshing the browser page discards all database changes, uploads, and modifications. -->
 
@@ -70,9 +70,9 @@ El botón de actualización dedicado dentro de Playground solo recarga el conten
 </figure>
 </blockquote>
 
-<!-- ### Browser support {#browser-support} -->
+<!-- ### Browser support -->
 
-### Compatibilidad con navegadores {#browser-support}
+### Compatibilidad con navegadores
 
 <!-- WordPress Playground is designed to work across all major desktop and mobile browsers. This includes: -->
 
@@ -88,9 +88,9 @@ WordPress Playground está diseñado para funcionar en todos los principales nav
 
 Playground aprovecha las tecnologías web modernas y debería funcionar de manera consistente en estos entornos de navegador. Sin embargo, algunas funciones avanzadas pueden tener diferentes niveles de soporte dependiendo del navegador específico y su versión.
 
-<!-- ### Performance expectations {#performance-expectations} -->
+<!-- ### Performance expectations -->
 
-### Expectativas de rendimiento {#performance-expectations}
+### Expectativas de rendimiento
 
 <!-- Loading times vary based on what Playground needs to set up: -->
 
@@ -117,13 +117,13 @@ Los tiempos de carga varían según lo que Playground necesita configurar:
 <strong>Nota:</strong> El soporte para Opera Mini no está confirmado actualmente.
 </blockquote>
 
-<!-- ## When developing with Playground {#when-developing-with-playground} -->
+<!-- ## When developing with Playground -->
 
-## Al desarrollar con Playground {#when-developing-with-playground}
+## Al desarrollar con Playground
 
-<!-- ### Iframe quirks {#iframe-quirks} -->
+<!-- ### Iframe quirks -->
 
-### Peculiaridades del iframe {#iframe-quirks}
+### Peculiaridades del iframe
 
 <!-- Playground renders WordPress in an [`iframe`](/developers/architecture/browser-iframe-rendering) so clicking links with `target="_top"` will reload the page you're working on. -->
 
@@ -133,9 +133,9 @@ Playground renderiza WordPress en un [`iframe`](/developers/architecture/browser
 
 Además, los popups de JavaScript que se originan en el `iframe` pueden no mostrarse siempre.
 
-<!-- ### Run WordPress PHP functions {#run-wordpress-php-functions} -->
+<!-- ### Run WordPress PHP functions -->
 
-### Ejecutar funciones PHP de WordPress {#run-wordpress-php-functions}
+### Ejecutar funciones PHP de WordPress
 
 <!-- Playground supports running PHP code in Blueprints using the [`runPHP` step](/blueprints/steps#RunPHPStep). To run WordPress-specific PHP functions, you'd need to first require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php): -->
 
@@ -148,9 +148,9 @@ Playground soporta la ejecución de código PHP en Blueprints usando el [paso `r
 }
 ```
 
-<!-- ### Using WP-CLI {#using-wp-cli} -->
+<!-- ### Using WP-CLI -->
 
-### Usando WP-CLI {#using-wp-cli}
+### Usando WP-CLI
 
 <!-- You can execute `wp-cli` commands via the Blueprints [`wp-cli`](/blueprints/steps#WPCLIStep) step. However, since Playground runs in the browser, it doesn't support the [full array](https://developer.wordpress.org/cli/commands/) of available commands. While there is no definite list of supported commands, experimenting in [the online demo](https://playground.wordpress.net/demos/wp-cli.html) will help you assess what's possible. -->
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -5,10 +5,10 @@ description: Una guía detallada de la interfaz web en playground.wordpress.net,
 ---
 
 <!--
-# WordPress Playground web instance {#wordpress-playground-web-instance}
+# WordPress Playground web instance
 -->
 
-# Instancia web de WordPress Playground {#wordpress-playground-web-instance}
+# Instancia web de WordPress Playground
 
 <!--
 [https://playground.wordpress.net/](https://playground.wordpress.net/) lets developers run WordPress in a browser without a server. This environment makes testing plugins, themes, and features quick and easy.
@@ -45,10 +45,10 @@ El sitio web de Playground incluye barras de herramientas que personalizan tu in
 ![Playground Toolbar Snapshot](@site/static/img/about/playground-toolbar.webp)
 
 <!--
-## Customize Playground {#customize-playground}
+## Customize Playground
 -->
 
-## Personalizar Playground {#customize-playground}
+## Personalizar Playground
 
 <!--
 On the toolbar, you'll find:
@@ -65,10 +65,10 @@ En la barra de herramientas, encontrarás:
 - **Panel de Lanzamiento de Playground**: El Panel de Lanzamiento muestra todas las formas de iniciar una instancia de WordPress Playground.
 
 <!--
-### Playground Settings {#playground-settings}
+### Playground Settings
 -->
 
-### Configuración de Playground {#playground-settings}
+### Configuración de Playground
 
 ![snapshot of customize Playground window at Playground instance](@site/static/img/about/playground-settings-panel.webp)
 
@@ -91,10 +91,10 @@ El **Panel de Configuración de Playground** incluye estas [opciones de la API d
 - `networking`: Habilita el acceso a la red para el Directorio de Plugins de WordPress y las APIs de WordPress.
 
 <!--
-## Playground Manager {#playground-manager}
+## Playground Manager
 -->
 
-## Administrador de Playground {#playground-manager}
+## Administrador de Playground
 
 ![Playground settings panel allow users to save export and edit the WordPress directly](@site/static/img/about/playground-dashboard.webp)
 
@@ -125,10 +125,10 @@ Click "Save" to create an instance and list it in the Playground Launch Panel. T
 Haz clic en "Guardar" para crear una instancia y listarla en el Panel de Lanzamiento de Playground. El Panel de Playground también ofrece opciones de exportación y descarga a través del menú de Acciones adicionales:
 
 <!--
-### Additional actions menu {#additional-actions-menu}
+### Additional actions menu
 -->
 
-### Menú de acciones adicionales {#additional-actions-menu}
+### Menú de acciones adicionales
 
 ![Additional actions Menu](@site/static/img/about/additional-options-playground-dashboard.webp)
 
@@ -141,10 +141,10 @@ Haz clic en "Guardar" para crear una instancia y listarla en el Panel de Lanzami
 - **Descargar como .zip**: Crea un archivo `.zip` con la configuración de la instancia de Playground, incluidos los temas o plugins instalados. Este `.zip` no incluye contenido ni cambios en la base de datos.
 
 <!--
-### Blueprint Editor {#blueprint-editor}
+### Blueprint Editor
 -->
 
-### Editor de Blueprint {#blueprint-editor}
+### Editor de Blueprint
 
 ![Blueprint editor WordPress Playground](@site/static/img/about/playground-blueprint-editor.webp)
 
@@ -155,10 +155,10 @@ The Blueprint editor replaced the older Blueprint builder, offering the ability 
 El editor de Blueprint reemplazó al antiguo constructor de Blueprint, ofreciendo la capacidad de administrar múltiples Blueprints y validación de código.
 
 <!--
-### Launch Playground Panel {#launch-playground-panel}
+### Launch Playground Panel
 -->
 
-### Panel de Lanzamiento de Playground {#launch-playground-panel}
+### Panel de Lanzamiento de Playground
 
 ![Playground Launch Panel](@site/static/img/dashboard/import-playground.webp)
 

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/23-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/23-architecture/18-host-your-own-playground.md
@@ -2,9 +2,9 @@
 slug: /developers/architecture/host-your-own-playground
 ---
 
-<!-- # Host your own Playground {#host-your-own-playground} -->
+<!-- # Host your own Playground -->
 
-# Hébergez votre propre Playground {#host-your-own-playground}
+# Hébergez votre propre Playground
 
 <!-- You can host the Playground on your own domain instead of `playground.wordpress.net`. -->
 
@@ -14,17 +14,17 @@ Vous pouvez héberger le Playground sur votre propre domaine au lieu de `playgro
 
 C'est utile pour avoir un contrôle total sur son contenu et son comportement, ainsi que pour supprimer la dépendance à un serveur tiers. Cela peut fournir une expérience utilisateur plus personnalisée, par exemple : un playground avec des plugins et thèmes préinstallés, des paramètres de site par défaut ou du contenu de démonstration.
 
-<!-- ## Before you start {#before-you-start} -->
+<!-- ## Before you start -->
 
-## Avant de commencer {#before-you-start}
+## Avant de commencer
 
 <!-- Self-hosting Playground gives you full control, but requires understanding a few key concepts: -->
 
 L'auto-hébergement de Playground vous donne un contrôle total, mais nécessite de comprendre quelques concepts clés :
 
-<!-- ### What to expect {#what-to-expect} -->
+<!-- ### What to expect -->
 
-### À quoi s'attendre {#what-to-expect}
+### À quoi s'attendre
 
 <!-- - **Initial setup complexity**: Building and deploying Playground involves multiple steps. Allow time for troubleshooting during your first deployment. -->
 <!-- - **Static file hosting**: Playground is primarily static files (HTML, JS, WASM) with minimal server-side requirements. -->
@@ -34,9 +34,9 @@ L'auto-hébergement de Playground vous donne un contrôle total, mais nécessite
 - **Hébergement de fichiers statiques** : Playground est principalement composé de fichiers statiques (HTML, JS, WASM) avec des exigences minimales côté serveur.
 - **Exécution basée sur le navigateur** : Tout le traitement WordPress se fait dans le navigateur de l'utilisateur via WebAssembly—votre serveur ne fait que livrer les fichiers.
 
-<!-- ### Performance considerations {#performance-considerations} -->
+<!-- ### Performance considerations -->
 
-### Considérations de performance {#performance-considerations}
+### Considérations de performance
 
 <!-- Loading times depend on several factors: -->
 
@@ -56,9 +56,9 @@ Les temps de chargement dépendent de plusieurs facteurs :
 | **Navigateur**        | Chrome/Edge sont les plus performants ; Safari utilise des mécanismes de secours | Testez sur différents navigateurs                                      |
 | **Appareil**          | Les appareils mobiles chargent plus lentement que les ordinateurs                | Avertissez les utilisateurs mobiles des temps de chargement plus longs |
 
-<!-- ### Browser compatibility {#browser-compatibility} -->
+<!-- ### Browser compatibility -->
 
-### Compatibilité des navigateurs {#browser-compatibility}
+### Compatibilité des navigateurs
 
 <!-- Playground works across modern browsers, but with some differences: -->
 
@@ -82,9 +82,9 @@ Playground fonctionne sur les navigateurs modernes, mais avec quelques différen
 
 **Note technique** : Safari utilise MessagePorts au lieu de SharedArrayBuffer pour les réponses en streaming. Ce mécanisme de secours fonctionne de manière fiable mais ajoute une légère surcharge par rapport à Chrome/Edge.
 
-<!-- ## Usage {#usage} -->
+<!-- ## Usage -->
 
-## Utilisation {#usage}
+## Utilisation
 
 <!-- A self-hosted Playground can be embedded as an iframe. -->
 
@@ -107,9 +107,9 @@ const client = await startPlaygroundWeb({
 });
 ```
 
-<!-- ## Static assets {#static-assets} -->
+<!-- ## Static assets -->
 
-## Ressources statiques {#static-assets}
+## Ressources statiques
 
 <!-- There are several ways to get the static assets necessary to host the Playground. -->
 
@@ -127,9 +127,9 @@ Par ordre de commodité et de facilité :
 - Forker le dépôt et construire avec GitHub Action
 - Construire localement
 
-<!-- ### Download pre-built package {#download-pre-built-package} -->
+<!-- ### Download pre-built package -->
 
-### Télécharger le package pré-construit {#download-pre-built-package}
+### Télécharger le package pré-construit
 
 <!-- To host the Playground as is, without making changes, you can download the built artifact from [the latest successful GitHub Action](https://github.com/WordPress/wordpress-playground/actions/workflows/deploy-website.yml?query=is%3Asuccess). -->
 
@@ -143,9 +143,9 @@ Pour héberger le Playground tel quel, sans modification, vous pouvez téléchar
 - Dans la section **Artifacts** en bas de la page, cliquez sur `playground-website`.
 - C'est un package zip avec les mêmes fichiers déployés sur le site public.
 
-<!-- ### Fork the repository and build with GitHub Action {#fork-repository-and-build-with-github-actions} -->
+<!-- ### Fork the repository and build with GitHub Action -->
 
-### Forker le dépôt et construire avec GitHub Action {#fork-repository-and-build-with-github-actions}
+### Forker le dépôt et construire avec GitHub Action
 
 <!-- To customize the Playground, you can [fork the Git repository](https://github.com/WordPress/wordpress-playground/fork). -->
 
@@ -155,9 +155,9 @@ Pour personnaliser le Playground, vous pouvez [forker le dépôt Git](https://gi
 
 Construisez-le depuis la page GitHub de votre fork en allant à : **Actions -> Deploy Playground website -> Run workflow**.
 
-<!-- ### Build locally {#build-locally} -->
+<!-- ### Build locally -->
 
-### Construire localement {#build-locally}
+### Construire localement
 
 <!-- The most flexible and customizable method is to build the site locally. -->
 
@@ -200,9 +200,9 @@ dist/packages/playground/wasm-wordpress-net
 
 L'ensemble du service du Playground consiste en le contenu de ce dossier.
 
-<!-- ## Summary of included files {#summary-of-included-files} -->
+<!-- ## Summary of included files -->
 
-## Résumé des fichiers inclus {#summary-of-included-files}
+## Résumé des fichiers inclus
 
 <!-- The static assets include: -->
 
@@ -234,9 +234,9 @@ C'est un site statique, sauf pour ces aspects dynamiques.
 
 Pour que ceux-ci fonctionnent, vous avez besoin d'un environnement serveur avec Apache et PHP installés.
 
-<!-- ## NGINX configuration {#nginx-configuration} -->
+<!-- ## NGINX configuration -->
 
-## Configuration NGINX {#nginx-configuration}
+## Configuration NGINX
 
 <!-- As an alternative to Apache, here is an example of using NGINX to serve the Playground. -->
 
@@ -278,9 +278,9 @@ Vous devrez peut-être ajuster ce qui précède selon les spécificités du serv
 
 [Le serveur web Caddy](https://caddyserver.com) ne nécessite aucune configuration spéciale pour fonctionner.
 
-<!-- ## Customize bundled data {#customize-bundled-data} -->
+<!-- ## Customize bundled data -->
 
-## Personnaliser les données empaquetées {#customize-bundled-data}
+## Personnaliser les données empaquetées
 
 <!-- The file `wp.zip` is a bundle of all the files for the virtual file system in Playground. There's a data file for each available WordPress version. -->
 
@@ -306,9 +306,9 @@ npm run rebuild:wordpress-builds
 
 Pour reconstruire le site web afin d'inclure les builds WordPress personnalisés, suivez les instructions [ici](#build-locally).
 
-<!-- ### Install plugins {#install-plugins} -->
+<!-- ### Install plugins -->
 
-### Installer des plugins {#install-plugins}
+### Installer des plugins
 
 <!-- Here's an example of installing plugins for the data bundle. -->
 
@@ -348,9 +348,9 @@ COPY ./build-assets/*.zip /root/
 
 Ensuite, placez les fichiers zip des plugins dans `build-assets`. Dans ce cas, vous voudrez peut-être ajouter leurs chemins à `.gitignore`.
 
-<!-- ### Import content {#import-content} -->
+<!-- ### Import content -->
 
-### Importer du contenu {#import-content}
+### Importer du contenu
 
 <!-- Here's an example of importing content. -->
 
@@ -369,9 +369,9 @@ RUN cd wordpress ; \
 
 Cela suppose que vous avez mis un fichier d'export WXR nommé `content.xml` dans le dossier `build-assets`. Vous pouvez ajouter son chemin à `.gitignore`.
 
-<!-- ## Production deployment checklist {#production-deployment-checklist} -->
+<!-- ## Production deployment checklist -->
 
-## Liste de vérification pour le déploiement en production {#production-deployment-checklist}
+## Liste de vérification pour le déploiement en production
 
 <!-- Before going live, verify your self-hosted Playground meets these requirements: -->
 

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/24-limitations/01-index.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/developers/24-limitations/01-index.md
@@ -16,13 +16,13 @@ WordPress Playground est en développement actif et présente certaines limitati
 
 Vous pouvez suivre l'état de ces problèmes sur le [tableau de bord du projet Playground](https://github.com/orgs/WordPress/projects/180).
 
-<!-- ## In the browser {#in-the-browser} -->
+<!-- ## In the browser -->
 
-## Dans le navigateur {#in-the-browser}
+## Dans le navigateur
 
-<!-- ### Temporary by design {#temporary-by-design} -->
+<!-- ### Temporary by design -->
 
-### Conçu pour être temporaire {#temporary-by-design}
+### Conçu pour être temporaire
 
 <!-- Playground creates fresh WordPress instances on each page load. Refreshing the browser page discards all database changes, uploads, and modifications. -->
 
@@ -70,9 +70,9 @@ Le bouton d'actualisation dédié dans Playground ne recharge que le contenu Wor
 </figure>
 </blockquote>
 
-<!-- ### Browser support {#browser-support} -->
+<!-- ### Browser support -->
 
-### Compatibilité des navigateurs {#browser-support}
+### Compatibilité des navigateurs
 
 <!-- WordPress Playground is designed to work across all major desktop and mobile browsers. This includes: -->
 
@@ -88,9 +88,9 @@ WordPress Playground est conçu pour fonctionner sur tous les principaux navigat
 
 Playground exploite les technologies web modernes et devrait fonctionner de manière cohérente dans ces environnements de navigateur. Cependant, certaines fonctionnalités avancées peuvent avoir différents niveaux de support selon le navigateur spécifique et sa version.
 
-<!-- ### Performance expectations {#performance-expectations} -->
+<!-- ### Performance expectations -->
 
-### Attentes de performance {#performance-expectations}
+### Attentes de performance
 
 <!-- Loading times vary based on what Playground needs to set up: -->
 
@@ -117,13 +117,13 @@ Les temps de chargement varient en fonction de ce que Playground doit configurer
 <strong>Note :</strong> Le support d'Opera Mini n'est pas actuellement confirmé.
 </blockquote>
 
-<!-- ## When developing with Playground {#when-developing-with-playground} -->
+<!-- ## When developing with Playground -->
 
-## Lors du développement avec Playground {#when-developing-with-playground}
+## Lors du développement avec Playground
 
-<!-- ### Iframe quirks {#iframe-quirks} -->
+<!-- ### Iframe quirks -->
 
-### Particularités des iframes {#iframe-quirks}
+### Particularités des iframes
 
 <!-- Playground renders WordPress in an [`iframe`](/developers/architecture/browser-iframe-rendering) so clicking links with `target="_top"` will reload the page you're working on. -->
 
@@ -133,9 +133,9 @@ Playground affiche WordPress dans un [`iframe`](/developers/architecture/browser
 
 De plus, les popups JavaScript provenant de l'`iframe` peuvent ne pas toujours s'afficher.
 
-<!-- ### Run WordPress PHP functions {#run-wordpress-php-functions} -->
+<!-- ### Run WordPress PHP functions -->
 
-### Exécuter des fonctions PHP WordPress {#run-wordpress-php-functions}
+### Exécuter des fonctions PHP WordPress
 
 <!-- Playground supports running PHP code in Blueprints using the [`runPHP` step](/blueprints/steps#RunPHPStep). To run WordPress-specific PHP functions, you'd need to first require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php): -->
 
@@ -148,9 +148,9 @@ Playground prend en charge l'exécution de code PHP dans les Blueprints en utili
 }
 ```
 
-<!-- ### Using WP-CLI {#using-wp-cli} -->
+<!-- ### Using WP-CLI -->
 
-### Utilisation de WP-CLI {#using-wp-cli}
+### Utilisation de WP-CLI
 
 <!-- You can execute `wp-cli` commands via the Blueprints [`wp-cli`](/blueprints/steps#WPCLIStep) step. However, since Playground runs in the browser, it doesn't support the [full array](https://developer.wordpress.org/cli/commands/) of available commands. While there is no definite list of supported commands, experimenting in [the online demo](https://playground.wordpress.net/demos/wp-cli.html) will help you assess what's possible. -->
 

--- a/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/gu/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -5,10 +5,10 @@ description: playground.wordpress.net પર વેબ ઈન્ટરફેસ 
 ---
 
 <!--
-# WordPress Playground web instance {#wordpress-playground-web-instance}
+# WordPress Playground web instance
 -->
 
-# વર્ડપ્રેસ પ્લેગ્રાઉન્ડ વેબ ઇન્સ્ટન્સ {#wordpress-playground-web-instance}
+# વર્ડપ્રેસ પ્લેગ્રાઉન્ડ વેબ ઇન્સ્ટન્સ
 
 <!--
 [https://playground.wordpress.net/](https://playground.wordpress.net/) lets developers run WordPress in a browser without a server. This environment makes testing plugins, themes, and features quick and easy.
@@ -45,10 +45,10 @@ The Playground website includes toolbars that customize your instance and provid
 ![Playground Toolbar Snapshot](@site/static/img/about/playground-toolbar.webp)
 
 <!--
-## Customize Playground {#customize-playground}
+## Customize Playground
 -->
 
-## પ્લેગ્રાઉન્ડ કસ્ટમાઇઝ કરો {#customize-playground}
+## પ્લેગ્રાઉન્ડ કસ્ટમાઇઝ કરો
 
 <!--
 On the toolbar, you'll find:
@@ -65,10 +65,10 @@ On the toolbar, you'll find:
 - **પ્લેગ્રાઉન્ડ લૉન્ચ પેનલ**: લૉન્ચ પેનલ વર્ડપ્રેસ પ્લેગ્રાઉન્ડ ઇન્સ્ટન્સ લૉન્ચ કરવાની બધી રીતો બતાવે છે.
 
 <!--
-### Playground Settings {#playground-settings}
+### Playground Settings
 -->
 
-### પ્લેગ્રાઉન્ડ સેટિંગ્સ {#playground-settings}
+### પ્લેગ્રાઉન્ડ સેટિંગ્સ
 
 ![snapshot of customize Playground window at Playground instance](@site/static/img/about/playground-settings-panel.webp)
 
@@ -91,10 +91,10 @@ The **Playground Settings Panel** includes these [Query API options](/developers
 - `networking`: વર્ડપ્રેસ પ્લગઇન ડિરેક્ટરી અને વર્ડપ્રેસ API માટે નેટવર્ક ઍક્સેસ સક્ષમ કરે છે.
 
 <!--
-## Playground Manager {#playground-manager}
+## Playground Manager
 -->
 
-## પ્લેગ્રાઉન્ડ મેનેજર {#playground-manager}
+## પ્લેગ્રાઉન્ડ મેનેજર
 
 ![Playground settings panel allow users to save export and edit the WordPress directly](@site/static/img/about/playground-dashboard.webp)
 
@@ -125,10 +125,10 @@ Click "Save" to create an instance and list it in the Playground Launch Panel. T
 ઇન્સ્ટન્સ બનાવવા અને પ્લેગ્રાઉન્ડ લૉન્ચ પેનલમાં સૂચિબદ્ધ કરવા માટે "Save" પર ક્લિક કરો. પ્લેગ્રાઉન્ડ ડેશબોર્ડ Additional actions મેનૂ દ્વારા એક્સપોર્ટ અને ડાઉનલોડ વિકલ્પો પણ આપે છે:
 
 <!--
-### Additional actions menu {#additional-actions-menu}
+### Additional actions menu
 -->
 
-### એડિશનલ એક્શન્‍સ મેનુ {#additional-actions-menu}
+### એડિશનલ એક્શન્‍સ મેનુ
 
 ![Additional actions Menu](@site/static/img/about/additional-options-playground-dashboard.webp)
 
@@ -141,10 +141,10 @@ Click "Save" to create an instance and list it in the Playground Launch Panel. T
 - **zip તરીકે ડાઉનલોડ કરો**: પ્લેગ્રાઉન્ડ ઇન્સ્ટન્સના સેટઅપ સાથે `.zip` ફાઇલ બનાવે છે, જેમાં કોઈપણ ઇન્સ્ટોલ કરેલી થીમ્સ અથવા પ્લગઇન્સ શામેલ છે. આ `.zip` કન્ટેન્ટ અને ડેટાબેસ ફેરફારો શામેલ કરતું નથી.
 
 <!--
-### Blueprint Editor {#blueprint-editor}
+### Blueprint Editor
 -->
 
-### બ્લુપ્રીન્ટ એડિટર {#blueprint-editor}
+### બ્લુપ્રીન્ટ એડિટર
 
 ![Blueprint editor WordPress Playground](@site/static/img/about/playground-blueprint-editor.webp)
 
@@ -155,10 +155,10 @@ The Blueprint editor replaced the older Blueprint builder, offering the ability 
 બ્લુપ્રીન્ટ એડિટરે જૂના બ્લુપ્રીન્ટ બિલ્ડરને બદલ્યું, જે બહુવિધ બ્લુપ્રીન્ટ મેનેજ કરવાની અને કોડ વેલિડેશનની ક્ષમતા આપે છે.
 
 <!--
-### Launch Playground Panel {#launch-playground-panel}
+### Launch Playground Panel
 -->
 
-### પ્લેગ્રાઉન્ડ લૉન્ચ પેનલ {#launch-playground-panel}
+### પ્લેગ્રાઉન્ડ લૉન્ચ પેનલ
 
 ![Playground Launch Panel](@site/static/img/dashboard/import-playground.webp)
 

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/developers/24-limitations/01-index.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/developers/24-limitations/01-index.md
@@ -21,16 +21,16 @@ WordPress Playground is under active development and has some limitations you sh
 You can track the status of these issues on the [Playground Project board](https://github.com/orgs/WordPress/projects/180).
 -->
 
-## ブラウザの中で {#in-the-browser}
+## ブラウザの中で
 
 <!--
-## In the browser {#in-the-browser}
+## In the browser
 -->
 
-### 設計上は一時的なもの {#temporary-by-design}
+### 設計上は一時的なもの
 
 <!--
-### Temporary by design {#temporary-by-design}
+### Temporary by design
 -->
 
 Playground は、ページを読み込むたびに新しい WordPress インスタンスを作成します。そのため、ブラウザを更新すると、データベースの変更、アップロード、修正はすべて破棄されます。
@@ -105,10 +105,10 @@ The dedicated refresh button inside Playground only reloads WordPress content—
 </blockquote>
 -->
 
-### ブラウザサポート {#browser-support}
+### ブラウザサポート
 
 <!--
-### Browser support {#browser-support}
+### Browser support
 -->
 
 WordPress Playgroundは、主要なデスクトップおよびモバイルブラウザすべてで動作するように設計されています。対応ブラウザは以下の通りです。
@@ -134,7 +134,7 @@ Playground leverages modern web technologies and should function consistently ac
 ### パフォーマンスに関する注意点
 
 <!--
-### Performance expectations {#performance-expectations}
+### Performance expectations
 -->
 
 Playgroundがセットアップする内容によって、読み込み時間は異なります。
@@ -187,16 +187,16 @@ Loading times vary based on what Playground needs to set up:
 <strong>Note:</strong> Opera Mini support is not currently confirmed.
 </blockquote>
 
-## Playground で開発する場合 {#when-developing-with-playground}
+## Playground で開発する場合
 
 <!--
-## When developing with Playground {#when-developing-with-playground}
+## When developing with Playground
 -->
 
-### iframe の癖 {#iframe-quirks}
+### iframe の癖
 
 <!--
-### Iframe quirks {#iframe-quirks}
+### Iframe quirks
 -->
 
 Playground は WordPress を [`iframe`](/developers/architecture/browser-iframe-rendering) でレンダリングするため、`target="_top"` を含むリンクをクリックすると作業中のページがリロードされます。
@@ -207,10 +207,10 @@ Playground renders WordPress in an [`iframe`](/developers/architecture/browser-i
 Also, JavaScript popups originating in the `iframe` may not always display.
 -->
 
-### WordPress PHP 関数を実行する {#run-wordpress-php-functions}
+### WordPress PHP 関数を実行する
 
 <!--
-### Run WordPress PHP functions {#run-wordpress-php-functions}
+### Run WordPress PHP functions
 -->
 
 Playgroundでは、`runPHP`ステップを使ってブループリント内でPHPコードを実行できます。WordPress固有のPHP関数を実行するには、まず`wp-load.php`を読み込む必要があります。
@@ -226,10 +226,10 @@ Playground supports running PHP code in Blueprints using the [`runPHP` step](/
 }
 ```
 
-### WP-CLI の使用 {#using-wp-cli}
+### WP-CLI の使用
 
 <!--
-### Using WP-CLI {#using-wp-cli}
+### Using WP-CLI
 -->
 
 ブループリントの[`wp-cli`](/blueprints/steps#WPCLIStep)ステップから`wp-cli`コマンドを実行できます。ただし、Playground はブラウザ内で実行されるため、[利用可能なコマンドの全て](https://developer.wordpress.org/cli/commands/)をサポートしているわけではありません。サポートされているコマンドの明確なリストはありませんが、[オンラインデモ](https://playground.wordpress.net/demos/wp-cli.html)で試してみることで、どのようなことが可能かを確認するのに役立ちます。

--- a/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/ja/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -5,10 +5,10 @@ description: ツールバー、設定、インスタンス マネージャーを
 ---
 
 <!--
-# WordPress Playground web instance {#wordpress-playground-web-instance}
+# WordPress Playground web instance
 -->
 
-# WordPress Playground ウェブ インスタンス {#wordpress-playground-web-instance}
+# WordPress Playground ウェブ インスタンス
 
 <!--
 [https://playground.wordpress.net/](https://playground.wordpress.net/) lets developers run WordPress in a browser without a server. This environment makes testing plugins, themes, and features quick and easy.
@@ -45,10 +45,10 @@ Playground Web サイトには、インスタンスをカスタマイズした�
 ![Playground Toolbar Snapshot](@site/static/img/about/playground-toolbar.webp)
 
 <!--
-## Customize Playground {#customize-playground}
+## Customize Playground
 -->
 
-## Playground をカスタマイズする {#customize-playground}
+## Playground をカスタマイズする
 
 <!--
 On the toolbar, you'll find:
@@ -65,10 +65,10 @@ On the toolbar, you'll find:
 - **Playground 起動パネル**: WordPress Playground インスタンスを起動するさまざまな方法を表示するパネルです。
 
 <!--
-### Playground Settings {#playground-settings}
+### Playground Settings
 -->
 
-### Playground 設定 {#playground-settings}
+### Playground 設定
 
 ![snapshot of customize Playground window at Playground instance](@site/static/img/about/playground-settings-panel.webp)
 
@@ -91,10 +91,10 @@ The **Playground Settings Panel** includes these [Query API options](/developers
 - `networking`: WordPress プラグインディレクトリと WordPress API へのネットワークアクセスを有効にします。
 
 <!--
-## Playground Manager {#playground-manager}
+## Playground Manager
 -->
 
-## Playground マネージャー {#playground-manager}
+## Playground マネージャー
 
 ![Playground settings panel allow users to save export and edit the WordPress directly](@site/static/img/about/playground-dashboard.webp)
 
@@ -125,10 +125,10 @@ Click "Save" to create an instance and list it in the Playground Launch Panel. T
 「保存」をクリックすると、インスタンスが作成され、Playground 起動パネルにリストされます。Playground ダッシュボードでは、追加アクションメニューからエクスポートやダウンロードオプションも利用できます:
 
 <!--
-### Additional actions menu {#additional-actions-menu}
+### Additional actions menu
 -->
 
-### 追加アクションメニュー {#additional-actions-menu}
+### 追加アクションメニュー
 
 ![Additional actions Menu](@site/static/img/about/additional-options-playground-dashboard.webp)
 
@@ -141,10 +141,10 @@ Click "Save" to create an instance and list it in the Playground Launch Panel. T
 - **zip としてダウンロード**: テーマやプラグインがインストールされた状態を含む、Playground インスタンスのセットアップを含む `.zip` ファイルが作成されます。この `.zip` ファイルには、コンテンツやデータベースの変更は含まれません。
 
 <!--
-### Blueprint Editor {#blueprint-editor}
+### Blueprint Editor
 -->
 
-### ブループリントエディタ {#blueprint-editor}
+### ブループリントエディタ
 
 ![Blueprint editor WordPress Playground](@site/static/img/about/playground-blueprint-editor.webp)
 
@@ -155,10 +155,10 @@ The Blueprint editor replaced the older Blueprint builder, offering the ability 
 ブループリントエディタは、以前のブループリントビルダーに代わるもので、複数のブループリントを管理し、コード検証を行う機能を提供します。
 
 <!--
-### Launch Playground Panel {#launch-playground-panel}
+### Launch Playground Panel
 -->
 
-### Playground 起動パネル {#launch-playground-panel}
+### Playground 起動パネル
 
 ![Playground Launch Panel](@site/static/img/dashboard/import-playground.webp)
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/23-architecture/18-host-your-own-playground.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/23-architecture/18-host-your-own-playground.md
@@ -2,9 +2,9 @@
 slug: /developers/architecture/host-your-own-playground
 ---
 
-<!-- # Host your own Playground {#host-your-own-playground} -->
+<!-- # Host your own Playground -->
 
-# Hospede seu próprio Playground {#host-your-own-playground}
+# Hospede seu próprio Playground
 
 <!-- You can host the Playground on your own domain instead of `playground.wordpress.net`. -->
 
@@ -14,17 +14,17 @@ Você pode hospedar o Playground no seu próprio domínio ao invés de `playgrou
 
 Isso é útil para ter controle total sobre seu conteúdo e comportamento, assim como remover a dependência de um servidor de terceiros. Pode fornecer uma experiência de usuário mais personalizada, por exemplo: um playground com plugins e temas pré-instalados, configurações padrão do site ou conteúdo de demonstração.
 
-<!-- ## Before you start {#before-you-start} -->
+<!-- ## Before you start -->
 
-## Antes de começar {#before-you-start}
+## Antes de começar
 
 <!-- Self-hosting Playground gives you full control, but requires understanding a few key concepts: -->
 
 Hospedar o Playground por conta própria dá controle total, mas requer entender alguns conceitos-chave:
 
-<!-- ### What to expect {#what-to-expect} -->
+<!-- ### What to expect -->
 
-### O que esperar {#what-to-expect}
+### O que esperar
 
 <!-- - **Initial setup complexity**: Building and deploying Playground involves multiple steps. Allow time for troubleshooting during your first deployment. -->
 <!-- - **Static file hosting**: Playground is primarily static files (HTML, JS, WASM) with minimal server-side requirements. -->
@@ -34,9 +34,9 @@ Hospedar o Playground por conta própria dá controle total, mas requer entender
 - **Hospedagem de arquivos estáticos**: O Playground é principalmente arquivos estáticos (HTML, JS, WASM) com requisitos mínimos do lado do servidor.
 - **Execução baseada em navegador**: Todo o processamento do WordPress acontece no navegador do usuário via WebAssembly—seu servidor apenas entrega arquivos.
 
-<!-- ### Performance considerations {#performance-considerations} -->
+<!-- ### Performance considerations -->
 
-### Considerações de desempenho {#performance-considerations}
+### Considerações de desempenho
 
 <!-- Loading times depend on several factors: -->
 
@@ -56,9 +56,9 @@ Os tempos de carregamento dependem de vários fatores:
 | **Navegador**          | Chrome/Edge têm melhor desempenho; Safari usa mecanismos de fallback  | Teste em diferentes navegadores                     |
 | **Dispositivo**        | Dispositivos móveis carregam mais devagar que desktop                 | Avise usuários móveis sobre tempos de carga maiores |
 
-<!-- ### Browser compatibility {#browser-compatibility} -->
+<!-- ### Browser compatibility -->
 
-### Compatibilidade com navegadores {#browser-compatibility}
+### Compatibilidade com navegadores
 
 <!-- Playground works across modern browsers, but with some differences: -->
 
@@ -82,9 +82,9 @@ O Playground funciona em navegadores modernos, mas com algumas diferenças:
 
 **Nota técnica**: O Safari usa MessagePorts ao invés de SharedArrayBuffer para respostas em streaming. Este mecanismo de fallback funciona de forma confiável mas adiciona uma pequena sobrecarga comparado ao Chrome/Edge.
 
-<!-- ## Usage {#usage} -->
+<!-- ## Usage -->
 
-## Uso {#usage}
+## Uso
 
 <!-- A self-hosted Playground can be embedded as an iframe. -->
 
@@ -107,9 +107,9 @@ const client = await startPlaygroundWeb({
 });
 ```
 
-<!-- ## Static assets {#static-assets} -->
+<!-- ## Static assets -->
 
-## Recursos estáticos {#static-assets}
+## Recursos estáticos
 
 <!-- There are several ways to get the static assets necessary to host the Playground. -->
 
@@ -127,9 +127,9 @@ Em ordem de conveniência e facilidade:
 - Fazer fork do repositório e construir com GitHub Action
 - Construir localmente
 
-<!-- ### Download pre-built package {#download-pre-built-package} -->
+<!-- ### Download pre-built package -->
 
-### Baixar pacote pré-construído {#download-pre-built-package}
+### Baixar pacote pré-construído
 
 <!-- To host the Playground as is, without making changes, you can download the built artifact from [the latest successful GitHub Action](https://github.com/WordPress/wordpress-playground/actions/workflows/deploy-website.yml?query=is%3Asuccess). -->
 
@@ -143,9 +143,9 @@ Para hospedar o Playground como está, sem fazer alterações, você pode baixar
 - Na seção **Artifacts** no final da página, clique em `playground-website`.
 - É um pacote zip com os mesmos arquivos implantados no site público.
 
-<!-- ### Fork the repository and build with GitHub Action {#fork-repository-and-build-with-github-actions} -->
+<!-- ### Fork the repository and build with GitHub Action -->
 
-### Fazer fork do repositório e construir com GitHub Action {#fork-repository-and-build-with-github-actions}
+### Fazer fork do repositório e construir com GitHub Action
 
 <!-- To customize the Playground, you can [fork the Git repository](https://github.com/WordPress/wordpress-playground/fork). -->
 
@@ -155,9 +155,9 @@ Para personalizar o Playground, você pode [fazer fork do repositório Git](http
 
 Construa-o da página GitHub do seu fork indo para: **Actions -> Deploy Playground website -> Run workflow**.
 
-<!-- ### Build locally {#build-locally} -->
+<!-- ### Build locally -->
 
-### Construir localmente {#build-locally}
+### Construir localmente
 
 <!-- The most flexible and customizable method is to build the site locally. -->
 
@@ -200,9 +200,9 @@ dist/packages/playground/wasm-wordpress-net
 
 O serviço completo do Playground consiste no conteúdo desta pasta.
 
-<!-- ## Summary of included files {#summary-of-included-files} -->
+<!-- ## Summary of included files -->
 
-## Resumo dos arquivos incluídos {#summary-of-included-files}
+## Resumo dos arquivos incluídos
 
 <!-- The static assets include: -->
 
@@ -234,9 +234,9 @@ Você pode implantar o conteúdo da pasta no seu servidor usando SSH, como `scp`
 
 Para que estes funcionem, você precisa de um ambiente de servidor com Apache e PHP instalados.
 
-<!-- ## NGINX configuration {#nginx-configuration} -->
+<!-- ## NGINX configuration -->
 
-## Configuração NGINX {#nginx-configuration}
+## Configuração NGINX
 
 <!-- As an alternative to Apache, here is an example of using NGINX to serve the Playground. -->
 
@@ -278,9 +278,9 @@ Você pode precisar ajustar o acima de acordo com as especificidades do servidor
 
 [O servidor web Caddy](https://caddyserver.com) não requer nenhuma configuração especial para funcionar.
 
-<!-- ## Customize bundled data {#customize-bundled-data} -->
+<!-- ## Customize bundled data -->
 
-## Personalizar dados empacotados {#customize-bundled-data}
+## Personalizar dados empacotados
 
 <!-- The file `wp.zip` is a bundle of all the files for the virtual file system in Playground. There's a data file for each available WordPress version. -->
 
@@ -306,9 +306,9 @@ npm run rebuild:wordpress-builds
 
 Para reconstruir o site para incluir os builds personalizados do WordPress, siga as instruções [aqui](#build-locally).
 
-<!-- ### Install plugins {#install-plugins} -->
+<!-- ### Install plugins -->
 
-### Instalar plugins {#install-plugins}
+### Instalar plugins
 
 <!-- Here's an example of installing plugins for the data bundle. -->
 
@@ -348,9 +348,9 @@ COPY ./build-assets/*.zip /root/
 
 Então coloque os arquivos zip dos plugins em `build-assets`. Neste caso, você pode querer adicionar seus caminhos ao `.gitignore`.
 
-<!-- ### Import content {#import-content} -->
+<!-- ### Import content -->
 
-### Importar conteúdo {#import-content}
+### Importar conteúdo
 
 <!-- Here's an example of importing content. -->
 
@@ -369,9 +369,9 @@ RUN cd wordpress ; \
 
 Isso assume que você colocou um arquivo de exportação WXR chamado `content.xml` na pasta `build-assets`. Você pode adicionar seu caminho ao `.gitignore`.
 
-<!-- ## Production deployment checklist {#production-deployment-checklist} -->
+<!-- ## Production deployment checklist -->
 
-## Lista de verificação para implantação em produção {#production-deployment-checklist}
+## Lista de verificação para implantação em produção
 
 <!-- Before going live, verify your self-hosted Playground meets these requirements: -->
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/24-limitations/01-index.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/developers/24-limitations/01-index.md
@@ -16,13 +16,13 @@ O WordPress Playground está em desenvolvimento ativo e possui algumas limitaç�
 
 Você pode acompanhar o status dessas questões no [quadro do projeto Playground](https://github.com/orgs/WordPress/projects/180).
 
-<!-- ## In the browser {#in-the-browser} -->
+<!-- ## In the browser -->
 
-## No navegador {#in-the-browser}
+## No navegador
 
-<!-- ### Temporary by design {#temporary-by-design} -->
+<!-- ### Temporary by design -->
 
-### Temporário por design {#temporary-by-design}
+### Temporário por design
 
 <!-- Playground creates fresh WordPress instances on each page load. Refreshing the browser page discards all database changes, uploads, and modifications. -->
 
@@ -70,9 +70,9 @@ O botão de atualização dedicado dentro do Playground apenas recarrega o conte
 </figure>
 </blockquote>
 
-<!-- ### Browser support {#browser-support} -->
+<!-- ### Browser support -->
 
-### Suporte a navegadores {#browser-support}
+### Suporte a navegadores
 
 <!-- WordPress Playground is designed to work across all major desktop and mobile browsers. This includes: -->
 
@@ -88,9 +88,9 @@ O WordPress Playground foi projetado para funcionar em todos os principais naveg
 
 O Playground utiliza tecnologias web modernas e deve funcionar consistentemente nesses ambientes de navegador. No entanto, alguns recursos avançados podem ter diferentes níveis de suporte dependendo do navegador específico e sua versão.
 
-<!-- ### Performance expectations {#performance-expectations} -->
+<!-- ### Performance expectations -->
 
-### Expectativas de desempenho {#performance-expectations}
+### Expectativas de desempenho
 
 <!-- Loading times vary based on what Playground needs to set up: -->
 
@@ -117,13 +117,13 @@ Os tempos de carregamento variam de acordo com o que o Playground precisa config
 <strong>Nota:</strong> O suporte ao Opera Mini não está confirmado atualmente.
 </blockquote>
 
-<!-- ## When developing with Playground {#when-developing-with-playground} -->
+<!-- ## When developing with Playground -->
 
-## Ao desenvolver com o Playground {#when-developing-with-playground}
+## Ao desenvolver com o Playground
 
-<!-- ### Iframe quirks {#iframe-quirks} -->
+<!-- ### Iframe quirks -->
 
-### Peculiaridades do iframe {#iframe-quirks}
+### Peculiaridades do iframe
 
 <!-- Playground renders WordPress in an [`iframe`](/developers/architecture/browser-iframe-rendering) so clicking links with `target="_top"` will reload the page you're working on. -->
 
@@ -133,9 +133,9 @@ O Playground renderiza o WordPress em um [`iframe`](/developers/architecture/bro
 
 Além disso, pop-ups JavaScript originados no `iframe` podem nem sempre ser exibidos.
 
-<!-- ### Run WordPress PHP functions {#run-wordpress-php-functions} -->
+<!-- ### Run WordPress PHP functions -->
 
-### Executar funções PHP do WordPress {#run-wordpress-php-functions}
+### Executar funções PHP do WordPress
 
 <!-- Playground supports running PHP code in Blueprints using the [`runPHP` step](/blueprints/steps#RunPHPStep). To run WordPress-specific PHP functions, you'd need to first require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php): -->
 
@@ -148,9 +148,9 @@ O Playground suporta a execução de código PHP em Blueprints usando o [passo `
 }
 ```
 
-<!-- ### Using WP-CLI {#using-wp-cli} -->
+<!-- ### Using WP-CLI -->
 
-### Usando WP-CLI {#using-wp-cli}
+### Usando WP-CLI
 
 <!-- You can execute `wp-cli` commands via the Blueprints [`wp-cli`](/blueprints/steps#WPCLIStep) step. However, since Playground runs in the browser, it doesn't support the [full array](https://developer.wordpress.org/cli/commands/) of available commands. While there is no definite list of supported commands, experimenting in [the online demo](https://playground.wordpress.net/demos/wp-cli.html) will help you assess what's possible. -->
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/agent-skill-wp-playground.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/guides/agent-skill-wp-playground.md
@@ -5,10 +5,10 @@ description: Instale e use a skill wp-playground para automatizar fluxos de trab
 ---
 
 <!--
-# Using the WordPress Playground Agent Skill {#using-wordpress-playground-agent-skill}
+# Using the WordPress Playground Agent Skill
 -->
 
-# Usando a Skill de Agente do WordPress Playground {#using-wordpress-playground-agent-skill}
+# Usando a Skill de Agente do WordPress Playground
 
 <!--
 Want an AI assistant that already knows how to spin up WordPress instances, run Blueprints, and debug plugins? The **wp-playground** agent skill teaches coding agents the WordPress Playground CLI and browser workflows. You describe what you need in plain language. The agent handles the commands.
@@ -23,10 +23,10 @@ Your coding agent reads the skill reference — a document with CLI flags, proce
 Seu agente de codificação lê a referência da skill — um documento com flags do CLI, procedimentos e etapas de solução de problemas — antes de responder. Isso garante que os comandos do Playground sejam executados corretamente.
 
 <!--
-## Prerequisites {#prerequisites}
+## Prerequisites
 -->
 
-## Pré-requisitos {#prerequisites}
+## Pré-requisitos
 
 <!--
 Before installing the skill, confirm you have:
@@ -51,16 +51,16 @@ You also need a coding agent that supports agent skills: Antigravity, Claude Cod
 Você também precisa de um agente de codificação que suporte skills de agente: Antigravity, Claude Code, Codex, Copilot, Cursor ou Gemini CLI. Certifique-se de que seu CLI ou IDE execute a versão mais recente. A qualidade da saída depende do modelo escolhido.
 
 <!--
-## Installation {#installation}
+## Installation
 -->
 
-## Instalação {#installation}
+## Instalação
 
 <!--
-### 1. Install via terminal {#install-via-terminal}
+### 1. Install via terminal
 -->
 
-### 1. Instalar via terminal {#install-via-terminal}
+### 1. Instalar via terminal
 
 <!--
 Install the skill using the `npx skills` CLI:
@@ -77,10 +77,10 @@ npx skills add wordpress/agent-skills --skill wp-playground
 ```
 
 <!--
-### 2. Install manually {#install-manually}
+### 2. Install manually
 -->
 
-### 2. Instalar manualmente {#install-manually}
+### 2. Instalar manualmente
 
 <!--
 ```bash
@@ -175,10 +175,10 @@ gemini /skills list
 ```
 
 <!--
-## Use the skill in the terminal {#use-the-skill-in-the-terminal}
+## Use the skill in the terminal
 -->
 
-## Usar a skill no terminal {#use-the-skill-in-the-terminal}
+## Usar a skill no terminal
 
 <!--
 With the skill installed, describe your WordPress environment to your coding agent. The agent builds the Blueprint, runs the CLI commands, and starts the server.
@@ -207,10 +207,10 @@ The agent reads the skill reference, detects your project layout, and runs `serv
 O agente lê a referência da skill, detecta o layout do seu projeto e executa `server --auto-mount`. A instância inicia em `http://localhost:9400`.
 
 <!--
-### Generating content on the fly {#generating-content-on-the-fly}
+### Generating content on the fly
 -->
 
-### Gerando conteúdo dinamicamente {#generating-content-on-the-fly}
+### Gerando conteúdo dinamicamente
 
 <!--
 Need sample data for testing or a demo? Describe the content structure you want:
@@ -269,10 +269,10 @@ Each prompt produces a complete Blueprint that runs locally, handling user creat
 Cada prompt produz um Blueprint completo que roda localmente, gerenciando criação de usuários, atribuição de funções, geração de posts e configuração de taxonomias através dos passos do Blueprint.
 
 <!--
-### Version compatibility testing {#version-compatibility-testing}
+### Version compatibility testing
 -->
 
-### Testes de compatibilidade de versão {#version-compatibility-testing}
+### Testes de compatibilidade de versão
 
 <!--
 Does your plugin work on older PHP versions? Ask directly:
@@ -317,10 +317,10 @@ O agente adiciona as flags `--wp` e `--php` para corresponder à sua solicitaç�
 | PHP legado         | "Inicie WordPress com PHP 7.4"                                 |
 
 <!--
-### Complex scenarios {#complex-scenarios}
+### Complex scenarios
 -->
 
-### Cenários complexos {#complex-scenarios}
+### Cenários complexos
 
 <!--
 Combine multiple requirements in a single prompt:
@@ -355,10 +355,10 @@ The agent breaks these into the right sequence of Blueprint steps and CLI flags.
 O agente divide isso na sequência correta de passos do Blueprint e flags do CLI. Cada solicitação produz uma instância totalmente configurada e em execução.
 
 <!--
-## How the skill works {#how-the-skill-works}
+## How the skill works
 -->
 
-## Como a skill funciona {#how-the-skill-works}
+## Como a skill funciona
 
 <!--
 The wp-playground skill is a set of Markdown files that your coding agent loads into its context when your request matches Playground-related patterns. The skill includes:
@@ -383,10 +383,10 @@ Your coding agent reads these files before generating commands, ensuring correct
 Seu agente de codificação lê esses arquivos antes de gerar comandos, garantindo flags corretas e alertando sobre armadilhas comuns.
 
 <!--
-## Next steps {#next-steps}
+## Next steps
 -->
 
-## Próximos passos {#next-steps}
+## Próximos passos
 
 <!--
 - [WordPress Playground for Plugin Developers](/guides/for-plugin-developers) — Showcase and develop plugins with Playground

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -5,10 +5,10 @@ description: Um guia detalhado da interface web em playground.wordpress.net, cob
 ---
 
 <!--
-# WordPress Playground web instance {#wordpress-playground-web-instance}
+# WordPress Playground web instance
 -->
 
-# Instância web do WordPress Playground {#wordpress-playground-web-instance}
+# Instância web do WordPress Playground
 
 <!--
 [https://playground.wordpress.net/](https://playground.wordpress.net/) lets developers run WordPress in a browser without a server. This environment makes testing plugins, themes, and features quick and easy.
@@ -45,10 +45,10 @@ O site do Playground inclui barras de ferramentas que personalizam sua instânci
 ![Playground Toolbar Snapshot](@site/static/img/about/playground-toolbar.webp)
 
 <!--
-## Customize Playground {#customize-playground}
+## Customize Playground
 -->
 
-## Personalizar Playground {#customize-playground}
+## Personalizar Playground
 
 <!--
 On the toolbar, you'll find:
@@ -65,10 +65,10 @@ Na barra de ferramentas, você encontrará:
 - **Painel de Lançamento do Playground**: O Painel de Lançamento mostra todas as formas de iniciar uma instância do WordPress Playground.
 
 <!--
-### Playground Settings {#playground-settings}
+### Playground Settings
 -->
 
-### Configurações do Playground {#playground-settings}
+### Configurações do Playground
 
 ![snapshot of customize Playground window at Playground instance](@site/static/img/about/playground-settings-panel.webp)
 
@@ -91,10 +91,10 @@ O **Painel de Configurações do Playground** inclui estas [opções da API de C
 - `networking`: Habilita o acesso à rede para o Diretório de Plugins do WordPress e APIs do WordPress.
 
 <!--
-## Playground Manager {#playground-manager}
+## Playground Manager
 -->
 
-## Gerenciador do Playground {#playground-manager}
+## Gerenciador do Playground
 
 ![Playground settings panel allow users to save export and edit the WordPress directly](@site/static/img/about/playground-dashboard.webp)
 
@@ -125,10 +125,10 @@ Click "Save" to create an instance and list it in the Playground Launch Panel. T
 Clique em "Salvar" para criar uma instância e listá-la no Painel de Lançamento do Playground. O Painel do Playground também oferece opções de exportação e download através do menu de Ações adicionais:
 
 <!--
-### Additional actions menu {#additional-actions-menu}
+### Additional actions menu
 -->
 
-### Menu de ações adicionais {#additional-actions-menu}
+### Menu de ações adicionais
 
 ![Additional actions Menu](@site/static/img/about/additional-options-playground-dashboard.webp)
 
@@ -141,10 +141,10 @@ Clique em "Salvar" para criar uma instância e listá-la no Painel de Lançament
 - **Baixar como .zip**: Cria um arquivo `.zip` com a configuração da instância do Playground, incluindo quaisquer temas ou plugins instalados. Este `.zip` não inclui conteúdo e alterações do banco de dados.
 
 <!--
-### Blueprint Editor {#blueprint-editor}
+### Blueprint Editor
 -->
 
-### Editor de Blueprint {#blueprint-editor}
+### Editor de Blueprint
 
 ![Blueprint editor WordPress Playground](@site/static/img/about/playground-blueprint-editor.webp)
 
@@ -155,10 +155,10 @@ The Blueprint editor replaced the older Blueprint builder, offering the ability 
 O editor de Blueprint substituiu o antigo construtor de Blueprint, oferecendo a capacidade de gerenciar múltiplos Blueprints e validação de código.
 
 <!--
-### Launch Playground Panel {#launch-playground-panel}
+### Launch Playground Panel
 -->
 
-### Painel de Lançamento do Playground {#launch-playground-panel}
+### Painel de Lançamento do Playground
 
 ![Playground Launch Panel](@site/static/img/dashboard/import-playground.webp)
 

--- a/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/web-instance.md
+++ b/packages/docs/site/i18n/tl/docusaurus-plugin-content-docs/current/main/web-instance.md
@@ -5,10 +5,10 @@ description: Isang detalyadong gabay sa web interface sa playground.wordpress.ne
 ---
 
 <!--
-# WordPress Playground web instance {#wordpress-playground-web-instance}
+# WordPress Playground web instance
 -->
 
-# WordPress Playground web instance {#wordpress-playground-web-instance}
+# WordPress Playground web instance
 
 <!--
 [https://playground.wordpress.net/](https://playground.wordpress.net/) lets developers run WordPress in a browser without a server. This environment makes testing plugins, themes, and features quick and easy.
@@ -45,10 +45,10 @@ Ang Playground website ay may kasamang mga toolbar na nagpapasadya sa iyong inst
 ![Playground Toolbar Snapshot](@site/static/img/about/playground-toolbar.webp)
 
 <!--
-## Customize Playground {#customize-playground}
+## Customize Playground
 -->
 
-## I-customize ang Playground {#customize-playground}
+## I-customize ang Playground
 
 <!--
 On the toolbar, you'll find:
@@ -65,10 +65,10 @@ Sa toolbar, makikita mo ang:
 - **Playground Launch Panel**: Ang Launch Panel ay nagpapakita ng lahat ng paraan para maglunsad ng WordPress Playground instance.
 
 <!--
-### Playground Settings {#playground-settings}
+### Playground Settings
 -->
 
-### Playground Settings {#playground-settings}
+### Playground Settings
 
 ![snapshot of customize Playground window at Playground instance](@site/static/img/about/playground-settings-panel.webp)
 
@@ -91,10 +91,10 @@ Ang **Playground Settings Panel** ay may kasamang mga [Query API options](/devel
 - `networking`: Pinapagana ang network access sa WordPress Plugin Directory at WordPress APIs.
 
 <!--
-## Playground Manager {#playground-manager}
+## Playground Manager
 -->
 
-## Playground Manager {#playground-manager}
+## Playground Manager
 
 ![Playground settings panel allow users to save export and edit the WordPress directly](@site/static/img/about/playground-dashboard.webp)
 
@@ -125,10 +125,10 @@ Click "Save" to create an instance and list it in the Playground Launch Panel. T
 I-click ang "Save" para lumikha ng instance at ilista ito sa Playground Launch Panel. Ang Playground Dashboard ay nag-aalok din ng mga export at download options sa pamamagitan ng Additional actions menu:
 
 <!--
-### Additional actions menu {#additional-actions-menu}
+### Additional actions menu
 -->
 
-### Additional actions menu {#additional-actions-menu}
+### Additional actions menu
 
 ![Additional actions Menu](@site/static/img/about/additional-options-playground-dashboard.webp)
 
@@ -141,10 +141,10 @@ I-click ang "Save" para lumikha ng instance at ilista ito sa Playground Launch P
 - **Download as .zip**: Gumagawa ng `.zip` file na may setup ng Playground instance, kasama ang anumang naka-install na theme o plugin. Ang `.zip` na ito ay hindi kasama ang content at database changes.
 
 <!--
-### Blueprint Editor {#blueprint-editor}
+### Blueprint Editor
 -->
 
-### Blueprint Editor {#blueprint-editor}
+### Blueprint Editor
 
 ![Blueprint editor WordPress Playground](@site/static/img/about/playground-blueprint-editor.webp)
 
@@ -155,10 +155,10 @@ The Blueprint editor replaced the older Blueprint builder, offering the ability 
 Ang Blueprint editor ay pinalitan ang lumang Blueprint builder, na nag-aalok ng kakayahang pamahalaan ang maraming Blueprint at code validation.
 
 <!--
-### Launch Playground Panel {#launch-playground-panel}
+### Launch Playground Panel
 -->
 
-### Launch Playground Panel {#launch-playground-panel}
+### Launch Playground Panel
 
 ![Playground Launch Panel](@site/static/img/dashboard/import-playground.webp)
 


### PR DESCRIPTION
This pull request removes all hash link anchors (e.g., `{#section-id}`) from section and subsection headings in several documentation files. The content, structure, and navigation of the documents remain unchanged; only the explicit anchor tags in markdown headings have been removed.

This change was made to remove the issue with the migration to the Handbook docs:
<img width="1155" height="606" alt="Screenshot 2026-02-23 at 13 54 15" src="https://github.com/user-attachments/assets/acbf4f1a-9f22-4567-a8fb-7e94bc6b409c" />
