### PR TITLE
[GitHub Actions] Fix GitHub release missing changelog

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -3,7 +3,7 @@ name: Publish GitHub Release
 on:
     workflow_dispatch:
     workflow_run:
-        workflows: [Release NPM packages]
+        workflows: [Update CHANGELOG.md]
         types:
             - completed
 


### PR DESCRIPTION
## Motivation for the change, related issues

Follow-up on #3488

The `Publish GitHub Release` and `Update CHANGELOG.md` workflows both trigger on `Release NPM packages` completion, so they run in parallel. This means the GitHub release reads `CHANGELOG.md` before it's been updated, resulting in releases with no changelog.

## Implementation details

Changed `publish-github-release.yml` to trigger on `Update CHANGELOG.md` completion instead of `Release NPM packages` completion. This ensures the workflow chain is sequential:

1. `Release NPM packages` completes
2. `Update CHANGELOG.md` triggers, generates and commits the changelog
3. `Publish GitHub Release` triggers, reads the now-updated `CHANGELOG.md`

## Testing Instructions (or ideally a Blueprint)

  1. Trigger the `Release NPM packages` workflow manually.
  2. Wait for `Update CHANGELOG.md` to complete.
  3. Verify `Publish GitHub Release` triggers after `Update CHANGELOG.md` not after `Release NPM packages`.
  4. Confirm the GitHub release body contains the actual changelog entries instead of "No changelog entries for this release."