### PR TITLE
[php-code-snippet] Add wp="none" demo example

### DIFF
--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -24,6 +24,7 @@ test.describe('php-code-snippet embed', () => {
 			'greet-bob.php',
 			'scratch.php',
 			'precomputed.php',
+			'just-php.php',
 		]) {
 			const snippet = page.locator(`php-snippet[name="${name}"]`);
 			await expect(snippet).toBeVisible();

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -165,22 +165,48 @@
 		</php-snippet>
 
 		<h2>6. Expected output</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px;">
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
 			When <code>expected-output</code> is provided (as an attribute or a
-			<code>&lt;script type="text/expected-output"&gt;</code> child),
-			the snippet displays that text before Run is clicked. Clicking Run
-			still loads the Playground runtime and replaces the placeholder with
-			the real output.
+			<code>&lt;script type="text/expected-output"&gt;</code> child), the
+			snippet displays that text before Run is clicked. Clicking Run still
+			loads the Playground runtime and replaces the placeholder with the
+			real output.
 		</p>
 		<php-snippet name="precomputed.php">
 			<script type="application/x-php">
-<?php
-echo "2 + 2 = " . (2 + 2) . "\n";
-echo "WordPress is awesome.";
+				<?php
+				echo "2 + 2 = " . (2 + 2) . "\n";
+				echo "WordPress is awesome.";
 			</script>
 			<script type="text/expected-output">
 				2 + 2 = 4
 				WordPress is awesome.
+			</script>
+		</php-snippet>
+
+		<h2>7. PHP-only (no WordPress)</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			<code>wp="none"</code> boots PHP without downloading or installing
+			WordPress. The PHP runtime still loads, but no
+			<code>wp-*.zip</code> request fires — handy for snippets that
+			showcase plain PHP language features without paying the WP boot
+			cost.
+		</p>
+		<php-snippet name="just-php.php" wp="none">
+			<script type="application/x-php">
+				<?php
+				echo "PHP " . phpversion() . "\n";
+				echo "WordPress installed: " . (file_exists('/wordpress/wp-includes/version.php') ? 'yes' : 'no') . "\n";
+
+				// Pure-PHP feature demo: enums (PHP 8.1+).
+				enum Status: string {
+				    case Draft   = 'draft';
+				    case Pending = 'pending';
+				    case Live    = 'live';
+				}
+				foreach (Status::cases() as $status) {
+				    echo "- {$status->name}: {$status->value}\n";
+				}
 			</script>
 		</php-snippet>
 


### PR DESCRIPTION
## Summary

Adds a 7th section to the `<php-snippet>` demo page that uses `wp="none"` to boot PHP without downloading or installing WordPress. The example uses a small PHP 8.1 enum so it stands on its own without touching `wp-load.php`.

Confirms WP isn't installed via `file_exists('/wordpress/wp-includes/version.php')`.

## Test plan

- [ ] `npx nx e2e playground-website -- --grep "renders all snippets"` — the rendering check now expects the new `just-php.php` snippet too.
- [ ] Open `php-code-snippet-demo.html` and click Run on section 7. Output should show the PHP version, `WordPress installed: no`, and the enum cases. Network tab: no `wp-*.zip` request.