### PR TITLE
Blueprints: loadPHPExtension step (draft)

### DIFF
--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -14,6 +14,8 @@ export { FSHelpers } from './fs-helpers';
 export type { ListFilesOptions, RmDirOptions } from './fs-helpers';
 export { PHPWorker } from './php-worker';
 export { getPhpIniEntries, setPhpIniEntries, withPHPIniValues } from './ini';
+export { loadPHPExtension, PHP_EXTENSIONS_DIR } from './load-extension';
+export type { LoadPHPExtensionOptions } from './load-extension';
 export {
 	printDebugDetails,
 	prettyPrintFullStackTrace,

--- a/packages/php-wasm/universal/src/lib/load-extension.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.ts
@@ -1,0 +1,101 @@
+import { joinPaths } from '@php-wasm/util';
+import type { UniversalPHP } from './universal-php';
+import { PHP_INI_PATH } from './php';
+
+/**
+ * Directory scanned by PHP for additional .ini files. Matches the
+ * convention already used by `withXdebug` / `withIntl` in the node
+ * extension wrappers, so an extension dropped here is picked up by
+ * any runtime that has `PHP_INI_SCAN_DIR` pointing at it.
+ */
+export const PHP_EXTENSIONS_DIR = '/internal/shared/extensions';
+
+export interface LoadPHPExtensionOptions {
+	/**
+	 * A short identifier used as the file name on disk, e.g. `wp_mysql_parser`.
+	 * The `.so` and `.ini` files are written as `<name>.so` / `<name>.ini`.
+	 */
+	name: string;
+	/**
+	 * The compiled side-module bytes. Caller is responsible for fetching them
+	 * (from a URL, npm package, mounted directory, …) before calling this.
+	 */
+	soBytes: Uint8Array;
+	/**
+	 * Whether this is a Zend extension (e.g. opcache, xdebug) or a regular
+	 * PHP extension. Defaults to `extension` which matches almost every
+	 * userland module.
+	 */
+	kind?: 'extension' | 'zend_extension';
+	/**
+	 * Extra ini directives scoped to this extension, written into the same
+	 * `<name>.ini` file. Use this for things like `wp_mysql_parser.debug=1`.
+	 */
+	iniEntries?: Record<string, string>;
+}
+
+/**
+ * Loads a pre-built PHP extension into a running PHP runtime.
+ *
+ * The extension takes effect on the next runtime startup — typically the
+ * next request, or after `rotatePHPRuntime()`. PHP only reads `extension=`
+ * directives during module init, so we cannot dlopen into an already-booted
+ * interpreter from JS.
+ *
+ * The runtime must have `PHP_INI_SCAN_DIR` pointing at `PHP_EXTENSIONS_DIR`.
+ * The node extension wrappers (`withXdebug`, `withIntl`, …) already set this
+ * env var; for fresh runtimes that don't, also append `extension=` lines to
+ * php.ini so the extension still loads.
+ *
+ * @example
+ * ```ts
+ * const soBytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
+ * await loadPHPExtension(php, { name: 'wp_mysql_parser', soBytes });
+ * ```
+ */
+export async function loadPHPExtension(
+	php: UniversalPHP,
+	options: LoadPHPExtensionOptions
+): Promise<void> {
+	const { name, soBytes, kind = 'extension', iniEntries = {} } = options;
+
+	if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+		throw new Error(
+			`loadPHPExtension: invalid extension name ${JSON.stringify(
+				name
+			)}. Use only [a-zA-Z0-9_-].`
+		);
+	}
+
+	if (!(await php.isDir(PHP_EXTENSIONS_DIR))) {
+		await php.mkdir(PHP_EXTENSIONS_DIR);
+	}
+
+	const soPath = joinPaths(PHP_EXTENSIONS_DIR, `${name}.so`);
+	const iniPath = joinPaths(PHP_EXTENSIONS_DIR, `${name}.ini`);
+
+	await php.writeFile(soPath, soBytes);
+
+	const iniLines = [`${kind}=${soPath}`];
+	for (const [key, value] of Object.entries(iniEntries)) {
+		iniLines.push(`${key}=${value}`);
+	}
+	await php.writeFile(iniPath, iniLines.join('\n') + '\n');
+
+	/*
+	 * Belt-and-braces: also append the extension directive to the main
+	 * php.ini. If `PHP_INI_SCAN_DIR` is set, this is redundant; if it
+	 * isn't, this is what makes the extension actually load.
+	 *
+	 * We append rather than parse-and-rewrite to avoid the `ini` package
+	 * mangling repeated keys (multiple `extension=` entries are valid).
+	 */
+	const phpIni = await php.readFileAsText(PHP_INI_PATH);
+	const directive = `${kind}=${soPath}`;
+	if (!phpIni.includes(directive)) {
+		await php.writeFile(
+			PHP_INI_PATH,
+			phpIni.replace(/\n*$/, '\n') + directive + '\n'
+		);
+	}
+}

--- a/packages/playground/blueprints/src/lib/steps/handlers.ts
+++ b/packages/playground/blueprints/src/lib/steps/handlers.ts
@@ -28,3 +28,4 @@ export { defineWpConfigConsts } from './define-wp-config-consts';
 export { zipWpContent } from './zip-wp-content';
 export { wpCLI } from './wp-cli';
 export { setSiteLanguage } from './set-site-language';
+export { loadPHPExtensionStep as loadPHPExtension } from './load-php-extension';

