### PR TITLE
[Github actions] Modify the time slot of the `refresh-sqlite-integration` workflow

### DIFF
--- a/.github/workflows/refresh-sqlite-integration.yml
+++ b/.github/workflows/refresh-sqlite-integration.yml
@@ -2,9 +2,8 @@ name: 'Refresh SQLite plugin'
 
 on:
     workflow_dispatch:
-    # Every 20 minutes
     schedule:
-        - cron: '0 9 * * *'
+        - cron: '0 10 * * *'
 
 jobs:
     build_and_deploy:


### PR DESCRIPTION
## Motivation for the change, related issues

The `Publish NPM packages` workflow [failed today](https://github.com/WordPress/wordpress-playground/actions/runs/24659493612). And based on the stack trace : pushing the branch `trunk` was rejected because the remote is ahead. The only file modification on `trunk` is `packages/playground/wordpress-builds/src/sqlite-database-integration/sqlite-database-integration-trunk.zip` because of [this commit](https://github.com/WordPress/wordpress-playground/commit/4e2c90c900c8771c736469a34d428f64d5a8039a). Which I suspect made the process of publishing NPM packages fail.

Both workflows triggered at the same time, and the other workflow pushed that commit to trunk before the publish workflow could push its version bump commit. 

## Implementation details

Modified cron to be`'0 10 * * *'` instead of same time slot as `publish-npm-packages`: '0 9 * * *'

## Testing Instructions

`Publish NPM packages` workflow completion next monday.