### PR TITLE
[php-wasm-logger] Remove unnecessary `@php-wasm/node-polyfills` dependency

### DIFF
--- a/packages/php-wasm/logger/src/index.ts
+++ b/packages/php-wasm/logger/src/index.ts
@@ -1,6 +1,3 @@
-// PHP.wasm requires WordPress Playground's Node polyfills.
-import '@php-wasm/node-polyfills';
-
 export * from './lib/logger';
 export * from './lib/log-collector';
 export * from './lib/log-handlers';


### PR DESCRIPTION
## Motivation for the change, related issues

The `@php-wasm/logger` package imports `@php-wasm/node-polyfills` solely for the `CustomEvent` polyfill (used in `log-event.ts` and `collect-php-logs.ts`). However, `CustomEvent` has been a native global since Node.js v19, and this project requires Node.js >= 20.10.0. The import is dead weight — it pulls in unnecessary polyfills (File, Blob, etc.) that the logger never uses.

## Implementation details

- Removed the import `@php-wasm/node-polyfills` side-effect import from `packages/php-wasm/logger/src/index.ts`
- The `@php-wasm/node-polyfills` dependency in the dist package.json is auto-generated during build and will be dropped automatically.

## Testing Instructions (or ideally a Blueprint)

CI