### PR TITLE
Export SQLite auto-extension symbols for PHP.wasm side modules

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -1444,9 +1444,11 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "sqlite_handle_closer",\
 "sqlite_handle_doer",\
 "sqlite_handle_preparer",\
+"sqlite3_auto_extension",\
 "sqlite3_autovacuum_pages",\
 "sqlite3_backup_step",\
 "sqlite3_bind_pointer",\
+"sqlite3_cancel_auto_extension",\
 "sqlite3_exec",\
 "sqlite3_finalize",\
 "sqlite3_free",\

--- a/packages/php-wasm/compile/php/Dockerfile-5-2
+++ b/packages/php-wasm/compile/php/Dockerfile-5-2
@@ -1461,9 +1461,11 @@ RUN export ASYNCIFY_IMPORTS=$'[\n\
 "sqlite_handle_closer",\
 "sqlite_handle_doer",\
 "sqlite_handle_preparer",\
+"sqlite3_auto_extension",\
 "sqlite3_autovacuum_pages",\
 "sqlite3_backup_step",\
 "sqlite3_bind_pointer",\
+"sqlite3_cancel_auto_extension",\
 "sqlite3_exec",\
 "sqlite3_finalize",\
 "sqlite3_free",\


### PR DESCRIPTION
## What it does

Exports SQLite's `sqlite3_auto_extension()` and
`sqlite3_cancel_auto_extension()` symbols from PHP.wasm main modules.

## Rationale

External PHP.wasm side modules can register SQLite virtual table modules by
calling `sqlite3_auto_extension()` during PHP startup. The markdown editor now
lives in `adamziel/wp-extensions` and uses this path to register its
`markdown_posts` and `markdown_postmeta` virtual tables.

The current published `@wp-playground/cli@3.1.30` cannot run that extension:
it does not expose the complete `--php-extension` workflow, and its PHP.wasm
builds do not export these SQLite symbols. This PR is the Playground-side
runtime change needed before the `wp-extensions` instructions can use a
published CLI release.

Related feature PR: https://github.com/adamziel/wp-extensions/pull/1

## Implementation

Adds `sqlite3_auto_extension` and `sqlite3_cancel_auto_extension` to the
Asyncify export lists in:

- `packages/php-wasm/compile/php/Dockerfile`
- `packages/php-wasm/compile/php/Dockerfile-5-2`

The markdown-editor command, mu-plugin, SQLite extension source, and
`php-toolkit` submodule are intentionally not in this Playground PR.

## Testing instructions

```bash
git diff --check origin/trunk...HEAD
```

Full verification requires recompiling PHP.wasm and loading an external side
module that calls `sqlite3_auto_extension()`. The consumer lives in
https://github.com/adamziel/wp-extensions/pull/1.
