### PR TITLE
Docs: Treat changelog as a markdown file

### DIFF
--- a/packages/docs/site/bin/refresh-changelog.ts
+++ b/packages/docs/site/bin/refresh-changelog.ts
@@ -11,7 +11,14 @@ const existingContent = fs.readFileSync(destinationPath, 'utf-8');
 const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
 const existingFrontmatter = existingContent.match(frontmatterRegex)?.[0] || '';
 
-const changelogWithFrontmatter = existingFrontmatter + '\n\n' + changelog;
+// Docusaurus parses `.md` files as MDX, so unescaped `{...}` in PR titles
+// (e.g. `@php-wasm/{web,node}-5-2`) gets evaluated as a JSX expression and
+// crashes the build with "ReferenceError: web is not defined". Escape braces
+// so they render as literal characters.
+const mdxSafeChangelog = changelog.replace(/[{}]/g, '\\$&');
+
+const changelogWithFrontmatter =
+	existingFrontmatter + '\n\n' + mdxSafeChangelog;
 
 // Write the modified changelog to the destination file
 fs.writeFileSync(destinationPath, changelogWithFrontmatter, 'utf-8');

--- a/packages/docs/site/bin/refresh-changelog.ts
+++ b/packages/docs/site/bin/refresh-changelog.ts
@@ -11,14 +11,11 @@ const existingContent = fs.readFileSync(destinationPath, 'utf-8');
 const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
 const existingFrontmatter = existingContent.match(frontmatterRegex)?.[0] || '';
 
-// Docusaurus parses `.md` files as MDX, so unescaped `{...}` in PR titles
-// (e.g. `@php-wasm/{web,node}-5-2`) gets evaluated as a JSX expression and
-// crashes the build with "ReferenceError: web is not defined". Escape braces
-// so they render as literal characters.
-const mdxSafeChangelog = changelog.replace(/[{}]/g, '\\$&');
-
-const changelogWithFrontmatter =
-	existingFrontmatter + '\n\n' + mdxSafeChangelog;
+// The destination file's frontmatter sets `format: md` so Docusaurus parses
+// it as plain CommonMark instead of MDX. Without that, unescaped `{...}` or
+// `<...>` in PR titles (e.g. `@php-wasm/{web,node}-5-2`) would be treated as
+// JSX and crash the build.
+const changelogWithFrontmatter = existingFrontmatter + '\n\n' + changelog;
 
 // Write the modified changelog to the destination file
 fs.writeFileSync(destinationPath, changelogWithFrontmatter, 'utf-8');

--- a/packages/docs/site/docs/main/changelog.md
+++ b/packages/docs/site/docs/main/changelog.md
@@ -9,7 +9,7 @@ All notable changes to this project are documented in this file by a CI job
 that runs on every NPM release. The file follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 format.
 
-## [v3.1.21] (2026-04-20) 
+## [v3.1.21] (2026-04-20)
 
 ### PHP WebAssembly
 
