### PR TITLE
CI: suggest PR labels once on open via Copilot AI

### DIFF
--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -1,0 +1,136 @@
+name: Auto-label PRs with Copilot
+
+# Uses GitHub's Copilot-powered AI inference action to read each PR's title,
+# body, and changed file paths, then suggest labels drawn from the repo's
+# existing label set. Helpful because labels here are structured ([Type],
+# [Aspect], [Feature], [Package][@..]) and easy to forget on smaller PRs.
+#
+# The model is constrained to existing labels only — it cannot invent new ones.
+# Re-runs on edits and on every push, but only adds missing labels; it never
+# removes labels a human applied.
+
+on:
+    pull_request_target:
+        types: [opened, reopened, edited, synchronize, ready_for_review]
+
+permissions:
+    contents: read
+    pull-requests: write
+    models: read
+
+jobs:
+    suggest-labels:
+        if: github.repository == 'WordPress/wordpress-playground' && github.event.pull_request.draft == false
+        runs-on: ubuntu-latest
+        steps:
+            - name: Collect PR context
+              id: context
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+                  PR_BODY: ${{ github.event.pull_request.body }}
+              run: |
+                  set -euo pipefail
+
+                  # Pull the full label set from the repo so the model can only
+                  # choose from labels that actually exist. Excludes meta labels
+                  # that don't describe the change (Triage, Duplicate, etc.).
+                  gh label list --limit 200 --json name,description \
+                      --jq '[.[] | select(.name | test("^(Needs Triage|Duplicate|Wontfix|Help Wanted|Good First Issue|Do not merge|Blocker|Blocked|Mission-critical|\\[Priority\\]|\\[Type\\] Invalid|\\[Type\\] Question|\\[Type\\] Discussion|\\[Type\\] Idea|\\[Type\\] Tracking|\\[Type\\] Exploration|\\[Type\\] Marketing|\\[Type\\] Devrel|\\[Type\\] Community|\\[Type\\] Repo / Project Management|Breaking change|Tests|Accessibility|dependencies)") | not)]' \
+                      > /tmp/labels.json
+
+                  # File paths give the model strong signal for [Package][@..]
+                  # and [Aspect] labels — far more reliable than title parsing.
+                  gh pr view "$PR_NUMBER" --json files \
+                      --jq '[.files[].path] | .[0:200]' > /tmp/files.json
+
+                  # Existing labels: we'll merge with suggestions, never override.
+                  gh pr view "$PR_NUMBER" --json labels \
+                      --jq '[.labels[].name]' > /tmp/existing.json
+
+                  {
+                      echo "PR #${PR_NUMBER}"
+                      echo ""
+                      echo "Title: ${PR_TITLE}"
+                      echo ""
+                      echo "Body:"
+                      echo "${PR_BODY:-(empty)}"
+                      echo ""
+                      echo "Changed files:"
+                      jq -r '.[]' /tmp/files.json
+                      echo ""
+                      echo "Currently applied labels:"
+                      jq -r '.[]' /tmp/existing.json
+                      echo ""
+                      echo "Available labels (JSON):"
+                      cat /tmp/labels.json
+                  } > /tmp/prompt-input.txt
+
+                  echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+            - name: Ask Copilot for label suggestions
+              id: ai
+              uses: actions/ai-inference@v1
+              with:
+                  model: openai/gpt-4o-mini
+                  system-prompt: |
+                      You triage GitHub pull requests for the WordPress Playground monorepo.
+
+                      Given a PR's title, body, changed files, and a JSON list of available labels with descriptions, pick the labels that best describe the change.
+
+                      Rules:
+                      - Pick labels ONLY from the provided list. Never invent labels.
+                      - Pick exactly one [Type] label if the change is clearly a bug fix, enhancement, documentation update, performance work, reliability work, developer experience, or new API. Skip if unclear.
+                      - Pick [Aspect], [Feature], and [Focus] labels when they clearly apply (multiple allowed).
+                      - Pick [Package][@..] labels based on changed file paths under packages/. A file under packages/playground/website/ implies [Package][@wp-playground] Website. A file under packages/php-wasm/web/ implies [Package][@php-wasm] Web. And so on.
+                      - Prefer fewer, high-confidence labels over many uncertain ones. Aim for 1–5 labels total.
+                      - Pure i18n / translation PRs: only [Type] Documentation.
+                      - Output ONLY a JSON array of strings, no prose, no code fences. Example: ["[Type] Bug","[Package][@php-wasm] Web"]
+                  prompt-file: /tmp/prompt-input.txt
+                  max-tokens: 400
+
+            - name: Apply suggested labels
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+                  AI_RESPONSE: ${{ steps.ai.outputs.response }}
+              run: |
+                  set -euo pipefail
+
+                  # Strip code fences if the model added them despite instructions.
+                  CLEAN=$(printf '%s' "$AI_RESPONSE" | sed -E 's/^```(json)?//; s/```$//' | tr -d '\r')
+
+                  if ! echo "$CLEAN" | jq -e 'type == "array"' > /dev/null 2>&1; then
+                      echo "Model did not return a JSON array. Raw response:"
+                      echo "$AI_RESPONSE"
+                      exit 0
+                  fi
+
+                  # Intersect suggestions with the canonical label list to filter
+                  # any hallucinations that slipped past the system prompt.
+                  jq -r '.[]' /tmp/labels.json | jq -R -s -c 'split("\n") | map(select(length > 0))' > /tmp/valid.json
+                  SUGGESTED=$(echo "$CLEAN" | jq --argjson valid "$(cat /tmp/valid.json)" -c '[.[] | select(. as $l | $valid | index($l))]')
+
+                  echo "Suggested labels: $SUGGESTED"
+
+                  COUNT=$(echo "$SUGGESTED" | jq 'length')
+                  if [ "$COUNT" -eq 0 ]; then
+                      echo "No valid label suggestions. Skipping."
+                      exit 0
+                  fi
+
+                  # Add only labels not already on the PR. We never remove labels
+                  # — humans may have applied them deliberately.
+                  TO_ADD=$(jq -n --argjson s "$SUGGESTED" --slurpfile e /tmp/existing.json \
+                      '[$s[] | select(. as $l | $e[0] | index($l) | not)]')
+
+                  if [ "$(echo "$TO_ADD" | jq 'length')" -eq 0 ]; then
+                      echo "All suggested labels already applied. Nothing to do."
+                      exit 0
+                  fi
+
+                  echo "$TO_ADD" | jq -r '.[]' | while read -r label; do
+                      echo "Adding: $label"
+                      gh pr edit "$PR_NUMBER" --add-label "$label" || true
+                  done

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -6,12 +6,13 @@ name: Auto-label PRs with Copilot
 # [Aspect], [Feature], [Package][@..]) and easy to forget on smaller PRs.
 #
 # The model is constrained to existing labels only — it cannot invent new ones.
