### PR TITLE
[Website] <php-snippet> setup blueprints via <template>

### DIFF
--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -90,6 +90,40 @@ Every later Run — on the same snippet or any other — calls `client.run({ cod
 
 While the boot is in progress, every snippet that has its Run clicked shows the same staged progress bar (download → install → ready) drawn from the live progress events Playground emits internally.
 
+### Sharing setup across snippets
+
+If several snippets need the same baseline — a mu-plugin, a couple of files, a configured option — drop a single `<template>` on the page that contains a JSON [Blueprint](/blueprints/), and point each snippet at it with a `setup` attribute:
+
+```html
+<template id="toolkit-setup" data-php-snippet-blueprint>
+{
+  "steps": [
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/toolkit.php",
+      "data": "<?php\nfunction toolkit_say($s) { return strtoupper($s); }"
+    }
+  ]
+}
+</template>
+
+<php-snippet name="a.php" setup="toolkit-setup">
+  <script type="application/x-php">
+<?php require '/wordpress/wp-load.php'; echo toolkit_say('hello');
+  </script>
+</php-snippet>
+
+<php-snippet name="b.php" setup="toolkit-setup">
+  <script type="application/x-php">
+<?php require '/wordpress/wp-load.php'; echo toolkit_say('world');
+  </script>
+</php-snippet>
+```
+
+Browsers don't render or execute `<template>` content, so the JSON sits inert until the component reads it. The blueprint is JSON-stringified and folded into the runtime cache key, so two snippets with the same `setup` share one runtime boot. Two snippets with different `setup` values get separate runtimes — usually what you want.
+
+The `setup` attribute accepts either an id or any CSS selector.
+
 ### Editable snippets
 
 Add the `editable` attribute and visitors can tweak the code before clicking Run. The keystrokes go into a transparent textarea overlaid on the highlighted code, so the syntax colors update as they type.
@@ -115,6 +149,7 @@ Useful for "now you try" sections in tutorials, or for letting readers experimen
 | `wp`                 | `latest`                             | WordPress version                             |
 | `src`                | —                                    | Load PHP from a URL instead of inline         |
 | `editable`           | (off)                                | Let visitors edit the code before running     |
+| `setup`              | —                                    | Id or CSS selector of a `<template>` containing a JSON Blueprint to run before the snippet |
 | `playground-origin`  | `https://playground.wordpress.net`   | Override the runtime origin (local dev, etc.) |
 
 Snippets that share the same `php`, `wp`, and `playground-origin` values share one runtime; mixing different versions on the same page boots a separate runtime per combination.

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -124,6 +124,10 @@ Browsers don't render or execute `<template>` content, so the JSON sits inert un
 
 The `setup` attribute accepts either an id or any CSS selector.
 
+:::caution
+HTML still applies its parser to the contents of a `<template>`. If your blueprint string contains a literal `<?` (for example a `writeFile` step that drops `<?php` into a PHP file), the HTML parser treats `<?` as the start of a bogus comment and consumes everything up to the next `>` — which can swallow the closing `</template>` tag and break the page. Escape the `<` as `\u003c` in your JSON: `"data": "\u003c?php …"`. The JSON parser turns it back into `<` at runtime.
+:::
+
 ### Editable snippets
 
 Add the `editable` attribute and visitors can tweak the code before clicking Run. The keystrokes go into a transparent textarea overlaid on the highlighted code, so the syntax colors update as they type.

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -90,12 +90,12 @@ Every later Run — on the same snippet or any other — calls `client.run({ cod
 
 While the boot is in progress, every snippet that has its Run clicked shows the same staged progress bar (download → install → ready) drawn from the live progress events Playground emits internally.
 
-### Sharing setup across snippets
+### Sharing a blueprint across snippets
 
-If several snippets need the same baseline — a mu-plugin, a couple of files, a configured option — drop a single `<script type="application/json">` on the page that contains a JSON [Blueprint](/blueprints/), and point each snippet at it with a `setup` attribute:
+If several snippets need the same baseline — a mu-plugin, a couple of files, a configured option — drop a single `<script type="application/json">` on the page that contains a JSON [Blueprint](/blueprints/), and point each snippet at it with a `blueprint` attribute:
 
 ```html
