### PR TITLE
Auto-label PRs: path-based labeler (replaces GitHub Models)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,190 @@
+# Path-based labels for actions/labeler.
+#
+# Drives the [Package][@..], [Aspect], and [Focus] labels off changed file
+# paths. Title/body-driven [Type] labels are intentionally not handled here —
+# those need human judgment and there isn't a reliable path heuristic. The
+# previous AI-based labeler (auto-label-prs.yml) is gone because GitHub
+# Models access in Actions is gated by an org-level toggle we can't flip.
+#
+# Format: each top-level key is a label name, value is a list of glob match
+# rules. See https://github.com/actions/labeler for syntax. We use the
+# `changed-files` / `any-glob-to-any-file` form throughout.
+
+# ---------------------------------------------------------------------------
+# [Package][@php-wasm] *
+# ---------------------------------------------------------------------------
+
+'[Package][@php-wasm] CLI':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/cli/**'
+
+'[Package][@php-wasm] CLI-Util':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/cli-util/**'
+
+'[Package][@php-wasm] Compile':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/compile/**'
+
+'[Package][@php-wasm] FS Journal':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/fs-journal/**'
+
+'[Package][@php-wasm] Logger':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/logger/**'
+
+'[Package][@php-wasm] Node':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/node/**'
+
+'[Package][@php-wasm] Progress':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/progress/**'
+
+'[Package][@php-wasm] Scopes':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/scopes/**'
+
+'[Package][@php-wasm] Stream Compression':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/stream-compression/**'
+
+'[Package][@php-wasm] Universal':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/universal/**'
+
+'[Package][@php-wasm] Util':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/util/**'
+
+'[Package][@php-wasm] Web':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/php-wasm/web/**'
+                - 'packages/php-wasm/web-service-worker/**'
+
+'[Package][@php-wasm] Xdebug Bridge':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/php-wasm/xdebug-bridge/**'
+
+# ---------------------------------------------------------------------------
+# [Package][@wp-playground] *
+# ---------------------------------------------------------------------------
+
+'[Package][@wp-playground] Blueprints':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/blueprints/**'
+
+'[Package][@wp-playground] CLI':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/cli/**'
+
+'[Package][@wp-playground] Client':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/client/**'
+
+'[Package][@wp-playground] Common':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/common/**'
+
+'[Package][@wp-playground] Components':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/components/**'
+
+'[Package][@wp-playground] CORS Proxy':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/php-cors-proxy/**'
+
+'[Package][@wp-playground] Remote':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/remote/**'
+
+'[Package][@wp-playground] Storage':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/storage/**'
+
+'[Package][@wp-playground] Sync':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/sync/**'
+
+'[Package][@wp-playground] Website':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/playground/website/**'
+                - 'packages/playground/website-extras/**'
+
+'[Package][@wp-playground] WordPress':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/wordpress/**'
+
+'[Package][@wp-playground] WordPress Builds':
+    - changed-files:
+          - any-glob-to-any-file: 'packages/playground/wordpress-builds/**'
+
+# ---------------------------------------------------------------------------
+# [Aspect] *  — cross-cutting concerns inferable from paths
+# ---------------------------------------------------------------------------
+
+'[Aspect] Browser':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/php-wasm/web/**'
+                - 'packages/php-wasm/web-service-worker/**'
+                - 'packages/playground/website/**'
+                - 'packages/playground/remote/**'
+
+'[Aspect] Node.js':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/php-wasm/node/**'
+                - 'packages/php-wasm/cli/**'
+                - 'packages/playground/cli/**'
+
+'[Aspect] Service Worker':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/php-wasm/web-service-worker/**'
+                - '**/service-worker*.{ts,js}'
+
+'[Aspect] Sqlite':
+    - changed-files:
+          - any-glob-to-any-file: '**/sqlite*/**'
+
+'[Aspect] WordPress':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/playground/wordpress/**'
+                - 'packages/playground/wordpress-builds/**'
+
+'[Aspect] Website':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/playground/website/**'
+                - 'packages/playground/website-extras/**'
+
+# ---------------------------------------------------------------------------
+# [Feature] / [Focus] — only the few that map cleanly to paths
+# ---------------------------------------------------------------------------
+
+'[Feature] PHP.wasm':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/php-wasm/compile/**'
+                - 'packages/php-wasm/universal/**'
+
+'[Focus] Developer Tools':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/playground/devtools-extension/**'
+                - 'packages/php-wasm/xdebug-bridge/**'
+
+# ---------------------------------------------------------------------------
+# [Type] Documentation — the one [Type] label that has a clean path heuristic
+# ---------------------------------------------------------------------------
+
+'[Type] Documentation':
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'packages/docs/**'
+                - '**/*.md'

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -1,161 +1,38 @@
-name: Auto-label PRs with Copilot
+name: Auto-label PRs
 
