### PR TITLE
[CLI] Pin file-locking test suite to 3 workers

### DIFF
--- a/packages/playground/cli/tests/file-locking.spec.ts
+++ b/packages/playground/cli/tests/file-locking.spec.ts
@@ -24,6 +24,10 @@ describe('Playground CLI file locking', () => {
 			command: 'server',
 			// Use a unique port to avoid conflicts with other test suites
 			port: 9600,
+			// The `multi shared locks` test runs three PHP scripts in
+			// parallel; with fewer than 3 workers it deadlocks and poisons
+			// every subsequent test via the shared beforeAll server.
+			workers: 3,
 			mount: [
 				{
 					hostPath: nativeTestDir,


### PR DESCRIPTION
## Motivation for the change, related issues

Follow-up to #3504.

`test-playground-cli (macos-latest)` started failing consistently after #3504 merged. Every failing run showed the same five timeouts in `packages/playground/cli/tests/file-locking.spec.ts`:

- `PHP flock() > should grant multiple shared locks on a file`
- `PHP flock() > should release a shared lock when its associated file descriptor is closed`
- `PHP flock() > should release an exclusive lock when its associated file descriptor is closed`
- `PHP flock() > should release a shared lock when the owning process exits`
- `PHP flock() > should release an exclusive lock when the owning process exits`

### Root cause

The `multi shared locks` test at `file-locking.spec.ts:1090` fires three concurrent PHP requests with `Promise.all`. Each script busy-waits on a coordination file that only the *next* script in the chain can write, so all three must run concurrently.

Before #3504 the CLI hardcoded 6 workers, which was always enough. After #3504 the default dropped to `min(6, max(1, cpus - 1))`. GitHub's `macos-latest` runners report 3 CPUs, resolving to **2 workers** — so PHP3 is permanently queued and the test deadlocks.

### Why four unrelated tests also fail

The `runCLI` server is created once in `beforeAll` and shared across every test in the `describe`. When the multi-shared test times out, its two workers are still spinning inside PHP-level `while (file_get_contents(...) \!== ...)` loops — vitest can abort the JS `await`, but there's no hook to unblock PHP. The four two-script tests that follow multi-shared in file order each do `Promise.all([fetchScript(php1), fetchScript(php2)])`, inherit a pool with zero free workers, and time out at 60 s each.

Evidence this is the right model:
- The two-script tests that run *before* multi-shared pass (deny-exclusive-with-shared, deny-shared-with-exclusive). The two-script tests *after* fail. Failures aren't interleaved among the earlier ones.
- Every failure is a 60 s timeout, never an assertion error. Independent flock races would surface as `expect(lock_acquired).toBe(false)`-style failures.
- A 200-run audit of `test-playground-cli (macos-latest)` across all branches shows no consistent failure pattern before #3504 merged.

## Implementation details

Pass `workers: 3` to `runCLI()` in the suite's `beforeAll`. Three is the minimum the multi-shared test needs; anything lower re-introduces the cascade. Explicit integer values bypass the `min(6, cpus-1)` default clamp (confirmed by the `honors an explicit --workers=3` test at `run-cli.spec.ts:1886`), so the suite is now robust to host CPU count.

No production code changes. Only the test file is touched.

## Testing Instructions (or ideally a Blueprint)

```bash
# Passes on macOS-like hosts with 3 CPUs:
npx nx test-playground-cli playground-cli --testFile=file-locking.spec.ts

# To reproduce the original failure, temporarily change workers: 3 to workers: 2:
# expect 5 timeouts in the PHP flock() describe.
```

On CI, the `test-playground-cli (macos-latest)` job should turn green. Ubuntu and Windows runners were already passing (their default worker count was already ≥3) and should remain so.

## AI disclosure

Per [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/):

**AI assistance:** Yes
**Tool:** Claude Code (Claude Opus 4.7)
**Used for:** Root-cause analysis of the worker-starvation cascade, drafting the fix and this PR description. All code was reviewed and tested by the author.