-<script id="toolkit-setup" type="application/json">
+<script id="toolkit" type="application/json">
 {
   "steps": [
     {
@@ -107,22 +107,22 @@ If several snippets need the same baseline — a mu-plugin, a couple of files, a
 }
 </script>
 
-<php-snippet name="a.php" setup="toolkit-setup">
+<php-snippet name="a.php" blueprint="toolkit">
   <script type="application/x-php">
 <?php require '/wordpress/wp-load.php'; echo toolkit_say('hello');
   </script>
 </php-snippet>
 
-<php-snippet name="b.php" setup="toolkit-setup">
+<php-snippet name="b.php" blueprint="toolkit">
   <script type="application/x-php">
 <?php require '/wordpress/wp-load.php'; echo toolkit_say('world');
   </script>
 </php-snippet>
 ```
 
-Browsers don't execute scripts whose `type` they don't recognize, so the JSON sits inert until the component reads it. The blueprint is JSON-stringified and folded into the runtime cache key, so two snippets with the same `setup` share one runtime boot. Two snippets with different `setup` values get separate runtimes — usually what you want.
+Browsers don't execute scripts whose `type` they don't recognize, so the JSON sits inert until the component reads it. The blueprint is JSON-stringified and folded into the runtime cache key, so two snippets with the same `blueprint` share one runtime boot. Two snippets with different `blueprint` values get separate runtimes — usually what you want.
 
-The `setup` attribute accepts either an id or any CSS selector. Any element will do — `<script type="application/json">` is recommended because the HTML parser treats its contents as raw text, so a literal `<?php` inside the JSON is harmless. A `<template>` works too, but its content is parsed as HTML, and the `<?` in `<?php` is treated as the start of a bogus comment that runs to the next `>`. That can swallow the closing `</template>` and quietly break the page. If you do use a `<template>`, escape `<` as `\u003c` in the JSON.
+The `blueprint` attribute accepts either an id or any CSS selector. Any element will do — `<script type="application/json">` is recommended because the HTML parser treats its contents as raw text, so a literal `<?php` inside the JSON is harmless. A `<template>` works too, but its content is parsed as HTML, and the `<?` in `<?php` is treated as the start of a bogus comment that runs to the next `>`. That can swallow the closing `</template>` and quietly break the page. If you do use a `<template>`, escape `<` as `\u003c` in the JSON.
 
 ### Editable snippets
 
@@ -149,7 +149,7 @@ Useful for "now you try" sections in tutorials, or for letting readers experimen
 | `wp`                 | `latest`                             | WordPress version                             |
 | `src`                | —                                    | Load PHP from a URL instead of inline         |
 | `editable`           | (off)                                | Let visitors edit the code before running     |
-| `setup`              | —                                    | Id or CSS selector of a `<script type="application/json">` (or `<template>`) containing a JSON Blueprint to run before the snippet |
+| `blueprint`          | —                                    | Id or CSS selector of a `<script type="application/json">` (or `<template>`) containing a JSON Blueprint to run before the snippet |
 | `playground-origin`  | `https://playground.wordpress.net`   | Override the runtime origin (local dev, etc.) |
 
 Snippets that share the same `php`, `wp`, and `playground-origin` values share one runtime; mixing different versions on the same page boots a separate runtime per combination.

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -92,10 +92,10 @@ While the boot is in progress, every snippet that has its Run clicked shows the 
 
 ### Sharing setup across snippets
 
-If several snippets need the same baseline — a mu-plugin, a couple of files, a configured option — drop a single `<template>` on the page that contains a JSON [Blueprint](/blueprints/), and point each snippet at it with a `setup` attribute:
+If several snippets need the same baseline — a mu-plugin, a couple of files, a configured option — drop a single `<script type="application/json">` on the page that contains a JSON [Blueprint](/blueprints/), and point each snippet at it with a `setup` attribute:
 
 ```html
-<template id="toolkit-setup" data-php-snippet-blueprint>
+<script id="toolkit-setup" type="application/json">
 {
   "steps": [
     {
@@ -105,7 +105,7 @@ If several snippets need the same baseline — a mu-plugin, a couple of files, a
     }
   ]
 }
-</template>
+</script>
 
 <php-snippet name="a.php" setup="toolkit-setup">
   <script type="application/x-php">
@@ -120,13 +120,9 @@ If several snippets need the same baseline — a mu-plugin, a couple of files, a
 </php-snippet>
 ```
 
-Browsers don't render or execute `<template>` content, so the JSON sits inert until the component reads it. The blueprint is JSON-stringified and folded into the runtime cache key, so two snippets with the same `setup` share one runtime boot. Two snippets with different `setup` values get separate runtimes — usually what you want.
+Browsers don't execute scripts whose `type` they don't recognize, so the JSON sits inert until the component reads it. The blueprint is JSON-stringified and folded into the runtime cache key, so two snippets with the same `setup` share one runtime boot. Two snippets with different `setup` values get separate runtimes — usually what you want.
 
-The `setup` attribute accepts either an id or any CSS selector.
-
-:::caution
-HTML still applies its parser to the contents of a `<template>`. If your blueprint string contains a literal `<?` (for example a `writeFile` step that drops `<?php` into a PHP file), the HTML parser treats `<?` as the start of a bogus comment and consumes everything up to the next `>` — which can swallow the closing `</template>` tag and break the page. Escape the `<` as `\u003c` in your JSON: `"data": "\u003c?php …"`. The JSON parser turns it back into `<` at runtime.
-:::
+The `setup` attribute accepts either an id or any CSS selector. Any element will do — `<script type="application/json">` is recommended because the HTML parser treats its contents as raw text, so a literal `<?php` inside the JSON is harmless. A `<template>` works too, but its content is parsed as HTML, and the `<?` in `<?php` is treated as the start of a bogus comment that runs to the next `>`. That can swallow the closing `</template>` and quietly break the page. If you do use a `<template>`, escape `<` as `\u003c` in the JSON.
 
 ### Editable snippets
 
@@ -153,7 +149,7 @@ Useful for "now you try" sections in tutorials, or for letting readers experimen
 | `wp`                 | `latest`                             | WordPress version                             |
 | `src`                | —                                    | Load PHP from a URL instead of inline         |
 | `editable`           | (off)                                | Let visitors edit the code before running     |
-| `setup`              | —                                    | Id or CSS selector of a `<template>` containing a JSON Blueprint to run before the snippet |
+| `setup`              | —                                    | Id or CSS selector of a `<script type="application/json">` (or `<template>`) containing a JSON Blueprint to run before the snippet |
 | `playground-origin`  | `https://playground.wordpress.net`   | Override the runtime origin (local dev, etc.) |
 
 Snippets that share the same `php`, `wp`, and `playground-origin` values share one runtime; mixing different versions on the same page boots a separate runtime per combination.

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -113,7 +113,7 @@ test.describe('php-code-snippet embed', () => {
 		expect(runtimeIframes).toBe(1);
 	});
 
-	test('snippets sharing a setup template share one runtime and see its mu-plugin', async ({
+	test('snippets sharing a blueprint share one runtime and see its mu-plugin', async ({
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
@@ -136,10 +136,10 @@ test.describe('php-code-snippet embed', () => {
 
 		// Both snippets resolved to the same blueprint hash, so only one
 		// runtime iframe exists for this {origin, php, wp, blueprint} key.
-		const setupIframes = await page
+		const blueprintIframes = await page
 			.locator('iframe[title="PHP Snippet runtime"]')
 			.count();
-		expect(setupIframes).toBe(1);
+		expect(blueprintIframes).toBe(1);
 	});
 
 	test('editable snippet runs the user-typed code', async ({ page }) => {

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -20,6 +20,8 @@ test.describe('php-code-snippet embed', () => {
 			'hello.php',
 			'lazy-load-images.php',
 			'parse-blocks.php',
+			'greet-alice.php',
+			'greet-bob.php',
 			'scratch.php',
 		]) {
 			const snippet = page.locator(`php-snippet[name="${name}"]`);
@@ -109,6 +111,35 @@ test.describe('php-code-snippet embed', () => {
 			.locator('iframe[title="PHP Snippet runtime"]')
 			.count();
 		expect(runtimeIframes).toBe(1);
+	});
+
+	test('snippets sharing a setup template share one runtime and see its mu-plugin', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const alice = page.locator('php-snippet[name="greet-alice.php"]');
+		const bob = page.locator('php-snippet[name="greet-bob.php"]');
+
+		await alice.locator('.run').click();
+		await expect(alice.locator('.output')).toBeVisible({
+			timeout: 240_000,
+		});
+		await expect(alice.locator('.output-body')).toContainText(
+			'Hello, Alice!'
+		);
+
+		await bob.locator('.run').click();
+		await expect(bob.locator('.output')).toBeVisible({ timeout: 60_000 });
+		await expect(bob.locator('.output-body')).toContainText(
+			'Hello, Bob!'
+		);
+
+		// Both snippets resolved to the same blueprint hash, so only one
+		// runtime iframe exists for this {origin, php, wp, blueprint} key.
+		const setupIframes = await page
+			.locator('iframe[title="PHP Snippet runtime"]')
+			.count();
+		expect(setupIframes).toBe(1);
 	});
 
 	test('editable snippet runs the user-typed code', async ({ page }) => {

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -111,7 +111,7 @@ foreach ( $blocks as $block ) {
 					{
 						"step": "writeFile",
 						"path": "/wordpress/wp-content/mu-plugins/greeter.php",
-						"data": "<?php\nfunction greeter_say($name) { return 'Hello, ' . $name . '!'; }"
+						"data": "\u003c?php\nfunction greeter_say($name) { return 'Hello, ' . $name . '!'; }"
 					}
 				]
 			}

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -99,7 +99,41 @@ foreach ( $blocks as $block ) {
 			</script>
 		</php-snippet>
 
-		<h2>4. Editable</h2>
+		<h2>4. Shared setup via &lt;template&gt;</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
+			Two snippets reference the same blueprint by id, so their
+			runtime is booted once with a pre-installed mu-plugin.
+		</p>
+
+		<template id="greeter-setup" data-php-snippet-blueprint>
+			{
+				"steps": [
+					{
+						"step": "writeFile",
+						"path": "/wordpress/wp-content/mu-plugins/greeter.php",
+						"data": "<?php\nfunction greeter_say($name) { return 'Hello, ' . $name . '!'; }"
+					}
+				]
+			}
+		</template>
+
+		<php-snippet name="greet-alice.php" setup="greeter-setup">
+			<script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+echo greeter_say('Alice');
+			</script>
+		</php-snippet>
+
+		<php-snippet name="greet-bob.php" setup="greeter-setup">
+			<script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+echo greeter_say('Bob');
+			</script>
+		</php-snippet>
+
+		<h2>5. Editable</h2>
 		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
 			Type into the snippet, then click Run.
 		</p>

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -99,23 +99,25 @@ foreach ( $blocks as $block ) {
 			</script>
 		</php-snippet>
 
-		<h2>4. Shared setup via &lt;template&gt;</h2>
+		<h2>4. Shared setup via JSON script</h2>
 		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
 			Two snippets reference the same blueprint by id, so their
 			runtime is booted once with a pre-installed mu-plugin.
+			Using <code>&lt;script type="application/json"&gt;</code> lets
+			the JSON contain literal <code>&lt;?php</code> without escaping.
 		</p>
 
-		<template id="greeter-setup" data-php-snippet-blueprint>
+		<script id="greeter-setup" type="application/json">
 			{
 				"steps": [
 					{
 						"step": "writeFile",
 						"path": "/wordpress/wp-content/mu-plugins/greeter.php",
-						"data": "\u003c?php\nfunction greeter_say($name) { return 'Hello, ' . $name . '!'; }"
+						"data": "<?php\nfunction greeter_say($name) { return 'Hello, ' . $name . '!'; }"
 					}
 				]
 			}
-		</template>
+		</script>
 
 		<php-snippet name="greet-alice.php" setup="greeter-setup">
 			<script type="application/x-php">

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -99,7 +99,7 @@ foreach ( $blocks as $block ) {
 			</script>
 		</php-snippet>
 
-		<h2>4. Shared setup via JSON script</h2>
+		<h2>4. Shared blueprint via JSON script</h2>
 		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
 			Two snippets reference the same blueprint by id, so their
 			runtime is booted once with a pre-installed mu-plugin.
@@ -107,7 +107,7 @@ foreach ( $blocks as $block ) {
 			the JSON contain literal <code>&lt;?php</code> without escaping.
 		</p>
 
-		<script id="greeter-setup" type="application/json">
+		<script id="greeter-blueprint" type="application/json">
 			{
 				"steps": [
 					{
@@ -119,7 +119,7 @@ foreach ( $blocks as $block ) {
 			}
 		</script>
 
-		<php-snippet name="greet-alice.php" setup="greeter-setup">
+		<php-snippet name="greet-alice.php" blueprint="greeter-blueprint">
 			<script type="application/x-php">
 <?php
 require '/wordpress/wp-load.php';
@@ -127,7 +127,7 @@ echo greeter_say('Alice');
 			</script>
 		</php-snippet>
 
-		<php-snippet name="greet-bob.php" setup="greeter-setup">
+		<php-snippet name="greet-bob.php" blueprint="greeter-blueprint">
 			<script type="application/x-php">
 <?php
 require '/wordpress/wp-load.php';

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -29,10 +29,10 @@
  *   editable              make the snippet editable; visitors type into a
  *                         transparent textarea overlaid on the highlighted
  *                         code, and Run executes whatever they typed
- *   setup="my-blueprint"  CSS-selector-or-id of a JSON Blueprint container
+ *   blueprint="toolkit"  CSS-selector-or-id of a JSON Blueprint container
  *                         on the page (a <script type="application/json"> is
  *                         recommended; <template> works too). Snippets that
- *                         share the same setup share one runtime — the
+ *                         share the same blueprint share one runtime — the
  *                         blueprint is JSON-stringified and folded into the
  *                         cache key.
  *   playground-origin="https://playground.wordpress.net"
@@ -236,7 +236,7 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 }
 
 /**
- * Resolve a snippet's `setup` attribute to a Blueprint object.
+ * Resolve a snippet's `blueprint` attribute to a Blueprint object.
  *
  * The lookup tries in order: a CSS selector, then `getElementById`, then
  * (if neither matched) returns null. The element is expected to be a
@@ -245,7 +245,7 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
  * blueprints into a single runtime boot.
  */
 function resolveSetupBlueprint(snippet) {
-	const ref = snippet.getAttribute('setup');
+	const ref = snippet.getAttribute('blueprint');
 	if (!ref) return { blueprint: null, key: '' };
 	let el = null;
 	try {
@@ -256,7 +256,7 @@ function resolveSetupBlueprint(snippet) {
 	if (!el) el = snippet.ownerDocument.getElementById(ref);
 	if (!el) {
 		throw new Error(
-			`<php-snippet setup="${ref}"> could not find a matching element on the page.`
+			`<php-snippet blueprint="${ref}"> could not find a matching element on the page.`
 		);
 	}
 	const source =
@@ -268,7 +268,7 @@ function resolveSetupBlueprint(snippet) {
 		blueprint = JSON.parse(text);
 	} catch (err) {
 		throw new Error(
-			`<php-snippet setup="${ref}"> contains invalid JSON: ${err.message}`
+			`<php-snippet blueprint="${ref}"> contains invalid JSON: ${err.message}`
 		);
 	}
 	// Stable stringification — the JSON object's textual form is the cache

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -29,6 +29,10 @@
  *   editable              make the snippet editable; visitors type into a
  *                         transparent textarea overlaid on the highlighted
  *                         code, and Run executes whatever they typed
+ *   setup="my-blueprint"  CSS-selector-or-id of a <template> on the page
+ *                         containing a JSON Blueprint. Snippets that share
+ *                         the same setup share one runtime — the blueprint
+ *                         is JSON-stringified and folded into the cache key.
  *   playground-origin="https://playground.wordpress.net"
  *                         override the runtime origin (useful for local dev)
  */
@@ -136,8 +140,11 @@ class ProgressTracker extends EventTarget {
  */
 const runtimes = new Map();
 
-async function getSharedClient({ origin, php, wp }, onProgress) {
-	const key = `${origin}|${php}|${wp}`;
+async function getSharedClient(
+	{ origin, php, wp, blueprint, blueprintKey },
+	onProgress
+) {
+	const key = `${origin}|${php}|${wp}|${blueprintKey}`;
 	let entry = runtimes.get(key);
 
 	if (entry && entry.client) {
@@ -157,14 +164,15 @@ async function getSharedClient({ origin, php, wp }, onProgress) {
 			}
 		});
 		entry = { tracker, subscribers, client: null, promise: null };
-		entry.promise = bootRuntime({ origin, php, wp }, entry).catch(
-			(err) => {
-				// Drop the failed entry so a future Run can retry from scratch
-				// instead of forever awaiting the same rejected promise.
-				runtimes.delete(key);
-				throw err;
-			}
-		);
+		entry.promise = bootRuntime(
+			{ origin, php, wp, blueprint },
+			entry
+		).catch((err) => {
+			// Drop the failed entry so a future Run can retry from scratch
+			// instead of forever awaiting the same rejected promise.
+			runtimes.delete(key);
+			throw err;
+		});
 		runtimes.set(key, entry);
 	} else {
 		// Boot in flight — replay the latest progress so a late-arriving
@@ -183,7 +191,7 @@ async function getSharedClient({ origin, php, wp }, onProgress) {
 	}
 }
 
-async function bootRuntime({ origin, php, wp }, entry) {
+async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 	const { startPlaygroundWeb } = await import(
 		/* @vite-ignore */ `${origin}/client/index.js`
 	);
@@ -199,11 +207,73 @@ async function bootRuntime({ origin, php, wp }, entry) {
 		remoteUrl: iframe.src,
 		disableProgressBar: true,
 		progressTracker: entry.tracker,
-		blueprint: { preferredVersions: { php, wp } },
+		blueprint: {
+			...(blueprint || {}),
+			preferredVersions: { php, wp },
+		},
 	});
 	await client.isReady;
 	entry.client = client;
 	return client;
+}
+
+/**
+ * Resolve a snippet's `setup` attribute to a Blueprint object.
+ *
+ * The lookup tries in order: a CSS selector, then `getElementById`, then
+ * (if neither matched) returns null. The element is expected to be a
+ * <template> whose textContent is a JSON Blueprint. The text is parsed
+ * once per snippet but the resulting cache key collapses identical
+ * blueprints into a single runtime boot.
+ */
+function resolveSetupBlueprint(snippet) {
+	const ref = snippet.getAttribute('setup');
+	if (!ref) return { blueprint: null, key: '' };
+	let el = null;
+	try {
+		el = snippet.ownerDocument.querySelector(ref);
+	} catch {
+		// Invalid selector — fall through to getElementById.
+	}
+	if (!el) el = snippet.ownerDocument.getElementById(ref);
+	if (!el) {
+		throw new Error(
+			`<php-snippet setup="${ref}"> could not find a matching element on the page.`
+		);
+	}
+	const source =
+		el.tagName === 'TEMPLATE' ? el.content.textContent : el.textContent;
+	const text = (source || '').trim();
+	if (!text) return { blueprint: null, key: '' };
+	let blueprint;
+	try {
+		blueprint = JSON.parse(text);
+	} catch (err) {
+		throw new Error(
+			`<php-snippet setup="${ref}"> contains invalid JSON: ${err.message}`
+		);
+	}
+	// Stable stringification — the JSON object's textual form is the cache
+	// key suffix. Two snippets that point at the same <template> end up with
+	// the same string, hence the same key, hence one shared runtime.
+	return { blueprint, key: stableStringify(blueprint) };
+}
+
+function stableStringify(value) {
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value);
+	}
+	if (Array.isArray(value)) {
+		return '[' + value.map(stableStringify).join(',') + ']';
+	}
+	const keys = Object.keys(value).sort();
+	return (
+		'{' +
+		keys
+			.map((k) => JSON.stringify(k) + ':' + stableStringify(value[k]))
+			.join(',') +
+		'}'
+	);
 }
 
 /**
@@ -638,6 +708,8 @@ class PhpSnippet extends HTMLElement {
 		fill.style.width = '0%';
 		percent.textContent = '0%';
 		try {
+			const { blueprint, key: blueprintKey } =
+				resolveSetupBlueprint(this);
 			const client = await getSharedClient(
 				{
 					origin:
@@ -645,6 +717,8 @@ class PhpSnippet extends HTMLElement {
 						DEFAULT_ORIGIN,
 					php: this.getAttribute('php') || DEFAULT_PHP,
 					wp: this.getAttribute('wp') || DEFAULT_WP,
+					blueprint,
+					blueprintKey,
 				},
 				({ progress: pct, caption: cap }) => {
 					const rounded = Math.round(pct);

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -29,10 +29,12 @@
  *   editable              make the snippet editable; visitors type into a
  *                         transparent textarea overlaid on the highlighted
  *                         code, and Run executes whatever they typed
- *   setup="my-blueprint"  CSS-selector-or-id of a <template> on the page
- *                         containing a JSON Blueprint. Snippets that share
- *                         the same setup share one runtime — the blueprint
- *                         is JSON-stringified and folded into the cache key.
+ *   setup="my-blueprint"  CSS-selector-or-id of a JSON Blueprint container
+ *                         on the page (a <script type="application/json"> is
+ *                         recommended; <template> works too). Snippets that
+ *                         share the same setup share one runtime — the
+ *                         blueprint is JSON-stringified and folded into the
+ *                         cache key.
  *   playground-origin="https://playground.wordpress.net"
  *                         override the runtime origin (useful for local dev)
  */

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -95,10 +95,26 @@ class ProgressTracker extends EventTarget {
 	}
 	setCaption(c) { this._selfCaption = c; this._notify(); }
 	finish() {
+		if (this._fillInterval) {
+			clearInterval(this._fillInterval);
+			this._fillInterval = null;
+		}
+		this._isFilling = false;
 		this._selfDone = true;
 		this._selfProgress = 100;
 		this._notify();
 		this._notifyDone();
+	}
+	fillSlowly({ stopBeforeFinishing = true } = {}) {
+		if (this._isFilling) return;
+		this._isFilling = true;
+		this._fillInterval = setInterval(() => {
+			this.set(this._selfProgress + 1);
+			if (stopBeforeFinishing && this._selfProgress >= 99) {
+				clearInterval(this._fillInterval);
+				this._fillInterval = null;
+			}
+		}, 40);
 	}
 	pipe(receiver) {
 		receiver.setProgress({ progress: this.progress, caption: this.caption });


### PR DESCRIPTION

# Inline blueprint, defined once, referenced by id

Use a `<script type="application/json">` element on the page as the blueprint definition, and have each snippet point at it by id. Inline (no external URL), defined once, deduped automatically.

## Shape

```html
<script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>

<script id="blueprint-toolkit" type="application/json">
{
  "steps": [
    {
      "step": "writeFile",
      "path": "/wordpress/wp-content/mu-plugins/php-toolkit.php",
      "data": "<?php\nspl_autoload_register(function ($class) { /* …classmap inline… */ });"
    }
  ]
}
</script>

<php-snippet blueprint="blueprint-toolkit" name="create-zip.php">
  <script type="application/x-php">
<?php
use WordPress\Zip\ZipEncoder;
$enc = new ZipEncoder( new BufferedWriteStream() );
…
  </script>
</php-snippet>

<php-snippet blueprint="blueprint-toolkit" name="read-zip.php">
  <script type="application/x-php">…</script>
</php-snippet>
```

## Why `<script type="application/json">`

- The HTML parser treats script content as raw text until `</script>`, so a literal `<?php` inside the JSON is harmless. No escaping, no surprises.
- `type="application/json"` tells browsers "don't execute this", so the JSON sits inert until the component reads it. Same pattern as JSON-LD, Twitter widgets, and most other "embedded data" widgets.
- Multiple references collapse to one cache key — all snippets pointing at the same blueprint share one runtime boot.

A `<template>` works too (the component reads `el.tagName === 'TEMPLATE' ? el.content.textContent : el.textContent`), but `<template>` content is parsed as HTML and a literal `<?php` opens a bogus comment that runs to the next `>`, often eating the closing `</template>` and quietly breaking the page. `<script type="application/json">` avoids the footgun entirely.

## Resolution rule for the component

Today this PR ships only the first row. The rest is the intended trajectory:

```
blueprint="toolkit"            → look up element by id (or CSS selector)
inline blueprint child         → read directly                     [future]
blueprint-json="…"             → parse attribute                    [future]
auto-prepend / mount sugar     → expand to a synthesized blueprint  [future]
(none)                          → no-op, behavior unchanged
```

Multiple sources merge in that order; the final object is JSON-stringified (with sorted keys for determinism) and folded into the runtime cache key. So:

- 5 snippets, all `blueprint="toolkit"` → 1 hash → 1 boot.
- 5 snippets, 4 with `blueprint="a"` and 1 with `blueprint="b"` → 2 hashes → 2 boots (probably what you want).

## Why I'd reach for this over the alternatives

- **Per-snippet inline blueprint:** verbose, easy to drift out of sync between snippets, payload bloat. Hash-based dedup saves the runtime cost but not the page weight or maintainability.
- **Wrapper element (`<php-snippet-group>`):** forces nesting, breaks linear reading order in source, and authors tend to want snippets interleaved with prose anyway.
- **Page-level `<meta>` default:** hidden coupling — a reader of the snippet HTML can't tell where the toolkit comes from.

The `<script type="application/json">` pattern keeps the blueprint visible, inline, defined once, and explicitly referenced by every snippet that needs it.

## Bonus: the autoloader without external URLs

Since the blueprint's `writeFile.data` is a string, you can embed the toolkit's autoloader (and a small classmap) directly in the script. That makes the entire docs page self-contained — no `cdn.jsdelivr.net`, no `raw.githubusercontent.com`, no network beyond Playground itself. A small `bin/build-snippet-blueprint.php` in the repo would generate the script tag once at release time.

## What's in the patch

- `blueprint` attribute on `<php-snippet>`. Resolves via `querySelector` first, then `getElementById`. Works with `<script type="application/json">` (recommended) or `<template>`.
- Cache key extended from `${origin}|${php}|${wp}` to `${origin}|${php}|${wp}|${stableJSON(blueprint)}`. Stable stringification sorts object keys so equivalent blueprints fold to the same key.
- Two demo snippets at `/website-server/php-code-snippet-demo.html` (`greet-alice.php` + `greet-bob.php`) sharing one `<script id="greeter-blueprint">` mu-plugin.
- Playwright test that runs both, checks they each see the mu-plugin's function, and asserts the page only ever has one runtime iframe.
- `fillSlowly()` added to the duck-typed `ProgressTracker` so the Blueprint executor doesn't crash mid-step.
- Guide section in `/guides/php-code-snippets`.

## Try it

```bash
npm run dev
open http://127.0.0.1:5400/website-server/php-code-snippet-demo.html
```

Click Run on Alice, then Bob — Bob's run reuses Alice's runtime and still sees `greeter_say()`.