### PR TITLE
[Blueprints] support `preferredVersions.wp: false` for PHP-only Playgrounds

### DIFF
--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -49,12 +49,6 @@ const schema11 = {
 					description:
 						'Optional metadata. Used by the Blueprints gallery at https://github.com/WordPress/blueprints',
 				},
-				wordpress: {
-					type: 'boolean',
-					const: false,
-					description:
-						'Set to `false` to boot a PHP-only Playground without downloading or installing WordPress. Useful for running pure-PHP snippets.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time. `preferredVersions.wp` is ignored.',
-				},
 				preferredVersions: {
 					type: 'object',
 					properties: {
@@ -67,9 +61,13 @@ const schema11 = {
 								'The preferred PHP version to use. If not specified, the latest supported version will be used.\n\nNote: PHP 7.2 and 7.3 are deprecated and will be automatically upgraded to 7.4.',
 						},
 						wp: {
-							type: 'string',
+							anyOf: [
+								{ type: 'string' },
+								{ type: 'string', const: 'latest' },
+								{ type: 'boolean', const: false },
+							],
 							description:
-								'The preferred WordPress version to use. If not specified, the latest supported version will be used',
+								'The preferred WordPress version to use, or `false` to boot a PHP-only Playground without downloading or installing WordPress. If not specified, the latest supported version will be used.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time.',
 						},
 					},
 					required: ['php', 'wp'],
@@ -1469,12 +1467,6 @@ const schema12 = {
 			description:
 				'Optional metadata. Used by the Blueprints gallery at https://github.com/WordPress/blueprints',
 		},
-		wordpress: {
-			type: 'boolean',
-			const: false,
-			description:
-				'Set to `false` to boot a PHP-only Playground without downloading or installing WordPress. Useful for running pure-PHP snippets.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time. `preferredVersions.wp` is ignored.',
-		},
 		preferredVersions: {
 			type: 'object',
 			properties: {
@@ -1487,9 +1479,13 @@ const schema12 = {
 						'The preferred PHP version to use. If not specified, the latest supported version will be used.\n\nNote: PHP 7.2 and 7.3 are deprecated and will be automatically upgraded to 7.4.',
 				},
 				wp: {
-					type: 'string',
+					anyOf: [
+						{ type: 'string' },
+						{ type: 'string', const: 'latest' },
+						{ type: 'boolean', const: false },
+					],
 					description:
-						'The preferred WordPress version to use. If not specified, the latest supported version will be used',
+						'The preferred WordPress version to use, or `false` to boot a PHP-only Playground without downloading or installing WordPress. If not specified, the latest supported version will be used.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time.',
 				},
 			},
 			required: ['php', 'wp'],
@@ -20392,158 +20388,261 @@ function validate11(
 							var valid0 = true;
 						}
 						if (valid0) {
-							if (data.wordpress !== undefined) {
-								let data8 = data.wordpress;
+							if (data.preferredVersions !== undefined) {
+								let data8 = data.preferredVersions;
 								const _errs19 = errors;
-								if (typeof data8 !== 'boolean') {
-									validate11.errors = [
-										{
-											instancePath:
-												instancePath + '/wordpress',
-											schemaPath:
-												'#/properties/wordpress/type',
-											keyword: 'type',
-											params: { type: 'boolean' },
-											message: 'must be boolean',
-										},
-									];
-									return false;
-								}
-								if (false !== data8) {
-									validate11.errors = [
-										{
-											instancePath:
-												instancePath + '/wordpress',
-											schemaPath:
-												'#/properties/wordpress/const',
-											keyword: 'const',
-											params: { allowedValue: false },
-											message:
-												'must be equal to constant',
-										},
-									];
-									return false;
-								}
-								var valid0 = _errs19 === errors;
-							} else {
-								var valid0 = true;
-							}
-							if (valid0) {
-								if (data.preferredVersions !== undefined) {
-									let data9 = data.preferredVersions;
-									const _errs21 = errors;
-									if (errors === _errs21) {
+								if (errors === _errs19) {
+									if (
+										data8 &&
+										typeof data8 == 'object' &&
+										!Array.isArray(data8)
+									) {
+										let missing1;
 										if (
-											data9 &&
-											typeof data9 == 'object' &&
-											!Array.isArray(data9)
+											(data8.php === undefined &&
+												(missing1 = 'php')) ||
+											(data8.wp === undefined &&
+												(missing1 = 'wp'))
 										) {
-											let missing1;
-											if (
-												(data9.php === undefined &&
-													(missing1 = 'php')) ||
-												(data9.wp === undefined &&
-													(missing1 = 'wp'))
-											) {
-												validate11.errors = [
-													{
-														instancePath:
-															instancePath +
-															'/preferredVersions',
-														schemaPath:
-															'#/properties/preferredVersions/required',
-														keyword: 'required',
-														params: {
-															missingProperty:
-																missing1,
-														},
-														message:
-															"must have required property '" +
-															missing1 +
-															"'",
+											validate11.errors = [
+												{
+													instancePath:
+														instancePath +
+														'/preferredVersions',
+													schemaPath:
+														'#/properties/preferredVersions/required',
+													keyword: 'required',
+													params: {
+														missingProperty:
+															missing1,
 													},
-												];
-												return false;
-											} else {
-												const _errs23 = errors;
-												for (const key2 in data9) {
+													message:
+														"must have required property '" +
+														missing1 +
+														"'",
+												},
+											];
+											return false;
+										} else {
+											const _errs21 = errors;
+											for (const key2 in data8) {
+												if (
+													!(
+														key2 === 'php' ||
+														key2 === 'wp'
+													)
+												) {
+													validate11.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/preferredVersions',
+															schemaPath:
+																'#/properties/preferredVersions/additionalProperties',
+															keyword:
+																'additionalProperties',
+															params: {
+																additionalProperty:
+																	key2,
+															},
+															message:
+																'must NOT have additional properties',
+														},
+													];
+													return false;
+													break;
+												}
+											}
+											if (_errs21 === errors) {
+												if (data8.php !== undefined) {
+													let data9 = data8.php;
+													const _errs22 = errors;
+													const _errs23 = errors;
+													let valid4 = false;
+													const _errs24 = errors;
 													if (
-														!(
-															key2 === 'php' ||
-															key2 === 'wp'
-														)
+														!validate12(data9, {
+															instancePath:
+																instancePath +
+																'/preferredVersions/php',
+															parentData: data8,
+															parentDataProperty:
+																'php',
+															rootData,
+														})
 													) {
-														validate11.errors = [
-															{
+														vErrors =
+															vErrors === null
+																? validate12.errors
+																: vErrors.concat(
+																		validate12.errors
+																	);
+														errors = vErrors.length;
+													}
+													var _valid0 =
+														_errs24 === errors;
+													valid4 = valid4 || _valid0;
+													if (!valid4) {
+														const _errs25 = errors;
+														if (
+															typeof data9 !==
+															'string'
+														) {
+															const err0 = {
 																instancePath:
 																	instancePath +
-																	'/preferredVersions',
+																	'/preferredVersions/php',
 																schemaPath:
-																	'#/properties/preferredVersions/additionalProperties',
-																keyword:
-																	'additionalProperties',
+																	'#/properties/preferredVersions/properties/php/anyOf/1/type',
+																keyword: 'type',
 																params: {
-																	additionalProperty:
-																		key2,
+																	type: 'string',
 																},
 																message:
-																	'must NOT have additional properties',
-															},
-														];
-														return false;
-														break;
-													}
-												}
-												if (_errs23 === errors) {
-													if (
-														data9.php !== undefined
-													) {
-														let data10 = data9.php;
-														const _errs24 = errors;
-														const _errs25 = errors;
-														let valid4 = false;
-														const _errs26 = errors;
-														if (
-															!validate12(
-																data10,
-																{
-																	instancePath:
-																		instancePath +
-																		'/preferredVersions/php',
-																	parentData:
-																		data9,
-																	parentDataProperty:
-																		'php',
-																	rootData,
-																}
-															)
-														) {
-															vErrors =
+																	'must be string',
+															};
+															if (
 																vErrors === null
-																	? validate12.errors
-																	: vErrors.concat(
-																			validate12.errors
-																		);
-															errors =
-																vErrors.length;
+															) {
+																vErrors = [
+																	err0,
+																];
+															} else {
+																vErrors.push(
+																	err0
+																);
+															}
+															errors++;
+														}
+														if (
+															'latest' !== data9
+														) {
+															const err1 = {
+																instancePath:
+																	instancePath +
+																	'/preferredVersions/php',
+																schemaPath:
+																	'#/properties/preferredVersions/properties/php/anyOf/1/const',
+																keyword:
+																	'const',
+																params: {
+																	allowedValue:
+																		'latest',
+																},
+																message:
+																	'must be equal to constant',
+															};
+															if (
+																vErrors === null
+															) {
+																vErrors = [
+																	err1,
+																];
+															} else {
+																vErrors.push(
+																	err1
+																);
+															}
+															errors++;
 														}
 														var _valid0 =
-															_errs26 === errors;
+															_errs25 === errors;
 														valid4 =
 															valid4 || _valid0;
-														if (!valid4) {
-															const _errs27 =
+													}
+													if (!valid4) {
+														const err2 = {
+															instancePath:
+																instancePath +
+																'/preferredVersions/php',
+															schemaPath:
+																'#/properties/preferredVersions/properties/php/anyOf',
+															keyword: 'anyOf',
+															params: {},
+															message:
+																'must match a schema in anyOf',
+														};
+														if (vErrors === null) {
+															vErrors = [err2];
+														} else {
+															vErrors.push(err2);
+														}
+														errors++;
+														validate11.errors =
+															vErrors;
+														return false;
+													} else {
+														errors = _errs23;
+														if (vErrors !== null) {
+															if (_errs23) {
+																vErrors.length =
+																	_errs23;
+															} else {
+																vErrors = null;
+															}
+														}
+													}
+													var valid3 =
+														_errs22 === errors;
+												} else {
+													var valid3 = true;
+												}
+												if (valid3) {
+													if (
+														data8.wp !== undefined
+													) {
+														let data10 = data8.wp;
+														const _errs27 = errors;
+														const _errs28 = errors;
+														let valid5 = false;
+														const _errs29 = errors;
+														if (
+															typeof data10 !==
+															'string'
+														) {
+															const err3 = {
+																instancePath:
+																	instancePath +
+																	'/preferredVersions/wp',
+																schemaPath:
+																	'#/properties/preferredVersions/properties/wp/anyOf/0/type',
+																keyword: 'type',
+																params: {
+																	type: 'string',
+																},
+																message:
+																	'must be string',
+															};
+															if (
+																vErrors === null
+															) {
+																vErrors = [
+																	err3,
+																];
+															} else {
+																vErrors.push(
+																	err3
+																);
+															}
+															errors++;
+														}
+														var _valid1 =
+															_errs29 === errors;
+														valid5 =
+															valid5 || _valid1;
+														if (!valid5) {
+															const _errs31 =
 																errors;
 															if (
 																typeof data10 !==
 																'string'
 															) {
-																const err0 = {
+																const err4 = {
 																	instancePath:
 																		instancePath +
-																		'/preferredVersions/php',
+																		'/preferredVersions/wp',
 																	schemaPath:
-																		'#/properties/preferredVersions/properties/php/anyOf/1/type',
+																		'#/properties/preferredVersions/properties/wp/anyOf/1/type',
 																	keyword:
 																		'type',
 																	params: {
@@ -20557,11 +20656,11 @@ function validate11(
 																	null
 																) {
 																	vErrors = [
-																		err0,
+																		err4,
 																	];
 																} else {
 																	vErrors.push(
-																		err0
+																		err4
 																	);
 																}
 																errors++;
@@ -20570,12 +20669,12 @@ function validate11(
 																'latest' !==
 																data10
 															) {
-																const err1 = {
+																const err5 = {
 																	instancePath:
 																		instancePath +
-																		'/preferredVersions/php',
+																		'/preferredVersions/wp',
 																	schemaPath:
-																		'#/properties/preferredVersions/properties/php/anyOf/1/const',
+																		'#/properties/preferredVersions/properties/wp/anyOf/1/const',
 																	keyword:
 																		'const',
 																	params: {
@@ -20584,804 +20683,6 @@ function validate11(
 																	},
 																	message:
 																		'must be equal to constant',
-																};
-																if (
-																	vErrors ===
-																	null
-																) {
-																	vErrors = [
-																		err1,
-																	];
-																} else {
-																	vErrors.push(
-																		err1
-																	);
-																}
-																errors++;
-															}
-															var _valid0 =
-																_errs27 ===
-																errors;
-															valid4 =
-																valid4 ||
-																_valid0;
-														}
-														if (!valid4) {
-															const err2 = {
-																instancePath:
-																	instancePath +
-																	'/preferredVersions/php',
-																schemaPath:
-																	'#/properties/preferredVersions/properties/php/anyOf',
-																keyword:
-																	'anyOf',
-																params: {},
-																message:
-																	'must match a schema in anyOf',
-															};
-															if (
-																vErrors === null
-															) {
-																vErrors = [
-																	err2,
-																];
-															} else {
-																vErrors.push(
-																	err2
-																);
-															}
-															errors++;
-															validate11.errors =
-																vErrors;
-															return false;
-														} else {
-															errors = _errs25;
-															if (
-																vErrors !== null
-															) {
-																if (_errs25) {
-																	vErrors.length =
-																		_errs25;
-																} else {
-																	vErrors =
-																		null;
-																}
-															}
-														}
-														var valid3 =
-															_errs24 === errors;
-													} else {
-														var valid3 = true;
-													}
-													if (valid3) {
-														if (
-															data9.wp !==
-															undefined
-														) {
-															const _errs29 =
-																errors;
-															if (
-																typeof data9.wp !==
-																'string'
-															) {
-																validate11.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/preferredVersions/wp',
-																			schemaPath:
-																				'#/properties/preferredVersions/properties/wp/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'string',
-																			},
-																			message:
-																				'must be string',
-																		},
-																	];
-																return false;
-															}
-															var valid3 =
-																_errs29 ===
-																errors;
-														} else {
-															var valid3 = true;
-														}
-													}
-												}
-											}
-										} else {
-											validate11.errors = [
-												{
-													instancePath:
-														instancePath +
-														'/preferredVersions',
-													schemaPath:
-														'#/properties/preferredVersions/type',
-													keyword: 'type',
-													params: { type: 'object' },
-													message: 'must be object',
-												},
-											];
-											return false;
-										}
-									}
-									var valid0 = _errs21 === errors;
-								} else {
-									var valid0 = true;
-								}
-								if (valid0) {
-									if (data.features !== undefined) {
-										let data12 = data.features;
-										const _errs31 = errors;
-										if (errors === _errs31) {
-											if (
-												data12 &&
-												typeof data12 == 'object' &&
-												!Array.isArray(data12)
-											) {
-												const _errs33 = errors;
-												for (const key3 in data12) {
-													if (
-														!(
-															key3 === 'intl' ||
-															key3 ===
-																'networking'
-														)
-													) {
-														validate11.errors = [
-															{
-																instancePath:
-																	instancePath +
-																	'/features',
-																schemaPath:
-																	'#/properties/features/additionalProperties',
-																keyword:
-																	'additionalProperties',
-																params: {
-																	additionalProperty:
-																		key3,
-																},
-																message:
-																	'must NOT have additional properties',
-															},
-														];
-														return false;
-														break;
-													}
-												}
-												if (_errs33 === errors) {
-													if (
-														data12.intl !==
-														undefined
-													) {
-														const _errs34 = errors;
-														if (
-															typeof data12.intl !==
-															'boolean'
-														) {
-															validate11.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/features/intl',
-																		schemaPath:
-																			'#/properties/features/properties/intl/type',
-																		keyword:
-																			'type',
-																		params: {
-																			type: 'boolean',
-																		},
-																		message:
-																			'must be boolean',
-																	},
-																];
-															return false;
-														}
-														var valid5 =
-															_errs34 === errors;
-													} else {
-														var valid5 = true;
-													}
-													if (valid5) {
-														if (
-															data12.networking !==
-															undefined
-														) {
-															const _errs36 =
-																errors;
-															if (
-																typeof data12.networking !==
-																'boolean'
-															) {
-																validate11.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/features/networking',
-																			schemaPath:
-																				'#/properties/features/properties/networking/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'boolean',
-																			},
-																			message:
-																				'must be boolean',
-																		},
-																	];
-																return false;
-															}
-															var valid5 =
-																_errs36 ===
-																errors;
-														} else {
-															var valid5 = true;
-														}
-													}
-												}
-											} else {
-												validate11.errors = [
-													{
-														instancePath:
-															instancePath +
-															'/features',
-														schemaPath:
-															'#/properties/features/type',
-														keyword: 'type',
-														params: {
-															type: 'object',
-														},
-														message:
-															'must be object',
-													},
-												];
-												return false;
-											}
-										}
-										var valid0 = _errs31 === errors;
-									} else {
-										var valid0 = true;
-									}
-									if (valid0) {
-										if (data.extraLibraries !== undefined) {
-											let data15 = data.extraLibraries;
-											const _errs38 = errors;
-											if (errors === _errs38) {
-												if (Array.isArray(data15)) {
-													var valid6 = true;
-													const len1 = data15.length;
-													for (
-														let i1 = 0;
-														i1 < len1;
-														i1++
-													) {
-														let data16 = data15[i1];
-														const _errs40 = errors;
-														if (
-															typeof data16 !==
-															'string'
-														) {
-															validate11.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/extraLibraries/' +
-																			i1,
-																		schemaPath:
-																			'#/definitions/ExtraLibrary/type',
-																		keyword:
-																			'type',
-																		params: {
-																			type: 'string',
-																		},
-																		message:
-																			'must be string',
-																	},
-																];
-															return false;
-														}
-														if (
-															'wp-cli' !== data16
-														) {
-															validate11.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/extraLibraries/' +
-																			i1,
-																		schemaPath:
-																			'#/definitions/ExtraLibrary/const',
-																		keyword:
-																			'const',
-																		params: {
-																			allowedValue:
-																				'wp-cli',
-																		},
-																		message:
-																			'must be equal to constant',
-																	},
-																];
-															return false;
-														}
-														var valid6 =
-															_errs40 === errors;
-														if (!valid6) {
-															break;
-														}
-													}
-												} else {
-													validate11.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/extraLibraries',
-															schemaPath:
-																'#/properties/extraLibraries/type',
-															keyword: 'type',
-															params: {
-																type: 'array',
-															},
-															message:
-																'must be array',
-														},
-													];
-													return false;
-												}
-											}
-											var valid0 = _errs38 === errors;
-										} else {
-											var valid0 = true;
-										}
-										if (valid0) {
-											if (data.constants !== undefined) {
-												let data17 = data.constants;
-												const _errs43 = errors;
-												const _errs44 = errors;
-												if (errors === _errs44) {
-													if (
-														data17 &&
-														typeof data17 ==
-															'object' &&
-														!Array.isArray(data17)
-													) {
-														for (const key4 in data17) {
-															let data18 =
-																data17[key4];
-															const _errs47 =
-																errors;
-															if (
-																typeof data18 !==
-																	'string' &&
-																typeof data18 !==
-																	'boolean' &&
-																!(
-																	typeof data18 ==
-																		'number' &&
-																	isFinite(
-																		data18
-																	)
-																)
-															) {
-																validate11.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/constants/' +
-																				key4
-																					.replace(
-																						/~/g,
-																						'~0'
-																					)
-																					.replace(
-																						/\//g,
-																						'~1'
-																					),
-																			schemaPath:
-																				'#/definitions/PHPConstants/additionalProperties/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: schema18
-																					.additionalProperties
-																					.type,
-																			},
-																			message:
-																				'must be string,boolean,number',
-																		},
-																	];
-																return false;
-															}
-															var valid9 =
-																_errs47 ===
-																errors;
-															if (!valid9) {
-																break;
-															}
-														}
-													} else {
-														validate11.errors = [
-															{
-																instancePath:
-																	instancePath +
-																	'/constants',
-																schemaPath:
-																	'#/definitions/PHPConstants/type',
-																keyword: 'type',
-																params: {
-																	type: 'object',
-																},
-																message:
-																	'must be object',
-															},
-														];
-														return false;
-													}
-												}
-												var valid0 = _errs43 === errors;
-											} else {
-												var valid0 = true;
-											}
-											if (valid0) {
-												if (
-													data.plugins !== undefined
-												) {
-													let data19 = data.plugins;
-													const _errs49 = errors;
-													if (errors === _errs49) {
-														if (
-															Array.isArray(
-																data19
-															)
-														) {
-															var valid10 = true;
-															const len2 =
-																data19.length;
-															for (
-																let i2 = 0;
-																i2 < len2;
-																i2++
-															) {
-																let data20 =
-																	data19[i2];
-																const _errs51 =
-																	errors;
-																const _errs52 =
-																	errors;
-																let valid11 = false;
-																const _errs53 =
-																	errors;
-																if (
-																	typeof data20 !==
-																	'string'
-																) {
-																	const err3 =
-																		{
-																			instancePath:
-																				instancePath +
-																				'/plugins/' +
-																				i2,
-																			schemaPath:
-																				'#/properties/plugins/items/anyOf/0/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'string',
-																			},
-																			message:
-																				'must be string',
-																		};
-																	if (
-																		vErrors ===
-																		null
-																	) {
-																		vErrors =
-																			[
-																				err3,
-																			];
-																	} else {
-																		vErrors.push(
-																			err3
-																		);
-																	}
-																	errors++;
-																}
-																var _valid1 =
-																	_errs53 ===
-																	errors;
-																valid11 =
-																	valid11 ||
-																	_valid1;
-																if (!valid11) {
-																	const _errs55 =
-																		errors;
-																	if (
-																		!validate16(
-																			data20,
-																			{
-																				instancePath:
-																					instancePath +
-																					'/plugins/' +
-																					i2,
-																				parentData:
-																					data19,
-																				parentDataProperty:
-																					i2,
-																				rootData,
-																			}
-																		)
-																	) {
-																		vErrors =
-																			vErrors ===
-																			null
-																				? validate16.errors
-																				: vErrors.concat(
-																						validate16.errors
-																					);
-																		errors =
-																			vErrors.length;
-																	}
-																	var _valid1 =
-																		_errs55 ===
-																		errors;
-																	valid11 =
-																		valid11 ||
-																		_valid1;
-																}
-																if (!valid11) {
-																	const err4 =
-																		{
-																			instancePath:
-																				instancePath +
-																				'/plugins/' +
-																				i2,
-																			schemaPath:
-																				'#/properties/plugins/items/anyOf',
-																			keyword:
-																				'anyOf',
-																			params: {},
-																			message:
-																				'must match a schema in anyOf',
-																		};
-																	if (
-																		vErrors ===
-																		null
-																	) {
-																		vErrors =
-																			[
-																				err4,
-																			];
-																	} else {
-																		vErrors.push(
-																			err4
-																		);
-																	}
-																	errors++;
-																	validate11.errors =
-																		vErrors;
-																	return false;
-																} else {
-																	errors =
-																		_errs52;
-																	if (
-																		vErrors !==
-																		null
-																	) {
-																		if (
-																			_errs52
-																		) {
-																			vErrors.length =
-																				_errs52;
-																		} else {
-																			vErrors =
-																				null;
-																		}
-																	}
-																}
-																var valid10 =
-																	_errs51 ===
-																	errors;
-																if (!valid10) {
-																	break;
-																}
-															}
-														} else {
-															validate11.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/plugins',
-																		schemaPath:
-																			'#/properties/plugins/type',
-																		keyword:
-																			'type',
-																		params: {
-																			type: 'array',
-																		},
-																		message:
-																			'must be array',
-																	},
-																];
-															return false;
-														}
-													}
-													var valid0 =
-														_errs49 === errors;
-												} else {
-													var valid0 = true;
-												}
-												if (valid0) {
-													if (
-														data.siteOptions !==
-														undefined
-													) {
-														let data21 =
-															data.siteOptions;
-														const _errs56 = errors;
-														if (
-															errors === _errs56
-														) {
-															if (
-																data21 &&
-																typeof data21 ==
-																	'object' &&
-																!Array.isArray(
-																	data21
-																)
-															) {
-																const _errs58 =
-																	errors;
-																for (const key5 in data21) {
-																	if (
-																		!(
-																			key5 ===
-																			'blogname'
-																		)
-																	) {
-																		const _errs59 =
-																			errors;
-																		if (
-																			typeof data21[
-																				key5
-																			] !==
-																			'string'
-																		) {
-																			validate11.errors =
-																				[
-																					{
-																						instancePath:
-																							instancePath +
-																							'/siteOptions/' +
-																							key5
-																								.replace(
-																									/~/g,
-																									'~0'
-																								)
-																								.replace(
-																									/\//g,
-																									'~1'
-																								),
-																						schemaPath:
-																							'#/properties/siteOptions/additionalProperties/type',
-																						keyword:
-																							'type',
-																						params: {
-																							type: 'string',
-																						},
-																						message:
-																							'must be string',
-																					},
-																				];
-																			return false;
-																		}
-																		var valid12 =
-																			_errs59 ===
-																			errors;
-																		if (
-																			!valid12
-																		) {
-																			break;
-																		}
-																	}
-																}
-																if (
-																	_errs58 ===
-																	errors
-																) {
-																	if (
-																		data21.blogname !==
-																		undefined
-																	) {
-																		if (
-																			typeof data21.blogname !==
-																			'string'
-																		) {
-																			validate11.errors =
-																				[
-																					{
-																						instancePath:
-																							instancePath +
-																							'/siteOptions/blogname',
-																						schemaPath:
-																							'#/properties/siteOptions/properties/blogname/type',
-																						keyword:
-																							'type',
-																						params: {
-																							type: 'string',
-																						},
-																						message:
-																							'must be string',
-																					},
-																				];
-																			return false;
-																		}
-																	}
-																}
-															} else {
-																validate11.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/siteOptions',
-																			schemaPath:
-																				'#/properties/siteOptions/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'object',
-																			},
-																			message:
-																				'must be object',
-																		},
-																	];
-																return false;
-															}
-														}
-														var valid0 =
-															_errs56 === errors;
-													} else {
-														var valid0 = true;
-													}
-													if (valid0) {
-														if (
-															data.login !==
-															undefined
-														) {
-															let data24 =
-																data.login;
-															const _errs63 =
-																errors;
-															const _errs64 =
-																errors;
-															let valid14 = false;
-															const _errs65 =
-																errors;
-															if (
-																typeof data24 !==
-																'boolean'
-															) {
-																const err5 = {
-																	instancePath:
-																		instancePath +
-																		'/login',
-																	schemaPath:
-																		'#/properties/login/anyOf/0/type',
-																	keyword:
-																		'type',
-																	params: {
-																		type: 'boolean',
-																	},
-																	message:
-																		'must be boolean',
 																};
 																if (
 																	vErrors ===
@@ -21397,263 +20698,563 @@ function validate11(
 																}
 																errors++;
 															}
-															var _valid2 =
-																_errs65 ===
+															var _valid1 =
+																_errs31 ===
 																errors;
-															valid14 =
-																valid14 ||
-																_valid2;
-															if (!valid14) {
-																const _errs67 =
+															valid5 =
+																valid5 ||
+																_valid1;
+															if (!valid5) {
+																const _errs33 =
 																	errors;
 																if (
-																	errors ===
-																	_errs67
+																	typeof data10 !==
+																	'boolean'
 																) {
+																	const err6 =
+																		{
+																			instancePath:
+																				instancePath +
+																				'/preferredVersions/wp',
+																			schemaPath:
+																				'#/properties/preferredVersions/properties/wp/anyOf/2/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'boolean',
+																			},
+																			message:
+																				'must be boolean',
+																		};
 																	if (
-																		data24 &&
-																		typeof data24 ==
-																			'object' &&
-																		!Array.isArray(
-																			data24
-																		)
+																		vErrors ===
+																		null
 																	) {
-																		let missing2;
-																		if (
-																			(data24.username ===
-																				undefined &&
-																				(missing2 =
-																					'username')) ||
-																			(data24.password ===
-																				undefined &&
-																				(missing2 =
-																					'password'))
-																		) {
-																			const err6 =
-																				{
-																					instancePath:
-																						instancePath +
-																						'/login',
-																					schemaPath:
-																						'#/properties/login/anyOf/1/required',
-																					keyword:
-																						'required',
-																					params: {
-																						missingProperty:
-																							missing2,
-																					},
-																					message:
-																						"must have required property '" +
-																						missing2 +
-																						"'",
-																				};
-																			if (
-																				vErrors ===
-																				null
-																			) {
-																				vErrors =
-																					[
-																						err6,
-																					];
-																			} else {
-																				vErrors.push(
-																					err6
-																				);
-																			}
-																			errors++;
-																		} else {
-																			const _errs69 =
-																				errors;
-																			for (const key6 in data24) {
-																				if (
-																					!(
-																						key6 ===
-																							'username' ||
-																						key6 ===
-																							'password'
-																					)
-																				) {
-																					const err7 =
-																						{
-																							instancePath:
-																								instancePath +
-																								'/login',
-																							schemaPath:
-																								'#/properties/login/anyOf/1/additionalProperties',
-																							keyword:
-																								'additionalProperties',
-																							params: {
-																								additionalProperty:
-																									key6,
-																							},
-																							message:
-																								'must NOT have additional properties',
-																						};
-																					if (
-																						vErrors ===
-																						null
-																					) {
-																						vErrors =
-																							[
-																								err7,
-																							];
-																					} else {
-																						vErrors.push(
-																							err7
-																						);
-																					}
-																					errors++;
-																					break;
-																				}
-																			}
-																			if (
-																				_errs69 ===
-																				errors
-																			) {
-																				if (
-																					data24.username !==
-																					undefined
-																				) {
-																					const _errs70 =
-																						errors;
-																					if (
-																						typeof data24.username !==
-																						'string'
-																					) {
-																						const err8 =
-																							{
-																								instancePath:
-																									instancePath +
-																									'/login/username',
-																								schemaPath:
-																									'#/properties/login/anyOf/1/properties/username/type',
-																								keyword:
-																									'type',
-																								params: {
-																									type: 'string',
-																								},
-																								message:
-																									'must be string',
-																							};
-																						if (
-																							vErrors ===
-																							null
-																						) {
-																							vErrors =
-																								[
-																									err8,
-																								];
-																						} else {
-																							vErrors.push(
-																								err8
-																							);
-																						}
-																						errors++;
-																					}
-																					var valid15 =
-																						_errs70 ===
-																						errors;
-																				} else {
-																					var valid15 = true;
-																				}
-																				if (
-																					valid15
-																				) {
-																					if (
-																						data24.password !==
-																						undefined
-																					) {
-																						const _errs72 =
-																							errors;
-																						if (
-																							typeof data24.password !==
-																							'string'
-																						) {
-																							const err9 =
-																								{
-																									instancePath:
-																										instancePath +
-																										'/login/password',
-																									schemaPath:
-																										'#/properties/login/anyOf/1/properties/password/type',
-																									keyword:
-																										'type',
-																									params: {
-																										type: 'string',
-																									},
-																									message:
-																										'must be string',
-																								};
-																							if (
-																								vErrors ===
-																								null
-																							) {
-																								vErrors =
-																									[
-																										err9,
-																									];
-																							} else {
-																								vErrors.push(
-																									err9
-																								);
-																							}
-																							errors++;
-																						}
-																						var valid15 =
-																							_errs72 ===
-																							errors;
-																					} else {
-																						var valid15 = true;
-																					}
-																				}
-																			}
-																		}
+																		vErrors =
+																			[
+																				err6,
+																			];
 																	} else {
-																		const err10 =
-																			{
-																				instancePath:
-																					instancePath +
-																					'/login',
-																				schemaPath:
-																					'#/properties/login/anyOf/1/type',
-																				keyword:
-																					'type',
-																				params: {
-																					type: 'object',
-																				},
-																				message:
-																					'must be object',
-																			};
-																		if (
-																			vErrors ===
-																			null
-																		) {
-																			vErrors =
-																				[
-																					err10,
-																				];
-																		} else {
-																			vErrors.push(
-																				err10
-																			);
-																		}
-																		errors++;
+																		vErrors.push(
+																			err6
+																		);
 																	}
+																	errors++;
 																}
-																var _valid2 =
-																	_errs67 ===
+																if (
+																	false !==
+																	data10
+																) {
+																	const err7 =
+																		{
+																			instancePath:
+																				instancePath +
+																				'/preferredVersions/wp',
+																			schemaPath:
+																				'#/properties/preferredVersions/properties/wp/anyOf/2/const',
+																			keyword:
+																				'const',
+																			params: {
+																				allowedValue: false,
+																			},
+																			message:
+																				'must be equal to constant',
+																		};
+																	if (
+																		vErrors ===
+																		null
+																	) {
+																		vErrors =
+																			[
+																				err7,
+																			];
+																	} else {
+																		vErrors.push(
+																			err7
+																		);
+																	}
+																	errors++;
+																}
+																var _valid1 =
+																	_errs33 ===
 																	errors;
-																valid14 =
-																	valid14 ||
-																	_valid2;
+																valid5 =
+																	valid5 ||
+																	_valid1;
 															}
-															if (!valid14) {
-																const err11 = {
+														}
+														if (!valid5) {
+															const err8 = {
+																instancePath:
+																	instancePath +
+																	'/preferredVersions/wp',
+																schemaPath:
+																	'#/properties/preferredVersions/properties/wp/anyOf',
+																keyword:
+																	'anyOf',
+																params: {},
+																message:
+																	'must match a schema in anyOf',
+															};
+															if (
+																vErrors === null
+															) {
+																vErrors = [
+																	err8,
+																];
+															} else {
+																vErrors.push(
+																	err8
+																);
+															}
+															errors++;
+															validate11.errors =
+																vErrors;
+															return false;
+														} else {
+															errors = _errs28;
+															if (
+																vErrors !== null
+															) {
+																if (_errs28) {
+																	vErrors.length =
+																		_errs28;
+																} else {
+																	vErrors =
+																		null;
+																}
+															}
+														}
+														var valid3 =
+															_errs27 === errors;
+													} else {
+														var valid3 = true;
+													}
+												}
+											}
+										}
+									} else {
+										validate11.errors = [
+											{
+												instancePath:
+													instancePath +
+													'/preferredVersions',
+												schemaPath:
+													'#/properties/preferredVersions/type',
+												keyword: 'type',
+												params: { type: 'object' },
+												message: 'must be object',
+											},
+										];
+										return false;
+									}
+								}
+								var valid0 = _errs19 === errors;
+							} else {
+								var valid0 = true;
+							}
+							if (valid0) {
+								if (data.features !== undefined) {
+									let data11 = data.features;
+									const _errs35 = errors;
+									if (errors === _errs35) {
+										if (
+											data11 &&
+											typeof data11 == 'object' &&
+											!Array.isArray(data11)
+										) {
+											const _errs37 = errors;
+											for (const key3 in data11) {
+												if (
+													!(
+														key3 === 'intl' ||
+														key3 === 'networking'
+													)
+												) {
+													validate11.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/features',
+															schemaPath:
+																'#/properties/features/additionalProperties',
+															keyword:
+																'additionalProperties',
+															params: {
+																additionalProperty:
+																	key3,
+															},
+															message:
+																'must NOT have additional properties',
+														},
+													];
+													return false;
+													break;
+												}
+											}
+											if (_errs37 === errors) {
+												if (data11.intl !== undefined) {
+													const _errs38 = errors;
+													if (
+														typeof data11.intl !==
+														'boolean'
+													) {
+														validate11.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/features/intl',
+																schemaPath:
+																	'#/properties/features/properties/intl/type',
+																keyword: 'type',
+																params: {
+																	type: 'boolean',
+																},
+																message:
+																	'must be boolean',
+															},
+														];
+														return false;
+													}
+													var valid6 =
+														_errs38 === errors;
+												} else {
+													var valid6 = true;
+												}
+												if (valid6) {
+													if (
+														data11.networking !==
+														undefined
+													) {
+														const _errs40 = errors;
+														if (
+															typeof data11.networking !==
+															'boolean'
+														) {
+															validate11.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/features/networking',
+																		schemaPath:
+																			'#/properties/features/properties/networking/type',
+																		keyword:
+																			'type',
+																		params: {
+																			type: 'boolean',
+																		},
+																		message:
+																			'must be boolean',
+																	},
+																];
+															return false;
+														}
+														var valid6 =
+															_errs40 === errors;
+													} else {
+														var valid6 = true;
+													}
+												}
+											}
+										} else {
+											validate11.errors = [
+												{
+													instancePath:
+														instancePath +
+														'/features',
+													schemaPath:
+														'#/properties/features/type',
+													keyword: 'type',
+													params: { type: 'object' },
+													message: 'must be object',
+												},
+											];
+											return false;
+										}
+									}
+									var valid0 = _errs35 === errors;
+								} else {
+									var valid0 = true;
+								}
+								if (valid0) {
+									if (data.extraLibraries !== undefined) {
+										let data14 = data.extraLibraries;
+										const _errs42 = errors;
+										if (errors === _errs42) {
+											if (Array.isArray(data14)) {
+												var valid7 = true;
+												const len1 = data14.length;
+												for (
+													let i1 = 0;
+													i1 < len1;
+													i1++
+												) {
+													let data15 = data14[i1];
+													const _errs44 = errors;
+													if (
+														typeof data15 !==
+														'string'
+													) {
+														validate11.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/extraLibraries/' +
+																	i1,
+																schemaPath:
+																	'#/definitions/ExtraLibrary/type',
+																keyword: 'type',
+																params: {
+																	type: 'string',
+																},
+																message:
+																	'must be string',
+															},
+														];
+														return false;
+													}
+													if ('wp-cli' !== data15) {
+														validate11.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/extraLibraries/' +
+																	i1,
+																schemaPath:
+																	'#/definitions/ExtraLibrary/const',
+																keyword:
+																	'const',
+																params: {
+																	allowedValue:
+																		'wp-cli',
+																},
+																message:
+																	'must be equal to constant',
+															},
+														];
+														return false;
+													}
+													var valid7 =
+														_errs44 === errors;
+													if (!valid7) {
+														break;
+													}
+												}
+											} else {
+												validate11.errors = [
+													{
+														instancePath:
+															instancePath +
+															'/extraLibraries',
+														schemaPath:
+															'#/properties/extraLibraries/type',
+														keyword: 'type',
+														params: {
+															type: 'array',
+														},
+														message:
+															'must be array',
+													},
+												];
+												return false;
+											}
+										}
+										var valid0 = _errs42 === errors;
+									} else {
+										var valid0 = true;
+									}
+									if (valid0) {
+										if (data.constants !== undefined) {
+											let data16 = data.constants;
+											const _errs47 = errors;
+											const _errs48 = errors;
+											if (errors === _errs48) {
+												if (
+													data16 &&
+													typeof data16 == 'object' &&
+													!Array.isArray(data16)
+												) {
+													for (const key4 in data16) {
+														let data17 =
+															data16[key4];
+														const _errs51 = errors;
+														if (
+															typeof data17 !==
+																'string' &&
+															typeof data17 !==
+																'boolean' &&
+															!(
+																typeof data17 ==
+																	'number' &&
+																isFinite(data17)
+															)
+														) {
+															validate11.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/constants/' +
+																			key4
+																				.replace(
+																					/~/g,
+																					'~0'
+																				)
+																				.replace(
+																					/\//g,
+																					'~1'
+																				),
+																		schemaPath:
+																			'#/definitions/PHPConstants/additionalProperties/type',
+																		keyword:
+																			'type',
+																		params: {
+																			type: schema18
+																				.additionalProperties
+																				.type,
+																		},
+																		message:
+																			'must be string,boolean,number',
+																	},
+																];
+															return false;
+														}
+														var valid10 =
+															_errs51 === errors;
+														if (!valid10) {
+															break;
+														}
+													}
+												} else {
+													validate11.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/constants',
+															schemaPath:
+																'#/definitions/PHPConstants/type',
+															keyword: 'type',
+															params: {
+																type: 'object',
+															},
+															message:
+																'must be object',
+														},
+													];
+													return false;
+												}
+											}
+											var valid0 = _errs47 === errors;
+										} else {
+											var valid0 = true;
+										}
+										if (valid0) {
+											if (data.plugins !== undefined) {
+												let data18 = data.plugins;
+												const _errs53 = errors;
+												if (errors === _errs53) {
+													if (Array.isArray(data18)) {
+														var valid11 = true;
+														const len2 =
+															data18.length;
+														for (
+															let i2 = 0;
+															i2 < len2;
+															i2++
+														) {
+															let data19 =
+																data18[i2];
+															const _errs55 =
+																errors;
+															const _errs56 =
+																errors;
+															let valid12 = false;
+															const _errs57 =
+																errors;
+															if (
+																typeof data19 !==
+																'string'
+															) {
+																const err9 = {
 																	instancePath:
 																		instancePath +
-																		'/login',
+																		'/plugins/' +
+																		i2,
 																	schemaPath:
-																		'#/properties/login/anyOf',
+																		'#/properties/plugins/items/anyOf/0/type',
+																	keyword:
+																		'type',
+																	params: {
+																		type: 'string',
+																	},
+																	message:
+																		'must be string',
+																};
+																if (
+																	vErrors ===
+																	null
+																) {
+																	vErrors = [
+																		err9,
+																	];
+																} else {
+																	vErrors.push(
+																		err9
+																	);
+																}
+																errors++;
+															}
+															var _valid2 =
+																_errs57 ===
+																errors;
+															valid12 =
+																valid12 ||
+																_valid2;
+															if (!valid12) {
+																const _errs59 =
+																	errors;
+																if (
+																	!validate16(
+																		data19,
+																		{
+																			instancePath:
+																				instancePath +
+																				'/plugins/' +
+																				i2,
+																			parentData:
+																				data18,
+																			parentDataProperty:
+																				i2,
+																			rootData,
+																		}
+																	)
+																) {
+																	vErrors =
+																		vErrors ===
+																		null
+																			? validate16.errors
+																			: vErrors.concat(
+																					validate16.errors
+																				);
+																	errors =
+																		vErrors.length;
+																}
+																var _valid2 =
+																	_errs59 ===
+																	errors;
+																valid12 =
+																	valid12 ||
+																	_valid2;
+															}
+															if (!valid12) {
+																const err10 = {
+																	instancePath:
+																		instancePath +
+																		'/plugins/' +
+																		i2,
+																	schemaPath:
+																		'#/properties/plugins/items/anyOf',
 																	keyword:
 																		'anyOf',
 																	params: {},
@@ -21665,11 +21266,11 @@ function validate11(
 																	null
 																) {
 																	vErrors = [
-																		err11,
+																		err10,
 																	];
 																} else {
 																	vErrors.push(
-																		err11
+																		err10
 																	);
 																}
 																errors++;
@@ -21678,115 +21279,350 @@ function validate11(
 																return false;
 															} else {
 																errors =
-																	_errs64;
+																	_errs56;
 																if (
 																	vErrors !==
 																	null
 																) {
 																	if (
-																		_errs64
+																		_errs56
 																	) {
 																		vErrors.length =
-																			_errs64;
+																			_errs56;
 																	} else {
 																		vErrors =
 																			null;
 																	}
 																}
 															}
-															var valid0 =
-																_errs63 ===
+															var valid11 =
+																_errs55 ===
 																errors;
-														} else {
-															var valid0 = true;
+															if (!valid11) {
+																break;
+															}
 														}
-														if (valid0) {
-															if (
-																data.steps !==
-																undefined
-															) {
-																let data27 =
-																	data.steps;
-																const _errs74 =
-																	errors;
+													} else {
+														validate11.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/plugins',
+																schemaPath:
+																	'#/properties/plugins/type',
+																keyword: 'type',
+																params: {
+																	type: 'array',
+																},
+																message:
+																	'must be array',
+															},
+														];
+														return false;
+													}
+												}
+												var valid0 = _errs53 === errors;
+											} else {
+												var valid0 = true;
+											}
+											if (valid0) {
+												if (
+													data.siteOptions !==
+													undefined
+												) {
+													let data20 =
+														data.siteOptions;
+													const _errs60 = errors;
+													if (errors === _errs60) {
+														if (
+															data20 &&
+															typeof data20 ==
+																'object' &&
+															!Array.isArray(
+																data20
+															)
+														) {
+															const _errs62 =
+																errors;
+															for (const key5 in data20) {
 																if (
-																	errors ===
-																	_errs74
+																	!(
+																		key5 ===
+																		'blogname'
+																	)
+																) {
+																	const _errs63 =
+																		errors;
+																	if (
+																		typeof data20[
+																			key5
+																		] !==
+																		'string'
+																	) {
+																		validate11.errors =
+																			[
+																				{
+																					instancePath:
+																						instancePath +
+																						'/siteOptions/' +
+																						key5
+																							.replace(
+																								/~/g,
+																								'~0'
+																							)
+																							.replace(
+																								/\//g,
+																								'~1'
+																							),
+																					schemaPath:
+																						'#/properties/siteOptions/additionalProperties/type',
+																					keyword:
+																						'type',
+																					params: {
+																						type: 'string',
+																					},
+																					message:
+																						'must be string',
+																				},
+																			];
+																		return false;
+																	}
+																	var valid13 =
+																		_errs63 ===
+																		errors;
+																	if (
+																		!valid13
+																	) {
+																		break;
+																	}
+																}
+															}
+															if (
+																_errs62 ===
+																errors
+															) {
+																if (
+																	data20.blogname !==
+																	undefined
 																) {
 																	if (
-																		Array.isArray(
-																			data27
-																		)
+																		typeof data20.blogname !==
+																		'string'
 																	) {
-																		var valid16 = true;
-																		const len3 =
-																			data27.length;
-																		for (
-																			let i3 = 0;
-																			i3 <
-																			len3;
-																			i3++
+																		validate11.errors =
+																			[
+																				{
+																					instancePath:
+																						instancePath +
+																						'/siteOptions/blogname',
+																					schemaPath:
+																						'#/properties/siteOptions/properties/blogname/type',
+																					keyword:
+																						'type',
+																					params: {
+																						type: 'string',
+																					},
+																					message:
+																						'must be string',
+																				},
+																			];
+																		return false;
+																	}
+																}
+															}
+														} else {
+															validate11.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/siteOptions',
+																		schemaPath:
+																			'#/properties/siteOptions/type',
+																		keyword:
+																			'type',
+																		params: {
+																			type: 'object',
+																		},
+																		message:
+																			'must be object',
+																	},
+																];
+															return false;
+														}
+													}
+													var valid0 =
+														_errs60 === errors;
+												} else {
+													var valid0 = true;
+												}
+												if (valid0) {
+													if (
+														data.login !== undefined
+													) {
+														let data23 = data.login;
+														const _errs67 = errors;
+														const _errs68 = errors;
+														let valid15 = false;
+														const _errs69 = errors;
+														if (
+															typeof data23 !==
+															'boolean'
+														) {
+															const err11 = {
+																instancePath:
+																	instancePath +
+																	'/login',
+																schemaPath:
+																	'#/properties/login/anyOf/0/type',
+																keyword: 'type',
+																params: {
+																	type: 'boolean',
+																},
+																message:
+																	'must be boolean',
+															};
+															if (
+																vErrors === null
+															) {
+																vErrors = [
+																	err11,
+																];
+															} else {
+																vErrors.push(
+																	err11
+																);
+															}
+															errors++;
+														}
+														var _valid3 =
+															_errs69 === errors;
+														valid15 =
+															valid15 || _valid3;
+														if (!valid15) {
+															const _errs71 =
+																errors;
+															if (
+																errors ===
+																_errs71
+															) {
+																if (
+																	data23 &&
+																	typeof data23 ==
+																		'object' &&
+																	!Array.isArray(
+																		data23
+																	)
+																) {
+																	let missing2;
+																	if (
+																		(data23.username ===
+																			undefined &&
+																			(missing2 =
+																				'username')) ||
+																		(data23.password ===
+																			undefined &&
+																			(missing2 =
+																				'password'))
+																	) {
+																		const err12 =
+																			{
+																				instancePath:
+																					instancePath +
+																					'/login',
+																				schemaPath:
+																					'#/properties/login/anyOf/1/required',
+																				keyword:
+																					'required',
+																				params: {
+																					missingProperty:
+																						missing2,
+																				},
+																				message:
+																					"must have required property '" +
+																					missing2 +
+																					"'",
+																			};
+																		if (
+																			vErrors ===
+																			null
 																		) {
-																			let data28 =
-																				data27[
-																					i3
+																			vErrors =
+																				[
+																					err12,
 																				];
-																			const _errs76 =
-																				errors;
-																			const _errs77 =
-																				errors;
-																			let valid17 = false;
-																			const _errs78 =
-																				errors;
+																		} else {
+																			vErrors.push(
+																				err12
+																			);
+																		}
+																		errors++;
+																	} else {
+																		const _errs73 =
+																			errors;
+																		for (const key6 in data23) {
 																			if (
-																				!validate28(
-																					data28,
+																				!(
+																					key6 ===
+																						'username' ||
+																					key6 ===
+																						'password'
+																				)
+																			) {
+																				const err13 =
 																					{
 																						instancePath:
 																							instancePath +
-																							'/steps/' +
-																							i3,
-																						parentData:
-																							data27,
-																						parentDataProperty:
-																							i3,
-																						rootData,
-																					}
-																				)
-																			) {
-																				vErrors =
+																							'/login',
+																						schemaPath:
+																							'#/properties/login/anyOf/1/additionalProperties',
+																						keyword:
+																							'additionalProperties',
+																						params: {
+																							additionalProperty:
+																								key6,
+																						},
+																						message:
+																							'must NOT have additional properties',
+																					};
+																				if (
 																					vErrors ===
 																					null
-																						? validate28.errors
-																						: vErrors.concat(
-																								validate28.errors
-																							);
-																				errors =
-																					vErrors.length;
+																				) {
+																					vErrors =
+																						[
+																							err13,
+																						];
+																				} else {
+																					vErrors.push(
+																						err13
+																					);
+																				}
+																				errors++;
+																				break;
 																			}
-																			var _valid3 =
-																				_errs78 ===
-																				errors;
-																			valid17 =
-																				valid17 ||
-																				_valid3;
+																		}
+																		if (
+																			_errs73 ===
+																			errors
+																		) {
 																			if (
-																				!valid17
+																				data23.username !==
+																				undefined
 																			) {
-																				const _errs79 =
+																				const _errs74 =
 																					errors;
 																				if (
-																					typeof data28 !==
+																					typeof data23.username !==
 																					'string'
 																				) {
-																					const err12 =
+																					const err14 =
 																						{
 																							instancePath:
 																								instancePath +
-																								'/steps/' +
-																								i3,
+																								'/login/username',
 																							schemaPath:
-																								'#/properties/steps/items/anyOf/1/type',
+																								'#/properties/login/anyOf/1/properties/username/type',
 																							keyword:
 																								'type',
 																							params: {
@@ -21801,207 +21637,253 @@ function validate11(
 																					) {
 																						vErrors =
 																							[
-																								err12,
+																								err14,
 																							];
 																					} else {
 																						vErrors.push(
-																							err12
+																							err14
 																						);
 																					}
 																					errors++;
 																				}
-																				var _valid3 =
-																					_errs79 ===
+																				var valid16 =
+																					_errs74 ===
 																					errors;
-																				valid17 =
-																					valid17 ||
-																					_valid3;
-																				if (
-																					!valid17
-																				) {
-																					const _errs81 =
-																						errors;
-																					const err13 =
-																						{
-																							instancePath:
-																								instancePath +
-																								'/steps/' +
-																								i3,
-																							schemaPath:
-																								'#/properties/steps/items/anyOf/2/not',
-																							keyword:
-																								'not',
-																							params: {},
-																							message:
-																								'must NOT be valid',
-																						};
-																					if (
-																						vErrors ===
-																						null
-																					) {
-																						vErrors =
-																							[
-																								err13,
-																							];
-																					} else {
-																						vErrors.push(
-																							err13
-																						);
-																					}
-																					errors++;
-																					var _valid3 =
-																						_errs81 ===
-																						errors;
-																					valid17 =
-																						valid17 ||
-																						_valid3;
-																					if (
-																						!valid17
-																					) {
-																						const _errs83 =
-																							errors;
-																						if (
-																							typeof data28 !==
-																							'boolean'
-																						) {
-																							const err14 =
-																								{
-																									instancePath:
-																										instancePath +
-																										'/steps/' +
-																										i3,
-																									schemaPath:
-																										'#/properties/steps/items/anyOf/3/type',
-																									keyword:
-																										'type',
-																									params: {
-																										type: 'boolean',
-																									},
-																									message:
-																										'must be boolean',
-																								};
-																							if (
-																								vErrors ===
-																								null
-																							) {
-																								vErrors =
-																									[
-																										err14,
-																									];
-																							} else {
-																								vErrors.push(
-																									err14
-																								);
-																							}
-																							errors++;
-																						}
-																						if (
-																							false !==
-																							data28
-																						) {
-																							const err15 =
-																								{
-																									instancePath:
-																										instancePath +
-																										'/steps/' +
-																										i3,
-																									schemaPath:
-																										'#/properties/steps/items/anyOf/3/const',
-																									keyword:
-																										'const',
-																									params: {
-																										allowedValue: false,
-																									},
-																									message:
-																										'must be equal to constant',
-																								};
-																							if (
-																								vErrors ===
-																								null
-																							) {
-																								vErrors =
-																									[
-																										err15,
-																									];
-																							} else {
-																								vErrors.push(
-																									err15
-																								);
-																							}
-																							errors++;
-																						}
-																						var _valid3 =
-																							_errs83 ===
-																							errors;
-																						valid17 =
-																							valid17 ||
-																							_valid3;
-																						if (
-																							!valid17
-																						) {
-																							const _errs85 =
-																								errors;
-																							if (
-																								data28 !==
-																								null
-																							) {
-																								const err16 =
-																									{
-																										instancePath:
-																											instancePath +
-																											'/steps/' +
-																											i3,
-																										schemaPath:
-																											'#/properties/steps/items/anyOf/4/type',
-																										keyword:
-																											'type',
-																										params: {
-																											type: 'null',
-																										},
-																										message:
-																											'must be null',
-																									};
-																								if (
-																									vErrors ===
-																									null
-																								) {
-																									vErrors =
-																										[
-																											err16,
-																										];
-																								} else {
-																									vErrors.push(
-																										err16
-																									);
-																								}
-																								errors++;
-																							}
-																							var _valid3 =
-																								_errs85 ===
-																								errors;
-																							valid17 =
-																								valid17 ||
-																								_valid3;
-																						}
-																					}
-																				}
+																			} else {
+																				var valid16 = true;
 																			}
 																			if (
-																				!valid17
+																				valid16
 																			) {
-																				const err17 =
+																				if (
+																					data23.password !==
+																					undefined
+																				) {
+																					const _errs76 =
+																						errors;
+																					if (
+																						typeof data23.password !==
+																						'string'
+																					) {
+																						const err15 =
+																							{
+																								instancePath:
+																									instancePath +
+																									'/login/password',
+																								schemaPath:
+																									'#/properties/login/anyOf/1/properties/password/type',
+																								keyword:
+																									'type',
+																								params: {
+																									type: 'string',
+																								},
+																								message:
+																									'must be string',
+																							};
+																						if (
+																							vErrors ===
+																							null
+																						) {
+																							vErrors =
+																								[
+																									err15,
+																								];
+																						} else {
+																							vErrors.push(
+																								err15
+																							);
+																						}
+																						errors++;
+																					}
+																					var valid16 =
+																						_errs76 ===
+																						errors;
+																				} else {
+																					var valid16 = true;
+																				}
+																			}
+																		}
+																	}
+																} else {
+																	const err16 =
+																		{
+																			instancePath:
+																				instancePath +
+																				'/login',
+																			schemaPath:
+																				'#/properties/login/anyOf/1/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'object',
+																			},
+																			message:
+																				'must be object',
+																		};
+																	if (
+																		vErrors ===
+																		null
+																	) {
+																		vErrors =
+																			[
+																				err16,
+																			];
+																	} else {
+																		vErrors.push(
+																			err16
+																		);
+																	}
+																	errors++;
+																}
+															}
+															var _valid3 =
+																_errs71 ===
+																errors;
+															valid15 =
+																valid15 ||
+																_valid3;
+														}
+														if (!valid15) {
+															const err17 = {
+																instancePath:
+																	instancePath +
+																	'/login',
+																schemaPath:
+																	'#/properties/login/anyOf',
+																keyword:
+																	'anyOf',
+																params: {},
+																message:
+																	'must match a schema in anyOf',
+															};
+															if (
+																vErrors === null
+															) {
+																vErrors = [
+																	err17,
+																];
+															} else {
+																vErrors.push(
+																	err17
+																);
+															}
+															errors++;
+															validate11.errors =
+																vErrors;
+															return false;
+														} else {
+															errors = _errs68;
+															if (
+																vErrors !== null
+															) {
+																if (_errs68) {
+																	vErrors.length =
+																		_errs68;
+																} else {
+																	vErrors =
+																		null;
+																}
+															}
+														}
+														var valid0 =
+															_errs67 === errors;
+													} else {
+														var valid0 = true;
+													}
+													if (valid0) {
+														if (
+															data.steps !==
+															undefined
+														) {
+															let data26 =
+																data.steps;
+															const _errs78 =
+																errors;
+															if (
+																errors ===
+																_errs78
+															) {
+																if (
+																	Array.isArray(
+																		data26
+																	)
+																) {
+																	var valid17 = true;
+																	const len3 =
+																		data26.length;
+																	for (
+																		let i3 = 0;
+																		i3 <
+																		len3;
+																		i3++
+																	) {
+																		let data27 =
+																			data26[
+																				i3
+																			];
+																		const _errs80 =
+																			errors;
+																		const _errs81 =
+																			errors;
+																		let valid18 = false;
+																		const _errs82 =
+																			errors;
+																		if (
+																			!validate28(
+																				data27,
+																				{
+																					instancePath:
+																						instancePath +
+																						'/steps/' +
+																						i3,
+																					parentData:
+																						data26,
+																					parentDataProperty:
+																						i3,
+																					rootData,
+																				}
+																			)
+																		) {
+																			vErrors =
+																				vErrors ===
+																				null
+																					? validate28.errors
+																					: vErrors.concat(
+																							validate28.errors
+																						);
+																			errors =
+																				vErrors.length;
+																		}
+																		var _valid4 =
+																			_errs82 ===
+																			errors;
+																		valid18 =
+																			valid18 ||
+																			_valid4;
+																		if (
+																			!valid18
+																		) {
+																			const _errs83 =
+																				errors;
+																			if (
+																				typeof data27 !==
+																				'string'
+																			) {
+																				const err18 =
 																					{
 																						instancePath:
 																							instancePath +
 																							'/steps/' +
 																							i3,
 																						schemaPath:
-																							'#/properties/steps/items/anyOf',
+																							'#/properties/steps/items/anyOf/1/type',
 																						keyword:
-																							'anyOf',
-																						params: {},
+																							'type',
+																						params: {
+																							type: 'string',
+																						},
 																						message:
-																							'must match a schema in anyOf',
+																							'must be string',
 																					};
 																				if (
 																					vErrors ===
@@ -22009,107 +21891,314 @@ function validate11(
 																				) {
 																					vErrors =
 																						[
-																							err17,
+																							err18,
 																						];
 																				} else {
 																					vErrors.push(
-																						err17
+																						err18
 																					);
 																				}
 																				errors++;
-																				validate11.errors =
-																					vErrors;
-																				return false;
-																			} else {
-																				errors =
-																					_errs77;
+																			}
+																			var _valid4 =
+																				_errs83 ===
+																				errors;
+																			valid18 =
+																				valid18 ||
+																				_valid4;
+																			if (
+																				!valid18
+																			) {
+																				const _errs85 =
+																					errors;
+																				const err19 =
+																					{
+																						instancePath:
+																							instancePath +
+																							'/steps/' +
+																							i3,
+																						schemaPath:
+																							'#/properties/steps/items/anyOf/2/not',
+																						keyword:
+																							'not',
+																						params: {},
+																						message:
+																							'must NOT be valid',
+																					};
 																				if (
-																					vErrors !==
+																					vErrors ===
 																					null
 																				) {
+																					vErrors =
+																						[
+																							err19,
+																						];
+																				} else {
+																					vErrors.push(
+																						err19
+																					);
+																				}
+																				errors++;
+																				var _valid4 =
+																					_errs85 ===
+																					errors;
+																				valid18 =
+																					valid18 ||
+																					_valid4;
+																				if (
+																					!valid18
+																				) {
+																					const _errs87 =
+																						errors;
 																					if (
-																						_errs77
+																						typeof data27 !==
+																						'boolean'
 																					) {
-																						vErrors.length =
-																							_errs77;
-																					} else {
-																						vErrors =
-																							null;
+																						const err20 =
+																							{
+																								instancePath:
+																									instancePath +
+																									'/steps/' +
+																									i3,
+																								schemaPath:
+																									'#/properties/steps/items/anyOf/3/type',
+																								keyword:
+																									'type',
+																								params: {
+																									type: 'boolean',
+																								},
+																								message:
+																									'must be boolean',
+																							};
+																						if (
+																							vErrors ===
+																							null
+																						) {
+																							vErrors =
+																								[
+																									err20,
+																								];
+																						} else {
+																							vErrors.push(
+																								err20
+																							);
+																						}
+																						errors++;
+																					}
+																					if (
+																						false !==
+																						data27
+																					) {
+																						const err21 =
+																							{
+																								instancePath:
+																									instancePath +
+																									'/steps/' +
+																									i3,
+																								schemaPath:
+																									'#/properties/steps/items/anyOf/3/const',
+																								keyword:
+																									'const',
+																								params: {
+																									allowedValue: false,
+																								},
+																								message:
+																									'must be equal to constant',
+																							};
+																						if (
+																							vErrors ===
+																							null
+																						) {
+																							vErrors =
+																								[
+																									err21,
+																								];
+																						} else {
+																							vErrors.push(
+																								err21
+																							);
+																						}
+																						errors++;
+																					}
+																					var _valid4 =
+																						_errs87 ===
+																						errors;
+																					valid18 =
+																						valid18 ||
+																						_valid4;
+																					if (
+																						!valid18
+																					) {
+																						const _errs89 =
+																							errors;
+																						if (
+																							data27 !==
+																							null
+																						) {
+																							const err22 =
+																								{
+																									instancePath:
+																										instancePath +
+																										'/steps/' +
+																										i3,
+																									schemaPath:
+																										'#/properties/steps/items/anyOf/4/type',
+																									keyword:
+																										'type',
+																									params: {
+																										type: 'null',
+																									},
+																									message:
+																										'must be null',
+																								};
+																							if (
+																								vErrors ===
+																								null
+																							) {
+																								vErrors =
+																									[
+																										err22,
+																									];
+																							} else {
+																								vErrors.push(
+																									err22
+																								);
+																							}
+																							errors++;
+																						}
+																						var _valid4 =
+																							_errs89 ===
+																							errors;
+																						valid18 =
+																							valid18 ||
+																							_valid4;
 																					}
 																				}
 																			}
-																			var valid16 =
-																				_errs76 ===
-																				errors;
-																			if (
-																				!valid16
-																			) {
-																				break;
-																			}
 																		}
-																	} else {
-																		validate11.errors =
-																			[
+																		if (
+																			!valid18
+																		) {
+																			const err23 =
 																				{
 																					instancePath:
 																						instancePath +
-																						'/steps',
+																						'/steps/' +
+																						i3,
 																					schemaPath:
-																						'#/properties/steps/type',
+																						'#/properties/steps/items/anyOf',
 																					keyword:
-																						'type',
-																					params: {
-																						type: 'array',
-																					},
+																						'anyOf',
+																					params: {},
 																					message:
-																						'must be array',
-																				},
-																			];
-																		return false;
+																						'must match a schema in anyOf',
+																				};
+																			if (
+																				vErrors ===
+																				null
+																			) {
+																				vErrors =
+																					[
+																						err23,
+																					];
+																			} else {
+																				vErrors.push(
+																					err23
+																				);
+																			}
+																			errors++;
+																			validate11.errors =
+																				vErrors;
+																			return false;
+																		} else {
+																			errors =
+																				_errs81;
+																			if (
+																				vErrors !==
+																				null
+																			) {
+																				if (
+																					_errs81
+																				) {
+																					vErrors.length =
+																						_errs81;
+																				} else {
+																					vErrors =
+																						null;
+																				}
+																			}
+																		}
+																		var valid17 =
+																			_errs80 ===
+																			errors;
+																		if (
+																			!valid17
+																		) {
+																			break;
+																		}
 																	}
+																} else {
+																	validate11.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/steps',
+																				schemaPath:
+																					'#/properties/steps/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'array',
+																				},
+																				message:
+																					'must be array',
+																			},
+																		];
+																	return false;
+																}
+															}
+															var valid0 =
+																_errs78 ===
+																errors;
+														} else {
+															var valid0 = true;
+														}
+														if (valid0) {
+															if (
+																data.$schema !==
+																undefined
+															) {
+																const _errs91 =
+																	errors;
+																if (
+																	typeof data.$schema !==
+																	'string'
+																) {
+																	validate11.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/$schema',
+																				schemaPath:
+																					'#/properties/%24schema/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'string',
+																				},
+																				message:
+																					'must be string',
+																			},
+																		];
+																	return false;
 																}
 																var valid0 =
-																	_errs74 ===
+																	_errs91 ===
 																	errors;
 															} else {
 																var valid0 = true;
-															}
-															if (valid0) {
-																if (
-																	data.$schema !==
-																	undefined
-																) {
-																	const _errs87 =
-																		errors;
-																	if (
-																		typeof data.$schema !==
-																		'string'
-																	) {
-																		validate11.errors =
-																			[
-																				{
-																					instancePath:
-																						instancePath +
-																						'/$schema',
-																					schemaPath:
-																						'#/properties/%24schema/type',
-																					keyword:
-																						'type',
-																					params: {
-																						type: 'string',
-																					},
-																					message:
-																						'must be string',
-																				},
-																			];
-																		return false;
-																	}
-																	var valid0 =
-																		_errs87 ===
-																		errors;
-																} else {
-																	var valid0 = true;
-																}
 															}
 														}
 													}

