### PR TITLE
[Web] expected-output in <php-snippet> component

### DIFF
--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -148,6 +148,25 @@ echo "Product: " . array_product($nums) . "\n";
 			</script>
 		</php-snippet>
 
+		<h2>6. Expected output (no runtime boot)</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
+			When <code>expected-output</code> is provided (as an attribute or a
+			<code>&lt;script type="text/expected-output"&gt;</code> child),
+			clicking Run shows that text immediately without loading the
+			Playground runtime.
+		</p>
+		<php-snippet name="precomputed.php">
+			<script type="application/x-php">
+<?php
+echo "2 + 2 = " . (2 + 2) . "\n";
+echo "WordPress is awesome.";
+			</script>
+			<script type="text/expected-output">
+				2 + 2 = 4
+				WordPress is awesome.
+			</script>
+		</php-snippet>
+
 		<script type="module" src="./php-code-snippet.js"></script>
 	</body>
 </html>

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -320,6 +320,18 @@ function escapeHtml(s) {
 		.replace(/>/g, '&gt;');
 }
 
+function dedentLeading(s) {
+	const lines = s.replace(/^\n+|\s+$/g, '').split('\n');
+	let min = Infinity;
+	for (const line of lines) {
+		if (!line.trim()) continue;
+		const m = line.match(/^[ \t]*/);
+		if (m && m[0].length < min) min = m[0].length;
+	}
+	if (!isFinite(min) || min === 0) return lines.join('\n');
+	return lines.map((l) => l.slice(min)).join('\n');
+}
+
 function highlightPhp(code) {
 	const tokens = [];
 	let i = 0;
@@ -623,13 +635,28 @@ class PhpSnippet extends HTMLElement {
 		super();
 		this.attachShadow({ mode: 'open' });
 		this._code = '';
+		this._expectedOutput = null;
 	}
 
 	connectedCallback() {
+		this._expectedOutput = this._readExpectedOutput();
 		this._readCode().then((code) => {
 			this._code = code.trim();
 			this._render();
 		});
+	}
+
+	_readExpectedOutput() {
+		const script = this.querySelector(
+			'script[type="text/expected-output"]'
+		);
+		if (script) {
+			return dedentLeading(script.textContent || '');
+		}
+		if (this.hasAttribute('expected-output')) {
+			return this.getAttribute('expected-output');
+		}
+		return null;
 	}
 
 	async _readCode() {
@@ -721,6 +748,12 @@ class PhpSnippet extends HTMLElement {
 		const outputBody = this.shadowRoot.querySelector('.output-body');
 		btn.disabled = true;
 		outputBody.classList.remove('error');
+		if (this._expectedOutput !== null) {
+			outputBody.textContent = this._expectedOutput || '(no output)';
+			outputWrap.classList.add('visible');
+			btn.disabled = false;
+			return;
+		}
 		progress.classList.add('visible');
 		caption.textContent = 'Loading runtime…';
 		fill.style.width = '0%';


### PR DESCRIPTION
## What changed

Adds precomputed expected output support to the `<php-snippet>` web component. Snippets can now provide output with either an `expected-output` attribute or a `<script type="text/expected-output">` child.

When expected output is present, Run renders that text directly in the output pane and skips the shared Playground client boot entirely, avoiding iframe creation and PHP/WordPress downloads.

The demo page also includes a new expected-output example using the script child form for multiline output.

## Usage

Use `expected-output` for short output:

```html
<php-snippet name="precomputed.php" expected-output="Hello, world!">
  <script type="application/x-php"><?php echo 'Hello, world!'; ?></script>
</php-snippet>
```

Use a `text/expected-output` script child for multiline output:

```html
<php-snippet name="precomputed.php">
  <script type="application/x-php">
<?php
print "2 + 2 = " . (2 + 2) . "\n";
print "WordPress is awesome.";
  </script>
  <script type="text/expected-output">
    2 + 2 = 4
    WordPress is awesome.
  </script>
</php-snippet>
```

## Validation

- `git diff --check origin/trunk...HEAD`
- `npm exec nx lint playground-website`
- `npm exec nx test playground-website`
