### PR TITLE
wp_mysql_parser: conditional WASM loader for PHP 8.4 (draft, stacked)

### DIFF
--- a/packages/php-wasm/node/src/lib/extensions/wp-mysql-parser/with-wp-mysql-parser.ts
+++ b/packages/php-wasm/node/src/lib/extensions/wp-mysql-parser/with-wp-mysql-parser.ts
@@ -1,0 +1,65 @@
+import {
+	type EmscriptenOptions,
+	type PHPRuntime,
+	type SupportedPHPVersion,
+	installPHPExtensionFilesSync,
+	PHP_EXTENSIONS_DIR,
+} from '@php-wasm/universal';
+import fs from 'fs';
+
+export interface WpMysqlParserOptions {
+	/**
+	 * Absolute path on the host filesystem to a `wp_mysql_parser.so` side
+	 * module compiled for the target PHP version and async mode.
+	 *
+	 * The extension itself lives at
+	 * https://github.com/WordPress/sqlite-database-integration/pull/381
+	 * and is not yet packaged with Playground; users build it themselves
+	 * (or fetch it from a release artifact) and pass the path via
+	 * `--wp-mysql-parser-so=<path>` on the CLI.
+	 */
+	soPath: string;
+}
+
+/*
+ * The PR #381 build hasn't been validated against earlier PHP versions
+ * yet, so this run only wires it up for PHP 8.4. Widening to other
+ * versions is a one-line change once we have artifacts to test against.
+ */
+const SUPPORTED_VERSIONS: ReadonlyArray<SupportedPHPVersion> = ['8.4'];
+
+export async function withWpMysqlParser(
+	version: SupportedPHPVersion,
+	options: EmscriptenOptions,
+	wpMysqlParserOptions: WpMysqlParserOptions
+): Promise<EmscriptenOptions> {
+	if (!SUPPORTED_VERSIONS.includes(version)) {
+		throw new Error(
+			`withWpMysqlParser: only PHP ${SUPPORTED_VERSIONS.join(
+				', '
+			)} are supported in this build; got ${version}.`
+		);
+	}
+
+	const soBytes = new Uint8Array(
+		fs.readFileSync(wpMysqlParserOptions.soPath)
+	);
+
+	return {
+		...options,
+		ENV: {
+			...options.ENV,
+			PHP_INI_SCAN_DIR: PHP_EXTENSIONS_DIR,
+		},
+		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
+			if (options.onRuntimeInitialized) {
+				options.onRuntimeInitialized(phpRuntime);
+			}
+
+			installPHPExtensionFilesSync(phpRuntime.FS, {
+				name: 'wp_mysql_parser',
+				soBytes,
+			});
+		},
+	};
+}

--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -25,6 +25,10 @@ import {
 import { withIntl } from './extensions/intl/with-intl';
 import { withRedis } from './extensions/redis/with-redis';
 import { withMemcached } from './extensions/memcached/with-memcached';
+import {
+	withWpMysqlParser,
+	type WpMysqlParserOptions,
+} from './extensions/wp-mysql-parser/with-wp-mysql-parser';
 import { dirname, joinPaths, toPosixPath } from '@php-wasm/util';
 import { platform } from 'os';
 
@@ -34,6 +38,7 @@ export interface PHPLoaderOptions {
 	withIntl?: boolean;
 	withRedis?: boolean;
 	withMemcached?: boolean;
+	withWpMysqlParser?: WpMysqlParserOptions;
 }
 
 export type PHPLoaderOptionsForNode = PHPLoaderOptions & {
@@ -342,6 +347,13 @@ export async function loadNodeRuntime(
 			emscriptenOptions = await withMemcached(
 				modernVersion,
 				emscriptenOptions
+			);
+		}
+		if (options?.withWpMysqlParser) {
+			emscriptenOptions = await withWpMysqlParser(
+				modernVersion,
+				emscriptenOptions,
+				options.withWpMysqlParser
 			);
 		}
 	}

--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -201,6 +201,7 @@ export class BlueprintsV1Handler {
 			withRedis: this.args.redis,
 			withMemcached: this.args.memcached,
 			withXdebug: !!this.args.xdebug,
+			withWpMysqlParserSo: this.args['wp-mysql-parser-so'],
 			nativeInternalDirPath,
 			pathAliases: this.args.pathAliases,
 		});

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -52,6 +52,7 @@ interface WorkerBootRequestHandlerOptions {
 	withRedis?: boolean;
 	withMemcached?: boolean;
 	withXdebug?: boolean;
+	withWpMysqlParserSo?: string;
 	pathAliases?: PathAlias[];
 }
 