-# Uses GitHub's Copilot-powered AI inference action to read each PR's title,
-# body, and changed file paths, then suggest labels drawn from the repo's
-# existing label set. Helpful because labels here are structured ([Type],
-# [Aspect], [Feature], [Package][@..]) and easy to forget on smaller PRs.
+# Path-based PR labeling. Reads .github/labeler.yml and applies any
+# [Package][@..], [Aspect], [Feature], [Focus] or [Type] Documentation
+# label whose globs match the changed file paths.
 #
-# The model is constrained to existing labels only — it cannot invent new ones.
-# Runs once when a PR is opened so humans stay in control afterwards: if a
-# maintainer removes an AI-applied label, we won't sneak it back in on the
-# next push or description edit.
+# We do not auto-apply [Type] (other than Documentation), [Priority],
+# [Triage], [Discussion], or [Breaking change] — those need human judgment.
+#
+# History note: an earlier version of this workflow used GitHub Models
+# (actions/ai-inference) to suggest labels from PR title + body + paths.
+# That returned 403 from the workflow's GITHUB_TOKEN because GitHub Models
+# access in Actions is gated by an org-level toggle that isn't enabled
+# for this org and isn't something repo maintainers can flip. Path-based
+# labeling covers the bulk of the structured labels for this monorepo
+# (the model's strongest signal was already file paths) and runs without
+# any external service or quota.
 
 on:
     pull_request_target:
-        types: [opened, ready_for_review]
+        types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
     contents: read
     pull-requests: write
-    models: read
 
 jobs:
-    suggest-labels:
+    label:
         if: github.repository == 'WordPress/wordpress-playground'
         runs-on: ubuntu-latest
         steps:
-            - name: Collect PR context
-              id: context
-              # SECURITY: PR_TITLE and PR_BODY are attacker-controlled (any
-              # PR author can set them). They MUST stay in env: and be
-              # referenced as "$PR_TITLE" / "$PR_BODY" inside the script —
-              # never interpolated as ${{ github.event.pull_request.title }}
-              # in the run: block, which would be shell injection with the
-              # write token. They flow only into the model prompt and stdout,
-              # both safe sinks. Don't pipe them into gh / curl / eval.
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GH_REPO: ${{ github.repository }}
-                  PR_NUMBER: ${{ github.event.pull_request.number }}
-                  PR_TITLE: ${{ github.event.pull_request.title }}
-                  PR_BODY: ${{ github.event.pull_request.body }}
-              run: |
-                  set -euo pipefail
-
-                  # Pull the label set from the repo so the model can only
-                  # choose from labels that actually exist. Allow-list the four
-                  # structured families that describe the change itself —
-                  # Type / Aspect / Feature / Focus and any [Package][@..]
-                  # variant. Anything else (Priority, Triage, Discussion,
-                  # Breaking change, …) needs human judgment, so we keep it
-                  # off-limits to the model. Limit raised well above the
-                  # current ~110 labels so future additions aren't truncated.
-                  gh label list --limit 500 --json name,description \
-                      --jq '[.[] | select(.name | test("^(\\[(Type|Aspect|Feature|Focus)\\]|\\[Package\\]\\[@)"))]' \
-                      > /tmp/labels.json
-
-                  # File paths give the model strong signal for [Package][@..]
-                  # and [Aspect] labels — far more reliable than title parsing.
-                  gh pr view "$PR_NUMBER" --json files \
-                      --jq '[.files[].path] | .[0:200]' > /tmp/files.json
-
-                  # Existing labels: we'll merge with suggestions, never override.
-                  gh pr view "$PR_NUMBER" --json labels \
-                      --jq '[.labels[].name]' > /tmp/existing.json
-
-                  {
-                      echo "PR #${PR_NUMBER}"
-                      echo ""
-                      echo "Title: ${PR_TITLE}"
-                      echo ""
-                      echo "Body:"
-                      echo "${PR_BODY:-(empty)}"
-                      echo ""
-                      echo "Changed files:"
-                      jq -r '.[]' /tmp/files.json
-                      echo ""
-                      echo "Currently applied labels:"
-                      jq -r '.[]' /tmp/existing.json
-                      echo ""
-                      echo "Available labels (JSON):"
-                      cat /tmp/labels.json
-                  } > /tmp/prompt-input.txt
-
-                  echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-
-            - name: Ask Copilot for label suggestions
-              id: ai
-              # Pinned to a commit SHA, not a tag: this job runs with
-              # pull-requests:write, so a moved tag would be a supply-chain
-              # foothold. Bump deliberately when upgrading.
-              uses: actions/ai-inference@b81b2afb8390ee6839b494a404766bef6493c7d9 # v1
+            # Pinned to a commit SHA, not a tag: this job runs with
+            # pull-requests:write, so a moved tag would be a supply-chain
+            # foothold. Bump deliberately when upgrading.
+            - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
               with:
