### PR TITLE
[PHP] Align @php-wasm/{web,node}-5-2 with workspace and add READMEs

### DIFF
--- a/packages/php-wasm/node-builds/5-2/README.md
+++ b/packages/php-wasm/node-builds/5-2/README.md
@@ -1,0 +1,33 @@
+# @php-wasm/node-5-2
+
+PHP 5.2 WebAssembly binaries for Node.js (legacy).
+
+This package contains:
+
+- JSPI and Asyncify variants of PHP 5.2 compiled to WebAssembly
+
+No bundled extensions (intl, Xdebug, Redis, Memcached) — calling the
+corresponding getter functions throws.
+
+## Installation
+
+```bash
+npm install @php-wasm/node-5-2
+```
+
+## Usage
+
+```typescript
+import { getPHPLoaderModule } from '@php-wasm/node-5-2';
+
+const loaderModule = await getPHPLoaderModule();
+```
+
+## Related Packages
+
+- [@php-wasm/node](https://www.npmjs.com/package/@php-wasm/node) - Main package (requires version packages)
+- [@php-wasm/universal](https://www.npmjs.com/package/@php-wasm/universal) - Universal PHP.wasm bindings
+
+## License
+
+GPL-2.0-or-later

--- a/packages/php-wasm/node-builds/5-2/package.json
+++ b/packages/php-wasm/node-builds/5-2/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@php-wasm/node-5-2",
-	"version": "3.1.19",
+	"version": "3.1.20",
 	"description": "PHP 5.2 WebAssembly binaries for node (legacy)",
 	"repository": {
 		"type": "git",

--- a/packages/php-wasm/web-builds/5-2/README.md
+++ b/packages/php-wasm/web-builds/5-2/README.md
@@ -1,0 +1,33 @@
+# @php-wasm/web-5-2
+
+PHP 5.2 WebAssembly binaries for the web (legacy).
+
+This package contains:
+
+- JSPI and Asyncify variants of PHP 5.2 compiled to WebAssembly
+
+No bundled extensions (intl, Xdebug, Redis, Memcached) — calling the
+corresponding getter functions throws.
+
+## Installation
+
+```bash
+npm install @php-wasm/web-5-2
+```
+
+## Usage
+
+```typescript
+import { getPHPLoaderModule } from '@php-wasm/web-5-2';
+
+const loaderModule = await getPHPLoaderModule();
+```
+
+## Related Packages
+
+- [@php-wasm/web](https://www.npmjs.com/package/@php-wasm/web) - Main package (requires version packages)
+- [@php-wasm/universal](https://www.npmjs.com/package/@php-wasm/universal) - Universal PHP.wasm bindings
+
+## License
+
+GPL-2.0-or-later

--- a/packages/php-wasm/web-builds/5-2/package.json
+++ b/packages/php-wasm/web-builds/5-2/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@php-wasm/web-5-2",
-	"version": "3.1.19",
+	"version": "3.1.20",
 	"description": "PHP 5.2 WebAssembly binaries for web (legacy)",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- Bumps the newly-introduced `@php-wasm/web-5-2` and `@php-wasm/node-5-2` packages from `3.1.19` → `3.1.20` to match the current workspace version (`lerna.json`). Without this they would have been published below their own `@php-wasm/universal@3.1.20` dependency and skipped by the next `lerna publish patch`.
- Adds `README.md` for both packages, mirroring the 8-5 style. The blurb notes that 5.2 bundles no extensions (intl/Xdebug/Redis/Memcached getters all throw), so the npmjs.com page isn't blank and consumers aren't surprised.

Follow-up to #3501. Both packages are already live on npm at `3.1.20` — this PR brings the source tree in sync so the weekly `lerna publish` CI picks up cleanly from here.

## Test plan

- [x] `npm view @php-wasm/web-5-2 version` → `3.1.20`
- [x] `npm view @php-wasm/node-5-2 version` → `3.1.20`
- [x] `npm access list collaborators @php-wasm/web-5-2` matches `@php-wasm/web-8-5`
- [x] Trusted Publisher configured on npmjs.com for both packages (repo `WordPress/wordpress-playground`, workflow `publish-npm-packages.yml`, environment `npm`)