### PR TITLE
Update docs blueprint supporting encodeURIComponent URL fragments

### DIFF
--- a/packages/docs/site/docs/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/docs/blueprints/02-using-blueprints.md
@@ -8,10 +8,10 @@ description: Discover the different ways to use Blueprints, including via URL fr
 
 You can use Blueprints in one of the following ways:
 
--   By passing them as a URL fragment to the Playground.
--   By loading them from a URL using the `blueprint-url` parameter.
--   By using Blueprint bundles (ZIP files or directories).
--   By using the JavaScript API.
+- By passing them as a URL fragment to the Playground.
+- By loading them from a URL using the `blueprint-url` parameter.
+- By using Blueprint bundles (ZIP files or directories).
+- By using the JavaScript API.
 
 ## URL Fragment
 
@@ -45,6 +45,8 @@ const blueprintJson = `{
 	}
 }`;
 const minifiedBlueprintJson = JSON.stringify(JSON.parse(blueprintJson)); // {"preferredVersions":{"php":"8.3","wp":"6.5"}}
+const encodedBlueprint = encodeURIComponent(minifiedBlueprintJson);
+const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
 ```
 
 :::
@@ -60,9 +62,22 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 	}
 }} />
 
-### Base64 encoded Blueprints
+### Encoded Blueprint fragments
 
-Some tools, including GitHub, might not format the Blueprint correctly when pasted into the URL. In such cases, encode your Blueprint in Base64 and append it to the URL. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`:
+
+```js
+const blueprint = {
+	$schema: 'https://playground.wordpress.net/blueprint-schema.json',
+	preferredVersions: {
+		php: '8.3',
+		wp: '6.5',
+	},
+};
+const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
+```
+
+Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
 
 To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
 

