### PR TITLE
CLI: Set PLAYGROUND_AUTO_LOGIN_AS_USER at boot time for all workers when --login is used

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/login.ts
+++ b/packages/playground/blueprints/src/lib/steps/login.ts
@@ -28,9 +28,12 @@ export type LoginStep = {
 /**
  * Logs in to Playground.
  * Under the hood, this function sets the `PLAYGROUND_AUTO_LOGIN_AS_USER` constant.
- * The `0-auto-login.php` mu-plugin uses that constant to log in the user on the first load.
+ * The `1-auto-login.php` mu-plugin uses that constant to log in the user on the first load.
  * This step depends on the `@wp-playground/wordpress` package because
  * the plugin is located in and loaded automatically by the `@wp-playground/wordpress` package.
+ *
+ * In the CLI, the `--login` flag injects this constant at boot time via
+ * `mergeDefinedConstants` so every worker has it before the server starts.
  */
 export const login: StepHandler<LoginStep> = async (
 	playground,
@@ -39,6 +42,5 @@ export const login: StepHandler<LoginStep> = async (
 ) => {
 	progress?.tracker.setCaption(progress?.initialCaption || 'Logging in');
 
-	// TODO: Make defineConstant apply to all workers
 	playground.defineConstant('PLAYGROUND_AUTO_LOGIN_AS_USER', username);
 };

--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -238,7 +238,7 @@ export class BlueprintsV1Handler {
 		return isBlueprintBundle(resolvedBlueprint)
 			? resolvedBlueprint
 			: {
-					login: this.args.login,
+					login: this.getEffectiveLogin(),
 					...(resolvedBlueprint || {}),
 					preferredVersions: {
 						php:
@@ -252,5 +252,21 @@ export class BlueprintsV1Handler {
 						...(resolvedBlueprint?.preferredVersions || {}),
 					},
 				};
+	}
+
+	/**
+	 * When the user explicitly sets PLAYGROUND_AUTO_LOGIN_AS_USER via
+	 * --define, skip the blueprint login step — the boot-time constant
+	 * from mergeDefinedConstants already handles auto-login and the
+	 * blueprint step would overwrite the custom username with 'admin'.
+	 */
+	private getEffectiveLogin(): boolean {
+		if (!this.args.login) {
+			return false;
+		}
+		if (this.args.define?.['PLAYGROUND_AUTO_LOGIN_AS_USER']) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -195,6 +195,7 @@ export class BlueprintsV1Handler {
 			withXdebug: !!this.args.xdebug,
 			nativeInternalDirPath,
 			pathAliases: this.args.pathAliases,
+			constants: mergeDefinedConstants(this.args),
 		});
 		await playground.isReady();
 		return playground;

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -52,6 +52,7 @@ interface WorkerBootRequestHandlerOptions {
 	withMemcached?: boolean;
 	withXdebug?: boolean;
 	pathAliases?: PathAlias[];
+	constants?: Record<string, string | number | boolean>;
 }
 
 /**
@@ -162,6 +163,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 			const requestHandler = await bootRequestHandler({
 				siteUrl: options.siteUrl,
 				maxPhpInstances: 1,
+				constants: options.constants,
 				createPhpRuntime: createPhpRuntimeFactory(
 					options,
 					this.fileLockManager!

--- a/packages/playground/cli/src/defines.ts
+++ b/packages/playground/cli/src/defines.ts
@@ -172,6 +172,10 @@ function mergeConstants(
 /**
  * Merge all constants from CLI arguments.
  *
+ * When `login` is true, `PLAYGROUND_AUTO_LOGIN_AS_USER` is injected so that
+ * every PHP worker defines the constant at boot time — not just the single
+ * worker that would run the blueprint `login` step via the pool proxy.
+ *
  * @param args - CLI arguments
  * @returns Merged constants
  */
@@ -179,10 +183,17 @@ export function mergeDefinedConstants(args: {
 	define?: Record<string, string>;
 	'define-bool'?: Record<string, boolean>;
 	'define-number'?: Record<string, number>;
+	login?: boolean;
 }): Record<string, string | number | boolean> {
-	return mergeConstants(
+	const merged = mergeConstants(
 		args['define'],
 		args['define-bool'],
 		args['define-number']
 	);
+
+	if (args.login && !Object.hasOwn(merged, 'PLAYGROUND_AUTO_LOGIN_AS_USER')) {
+		merged['PLAYGROUND_AUTO_LOGIN_AS_USER'] = 'admin';
+	}
+
+	return merged;
 }

--- a/packages/playground/cli/tests/merge-defined-constants.spec.ts
+++ b/packages/playground/cli/tests/merge-defined-constants.spec.ts
@@ -1,0 +1,61 @@
+import { mergeDefinedConstants } from '../src/defines';
+
+describe('mergeDefinedConstants', () => {
+	it('should merge string, boolean, and number constants', () => {
+		const result = mergeDefinedConstants({
+			define: { API_KEY: 'secret' },
+			'define-bool': { WP_DEBUG: true },
+			'define-number': { LIMIT: 100 },
+		});
+		expect(result).toEqual({
+			API_KEY: 'secret',
+			WP_DEBUG: true,
+			LIMIT: 100,
+		});
+	});
+
+	it('should return empty object when no constants are provided', () => {
+		const result = mergeDefinedConstants({});
+		expect(result).toEqual({});
+	});
+
+	it('should inject PLAYGROUND_AUTO_LOGIN_AS_USER when login is true', () => {
+		const result = mergeDefinedConstants({ login: true });
+		expect(result).toEqual({
+			PLAYGROUND_AUTO_LOGIN_AS_USER: 'admin',
+		});
+	});
+
+	it('should not inject login constant when login is false', () => {
+		const result = mergeDefinedConstants({ login: false });
+		expect(result).toEqual({});
+	});
+
+	it('should not inject login constant when login is undefined', () => {
+		const result = mergeDefinedConstants({});
+		expect(result).toEqual({});
+	});
+
+	it('should not override explicit PLAYGROUND_AUTO_LOGIN_AS_USER from --define', () => {
+		const result = mergeDefinedConstants({
+			define: { PLAYGROUND_AUTO_LOGIN_AS_USER: 'editor' },
+			login: true,
+		});
+		expect(result).toEqual({
+			PLAYGROUND_AUTO_LOGIN_AS_USER: 'editor',
+		});
+	});
+
+	it('should preserve other constants alongside the injected login constant', () => {
+		const result = mergeDefinedConstants({
+			define: { API_KEY: 'secret' },
+			'define-bool': { WP_DEBUG: true },
+			login: true,
+		});
+		expect(result).toEqual({
+			API_KEY: 'secret',
+			WP_DEBUG: true,
+			PLAYGROUND_AUTO_LOGIN_AS_USER: 'admin',
+		});
+	});
+});


### PR DESCRIPTION
## Motivation for the change, related issues

When the CLI runs `server --login`, the blueprint `login` step calls
`playground.defineConstant('PLAYGROUND_AUTO_LOGIN_AS_USER', username)` once
through the pool proxy. There was an existing TODO acknowledging a potential
issue with this:

```ts
// TODO: Make defineConstant apply to all workers
playground.defineConstant('PLAYGROUND_AUTO_LOGIN_AS_USER', username);
```

In practice, all CLI workers share a native `/internal/` directory
(`nativeInternalDirPath`), so the `consts.json` file written by
`defineConstant` is visible across workers and the login flakiness is hard
to reproduce manually. However, the constant is set *during blueprint step
execution* rather than at PHP boot time. Moving it into the boot-time
constants path:

- Makes the login constant available before the server starts accepting
  requests, rather than relying on the shared filesystem being written to
  during blueprint execution
- Ensures the constant survives PHP runtime rotation cleanly (every ~400
  requests a new PHP instance is created via `createPhp`, which applies
  `options.constants` — the proper boot-time path)
- Resolves the TODO in `login.ts`

Additionally, the V1 handler's per-worker `bootRequestHandler` was not
forwarding `--define` / `--define-bool` / `--define-number` constants at
all. Those constants only reached the single worker that the pool proxy
selected for `bootWordPress`. This PR fixes that gap so every V1 worker
gets CLI-defined constants at PHP instance creation time.

## Implementation details

**`packages/playground/cli/src/defines.ts`**
- `mergeDefinedConstants` now accepts an optional `login` boolean
- When `login` is true, injects `PLAYGROUND_AUTO_LOGIN_AS_USER: 'admin'`
  (matching the blueprint login step's default)
- Respects an explicit `--define PLAYGROUND_AUTO_LOGIN_AS_USER` override

**`packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts`**
- Passes `constants: mergeDefinedConstants(this.args)` to each worker's
  `bootRequestHandler`, so every worker gets CLI-defined constants at PHP
  instance creation time

**`packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts`**
- Adds `constants` to `WorkerBootRequestHandlerOptions`
- Forwards `constants` to the `@wp-playground/wordpress` `bootRequestHandler`,
  which applies them in `createPhp` for every PHP instance (including after
  runtime rotation)

**`packages/playground/blueprints/src/lib/steps/login.ts`**
- Removes the resolved TODO comment
- Fixes the mu-plugin filename reference from `0-auto-login.php` to
  `1-auto-login.php`

V2 already passes `mergeDefinedConstants(this.args)` per-worker in
`bootWorker`, so the `defines.ts` change is sufficient there.

## Testing Instructions (or ideally a Blueprint)

**Unit tests** (added in this PR):

```bash
npx nx test-playground-cli playground-cli --testFile=merge-defined-constants.spec.ts
```

Covers: login=true injects the constant, login=false/undefined does not,
explicit `--define` override is preserved, and coexistence with other
constants.

**Existing tests** (verify no regressions):

```bash
npx nx test-playground-cli playground-cli --testFile=parse-define-arguments.spec.ts
npx nx typecheck playground-cli
npx nx lint playground-cli
```

**Code review notes:**

The login flakiness from the missing constant has been observed in E2E tests
but is difficult to reproduce manually, because CLI workers share a native
`/internal/` directory and the `consts.json` file written by `defineConstant`
is visible across all workers. The primary value of this change is
architectural correctness: constants now flow through the proper boot-time
path (`bootRequestHandler` → `createPhp`) rather than relying on a
shared-filesystem side effect of the blueprint `login` step. This also fixes
`--define` constant propagation to all V1 workers, which had the same gap.