### PR TITLE
[php-snippet] Add non-runnable PHP snippets

### DIFF
--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -32,6 +32,23 @@ test.describe('php-code-snippet embed', () => {
 		}
 	});
 
+	test('runnable=false renders a read-only snippet without Run', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const snippet = page.locator('php-snippet[name="illustration.php"]');
+
+		await expect(snippet).toBeVisible();
+		await expect(snippet.locator('.run')).toHaveCount(0);
+		await expect(snippet.locator('textarea.ta')).toHaveCount(0);
+		await expect(snippet.locator('pre code')).toContainText(
+			'Just an illustration'
+		);
+		await expect(
+			page.locator('iframe[title="PHP Snippet runtime"]')
+		).toHaveCount(0);
+	});
+
 	test('first Run boots the runtime and shows progress + output', async ({
 		page,
 	}) => {
@@ -172,7 +189,7 @@ test.describe('php-code-snippet embed', () => {
 
 	test('editable snippet runs the user-typed code', async ({ page }) => {
 		await page.goto(DEMO_URL);
-		const editable = page.locator('php-snippet[editable]');
+		const editable = page.locator('php-snippet[name="scratch.php"]');
 		await expect(editable).toBeVisible();
 		const textarea = editable.locator('textarea.ta');
 		await expect(textarea).toBeVisible();

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -210,6 +210,17 @@
 			</script>
 		</php-snippet>
 
+		<h2>8. Read-only illustration</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			This snippet is syntax-highlighted but is not meant to execute.
+		</p>
+		<php-snippet name="illustration.php" runnable="false" editable>
+			<script type="application/x-php">
+				<?php
+				echo "Just an illustration";
+			</script>
+		</php-snippet>
+
 		<script type="module" src="./php-code-snippet.js"></script>
 	</body>
 </html>

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -28,6 +28,9 @@
  *                         to boot PHP without installing WordPress — handy for
  *                         pure-PHP snippets that don't touch wp-load.php.
  *   src="path/to.php"     load code from a URL instead of inline
+ *   runnable="false"      hide the Run button and render the snippet as a
+ *                         read-only, syntax-highlighted code block. Useful for
+ *                         illustrative examples that aren't meant to execute.
  *   editable              make the snippet editable; visitors type into a
  *                         transparent textarea overlaid on the highlighted
  *                         code, and Run executes whatever they typed
@@ -759,7 +762,8 @@ class PhpSnippet extends HTMLElement {
 
 	_render() {
 		const name = this.getAttribute('name') || 'snippet.php';
-		const editable = this.hasAttribute('editable');
+		const runnable = this.getAttribute('runnable') !== 'false';
+		const editable = runnable && this.hasAttribute('editable');
 		const style = document.createElement('style');
 		style.textContent = TEMPLATE_CSS;
 		const codeArea = editable
@@ -773,7 +777,7 @@ class PhpSnippet extends HTMLElement {
 			<div class="card">
 				<div class="header">
 					<span class="name">${escapeHtml(name)}</span>
-					<button class="run" type="button">Run</button>
+					${runnable ? '<button class="run" type="button">Run</button>' : ''}
 				</div>
 				<div class="progress" role="status" aria-live="polite" aria-atomic="true">
 					<span class="caption">Loading…</span>
@@ -788,9 +792,10 @@ class PhpSnippet extends HTMLElement {
 			</div>
 		`;
 		this.shadowRoot.replaceChildren(style, tpl.content);
-		this.shadowRoot
-			.querySelector('.run')
-			.addEventListener('click', () => this._run());
+		const runBtn = this.shadowRoot.querySelector('.run');
+		if (runBtn) {
+			runBtn.addEventListener('click', () => this._run());
+		}
 		if (editable) this._wireEditor();
 	}
 


### PR DESCRIPTION
## What changed

Adds a `runnable="false"` attribute for `<php-snippet>` embeds. Non-runnable snippets render as read-only, syntax-highlighted code blocks without a Run button, and `editable` is ignored because there is no execution path.

The demo page now includes a read-only illustration example, and the Playwright coverage asserts that it has no Run button, no editor textarea, and does not create a runtime iframe on render.

## Validation

- `npm exec nx lint playground-website`
- `./node_modules/.bin/nx run playground-website:e2e:playwright --args="--grep runnable=false --project=chromium"`

Note: the narrowed Playwright run passed, though the website dev server logged existing missing `isomorphic-git/src/...` imports during startup. The static regression did not depend on those imports.