### PR TITLE
[Github Actions] Fix GitHub release publishing wrong version

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -29,7 +29,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
               with:
-                  ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+                  ref: ${{ github.event.workflow_run.head_branch || github.ref }}
 
             - name: Read version from lerna.json
               id: version

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -19,6 +19,9 @@ permissions:
     id-token: write
     contents: write
 
+concurrency:
+    group: npm-release
+
 jobs:
     release:
         # Only run on the playground repo, and only allow Playground maintainers to trigger this workflow.


### PR DESCRIPTION
## Motivation for the change, related issues

The `Publish GitHub Release` workflow used `workflow_run.head_sha` to checkout the codebase, but that SHA is captured when the `Release NPM packages` workflow starts, before `lerna publish` bumps the version. This caused the GitHub release to always be created for the previous version instead of the current one.

## Implementation details

- `publish-github-release.yml` : Changed the checkout ref from `head_sha` (pre-bump commit) to `head_branch` (tip of trunk, which includes both the version bump and changelog commits).
- `publish-npm-packages.yml` : Added a concurrency group to prevent overlapping NPM releases, which ensures trunk doesn't move to a newer version while the GitHub release workflow is running.

## Testing Instructions after merge

1. Trigger the "Release NPM packages" workflow manually.
2. Verify the "Publish GitHub Release" workflow creates a release matching the version in `lerna.json` after the bump.
3. Confirm the changelog content in the GitHub release matches the correct version entry.