### PR TITLE
[CLI] Fix intermittent ENOTDIR crash when applying post-install mounts

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -750,14 +750,14 @@ function describeError(error: unknown): string {
 		// { name: 'ErrnoError', errno: 20 } with no .message.
 		const parts = [];
 		const obj = error as Record<string, unknown>;
-		if (obj.name) {
-			parts.push(String(obj.name));
+		if (obj['name']) {
+			parts.push(String(obj['name']));
 		}
-		if (obj.message) {
-			parts.push(String(obj.message));
+		if (obj['message']) {
+			parts.push(String(obj['message']));
 		}
-		if (obj.errno !== undefined) {
-			parts.push(`errno: ${obj.errno}`);
+		if (obj['errno'] !== undefined) {
+			parts.push(`errno: ${obj['errno']}`);
 		}
 		if (parts.length > 0) {
 			return parts.join(' — ');

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -712,25 +712,65 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		};
 	} catch (e) {
 		console.error(e);
-		if (!(e instanceof Error)) {
-			throw e;
-		}
 		const debug = process.argv.includes('--debug');
-		if (debug) {
-			printDebugDetails(e);
+		if (e instanceof Error) {
+			if (debug) {
+				printDebugDetails(e);
+			} else {
+				const messageChain = [];
+				let currentError: Error | undefined = e;
+				do {
+					messageChain.push(currentError.message);
+					currentError = currentError.cause as Error;
+				} while (currentError instanceof Error);
+				console.error(
+					'\x1b[1m' +
+						messageChain.join(' caused by: ') +
+						'\x1b[0m'
+				);
+			}
 		} else {
-			const messageChain = [];
-			let currentError = e;
-			do {
-				messageChain.push(currentError.message);
-				currentError = currentError.cause as Error;
-			} while (currentError instanceof Error);
-			console.error(
-				'\x1b[1m' + messageChain.join(' caused by: ') + '\x1b[0m'
-			);
+			console.error('\x1b[1m' + describeError(e) + '\x1b[0m');
 		}
 		process.exit(1);
 	}
+}
+
+/**
+ * Describe an error for display. Handles Error instances, Comlink-serialized
+ * plain objects (which lose their Error prototype during worker thread
+ * transfer), and arbitrary values.
+ */
+function describeError(error: unknown): string {
+	if (error instanceof Error) {
+		return error.message;
+	}
+	if (error && typeof error === 'object') {
+		// Comlink-serialized errors arrive as plain objects like
+		// { name: 'ErrnoError', errno: 20 } with no .message.
+		const parts = [];
+		const obj = error as Record<string, unknown>;
+		if (obj.name) {
+			parts.push(String(obj.name));
+		}
+		if (obj.message) {
+			parts.push(String(obj.message));
+		}
+		if (obj.errno !== undefined) {
+			parts.push(`errno: ${obj.errno}`);
+		}
+		if (parts.length > 0) {
+			return parts.join(' — ');
+		}
+		// Last resort: JSON-serialize the object so we at least see
+		// what fields it has.
+		try {
+			return JSON.stringify(error);
+		} catch {
+			return String(error);
+		}
+	}
+	return String(error);
 }
 
 function getMountForVfsPath(
@@ -1362,7 +1402,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 								return;
 							}
 
-							if (exitCode !== 0) {
+							if (exitCode === 0) {
 								return;
 							}
 
@@ -1436,15 +1476,16 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 					await exposeAPI(
 						{
 							applyPostInstallMountsToAllWorkers: async () => {
-								await Promise.all(
-									Array.from(
-										workerToPlaygroundMap.values()
-									).map((playground) =>
-										playground!.mountAfterWordPressInstall(
-											args['mount'] || []
-										)
-									)
-								);
+								// Apply post-install mounts to workers
+								// one at a time. Each worker's mount handler
+								// creates placeholder files on the shared
+								// host filesystem via NODEFS before mounting.
+								// Concurrent creation races cause ENOTDIR.
+								for (const playground of workerToPlaygroundMap.values()) {
+									await playground!.mountAfterWordPressInstall(
+										args['mount'] || []
+									);
+								}
 							},
 						},
 						undefined,
@@ -1632,7 +1673,7 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			return response;
 		},
 	}).catch((error) => {
-		cliOutput.printError(error.message);
+		cliOutput.printError(describeError(error));
 		process.exit(1);
 	});
 
@@ -1804,10 +1845,11 @@ export function spawnWorkerThread(
 			processIdAllocator.release(processId);
 
 			console.error(e);
+			const originalMessage =
+				e?.message || (e ? String(e) : 'unknown error');
 			const error = new Error(
-				`Worker failed to load worker. ${
-					e.message ? `Original error: ${e.message}` : ''
-				}`
+				`Worker failed to load. Original error: ${originalMessage}`,
+				{ cause: e }
 			);
 			reject(error);
 		});

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -327,7 +327,45 @@ describe.each(blueprintVersions)(
 			expect(response.text).toContain('My WordPress Website');
 		});
 
