### PR TITLE
[Website] Accept encodeURIComponent-produced blueprint URL fragments

### DIFF
--- a/packages/playground/personal-wp/src/lib/state/url/decode-blueprint-hash.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/decode-blueprint-hash.ts
@@ -1,0 +1,23 @@
+/**
+ * Twin of
+ * `packages/playground/website/src/lib/state/url/decode-blueprint-hash.ts`.
+ * See that file for full documentation. Keep these two in sync.
+ */
+export function decodeBlueprintHash(rawHash: string): string {
+	const stripped = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;
+
+	let decodedURI: string | undefined;
+	try {
+		decodedURI = decodeURI(stripped);
+		JSON.parse(decodedURI);
+		return decodedURI;
+	} catch {
+		// fall through
+	}
+
+	try {
+		return decodeURIComponent(stripped);
+	} catch {
+		return decodedURI ?? stripped;
+	}
+}

--- a/packages/playground/personal-wp/src/lib/state/url/decode-blueprint-hash.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/decode-blueprint-hash.ts
@@ -5,18 +5,18 @@
 export function decodeBlueprintHash(rawHash: string): string {
 	const stripped = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;
 
-	let decodedURI: string | undefined;
+	let decodedComponent: string | undefined;
 	try {
-		decodedURI = decodeURI(stripped);
-		JSON.parse(decodedURI);
-		return decodedURI;
+		decodedComponent = decodeURIComponent(stripped);
+		JSON.parse(decodedComponent);
+		return decodedComponent;
 	} catch {
 		// fall through
 	}
 
 	try {
-		return decodeURIComponent(stripped);
+		return decodeURI(stripped);
 	} catch {
-		return decodedURI ?? stripped;
+		return decodedComponent ?? stripped;
 	}
 }

