### PR TITLE
Skip running irrelevant actions on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     # take ~25s just to run git clone and restore node_modules.
     lint-and-typecheck:
         name: 'Lint and typecheck'
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -27,6 +28,7 @@ jobs:
             - run: npx nx check-orphan-pages docs-site
             - run: bash tools/check-node-engine-alignment.sh
     test-unit-asyncify:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
@@ -75,6 +77,7 @@ jobs:
                   MYSQL_USER: user
                   MYSQL_PASSWORD: password
     test-unit-jspi:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
@@ -121,6 +124,7 @@ jobs:
                   MYSQL_USER: user
                   MYSQL_PASSWORD: password
     test-playground-cli:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
@@ -137,6 +141,7 @@ jobs:
             - name: Run full test suite
               run: node node_modules/nx/bin/nx affected --target=test-playground-cli
     test-file-locking:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
@@ -154,6 +159,7 @@ jobs:
             - name: Run full test suite
               run: node node_modules/nx/bin/nx affected --target=test-file-locking-${{ matrix.async-strategy }}
     test-e2e-php-wasm-web-jspi:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -163,6 +169,7 @@ jobs:
             - run: sudo npx playwright install
             - run: sudo CI=true JSPI=true npx nx e2e php-wasm-web
     test-e2e-php-wasm-web-asyncify:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -172,6 +179,7 @@ jobs:
             - run: sudo npx playwright install
             - run: sudo CI=true npx nx e2e php-wasm-web
     test-e2e:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         # Run as root to allow node to bind to port 80
         steps:
@@ -191,6 +199,7 @@ jobs:
     # Previously used a prepare job + artifact sharing, but inline builds allow
     # all shards to start immediately in parallel, reducing total wall time.
     test-e2e-playwright:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
@@ -290,6 +299,7 @@ jobs:
                   if-no-files-found: ignore
 
     test-e2e-components:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -329,6 +339,7 @@ jobs:
                   if-no-files-found: ignore
 
     test-docs-api-reference:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -347,6 +358,7 @@ jobs:
                   if-no-files-found: ignore
 
     test-built-npm-packages:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -359,6 +371,7 @@ jobs:
               run: packages/playground/test-built-npm-packages/run-tests.sh
 
     test-running-unbuilt-playground-cli:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -370,6 +383,7 @@ jobs:
             - run: packages/playground/cli/tests/test-running-unbuilt-cli.sh
 
     test-php-wasm-cli-smoke:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
@@ -385,6 +399,7 @@ jobs:
     # Redis requires JSPI because asyncify cannot properly handle exceptions
     # during network I/O. Attempting to load Redis with asyncify throws an error.
     test-redis-extension:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         services:
             redis:
@@ -412,6 +427,7 @@ jobs:
     # Memcached extension tests - verifies the php-memcached extension loads
     # and provides the expected API, and can connect to a real memcached server.
     test-memcached-extension:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         services:
             memcached:
@@ -434,6 +450,7 @@ jobs:
                   MEMCACHED_PORT: 11211
 
     build:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -8,9 +8,10 @@ concurrency:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow from the trunk branch and when it's triggered by a maintainer listed below
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a maintainer listed below
         # TODO: Can we check for group membership?
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -8,10 +8,10 @@ concurrency:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a maintainer listed below
+        # Only run this workflow when deploy secrets are configured, from the trunk branch, and when triggered by a maintainer listed below
         # TODO: Can we check for group membership?
         if: >
-            github.repository == 'WordPress/wordpress-playground' &&
+            secrets.DEPLOY_CORS_PROXY_TARGET_HOST != '' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/deploy-my-wordpress-net.yml
+++ b/.github/workflows/deploy-my-wordpress-net.yml
@@ -11,9 +11,9 @@ concurrency:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
+        # Only run this workflow when deploy secrets are configured, from the trunk branch, and when triggered by a Playground maintainer
         if: >
-            github.repository == 'WordPress/wordpress-playground' &&
+            secrets.DEPLOY_MY_WORDPRESS_NET_HOST != '' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||

--- a/.github/workflows/deploy-my-wordpress-net.yml
+++ b/.github/workflows/deploy-my-wordpress-net.yml
@@ -11,8 +11,9 @@ concurrency:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow from the trunk branch and when it's triggered by a Playground maintainer
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -11,9 +11,9 @@ concurrency:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by another workflow OR a Playground maintainer
+        # Only run this workflow when deploy secrets are configured, from the trunk branch, and when triggered by another workflow OR a Playground maintainer
         if: >
