### PR TITLE
[Web] Fix non-deterministic TLS bridge failures from non-minimal DER serial numbers

### DIFF
--- a/packages/php-wasm/web/src/lib/tls/certificates.spec.ts
+++ b/packages/php-wasm/web/src/lib/tls/certificates.spec.ts
@@ -201,6 +201,36 @@ describe('generateCertificate', () => {
 		expect(decryptedMessage).toBe(testMessage);
 	});
 
+	it('should produce DER-valid certificates regardless of serial number byte pattern', async () => {
+		// Reproduces an `illegal padding` failure surfaced by OpenSSL's
+		// c2i_ibuf when an ASN.1 INTEGER has a redundant leading 0x00 byte
+		// (DER minimal-length rule, X.690 §8.3.2). The serial number in
+		// generateCertificate() is 4 random bytes by default, so roughly
+		// 1 in 256 sessions produces a serial like [0x00, 0x12, 0x34, 0x56]
+		// — invalid DER, and OpenSSL refuses to parse the cert with:
+		//   error:0D0E20DD:asn1 encoding routines:c2i_ibuf:illegal padding
+		// In Playground that breaks the entire TLS-over-fetch bridge for
+		// the lifetime of the session.
+		const SiteCert = await generateCertificate({
+			serialNumber: new Uint8Array([0x00, 0x12, 0x34, 0x56]),
+			subject: {
+				commonName: 'playground-site',
+				organizationName: 'Playground Site',
+				countryName: 'US',
+			},
+		});
+
+		const siteCertPEM = certificateToPEM(SiteCert.certificate);
+		writeFileSync(siteCertPath, siteCertPEM);
+
+		// Plain `openssl x509 -text` is enough — it triggers the same
+		// ASN.1 INTEGER decode path that fails inside libcurl.
+		const out = execSync(
+			`openssl x509 -in ${siteCertPath} -noout -serial`
+		).toString();
+		expect(out).toMatch(/serial=/i);
+	});
+
 	it('should generate certificates that can be used for signing and verification', async () => {
 		const SiteCert = await generateCertificate({
 			subject: {

--- a/packages/php-wasm/web/src/lib/tls/certificates.spec.ts
+++ b/packages/php-wasm/web/src/lib/tls/certificates.spec.ts
@@ -223,7 +223,7 @@ describe('generateCertificate', () => {
 		const siteCertPEM = certificateToPEM(SiteCert.certificate);
 		writeFileSync(siteCertPath, siteCertPEM);
 
-		// Plain `openssl x509 -text` is enough — it triggers the same
+		// `openssl x509 -noout -serial` is enough — it triggers the same
 		// ASN.1 INTEGER decode path that fails inside libcurl.
 		const out = execSync(
 			`openssl x509 -in ${siteCertPath} -noout -serial`

--- a/packages/php-wasm/web/src/lib/tls/certificates.ts
+++ b/packages/php-wasm/web/src/lib/tls/certificates.ts
@@ -520,7 +520,26 @@ class ASN1Encoder {
 	}
 
 	static integer(number: Uint8Array): Uint8Array {
-		// Ensure number is positive and first bit is 0
+		// DER requires INTEGER values to be encoded in the minimum number
+		// of octets (X.690 §8.3.2): a leading 0x00 byte is only allowed
+		// when the next byte's high bit is set (to signal a positive
+		// number). Random serial numbers occasionally start with 0x00
+		// followed by a byte < 0x80, which OpenSSL rejects with
+		// "c2i_ibuf:illegal padding" — strip those redundant zeros.
+		let start = 0;
+		while (
+			start < number.length - 1 &&
+			number[start] === 0x00 &&
+			number[start + 1] < 0x80
+		) {
+			start++;
+		}
+		if (start > 0) {
+			number = number.subarray(start);
+		}
+		// Conversely, if the high bit of the first byte is set, prepend
+		// 0x00 so the value isn't interpreted as a negative two's
+		// complement integer.
 		if (number[0] > 0x7f) {
 			const extendedNumber = new Uint8Array(number.length + 1);
 			extendedNumber[0] = 0x00;


### PR DESCRIPTION
## What

The TLS-over-fetch bridge synthesizes X.509 certs in the browser so PHP's libcurl can talk to real HTTPS hosts through `fetch()`. The ASN.1 INTEGER encoder in `certificates.ts` was prepending a `0x00` byte when needed to keep a value positive, but it never stripped *redundant* leading `0x00` bytes — so the encoded serial number sometimes wasn't valid DER.

With a 4-byte random serial, about 1 session in 256 produced something like `[0x00, 0x12, 0x34, 0x56]`, encoded as `02 04 00 12 34 56`. That violates DER's minimal-length rule (X.690 §8.3.2), and OpenSSL refuses to parse the cert with:

```
error:0D0E20DD:asn1 encoding routines:c2i_ibuf:illegal padding
```

Once a session generated a bad cert, every HTTPS request through the bridge surfaced as `cURL error (35)` in PHP until the page was reloaded. The original report blamed wpcomstaging.com, but it was a coincidence — any host could trigger it.

## Fix

In `ASN1Encoder.integer()`, strip leading `0x00` bytes whose successor has the high bit clear (they're unnecessary), then apply the existing high-bit prepend for sign disambiguation.

## Test

A new case in `certificates.spec.ts` pins a serial number with the offending shape and round-trips the cert through `openssl x509`. Failed before the fix, passes after.