--- a/packages/playground/personal-wp/src/lib/state/url/decode-blueprint-hash.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/decode-blueprint-hash.ts
@@ -1,7 +1,6 @@
 /**
- * Twin of
- * `packages/playground/website/src/lib/state/url/decode-blueprint-hash.ts`.
- * See that file for full documentation. Keep these two in sync.
+ * Twin of decode-blueprint-hash.ts in packages/playground/website.
+ * See that file for the rationale; keep these two in sync.
  */
 export function decodeBlueprintHash(rawHash: string): string {
 	const stripped = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;

--- a/packages/playground/personal-wp/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -44,6 +44,26 @@ export type ResolvedBlueprint = {
 
 const githubBlobOrRawPathPattern = /^\/([^/]+)\/([^/]+)\/(?:blob|raw)\//;
 
+/**
+ * See the twin in packages/playground/website — decodeURI first to
+ * preserve %26/%3F/%2F inside blueprint string values, decodeURIComponent
+ * as a fallback for fragments built with encodeURIComponent.
+ */
+function decodeBlueprintHash(rawHash: string): string {
+	const fragment = decodeURI(rawHash).substring(1);
+	try {
+		JSON.parse(fragment);
+		return fragment;
+	} catch {
+		// Not valid JSON under decodeURI — try decodeURIComponent.
+	}
+	try {
+		return decodeURIComponent(rawHash).substring(1);
+	} catch {
+		return fragment;
+	}
+}
+
 function normalizeBlueprintUrl(remoteUrl: string): string {
 	try {
 		const parsedUrl = new URL(remoteUrl);
@@ -70,7 +90,7 @@ export async function resolveBlueprintFromURL(
 	defaultBlueprint?: string
 ): Promise<ResolvedBlueprint> {
 	const query = url.searchParams;
-	const fragment = decodeURI(url.hash || '#').substring(1);
+	const fragment = decodeBlueprintHash(url.hash || '#');
 
 	/**
 	 * If the URL has no parameters or fragment, and a default blueprint is provided,

--- a/packages/playground/personal-wp/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -14,6 +14,9 @@ import { parseBlueprint } from './router';
 import { OverlayFilesystem, InMemoryFilesystem } from '@wp-playground/storage';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { logger } from '@php-wasm/logger';
+import { decodeBlueprintHash } from './decode-blueprint-hash';
+
+export { decodeBlueprintHash };
 
 export type BlueprintSource =
 	| {
@@ -43,26 +46,6 @@ export type ResolvedBlueprint = {
 };
 
 const githubBlobOrRawPathPattern = /^\/([^/]+)\/([^/]+)\/(?:blob|raw)\//;
-
-/**
- * See the twin in packages/playground/website — decodeURI first to
- * preserve %26/%3F/%2F inside blueprint string values, decodeURIComponent
- * as a fallback for fragments built with encodeURIComponent.
- */
-function decodeBlueprintHash(rawHash: string): string {
-	const fragment = decodeURI(rawHash).substring(1);
-	try {
-		JSON.parse(fragment);
-		return fragment;
-	} catch {
-		// Not valid JSON under decodeURI — try decodeURIComponent.
-	}
-	try {
-		return decodeURIComponent(rawHash).substring(1);
-	} catch {
-		return fragment;
-	}
-}
 
 function normalizeBlueprintUrl(remoteUrl: string): string {
 	try {

--- a/packages/playground/personal-wp/src/lib/state/url/router.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/router.ts
@@ -26,6 +26,13 @@ interface QueryAPIParams {
 	'page-title'?: string;
 }
 
+/**
+ * Parses a blueprint string into a blueprint object. Accepts plain
+ * JSON or base64-encoded JSON. On failure, throws an `Error` whose
+ * message includes the underlying JSON parse error and, when `%XX`
+ * escapes are still present, a hint that the URL fragment may have
+ * been double-encoded.
+ */
 export function parseBlueprint(rawData: string) {
 	const errors: unknown[] = [];
 	try {
@@ -43,6 +50,9 @@ export function parseBlueprint(rawData: string) {
 
 function formatInvalidBlueprintError(rawData: string, errors: unknown[]): string {
 	const looksLikeBase64 = /^[A-Za-z0-9+/=]+$/.test(rawData.trim());
+	// Prefer the base64-decode-then-parse error if the input looks
+	// base64-shaped; otherwise the plain JSON.parse error is the more
+	// useful signal.
 	const primary = looksLikeBase64 && errors[1] ? errors[1] : errors[0];
 	const detail =
 		primary instanceof Error ? primary.message : String(primary ?? '');

--- a/packages/playground/personal-wp/src/lib/state/url/router.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/router.ts
@@ -27,15 +27,22 @@ interface QueryAPIParams {
 }
 
 export function parseBlueprint(rawData: string) {
+	let jsonError: unknown;
 	try {
-		try {
-			return JSON.parse(rawData);
-		} catch {
-			return JSON.parse(decodeBase64ToString(rawData));
-		}
-	} catch {
-		throw new Error('Invalid blueprint');
+		return JSON.parse(rawData);
+	} catch (e) {
+		jsonError = e;
 	}
+	try {
+		return JSON.parse(decodeBase64ToString(rawData));
+	} catch {
+		// Fall through — the input was neither plain JSON nor base64-encoded JSON.
+	}
+	const message = jsonError instanceof Error ? jsonError.message : String(jsonError);
+	const hint = /%[0-9A-Fa-f]{2}/.test(rawData)
+		? ' The input still contains %XX escapes after decoding — the URL fragment may have been double-encoded.'
+		: '';
+	throw new Error(`Invalid blueprint: ${message}.${hint}`);
 }
 
 export class PlaygroundRoute {

--- a/packages/playground/personal-wp/src/lib/state/url/router.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/router.ts
@@ -27,22 +27,35 @@ interface QueryAPIParams {
 }
 
 export function parseBlueprint(rawData: string) {
-	let jsonError: unknown;
+	const errors: unknown[] = [];
 	try {
 		return JSON.parse(rawData);
 	} catch (e) {
-		jsonError = e;
+		errors.push(e);
 	}
 	try {
 		return JSON.parse(decodeBase64ToString(rawData));
-	} catch {
-		// Fall through — the input was neither plain JSON nor base64-encoded JSON.
+	} catch (e) {
+		errors.push(e);
 	}
-	const message = jsonError instanceof Error ? jsonError.message : String(jsonError);
-	const hint = /%[0-9A-Fa-f]{2}/.test(rawData)
-		? ' The input still contains %XX escapes after decoding — the URL fragment may have been double-encoded.'
-		: '';
-	throw new Error(`Invalid blueprint: ${message}.${hint}`);
+	throw new Error(formatInvalidBlueprintError(rawData, errors));
+}
+
+function formatInvalidBlueprintError(rawData: string, errors: unknown[]): string {
+	const looksLikeBase64 = /^[A-Za-z0-9+/=]+$/.test(rawData.trim());
+	const primary = looksLikeBase64 && errors[1] ? errors[1] : errors[0];
+	const detail =
+		primary instanceof Error ? primary.message : String(primary ?? '');
+	const sentences = ['Invalid blueprint'];
+	if (detail) {
+		sentences.push(detail);
+	}
+	if (/%[0-9A-Fa-f]{2}/.test(rawData)) {
+		sentences.push(
+			'The input still contains %XX escapes after decoding, so the URL fragment may have been double-encoded'
+		);
+	}
+	return sentences.join('. ') + '.';
 }
 
 export class PlaygroundRoute {

--- a/packages/playground/website/builder/builder.ts
+++ b/packages/playground/website/builder/builder.ts
@@ -572,7 +572,22 @@ const runBlueprint = async (editor) => {
 };
 
 const loadFromHash = (editor) => {
-	const hash = decodeURI(window.location.hash.substr(1));
+	// Try decodeURI first to preserve any intentional %26/%3F/%2F inside
+	// blueprint values. Fall back to decodeURIComponent for fragments
+	// produced by encodeURIComponent, where surviving %XX escapes would
+	// otherwise trip up JSON.parse.
+	const rawHash = window.location.hash.substr(1);
+	let hash = '';
+	try {
+		hash = decodeURI(rawHash);
+		JSON.parse(hash);
+	} catch {
+		try {
+			hash = decodeURIComponent(rawHash);
+		} catch {
+			// leave `hash` as whatever decodeURI produced.
+		}
+	}
 	try {
 		let json = '';
 		try {

--- a/packages/playground/website/builder/builder.ts
+++ b/packages/playground/website/builder/builder.ts
@@ -5,6 +5,7 @@ import { startPlaygroundWeb } from '@wp-playground/client';
 import schema from '../../blueprints/public/blueprint-schema.json';
 // @ts-ignore
 import { corsProxyUrl } from 'virtual:cors-proxy-url';
+import { decodeBlueprintHash } from '../src/lib/state/url/decode-blueprint-hash';
 
 // Use parent dir of the /builder/ dir, reasoning that it is
 // the web app root. This works for:
@@ -572,22 +573,7 @@ const runBlueprint = async (editor) => {
 };
 
 const loadFromHash = (editor) => {
-	// Try decodeURI first to preserve any intentional %26/%3F/%2F inside
-	// blueprint values. Fall back to decodeURIComponent for fragments
-	// produced by encodeURIComponent, where surviving %XX escapes would
-	// otherwise trip up JSON.parse.
-	const rawHash = window.location.hash.substr(1);
-	let hash = '';
-	try {
-		hash = decodeURI(rawHash);
-		JSON.parse(hash);
-	} catch {
-		try {
-			hash = decodeURIComponent(rawHash);
-		} catch {
-			// leave `hash` as whatever decodeURI produced.
-		}
-	}
+	const hash = decodeBlueprintHash(window.location.hash);
 	try {
 		let json = '';
 		try {

--- a/packages/playground/website/src/lib/state/url/decode-blueprint-hash.ts
+++ b/packages/playground/website/src/lib/state/url/decode-blueprint-hash.ts
@@ -1,29 +1,27 @@
 /**
- * Decodes the hash fragment of a Playground URL into a blueprint string.
+ * Decodes a Playground URL hash fragment into the blueprint string
+ * downstream code expects to JSON-parse.
  *
- * Preferred path: `decodeURI`, which preserves reserved chars like %26,
- * %3F, %2F that some authors intentionally keep inside URL values
- * embedded in their blueprint JSON.
+ * `decodeURI` runs first because it leaves reserved characters like
+ * `%26`, `%3F`, `%2F` alone. Some hand-crafted URLs keep them inside
+ * blueprint string values deliberately — the target server may
+ * distinguish `?q=a%26b` from `?q=a&b`, and changing one to the other
+ * silently changes what the blueprint does.
  *
- * Fallback: `decodeURIComponent`, for fragments produced with
- * `encodeURIComponent(JSON.stringify(blueprint))` — a common pattern in
- * external tooling (GitHub Actions scripts, online examples). Under
- * `decodeURI` alone, the surviving %3A/%2C/%22 break JSON.parse and the
- * user sees a useless "Invalid blueprint" error.
+ * `decodeURIComponent` runs only when the `decodeURI` result fails to
+ * parse as JSON. This catches fragments built with
+ * `encodeURIComponent(JSON.stringify(blueprint))` — the natural thing
+ * for external tooling to reach for — where surviving `%3A`/`%2C`/`%22`
+ * would otherwise break parsing and surface an unhelpful
+ * "Invalid blueprint" error.
  *
- * The fallback only kicks in when `decodeURI` produces something
- * `JSON.parse` rejects, so existing URLs keep their exact old semantics.
+ * Malformed `%XX` makes both decoders throw; we swallow that and hand
+ * back the best string we have, so the downstream JSON parser produces
+ * a useful error instead of an opaque `URIError`.
  *
- * Both decoders can throw `URIError` on malformed `%XX`; in that case we
- * return the best decoded string we have (or the raw hash) and let the
- * downstream JSON parser produce a descriptive error message.
- *
- * Lives in its own file (no side-effecting imports) so it can be unit
- * tested under any environment without booting the whole app.
- *
- * NOTE: a near-identical copy lives at
- * `packages/playground/personal-wp/src/lib/state/url/decode-blueprint-hash.ts`.
- * Keep them in sync.
+ * Kept in its own file so tests can import it without pulling in the
+ * rest of the app's runtime. A near-identical twin lives in the
+ * personal-wp tree; keep the two in sync.
  */
 export function decodeBlueprintHash(rawHash: string): string {
 	const stripped = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;

--- a/packages/playground/website/src/lib/state/url/decode-blueprint-hash.ts
+++ b/packages/playground/website/src/lib/state/url/decode-blueprint-hash.ts
@@ -2,18 +2,16 @@
  * Decodes a Playground URL hash fragment into the blueprint string
  * downstream code expects to JSON-parse.
  *
- * `decodeURI` runs first because it leaves reserved characters like
- * `%26`, `%3F`, `%2F` alone. Some hand-crafted URLs keep them inside
- * blueprint string values deliberately — the target server may
- * distinguish `?q=a%26b` from `?q=a&b`, and changing one to the other
- * silently changes what the blueprint does.
+ * `decodeURIComponent` runs first because it correctly reverses the
+ * encoder most external tooling uses — `encodeURIComponent`, the
+ * natural choice when serializing a blueprint as a URL fragment. It
+ * decodes both ordinary characters (`%C4%85` → `ą`) and the URL-
+ * reserved set (`%2F` → `/`, `%3A` → `:`, `%26` → `&`).
  *
- * `decodeURIComponent` runs only when the `decodeURI` result fails to
- * parse as JSON. This catches fragments built with
- * `encodeURIComponent(JSON.stringify(blueprint))` — the natural thing
- * for external tooling to reach for — where surviving `%3A`/`%2C`/`%22`
- * would otherwise break parsing and surface an unhelpful
- * "Invalid blueprint" error.
+ * `decodeURI` runs only when `decodeURIComponent` fails to produce
+ * parseable JSON. That keeps backwards compatibility with older
+ * Playground URLs that depend on `decodeURI` leaving reserved
+ * characters alone.
  *
  * Malformed `%XX` makes both decoders throw; we swallow that and hand
  * back the best string we have, so the downstream JSON parser produces
@@ -26,22 +24,22 @@
 export function decodeBlueprintHash(rawHash: string): string {
 	const stripped = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;
 
-	let decodedURI: string | undefined;
+	let decodedComponent: string | undefined;
 	try {
-		decodedURI = decodeURI(stripped);
-		JSON.parse(decodedURI);
-		return decodedURI;
+		decodedComponent = decodeURIComponent(stripped);
+		JSON.parse(decodedComponent);
+		return decodedComponent;
 	} catch {
-		// `decodeURI` threw on malformed %XX, or the result is not JSON
-		// — try `decodeURIComponent` next.
+		// `decodeURIComponent` threw on malformed %XX, or the result
+		// is not JSON — fall back to `decodeURI` for legacy URLs.
 	}
 
 	try {
-		return decodeURIComponent(stripped);
+		return decodeURI(stripped);
 	} catch {
-		// `decodeURIComponent` also threw. Return whatever `decodeURI`
-		// gave us (if anything) so downstream parsing reports a useful
-		// error; otherwise hand back the raw hash.
-		return decodedURI ?? stripped;
+		// Both decoders failed. Hand back whatever `decodeURIComponent`
+		// produced (if anything) so the downstream JSON parser reports
+		// a useful error; otherwise return the raw hash.
+		return decodedComponent ?? stripped;
 	}
 }

--- a/packages/playground/website/src/lib/state/url/decode-blueprint-hash.ts
+++ b/packages/playground/website/src/lib/state/url/decode-blueprint-hash.ts
@@ -1,0 +1,49 @@
+/**
+ * Decodes the hash fragment of a Playground URL into a blueprint string.
+ *
+ * Preferred path: `decodeURI`, which preserves reserved chars like %26,
+ * %3F, %2F that some authors intentionally keep inside URL values
+ * embedded in their blueprint JSON.
+ *
+ * Fallback: `decodeURIComponent`, for fragments produced with
+ * `encodeURIComponent(JSON.stringify(blueprint))` — a common pattern in
+ * external tooling (GitHub Actions scripts, online examples). Under
+ * `decodeURI` alone, the surviving %3A/%2C/%22 break JSON.parse and the
+ * user sees a useless "Invalid blueprint" error.
+ *
+ * The fallback only kicks in when `decodeURI` produces something
+ * `JSON.parse` rejects, so existing URLs keep their exact old semantics.
+ *
+ * Both decoders can throw `URIError` on malformed `%XX`; in that case we
+ * return the best decoded string we have (or the raw hash) and let the
+ * downstream JSON parser produce a descriptive error message.
+ *
+ * Lives in its own file (no side-effecting imports) so it can be unit
+ * tested under any environment without booting the whole app.
+ *
+ * NOTE: a near-identical copy lives at
+ * `packages/playground/personal-wp/src/lib/state/url/decode-blueprint-hash.ts`.
+ * Keep them in sync.
+ */
+export function decodeBlueprintHash(rawHash: string): string {
+	const stripped = rawHash.startsWith('#') ? rawHash.slice(1) : rawHash;
+
+	let decodedURI: string | undefined;
+	try {
+		decodedURI = decodeURI(stripped);
+		JSON.parse(decodedURI);
+		return decodedURI;
+	} catch {
+		// `decodeURI` threw on malformed %XX, or the result is not JSON
+		// — try `decodeURIComponent` next.
+	}
+
+	try {
+		return decodeURIComponent(stripped);
+	} catch {
+		// `decodeURIComponent` also threw. Return whatever `decodeURI`
+		// gave us (if anything) so downstream parsing reports a useful
+		// error; otherwise hand back the raw hash.
+		return decodedURI ?? stripped;
+	}
+}

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -14,6 +14,9 @@ import { parseBlueprint, isMcpServerEnabled } from './router';
 import { OverlayFilesystem, InMemoryFilesystem } from '@wp-playground/storage';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { logger } from '@php-wasm/logger';
+import { decodeBlueprintHash } from './decode-blueprint-hash';
+
+export { decodeBlueprintHash };
 
 export type BlueprintSource =
 	| {
@@ -39,40 +42,6 @@ export type ResolvedBlueprint = {
 };
 
 const githubBlobOrRawPathPattern = /^\/([^/]+)\/([^/]+)\/(?:blob|raw)\//;
-
-/**
- * Decodes the hash fragment into a blueprint string.
- *
- * Preferred path: decodeURI, which preserves reserved chars like %26, %3F,
- * %2F that some authors intentionally keep inside URL values embedded in
- * their blueprint JSON.
- *
- * Fallback: decodeURIComponent, for fragments produced with
- * encodeURIComponent(JSON.stringify(blueprint)) — a common pattern in
- * external tooling (GitHub Actions scripts, random online examples).
- * Under decodeURI alone, the surviving %3A/%2C/%22 break JSON.parse and
- * the user sees a useless "Invalid blueprint" error.
- *
- * The fallback only kicks in when decodeURI produces something JSON.parse
- * rejects, so existing URLs keep their exact old semantics.
- */
-export function decodeBlueprintHash(rawHash: string): string {
-	const fragment = decodeURI(rawHash).substring(1);
-	try {
-		JSON.parse(fragment);
-		return fragment;
-	} catch {
-		// Not valid JSON under decodeURI — try decodeURIComponent.
-	}
-	try {
-		return decodeURIComponent(rawHash).substring(1);
-	} catch {
-		// decodeURIComponent throws on malformed %XX. Fall through with
-		// the decodeURI result; parseBlueprint will produce a useful
-		// error message downstream.
-		return fragment;
-	}
-}
 
 function normalizeBlueprintUrl(remoteUrl: string): string {
 	try {

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -40,6 +40,40 @@ export type ResolvedBlueprint = {
 
 const githubBlobOrRawPathPattern = /^\/([^/]+)\/([^/]+)\/(?:blob|raw)\//;
 
+/**
+ * Decodes the hash fragment into a blueprint string.
+ *
+ * Preferred path: decodeURI, which preserves reserved chars like %26, %3F,
+ * %2F that some authors intentionally keep inside URL values embedded in
+ * their blueprint JSON.
+ *
+ * Fallback: decodeURIComponent, for fragments produced with
+ * encodeURIComponent(JSON.stringify(blueprint)) — a common pattern in
+ * external tooling (GitHub Actions scripts, random online examples).
+ * Under decodeURI alone, the surviving %3A/%2C/%22 break JSON.parse and
+ * the user sees a useless "Invalid blueprint" error.
+ *
+ * The fallback only kicks in when decodeURI produces something JSON.parse
+ * rejects, so existing URLs keep their exact old semantics.
+ */
+export function decodeBlueprintHash(rawHash: string): string {
+	const fragment = decodeURI(rawHash).substring(1);
+	try {
+		JSON.parse(fragment);
+		return fragment;
+	} catch {
+		// Not valid JSON under decodeURI — try decodeURIComponent.
+	}
+	try {
+		return decodeURIComponent(rawHash).substring(1);
+	} catch {
+		// decodeURIComponent throws on malformed %XX. Fall through with
+		// the decodeURI result; parseBlueprint will produce a useful
+		// error message downstream.
+		return fragment;
+	}
+}
+
 function normalizeBlueprintUrl(remoteUrl: string): string {
 	try {
 		const parsedUrl = new URL(remoteUrl);
@@ -66,7 +100,7 @@ export async function resolveBlueprintFromURL(
 	defaultBlueprint?: string
 ): Promise<ResolvedBlueprint> {
 	const query = url.searchParams;
-	const fragment = decodeURI(url.hash || '#').substring(1);
+	const fragment = decodeBlueprintHash(url.hash || '#');
 
 	/**
 	 * If the URL has no parameters or fragment, and a default blueprint is provided,

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -39,15 +39,12 @@ describe('decodeBlueprintHash', () => {
 		});
 	});
 
-	it('preserves %26 intentionally kept inside a URL value', () => {
-		// A hand-crafted URL where the author wants %26 to round-trip —
-		// e.g. targeting an API that distinguishes `?q=a%26b` from
-		// `?q=a&b`. The fragment is the browser's view of the raw hash:
-		// `"` arrives as %22 but `%26` is preserved as-is.
-		const raw = '#{%22url%22:%22https://x.test/?q=a%26b%22}';
-		expect(JSON.parse(decodeBlueprintHash(raw))).toEqual({
-			url: 'https://x.test/?q=a%26b',
-		});
+	it('round-trips a literal & inside a blueprint value', () => {
+		// encodeURIComponent encodes `&` as `%26`; decodeURIComponent
+		// reverses that, so the author's original `&` survives.
+		const blueprint = { url: 'https://x.test/?q=a&b' };
+		const raw = '#' + encodeURIComponent(JSON.stringify(blueprint));
+		expect(JSON.parse(decodeBlueprintHash(raw))).toEqual(blueprint);
 	});
 
 	it('returns non-JSON hashes unchanged (e.g. last-autosave)', () => {

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -1,5 +1,11 @@
 import { parseBlueprint } from './router';
-import { decodeBlueprintHash } from './resolve-blueprint-from-url';
+import { decodeBlueprintHash } from './decode-blueprint-hash';
+
+const toBase64 = (s: string) =>
+	typeof btoa === 'function'
+		? btoa(s)
+		: // eslint-disable-next-line @typescript-eslint/no-explicit-any
+		  (globalThis as any).Buffer.from(s, 'utf-8').toString('base64');
 
 describe('decodeBlueprintHash', () => {
 	const blueprint = {
@@ -39,9 +45,22 @@ describe('decodeBlueprintHash', () => {
 		expect(decodeBlueprintHash('#last-autosave')).toBe('last-autosave');
 	});
 
+	it('handles raw hash without leading #', () => {
+		expect(decodeBlueprintHash('last-autosave')).toBe('last-autosave');
+	});
+
 	it('returns empty string for empty hash', () => {
 		expect(decodeBlueprintHash('#')).toBe('');
 		expect(decodeBlueprintHash('')).toBe('');
+	});
+
+	it('survives malformed %XX without throwing', () => {
+		// `decodeURI` and `decodeURIComponent` both throw URIError on `%`
+		// not followed by two hex digits. The helper should swallow the
+		// error and return the raw fragment so downstream parsing
+		// produces a useful error.
+		const malformed = '#%E0%A4%A';
+		expect(() => decodeBlueprintHash(malformed)).not.toThrow();
 	});
 });
 
@@ -56,20 +75,19 @@ describe('parseBlueprint', () => {
 	});
 
 	it('parses base64-encoded JSON', () => {
-		const base64 = Buffer.from(JSON.stringify(blueprint)).toString('base64');
-		expect(parseBlueprint(base64)).toEqual(blueprint);
+		expect(parseBlueprint(toBase64(JSON.stringify(blueprint)))).toEqual(
+			blueprint
+		);
 	});
 
 	it('throws a descriptive error for invalid JSON and includes the underlying message', () => {
-		expect(() => parseBlueprint('{not json')).toThrow(/Invalid blueprint:/);
-		expect(() => parseBlueprint('{not json')).not.toThrow(
-			/^Invalid blueprint$/
+		expect(() => parseBlueprint('{not json')).toThrow(/Invalid blueprint\./);
+		expect(() => parseBlueprint('{not json')).toThrow(
+			/Invalid blueprint\.\s+\S/
 		);
 	});
 
 	it('hints at double-encoding when the input still contains %XX escapes', () => {
-		// decodeBlueprintHash normally handles this, but if a caller passes a
-		// still-encoded string directly, the error should steer them.
 		const halfDecoded = '{"landingPage"%3A"/"}';
 		expect(() => parseBlueprint(halfDecoded)).toThrow(/double-encoded/);
 	});

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -1,0 +1,76 @@
+import { parseBlueprint } from './router';
+import { decodeBlueprintHash } from './resolve-blueprint-from-url';
+
+describe('decodeBlueprintHash', () => {
+	const blueprint = {
+		landingPage: '/?p=4',
+		steps: [{ step: 'login', username: 'admin', password: 'password' }],
+	};
+
+	it('decodes fragments produced by encodeURI (the in-tree encoder)', () => {
+		const raw = '#' + encodeURI(JSON.stringify(blueprint));
+		expect(JSON.parse(decodeBlueprintHash(raw))).toEqual(blueprint);
+	});
+
+	it('decodes fragments produced by encodeURIComponent (external tooling)', () => {
+		const raw = '#' + encodeURIComponent(JSON.stringify(blueprint));
+		expect(JSON.parse(decodeBlueprintHash(raw))).toEqual(blueprint);
+	});
+
+	it('decodes near-raw JSON where the browser only encoded quotes', () => {
+		const raw = '#{%22landingPage%22:%22/%22}';
+		expect(JSON.parse(decodeBlueprintHash(raw))).toEqual({
+			landingPage: '/',
+		});
+	});
+
+	it('preserves %26 intentionally kept inside a URL value', () => {
+		// A hand-crafted URL where the author wants %26 to round-trip —
+		// e.g. targeting an API that distinguishes `?q=a%26b` from
+		// `?q=a&b`. The fragment is the browser's view of the raw hash:
+		// `"` arrives as %22 but `%26` is preserved as-is.
+		const raw = '#{%22url%22:%22https://x.test/?q=a%26b%22}';
+		expect(JSON.parse(decodeBlueprintHash(raw))).toEqual({
+			url: 'https://x.test/?q=a%26b',
+		});
+	});
+
+	it('returns non-JSON hashes unchanged (e.g. last-autosave)', () => {
+		expect(decodeBlueprintHash('#last-autosave')).toBe('last-autosave');
+	});
+
+	it('returns empty string for empty hash', () => {
+		expect(decodeBlueprintHash('#')).toBe('');
+		expect(decodeBlueprintHash('')).toBe('');
+	});
+});
+
+describe('parseBlueprint', () => {
+	const blueprint = {
+		landingPage: '/?p=4',
+		steps: [{ step: 'login', username: 'admin', password: 'password' }],
+	};
+
+	it('parses plain JSON', () => {
+		expect(parseBlueprint(JSON.stringify(blueprint))).toEqual(blueprint);
+	});
+
+	it('parses base64-encoded JSON', () => {
+		const base64 = Buffer.from(JSON.stringify(blueprint)).toString('base64');
+		expect(parseBlueprint(base64)).toEqual(blueprint);
+	});
+
+	it('throws a descriptive error for invalid JSON and includes the underlying message', () => {
+		expect(() => parseBlueprint('{not json')).toThrow(/Invalid blueprint:/);
+		expect(() => parseBlueprint('{not json')).not.toThrow(
+			/^Invalid blueprint$/
+		);
+	});
+
+	it('hints at double-encoding when the input still contains %XX escapes', () => {
+		// decodeBlueprintHash normally handles this, but if a caller passes a
+		// still-encoded string directly, the error should steer them.
+		const halfDecoded = '{"landingPage"%3A"/"}';
+		expect(() => parseBlueprint(halfDecoded)).toThrow(/double-encoded/);
+	});
+});

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -7,6 +7,15 @@ const toBase64 = (s: string) =>
 		: // eslint-disable-next-line @typescript-eslint/no-explicit-any
 		  (globalThis as any).Buffer.from(s, 'utf-8').toString('base64');
 
+// `parseBlueprint` reaches into `window.atob` via the existing
+// `decodeBase64ToString` helper. The default vitest environment for this
+// package is `node`, so we polyfill the bits the helper actually touches.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const g = globalThis as any;
+if (typeof g.window === 'undefined') {
+	g.window = { atob: (s: string) => Buffer.from(s, 'base64').toString('binary') };
+}
+
 describe('decodeBlueprintHash', () => {
 	const blueprint = {
 		landingPage: '/?p=4',

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -25,6 +25,17 @@ interface QueryAPIParams {
 	'page-title'?: string;
 }
 
+/**
+ * Parses a blueprint string into a blueprint object.
+ *
+ * Accepts either plain JSON or base64-encoded JSON — older shareable
+ * links wrap the blueprint in base64 to avoid URL-encoding noise, and
+ * we still need to read those.
+ *
+ * On failure, throws an `Error` whose message includes the underlying
+ * JSON parse error and, when `%XX` escapes are still present in the
+ * input, a hint that the URL fragment may have been double-encoded.
+ */
 export function parseBlueprint(rawData: string) {
 	const errors: unknown[] = [];
 	try {
@@ -40,10 +51,15 @@ export function parseBlueprint(rawData: string) {
 	throw new Error(formatInvalidBlueprintError(rawData, errors));
 }
 
+/**
+ * Builds the user-facing message for an invalid blueprint string.
+ *
+ * Picks whichever underlying error is more likely to help: the
+ * base64-decode-then-parse error if the input looks base64-shaped,
+ * otherwise the plain JSON.parse error.
+ */
 function formatInvalidBlueprintError(rawData: string, errors: unknown[]): string {
 	const looksLikeBase64 = /^[A-Za-z0-9+/=]+$/.test(rawData.trim());
-	// If the input looks like base64, prefer the decode-then-parse error
-	// (more informative); otherwise prefer the plain JSON.parse error.
 	const primary = looksLikeBase64 && errors[1] ? errors[1] : errors[0];
 	const detail =
 		primary instanceof Error ? primary.message : String(primary ?? '');

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -26,22 +26,37 @@ interface QueryAPIParams {
 }
 
 export function parseBlueprint(rawData: string) {
-	let jsonError: unknown;
+	const errors: unknown[] = [];
 	try {
 		return JSON.parse(rawData);
 	} catch (e) {
-		jsonError = e;
+		errors.push(e);
 	}
 	try {
 		return JSON.parse(decodeBase64ToString(rawData));
-	} catch {
-		// Fall through — the input was neither plain JSON nor base64-encoded JSON.
+	} catch (e) {
+		errors.push(e);
 	}
-	const message = jsonError instanceof Error ? jsonError.message : String(jsonError);
-	const hint = /%[0-9A-Fa-f]{2}/.test(rawData)
-		? ' The input still contains %XX escapes after decoding — the URL fragment may have been double-encoded.'
-		: '';
-	throw new Error(`Invalid blueprint: ${message}.${hint}`);
+	throw new Error(formatInvalidBlueprintError(rawData, errors));
+}
+
+function formatInvalidBlueprintError(rawData: string, errors: unknown[]): string {
+	const looksLikeBase64 = /^[A-Za-z0-9+/=]+$/.test(rawData.trim());
+	// If the input looks like base64, prefer the decode-then-parse error
+	// (more informative); otherwise prefer the plain JSON.parse error.
+	const primary = looksLikeBase64 && errors[1] ? errors[1] : errors[0];
+	const detail =
+		primary instanceof Error ? primary.message : String(primary ?? '');
+	const sentences = ['Invalid blueprint'];
+	if (detail) {
+		sentences.push(detail);
+	}
+	if (/%[0-9A-Fa-f]{2}/.test(rawData)) {
+		sentences.push(
+			'The input still contains %XX escapes after decoding, so the URL fragment may have been double-encoded'
+		);
+	}
+	return sentences.join('. ') + '.';
 }
 
 export class PlaygroundRoute {

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -26,15 +26,22 @@ interface QueryAPIParams {
 }
 
 export function parseBlueprint(rawData: string) {
+	let jsonError: unknown;
 	try {
-		try {
-			return JSON.parse(rawData);
-		} catch {
-			return JSON.parse(decodeBase64ToString(rawData));
-		}
-	} catch {
-		throw new Error('Invalid blueprint');
+		return JSON.parse(rawData);
+	} catch (e) {
+		jsonError = e;
 	}
+	try {
+		return JSON.parse(decodeBase64ToString(rawData));
+	} catch {
+		// Fall through — the input was neither plain JSON nor base64-encoded JSON.
+	}
+	const message = jsonError instanceof Error ? jsonError.message : String(jsonError);
+	const hint = /%[0-9A-Fa-f]{2}/.test(rawData)
+		? ' The input still contains %XX escapes after decoding — the URL fragment may have been double-encoded.'
+		: '';
+	throw new Error(`Invalid blueprint: ${message}.${hint}`);
 }
 
 export class PlaygroundRoute {


### PR DESCRIPTION
## What

Decode Blueprints via `encodeURIComponent`.

## Rationale

@annezazu asked Claude to set up a PR preview button. The model  `encodeURIComponent(JSON.stringify(blueprint))` to produce a Playground link such as `https://playground.wordpress.net#encodedBlueprint`, which resulted in an "Invalid blueprint" error in Playground with no debugging details.

The `encodeURIComponent` function used by Claude wasn't the right choice. Playground decodes those URLs via `decodeURI`, not `decodeURIComponent`. The former decodes `%C4%85` as `ą` but it leaves `%2F` as `%2F`. The latter decodes `%C4%85` as `ą`, `%2F` as `/`, `%3A` as `:`, and so on for `,`, `/`, `&`, and other codepoints that play a special role in URLs.

## Implementation

More precisely, this PR tries `decodeURIComponent` first, and on failure it falls back to `decodeURI` to retain BC with existing Playground URLs that rely on `decodeURI` semantics.

The error message is also more useful now — if parsing fails, you see the actual JSON error, plus a nudge about double-encoding when the input still has `%XX` escapes left over.

## Test plan

- [ ] CI green
- [ ] Pasting `https://playground.wordpress.net/#%7B%22landingPage%22%3A%22%2Fwp-admin%2F%22%7D` boots into wp-admin
- [ ] Existing encodeURI-built shareable links still load identically
- [ ] A URL with a literal `%26` inside a blueprint value preserves it