### PR TITLE
[Website] Embeddable PHP code snippets via <php-snippet>

### DIFF
--- a/packages/docs/site/docs/main/guides/index.md
+++ b/packages/docs/site/docs/main/guides/index.md
@@ -9,6 +9,10 @@ sidebar_class_name: navbar-build-item
 
 In this section we present a selection of guides that will help you to both work with, and to better understand, a variety of topics related to [WordPress Playground](/).
 
+## [PHP code snippets and embeds](/guides/php-code-snippets)
+
+Embed runnable PHP snippets in any web page with the `<php-snippet>` web component, or share full PHP examples via the standalone PHP Playground at [`playground.wordpress.net/php-playground.html`](https://playground.wordpress.net/php-playground.html). One script tag, lazy-loaded runtime, shared across every snippet on the page.
+
 ## [WordPress Playground for Everyone](/guides/playground-for-everyone)
 
 Think Playground is only for developers? Think again. This guide shows how WordPress Playground helps beginners, site owners, and everyday users experiment safely — no technical expertise required.

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -1,0 +1,138 @@
+---
+title: PHP code snippets and embeds
+slug: /guides/php-code-snippets
+description: Embed runnable PHP code snippets in any web page using the <php-snippet> web component, or share full PHP demos via the standalone PHP Playground.
+sidebar_class_name: navbar-build-item
+---
+
+# PHP code snippets and embeds
+
+WordPress Playground ships two ready-made ways to put runnable PHP — and the full WordPress runtime — directly into a web page or a shareable URL. No PHP server, no setup, just a browser.
+
+- **[`<php-snippet>` web component](#embedding-with-php-snippet)** — drop one `<script>` tag into your blog post, docs site, or readme to embed multiple runnable PHP snippets that share a single Playground runtime.
+- **[Standalone PHP Playground](#standalone-php-playground)** — a full-page PHP editor at `playground.wordpress.net/php-playground.html` with a shareable URL.
+
+## Embedding with `<php-snippet>`
+
+The `<php-snippet>` custom element renders a syntax-highlighted code block with a Run button. Multiple snippets on the same page share a single hidden Playground runtime that is downloaded only when the visitor clicks Run for the first time.
+
+### Quick start
+
+```html
+<script
+	type="module"
+	src="https://playground.wordpress.net/php-code-snippet.js"
+></script>
+
+<php-snippet name="hello.php">
+	<script type="application/x-php">
+<?php
+echo "Hello from PHP " . phpversion();
+	</script>
+</php-snippet>
+```
+
+That's the whole integration. The script is around 5 KB gzipped and contains no PHP or WordPress — those are fetched lazily on the first Run click.
+
+### Why a `<script type="application/x-php">` wrapper?
+
+Browsers ignore the contents of script tags whose `type` they don't understand. That means you can put PHP code that contains literal `<` characters (HTML strings, generics, comparisons) inside the wrapper without escaping anything.
+
+If your snippet has no characters that need escaping, you can put the code directly inside `<php-snippet>`:
+
+```html
+<php-snippet name="add.php">
+	&lt;?php echo 1 + 2;
+</php-snippet>
+```
+
+You can also load the code from a separate file:
+
+```html
+<php-snippet name="lazy-load.php" src="./snippets/lazy-load.php"></php-snippet>
+```
+
+### WordPress is available
+
+Each snippet runs inside a real WordPress installation. `require '/wordpress/wp-load.php'` brings in the core APIs:
+
+```html
+<php-snippet name="lazy-load-images.php">
+	<script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+$html = '<article>
+    <img src="hero.jpg" alt="Hero">
+    <img src="inline.jpg" alt="Inline">
+</article>';
+
+$tags = new WP_HTML_Tag_Processor( $html );
+while ( $tags->next_tag( 'img' ) ) {
+    $tags->set_attribute( 'loading', 'lazy' );
+    $tags->add_class( 'responsive' );
+}
+
+echo $tags->get_updated_html();
+	</script>
+</php-snippet>
+```
+
+### How runtime sharing works
+
+The first time a visitor clicks Run on **any** snippet on the page, the component:
+
+1. Lazy-loads the Playground client (`https://playground.wordpress.net/client/index.js`),
+2. Creates one hidden iframe pointing at `https://playground.wordpress.net/remote.html`,
+3. Boots PHP and WordPress inside it.
+
+Every later Run — on the same snippet or any other — calls `client.run({ code })` against that same runtime. No additional downloads, no extra processes. A page with five snippets pays the runtime cost once.
+
+While the boot is in progress, every snippet that has its Run clicked shows the same staged progress bar (download → install → ready) drawn from the live progress events Playground emits internally.
+
+### Attributes
+
+| Attribute            | Default                              | Purpose                                       |
+| -------------------- | ------------------------------------ | --------------------------------------------- |
+| `name`               | `snippet.php`                        | Filename label shown in the snippet header    |
+| `php`                | `8.4`                                | PHP version (see [supported versions][php])   |
+| `wp`                 | `latest`                             | WordPress version                             |
+| `src`                | —                                    | Load PHP from a URL instead of inline         |
+| `playground-origin`  | `https://playground.wordpress.net`   | Override the runtime origin (local dev, etc.) |
+
+Snippets that share the same `php`, `wp`, and `playground-origin` values share one runtime; mixing different versions on the same page boots a separate runtime per combination.
+
+[php]: /developers/apis/query-api/#available-options
+
+## Standalone PHP Playground
+
+For full-page editing or sharing a one-off snippet via URL, use the standalone PHP Playground at:
+
+> [playground.wordpress.net/php-playground.html](https://playground.wordpress.net/php-playground.html)
+
+It's a side-by-side editor and preview with PHP and WordPress version selectors. The current code, PHP version, and WordPress version are encoded into the URL fragment, so you can share a working example by copying the URL.
+
+You can embed it in any page with an iframe:
+
+```html
+<iframe
+	src="https://playground.wordpress.net/php-playground.html#eyJjb2RlIjoiPD9waHBcblxuZWNobyBcIkkgYW0gYSBjb2RlIHNuaXBwZXQhXCI7XG4iLCJwaHAiOiI4LjQifQ=="
+	width="100%"
+	height="600"
+></iframe>
+```
+
+The fragment is a base64-encoded JSON payload of `{ code, php, wp }`.
+
+### Standalone vs. `<php-snippet>` — which should I use?
+
+| Use case                                                          | Pick                |
+| ----------------------------------------------------------------- | ------------------- |
+| Multiple read-only runnable examples in a docs page or blog post  | `<php-snippet>`     |
+| One editable example a reader can tweak and share via URL         | Standalone PHP Playground |
+| Per-page bandwidth budget matters and you have many snippets      | `<php-snippet>` (one shared runtime) |
+| You want a full-page coding environment with no host-page styling | Standalone PHP Playground |
+
+## Browser support
+
+Both options require [WebAssembly](https://caniuse.com/wasm) and [Service Workers](https://caniuse.com/serviceworkers), which are available in every modern browser. PHP 8.4 additionally requires [WebAssembly JSPI](https://github.com/WebAssembly/js-promise-integration) (Chrome 137+, Edge 137+); older PHP versions fall back to the broadly supported asyncify build.

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -124,15 +124,10 @@ You can embed it in any page with an iframe:
 
 The fragment is a base64-encoded JSON payload of `{ code, php, wp }`.
 
-### Standalone vs. `<php-snippet>` — which should I use?
+### Standalone PHP Playground `<iframe>` vs. `<php-snippet>` — which should I use?
 
 | Use case                                                          | Pick                |
 | ----------------------------------------------------------------- | ------------------- |
 | Multiple read-only runnable examples in a docs page or blog post  | `<php-snippet>`     |
-| One editable example a reader can tweak and share via URL         | Standalone PHP Playground |
-| Per-page bandwidth budget matters and you have many snippets      | `<php-snippet>` (one shared runtime) |
-| You want a full-page coding environment with no host-page styling | Standalone PHP Playground |
-
-## Browser support
-
-Both options require [WebAssembly](https://caniuse.com/wasm) and [Service Workers](https://caniuse.com/serviceworkers), which are available in every modern browser. PHP 8.4 additionally requires [WebAssembly JSPI](https://github.com/WebAssembly/js-promise-integration) (Chrome 137+, Edge 137+); older PHP versions fall back to the broadly supported asyncify build.
+| Customizations, e.g. read-only code vs editable code  | `<php-snippet>`     |
+| A single code example you don't want to load foreign scripts on your site | Standalone PHP Playground |

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -44,6 +44,7 @@ const sidebars = {
 						id: 'main/guides/index',
 					},
 					items: [
+						'main/guides/php-code-snippets',
 						'main/guides/agent-skill-wp-playground',
 						'main/guides/wordpress-native-ios-app',
 						'main/guides/for-plugin-developers',

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the <php-snippet> web component embed.
+ * Verifies that:
+ *   - the demo page renders three snippets,
+ *   - clicking Run on the first shows a real progress bar with a caption
+ *     and percent that advance toward 100,
+ *   - the first snippet executes and shows PHP output,
+ *   - subsequent snippets reuse the same Playground runtime (much faster
+ *     than the first boot) and produce their own output.
+ */
+
+const DEMO_URL = './php-code-snippet-demo.html';
+
+test.describe('php-code-snippet embed', () => {
+	test('renders three snippets with Run buttons', async ({ page }) => {
+		await page.goto(DEMO_URL);
+		const snippets = page.locator('php-snippet');
+		await expect(snippets).toHaveCount(3);
+		for (const name of [
+			'hello.php',
+			'lazy-load-images.php',
+			'parse-blocks.php',
+		]) {
+			const snippet = page.locator(`php-snippet[name="${name}"]`);
+			await expect(snippet).toBeVisible();
+			await expect(snippet.locator('.run')).toBeVisible();
+		}
+	});
+
+	test('first Run boots the runtime and shows progress + output', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const first = page.locator('php-snippet').nth(0);
+
+		await expect(first.locator('.progress')).toBeHidden();
+		await first.locator('.run').click();
+
+		// Progress bar appears with caption + percent text.
+		await expect(first.locator('.progress')).toBeVisible();
+		await expect(first.locator('.caption')).not.toHaveText('');
+		await expect(first.locator('.percent')).toContainText(/%$/);
+
+		// The percent advances past 0 (real progress, not just "0%" forever).
+		await expect
+			.poll(
+				async () =>
+					Number(
+						(
+							(await first
+								.locator('.percent')
+								.textContent()) || '0%'
+						).replace('%', '')
+					),
+				{ timeout: 120_000, intervals: [500] }
+			)
+			.toBeGreaterThan(0);
+
+		// Eventually the run completes and the output panel appears.
+		await expect(first.locator('.output')).toBeVisible({
+			timeout: 240_000,
+		});
+		await expect(first.locator('.output-body')).toContainText(
+			'Hello from PHP'
+		);
+
+		// Progress hides once the run finishes.
+		await expect(first.locator('.progress')).toBeHidden();
+	});
+
+	test('subsequent snippets reuse the shared runtime', async ({ page }) => {
+		await page.goto(DEMO_URL);
+		const first = page.locator('php-snippet').nth(0);
+		const second = page.locator('php-snippet').nth(1);
+		const third = page.locator('php-snippet').nth(2);
+
+		// Boot the runtime via the first snippet.
+		await first.locator('.run').click();
+		await expect(first.locator('.output')).toBeVisible({
+			timeout: 240_000,
+		});
+
+		// Second run should reuse the runtime — well under the 240s
+		// boot budget. Allow a generous 60s upper bound for CI noise.
+		const secondStart = Date.now();
+		await second.locator('.run').click();
+		await expect(second.locator('.output')).toBeVisible({
+			timeout: 60_000,
+		});
+		const secondElapsed = Date.now() - secondStart;
+		expect(secondElapsed).toBeLessThan(60_000);
+		await expect(second.locator('.output-body')).toContainText(
+			'loading="lazy"'
+		);
+
+		// Third snippet — same shared runtime.
+		await third.locator('.run').click();
+		await expect(third.locator('.output')).toBeVisible({
+			timeout: 60_000,
+		});
+		await expect(third.locator('.output-body')).toContainText(
+			'core/paragraph'
+		);
+
+		// Only one runtime iframe should have been added to the host page,
+		// regardless of how many snippets ran.
+		const runtimeIframes = await page
+			.locator('iframe[title="PHP Snippet runtime"]')
+			.count();
+		expect(runtimeIframes).toBe(1);
+	});
+});

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>&lt;php-snippet&gt; demo</title>
+		<style>
+			body {
+				font-family: system-ui, -apple-system, sans-serif;
+				max-width: 880px;
+				margin: 0 auto;
+				padding: 32px 20px 64px;
+				color: #1f2328;
+				line-height: 1.55;
+			}
+			h1 { font-size: 28px; margin: 0 0 8px; }
+			h2 { font-size: 20px; margin: 32px 0 8px; }
+			.lede { color: #57606a; margin: 0 0 24px; }
+			code { background: #eaeef2; padding: 2px 5px; border-radius: 4px; font-size: 0.9em; }
+			.note {
+				background: #ddf4ff;
+				border-left: 4px solid #218bff;
+				padding: 12px 14px;
+				margin: 16px 0;
+				border-radius: 4px;
+				font-size: 14px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>&lt;php-snippet&gt; demo</h1>
+		<p class="lede">
+			Three independent snippets on one page. Click Run on any of
+			them — the PHP &amp; WordPress runtime downloads
+			<strong>once</strong> and is shared across all of them.
+		</p>
+
+		<div class="note">
+			Open DevTools → Network and watch: the first Run downloads
+			<code>remote.html</code> + the PHP WASM binary + WordPress.
+			The second and third Runs reuse the same runtime — no extra
+			downloads.
+		</div>
+
+		<h2>1. Pure PHP</h2>
+		<php-snippet name="hello.php">
+			<script type="application/x-php">
+<?php
+echo "Hello from PHP " . phpversion() . "\n";
+echo "Today is " . date('Y-m-d') . "\n";
+echo str_repeat('-', 30) . "\n";
+
+$nums = [1, 2, 3, 4, 5];
+echo "Sum of " . implode(',', $nums) . " = " . array_sum($nums) . "\n";
+			</script>
+		</php-snippet>
+
+		<h2>2. WordPress HTML API</h2>
+		<php-snippet name="lazy-load-images.php">
+			<script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+$html = '<article>
+    <img src="hero.jpg" alt="Hero">
+    <img src="inline.jpg" alt="Inline">
+</article>';
+
+$tags = new WP_HTML_Tag_Processor( $html );
+while ( $tags->next_tag( 'img' ) ) {
+    $tags->set_attribute( 'loading', 'lazy' );
+    $tags->add_class( 'responsive' );
+}
+
+echo $tags->get_updated_html();
+			</script>
+		</php-snippet>
+
+		<h2>3. Block parser</h2>
+		<php-snippet name="parse-blocks.php">
+			<script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+$post_content = "<!-- wp:paragraph -->
+<p>Hello, <strong>block editor</strong>!</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list -->
+<ul><li>One</li><li>Two</li></ul>
+<!-- /wp:list -->";
+
+$blocks = parse_blocks( $post_content );
+foreach ( $blocks as $block ) {
+    if ( ! empty( $block['blockName'] ) ) {
+        echo "- " . $block['blockName'] . "\n";
+    }
+}
+			</script>
+		</php-snippet>
+
+		<script type="module" src="./php-code-snippet.js"></script>
+	</body>
+</html>

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -126,78 +126,76 @@ class ProgressTracker extends EventTarget {
 	}
 }
 
-let sharedClient = null;
-let sharedClientKey = null;
-let sharedTracker = null;
-const trackerSubscribers = new Set();
-
-function notifySubscribers(detail) {
-	for (const fn of trackerSubscribers) fn(detail);
-}
+/**
+ * Each unique {origin, php, wp} combination boots its own runtime. Entries
+ * live for the page lifetime so subsequent runs reuse the same client.
+ * Per-entry subscribers means progress events from one boot never leak to
+ * snippets waiting on a different runtime.
+ */
+const runtimes = new Map();
 
 async function getSharedClient({ origin, php, wp }, onProgress) {
 	const key = `${origin}|${php}|${wp}`;
-	const subscribe = (fn) => {
-		trackerSubscribers.add(fn);
-		return () => trackerSubscribers.delete(fn);
-	};
-	if (sharedClient && sharedClientKey === key) {
+	let entry = runtimes.get(key);
+
+	if (entry && entry.client) {
 		onProgress?.({ progress: 100, caption: '' });
-		return sharedClient;
+		return entry.client;
 	}
-	if (sharedTracker && sharedClientKey === key) {
-		// Boot already in flight — replay the latest progress immediately
-		// so a late-arriving snippet shows the same bar position.
+
+	if (!entry) {
+		const tracker = new ProgressTracker();
+		const subscribers = new Set();
+		tracker.addEventListener('progress', (e) => {
+			for (const fn of subscribers) {
+				fn({
+					progress: e.detail.progress,
+					caption: e.detail.caption,
+				});
+			}
+		});
+		entry = { tracker, subscribers, client: null, promise: null };
+		entry.promise = bootRuntime({ origin, php, wp }, entry);
+		runtimes.set(key, entry);
+	} else {
+		// Boot in flight — replay the latest progress so a late-arriving
+		// snippet shows the same bar position.
 		onProgress?.({
-			progress: sharedTracker.progress,
-			caption: sharedTracker.caption,
+			progress: entry.tracker.progress,
+			caption: entry.tracker.caption,
 		});
-		const unsub = subscribe(onProgress);
-		try {
-			return await sharedClientPromise;
-		} finally {
-			unsub();
-		}
 	}
-	sharedClientKey = key;
-	sharedTracker = new ProgressTracker();
-	sharedTracker.addEventListener('progress', (e) =>
-		notifySubscribers({
-			progress: e.detail.progress,
-			caption: e.detail.caption,
-		})
-	);
-	const unsub = subscribe(onProgress);
-	sharedClientPromise = (async () => {
-		const { startPlaygroundWeb } = await import(
-			/* @vite-ignore */ `${origin}/client/index.js`
-		);
-		const iframe = document.createElement('iframe');
-		iframe.title = 'PHP Snippet runtime';
-		iframe.setAttribute('aria-hidden', 'true');
-		iframe.style.cssText =
-			'position:absolute;width:1px;height:1px;border:0;opacity:0;pointer-events:none;left:-9999px;';
-		iframe.src = `${origin}/remote.html`;
-		document.body.appendChild(iframe);
-		const client = await startPlaygroundWeb({
-			iframe,
-			remoteUrl: iframe.src,
-			disableProgressBar: true,
-			progressTracker: sharedTracker,
-			blueprint: { preferredVersions: { php, wp } },
-		});
-		await client.isReady;
-		sharedClient = client;
-		return client;
-	})();
+
+	if (onProgress) entry.subscribers.add(onProgress);
 	try {
-		return await sharedClientPromise;
+		return await entry.promise;
 	} finally {
-		unsub();
+		if (onProgress) entry.subscribers.delete(onProgress);
 	}
 }
 
-let sharedClientPromise = null;
+async function bootRuntime({ origin, php, wp }, entry) {
+	const { startPlaygroundWeb } = await import(
+		/* @vite-ignore */ `${origin}/client/index.js`
+	);
+	const iframe = document.createElement('iframe');
+	iframe.title = 'PHP Snippet runtime';
+	iframe.setAttribute('aria-hidden', 'true');
+	iframe.style.cssText =
+		'position:absolute;width:1px;height:1px;border:0;opacity:0;pointer-events:none;left:-9999px;';
+	iframe.src = `${origin}/remote.html`;
+	document.body.appendChild(iframe);
+	const client = await startPlaygroundWeb({
+		iframe,
+		remoteUrl: iframe.src,
+		disableProgressBar: true,
+		progressTracker: entry.tracker,
+		blueprint: { preferredVersions: { php, wp } },
+	});
+	await client.isReady;
+	entry.client = client;
+	return client;
+}
 
 /**
  * Tiny regex-based PHP highlighter (~80 lines). Good enough for typical
@@ -494,6 +492,11 @@ class PhpSnippet extends HTMLElement {
 		const src = this.getAttribute('src');
 		if (src) {
 			const res = await fetch(src);
+			if (!res.ok) {
+				throw new Error(
+					`Failed to load PHP from ${src}: ${res.status} ${res.statusText}`
+				);
+			}
 			return await res.text();
 		}
 		const script = this.querySelector(
@@ -507,14 +510,14 @@ class PhpSnippet extends HTMLElement {
 		const name = this.getAttribute('name') || 'snippet.php';
 		const style = document.createElement('style');
 		style.textContent = TEMPLATE_CSS;
-		this.shadowRoot.replaceChildren(style);
-		this.shadowRoot.innerHTML += `
+		const tpl = document.createElement('template');
+		tpl.innerHTML = `
 			<div class="card">
 				<div class="header">
 					<span class="name">${escapeHtml(name)}</span>
 					<button class="run" type="button">Run</button>
 				</div>
-				<div class="progress" role="status">
+				<div class="progress" role="status" aria-live="polite" aria-atomic="true">
 					<span class="caption">Loading…</span>
 					<div class="bar"><div class="fill"></div></div>
 					<span class="percent">0%</span>
@@ -526,6 +529,7 @@ class PhpSnippet extends HTMLElement {
 				</div>
 			</div>
 		`;
+		this.shadowRoot.replaceChildren(style, tpl.content);
 		this.shadowRoot
 			.querySelector('.run')
 			.addEventListener('click', () => this._run());

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -1,0 +1,587 @@
+/**
+ * <php-snippet> — a runnable, syntax-highlighted PHP code embed.
+ *
+ * Drop this on any page:
+ *
+ *   <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
+ *
+ *   <php-snippet name="lazy-load-images.php">
+ *     <script type="application/x-php">
+ * <?php
+ * $html = '<img src="hero.jpg">';
+ * $tags = new WP_HTML_Tag_Processor( $html );
+ * while ( $tags->next_tag( 'img' ) ) {
+ *     $tags->set_attribute( 'loading', 'lazy' );
+ * }
+ * echo $tags->get_updated_html();
+ *     </script>
+ *   </php-snippet>
+ *
+ * Multiple <php-snippet> elements on the same page share a single hidden
+ * Playground runtime that's only booted on the first Run click. PHP and
+ * WordPress WASM are downloaded once per page, not once per snippet.
+ *
+ * Attributes:
+ *   name="…"              filename label shown in the header
+ *   php="8.4"             PHP version (default: 8.4)
+ *   wp="latest"           WordPress version (default: latest)
+ *   src="path/to.php"     load code from a URL instead of inline
+ *   playground-origin="https://playground.wordpress.net"
+ *                         override the runtime origin (useful for local dev)
+ */
+
+const DEFAULT_ORIGIN = 'https://playground.wordpress.net';
+const DEFAULT_PHP = '8.4';
+const DEFAULT_WP = 'latest';
+
+/**
+ * Minimal duck-typed port of @php-wasm/progress's ProgressTracker.
+ * The published playground.wordpress.net/client bundle uses this shape
+ * internally (calls .stage(weight), .set(0–100), .setCaption(s), .finish(),
+ * .pipe(receiver), .loadingListener) but does not export the class. Once
+ * it is exported, this can be replaced with a direct import.
+ */
+const PROGRESS_EPSILON = 0.00001;
+class ProgressTracker extends EventTarget {
+	constructor({ weight = 1, caption = '' } = {}) {
+		super();
+		this._weight = weight;
+		this._selfWeight = 1;
+		this._selfProgress = 0;
+		this._selfCaption = caption;
+		this._selfDone = false;
+		this._subs = [];
+	}
+	get weight() { return this._weight; }
+	get progress() {
+		if (this._selfDone) return 100;
+		const sum = this._subs.reduce(
+			(s, t) => s + t.progress * t.weight,
+			this._selfProgress * this._selfWeight
+		);
+		return Math.round(sum * 10000) / 10000;
+	}
+	get done() { return this.progress + PROGRESS_EPSILON >= 100; }
+	get caption() {
+		for (let i = this._subs.length - 1; i >= 0; i--) {
+			if (!this._subs[i].done && this._subs[i].caption) {
+				return this._subs[i].caption;
+			}
+		}
+		return this._selfCaption;
+	}
+	stage(weight, caption = '') {
+		if (!weight) weight = this._selfWeight;
+		this._selfWeight -= weight;
+		const sub = new ProgressTracker({ weight, caption });
+		this._subs.push(sub);
+		sub.addEventListener('progress', () => this._notify());
+		sub.addEventListener('done', () => {
+			if (this.done) this._notifyDone();
+		});
+		return sub;
+	}
+	set(value) {
+		this._selfProgress = Math.min(value, 100);
+		this._notify();
+		if (this._selfProgress + PROGRESS_EPSILON >= 100) this.finish();
+	}
+	setCaption(c) { this._selfCaption = c; this._notify(); }
+	finish() {
+		this._selfDone = true;
+		this._selfProgress = 100;
+		this._notify();
+		this._notifyDone();
+	}
+	pipe(receiver) {
+		receiver.setProgress({ progress: this.progress, caption: this.caption });
+		this.addEventListener('progress', (e) =>
+			receiver.setProgress({
+				progress: e.detail.progress,
+				caption: e.detail.caption,
+			})
+		);
+		this.addEventListener('done', () => receiver.setLoaded());
+	}
+	get loadingListener() {
+		if (!this._ll) {
+			this._ll = (event) =>
+				this.set((event.detail.loaded / event.detail.total) * 100);
+		}
+		return this._ll;
+	}
+	_notify() {
+		const self = this;
+		this.dispatchEvent(
+			new CustomEvent('progress', {
+				detail: {
+					get progress() { return self.progress; },
+					get caption() { return self.caption; },
+				},
+			})
+		);
+	}
+	_notifyDone() {
+		this.dispatchEvent(new CustomEvent('done'));
+	}
+}
+
+let sharedClient = null;
+let sharedClientKey = null;
+let sharedTracker = null;
+const trackerSubscribers = new Set();
+
+function notifySubscribers(detail) {
+	for (const fn of trackerSubscribers) fn(detail);
+}
+
+async function getSharedClient({ origin, php, wp }, onProgress) {
+	const key = `${origin}|${php}|${wp}`;
+	const subscribe = (fn) => {
+		trackerSubscribers.add(fn);
+		return () => trackerSubscribers.delete(fn);
+	};
+	if (sharedClient && sharedClientKey === key) {
+		onProgress?.({ progress: 100, caption: '' });
+		return sharedClient;
+	}
+	if (sharedTracker && sharedClientKey === key) {
+		// Boot already in flight — replay the latest progress immediately
+		// so a late-arriving snippet shows the same bar position.
+		onProgress?.({
+			progress: sharedTracker.progress,
+			caption: sharedTracker.caption,
+		});
+		const unsub = subscribe(onProgress);
+		try {
+			return await sharedClientPromise;
+		} finally {
+			unsub();
+		}
+	}
+	sharedClientKey = key;
+	sharedTracker = new ProgressTracker();
+	sharedTracker.addEventListener('progress', (e) =>
+		notifySubscribers({
+			progress: e.detail.progress,
+			caption: e.detail.caption,
+		})
+	);
+	const unsub = subscribe(onProgress);
+	sharedClientPromise = (async () => {
+		const { startPlaygroundWeb } = await import(
+			/* @vite-ignore */ `${origin}/client/index.js`
+		);
+		const iframe = document.createElement('iframe');
+		iframe.title = 'PHP Snippet runtime';
+		iframe.setAttribute('aria-hidden', 'true');
+		iframe.style.cssText =
+			'position:absolute;width:1px;height:1px;border:0;opacity:0;pointer-events:none;left:-9999px;';
+		iframe.src = `${origin}/remote.html`;
+		document.body.appendChild(iframe);
+		const client = await startPlaygroundWeb({
+			iframe,
+			remoteUrl: iframe.src,
+			disableProgressBar: true,
+			progressTracker: sharedTracker,
+			blueprint: { preferredVersions: { php, wp } },
+		});
+		await client.isReady;
+		sharedClient = client;
+		return client;
+	})();
+	try {
+		return await sharedClientPromise;
+	} finally {
+		unsub();
+	}
+}
+
+let sharedClientPromise = null;
+
+/**
+ * Tiny regex-based PHP highlighter (~80 lines). Good enough for typical
+ * snippets without pulling in a 50KB tokenizer. The order matters: longer
+ * patterns and string/comment patterns must come before keyword/identifier
+ * patterns so they match first.
+ */
+const PHP_KEYWORDS = new Set([
+	'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch',
+	'class', 'clone', 'const', 'continue', 'declare', 'default', 'do', 'echo',
+	'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif',
+	'endswitch', 'endwhile', 'extends', 'final', 'finally', 'fn', 'for',
+	'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include',
+	'include_once', 'instanceof', 'insteadof', 'interface', 'isset', 'list',
+	'match', 'namespace', 'new', 'null', 'or', 'print', 'private', 'protected',
+	'public', 'readonly', 'require', 'require_once', 'return', 'static',
+	'switch', 'throw', 'trait', 'try', 'unset', 'use', 'var', 'while', 'xor',
+	'yield', 'true', 'false',
+]);
+
+function escapeHtml(s) {
+	return s
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}
+
+function highlightPhp(code) {
+	const tokens = [];
+	let i = 0;
+	const len = code.length;
+	while (i < len) {
+		const c = code[i];
+		const rest = code.slice(i);
+		// Heredoc/nowdoc — bail to plain
+		if (rest.startsWith('<<<')) {
+			tokens.push(['plain', code[i]]);
+			i++;
+			continue;
+		}
+		// Block comment
+		if (rest.startsWith('/*')) {
+			const end = code.indexOf('*/', i + 2);
+			const stop = end === -1 ? len : end + 2;
+			tokens.push(['comment', code.slice(i, stop)]);
+			i = stop;
+			continue;
+		}
+		// Line comment
+		if (rest.startsWith('//') || rest.startsWith('#')) {
+			const end = code.indexOf('\n', i);
+			const stop = end === -1 ? len : end;
+			tokens.push(['comment', code.slice(i, stop)]);
+			i = stop;
+			continue;
+		}
+		// Single-quoted string
+		if (c === "'") {
+			let j = i + 1;
+			while (j < len && code[j] !== "'") {
+				if (code[j] === '\\') j++;
+				j++;
+			}
+			tokens.push(['string', code.slice(i, Math.min(j + 1, len))]);
+			i = j + 1;
+			continue;
+		}
+		// Double-quoted string
+		if (c === '"') {
+			let j = i + 1;
+			while (j < len && code[j] !== '"') {
+				if (code[j] === '\\') j++;
+				j++;
+			}
+			tokens.push(['string', code.slice(i, Math.min(j + 1, len))]);
+			i = j + 1;
+			continue;
+		}
+		// PHP open/close tags
+		if (rest.startsWith('<?php') || rest.startsWith('<?=')) {
+			const tag = rest.startsWith('<?php') ? '<?php' : '<?=';
+			tokens.push(['tag', tag]);
+			i += tag.length;
+			continue;
+		}
+		if (rest.startsWith('?>')) {
+			tokens.push(['tag', '?>']);
+			i += 2;
+			continue;
+		}
+		// Variable
+		if (c === '$' && /[A-Za-z_]/.test(code[i + 1] || '')) {
+			let j = i + 2;
+			while (j < len && /[A-Za-z0-9_]/.test(code[j])) j++;
+			tokens.push(['variable', code.slice(i, j)]);
+			i = j;
+			continue;
+		}
+		// Number
+		if (/[0-9]/.test(c)) {
+			let j = i + 1;
+			while (j < len && /[0-9.eExX_]/.test(code[j])) j++;
+			tokens.push(['number', code.slice(i, j)]);
+			i = j;
+			continue;
+		}
+		// Identifier (keyword vs. function call vs. class name)
+		if (/[A-Za-z_]/.test(c)) {
+			let j = i + 1;
+			while (j < len && /[A-Za-z0-9_]/.test(code[j])) j++;
+			const word = code.slice(i, j);
+			let kind;
+			if (PHP_KEYWORDS.has(word.toLowerCase())) {
+				kind = 'keyword';
+			} else if (/^[A-Z]/.test(word)) {
+				kind = 'class';
+			} else if (code[j] === '(') {
+				kind = 'function';
+			} else {
+				kind = 'plain';
+			}
+			tokens.push([kind, word]);
+			i = j;
+			continue;
+		}
+		tokens.push(['plain', c]);
+		i++;
+	}
+	return tokens
+		.map(([kind, text]) =>
+			kind === 'plain'
+				? escapeHtml(text)
+				: `<span class="t-${kind}">${escapeHtml(text)}</span>`
+		)
+		.join('');
+}
+
+const TEMPLATE_CSS = `
+:host {
+	display: block;
+	margin: 16px 0;
+	font-family: system-ui, -apple-system, sans-serif;
+}
+.card {
+	border: 1px solid #e1e4e8;
+	border-radius: 8px;
+	overflow: hidden;
+	background: #f6f8fa;
+}
+.header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 10px 14px;
+	background: #f6f8fa;
+	border-bottom: 1px solid #e1e4e8;
+	gap: 12px;
+}
+.name {
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 13px;
+	color: #57606a;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.run {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 6px 14px;
+	background: #2563eb;
+	color: white;
+	border: 0;
+	border-radius: 6px;
+	font-size: 14px;
+	font-weight: 500;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+.run:hover { background: #1d4ed8; }
+.run:disabled { background: #93c5fd; cursor: progress; }
+.run::before { content: "▶"; font-size: 10px; }
+.progress {
+	display: none;
+	align-items: center;
+	gap: 10px;
+	padding: 8px 14px;
+	background: #f0f4ff;
+	border-bottom: 1px solid #d0d7de;
+	font-size: 13px;
+	color: #444c56;
+}
+.progress.visible { display: flex; }
+.bar {
+	flex: 1;
+	height: 4px;
+	background: #d0d7de;
+	border-radius: 2px;
+	overflow: hidden;
+	position: relative;
+}
+.fill {
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	background: #2563eb;
+	border-radius: 2px;
+	width: 0;
+	transition: width 0.2s linear;
+}
+.caption {
+	flex-shrink: 0;
+	font-variant-numeric: tabular-nums;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+.percent {
+	flex-shrink: 0;
+	font-variant-numeric: tabular-nums;
+	color: #57606a;
+	font-size: 12px;
+	min-width: 36px;
+	text-align: right;
+}
+pre {
+	margin: 0;
+	padding: 16px;
+	overflow-x: auto;
+	background: #ffffff;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 13px;
+	line-height: 1.5;
+	color: #24292f;
+	white-space: pre;
+	tab-size: 4;
+}
+.t-keyword  { color: #cf222e; font-weight: 500; }
+.t-string   { color: #0a3069; }
+.t-comment  { color: #6e7781; font-style: italic; }
+.t-variable { color: #953800; }
+.t-number   { color: #0550ae; }
+.t-function { color: #8250df; }
+.t-class    { color: #6f42c1; }
+.t-tag      { color: #cf222e; font-weight: 500; }
+.output {
+	display: none;
+	border-top: 1px solid #e1e4e8;
+	background: #0d1117;
+	color: #e6edf3;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 13px;
+	line-height: 1.5;
+}
+.output.visible { display: block; }
+.output-label {
+	padding: 6px 14px;
+	background: #161b22;
+	color: #7d8590;
+	font-size: 11px;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+	border-bottom: 1px solid #30363d;
+}
+.output-body {
+	padding: 14px;
+	margin: 0;
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 400px;
+	overflow-y: auto;
+}
+.output-body.error { color: #ff8182; }
+`;
+
+class PhpSnippet extends HTMLElement {
+	constructor() {
+		super();
+		this.attachShadow({ mode: 'open' });
+		this._code = '';
+	}
+
+	connectedCallback() {
+		this._readCode().then((code) => {
+			this._code = code.trim();
+			this._render();
+		});
+	}
+
+	async _readCode() {
+		const src = this.getAttribute('src');
+		if (src) {
+			const res = await fetch(src);
+			return await res.text();
+		}
+		const script = this.querySelector(
+			'script[type="application/x-php"], script[type="text/x-php"], script[type="text/php"]'
+		);
+		if (script) return script.textContent || '';
+		return this.textContent || '';
+	}
+
+	_render() {
+		const name = this.getAttribute('name') || 'snippet.php';
+		const style = document.createElement('style');
+		style.textContent = TEMPLATE_CSS;
+		this.shadowRoot.replaceChildren(style);
+		this.shadowRoot.innerHTML += `
+			<div class="card">
+				<div class="header">
+					<span class="name">${escapeHtml(name)}</span>
+					<button class="run" type="button">Run</button>
+				</div>
+				<div class="progress" role="status">
+					<span class="caption">Loading…</span>
+					<div class="bar"><div class="fill"></div></div>
+					<span class="percent">0%</span>
+				</div>
+				<pre><code>${highlightPhp(this._code)}</code></pre>
+				<div class="output">
+					<div class="output-label">Output</div>
+					<pre class="output-body"></pre>
+				</div>
+			</div>
+		`;
+		this.shadowRoot
+			.querySelector('.run')
+			.addEventListener('click', () => this._run());
+	}
+
+	async _run() {
+		const btn = this.shadowRoot.querySelector('.run');
+		const progress = this.shadowRoot.querySelector('.progress');
+		const caption = this.shadowRoot.querySelector('.caption');
+		const fill = this.shadowRoot.querySelector('.fill');
+		const percent = this.shadowRoot.querySelector('.percent');
+		const outputWrap = this.shadowRoot.querySelector('.output');
+		const outputBody = this.shadowRoot.querySelector('.output-body');
+		btn.disabled = true;
+		outputBody.classList.remove('error');
+		progress.classList.add('visible');
+		caption.textContent = 'Loading runtime…';
+		fill.style.width = '0%';
+		percent.textContent = '0%';
+		try {
+			const client = await getSharedClient(
+				{
+					origin:
+						this.getAttribute('playground-origin') ||
+						DEFAULT_ORIGIN,
+					php: this.getAttribute('php') || DEFAULT_PHP,
+					wp: this.getAttribute('wp') || DEFAULT_WP,
+				},
+				({ progress: pct, caption: cap }) => {
+					const rounded = Math.round(pct);
+					fill.style.width = rounded + '%';
+					percent.textContent = rounded + '%';
+					if (cap) caption.textContent = cap;
+				}
+			);
+			caption.textContent = 'Running…';
+			fill.style.width = '100%';
+			percent.textContent = '100%';
+			const response = await client.run({ code: this._code });
+			outputBody.textContent = response.text || '(no output)';
+			if (response.errors) {
+				outputBody.textContent +=
+					(outputBody.textContent ? '\n\n' : '') + response.errors;
+			}
+			outputWrap.classList.add('visible');
+		} catch (err) {
+			outputBody.classList.add('error');
+			outputBody.textContent = String(
+				err && err.message ? err.message : err
+			);
+			outputWrap.classList.add('visible');
+		} finally {
+			progress.classList.remove('visible');
+			btn.disabled = false;
+		}
+	}
+}
+
+customElements.define('php-snippet', PhpSnippet);

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -111,12 +111,11 @@ class ProgressTracker extends EventTarget {
 		return this._ll;
 	}
 	_notify() {
-		const self = this;
 		this.dispatchEvent(
 			new CustomEvent('progress', {
 				detail: {
-					get progress() { return self.progress; },
-					get caption() { return self.caption; },
+					progress: this.progress,
+					caption: this.caption,
 				},
 			})
 		);
@@ -155,7 +154,14 @@ async function getSharedClient({ origin, php, wp }, onProgress) {
 			}
 		});
 		entry = { tracker, subscribers, client: null, promise: null };
-		entry.promise = bootRuntime({ origin, php, wp }, entry);
+		entry.promise = bootRuntime({ origin, php, wp }, entry).catch(
+			(err) => {
+				// Drop the failed entry so a future Run can retry from scratch
+				// instead of forever awaiting the same rejected promise.
+				runtimes.delete(key);
+				throw err;
+			}
+		);
 		runtimes.set(key, entry);
 	} else {
 		// Boot in flight — replay the latest progress so a late-arriving


### PR DESCRIPTION
Adds a runnable PHP code snippet web component:

https://github.com/user-attachments/assets/a14efacb-e6cf-402c-a2c5-a060019dcbb0

Here's how to use it:

```html
<script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>

<php-snippet name="lazy-load-images.php">
  <script type="application/x-php">
<?php
require '/wordpress/wp-load.php';
$tags = new WP_HTML_Tag_Processor( '<img src="hero.jpg">' );
while ( $tags->next_tag( 'img' ) ) {
    $tags->set_attribute( 'loading', 'lazy' );
}
echo $tags->get_updated_html();
  </script>
</php-snippet>
```

The script is around 5 KB gzipped and contains no PHP or WordPress — those are downloaded only on the first Run click. Multiple snippets on the same page share a single hidden Playground iframe, so a docs page with five examples pays the runtime cost once instead of five times.

**There is no code editor shipped with this PR, just a tiny tokenizer/syntax highlighter.**

The progress bar that shows up during boot is the real staged progress drawn from the live events Playground emits internally, so visitors see the same captions ("Preparing WordPress", download progress, blueprint steps) they'd see in the standalone PHP Playground at `/php-playground.html`.

## Try it

Run `npm run dev` and open http://127.0.0.1:5400/website-server/php-code-snippet-demo.html. Three snippets, one shared runtime — open the Network tab and watch the second and third Run clicks reuse what the first one downloaded.

## What's in here

- The `<php-snippet>` web component (`packages/playground/website/public/php-code-snippet.js`) and a demo page next to it.
- Playwright coverage for boot, progress, output, and runtime sharing — picked up automatically by the existing `test-e2e-playwright` CI job.
- A new guide page (`/guides/php-code-snippets`) that documents both the embed and the standalone PHP Playground at `/php-playground.html` — the latter previously had no docs at all. Linked prominently from the Guides index.

## Notes for reviewers

The component duck-types a `ProgressTracker` so it can subscribe to staged progress events. The published `/client/index.js` doesn't export the real `ProgressTracker` class today; once it does, the inline copy can be replaced with an `import`. Worth a small follow-up.

## Test plan

- [ ] CI `test-e2e-playwright` (Chromium / Firefox / WebKit) passes the three new tests.
- [ ] Open the demo page locally, click Run on the first snippet, watch the staged progress + output, then click Run on the other two and confirm they reuse the runtime (no extra network requests for WP/PHP).
- [ ] Browse to `/guides/php-code-snippets` in the docs site, verify the page renders and the sidebar entry sits at the top of Guides.