@@ -18,7 +18,7 @@ format.
 ### Various
 
 - [Docs] Update trusted publisher setup instructions. ([#3505](https://github.com/WordPress/wordpress-playground/pull/3505))
-- [PHP] Align @php-wasm/{web,node}-5-2 with workspace and add READMEs. ([#3506](https://github.com/WordPress/wordpress-playground/pull/3506))
+- [PHP] Align @php-wasm/\{web,node\}-5-2 with workspace and add READMEs. ([#3506](https://github.com/WordPress/wordpress-playground/pull/3506))
 
 ### Contributors
 
@@ -26,11 +26,9 @@ The following contributors merged PRs in this release:
 
 @adamziel @JanJakes
 
-
-## [v3.1.20] (2026-04-16) 
+## [v3.1.20] (2026-04-16)
 
 ### Tools
-
 
 #### GitHub integration
 
@@ -70,8 +68,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @ashfame @fellyph @mho22 @perashanid
 
-
-## [v3.1.19] (2026-04-13) 
+## [v3.1.19] (2026-04-13)
 
 ### Documentation
 
@@ -105,13 +102,9 @@ The following contributors merged PRs in this release:
 
 @ashfame @brandonpayton @dd32 @fellyph @JanJakes @mho22 @perashanid @Rima1889
 
+## [v3.1.18] (2026-04-07)
 
-## [v3.1.18] (2026-04-07) 
-
-
-
-
-## [v3.1.17] (2026-04-07) 
+## [v3.1.17] (2026-04-07)
 
 ### Enhancements
 
@@ -131,8 +124,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @fellyph
 
-
-## [v3.1.16] (2026-04-06) 
+## [v3.1.16] (2026-04-06)
 
 ### Website
 
@@ -156,8 +148,7 @@ The following contributors merged PRs in this release:
 
 @bgrgicak @JanJakes @mho22 @noruzzamans @shimotmk
 
-
-## [v3.1.15] (2026-03-31) 
+## [v3.1.15] (2026-03-31)
 
 ### PHP WebAssembly
 
@@ -169,12 +160,11 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.1.14] (2026-03-30) 
+## [v3.1.14] (2026-03-30)
 
 ### PHP WebAssembly
 
-- [Redis]  va_arg long to va_arg zend_long for WASM32 ABI compatibility. ([#3417](https://github.com/WordPress/wordpress-playground/pull/3417))
+- [Redis] va_arg long to va_arg zend_long for WASM32 ABI compatibility. ([#3417](https://github.com/WordPress/wordpress-playground/pull/3417))
 
 ### Internal
 
@@ -203,8 +193,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @beryl-dlg @bgrgicak @JanJakes @mho22 @perashanid @shimotmk @wojtekn
 
-
-## [v3.1.13] (2026-03-23) 
+## [v3.1.13] (2026-03-23)
 
 ### Enhancements
 
@@ -222,7 +211,7 @@ The following contributors merged PRs in this release:
 
 - CLI: Add site editor performance benchmark. ([#3408](https://github.com/WordPress/wordpress-playground/pull/3408))
 
-### 
+###
 
 - CLI]: Consider it a lint error for CLI to depend on large Playground web packages. ([#3410](https://github.com/WordPress/wordpress-playground/pull/3410))
 - Claude] Harden allow/deny lists and clarify dev server behavior. ([#3373](https://github.com/WordPress/wordpress-playground/pull/3373))
@@ -241,11 +230,9 @@ The following contributors merged PRs in this release:
 
 @adamziel @ashfame @bgrgicak @brandonpayton @wojtekn
 
-
-## [v3.1.12] (2026-03-16) 
+## [v3.1.12] (2026-03-16)
 
 ### Enhancements
-
 
 #### Personal Playground
 
@@ -275,8 +262,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @ashfame @brandonpayton @fellyph @zaerl
 
-
-## [v3.1.11] (2026-03-12) 
+## [v3.1.11] (2026-03-12)
 
 ### Enhancements
 
@@ -284,7 +270,7 @@ The following contributors merged PRs in this release:
 
 ### Various
 
-- [PHP] Mount parent directory for file symlinks so __DIR__ works. ([#3377](https://github.com/WordPress/wordpress-playground/pull/3377))
+- [PHP] Mount parent directory for file symlinks so **DIR** works. ([#3377](https://github.com/WordPress/wordpress-playground/pull/3377))
 
 ### Contributors
 
@@ -292,8 +278,7 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.1.10] (2026-03-12) 
+## [v3.1.10] (2026-03-12)
 
 ### Various
 
@@ -305,8 +290,7 @@ The following contributors merged PRs in this release:
 
 @brandonpayton
 
-
-## [v3.1.9] (2026-03-11) 
+## [v3.1.9] (2026-03-11)
 
 ### Enhancements
 
@@ -328,8 +312,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @bgrgicak @brandonpayton @mho22
 
-
-## [v3.1.8] (2026-03-10) 
+## [v3.1.8] (2026-03-10)
 
 ### Website
 
@@ -345,13 +328,9 @@ The following contributors merged PRs in this release:
 
 @bgrgicak @mho22
 
+## [v3.1.7] (2026-03-10)
 
-## [v3.1.7] (2026-03-10) 
-
-
-
-
-## [v3.1.6] (2026-03-10) 
+## [v3.1.6] (2026-03-10)
 
 ### PHP WebAssembly
 
@@ -373,8 +352,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @bgrgicak @fellyph @pkevan
 
-
-## [v3.1.5] (2026-03-09) 
+## [v3.1.5] (2026-03-09)
 
 ### Documentation
 
@@ -407,8 +385,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @andreilupu @bcotrim @brandonpayton @dd32 @fellyph @JanJakes @mho22
 
-
-## [v3.1.3] (2026-03-02) 
+## [v3.1.3] (2026-03-02)
 
 ### Tools
 
@@ -451,8 +428,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @brandonpayton @dd32 @epeicher @fellyph @fredrikekelund @JanJakes @mho22 @n8finch @zaerl
 
-
-## [v3.1.2] (2026-02-23) 
+## [v3.1.2] (2026-02-23)
 
 ### Tools
 
@@ -477,8 +453,7 @@ The following contributors merged PRs in this release:
 
 @ashfame @bgrgicak @brandonpayton @epeicher @JanJakes
 
-
-## [v3.1.1] (2026-02-18) 
+## [v3.1.1] (2026-02-18)
 
 ### Bug Fixes
 
@@ -490,8 +465,7 @@ The following contributors merged PRs in this release:
 
 @brandonpayton
 
-
-## [v3.1.0] (2026-02-18) 
+## [v3.1.0] (2026-02-18)
 
 ### Bug Fixes
 
@@ -503,12 +477,11 @@ The following contributors merged PRs in this release:
 
 @brandonpayton
 
-
-## [v3.0.54] (2026-02-18) 
+## [v3.0.54] (2026-02-18)
 
 ### Blueprints
 
-- Define $_SERVER['HTTP_HOST'] in the enableMultisite step. ([#3214](https://github.com/WordPress/wordpress-playground/pull/3214))
+- Define $\_SERVER['HTTP_HOST'] in the enableMultisite step. ([#3214](https://github.com/WordPress/wordpress-playground/pull/3214))
 
 ### Tools
 
@@ -528,8 +501,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @bcotrim @bookchiq @JanJakes @noruzzamans @shimotmk
 
-
-## [v3.0.53] (2026-02-16) 
+## [v3.0.53] (2026-02-16)
 
 ### Various
 
@@ -542,13 +514,9 @@ The following contributors merged PRs in this release:
 
 @brandonpayton
 
+## [v3.0.52] (2026-02-12)
 
-## [v3.0.52] (2026-02-12) 
-
-
-
-
-## [v3.0.51] (2026-02-12) 
+## [v3.0.51] (2026-02-12)
 
 ### Bug Fixes
 
@@ -560,8 +528,7 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.0.50] (2026-02-12) 
+## [v3.0.50] (2026-02-12)
 
 ### PHP WebAssembly
 
@@ -573,8 +540,7 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.0.49] (2026-02-12) 
+## [v3.0.49] (2026-02-12)
 
 ### Various
 
@@ -586,8 +552,7 @@ The following contributors merged PRs in this release:
 
 @mho22
 
-
-## [v3.0.48] (2026-02-11) 
+## [v3.0.48] (2026-02-11)
 
 ### Enhancements
 
@@ -633,8 +598,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @ashfame @bgrgicak @bph @brandonpayton @fellyph @JanJakes @mho22 @noruzzamans @Omcodes23 @shimotmk
 
-
-## [v3.0.47] (2026-02-02) 
+## [v3.0.47] (2026-02-02)
 
 ### Blueprints
 
@@ -699,8 +663,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @akirk @beryl-dlg @epeicher @fellyph @JanJakes @mho22 @noruzzamans
 
-
-## [v3.0.46] (2026-01-26) 
+## [v3.0.46] (2026-01-26)
 
 ### PHP WebAssembly
 
@@ -722,11 +685,9 @@ The following contributors merged PRs in this release:
 
 @adamziel @akirk @noruzzamans
 
-
-## [v3.0.45] (2026-01-22) 
+## [v3.0.45] (2026-01-22)
 
 ### Tools
-
 
 #### PHP WebAssembly
 
@@ -764,8 +725,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @akirk @beryl-dlg @noruzzamans @shimotmk
 
-
-## [v3.0.44] (2026-01-20) 
+## [v3.0.44] (2026-01-20)
 
 ### Enhancements
 
@@ -789,8 +749,7 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.0.43] (2026-01-19) 
+## [v3.0.43] (2026-01-19)
 
 ### Enhancements
 
@@ -816,8 +775,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @fellyph
 
-
-## [v3.0.42] (2026-01-15) 
+## [v3.0.42] (2026-01-15)
 
 ### Enhancements
 
@@ -833,8 +791,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @fellyph
 
-
-## [v3.0.41] (2026-01-14) 
+## [v3.0.41] (2026-01-14)
 
 ### Enhancements
 
@@ -858,8 +815,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @fellyph @mho22
 
-
-## [v3.0.40] (2026-01-12) 
+## [v3.0.40] (2026-01-12)
 
 ### Documentation
 
@@ -878,12 +834,11 @@ The following contributors merged PRs in this release:
 
 @adamziel @fellyph @noruzzamans
 
-
-## [v3.0.39] (2026-01-07) 
+## [v3.0.39] (2026-01-07)
 
 ### PHP WebAssembly
 
-- [CLI] Fix __dirname not defined error in intl extension. ([#3094](https://github.com/WordPress/wordpress-playground/pull/3094))
+- [CLI] Fix \_\_dirname not defined error in intl extension. ([#3094](https://github.com/WordPress/wordpress-playground/pull/3094))
 
 ### Various
 
@@ -895,13 +850,9 @@ The following contributors merged PRs in this release:
 
 @brandonpayton @iamsohilvahora
 
+## [v3.0.38] (2026-01-06)
 
-## [v3.0.38] (2026-01-06) 
-
-
-
-
-## [v3.0.37] (2026-01-06) 
+## [v3.0.37] (2026-01-06)
 
 ### PHP WebAssembly
 
@@ -922,13 +873,9 @@ The following contributors merged PRs in this release:
 
 @mho22 @noruzzamans
 
+## [v3.0.36] (2026-01-05)
 
-## [v3.0.36] (2026-01-05) 
-
-
-
-
-## [v3.0.35] (2025-12-29) 
+## [v3.0.35] (2025-12-29)
 
 ### PHP WebAssembly
 
@@ -949,8 +896,7 @@ The following contributors merged PRs in this release:
 
 @adamziel @noruzzamans @shimotmk
 
-
-## [v3.0.34] (2025-12-24) 
+## [v3.0.34] (2025-12-24)
 
 ### PHP WebAssembly
 
@@ -972,8 +918,7 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.0.33] (2025-12-22) 
+## [v3.0.33] (2025-12-22)
 
 ### Website
 
@@ -985,8 +930,7 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.0.32] (2025-12-18) 
+## [v3.0.32] (2025-12-18)
 
 ### PHP WebAssembly
 
@@ -1003,13 +947,9 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
+## [v3.0.31] (2025-12-17)
 
-## [v3.0.31] (2025-12-17) 
-
-
-
-
-## [v3.0.30] (2025-12-17) 
+## [v3.0.30] (2025-12-17)
 
 ### Documentation
 
@@ -1029,8 +969,7 @@ The following contributors merged PRs in this release:
 
 @mho22
 
-
-## [v3.0.29] (2025-12-17) 
+## [v3.0.29] (2025-12-17)
 
 ### Tools
 
@@ -1050,13 +989,9 @@ The following contributors merged PRs in this release:
 
 @adamziel @akirk
 
+## [v3.0.28] (2025-12-17)
 
-## [v3.0.28] (2025-12-17) 
-
-
-
-
-## [v3.0.27] (2025-12-16) 
+## [v3.0.27] (2025-12-16)
 
 ### Internal
 
@@ -1068,13 +1003,9 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
+## [v3.0.26] (2025-12-16)
 
-## [v3.0.26] (2025-12-16) 
-
-
-
-
-## [v3.0.25] (2025-12-16) 
+## [v3.0.25] (2025-12-16)
 
 ### Website
 
@@ -1095,8 +1026,7 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.0.24] (2025-12-16) 
+## [v3.0.24] (2025-12-16)
 
 ### Website
 
@@ -1112,8 +1042,7 @@ The following contributors merged PRs in this release:
 
 @adamziel
 
-
-## [v3.0.23] (2025-12-16) 
+## [v3.0.23] (2025-12-16)
 
 ### Enhancements
 
@@ -1176,7 +1105,6 @@ The following contributors merged PRs in this release:
 - [i18n] ja translations developer architecture. ([#3000](https://github.com/WordPress/wordpress-playground/pull/3000))
 
 ### Experiments
-
 
 #### GitHub integration
 
@@ -1248,7 +1176,7 @@ The following contributors merged PRs in this release:
 - [Docs] Fix API reference. ([#2905](https://github.com/WordPress/wordpress-playground/pull/2905))
 - [Docs] Fix documentation site build failures. ([#2913](https://github.com/WordPress/wordpress-playground/pull/2913))
 
-### 
+###
 
 - Xdebug ] Relocate `xdebug` into shared library directory. ([#3045](https://github.com/WordPress/wordpress-playground/pull/3045))
 
@@ -1274,11 +1202,9 @@ The following contributors merged PRs in this release:
 
 @adamziel @akirk @andr3ribeiro @bgrgicak @brandonpayton @epeicher @fellyph @JanJakes @jeffpaul @mho22 @shimotmk @SirLouen @Utsav-Ladani @wojtekn
 
-
-## [v3.0.22] (2025-11-17) 
+## [v3.0.22] (2025-11-17)
 
 ### Enhancements
-
 
 #### Boot Flow
 
@@ -1309,7 +1235,7 @@ The following contributors merged PRs in this release:
 - [CLI] Fix null and "latest" WP version resolution and improve unzip error message. ([#2889](https://github.com/WordPress/wordpress-playground/pull/2889))
 - [CLI] Fix run-cli leak which was revealed by repeated runCLI() calls during test. ([#2888](https://github.com/WordPress/wordpress-playground/pull/2888))
 
-### 
+###
 
 - CLI] Allow API consumers to rely upon option validation and default values. ([#2883](https://github.com/WordPress/wordpress-playground/pull/2883))
 
@@ -1329,7 +1255,6 @@ The following contributors merged PRs in this release:
 The following contributors merged PRs in this release:
 
 @adamziel @brandonpayton @fellyph @mehrazmorshed @praful2111 @shimotmk @SirLouen @Successfulsebunya
-
 
 ## [v3.0.21] (2025-11-10)
 

--- a/packages/docs/site/docs/main/changelog.md
+++ b/packages/docs/site/docs/main/changelog.md
@@ -1,6 +1,7 @@
 ---
 title: Changelog
 slug: /changelog
+format: md
 ---
 
 # Changelog
@@ -18,7 +19,7 @@ format.
 ### Various
 
 - [Docs] Update trusted publisher setup instructions. ([#3505](https://github.com/WordPress/wordpress-playground/pull/3505))
-- [PHP] Align @php-wasm/\{web,node\}-5-2 with workspace and add READMEs. ([#3506](https://github.com/WordPress/wordpress-playground/pull/3506))
+- [PHP] Align @php-wasm/{web,node}-5-2 with workspace and add READMEs. ([#3506](https://github.com/WordPress/wordpress-playground/pull/3506))
 
 ### Contributors
 


### PR DESCRIPTION
## Summary

The `chore: update changelog` bot has been failing CI on trunk since v3.1.21. Docusaurus parses `packages/docs/site/docs/main/changelog.md` as MDX, so the auto-generated entry for PR #3506 — `@php-wasm/{web,node}-5-2` — was read as a JSX expression and crashed the SSG with `ReferenceError: web is not defined`. That took out both `test-docs-api-reference` and `Deploy doc site`.

This PR treats the changelog as a markdown file, not MDX.

## Test plan

- [ ] `test-docs-api-reference` passes
- [ ] `Deploy doc site` passes