--- a/packages/playground/blueprints/src/lib/steps/index.ts
+++ b/packages/playground/blueprints/src/lib/steps/index.ts
@@ -36,6 +36,7 @@ import type { EnableMultisiteStep } from './enable-multisite';
 import type { WPCLIStep } from './wp-cli';
 import type { ResetDataStep } from './reset-data';
 import type { SetSiteLanguageStep } from './set-site-language';
+import type { LoadPHPExtensionStep } from './load-php-extension';
 
 export type Step = GenericStep<FileReference, DirectoryReference>;
 export type StepDefinition = Step & {
@@ -80,7 +81,8 @@ export type GenericStep<FileResource, DirectoryResource> =
 	| WriteFileStep<FileResource>
 	| WriteFilesStep<DirectoryResource>
 	| WPCLIStep
-	| SetSiteLanguageStep;
+	| SetSiteLanguageStep
+	| LoadPHPExtensionStep;
 
 export type {
 	ActivatePluginStep,
@@ -115,6 +117,7 @@ export type {
 	WriteFilesStep,
 	WPCLIStep,
 	SetSiteLanguageStep,
+	LoadPHPExtensionStep,
 };
 
 /**

--- a/packages/playground/blueprints/src/lib/steps/load-php-extension.ts
+++ b/packages/playground/blueprints/src/lib/steps/load-php-extension.ts
@@ -1,0 +1,57 @@
+import { loadPHPExtension } from '@php-wasm/universal';
+import type { StepHandler } from '.';
+
+/**
+ * @inheritDoc loadPHPExtension
+ * @example
+ *
+ * <code>
+ * {
+ *   "step": "loadPHPExtension",
+ *   "name": "wp_mysql_parser",
+ *   "url": "https://example.com/wp_mysql_parser-php8.3-jspi.so"
+ * }
+ * </code>
+ */
+export interface LoadPHPExtensionStep {
+	step: 'loadPHPExtension';
+	/**
+	 * Identifier used as the on-disk file name (no extension).
+	 * Use snake_case or kebab-case; the regex `[A-Za-z0-9_-]+` is enforced.
+	 */
+	name: string;
+	/**
+	 * URL to the compiled `.so` side module. Must match the running PHP
+	 * version and async mode (Asyncify vs JSPI). For multi-target
+	 * extensions, point this at the right artifact for the runtime —
+	 * a manifest-aware loader is on the roadmap.
+	 */
+	url: string;
+	/**
+	 * `extension=` (default) or `zend_extension=`. Use the latter for
+	 * Xdebug-style extensions that hook into the Zend engine.
+	 */
+	kind?: 'extension' | 'zend_extension';
+	/** Extra ini entries written into the per-extension ini file. */
+	iniEntries?: Record<string, string>;
+}
+
+/**
+ * Loads a pre-built PHP extension (.so side module) into the running
+ * Playground PHP runtime. The extension takes effect on the next
+ * runtime startup — for blueprints this means subsequent steps and
+ * the first user-visible request.
+ */
+export const loadPHPExtensionStep: StepHandler<LoadPHPExtensionStep> = async (
+	playground,
+	{ name, url, kind, iniEntries }
+) => {
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`loadPHPExtension: failed to fetch ${url} (HTTP ${response.status})`
+		);
+	}
+	const soBytes = new Uint8Array(await response.arrayBuffer());
+	await loadPHPExtension(playground, { name, soBytes, kind, iniEntries });
+};


### PR DESCRIPTION
## Summary

Explores the `loadPHPExtension()` API shape from the discussion. Assumes the `.so` is already built — pairs with the SQLite-integration / MySQL-parser PR at WordPress/sqlite-database-integration#381 and similar "I have a side module, let me run it in Playground" workflows.

Two new pieces:

- **`loadPHPExtension(php, { name, soBytes, kind?, iniEntries? })`** in `@php-wasm/universal` — writes the `.so` and a per-extension `.ini` to `/internal/shared/extensions/`, the same scan dir already used by `withXdebug` / `withIntl`. Also appends `extension=` to `php.ini` so the directive applies to runtimes that don't have `PHP_INI_SCAN_DIR` set.
- **`loadPHPExtension` blueprint step** that fetches a URL and calls the helper. Lets a JSON blueprint pull a `.so` exactly like it pulls a plugin zip.

The extension takes effect on the next runtime startup (next request / after `rotatePHPRuntime`), since PHP only reads `extension=` during MINIT — we can't dlopen into a live interpreter from JS.

## Out of scope (intentional, follow-ups)

- \`--php-extension\` CLI flag
- \`?php-extension=\` website query param
- \`@php-wasm/compile-extension\` helper that produces the (PHP version × async mode) \`.so\` matrix and a manifest, plus a manifest-aware loader so callers pass one URL instead of picking the right artifact themselves
- A "test-extension" CLI mode that runs PHPUnit against a Playground with an extension preloaded

## Caller responsibility right now

The \`.so\` must match the running PHP version and async mode (Asyncify vs JSPI). The compile helper + manifest will collapse this into one URL; without it, callers pick the right artifact themselves.

## Test plan

- [ ] Build \`wp_mysql_parser\` against PHP 8.3 JSPI, host the \`.so\`, run a blueprint with \`loadPHPExtension\`, verify \`extension_loaded('wp_mysql_parser')\` is true on the next request.
- [ ] Confirm \`withXdebug\` still works (scan dir / php.ini paths don't conflict).
- [ ] Add a unit test in \`packages/playground/blueprints\` once the API stabilizes.