### PR TITLE
[Website] Reduce border radius in browser chrome save button

### DIFF
--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.module.css
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.module.css
@@ -39,7 +39,7 @@
 	background: #fcd34d;
 	color: #1e2327;
 	border: none;
-	border-radius: 4px;
+	border-radius: 3px;
 	font-size: 13px;
 	font-weight: 600;
 	cursor: pointer;


### PR DESCRIPTION
## Motivation for the change, related issues

The save button in the top bar browser chrome currently has a border radius of 4px. This is different to the standard WordPress button radius of 3px.

It is _obviously_ mission critical that there be no discrepancy.

## Before

Wildly disproportionate and utterly distracting button.

<img width="65" height="43" alt="Screenshot 2026-04-13 at 10 42 54 pm" src="https://github.com/user-attachments/assets/c11ef4f0-c1b4-471a-a2b4-8d8f90e9cdd6" />

## After

Corrected. Perfection.

<img width="64" height="40" alt="Screenshot 2026-04-13 at 10 43 15 pm" src="https://github.com/user-attachments/assets/83972fa9-8ab0-4ede-81e3-59b93a09bd85" />

## AI Disclosure

`no-ai` No AI was used in this PR.