-		// TODO: Testing mounting NODEFS within a NODEFS mount
+		// Regression test: mounting files under /tmp (which is already
+		// NODEFS-mounted to a shared host directory) used to race
+		// across 6 workers and intermittently fail with ErrnoError 20
+		// (ENOTDIR) when the concurrent NODEFS placeholder creation
+		// collided on the host filesystem.
+		test('should mount files under /tmp as post-install mounts without ENOTDIR', async () => {
+			const hostTmpDir = await mkdtemp(
+				path.join(tmpdir(), 'playground-test-mount-')
+			);
+
+			const mounts = [];
+			for (let i = 0; i < 5; i++) {
+				const hostSubDir = path.join(
+					hostTmpDir,
+					`migration-${i}`
+				);
+				mkdirSync(hostSubDir, { recursive: true });
+				const hostFilePath = path.join(
+					hostSubDir,
+					'.import-state.json'
+				);
+				writeFileSync(hostFilePath, `{"index":${i}}`);
+				mounts.push({
+					hostPath: hostFilePath,
+					vfsPath: `/tmp/migration-${i}/.import-state.json`,
+				});
+			}
+
+			try {
+				await using cliServer = await runCLI({
+					...suiteCliArgs,
+					command: 'server',
+					mount: mounts,
+				});
+				expect(cliServer.serverUrl).toBeTruthy();
+			} finally {
+				rmSync(hostTmpDir, { recursive: true, force: true });
+			}
+		});
 
 		if (version === 2) {
 			// @TODO: Test modes


### PR DESCRIPTION
## The problem

When Playground CLI starts a server with `--mount` entries (post-install mounts), it applies those mounts to all 6 workers concurrently via `Promise.all`. Each worker's mount handler (`createNodeFsMountHandler` in `@php-wasm/node`) creates placeholder files and directories on the host filesystem through NODEFS before mounting. Since all workers share the same host temp directory (e.g. `/tmp` is NODEFS-backed by a single process-level directory), the concurrent creation operations race on the same host paths, intermittently triggering Emscripten's `ErrnoError { errno: 20 }` (ENOTDIR).

The error was nearly impossible to diagnose because it crossed the Comlink worker boundary as a plain object `{ name: 'ErrnoError', errno: 20 }`, losing its Error prototype, message, and stack trace. By the time it reached the CLI's error handler, it printed as the opaque **"Error: undefined"** and called `process.exit(1)`.

This showed up in Studio as an intermittent first-attempt server start failure during site imports. The retry mechanism masked it, but downstream consumers shouldn't need retries for what is a deterministic concurrency bug.

### How to reproduce

Mount multiple files under `/tmp` as post-install mounts with default 6 workers:

```js
await runCLI({
  command: 'server',
  mount: [
    { hostPath: '/path/to/file1.json', vfsPath: '/tmp/migration-0/.import-state.json' },
    { hostPath: '/path/to/file2.json', vfsPath: '/tmp/migration-1/.import-state.json' },
    // ... more mounts under /tmp
  ],
});
```

Fails ~10% of the time with `Error: undefined` (actually `ErrnoError { errno: 20 }`).

### The race condition

1. Worker 0 boots, `applyPostInstallMountsToAllWorkers` fires for all 6 workers via `Promise.all`
2. Each worker calls `createNodeFsMountHandler`, which checks VFS, finds no mount point, and creates placeholder directories/files through NODEFS
3. Since `/tmp` is already NODEFS-mounted (shared host directory), `FS.mkdirTree` and `FS.writeFile` operations hit the real filesystem concurrently
4. The concurrent operations race, causing ENOTDIR when a worker sees stale NODEFS state during path traversal
5. The `ErrnoError` crosses Comlink serialization, loses its prototype and message, arrives as `{ name: 'ErrnoError', errno: 20 }`, and prints as "Error: undefined"

## The fix

**Serialize post-install mount application** — apply mounts to one worker at a time instead of `Promise.all`. This eliminates the NODEFS race with no meaningful performance impact (mount operations are fast, and this only runs once at boot).

Also fixes several error handling issues that made this bug hard to diagnose:

- **`describeError()` helper** — Handles Comlink-serialized error objects that arrive as plain objects. `{ name: 'ErrnoError', errno: 20 }` now displays as `"ErrnoError — errno: 20"` instead of `"undefined"`.

- **Catch block for non-Error objects** — The main catch block re-threw non-`instanceof Error` objects instead of displaying them, causing them to fall through to a handler that only read `.message` (undefined on plain objects).

- **Inverted exit code check** — `if (exitCode !== 0) { return; }` silenced all worker error exits while logging only clean exits. Flipped to `exitCode === 0`.

- **Worker error wrapping** — Preserved original errors as `.cause` so the error chain walker can surface root causes.

## Test plan

- [x] Added regression test that mounts 5 files under `/tmp` as post-install mounts (replaces existing `// TODO: Testing mounting NODEFS within a NODEFS mount` placeholder)
- [x] Ran the test 20 times after the fix: 0/20 failures (was ~1/10 before)
- [x] Existing CLI tests continue to pass