### PR TITLE
[Node] Handle symlinked directories in Node FS mounts

### DIFF
--- a/packages/php-wasm/node/src/lib/node-fs-mount.ts
+++ b/packages/php-wasm/node/src/lib/node-fs-mount.ts
@@ -4,7 +4,7 @@ import {
 	type MountHandler,
 } from '@php-wasm/universal';
 import { isParentOf } from '@php-wasm/util';
-import { lstatSync } from 'fs';
+import { realpathSync, statSync } from 'fs';
 import { dirname } from 'path';
 
 export function createNodeFsMountHandler(localPath: string): MountHandler {
@@ -23,16 +23,19 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 		 * PHP-WASM source: https://github.com/WordPress/wordpress-playground/blob/5821cee231f452d050fd337b99ad0b26ebda487e/packages/php-wasm/compile/php/Dockerfile#L2148
 		 */
 		let removeVfsNode = false;
+		const mountRoot = realpathSync(localPath);
 		if (!FSHelpers.fileExists(FS, vfsMountPoint)) {
-			const lstat = lstatSync(localPath);
-			if (lstat.isFile() || lstat.isSymbolicLink()) {
+			// Resolve symlinks so both the VFS placeholder and NODEFS root
+			// match the target's file-or-directory shape.
+			const stat = statSync(mountRoot);
+			if (stat.isFile()) {
 				FS.mkdirTree(dirname(vfsMountPoint));
 				FS.writeFile(vfsMountPoint, '');
-			} else if (lstat.isDirectory()) {
+			} else if (stat.isDirectory()) {
 				FS.mkdirTree(vfsMountPoint);
 			} else {
 				throw new Error(
-					'Unsupported file type. PHP-wasm supports only symlinks that link to files, directories, or symlinks.'
+					'Unsupported file type. PHP-wasm supports mounting only files and directories, including symlinks that resolve to files or directories.'
 				);
 			}
 			removeVfsNode = true;
@@ -49,7 +52,7 @@ export function createNodeFsMountHandler(localPath: string): MountHandler {
 			}
 			throw e;
 		}
-		FS.mount(FS.filesystems['NODEFS'], { root: localPath }, vfsMountPoint);
+		FS.mount(FS.filesystems['NODEFS'], { root: mountRoot }, vfsMountPoint);
 		return () => {
 			FS!.unmount(vfsMountPoint);
 			if (removeVfsNode) {

--- a/packages/php-wasm/node/src/test/mount.spec.ts
+++ b/packages/php-wasm/node/src/test/mount.spec.ts
@@ -92,9 +92,8 @@ describe('Mounting', () => {
 					createNodeFsMountHandler(filePath)
 				);
 
-				const originalContent = await php.readFileAsText(
-					fileMountPoint
-				);
+				const originalContent =
+					await php.readFileAsText(fileMountPoint);
 				await php.writeFile(fileMountPoint, 'new content');
 
 				expect(await php.readFileAsText(fileMountPoint)).toBe(
@@ -521,6 +520,17 @@ describe('Mounting', () => {
 
 				unmount();
 				expect(php.isDir(directoryMountPoint)).toBe(true);
+			});
+
+			it('Should create a directory node when mounting a directory', async () => {
+				await php.mount(
+					directoryMountPoint,
+					createNodeFsMountHandler(directoryPath)
+				);
+
+				const FS = php[__private__dont__use].FS;
+				const lookup = FS.lookupPath(directoryMountPoint);
+				expect(FS.isDir(lookup.node.mode)).toBe(true);
 			});
 
 			it('Should remount mounted directory after unmounting', async () => {


### PR DESCRIPTION
## What it does

Makes `NodeFSMountHandler` preserve symlinked directories as directories when mounting host paths into PHP.wasm.

## Rationale

`lstatSync()` reports the symlink itself, so a symlink pointing at a directory was treated like a file. `statSync()` fixes the placeholder decision, but `NODEFS` also reads the mount root path. Passing the original symlink path still leaves the mounted root shaped like the symlink.

## Implementation

Resolves `localPath` with `realpathSync()` before creating the VFS placeholder and before calling `FS.mount()`. The placeholder is then created from `statSync(mountRoot)`, and `NODEFS` receives the resolved root path.

Added a regression test that checks the actual mounted VFS node mode for both normal directories and symlinked directories. Before this PR, the symlinked-directory case produced a non-directory mount node.

## Testing instructions

Focused checks run locally:

```bash
npx vitest run --config packages/php-wasm/node/vite.config.ts packages/php-wasm/node/src/test/mount.spec.ts
npx vitest run --config packages/php-wasm/node/vite.jspi.config.ts packages/php-wasm/node/src/test/mount.spec.ts
```

CI group checks run locally:

```bash
npx nx run php-wasm-node:test-group-3-asyncify
npx nx run php-wasm-node:test-group-3-jspi
```