### PR TITLE
Refactor xdebug + intl to use loadPHPExtension helper (draft, stacked)

### DIFF
--- a/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
@@ -3,7 +3,11 @@ import type {
 	PHPRuntime,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
-import { LatestSupportedPHPVersion, FSHelpers } from '@php-wasm/universal';
+import {
+	LatestSupportedPHPVersion,
+	installPHPExtensionFilesSync,
+	PHP_EXTENSIONS_DIR,
+} from '@php-wasm/universal';
 import fs from 'fs';
 import path from 'path';
 import { getIntlExtensionModule } from './get-intl-extension-module';
@@ -12,88 +16,43 @@ export async function withIntl(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion,
 	options: EmscriptenOptions
 ): Promise<EmscriptenOptions> {
-	const extensionName = 'intl.so';
 	const extensionPath = await getIntlExtensionModule(version);
-	const extension = fs.readFileSync(extensionPath);
+	const soBytes = new Uint8Array(fs.readFileSync(extensionPath));
 
-	const dataName = 'icu.dat';
 	const moduleDir =
 		typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-	const dataPath = path.join(moduleDir, 'shared', dataName);
-	const ICUData = fs.readFileSync(dataPath);
+	const icuDataBytes = new Uint8Array(
+		fs.readFileSync(path.join(moduleDir, 'shared', 'icu.dat'))
+	);
+	const icuDataDir = '/internal/shared';
 
 	return {
 		...options,
 		ENV: {
 			...options.ENV,
-			PHP_INI_SCAN_DIR: '/internal/shared/extensions',
-			ICU_DATA: '/internal/shared',
+			PHP_INI_SCAN_DIR: PHP_EXTENSIONS_DIR,
+			ICU_DATA: icuDataDir,
 		},
 		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
 			if (options.onRuntimeInitialized) {
 				options.onRuntimeInitialized(phpRuntime);
 			}
-			/*
-			 * The extension file previously read
-			 * is written inside the /extensions directory
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions'
-				)
-			) {
-				phpRuntime.FS.mkdirTree('/internal/shared/extensions');
-			}
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`/internal/shared/extensions/${extensionName}`
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					`/internal/shared/extensions/${extensionName}`,
-					new Uint8Array(extension)
-				);
-			}
-			/* The extension has its share of ini entries
-			 * to write in a separate ini file
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions/intl.ini'
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					'/internal/shared/extensions/intl.ini',
-					[
-						`extension=/internal/shared/extensions/${extensionName}`,
-					].join('\n')
-				);
-			}
-			/*
-			 * An ICU data file must be loaded to support Intl extension.
-			 * To achieve this, a shared directory is mounted and referenced
-			 * via the ICU_DATA environment variable.
-			 * By default, this variable is set to '/internal/shared',
-			 * which corresponds to the actual file location.
-			 *
-			 * The Intl extension is hard-coded to look for the `icudt74l` filename,
-			 * which means the ICU data file must use that exact name.
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`${phpRuntime.ENV.ICU_DATA}/${dataName}`
-				)
-			) {
-				phpRuntime.FS.mkdirTree(phpRuntime.ENV.ICU_DATA);
-				phpRuntime.FS.writeFile(
-					`${phpRuntime.ENV.ICU_DATA}/icudt74l.dat`,
-					new Uint8Array(ICUData)
-				);
-			}
+
+			installPHPExtensionFilesSync(phpRuntime.FS, {
+				name: 'intl',
+				soBytes,
+				/*
+				 * The Intl extension is hard-coded to look for the `icudt74l`
+				 * filename, so we drop the data file under that exact name
+				 * inside ICU_DATA.
+				 */
+				extraFiles: [
+					{
+						path: `${icuDataDir}/icudt74l.dat`,
+						data: icuDataBytes,
+					},
+				],
+			});
 		},
 	};
 }

--- a/packages/php-wasm/node/src/lib/extensions/xdebug/with-xdebug.ts
+++ b/packages/php-wasm/node/src/lib/extensions/xdebug/with-xdebug.ts
@@ -3,10 +3,11 @@ import {
 	type EmscriptenOptions,
 	type PHPRuntime,
 	type SupportedPHPVersion,
-	FSHelpers,
+	installPHPExtensionFilesSync,
 	LatestSupportedPHPVersion,
 	SupportedPHPVersions,
 	SupportedPHPVersionsList,
+	PHP_EXTENSIONS_DIR,
 } from '@php-wasm/universal';
 import fs from 'fs';
 import { getXdebugExtensionModule } from './get-xdebug-extension-module';