-# Re-runs on edits and on every push, but only adds missing labels; it never
-# removes labels a human applied.
+# Runs once when a PR is opened so humans stay in control afterwards: if a
+# maintainer removes an AI-applied label, we won't sneak it back in on the
+# next push or description edit.
 
 on:
     pull_request_target:
-        types: [opened, reopened, edited, synchronize, ready_for_review]
+        types: [opened]
 
 permissions:
     contents: read

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -33,11 +33,16 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  # Pull the full label set from the repo so the model can only
-                  # choose from labels that actually exist. Excludes meta labels
-                  # that don't describe the change (Triage, Duplicate, etc.).
-                  gh label list --limit 200 --json name,description \
-                      --jq '[.[] | select(.name | test("^(Needs Triage|Duplicate|Wontfix|Help Wanted|Good First Issue|Do not merge|Blocker|Blocked|Mission-critical|\\[Priority\\]|\\[Type\\] Invalid|\\[Type\\] Question|\\[Type\\] Discussion|\\[Type\\] Idea|\\[Type\\] Tracking|\\[Type\\] Exploration|\\[Type\\] Marketing|\\[Type\\] Devrel|\\[Type\\] Community|\\[Type\\] Repo / Project Management|Breaking change|Tests|Accessibility|dependencies)") | not)]' \
+                  # Pull the label set from the repo so the model can only
+                  # choose from labels that actually exist. Allow-list the four
+                  # structured families that describe the change itself —
+                  # Type / Aspect / Feature / Focus and any [Package][@..]
+                  # variant. Anything else (Priority, Triage, Discussion,
+                  # Breaking change, …) needs human judgment, so we keep it
+                  # off-limits to the model. Limit raised well above the
+                  # current ~110 labels so future additions aren't truncated.
+                  gh label list --limit 500 --json name,description \
+                      --jq '[.[] | select(.name | test("^(\\[(Type|Aspect|Feature|Focus)\\]|\\[Package\\]\\[@)"))]' \
                       > /tmp/labels.json
 
                   # File paths give the model strong signal for [Package][@..]