-                  model: openai/gpt-4o-mini
-                  system-prompt: |
-                      You triage GitHub pull requests for the WordPress Playground monorepo.
-
-                      Given a PR's title, body, changed files, and a JSON list of available labels with descriptions, pick the labels that best describe the change.
-
-                      Rules:
-                      - Pick labels ONLY from the provided list. Never invent labels.
-                      - Pick exactly one [Type] label if the change is clearly a bug fix, enhancement, documentation update, performance work, reliability work, developer experience, or new API. Skip if unclear.
-                      - Pick [Aspect], [Feature], and [Focus] labels when they clearly apply (multiple allowed).
-                      - Pick [Package][@..] labels based on changed file paths under packages/. A file under packages/playground/website/ implies [Package][@wp-playground] Website. A file under packages/php-wasm/web/ implies [Package][@php-wasm] Web. And so on.
-                      - Prefer fewer, high-confidence labels over many uncertain ones. Aim for 1–5 labels total.
-                      - Pure i18n / translation PRs: only [Type] Documentation.
-                      - Output ONLY a JSON array of strings, no prose, no code fences. Example: ["[Type] Bug","[Package][@php-wasm] Web"]
-                  prompt-file: /tmp/prompt-input.txt
-                  max-tokens: 400
-
-            - name: Apply suggested labels
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  GH_REPO: ${{ github.repository }}
-                  PR_NUMBER: ${{ steps.context.outputs.pr_number }}
-                  AI_RESPONSE: ${{ steps.ai.outputs.response }}
-              run: |
-                  set -euo pipefail
-
-                  # The model is told not to wrap output in code fences, but
-                  # smaller models do it anyway. Strip any leading/trailing
-                  # ``` lines (with optional language tag and surrounding
-                  # whitespace) before handing the text to jq.
-                  CLEAN=$(printf '%s' "$AI_RESPONSE" \
-                      | tr -d '\r' \
-                      | sed -E '/^[[:space:]]*```[[:alnum:]_-]*[[:space:]]*$/d')
-
-                  if ! echo "$CLEAN" | jq -e 'type == "array"' > /dev/null 2>&1; then
-                      echo "Model did not return a JSON array. Raw response:"
-                      echo "$AI_RESPONSE"
-                      exit 0
-                  fi
-
-                  # Intersect suggestions with the canonical label list to
-                  # drop any hallucinations that slipped past the system
-                  # prompt. labels.json is an array of {name, description}
-                  # objects — pick out the names so we can compare strings.
-                  jq -c 'map(.name)' /tmp/labels.json > /tmp/valid.json
-                  SUGGESTED=$(echo "$CLEAN" | jq --argjson valid "$(cat /tmp/valid.json)" -c '[.[] | select(. as $l | $valid | index($l))]')
-
-                  echo "Suggested labels: $SUGGESTED"
-
-                  COUNT=$(echo "$SUGGESTED" | jq 'length')
-                  if [ "$COUNT" -eq 0 ]; then
-                      echo "No valid label suggestions. Skipping."
-                      exit 0
-                  fi
-
-                  # Add only labels not already on the PR. We never remove labels
-                  # — humans may have applied them deliberately.
-                  TO_ADD=$(jq -n --argjson s "$SUGGESTED" --slurpfile e /tmp/existing.json \
-                      '[$s[] | select(. as $l | $e[0] | index($l) | not)]')
-
-                  if [ "$(echo "$TO_ADD" | jq 'length')" -eq 0 ]; then
-                      echo "All suggested labels already applied. Nothing to do."
-                      exit 0
-                  fi
-
-                  echo "$TO_ADD" | jq -r '.[]' | while read -r label; do
-                      echo "Adding: $label"
-                      gh pr edit "$PR_NUMBER" --add-label "$label" || true
-                  done
+                  configuration-path: .github/labeler.yml
+                  sync-labels: false


### PR DESCRIPTION
The earlier AI-driven labeler used `actions/ai-inference` against GitHub Models. It's been 403'ing on every real PR because GitHub Models access from Actions is gated by an org-level policy this org doesn't have enabled, and that's not something a repo maintainer can flip.

Switching to `actions/labeler` driven by `.github/labeler.yml`, which maps file paths under `packages/*` to the structured `[Package][@..]`, `[Aspect]`, `[Feature]`, `[Focus]`, and `[Type] Documentation` labels. Paths were already the model's strongest signal for this monorepo, so we lose little and gain a workflow that runs without any external service or quota.

`[Type]` (other than Documentation), `[Priority]`, `[Triage]`, and `[Breaking change]` still need human judgment and are intentionally not handled here. `sync-labels: false` so the workflow never removes a label a human applied.

The action is pinned to a commit SHA — this job has `pull-requests: write`, so a moved tag would be a supply-chain foothold.