@@ -251,6 +252,9 @@ function createPhpRuntimeFactory(
 				withRedis: options.withRedis,
 				withMemcached: options.withMemcached,
 				withXdebug: options.withXdebug,
+				withWpMysqlParser: options.withWpMysqlParserSo
+					? { soPath: options.withWpMysqlParserSo }
+					: undefined,
 			}
 		);
 	};

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -299,6 +299,14 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				type: 'boolean',
 				default: false,
 			},
+			'wp-mysql-parser-so': {
+				describe:
+					'Path to a wp_mysql_parser.so side module compiled for the ' +
+					'target PHP version. Only PHP 8.4 is supported in this build. ' +
+					'See https://github.com/WordPress/sqlite-database-integration/pull/381',
+				type: 'string',
+				normalize: true,
+			},
 			'experimental-unsafe-ide-integration': {
 				describe:
 					'Enable experimental IDE development tools. This option edits IDE config files ' +
@@ -890,6 +898,7 @@ export interface RunCLIArgs {
 	redis?: boolean;
 	memcached?: boolean;
 	xdebug?: boolean | XdebugOptions;
+	'wp-mysql-parser-so'?: string;
 	experimentalUnsafeIdeIntegration?: string[];
 	experimentalDevtools?: boolean;
 	'experimental-blueprints-v2-runner'?: boolean;


### PR DESCRIPTION
Stacked on #3547. Third PR in the chain exploring extension loading.

## What

Wires the MySQL lexer/parser extension from WordPress/sqlite-database-integration#381 into Playground as a side module. Gated to PHP 8.4 in this run while we have no broader build matrix to test against — other versions throw a clear error at boot.

## How to use

The .so isn't bundled (no published artifact yet). Build the extension from PR #381 and pass the path:

\`\`\`
npx @wp-playground/cli server --php=8.4 \
    --wp-mysql-parser-so=/path/to/wp_mysql_parser.so
\`\`\`

## Implementation

- New \`with-wp-mysql-parser.ts\` wrapper, same shape as \`with-xdebug\` / \`with-intl\` after the refactor in #3547. Calls \`installPHPExtensionFilesSync\` in \`onRuntimeInitialized\`.
- Plumbed through Blueprints v1: \`run-cli.ts\` → \`blueprints-v1-handler.ts\` → \`worker-thread-v1.ts\` → \`loadNodeRuntime\` → \`withWpMysqlParser\`.
- The version gate is in the wrapper itself (\`SUPPORTED_VERSIONS = ['8.4']\`) so widening is a one-line change.

## Out of scope

- Blueprints v2 plumbing
- Browser-side loader (this wrapper is node-only — it \`fs.readFileSync\`s the .so; a web counterpart would \`fetch\` it)
- Bundling a prebuilt artifact into a per-version package like \`@php-wasm/wp-mysql-parser-8-4\` (mirroring how Xdebug ships)
- A blueprint-step variant — the generic \`loadPHPExtension\` step from #3545 already covers the URL-fetch case

## Test plan

- [ ] Build wp_mysql_parser.so against PHP 8.4 JSPI, run \`server --php=8.4 --wp-mysql-parser-so=...\`, verify \`extension_loaded('wp_mysql_parser')\` is true
- [ ] Pass --php=8.3 with --wp-mysql-parser-so and confirm the clear error message
- [ ] Confirm Xdebug + intl still work (they share installPHPExtensionFilesSync via #3547)