### PR TITLE
Harden non-streaming fallback tests for fetchWithCorsProxy

### DIFF
--- a/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/fetch-with-cors-proxy.spec.ts
@@ -327,17 +327,16 @@ describe('fetchWithCorsProxy', () => {
 
 	/**
 	 * These tests exercise the non-streaming fallback path (Safari/Firefox)
-	 * by resetting the cached probe result and mocking the
-	 * `supportsReadableStreamBody` probe fetch to reject. The probe now
-	 * fires inside the retry (catch) path — after the direct fetch fails —
-	 * so mock ordering is: [direct fetch, probe, CORS proxy fetch].
-	 *
-	 * The GET case has no request body, so there is no probe; only
-	 * direct-fetch behavior is exercised.
+	 * by forcing `supportsReadableStreamBody()` to return `false` in
+	 * beforeEach, then asserting it before each test runs.
+	 * Because the cached result is already set, no probe fetch fires
+	 * during the retry path — mock ordering is just: [direct fetch,
+	 * CORS proxy fetch].
 	 */
 	describe('non-streaming fallback (Safari/Firefox)', () => {
-		beforeEach(() => {
-			__testing.resetStreamBodySupported();
+		beforeEach(async () => {
+			__testing.setStreamBodySupported(false);
+			expect(await supportsReadableStreamBody()).toBe(false);
 		});
 
 		it('succeeds on direct POST fetch without needing the streaming probe', async () => {
@@ -366,14 +365,11 @@ describe('fetchWithCorsProxy', () => {
 			const corsProxyHeaders = new Headers();
 			corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
 
-			// Mock ordering: direct fetch → probe → CORS proxy fetch.
-			// The probe fires inside the catch block after direct fails.
+			// Streaming is already forced unsupported in beforeEach, so no
+			// probe fires — mock ordering is just: direct fetch → CORS proxy.
 			const fetchMock = vi
 				.spyOn(globalThis, 'fetch')
 				.mockRejectedValueOnce(new Error('CORS'))
-				.mockRejectedValueOnce(
-					new TypeError('ReadableStream uploading is not supported')
-				)
 				.mockResolvedValueOnce(
 					new Response('proxied', { headers: corsProxyHeaders })
 				);
@@ -389,9 +385,8 @@ describe('fetchWithCorsProxy', () => {
 				'https://proxy.test/?url='
 			);
 
-			// direct + probe + proxy
-			expect(fetchMock).toHaveBeenCalledTimes(3);
-			const proxyReq = fetchMock.mock.calls[2][0] as Request;
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			const proxyReq = fetchMock.mock.calls[1][0] as Request;
 			expect(proxyReq.url).toBe(
 				'https://proxy.test/?url=https://example.com/upload'
 			);

--- a/packages/php-wasm/web-service-worker/src/lib/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/lib/utils.ts
@@ -275,6 +275,9 @@ export const __testing = {
 	resetStreamBodySupported(): void {
 		streamBodySupported = undefined;
 	},
+	setStreamBodySupported(value: boolean): void {
+		streamBodySupported = value;
+	},
 };
 
 /**

--- a/packages/php-wasm/web-service-worker/src/test/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/test/fetch-with-cors-proxy.spec.ts
@@ -415,16 +415,18 @@ describe('fetchWithCorsProxy', () => {
 
 	/**
 	 * These tests exercise the non-streaming fallback path (Safari/Firefox)
-	 * by resetting the cached probe result and mocking the
-	 * `supportsReadableStreamBody` probe fetch to reject. The probe now
-	 * fires inside the retry (catch) path — after the direct fetch fails —
-	 * so mock ordering is: [direct fetch, probe, CORS proxy fetch].
-	 *
-	 * The GET case has no request body, so there is no probe; only
-	 * direct-fetch behavior is exercised.
+	 * by forcing `supportsReadableStreamBody()` to return `false` in
+	 * beforeEach, then asserting it before each test runs. Because the cached
+	 * result is already set, no probe fetch fires during the retry path — mock
+	 * ordering is just: [direct fetch, CORS proxy fetch].
 	 */
 	describe('non-streaming fallback (Safari/Firefox)', () => {
-		beforeEach(() => {
+		beforeEach(async () => {
+			__testing.setStreamBodySupported(false);
+			expect(await supportsReadableStreamBody()).toBe(false);
+		});
+
+		afterEach(() => {
 			__testing.resetStreamBodySupported();
 		});
 
@@ -454,14 +456,11 @@ describe('fetchWithCorsProxy', () => {
 			const corsProxyHeaders = new Headers();
 			corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
 
-			// Mock ordering: direct fetch → probe → CORS proxy fetch.
-			// The probe fires inside the catch block after direct fails.
+			// Streaming is already forced unsupported in beforeEach, so no
+			// probe fires — mock ordering is just: direct fetch → CORS proxy.
 			const fetchMock = vi
 				.spyOn(globalThis, 'fetch')
 				.mockRejectedValueOnce(new Error('CORS'))
-				.mockRejectedValueOnce(
-					new TypeError('ReadableStream uploading is not supported')
-				)
 				.mockResolvedValueOnce(
 					new Response('proxied', { headers: corsProxyHeaders })
 				);
@@ -477,9 +476,8 @@ describe('fetchWithCorsProxy', () => {
 				'https://proxy.test/?url='
 			);
 
-			// direct + probe + proxy
-			expect(fetchMock).toHaveBeenCalledTimes(3);
-			const proxyReq = fetchMock.mock.calls[2][0] as Request;
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			const proxyReq = fetchMock.mock.calls[1][0] as Request;
 			expect(proxyReq.url).toBe(
 				'https://proxy.test/?url=https://example.com/upload'
 			);

--- a/packages/php-wasm/web-service-worker/src/utils.ts
+++ b/packages/php-wasm/web-service-worker/src/utils.ts
@@ -275,6 +275,9 @@ export const __testing = {
 	resetStreamBodySupported(): void {
 		streamBodySupported = undefined;
 	},
+	setStreamBodySupported(value: boolean): void {
+		streamBodySupported = value;
+	},
 };
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #3440, specifically addressing Brandon's comments [the request to assert unsupported streaming in each fallback test](https://github.com/WordPress/wordpress-playground/pull/3440#discussion_r3084086242) and [the concern that resetting the cache allows Node.js/V8 to detect streaming support](https://github.com/WordPress/wordpress-playground/pull/3440#discussion_r3084089664).

- The non-streaming fallback suite now sets the cached `supportsReadableStreamBody()` result to `false` in `beforeEach()` and asserts that value before every test runs.
- The suite resets that test-only cache in `afterEach()`, keeping the test state hermetic.
- The proxy-retry test now correctly expects only direct-fetch and proxy-fetch calls, because no detection probe runs when unsupported mode is already cached.

## Test plan

- [x] `npm exec nx test php-wasm-web-service-worker --testFile=fetch-with-cors-proxy.spec.ts`
- [x] `npm exec nx lint php-wasm-web-service-worker`