@@ -27,68 +28,36 @@ export async function withXdebug(
 	options: EmscriptenOptions,
 	xdebugOptions: XdebugOptions
 ): Promise<EmscriptenOptions> {
-	const fileName = 'xdebug.so';
 	const filePath = await getXdebugExtensionModule(version);
-	const extension = fs.readFileSync(filePath);
+	const soBytes = new Uint8Array(fs.readFileSync(filePath));
+	const ideKey = xdebugOptions.ideKey || DEFAULT_IDE_KEY;
 
 	return {
 		...options,
 		ENV: {
 			...options.ENV,
-			PHP_INI_SCAN_DIR: '/internal/shared/extensions',
+			PHP_INI_SCAN_DIR: PHP_EXTENSIONS_DIR,
 		},
 		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
 			if (options.onRuntimeInitialized) {
 				options.onRuntimeInitialized(phpRuntime);
 			}
-			/*
-			 * The extension file previously read
-			 * is written inside the /extensions directory
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions'
-				)
-			) {
-				phpRuntime.FS.mkdirTree('/internal/shared/extensions');
-			}
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`/internal/shared/extensions/${fileName}`
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					`/internal/shared/extensions/${fileName}`,
-					new Uint8Array(extension)
-				);
-			}
-			/*
-			 * The extension has its share of ini entries
-			 * to write in a separate ini file
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions/xdebug.ini'
-				)
-			) {
-				const ideKey = xdebugOptions.ideKey || DEFAULT_IDE_KEY;
-				phpRuntime.FS.writeFile(
-					'/internal/shared/extensions/xdebug.ini',
-					[
-						'zend_extension=/internal/shared/extensions/xdebug.so',
-						'xdebug.mode=debug,develop',
-						'xdebug.start_with_request=yes',
-						`xdebug.idekey="${ideKey}"`,
-						// Path mapping is only available starting
-						// from Xdebug 3.5, which is used by PHP 8.5+
-						// Previous versions will ignore this entry.
-						'xdebug.path_mapping=yes',
-					].join('\n')
-				);
-			}
+
+			installPHPExtensionFilesSync(phpRuntime.FS, {
+				name: 'xdebug',
+				soBytes,
+				kind: 'zend_extension',
+				iniEntries: {
+					'xdebug.mode': 'debug,develop',
+					'xdebug.start_with_request': 'yes',
+					'xdebug.idekey': `"${ideKey}"`,
+					// Path mapping is only available starting from
+					// Xdebug 3.5, used by PHP 8.5+. Older versions
+					// silently ignore this entry.
+					'xdebug.path_mapping': 'yes',
+				},
+			});
+
 			/*
 			 * Path mapping and skipping is only
 			 * available starting from Xdebug 3.5,

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -14,7 +14,11 @@ export { FSHelpers } from './fs-helpers';
 export type { ListFilesOptions, RmDirOptions } from './fs-helpers';
 export { PHPWorker } from './php-worker';
 export { getPhpIniEntries, setPhpIniEntries, withPHPIniValues } from './ini';
-export { loadPHPExtension, PHP_EXTENSIONS_DIR } from './load-extension';
+export {
+	loadPHPExtension,
+	installPHPExtensionFilesSync,
+	PHP_EXTENSIONS_DIR,
+} from './load-extension';
 export type { LoadPHPExtensionOptions } from './load-extension';
 export {
 	printDebugDetails,

--- a/packages/php-wasm/universal/src/lib/load-extension.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.ts
@@ -69,7 +69,7 @@ function buildExtensionFiles(
 	for (const [key, value] of Object.entries(iniEntries)) {
 		iniLines.push(`${key}=${value}`);
 	}
-	return { soPath, iniPath, iniContent: iniLines.join('\n') + '\n' };
+	return { soPath, iniPath, iniContent: iniLines.join('\n') };
 }
 
 /**

--- a/packages/php-wasm/universal/src/lib/load-extension.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.ts
@@ -1,12 +1,13 @@
 import { joinPaths } from '@php-wasm/util';
-import type { UniversalPHP } from './universal-php';
+import type { Emscripten } from './emscripten-types';
+import { FSHelpers } from './fs-helpers';
 import { PHP_INI_PATH } from './php';
+import type { UniversalPHP } from './universal-php';
 
 /**
- * Directory scanned by PHP for additional .ini files. Matches the
- * convention already used by `withXdebug` / `withIntl` in the node
- * extension wrappers, so an extension dropped here is picked up by
- * any runtime that has `PHP_INI_SCAN_DIR` pointing at it.
+ * Directory scanned by PHP for additional .ini files. Runtimes that
+ * load extensions via this module must set `PHP_INI_SCAN_DIR` to this
+ * path in their Emscripten ENV (the node `with*` wrappers do).
  */
 export const PHP_EXTENSIONS_DIR = '/internal/shared/extensions';
 
@@ -29,36 +30,32 @@ export interface LoadPHPExtensionOptions {
 	kind?: 'extension' | 'zend_extension';
 	/**
 	 * Extra ini directives scoped to this extension, written into the same
-	 * `<name>.ini` file. Use this for things like `wp_mysql_parser.debug=1`.
+	 * `<name>.ini` file. Use this for things like `xdebug.mode=debug`.
 	 */
 	iniEntries?: Record<string, string>;
+	/**
+	 * Companion files to drop into the runtime alongside the `.so`. Used by
+	 * extensions that need data shipped next to the binary — e.g. intl
+	 * needs `icu.dat`, MaxMind GeoIP needs `.mmdb` files.
+	 */
+	extraFiles?: Array<{ path: string; data: Uint8Array }>;
+}
+
+interface BuiltExtensionFiles {
+	soPath: string;
+	iniPath: string;
+	iniContent: string;
 }
 
 /**
- * Loads a pre-built PHP extension into a running PHP runtime.
- *
- * The extension takes effect on the next runtime startup — typically the
- * next request, or after `rotatePHPRuntime()`. PHP only reads `extension=`
- * directives during module init, so we cannot dlopen into an already-booted
- * interpreter from JS.
- *
- * The runtime must have `PHP_INI_SCAN_DIR` pointing at `PHP_EXTENSIONS_DIR`.
- * The node extension wrappers (`withXdebug`, `withIntl`, …) already set this
- * env var; for fresh runtimes that don't, also append `extension=` lines to
- * php.ini so the extension still loads.
- *
- * @example
- * ```ts
- * const soBytes = new Uint8Array(await (await fetch(url)).arrayBuffer());
- * await loadPHPExtension(php, { name: 'wp_mysql_parser', soBytes });
- * ```
+ * Pure: returns the canonical paths and ini content for an extension,
+ * without writing anything. Shared by the async (`loadPHPExtension`) and
+ * sync (`installPHPExtensionFilesSync`) paths so both stay in lockstep.
  */
-export async function loadPHPExtension(
-	php: UniversalPHP,
+function buildExtensionFiles(
 	options: LoadPHPExtensionOptions
-): Promise<void> {
-	const { name, soBytes, kind = 'extension', iniEntries = {} } = options;
-
+): BuiltExtensionFiles {
+	const { name, kind = 'extension', iniEntries = {} } = options;
 	if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
 		throw new Error(
 			`loadPHPExtension: invalid extension name ${JSON.stringify(
@@ -66,36 +63,88 @@ export async function loadPHPExtension(
 			)}. Use only [a-zA-Z0-9_-].`
 		);
 	}
+	const soPath = joinPaths(PHP_EXTENSIONS_DIR, `${name}.so`);
+	const iniPath = joinPaths(PHP_EXTENSIONS_DIR, `${name}.ini`);
+	const iniLines = [`${kind}=${soPath}`];
+	for (const [key, value] of Object.entries(iniEntries)) {
+		iniLines.push(`${key}=${value}`);
+	}
+	return { soPath, iniPath, iniContent: iniLines.join('\n') + '\n' };
+}
+
+/**
+ * Loads a pre-built PHP extension into a running PHP runtime exposed
+ * through the `UniversalPHP` interface (typically called from a blueprint
+ * step). The extension takes effect on the next runtime startup — PHP
+ * only reads `extension=` during MINIT, so we cannot dlopen into a
+ * live interpreter from JS.
+ *
+ * The runtime must have `PHP_INI_SCAN_DIR=/internal/shared/extensions`
+ * set. As a belt-and-braces measure for runtimes that don't, we also
+ * append the `extension=` directive to php.ini directly.
+ */
+export async function loadPHPExtension(
+	php: UniversalPHP,
+	options: LoadPHPExtensionOptions
+): Promise<void> {
+	const { soBytes, extraFiles = [] } = options;
+	const { soPath, iniPath, iniContent } = buildExtensionFiles(options);
 
 	if (!(await php.isDir(PHP_EXTENSIONS_DIR))) {
 		await php.mkdir(PHP_EXTENSIONS_DIR);
 	}
 
-	const soPath = joinPaths(PHP_EXTENSIONS_DIR, `${name}.so`);
-	const iniPath = joinPaths(PHP_EXTENSIONS_DIR, `${name}.ini`);
-
 	await php.writeFile(soPath, soBytes);
+	await php.writeFile(iniPath, iniContent);
 
-	const iniLines = [`${kind}=${soPath}`];
-	for (const [key, value] of Object.entries(iniEntries)) {
-		iniLines.push(`${key}=${value}`);
+	for (const file of extraFiles) {
+		await php.writeFile(file.path, file.data);
 	}
-	await php.writeFile(iniPath, iniLines.join('\n') + '\n');
 
-	/*
-	 * Belt-and-braces: also append the extension directive to the main
-	 * php.ini. If `PHP_INI_SCAN_DIR` is set, this is redundant; if it
-	 * isn't, this is what makes the extension actually load.
-	 *
-	 * We append rather than parse-and-rewrite to avoid the `ini` package
-	 * mangling repeated keys (multiple `extension=` entries are valid).
-	 */
+	const directive = iniContent.split('\n', 1)[0];
 	const phpIni = await php.readFileAsText(PHP_INI_PATH);
-	const directive = `${kind}=${soPath}`;
 	if (!phpIni.includes(directive)) {
 		await php.writeFile(
 			PHP_INI_PATH,
 			phpIni.replace(/\n*$/, '\n') + directive + '\n'
 		);
+	}
+}
+
+/**
+ * Synchronous, raw-FS variant of `loadPHPExtension`. Intended for use
+ * inside Emscripten's `onRuntimeInitialized` callback, where only the
+ * raw `PHPRuntime.FS` is available and the universal PHP class hasn't
+ * been constructed yet.
+ *
+ * Skips the php.ini append because php.ini is written *later* by the
+ * `PHP` constructor; callers using this path must set
+ * `PHP_INI_SCAN_DIR=/internal/shared/extensions` in Emscripten ENV.
+ */
+export function installPHPExtensionFilesSync(
+	fs: Emscripten.RootFS,
+	options: LoadPHPExtensionOptions
+): void {
+	const { soBytes, extraFiles = [] } = options;
+	const { soPath, iniPath, iniContent } = buildExtensionFiles(options);
+
+	if (!FSHelpers.fileExists(fs, PHP_EXTENSIONS_DIR)) {
+		fs.mkdirTree(PHP_EXTENSIONS_DIR);
+	}
+	if (!FSHelpers.fileExists(fs, soPath)) {
+		fs.writeFile(soPath, soBytes);
+	}
+	if (!FSHelpers.fileExists(fs, iniPath)) {
+		fs.writeFile(iniPath, iniContent);
+	}
+	for (const file of extraFiles) {
+		if (FSHelpers.fileExists(fs, file.path)) {
+			continue;
+		}
+		const dir = file.path.substring(0, file.path.lastIndexOf('/'));
+		if (dir && !FSHelpers.fileExists(fs, dir)) {
+			fs.mkdirTree(dir);
+		}
+		fs.writeFile(file.path, file.data);
 	}
 }


### PR DESCRIPTION
Stacked on #3545.

## Why

When I tried to dogfood the `loadPHPExtension()` API from #3545 against the bundled extension wrappers (`with-xdebug`, `with-intl`), two gaps surfaced:

1. The wrappers run inside Emscripten's `onRuntimeInitialized` where only a raw `PHPRuntime.FS` is available — `UniversalPHP` doesn't exist yet, and `php.ini` hasn't been written.
2. `with-intl` needs to drop `icu.dat` next to the `.so`. The original API had no way to express "ship these companion files alongside the extension."

So this PR extends the API and converts both wrappers to use it.

## API additions

- **`installPHPExtensionFilesSync(fs, options)`** — sync, raw-FS sibling of `loadPHPExtension`. Both helpers share a `buildExtensionFiles()` core so the on-disk layout stays in lockstep between blueprint-loaded and bundled extensions.
- **`extraFiles: Array<{ path, data }>`** option — companion data files. Used by intl for `icudt74l.dat`; future-friendly for things like MaxMind GeoIP `.mmdb` files.

## Refactors

- `with-xdebug.ts`: ~80 lines of FS plumbing → one `installPHPExtensionFilesSync` call plus an `iniEntries` map. The `/.xdebug/` path-mapping block stays inline because it writes outside the extensions dir.
- `with-intl.ts`: ~60 lines → one call with an `extraFiles` entry. ENV setup (`ICU_DATA`, `PHP_INI_SCAN_DIR`) stays at the EmscriptenOptions layer because Emscripten ENV must be set before runtime init.

## Out of scope

- redis and memcached wrappers — same shape, but I'd rather convert them in a follow-up PR to keep this one's blast radius small.

## Test plan

- [ ] \`npx nx test php-wasm-node\` passes
- [ ] Boot with \`--xdebug\` and confirm \`xdebug.so\` is loaded in \`phpinfo()\`
- [ ] Boot with \`--intl\` (default) and confirm \`Intl\` extension is loaded