### PR TITLE
[Blueprints] Surface more activation errors from activatePlugin

### DIFF
--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
@@ -243,11 +243,74 @@ describe('Blueprint step activatePlugin()', () => {
 			`
 		);
 
+		// WP's own message for an unmet PHP requirement mentions PHP and
+		// the version it expected — assert the gist is reachable, not the
+		// exact phrasing.
 		await expect(
 			activatePlugin(php, {
 				pluginPath: 'wp-error-plugin.php',
 			})
-		).rejects.toThrow(/WordPress said:\s*\S+/i);
+		).rejects.toThrow(/WordPress said:[^\n]*PHP/i);
+	});
+
+	it('should surface the missing-plugin message when the plugin file does not exist', async () => {
+		await expect(
+			activatePlugin(php, {
+				pluginPath: 'no-such-plugin.php',
+			})
+		).rejects.toThrow(
+			/wasn't able to find the plugin no-such-plugin\.php/
+		);
+	});
+
+	it('should include response headers and a pointer to the console in the error message', async () => {
+		const docroot = handler.documentRoot;
+		php.writeFile(
+			`${docroot}/wp-content/plugins/header-trailer-plugin.php`,
+			`<?php
+			/**
+			 * Plugin Name: Header Trailer Plugin
+			 * Requires PHP: 99.0
+			 */
+			`
+		);
+
+		let caught: Error | undefined;
+		try {
+			await activatePlugin(php, {
+				pluginPath: 'header-trailer-plugin.php',
+			});
+		} catch (error) {
+			caught = error as Error;
+		}
+
+		expect(caught).toBeDefined();
+		expect(caught!.message).toMatch(/Response headers:\s*\{/);
+		expect(caught!.message).toMatch(/Playground console.*CLI output/);
+	});
+
+	it('should surface PHP errors logged during activation in the scratch log', async () => {
+		const docroot = handler.documentRoot;
+		// A plugin that error_log()s and prints output at file scope.
+		// WordPress includes the file via plugin_sandbox_scrape during
+		// activation; the print triggers WP's "unexpected output"
+		// WP_Error, and the error_log() call lands in our scratch log.
+		php.writeFile(
+			`${docroot}/wp-content/plugins/error-log-plugin.php`,
+			`<?php
+			/**
+			 * Plugin Name: Error Log Plugin
+			 */
+			error_log('marker-from-plugin-file');
+			echo 'unexpected-output-from-plugin';
+			`
+		);
+
+		await expect(
+			activatePlugin(php, {
+				pluginPath: 'error-log-plugin.php',
+			})
+		).rejects.toThrow(/PHP error log:[\s\S]*marker-from-plugin-file/);
 	});
 
 	it('should not throw an error if the plugin is already active', async () => {

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
@@ -231,6 +231,25 @@ describe('Blueprint step activatePlugin()', () => {
 		).rejects.toThrow(/Uncaught Exception: Activation failed/);
 	});
 
+	it('should surface the WP_Error message when activation is rejected (e.g. unmet PHP requirement)', async () => {
+		const docroot = handler.documentRoot;
+		php.writeFile(
+			`${docroot}/wp-content/plugins/wp-error-plugin.php`,
+			`<?php
+			/**
+			 * Plugin Name: WP Error Plugin
+			 * Requires PHP: 99.0
+			 */
+			`
+		);
+
+		await expect(
+			activatePlugin(php, {
+				pluginPath: 'wp-error-plugin.php',
+			})
+		).rejects.toThrow(/WordPress said: .*PHP/i);
+	});
+
 	it('should not throw an error if the plugin is already active', async () => {
 		const docroot = handler.documentRoot;
 		php.writeFile(

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
@@ -247,7 +247,7 @@ describe('Blueprint step activatePlugin()', () => {
 			activatePlugin(php, {
 				pluginPath: 'wp-error-plugin.php',
 			})
-		).rejects.toThrow(/WordPress said: .*PHP/i);
+		).rejects.toThrow(/WordPress said:\s*\S+/i);
 	});
 
 	it('should not throw an error if the plugin is already active', async () => {

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.spec.ts
@@ -258,9 +258,7 @@ describe('Blueprint step activatePlugin()', () => {
 			activatePlugin(php, {
 				pluginPath: 'no-such-plugin.php',
 			})
-		).rejects.toThrow(
-			/wasn't able to find the plugin no-such-plugin\.php/
-		);
+		).rejects.toThrow(/WordPress said: Plugin file does not exist/);
 	});
 
 	it('should include response headers and a pointer to the console in the error message', async () => {
@@ -291,18 +289,23 @@ describe('Blueprint step activatePlugin()', () => {
 
 	it('should surface PHP errors logged during activation in the scratch log', async () => {
 		const docroot = handler.documentRoot;
-		// A plugin that error_log()s and prints output at file scope.
-		// WordPress includes the file via plugin_sandbox_scrape during
-		// activation; the print triggers WP's "unexpected output"
-		// WP_Error, and the error_log() call lands in our scratch log.
+		// Activation hook calls error_log() then wp_die()s. Because
+		// wp_die fires inside do_action("activate_{$plugin}") — which
+		// runs *before* WordPress writes the active_plugins option —
+		// the plugin is never marked active, so the activation-status
+		// check returns false and the JS step throws. The error_log()
+		// output should be captured into our scratch log and surfaced
+		// in that thrown error.
 		php.writeFile(
 			`${docroot}/wp-content/plugins/error-log-plugin.php`,
 			`<?php
 			/**
 			 * Plugin Name: Error Log Plugin
 			 */
-			error_log('marker-from-plugin-file');
-			echo 'unexpected-output-from-plugin';
+			register_activation_hook(__FILE__, function() {
+				error_log('marker-from-activation-hook');
+				wp_die('halted-by-hook');
+			});
 			`
 		);
 
@@ -310,7 +313,9 @@ describe('Blueprint step activatePlugin()', () => {
 			activatePlugin(php, {
 				pluginPath: 'error-log-plugin.php',
 			})
-		).rejects.toThrow(/PHP error log:[\s\S]*marker-from-plugin-file/);
+		).rejects.toThrow(
+			/PHP error log:[\s\S]*marker-from-activation-hook/
+		);
 	});
 
 	it('should not throw an error if the plugin is already active', async () => {

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -37,6 +37,18 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 	progress?.tracker.setCaption(`Activating ${pluginName || pluginPath}`);
 
 	const docroot = await playground.documentRoot;
+
+	/**
+	 * Route this request's PHP errors to a scratch file we own, so we can
+	 * include them in the JS-side error message if activation fails. We
+	 * don't touch the user's debug.log — the activation snippet ini_sets
+	 * the path for this single request only.
+	 */
+	const activationLogPath = '/tmp/playground-activate-plugin.log';
+	if (await playground.fileExists(activationLogPath)) {
+		await playground.unlink(activationLogPath);
+	}
+
 	/**
 	 * Instead of checking the plugin activation response,
 	 * check if the plugin is active by looking at the active plugins list.
@@ -57,6 +69,12 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 			define( 'WP_ADMIN', true );
 			require_once( getenv('DOCROOT') . "/wp-load.php" );
 			require_once( getenv('DOCROOT') . "/wp-admin/includes/plugin.php" );
+
+			// Force PHP errors to our scratch log for this request so the
+			// JS caller can surface them when activation fails. This wins
+			// over whatever WP_DEBUG_LOG resolved to during bootstrap.
+			ini_set('log_errors', '1');
+			ini_set('error_log', getenv('ACTIVATION_LOG'));
 
 			// Set current user to admin
 			wp_set_current_user( get_users(array('role' => 'Administrator') )[0]->ID );
@@ -87,6 +105,7 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 		env: {
 			PLUGIN_PATH: pluginPath,
 			DOCROOT: docroot,
+			ACTIVATION_LOG: activationLogPath,
 		},
 	});
 	if (activatePluginResult.text) {
@@ -151,12 +170,31 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 		logger.debug(rawStatus);
 	}
 
+	/**
+	 * At this point php.run() has already returned with exit code 0
+	 * (otherwise it would have thrown). The plugin still isn't active,
+	 * which usually means activate_plugin() returned a WP_Error and the
+	 * activation snippet die()'d with the message — that text is in
+	 * activatePluginResult.text. PHP errors emitted via error_log() are
+	 * in our scratch log. Surface both.
+	 */
+	let activationLog = '';
+	if (await playground.fileExists(activationLogPath)) {
+		activationLog = (await playground.readFileAsText(activationLogPath)).trim();
+		await playground.unlink(activationLogPath);
+	}
+
+	const details: string[] = [];
+	const wpOutput = (activatePluginResult.text ?? '').trim();
+	if (wpOutput) {
+		details.push(`WordPress said: ${wpOutput}`);
+	}
+	if (activationLog) {
+		details.push(`PHP error log:\n${activationLog}`);
+	}
+
 	throw new Error(
-		`Plugin ${pluginPath} could not be activated - WordPress exited with exit code ${activatePluginResult.exitCode}. ` +
-			`Inspect the "debug" logs in the console for more details. Output headers: ${JSON.stringify(
-				activatePluginResult.headers,
-				null,
-				2
-			)}`
+		`Plugin ${pluginPath} could not be activated.` +
+			(details.length ? `\n\n${details.join('\n\n')}` : '')
 	);
 };

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -115,6 +115,20 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 	}
 
 	/**
+	 * Drain the scratch log immediately so the file is gone whether
+	 * activation succeeded or failed. We only need its contents on the
+	 * failure path below, but reading and deleting unconditionally
+	 * keeps cleanup off the error branches.
+	 */
+	let activationLog = '';
+	if (await playground.fileExists(activationLogPath)) {
+		activationLog = (
+			await playground.readFileAsText(activationLogPath)
+		).trim();
+		await playground.unlink(activationLogPath);
+	}
+
+	/**
 	 * Instead of trusting the activation response, check the active plugins list.
 	 *
 	 * We try to discard any extra output via output buffering. The output of the script below
@@ -175,15 +189,9 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 	 * (otherwise it would have thrown). The plugin still isn't active,
 	 * which usually means activate_plugin() returned a WP_Error and the
 	 * activation snippet die()'d with the message — that text is in
-	 * activatePluginResult.text. PHP errors emitted via error_log() are
-	 * in our scratch log. Surface both.
+	 * activatePluginResult.text. Combine that with anything PHP wrote
+	 * to the scratch log during the activation request.
 	 */
-	let activationLog = '';
-	if (await playground.fileExists(activationLogPath)) {
-		activationLog = (await playground.readFileAsText(activationLogPath)).trim();
-		await playground.unlink(activationLogPath);
-	}
-
 	const details: string[] = [];
 	const wpOutput = (activatePluginResult.text ?? '').trim();
 	if (wpOutput) {

--- a/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
+++ b/packages/playground/blueprints/src/lib/steps/activate-plugin.ts
@@ -201,8 +201,31 @@ export const activatePlugin: StepHandler<ActivatePluginStep> = async (
 		details.push(`PHP error log:\n${activationLog}`);
 	}
 
+	/**
+	 * Response headers are sometimes the only signal — e.g. plugins that
+	 * redirect during activation produce no body at all. Always include
+	 * them as a last line. Reuse the same JSON layout the previous error
+	 * message used so anyone grepping logs for "Response headers:" still
+	 * finds it.
+	 */
+	details.push(
+		`Response headers: ${JSON.stringify(
+			activatePluginResult.headers,
+			null,
+			2
+		)}`
+	);
+
+	/**
+	 * The browser app surfaces PHP debug logs via the in-page console;
+	 * the CLI prints them to stderr. Point at both so the message is
+	 * useful regardless of where the Blueprint is being run.
+	 */
+	details.push(
+		`If you need more context, check the Playground console (browser DevTools) or the CLI output where this Blueprint was run.`
+	);
+
 	throw new Error(
-		`Plugin ${pluginPath} could not be activated.` +
-			(details.length ? `\n\n${details.join('\n\n')}` : '')
+		`Plugin ${pluginPath} could not be activated.\n\n${details.join('\n\n')}`
 	);
 };


### PR DESCRIPTION
## Summary

When a plugin failed to activate because `activate_plugin()` returned a `WP_Error` (unmet PHP requirement, missing plugin file, plugin printing output during validation, etc.), the thrown JS error read \"WordPress exited with exit code 0\" — useless. The actual WP_Error message was sitting in the activation script's stdout, only emitted as a `logger.warn`, and any `error_log()` output during activation went to `debug.log` where the caller had to know to look.

Route this request's PHP errors to a scratch log file owned by the step (`ini_set` per-request, no impact on the user's `debug.log`), then on the failure path include both the WordPress `die()` text and any logged PHP errors in the rejected promise. Drops the misleading exit-code wording, since by the time we reach that branch `php.run()` has already returned with exit code 0 — non-zero exits throw upstream with stdout+stderr already.

Adds a regression test for the WP_Error branch, which previously had no coverage.

## Test plan

- [ ] CI runs `playground-blueprints` test suite, including the new \"unmet PHP requirement\" case
- [ ] Existing activation tests (\"noisy plugin\", \"already active\", \"throws on uncaught exception\") still pass — none of those paths reach the rewritten throw