### PR TITLE
[Blueprint] Support .git repository URLs

### DIFF
--- a/packages/docs/site/docs/blueprints/04-resources.md
+++ b/packages/docs/site/docs/blueprints/04-resources.md
@@ -88,6 +88,7 @@ type GitDirectoryReference = {
 
 - When using a branch or tag name for `ref`, you must specify `refType` (e.g. `"refType": "branch"`). Without it, only `HEAD` is reliably resolved.
 - Playground automatically detects providers like GitHub and GitLab.
+- Repository URLs may include or omit a trailing `.git` suffix. Extra trailing slashes are ignored.
 - It handles CORS-proxied fetches and sparse checkouts, so you can use URLs that point to specific subdirectories or branches.
 - This resource can be used with steps like [`installPlugin`](/blueprints/steps#InstallPluginStep) and [`installTheme`](/blueprints/steps#InstallThemeStep).
 - Set `".git": true` to include a `.git` folder containing packfiles and refs so Git-aware tooling can detect the checkout. This currently mirrors a shallow clone of the selected ref.

--- a/packages/docs/site/docs/main/guides/github-action-pr-preview.md
+++ b/packages/docs/site/docs/main/guides/github-action-pr-preview.md
@@ -299,7 +299,7 @@ Configuration options: [Expose Artifact Inputs](https://github.com/WordPress/act
 
 **`plugin-path` or `theme-path` resolves to an empty directory:** The path is relative to the repository root, not to the workflow file. Use `.` for repo-root plugins, `plugins/my-plugin` for subdirectories.
 
-**`Git ref refs/heads/<branch> not found` on a fork PR:** Your blueprint uses `context.repo.owner`/`context.repo.repo` to build the `git:directory` URL, which points at the base repository. Fork PRs live on the contributor's fork — use `context.payload.pull_request.head.repo.full_name` and `head.ref` instead. Also drop any trailing `.git` from the URL; `git:directory` does not accept it.
+**`Git ref refs/heads/<branch> not found` on a fork PR:** Your blueprint uses `context.repo.owner`/`context.repo.repo` to build the `git:directory` URL, which points at the base repository. Fork PRs live on the contributor's fork — use `context.payload.pull_request.head.repo.full_name` and `head.ref` instead. Repository URLs with or without a trailing `.git` suffix are supported.
 
 **Blueprint references `github-proxy.com` and times out:** The community `github-proxy.com` service is unreliable. Switch to the `git:directory` resource (shown in [Custom blueprints](#custom-blueprints)), which fetches directly from GitHub and does not need a proxy. Playground's built-in `plugin-proxy.php` only accepts repos under `wordpress`, `automattic`, and `woocommerce`, so it is not a general fallback.
 

--- a/packages/playground/blueprints/src/lib/v1/compile.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.spec.ts
@@ -329,7 +329,30 @@ describe('Blueprints', () => {
 			});
 		});
 
-		it('should convert a GitLab .git URL to a zip(git:directory) resource', async () => {
+		it('should preserve a GitHub .git URL and normalize harmless whitespace and slashes', async () => {
+			let validatedBlueprint: any;
+			await compileBlueprintV1(
+				{
+					plugins: ['  https://github.com/user/project.git///  '],
+				},
+				{
+					onBlueprintValidated: (bp) => {
+						validatedBlueprint = bp;
+					},
+				}
+			);
+			const step = validatedBlueprint.steps[0];
+			expect(step.pluginData).toEqual({
+				resource: 'zip',
+				inner: {
+					resource: 'git:directory',
+					url: 'https://github.com/user/project.git',
+					ref: 'HEAD',
+				},
+			});
+		});
+
+		it('should preserve a GitLab .git URL in a zip(git:directory) resource', async () => {
 			let validatedBlueprint: any;
 			await compileBlueprintV1(
 				{
@@ -346,7 +369,7 @@ describe('Blueprints', () => {
 				resource: 'zip',
 				inner: {
 					resource: 'git:directory',
-					url: 'https://gitlab.com/group/project',
+					url: 'https://gitlab.com/group/project.git',
 					ref: 'HEAD',
 				},
 			});
@@ -375,7 +398,7 @@ describe('Blueprints', () => {
 			});
 		});
 
-		it('should convert a self-hosted .git URL to a zip(git:directory) resource', async () => {
+		it('should preserve a self-hosted .git URL in a zip(git:directory) resource', async () => {
 			let validatedBlueprint: any;
 			await compileBlueprintV1(
 				{
@@ -392,7 +415,7 @@ describe('Blueprints', () => {
 				resource: 'zip',
 				inner: {
 					resource: 'git:directory',
-					url: 'https://git.example.com/org/repo',
+					url: 'https://git.example.com/org/repo.git',
 					ref: 'HEAD',
 				},
 			});

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -260,9 +260,7 @@ function compileBlueprintJson(
 							resource: 'zip',
 							inner: {
 								resource: 'git:directory',
-								url: value
-									.replace(/\.git\/?$/, '')
-									.replace(/\/$/, ''),
+								url: value.trim().replace(/\/+$/, ''),
 								ref: 'HEAD',
 							},
 						} as FileReference;
@@ -794,15 +792,18 @@ export async function runBlueprintV1Steps(
 }
 
 function isGitRepoUrl(url: string): boolean {
-	if (/^https:\/\/.+\.git\/?$/.test(url)) {
+	const normalizedUrl = url.trim().replace(/\/+$/, '');
+	if (/^https:\/\/.+\.git$/.test(normalizedUrl)) {
 		return true;
 	}
 	// GitHub: exactly /owner/repo
-	if (/^https:\/\/github\.com\/[^/]+\/[^/]+\/?$/.test(url)) {
+	if (/^https:\/\/github\.com\/[^/]+\/[^/]+$/.test(normalizedUrl)) {
 		return true;
 	}
 	// GitLab: /group[/subgroup...]/project (2+ path segments)
-	if (/^https:\/\/gitlab\.com\/[^/]+\/[^/]+(\/[^/]+)*\/?$/.test(url)) {
+	if (
+		/^https:\/\/gitlab\.com\/[^/]+\/[^/]+(\/[^/]+)*$/.test(normalizedUrl)
+	) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
## Summary

Removes the unreasonable limitation Playground had for `git:directory` resources where the `.git` suffix in the URL wasn't accepted. This PR makes it easier for the user and accepts either form: with, or without the `.git` suffix.

## Tests
- Added Blueprint compile regression tests for GitHub `.git` URLs with whitespace/trailing slashes, GitLab `.git` URLs, and self-hosted `.git` URLs.
- `git diff --check`
- Not run locally: focused Nx tests could not start because Nx modules are not installed in this checkout.