### PR TITLE
Docs: escape MDX braces in changelog body

### DIFF
--- a/packages/docs/site/bin/refresh-changelog.ts
+++ b/packages/docs/site/bin/refresh-changelog.ts
@@ -11,11 +11,15 @@ const existingContent = fs.readFileSync(destinationPath, 'utf-8');
 const frontmatterRegex = /^---\n([\s\S]*?)\n---/;
 const existingFrontmatter = existingContent.match(frontmatterRegex)?.[0] || '';
 
-// The destination file's frontmatter sets `format: md` so Docusaurus parses
-// it as plain CommonMark instead of MDX. Without that, unescaped `{...}` or
-// `<...>` in PR titles (e.g. `@php-wasm/{web,node}-5-2`) would be treated as
-// JSX and crash the build.
-const changelogWithFrontmatter = existingFrontmatter + '\n\n' + changelog;
+// Docusaurus 3 parses `.md` files through the MDX pipeline, so unescaped
+// `{` / `}` in PR titles (e.g. `@php-wasm/{web,node}-5-2`) get read as JSX
+// expressions and crash the SSG with `ReferenceError: web is not defined`.
+// The destination file's frontmatter sets `format: md` as a hint, but that
+// alone has not been enough in practice — escape the braces directly so the
+// content is inert regardless of how Docusaurus parses it.
+const escapedChangelog = changelog.replace(/[{}]/g, (c) => '\\' + c);
+const changelogWithFrontmatter =
+	existingFrontmatter + '\n\n' + escapedChangelog;
 
 // Write the modified changelog to the destination file
 fs.writeFileSync(destinationPath, changelogWithFrontmatter, 'utf-8');

--- a/packages/docs/site/docs/main/changelog.md
+++ b/packages/docs/site/docs/main/changelog.md
@@ -19,7 +19,7 @@ format.
 ### Various
 
 - [Docs] Update trusted publisher setup instructions. ([#3505](https://github.com/WordPress/wordpress-playground/pull/3505))
-- [PHP] Align @php-wasm/{web,node}-5-2 with workspace and add READMEs. ([#3506](https://github.com/WordPress/wordpress-playground/pull/3506))
+- [PHP] Align @php-wasm/\{web,node\}-5-2 with workspace and add READMEs. ([#3506](https://github.com/WordPress/wordpress-playground/pull/3506))
 
 ### Contributors
 


### PR DESCRIPTION
## What happened

#3531 tried to fix the broken docs build by telling Docusaurus to parse `changelog.md` as plain CommonMark instead of MDX — adding a `format: md` frontmatter to the file. The hope was that Docusaurus would then leave `{` / `}` / `<…>` in PR titles alone.

It didn't work. The CI run on trunk for that exact commit still crashed during SSG with:

```
ReferenceError: web is not defined
  at _createMdxContent (server.bundle.js:17281:47)
```

…on `@php-wasm/{web,node}-5-2`. Docusaurus 3.9.2 ran the file through the MDX pipeline anyway, so `test-docs-api-reference` and `Deploy doc site` are still red on trunk.

I don't fully understand why `format: md` was ignored here — it might need a global `markdown.format` setting, a different file extension, or it may simply not behave the way the docs imply in this version. Worth a follow-up, but trunk needs to be green now.

## This PR (workaround)

Stop relying on Docusaurus mode and make the content itself inert:

- `refresh-changelog.ts` now backslash-escapes `{` and `}` in the copied changelog body, so future PR titles with braces stay safe regardless of how Docusaurus parses the file.
- The currently-broken v3.1.21 entry is escaped directly to unbreak trunk immediately.

## Test plan

- [ ] `test-docs-api-reference` passes
- [ ] `Deploy doc site` passes