### PR TITLE
[PHP] Add `TSRMLS_CC` fallback defines for PHP versions above 7

### DIFF
--- a/packages/php-wasm/compile/php-post-message-to-js/post_message_to_js.c
+++ b/packages/php-wasm/compile/php-post-message-to-js/post_message_to_js.c
@@ -8,6 +8,11 @@
 #define PHP_FE_END {NULL, NULL, NULL}
 #endif
 
+/* TSRMLS macros were removed in PHP 7; provide empty fallbacks */
+#if !defined(TSRMLS_CC)
+#define TSRMLS_CC
+#endif
+
 /**
  * Provided by php_wasm.c:
  */
@@ -83,4 +88,4 @@ zend_module_entry post_message_to_js_module_entry = {
 ZEND_TSRMLS_CACHE_DEFINE()
 #endif
 ZEND_GET_MODULE(post_message_to_js)
-#endif 
+#endif

--- a/packages/php-wasm/compile/php-post-message-to-js/post_message_to_js.c
+++ b/packages/php-wasm/compile/php-post-message-to-js/post_message_to_js.c
@@ -9,7 +9,7 @@
 #endif
 
 /* TSRMLS macros were removed in PHP 7; provide empty fallbacks */
-#if !defined(TSRMLS_CC)
+#ifndef TSRMLS_CC
 #define TSRMLS_CC
 #endif
 

--- a/packages/php-wasm/compile/php-wasm-dns-polyfill/dns_polyfill.c
+++ b/packages/php-wasm/compile/php-wasm-dns-polyfill/dns_polyfill.c
@@ -11,7 +11,7 @@
 #endif
 
 /* TSRMLS macros were removed in PHP 7; provide empty fallbacks */
-#if !defined(TSRMLS_CC)
+#ifndef TSRMLS_CC
 #define TSRMLS_CC
 #endif
 

--- a/packages/php-wasm/compile/php-wasm-dns-polyfill/dns_polyfill.c
+++ b/packages/php-wasm/compile/php-wasm-dns-polyfill/dns_polyfill.c
@@ -10,6 +10,11 @@
 #define ZEND_FE_END {NULL, NULL, NULL}
 #endif
 
+/* TSRMLS macros were removed in PHP 7; provide empty fallbacks */
+#if !defined(TSRMLS_CC)
+#define TSRMLS_CC
+#endif
+
 #ifdef HAVE_SYS_SOCKET_H
 #include <sys/socket.h>
 #endif


### PR DESCRIPTION
## Motivation for the change, related issues

[Add PHP 5.2 WebAssembly builds and runtime support](https://github.com/WordPress/wordpress-playground/pull/3501) added `TSRMLS_CC` macros to `dns_polyfill` and `post_message_to_js` for PHP 5.x compatibility, but these macros don't exist in PHP 7+. This breaks recompilation of PHP.wasm for all PHP versions 7.0 through 8.5.

## Implementation details

 Added empty `TSRMLS_CC` fallback defines to `dns_polyfill.c` and `post_message_to_js.c`

## Testing Instructions (or ideally a Blueprint)

- [x] `nx run php-wasm-node:recompile-php:jspi`
- [x] `nx run php-wasm-node:recompile-php:asyncify`
- [x] `nx run php-wasm-web:recompile-php:jspi`
- [x] `nx run php-wasm-web:recompile-php:asyncify`