@@ -98,8 +103,13 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  # Strip code fences if the model added them despite instructions.
-                  CLEAN=$(printf '%s' "$AI_RESPONSE" | sed -E 's/^```(json)?//; s/```$//' | tr -d '\r')
+                  # The model is told not to wrap output in code fences, but
+                  # smaller models do it anyway. Strip any leading/trailing
+                  # ``` lines (with optional language tag and surrounding
+                  # whitespace) before handing the text to jq.
+                  CLEAN=$(printf '%s' "$AI_RESPONSE" \
+                      | tr -d '\r' \
+                      | sed -E '/^[[:space:]]*```[[:alnum:]_-]*[[:space:]]*$/d')
 
                   if ! echo "$CLEAN" | jq -e 'type == "array"' > /dev/null 2>&1; then
                       echo "Model did not return a JSON array. Raw response:"
@@ -107,9 +117,11 @@ jobs:
                       exit 0
                   fi
 
-                  # Intersect suggestions with the canonical label list to filter
-                  # any hallucinations that slipped past the system prompt.
-                  jq -r '.[]' /tmp/labels.json | jq -R -s -c 'split("\n") | map(select(length > 0))' > /tmp/valid.json
+                  # Intersect suggestions with the canonical label list to
+                  # drop any hallucinations that slipped past the system
+                  # prompt. labels.json is an array of {name, description}
+                  # objects — pick out the names so we can compare strings.
+                  jq -c 'map(.name)' /tmp/labels.json > /tmp/valid.json
                   SUGGESTED=$(echo "$CLEAN" | jq --argjson valid "$(cat /tmp/valid.json)" -c '[.[] | select(. as $l | $valid | index($l))]')
 
                   echo "Suggested labels: $SUGGESTED"


### PR DESCRIPTION
About 40% of recently merged PRs ship without any of the structured `[Type]`, `[Aspect]`, `[Feature]`, or `[Package][@..]` labels we rely on for changelog grouping and triage. This workflow gives every new PR a starting set of suggested labels from GitHub's Copilot-powered AI inference action, so the labels are there by the time a human looks.

## How it works

- Triggers **once**, on `pull_request_target: opened`. No re-runs on edits, pushes, or `ready_for_review` — humans stay in control after the first pass.
- Sends the model the PR title, body, and changed file paths plus a JSON list of available labels. The label set is allow-listed to the four structured families — `[Type]`, `[Aspect]`, `[Feature]`, `[Focus]`, and `[Package][@..]` — so Priority, Triage, Discussion, Breaking change, and any future meta labels stay off-limits to the AI by default.
- Validates the model's JSON response against the canonical label list to drop hallucinations, then applies only labels not already present. Never removes labels.
- Runs only on `WordPress/wordpress-playground` so forks don't trigger it. Skipped on draft PRs.

## Behaviour with manual labels

- Apply a label before the workflow finishes? It's preserved.
- Remove an AI-applied label after the fact? It stays removed — the workflow doesn't re-fire.
- Add labels manually instead of letting the AI suggest? The workflow won't argue.

cc @fellyph — would love your eyes on the prompt and the allow-list before we turn this on.

## Test plan

- [ ] Open a few test PRs touching different areas (a docs change, a `packages/php-wasm/web` change, a `packages/playground/website` change) and confirm the suggested labels make sense
- [ ] Remove an AI-applied label and push a new commit — confirm the label stays removed
- [ ] Confirm the workflow is a no-op on draft PRs and on forks of the repo