### PR TITLE
[Website] <php-snippet> – display expected output by default

### DIFF
--- a/packages/playground/website/.htaccess
+++ b/packages/playground/website/.htaccess
@@ -5,7 +5,7 @@ AddEncoding x-gzip .gz
 Header unset ETag
 Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
 </FilesMatch>
-<FilesMatch "index\.js|blueprint-schema\.json|logger.php|wp-cli.phar|wordpress-importer.zip">
+<FilesMatch "index\.js|blueprint-schema\.json|logger.php|wp-cli.phar|wordpress-importer.zip|php-code-snippet\.js">
 Header set Access-Control-Allow-Origin "*"
 Header unset ETag
 Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -23,6 +23,7 @@ test.describe('php-code-snippet embed', () => {
 			'greet-alice.php',
 			'greet-bob.php',
 			'scratch.php',
+			'precomputed.php',
 		]) {
 			const snippet = page.locator(`php-snippet[name="${name}"]`);
 			await expect(snippet).toBeVisible();
@@ -163,5 +164,31 @@ test.describe('php-code-snippet embed', () => {
 		await expect(editable.locator('.output-body')).toContainText(
 			'edited:42'
 		);
+	});
+
+	test('expected output shows before Run and is replaced by real output', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const snippet = page.locator('php-snippet[name="precomputed.php"]');
+
+		await expect(snippet.locator('.progress')).toBeHidden();
+		await expect(snippet.locator('.output')).toBeVisible();
+		await expect(snippet.locator('.output-body')).toContainText(
+			'2 + 2 = 4'
+		);
+
+		await snippet.locator('.run').click();
+		await expect(snippet.locator('.progress')).toBeVisible();
+		await expect(snippet.locator('.output')).toBeVisible({
+			timeout: 240_000,
+		});
+		await expect(snippet.locator('.output-body')).toContainText(
+			'WordPress is awesome.'
+		);
+		await expect(snippet.locator('.progress')).toBeHidden();
+		await expect(
+			page.locator('iframe[title="PHP Snippet runtime"]')
+		).toHaveCount(1);
 	});
 });

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -148,12 +148,13 @@ echo "Product: " . array_product($nums) . "\n";
 			</script>
 		</php-snippet>
 
-		<h2>6. Expected output (no runtime boot)</h2>
+		<h2>6. Expected output</h2>
 		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
 			When <code>expected-output</code> is provided (as an attribute or a
 			<code>&lt;script type="text/expected-output"&gt;</code> child),
-			clicking Run shows that text immediately without loading the
-			Playground runtime.
+			the snippet displays that text before Run is clicked. Clicking Run
+			still loads the Playground runtime and replaces the placeholder with
+			the real output.
 		</p>
 		<php-snippet name="precomputed.php">
 			<script type="application/x-php">

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -643,7 +643,18 @@ class PhpSnippet extends HTMLElement {
 		this._readCode().then((code) => {
 			this._code = code.trim();
 			this._render();
+			if (this._expectedOutput !== null) {
+				this._showExpectedOutput();
+			}
 		});
+	}
+
+	_showExpectedOutput() {
+		const outputWrap = this.shadowRoot.querySelector('.output');
+		const outputBody = this.shadowRoot.querySelector('.output-body');
+		outputBody.classList.remove('error');
+		outputBody.textContent = this._expectedOutput || '(no output)';
+		outputWrap.classList.add('visible');
 	}
 
 	_readExpectedOutput() {
@@ -748,12 +759,6 @@ class PhpSnippet extends HTMLElement {
 		const outputBody = this.shadowRoot.querySelector('.output-body');
 		btn.disabled = true;
 		outputBody.classList.remove('error');
-		if (this._expectedOutput !== null) {
-			outputBody.textContent = this._expectedOutput || '(no output)';
-			outputWrap.classList.add('visible');
-			btn.disabled = false;
-			return;
-		}
 		progress.classList.add('visible');
 		caption.textContent = 'Loading runtime…';
 		fill.style.width = '0%';


### PR DESCRIPTION
## What it does

Fixes two issues with the `php-snippet` embed:

- `php-code-snippet.js` now gets the same no-cache headers as `index.js` and `blueprint-schema.json`, so external consumers do not keep using stale embed code.
- Expected output is shown immediately when a snippet renders, but clicking `Run` still boots the Playground runtime and executes the PHP.

## Rationale

`expected-output` was acting as a shortcut: once it was present, `Run` only displayed the expected text and returned before loading the runtime. That made it useful as a placeholder, but impossible to verify the actual snippet output from the embed.

The script also was not covered by the existing `.htaccess` no-cache rule, so consumers embedding `php-code-snippet.js` could keep getting an old version after deployments.

## Implementation

The output placeholder now moves to render time:

```js
if (this._expectedOutput !== null) {
	this._showExpectedOutput();
}
```

The `Run` handler no longer returns early for expected output. It always calls `getSharedClient()`, downloads or reuses the runtime, runs the snippet, and replaces the placeholder with `response.text`.

The demo copy and Playwright e2e coverage were updated to assert the intended flow: expected output is visible before clicking `Run`, and a runtime iframe appears after the click.

## Testing instructions

Manual check:

1. Start the website with `npm run dev`.
2. Open `http://localhost:5400/php-code-snippet-demo.html`.
3. Verify `precomputed.php` shows its expected output before clicking `Run`.
4. Click `Run` and verify the progress bar appears, the runtime loads, and the output remains visible after execution.

Local checks run:

- `node --check packages/playground/website/public/php-code-snippet.js`
- `git diff --check`

Full Nx checks were not run in this checkout because `node_modules` are missing, and Nx reports: `Could not find Nx modules in this workspace`.
