### PR TITLE
[DOCS] Running PHPUnit tests using the Playground CLI

### DIFF
--- a/packages/docs/site/docs/main/guides/index.md
+++ b/packages/docs/site/docs/main/guides/index.md
@@ -41,6 +41,10 @@ Automate WordPress Playground workflows with Claude Code. Learn how to install t
 
 Learn how to use the `runCLI` function to control WordPress Playground programmatically from JavaScript/TypeScript for automation, end-to-end testing, and CI/CD pipelines.
 
+## [Running PHPUnit with the Playground CLI](/guides/phpunit-testing)
+
+Run PHPUnit tests for WordPress plugins and themes using the Playground CLI — no database required, clean environment on every run.
+
 ## [E2E Testing with Playwright and WordPress Playground](/guides/e2e-testing-with-playwright)
 
 Set up automated end-to-end tests for your WordPress plugins and themes using Playwright and the WordPress Playground CLI.

--- a/packages/docs/site/docs/main/guides/phpunit-testing.md
+++ b/packages/docs/site/docs/main/guides/phpunit-testing.md
@@ -5,7 +5,7 @@ description: Run PHPUnit tests for WordPress plugins and themes using the Playgr
 sidebar_class_name: navbar-build-item
 ---
 
-The [Playground CLI](/developers/local-development/wp-playground-cli) includes a `php` subcommand that runs PHP scripts directly inside the Playground environment. Combined with `--auto-mount`, you can run PHPUnit for your plugin or theme without a local database. Every run starts with a clean WordPress installation, so tests are fully isolated.
+The [Playground CLI](/developers/local-development/wp-playground-cli) includes a `php` subcommand that runs PHP scripts directly inside the Playground environment. By mounting your plugin or theme into the Playground filesystem, you can run PHPUnit without a local database. Every run starts with a clean WordPress installation, so tests are fully isolated.
 
 :::info
 This guide assumes your plugin or theme has PHPUnit installed via Composer (`composer require --dev phpunit/phpunit`). The `vendor/bin/phpunit` path used below assumes a standard Composer setup.
@@ -30,6 +30,16 @@ For a plugin, the path would use `plugins/` instead:
 ```bash
 npx @wp-playground/cli@latest php \
   --auto-mount \
+  -- \
+  /wordpress/wp-content/plugins/MY_PLUGIN/vendor/bin/phpunit \
+  -c /wordpress/wp-content/plugins/MY_PLUGIN/phpunit.xml.dist
+```
+
+You can also use `--mount` to explicitly map a local directory to a path inside the Playground filesystem:
+
+```bash
+npx @wp-playground/cli@latest php \
+  --mount=.:/wordpress/wp-content/plugins/MY_PLUGIN \
   -- \
   /wordpress/wp-content/plugins/MY_PLUGIN/vendor/bin/phpunit \
   -c /wordpress/wp-content/plugins/MY_PLUGIN/phpunit.xml.dist

--- a/packages/docs/site/docs/main/guides/phpunit-testing.md
+++ b/packages/docs/site/docs/main/guides/phpunit-testing.md
@@ -1,0 +1,57 @@
+---
+title: Running PHPUnit with the Playground CLI
+slug: /guides/phpunit-testing
+description: Run PHPUnit tests for WordPress plugins and themes using the Playground CLI — no database required, clean environment on every run.
+sidebar_class_name: navbar-build-item
+---
+
+The [Playground CLI](/developers/local-development/wp-playground-cli) includes a `php` subcommand that runs PHP scripts directly inside the Playground environment. Combined with `--auto-mount`, you can run PHPUnit for your plugin or theme without a local database. Every run starts with a clean WordPress installation, so tests are fully isolated.
+
+:::info
+This guide assumes your plugin or theme has PHPUnit installed via Composer (`composer require --dev phpunit/phpunit`). The `vendor/bin/phpunit` path used below assumes a standard Composer setup.
+:::
+
+## Running tests
+
+From your plugin or theme directory, run the following command. Replace `themes/THEME_NAME` with the path to your plugin or theme:
+
+```bash
+npx @wp-playground/cli@latest php \
+  --auto-mount \
+  -- \
+  /wordpress/wp-content/themes/THEME_NAME/vendor/bin/phpunit \
+  -c /wordpress/wp-content/themes/THEME_NAME/phpunit.xml.dist
+```
+
+The `--auto-mount` flag detects whether the current directory is a plugin, theme, or WordPress installation and mounts it at the correct path under `/wordpress/wp-content/`. The `--` separates CLI flags from arguments passed to the PHP interpreter, and you can pass any arguments supported by your PHPUnit configuration.
+
+For a plugin, the path would use `plugins/` instead:
+
+```bash
+npx @wp-playground/cli@latest php \
+  --auto-mount \
+  -- \
+  /wordpress/wp-content/plugins/MY_PLUGIN/vendor/bin/phpunit \
+  -c /wordpress/wp-content/plugins/MY_PLUGIN/phpunit.xml.dist
+```
+
+## Choosing PHP and WordPress versions
+
+Use the `--php` and `--wp` flags to test against specific versions:
+
+```bash
+npx @wp-playground/cli@latest php \
+  --auto-mount \
+  --php=8.1 \
+  --wp=6.5 \
+  -- \
+  /wordpress/wp-content/plugins/MY_PLUGIN/vendor/bin/phpunit \
+  -c /wordpress/wp-content/plugins/MY_PLUGIN/phpunit.xml.dist
+```
+
+Supported PHP versions range from 7.4 to 8.5. For WordPress, you can use a specific version number, `latest`, `nightly`, or `beta`.
+
+## Next steps
+
+- [Playground CLI documentation](/developers/local-development/wp-playground-cli) — full CLI reference and configuration options
+- [E2E Testing with Playwright](/guides/e2e-testing-with-playwright) — browser-based end-to-end testing for WordPress plugins and themes

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -52,6 +52,7 @@ const sidebars = {
 						'main/guides/github-action-pr-preview',
 						'main/guides/playground-for-everyone',
 						'main/guides/programmatic-playground-cli',
+						'main/guides/phpunit-testing',
 						'main/guides/e2e-testing-with-playwright',
 					],
 				},


### PR DESCRIPTION
## Motivation for the change, related issues

The Playground CLI's `php` subcommand makes it easy to run PHPUnit for plugins and themes without a local database, but there's no guide documenting this workflow.

## Implementation details

- Adds a new guide at `packages/docs/site/docs/main/guides/phpunit-testing.md` covering:
  - Basic usage with `npx @wp-playground/cli@latest php`
  - Examples for both plugins and themes
  - Choosing PHP and WordPress versions
- Adds the guide to the sidebar in `sidebars.js` (between the programmatic CLI guide and the E2E testing guide)
- Adds a link to the guide in the guides index page

## Testing Instructions

1. Run `npm run dev:docs`
2. Navigate to the Guides section
3. Confirm the "Running PHPUnit with the Playground CLI" guide appears in the sidebar and index
4. Open the guide and verify all links work
5. Review the guide content and test it