--- a/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -97,7 +97,7 @@ The developer tools window allows you to inspect network requests, view console 
 
 You can `error_log` your own error messages through [`runPHP` step](/blueprints/steps#RunPHPStep) (see [blueprint example](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) and check them from the ["View Logs" option](/web-instance#playground-options-menu) or from the browser's console.
 
-![Log errors snapshot](@site/static/img/blueprints/log-errors.webp)
+![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
 :::info
 When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance.

--- a/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -14,6 +14,12 @@ When you build Blueprints, you might run into issues. Here are tips and tools to
 
 ## Common Issues and Solutions
 
+### Invalid Blueprint After Opening a Link
+
+If Playground reports `Invalid blueprint`, read the detailed error message. It includes the underlying JSON parsing error when one is available.
+
+If the message says the input still contains `%XX` escapes after decoding, the URL fragment was likely double-encoded. Rebuild the link from the original Blueprint object and encode it once with `encodeURIComponent(JSON.stringify(blueprint))`, or use Base64. Do not encode a fragment that is already encoded.
+
 ### WP-CLI: Error Establishing a Database Connection on Mounted Sites
 
 When using `wp-cli` with a mounted Playground site (e.g., via `--mount-before-install`), you might encounter an "Error establishing a database connection." This happens because WordPress Playground loads the SQLite database integration plugin from its internal files by default, not from the mounted directory, meaning it's not persisted for external `wp-cli` calls.
@@ -91,13 +97,11 @@ The developer tools window allows you to inspect network requests, view console 
 
 You can `error_log` your own error messages through [`runPHP` step](/blueprints/steps#RunPHPStep) (see [blueprint example](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) and check them from the ["View Logs" option](/web-instance#playground-options-menu) or from the browser's console.
 
-![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
+![Log errors snapshot](@site/static/img/blueprints/log-errors.webp)
 
-<div class="callout callout-info">
-
+:::info
 When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance.
-
-</div>
+:::
 
 ## Ask for help
 

--- a/packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md
+++ b/packages/docs/site/docs/blueprints/tutorial/02-how-to-load-run-blueprints.md
@@ -28,9 +28,11 @@ To run it, go to `https://playground.wordpress.net/#{"preferredVersions": {"php"
 
 Use this method to run the example code in the next chapter, [**Build your first Blueprint**](/blueprints/tutorial/build-your-first-blueprint).
 
-### Base64 encoded Blueprints
+### Encoded Blueprint fragments
 
-Some tools, including GitHub, might not format the Blueprint correctly when pasted into the URL. In such cases, [encode your Blueprint in Base64](https://www.base64encode.org) and append it to the URL. For example, that's the above Blueprint in Base64 format: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
+When you build a Playground link from JavaScript or an automation tool, encode the Blueprint JSON once with `encodeURIComponent(JSON.stringify(blueprint))` and append it after `#`.
+
+Playground also supports [Base64-encoded Blueprints](https://www.base64encode.org), which are useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
 
 To run it, go to [https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19](https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19)
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
@@ -1,0 +1,293 @@
+---
+title: Usar Blueprints
+slug: /blueprints/using-blueprints
+description: Descubre las diferentes formas de usar Blueprints, incluso mediante fragmento de URL, parámetro de consulta, paquetes y la API de JavaScript.
+---
+
+<!--
+title: Using Blueprints
+description: Discover the different ways to use Blueprints, including via URL fragment, query parameter, bundles, and the JavaScript API.
+-->
+
+<!--
+# Using Blueprints
+-->
+
+# Usar Blueprints
+
+<!--
+You can use Blueprints in one of the following ways:
+-->
+
+Puedes usar Blueprints de una de las siguientes formas:
+
+<!--
+- By passing them as a URL fragment to the Playground.
+- By loading them from a URL using the `blueprint-url` parameter.
+- By using Blueprint bundles (ZIP files or directories).
+- By using the JavaScript API.
+-->
+
+- Pasándolos como fragmento de URL al Playground.
+- Cargándolos desde una URL con el parámetro `blueprint-url`.
+- Usando paquetes de Blueprint (archivos ZIP o directorios).
+- Usando la API de JavaScript.
+
+<!--
+## URL Fragment
+-->
+
+## Fragmento de URL {#url-fragment}
+
+<!--
+The easiest way to start using Blueprints is to paste one into the URL "fragment" on WordPress Playground website, e.g. `https://playground.wordpress.net/#{"preferredVersions...`.
+-->
+
+La forma más sencilla de empezar a usar Blueprints es pegar uno en el "fragmento" de URL del sitio de WordPress Playground, por ejemplo `https://playground.wordpress.net/#{"preferredVersions...`.
+
+<!--
+For example, to create a Playground with specific versions of WordPress and PHP you would use the following Blueprint:
+-->
+
+Por ejemplo, para crear un Playground con versiones específicas de WordPress y PHP, usarías el siguiente Blueprint:
+
+```json
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	}
+}
+```
+
+<!--
+And then you would go to
+`https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
+-->
+
+Luego irías a
+`https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
+
+:::tip
+
+<!--
+In Javascript, you can get a compact version of any blueprint JSON with [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) and [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
+Example:
+-->
+
+En JavaScript, puedes obtener una versión compacta de cualquier JSON de Blueprint con [`JSON.stringify`](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) y [`JSON.parse`](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
+Ejemplo:
+
+```js
+const blueprintJson = `{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	}
+}`;
+const minifiedBlueprintJson = JSON.stringify(JSON.parse(blueprintJson)); // {"preferredVersions":{"php":"8.3","wp":"6.5"}}
+const encodedBlueprint = encodeURIComponent(minifiedBlueprintJson);
+const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
+```
+
+:::
+
+<!--
+You won't have to paste links to follow along. We'll use code examples with a "Try it out" button that will automatically run the examples for you:
+-->
+
+No tendrás que pegar enlaces para seguir el tutorial. Usaremos ejemplos de código con un botón "Pruébalo" que ejecutará automáticamente los ejemplos por ti:
+
+import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
+
+<BlueprintExample justButton={true} blueprint={{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	}
+}} />
+
+<!--
+### Encoded Blueprint fragments
+-->
+
+### Fragmentos de Blueprint codificados
+
+<!--
+When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`:
+-->
+
+Cuando crees enlaces de Playground desde JavaScript o herramientas de automatización, codifica el JSON minificado una sola vez con `encodeURIComponent()` y añádelo después de `#`:
+
+```js
+const blueprint = {
+	$schema: 'https://playground.wordpress.net/blueprint-schema.json',
+	preferredVersions: {
+		php: '8.3',
+		wp: '6.5',
+	},
+};
+const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
+```
+
+<!--
+Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+-->
+
+Playground también admite Blueprints codificados en Base64. Base64 es útil cuando una plataforma modifica fragmentos JSON o cuando quieres un enlace compacto y fácil de copiar. Por ejemplo, este es el Blueprint anterior en formato Base64: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+
+<!--
+To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
+-->
+
+Para ejecutarlo, ve a https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
+
+:::tip
+
+<!--
+In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`.
+
+Example:
+-->
+
+En JavaScript, puedes convertir cualquier JSON de Blueprint a [formato Base64](https://developer.mozilla.org/es/docs/Glossary/Base64#javascript_support) con la función global `btoa()`.
+
+Ejemplo:
+
+```js
+const blueprintJson = `{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	}
+}`;
+const minifiedBlueprintJson = btoa(blueprintJson); // eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
+```
+
+:::
+
+<!--
+### Load Blueprint from a URL
+-->
+
+### Cargar Blueprint desde una URL
+
+<!--
+When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this:
+-->
+
+Cuando tu Blueprint sea demasiado difícil de manejar, puedes cargarlo mediante el parámetro de consulta `?blueprint-url` en la URL, así:
+
+[https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
+
+<!--
+Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
+-->
+
+Ten en cuenta que el Blueprint debe ser accesible públicamente y servirse con [el encabezado `Access-Control-Allow-Origin` correcto](https://developer.mozilla.org/es/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
+
+```
+Access-Control-Allow-Origin: *
+```
+
+<!--
+#### Blueprint Bundles
+-->
+
+#### Paquetes de Blueprint
+
+<!--
+The `?blueprint-url` parameter now also supports Blueprint bundles in ZIP format. A Blueprint bundle is a ZIP file that contains a `blueprint.json` file at the root level, along with any additional resources referenced by the Blueprint.
+-->
+
+El parámetro `?blueprint-url` ahora también admite paquetes de Blueprint en formato ZIP. Un paquete de Blueprint es un archivo ZIP que contiene un archivo `blueprint.json` en el nivel raíz, junto con cualquier recurso adicional al que haga referencia el Blueprint.
+
+<!--
+For example, you can load a Blueprint bundle like this:
+-->
+
+Por ejemplo, puedes cargar un paquete de Blueprint así:
+
+[https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip](https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip)
+
+<!--
+When using a Blueprint bundle, you can reference bundled resources using the `bundled` resource type:
+-->
+
+Al usar un paquete de Blueprint, puedes referenciar recursos incluidos en el paquete con el tipo de recurso `bundled`:
+
+```json
+{
+	"landingPage": "/my-file.txt",
+	"steps": [
+		{
+			"step": "writeFile",
+			"path": "/wordpress/my-file.txt",
+			"data": {
+				"resource": "bundled",
+				"path": "/bundled-text-file.txt"
+			}
+		}
+	]
+}
+```
+
+<!--
+For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation.
+-->
+
+Para obtener más información sobre los paquetes de Blueprint, consulta la documentación de [Paquetes de Blueprint](/blueprints/bundles).
+
+<!--
+## JavaScript API
+-->
+
+## API de JavaScript {#javascript-api}
+
+<!--
+You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen:
+-->
+
+También puedes usar Blueprints con la API de JavaScript mediante la función `startPlaygroundWeb()` del paquete `@wp-playground/client`. Aquí tienes un ejemplo pequeño y autónomo que puedes ejecutar en JSFiddle o CodePen:
+
+```html
+<iframe id="wp-playground" style="width: 1200px; height: 800px"></iframe>
+<script type="module">
+	import { startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
+
+	const client = await startPlaygroundWeb({
+		iframe: document.getElementById('wp-playground'),
+		remoteUrl: `https://playground.wordpress.net/remote.html`,
+		blueprint: {
+			landingPage: '/wp-admin/',
+			preferredVersions: {
+				php: '8.3',
+				wp: 'latest',
+			},
+			steps: [
+				{
+					step: 'login',
+					username: 'admin',
+					password: 'password',
+				},
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'wordpress.org/plugins',
+						slug: 'friends',
+					},
+				},
+			],
+		},
+	});
+
+	const response = await client.run({
+		// wp-load.php is only required if you want to interact with WordPress.
+		code: '<?php require_once "/wordpress/wp-load.php"; $posts = get_posts(); echo "Post Title: " . $posts[0]->post_title;',
+	});
+	console.log(response.text);
+</script>
+```

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -223,10 +223,10 @@ You can `error_log` your own error messages through [`runPHP` step](/blueprints/
 Puedes registrar tus propios mensajes de error con `error_log` mediante el [paso `runPHP`](/blueprints/steps#RunPHPStep) (consulta el [ejemplo de Blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) y la [demo en vivo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) y revisarlos desde la opción ["View Logs"](/web-instance#playground-options-menu) o desde la consola del navegador.
 
 <!--
-![Log errors snapshot](@site/static/img/blueprints/log-errors.webp)
+![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 -->
 
-![Captura de errores de registro](@site/static/img/blueprints/log-errors.webp)
+![Captura de errores de registro](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
 :::info
 

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -1,0 +1,263 @@
+---
+title: Solucionar problemas y depurar
+slug: /blueprints/troubleshoot-and-debug
+description: Una guía con consejos y herramientas para ayudarte a solucionar problemas y depurar tus Blueprints, desde problemas comunes hasta herramientas del navegador.
+---
+
+<!--
+title: Troubleshoot and debug
+description: A guide with tips and tools to help you troubleshoot and debug your Blueprints, from common issues to browser tools.
+-->
+
+<!--
+# Troubleshoot and debug Blueprints
+-->
+
+# Solucionar problemas y depurar Blueprints
+
+<!--
+When you build Blueprints, you might run into issues. Here are tips and tools to help you debug them:
+-->
+
+Cuando creas Blueprints, puedes encontrarte con problemas. Aquí tienes consejos y herramientas para ayudarte a depurarlos:
+
+<!--
+## Review Common gotchas
+-->
+
+## Revisa problemas comunes
+
+<!--
+- Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you’d need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('wordpress/wp-load.php'); REST_OF_YOUR_CODE"`.
+-->
+
+- Requiere `wp-load`: para ejecutar una función PHP de WordPress usando el paso `runPHP`, tendrás que requerir [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). Por eso, el valor de la clave `code` debe empezar con `"<?php require_once('wordpress/wp-load.php'); RESTO_DE_TU_CÓDIGO"`.
+
+<!--
+## Common Issues and Solutions
+-->
+
+## Problemas comunes y soluciones
+
+<!--
+### Invalid Blueprint After Opening a Link
+-->
+
+### Blueprint no válido después de abrir un enlace
+
+<!--
+If Playground reports `Invalid blueprint`, read the detailed error message. It includes the underlying JSON parsing error when one is available.
+-->
+
+Si Playground informa `Invalid blueprint`, lee el mensaje de error detallado. Incluye el error de análisis JSON subyacente cuando está disponible.
+
+<!--
+If the message says the input still contains `%XX` escapes after decoding, the URL fragment was likely double-encoded. Rebuild the link from the original Blueprint object and encode it once with `encodeURIComponent(JSON.stringify(blueprint))`, or use Base64. Do not encode a fragment that is already encoded.
+-->
+
+Si el mensaje dice que la entrada todavía contiene secuencias de escape `%XX` después de decodificarla, es probable que el fragmento de URL se haya codificado dos veces. Reconstruye el enlace a partir del objeto Blueprint original y codifícalo una sola vez con `encodeURIComponent(JSON.stringify(blueprint))`, o usa Base64. No codifiques un fragmento que ya esté codificado.
+
+<!--
+### WP-CLI: Error Establishing a Database Connection on Mounted Sites
+-->
+
+### WP-CLI: error al establecer una conexión con la base de datos en sitios montados {#wp-cli-error-establishing-a-database-connection-on-mounted-sites}
+
+<!--
+When using `wp-cli` with a mounted Playground site (e.g., via `--mount-before-install`), you might encounter an "Error establishing a database connection." This happens because WordPress Playground loads the SQLite database integration plugin from its internal files by default, not from the mounted directory, meaning it's not persisted for external `wp-cli` calls.
+-->
+
+Al usar `wp-cli` con un sitio Playground montado (por ejemplo, mediante `--mount-before-install`), puedes encontrar un mensaje de "Error establishing a database connection". Esto ocurre porque WordPress Playground carga por defecto el plugin de integración de base de datos SQLite desde sus archivos internos, no desde el directorio montado, lo que significa que no se conserva para llamadas externas de `wp-cli`.
+
+<!--
+To resolve this, you need to explicitly install and configure the SQLite database integration plugin within your Blueprint.
+-->
+
+Para resolverlo, debes instalar y configurar explícitamente el plugin de integración de base de datos SQLite dentro de tu Blueprint.
+
+<!--
+**Solution:** Add the following steps to your Blueprint:
+-->
+
+**Solución:** añade los siguientes pasos a tu Blueprint:
+
+```json
+{
+	"plugins": ["sqlite-database-integration"]
+}
+```
+
+<!--
+**Example Usage:**
+-->
+
+**Ejemplo de uso:**
+
+<!--
+To test this locally, combine the Blueprint with your Playground CLI command:
+-->
+
+Para probarlo localmente, combina el Blueprint con tu comando de Playground CLI:
+
+```bash
+mkdir wordpress
+# Ensure your blueprint with the above steps is saved as, for example, './blueprint.json'
+npx @wp-playground/cli server --mount-before-install=wordpress:/wordpress --blueprint=./blueprint.json
+cd wordpress
+wp post list
+```
+
+<!--
+This will ensure the SQLite plugin is installed correctly and configured within your mounted WordPress site, allowing `wp-cli` commands to function correctly.
+-->
+
+Esto garantiza que el plugin SQLite se instale correctamente y se configure dentro de tu sitio WordPress montado, lo que permite que los comandos `wp-cli` funcionen correctamente.
+
+<!--
+## Blueprints Builder
+-->
+
+## Constructor de Blueprints
+
+<!--
+You can use an in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to build, validate, and preview your Blueprints in the browser.
+-->
+
+Puedes usar un [editor de Blueprints](https://playground.wordpress.net/builder/builder.html) en el navegador para crear, validar y previsualizar tus Blueprints.
+
+:::danger Precaución
+
+<!--
+The editor is under development and the embedded Playground sometimes fails to load. To get around it, refresh the page. We're aware of that, and are working to improve the experience.
+-->
+
+El editor está en desarrollo y el Playground incrustado a veces no carga. Para solucionarlo, actualiza la página. Somos conscientes de ello y estamos trabajando para mejorar la experiencia.
+
+:::
+
+<!--
+## Check for the Filesystem and Database
+-->
+
+## Revisa el sistema de archivos y la base de datos
+
+<!--
+Some blueprint steps (such as [`writeFile`](/blueprints/steps#WriteFileStep)) alter the internal Filesystem structure of the Playground instance and some others (such as [`runSql`](/blueprints/steps#runSql)) alter the internal WordPress database.
+-->
+
+Algunos pasos de Blueprint (como [`writeFile`](/blueprints/steps#WriteFileStep)) modifican la estructura interna del sistema de archivos de la instancia de Playground, y otros (como [`runSql`](/blueprints/steps#runSql)) modifican la base de datos interna de WordPress.
+
+<!--
+To check the final internal filesystem structure and database (after the blueprint steps have been applied) we can leverage some WordPress plugins that provide a SQL manager and a file explorer such as [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and [`WPide`](https://wordpress.org/plugins/wpide/) (you can see them in action from https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide)
+-->
+
+Para revisar la estructura final del sistema de archivos interno y la base de datos (después de aplicar los pasos del Blueprint), podemos usar algunos plugins de WordPress que proporcionan un gestor SQL y un explorador de archivos, como [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) y [`WPide`](https://wordpress.org/plugins/wpide/) (puedes verlos en acción desde https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide).
+
+:::tip
+
+<!--
+There are a bunch of methods we can launch from the console of any WordPress Playground instance to inspect the internals of that instance. They're exposed as part of `window.playground` object (see [Developers > JavaScript API > Debugging and testing](/developers/apis/javascript-api/#debugging-and-testing)). Some examples:
+-->
+
+Hay varios métodos que podemos ejecutar desde la consola de cualquier instancia de WordPress Playground para inspeccionar sus partes internas. Están expuestos como parte del objeto `window.playground` (consulta [Desarrolladores > API de JavaScript > Depuración y pruebas](/developers/apis/javascript-api/#debugging-and-testing)). Algunos ejemplos:
+
+```
+> await playground.isDir("/wordpress/wp-content/plugins")
+true
+> await playground.listFiles("/wordpress/wp-content/plugins")
+(3) ['hello.php', 'index.php', 'WordPress-Importer-master']
+```
+
+<!--
+Full list of methods we can use is available [here](/api/client/interface/PlaygroundClient)
+-->
+
+La lista completa de métodos que podemos usar está disponible [aquí](/api/client/interface/PlaygroundClient).
+
+:::
+
+<!--
+## Check for errors in the browser console
+-->
+
+## Revisa errores en la consola del navegador
+
+<!--
+If your Blueprint isn’t running as expected, open the browser developer tools to check for any errors.
+-->
+
+Si tu Blueprint no se está ejecutando como esperas, abre las herramientas de desarrollo del navegador para comprobar si hay errores.
+
+<!--
+To open the developer tools in Chrome, Firefox, Safari\*, and Edge: press `Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
+-->
+
+Para abrir las herramientas de desarrollo en Chrome, Firefox, Safari\* y Edge: pulsa `Ctrl + Shift + I` en Windows/Linux o `Cmd + Option + I` en macOS.
+
+:::caution
+
+<!--
+If you haven't yet, enable the Develop menu: go to **Safari > Settings... > Advanced** and check **Show features for web developers**.
+-->
+
+Si aún no lo has hecho, activa el menú Desarrollo: ve a **Safari > Configuración... > Avanzado** y marca **Mostrar funciones para desarrolladores web**.
+
+:::
+
+<!--
+The developer tools window allows you to inspect network requests, view console logs, debug JavaScript, and examine the DOM and CSS styles applied to your webpage. This is crucial for diagnosing and fixing issues with Blueprints.
+-->
+
+La ventana de herramientas de desarrollo te permite inspeccionar solicitudes de red, ver registros de consola, depurar JavaScript y examinar el DOM y los estilos CSS aplicados a tu página. Esto es clave para diagnosticar y corregir problemas con Blueprints.
+
+<!--
+## Log your own error messages
+-->
+
+## Registra tus propios mensajes de error
+
+<!--
+You can `error_log` your own error messages through [`runPHP` step](/blueprints/steps#RunPHPStep) (see [blueprint example](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) and check them from the ["View Logs" option](/web-instance#playground-options-menu) or from the browser's console.
+-->
+
+Puedes registrar tus propios mensajes de error con `error_log` mediante el [paso `runPHP`](/blueprints/steps#RunPHPStep) (consulta el [ejemplo de Blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) y la [demo en vivo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) y revisarlos desde la opción ["View Logs"](/web-instance#playground-options-menu) o desde la consola del navegador.
+
+<!--
+![Log errors snapshot](@site/static/img/blueprints/log-errors.webp)
+-->
+
+![Captura de errores de registro](@site/static/img/blueprints/log-errors.webp)
+
+:::info
+
+<!--
+When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance.
+-->
+
+Cuando descargas tu instancia de Playground como un `zip` mediante la opción ["Download as zip"](/web-instance#playground-options-menu), también descargas el archivo `debug.log`, que contiene todos los registros de tu instancia de Playground.
+
+:::
+
+<!--
+## Ask for help
+-->
+
+## Pide ayuda
+
+<!--
+The community is here to help! If you have questions or comments, [open a new issue](https://github.com/adamziel/blueprints/issues) in this repository. Remember to include the following details:
+-->
+
+La comunidad está aquí para ayudar. Si tienes preguntas o comentarios, [abre un nuevo issue](https://github.com/adamziel/blueprints/issues) en este repositorio. Recuerda incluir los siguientes detalles:
+
+<!--
+- The Blueprint you’re trying to run.
+- The error message you’re seeing, if any.
+- The full output from the browser developer tools.
+- Any other relevant information that might help us understand the issue: OS, browser version, etc.
+-->
+
+- El Blueprint que intentas ejecutar.
+- El mensaje de error que ves, si lo hay.
+- La salida completa de las herramientas de desarrollo del navegador.
+- Cualquier otra información relevante que pueda ayudarnos a entender el problema: sistema operativo, versión del navegador, etc.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/tutorial/02-how-to-load-run-blueprints.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/tutorial/02-how-to-load-run-blueprints.md
@@ -1,0 +1,106 @@
+---
+title: Cómo ejecutar Blueprints
+slug: /blueprints/tutorial/how-to-load-run-blueprints
+description: Aprende los distintos métodos para cargar y ejecutar Blueprints, incluso mediante un fragmento de URL o el parámetro blueprint-url.
+---
+
+<!--
+title: How to run Blueprints
+description: Learn the various methods for loading and running Blueprints, including using a URL fragment or the blueprint-url parameter.
+-->
+
+<!--
+# How to load and run Blueprints
+-->
+
+# Cómo cargar y ejecutar Blueprints
+
+<!--
+## URL fragment
+-->
+
+## Fragmento de URL
+
+<!--
+The fastest way to run Blueprints is to paste one into the URL "fragment" of a WordPress Playground website. Just add a `#` after the `.net/`.
+-->
+
+La forma más rápida de ejecutar Blueprints es pegar uno en el "fragmento" de URL de un sitio de WordPress Playground. Solo añade un `#` después de `.net/`.
+
+<!--
+Let's say you want to create a Playground with specific versions of WordPress and PHP using the following Blueprint:
+-->
+
+Supongamos que quieres crear un Playground con versiones específicas de WordPress y PHP usando el siguiente Blueprint:
+
+```json
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "5.9"
+	}
+}
+```
+
+<!--
+To run it, go to `https://playground.wordpress.net/#{"preferredVersions": {"php":"8.3", "wp":"5.9"}}`. You can also use the button below:
+-->
+
+Para ejecutarlo, ve a `https://playground.wordpress.net/#{"preferredVersions": {"php":"8.3", "wp":"5.9"}}`. También puedes usar el botón de abajo:
+
+[<kbd> &nbsp; Ejecutar Blueprint &nbsp; </kbd>](https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"5.9"}})
+
+<!--
+Use this method to run the example code in the next chapter, [**Build your first Blueprint**](/blueprints/tutorial/build-your-first-blueprint).
+-->
+
+Usa este método para ejecutar el código de ejemplo del siguiente capítulo, [**Crea tu primer Blueprint**](/blueprints/tutorial/build-your-first-blueprint).
+
+<!--
+### Encoded Blueprint fragments
+-->
+
+### Fragmentos de Blueprint codificados
+
+<!--
+When you build a Playground link from JavaScript or an automation tool, encode the Blueprint JSON once with `encodeURIComponent(JSON.stringify(blueprint))` and append it after `#`.
+-->
+
+Cuando construyas un enlace de Playground desde JavaScript o una herramienta de automatización, codifica el JSON de Blueprint una sola vez con `encodeURIComponent(JSON.stringify(blueprint))` y añádelo después de `#`.
+
+<!--
+Playground also supports [Base64-encoded Blueprints](https://www.base64encode.org), which are useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
+-->
+
+Playground también admite [Blueprints codificados en Base64](https://www.base64encode.org), que son útiles cuando una plataforma modifica fragmentos JSON o cuando quieres un enlace compacto y fácil de copiar. Por ejemplo, este es el Blueprint anterior en formato Base64: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
+
+<!--
+To run it, go to [https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19](https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19)
+-->
+
+Para ejecutarlo, ve a [https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19](https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19)
+
+<!--
+### Load Blueprint from a URL
+-->
+
+### Cargar Blueprint desde una URL
+
+<!--
+When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this:
+-->
+
+Cuando tu Blueprint sea demasiado difícil de manejar, puedes cargarlo mediante el parámetro de consulta `?blueprint-url` en la URL, así:
+
+[https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
+
+<!--
+Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
+-->
+
+Ten en cuenta que el Blueprint debe ser accesible públicamente y servirse con [el encabezado `Access-Control-Allow-Origin` correcto](https://developer.mozilla.org/es/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
+
+```
+Access-Control-Allow-Origin: *
+```

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
@@ -1,0 +1,293 @@
+---
+title: Utiliser les Blueprints
+slug: /blueprints/using-blueprints
+description: Découvrez les différentes façons d’utiliser les Blueprints, notamment avec un fragment d’URL, un paramètre de requête, des paquets et l’API JavaScript.
+---
+
+<!--
+title: Using Blueprints
+description: Discover the different ways to use Blueprints, including via URL fragment, query parameter, bundles, and the JavaScript API.
+-->
+
+<!--
+# Using Blueprints
+-->
+
+# Utiliser les Blueprints
+
+<!--
+You can use Blueprints in one of the following ways:
+-->
+
+Vous pouvez utiliser les Blueprints de l’une des façons suivantes :
+
+<!--
+- By passing them as a URL fragment to the Playground.
+- By loading them from a URL using the `blueprint-url` parameter.
+- By using Blueprint bundles (ZIP files or directories).
+- By using the JavaScript API.
+-->
+
+- En les passant comme fragment d’URL au Playground.
+- En les chargeant depuis une URL avec le paramètre `blueprint-url`.
+- En utilisant des paquets Blueprint (fichiers ZIP ou répertoires).
+- En utilisant l’API JavaScript.
+
+<!--
+## URL Fragment
+-->
+
+## Fragment d’URL {#url-fragment}
+
+<!--
+The easiest way to start using Blueprints is to paste one into the URL "fragment" on WordPress Playground website, e.g. `https://playground.wordpress.net/#{"preferredVersions...`.
+-->
+
+La façon la plus simple de commencer à utiliser les Blueprints est d’en coller un dans le « fragment » d’URL du site WordPress Playground, par exemple `https://playground.wordpress.net/#{"preferredVersions...`.
+
+<!--
+For example, to create a Playground with specific versions of WordPress and PHP you would use the following Blueprint:
+-->
+
+Par exemple, pour créer un Playground avec des versions spécifiques de WordPress et de PHP, vous utiliseriez le Blueprint suivant :
+
+```json
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	}
+}
+```
+
+<!--
+And then you would go to
+`https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
+-->
+
+Vous iriez ensuite à
+`https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
+
+:::tip
+
+<!--
+In Javascript, you can get a compact version of any blueprint JSON with [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) and [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
+Example:
+-->
+
+En JavaScript, vous pouvez obtenir une version compacte de n’importe quel JSON de Blueprint avec [`JSON.stringify`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) et [`JSON.parse`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
+Exemple :
+
+```js
+const blueprintJson = `{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	}
+}`;
+const minifiedBlueprintJson = JSON.stringify(JSON.parse(blueprintJson)); // {"preferredVersions":{"php":"8.3","wp":"6.5"}}
+const encodedBlueprint = encodeURIComponent(minifiedBlueprintJson);
+const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
+```
+
+:::
+
+<!--
+You won't have to paste links to follow along. We'll use code examples with a "Try it out" button that will automatically run the examples for you:
+-->
+
+Vous n’aurez pas besoin de coller de liens pour suivre. Nous utiliserons des exemples de code avec un bouton « Essayer » qui exécutera automatiquement les exemples pour vous :
+
+import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
+
+<BlueprintExample justButton={true} blueprint={{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	}
+}} />
+
+<!--
+### Encoded Blueprint fragments
+-->
+
+### Fragments de Blueprint encodés
+
+<!--
+When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`:
+-->
+
+Lorsque vous créez des liens Playground depuis JavaScript ou des outils d’automatisation, encodez le JSON minifié une seule fois avec `encodeURIComponent()` et ajoutez-le après `#` :
+
+```js
+const blueprint = {
+	$schema: 'https://playground.wordpress.net/blueprint-schema.json',
+	preferredVersions: {
+		php: '8.3',
+		wp: '6.5',
+	},
+};
+const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
+```
+
+<!--
+Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+-->
+
+Playground prend également en charge les Blueprints encodés en Base64. Base64 est utile lorsqu’une plateforme modifie les fragments JSON ou lorsque vous voulez un lien compact et facile à copier. Par exemple, voici le Blueprint ci-dessus au format Base64 : `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+
+<!--
+To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
+-->
+
+Pour l’exécuter, allez sur https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
+
+:::tip
+
+<!--
+In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`.
+
+Example:
+-->
+
+En JavaScript, vous pouvez convertir n’importe quel JSON de Blueprint au [format Base64](https://developer.mozilla.org/fr/docs/Glossary/Base64#javascript_support) avec la fonction globale `btoa()`.
+
+Exemple :
+
+```js
+const blueprintJson = `{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	}
+}`;
+const minifiedBlueprintJson = btoa(blueprintJson); // eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
+```
+
+:::
+
+<!--
+### Load Blueprint from a URL
+-->
+
+### Charger un Blueprint depuis une URL
+
+<!--
+When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this:
+-->
+
+Lorsque votre Blueprint devient trop difficile à gérer, vous pouvez le charger avec le paramètre de requête `?blueprint-url` dans l’URL, comme ceci :
+
+[https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
+
+<!--
+Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
+-->
+
+Notez que le Blueprint doit être accessible publiquement et servi avec [le bon en-tête `Access-Control-Allow-Origin`](https://developer.mozilla.org/fr/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin) :
+
+```
+Access-Control-Allow-Origin: *
+```
+
+<!--
+#### Blueprint Bundles
+-->
+
+#### Paquets Blueprint
+
+<!--
+The `?blueprint-url` parameter now also supports Blueprint bundles in ZIP format. A Blueprint bundle is a ZIP file that contains a `blueprint.json` file at the root level, along with any additional resources referenced by the Blueprint.
+-->
+
+Le paramètre `?blueprint-url` prend désormais aussi en charge les paquets Blueprint au format ZIP. Un paquet Blueprint est un fichier ZIP qui contient un fichier `blueprint.json` à la racine, ainsi que toutes les ressources supplémentaires référencées par le Blueprint.
+
+<!--
+For example, you can load a Blueprint bundle like this:
+-->
+
+Par exemple, vous pouvez charger un paquet Blueprint comme ceci :
+
+[https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip](https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip)
+
+<!--
+When using a Blueprint bundle, you can reference bundled resources using the `bundled` resource type:
+-->
+
+Lorsque vous utilisez un paquet Blueprint, vous pouvez référencer les ressources incluses avec le type de ressource `bundled` :
+
+```json
+{
+	"landingPage": "/my-file.txt",
+	"steps": [
+		{
+			"step": "writeFile",
+			"path": "/wordpress/my-file.txt",
+			"data": {
+				"resource": "bundled",
+				"path": "/bundled-text-file.txt"
+			}
+		}
+	]
+}
+```
+
+<!--
+For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation.
+-->
+
+Pour en savoir plus sur les paquets Blueprint, consultez la documentation [Paquets Blueprint](/blueprints/bundles).
+
+<!--
+## JavaScript API
+-->
+
+## API JavaScript {#javascript-api}
+
+<!--
+You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen:
+-->
+
+Vous pouvez aussi utiliser les Blueprints avec l’API JavaScript grâce à la fonction `startPlaygroundWeb()` du paquet `@wp-playground/client`. Voici un petit exemple autonome que vous pouvez exécuter sur JSFiddle ou CodePen :
+
+```html
+<iframe id="wp-playground" style="width: 1200px; height: 800px"></iframe>
+<script type="module">
+	import { startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
+
+	const client = await startPlaygroundWeb({
+		iframe: document.getElementById('wp-playground'),
+		remoteUrl: `https://playground.wordpress.net/remote.html`,
+		blueprint: {
+			landingPage: '/wp-admin/',
+			preferredVersions: {
+				php: '8.3',
+				wp: 'latest',
+			},
+			steps: [
+				{
+					step: 'login',
+					username: 'admin',
+					password: 'password',
+				},
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'wordpress.org/plugins',
+						slug: 'friends',
+					},
+				},
+			],
+		},
+	});
+
+	const response = await client.run({
+		// wp-load.php is only required if you want to interact with WordPress.
+		code: '<?php require_once "/wordpress/wp-load.php"; $posts = get_posts(); echo "Post Title: " . $posts[0]->post_title;',
+	});
+	console.log(response.text);
+</script>
+```

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -1,0 +1,263 @@
+---
+title: Dépanner et déboguer
+slug: /blueprints/troubleshoot-and-debug
+description: Un guide avec des conseils et des outils pour vous aider à dépanner et déboguer vos Blueprints, des problèmes courants aux outils du navigateur.
+---
+
+<!--
+title: Troubleshoot and debug
+description: A guide with tips and tools to help you troubleshoot and debug your Blueprints, from common issues to browser tools.
+-->
+
+<!--
+# Troubleshoot and debug Blueprints
+-->
+
+# Dépanner et déboguer les Blueprints
+
+<!--
+When you build Blueprints, you might run into issues. Here are tips and tools to help you debug them:
+-->
+
+Lorsque vous créez des Blueprints, vous pouvez rencontrer des problèmes. Voici des conseils et des outils pour vous aider à les déboguer :
+
+<!--
+## Review Common gotchas
+-->
+
+## Vérifier les pièges courants
+
+<!--
+- Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you’d need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('wordpress/wp-load.php'); REST_OF_YOUR_CODE"`.
+-->
+
+- Requérir `wp-load` : pour exécuter une fonction PHP de WordPress avec l’étape `runPHP`, vous devez requérir [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). La valeur de la clé `code` doit donc commencer par `"<?php require_once('wordpress/wp-load.php'); LE_RESTE_DE_VOTRE_CODE"`.
+
+<!--
+## Common Issues and Solutions
+-->
+
+## Problèmes courants et solutions
+
+<!--
+### Invalid Blueprint After Opening a Link
+-->
+
+### Blueprint non valide après l’ouverture d’un lien
+
+<!--
+If Playground reports `Invalid blueprint`, read the detailed error message. It includes the underlying JSON parsing error when one is available.
+-->
+
+Si Playground indique `Invalid blueprint`, lisez le message d’erreur détaillé. Il inclut l’erreur d’analyse JSON sous-jacente lorsqu’elle est disponible.
+
+<!--
+If the message says the input still contains `%XX` escapes after decoding, the URL fragment was likely double-encoded. Rebuild the link from the original Blueprint object and encode it once with `encodeURIComponent(JSON.stringify(blueprint))`, or use Base64. Do not encode a fragment that is already encoded.
+-->
+
+Si le message indique que l’entrée contient encore des échappements `%XX` après le décodage, le fragment d’URL a probablement été encodé deux fois. Reconstruisez le lien depuis l’objet Blueprint d’origine et encodez-le une seule fois avec `encodeURIComponent(JSON.stringify(blueprint))`, ou utilisez Base64. N’encodez pas un fragment qui est déjà encodé.
+
+<!--
+### WP-CLI: Error Establishing a Database Connection on Mounted Sites
+-->
+
+### WP-CLI : erreur lors de l’établissement d’une connexion à la base de données sur les sites montés {#wp-cli-error-establishing-a-database-connection-on-mounted-sites}
+
+<!--
+When using `wp-cli` with a mounted Playground site (e.g., via `--mount-before-install`), you might encounter an "Error establishing a database connection." This happens because WordPress Playground loads the SQLite database integration plugin from its internal files by default, not from the mounted directory, meaning it's not persisted for external `wp-cli` calls.
+-->
+
+Lorsque vous utilisez `wp-cli` avec un site Playground monté (par exemple avec `--mount-before-install`), vous pouvez rencontrer une erreur « Error establishing a database connection ». Cela se produit parce que WordPress Playground charge par défaut l’extension d’intégration de base de données SQLite depuis ses fichiers internes, et non depuis le répertoire monté, ce qui signifie qu’elle n’est pas conservée pour les appels externes à `wp-cli`.
+
+<!--
+To resolve this, you need to explicitly install and configure the SQLite database integration plugin within your Blueprint.
+-->
+
+Pour résoudre ce problème, vous devez installer et configurer explicitement l’extension d’intégration de base de données SQLite dans votre Blueprint.
+
+<!--
+**Solution:** Add the following steps to your Blueprint:
+-->
+
+**Solution :** ajoutez les étapes suivantes à votre Blueprint :
+
+```json
+{
+	"plugins": ["sqlite-database-integration"]
+}
+```
+
+<!--
+**Example Usage:**
+-->
+
+**Exemple d’utilisation :**
+
+<!--
+To test this locally, combine the Blueprint with your Playground CLI command:
+-->
+
+Pour tester cela localement, combinez le Blueprint avec votre commande Playground CLI :
+
+```bash
+mkdir wordpress
+# Ensure your blueprint with the above steps is saved as, for example, './blueprint.json'
+npx @wp-playground/cli server --mount-before-install=wordpress:/wordpress --blueprint=./blueprint.json
+cd wordpress
+wp post list
+```
+
+<!--
+This will ensure the SQLite plugin is installed correctly and configured within your mounted WordPress site, allowing `wp-cli` commands to function correctly.
+-->
+
+Cela garantit que l’extension SQLite est installée correctement et configurée dans votre site WordPress monté, ce qui permet aux commandes `wp-cli` de fonctionner correctement.
+
+<!--
+## Blueprints Builder
+-->
+
+## Générateur de Blueprints
+
+<!--
+You can use an in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to build, validate, and preview your Blueprints in the browser.
+-->
+
+Vous pouvez utiliser un [éditeur de Blueprints](https://playground.wordpress.net/builder/builder.html) dans le navigateur pour créer, valider et prévisualiser vos Blueprints.
+
+:::danger Attention
+
+<!--
+The editor is under development and the embedded Playground sometimes fails to load. To get around it, refresh the page. We're aware of that, and are working to improve the experience.
+-->
+
+L’éditeur est en cours de développement et le Playground intégré ne se charge pas toujours. Pour contourner le problème, actualisez la page. Nous en sommes conscients et travaillons à améliorer l’expérience.
+
+:::
+
+<!--
+## Check for the Filesystem and Database
+-->
+
+## Vérifier le système de fichiers et la base de données
+
+<!--
+Some blueprint steps (such as [`writeFile`](/blueprints/steps#WriteFileStep)) alter the internal Filesystem structure of the Playground instance and some others (such as [`runSql`](/blueprints/steps#runSql)) alter the internal WordPress database.
+-->
+
+Certaines étapes de Blueprint (comme [`writeFile`](/blueprints/steps#WriteFileStep)) modifient la structure interne du système de fichiers de l’instance Playground, et d’autres (comme [`runSql`](/blueprints/steps#runSql)) modifient la base de données WordPress interne.
+
+<!--
+To check the final internal filesystem structure and database (after the blueprint steps have been applied) we can leverage some WordPress plugins that provide a SQL manager and a file explorer such as [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and [`WPide`](https://wordpress.org/plugins/wpide/) (you can see them in action from https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide)
+-->
+
+Pour vérifier la structure finale du système de fichiers interne et de la base de données (après l’application des étapes du Blueprint), nous pouvons utiliser des extensions WordPress qui fournissent un gestionnaire SQL et un explorateur de fichiers, comme [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) et [`WPide`](https://wordpress.org/plugins/wpide/) (vous pouvez les voir en action depuis https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide).
+
+:::tip
+
+<!--
+There are a bunch of methods we can launch from the console of any WordPress Playground instance to inspect the internals of that instance. They're exposed as part of `window.playground` object (see [Developers > JavaScript API > Debugging and testing](/developers/apis/javascript-api/#debugging-and-testing)). Some examples:
+-->
+
+Plusieurs méthodes peuvent être lancées depuis la console de n’importe quelle instance WordPress Playground pour en inspecter les éléments internes. Elles sont exposées dans l’objet `window.playground` (voir [Développeurs > API JavaScript > Débogage et tests](/developers/apis/javascript-api/#debugging-and-testing)). Quelques exemples :
+
+```
+> await playground.isDir("/wordpress/wp-content/plugins")
+true
+> await playground.listFiles("/wordpress/wp-content/plugins")
+(3) ['hello.php', 'index.php', 'WordPress-Importer-master']
+```
+
+<!--
+Full list of methods we can use is available [here](/api/client/interface/PlaygroundClient)
+-->
+
+La liste complète des méthodes que nous pouvons utiliser est disponible [ici](/api/client/interface/PlaygroundClient).
+
+:::
+
+<!--
+## Check for errors in the browser console
+-->
+
+## Vérifier les erreurs dans la console du navigateur
+
+<!--
+If your Blueprint isn’t running as expected, open the browser developer tools to check for any errors.
+-->
+
+Si votre Blueprint ne s’exécute pas comme prévu, ouvrez les outils de développement du navigateur pour vérifier les erreurs.
+
+<!--
+To open the developer tools in Chrome, Firefox, Safari\*, and Edge: press `Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
+-->
+
+Pour ouvrir les outils de développement dans Chrome, Firefox, Safari\* et Edge : appuyez sur `Ctrl + Shift + I` sous Windows/Linux ou sur `Cmd + Option + I` sous macOS.
+
+:::caution
+
+<!--
+If you haven't yet, enable the Develop menu: go to **Safari > Settings... > Advanced** and check **Show features for web developers**.
+-->
+
+Si ce n’est pas encore fait, activez le menu Développement : allez dans **Safari > Réglages... > Avancé** et cochez **Afficher les fonctionnalités pour les développeurs web**.
+
+:::
+
+<!--
+The developer tools window allows you to inspect network requests, view console logs, debug JavaScript, and examine the DOM and CSS styles applied to your webpage. This is crucial for diagnosing and fixing issues with Blueprints.
+-->
+
+La fenêtre des outils de développement vous permet d’inspecter les requêtes réseau, de consulter les journaux de console, de déboguer JavaScript et d’examiner le DOM ainsi que les styles CSS appliqués à votre page. C’est essentiel pour diagnostiquer et corriger les problèmes avec les Blueprints.
+
+<!--
+## Log your own error messages
+-->
+
+## Journaliser vos propres messages d’erreur
+
+<!--
+You can `error_log` your own error messages through [`runPHP` step](/blueprints/steps#RunPHPStep) (see [blueprint example](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) and check them from the ["View Logs" option](/web-instance#playground-options-menu) or from the browser's console.
+-->
+
+Vous pouvez journaliser vos propres messages d’erreur avec `error_log` via l’[étape `runPHP`](/blueprints/steps#RunPHPStep) (voir l’[exemple de Blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) et la [démo en direct](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) puis les consulter depuis l’option ["View Logs"](/web-instance#playground-options-menu) ou depuis la console du navigateur.
+
+<!--
+![Log errors snapshot](@site/static/img/blueprints/log-errors.webp)
+-->
+
+![Capture des erreurs journalisées](@site/static/img/blueprints/log-errors.webp)
+
+:::info
+
+<!--
+When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance.
+-->
+
+Lorsque vous téléchargez votre instance Playground sous forme de `zip` avec l’option ["Download as zip"](/web-instance#playground-options-menu), vous téléchargez aussi le fichier `debug.log` qui contient tous les journaux de votre instance Playground.
+
+:::
+
+<!--
+## Ask for help
+-->
+
+## Demander de l’aide
+
+<!--
+The community is here to help! If you have questions or comments, [open a new issue](https://github.com/adamziel/blueprints/issues) in this repository. Remember to include the following details:
+-->
+
+La communauté est là pour aider. Si vous avez des questions ou des commentaires, [ouvrez une nouvelle issue](https://github.com/adamziel/blueprints/issues) dans ce dépôt. Pensez à inclure les informations suivantes :
+
+<!--
+- The Blueprint you’re trying to run.
+- The error message you’re seeing, if any.
+- The full output from the browser developer tools.
+- Any other relevant information that might help us understand the issue: OS, browser version, etc.
+-->
+
+- Le Blueprint que vous essayez d’exécuter.
+- Le message d’erreur que vous voyez, le cas échéant.
+- La sortie complète des outils de développement du navigateur.
+- Toute autre information pertinente qui pourrait nous aider à comprendre le problème : système d’exploitation, version du navigateur, etc.

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -223,10 +223,10 @@ You can `error_log` your own error messages through [`runPHP` step](/blueprints/
 Vous pouvez journaliser vos propres messages d’erreur avec `error_log` via l’[étape `runPHP`](/blueprints/steps#RunPHPStep) (voir l’[exemple de Blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) et la [démo en direct](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) puis les consulter depuis l’option ["View Logs"](/web-instance#playground-options-menu) ou depuis la console du navigateur.
 
 <!--
-![Log errors snapshot](@site/static/img/blueprints/log-errors.webp)
+![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 -->
 
-![Capture des erreurs journalisées](@site/static/img/blueprints/log-errors.webp)
+![Capture des erreurs journalisées](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
 :::info
 

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/tutorial/02-how-to-load-run-blueprints.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/tutorial/02-how-to-load-run-blueprints.md
@@ -1,0 +1,106 @@
+---
+title: Comment exécuter des Blueprints
+slug: /blueprints/tutorial/how-to-load-run-blueprints
+description: Découvrez les différentes méthodes pour charger et exécuter des Blueprints, notamment avec un fragment d’URL ou le paramètre blueprint-url.
+---
+
+<!--
+title: How to run Blueprints
+description: Learn the various methods for loading and running Blueprints, including using a URL fragment or the blueprint-url parameter.
+-->
+
+<!--
+# How to load and run Blueprints
+-->
+
+# Comment charger et exécuter des Blueprints
+
+<!--
+## URL fragment
+-->
+
+## Fragment d’URL
+
+<!--
+The fastest way to run Blueprints is to paste one into the URL "fragment" of a WordPress Playground website. Just add a `#` after the `.net/`.
+-->
+
+La façon la plus rapide d’exécuter des Blueprints consiste à en coller un dans le « fragment » d’URL d’un site WordPress Playground. Ajoutez simplement un `#` après `.net/`.
+
+<!--
+Let's say you want to create a Playground with specific versions of WordPress and PHP using the following Blueprint:
+-->
+
+Supposons que vous vouliez créer un Playground avec des versions spécifiques de WordPress et de PHP avec le Blueprint suivant :
+
+```json
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "5.9"
+	}
+}
+```
+
+<!--
+To run it, go to `https://playground.wordpress.net/#{"preferredVersions": {"php":"8.3", "wp":"5.9"}}`. You can also use the button below:
+-->
+
+Pour l’exécuter, allez sur `https://playground.wordpress.net/#{"preferredVersions": {"php":"8.3", "wp":"5.9"}}`. Vous pouvez aussi utiliser le bouton ci-dessous :
+
+[<kbd> &nbsp; Exécuter le Blueprint &nbsp; </kbd>](https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"5.9"}})
+
+<!--
+Use this method to run the example code in the next chapter, [**Build your first Blueprint**](/blueprints/tutorial/build-your-first-blueprint).
+-->
+
+Utilisez cette méthode pour exécuter l’exemple de code du chapitre suivant, [**Créer votre premier Blueprint**](/blueprints/tutorial/build-your-first-blueprint).
+
+<!--
+### Encoded Blueprint fragments
+-->
+
+### Fragments de Blueprint encodés
+
+<!--
+When you build a Playground link from JavaScript or an automation tool, encode the Blueprint JSON once with `encodeURIComponent(JSON.stringify(blueprint))` and append it after `#`.
+-->
+
+Lorsque vous créez un lien Playground depuis JavaScript ou un outil d’automatisation, encodez le JSON du Blueprint une seule fois avec `encodeURIComponent(JSON.stringify(blueprint))` et ajoutez-le après `#`.
+
+<!--
+Playground also supports [Base64-encoded Blueprints](https://www.base64encode.org), which are useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
+-->
+
+Playground prend également en charge les [Blueprints encodés en Base64](https://www.base64encode.org), qui sont utiles lorsqu’une plateforme modifie les fragments JSON ou lorsque vous voulez un lien compact et facile à copier. Par exemple, voici le Blueprint ci-dessus au format Base64 : `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
+
+<!--
+To run it, go to [https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19](https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19)
+-->
+
+Pour l’exécuter, allez sur [https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19](https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19)
+
+<!--
+### Load Blueprint from a URL
+-->
+
+### Charger un Blueprint depuis une URL
+
+<!--
+When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this:
+-->
+
+Lorsque votre Blueprint devient trop difficile à gérer, vous pouvez le charger avec le paramètre de requête `?blueprint-url` dans l’URL, comme ceci :
+
+[https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
+
+<!--
+Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
+-->
+
+Notez que le Blueprint doit être accessible publiquement et servi avec [le bon en-tête `Access-Control-Allow-Origin`](https://developer.mozilla.org/fr/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin) :
+
+```
+Access-Control-Allow-Origin: *
+```

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
@@ -13,14 +13,14 @@ Você pode usar Blueprints de uma das seguintes maneiras:
 <!-- -   By passing them as a URL fragment to the Playground. -->
 
 - Passando-os como um fragmento de URL para o Playground.
-  <!-- -   By loading them from a URL using the `blueprint-url` parameter. -->
+    <!-- -   By loading them from a URL using the `blueprint-url` parameter. -->
 - Carregando-os de uma URL usando o parâmetro `blueprint-url`.
-  <!-- -   By using Blueprint bundles (ZIP files or directories). -->
+    <!-- -   By using Blueprint bundles (ZIP files or directories). -->
 - Usando pacotes de Blueprint (arquivos ZIP ou diretórios).
-  <!-- -   By using the JavaScript API. -->
+    <!-- -   By using the JavaScript API. -->
 - Usando a API JavaScript.
 
-## Fragmento de URL
+## Fragmento de URL {#url-fragment}
 
 <!-- The easiest way to start using Blueprints is to paste one into the URL "fragment" on WordPress Playground website, e.g. `https://playground.wordpress.net/#{"preferredVersions...`. -->
 
@@ -64,6 +64,8 @@ const blueprintJson = `{
 	}
 }`;
 const minifiedBlueprintJson = JSON.stringify(JSON.parse(blueprintJson)); // {"preferredVersions":{"php":"8.3","wp":"6.5"}}
+const encodedBlueprint = encodeURIComponent(minifiedBlueprintJson);
+const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
 ```
 
 :::
@@ -81,11 +83,26 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 	}
 }} />
 
-### Blueprints codificados em Base64
+### Fragmentos de Blueprint codificados
 
-<!-- Some tools, including GitHub, might not format the Blueprint correctly when pasted into the URL. In such cases, encode your Blueprint in Base64 and append it to the URL. For example, that's the above Blueprint in Base64 format: -->
+<!-- When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`: -->
 
-Algumas ferramentas, incluindo GitHub, podem não formatar o Blueprint corretamente quando colado na URL. Nesses casos, codifique seu Blueprint em Base64 e anexe-o à URL. Por exemplo, este é o Blueprint acima em formato Base64: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+Ao criar links do Playground a partir de JavaScript ou ferramentas de automação, codifique o JSON minificado uma vez com `encodeURIComponent()` e adicione-o depois de `#`:
+
+```js
+const blueprint = {
+	$schema: 'https://playground.wordpress.net/blueprint-schema.json',
+	preferredVersions: {
+		php: '8.3',
+		wp: '6.5',
+	},
+};
+const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
+```
+
+<!-- Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: -->
+
+O Playground também oferece suporte a Blueprints codificados em Base64. Base64 é útil quando uma plataforma modifica fragmentos JSON ou quando você quer um link compacto e fácil de copiar. Por exemplo, este é o Blueprint acima em formato Base64: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
 
 <!-- To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19 -->
 
@@ -166,7 +183,7 @@ Ao usar um pacote de Blueprint, você pode referenciar recursos empacotados usan
 
 Para mais informações sobre pacotes de Blueprint, consulte a documentação de [Pacotes de Blueprint](/blueprints/bundles).
 
-## API JavaScript
+## API JavaScript {#javascript-api}
 
 <!-- You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen: -->
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -16,9 +16,21 @@ description: Um guia com dicas e ferramentas para ajudar você a solucionar prob
 
 ## Problemas e Soluções Comuns
 
+<!-- Invalid Blueprint After Opening a Link -->
+
+### Blueprint inválido após abrir um link
+
+<!-- If Playground reports `Invalid blueprint`, read the detailed error message. It includes the underlying JSON parsing error when one is available. -->
+
+Se o Playground informar `Invalid blueprint`, leia a mensagem de erro detalhada. Ela inclui o erro de análise JSON subjacente quando ele estiver disponível.
+
+<!-- If the message says the input still contains `%XX` escapes after decoding, the URL fragment was likely double-encoded. Rebuild the link from the original Blueprint object and encode it once with `encodeURIComponent(JSON.stringify(blueprint))`, or use Base64. Do not encode a fragment that is already encoded. -->
+
+Se a mensagem disser que a entrada ainda contém escapes `%XX` após a decodificação, o fragmento de URL provavelmente foi codificado duas vezes. Recrie o link a partir do objeto Blueprint original e codifique-o uma vez com `encodeURIComponent(JSON.stringify(blueprint))`, ou use Base64. Não codifique um fragmento que já está codificado.
+
 <!-- WP-CLI: Error Establishing a Database Connection on Mounted Sites -->
 
-### WP-CLI: Erro ao Estabelecer Conexão com Banco de Dados em Sites Montados
+### WP-CLI: Erro ao Estabelecer Conexão com Banco de Dados em Sites Montados {#wp-cli-error-establishing-a-database-connection-on-mounted-sites}
 
 <!-- When using `wp-cli` with a mounted Playground site (e.g., via `--mount-before-install`), you might encounter an "Error establishing a database connection." This happens because WordPress Playground loads the SQLite database integration plugin from its internal files by default, not from the mounted directory, meaning it's not persisted for external `wp-cli` calls. -->
 
@@ -114,15 +126,15 @@ Você pode usar `error_log` para suas próprias mensagens de erro através da [e
 
 <!-- Log errors snapshot -->
 
-![Captura de tela de erros de log](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
+![Captura de tela de erros de log](@site/static/img/blueprints/log-errors.webp)
 
 <!-- :::info When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance. ::: -->
 
-<div class="callout callout-info">
+:::info
 
 Quando você baixa sua instância do Playground como um `zip` através da opção ["Baixar como zip"](/web-instance#playground-options-menu), você também baixa o arquivo `debug.log` contendo todos os logs de sua instância do Playground.
 
-</div>
+:::
 
 <!-- Ask for help -->
 

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/tutorial/02-how-to-load-run-blueprints.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/tutorial/02-how-to-load-run-blueprints.md
@@ -60,15 +60,19 @@ Para executá-lo, acesse `https://playground.wordpress.net/#{"preferredVersions"
 
 Use este método para executar o código de exemplo no próximo capítulo, [**Crie seu primeiro Blueprint**](/blueprints/tutorial/build-your-first-blueprint).
 
-<!-- Base64 encoded Blueprints
+<!-- Encoded Blueprint fragments
 
-Some tools, including GitHub, might not format the Blueprint correctly when pasted into the URL. In such cases, [encode your Blueprint in Base64](https://www.base64encode.org) and append it to the URL. For example, that's the above Blueprint in Base64 format: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
+When you build a Playground link from JavaScript or an automation tool, encode the Blueprint JSON once with `encodeURIComponent(JSON.stringify(blueprint))` and append it after `#`.
+
+Playground also supports [Base64-encoded Blueprints](https://www.base64encode.org), which are useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
 
 To run it, go to [https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19](https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19) -->
 
-### Blueprints codificados em Base64
+### Fragmentos de Blueprint codificados
 
-Algumas ferramentas, incluindo o GitHub, podem não formatar o Blueprint corretamente quando colado na URL. Nesses casos, [codifique seu Blueprint em Base64](https://www.base64encode.org) e anexe-o à URL. Por exemplo, esse é o Blueprint acima em formato Base64: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
+Ao criar um link do Playground a partir de JavaScript ou de uma ferramenta de automação, codifique o JSON do Blueprint uma vez com `encodeURIComponent(JSON.stringify(blueprint))` e adicione-o depois de `#`.
+
+O Playground também oferece suporte a [Blueprints codificados em Base64](https://www.base64encode.org), que são úteis quando uma plataforma modifica fragmentos JSON ou quando você quer um link compacto e fácil de copiar. Por exemplo, esse é o Blueprint acima em formato Base64: `eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19`.
 
 Para executá-lo, acesse [https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19](https://playground.wordpress.net/#eyJwcmVmZXJyZWRWZXJzaW9ucyI6IHsicGhwIjoiNy40IiwgIndwIjoiNS45In19)
 


### PR DESCRIPTION
## Motivation for the change, related issues

Website now supports the `encodeURIComponent` feature included on PR #3527. This pull request includes examples and updates the tutorials with related content. 

## Implementation details
Updated the following pages in English, Spanish, Portuguese and French:
- packages/docs/site/docs/blueprints/02-using-blueprints.md
- packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
- packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md

## Testing Instructions (or ideally a Blueprint)
1. Pull the branch `update-docs-blueprint-url`
2. Install the packages 
3. Run the command `npm run dev:docs`
4. Review the content on the pages