### PR TITLE
compile-extension: add Rust extension recipe (draft, stacked)

### DIFF
--- a/packages/php-wasm/compile-extension/README.md
+++ b/packages/php-wasm/compile-extension/README.md
@@ -19,6 +19,54 @@ Docker is required. The build reuses the `packages/php-wasm/compile` base image
 and its PHP patch set, then runs `phpize`, `emconfigure`, and `emmake` inside
 the container.
 
+## Languages
+
+The CLI auto-detects the source language:
+
+- A `Cargo.toml` next to the source ⇒ **Rust** (built via `cargo build
+  --target=wasm32-unknown-emscripten`, see [Rust extensions](#rust-extensions)).
+- A `config.m4` next to the source ⇒ **C** (built via `phpize` + `emconfigure`).
+
+Override with `--language=rust|c` if the auto-detect picks the wrong one.
+
+## Rust extensions
+
+Pass a Rust crate that uses [`ext-php-rs`](https://crates.io/crates/ext-php-rs)
+with `crate-type = ["cdylib"]`:
+
+```toml
+[package]
+name = "wp_mysql_parser"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "wp_mysql_parser"
+crate-type = ["cdylib"]
+
+[dependencies]
+ext-php-rs = "0.12"
+```
+
+Then run the helper exactly as for a C extension:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./wp-mysql-parser \
+	--php-versions 8.4 \
+	--async-modes jspi
+```
+
+Under the hood, the helper layers a Rust toolchain onto the base PHP-cross
+image (`Dockerfile.rust-ext`), adds the `wasm32-unknown-emscripten` target,
+and runs `cargo build --release` with `-C link-arg=-sSIDE_MODULE=1` plus the
+matching JSPI/Asyncify flags. `bindgen` (driven by `ext-php-rs`'s `build.rs`)
+runs on the host CPU against the cross-compiled PHP headers staged at
+`/usr/local/include/php`.
+
+PHP 8.0+ is required for Rust extensions because `ext-php-rs` does not target
+the PHP 7 ABI.
+
 ## Loading the result
 
 Host the entire output directory somewhere static and pass the manifest URL to

--- a/packages/php-wasm/compile-extension/docker/Dockerfile.rust-ext
+++ b/packages/php-wasm/compile-extension/docker/Dockerfile.rust-ext
@@ -1,0 +1,102 @@
+#
+# Rust extension build image.
+#
+# Layered on top of the PHP-cross-compile image produced by Dockerfile.ext:
+# we reuse its Emscripten toolchain, its cross-built PHP install at
+# /usr/local, and the PHP headers under /usr/local/include/php so
+# `bindgen` (driven by ext-php-rs's build.rs) can run on the host CPU
+# while the final cdylib is linked for wasm32-unknown-emscripten.
+#
+# We do NOT replace `phpize`-based builds — this image is selected only
+# when --language=rust (auto-detected from a Cargo.toml in the source).
+#
+FROM playground-php-wasm:base AS php-headers
+
+ARG PHP_VERSION
+ARG JSPI="no"
+
+RUN apt-get update && apt-get install -y bison
+
+RUN git clone https://github.com/php/php-src.git /root/php-src \
+	--branch php-$PHP_VERSION \
+	--single-branch \
+	--depth 1
+
+RUN cd /root/php-src && ./buildconf --force
+
+COPY ./compile/php/php*.patch /root/
+RUN cd /root && git apply --no-index /root/php${PHP_VERSION:0:3}*.patch -v
+
+RUN source /root/emsdk/emsdk_env.sh && \
+	cd /root/php-src && \
+	emconfigure ./configure \
+	--disable-fiber-asm \
+	--enable-embed \
+	--disable-cgi \
+	--disable-opcache-jit \
+	--disable-opcache \
+	--disable-phpdbg \
+	--without-pcre-jit \
+	--disable-cli \
+	--disable-libxml \
+	--without-libxml \
+	--disable-dom \
+	--disable-xml \
+	--disable-simplexml \
+	--disable-xmlreader \
+	--disable-xmlwriter \
+	--without-sqlite3 \
+	--without-pdo-sqlite \
+	--without-iconv
+
+RUN /root/replace.sh 's/ZEND_USE_ASM_ARITHMETIC 1/ZEND_USE_ASM_ARITHMETIC 0/g' /root/php-src/Zend/zend_operators.h
+RUN /root/replace.sh 's/defined\(__GNUC__\)/0/g' /root/php-src/Zend/zend_multiply.h
+RUN /root/replace.sh 's/defined\(__GNUC__\)/0/g' /root/php-src/Zend/zend_cpuinfo.c
+RUN /root/replace.sh 's/defined\(__clang__\)/0/g' /root/php-src/Zend/zend_cpuinfo.c
+
+RUN source /root/emsdk/emsdk_env.sh && \
+	cd /root/php-src && \
+	emmake make install
+
+RUN mkdir -p /usr/local/include/php/ext/standard && \
+	if [ -f /root/php-src/ext/standard/php_smart_string.h ]; then \
+		cp /root/php-src/ext/standard/*.h /usr/local/include/php/ext/standard/; \
+	else \
+		echo '#include "Zend/zend_smart_string.h"' > /usr/local/include/php/ext/standard/php_smart_string.h; \
+	fi && \
+	if [ -d /root/php-src/ext/random ]; then \
+		cp /root/php-src/ext/random/*.h /usr/local/include/php/ext/standard/; \
+	fi
+
+#
+# Add the Rust toolchain. We need:
+#   - rustup + a stable toolchain (required by ext-php-rs)
+#   - the wasm32-unknown-emscripten target (third-tier but functional)
+#   - libclang for bindgen (ext-php-rs uses bindgen at build time to
+#     generate Rust FFI from PHP headers)
+#
+ENV RUSTUP_HOME=/root/rustup
+ENV CARGO_HOME=/root/cargo
+ENV PATH="/root/cargo/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y \
+		curl \
+		ca-certificates \
+		clang \
+		llvm-dev \
+		libclang-dev \
+		pkg-config \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+	sh -s -- -y --default-toolchain stable --profile minimal
+
+RUN rustup target add wasm32-unknown-emscripten
+
+# bindgen looks here when LIBCLANG_PATH isn't set; pin it to be safe.
+ENV LIBCLANG_PATH=/usr/lib/llvm-14/lib
+
+COPY ./compile-extension/scripts/build-rust-in-docker.sh /usr/local/bin/build-php-wasm-rust-extension
+RUN chmod +x /usr/local/bin/build-php-wasm-rust-extension
+
+ENTRYPOINT ["/usr/local/bin/build-php-wasm-rust-extension"]

--- a/packages/php-wasm/compile-extension/scripts/build-rust-in-docker.sh
+++ b/packages/php-wasm/compile-extension/scripts/build-rust-in-docker.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+#
+# Build a Rust PHP extension as a wasm32-unknown-emscripten cdylib that
+# Playground can load as a SIDE_MODULE.
+#
+# Required env (set by docker.ts):
+#   EXTENSION_NAME      Output basename (without .so) — also the cdylib name
+#   ASYNC_MODE          jspi | asyncify
+#   PHP_VERSION_SHORT   e.g. 8.4
+#   ARTIFACT_FILENAME   final filename written to /out
+#
+# Optional:
+#   OPTIMIZE            cargo profile (default: release)
+#   EXTRA_CFLAGS        -C link-arg= … forwarded to the linker
+#   EXTRA_LDFLAGS       same; appended after async-mode flags
+#
+set -euo pipefail
+
+if [ ! -d /src ]; then
+	echo "Missing /src extension source mount." >&2
+	exit 1
+fi
+if [ -z "${EXTENSION_NAME:-}" ]; then
+	echo "Missing EXTENSION_NAME." >&2
+	exit 1
+fi
+
+ASYNC_MODE="${ASYNC_MODE:-asyncify}"
+ARTIFACT_FILENAME="${ARTIFACT_FILENAME:-${EXTENSION_NAME}-php${PHP_VERSION_SHORT:-unknown}-${ASYNC_MODE}.so}"
+USER_EXTRA_CFLAGS="${EXTRA_CFLAGS:-}"
+USER_EXTRA_LDFLAGS="${EXTRA_LDFLAGS:-}"
+unset EXTRA_CFLAGS EXTRA_LDFLAGS
+
+rm -rf /build
+mkdir -p /build /out
+cp -R /src/. /build/
+cd /build
+
+source /root/emsdk/emsdk_env.sh
+
+#
+# Side-module link flags.
+#
+# emcc is the linker for wasm32-unknown-emscripten cargo targets, so we
+# pass these via -C link-arg= rather than via LDFLAGS — Cargo only honors
+# the former for the final cdylib link step.
+#
+LINK_ARGS=(
+	"-C" "link-arg=-sSIDE_MODULE=1"
+	"-C" "link-arg=-sWASM_BIGINT"
+	"-C" "link-arg=-fPIC"
+)
+
+if [ "$ASYNC_MODE" = "jspi" ]; then
+	LINK_ARGS+=(
+		"-C" "link-arg=-sSUPPORT_LONGJMP=wasm"
+		"-C" "link-arg=-fwasm-exceptions"
+		"-C" "link-arg=-sJSPI"
+	)
+elif [ "$ASYNC_MODE" = "asyncify" ]; then
+	LINK_ARGS+=(
+		"-C" "link-arg=-sASYNCIFY=1"
+		"-C" "link-arg=-sASYNCIFY_ADVISE"
+	)
+else
+	echo "Unsupported ASYNC_MODE: ${ASYNC_MODE}" >&2
+	exit 1
+fi
+
+for flag in $USER_EXTRA_LDFLAGS; do
+	LINK_ARGS+=("-C" "link-arg=${flag}")
+done
+
+#
+# ext-php-rs's build.rs runs bindgen against PHP headers. Point it at
+# the cross-compiled headers from the base image.
+#
+export PHP_CONFIG="/usr/local/bin/php-config"
+export EXT_PHP_RS_PHP_CONFIG="${PHP_CONFIG}"
+export BINDGEN_EXTRA_CLANG_ARGS="-I/usr/local/include/php -I/usr/local/include/php/main -I/usr/local/include/php/Zend -I/usr/local/include/php/TSRM -I/usr/local/include/php/ext"
+
+#
+# Emscripten's emcc-as-linker needs CC pointed at it explicitly under
+# the Cargo wasm32-unknown-emscripten target.
+#
+export CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_LINKER="emcc"
+export CC_wasm32_unknown_emscripten="emcc"
+export AR_wasm32_unknown_emscripten="emar"
+
+if [ -n "$USER_EXTRA_CFLAGS" ]; then
+	export CFLAGS="${USER_EXTRA_CFLAGS}"
+	export EMCC_CFLAGS="${USER_EXTRA_CFLAGS}"
+fi
+
+cargo build \
+	--release \
+	--target wasm32-unknown-emscripten \
+	--config "build.rustflags=[$(printf '"%s",' "${LINK_ARGS[@]}" | sed 's/,$//')]"
+
+#
+# Cargo writes lib<crate>.so under target/<triple>/release/. The cdylib
+# name follows the [lib].name → [package].name lookup, with hyphens in
+# crate names normalized to underscores.
+#
+crate_basename="$(echo "${EXTENSION_NAME}" | tr '-' '_')"
+candidate="target/wasm32-unknown-emscripten/release/lib${crate_basename}.so"
+if [ ! -f "$candidate" ]; then
+	candidate="$(find target/wasm32-unknown-emscripten/release -maxdepth 1 -name '*.so' -print -quit)"
+fi
+if [ -z "$candidate" ] || [ ! -f "$candidate" ]; then
+	echo "Could not find a Rust-built .so under target/wasm32-unknown-emscripten/release." >&2
+	exit 1
+fi
+
+if [ -x /root/emsdk/upstream/bin/wasm-opt ]; then
+	/root/emsdk/upstream/bin/wasm-opt -Oz \
+		--enable-bulk-memory \
+		--enable-nontrapping-float-to-int \
+		--enable-sign-ext \
+		--enable-mutable-globals \
+		--enable-exception-handling \
+		"$candidate" \
+		-o "$candidate"
+fi
+
+cp "$candidate" "/out/${ARTIFACT_FILENAME}"

--- a/packages/php-wasm/compile-extension/src/cli.ts
+++ b/packages/php-wasm/compile-extension/src/cli.ts
@@ -10,7 +10,11 @@ import {
 	compileExtensionMatrix,
 	SupportedExtensionPHPVersions,
 } from './compile';
-import { detectExtensionName } from './detect';
+import {
+	detectExtensionName,
+	detectLanguage,
+	type ExtensionLanguage,
+} from './detect';
 import type { AsyncMode } from './manifest';
 
 const DefaultAsyncModes: AsyncMode[] = ['jspi', 'asyncify'];
@@ -72,6 +76,12 @@ export async function main(args = hideBin(process.argv)) {
 				type: 'number',
 				description: 'Maximum concurrent docker builds.',
 			},
+			language: {
+				type: 'string',
+				choices: ['c', 'rust'] as const,
+				description:
+					'Source language. Defaults to auto-detect: Cargo.toml ⇒ rust, config.m4 ⇒ c.',
+			},
 		})
 		.strict()
 		.help()
@@ -79,9 +89,12 @@ export async function main(args = hideBin(process.argv)) {
 
 	const workspaceRoot = findWorkspaceRoot(process.cwd());
 	const sourceDir = path.resolve(workspaceRoot, argv['source'] as string);
+	const language: ExtensionLanguage =
+		(argv['language'] as ExtensionLanguage | undefined) ??
+		(await detectLanguage(sourceDir));
 	const name =
 		(argv['name'] as string | undefined) ??
-		(await detectExtensionName(sourceDir));
+		(await detectExtensionName(sourceDir, language));
 	const phpVersions = parseCsv(
 		argv['php-versions'] as string,
 		'php-versions'
@@ -94,6 +107,7 @@ export async function main(args = hideBin(process.argv)) {
 		sourceDir,
 		outDir: argv['out'] as string,
 		name,
+		language,
 		phpVersions,
 		asyncModes,
 		extraCflags: argv['extra-cflags'] as string | undefined,

--- a/packages/php-wasm/compile-extension/src/compile.ts
+++ b/packages/php-wasm/compile-extension/src/compile.ts
@@ -9,6 +9,7 @@ import {
 	createDockerContext,
 	runExtensionBuild,
 } from './docker';
+import type { ExtensionLanguage } from './detect';
 import type { AsyncMode, BuiltArtifact } from './manifest';
 import { createManifest, writeManifest } from './manifest';
 
@@ -37,6 +38,7 @@ export interface CompileExtensionOptions {
 	sourceDir: string;
 	outDir: string;
 	name: string;
+	language: ExtensionLanguage;
 	phpVersions: string[];
 	asyncModes: AsyncMode[];
 	extraCflags?: string;
@@ -72,6 +74,7 @@ export async function compileExtensionMatrix(
 				phpVersion,
 				phpRelease,
 				asyncMode,
+				language: options.language,
 			});
 			await runExtensionBuild({
 				...context,
@@ -86,6 +89,7 @@ export async function compileExtensionMatrix(
 				extraCflags: options.extraCflags,
 				extraLdflags: options.extraLdflags,
 				configArgs: options.configArgs,
+				language: options.language,
 			});
 			return {
 				phpVersion,

--- a/packages/php-wasm/compile-extension/src/detect.spec.ts
+++ b/packages/php-wasm/compile-extension/src/detect.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { detectExtensionNameFromConfig } from './detect';
+import {
+	detectExtensionNameFromConfig,
+	detectRustCrateNameFromCargo,
+} from './detect';
 
 describe('detectExtensionNameFromConfig', () => {
 	it('detects PHP_ARG_ENABLE names', () => {
@@ -25,5 +28,27 @@ describe('detectExtensionNameFromConfig', () => {
 				'PHP_NEW_EXTENSION([hello], hello.c, $ext_shared)'
 			)
 		).toBe('hello');
+	});
+});
+
+describe('detectRustCrateNameFromCargo', () => {
+	it('reads [package].name', () => {
+		expect(
+			detectRustCrateNameFromCargo(
+				`[package]\nname = "wp_mysql_parser"\nversion = "0.1.0"\n`
+			)
+		).toBe('wp_mysql_parser');
+	});
+
+	it('prefers [lib].name when set', () => {
+		expect(
+			detectRustCrateNameFromCargo(
+				`[package]\nname = "wp-mysql-parser"\n[lib]\nname = "wp_mysql_parser"\n`
+			)
+		).toBe('wp_mysql_parser');
+	});
+
+	it('returns null when no package name is present', () => {
+		expect(detectRustCrateNameFromCargo(`[dependencies]\nfoo = "1"\n`)).toBeNull();
 	});
 });

--- a/packages/php-wasm/compile-extension/src/detect.ts
+++ b/packages/php-wasm/compile-extension/src/detect.ts
@@ -1,5 +1,7 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import path from 'node:path';
+
+export type ExtensionLanguage = 'c' | 'rust';
 
 const EXTENSION_NAME_PATTERNS = [
 	/\bPHP_ARG_ENABLE\(\s*\[?([A-Za-z0-9_]+)\]?/m,
@@ -7,7 +9,39 @@ const EXTENSION_NAME_PATTERNS = [
 	/\bPHP_NEW_EXTENSION\(\s*\[?([A-Za-z0-9_]+)\]?/m,
 ];
 
-export async function detectExtensionName(sourceDir: string): Promise<string> {
+/**
+ * Decides the language by what's on disk:
+ *   - `Cargo.toml` ⇒ rust
+ *   - `config.m4` ⇒ c
+ *
+ * If neither exists we throw; if both exist we prefer rust because that
+ * matches how Rust extensions ship today (a `Cargo.toml` plus an empty
+ * stub `config.m4` from `phpize` is rare in practice).
+ */
+export async function detectLanguage(
+	sourceDir: string
+): Promise<ExtensionLanguage> {
+	const hasCargo = await pathExists(path.join(sourceDir, 'Cargo.toml'));
+	if (hasCargo) {
+		return 'rust';
+	}
+	const hasConfigM4 = await pathExists(path.join(sourceDir, 'config.m4'));
+	if (hasConfigM4) {
+		return 'c';
+	}
+	throw new Error(
+		`Could not detect language: ${sourceDir} has neither Cargo.toml nor config.m4. ` +
+			`Pass --language=rust|c explicitly.`
+	);
+}
+
+export async function detectExtensionName(
+	sourceDir: string,
+	language: ExtensionLanguage = 'c'
+): Promise<string> {
+	if (language === 'rust') {
+		return detectRustCrateName(sourceDir);
+	}
 	const configPath = path.join(sourceDir, 'config.m4');
 	let config: string;
 	try {
@@ -36,4 +70,68 @@ export function detectExtensionNameFromConfig(config: string): string | null {
 		}
 	}
 	return null;
+}
+
+/*
+ * For Rust extensions, the on-disk filename of the cdylib is derived from
+ * `[package].name` (or `[lib].name`, if set) in Cargo.toml. We only need
+ * a tiny TOML reader here — pulling in a full parser would be overkill.
+ */
+export async function detectRustCrateName(sourceDir: string): Promise<string> {
+	const cargoPath = path.join(sourceDir, 'Cargo.toml');
+	let cargo: string;
+	try {
+		cargo = await readFile(cargoPath, 'utf8');
+	} catch (error) {
+		throw new Error(
+			`Could not read ${cargoPath}. Pass --name explicitly.`,
+			{ cause: error }
+		);
+	}
+	const detected = detectRustCrateNameFromCargo(cargo);
+	if (!detected) {
+		throw new Error(
+			`Could not detect the crate name from ${cargoPath}. Pass --name explicitly.`
+		);
+	}
+	return detected;
+}
+
+export function detectRustCrateNameFromCargo(cargo: string): string | null {
+	// Prefer [lib].name when set — that's what controls the cdylib filename.
+	const lib = matchTableScalar(cargo, 'lib', 'name');
+	if (lib) {
+		return lib;
+	}
+	return matchTableScalar(cargo, 'package', 'name');
+}
+
+function matchTableScalar(
+	text: string,
+	table: string,
+	key: string
+): string | null {
+	const tableHeader = new RegExp(`^\\[\\s*${table}\\s*\\]`, 'm');
+	const start = tableHeader.exec(text);
+	if (!start) {
+		return null;
+	}
+	const after = text.slice(start.index + start[0].length);
+	const next = /^\[/m.exec(after);
+	const section = next ? after.slice(0, next.index) : after;
+	const keyPattern = new RegExp(
+		`^\\s*${key}\\s*=\\s*"([^"\\n]+)"\\s*$`,
+		'm'
+	);
+	const match = keyPattern.exec(section);
+	return match ? match[1] : null;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+	try {
+		await stat(p);
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/packages/php-wasm/compile-extension/src/docker.ts
+++ b/packages/php-wasm/compile-extension/src/docker.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import path from 'node:path';
 
+import type { ExtensionLanguage } from './detect';
 import type { AsyncMode } from './manifest';
 
 export interface DockerBuildContext {
@@ -13,6 +14,7 @@ export interface DockerImageOptions extends DockerBuildContext {
 	phpVersion: string;
 	phpRelease: string;
 	asyncMode: AsyncMode;
+	language: ExtensionLanguage;
 }
 
 export interface DockerRunOptions extends DockerImageOptions {
@@ -58,12 +60,16 @@ export async function buildExtensionImage(
 	options: DockerImageOptions
 ): Promise<string> {
 	const imageTag = getExtensionImageTag(options);
+	const dockerfile =
+		options.language === 'rust'
+			? 'compile-extension/docker/Dockerfile.rust-ext'
+			: 'compile-extension/docker/Dockerfile.ext';
 	await runCommand(
 		'docker',
 		[
 			'build',
 			'-f',
-			'compile-extension/docker/Dockerfile.ext',
+			dockerfile,
 			'.',
 			`--tag=${imageTag}`,
 			'--progress=plain',
@@ -102,6 +108,8 @@ export async function runExtensionBuild(options: DockerRunOptions) {
 		`OPTIMIZE=${options.optimize}`,
 		'--env',
 		`CONFIG_ARGS_COUNT=${options.configArgs.length}`,
+		'--env',
+		`LANGUAGE=${options.language}`,
 	];
 
 	if (options.extraCflags) {
@@ -123,10 +131,11 @@ export async function runExtensionBuild(options: DockerRunOptions) {
 }
 
 function getExtensionImageTag(
-	options: Pick<DockerImageOptions, 'phpVersion' | 'asyncMode'>
+	options: Pick<DockerImageOptions, 'phpVersion' | 'asyncMode' | 'language'>
 ) {
 	const phpVersion = options.phpVersion.replaceAll('.', '-');
-	return `playground-php-wasm:compile-extension-php${phpVersion}-${options.asyncMode}`;
+	const langSuffix = options.language === 'rust' ? '-rust' : '';
+	return `playground-php-wasm:compile-extension-php${phpVersion}-${options.asyncMode}${langSuffix}`;
 }
 
 interface RunCommandOptions {

--- a/packages/php-wasm/compile-extension/tests/fixtures/hello-rs/Cargo.toml
+++ b/packages/php-wasm/compile-extension/tests/fixtures/hello-rs/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "playground_hello_rs"
+version = "0.1.0"
+edition = "2021"
+
+# Mirrors the C `hello` fixture: smallest possible ext-php-rs extension
+# that we can boot under PHP.wasm to confirm the Rust pipeline works.
+
+[lib]
+name = "playground_hello_rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+ext-php-rs = "0.12"

--- a/packages/php-wasm/compile-extension/tests/fixtures/hello-rs/src/lib.rs
+++ b/packages/php-wasm/compile-extension/tests/fixtures/hello-rs/src/lib.rs
@@ -1,0 +1,16 @@
+// Smallest viable ext-php-rs extension. The integration test loads this
+// .so under PHP.wasm and asserts that hello_rs() returns the expected
+// string — that proves the Rust → wasm32-unknown-emscripten → SIDE_MODULE
+// pipeline works end-to-end.
+
+use ext_php_rs::prelude::*;
+
+#[php_function]
+pub fn hello_rs() -> String {
+	"Hello from a Rust PHP extension running in PHP.wasm".to_string()
+}
+
+#[php_module]
+pub fn module(module: ModuleBuilder) -> ModuleBuilder {
+	module
+}

--- a/packages/php-wasm/compile-extension/tests/run-integration-tests.sh
+++ b/packages/php-wasm/compile-extension/tests/run-integration-tests.sh
@@ -130,6 +130,17 @@ verify_extension \
 	"dependency backed extension"
 echo "::endgroup::"
 
+echo "::group::Build and load Rust extension"
+compile_extension \
+	--source packages/php-wasm/compile-extension/tests/fixtures/hello-rs \
+	--language rust \
+	--out "$WORK_DIR/hello-rs"
+verify_extension \
+	"$WORK_DIR/hello-rs/manifest.json" \
+	"<?php echo hello_rs();" \
+	"Hello from a Rust PHP extension running in PHP.wasm"
+echo "::endgroup::"
+
 echo "::group::Build and load extension backed by non-Playground library"
 EXTERNAL_SOURCE="$WORK_DIR/external-lib-probe"
 cp -R \


### PR DESCRIPTION
Stacked on #3546.

## Why

We want to ship `wp_mysql_parser` (WordPress/sqlite-database-integration#381) through `@php-wasm/compile-extension` so it lands in Playground via the same manifest pipeline as every other extension. That extension is written in Rust against `ext-php-rs`, but #3546's helper only knows the C `phpize → emconfigure → emmake` flow. This PR adds a Rust build mode so the same `npx @php-wasm/compile-extension --source ./ext` invocation works for either language.

## What

- **CLI** — new `--language=c|rust` flag with auto-detect: `Cargo.toml` next to source ⇒ rust, `config.m4` ⇒ c. New `detectLanguage()` and `detectRustCrateName()` helpers, plus unit tests for Cargo.toml parsing.
- **Docker** — sibling `Dockerfile.rust-ext` that layers `rustup`, the `wasm32-unknown-emscripten` target, and `libclang` on top of the existing PHP-cross base. `bindgen` (driven by ext-php-rs's `build.rs`) runs on the host CPU against the cross-compiled PHP headers staged at `/usr/local/include/php`; the final cdylib is linked for `wasm32-unknown-emscripten`.
- **`build-rust-in-docker.sh`** — runs `cargo build --release --target=wasm32-unknown-emscripten` with `-C link-arg=-sSIDE_MODULE=1`, `-sWASM_BIGINT`, `-fPIC`, plus async-mode flags (`-sJSPI`/`-fwasm-exceptions`/`-sSUPPORT_LONGJMP=wasm` for JSPI; `-sASYNCIFY=1`/`-sASYNCIFY_ADVISE` for Asyncify). Output naming and manifest layout are unchanged so `loadExtension({ manifestUrl })` doesn't care which language produced the `.so`.
- **Fixture** — minimal `playground_hello_rs` ext-php-rs extension; integration runner builds + loads it alongside the existing C fixtures.

## Constraint

PHP 8.0+ only — ext-php-rs doesn't target the PHP 7 ABI. Documented in README.

## Caveats

The Docker side has not been validated end-to-end here (no Docker available in the dev session). The flag layering matches #3546's C path, but a reviewer should run the integration test to confirm the Rust fixture builds and loads. Likely areas of friction if it doesn't work first try:

1. \`BINDGEN_EXTRA_CLANG_ARGS\` may need additional \`-D\` defines that match the cross-compiled PHP's configure flags (e.g. \`-DZEND_ENABLE_ZVAL_LONG64\`).
2. \`LIBCLANG_PATH=/usr/lib/llvm-14/lib\` — adjust if libclang is in a different location on the base image.
3. ext-php-rs may pick a different cdylib filename; the build script falls back to a \`find\`.

## Test plan

- [ ] \`PHP_VERSION=8.3 ASYNC_MODE=asyncify npx nx test-compile-extension-integration php-wasm-compile-extension\`
- [ ] \`PHP_VERSION=8.4 ASYNC_MODE=jspi npx nx test-compile-extension-integration php-wasm-compile-extension\`
- [ ] \`npx nx test php-wasm-compile-extension\` — covers the new Cargo.toml parsing unit tests
- [ ] Once green: build wp_mysql_parser from sqlite-database-integration#381 against PHP 8.4 JSPI and confirm it loads via \`loadExtension({ manifestUrl })\`