### PR TITLE
[Remote] Re-enable client-side media processing via Document-Isolation-Policy

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -225,7 +225,7 @@ self.addEventListener('fetch', (event) => {
 		const scope = getURLScope(url)!;
 		return event.respondWith(
 			handleScopedRequest(event, scope).then((response) =>
-				rewriteCoopHeadersToDocumentIsolationPolicy(response, scope)
+				applyCrossOriginIsolationHeaders(response, scope)
 			)
 		);
 	}
@@ -648,25 +648,40 @@ self.addEventListener('message', (event) => {
 });
 
 /**
- * Rewrites COEP/COOP headers to Document-Isolation-Policy for browsers that support it.
+ * Ensures cross-origin isolation is applied consistently for scoped responses.
  *
- * When the browser supports Document-Isolation-Policy, this function:
- * - Removes Cross-Origin-Embedder-Policy (COEP) header
- * - Removes Cross-Origin-Opener-Policy (COOP) header
- * - Adds Document-Isolation-Policy: isolate-and-credentialless
+ * Handles two cases:
  *
- * This enables cross-origin isolation (for SharedArrayBuffer) without serving
- * the entire playground.wordpress.net site with COEP/COOP headers (which would
- * break embedding it on other sites).
+ * 1. Response already carries `Document-Isolation-Policy`. This is what
+ *    Gutenberg ≥ 21.8 / Gutenberg PR #75991 sends directly on editor screens in
+ *    Chromium 137+. The response is left as-is, but the scope is tracked so
+ *    that `empty.html` (the block editor's inner iframe) also receives DIP —
+ *    parent and child frames need the same DIP for the editor to function
+ *    (see https://github.com/WordPress/wordpress-playground/pull/3320).
+ *
+ * 2. Response carries COEP/COOP (older Gutenberg, WordPress core's
+ *    `wp_set_up_cross_origin_isolation`, or custom plugins). When the browser
+ *    supports DIP, the COEP/COOP pair is rewritten to the equivalent DIP value
+ *    so the page is cross-origin isolated without making the whole host send
+ *    COEP/COOP — that would break external embeds and third-party embedders of
+ *    Playground.
  *
  * @param response The response to potentially modify
  * @param scope The scope of the request, used to track which scopes have cross-origin isolation
- * @returns A new Response with rewritten headers, or the original response if no rewriting is needed
+ * @returns A new Response with rewritten headers, or the original response if no changes are needed
  */
-function rewriteCoopHeadersToDocumentIsolationPolicy(
+function applyCrossOriginIsolationHeaders(
 	response: Response,
 	scope: string
 ): Response {
+	// If the response already opts into DIP, track the scope so empty.html gets DIP too.
+	// This is the modern path once Gutenberg sends DIP directly — see
+	// https://github.com/WordPress/gutenberg/pull/75991.
+	if (response.headers.has('document-isolation-policy')) {
+		scopesWithCrossOriginIsolation.add(scope);
+		return response;
+	}
+
 	// If we don't know whether the browser supports Document-Isolation-Policy,
 	// or if it doesn't support it, return the original response unchanged.
 	if (!browserSupportsDocumentIsolationPolicy) {
@@ -736,7 +751,7 @@ function rewriteCoopHeadersToDocumentIsolationPolicy(
  * with the `Document-Isolation-Policy` header. SharedArrayBuffer is only available
  * in this document if the browser supports `Document-Isolation-Policy`.
  *
- * @see rewriteCoopHeadersToDocumentIsolationPolicy
+ * @see applyCrossOriginIsolationHeaders
  */
 function documentIsolationPolicyHtml() {
 	return new Response(

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -653,7 +653,7 @@ self.addEventListener('message', (event) => {
  * Handles two cases:
  *
  * 1. Response already carries `Document-Isolation-Policy`. This is what
- *    Gutenberg ≥ 21.8 / Gutenberg PR #75991 sends directly on editor screens in
+ *    Gutenberg ≥ 22.6 / Gutenberg PR #75991 sends directly on editor screens in
  *    Chromium 137+. The response is left as-is, but the scope is tracked so
  *    that `empty.html` (the block editor's inner iframe) also receives DIP —
  *    parent and child frames need the same DIP for the editor to function

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -263,17 +263,6 @@ add_action('init', function() {
 });
 
 /**
- * ¡TEMPORARY WORKAROUND!
- * On 2026-02-26, with Gutenberg v22.6.0 and above, the site editor and post
- * editor fail to load. This appears related the `cross-origin-embedder-policy: credentialless`
- * header which is added when client side media is enabled by default.
- *
- * This has something to do with our /wp-includes/empty.html workaround.
- * @TODO: Let's find a solution that doesn't require us to disable client side media processing.
- */
-add_filter('wp_client_side_media_processing_enabled', '__return_false');
-
-/**
  * Disable the WP Cron.
  * 
  * Around WordPress 7.0 beta 1, many wp-cron requests in the Playground started

--- a/packages/playground/website/playwright/e2e/client-side-media.spec.ts
+++ b/packages/playground/website/playwright/e2e/client-side-media.spec.ts
@@ -20,16 +20,30 @@ import type { Blueprint } from '@wp-playground/blueprints';
  * document-isolation-policy.spec.ts covers that the editor renders
  * successfully (which implicitly verifies parent/child DIP parity).
  *
- * Playwright's default `chromium_headless_shell` build does not honor
- * Document-Isolation-Policy, so these tests opt into `channel: 'chromium'`
- * (the full Chromium browser) via `test.use()`. Playwright's CI install
- * step already installs it via `playwright install chromium --with-deps`.
+ * These tests are Chromium-only (DIP is a Chromium-only spec and Gutenberg
+ * only sends the header there). The file-level `test.skip()` below must
+ * run before the file-level `test.use({ channel })` takes effect so the
+ * non-Chromium projects never try to launch WebKit/Firefox with a
+ * chromium channel, which would error with `Unsupported <browser>
+ * channel "chromium"`.
+ *
+ * The `channel: 'chromium'` opt-in is required because Playwright's
+ * default `chromium_headless_shell` build does not honor
+ * Document-Isolation-Policy — `window.crossOriginIsolated` is always
+ * false there even when the response carries a DIP header. The full
+ * Chromium channel is already installed by Playwright's CI step
+ * (`playwright install chromium --with-deps`).
  *
  * @see https://github.com/WordPress/wordpress-playground/issues/3514
  * @see https://github.com/WordPress/wordpress-playground/issues/2954
  * @see https://github.com/WordPress/gutenberg/pull/75991
  * @see https://developer.chrome.com/blog/document-isolation-policy
  */
+
+test.skip(
+	({ browserName }) => browserName !== 'chromium',
+	'Document-Isolation-Policy and client-side media are only supported in Chromium-based browsers'
+);
 
 test.use({ channel: 'chromium' });
 
@@ -50,20 +64,10 @@ const clientSideMediaBlueprint: Blueprint = {
 	],
 };
 
-function skipNonChromium(browserName: string) {
-	test.skip(
-		browserName === 'firefox' || browserName === 'webkit',
-		'Document-Isolation-Policy and client-side media are only supported in Chromium-based browsers'
-	);
-}
-
 test('Post editor should be cross-origin isolated with SharedArrayBuffer available', async ({
 	website,
 	wordpress,
-	browserName,
 }) => {
-	skipNonChromium(browserName);
-
 	await website.goto(`./#${JSON.stringify(clientSideMediaBlueprint)}`);
 
 	// Wait for the block editor to fully load. The editor header is visible in both
@@ -91,10 +95,7 @@ test('Post editor should be cross-origin isolated with SharedArrayBuffer availab
 test('Gutenberg should report client-side media processing as enabled', async ({
 	website,
 	wordpress,
-	browserName,
 }) => {
-	skipNonChromium(browserName);
-
 	await website.goto(`./#${JSON.stringify(clientSideMediaBlueprint)}`);
 
 	await expect(

--- a/packages/playground/website/playwright/e2e/client-side-media.spec.ts
+++ b/packages/playground/website/playwright/e2e/client-side-media.spec.ts
@@ -10,8 +10,9 @@ import type { Blueprint } from '@wp-playground/blueprints';
  *
  * On Chromium 137+, Gutenberg sends `Document-Isolation-Policy:
  * isolate-and-credentialless` on the editor admin screens (see Gutenberg
- * PR #75991). Playground's service worker additionally injects DIP on the
- * inner `empty.html` editor iframe so parent/child DIP stay in parity.
+ * PR #75991, shipped in Gutenberg 22.6+). Playground's service worker
+ * additionally injects DIP on the inner `empty.html` editor iframe so
+ * parent/child DIP stay in parity.
  *
  * These tests validate that client-side media is re-enabled in Playground
  * (issue #3514) and that the editor frame actually ends up cross-origin
@@ -19,11 +20,18 @@ import type { Blueprint } from '@wp-playground/blueprints';
  * document-isolation-policy.spec.ts covers that the editor renders
  * successfully (which implicitly verifies parent/child DIP parity).
  *
+ * Playwright's default `chromium_headless_shell` build does not honor
+ * Document-Isolation-Policy, so these tests opt into `channel: 'chromium'`
+ * (the full Chromium browser) via `test.use()`. Playwright's CI install
+ * step already installs it via `playwright install chromium --with-deps`.
+ *
  * @see https://github.com/WordPress/wordpress-playground/issues/3514
  * @see https://github.com/WordPress/wordpress-playground/issues/2954
  * @see https://github.com/WordPress/gutenberg/pull/75991
  * @see https://developer.chrome.com/blog/document-isolation-policy
  */
+
+test.use({ channel: 'chromium' });
 
 const clientSideMediaBlueprint: Blueprint = {
 	landingPage: '/wp-admin/post-new.php',
@@ -42,15 +50,19 @@ const clientSideMediaBlueprint: Blueprint = {
 	],
 };
 
+function skipNonChromium(browserName: string) {
+	test.skip(
+		browserName === 'firefox' || browserName === 'webkit',
+		'Document-Isolation-Policy and client-side media are only supported in Chromium-based browsers'
+	);
+}
+
 test('Post editor should be cross-origin isolated with SharedArrayBuffer available', async ({
 	website,
 	wordpress,
 	browserName,
 }) => {
-	test.skip(
-		browserName === 'firefox' || browserName === 'webkit',
-		'Document-Isolation-Policy and client-side media are only supported in Chromium-based browsers'
-	);
+	skipNonChromium(browserName);
 
 	await website.goto(`./#${JSON.stringify(clientSideMediaBlueprint)}`);
 
@@ -81,10 +93,7 @@ test('Gutenberg should report client-side media processing as enabled', async ({
 	wordpress,
 	browserName,
 }) => {
-	test.skip(
-		browserName === 'firefox' || browserName === 'webkit',
-		'Document-Isolation-Policy and client-side media are only supported in Chromium-based browsers'
-	);
+	skipNonChromium(browserName);
 
 	await website.goto(`./#${JSON.stringify(clientSideMediaBlueprint)}`);
 

--- a/packages/playground/website/playwright/e2e/client-side-media.spec.ts
+++ b/packages/playground/website/playwright/e2e/client-side-media.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '../playground-fixtures';
+import type { Blueprint } from '@wp-playground/blueprints';
+
+/**
+ * Tests for Gutenberg's client-side media processing in Playground.
+ *
+ * Client-side media processing needs SharedArrayBuffer (for wasm-vips
+ * threading), which is only available when the document is cross-origin
+ * isolated. Gutenberg's own feature detection short-circuits otherwise.
+ *
+ * On Chromium 137+, Gutenberg sends `Document-Isolation-Policy:
+ * isolate-and-credentialless` on the editor admin screens (see Gutenberg
+ * PR #75991). Playground's service worker additionally injects DIP on the
+ * inner `empty.html` editor iframe so parent/child DIP stay in parity.
+ *
+ * These tests validate that client-side media is re-enabled in Playground
+ * (issue #3514) and that the editor frame actually ends up cross-origin
+ * isolated with SharedArrayBuffer available. The existing
+ * document-isolation-policy.spec.ts covers that the editor renders
+ * successfully (which implicitly verifies parent/child DIP parity).
+ *
+ * @see https://github.com/WordPress/wordpress-playground/issues/3514
+ * @see https://github.com/WordPress/wordpress-playground/issues/2954
+ * @see https://github.com/WordPress/gutenberg/pull/75991
+ * @see https://developer.chrome.com/blog/document-isolation-policy
+ */
+
+const clientSideMediaBlueprint: Blueprint = {
+	landingPage: '/wp-admin/post-new.php',
+	plugins: ['gutenberg'],
+	login: true,
+	steps: [
+		{
+			step: 'runPHP',
+			code: `<?php
+				require '/wordpress/wp-load.php';
+				update_option('gutenberg-experiments', array(
+					'gutenberg-media-processing' => true
+				));
+			`,
+		},
+	],
+};
+
+test('Post editor should be cross-origin isolated with SharedArrayBuffer available', async ({
+	website,
+	wordpress,
+	browserName,
+}) => {
+	test.skip(
+		browserName === 'firefox' || browserName === 'webkit',
+		'Document-Isolation-Policy and client-side media are only supported in Chromium-based browsers'
+	);
+
+	await website.goto(`./#${JSON.stringify(clientSideMediaBlueprint)}`);
+
+	// Wait for the block editor to fully load. The editor header is visible in both
+	// fullscreen and non-fullscreen modes.
+	await expect(
+		wordpress.locator('.edit-post-header, .editor-header')
+	).toBeVisible({
+		timeout: 120000,
+	});
+
+	// The editor window should be cross-origin isolated, which is the required
+	// precondition for SharedArrayBuffer and therefore for wasm-vips / client-side
+	// media processing.
+	const isCrossOriginIsolated = await wordpress
+		.locator('html')
+		.evaluate(() => window.crossOriginIsolated);
+	expect(isCrossOriginIsolated).toBe(true);
+
+	const sharedArrayBufferAvailable = await wordpress
+		.locator('html')
+		.evaluate(() => typeof SharedArrayBuffer !== 'undefined');
+	expect(sharedArrayBufferAvailable).toBe(true);
+});
+
+test('Gutenberg should report client-side media processing as enabled', async ({
+	website,
+	wordpress,
+	browserName,
+}) => {
+	test.skip(
+		browserName === 'firefox' || browserName === 'webkit',
+		'Document-Isolation-Policy and client-side media are only supported in Chromium-based browsers'
+	);
+
+	await website.goto(`./#${JSON.stringify(clientSideMediaBlueprint)}`);
+
+	await expect(
+		wordpress.locator('.edit-post-header, .editor-header')
+	).toBeVisible({
+		timeout: 120000,
+	});
+
+	// Gutenberg sets this global when client-side media processing is enabled AND
+	// cross-origin isolation is available server-side. If either is missing, the
+	// flag will be undefined.
+	// @see Gutenberg lib/media/load.php — gutenberg_set_client_side_media_processing_flag
+	const clientSideMediaFlag = await wordpress
+		.locator('html')
+		.evaluate(
+			() =>
+				(window as unknown as Record<string, unknown>)
+					.__clientSideMediaProcessing
+		);
+	expect(clientSideMediaFlag).toBe(true);
+});


### PR DESCRIPTION
## Motivation for the change, related issues

Fixes #3514.

Playground currently disables Gutenberg's **client-side media processing** experiment via an `__return_false` filter in the mu-plugin ([0-playground.php#L265-L274](https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php#L265-L274)). That workaround was added in #3312 because, at the time, Gutenberg was emitting COEP/COOP for the editor and — even when rewritten to `Document-Isolation-Policy` by the service worker — the editor's inner iframe was crashing.

[Gutenberg PR #75991](https://github.com/WordPress/gutenberg/pull/75991) (shipped in 22.6+) changed the isolation strategy: on Chromium 137+ Gutenberg now sends `Document-Isolation-Policy: isolate-and-credentialless` **directly** on editor screens and no longer sends COEP/COOP. That removes the root cause of the breakage — but it also means Playground's existing COEP→DIP rewrite path never fires on current Gutenberg, so the scope is never added to `scopesWithCrossOriginIsolation`, `empty.html` doesn't receive DIP, and parent/child DIP parity breaks inside the block editor canvas (see #3320 for why parity matters).

## Implementation details

Two small, coordinated changes:

1. **`packages/playground/remote/service-worker.ts`** — broaden the post-response handler (now `applyCrossOriginIsolationHeaders`) so that:
   - If a response already carries `Document-Isolation-Policy`, the scope is added to `scopesWithCrossOriginIsolation` and the response passes through unchanged. This is the modern path once Gutenberg serves DIP directly.
   - If a response carries COEP/COOP, the existing rewrite path continues to operate unchanged (covers older Gutenberg, WP core's `wp_set_up_cross_origin_isolation`, or custom plugins).

   The existing `empty.html` branch (which adds DIP to the inner editor iframe when the scope is tracked) needs no change — it now gets populated in both cases.

2. **`packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php`** — remove `add_filter('wp_client_side_media_processing_enabled', '__return_false')` and its comment block. The workaround is no longer necessary.

## Tests

New Playwright spec: `packages/playground/website/playwright/e2e/client-side-media.spec.ts`

- Chromium-only (skipped in Firefox/Safari — DIP and client-side media are Chromium-only today).
- Boots Playground with Gutenberg + `gutenberg-media-processing` experiment on `/wp-admin/post-new.php` and asserts, inside the WP admin iframe:
  - `window.crossOriginIsolated === true`
  - `typeof SharedArrayBuffer !== 'undefined'`
  - `window.__clientSideMediaProcessing === true` (Gutenberg's own enablement flag)

Editor rendering under DIP is already covered by the existing `document-isolation-policy.spec.ts` suite, which implicitly verifies parent/child DIP parity.

## Testing instructions

Manual (Chromium ≥ 137):

1. Run `npm run dev` and open `http://127.0.0.1:5400/website-server/`.
2. Load Guetnberg with this Blueprint (paste into the URL after `#`):

```json
{
  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
  "landingPage": "/wp-admin/post-new.php",
  "plugins": ["gutenberg"],
  "login": true,
  "steps": [
    {
      "step": "runPHP",
      "code": "<?php require '/wordpress/wp-load.php'; update_option('gutenberg-experiments', array('gutenberg-media-processing' => true));"
    }
  ]
}
```

3. The post editor loads without crashing. 
4.  In the WP iframe's DevTools console:
   - `crossOriginIsolated` → `true`
   - `typeof SharedArrayBuffer` → `"function"`
   - `window.__clientSideMediaProcessing` → `true`
5. The admin document response carries `Document-Isolation-Policy: isolate-and-credentialless` and no COEP/COOP.
6. Upload an image — it is processed client-side (wasm-vips loads; no server-side sub-size generation request).
7. Upload a small AVIF image (sample attached below) - it works (before this PR it fails)
8. Non-Chromium (Firefox/Safari): editor still opens; client-side media is simply not engaged (unchanged behavior).
9. Embedded Playground on a 3rd-party page with no COEP/COOP still loads (DIP is per-document, so this should hold).
10. Embedding 3p elements on the page, eg. a YouTube embed, still work
11. Iframe using elements such as the classic block work as expected

Automated:

```
npx nx e2e playground-website --grep="Document-Isolation-Policy|client-side media|crossOriginIsolated"
```

## Notes on backwards compatibility

- No user-facing breaking changes.
- The COEP→DIP rewrite path is preserved, so older WordPress/Gutenberg versions, or plugins that set COEP/COOP themselves, keep working as they do today.
- Non-Chromium browsers: no regression — DIP is unsupported there, Playground's feature detection returns `false`, headers pass through, and Gutenberg's JS feature detection falls back the same as before.