--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -49,6 +49,12 @@ const schema11 = {
 					description:
 						'Optional metadata. Used by the Blueprints gallery at https://github.com/WordPress/blueprints',
 				},
+				wordpress: {
+					type: 'boolean',
+					const: false,
+					description:
+						'Set to `false` to boot a PHP-only Playground without downloading or installing WordPress. Useful for running pure-PHP snippets.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time. `preferredVersions.wp` is ignored.',
+				},
 				preferredVersions: {
 					type: 'object',
 					properties: {
@@ -1462,6 +1468,12 @@ const schema12 = {
 			additionalProperties: false,
 			description:
 				'Optional metadata. Used by the Blueprints gallery at https://github.com/WordPress/blueprints',
+		},
+		wordpress: {
+			type: 'boolean',
+			const: false,
+			description:
+				'Set to `false` to boot a PHP-only Playground without downloading or installing WordPress. Useful for running pure-PHP snippets.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time. `preferredVersions.wp` is ignored.',
 		},
 		preferredVersions: {
 			type: 'object',
@@ -20380,337 +20392,374 @@ function validate11(
 							var valid0 = true;
 						}
 						if (valid0) {
-							if (data.preferredVersions !== undefined) {
-								let data8 = data.preferredVersions;
+							if (data.wordpress !== undefined) {
+								let data8 = data.wordpress;
 								const _errs19 = errors;
-								if (errors === _errs19) {
-									if (
-										data8 &&
-										typeof data8 == 'object' &&
-										!Array.isArray(data8)
-									) {
-										let missing1;
-										if (
-											(data8.php === undefined &&
-												(missing1 = 'php')) ||
-											(data8.wp === undefined &&
-												(missing1 = 'wp'))
-										) {
-											validate11.errors = [
-												{
-													instancePath:
-														instancePath +
-														'/preferredVersions',
-													schemaPath:
-														'#/properties/preferredVersions/required',
-													keyword: 'required',
-													params: {
-														missingProperty:
-															missing1,
-													},
-													message:
-														"must have required property '" +
-														missing1 +
-														"'",
-												},
-											];
-											return false;
-										} else {
-											const _errs21 = errors;
-											for (const key2 in data8) {
-												if (
-													!(
-														key2 === 'php' ||
-														key2 === 'wp'
-													)
-												) {
-													validate11.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/preferredVersions',
-															schemaPath:
-																'#/properties/preferredVersions/additionalProperties',
-															keyword:
-																'additionalProperties',
-															params: {
-																additionalProperty:
-																	key2,
-															},
-															message:
-																'must NOT have additional properties',
-														},
-													];
-													return false;
-													break;
-												}
-											}
-											if (_errs21 === errors) {
-												if (data8.php !== undefined) {
-													let data9 = data8.php;
-													const _errs22 = errors;
-													const _errs23 = errors;
-													let valid4 = false;
-													const _errs24 = errors;
-													if (
-														!validate12(data9, {
-															instancePath:
-																instancePath +
-																'/preferredVersions/php',
-															parentData: data8,
-															parentDataProperty:
-																'php',
-															rootData,
-														})
-													) {
-														vErrors =
-															vErrors === null
-																? validate12.errors
-																: vErrors.concat(
-																		validate12.errors
-																	);
-														errors = vErrors.length;
-													}
-													var _valid0 =
-														_errs24 === errors;
-													valid4 = valid4 || _valid0;
-													if (!valid4) {
-														const _errs25 = errors;
-														if (
-															typeof data9 !==
-															'string'
-														) {
-															const err0 = {
-																instancePath:
-																	instancePath +
-																	'/preferredVersions/php',
-																schemaPath:
-																	'#/properties/preferredVersions/properties/php/anyOf/1/type',
-																keyword: 'type',
-																params: {
-																	type: 'string',
-																},
-																message:
-																	'must be string',
-															};
-															if (
-																vErrors === null
-															) {
-																vErrors = [
-																	err0,
-																];
-															} else {
-																vErrors.push(
-																	err0
-																);
-															}
-															errors++;
-														}
-														if (
-															'latest' !== data9
-														) {
-															const err1 = {
-																instancePath:
-																	instancePath +
-																	'/preferredVersions/php',
-																schemaPath:
-																	'#/properties/preferredVersions/properties/php/anyOf/1/const',
-																keyword:
-																	'const',
-																params: {
-																	allowedValue:
-																		'latest',
-																},
-																message:
-																	'must be equal to constant',
-															};
-															if (
-																vErrors === null
-															) {
-																vErrors = [
-																	err1,
-																];
-															} else {
-																vErrors.push(
-																	err1
-																);
-															}
-															errors++;
-														}
-														var _valid0 =
-															_errs25 === errors;
-														valid4 =
-															valid4 || _valid0;
-													}
-													if (!valid4) {
-														const err2 = {
-															instancePath:
-																instancePath +
-																'/preferredVersions/php',
-															schemaPath:
-																'#/properties/preferredVersions/properties/php/anyOf',
-															keyword: 'anyOf',
-															params: {},
-															message:
-																'must match a schema in anyOf',
-														};
-														if (vErrors === null) {
-															vErrors = [err2];
-														} else {
-															vErrors.push(err2);
-														}
-														errors++;
-														validate11.errors =
-															vErrors;
-														return false;
-													} else {
-														errors = _errs23;
-														if (vErrors !== null) {
-															if (_errs23) {
-																vErrors.length =
-																	_errs23;
-															} else {
-																vErrors = null;
-															}
-														}
-													}
-													var valid3 =
-														_errs22 === errors;
-												} else {
-													var valid3 = true;
-												}
-												if (valid3) {
-													if (
-														data8.wp !== undefined
-													) {
-														const _errs27 = errors;
-														if (
-															typeof data8.wp !==
-															'string'
-														) {
-															validate11.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/preferredVersions/wp',
-																		schemaPath:
-																			'#/properties/preferredVersions/properties/wp/type',
-																		keyword:
-																			'type',
-																		params: {
-																			type: 'string',
-																		},
-																		message:
-																			'must be string',
-																	},
-																];
-															return false;
-														}
-														var valid3 =
-															_errs27 === errors;
-													} else {
-														var valid3 = true;
-													}
-												}
-											}
-										}
-									} else {
-										validate11.errors = [
-											{
-												instancePath:
-													instancePath +
-													'/preferredVersions',
-												schemaPath:
-													'#/properties/preferredVersions/type',
-												keyword: 'type',
-												params: { type: 'object' },
-												message: 'must be object',
-											},
-										];
-										return false;
-									}
+								if (typeof data8 !== 'boolean') {
+									validate11.errors = [
+										{
+											instancePath:
+												instancePath + '/wordpress',
+											schemaPath:
+												'#/properties/wordpress/type',
+											keyword: 'type',
+											params: { type: 'boolean' },
+											message: 'must be boolean',
+										},
+									];
+									return false;
+								}
+								if (false !== data8) {
+									validate11.errors = [
+										{
+											instancePath:
+												instancePath + '/wordpress',
+											schemaPath:
+												'#/properties/wordpress/const',
+											keyword: 'const',
+											params: { allowedValue: false },
+											message:
+												'must be equal to constant',
+										},
+									];
+									return false;
 								}
 								var valid0 = _errs19 === errors;
 							} else {
 								var valid0 = true;
 							}
 							if (valid0) {
-								if (data.features !== undefined) {
-									let data11 = data.features;
-									const _errs29 = errors;
-									if (errors === _errs29) {
+								if (data.preferredVersions !== undefined) {
+									let data9 = data.preferredVersions;
+									const _errs21 = errors;
+									if (errors === _errs21) {
 										if (
-											data11 &&
-											typeof data11 == 'object' &&
-											!Array.isArray(data11)
+											data9 &&
+											typeof data9 == 'object' &&
+											!Array.isArray(data9)
 										) {
-											const _errs31 = errors;
-											for (const key3 in data11) {
-												if (
-													!(
-														key3 === 'intl' ||
-														key3 === 'networking'
-													)
-												) {
-													validate11.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/features',
-															schemaPath:
-																'#/properties/features/additionalProperties',
-															keyword:
-																'additionalProperties',
-															params: {
-																additionalProperty:
-																	key3,
-															},
-															message:
-																'must NOT have additional properties',
+											let missing1;
+											if (
+												(data9.php === undefined &&
+													(missing1 = 'php')) ||
+												(data9.wp === undefined &&
+													(missing1 = 'wp'))
+											) {
+												validate11.errors = [
+													{
+														instancePath:
+															instancePath +
+															'/preferredVersions',
+														schemaPath:
+															'#/properties/preferredVersions/required',
+														keyword: 'required',
+														params: {
+															missingProperty:
+																missing1,
 														},
-													];
-													return false;
-													break;
-												}
-											}
-											if (_errs31 === errors) {
-												if (data11.intl !== undefined) {
-													const _errs32 = errors;
+														message:
+															"must have required property '" +
+															missing1 +
+															"'",
+													},
+												];
+												return false;
+											} else {
+												const _errs23 = errors;
+												for (const key2 in data9) {
 													if (
-														typeof data11.intl !==
-														'boolean'
+														!(
+															key2 === 'php' ||
+															key2 === 'wp'
+														)
 													) {
 														validate11.errors = [
 															{
 																instancePath:
 																	instancePath +
-																	'/features/intl',
+																	'/preferredVersions',
 																schemaPath:
-																	'#/properties/features/properties/intl/type',
-																keyword: 'type',
+																	'#/properties/preferredVersions/additionalProperties',
+																keyword:
+																	'additionalProperties',
 																params: {
-																	type: 'boolean',
+																	additionalProperty:
+																		key2,
 																},
 																message:
-																	'must be boolean',
+																	'must NOT have additional properties',
 															},
 														];
 														return false;
+														break;
 													}
-													var valid5 =
-														_errs32 === errors;
-												} else {
-													var valid5 = true;
 												}
-												if (valid5) {
+												if (_errs23 === errors) {
 													if (
-														data11.networking !==
+														data9.php !== undefined
+													) {
+														let data10 = data9.php;
+														const _errs24 = errors;
+														const _errs25 = errors;
+														let valid4 = false;
+														const _errs26 = errors;
+														if (
+															!validate12(
+																data10,
+																{
+																	instancePath:
+																		instancePath +
+																		'/preferredVersions/php',
+																	parentData:
+																		data9,
+																	parentDataProperty:
+																		'php',
+																	rootData,
+																}
+															)
+														) {
+															vErrors =
+																vErrors === null
+																	? validate12.errors
+																	: vErrors.concat(
+																			validate12.errors
+																		);
+															errors =
+																vErrors.length;
+														}
+														var _valid0 =
+															_errs26 === errors;
+														valid4 =
+															valid4 || _valid0;
+														if (!valid4) {
+															const _errs27 =
+																errors;
+															if (
+																typeof data10 !==
+																'string'
+															) {
+																const err0 = {
+																	instancePath:
+																		instancePath +
+																		'/preferredVersions/php',
+																	schemaPath:
+																		'#/properties/preferredVersions/properties/php/anyOf/1/type',
+																	keyword:
+																		'type',
+																	params: {
+																		type: 'string',
+																	},
+																	message:
+																		'must be string',
+																};
+																if (
+																	vErrors ===
+																	null
+																) {
+																	vErrors = [
+																		err0,
+																	];
+																} else {
+																	vErrors.push(
+																		err0
+																	);
+																}
+																errors++;
+															}
+															if (
+																'latest' !==
+																data10
+															) {
+																const err1 = {
+																	instancePath:
+																		instancePath +
+																		'/preferredVersions/php',
+																	schemaPath:
+																		'#/properties/preferredVersions/properties/php/anyOf/1/const',
+																	keyword:
+																		'const',
+																	params: {
+																		allowedValue:
+																			'latest',
+																	},
+																	message:
+																		'must be equal to constant',
+																};
+																if (
+																	vErrors ===
+																	null
+																) {
+																	vErrors = [
+																		err1,
+																	];
+																} else {
+																	vErrors.push(
+																		err1
+																	);
+																}
+																errors++;
+															}
+															var _valid0 =
+																_errs27 ===
+																errors;
+															valid4 =
+																valid4 ||
+																_valid0;
+														}
+														if (!valid4) {
+															const err2 = {
+																instancePath:
+																	instancePath +
+																	'/preferredVersions/php',
+																schemaPath:
+																	'#/properties/preferredVersions/properties/php/anyOf',
+																keyword:
+																	'anyOf',
+																params: {},
+																message:
+																	'must match a schema in anyOf',
+															};
+															if (
+																vErrors === null
+															) {
+																vErrors = [
+																	err2,
+																];
+															} else {
+																vErrors.push(
+																	err2
+																);
+															}
+															errors++;
+															validate11.errors =
+																vErrors;
+															return false;
+														} else {
+															errors = _errs25;
+															if (
+																vErrors !== null
+															) {
+																if (_errs25) {
+																	vErrors.length =
+																		_errs25;
+																} else {
+																	vErrors =
+																		null;
+																}
+															}
+														}
+														var valid3 =
+															_errs24 === errors;
+													} else {
+														var valid3 = true;
+													}
+													if (valid3) {
+														if (
+															data9.wp !==
+															undefined
+														) {
+															const _errs29 =
+																errors;
+															if (
+																typeof data9.wp !==
+																'string'
+															) {
+																validate11.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/preferredVersions/wp',
+																			schemaPath:
+																				'#/properties/preferredVersions/properties/wp/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'string',
+																			},
+																			message:
+																				'must be string',
+																		},
+																	];
+																return false;
+															}
+															var valid3 =
+																_errs29 ===
+																errors;
+														} else {
+															var valid3 = true;
+														}
+													}
+												}
+											}
+										} else {
+											validate11.errors = [
+												{
+													instancePath:
+														instancePath +
+														'/preferredVersions',
+													schemaPath:
+														'#/properties/preferredVersions/type',
+													keyword: 'type',
+													params: { type: 'object' },
+													message: 'must be object',
+												},
+											];
+											return false;
+										}
+									}
+									var valid0 = _errs21 === errors;
+								} else {
+									var valid0 = true;
+								}
+								if (valid0) {
+									if (data.features !== undefined) {
+										let data12 = data.features;
+										const _errs31 = errors;
+										if (errors === _errs31) {
+											if (
+												data12 &&
+												typeof data12 == 'object' &&
+												!Array.isArray(data12)
+											) {
+												const _errs33 = errors;
+												for (const key3 in data12) {
+													if (
+														!(
+															key3 === 'intl' ||
+															key3 ===
+																'networking'
+														)
+													) {
+														validate11.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/features',
+																schemaPath:
+																	'#/properties/features/additionalProperties',
+																keyword:
+																	'additionalProperties',
+																params: {
+																	additionalProperty:
+																		key3,
+																},
+																message:
+																	'must NOT have additional properties',
+															},
+														];
+														return false;
+														break;
+													}
+												}
+												if (_errs33 === errors) {
+													if (
+														data12.intl !==
 														undefined
 													) {
 														const _errs34 = errors;
 														if (
-															typeof data11.networking !==
+															typeof data12.intl !==
 															'boolean'
 														) {
 															validate11.errors =
@@ -20718,9 +20767,9 @@ function validate11(
 																	{
 																		instancePath:
 																			instancePath +
-																			'/features/networking',
+																			'/features/intl',
 																		schemaPath:
-																			'#/properties/features/properties/networking/type',
+																			'#/properties/features/properties/intl/type',
 																		keyword:
 																			'type',
 																		params: {
@@ -20737,90 +20786,42 @@ function validate11(
 													} else {
 														var valid5 = true;
 													}
-												}
-											}
-										} else {
-											validate11.errors = [
-												{
-													instancePath:
-														instancePath +
-														'/features',
-													schemaPath:
-														'#/properties/features/type',
-													keyword: 'type',
-													params: { type: 'object' },
-													message: 'must be object',
-												},
-											];
-											return false;
-										}
-									}
-									var valid0 = _errs29 === errors;
-								} else {
-									var valid0 = true;
-								}
-								if (valid0) {
-									if (data.extraLibraries !== undefined) {
-										let data14 = data.extraLibraries;
-										const _errs36 = errors;
-										if (errors === _errs36) {
-											if (Array.isArray(data14)) {
-												var valid6 = true;
-												const len1 = data14.length;
-												for (
-													let i1 = 0;
-													i1 < len1;
-													i1++
-												) {
-													let data15 = data14[i1];
-													const _errs38 = errors;
-													if (
-														typeof data15 !==
-														'string'
-													) {
-														validate11.errors = [
-															{
-																instancePath:
-																	instancePath +
-																	'/extraLibraries/' +
-																	i1,
-																schemaPath:
-																	'#/definitions/ExtraLibrary/type',
-																keyword: 'type',
-																params: {
-																	type: 'string',
-																},
-																message:
-																	'must be string',
-															},
-														];
-														return false;
-													}
-													if ('wp-cli' !== data15) {
-														validate11.errors = [
-															{
-																instancePath:
-																	instancePath +
-																	'/extraLibraries/' +
-																	i1,
-																schemaPath:
-																	'#/definitions/ExtraLibrary/const',
-																keyword:
-																	'const',
-																params: {
-																	allowedValue:
-																		'wp-cli',
-																},
-																message:
-																	'must be equal to constant',
-															},
-														];
-														return false;
-													}
-													var valid6 =
-														_errs38 === errors;
-													if (!valid6) {
-														break;
+													if (valid5) {
+														if (
+															data12.networking !==
+															undefined
+														) {
+															const _errs36 =
+																errors;
+															if (
+																typeof data12.networking !==
+																'boolean'
+															) {
+																validate11.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/features/networking',
+																			schemaPath:
+																				'#/properties/features/properties/networking/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'boolean',
+																			},
+																			message:
+																				'must be boolean',
+																		},
+																	];
+																return false;
+															}
+															var valid5 =
+																_errs36 ===
+																errors;
+														} else {
+															var valid5 = true;
+														}
 													}
 												}
 											} else {
@@ -20828,83 +20829,90 @@ function validate11(
 													{
 														instancePath:
 															instancePath +
-															'/extraLibraries',
+															'/features',
 														schemaPath:
-															'#/properties/extraLibraries/type',
+															'#/properties/features/type',
 														keyword: 'type',
 														params: {
-															type: 'array',
+															type: 'object',
 														},
 														message:
-															'must be array',
+															'must be object',
 													},
 												];
 												return false;
 											}
 										}
-										var valid0 = _errs36 === errors;
+										var valid0 = _errs31 === errors;
 									} else {
 										var valid0 = true;
 									}
 									if (valid0) {
-										if (data.constants !== undefined) {
-											let data16 = data.constants;
-											const _errs41 = errors;
-											const _errs42 = errors;
-											if (errors === _errs42) {
-												if (
-													data16 &&
-													typeof data16 == 'object' &&
-													!Array.isArray(data16)
-												) {
-													for (const key4 in data16) {
-														let data17 =
-															data16[key4];
-														const _errs45 = errors;
+										if (data.extraLibraries !== undefined) {
+											let data15 = data.extraLibraries;
+											const _errs38 = errors;
+											if (errors === _errs38) {
+												if (Array.isArray(data15)) {
+													var valid6 = true;
+													const len1 = data15.length;
+													for (
+														let i1 = 0;
+														i1 < len1;
+														i1++
+													) {
+														let data16 = data15[i1];
+														const _errs40 = errors;
 														if (
-															typeof data17 !==
-																'string' &&
-															typeof data17 !==
-																'boolean' &&
-															!(
-																typeof data17 ==
-																	'number' &&
-																isFinite(data17)
-															)
+															typeof data16 !==
+															'string'
 														) {
 															validate11.errors =
 																[
 																	{
 																		instancePath:
 																			instancePath +
-																			'/constants/' +
-																			key4
-																				.replace(
-																					/~/g,
-																					'~0'
-																				)
-																				.replace(
-																					/\//g,
-																					'~1'
-																				),
+																			'/extraLibraries/' +
+																			i1,
 																		schemaPath:
-																			'#/definitions/PHPConstants/additionalProperties/type',
+																			'#/definitions/ExtraLibrary/type',
 																		keyword:
 																			'type',
 																		params: {
-																			type: schema18
-																				.additionalProperties
-																				.type,
+																			type: 'string',
 																		},
 																		message:
-																			'must be string,boolean,number',
+																			'must be string',
 																	},
 																];
 															return false;
 														}
-														var valid9 =
-															_errs45 === errors;
-														if (!valid9) {
+														if (
+															'wp-cli' !== data16
+														) {
+															validate11.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/extraLibraries/' +
+																			i1,
+																		schemaPath:
+																			'#/definitions/ExtraLibrary/const',
+																		keyword:
+																			'const',
+																		params: {
+																			allowedValue:
+																				'wp-cli',
+																		},
+																		message:
+																			'must be equal to constant',
+																	},
+																];
+															return false;
+														}
+														var valid6 =
+															_errs40 === errors;
+														if (!valid6) {
 															break;
 														}
 													}
@@ -20913,174 +20921,88 @@ function validate11(
 														{
 															instancePath:
 																instancePath +
-																'/constants',
+																'/extraLibraries',
 															schemaPath:
-																'#/definitions/PHPConstants/type',
+																'#/properties/extraLibraries/type',
 															keyword: 'type',
 															params: {
-																type: 'object',
+																type: 'array',
 															},
 															message:
-																'must be object',
+																'must be array',
 														},
 													];
 													return false;
 												}
 											}
-											var valid0 = _errs41 === errors;
+											var valid0 = _errs38 === errors;
 										} else {
 											var valid0 = true;
 										}
 										if (valid0) {
-											if (data.plugins !== undefined) {
-												let data18 = data.plugins;
-												const _errs47 = errors;
-												if (errors === _errs47) {
-													if (Array.isArray(data18)) {
-														var valid10 = true;
-														const len2 =
-															data18.length;
-														for (
-															let i2 = 0;
-															i2 < len2;
-															i2++
-														) {
-															let data19 =
-																data18[i2];
-															const _errs49 =
-																errors;
-															const _errs50 =
-																errors;
-															let valid11 = false;
-															const _errs51 =
+											if (data.constants !== undefined) {
+												let data17 = data.constants;
+												const _errs43 = errors;
+												const _errs44 = errors;
+												if (errors === _errs44) {
+													if (
+														data17 &&
+														typeof data17 ==
+															'object' &&
+														!Array.isArray(data17)
+													) {
+														for (const key4 in data17) {
+															let data18 =
+																data17[key4];
+															const _errs47 =
 																errors;
 															if (
-																typeof data19 !==
-																'string'
+																typeof data18 !==
+																	'string' &&
+																typeof data18 !==
+																	'boolean' &&
+																!(
+																	typeof data18 ==
+																		'number' &&
+																	isFinite(
+																		data18
+																	)
+																)
 															) {
-																const err3 = {
-																	instancePath:
-																		instancePath +
-																		'/plugins/' +
-																		i2,
-																	schemaPath:
-																		'#/properties/plugins/items/anyOf/0/type',
-																	keyword:
-																		'type',
-																	params: {
-																		type: 'string',
-																	},
-																	message:
-																		'must be string',
-																};
-																if (
-																	vErrors ===
-																	null
-																) {
-																	vErrors = [
-																		err3,
-																	];
-																} else {
-																	vErrors.push(
-																		err3
-																	);
-																}
-																errors++;
-															}
-															var _valid1 =
-																_errs51 ===
-																errors;
-															valid11 =
-																valid11 ||
-																_valid1;
-															if (!valid11) {
-																const _errs53 =
-																	errors;
-																if (
-																	!validate16(
-																		data19,
+																validate11.errors =
+																	[
 																		{
 																			instancePath:
 																				instancePath +
-																				'/plugins/' +
-																				i2,
-																			parentData:
-																				data18,
-																			parentDataProperty:
-																				i2,
-																			rootData,
-																		}
-																	)
-																) {
-																	vErrors =
-																		vErrors ===
-																		null
-																			? validate16.errors
-																			: vErrors.concat(
-																					validate16.errors
-																				);
-																	errors =
-																		vErrors.length;
-																}
-																var _valid1 =
-																	_errs53 ===
-																	errors;
-																valid11 =
-																	valid11 ||
-																	_valid1;
-															}
-															if (!valid11) {
-																const err4 = {
-																	instancePath:
-																		instancePath +
-																		'/plugins/' +
-																		i2,
-																	schemaPath:
-																		'#/properties/plugins/items/anyOf',
-																	keyword:
-																		'anyOf',
-																	params: {},
-																	message:
-																		'must match a schema in anyOf',
-																};
-																if (
-																	vErrors ===
-																	null
-																) {
-																	vErrors = [
-																		err4,
+																				'/constants/' +
+																				key4
+																					.replace(
+																						/~/g,
+																						'~0'
+																					)
+																					.replace(
+																						/\//g,
+																						'~1'
+																					),
+																			schemaPath:
+																				'#/definitions/PHPConstants/additionalProperties/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: schema18
+																					.additionalProperties
+																					.type,
+																			},
+																			message:
+																				'must be string,boolean,number',
+																		},
 																	];
-																} else {
-																	vErrors.push(
-																		err4
-																	);
-																}
-																errors++;
-																validate11.errors =
-																	vErrors;
 																return false;
-															} else {
-																errors =
-																	_errs50;
-																if (
-																	vErrors !==
-																	null
-																) {
-																	if (
-																		_errs50
-																	) {
-																		vErrors.length =
-																			_errs50;
-																	} else {
-																		vErrors =
-																			null;
-																	}
-																}
 															}
-															var valid10 =
-																_errs49 ===
+															var valid9 =
+																_errs47 ===
 																errors;
-															if (!valid10) {
+															if (!valid9) {
 																break;
 															}
 														}
@@ -21089,127 +21011,185 @@ function validate11(
 															{
 																instancePath:
 																	instancePath +
-																	'/plugins',
+																	'/constants',
 																schemaPath:
-																	'#/properties/plugins/type',
+																	'#/definitions/PHPConstants/type',
 																keyword: 'type',
 																params: {
-																	type: 'array',
+																	type: 'object',
 																},
 																message:
-																	'must be array',
+																	'must be object',
 															},
 														];
 														return false;
 													}
 												}
-												var valid0 = _errs47 === errors;
+												var valid0 = _errs43 === errors;
 											} else {
 												var valid0 = true;
 											}
 											if (valid0) {
 												if (
-													data.siteOptions !==
-													undefined
+													data.plugins !== undefined
 												) {
-													let data20 =
-														data.siteOptions;
-													const _errs54 = errors;
-													if (errors === _errs54) {
+													let data19 = data.plugins;
+													const _errs49 = errors;
+													if (errors === _errs49) {
 														if (
-															data20 &&
-															typeof data20 ==
-																'object' &&
-															!Array.isArray(
-																data20
+															Array.isArray(
+																data19
 															)
 														) {
-															const _errs56 =
-																errors;
-															for (const key5 in data20) {
+															var valid10 = true;
+															const len2 =
+																data19.length;
+															for (
+																let i2 = 0;
+																i2 < len2;
+																i2++
+															) {
+																let data20 =
+																	data19[i2];
+																const _errs51 =
+																	errors;
+																const _errs52 =
+																	errors;
+																let valid11 = false;
+																const _errs53 =
+																	errors;
 																if (
-																	!(
-																		key5 ===
-																		'blogname'
-																	)
+																	typeof data20 !==
+																	'string'
 																) {
-																	const _errs57 =
-																		errors;
+																	const err3 =
+																		{
+																			instancePath:
+																				instancePath +
+																				'/plugins/' +
+																				i2,
+																			schemaPath:
+																				'#/properties/plugins/items/anyOf/0/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'string',
+																			},
+																			message:
+																				'must be string',
+																		};
 																	if (
-																		typeof data20[
-																			key5
-																		] !==
-																		'string'
+																		vErrors ===
+																		null
 																	) {
-																		validate11.errors =
+																		vErrors =
 																			[
-																				{
-																					instancePath:
-																						instancePath +
-																						'/siteOptions/' +
-																						key5
-																							.replace(
-																								/~/g,
-																								'~0'
-																							)
-																							.replace(
-																								/\//g,
-																								'~1'
-																							),
-																					schemaPath:
-																						'#/properties/siteOptions/additionalProperties/type',
-																					keyword:
-																						'type',
-																					params: {
-																						type: 'string',
-																					},
-																					message:
-																						'must be string',
-																				},
+																				err3,
 																			];
-																		return false;
+																	} else {
+																		vErrors.push(
+																			err3
+																		);
 																	}
-																	var valid12 =
-																		_errs57 ===
+																	errors++;
+																}
+																var _valid1 =
+																	_errs53 ===
+																	errors;
+																valid11 =
+																	valid11 ||
+																	_valid1;
+																if (!valid11) {
+																	const _errs55 =
 																		errors;
 																	if (
-																		!valid12
+																		!validate16(
+																			data20,
+																			{
+																				instancePath:
+																					instancePath +
+																					'/plugins/' +
+																					i2,
+																				parentData:
+																					data19,
+																				parentDataProperty:
+																					i2,
+																				rootData,
+																			}
+																		)
 																	) {
-																		break;
+																		vErrors =
+																			vErrors ===
+																			null
+																				? validate16.errors
+																				: vErrors.concat(
+																						validate16.errors
+																					);
+																		errors =
+																			vErrors.length;
+																	}
+																	var _valid1 =
+																		_errs55 ===
+																		errors;
+																	valid11 =
+																		valid11 ||
+																		_valid1;
+																}
+																if (!valid11) {
+																	const err4 =
+																		{
+																			instancePath:
+																				instancePath +
+																				'/plugins/' +
+																				i2,
+																			schemaPath:
+																				'#/properties/plugins/items/anyOf',
+																			keyword:
+																				'anyOf',
+																			params: {},
+																			message:
+																				'must match a schema in anyOf',
+																		};
+																	if (
+																		vErrors ===
+																		null
+																	) {
+																		vErrors =
+																			[
+																				err4,
+																			];
+																	} else {
+																		vErrors.push(
+																			err4
+																		);
+																	}
+																	errors++;
+																	validate11.errors =
+																		vErrors;
+																	return false;
+																} else {
+																	errors =
+																		_errs52;
+																	if (
+																		vErrors !==
+																		null
+																	) {
+																		if (
+																			_errs52
+																		) {
+																			vErrors.length =
+																				_errs52;
+																		} else {
+																			vErrors =
+																				null;
+																		}
 																	}
 																}
-															}
-															if (
-																_errs56 ===
-																errors
-															) {
-																if (
-																	data20.blogname !==
-																	undefined
-																) {
-																	if (
-																		typeof data20.blogname !==
-																		'string'
-																	) {
-																		validate11.errors =
-																			[
-																				{
-																					instancePath:
-																						instancePath +
-																						'/siteOptions/blogname',
-																					schemaPath:
-																						'#/properties/siteOptions/properties/blogname/type',
-																					keyword:
-																						'type',
-																					params: {
-																						type: 'string',
-																					},
-																					message:
-																						'must be string',
-																				},
-																			];
-																		return false;
-																	}
+																var valid10 =
+																	_errs51 ===
+																	errors;
+																if (!valid10) {
+																	break;
 																}
 															}
 														} else {
@@ -21218,200 +21198,296 @@ function validate11(
 																	{
 																		instancePath:
 																			instancePath +
-																			'/siteOptions',
+																			'/plugins',
 																		schemaPath:
-																			'#/properties/siteOptions/type',
+																			'#/properties/plugins/type',
 																		keyword:
 																			'type',
 																		params: {
-																			type: 'object',
+																			type: 'array',
 																		},
 																		message:
-																			'must be object',
+																			'must be array',
 																	},
 																];
 															return false;
 														}
 													}
 													var valid0 =
-														_errs54 === errors;
+														_errs49 === errors;
 												} else {
 													var valid0 = true;
 												}
 												if (valid0) {
 													if (
-														data.login !== undefined
+														data.siteOptions !==
+														undefined
 													) {
-														let data23 = data.login;
-														const _errs61 = errors;
-														const _errs62 = errors;
-														let valid14 = false;
-														const _errs63 = errors;
+														let data21 =
+															data.siteOptions;
+														const _errs56 = errors;
 														if (
-															typeof data23 !==
-															'boolean'
+															errors === _errs56
 														) {
-															const err5 = {
-																instancePath:
-																	instancePath +
-																	'/login',
-																schemaPath:
-																	'#/properties/login/anyOf/0/type',
-																keyword: 'type',
-																params: {
-																	type: 'boolean',
-																},
-																message:
-																	'must be boolean',
-															};
 															if (
-																vErrors === null
+																data21 &&
+																typeof data21 ==
+																	'object' &&
+																!Array.isArray(
+																	data21
+																)
 															) {
-																vErrors = [
-																	err5,
-																];
-															} else {
-																vErrors.push(
-																	err5
-																);
-															}
-															errors++;
-														}
-														var _valid2 =
-															_errs63 === errors;
-														valid14 =
-															valid14 || _valid2;
-														if (!valid14) {
-															const _errs65 =
-																errors;
-															if (
-																errors ===
-																_errs65
-															) {
-																if (
-																	data23 &&
-																	typeof data23 ==
-																		'object' &&
-																	!Array.isArray(
-																		data23
-																	)
-																) {
-																	let missing2;
+																const _errs58 =
+																	errors;
+																for (const key5 in data21) {
 																	if (
-																		(data23.username ===
-																			undefined &&
-																			(missing2 =
-																				'username')) ||
-																		(data23.password ===
-																			undefined &&
-																			(missing2 =
-																				'password'))
+																		!(
+																			key5 ===
+																			'blogname'
+																		)
 																	) {
-																		const err6 =
-																			{
-																				instancePath:
-																					instancePath +
-																					'/login',
-																				schemaPath:
-																					'#/properties/login/anyOf/1/required',
-																				keyword:
-																					'required',
-																				params: {
-																					missingProperty:
-																						missing2,
-																				},
-																				message:
-																					"must have required property '" +
-																					missing2 +
-																					"'",
-																			};
-																		if (
-																			vErrors ===
-																			null
-																		) {
-																			vErrors =
-																				[
-																					err6,
-																				];
-																		} else {
-																			vErrors.push(
-																				err6
-																			);
-																		}
-																		errors++;
-																	} else {
-																		const _errs67 =
+																		const _errs59 =
 																			errors;
-																		for (const key6 in data23) {
-																			if (
-																				!(
-																					key6 ===
-																						'username' ||
-																					key6 ===
-																						'password'
-																				)
-																			) {
-																				const err7 =
+																		if (
+																			typeof data21[
+																				key5
+																			] !==
+																			'string'
+																		) {
+																			validate11.errors =
+																				[
 																					{
 																						instancePath:
 																							instancePath +
-																							'/login',
+																							'/siteOptions/' +
+																							key5
+																								.replace(
+																									/~/g,
+																									'~0'
+																								)
+																								.replace(
+																									/\//g,
+																									'~1'
+																								),
 																						schemaPath:
-																							'#/properties/login/anyOf/1/additionalProperties',
+																							'#/properties/siteOptions/additionalProperties/type',
 																						keyword:
-																							'additionalProperties',
+																							'type',
 																						params: {
-																							additionalProperty:
-																								key6,
+																							type: 'string',
 																						},
 																						message:
-																							'must NOT have additional properties',
-																					};
-																				if (
-																					vErrors ===
-																					null
-																				) {
-																					vErrors =
-																						[
-																							err7,
-																						];
-																				} else {
-																					vErrors.push(
-																						err7
-																					);
-																				}
-																				errors++;
-																				break;
-																			}
+																							'must be string',
+																					},
+																				];
+																			return false;
 																		}
+																		var valid12 =
+																			_errs59 ===
+																			errors;
 																		if (
-																			_errs67 ===
-																			errors
+																			!valid12
 																		) {
+																			break;
+																		}
+																	}
+																}
+																if (
+																	_errs58 ===
+																	errors
+																) {
+																	if (
+																		data21.blogname !==
+																		undefined
+																	) {
+																		if (
+																			typeof data21.blogname !==
+																			'string'
+																		) {
+																			validate11.errors =
+																				[
+																					{
+																						instancePath:
+																							instancePath +
+																							'/siteOptions/blogname',
+																						schemaPath:
+																							'#/properties/siteOptions/properties/blogname/type',
+																						keyword:
+																							'type',
+																						params: {
+																							type: 'string',
+																						},
+																						message:
+																							'must be string',
+																					},
+																				];
+																			return false;
+																		}
+																	}
+																}
+															} else {
+																validate11.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/siteOptions',
+																			schemaPath:
+																				'#/properties/siteOptions/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'object',
+																			},
+																			message:
+																				'must be object',
+																		},
+																	];
+																return false;
+															}
+														}
+														var valid0 =
+															_errs56 === errors;
+													} else {
+														var valid0 = true;
+													}
+													if (valid0) {
+														if (
+															data.login !==
+															undefined
+														) {
+															let data24 =
+																data.login;
+															const _errs63 =
+																errors;
+															const _errs64 =
+																errors;
+															let valid14 = false;
+															const _errs65 =
+																errors;
+															if (
+																typeof data24 !==
+																'boolean'
+															) {
+																const err5 = {
+																	instancePath:
+																		instancePath +
+																		'/login',
+																	schemaPath:
+																		'#/properties/login/anyOf/0/type',
+																	keyword:
+																		'type',
+																	params: {
+																		type: 'boolean',
+																	},
+																	message:
+																		'must be boolean',
+																};
+																if (
+																	vErrors ===
+																	null
+																) {
+																	vErrors = [
+																		err5,
+																	];
+																} else {
+																	vErrors.push(
+																		err5
+																	);
+																}
+																errors++;
+															}
+															var _valid2 =
+																_errs65 ===
+																errors;
+															valid14 =
+																valid14 ||
+																_valid2;
+															if (!valid14) {
+																const _errs67 =
+																	errors;
+																if (
+																	errors ===
+																	_errs67
+																) {
+																	if (
+																		data24 &&
+																		typeof data24 ==
+																			'object' &&
+																		!Array.isArray(
+																			data24
+																		)
+																	) {
+																		let missing2;
+																		if (
+																			(data24.username ===
+																				undefined &&
+																				(missing2 =
+																					'username')) ||
+																			(data24.password ===
+																				undefined &&
+																				(missing2 =
+																					'password'))
+																		) {
+																			const err6 =
+																				{
+																					instancePath:
+																						instancePath +
+																						'/login',
+																					schemaPath:
+																						'#/properties/login/anyOf/1/required',
+																					keyword:
+																						'required',
+																					params: {
+																						missingProperty:
+																							missing2,
+																					},
+																					message:
+																						"must have required property '" +
+																						missing2 +
+																						"'",
+																				};
 																			if (
-																				data23.username !==
-																				undefined
+																				vErrors ===
+																				null
 																			) {
-																				const _errs68 =
-																					errors;
+																				vErrors =
+																					[
+																						err6,
+																					];
+																			} else {
+																				vErrors.push(
+																					err6
+																				);
+																			}
+																			errors++;
+																		} else {
+																			const _errs69 =
+																				errors;
+																			for (const key6 in data24) {
 																				if (
-																					typeof data23.username !==
-																					'string'
+																					!(
+																						key6 ===
+																							'username' ||
+																						key6 ===
+																							'password'
+																					)
 																				) {
-																					const err8 =
+																					const err7 =
 																						{
 																							instancePath:
 																								instancePath +
-																								'/login/username',
+																								'/login',
 																							schemaPath:
-																								'#/properties/login/anyOf/1/properties/username/type',
+																								'#/properties/login/anyOf/1/additionalProperties',
 																							keyword:
-																								'type',
+																								'additionalProperties',
 																							params: {
-																								type: 'string',
+																								additionalProperty:
+																									key6,
 																							},
 																							message:
-																								'must be string',
+																								'must NOT have additional properties',
 																						};
 																					if (
 																						vErrors ===
@@ -21419,41 +21495,38 @@ function validate11(
 																					) {
 																						vErrors =
 																							[
-																								err8,
+																								err7,
 																							];
 																					} else {
 																						vErrors.push(
-																							err8
+																							err7
 																						);
 																					}
 																					errors++;
+																					break;
 																				}
-																				var valid15 =
-																					_errs68 ===
-																					errors;
-																			} else {
-																				var valid15 = true;
 																			}
 																			if (
-																				valid15
+																				_errs69 ===
+																				errors
 																			) {
 																				if (
-																					data23.password !==
+																					data24.username !==
 																					undefined
 																				) {
 																					const _errs70 =
 																						errors;
 																					if (
-																						typeof data23.password !==
+																						typeof data24.username !==
 																						'string'
 																					) {
-																						const err9 =
+																						const err8 =
 																							{
 																								instancePath:
 																									instancePath +
-																									'/login/password',
+																									'/login/username',
 																								schemaPath:
-																									'#/properties/login/anyOf/1/properties/password/type',
+																									'#/properties/login/anyOf/1/properties/username/type',
 																								keyword:
 																									'type',
 																								params: {
@@ -21468,11 +21541,11 @@ function validate11(
 																						) {
 																							vErrors =
 																								[
-																									err9,
+																									err8,
 																								];
 																						} else {
 																							vErrors.push(
-																								err9
+																								err8
 																							);
 																						}
 																						errors++;
@@ -21483,207 +21556,216 @@ function validate11(
 																				} else {
 																					var valid15 = true;
 																				}
+																				if (
+																					valid15
+																				) {
+																					if (
+																						data24.password !==
+																						undefined
+																					) {
+																						const _errs72 =
+																							errors;
+																						if (
+																							typeof data24.password !==
+																							'string'
+																						) {
+																							const err9 =
+																								{
+																									instancePath:
+																										instancePath +
+																										'/login/password',
+																									schemaPath:
+																										'#/properties/login/anyOf/1/properties/password/type',
+																									keyword:
+																										'type',
+																									params: {
+																										type: 'string',
+																									},
+																									message:
+																										'must be string',
+																								};
+																							if (
+																								vErrors ===
+																								null
+																							) {
+																								vErrors =
+																									[
+																										err9,
+																									];
+																							} else {
+																								vErrors.push(
+																									err9
+																								);
+																							}
+																							errors++;
+																						}
+																						var valid15 =
+																							_errs72 ===
+																							errors;
+																					} else {
+																						var valid15 = true;
+																					}
+																				}
 																			}
 																		}
-																	}
-																} else {
-																	const err10 =
-																		{
-																			instancePath:
-																				instancePath +
-																				'/login',
-																			schemaPath:
-																				'#/properties/login/anyOf/1/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'object',
-																			},
-																			message:
-																				'must be object',
-																		};
-																	if (
-																		vErrors ===
-																		null
-																	) {
-																		vErrors =
-																			[
-																				err10,
-																			];
 																	} else {
-																		vErrors.push(
-																			err10
-																		);
-																	}
-																	errors++;
-																}
-															}
-															var _valid2 =
-																_errs65 ===
-																errors;
-															valid14 =
-																valid14 ||
-																_valid2;
-														}
-														if (!valid14) {
-															const err11 = {
-																instancePath:
-																	instancePath +
-																	'/login',
-																schemaPath:
-																	'#/properties/login/anyOf',
-																keyword:
-																	'anyOf',
-																params: {},
-																message:
-																	'must match a schema in anyOf',
-															};
-															if (
-																vErrors === null
-															) {
-																vErrors = [
-																	err11,
-																];
-															} else {
-																vErrors.push(
-																	err11
-																);
-															}
-															errors++;
-															validate11.errors =
-																vErrors;
-															return false;
-														} else {
-															errors = _errs62;
-															if (
-																vErrors !== null
-															) {
-																if (_errs62) {
-																	vErrors.length =
-																		_errs62;
-																} else {
-																	vErrors =
-																		null;
-																}
-															}
-														}
-														var valid0 =
-															_errs61 === errors;
-													} else {
-														var valid0 = true;
-													}
-													if (valid0) {
-														if (
-															data.steps !==
-															undefined
-														) {
-															let data26 =
-																data.steps;
-															const _errs72 =
-																errors;
-															if (
-																errors ===
-																_errs72
-															) {
-																if (
-																	Array.isArray(
-																		data26
-																	)
-																) {
-																	var valid16 = true;
-																	const len3 =
-																		data26.length;
-																	for (
-																		let i3 = 0;
-																		i3 <
-																		len3;
-																		i3++
-																	) {
-																		let data27 =
-																			data26[
-																				i3
-																			];
-																		const _errs74 =
-																			errors;
-																		const _errs75 =
-																			errors;
-																		let valid17 = false;
-																		const _errs76 =
-																			errors;
+																		const err10 =
+																			{
+																				instancePath:
+																					instancePath +
+																					'/login',
+																				schemaPath:
+																					'#/properties/login/anyOf/1/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'object',
+																				},
+																				message:
+																					'must be object',
+																			};
 																		if (
-																			!validate28(
-																				data27,
-																				{
-																					instancePath:
-																						instancePath +
-																						'/steps/' +
-																						i3,
-																					parentData:
-																						data26,
-																					parentDataProperty:
-																						i3,
-																					rootData,
-																				}
-																			)
+																			vErrors ===
+																			null
 																		) {
 																			vErrors =
-																				vErrors ===
-																				null
-																					? validate28.errors
-																					: vErrors.concat(
-																							validate28.errors
-																						);
-																			errors =
-																				vErrors.length;
+																				[
+																					err10,
+																				];
+																		} else {
+																			vErrors.push(
+																				err10
+																			);
 																		}
-																		var _valid3 =
-																			_errs76 ===
-																			errors;
-																		valid17 =
-																			valid17 ||
-																			_valid3;
-																		if (
-																			!valid17
+																		errors++;
+																	}
+																}
+																var _valid2 =
+																	_errs67 ===
+																	errors;
+																valid14 =
+																	valid14 ||
+																	_valid2;
+															}
+															if (!valid14) {
+																const err11 = {
+																	instancePath:
+																		instancePath +
+																		'/login',
+																	schemaPath:
+																		'#/properties/login/anyOf',
+																	keyword:
+																		'anyOf',
+																	params: {},
+																	message:
+																		'must match a schema in anyOf',
+																};
+																if (
+																	vErrors ===
+																	null
+																) {
+																	vErrors = [
+																		err11,
+																	];
+																} else {
+																	vErrors.push(
+																		err11
+																	);
+																}
+																errors++;
+																validate11.errors =
+																	vErrors;
+																return false;
+															} else {
+																errors =
+																	_errs64;
+																if (
+																	vErrors !==
+																	null
+																) {
+																	if (
+																		_errs64
+																	) {
+																		vErrors.length =
+																			_errs64;
+																	} else {
+																		vErrors =
+																			null;
+																	}
+																}
+															}
+															var valid0 =
+																_errs63 ===
+																errors;
+														} else {
+															var valid0 = true;
+														}
+														if (valid0) {
+															if (
+																data.steps !==
+																undefined
+															) {
+																let data27 =
+																	data.steps;
+																const _errs74 =
+																	errors;
+																if (
+																	errors ===
+																	_errs74
+																) {
+																	if (
+																		Array.isArray(
+																			data27
+																		)
+																	) {
+																		var valid16 = true;
+																		const len3 =
+																			data27.length;
+																		for (
+																			let i3 = 0;
+																			i3 <
+																			len3;
+																			i3++
 																		) {
+																			let data28 =
+																				data27[
+																					i3
+																				];
+																			const _errs76 =
+																				errors;
 																			const _errs77 =
 																				errors;
+																			let valid17 = false;
+																			const _errs78 =
+																				errors;
 																			if (
-																				typeof data27 !==
-																				'string'
-																			) {
-																				const err12 =
+																				!validate28(
+																					data28,
 																					{
 																						instancePath:
 																							instancePath +
 																							'/steps/' +
 																							i3,
-																						schemaPath:
-																							'#/properties/steps/items/anyOf/1/type',
-																						keyword:
-																							'type',
-																						params: {
-																							type: 'string',
-																						},
-																						message:
-																							'must be string',
-																					};
-																				if (
+																						parentData:
+																							data27,
+																						parentDataProperty:
+																							i3,
+																						rootData,
+																					}
+																				)
+																			) {
+																				vErrors =
 																					vErrors ===
 																					null
-																				) {
-																					vErrors =
-																						[
-																							err12,
-																						];
-																				} else {
-																					vErrors.push(
-																						err12
-																					);
-																				}
-																				errors++;
+																						? validate28.errors
+																						: vErrors.concat(
+																								validate28.errors
+																							);
+																				errors =
+																					vErrors.length;
 																			}
 																			var _valid3 =
-																				_errs77 ===
+																				_errs78 ===
 																				errors;
 																			valid17 =
 																				valid17 ||
@@ -21693,34 +21775,41 @@ function validate11(
 																			) {
 																				const _errs79 =
 																					errors;
-																				const err13 =
-																					{
-																						instancePath:
-																							instancePath +
-																							'/steps/' +
-																							i3,
-																						schemaPath:
-																							'#/properties/steps/items/anyOf/2/not',
-																						keyword:
-																							'not',
-																						params: {},
-																						message:
-																							'must NOT be valid',
-																					};
 																				if (
-																					vErrors ===
-																					null
+																					typeof data28 !==
+																					'string'
 																				) {
-																					vErrors =
-																						[
-																							err13,
-																						];
-																				} else {
-																					vErrors.push(
-																						err13
-																					);
+																					const err12 =
+																						{
+																							instancePath:
+																								instancePath +
+																								'/steps/' +
+																								i3,
+																							schemaPath:
+																								'#/properties/steps/items/anyOf/1/type',
+																							keyword:
+																								'type',
+																							params: {
+																								type: 'string',
+																							},
+																							message:
+																								'must be string',
+																						};
+																					if (
+																						vErrors ===
+																						null
+																					) {
+																						vErrors =
+																							[
+																								err12,
+																							];
+																					} else {
+																						vErrors.push(
+																							err12
+																						);
+																					}
+																					errors++;
 																				}
-																				errors++;
 																				var _valid3 =
 																					_errs79 ===
 																					errors;
@@ -21732,76 +21821,34 @@ function validate11(
 																				) {
 																					const _errs81 =
 																						errors;
+																					const err13 =
+																						{
+																							instancePath:
+																								instancePath +
+																								'/steps/' +
+																								i3,
+																							schemaPath:
+																								'#/properties/steps/items/anyOf/2/not',
+																							keyword:
+																								'not',
+																							params: {},
+																							message:
+																								'must NOT be valid',
+																						};
 																					if (
-																						typeof data27 !==
-																						'boolean'
+																						vErrors ===
+																						null
 																					) {
-																						const err14 =
-																							{
-																								instancePath:
-																									instancePath +
-																									'/steps/' +
-																									i3,
-																								schemaPath:
-																									'#/properties/steps/items/anyOf/3/type',
-																								keyword:
-																									'type',
-																								params: {
-																									type: 'boolean',
-																								},
-																								message:
-																									'must be boolean',
-																							};
-																						if (
-																							vErrors ===
-																							null
-																						) {
-																							vErrors =
-																								[
-																									err14,
-																								];
-																						} else {
-																							vErrors.push(
-																								err14
-																							);
-																						}
-																						errors++;
+																						vErrors =
+																							[
+																								err13,
+																							];
+																					} else {
+																						vErrors.push(
+																							err13
+																						);
 																					}
-																					if (
-																						false !==
-																						data27
-																					) {
-																						const err15 =
-																							{
-																								instancePath:
-																									instancePath +
-																									'/steps/' +
-																									i3,
-																								schemaPath:
-																									'#/properties/steps/items/anyOf/3/const',
-																								keyword:
-																									'const',
-																								params: {
-																									allowedValue: false,
-																								},
-																								message:
-																									'must be equal to constant',
-																							};
-																						if (
-																							vErrors ===
-																							null
-																						) {
-																							vErrors =
-																								[
-																									err15,
-																								];
-																						} else {
-																							vErrors.push(
-																								err15
-																							);
-																						}
-																						errors++;
-																					}
+																					errors++;
 																					var _valid3 =
 																						_errs81 ===
 																						errors;
@@ -21814,24 +21861,24 @@ function validate11(
 																						const _errs83 =
 																							errors;
 																						if (
-																							data27 !==
-																							null
+																							typeof data28 !==
+																							'boolean'
 																						) {
-																							const err16 =
+																							const err14 =
 																								{
 																									instancePath:
 																										instancePath +
 																										'/steps/' +
 																										i3,
 																									schemaPath:
-																										'#/properties/steps/items/anyOf/4/type',
+																										'#/properties/steps/items/anyOf/3/type',
 																									keyword:
 																										'type',
 																									params: {
-																										type: 'null',
+																										type: 'boolean',
 																									},
 																									message:
-																										'must be null',
+																										'must be boolean',
 																								};
 																							if (
 																								vErrors ===
@@ -21839,11 +21886,46 @@ function validate11(
 																							) {
 																								vErrors =
 																									[
-																										err16,
+																										err14,
 																									];
 																							} else {
 																								vErrors.push(
-																									err16
+																									err14
+																								);
+																							}
+																							errors++;
+																						}
+																						if (
+																							false !==
+																							data28
+																						) {
+																							const err15 =
+																								{
+																									instancePath:
+																										instancePath +
+																										'/steps/' +
+																										i3,
+																									schemaPath:
+																										'#/properties/steps/items/anyOf/3/const',
+																									keyword:
+																										'const',
+																									params: {
+																										allowedValue: false,
+																									},
+																									message:
+																										'must be equal to constant',
+																								};
+																							if (
+																								vErrors ===
+																								null
+																							) {
+																								vErrors =
+																									[
+																										err15,
+																									];
+																							} else {
+																								vErrors.push(
+																									err15
 																								);
 																							}
 																							errors++;
@@ -21854,133 +21936,180 @@ function validate11(
 																						valid17 =
 																							valid17 ||
 																							_valid3;
+																						if (
+																							!valid17
+																						) {
+																							const _errs85 =
+																								errors;
+																							if (
+																								data28 !==
+																								null
+																							) {
+																								const err16 =
+																									{
+																										instancePath:
+																											instancePath +
+																											'/steps/' +
+																											i3,
+																										schemaPath:
+																											'#/properties/steps/items/anyOf/4/type',
+																										keyword:
+																											'type',
+																										params: {
+																											type: 'null',
+																										},
+																										message:
+																											'must be null',
+																									};
+																								if (
+																									vErrors ===
+																									null
+																								) {
+																									vErrors =
+																										[
+																											err16,
+																										];
+																								} else {
+																									vErrors.push(
+																										err16
+																									);
+																								}
+																								errors++;
+																							}
+																							var _valid3 =
+																								_errs85 ===
+																								errors;
+																							valid17 =
+																								valid17 ||
+																								_valid3;
+																						}
 																					}
 																				}
 																			}
+																			if (
+																				!valid17
+																			) {
+																				const err17 =
+																					{
+																						instancePath:
+																							instancePath +
+																							'/steps/' +
+																							i3,
+																						schemaPath:
+																							'#/properties/steps/items/anyOf',
+																						keyword:
+																							'anyOf',
+																						params: {},
+																						message:
+																							'must match a schema in anyOf',
+																					};
+																				if (
+																					vErrors ===
+																					null
+																				) {
+																					vErrors =
+																						[
+																							err17,
+																						];
+																				} else {
+																					vErrors.push(
+																						err17
+																					);
+																				}
+																				errors++;
+																				validate11.errors =
+																					vErrors;
+																				return false;
+																			} else {
+																				errors =
+																					_errs77;
+																				if (
+																					vErrors !==
+																					null
+																				) {
+																					if (
+																						_errs77
+																					) {
+																						vErrors.length =
+																							_errs77;
+																					} else {
+																						vErrors =
+																							null;
+																					}
+																				}
+																			}
+																			var valid16 =
+																				_errs76 ===
+																				errors;
+																			if (
+																				!valid16
+																			) {
+																				break;
+																			}
 																		}
-																		if (
-																			!valid17
-																		) {
-																			const err17 =
+																	} else {
+																		validate11.errors =
+																			[
 																				{
 																					instancePath:
 																						instancePath +
-																						'/steps/' +
-																						i3,
+																						'/steps',
 																					schemaPath:
-																						'#/properties/steps/items/anyOf',
+																						'#/properties/steps/type',
 																					keyword:
-																						'anyOf',
-																					params: {},
+																						'type',
+																					params: {
+																						type: 'array',
+																					},
 																					message:
-																						'must match a schema in anyOf',
-																				};
-																			if (
-																				vErrors ===
-																				null
-																			) {
-																				vErrors =
-																					[
-																						err17,
-																					];
-																			} else {
-																				vErrors.push(
-																					err17
-																				);
-																			}
-																			errors++;
-																			validate11.errors =
-																				vErrors;
-																			return false;
-																		} else {
-																			errors =
-																				_errs75;
-																			if (
-																				vErrors !==
-																				null
-																			) {
-																				if (
-																					_errs75
-																				) {
-																					vErrors.length =
-																						_errs75;
-																				} else {
-																					vErrors =
-																						null;
-																				}
-																			}
-																		}
-																		var valid16 =
-																			_errs74 ===
-																			errors;
-																		if (
-																			!valid16
-																		) {
-																			break;
-																		}
+																						'must be array',
+																				},
+																			];
+																		return false;
 																	}
-																} else {
-																	validate11.errors =
-																		[
-																			{
-																				instancePath:
-																					instancePath +
-																					'/steps',
-																				schemaPath:
-																					'#/properties/steps/type',
-																				keyword:
-																					'type',
-																				params: {
-																					type: 'array',
-																				},
-																				message:
-																					'must be array',
-																			},
-																		];
-																	return false;
-																}
-															}
-															var valid0 =
-																_errs72 ===
-																errors;
-														} else {
-															var valid0 = true;
-														}
-														if (valid0) {
-															if (
-																data.$schema !==
-																undefined
-															) {
-																const _errs85 =
-																	errors;
-																if (
-																	typeof data.$schema !==
-																	'string'
-																) {
-																	validate11.errors =
-																		[
-																			{
-																				instancePath:
-																					instancePath +
-																					'/$schema',
-																				schemaPath:
-																					'#/properties/%24schema/type',
-																				keyword:
-																					'type',
-																				params: {
-																					type: 'string',
-																				},
-																				message:
-																					'must be string',
-																			},
-																		];
-																	return false;
 																}
 																var valid0 =
-																	_errs85 ===
+																	_errs74 ===
 																	errors;
 															} else {
 																var valid0 = true;
+															}
+															if (valid0) {
+																if (
+																	data.$schema !==
+																	undefined
+																) {
+																	const _errs87 =
+																		errors;
+																	if (
+																		typeof data.$schema !==
+																		'string'
+																	) {
+																		validate11.errors =
+																			[
+																				{
+																					instancePath:
+																						instancePath +
+																						'/$schema',
+																					schemaPath:
+																						'#/properties/%24schema/type',
+																					keyword:
+																						'type',
+																					params: {
+																						type: 'string',
+																					},
+																					message:
+																						'must be string',
+																				},
+																			];
+																		return false;
+																	}
+																	var valid0 =
+																		_errs87 ===
+																		errors;
+																} else {
+																	var valid0 = true;
+																}
 															}
 														}
 													}

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -41,6 +41,11 @@
 					"additionalProperties": false,
 					"description": "Optional metadata. Used by the Blueprints gallery at https://github.com/WordPress/blueprints"
 				},
+				"wordpress": {
+					"type": "boolean",
+					"const": false,
+					"description": "Set to `false` to boot a PHP-only Playground without downloading or installing WordPress. Useful for running pure-PHP snippets.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time. `preferredVersions.wp` is ignored."
+				},
 				"preferredVersions": {
 					"type": "object",
 					"properties": {

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -41,11 +41,6 @@
 					"additionalProperties": false,
 					"description": "Optional metadata. Used by the Blueprints gallery at https://github.com/WordPress/blueprints"
 				},
-				"wordpress": {
-					"type": "boolean",
-					"const": false,
-					"description": "Set to `false` to boot a PHP-only Playground without downloading or installing WordPress. Useful for running pure-PHP snippets.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time. `preferredVersions.wp` is ignored."
-				},
 				"preferredVersions": {
 					"type": "object",
 					"properties": {
@@ -62,8 +57,20 @@
 							"description": "The preferred PHP version to use. If not specified, the latest supported version will be used.\n\nNote: PHP 7.2 and 7.3 are deprecated and will be automatically upgraded to 7.4."
 						},
 						"wp": {
-							"type": "string",
-							"description": "The preferred WordPress version to use. If not specified, the latest supported version will be used"
+							"anyOf": [
+								{
+									"type": "string"
+								},
+								{
+									"type": "string",
+									"const": "latest"
+								},
+								{
+									"type": "boolean",
+									"const": false
+								}
+							],
+							"description": "The preferred WordPress version to use, or `false` to boot a PHP-only Playground without downloading or installing WordPress. If not specified, the latest supported version will be used.\n\nWhen set to `false`, WordPress-specific Blueprint fields (`plugins`, `siteOptions`, `login`, and WordPress-only steps) are rejected at compile time."
 						}
 					},
 					"required": ["php", "wp"],

--- a/packages/playground/blueprints/src/lib/v1/compile.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.spec.ts
@@ -245,6 +245,69 @@ describe('Blueprints', () => {
 		});
 	});
 
+	describe('wordpress: false (PHP-only mode)', () => {
+		it('should compile a Blueprint with wordpress: false and run pure PHP', async () => {
+			const compiled = await compileBlueprintV1({
+				wordpress: false,
+				steps: [
+					{
+						step: 'writeFile',
+						path: '/index.php',
+						data: `<?php echo 'PHP only';`,
+					},
+				],
+			});
+			await runBlueprintV1Steps(compiled, php);
+			expect(php.readFileAsText('/index.php')).toBe(
+				`<?php echo 'PHP only';`
+			);
+		});
+
+		it('should reject `plugins` when wordpress is false', async () => {
+			await expect(
+				compileBlueprintV1({
+					wordpress: false,
+					plugins: ['gutenberg'],
+				})
+			).rejects.toThrow(/wordpress: false.*plugins/);
+		});
+
+		it('should reject `siteOptions` when wordpress is false', async () => {
+			await expect(
+				compileBlueprintV1({
+					wordpress: false,
+					siteOptions: { blogname: 'No WP' },
+				})
+			).rejects.toThrow(/wordpress: false.*siteOptions/);
+		});
+
+		it('should reject `login` when wordpress is false', async () => {
+			await expect(
+				compileBlueprintV1({
+					wordpress: false,
+					login: true,
+				})
+			).rejects.toThrow(/wordpress: false.*login/);
+		});
+
+		it('should reject WordPress-only steps when wordpress is false', async () => {
+			await expect(
+				compileBlueprintV1({
+					wordpress: false,
+					steps: [
+						{
+							step: 'installPlugin',
+							pluginData: {
+								resource: 'wordpress.org/plugins',
+								slug: 'gutenberg',
+							},
+						},
+					],
+				})
+			).rejects.toThrow(/wordpress: false.*installPlugin/);
+		});
+	});
+
 	describe('plugins shorthand', () => {
 		it('should convert a slug string to a wordpress.org/plugins resource', async () => {
 			let validatedBlueprint: any;

--- a/packages/playground/blueprints/src/lib/v1/compile.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.spec.ts
@@ -290,6 +290,15 @@ describe('Blueprints', () => {
 			).rejects.toThrow(/wordpress: false.*login/);
 		});
 
+		it("should reject extraLibraries: ['wp-cli'] when wordpress is false", async () => {
+			await expect(
+				compileBlueprintV1({
+					wordpress: false,
+					extraLibraries: ['wp-cli'],
+				})
+			).rejects.toThrow(/extraLibraries includes 'wp-cli'/);
+		});
+
 		it('should reject WordPress-only steps when wordpress is false', async () => {
 			await expect(
 				compileBlueprintV1({

--- a/packages/playground/blueprints/src/lib/v1/compile.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.spec.ts
@@ -245,10 +245,10 @@ describe('Blueprints', () => {
 		});
 	});
 
-	describe('wordpress: false (PHP-only mode)', () => {
-		it('should compile a Blueprint with wordpress: false and run pure PHP', async () => {
+	describe('preferredVersions.wp: false (PHP-only mode)', () => {
+		it('should compile a Blueprint with preferredVersions.wp: false and run pure PHP', async () => {
 			const compiled = await compileBlueprintV1({
-				wordpress: false,
+				preferredVersions: { php: 'latest', wp: false },
 				steps: [
 					{
 						step: 'writeFile',
@@ -263,46 +263,46 @@ describe('Blueprints', () => {
 			);
 		});
 
-		it('should reject `plugins` when wordpress is false', async () => {
+		it('should reject `plugins` when preferredVersions.wp is false', async () => {
 			await expect(
 				compileBlueprintV1({
-					wordpress: false,
+					preferredVersions: { php: 'latest', wp: false },
 					plugins: ['gutenberg'],
 				})
-			).rejects.toThrow(/wordpress: false.*plugins/);
+			).rejects.toThrow(/preferredVersions\.wp: false.*plugins/);
 		});
 
-		it('should reject `siteOptions` when wordpress is false', async () => {
+		it('should reject `siteOptions` when preferredVersions.wp is false', async () => {
 			await expect(
 				compileBlueprintV1({
-					wordpress: false,
+					preferredVersions: { php: 'latest', wp: false },
 					siteOptions: { blogname: 'No WP' },
 				})
-			).rejects.toThrow(/wordpress: false.*siteOptions/);
+			).rejects.toThrow(/preferredVersions\.wp: false.*siteOptions/);
 		});
 
-		it('should reject `login` when wordpress is false', async () => {
+		it('should reject `login` when preferredVersions.wp is false', async () => {
 			await expect(
 				compileBlueprintV1({
-					wordpress: false,
+					preferredVersions: { php: 'latest', wp: false },
 					login: true,
 				})
-			).rejects.toThrow(/wordpress: false.*login/);
+			).rejects.toThrow(/preferredVersions\.wp: false.*login/);
 		});
 
-		it("should reject extraLibraries: ['wp-cli'] when wordpress is false", async () => {
+		it("should reject extraLibraries: ['wp-cli'] when preferredVersions.wp is false", async () => {
 			await expect(
 				compileBlueprintV1({
-					wordpress: false,
+					preferredVersions: { php: 'latest', wp: false },
 					extraLibraries: ['wp-cli'],
 				})
 			).rejects.toThrow(/extraLibraries includes 'wp-cli'/);
 		});
 
-		it('should reject WordPress-only steps when wordpress is false', async () => {
+		it('should reject WordPress-only steps when preferredVersions.wp is false', async () => {
 			await expect(
 				compileBlueprintV1({
-					wordpress: false,
+					preferredVersions: { php: 'latest', wp: false },
 					steps: [
 						{
 							step: 'installPlugin',
@@ -313,7 +313,7 @@ describe('Blueprints', () => {
 						},
 					],
 				})
-			).rejects.toThrow(/wordpress: false.*installPlugin/);
+			).rejects.toThrow(/preferredVersions\.wp: false.*installPlugin/);
 		});
 	});
 

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -207,7 +207,7 @@ function compileBlueprintJson(
 
 	blueprint.steps = [...(blueprint.steps || []), ...(additionalSteps || [])];
 
-	if (blueprint.wordpress === false) {
+	if (blueprint.preferredVersions?.wp === false) {
 		assertNoWordPressFeatures(blueprint);
 	}
 
@@ -798,8 +798,9 @@ export async function runBlueprintV1Steps(
 }
 
 /**
- * Steps that require WordPress to be installed. When `wordpress: false` is
- * set on the Blueprint, these steps are rejected at compile time.
+ * Steps that require WordPress to be installed. When
+ * `preferredVersions.wp: false` is set on the Blueprint, these steps are
+ * rejected at compile time.
  */
 const WORDPRESS_ONLY_STEPS = new Set([
 	'installPlugin',
@@ -837,9 +838,9 @@ function assertNoWordPressFeatures(blueprint: BlueprintV1Declaration) {
 	}
 	if (offenders.length) {
 		throw new InvalidBlueprintError(
-			`Blueprint has \`wordpress: false\` but uses WordPress-only ` +
-				`features: ${offenders.join('; ')}. Remove these or drop ` +
-				`\`wordpress: false\`.`,
+			`Blueprint has \`preferredVersions.wp: false\` but uses ` +
+				`WordPress-only features: ${offenders.join('; ')}. Remove ` +
+				`these or drop \`preferredVersions.wp: false\`.`,
 			[]
 		);
 	}

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -823,7 +823,7 @@ function assertNoWordPressFeatures(blueprint: BlueprintV1Declaration) {
 	if (blueprint.siteOptions) offenders.push('siteOptions');
 	if (blueprint.login) offenders.push('login');
 	if (blueprint.extraLibraries?.includes('wp-cli')) {
-		offenders.push("extraLibraries: ['wp-cli']");
+		offenders.push("extraLibraries includes 'wp-cli'");
 	}
 	const badSteps = (blueprint.steps || [])
 		.filter(

--- a/packages/playground/blueprints/src/lib/v1/compile.ts
+++ b/packages/playground/blueprints/src/lib/v1/compile.ts
@@ -207,6 +207,10 @@ function compileBlueprintJson(
 
 	blueprint.steps = [...(blueprint.steps || []), ...(additionalSteps || [])];
 
+	if (blueprint.wordpress === false) {
+		assertNoWordPressFeatures(blueprint);
+	}
+
 	for (const step of blueprint.steps!) {
 		if (!step || typeof step !== 'object') {
 			continue;
@@ -791,6 +795,54 @@ export async function runBlueprintV1Steps(
 	playground: UniversalPHP
 ) {
 	await compiledBlueprint.run(playground);
+}
+
+/**
+ * Steps that require WordPress to be installed. When `wordpress: false` is
+ * set on the Blueprint, these steps are rejected at compile time.
+ */
+const WORDPRESS_ONLY_STEPS = new Set([
+	'installPlugin',
+	'installTheme',
+	'activatePlugin',
+	'activateTheme',
+	'login',
+	'setSiteOptions',
+	'updateUserMeta',
+	'importWxr',
+	'importFile',
+	'importWordPressFiles',
+	'enableMultisite',
+	'wp-cli',
+	'resetData',
+]);
+
+function assertNoWordPressFeatures(blueprint: BlueprintV1Declaration) {
+	const offenders: string[] = [];
+	if (blueprint.plugins?.length) offenders.push('plugins');
+	if (blueprint.siteOptions) offenders.push('siteOptions');
+	if (blueprint.login) offenders.push('login');
+	if (blueprint.extraLibraries?.includes('wp-cli')) {
+		offenders.push("extraLibraries: ['wp-cli']");
+	}
+	const badSteps = (blueprint.steps || [])
+		.filter(
+			(s): s is StepDefinition =>
+				!!s && typeof s === 'object' && 'step' in s
+		)
+		.map((s) => s.step)
+		.filter((name) => WORDPRESS_ONLY_STEPS.has(name as string));
+	if (badSteps.length) {
+		offenders.push(`steps: ${[...new Set(badSteps)].join(', ')}`);
+	}
+	if (offenders.length) {
+		throw new InvalidBlueprintError(
+			`Blueprint has \`wordpress: false\` but uses WordPress-only ` +
+				`features: ${offenders.join('; ')}. Remove these or drop ` +
+				`\`wordpress: false\`.`,
+			[]
+		);
+	}
 }
 
 function isGitRepoUrl(url: string): boolean {

--- a/packages/playground/blueprints/src/lib/v1/types.ts
+++ b/packages/playground/blueprints/src/lib/v1/types.ts
@@ -60,6 +60,15 @@ export type BlueprintV1Declaration = {
 		categories?: string[];
 	};
 	/**
+	 * Set to `false` to boot a PHP-only Playground without downloading or
+	 * installing WordPress. Useful for running pure-PHP snippets.
+	 *
+	 * When set to `false`, WordPress-specific Blueprint fields (`plugins`,
+	 * `siteOptions`, `login`, and WordPress-only steps) are rejected at
+	 * compile time. `preferredVersions.wp` is ignored.
+	 */
+	wordpress?: false;
+	/**
 	 * The preferred PHP and WordPress versions to use.
 	 */
 	preferredVersions?: {

--- a/packages/playground/blueprints/src/lib/v1/types.ts
+++ b/packages/playground/blueprints/src/lib/v1/types.ts
@@ -60,15 +60,6 @@ export type BlueprintV1Declaration = {
 		categories?: string[];
 	};
 	/**
-	 * Set to `false` to boot a PHP-only Playground without downloading or
-	 * installing WordPress. Useful for running pure-PHP snippets.
-	 *
-	 * When set to `false`, WordPress-specific Blueprint fields (`plugins`,
-	 * `siteOptions`, `login`, and WordPress-only steps) are rejected at
-	 * compile time. `preferredVersions.wp` is ignored.
-	 */
-	wordpress?: false;
-	/**
 	 * The preferred PHP and WordPress versions to use.
 	 */
 	preferredVersions?: {
@@ -80,10 +71,15 @@ export type BlueprintV1Declaration = {
 		 */
 		php: BlueprintPHPVersion | 'latest';
 		/**
-		 * The preferred WordPress version to use.
-		 * If not specified, the latest supported version will be used
+		 * The preferred WordPress version to use, or `false` to boot a
+		 * PHP-only Playground without downloading or installing WordPress.
+		 * If not specified, the latest supported version will be used.
+		 *
+		 * When set to `false`, WordPress-specific Blueprint fields
+		 * (`plugins`, `siteOptions`, `login`, and WordPress-only steps)
+		 * are rejected at compile time.
 		 */
-		wp: string | 'latest';
+		wp: string | 'latest' | false;
 	};
 	features?: {
 		/** Should boot with support for Intl dynamic extension */

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -55,14 +55,20 @@ export class BlueprintsV1Handler {
 			await resolveRuntimeConfiguration(blueprint);
 		await playground.onDownloadProgress(downloadProgress.loadingListener);
 		// Blueprint's `wordpress: false` is the declarative way to opt out of
-		// WordPress; the explicit `shouldInstallWordPress` option (if passed)
-		// still wins so callers can override per-boot. Bundles carry their
-		// declaration inside a JSON file we haven't read here, so we only
-		// honor the flag for inline declarations.
+		// WordPress. Bundles carry their declaration inside a JSON file we
+		// haven't read here, so we only honor the flag for inline
+		// declarations. If the caller also set `shouldInstallWordPress`
+		// explicitly and the two disagree, refuse to silently pick a winner.
 		const declarativeOptOut =
 			!isBlueprintBundle(blueprint) && blueprint.wordpress === false;
-		const installWordPress =
-			shouldInstallWordPress ?? !declarativeOptOut;
+		if (shouldInstallWordPress === true && declarativeOptOut) {
+			throw new Error(
+				'Conflicting options: `shouldInstallWordPress: true` was ' +
+					'passed to startPlaygroundWeb, but the Blueprint sets ' +
+					'`wordpress: false`. Pick one.'
+			);
+		}
+		const installWordPress = shouldInstallWordPress ?? !declarativeOptOut;
 		await playground.boot({
 			mounts,
 			sapiName,

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -3,6 +3,7 @@ import {
 	type PlaygroundClient,
 	type StartPlaygroundOptions,
 	compileBlueprintV1,
+	isBlueprintBundle,
 	runBlueprintV1Steps,
 	resolveRuntimeConfiguration,
 	BlueprintReflection,
@@ -55,10 +56,13 @@ export class BlueprintsV1Handler {
 		await playground.onDownloadProgress(downloadProgress.loadingListener);
 		// Blueprint's `wordpress: false` is the declarative way to opt out of
 		// WordPress; the explicit `shouldInstallWordPress` option (if passed)
-		// still wins so callers can override per-boot.
+		// still wins so callers can override per-boot. Bundles carry their
+		// declaration inside a JSON file we haven't read here, so we only
+		// honor the flag for inline declarations.
+		const declarativeOptOut =
+			!isBlueprintBundle(blueprint) && blueprint.wordpress === false;
 		const installWordPress =
-			shouldInstallWordPress ??
-			(blueprint as { wordpress?: false }).wordpress !== false;
+			shouldInstallWordPress ?? !declarativeOptOut;
 		await playground.boot({
 			mounts,
 			sapiName,

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -54,18 +54,19 @@ export class BlueprintsV1Handler {
 		const runtimeConfiguration =
 			await resolveRuntimeConfiguration(blueprint);
 		await playground.onDownloadProgress(downloadProgress.loadingListener);
-		// Blueprint's `wordpress: false` is the declarative way to opt out of
-		// WordPress. Bundles carry their declaration inside a JSON file we
-		// haven't read here, so we only honor the flag for inline
+		// Blueprint's `preferredVersions.wp: false` is the declarative way to
+		// opt out of WordPress. Bundles carry their declaration inside a JSON
+		// file we haven't read here, so we only honor the flag for inline
 		// declarations. If the caller also set `shouldInstallWordPress`
 		// explicitly and the two disagree, refuse to silently pick a winner.
 		const declarativeOptOut =
-			!isBlueprintBundle(blueprint) && blueprint.wordpress === false;
+			!isBlueprintBundle(blueprint) &&
+			blueprint.preferredVersions?.wp === false;
 		if (shouldInstallWordPress === true && declarativeOptOut) {
 			throw new Error(
 				'Conflicting options: `shouldInstallWordPress: true` was ' +
 					'passed to startPlaygroundWeb, but the Blueprint sets ' +
-					'`wordpress: false`. Pick one.'
+					'`preferredVersions.wp: false`. Pick one.'
 			);
 		}
 		const installWordPress = shouldInstallWordPress ?? !declarativeOptOut;

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -53,11 +53,17 @@ export class BlueprintsV1Handler {
 		const runtimeConfiguration =
 			await resolveRuntimeConfiguration(blueprint);
 		await playground.onDownloadProgress(downloadProgress.loadingListener);
+		// Blueprint's `wordpress: false` is the declarative way to opt out of
+		// WordPress; the explicit `shouldInstallWordPress` option (if passed)
+		// still wins so callers can override per-boot.
+		const installWordPress =
+			shouldInstallWordPress ??
+			(blueprint as { wordpress?: false }).wordpress !== false;
 		await playground.boot({
 			mounts,
 			sapiName,
 			scope: scope ?? Math.random().toFixed(16),
-			shouldInstallWordPress,
+			shouldInstallWordPress: installWordPress,
 			wordpressInstallMode,
 			phpVersion: runtimeConfiguration.phpVersion,
 			wpVersion: runtimeConfiguration.wpVersion,

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
@@ -27,6 +27,9 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 		const bootWordPress = vi.fn(async (_requestHandler, options) => {
 			await options.hooks.beforeWordPressFiles(php);
 		});
+		const requestHandler = {
+			getPrimaryPhp: vi.fn(async () => php),
+		};
 		let endpoint:
 			| {
 					boot(options: Record<string, unknown>): Promise<void>;
@@ -51,7 +54,9 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 		vi.spyOn(endpoint as any, 'computeSiteUrl').mockReturnValue(
 			'http://playground.test'
 		);
-		vi.spyOn(endpoint as any, 'createRequestHandler').mockResolvedValue({});
+		vi.spyOn(endpoint as any, 'createRequestHandler').mockResolvedValue(
+			requestHandler
+		);
 		vi.spyOn(endpoint as any, 'finalizeAfterBoot').mockResolvedValue(
 			undefined
 		);

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -153,6 +153,21 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				}
 			}
 
+			// PHP-only mode: the caller asked us to skip the WordPress
+			// install, so there's nothing for `bootWordPress` to do — and
+			// running it without WP files would still drop in the SQLite
+			// shim and then assert a (nonexistent) DB connection. Apply the
+			// OPFS mounts and stop, so the caller gets a usable PHP runtime.
+			if (!shouldInstallWordPress) {
+				const primaryPhp = await requestHandler.getPrimaryPhp();
+				for (const mount of mounts) {
+					await endpoint.mountOpfsIntoPhp(primaryPhp, mount);
+				}
+				this.__internal_setRequestHandler(requestHandler);
+				setApiReady();
+				return;
+			}
+
 			// Select the right SQLite version:
 			// - PHP 5.2: pre-patched v2.2.22 (closures replaced, PHP 5.2
 			//   polyfills added)

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -153,6 +153,21 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				}
 			}
 
+			// PHP-only mode: the caller asked us to skip the WordPress
+			// install, so there's nothing for `bootWordPress` to do — and
+			// running it without WP files would still drop in the SQLite
+			// shim and then assert a (nonexistent) DB connection. Apply the
+			// OPFS mounts directly and stop.
+			if (!shouldInstallWordPress) {
+				const primaryPhp = await requestHandler.getPrimaryPhp();
+				for (const mount of mounts) {
+					await endpoint.mountOpfsIntoPhp(primaryPhp, mount);
+				}
+				this.__internal_setRequestHandler(requestHandler);
+				setApiReady();
+				return;
+			}
+
 			// Select the right SQLite version:
 			// - PHP 5.2: pre-patched v2.2.22 (closures replaced, PHP 5.2
 			//   polyfills added)

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -153,21 +153,6 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				}
 			}
 
-			// PHP-only mode: the caller asked us to skip the WordPress
-			// install, so there's nothing for `bootWordPress` to do — and
-			// running it without WP files would still drop in the SQLite
-			// shim and then assert a (nonexistent) DB connection. Apply the
-			// OPFS mounts directly and stop.
-			if (!shouldInstallWordPress) {
-				const primaryPhp = await requestHandler.getPrimaryPhp();
-				for (const mount of mounts) {
-					await endpoint.mountOpfsIntoPhp(primaryPhp, mount);
-				}
-				this.__internal_setRequestHandler(requestHandler);
-				setApiReady();
-				return;
-			}
-
 			// Select the right SQLite version:
 			// - PHP 5.2: pre-patched v2.2.22 (closures replaced, PHP 5.2
 			//   polyfills added)

--- a/packages/playground/remote/src/lib/worker-utils.ts
+++ b/packages/playground/remote/src/lib/worker-utils.ts
@@ -132,7 +132,7 @@ export async function hasCachedStaticFilesRemovedFromMinifiedBuild(php: PHP) {
  * See backfillStaticFilesRemovedFromMinifiedBuild for more details.
  */
 export async function getWordPressStaticZipUrl(php: PHP) {
-	// PHP-only mode (Blueprint `wordpress: false`): no WP files exist, so
+	// PHP-only mode (Blueprint `preferredVersions.wp: false`): no WP files exist, so
 	// `getLoadedWordPressVersion` would crash trying to require
 	// wp-includes/version.php. There's nothing to backfill — bail out.
 	const versionPhpPath = joinPaths(

--- a/packages/playground/remote/src/lib/worker-utils.ts
+++ b/packages/playground/remote/src/lib/worker-utils.ts
@@ -132,6 +132,16 @@ export async function hasCachedStaticFilesRemovedFromMinifiedBuild(php: PHP) {
  * See backfillStaticFilesRemovedFromMinifiedBuild for more details.
  */
 export async function getWordPressStaticZipUrl(php: PHP) {
+	// PHP-only mode (Blueprint `wordpress: false`): no WP files exist, so
+	// `getLoadedWordPressVersion` would crash trying to require
+	// wp-includes/version.php. There's nothing to backfill — bail out.
+	const versionPhpPath = joinPaths(
+		php.requestHandler!.documentRoot,
+		'wp-includes/version.php'
+	);
+	if (!php.isFile(versionPhpPath)) {
+		return false;
+	}
 	const wpVersion = await getLoadedWordPressVersion(php.requestHandler!);
 	const staticAssetsDirectory = wpVersionToStaticAssetsDirectory(wpVersion);
 	if (!staticAssetsDirectory) {

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -962,6 +962,39 @@ test('WordPress homepage loads when mu-plugin prints a notice', async ({
 	);
 });
 
+test('Blueprint with `wordpress: false` boots Playground without WordPress', async ({
+	website,
+}) => {
+	const blueprint: Blueprint = { wordpress: false };
+	const encodedBlueprint = encodeStringAsBase64(JSON.stringify(blueprint));
+	await website.goto(`/#${encodedBlueprint}`);
+
+	// `window.playground` is exposed once the worker boot resolves.
+	await website.page.waitForFunction(
+		() => Boolean((window as any).playground),
+		null,
+		{ timeout: 240_000 }
+	);
+
+	const probe = await website.page.evaluate(async () => {
+		const playground = (window as any).playground;
+		const r = await playground.run({
+			code: `<?php echo json_encode([
+				'wp_dir' => is_dir('/wordpress'),
+				'wp_loaded' => function_exists('wp_get_current_user'),
+				'sqlite_drop_in' => file_exists('/internal/shared/preload/0-sqlite.php'),
+			]);`,
+		});
+		return r.text;
+	});
+
+	expect(JSON.parse(probe)).toEqual({
+		wp_dir: false,
+		wp_loaded: false,
+		sqlite_drop_in: false,
+	});
+});
+
 /**
  * WordPress 6.7 added a redirect from /sitemap.xml to /wp-sitemap.xml
  * (see https://core.trac.wordpress.org/ticket/61931). This test ensures

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -962,10 +962,12 @@ test('WordPress homepage loads when mu-plugin prints a notice', async ({
 	);
 });
 
-test('Blueprint with `wordpress: false` boots Playground without WordPress', async ({
+test('Blueprint with `preferredVersions.wp: false` boots Playground without WordPress', async ({
 	website,
 }) => {
-	const blueprint: Blueprint = { wordpress: false };
+	const blueprint: Blueprint = {
+		preferredVersions: { php: 'latest', wp: false },
+	};
 	const encodedBlueprint = encodeStringAsBase64(JSON.stringify(blueprint));
 	// `website.goto` waits for the WP iframe body to render, which never
 	// happens when WordPress isn't installed. Skip that wait and use the

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -967,7 +967,10 @@ test('Blueprint with `wordpress: false` boots Playground without WordPress', asy
 }) => {
 	const blueprint: Blueprint = { wordpress: false };
 	const encodedBlueprint = encodeStringAsBase64(JSON.stringify(blueprint));
-	await website.goto(`/#${encodedBlueprint}`);
+	// `website.goto` waits for the WP iframe body to render, which never
+	// happens when WordPress isn't installed. Skip that wait and use the
+	// raw page navigation instead.
+	await website.page.goto(`/#${encodedBlueprint}`);
 
 	// `window.playground` is exposed once the worker boot resolves.
 	await website.page.waitForFunction(

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -982,8 +982,12 @@ test('Blueprint with `wordpress: false` boots Playground without WordPress', asy
 	const probe = await website.page.evaluate(async () => {
 		const playground = (window as any).playground;
 		const r = await playground.run({
+			// `/wordpress` itself is created by PHPRequestHandler as the
+			// document root regardless of WP, so that's not a useful signal.
+			// What we really want is: no WP files, no WP runtime, no SQLite
+			// drop-in installed.
 			code: `<?php echo json_encode([
-				'wp_dir' => is_dir('/wordpress'),
+				'wp_files' => file_exists('/wordpress/wp-includes/version.php'),
 				'wp_loaded' => function_exists('wp_get_current_user'),
 				'sqlite_drop_in' => file_exists('/internal/shared/preload/0-sqlite.php'),
 			]);`,
@@ -992,7 +996,7 @@ test('Blueprint with `wordpress: false` boots Playground without WordPress', asy
 	});
 
 	expect(JSON.parse(probe)).toEqual({
-		wp_dir: false,
+		wp_files: false,
 		wp_loaded: false,
 		sqlite_drop_in: false,
 	});

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -23,7 +23,6 @@ test.describe('php-code-snippet embed', () => {
 			'greet-alice.php',
 			'greet-bob.php',
 			'scratch.php',
-			'php-only.php',
 		]) {
 			const snippet = page.locator(`php-snippet[name="${name}"]`);
 			await expect(snippet).toBeVisible();
@@ -138,50 +137,6 @@ test.describe('php-code-snippet embed', () => {
 			.locator('iframe[title="PHP Snippet runtime"]')
 			.count();
 		expect(blueprintIframes).toBe(1);
-	});
-
-	test('wp="none" runs PHP without downloading or installing WordPress', async ({
-		page,
-	}) => {
-		// Track every network request the page issues. The download path for
-		// WordPress goes through `playground.wordpress.net/wp-*.zip`,
-		// `wordpress.org/wordpress-*.zip`, or the minified-builds bucket —
-		// any of those firing means we didn't actually skip the install.
-		const wpRequests: string[] = [];
-		page.on('request', (req) => {
-			const url = req.url();
-			if (
-				/\/wp-[\d.]+(?:-[\w.]+)?\.zip(?:$|\?)/.test(url) ||
-				/wordpress-[\d.]+(?:-[\w.]+)?\.zip(?:$|\?)/.test(url) ||
-				/\/wp\/[\d.]+\//.test(url)
-			) {
-				wpRequests.push(url);
-			}
-		});
-
-		await page.goto(DEMO_URL);
-		// `wordpress: false` is part of THIS PR; the deployed
-		// playground.wordpress.net origin doesn't know about it yet, so
-		// force the snippet to boot against the local Playground build the
-		// dev server is serving (same one the demo page came from).
-		const phpOnly = page.locator('php-snippet[name="php-only.php"]');
-		await phpOnly.evaluate((el) =>
-			el.setAttribute('playground-origin', window.location.origin)
-		);
-		await phpOnly.locator('.run').click();
-		await expect(phpOnly.locator('.output')).toBeVisible({
-			timeout: 240_000,
-		});
-
-		// Functional confirmation: the runtime is up, but `/wordpress` was
-		// never created and WP's globals never loaded.
-		const body = phpOnly.locator('.output-body');
-		await expect(body).toContainText('php:');
-		await expect(body).toContainText('wp_loaded:no');
-		await expect(body).toContainText('wp_dir:no');
-
-		// Network confirmation: no WordPress zip was fetched.
-		expect(wpRequests).toEqual([]);
 	});
 
 	test('editable snippet runs the user-typed code', async ({ page }) => {

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -23,6 +23,7 @@ test.describe('php-code-snippet embed', () => {
 			'greet-alice.php',
 			'greet-bob.php',
 			'scratch.php',
+			'php-only.php',
 		]) {
 			const snippet = page.locator(`php-snippet[name="${name}"]`);
 			await expect(snippet).toBeVisible();
@@ -50,9 +51,8 @@ test.describe('php-code-snippet embed', () => {
 				async () =>
 					Number(
 						(
-							(await first
-								.locator('.percent')
-								.textContent()) || '0%'
+							(await first.locator('.percent').textContent()) ||
+							'0%'
 						).replace('%', '')
 					),
 				{ timeout: 120_000, intervals: [500] }
@@ -130,9 +130,7 @@ test.describe('php-code-snippet embed', () => {
 
 		await bob.locator('.run').click();
 		await expect(bob.locator('.output')).toBeVisible({ timeout: 60_000 });
-		await expect(bob.locator('.output-body')).toContainText(
-			'Hello, Bob!'
-		);
+		await expect(bob.locator('.output-body')).toContainText('Hello, Bob!');
 
 		// Both snippets resolved to the same blueprint hash, so only one
 		// runtime iframe exists for this {origin, php, wp, blueprint} key.
@@ -140,6 +138,43 @@ test.describe('php-code-snippet embed', () => {
 			.locator('iframe[title="PHP Snippet runtime"]')
 			.count();
 		expect(blueprintIframes).toBe(1);
+	});
+
+	test('wp="none" runs PHP without downloading or installing WordPress', async ({
+		page,
+	}) => {
+		// Track every network request the page issues. The download path for
+		// WordPress goes through `playground.wordpress.net/wp-*.zip`,
+		// `wordpress.org/wordpress-*.zip`, or the minified-builds bucket —
+		// any of those firing means we didn't actually skip the install.
+		const wpRequests: string[] = [];
+		page.on('request', (req) => {
+			const url = req.url();
+			if (
+				/\/wp-[\d.]+(?:-[\w.]+)?\.zip(?:$|\?)/.test(url) ||
+				/wordpress-[\d.]+(?:-[\w.]+)?\.zip(?:$|\?)/.test(url) ||
+				/\/wp\/[\d.]+\//.test(url)
+			) {
+				wpRequests.push(url);
+			}
+		});
+
+		await page.goto(DEMO_URL);
+		const phpOnly = page.locator('php-snippet[name="php-only.php"]');
+		await phpOnly.locator('.run').click();
+		await expect(phpOnly.locator('.output')).toBeVisible({
+			timeout: 240_000,
+		});
+
+		// Functional confirmation: the runtime is up, but `/wordpress` was
+		// never created and WP's globals never loaded.
+		const body = phpOnly.locator('.output-body');
+		await expect(body).toContainText('php:');
+		await expect(body).toContainText('wp_loaded:no');
+		await expect(body).toContainText('wp_dir:no');
+
+		// Network confirmation: no WordPress zip was fetched.
+		expect(wpRequests).toEqual([]);
 	});
 
 	test('editable snippet runs the user-typed code', async ({ page }) => {

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -160,7 +160,14 @@ test.describe('php-code-snippet embed', () => {
 		});
 
 		await page.goto(DEMO_URL);
+		// `wordpress: false` is part of THIS PR; the deployed
+		// playground.wordpress.net origin doesn't know about it yet, so
+		// force the snippet to boot against the local Playground build the
+		// dev server is serving (same one the demo page came from).
 		const phpOnly = page.locator('php-snippet[name="php-only.php"]');
+		await phpOnly.evaluate((el) =>
+			el.setAttribute('playground-origin', window.location.origin)
+		);
 		await phpOnly.locator('.run').click();
 		await expect(phpOnly.locator('.output')).toBeVisible({
 			timeout: 240_000,

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -164,20 +164,6 @@
 			</script>
 		</php-snippet>
 
-		<h2>6. PHP-only (no WordPress)</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
-			<code>wp="none"</code> boots PHP without downloading or installing
-			WordPress. Open Network — no <code>wp-*.zip</code> request fires.
-		</p>
-		<php-snippet name="php-only.php" wp="none">
-			<script type="application/x-php">
-				<?php
-				echo "php:" . phpversion() . "\n";
-				echo "wp_loaded:" . (function_exists('wp_get_current_user') ? 'yes' : 'no') . "\n";
-				echo "wp_dir:" . (is_dir('/wordpress') ? 'yes' : 'no') . "\n";
-			</script>
-		</php-snippet>
-
 		<script type="module" src="./php-code-snippet.js"></script>
 	</body>
 </html>

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
@@ -6,17 +6,34 @@
 		<title>&lt;php-snippet&gt; demo</title>
 		<style>
 			body {
-				font-family: system-ui, -apple-system, sans-serif;
+				font-family:
+					system-ui,
+					-apple-system,
+					sans-serif;
 				max-width: 880px;
 				margin: 0 auto;
 				padding: 32px 20px 64px;
 				color: #1f2328;
 				line-height: 1.55;
 			}
-			h1 { font-size: 28px; margin: 0 0 8px; }
-			h2 { font-size: 20px; margin: 32px 0 8px; }
-			.lede { color: #57606a; margin: 0 0 24px; }
-			code { background: #eaeef2; padding: 2px 5px; border-radius: 4px; font-size: 0.9em; }
+			h1 {
+				font-size: 28px;
+				margin: 0 0 8px;
+			}
+			h2 {
+				font-size: 20px;
+				margin: 32px 0 8px;
+			}
+			.lede {
+				color: #57606a;
+				margin: 0 0 24px;
+			}
+			code {
+				background: #eaeef2;
+				padding: 2px 5px;
+				border-radius: 4px;
+				font-size: 0.9em;
+			}
 			.note {
 				background: #ddf4ff;
 				border-left: 4px solid #218bff;
@@ -30,81 +47,80 @@
 	<body>
 		<h1>&lt;php-snippet&gt; demo</h1>
 		<p class="lede">
-			Three independent snippets on one page. Click Run on any of
-			them — the PHP &amp; WordPress runtime downloads
+			Three independent snippets on one page. Click Run on any of them —
+			the PHP &amp; WordPress runtime downloads
 			<strong>once</strong> and is shared across all of them.
 		</p>
 
 		<div class="note">
 			Open DevTools → Network and watch: the first Run downloads
-			<code>remote.html</code> + the PHP WASM binary + WordPress.
-			The second and third Runs reuse the same runtime — no extra
-			downloads.
+			<code>remote.html</code> + the PHP WASM binary + WordPress. The
+			second and third Runs reuse the same runtime — no extra downloads.
 		</div>
 
 		<h2>1. Pure PHP</h2>
 		<php-snippet name="hello.php">
 			<script type="application/x-php">
-<?php
-echo "Hello from PHP " . phpversion() . "\n";
-echo "Today is " . date('Y-m-d') . "\n";
-echo str_repeat('-', 30) . "\n";
+				<?php
+				echo "Hello from PHP " . phpversion() . "\n";
+				echo "Today is " . date('Y-m-d') . "\n";
+				echo str_repeat('-', 30) . "\n";
 
-$nums = [1, 2, 3, 4, 5];
-echo "Sum of " . implode(',', $nums) . " = " . array_sum($nums) . "\n";
+				$nums = [1, 2, 3, 4, 5];
+				echo "Sum of " . implode(',', $nums) . " = " . array_sum($nums) . "\n";
 			</script>
 		</php-snippet>
 
 		<h2>2. WordPress HTML API</h2>
 		<php-snippet name="lazy-load-images.php">
 			<script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
+				<?php
+				require '/wordpress/wp-load.php';
 
-$html = '<article>
-    <img src="hero.jpg" alt="Hero">
-    <img src="inline.jpg" alt="Inline">
-</article>';
+				$html = '<article>
+				    <img src="hero.jpg" alt="Hero">
+				    <img src="inline.jpg" alt="Inline">
+				</article>';
 
-$tags = new WP_HTML_Tag_Processor( $html );
-while ( $tags->next_tag( 'img' ) ) {
-    $tags->set_attribute( 'loading', 'lazy' );
-    $tags->add_class( 'responsive' );
-}
+				$tags = new WP_HTML_Tag_Processor( $html );
+				while ( $tags->next_tag( 'img' ) ) {
+				    $tags->set_attribute( 'loading', 'lazy' );
+				    $tags->add_class( 'responsive' );
+				}
 
-echo $tags->get_updated_html();
+				echo $tags->get_updated_html();
 			</script>
 		</php-snippet>
 
 		<h2>3. Block parser</h2>
 		<php-snippet name="parse-blocks.php">
 			<script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
+				<?php
+				require '/wordpress/wp-load.php';
 
-$post_content = "<!-- wp:paragraph -->
-<p>Hello, <strong>block editor</strong>!</p>
-<!-- /wp:paragraph -->
+				$post_content = "<!-- wp:paragraph -->
+				<p>Hello, <strong>block editor</strong>!</p>
+				<!-- /wp:paragraph -->
 
-<!-- wp:list -->
-<ul><li>One</li><li>Two</li></ul>
-<!-- /wp:list -->";
+				<!-- wp:list -->
+				<ul><li>One</li><li>Two</li></ul>
+				<!-- /wp:list -->";
 
-$blocks = parse_blocks( $post_content );
-foreach ( $blocks as $block ) {
-    if ( ! empty( $block['blockName'] ) ) {
-        echo "- " . $block['blockName'] . "\n";
-    }
-}
+				$blocks = parse_blocks( $post_content );
+				foreach ( $blocks as $block ) {
+				    if ( ! empty( $block['blockName'] ) ) {
+				        echo "- " . $block['blockName'] . "\n";
+				    }
+				}
 			</script>
 		</php-snippet>
 
 		<h2>4. Shared blueprint via JSON script</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
-			Two snippets reference the same blueprint by id, so their
-			runtime is booted once with a pre-installed mu-plugin.
-			Using <code>&lt;script type="application/json"&gt;</code> lets
-			the JSON contain literal <code>&lt;?php</code> without escaping.
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			Two snippets reference the same blueprint by id, so their runtime is
+			booted once with a pre-installed mu-plugin. Using
+			<code>&lt;script type="application/json"&gt;</code> lets the JSON
+			contain literal <code>&lt;?php</code> without escaping.
 		</p>
 
 		<script id="greeter-blueprint" type="application/json">
@@ -121,30 +137,44 @@ foreach ( $blocks as $block ) {
 
 		<php-snippet name="greet-alice.php" blueprint="greeter-blueprint">
 			<script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
-echo greeter_say('Alice');
+				<?php
+				require '/wordpress/wp-load.php';
+				echo greeter_say('Alice');
 			</script>
 		</php-snippet>
 
 		<php-snippet name="greet-bob.php" blueprint="greeter-blueprint">
 			<script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
-echo greeter_say('Bob');
+				<?php
+				require '/wordpress/wp-load.php';
+				echo greeter_say('Bob');
 			</script>
 		</php-snippet>
 
 		<h2>5. Editable</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
 			Type into the snippet, then click Run.
 		</p>
 		<php-snippet name="scratch.php" editable>
 			<script type="application/x-php">
-<?php
-$nums = range(1, 10);
-echo "Sum: " . array_sum($nums) . "\n";
-echo "Product: " . array_product($nums) . "\n";
+				<?php
+				$nums = range(1, 10);
+				echo "Sum: " . array_sum($nums) . "\n";
+				echo "Product: " . array_product($nums) . "\n";
+			</script>
+		</php-snippet>
+
+		<h2>6. PHP-only (no WordPress)</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			<code>wp="none"</code> boots PHP without downloading or installing
+			WordPress. Open Network — no <code>wp-*.zip</code> request fires.
+		</p>
+		<php-snippet name="php-only.php" wp="none">
+			<script type="application/x-php">
+				<?php
+				echo "php:" . phpversion() . "\n";
+				echo "wp_loaded:" . (function_exists('wp_get_current_user') ? 'yes' : 'no') . "\n";
+				echo "wp_dir:" . (is_dir('/wordpress') ? 'yes' : 'no') . "\n";
 			</script>
 		</php-snippet>
 

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -24,7 +24,9 @@
  * Attributes:
  *   name="…"              filename label shown in the header
  *   php="8.4"             PHP version (default: 8.4)
- *   wp="latest"           WordPress version (default: latest)
+ *   wp="latest"           WordPress version (default: latest). Use wp="none"
+ *                         to boot PHP without installing WordPress — handy for
+ *                         pure-PHP snippets that don't touch wp-load.php.
  *   src="path/to.php"     load code from a URL instead of inline
  *   editable              make the snippet editable; visitors type into a
  *                         transparent textarea overlaid on the highlighted
@@ -220,6 +222,10 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 		'position:absolute;width:1px;height:1px;border:0;opacity:0;pointer-events:none;left:-9999px;';
 	iframe.src = `${origin}/remote.html`;
 	document.body.appendChild(iframe);
+	// wp="none" maps to the Blueprint's declarative `wordpress: false`, which
+	// skips the WordPress download entirely. preferredVersions.wp is then
+	// ignored downstream, so we still pass DEFAULT_WP for the schema.
+	const skipWordPress = wp === 'none';
 	const client = await startPlaygroundWeb({
 		iframe,
 		remoteUrl: iframe.src,
@@ -227,7 +233,11 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 		progressTracker: entry.tracker,
 		blueprint: {
 			...(blueprint || {}),
-			preferredVersions: { php, wp },
+			...(skipWordPress ? { wordpress: false } : {}),
+			preferredVersions: {
+				php,
+				wp: skipWordPress ? DEFAULT_WP : wp,
+			},
 		},
 	});
 	await client.isReady;

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -63,7 +63,9 @@ class ProgressTracker extends EventTarget {
 		this._selfDone = false;
 		this._subs = [];
 	}
-	get weight() { return this._weight; }
+	get weight() {
+		return this._weight;
+	}
 	get progress() {
 		if (this._selfDone) return 100;
 		const sum = this._subs.reduce(
@@ -72,7 +74,9 @@ class ProgressTracker extends EventTarget {
 		);
 		return Math.round(sum * 10000) / 10000;
 	}
-	get done() { return this.progress + PROGRESS_EPSILON >= 100; }
+	get done() {
+		return this.progress + PROGRESS_EPSILON >= 100;
+	}
 	get caption() {
 		for (let i = this._subs.length - 1; i >= 0; i--) {
 			if (!this._subs[i].done && this._subs[i].caption) {
@@ -97,7 +101,10 @@ class ProgressTracker extends EventTarget {
 		this._notify();
 		if (this._selfProgress + PROGRESS_EPSILON >= 100) this.finish();
 	}
-	setCaption(c) { this._selfCaption = c; this._notify(); }
+	setCaption(c) {
+		this._selfCaption = c;
+		this._notify();
+	}
 	finish() {
 		if (this._fillInterval) {
 			clearInterval(this._fillInterval);
@@ -121,7 +128,10 @@ class ProgressTracker extends EventTarget {
 		}, 40);
 	}
 	pipe(receiver) {
-		receiver.setProgress({ progress: this.progress, caption: this.caption });
+		receiver.setProgress({
+			progress: this.progress,
+			caption: this.caption,
+		});
 		this.addEventListener('progress', (e) =>
 			receiver.setProgress({
 				progress: e.detail.progress,
@@ -222,9 +232,9 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 		'position:absolute;width:1px;height:1px;border:0;opacity:0;pointer-events:none;left:-9999px;';
 	iframe.src = `${origin}/remote.html`;
 	document.body.appendChild(iframe);
-	// wp="none" maps to the Blueprint's declarative `wordpress: false`, which
-	// skips the WordPress download entirely. preferredVersions.wp is then
-	// ignored downstream, so we still pass DEFAULT_WP for the schema.
+	// wp="none" maps to the Blueprint's declarative
+	// `preferredVersions.wp: false`, which skips the WordPress download
+	// entirely.
 	const skipWordPress = wp === 'none';
 	const client = await startPlaygroundWeb({
 		iframe,
@@ -233,10 +243,9 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 		progressTracker: entry.tracker,
 		blueprint: {
 			...(blueprint || {}),
-			...(skipWordPress ? { wordpress: false } : {}),
 			preferredVersions: {
 				php,
-				wp: skipWordPress ? DEFAULT_WP : wp,
+				wp: skipWordPress ? false : wp,
 			},
 		},
 	});
@@ -311,23 +320,79 @@ function stableStringify(value) {
  * patterns so they match first.
  */
 const PHP_KEYWORDS = new Set([
-	'abstract', 'and', 'array', 'as', 'break', 'callable', 'case', 'catch',
-	'class', 'clone', 'const', 'continue', 'declare', 'default', 'do', 'echo',
-	'else', 'elseif', 'empty', 'enddeclare', 'endfor', 'endforeach', 'endif',
-	'endswitch', 'endwhile', 'extends', 'final', 'finally', 'fn', 'for',
-	'foreach', 'function', 'global', 'goto', 'if', 'implements', 'include',
-	'include_once', 'instanceof', 'insteadof', 'interface', 'isset', 'list',
-	'match', 'namespace', 'new', 'null', 'or', 'print', 'private', 'protected',
-	'public', 'readonly', 'require', 'require_once', 'return', 'static',
-	'switch', 'throw', 'trait', 'try', 'unset', 'use', 'var', 'while', 'xor',
-	'yield', 'true', 'false',
+	'abstract',
+	'and',
+	'array',
+	'as',
+	'break',
+	'callable',
+	'case',
+	'catch',
+	'class',
+	'clone',
+	'const',
+	'continue',
+	'declare',
+	'default',
+	'do',
+	'echo',
+	'else',
+	'elseif',
+	'empty',
+	'enddeclare',
+	'endfor',
+	'endforeach',
+	'endif',
+	'endswitch',
+	'endwhile',
+	'extends',
+	'final',
+	'finally',
+	'fn',
+	'for',
+	'foreach',
+	'function',
+	'global',
+	'goto',
+	'if',
+	'implements',
+	'include',
+	'include_once',
+	'instanceof',
+	'insteadof',
+	'interface',
+	'isset',
+	'list',
+	'match',
+	'namespace',
+	'new',
+	'null',
+	'or',
+	'print',
+	'private',
+	'protected',
+	'public',
+	'readonly',
+	'require',
+	'require_once',
+	'return',
+	'static',
+	'switch',
+	'throw',
+	'trait',
+	'try',
+	'unset',
+	'use',
+	'var',
+	'while',
+	'xor',
+	'yield',
+	'true',
+	'false',
 ]);
 
 function escapeHtml(s) {
-	return s
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;');
+	return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 function highlightPhp(code) {
@@ -350,20 +415,17 @@ function highlightPhp(code) {
 		const rest = code.slice(i);
 		// Heredoc / nowdoc: <<<LABEL ... \nLABEL;  (nowdoc wraps label in '')
 		if (rest.startsWith('<<<')) {
-			const m = rest.match(/^<<<[ \t]*('?)([A-Za-z_][A-Za-z0-9_]*)\1\r?\n/);
+			const m = rest.match(
+				/^<<<[ \t]*('?)([A-Za-z_][A-Za-z0-9_]*)\1\r?\n/
+			);
 			if (m) {
 				const label = m[2];
 				const bodyStart = i + m[0].length;
 				// Closing label may be indented (PHP 7.3+); match at line start.
-				const closer = new RegExp(
-					`(^|\\n)[ \\t]*${label}\\b`,
-					'g'
-				);
+				const closer = new RegExp(`(^|\\n)[ \\t]*${label}\\b`, 'g');
 				closer.lastIndex = bodyStart;
 				const found = closer.exec(code);
-				const stop = found
-					? found.index + found[0].length
-					: len;
+				const stop = found ? found.index + found[0].length : len;
 				tokens.push(['string', code.slice(i, stop)]);
 				i = stop;
 				continue;
@@ -378,10 +440,7 @@ function highlightPhp(code) {
 			continue;
 		}
 		// Line comment ( // or # ).  #[ starts a PHP 8 attribute, not a comment.
-		if (
-			rest.startsWith('//') ||
-			(c === '#' && code[i + 1] !== '[')
-		) {
+		if (rest.startsWith('//') || (c === '#' && code[i + 1] !== '[')) {
 			const end = code.indexOf('\n', i);
 			const stop = end === -1 ? len : end;
 			tokens.push(['comment', code.slice(i, stop)]);

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -174,7 +174,15 @@ export function bootSiteClient(
 							},
 						]
 					: [],
-				shouldInstallWordPress: !isWordPressInstalled,
+				// PHP-only mode: a Blueprint with `wordpress: false`
+				// declares it doesn't want WordPress, so honor that even
+				// if the storage layer thinks WP isn't installed yet —
+				// passing `true` here would conflict with the Blueprint
+				// and the handler would throw.
+				shouldInstallWordPress:
+					(blueprint as { wordpress?: false })?.wordpress === false
+						? false
+						: !isWordPressInstalled,
 				corsProxy: corsProxyUrl,
 				gitAdditionalHeadersCallback: createGitAuthHeaders(),
 				pathAliases: [

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -147,6 +147,15 @@ export function bootSiteClient(
 			blueprint = site.metadata.originalBlueprint;
 		}
 
+		// PHP-only mode: a Blueprint with `preferredVersions.wp: false`
+		// declares it doesn't want WordPress, so honor that even if the
+		// storage layer thinks WP isn't installed yet — passing `true` here
+		// would conflict with the Blueprint and the handler would throw.
+		const blueprintRequestedNoWordPress =
+			!!blueprint &&
+			!isBlueprintBundle(blueprint) &&
+			blueprint.preferredVersions?.wp === false;
+
 		let playground: PlaygroundClient | undefined = undefined;
 		try {
 			await startPlaygroundWeb({
@@ -175,17 +184,9 @@ export function bootSiteClient(
 							},
 						]
 					: [],
-				// PHP-only mode: a Blueprint with `preferredVersions.wp:
-				// false` declares it doesn't want WordPress, so honor that
-				// even if the storage layer thinks WP isn't installed yet
-				// — passing `true` here would conflict with the Blueprint
-				// and the handler would throw.
-				shouldInstallWordPress:
-					blueprint &&
-					!isBlueprintBundle(blueprint) &&
-					blueprint.preferredVersions?.wp === false
-						? false
-						: !isWordPressInstalled,
+				shouldInstallWordPress: blueprintRequestedNoWordPress
+					? false
+					: !isWordPressInstalled,
 				corsProxy: corsProxyUrl,
 				gitAdditionalHeadersCallback: createGitAuthHeaders(),
 				pathAliases: [

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -14,6 +14,7 @@ import {
 	type Blueprint,
 	BlueprintFilesystemRequiredError,
 	InvalidBlueprintError,
+	isBlueprintBundle,
 } from '@wp-playground/blueprints';
 import { logger } from '@php-wasm/logger';
 import { setupPostMessageRelay } from '@php-wasm/web';
@@ -174,13 +175,15 @@ export function bootSiteClient(
 							},
 						]
 					: [],
-				// PHP-only mode: a Blueprint with `wordpress: false`
-				// declares it doesn't want WordPress, so honor that even
-				// if the storage layer thinks WP isn't installed yet —
-				// passing `true` here would conflict with the Blueprint
+				// PHP-only mode: a Blueprint with `preferredVersions.wp:
+				// false` declares it doesn't want WordPress, so honor that
+				// even if the storage layer thinks WP isn't installed yet
+				// — passing `true` here would conflict with the Blueprint
 				// and the handler would throw.
 				shouldInstallWordPress:
-					(blueprint as { wordpress?: false })?.wordpress === false
+					blueprint &&
+					!isBlueprintBundle(blueprint) &&
+					blueprint.preferredVersions?.wp === false
 						? false
 						: !isWordPressInstalled,
 				corsProxy: corsProxyUrl,

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -232,8 +232,8 @@ function applyQueryOverridesToDeclaration(
 	// PHP-only blueprints opt out of WordPress entirely. Skip the WP-bound
 	// query overrides — adding `login`, `enableMultisite`, etc. would
 	// trip the compile-time guard that rejects WP-only features when
-	// `wordpress: false` is set.
-	if ((blueprint as { wordpress?: false }).wordpress === false) {
+	// `preferredVersions.wp: false` is set.
+	if (blueprint.preferredVersions?.wp === false) {
 		return blueprint;
 	}
 	/**

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -229,6 +229,13 @@ function applyQueryOverridesToDeclaration(
 	blueprint: BlueprintV1Declaration,
 	query: URLSearchParams
 ): BlueprintV1Declaration {
+	// PHP-only blueprints opt out of WordPress entirely. Skip the WP-bound
+	// query overrides — adding `login`, `enableMultisite`, etc. would
+	// trip the compile-time guard that rejects WP-only features when
+	// `wordpress: false` is set.
+	if ((blueprint as { wordpress?: false }).wordpress === false) {
+		return blueprint;
+	}
 	/**
 	 * Allow overriding PHP and WordPress versions defined in a Blueprint
 	 * via query params.


### PR DESCRIPTION
## Summary

Lets a Blueprint declare it doesn't want WordPress at all — the boot flow skips the WordPress download entirely and just brings up PHP. Useful for running pure-PHP snippets, including the `<php-snippet>` web component.

```json
{ "preferredVersions": { "php": "8.4", "wp": false } }
```

When `preferredVersions.wp` is `false`, the compiler rejects WordPress-only fields and steps so the mistake surfaces at compile time instead of at runtime when something calls `wp-load.php`:

- top-level: `plugins`, `siteOptions`, `login`, `extraLibraries: ['wp-cli']`
- steps: `installPlugin`, `installTheme`, `activatePlugin`, `activateTheme`, `login`, `setSiteOptions`, `updateUserMeta`, `importWxr`, `importFile`, `importWordPressFiles`, `enableMultisite`, `wp-cli`, `resetData`

The client handler reads `blueprint.preferredVersions?.wp === false` and forwards it as `shouldInstallWordPress: false` to the worker. If the caller also passes `shouldInstallWordPress: true` and the Blueprint sets `wp: false`, the handler throws rather than silently picking a winner. Omitting the option is fine — the Blueprint flag wins by default.

`<php-snippet wp="none">` now folds `preferredVersions: { wp: false }` into the synthesized blueprint instead of setting `shouldInstallWordPress` directly.

## Not in this PR

- Blueprints v2 — the v2 schema and PHP runner do not honor `preferredVersions.wp: false` yet.

## Test plan

- [ ] `npx nx test playground-blueprints --testFile=compile.spec.ts` covers compile + run with `preferredVersions.wp: false`, and rejection of `plugins`, `siteOptions`, `login`, `extraLibraries`, and WordPress-only steps.
- [ ] Playwright e2e (`blueprints.spec.ts`) loads the website with `{ preferredVersions: { php: 'latest', wp: false } }` and asserts no WP files, no WP runtime, and no SQLite drop-in.