### PR TITLE
[PHP] Hold pooled workers until streamed responses finish

### DIFF
--- a/packages/php-wasm/universal/src/lib/object-pool-proxy.spec.ts
+++ b/packages/php-wasm/universal/src/lib/object-pool-proxy.spec.ts
@@ -156,6 +156,46 @@ describe('createPoolProxy', () => {
 		expect(accessLog).toEqual(['start-a', 'end-a', 'start-b', 'end-b']);
 	});
 
+	it('holds the lock until a streamed result finishes', async () => {
+		const accessLog: string[] = [];
+		let finishFirst!: () => void;
+
+		const instance = {
+			async requestStreamed(label: string) {
+				accessLog.push(`start-${label}`);
+				return {
+					label,
+					finished:
+						label === 'a'
+							? new Promise<void>((resolve) => {
+									finishFirst = resolve;
+								})
+							: Promise.resolve(),
+				};
+			},
+		};
+
+		const proxy = createObjectPoolProxy([instance]);
+		const first = await proxy.requestStreamed('a');
+		let secondResolved = false;
+		const secondPromise = proxy.requestStreamed('b').then((second) => {
+			secondResolved = true;
+			return second;
+		});
+
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(secondResolved).toBe(false);
+		expect(accessLog).toEqual(['start-a']);
+
+		finishFirst();
+		await first.finished;
+		const second = await secondPromise;
+
+		expect(secondResolved).toBe(true);
+		expect(second.label).toBe('b');
+		expect(accessLog).toEqual(['start-a', 'start-b']);
+	});
+
 	it('is not treated as a thenable', async () => {
 		const instance = { value: 1 };
 		const proxy = createObjectPoolProxy([instance]);

--- a/packages/php-wasm/universal/src/lib/object-pool-proxy.ts
+++ b/packages/php-wasm/universal/src/lib/object-pool-proxy.ts
@@ -32,6 +32,11 @@ export type Pooled<T extends object> = Omit<
  *
  * The returned proxy provides a promisified version of the original
  * interface: method calls and property accesses all return promises.
+ *
+ * Methods may return streamed response objects whose work continues
+ * after the method promise resolves. When a returned value exposes a
+ * `finished` promise, the pool keeps the instance checked out until
+ * that promise settles.
  */
 export function createObjectPoolProxy<T extends object>(
 	instances: T[]
@@ -65,6 +70,8 @@ export function createObjectPoolProxy<T extends object>(
 	function withInstance<R>(fn: (instance: T) => R | Promise<R>): Promise<R> {
 		return acquire().then((instance) => {
 			const releaseWhenComplete = (value: R): R => {
+				// `.finished` means this is a streamed response class.
+				// Keep the instance checked out until streaming settles.
 				const finished = (value as any)?.finished;
 				if (finished && typeof finished.then === 'function') {
 					Promise.resolve(finished).then(

--- a/packages/php-wasm/universal/src/lib/object-pool-proxy.ts
+++ b/packages/php-wasm/universal/src/lib/object-pool-proxy.ts
@@ -64,6 +64,19 @@ export function createObjectPoolProxy<T extends object>(
 
 	function withInstance<R>(fn: (instance: T) => R | Promise<R>): Promise<R> {
 		return acquire().then((instance) => {
+			const releaseWhenComplete = (value: R): R => {
+				const finished = (value as any)?.finished;
+				if (finished && typeof finished.then === 'function') {
+					Promise.resolve(finished).then(
+						() => release(instance),
+						() => release(instance)
+					);
+				} else {
+					release(instance);
+				}
+				return value;
+			};
+
 			let result: R | Promise<R>;
 			try {
 				result = fn(instance);
@@ -73,18 +86,14 @@ export function createObjectPoolProxy<T extends object>(
 			}
 			if (result != null && typeof (result as any).then === 'function') {
 				return (result as Promise<R>).then(
-					(val) => {
-						release(instance);
-						return val;
-					},
+					(val) => releaseWhenComplete(val),
 					(err) => {
 						release(instance);
 						throw err;
 					}
 				);
 			}
-			release(instance);
-			return result as R;
+			return releaseWhenComplete(result as R);
 		});
 	}
 


### PR DESCRIPTION
## What it does

Keeps a borrowed pooled worker checked out until a streamed result finishes.

## Rationale

`ObjectPoolProxy` released instances as soon as the proxied method returned. For streamed responses, the method returns before the stream is consumed, so another caller could reuse the same worker while the previous response was still active.

## Implementation

If the proxied result exposes a `finished` promise, release the instance only after that promise settles. The new test covers the streamed-result lock behavior.

## Testing instructions

Run `npx nx test:vite php-wasm-universal -- object-pool-proxy.spec.ts`, or use the CI matrix.