### PR TITLE
[Docs] Link PR preview guide to canonical GitHub plugin pattern; refresh WP alias list

### DIFF
--- a/packages/docs/site/docs/blueprints/03-data-format.md
+++ b/packages/docs/site/docs/blueprints/03-data-format.md
@@ -56,7 +56,7 @@ The `landingPage` property tells Playground which URL to navigate to after the B
 The `preferredVersions` property declares your preferred PHP and WordPress versions. It can contain the following properties:
 
 - `php` (string): Loads the specified PHP version. Accepts `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5`, or `latest`. Minor versions like `7.4.1` are not supported.
-- `wp` (string): Loads the specified WordPress version. Accepts the last six major WordPress versions. As of September 1, 2025, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7` or `6.8`. You can also use the generic values `latest`, `nightly`, or `beta`. To use a pre-release version of WordPress, `beta` will load the latest beta or release candidate versions of a release cycle (Beta or RC).
+- `wp` (string): Loads the specified WordPress version. Accepts the last seven major WordPress versions. As of April 28, 2026, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7`, `6.8`, or `6.9`. You can also use the generic values `latest`, `beta`, or `nightly` (alias `trunk`). `beta` resolves to the most recent Beta or Release Candidate of an active release cycle; `nightly`/`trunk` builds straight from the WordPress development branch.
 
 ```js
 {

--- a/packages/docs/site/docs/main/guides/github-action-pr-preview.md
+++ b/packages/docs/site/docs/main/guides/github-action-pr-preview.md
@@ -131,6 +131,8 @@ See [adamziel/preview-in-playground-button-built-artifact-example](https://githu
 
 Use blueprints to configure the Playground environment. You can install additional plugins, set WordPress options, import content, or run custom PHP.
 
+For the canonical pattern of installing a plugin straight from a GitHub repository — and when to publish a built ZIP instead because your plugin needs a Composer or npm build step — see [Plugin in a GitHub repository](/guides/for-plugin-developers#plugin-in-a-github-repository).
+
 Example installing your plugin with WooCommerce:
 
 ```yaml


### PR DESCRIPTION
## Summary

Two small docs improvements to help LLMs set up the Playground preview button:

1. Link to the canonical example of installing a plugin from a GitHub repo
2. Refresh the `preferredVersions.wp` syntax, update the version range, use `trunk` as an example

No code changes.

## Test plan

- [ ] `npm run build:docs` renders both pages without broken anchors
- [ ] The new link in the PR Preview guide resolves to the \"Plugin in a GitHub repository\" section