### PR TITLE
Distinguish WASM traps from Asyncify errors, allow crash recovery

### DIFF
--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -259,6 +259,7 @@
 				"reportsDirectory": "../../../coverage/packages/php-wasm/node",
 				"testFiles": [
 					"php-crash.spec.ts",
+					"php-curl-crash.spec.ts",
 					"php-ini.spec.ts",
 					"write-files.spec.ts",
 					"php-worker.spec.ts",
@@ -277,6 +278,7 @@
 				"reportsDirectory": "../../../coverage/packages/php-wasm/node",
 				"testFiles": [
 					"php-crash.spec.ts",
+					"php-curl-crash.spec.ts",
 					"php-ini.spec.ts",
 					"write-files.spec.ts",
 					"php-worker.spec.ts",

--- a/packages/php-wasm/node/src/test/php-crash.spec.ts
+++ b/packages/php-wasm/node/src/test/php-crash.spec.ts
@@ -236,6 +236,50 @@ describe.each(phpVersions)('PHP %s – ', async (phpVersion) => {
 			);
 		});
 
+		it('Recovers via runtime rotation after a WASM crash', async () => {
+			const originalCcall = php[__private__dont__use].ccall.bind(
+				php[__private__dont__use]
+			);
+
+			// Enable runtime rotation so the PHP instance can recover.
+			php.enableRuntimeRotation({
+				recreateRuntime: async () =>
+					await loadNodeRuntime(phpVersion as any, {
+						withXdebug: true,
+					}),
+				maxRequests: 400,
+			});
+
+			// First request: simulate a WASM crash (e.g. corrupt gzip
+			// causing zlib to access memory out of bounds).
+			let crashCount = 0;
+			const spy = vi.spyOn(php[__private__dont__use], 'ccall');
+			spy.mockImplementation((...args) => {
+				const [c_func] = args;
+				if (c_func === 'wasm_sapi_handle_request' && crashCount === 0) {
+					crashCount++;
+					throw new Error('memory access out of bounds');
+				}
+				return originalCcall(...args);
+			});
+
+			let firstError: unknown;
+			try {
+				await php.run({ code: `<?php echo "before crash";` });
+			} catch (error) {
+				firstError = error;
+			}
+			expect(firstError).toBeDefined();
+
+			spy.mockRestore();
+
+			// Second request: should succeed after rotation.
+			const result = await php.run({
+				code: `<?php echo "recovered";`,
+			});
+			expect(result.text).toBe('recovered');
+		});
+
 		it('Does not leak memory when creating and destroying instances', async () => {
 			if (!global.gc) {
 				console.error(

--- a/packages/php-wasm/node/src/test/php-curl-crash.spec.ts
+++ b/packages/php-wasm/node/src/test/php-curl-crash.spec.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests that PHP's curl handles corrupt gzip responses without crashing
+ * the WASM runtime.
+ *
+ * When curl auto-decompresses gzip via CURLOPT_ENCODING, zlib's inflate()
+ * processes the compressed data. With corrupt or truncated gzip, zlib can
+ * compute invalid buffer offsets that exceed the WASM linear memory,
+ * triggering a RuntimeError trap. Native PHP handles this gracefully
+ * (Z_DATA_ERROR → CURLE_WRITE_ERROR), but WASM PHP historically crashed.
+ *
+ * These tests verify that:
+ * - Corrupt gzip doesn't crash the Node.js process
+ * - The error message explains the real cause (not Asyncify)
+ * - The runtime recovers via rotation for subsequent requests
+ */
+import { vi } from 'vitest';
+import {
+	PHP,
+	SupportedPHPVersions,
+	setPhpIniEntries,
+} from '@php-wasm/universal';
+import { loadNodeRuntime } from '../lib';
+import http from 'http';
+import zlib from 'zlib';
+
+const phpVersions =
+	'PHP' in process.env ? [process.env['PHP']!] : SupportedPHPVersions;
+
+/**
+ * Creates an HTTP server that serves various gzip responses — both
+ * valid and corrupt — for testing curl's decompression error handling.
+ */
+function createGzipTestServer(): Promise<{
+	url: string;
+	server: http.Server;
+}> {
+	// Build a valid gzip payload large enough that zlib allocates a
+	// sliding window. The repetition produces long-distance back-
+	// references whose corruption is more likely to hit invalid offsets.
+	const payload = 'The quick brown fox jumps over the lazy dog. '.repeat(500);
+	const validGzip = zlib.gzipSync(payload);
+
+	// Corrupt gzip: flip bytes in the DEFLATE stream (past the 10-byte
+	// gzip header) so inflate encounters invalid distance/length codes.
+	const corruptGzip = Buffer.from(validGzip);
+	for (let i = 15; i < Math.min(80, corruptGzip.length); i++) {
+		corruptGzip[i] = corruptGzip[i]! ^ 0xff;
+	}
+
+	// Truncated gzip: cut the payload mid-stream so inflate hits
+	// unexpected EOF while the sliding window is partially filled.
+	const truncatedGzip = Buffer.from(validGzip.subarray(0, 30));
+
+	const server = http.createServer((req, res) => {
+		switch (req.url) {
+			case '/valid':
+				res.writeHead(200, { 'Content-Encoding': 'gzip' });
+				res.end(validGzip);
+				break;
+
+			case '/corrupt':
+				res.writeHead(200, { 'Content-Encoding': 'gzip' });
+				res.end(corruptGzip);
+				break;
+
+			case '/truncated':
+				res.writeHead(200, { 'Content-Encoding': 'gzip' });
+				res.end(truncatedGzip);
+				break;
+
+			case '/no-encoding':
+				// Same corrupt bytes but without Content-Encoding, so
+				// curl won't try to decompress them.
+				res.writeHead(200, {});
+				res.end(corruptGzip);
+				break;
+
+			default:
+				res.writeHead(404);
+				res.end('not found');
+		}
+	});
+
+	return new Promise((resolve) => {
+		server.listen(0, '127.0.0.1', () => {
+			const addr = server.address() as { port: number };
+			resolve({
+				url: `http://127.0.0.1:${addr.port}`,
+				server,
+			});
+		});
+	});
+}
+
+function stopServer(server: http.Server): Promise<void> {
+	return new Promise((resolve) => server.close(() => resolve()));
+}
+
+describe.each(phpVersions)(
+	'PHP %s – curl gzip crash handling',
+	(phpVersion) => {
+		let php: PHP;
+		let serverUrl: string;
+		let server: http.Server;
+
+		beforeEach(async () => {
+			const s = await createGzipTestServer();
+			serverUrl = s.url;
+			server = s.server;
+
+			php = new PHP(await loadNodeRuntime(phpVersion as any));
+			await setPhpIniEntries(php, {
+				allow_url_fopen: 1,
+				disable_functions: '',
+			});
+			vi.restoreAllMocks();
+		});
+
+		afterEach(async () => {
+			try {
+				php.exit();
+			} catch {
+				// Runtime may already be dead after a crash test.
+			}
+			await stopServer(server);
+		});
+
+		it('fetches valid gzip without error', async () => {
+			const { text } = await php.run({
+				code: `<?php
+				$ch = curl_init("${serverUrl}/valid");
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+				curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
+				$result = curl_exec($ch);
+				$err = curl_error($ch);
+				curl_close($ch);
+				if ($err) {
+					echo "CURL_ERROR: $err";
+				} else {
+					echo strlen($result) > 100 ? "OK" : "TOO_SHORT";
+				}
+			`,
+			});
+			expect(text).toBe('OK');
+		}, 15_000);
+
+		it('does not crash the process when curl decompresses corrupt gzip', async () => {
+			const uncaughtErrors: unknown[] = [];
+			function errorHandler(error: unknown) {
+				uncaughtErrors.push(error);
+			}
+			process.on('unhandledRejection', errorHandler);
+			process.on('uncaughtException', errorHandler);
+
+			let caughtError: unknown;
+			try {
+				await php.run({
+					code: `<?php
+					$ch = curl_init("${serverUrl}/corrupt");
+					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+					curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
+					$result = curl_exec($ch);
+					$err = curl_error($ch);
+					curl_close($ch);
+					echo $err ? "CURL_ERROR: $err" : "OK: " . strlen($result);
+				`,
+				});
+			} catch (error) {
+				caughtError = error;
+			}
+
+			// Give unhandled rejections a chance to surface.
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			process.off('unhandledRejection', errorHandler);
+			process.off('uncaughtException', errorHandler);
+
+			// Either PHP handled the error gracefully (returned a curl
+			// error string) or the WASM trap was caught by our error
+			// handling. The process must NOT have crashed.
+			if (caughtError) {
+				// WASM trap was caught — verify the error message
+				// doesn't blame Asyncify.
+				const message =
+					caughtError instanceof Error
+						? caughtError.message
+						: String(caughtError);
+				expect(message).not.toContain('ASYNCIFY_ONLY');
+			}
+
+			// No unhandled rejections should have escaped.
+			for (const error of uncaughtErrors) {
+				if (error instanceof Error) {
+					expect(error.message).not.toContain('ASYNCIFY_ONLY');
+				}
+			}
+		}, 15_000);
+
+		it('does not crash the process when curl decompresses truncated gzip', async () => {
+			const uncaughtErrors: unknown[] = [];
+			function errorHandler(error: unknown) {
+				uncaughtErrors.push(error);
+			}
+			process.on('unhandledRejection', errorHandler);
+			process.on('uncaughtException', errorHandler);
+
+			let caughtError: unknown;
+			try {
+				await php.run({
+					code: `<?php
+					$ch = curl_init("${serverUrl}/truncated");
+					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+					curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
+					$result = curl_exec($ch);
+					$err = curl_error($ch);
+					curl_close($ch);
+					echo $err ? "CURL_ERROR: $err" : "OK: " . strlen($result);
+				`,
+				});
+			} catch (error) {
+				caughtError = error;
+			}
+
+			await new Promise((resolve) => setTimeout(resolve, 500));
+
+			process.off('unhandledRejection', errorHandler);
+			process.off('uncaughtException', errorHandler);
+
+			if (caughtError) {
+				const message =
+					caughtError instanceof Error
+						? caughtError.message
+						: String(caughtError);
+				expect(message).not.toContain('ASYNCIFY_ONLY');
+			}
+
+			for (const error of uncaughtErrors) {
+				if (error instanceof Error) {
+					expect(error.message).not.toContain('ASYNCIFY_ONLY');
+				}
+			}
+		}, 15_000);
+
+		it('does not decompress when Content-Encoding is absent', async () => {
+			// Same corrupt bytes but served without Content-Encoding.
+			// Curl should pass the raw bytes through without invoking
+			// zlib, so no crash is possible.
+			const { text } = await php.run({
+				code: `<?php
+				$ch = curl_init("${serverUrl}/no-encoding");
+				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+				$result = curl_exec($ch);
+				$err = curl_error($ch);
+				curl_close($ch);
+				echo $err ? "CURL_ERROR: $err" : "RAW_BYTES: " . strlen($result);
+			`,
+			});
+			expect(text).toMatch(/RAW_BYTES: \d+/);
+		}, 15_000);
+
+		it('recovers via rotation after a curl-triggered WASM crash', async () => {
+			// Enable rotation so the runtime can recover.
+			php.enableRuntimeRotation({
+				recreateRuntime: () => loadNodeRuntime(phpVersion as any),
+				maxRequests: 400,
+			});
+
+			// First request: fetch corrupt gzip. This may either:
+			// (a) crash the WASM runtime (caught, marked for rotation), or
+			// (b) be handled gracefully by PHP's curl error path.
+			try {
+				await php.run({
+					code: `<?php
+					$ch = curl_init("${serverUrl}/corrupt");
+					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+					curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
+					curl_exec($ch);
+					curl_close($ch);
+				`,
+				});
+			} catch {
+				// Expected — WASM trap or PHP error.
+			}
+
+			// Second request: must succeed regardless of what happened
+			// above. If the first request crashed the WASM runtime,
+			// rotation should swap in a fresh one.
+			const result = await php.run({
+				code: `<?php echo "recovered";`,
+			});
+			expect(result.text).toBe('recovered');
+		}, 30_000);
+	}
+);

--- a/packages/php-wasm/node/src/test/php-curl-crash.spec.ts
+++ b/packages/php-wasm/node/src/test/php-curl-crash.spec.ts
@@ -133,7 +133,6 @@ describe.each(phpVersions)(
 				curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
 				$result = curl_exec($ch);
 				$err = curl_error($ch);
-				curl_close($ch);
 				if ($err) {
 					echo "CURL_ERROR: $err";
 				} else {
@@ -161,7 +160,6 @@ describe.each(phpVersions)(
 					curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
 					$result = curl_exec($ch);
 					$err = curl_error($ch);
-					curl_close($ch);
 					echo $err ? "CURL_ERROR: $err" : "OK: " . strlen($result);
 				`,
 				});
@@ -213,7 +211,6 @@ describe.each(phpVersions)(
 					curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
 					$result = curl_exec($ch);
 					$err = curl_error($ch);
-					curl_close($ch);
 					echo $err ? "CURL_ERROR: $err" : "OK: " . strlen($result);
 				`,
 				});
@@ -251,7 +248,6 @@ describe.each(phpVersions)(
 				curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 				$result = curl_exec($ch);
 				$err = curl_error($ch);
-				curl_close($ch);
 				echo $err ? "CURL_ERROR: $err" : "RAW_BYTES: " . strlen($result);
 			`,
 			});
@@ -275,7 +271,6 @@ describe.each(phpVersions)(
 					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 					curl_setopt($ch, CURLOPT_ENCODING, 'gzip');
 					curl_exec($ch);
-					curl_close($ch);
 				`,
 				});
 			} catch {

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -83,6 +83,7 @@ export class PHP implements Disposable {
 	]);
 	#messageListeners: MessageListener[] = [];
 	#mounts: Record<string, MountObject> = {};
+	#crashed = false;
 	#rotationOptions: {
 		enabled: boolean;
 		recreateRuntime: () => Promise<number> | number;
@@ -968,6 +969,20 @@ export class PHP implements Disposable {
 	async #executeWithErrorHandling(
 		executionFn: () => any
 	): Promise<StreamedPHPResponse> {
+		if (this.#crashed) {
+			if (
+				this.#rotationOptions.enabled &&
+				this.#rotationOptions.needsRotating
+			) {
+				await this.rotateRuntime();
+				this.#crashed = false;
+			} else {
+				throw new Error(
+					'PHP runtime has crashed. Enable runtime rotation ' +
+						'for automatic recovery, or create a new PHP instance.'
+				);
+			}
+		}
 		if (
 			this.#rotationOptions.enabled &&
 			this.#rotationOptions.needsRotating
@@ -1067,20 +1082,13 @@ export class PHP implements Disposable {
 				safeStreamError(headers.controller, e);
 				streamsClosed = true;
 
-				/**
-				 * A non-exit-code error means an irrecoverable crash. Let's make
-				 * it very clear to the consumers of this API – every method
-				 * call on this PHP instance will throw an error from now on.
-				 */
-				for (const name in this) {
-					if (typeof this[name] === 'function') {
-						(this as any)[name] = () => {
-							throw new Error(
-								`PHP runtime has crashed – see the earlier error for details.`
-							);
-						};
-					}
-				}
+				// Mark the runtime as crashed so it gets rotated on
+				// the next request. We intentionally do NOT disable
+				// all methods on the PHP instance — the WASM memory
+				// and globals survive a trap, and the rotation
+				// mechanism needs working methods to swap in a fresh
+				// runtime.
+				this.#crashed = true;
 				(this as any).functionsMaybeMissingFromAsyncify =
 					getFunctionsMaybeMissingFromAsyncify();
 
@@ -1380,6 +1388,7 @@ export class PHP implements Disposable {
 		);
 		this.#rotationOptions.requestsMade = 0;
 		this.#rotationOptions.needsRotating = false;
+		this.#crashed = false;
 	}
 
 	/**

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -1083,12 +1083,14 @@ export class PHP implements Disposable {
 				streamsClosed = true;
 
 				// Mark the runtime as crashed so it gets rotated on
-				// the next request. We intentionally do NOT disable
-				// all methods on the PHP instance — the WASM memory
-				// and globals survive a trap, and the rotation
-				// mechanism needs working methods to swap in a fresh
-				// runtime.
+				// the next request. We set needsRotating directly
+				// rather than relying on the event dispatch path
+				// (which could fail on a corrupted runtime).
+				// We intentionally do NOT disable all methods on the
+				// PHP instance — the rotation mechanism needs working
+				// methods to swap in a fresh runtime.
 				this.#crashed = true;
+				this.#rotationOptions.needsRotating = true;
 				(this as any).functionsMaybeMissingFromAsyncify =
 					getFunctionsMaybeMissingFromAsyncify();
 
@@ -1406,30 +1408,10 @@ export class PHP implements Disposable {
 		// old PHP runtime without propagating them to the new
 		// runtime.
 
+		let oldRootLevelPaths: string[] = [];
+		let oldCWD = '/';
 		const oldFS = this[__private__dont__use].FS;
-		const oldRootLevelPaths = this.listFiles('/').map((file) => `/${file}`);
 		const oldSpawnProcess = this[__private__dont__use].spawnProcess;
-
-		// Temporarily set CWD to / and restore it at the end of this method.
-		//
-		// There's a chance cleaning up old mounts via mount.unmount()
-		// will attempt removing the CWD. Normally, this would throw
-		// FS.ErrnoError(10) EBUSY and interrupt the PHP runtime rotation,
-		// leaving us in a broken state.
-		//
-		// Even though removing the CWD directory is not allowed by the
-		// filesystem, we don't care that much here – we're merely freeing
-		// all the resources allocated by the old filesystem before it's
-		// garbage collected. We are about to recreate the same filesystem
-		// structure and mounts in another PHP runtime.
-		//
-		// Therefore, let's suspend the strict EBUSY check by setting the CWD
-		// to / for the cleanup purposes. We'll attempt to restore the original
-		// CWD on the new runtime once we re-apply all the mounts there. We'll
-		// only have a real reason to throw an error if the CWD path does not
-		// exist in the new filesystem after the rotation.
-		const oldCWD = oldFS.cwd();
-		oldFS.chdir('/');
 
 		// Remember mounts to apply to new runtime
 		const mountHandlersToReapplyInOrder = Object.entries(this.#mounts).map(
@@ -1439,20 +1421,54 @@ export class PHP implements Disposable {
 			})
 		);
 
-		// Unmount all the mount handlers in reverse order because each nested
-		// mount depends upon the parent mount which preceded it.
-		const mountsToUnmountInReverseOrder = Object.values(
-			this.#mounts
-		).reverse();
-		for (const mount of mountsToUnmountInReverseOrder) {
-			await mount.unmount();
-		}
-
-		// Kill the current runtime
+		// Tear down the old runtime. The FS may be in a corrupted
+		// state after a WASM trap, so we wrap the entire teardown
+		// in a try/catch — if it fails, we still proceed to
+		// initialize the new runtime. Without this, a crash during
+		// teardown would leak the already-allocated new runtime
+		// (its WASM memory and network proxy server).
 		try {
+			oldRootLevelPaths = this.listFiles('/').map((file) => `/${file}`);
+
+			// Temporarily set CWD to / and restore it at the end of
+			// this method.
+			//
+			// There's a chance cleaning up old mounts via
+			// mount.unmount() will attempt removing the CWD.
+			// Normally, this would throw FS.ErrnoError(10) EBUSY
+			// and interrupt the PHP runtime rotation, leaving us in
+			// a broken state.
+			//
+			// Even though removing the CWD directory is not allowed
+			// by the filesystem, we don't care that much here – we're
+			// merely freeing all the resources allocated by the old
+			// filesystem before it's garbage collected. We are about
+			// to recreate the same filesystem structure and mounts in
+			// another PHP runtime.
+			//
+			// Therefore, let's suspend the strict EBUSY check by
+			// setting the CWD to / for the cleanup purposes. We'll
+			// attempt to restore the original CWD on the new runtime
+			// once we re-apply all the mounts there. We'll only have
+			// a real reason to throw an error if the CWD path does
+			// not exist in the new filesystem after the rotation.
+			oldCWD = oldFS.cwd();
+			oldFS.chdir('/');
+
+			// Unmount all the mount handlers in reverse order because
+			// each nested mount depends upon the parent mount which
+			// preceded it.
+			const mountsToUnmountInReverseOrder = Object.values(
+				this.#mounts
+			).reverse();
+			for (const mount of mountsToUnmountInReverseOrder) {
+				await mount.unmount();
+			}
+
 			this.exit();
 		} catch {
-			// Ignore the exit-related exception
+			// Old runtime teardown failed (likely corrupted after a
+			// WASM trap). Continue with the new runtime anyway.
 		}
 
 		// Initialize the new runtime

--- a/packages/php-wasm/universal/src/lib/wasm-error-reporting.spec.ts
+++ b/packages/php-wasm/universal/src/lib/wasm-error-reporting.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { clarifyErrorMessage } from './wasm-error-reporting';
+
+describe('clarifyErrorMessage', () => {
+	it('classifies "unreachable" with Asyncify stack and PHP functions as an Asyncify issue', () => {
+		const error = new Error('unreachable');
+		error.stack =
+			'Error: unreachable\n' +
+			'    at wasm://wasm/php_execute_script (wasm://wasm/0x1234)\n' +
+			'    at wasm://wasm/zend_execute (wasm://wasm/0x5678)';
+		const asyncifyStack =
+			'Error\n' +
+			'    at wasm://wasm/php_execute_script (wasm://wasm/0x1234)';
+
+		const result = clarifyErrorMessage(error, asyncifyStack);
+		expect(result).toContain('ASYNCIFY_ONLY');
+		expect(result).toContain('php_execute_script');
+	});
+
+	it('classifies "unreachable" without Asyncify stack as a WASM trap', () => {
+		const error = new Error('unreachable');
+		error.stack =
+			'Error: unreachable\n' +
+			'    at wasm://wasm/inflate (wasm://wasm/0x1234)\n' +
+			'    at wasm://wasm/updatewindow (wasm://wasm/0x5678)';
+
+		const result = clarifyErrorMessage(error, undefined);
+		expect(result).toContain('WASM runtime error');
+		expect(result).toContain('corrupt or malformed data');
+		expect(result).not.toContain('ASYNCIFY_ONLY');
+	});
+
+	it('classifies "unreachable" with Asyncify stack but no PHP functions as a WASM trap', () => {
+		const error = new Error('unreachable');
+		// Stack with no wasm:/ entries (no PHP functions extracted)
+		error.stack = 'Error: unreachable\n    at Object.run (index.js:1:1)';
+		const asyncifyStack = 'Error\n    at Object.run (index.js:1:1)';
+
+		const result = clarifyErrorMessage(error, asyncifyStack);
+		expect(result).toContain('WASM runtime error');
+		expect(result).not.toContain('ASYNCIFY_ONLY');
+	});
+
+	it('classifies "memory access out of bounds" as a WASM trap', () => {
+		const error = new Error('memory access out of bounds');
+
+		const result = clarifyErrorMessage(error, undefined);
+		expect(result).toContain('WASM runtime error');
+		expect(result).toContain('corrupt or malformed data');
+		expect(result).toContain('memory access out of bounds');
+	});
+
+	it('returns original message for other errors', () => {
+		const error = new Error('something else went wrong');
+
+		const result = clarifyErrorMessage(error, undefined);
+		expect(result).toBe('something else went wrong');
+	});
+});

--- a/packages/php-wasm/universal/src/lib/wasm-error-reporting.spec.ts
+++ b/packages/php-wasm/universal/src/lib/wasm-error-reporting.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { clarifyErrorMessage } from './wasm-error-reporting';
 
 describe('clarifyErrorMessage', () => {
-	it('classifies "unreachable" with Asyncify stack and PHP functions as an Asyncify issue', () => {
+	it('includes PHP functions from the stack when present', () => {
 		const error = new Error('unreachable');
 		error.stack =
 			'Error: unreachable\n' +
@@ -13,11 +13,12 @@ describe('clarifyErrorMessage', () => {
 			'    at wasm://wasm/php_execute_script (wasm://wasm/0x1234)';
 
 		const result = clarifyErrorMessage(error, asyncifyStack);
-		expect(result).toContain('ASYNCIFY_ONLY');
+		expect(result).toContain('WASM runtime error');
 		expect(result).toContain('php_execute_script');
+		expect(result).toContain('ASYNCIFY_ONLY');
 	});
 
-	it('classifies "unreachable" without Asyncify stack as a WASM trap', () => {
+	it('handles "unreachable" without Asyncify stack', () => {
 		const error = new Error('unreachable');
 		error.stack =
 			'Error: unreachable\n' +
@@ -26,28 +27,35 @@ describe('clarifyErrorMessage', () => {
 
 		const result = clarifyErrorMessage(error, undefined);
 		expect(result).toContain('WASM runtime error');
-		expect(result).toContain('corrupt or malformed data');
-		expect(result).not.toContain('ASYNCIFY_ONLY');
+		expect(result).toContain('inflate');
+		expect(result).toContain('unreachable');
 	});
 
-	it('classifies "unreachable" with Asyncify stack but no PHP functions as a WASM trap', () => {
+	it('handles "unreachable" with no WASM functions in trace', () => {
 		const error = new Error('unreachable');
-		// Stack with no wasm:/ entries (no PHP functions extracted)
 		error.stack = 'Error: unreachable\n    at Object.run (index.js:1:1)';
-		const asyncifyStack = 'Error\n    at Object.run (index.js:1:1)';
 
-		const result = clarifyErrorMessage(error, asyncifyStack);
+		const result = clarifyErrorMessage(error, undefined);
 		expect(result).toContain('WASM runtime error');
-		expect(result).not.toContain('ASYNCIFY_ONLY');
+		expect(result).not.toContain('PHP functions found');
 	});
 
-	it('classifies "memory access out of bounds" as a WASM trap', () => {
+	it('handles "memory access out of bounds"', () => {
 		const error = new Error('memory access out of bounds');
 
 		const result = clarifyErrorMessage(error, undefined);
 		expect(result).toContain('WASM runtime error');
-		expect(result).toContain('corrupt or malformed data');
 		expect(result).toContain('memory access out of bounds');
+	});
+
+	it('mentions all three common causes', () => {
+		const error = new Error('unreachable');
+		error.stack = 'Error: unreachable\n    at Object.run (index.js:1:1)';
+
+		const result = clarifyErrorMessage(error, undefined);
+		expect(result).toContain('ASYNCIFY_ONLY');
+		expect(result).toContain('Corrupt or malformed data');
+		expect(result).toContain('WASM memory');
 	});
 
 	it('returns original message for other errors', () => {

--- a/packages/php-wasm/universal/src/lib/wasm-error-reporting.ts
+++ b/packages/php-wasm/universal/src/lib/wasm-error-reporting.ts
@@ -99,14 +99,8 @@ export function clarifyErrorMessage(
 	asyncifyStack?: string
 ) {
 	if (crypticError.message === 'unreachable') {
-		let betterMessage = UNREACHABLE_ERROR;
-		if (!asyncifyStack) {
-			betterMessage +=
-				`\n\nThis stack trace is lacking. For a better one initialize \n` +
-				`the PHP runtime with debug: true, e.g. loadNodeRuntime('8.1', { emscriptenOptions: { debug: true } }).\n\n`;
-		}
-
-		// Extract all the PHP functions from the entire error chain.
+		// Extract all the PHP functions from the entire error chain
+		// to determine whether this looks like an Asyncify issue.
 		const uniqueFunctions = new Set<string>(
 			extractPHPFunctionsFromStack(asyncifyStack || '')
 		);
@@ -121,18 +115,52 @@ export function clarifyErrorMessage(
 		} while (lastError);
 		functionsMaybeMissingFromAsyncify = Array.from(uniqueFunctions);
 
-		for (const fn of uniqueFunctions) {
-			betterMessage += `    * ${fn}\n`;
+		// If there's an Asyncify stack and PHP functions in the trace,
+		// this is likely a missing ASYNCIFY_ONLY entry. Otherwise it's
+		// probably a data-related crash (e.g. corrupt gzip from a network
+		// response causing zlib to access memory out of bounds).
+		if (asyncifyStack && uniqueFunctions.size > 0) {
+			let betterMessage = ASYNCIFY_UNREACHABLE_ERROR;
+			for (const fn of uniqueFunctions) {
+				betterMessage += `    * ${fn}\n`;
+			}
+			betterMessage += `\nOriginal error message: ${crypticError.message}\n`;
+			return betterMessage;
 		}
 
-		betterMessage += `Original error message: ${crypticError.message}\n`;
-
-		return betterMessage;
+		return (
+			WASM_TRAP_ERROR +
+			`Original error message: ${crypticError.message}\n`
+		);
 	}
+
+	if (crypticError.message?.includes('memory access out of bounds')) {
+		return (
+			WASM_TRAP_ERROR +
+			`Original error message: ${crypticError.message}\n`
+		);
+	}
+
 	return crypticError.message;
 }
 
-const UNREACHABLE_ERROR = `
+const WASM_TRAP_ERROR = `\
+WASM runtime error.
+
+The PHP runtime encountered a fatal WebAssembly trap. This typically
+happens when PHP processes corrupt or malformed data (e.g. truncated
+gzip from a network response) that causes a C library like zlib to
+compute invalid buffer offsets and access memory out of bounds.
+
+The current PHP request has failed. If runtime rotation is enabled,
+the PHP runtime will automatically recover on the next request.
+
+If you believe this is a bug in WordPress Playground, please file
+an issue: https://github.com/WordPress/wordpress-playground/issues/new
+
+`;
+
+const ASYNCIFY_UNREACHABLE_ERROR = `\
 "unreachable" WASM instruction executed.
 
 The typical reason is a PHP function missing from the ASYNCIFY_ONLY

--- a/packages/php-wasm/universal/src/lib/wasm-error-reporting.ts
+++ b/packages/php-wasm/universal/src/lib/wasm-error-reporting.ts
@@ -98,91 +98,62 @@ export function clarifyErrorMessage(
 	crypticError: Error,
 	asyncifyStack?: string
 ) {
-	if (crypticError.message === 'unreachable') {
-		// Extract all the PHP functions from the entire error chain
-		// to determine whether this looks like an Asyncify issue.
-		const uniqueFunctions = new Set<string>(
-			extractPHPFunctionsFromStack(asyncifyStack || '')
-		);
-		let lastError = crypticError;
-		do {
-			for (const fn of extractPHPFunctionsFromStack(
-				lastError.stack || ''
-			)) {
-				uniqueFunctions.add(fn);
-			}
-			lastError = lastError.cause as Error;
-		} while (lastError);
-		functionsMaybeMissingFromAsyncify = Array.from(uniqueFunctions);
+	const isWasmTrap =
+		crypticError.message === 'unreachable' ||
+		crypticError.message?.includes('memory access out of bounds');
+	if (!isWasmTrap) {
+		return crypticError.message;
+	}
 
-		// If there's an Asyncify stack and PHP functions in the trace,
-		// this is likely a missing ASYNCIFY_ONLY entry. Otherwise it's
-		// probably a data-related crash (e.g. corrupt gzip from a network
-		// response causing zlib to access memory out of bounds).
-		if (asyncifyStack && uniqueFunctions.size > 0) {
-			let betterMessage = ASYNCIFY_UNREACHABLE_ERROR;
-			for (const fn of uniqueFunctions) {
-				betterMessage += `    * ${fn}\n`;
-			}
-			betterMessage += `\nOriginal error message: ${crypticError.message}\n`;
-			return betterMessage;
+	// Extract PHP functions from the entire error chain. These help
+	// diagnose Asyncify issues (missing ASYNCIFY_ONLY entries).
+	const uniqueFunctions = new Set<string>(
+		extractPHPFunctionsFromStack(asyncifyStack || '')
+	);
+	let lastError = crypticError;
+	do {
+		for (const fn of extractPHPFunctionsFromStack(lastError.stack || '')) {
+			uniqueFunctions.add(fn);
 		}
+		lastError = lastError.cause as Error;
+	} while (lastError);
+	functionsMaybeMissingFromAsyncify = Array.from(uniqueFunctions);
 
-		return (
-			WASM_TRAP_ERROR +
-			`Original error message: ${crypticError.message}\n`
-		);
+	let message = WASM_TRAP_ERROR;
+	if (uniqueFunctions.size > 0) {
+		message +=
+			`PHP functions found in the stack trace (may help if this\n` +
+			`is an Asyncify issue — see above):\n\n`;
+		for (const fn of uniqueFunctions) {
+			message += `    * ${fn}\n`;
+		}
+		message += '\n';
 	}
-
-	if (crypticError.message?.includes('memory access out of bounds')) {
-		return (
-			WASM_TRAP_ERROR +
-			`Original error message: ${crypticError.message}\n`
-		);
-	}
-
-	return crypticError.message;
+	message += `Original error message: ${crypticError.message}\n`;
+	return message;
 }
 
 const WASM_TRAP_ERROR = `\
 WASM runtime error.
 
-The PHP runtime encountered a fatal WebAssembly trap. This typically
-happens when PHP processes corrupt or malformed data (e.g. truncated
-gzip from a network response) that causes a C library like zlib to
-compute invalid buffer offsets and access memory out of bounds.
+The PHP runtime encountered a fatal WebAssembly trap. Common causes:
+
+* A PHP function missing from the ASYNCIFY_ONLY list (build issue)
+* Corrupt or malformed data (e.g. truncated gzip from a network
+  response) causing a C library to access memory out of bounds
+* Running out of WASM memory (allocation failure)
 
 The current PHP request has failed. If runtime rotation is enabled,
 the PHP runtime will automatically recover on the next request.
 
-If you believe this is a bug in WordPress Playground, please file
-an issue: https://github.com/WordPress/wordpress-playground/issues/new
+If this is an Asyncify issue, the fix is to add the missing function
+to the ASYNCIFY_ONLY list. Run 'npm run fix-asyncify' in the
+WordPress Playground repository.
 
-`;
-
-const ASYNCIFY_UNREACHABLE_ERROR = `\
-"unreachable" WASM instruction executed.
-
-The typical reason is a PHP function missing from the ASYNCIFY_ONLY
-list when building PHP.wasm.
-
-You will need to file a new issue in the WordPress Playground repository
-and paste this error message there:
-
+Please file an issue and paste this error message:
 https://github.com/WordPress/wordpress-playground/issues/new
 
-If you're a core developer, the typical fix is to:
-
-* Isolate a minimal reproduction of the error
-* Add a reproduction of the error to php-asyncify.spec.ts in the WordPress Playground repository
-* Run 'npm run fix-asyncify'
-* Commit the changes, push to the repo, release updated NPM packages
-
-Below is a list of all the PHP functions found in the stack trace to
-help with the minimal reproduction. If they're all already listed in
-the Dockerfile, you'll need to trigger this error again with long stack
-traces enabled. In node.js, you can do it using the --stack-trace-limit=100
-CLI option: \n\n`;
+`;
 
 // ANSI escape codes for CLI colors and formats
 const redBg = '\x1b[41m';


### PR DESCRIPTION
## Summary

When PHP.wasm hits a WASM trap — for example, zlib processing corrupt gzip data from a network response — the error message always blamed a missing ASYNCIFY_ONLY entry. Users seeing a crash from bad data were told to file an Asyncify bug, which was confusing and unhelpful.

This PR makes two changes:

**Better error classification.** "unreachable" errors are now split into two categories. If there's an Asyncify stack with PHP functions in the trace, the existing Asyncify guidance is shown. Otherwise (including "memory access out of bounds" errors), a new message explains the likely cause — corrupt data causing a C library to access memory out of bounds — and points to runtime rotation as the recovery path.

**Crash recovery via rotation.** The old crash handler tried to disable all methods on the PHP instance with a `for...in` loop, but this was a no-op because ES6 class methods live on the prototype and aren't enumerable. The new code sets a `#crashed` flag instead. On the next request, if runtime rotation is enabled, the runtime is swapped for a fresh one automatically. If rotation isn't enabled, a clear error tells the caller how to recover.

Relates to #2957.

## Test plan

- [x] New unit tests for error classification in `wasm-error-reporting.spec.ts` (5 cases: Asyncify with stack, unreachable without stack, unreachable without PHP functions, memory OOB, other errors)
- [x] New integration test verifying crash → rotation → successful next request
- [x] Existing crash tests pass (Asyncify and JSPI variants)
- [x] TypeScript compiles cleanly