### PR TITLE
Fix broken deploy workflow guards

### DIFF
--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -30,6 +30,8 @@ jobs:
                 github.actor == 'ashfame'
             )
         runs-on: ubuntu-latest
+        environment:
+            name: cors-proxy-wp-cloud
         outputs:
             meets_deploy_preconditions: ${{ steps.check.outputs.meets_deploy_preconditions }}
         steps:

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -7,11 +7,12 @@ concurrency:
     group: cors-proxy-deployment
 
 jobs:
-    build_and_deploy:
-        # Only run this workflow when deploy secrets are configured, from the trunk branch, and when triggered by a maintainer listed below
+    # Check preconditions in a separate job because secrets aren't
+    # available in job-level `if` conditions.
+    check_preconditions:
+        # Only run from the trunk branch when triggered by a maintainer listed below
         # TODO: Can we check for group membership?
         if: >
-            secrets.DEPLOY_CORS_PROXY_TARGET_HOST != '' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||
@@ -25,6 +26,31 @@ jobs:
                 github.actor == 'mho22' ||
                 github.actor == 'ashfame'
             )
+        runs-on: ubuntu-latest
+        outputs:
+            meets_deploy_preconditions: ${{ steps.check.outputs.meets_deploy_preconditions }}
+        steps:
+            # Confirm deploy secrets are configured. This way, this workflow won't
+            # run on a repo fork by default. It will only run when the fork admin opts
+            # in by configuring the workflow's required secrets.
+            #
+            # Secrets aren't available in job-level `if` conditions,
+            # so we check for them here.
+            - name: Check deploy secrets are configured
+              id: check
+              env:
+                  DEPLOY_HOST: ${{ secrets.DEPLOY_CORS_PROXY_TARGET_HOST }}
+              run: |
+                  if [ -z "$DEPLOY_HOST" ]; then
+                    echo "Deploy secrets are not configured. Skipping deployment."
+                    echo "meets_deploy_preconditions=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "meets_deploy_preconditions=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+    build_and_deploy:
+        needs: check_preconditions
+        if: needs.check_preconditions.outputs.meets_deploy_preconditions == 'true'
 
         # Specify runner + deployment step
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -12,8 +12,11 @@ jobs:
     check_preconditions:
         # Only run from the trunk branch when triggered by a maintainer listed below
         # TODO: Can we check for group membership?
+        # TODO: Revert this after testing and before merging.
+        # if: >
+        #     github.ref == 'refs/heads/trunk' && (
         if: >
