### PR TITLE
[Asyncify] Fix `fix-asyncify` command

### DIFF
--- a/packages/php-wasm/node/project.json
+++ b/packages/php-wasm/node/project.json
@@ -373,6 +373,18 @@
 				]
 			}
 		},
+		"test-php-asyncify-all": {
+			"executor": "nx:noop",
+			"dependsOn": [
+				"test-group-1-asyncify",
+				"test-group-2-asyncify",
+				"test-group-3-asyncify",
+				"test-group-4-asyncify",
+				"test-group-5-asyncify",
+				"test-group-6-asyncify",
+				"test-file-locking-asyncify"
+			]
+		},
 		"lint": {
 			"executor": "@nx/eslint:lint",
 			"outputs": ["{options.outputFile}"],


### PR DESCRIPTION
## Motivation for the change, related issues

Related to [this issue](https://github.com/WordPress/wordpress-playground/issues/3472)

The `npm run fix-asyncify` command was broken because the `test-php-asyncify-all` NX target was removed from `packages/php-wasm/node/project.json` in a previous pull request. The `rebuild-while-asyncify-functions-missing.mjs` script depends on this target to run all asyncify test groups, so without it, the `fix-asyncify` workflow fails.

## Implementation details

Re-added the `test-php-asyncify-all` target to `packages/php-wasm/node/project.json`. It is a `nx:noop` executor that depends on all asyncify test group targets, matching the original definition that was accidentally removed.

## Testing Instructions (or ideally a Blueprint)

Run `npm run fix-asyncify` and verify it no longer errors out with a missing target. 