### PR TITLE
Avoid php-snippet progress flash for cached runtimes

### DIFF
--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -97,11 +97,40 @@ test.describe('php-code-snippet embed', () => {
 			'loading="lazy"'
 		);
 
+		await expect(third.locator('.progress')).toBeHidden();
+		await third.evaluate((snippet: HTMLElement) => {
+			const progress = snippet.shadowRoot?.querySelector('.progress');
+			if (!progress) {
+				throw new Error('Missing progress element');
+			}
+			const state = {
+				wasVisible: progress.classList.contains('visible'),
+				observer: new MutationObserver(() => {
+					if (progress.classList.contains('visible')) {
+						state.wasVisible = true;
+					}
+				}),
+			};
+			state.observer.observe(progress, {
+				attributes: true,
+				attributeFilter: ['class'],
+			});
+			(snippet as any).__progressVisibilityState = state;
+		});
+
 		// Third snippet — same shared runtime.
 		await third.locator('.run').click();
 		await expect(third.locator('.output')).toBeVisible({
 			timeout: 60_000,
 		});
+		const thirdProgressWasVisible = await third.evaluate(
+			(snippet: HTMLElement) => {
+				const state = (snippet as any).__progressVisibilityState;
+				state.observer.disconnect();
+				return state.wasVisible;
+			}
+		);
+		expect(thirdProgressWasVisible).toBe(false);
 		await expect(third.locator('.output-body')).toContainText(
 			'core/paragraph'
 		);

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -166,7 +166,6 @@ async function getSharedClient(
 	let entry = runtimes.get(key);
 
 	if (entry && entry.client) {
-		onProgress?.({ progress: 100, caption: '' });
 		return entry.client;
 	}
 
@@ -192,6 +191,7 @@ async function getSharedClient(
 			throw err;
 		});
 		runtimes.set(key, entry);
+		onProgress?.({ progress: 0, caption: 'Loading runtime…' });
 	} else {
 		// Boot in flight — replay the latest progress so a late-arriving
 		// snippet shows the same bar position.
@@ -759,7 +759,6 @@ class PhpSnippet extends HTMLElement {
 		const outputBody = this.shadowRoot.querySelector('.output-body');
 		btn.disabled = true;
 		outputBody.classList.remove('error');
-		progress.classList.add('visible');
 		caption.textContent = 'Loading runtime…';
 		fill.style.width = '0%';
 		percent.textContent = '0%';
@@ -777,6 +776,7 @@ class PhpSnippet extends HTMLElement {
 					blueprintKey,
 				},
 				({ progress: pct, caption: cap }) => {
+					progress.classList.add('visible');
 					const rounded = Math.round(pct);
 					fill.style.width = rounded + '%';
 					percent.textContent = rounded + '%';


### PR DESCRIPTION
## What it does

Prevents `<php-snippet>` from briefly showing the runtime progress bar when the shared Playground runtime is already loaded.

## Rationale

The Run handler showed `.progress` before asking `getSharedClient()` for a runtime. Cached clients returned immediately, but the progress bar was still added to the DOM for a frame and then removed in `finally`, creating a visible flash on repeated runs.

## Implementation

Cached runtime lookups no longer emit a synthetic `100%` progress update. The Run handler now reveals the progress bar only from real boot progress callbacks.

Fresh runtime boots still emit an initial `0%` callback so first runs show loading state immediately, and snippets joining an in-flight boot still replay the current progress.

## Testing instructions

Run the php-snippet Playwright coverage:

```bash
npx nx e2e playground-website -- php-code-snippet.spec.ts
```

Local checks run:

```bash
node --check packages/playground/website/public/php-code-snippet.js
git diff --check
```

Full Nx checks were not run locally because this checkout has no `node_modules`; Nx reports: `Could not find Nx modules in this workspace`.