-            github.repository == 'WordPress/wordpress-playground' &&
+            secrets.DEPLOY_WEBSITE_TARGET_HOST != '' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -11,8 +11,9 @@ concurrency:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow from the trunk branch and when it's triggered by another workflow OR a Playground maintainer
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by another workflow OR a Playground maintainer
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||

--- a/.github/workflows/publish-devtools-extension.yml
+++ b/.github/workflows/publish-devtools-extension.yml
@@ -15,8 +15,9 @@ on:
 
 jobs:
     publish:
-        # Only run this workflow from the trunk branch and when triggered by a Playground maintainer
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -12,13 +12,16 @@ permissions:
 
 jobs:
     create-release:
-        # Only create a release after a successful npm publish on trunk,
-        # or when triggered manually.
+        # Only run on the playground repo. Create a release after a successful
+        # npm publish on trunk, or when triggered manually.
         if: >
-            github.event_name == 'workflow_dispatch' ||
+            github.repository == 'WordPress/wordpress-playground' &&
             (
-                github.event.workflow_run.conclusion == 'success' &&
-                github.event.workflow_run.head_branch == 'trunk'
+                github.event_name == 'workflow_dispatch' ||
+                (
+                    github.event.workflow_run.conclusion == 'success' &&
+                    github.event.workflow_run.head_branch == 'trunk'
+                )
             )
 
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -21,9 +21,10 @@ permissions:
 
 jobs:
     release:
-        # Only allow Playground maintainers to trigger this workflow.
+        # Only run on the playground repo, and only allow Playground maintainers to trigger this workflow.
         # Non-trunk branches are allowed but require a custom dist tag (not "latest").
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             (
               github.actor == 'adamziel' ||
               github.actor == 'dmsnell' ||

--- a/.github/workflows/publish-self-hosted-package-release.yml
+++ b/.github/workflows/publish-self-hosted-package-release.yml
@@ -16,8 +16,9 @@ on:
 
 jobs:
     publish:
-        # Only run this workflow from the trunk branch and when it's triggered by a Playground maintainer
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||

--- a/.github/workflows/refresh-sqlite-integration.yml
+++ b/.github/workflows/refresh-sqlite-integration.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow from the trunk branch and when it's triggered by a Playground maintainer
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||

--- a/.github/workflows/refresh-wordpress-major-and-beta.yml
+++ b/.github/workflows/refresh-wordpress-major-and-beta.yml
@@ -16,8 +16,9 @@ concurrency:
 
 jobs:
     build_wordpress_major_and_beta_push_to_github_and_deploy_website:
-        # Only run this workflow from the trunk branch and when it's triggered by a Playground maintainer
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||

--- a/.github/workflows/refresh-wordpress-nightly.yml
+++ b/.github/workflows/refresh-wordpress-nightly.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
     build_and_deploy:
-        # Only run this workflow from the trunk branch and when it's triggered by a Playground maintainer
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.actor == 'adamziel' ||
                 github.actor == 'dmsnell' ||

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -14,8 +14,9 @@ on:
 
 jobs:
     release:
-        # Only run this workflow from the trunk branch and when it's triggered by a Playground maintainer
+        # Only run this workflow on the playground repo, from the trunk branch, and when triggered by a Playground maintainer
         if: >
+            github.repository == 'WordPress/wordpress-playground' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event.workflow_run.conclusion == 'success' ||
                 github.actor == 'adamziel' ||


### PR DESCRIPTION
## Motivation for the change, related issues

While looking at my actions usage on my personal github account, I noticed that Playground is using up a lot of actions resources on my fork, dd32/wordpress-playground.

Upon looking into it, i saw that a bunch of jobs are running that doesn't appear to be needed.

## Implementation details

- Add github.repository == 'WordPress/wordpress-playground' guard to publish and refresh workflows so they no longer attempt to run on forks.
- Add a guard to assert a deployment-related secret exists before running each deployment workflow. That way, even scheduled workflows abort early by default, until a repository (fork or not) opts in by defining the secret.

## Testing Instructions (or ideally a Blueprint)

Unfortunately, GH workflow updates are difficult to test. Let's merge and keep an eye on things afterward.