### PR TITLE
Auto-label PRs: run on drafts too

### DIFF
--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -28,6 +28,7 @@ jobs:
               id: context
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   PR_TITLE: ${{ github.event.pull_request.title }}
                   PR_BODY: ${{ github.event.pull_request.body }}
@@ -99,6 +100,7 @@ jobs:
             - name: Apply suggested labels
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_REPO: ${{ github.repository }}
                   PR_NUMBER: ${{ steps.context.outputs.pr_number }}
                   AI_RESPONSE: ${{ steps.ai.outputs.response }}
               run: |

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -26,6 +26,13 @@ jobs:
         steps:
             - name: Collect PR context
               id: context
+              # SECURITY: PR_TITLE and PR_BODY are attacker-controlled (any
+              # PR author can set them). They MUST stay in env: and be
+              # referenced as "$PR_TITLE" / "$PR_BODY" inside the script —
+              # never interpolated as ${{ github.event.pull_request.title }}
+              # in the run: block, which would be shell injection with the
+              # write token. They flow only into the model prompt and stdout,
+              # both safe sinks. Don't pipe them into gh / curl / eval.
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   GH_REPO: ${{ github.repository }}
@@ -78,7 +85,10 @@ jobs:
 
             - name: Ask Copilot for label suggestions
               id: ai
-              uses: actions/ai-inference@v1
+              # Pinned to a commit SHA, not a tag: this job runs with
+              # pull-requests:write, so a moved tag would be a supply-chain
+              # foothold. Bump deliberately when upgrading.
+              uses: actions/ai-inference@b81b2afb8390ee6839b494a404766bef6493c7d9 # v1
               with:
                   model: openai/gpt-4o-mini
                   system-prompt: |

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -12,7 +12,7 @@ name: Auto-label PRs with Copilot
 
 on:
     pull_request_target:
-        types: [opened]
+        types: [opened, ready_for_review]
 
 permissions:
     contents: read
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
     suggest-labels:
-        if: github.repository == 'WordPress/wordpress-playground' && github.event.pull_request.draft == false
+        if: github.repository == 'WordPress/wordpress-playground'
         runs-on: ubuntu-latest
         steps:
             - name: Collect PR context


### PR DESCRIPTION
The auto-labeler skipped drafts (job-level `draft == false` check) and only triggered on `opened`, so a PR opened as a draft never got labels — even after being marked ready. PR #3540 is a recent example.

Two small changes:
- Drop the draft gate so drafts get labeled on open like everything else.
- Add `ready_for_review` to the trigger types as a backstop, in case a PR somehow slips through the `opened` event.