-            github.ref == 'refs/heads/trunk' && (
+            (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||

--- a/.github/workflows/deploy-cors-proxy.yml
+++ b/.github/workflows/deploy-cors-proxy.yml
@@ -12,11 +12,8 @@ jobs:
     check_preconditions:
         # Only run from the trunk branch when triggered by a maintainer listed below
         # TODO: Can we check for group membership?
-        # TODO: Revert this after testing and before merging.
-        # if: >
-        #     github.ref == 'refs/heads/trunk' && (
         if: >
-            (
+            github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 github.event_name == 'workflow_dispatch' ||
                 github.actor == 'adamziel' ||

--- a/.github/workflows/deploy-my-wordpress-net.yml
+++ b/.github/workflows/deploy-my-wordpress-net.yml
@@ -29,6 +29,8 @@ jobs:
                 github.actor == 'ashfame'
             )
         runs-on: ubuntu-latest
+        environment:
+            name: my-wordpress-net-wp-cloud
         outputs:
             meets_deploy_preconditions: ${{ steps.check.outputs.meets_deploy_preconditions }}
         steps:

--- a/.github/workflows/deploy-my-wordpress-net.yml
+++ b/.github/workflows/deploy-my-wordpress-net.yml
@@ -10,10 +10,11 @@ concurrency:
     group: my-wordpress-net-deployment
 
 jobs:
-    build_and_deploy:
-        # Only run this workflow when deploy secrets are configured, from the trunk branch, and when triggered by a Playground maintainer
+    # Check preconditions in a separate job because secrets aren't
+    # available in job-level `if` conditions.
+    check_preconditions:
+        # Only run from the trunk branch when triggered by a Playground maintainer
         if: >
-            secrets.DEPLOY_MY_WORDPRESS_NET_HOST != '' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||
@@ -27,6 +28,31 @@ jobs:
                 github.actor == 'mho22' ||
                 github.actor == 'ashfame'
             )
+        runs-on: ubuntu-latest
+        outputs:
+            meets_deploy_preconditions: ${{ steps.check.outputs.meets_deploy_preconditions }}
+        steps:
+            # Confirm deploy secrets are configured. This way, this workflow won't
+            # run on a repo fork by default. It will only run when the fork admin opts
+            # in by configuring the workflow's required secrets.
+            #
+            # Secrets aren't available in job-level `if` conditions,
+            # so we check for them here.
+            - name: Check deploy secrets are configured
+              id: check
+              env:
+                  DEPLOY_HOST: ${{ secrets.DEPLOY_MY_WORDPRESS_NET_HOST }}
+              run: |
+                  if [ -z "$DEPLOY_HOST" ]; then
+                    echo "Deploy secrets are not configured. Skipping deployment."
+                    echo "meets_deploy_preconditions=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "meets_deploy_preconditions=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+    build_and_deploy:
+        needs: check_preconditions
+        if: needs.check_preconditions.outputs.meets_deploy_preconditions == 'true'
 
         runs-on: ubuntu-latest
         environment:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -10,10 +10,11 @@ concurrency:
     group: website-deployment
 
 jobs:
-    build_and_deploy:
-        # Only run this workflow when deploy secrets are configured, from the trunk branch, and when triggered by another workflow OR a Playground maintainer
+    # Check preconditions in a separate job because secrets aren't
+    # available in job-level `if` conditions.
+    check_preconditions:
+        # Only run from the trunk branch when triggered by another workflow OR a Playground maintainer
         if: >
-            secrets.DEPLOY_WEBSITE_TARGET_HOST != '' &&
             github.ref == 'refs/heads/trunk' && (
                 github.event_name == 'workflow_run' ||
                 (github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]') ||
@@ -27,6 +28,31 @@ jobs:
                 github.actor == 'mho22' ||
                 github.actor == 'ashfame'
             )
+        runs-on: ubuntu-latest
+        outputs:
+            meets_deploy_preconditions: ${{ steps.check.outputs.meets_deploy_preconditions }}
+        steps:
+            # Confirm deploy secrets are configured. This way, this workflow won't
+            # run on a repo fork by default. It will only run when the fork admin opts
+            # in by configuring the workflow's required secrets.
+            #
+            # Secrets aren't available in job-level `if` conditions,
+            # so we check for them here.
+            - name: Check deploy secrets are configured
+              id: check
+              env:
+                  DEPLOY_HOST: ${{ secrets.DEPLOY_WEBSITE_TARGET_HOST }}
+              run: |
+                  if [ -z "$DEPLOY_HOST" ]; then
+                    echo "Deploy secrets are not configured. Skipping deployment."
+                    echo "meets_deploy_preconditions=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "meets_deploy_preconditions=true" >> "$GITHUB_OUTPUT"
+                  fi
+
+    build_and_deploy:
+        needs: check_preconditions
+        if: needs.check_preconditions.outputs.meets_deploy_preconditions == 'true'
 
         # Specify runner + deployment step
         runs-on: ubuntu-latest

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -29,6 +29,8 @@ jobs:
                 github.actor == 'ashfame'
             )
         runs-on: ubuntu-latest
+        environment:
+            name: playground-wordpress-net-wp-cloud
         outputs:
             meets_deploy_preconditions: ${{ steps.check.outputs.meets_deploy_preconditions }}
         steps:


### PR DESCRIPTION
## Summary

Fixes deploy workflows broken by #3473 (by the part I added). That PR added `secrets.*` checks to job-level `if` conditions, but GitHub Actions [doesn't make secrets available in that context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#contexts). This led to an error executing the workflow.

This PR moves the secrets check into a dedicated `check_preconditions` job that inspects secrets at step level (where they *are* available) and exposes the result as a job output. The `build_and_deploy` job then gates on that output.

## Affected workflows

| Workflow | Secret checked |
|---|---|
| `deploy-website.yml` | `DEPLOY_WEBSITE_TARGET_HOST` |
| `deploy-cors-proxy.yml` | `DEPLOY_CORS_PROXY_TARGET_HOST` |
| `deploy-my-wordpress-net.yml` | `DEPLOY_MY_WORDPRESS_NET_HOST` |

## Test plan

- [x] Temporarily allow the CORS proxy deployment to run on this branch and confirm it runs successfully.
- [ ] Merge to trunk and verify the deploy workflows trigger as expected
- [ ] Confirm the workflows still skip on forks that haven't configured deploy secrets