### PR TITLE
[PHP] Add Blueprint PHP extension loading step

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53799,6 +53799,9 @@
 			"name": "@php-wasm/node",
 			"version": "3.1.21",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"wasm-feature-detect": "1.8.0"
+			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
@@ -53920,6 +53923,9 @@
 			"name": "@php-wasm/web",
 			"version": "3.1.21",
 			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"wasm-feature-detect": "1.8.0"
+			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"

--- a/packages/php-wasm/node/package.json
+++ b/packages/php-wasm/node/package.json
@@ -38,6 +38,9 @@
 	},
 	"license": "GPL-2.0-or-later",
 	"types": "index.d.ts",
+	"dependencies": {
+		"wasm-feature-detect": "1.8.0"
+	},
 	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
 	"engines": {
 		"node": ">=20.10.0",

--- a/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/node/src/lib/extensions/intl/with-intl.ts
@@ -3,7 +3,11 @@ import type {
 	PHPRuntime,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
-import { LatestSupportedPHPVersion, FSHelpers } from '@php-wasm/universal';
+import {
+	installPHPExtensionFilesSync,
+	LatestSupportedPHPVersion,
+	PHP_EXTENSIONS_DIR,
+} from '@php-wasm/universal';
 import fs from 'fs';
 import path from 'path';
 import { getIntlExtensionModule } from './get-intl-extension-module';
@@ -12,9 +16,8 @@ export async function withIntl(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion,
 	options: EmscriptenOptions
 ): Promise<EmscriptenOptions> {
-	const extensionName = 'intl.so';
 	const extensionPath = await getIntlExtensionModule(version);
-	const extension = fs.readFileSync(extensionPath);
+	const soBytes = new Uint8Array(fs.readFileSync(extensionPath));
 
 	const dataName = 'icu.dat';
 	const moduleDir =
@@ -26,74 +29,25 @@ export async function withIntl(
 		...options,
 		ENV: {
 			...options.ENV,
-			PHP_INI_SCAN_DIR: '/internal/shared/extensions',
+			PHP_INI_SCAN_DIR: PHP_EXTENSIONS_DIR,
 			ICU_DATA: '/internal/shared',
 		},
 		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
 			if (options.onRuntimeInitialized) {
 				options.onRuntimeInitialized(phpRuntime);
 			}
-			/*
-			 * The extension file previously read
-			 * is written inside the /extensions directory
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions'
-				)
-			) {
-				phpRuntime.FS.mkdirTree('/internal/shared/extensions');
-			}
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`/internal/shared/extensions/${extensionName}`
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					`/internal/shared/extensions/${extensionName}`,
-					new Uint8Array(extension)
-				);
-			}
-			/* The extension has its share of ini entries
-			 * to write in a separate ini file
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions/intl.ini'
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					'/internal/shared/extensions/intl.ini',
-					[
-						`extension=/internal/shared/extensions/${extensionName}`,
-					].join('\n')
-				);
-			}
-			/*
-			 * An ICU data file must be loaded to support Intl extension.
-			 * To achieve this, a shared directory is mounted and referenced
-			 * via the ICU_DATA environment variable.
-			 * By default, this variable is set to '/internal/shared',
-			 * which corresponds to the actual file location.
-			 *
-			 * The Intl extension is hard-coded to look for the `icudt74l` filename,
-			 * which means the ICU data file must use that exact name.
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`${phpRuntime.ENV.ICU_DATA}/${dataName}`
-				)
-			) {
-				phpRuntime.FS.mkdirTree(phpRuntime.ENV.ICU_DATA);
-				phpRuntime.FS.writeFile(
-					`${phpRuntime.ENV.ICU_DATA}/icudt74l.dat`,
-					new Uint8Array(ICUData)
-				);
-			}
+			installPHPExtensionFilesSync(phpRuntime.FS, {
+				name: 'intl',
+				soBytes,
+				loadTiming: 'before-php-startup',
+				extraFiles: {
+					targetPath: '/internal/shared',
+					files: {
+						// The Intl extension looks for the hard-coded ICU data name.
+						'icudt74l.dat': new Uint8Array(ICUData),
+					},
+				},
+			});
 		},
 	};
 }

--- a/packages/php-wasm/node/src/lib/extensions/memcached/with-memcached.ts
+++ b/packages/php-wasm/node/src/lib/extensions/memcached/with-memcached.ts
@@ -3,7 +3,11 @@ import type {
 	PHPRuntime,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
-import { LatestSupportedPHPVersion, FSHelpers } from '@php-wasm/universal';
+import {
+	installPHPExtensionFilesSync,
+	LatestSupportedPHPVersion,
+	PHP_EXTENSIONS_DIR,
+} from '@php-wasm/universal';
 import fs from 'fs';
 import { getMemcachedExtensionModule } from './get-memcached-extension-module';
 
@@ -11,59 +15,24 @@ export async function withMemcached(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion,
 	options: EmscriptenOptions
 ): Promise<EmscriptenOptions> {
-	const extensionName = 'memcached.so';
 	const extensionPath = await getMemcachedExtensionModule(version);
-	const extension = fs.readFileSync(extensionPath);
+	const soBytes = new Uint8Array(fs.readFileSync(extensionPath));
 
 	return {
 		...options,
 		ENV: {
 			...options.ENV,
-			PHP_INI_SCAN_DIR: '/internal/shared/extensions',
+			PHP_INI_SCAN_DIR: PHP_EXTENSIONS_DIR,
 		},
 		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
 			if (options.onRuntimeInitialized) {
 				options.onRuntimeInitialized(phpRuntime);
 			}
-			/*
-			 * The extension file previously read
-			 * is written inside the /extensions directory
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions'
-				)
-			) {
-				phpRuntime.FS.mkdirTree('/internal/shared/extensions');
-			}
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`/internal/shared/extensions/${extensionName}`
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					`/internal/shared/extensions/${extensionName}`,
-					new Uint8Array(extension)
-				);
-			}
-			/* The extension has its share of ini entries
-			 * to write in a separate ini file
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions/memcached.ini'
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					'/internal/shared/extensions/memcached.ini',
-					[
-						`extension=/internal/shared/extensions/${extensionName}`,
-					].join('\n')
-				);
-			}
+			installPHPExtensionFilesSync(phpRuntime.FS, {
+				name: 'memcached',
+				soBytes,
+				loadTiming: 'before-php-startup',
+			});
 		},
 	};
 }

--- a/packages/php-wasm/node/src/lib/extensions/redis/with-redis.ts
+++ b/packages/php-wasm/node/src/lib/extensions/redis/with-redis.ts
@@ -3,7 +3,11 @@ import type {
 	PHPRuntime,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
-import { LatestSupportedPHPVersion, FSHelpers } from '@php-wasm/universal';
+import {
+	installPHPExtensionFilesSync,
+	LatestSupportedPHPVersion,
+	PHP_EXTENSIONS_DIR,
+} from '@php-wasm/universal';
 import fs from 'fs';
 import { getRedisExtensionModule } from './get-redis-extension-module';
 
@@ -11,59 +15,24 @@ export async function withRedis(
 	version: SupportedPHPVersion = LatestSupportedPHPVersion,
 	options: EmscriptenOptions
 ): Promise<EmscriptenOptions> {
-	const extensionName = 'redis.so';
 	const extensionPath = await getRedisExtensionModule(version);
-	const extension = fs.readFileSync(extensionPath);
+	const soBytes = new Uint8Array(fs.readFileSync(extensionPath));
 
 	return {
 		...options,
 		ENV: {
 			...options.ENV,
-			PHP_INI_SCAN_DIR: '/internal/shared/extensions',
+			PHP_INI_SCAN_DIR: PHP_EXTENSIONS_DIR,
 		},
 		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
 			if (options.onRuntimeInitialized) {
 				options.onRuntimeInitialized(phpRuntime);
 			}
-			/*
-			 * The extension file previously read
-			 * is written inside the /extensions directory
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions'
-				)
-			) {
-				phpRuntime.FS.mkdirTree('/internal/shared/extensions');
-			}
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`/internal/shared/extensions/${extensionName}`
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					`/internal/shared/extensions/${extensionName}`,
-					new Uint8Array(extension)
-				);
-			}
-			/* The extension has its share of ini entries
-			 * to write in a separate ini file
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions/redis.ini'
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					'/internal/shared/extensions/redis.ini',
-					[
-						`extension=/internal/shared/extensions/${extensionName}`,
-					].join('\n')
-				);
-			}
+			installPHPExtensionFilesSync(phpRuntime.FS, {
+				name: 'redis',
+				soBytes,
+				loadTiming: 'before-php-startup',
+			});
 		},
 	};
 }

--- a/packages/php-wasm/node/src/lib/extensions/xdebug/with-xdebug.ts
+++ b/packages/php-wasm/node/src/lib/extensions/xdebug/with-xdebug.ts
@@ -3,8 +3,9 @@ import {
 	type EmscriptenOptions,
 	type PHPRuntime,
 	type SupportedPHPVersion,
-	FSHelpers,
+	installPHPExtensionFilesSync,
 	LatestSupportedPHPVersion,
+	PHP_EXTENSIONS_DIR,
 	SupportedPHPVersions,
 	SupportedPHPVersionsList,
 } from '@php-wasm/universal';
@@ -27,68 +28,34 @@ export async function withXdebug(
 	options: EmscriptenOptions,
 	xdebugOptions: XdebugOptions
 ): Promise<EmscriptenOptions> {
-	const fileName = 'xdebug.so';
 	const filePath = await getXdebugExtensionModule(version);
-	const extension = fs.readFileSync(filePath);
+	const soBytes = new Uint8Array(fs.readFileSync(filePath));
 
 	return {
 		...options,
 		ENV: {
 			...options.ENV,
-			PHP_INI_SCAN_DIR: '/internal/shared/extensions',
+			PHP_INI_SCAN_DIR: PHP_EXTENSIONS_DIR,
 		},
 		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
 			if (options.onRuntimeInitialized) {
 				options.onRuntimeInitialized(phpRuntime);
 			}
-			/*
-			 * The extension file previously read
-			 * is written inside the /extensions directory
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions'
-				)
-			) {
-				phpRuntime.FS.mkdirTree('/internal/shared/extensions');
-			}
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`/internal/shared/extensions/${fileName}`
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					`/internal/shared/extensions/${fileName}`,
-					new Uint8Array(extension)
-				);
-			}
-			/*
-			 * The extension has its share of ini entries
-			 * to write in a separate ini file
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions/xdebug.ini'
-				)
-			) {
-				const ideKey = xdebugOptions.ideKey || DEFAULT_IDE_KEY;
-				phpRuntime.FS.writeFile(
-					'/internal/shared/extensions/xdebug.ini',
-					[
-						'zend_extension=/internal/shared/extensions/xdebug.so',
-						'xdebug.mode=debug,develop',
-						'xdebug.start_with_request=yes',
-						`xdebug.idekey="${ideKey}"`,
-						// Path mapping is only available starting
-						// from Xdebug 3.5, which is used by PHP 8.5+
-						// Previous versions will ignore this entry.
-						'xdebug.path_mapping=yes',
-					].join('\n')
-				);
-			}
+			const ideKey = xdebugOptions.ideKey || DEFAULT_IDE_KEY;
+			installPHPExtensionFilesSync(phpRuntime.FS, {
+				name: 'xdebug',
+				soBytes,
+				loadTiming: 'before-php-startup',
+				loadWithIniDirective: 'zend_extension',
+				iniEntries: {
+					'xdebug.mode': 'debug,develop',
+					'xdebug.start_with_request': 'yes',
+					'xdebug.idekey': `"${ideKey}"`,
+					// Path mapping is only available starting from Xdebug 3.5,
+					// which is used by PHP 8.5+. Previous versions ignore it.
+					'xdebug.path_mapping': 'yes',
+				},
+			});
 			/*
 			 * Path mapping and skipping is only
 			 * available starting from Xdebug 3.5,

--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -114,6 +114,7 @@ export async function loadNodeRuntime(
 			: undefined);
 
 	const isLegacy = isLegacyPHPVersion(phpVersion);
+	const phpWasmAsyncMode = await detectPHPWasmAsyncMode();
 
 	let emscriptenOptions: EmscriptenOptions = {
 		/**
@@ -138,6 +139,7 @@ export async function loadNodeRuntime(
 			return bindUserSpace({ fileLockManager }, userSpaceContext);
 		},
 		...(options.emscriptenOptions || {}),
+		phpWasmAsyncMode,
 		processId,
 		// For legacy PHP: pre-create php.ini via a preRun step. See
 		// createLegacyPhpIniPreRunStep for why this must run before
@@ -352,4 +354,9 @@ export async function loadNodeRuntime(
 
 	const runtimeId = await loadPHPRuntime(phpLoaderModule, emscriptenOptions);
 	return runtimeId;
+}
+
+async function detectPHPWasmAsyncMode(): Promise<'jspi' | 'asyncify'> {
+	const { jspi } = await import('wasm-feature-detect');
+	return (await jspi()) ? 'jspi' : 'asyncify';
 }

--- a/packages/php-wasm/node/src/test/php-dynamic-loading.spec.ts
+++ b/packages/php-wasm/node/src/test/php-dynamic-loading.spec.ts
@@ -2,13 +2,17 @@ import { loadNodeRuntime } from '..';
 import { DEFAULT_IDE_KEY } from '@php-wasm/cli-util';
 import {
 	PHP,
+	loadPHPExtension,
 	proxyFileSystem,
 	setPhpIniEntries,
 	SupportedPHPVersions,
 	SupportedPHPVersionsList,
 } from '@php-wasm/universal';
+import fs from 'fs';
+import path from 'path';
 import { createServer, type AddressInfo } from 'net';
 import { jspi } from 'wasm-feature-detect';
+import { getIntlExtensionModule } from '../lib/extensions/intl/get-intl-extension-module';
 
 // Check JSPI availability at module load time (top-level await)
 // so the value is available when tests are registered.
@@ -220,6 +224,50 @@ describe.each(phpVersions)('PHP %s', (phpVersion) => {
 		});
 
 		it('supports dynamic loading', async () => {
+			const result = await php.runStream({
+				code: `<?php
+					var_dump(extension_loaded('intl'));
+					var_dump(class_exists('Collator'));`,
+			});
+
+			expect(await result.stdoutText).toEqual('bool(true)\nbool(true)\n');
+		});
+
+		it('loads through loadPHPExtension()', async () => {
+			php.exit();
+			php = new PHP(await loadNodeRuntime(phpVersion as any));
+
+			const extensionPath = await getIntlExtensionModule(
+				phpVersion as any
+			);
+			const testDir =
+				typeof __dirname !== 'undefined'
+					? __dirname
+					: import.meta.dirname;
+			const icuDataPath = path.join(
+				testDir,
+				'../lib/extensions/intl/shared/icu.dat'
+			);
+
+			await loadPHPExtension(php, {
+				source: {
+					format: 'so',
+					name: 'intl',
+					bytes: new Uint8Array(fs.readFileSync(extensionPath)),
+				},
+				extraFiles: {
+					targetPath: '/internal/shared',
+					files: {
+						'icudt74l.dat': new Uint8Array(
+							fs.readFileSync(icuDataPath)
+						),
+					},
+				},
+				env: {
+					ICU_DATA: '/internal/shared',
+				},
+			});
+
 			const result = await php.runStream({
 				code: `<?php
 					var_dump(extension_loaded('intl'));

--- a/packages/php-wasm/node/src/test/php-dynamic-loading.spec.ts
+++ b/packages/php-wasm/node/src/test/php-dynamic-loading.spec.ts
@@ -17,9 +17,45 @@ import { getIntlExtensionModule } from '../lib/extensions/intl/get-intl-extensio
 // Check JSPI availability at module load time (top-level await)
 // so the value is available when tests are registered.
 const isJspiAvailable = await jspi();
+const lifecyclePHPVersion = '8.4';
 
 const phpVersions =
 	'PHP' in process.env ? [process.env['PHP']!] : SupportedPHPVersions;
+
+const bundledLifecycleExtensionNames = [
+	'xdebug',
+	'intl',
+	...(isJspiAvailable ? ['redis', 'memcached'] : []),
+];
+
+const bundledLifecycleLoaderOptions = {
+	withXdebug: true,
+	withIntl: true,
+	withRedis: isJspiAvailable,
+	withMemcached: isJspiAvailable,
+};
+
+describe(`Bundled extension lifecycle - PHP ${lifecyclePHPVersion}`, () => {
+	it('keeps enabled extensions loaded after runtime rotation', async () => {
+		const recreateRuntime = vitest.fn(() =>
+			loadNodeRuntime(lifecyclePHPVersion, bundledLifecycleLoaderOptions)
+		);
+		const php = new PHP(await recreateRuntime());
+		php.enableRuntimeRotation({
+			recreateRuntime,
+			maxRequests: 1,
+		});
+
+		try {
+			await expectExtensionsLoaded(php, bundledLifecycleExtensionNames);
+			await expectExtensionsLoaded(php, bundledLifecycleExtensionNames);
+			expect(recreateRuntime).toHaveBeenCalledTimes(2);
+		} finally {
+			php.exit();
+		}
+	}, 30_000);
+});
+
 describe.each(phpVersions)('PHP %s', (phpVersion) => {
 	describe('XDebug', () => {
 		let php: PHP;
@@ -526,3 +562,26 @@ describe.each(phpVersions)('PHP %s', (phpVersion) => {
 		);
 	});
 });
+
+async function expectExtensionsLoaded(php: PHP, extensionNames: string[]) {
+	const result = await php.run({
+		code: `<?php
+			$extensions = ${phpArrayLiteral(extensionNames)};
+			foreach ($extensions as $extension) {
+				echo $extension . ':' . (extension_loaded($extension) ? 'loaded' : 'missing') . "\\n";
+			}
+		`,
+	});
+
+	expect(result.text).toBe(
+		extensionNames
+			.map((extensionName) => `${extensionName}:loaded\n`)
+			.join('')
+	);
+}
+
+function phpArrayLiteral(values: string[]) {
+	return `array(${values
+		.map((value) => `'${value.replaceAll("'", "\\'")}'`)
+		.join(', ')})`;
+}

--- a/packages/php-wasm/node/src/test/php-worker.spec.ts
+++ b/packages/php-wasm/node/src/test/php-worker.spec.ts
@@ -2,20 +2,26 @@
 import { PHP, PHPRequestHandler, PHPWorker } from '@php-wasm/universal';
 import { loadNodeRuntime } from '..';
 import { RecommendedPHPVersion } from '@wp-playground/common';
+import { jspi } from 'wasm-feature-detect';
+
+const isJspiAvailable = await jspi();
+const workerLifecycleExtensionNames = [
+	'xdebug',
+	'intl',
+	...(isJspiAvailable ? ['redis', 'memcached'] : []),
+];
+const workerLifecycleLoaderOptions = {
+	withXdebug: true,
+	withIntl: true,
+	withRedis: isJspiAvailable,
+	withMemcached: isJspiAvailable,
+};
 
 describe('PHP Worker', () => {
 	let handler: PHPRequestHandler;
 	let worker: PHPWorker;
 	beforeEach(async () => {
-		handler = new PHPRequestHandler({
-			documentRoot: '/wordpress',
-			absoluteUrl: 'http://127.0.0.1:2398',
-			phpFactory: async () =>
-				new PHP(await loadNodeRuntime(RecommendedPHPVersion)),
-			maxPhpInstances: 3,
-		});
-		worker = new PHPWorker(handler);
-		await worker.setPrimaryPHP(await handler.getPrimaryPhp());
+		({ handler, worker } = await createWorker());
 	});
 
 	afterEach(async () => {
@@ -56,4 +62,80 @@ describe('PHP Worker', () => {
 		});
 		expect(received).toHaveLength(1);
 	});
+
+	it('loads configured extensions in every PHP instance acquired by the worker', async () => {
+		await worker[Symbol.asyncDispose]();
+		await handler[Symbol.asyncDispose]();
+		({ handler, worker } = await createWorker(
+			workerLifecycleLoaderOptions
+		));
+
+		const acquired = [];
+		try {
+			acquired.push(await handler.instanceManager.acquirePHPInstance());
+			acquired.push(await handler.instanceManager.acquirePHPInstance());
+
+			const heldResults = await Promise.all(
+				acquired.map(({ php }) =>
+					php.run({
+						code: extensionCheckCode(workerLifecycleExtensionNames),
+					})
+				)
+			);
+
+			expect(heldResults.map(({ text }) => text)).toEqual([
+				expectedExtensionCheckOutput(workerLifecycleExtensionNames),
+				expectedExtensionCheckOutput(workerLifecycleExtensionNames),
+			]);
+
+			const workerResult = await worker.run({
+				code: extensionCheckCode(workerLifecycleExtensionNames),
+			});
+			expect(workerResult.text).toBe(
+				expectedExtensionCheckOutput(workerLifecycleExtensionNames)
+			);
+		} finally {
+			for (const acquiredPhp of acquired) {
+				acquiredPhp.reap();
+			}
+		}
+	});
 });
+
+async function createWorker(
+	loaderOptions: Parameters<typeof loadNodeRuntime>[1] = {}
+) {
+	const handler = new PHPRequestHandler({
+		documentRoot: '/wordpress',
+		absoluteUrl: 'http://127.0.0.1:2398',
+		phpFactory: async () =>
+			new PHP(
+				await loadNodeRuntime(RecommendedPHPVersion, loaderOptions)
+			),
+		maxPhpInstances: 3,
+	});
+	const worker = new PHPWorker(handler);
+	await worker.setPrimaryPHP(await handler.getPrimaryPhp());
+	return { handler, worker };
+}
+
+function extensionCheckCode(extensionNames: string[]) {
+	return `<?php
+		$extensions = ${phpArrayLiteral(extensionNames)};
+		foreach ($extensions as $extension) {
+			echo $extension . ':' . (extension_loaded($extension) ? 'loaded' : 'missing') . "\\n";
+		}
+	`;
+}
+
+function expectedExtensionCheckOutput(extensionNames: string[]) {
+	return extensionNames
+		.map((extensionName) => `${extensionName}:loaded\n`)
+		.join('');
+}
+
+function phpArrayLiteral(values: string[]) {
+	return `array(${values
+		.map((value) => `'${value.replaceAll("'", "\\'")}'`)
+		.join(', ')})`;
+}

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -96,6 +96,28 @@ export type {
 export { rotatePHPRuntime } from './rotate-php-runtime';
 export { writeFiles } from './write-files';
 export type { FileTree } from './write-files';
+export {
+	buildPHPExtensionInstallPlan,
+	installPHPExtensionFiles,
+	installPHPExtensionFilesSync,
+	loadPHPExtension,
+	PHP_EXTENSION_PRELOAD_DIR,
+	PHP_EXTENSIONS_DIR,
+} from './load-extension';
+export type {
+	InstallPHPExtensionFilesOptions,
+	LoadedPHPExtension,
+	LoadPHPExtensionOptions,
+	PHPExtensionExtraFiles,
+	PHPExtensionIniDirective,
+	PHPExtensionInstallPlan,
+	PHPExtensionLoadTiming,
+	PHPExtensionManifest,
+	PHPExtensionManifestArtifact,
+	PHPExtensionSource,
+	PHPExtensionSourceFormat,
+	PHPWasmAsyncMode,
+} from './load-extension';
 
 export {
 	DEFAULT_BASE_URL,

--- a/packages/php-wasm/universal/src/lib/load-extension.spec.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildPHPExtensionInstallPlan,
+	loadPHPExtension,
+	PHP_EXTENSION_PRELOAD_DIR,
+	PHP_EXTENSIONS_DIR,
+} from './load-extension';
+import { PHP_INI_PATH } from './php';
+
+describe('buildPHPExtensionInstallPlan', () => {
+	it('loads regular extensions after startup by default', () => {
+		const plan = buildPHPExtensionInstallPlan({
+			name: 'example',
+			soBytes: new Uint8Array([1, 2, 3]),
+		});
+
+		expect(plan.loadTiming).toBe('after-php-startup');
+		expect(plan.soPath).toBe(`${PHP_EXTENSIONS_DIR}/example.so`);
+		expect(plan.iniContent).toBe(
+			`extension=${PHP_EXTENSIONS_DIR}/example.so`
+		);
+		expect(plan.preloadPath).toBe(
+			`${PHP_EXTENSION_PRELOAD_DIR}/example.php`
+		);
+	});
+
+	it('loads zend extensions before startup by default', () => {
+		const plan = buildPHPExtensionInstallPlan({
+			name: 'xdebug',
+			soBytes: new Uint8Array([1, 2, 3]),
+			loadWithIniDirective: 'zend_extension',
+		});
+
+		expect(plan.loadTiming).toBe('before-php-startup');
+		expect(plan.iniContent).toBe(
+			`zend_extension=${PHP_EXTENSIONS_DIR}/xdebug.so`
+		);
+		expect(plan.preloadPath).toBeUndefined();
+	});
+
+	it('rejects zend extensions after startup', () => {
+		expect(() =>
+			buildPHPExtensionInstallPlan({
+				name: 'xdebug',
+				soBytes: new Uint8Array([1, 2, 3]),
+				loadTiming: 'after-php-startup',
+				loadWithIniDirective: 'zend_extension',
+			})
+		).toThrow('Zend extensions must load before PHP startup.');
+	});
+});
+
+describe('loadPHPExtension', () => {
+	it('selects a manifest artifact and installs files for post-startup loading', async () => {
+		const php = createFakePHP();
+		const artifactBytes = new Uint8Array([4, 5, 6]);
+
+		await loadPHPExtension(php as any, {
+			source: {
+				format: 'manifest',
+				url: 'https://example.com/extensions/manifest.json',
+			},
+			phpVersion: '8.4',
+			asyncMode: 'asyncify',
+			fetch: async (url) => {
+				const requestUrl = String(url);
+				if (requestUrl.endsWith('/manifest.json')) {
+					return Response.json({
+						name: 'example',
+						version: '1.0.0',
+						artifacts: [
+							{
+								phpVersion: '8.4',
+								asyncMode: 'asyncify',
+								file: 'example-php8.4-asyncify.so',
+							},
+						],
+					});
+				}
+				if (requestUrl.endsWith('/example-php8.4-asyncify.so')) {
+					return new Response(artifactBytes);
+				}
+				return new Response('Not found', { status: 404 });
+			},
+		});
+
+		expect(php.files.get(`${PHP_EXTENSIONS_DIR}/example.so`)).toEqual(
+			artifactBytes
+		);
+		expect(php.files.get(`${PHP_EXTENSIONS_DIR}/example.ini`)).toBe(
+			`extension=${PHP_EXTENSIONS_DIR}/example.so`
+		);
+		expect(
+			String(php.files.get(`${PHP_EXTENSION_PRELOAD_DIR}/example.php`))
+		).toContain("dl('example.so')");
+		expect(php.files.get(PHP_INI_PATH)).toContain(
+			`extension_dir=${PHP_EXTENSIONS_DIR}`
+		);
+		expect(php.files.get(PHP_INI_PATH)).toContain('enable_dl=On');
+	});
+});
+
+function createFakePHP() {
+	const files = new Map<string, string | Uint8Array>([
+		[PHP_INI_PATH, 'memory_limit=256M\n'],
+	]);
+	const directories = new Set<string>(['/internal', '/internal/shared']);
+
+	return {
+		files,
+		directories,
+		async fileExists(path: string) {
+			return files.has(path) || directories.has(path);
+		},
+		async mkdirTree(path: string) {
+			directories.add(path);
+		},
+		async writeFile(path: string, data: string | Uint8Array) {
+			files.set(path, data);
+		},
+		async readFileAsText(path: string) {
+			const value = files.get(path);
+			if (value instanceof Uint8Array) {
+				return new TextDecoder().decode(value);
+			}
+			return value ?? '';
+		},
+	};
+}

--- a/packages/php-wasm/universal/src/lib/load-extension.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.ts
@@ -1,0 +1,633 @@
+import { dirname, joinPaths } from '@php-wasm/util';
+import type { Emscripten } from './emscripten-types';
+import { FSHelpers } from './fs-helpers';
+import { PHP, PHP_INI_PATH } from './php';
+import type { UniversalPHP } from './universal-php';
+import type { FileTree } from './write-files';
+import { writeFiles } from './write-files';
+
+export const PHP_EXTENSIONS_DIR = '/internal/shared/extensions';
+export const PHP_EXTENSION_PRELOAD_DIR = '/internal/shared/preload';
+
+export type PHPWasmAsyncMode = 'jspi' | 'asyncify';
+export type PHPExtensionLoadTiming =
+	| 'before-php-startup'
+	| 'after-php-startup'
+	| 'auto';
+export type PHPExtensionIniDirective = 'extension' | 'zend_extension';
+export type PHPExtensionSourceFormat = 'so' | 'manifest';
+
+export interface PHPExtensionManifestArtifact {
+	phpVersion: string;
+	asyncMode: PHPWasmAsyncMode;
+	/**
+	 * Relative to the manifest URL/base URL, or an absolute URL.
+	 */
+	file: string;
+	sha256?: string;
+}
+
+export interface PHPExtensionManifest {
+	name: string;
+	version?: string;
+	mode?: 'php-extension';
+	artifacts: PHPExtensionManifestArtifact[];
+}
+
+export type PHPExtensionSource =
+	| {
+			format: 'so';
+			name?: string;
+			bytes: Uint8Array | ArrayBuffer;
+			sha256?: string;
+	  }
+	| {
+			format: 'url';
+			name?: string;
+			url: string | URL;
+			sha256?: string;
+	  }
+	| {
+			format: 'manifest';
+			url: string | URL;
+	  }
+	| {
+			format: 'manifest';
+			manifest: PHPExtensionManifest;
+			baseUrl?: string | URL;
+	  };
+
+export interface PHPExtensionExtraFiles {
+	/**
+	 * Files are written here. Defaults to
+	 * `/internal/shared/extensions/<name>-assets`.
+	 */
+	targetPath?: string;
+	files: FileTree;
+}
+
+export interface LoadPHPExtensionOptions {
+	source: PHPExtensionSource;
+	name?: string;
+	phpVersion?: string;
+	asyncMode?: PHPWasmAsyncMode;
+	loadTiming?: PHPExtensionLoadTiming;
+	loadWithIniDirective?: PHPExtensionIniDirective;
+	iniEntries?: Record<string, string>;
+	extraFiles?: PHPExtensionExtraFiles;
+	env?: Record<string, string>;
+	extensionDir?: string;
+	fetch?: typeof fetch;
+}
+
+export interface InstallPHPExtensionFilesOptions {
+	name: string;
+	soBytes: Uint8Array | ArrayBuffer;
+	loadTiming?: PHPExtensionLoadTiming;
+	loadWithIniDirective?: PHPExtensionIniDirective;
+	iniEntries?: Record<string, string>;
+	extraFiles?: PHPExtensionExtraFiles;
+	env?: Record<string, string>;
+	extensionDir?: string;
+}
+
+export interface PHPExtensionInstallPlan {
+	name: string;
+	soPath: string;
+	soBytes: Uint8Array;
+	iniPath: string;
+	iniContent: string;
+	preloadPath?: string;
+	extraFiles?: PHPExtensionExtraFiles & { targetPath: string };
+	env?: Record<string, string>;
+	loadTiming: Exclude<PHPExtensionLoadTiming, 'auto'>;
+	loadWithIniDirective: PHPExtensionIniDirective;
+	extensionDir: string;
+}
+
+export interface LoadedPHPExtension {
+	name: string;
+	path: string;
+	iniPath: string;
+	preloadPath?: string;
+	manifest?: PHPExtensionManifest;
+	artifact?: PHPExtensionManifestArtifact;
+}
+
+interface ResolvedPHPExtensionSource {
+	name: string;
+	soBytes: Uint8Array;
+	manifest?: PHPExtensionManifest;
+	artifact?: PHPExtensionManifestArtifact;
+}
+
+export async function loadPHPExtension(
+	php: UniversalPHP,
+	options: LoadPHPExtensionOptions
+): Promise<LoadedPHPExtension> {
+	const fetchFn = options.fetch ?? globalThis.fetch;
+	const resolved = await resolvePHPExtensionSource(php, options, fetchFn);
+	const plan = buildPHPExtensionInstallPlan({
+		name: options.name ?? resolved.name,
+		soBytes: resolved.soBytes,
+		loadTiming: options.loadTiming,
+		loadWithIniDirective: options.loadWithIniDirective,
+		iniEntries: options.iniEntries,
+		extraFiles: options.extraFiles,
+		env: options.env,
+		extensionDir: options.extensionDir,
+	});
+
+	await installPHPExtensionFiles(php, plan);
+
+	return {
+		name: plan.name,
+		path: plan.soPath,
+		iniPath: plan.iniPath,
+		preloadPath: plan.preloadPath,
+		manifest: resolved.manifest,
+		artifact: resolved.artifact,
+	};
+}
+
+export function buildPHPExtensionInstallPlan(
+	options: InstallPHPExtensionFilesOptions
+): PHPExtensionInstallPlan {
+	const extensionDir = options.extensionDir ?? PHP_EXTENSIONS_DIR;
+	const name = validateExtensionName(options.name);
+	const loadWithIniDirective = options.loadWithIniDirective ?? 'extension';
+	const loadTiming = normalizeLoadTiming(
+		options.loadTiming ?? 'auto',
+		loadWithIniDirective
+	);
+	const soPath = joinPaths(extensionDir, `${name}.so`);
+	const iniPath = joinPaths(extensionDir, `${name}.ini`);
+	const iniContent = buildIniContent({
+		loadWithIniDirective,
+		soPath,
+		iniEntries: options.iniEntries ?? {},
+	});
+	const preloadPath =
+		loadTiming === 'after-php-startup'
+			? joinPaths(PHP_EXTENSION_PRELOAD_DIR, `${name}.php`)
+			: undefined;
+	const extraFiles = options.extraFiles
+		? {
+				...options.extraFiles,
+				targetPath:
+					options.extraFiles.targetPath ??
+					joinPaths(extensionDir, `${name}-assets`),
+			}
+		: undefined;
+
+	return {
+		name,
+		soPath,
+		soBytes: toUint8Array(options.soBytes),
+		iniPath,
+		iniContent,
+		preloadPath,
+		extraFiles,
+		env: options.env,
+		loadTiming,
+		loadWithIniDirective,
+		extensionDir,
+	};
+}
+
+export async function installPHPExtensionFiles(
+	php: UniversalPHP,
+	plan: PHPExtensionInstallPlan
+): Promise<void> {
+	await ensureDirectory(php, plan.extensionDir);
+	await php.writeFile(plan.soPath, plan.soBytes);
+	await php.writeFile(plan.iniPath, plan.iniContent);
+
+	if (plan.extraFiles) {
+		await writeFiles(
+			php,
+			plan.extraFiles.targetPath,
+			plan.extraFiles.files
+		);
+	}
+
+	if (plan.env && php instanceof PHP) {
+		registerRuntimeEnv(php, plan.env);
+	}
+	if (php instanceof PHP) {
+		registerRuntimeEnv(php, {
+			PHP_INI_SCAN_DIR: appendPathEnv(
+				getRuntimeEnv(php)['PHP_INI_SCAN_DIR'],
+				plan.extensionDir
+			),
+		});
+	}
+
+	await upsertPhpIniEntries(php, {
+		extension_dir: plan.extensionDir,
+		...(plan.loadTiming === 'after-php-startup' ? { enable_dl: 'On' } : {}),
+	});
+
+	if (plan.preloadPath) {
+		await ensureDirectory(php, dirname(plan.preloadPath));
+		await php.writeFile(
+			plan.preloadPath,
+			createExtensionPreloadScript(plan.name, plan.soPath)
+		);
+	}
+}
+
+export function installPHPExtensionFilesSync(
+	fs: Emscripten.RootFS,
+	options: InstallPHPExtensionFilesOptions | PHPExtensionInstallPlan
+): PHPExtensionInstallPlan {
+	const plan =
+		'soPath' in options ? options : buildPHPExtensionInstallPlan(options);
+	ensureDirectorySync(fs, plan.extensionDir);
+	fs.writeFile(plan.soPath, plan.soBytes);
+	fs.writeFile(plan.iniPath, plan.iniContent);
+	if (plan.extraFiles) {
+		writeFileTreeSync(
+			fs,
+			plan.extraFiles.targetPath,
+			plan.extraFiles.files
+		);
+	}
+	if (plan.preloadPath) {
+		ensureDirectorySync(fs, dirname(plan.preloadPath));
+		fs.writeFile(
+			plan.preloadPath,
+			createExtensionPreloadScript(plan.name, plan.soPath)
+		);
+	}
+	return plan;
+}
+
+async function resolvePHPExtensionSource(
+	php: UniversalPHP,
+	options: LoadPHPExtensionOptions,
+	fetchFn: typeof fetch | undefined
+): Promise<ResolvedPHPExtensionSource> {
+	const source = options.source;
+	if (source.format === 'so') {
+		const name = options.name ?? source.name;
+		if (!name) {
+			throw new Error(
+				'name is required when loading an extension from direct bytes.'
+			);
+		}
+		if (source.sha256) {
+			await assertSha256(source.bytes, source.sha256, name);
+		}
+		return { name, soBytes: toUint8Array(source.bytes) };
+	}
+
+	if (source.format === 'url') {
+		const name =
+			options.name ?? source.name ?? inferExtensionName(source.url);
+		if (!name) {
+			throw new Error(
+				'name is required when loading an extension from a direct URL.'
+			);
+		}
+		const soBytes = await fetchBytes(fetchFn, new URL(String(source.url)));
+		if (source.sha256) {
+			await assertSha256(soBytes, source.sha256, String(source.url));
+		}
+		return { name, soBytes };
+	}
+
+	const manifestUrl =
+		'url' in source ? new URL(String(source.url)) : undefined;
+	const manifest =
+		'manifest' in source
+			? validateExtensionManifest(source.manifest)
+			: validateExtensionManifest(await fetchJson(fetchFn, manifestUrl!));
+	const baseUrl =
+		'baseUrl' in source && source.baseUrl
+			? new URL(String(source.baseUrl))
+			: manifestUrl;
+	const phpVersion = options.phpVersion ?? getPHPVersionFromRuntime(php);
+	const asyncMode = options.asyncMode ?? getAsyncModeFromRuntime(php);
+
+	if (!phpVersion) {
+		throw new Error(
+			'Could not determine the PHP version for this runtime. Pass phpVersion explicitly.'
+		);
+	}
+	if (!asyncMode) {
+		throw new Error(
+			'Could not determine the PHP.wasm async mode for this runtime. Pass asyncMode explicitly.'
+		);
+	}
+
+	const artifact = manifest.artifacts.find(
+		(candidate) =>
+			candidate.phpVersion === phpVersion &&
+			candidate.asyncMode === asyncMode
+	);
+	if (!artifact) {
+		throw new Error(
+			`No extension artifact found for PHP ${phpVersion} ${asyncMode}.`
+		);
+	}
+	if (!baseUrl) {
+		throw new Error(
+			'Manifest artifacts require a manifest URL or baseUrl so relative files can be resolved.'
+		);
+	}
+
+	const artifactUrl = new URL(artifact.file, baseUrl);
+	const soBytes = await fetchBytes(fetchFn, artifactUrl);
+	if (artifact.sha256) {
+		await assertSha256(soBytes, artifact.sha256, artifact.file);
+	}
+
+	return {
+		name: manifest.name,
+		soBytes,
+		manifest,
+		artifact,
+	};
+}
+
+async function fetchJson(
+	fetchFn: typeof fetch | undefined,
+	url: URL
+): Promise<unknown> {
+	if (!fetchFn) {
+		throw new Error('loadPHPExtension() requires a fetch implementation.');
+	}
+	const response = await fetchFn(url);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch ${url}: ${response.status}`);
+	}
+	return await response.json();
+}
+
+async function fetchBytes(
+	fetchFn: typeof fetch | undefined,
+	url: URL
+): Promise<Uint8Array> {
+	if (!fetchFn) {
+		throw new Error('loadPHPExtension() requires a fetch implementation.');
+	}
+	const response = await fetchFn(url);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch ${url}: ${response.status}`);
+	}
+	return new Uint8Array(await response.arrayBuffer());
+}
+
+function validateExtensionManifest(candidate: unknown): PHPExtensionManifest {
+	if (!candidate || typeof candidate !== 'object') {
+		throw new Error('Extension manifest must be an object.');
+	}
+	const manifest = candidate as PHPExtensionManifest;
+	if (typeof manifest.name !== 'string' || !manifest.name) {
+		throw new Error('Extension manifest must include a name.');
+	}
+	if (!Array.isArray(manifest.artifacts)) {
+		throw new Error('Extension manifest must include an artifacts array.');
+	}
+	for (const artifact of manifest.artifacts) {
+		if (
+			!artifact ||
+			typeof artifact.phpVersion !== 'string' ||
+			(artifact.asyncMode !== 'jspi' &&
+				artifact.asyncMode !== 'asyncify') ||
+			typeof artifact.file !== 'string'
+		) {
+			throw new Error('Extension manifest contains an invalid artifact.');
+		}
+	}
+	return manifest;
+}
+
+function normalizeLoadTiming(
+	loadTiming: PHPExtensionLoadTiming,
+	loadWithIniDirective: PHPExtensionIniDirective
+): Exclude<PHPExtensionLoadTiming, 'auto'> {
+	if (
+		loadWithIniDirective === 'zend_extension' &&
+		loadTiming === 'after-php-startup'
+	) {
+		throw new Error('Zend extensions must load before PHP startup.');
+	}
+	if (loadTiming === 'auto') {
+		return loadWithIniDirective === 'zend_extension'
+			? 'before-php-startup'
+			: 'after-php-startup';
+	}
+	return loadTiming;
+}
+
+function buildIniContent({
+	loadWithIniDirective,
+	soPath,
+	iniEntries,
+}: {
+	loadWithIniDirective: PHPExtensionIniDirective;
+	soPath: string;
+	iniEntries: Record<string, string>;
+}): string {
+	return [
+		`${loadWithIniDirective}=${soPath}`,
+		...Object.entries(iniEntries).map(([key, value]) => `${key}=${value}`),
+	].join('\n');
+}
+
+function validateExtensionName(name: string): string {
+	if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+		throw new Error(
+			`loadPHPExtension: invalid extension name ${JSON.stringify(
+				name
+			)}. Use only [a-zA-Z0-9_-].`
+		);
+	}
+	return name;
+}
+
+function inferExtensionName(url: string | URL): string | undefined {
+	const path = new URL(String(url), 'https://example.com').pathname;
+	const file = path.split('/').pop() ?? '';
+	return file.endsWith('.so') ? file.slice(0, -3) : undefined;
+}
+
+function getPHPVersionFromRuntime(php: UniversalPHP): string | undefined {
+	if (!(php instanceof PHP)) {
+		return undefined;
+	}
+	const runtime = getPHPRuntime(php);
+	const version = runtime?.phpVersion;
+	if (
+		typeof version?.major === 'number' &&
+		typeof version?.minor === 'number'
+	) {
+		return `${version.major}.${version.minor}`;
+	}
+	return undefined;
+}
+
+function getAsyncModeFromRuntime(
+	php: UniversalPHP
+): PHPWasmAsyncMode | undefined {
+	if (!(php instanceof PHP)) {
+		return undefined;
+	}
+	return getPHPRuntime(php).phpWasmAsyncMode;
+}
+
+function getPHPRuntime(php: PHP): {
+	ENV?: Record<string, string>;
+	phpVersion?: { major?: number; minor?: number };
+	phpWasmAsyncMode?: PHPWasmAsyncMode;
+} {
+	const privateSymbol = Object.getOwnPropertySymbols(php)[0];
+	if (!privateSymbol) {
+		throw new Error(
+			'loadPHPExtension() requires an initialized PHP runtime.'
+		);
+	}
+	// The PHP wrapper intentionally hides the runtime. The loader only reads
+	// runtime metadata needed to pick a manifest artifact.
+	// @ts-ignore
+	const runtime = php[privateSymbol];
+	if (!runtime) {
+		throw new Error(
+			'loadPHPExtension() requires an initialized PHP runtime.'
+		);
+	}
+	return runtime;
+}
+
+function getRuntimeEnv(php: PHP): Record<string, string> {
+	const runtime = getPHPRuntime(php);
+	runtime.ENV = runtime.ENV ?? {};
+	return runtime.ENV;
+}
+
+function registerRuntimeEnv(php: PHP, env: Record<string, string>) {
+	Object.assign(getRuntimeEnv(php), env);
+}
+
+function appendPathEnv(current: string | undefined, path: string): string {
+	if (!current) {
+		return path;
+	}
+	const paths = current.split(':');
+	return paths.includes(path) ? current : [...paths, path].join(':');
+}
+
+async function ensureDirectory(php: UniversalPHP, directory: string) {
+	if (!(await php.fileExists(directory))) {
+		await php.mkdirTree(directory);
+	}
+}
+
+function ensureDirectorySync(fs: Emscripten.RootFS, directory: string) {
+	if (!FSHelpers.fileExists(fs, directory)) {
+		fs.mkdirTree(directory);
+	}
+}
+
+async function upsertPhpIniEntries(
+	php: UniversalPHP,
+	entries: Record<string, string>
+) {
+	let phpIni = await php.readFileAsText(PHP_INI_PATH);
+	for (const [key, value] of Object.entries(entries)) {
+		phpIni = upsertPhpIniEntry(phpIni, key, value);
+	}
+	await php.writeFile(PHP_INI_PATH, phpIni);
+}
+
+function upsertPhpIniEntry(phpIni: string, key: string, value: string): string {
+	const entry = `${key}=${value}`;
+	const pattern = new RegExp(`^\\s*${escapeRegExp(key)}\\s*=.*$`, 'm');
+	if (pattern.test(phpIni)) {
+		return phpIni.replace(pattern, entry);
+	}
+	return `${phpIni.trimEnd()}\n${entry}\n`;
+}
+
+function createExtensionPreloadScript(
+	extensionName: string,
+	extensionPath: string
+) {
+	const extensionDir = dirname(extensionPath);
+	const extensionFile = `${extensionName}.so`;
+	return `<?php
+if (!extension_loaded(${phpStringLiteral(extensionName)})) {
+	if (!function_exists('dl')) {
+		throw new RuntimeException(${phpStringLiteral(
+			`Cannot load PHP.wasm extension ${extensionName}: dl() is not available.`
+		)});
+	}
+	// PHP's dl() only accepts a filename, so point extension_dir at the
+	// directory where PHP.wasm staged the side module before loading it.
+	ini_set('extension_dir', ${phpStringLiteral(extensionDir)});
+	if (!dl(${phpStringLiteral(extensionFile)}) && !extension_loaded(${phpStringLiteral(
+		extensionName
+	)})) {
+		throw new RuntimeException(${phpStringLiteral(
+			`Failed to load PHP.wasm extension ${extensionName}.`
+		)});
+	}
+}
+`;
+}
+
+function writeFileTreeSync(
+	fs: Emscripten.RootFS,
+	root: string,
+	files: FileTree
+) {
+	ensureDirectorySync(fs, root);
+	for (const [relativePath, content] of Object.entries(files)) {
+		const filePath = joinPaths(root, relativePath);
+		ensureDirectorySync(fs, dirname(filePath));
+		if (content instanceof Uint8Array || typeof content === 'string') {
+			fs.writeFile(filePath, content);
+		} else {
+			writeFileTreeSync(fs, filePath, content);
+		}
+	}
+}
+
+async function assertSha256(
+	bytes: Uint8Array | ArrayBuffer,
+	expected: string,
+	file: string
+) {
+	const subtle = globalThis.crypto?.subtle;
+	if (!subtle) {
+		throw new Error(
+			`Cannot verify ${file}: crypto.subtle is not available.`
+		);
+	}
+	const actual = bytesToHex(
+		await subtle.digest('SHA-256', toUint8Array(bytes))
+	);
+	if (actual !== expected) {
+		throw new Error(`SHA-256 mismatch for ${file}.`);
+	}
+}
+
+function bytesToHex(bytes: ArrayBuffer): string {
+	return Array.from(new Uint8Array(bytes))
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+function toUint8Array(bytes: Uint8Array | ArrayBuffer): Uint8Array {
+	return bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+}
+
+function phpStringLiteral(value: string): string {
+	return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/php-wasm/universal/src/lib/load-php-runtime.ts
+++ b/packages/php-wasm/universal/src/lib/load-php-runtime.ts
@@ -157,6 +157,12 @@ export async function loadPHPRuntime(
 
 	await phpReady;
 
+	const phpWasmAsyncMode =
+		phpModuleArgs.phpWasmAsyncMode ?? phpLoaderModule.phpWasmAsyncMode;
+	if (phpWasmAsyncMode) {
+		PHPRuntime.phpWasmAsyncMode = phpWasmAsyncMode;
+	}
+
 	const id = ++lastRuntimeId;
 
 	// TODO: Ask @adamziel why this is here.
@@ -272,6 +278,7 @@ export type PHPRuntime = any;
 export type PHPLoaderModule = {
 	dependencyFilename: string;
 	dependenciesTotalSize: number;
+	phpWasmAsyncMode?: 'jspi' | 'asyncify';
 	init: (jsRuntime: string, options: EmscriptenOptions) => PHPRuntime;
 };
 

--- a/packages/php-wasm/web/package.json
+++ b/packages/php-wasm/web/package.json
@@ -37,6 +37,9 @@
 	"main": "./index.cjs",
 	"module": "./index.js",
 	"types": "index.d.ts",
+	"dependencies": {
+		"wasm-feature-detect": "1.8.0"
+	},
 	"gitHead": "2f8d8f3cea548fbd75111e8659a92f601cddc593",
 	"engines": {
 		"node": ">=20.10.0",

--- a/packages/php-wasm/web/src/lib/extensions/intl/with-intl.ts
+++ b/packages/php-wasm/web/src/lib/extensions/intl/with-intl.ts
@@ -3,7 +3,11 @@ import type {
 	PHPRuntime,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
-import { LatestSupportedPHPVersion, FSHelpers } from '@php-wasm/universal';
+import {
+	installPHPExtensionFilesSync,
+	LatestSupportedPHPVersion,
+	PHP_EXTENSIONS_DIR,
+} from '@php-wasm/universal';
 import { getIntlExtensionModule } from './get-intl-extension-module';
 import { createMemoizedFetch } from '@wp-playground/common';
 
@@ -12,9 +16,6 @@ export async function withIntl(
 	options: EmscriptenOptions
 ): Promise<EmscriptenOptions> {
 	const memoizedFetch = createMemoizedFetch(fetch);
-
-	const extensionName = 'intl.so';
-	const dataName = 'icu.dat';
 
 	const extensionPath = await getIntlExtensionModule(version);
 	// @ts-ignore
@@ -29,74 +30,25 @@ export async function withIntl(
 		...options,
 		ENV: {
 			...options.ENV,
-			PHP_INI_SCAN_DIR: '/internal/shared/extensions',
+			PHP_INI_SCAN_DIR: PHP_EXTENSIONS_DIR,
 			ICU_DATA: '/internal/shared',
 		},
 		onRuntimeInitialized: (phpRuntime: PHPRuntime) => {
 			if (options.onRuntimeInitialized) {
 				options.onRuntimeInitialized(phpRuntime);
 			}
-			/**
-			 * The extension file previously read
-			 * is written inside the /extensions directory
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions'
-				)
-			) {
-				phpRuntime.FS.mkdirTree('/internal/shared/extensions');
-			}
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`/internal/shared/extensions/${extensionName}`
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					`/internal/shared/extensions/${extensionName}`,
-					new Uint8Array(extension)
-				);
-			}
-			/* The extension has its share of ini entries
-			 * to write in a separate ini file
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					'/internal/shared/extensions/intl.ini'
-				)
-			) {
-				phpRuntime.FS.writeFile(
-					'/internal/shared/extensions/intl.ini',
-					[
-						`extension=/internal/shared/extensions/${extensionName}`,
-					].join('\n')
-				);
-			}
-			/*
-			 * An ICU data file must be loaded to support Intl extension.
-			 * To achieve this, a shared directory is mounted and referenced
-			 * via the ICU_DATA environment variable.
-			 * By default, this variable is set to '/internal/shared',
-			 * which corresponds to the actual file location.
-			 *
-			 * The Intl extension is hard-coded to look for the `icudt74l` filename,
-			 * which means the ICU data file must use that exact name.
-			 */
-			if (
-				!FSHelpers.fileExists(
-					phpRuntime.FS,
-					`${phpRuntime.ENV.ICU_DATA}/${dataName}`
-				)
-			) {
-				phpRuntime.FS.mkdirTree(phpRuntime.ENV.ICU_DATA);
-				phpRuntime.FS.writeFile(
-					`${phpRuntime.ENV.ICU_DATA}/icudt74l.dat`,
-					new Uint8Array(ICUData)
-				);
-			}
+			installPHPExtensionFilesSync(phpRuntime.FS, {
+				name: 'intl',
+				soBytes: new Uint8Array(extension),
+				loadTiming: 'before-php-startup',
+				extraFiles: {
+					targetPath: '/internal/shared',
+					files: {
+						// The Intl extension looks for the hard-coded ICU data name.
+						'icudt74l.dat': new Uint8Array(ICUData),
+					},
+				},
+			});
 		},
 	};
 }

--- a/packages/php-wasm/web/src/lib/load-runtime.ts
+++ b/packages/php-wasm/web/src/lib/load-runtime.ts
@@ -68,9 +68,12 @@ export async function loadWebRuntime(
 		) => setTimeout(fn, 0);
 	}
 
+	const phpWasmAsyncMode = await detectPHPWasmAsyncMode();
+
 	let emscriptenOptions: EmscriptenOptions | Promise<EmscriptenOptions> = {
 		...fakeWebsocket(),
 		...(loaderOptions.emscriptenOptions || {}),
+		phpWasmAsyncMode,
 	};
 
 	if (loaderOptions.tcpOverFetch) {
@@ -118,4 +121,9 @@ export async function loadWebRuntime(
 	loaderOptions.onPhpLoaderModuleLoaded?.(phpLoaderModule);
 
 	return await loadPHPRuntime(phpLoaderModule, options);
+}
+
+async function detectPHPWasmAsyncMode(): Promise<'jspi' | 'asyncify'> {
+	const { jspi } = await import('wasm-feature-detect');
+	return (await jspi()) ? 'jspi' : 'asyncify';
 }

--- a/packages/php-wasm/web/src/test/php-dynamic-loading.spec.ts
+++ b/packages/php-wasm/web/src/test/php-dynamic-loading.spec.ts
@@ -10,6 +10,8 @@ import { SupportedPHPVersions } from '../../../universal/src/lib/supported-php-v
 // which must wrap the entire process.
 SupportedPHPVersions.forEach((phpVersion) => {
 	test.describe(`Intl - PHP ${phpVersion}`, () => {
+		const lifecycleTest = phpVersion === '8.4' ? test : test.skip;
+
 		test.beforeEach(async ({ page }) => {
 			page.on('console', (log) => console.log(log.text()));
 
@@ -62,6 +64,108 @@ SupportedPHPVersions.forEach((phpVersion) => {
 
 			test.expect(result).toEqual('bool(true)\nbool(true)\n');
 		});
+
+		lifecycleTest('survives runtime rotation', async ({ page }) => {
+			const result = await page.evaluate(
+				async (options) => {
+					const recreateRuntime = async () =>
+						await window.loadWebRuntime(options.phpVersion as any, {
+							withIntl: true,
+						});
+					const php = new window.PHP(await recreateRuntime());
+					let recreations = 1;
+					php.enableRuntimeRotation({
+						recreateRuntime: async () => {
+							recreations++;
+							return await recreateRuntime();
+						},
+						maxRequests: 1,
+					});
+
+					try {
+						const beforeRotation = await php.run({
+							code: options.checkCode,
+						});
+						const afterRotation = await php.run({
+							code: options.checkCode,
+						});
+						return {
+							beforeRotation: beforeRotation.text,
+							afterRotation: afterRotation.text,
+							recreations,
+						};
+					} finally {
+						php.exit();
+					}
+				},
+				{
+					phpVersion,
+					checkCode: intlExtensionCheckCode(),
+				}
+			);
+
+			test.expect(result).toEqual({
+				beforeRotation: 'loaded',
+				afterRotation: 'loaded',
+				recreations: 2,
+			});
+		});
+
+		lifecycleTest(
+			'loads in every PHPRequestHandler PHP instance',
+			async ({ page }) => {
+				const result = await page.evaluate(
+					async (options) => {
+						const handler = new window.PHPRequestHandler({
+							documentRoot: '/www',
+							absoluteUrl: 'http://127.0.0.1:9400',
+							phpFactory: async () =>
+								new window.PHP(
+									await window.loadWebRuntime(
+										options.phpVersion as any,
+										{
+											withIntl: true,
+										}
+									)
+								),
+							maxPhpInstances: 3,
+						});
+						const acquired = [];
+
+						try {
+							acquired.push(
+								await handler.instanceManager.acquirePHPInstance()
+							);
+							acquired.push(
+								await handler.instanceManager.acquirePHPInstance()
+							);
+							acquired.push(
+								await handler.instanceManager.acquirePHPInstance()
+							);
+
+							const checks = await Promise.all(
+								acquired.map(({ php }) =>
+									php.run({ code: options.checkCode })
+								)
+							);
+
+							return checks.map(({ text }) => text);
+						} finally {
+							for (const acquiredPhp of acquired) {
+								acquiredPhp.reap();
+							}
+							await handler[Symbol.asyncDispose]();
+						}
+					},
+					{
+						phpVersion,
+						checkCode: intlExtensionCheckCode(),
+					}
+				);
+
+				test.expect(result).toEqual(['loaded', 'loaded', 'loaded']);
+			}
+		);
 
 		test('has its own ini file and entries', async ({ page }) => {
 			const result = await page.evaluate(async (phpVersion) => {
@@ -122,7 +226,9 @@ SupportedPHPVersions.forEach((phpVersion) => {
 					})
 				);
 
-				await window.proxyFileSystem(oldPhp, newPhp, ['/internal/shared']);
+				await window.proxyFileSystem(oldPhp, newPhp, [
+					'/internal/shared',
+				]);
 
 				const response = await newPhp.runStream({
 					code: `<?php
@@ -207,3 +313,9 @@ SupportedPHPVersions.forEach((phpVersion) => {
 		});
 	});
 });
+
+function intlExtensionCheckCode() {
+	return `<?php
+		echo extension_loaded('intl') && class_exists('Collator') ? 'loaded' : 'missing';
+	`;
+}

--- a/packages/php-wasm/web/src/test/playwright/globals.d.ts
+++ b/packages/php-wasm/web/src/test/playwright/globals.d.ts
@@ -1,9 +1,15 @@
-import type { PHP, setPhpIniEntries } from '@php-wasm/universal';
+import type {
+	PHP,
+	PHPRequestHandler,
+	proxyFileSystem,
+	setPhpIniEntries,
+} from '@php-wasm/universal';
 import type { loadWebRuntime, generateCertificate } from '../../lib';
 
 declare global {
 	interface Window {
 		PHP: typeof PHP;
+		PHPRequestHandler: typeof PHPRequestHandler;
 		loadWebRuntime: typeof loadWebRuntime;
 		proxyFileSystem: typeof proxyFileSystem;
 		setPhpIniEntries: typeof setPhpIniEntries;

--- a/packages/php-wasm/web/src/test/playwright/globals.ts
+++ b/packages/php-wasm/web/src/test/playwright/globals.ts
@@ -1,7 +1,13 @@
-import { PHP, proxyFileSystem, setPhpIniEntries } from '@php-wasm/universal';
+import {
+	PHP,
+	PHPRequestHandler,
+	proxyFileSystem,
+	setPhpIniEntries,
+} from '@php-wasm/universal';
 import { loadWebRuntime, generateCertificate } from '../../lib';
 
 (window as any).PHP = PHP;
+(window as any).PHPRequestHandler = PHPRequestHandler;
 (window as any).loadWebRuntime = loadWebRuntime;
 (window as any).proxyFileSystem = proxyFileSystem;
 (window as any).setPhpIniEntries = setPhpIniEntries;

--- a/packages/playground/blueprints/public/blueprint-schema-validator.js
+++ b/packages/playground/blueprints/public/blueprint-schema-validator.js
@@ -741,6 +741,88 @@ const schema11 = {
 							},
 							additionalProperties: false,
 						},
+						step: { type: 'string', const: 'loadPHPExtension' },
+						source: {
+							$ref: '#/definitions/FileReference',
+							description:
+								'The extension `.so` file or a compile-extension `manifest.json`.',
+						},
+						sourceFormat: {
+							$ref: '#/definitions/PHPExtensionSourceFormat',
+							description:
+								'Defaults to "manifest" for `.json` files and "so" otherwise.',
+						},
+						name: {
+							type: 'string',
+							description:
+								'Required when loading a `.so` file whose filename is not named after the extension.',
+						},
+						loadTiming: {
+							$ref: '#/definitions/PHPExtensionLoadTiming',
+							description: 'Defaults to "auto".',
+						},
+						loadWithIniDirective: {
+							$ref: '#/definitions/PHPExtensionIniDirective',
+							description:
+								'Defaults to "extension". Use "zend_extension" for extensions like Xdebug.',
+						},
+						iniEntries: {
+							type: 'object',
+							additionalProperties: { type: 'string' },
+							description:
+								'Extra `php.ini` entries to write next to the extension.',
+						},
+						extraFiles: {
+							$ref: '#/definitions/DirectoryReference',
+							description:
+								'Extra files required by the extension, such as ICU data or shared libraries.',
+						},
+						extraFilesPath: {
+							type: 'string',
+							description:
+								'Where to write `extraFiles`. Defaults to an extension-specific assets directory.',
+						},
+						env: {
+							type: 'object',
+							additionalProperties: { type: 'string' },
+							description:
+								'Runtime environment variables needed by the extension.',
+						},
+						phpVersion: {
+							type: 'string',
+							description:
+								'Overrides manifest artifact selection. Defaults to the running PHP version.',
+						},
+						asyncMode: {
+							$ref: '#/definitions/PHPWasmAsyncMode',
+							description:
+								'Overrides manifest artifact selection. Defaults to the running async mode.',
+						},
+						manifestBaseUrl: {
+							type: 'string',
+							description:
+								'Base URL for relative artifact paths in an inline or bundled manifest.',
+						},
+						extensionDir: {
+							type: 'string',
+							description:
+								'Where to install the extension `.so` and `.ini` files.',
+						},
+					},
+					required: ['source', 'step'],
+				},
+				{
+					type: 'object',
+					additionalProperties: false,
+					properties: {
+						progress: {
+							type: 'object',
+							properties: {
+								weight: { type: 'number' },
+								caption: { type: 'string' },
+							},
+							additionalProperties: false,
+						},
 						step: { type: 'string', const: 'login' },
 						username: {
 							type: 'string',
@@ -1226,6 +1308,16 @@ const schema11 = {
 			},
 			additionalProperties: false,
 		},
+		PHPExtensionSourceFormat: { type: 'string', enum: ['so', 'manifest'] },
+		PHPExtensionLoadTiming: {
+			type: 'string',
+			enum: ['before-php-startup', 'after-php-startup', 'auto'],
+		},
+		PHPExtensionIniDirective: {
+			type: 'string',
+			enum: ['extension', 'zend_extension'],
+		},
+		PHPWasmAsyncMode: { type: 'string', enum: ['jspi', 'asyncify'] },
 		PHPRequest: {
 			type: 'object',
 			properties: {
@@ -4724,6 +4816,88 @@ const schema32 = {
 					},
 					additionalProperties: false,
 				},
+				step: { type: 'string', const: 'loadPHPExtension' },
+				source: {
+					$ref: '#/definitions/FileReference',
+					description:
+						'The extension `.so` file or a compile-extension `manifest.json`.',
+				},
+				sourceFormat: {
+					$ref: '#/definitions/PHPExtensionSourceFormat',
+					description:
+						'Defaults to "manifest" for `.json` files and "so" otherwise.',
+				},
+				name: {
+					type: 'string',
+					description:
+						'Required when loading a `.so` file whose filename is not named after the extension.',
+				},
+				loadTiming: {
+					$ref: '#/definitions/PHPExtensionLoadTiming',
+					description: 'Defaults to "auto".',
+				},
+				loadWithIniDirective: {
+					$ref: '#/definitions/PHPExtensionIniDirective',
+					description:
+						'Defaults to "extension". Use "zend_extension" for extensions like Xdebug.',
+				},
+				iniEntries: {
+					type: 'object',
+					additionalProperties: { type: 'string' },
+					description:
+						'Extra `php.ini` entries to write next to the extension.',
+				},
+				extraFiles: {
+					$ref: '#/definitions/DirectoryReference',
+					description:
+						'Extra files required by the extension, such as ICU data or shared libraries.',
+				},
+				extraFilesPath: {
+					type: 'string',
+					description:
+						'Where to write `extraFiles`. Defaults to an extension-specific assets directory.',
+				},
+				env: {
+					type: 'object',
+					additionalProperties: { type: 'string' },
+					description:
+						'Runtime environment variables needed by the extension.',
+				},
+				phpVersion: {
+					type: 'string',
+					description:
+						'Overrides manifest artifact selection. Defaults to the running PHP version.',
+				},
+				asyncMode: {
+					$ref: '#/definitions/PHPWasmAsyncMode',
+					description:
+						'Overrides manifest artifact selection. Defaults to the running async mode.',
+				},
+				manifestBaseUrl: {
+					type: 'string',
+					description:
+						'Base URL for relative artifact paths in an inline or bundled manifest.',
+				},
+				extensionDir: {
+					type: 'string',
+					description:
+						'Where to install the extension `.so` and `.ini` files.',
+				},
+			},
+			required: ['source', 'step'],
+		},
+		{
+			type: 'object',
+			additionalProperties: false,
+			properties: {
+				progress: {
+					type: 'object',
+					properties: {
+						weight: { type: 'number' },
+						caption: { type: 'string' },
+					},
+					additionalProperties: false,
+				},
 				step: { type: 'string', const: 'login' },
 				username: {
 					type: 'string',
@@ -5188,7 +5362,14 @@ const schema34 = {
 	},
 	additionalProperties: false,
 };
-const schema41 = {
+const schema35 = { type: 'string', enum: ['so', 'manifest'] };
+const schema36 = {
+	type: 'string',
+	enum: ['before-php-startup', 'after-php-startup', 'auto'],
+};
+const schema37 = { type: 'string', enum: ['extension', 'zend_extension'] };
+const schema38 = { type: 'string', enum: ['jspi', 'asyncify'] };
+const schema45 = {
 	type: 'object',
 	properties: {
 		adminUsername: { type: 'string' },
@@ -5196,7 +5377,7 @@ const schema41 = {
 	},
 	additionalProperties: false,
 };
-const schema35 = {
+const schema39 = {
 	type: 'object',
 	properties: {
 		method: {
@@ -5293,12 +5474,12 @@ const schema35 = {
 	required: ['url'],
 	additionalProperties: false,
 };
-const schema36 = {
+const schema40 = {
 	type: 'string',
 	enum: ['GET', 'POST', 'HEAD', 'OPTIONS', 'PATCH', 'PUT', 'DELETE'],
 };
-const schema37 = { type: 'object', additionalProperties: { type: 'string' } };
-function validate37(
+const schema41 = { type: 'object', additionalProperties: { type: 'string' } };
+function validate39(
 	data,
 	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
 ) {
@@ -5308,7 +5489,7 @@ function validate37(
 		if (data && typeof data == 'object' && !Array.isArray(data)) {
 			let missing0;
 			if (data.url === undefined && (missing0 = 'url')) {
-				validate37.errors = [
+				validate39.errors = [
 					{
 						instancePath,
 						schemaPath: '#/required',
@@ -5330,7 +5511,7 @@ function validate37(
 							key0 === 'body'
 						)
 					) {
-						validate37.errors = [
+						validate39.errors = [
 							{
 								instancePath,
 								schemaPath: '#/additionalProperties',
@@ -5348,7 +5529,7 @@ function validate37(
 						let data0 = data.method;
 						const _errs2 = errors;
 						if (typeof data0 !== 'string') {
-							validate37.errors = [
+							validate39.errors = [
 								{
 									instancePath: instancePath + '/method',
 									schemaPath: '#/definitions/HTTPMethod/type',
@@ -5370,12 +5551,12 @@ function validate37(
 								data0 === 'DELETE'
 							)
 						) {
-							validate37.errors = [
+							validate39.errors = [
 								{
 									instancePath: instancePath + '/method',
 									schemaPath: '#/definitions/HTTPMethod/enum',
 									keyword: 'enum',
-									params: { allowedValues: schema36.enum },
+									params: { allowedValues: schema40.enum },
 									message:
 										'must be equal to one of the allowed values',
 								},
@@ -5390,7 +5571,7 @@ function validate37(
 						if (data.url !== undefined) {
 							const _errs5 = errors;
 							if (typeof data.url !== 'string') {
-								validate37.errors = [
+								validate39.errors = [
 									{
 										instancePath: instancePath + '/url',
 										schemaPath: '#/properties/url/type',
@@ -5421,7 +5602,7 @@ function validate37(
 											if (
 												typeof data2[key1] !== 'string'
 											) {
-												validate37.errors = [
+												validate39.errors = [
 													{
 														instancePath:
 															instancePath +
@@ -5453,7 +5634,7 @@ function validate37(
 											}
 										}
 									} else {
-										validate37.errors = [
+										validate39.errors = [
 											{
 												instancePath:
 													instancePath + '/headers',
@@ -7442,7 +7623,7 @@ function validate37(
 											vErrors.push(err34);
 										}
 										errors++;
-										validate37.errors = vErrors;
+										validate39.errors = vErrors;
 										return false;
 									} else {
 										errors = _errs14;
@@ -7464,7 +7645,7 @@ function validate37(
 				}
 			}
 		} else {
-			validate37.errors = [
+			validate39.errors = [
 				{
 					instancePath,
 					schemaPath: '#/type',
@@ -7476,10 +7657,10 @@ function validate37(
 			return false;
 		}
 	}
-	validate37.errors = vErrors;
+	validate39.errors = vErrors;
 	return errors === 0;
 }
-const schema38 = {
+const schema42 = {
 	type: 'object',
 	properties: {
 		relativeUri: {
@@ -7546,7 +7727,7 @@ const schema38 = {
 	},
 	additionalProperties: false,
 };
-function validate39(
+function validate41(
 	data,
 	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
 ) {
@@ -7556,8 +7737,8 @@ function validate39(
 		if (data && typeof data == 'object' && !Array.isArray(data)) {
 			const _errs1 = errors;
 			for (const key0 in data) {
-				if (!func2.call(schema38.properties, key0)) {
-					validate39.errors = [
+				if (!func2.call(schema42.properties, key0)) {
+					validate41.errors = [
 						{
 							instancePath,
 							schemaPath: '#/additionalProperties',
@@ -7574,7 +7755,7 @@ function validate39(
 				if (data.relativeUri !== undefined) {
 					const _errs2 = errors;
 					if (typeof data.relativeUri !== 'string') {
-						validate39.errors = [
+						validate41.errors = [
 							{
 								instancePath: instancePath + '/relativeUri',
 								schemaPath: '#/properties/relativeUri/type',
@@ -7593,7 +7774,7 @@ function validate39(
 					if (data.scriptPath !== undefined) {
 						const _errs4 = errors;
 						if (typeof data.scriptPath !== 'string') {
-							validate39.errors = [
+							validate41.errors = [
 								{
 									instancePath: instancePath + '/scriptPath',
 									schemaPath: '#/properties/scriptPath/type',
@@ -7612,7 +7793,7 @@ function validate39(
 						if (data.protocol !== undefined) {
 							const _errs6 = errors;
 							if (typeof data.protocol !== 'string') {
-								validate39.errors = [
+								validate41.errors = [
 									{
 										instancePath:
 											instancePath + '/protocol',
@@ -7634,7 +7815,7 @@ function validate39(
 								let data3 = data.method;
 								const _errs8 = errors;
 								if (typeof data3 !== 'string') {
-									validate39.errors = [
+									validate41.errors = [
 										{
 											instancePath:
 												instancePath + '/method',
@@ -7658,7 +7839,7 @@ function validate39(
 										data3 === 'DELETE'
 									)
 								) {
-									validate39.errors = [
+									validate41.errors = [
 										{
 											instancePath:
 												instancePath + '/method',
@@ -7666,7 +7847,7 @@ function validate39(
 												'#/definitions/HTTPMethod/enum',
 											keyword: 'enum',
 											params: {
-												allowedValues: schema36.enum,
+												allowedValues: schema40.enum,
 											},
 											message:
 												'must be equal to one of the allowed values',
@@ -7695,7 +7876,7 @@ function validate39(
 													typeof data4[key1] !==
 													'string'
 												) {
-													validate39.errors = [
+													validate41.errors = [
 														{
 															instancePath:
 																instancePath +
@@ -7727,7 +7908,7 @@ function validate39(
 												}
 											}
 										} else {
-											validate39.errors = [
+											validate41.errors = [
 												{
 													instancePath:
 														instancePath +
@@ -8365,7 +8546,7 @@ function validate39(
 												vErrors.push(err12);
 											}
 											errors++;
-											validate39.errors = vErrors;
+											validate41.errors = vErrors;
 											return false;
 										} else {
 											errors = _errs18;
@@ -8398,7 +8579,7 @@ function validate39(
 																key4
 															] !== 'string'
 														) {
-															validate39.errors =
+															validate41.errors =
 																[
 																	{
 																		instancePath:
@@ -8433,7 +8614,7 @@ function validate39(
 														}
 													}
 												} else {
-													validate39.errors = [
+													validate41.errors = [
 														{
 															instancePath:
 																instancePath +
@@ -8474,7 +8655,7 @@ function validate39(
 																	key5
 																] !== 'string'
 															) {
-																validate39.errors =
+																validate41.errors =
 																	[
 																		{
 																			instancePath:
@@ -8510,7 +8691,7 @@ function validate39(
 															}
 														}
 													} else {
-														validate39.errors = [
+														validate41.errors = [
 															{
 																instancePath:
 																	instancePath +
@@ -8539,7 +8720,7 @@ function validate39(
 														typeof data.code !==
 														'string'
 													) {
-														validate39.errors = [
+														validate41.errors = [
 															{
 																instancePath:
 																	instancePath +
@@ -8571,7 +8752,7 @@ function validate39(
 				}
 			}
 		} else {
-			validate39.errors = [
+			validate41.errors = [
 				{
 					instancePath,
 					schemaPath: '#/type',
@@ -8583,7 +8764,7 @@ function validate39(
 			return false;
 		}
 	}
-	validate39.errors = vErrors;
+	validate41.errors = vErrors;
 	return errors === 0;
 }
 function validate28(
@@ -13003,7 +13184,7 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'login') {
+					} else if (tag0 === 'loadPHPExtension') {
 						const _errs196 = errors;
 						if (errors === _errs196) {
 							if (
@@ -13013,8 +13194,10 @@ function validate28(
 							) {
 								let missing12;
 								if (
-									data.step === undefined &&
-									(missing12 = 'step')
+									(data.source === undefined &&
+										(missing12 = 'source')) ||
+									(data.step === undefined &&
+										(missing12 = 'step'))
 								) {
 									validate28.errors = [
 										{
@@ -13035,11 +13218,9 @@ function validate28(
 									const _errs198 = errors;
 									for (const key25 in data) {
 										if (
-											!(
-												key25 === 'progress' ||
-												key25 === 'step' ||
-												key25 === 'username' ||
-												key25 === 'password'
+											!func2.call(
+												schema32.oneOf[11].properties,
+												key25
 											)
 										) {
 											validate28.errors = [
@@ -13231,7 +13412,10 @@ function validate28(
 													];
 													return false;
 												}
-												if ('login' !== data76) {
+												if (
+													'loadPHPExtension' !==
+													data76
+												) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -13242,7 +13426,7 @@ function validate28(
 															keyword: 'const',
 															params: {
 																allowedValue:
-																	'login',
+																	'loadPHPExtension',
 															},
 															message:
 																'must be equal to constant',
@@ -13256,30 +13440,30 @@ function validate28(
 												var valid42 = true;
 											}
 											if (valid42) {
-												if (
-													data.username !== undefined
-												) {
+												if (data.source !== undefined) {
 													const _errs208 = errors;
 													if (
-														typeof data.username !==
-														'string'
-													) {
-														validate28.errors = [
+														!validate16(
+															data.source,
 															{
 																instancePath:
 																	instancePath +
-																	'/username',
-																schemaPath:
-																	'#/oneOf/11/properties/username/type',
-																keyword: 'type',
-																params: {
-																	type: 'string',
-																},
-																message:
-																	'must be string',
-															},
-														];
-														return false;
+																	'/source',
+																parentData:
+																	data,
+																parentDataProperty:
+																	'source',
+																rootData,
+															}
+														)
+													) {
+														vErrors =
+															vErrors === null
+																? validate16.errors
+																: vErrors.concat(
+																		validate16.errors
+																	);
+														errors = vErrors.length;
 													}
 													var valid42 =
 														_errs208 === errors;
@@ -13288,12 +13472,14 @@ function validate28(
 												}
 												if (valid42) {
 													if (
-														data.password !==
+														data.sourceFormat !==
 														undefined
 													) {
-														const _errs210 = errors;
+														let data78 =
+															data.sourceFormat;
+														const _errs209 = errors;
 														if (
-															typeof data.password !==
+															typeof data78 !==
 															'string'
 														) {
 															validate28.errors =
@@ -13301,9 +13487,9 @@ function validate28(
 																	{
 																		instancePath:
 																			instancePath +
-																			'/password',
+																			'/sourceFormat',
 																		schemaPath:
-																			'#/oneOf/11/properties/password/type',
+																			'#/definitions/PHPExtensionSourceFormat/type',
 																		keyword:
 																			'type',
 																		params: {
@@ -13315,10 +13501,669 @@ function validate28(
 																];
 															return false;
 														}
+														if (
+															!(
+																data78 ===
+																	'so' ||
+																data78 ===
+																	'manifest'
+															)
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/sourceFormat',
+																		schemaPath:
+																			'#/definitions/PHPExtensionSourceFormat/enum',
+																		keyword:
+																			'enum',
+																		params: {
+																			allowedValues:
+																				schema35.enum,
+																		},
+																		message:
+																			'must be equal to one of the allowed values',
+																	},
+																];
+															return false;
+														}
 														var valid42 =
-															_errs210 === errors;
+															_errs209 === errors;
 													} else {
 														var valid42 = true;
+													}
+													if (valid42) {
+														if (
+															data.name !==
+															undefined
+														) {
+															const _errs212 =
+																errors;
+															if (
+																typeof data.name !==
+																'string'
+															) {
+																validate28.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/name',
+																			schemaPath:
+																				'#/oneOf/11/properties/name/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'string',
+																			},
+																			message:
+																				'must be string',
+																		},
+																	];
+																return false;
+															}
+															var valid42 =
+																_errs212 ===
+																errors;
+														} else {
+															var valid42 = true;
+														}
+														if (valid42) {
+															if (
+																data.loadTiming !==
+																undefined
+															) {
+																let data80 =
+																	data.loadTiming;
+																const _errs214 =
+																	errors;
+																if (
+																	typeof data80 !==
+																	'string'
+																) {
+																	validate28.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/loadTiming',
+																				schemaPath:
+																					'#/definitions/PHPExtensionLoadTiming/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'string',
+																				},
+																				message:
+																					'must be string',
+																			},
+																		];
+																	return false;
+																}
+																if (
+																	!(
+																		data80 ===
+																			'before-php-startup' ||
+																		data80 ===
+																			'after-php-startup' ||
+																		data80 ===
+																			'auto'
+																	)
+																) {
+																	validate28.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/loadTiming',
+																				schemaPath:
+																					'#/definitions/PHPExtensionLoadTiming/enum',
+																				keyword:
+																					'enum',
+																				params: {
+																					allowedValues:
+																						schema36.enum,
+																				},
+																				message:
+																					'must be equal to one of the allowed values',
+																			},
+																		];
+																	return false;
+																}
+																var valid42 =
+																	_errs214 ===
+																	errors;
+															} else {
+																var valid42 = true;
+															}
+															if (valid42) {
+																if (
+																	data.loadWithIniDirective !==
+																	undefined
+																) {
+																	let data81 =
+																		data.loadWithIniDirective;
+																	const _errs217 =
+																		errors;
+																	if (
+																		typeof data81 !==
+																		'string'
+																	) {
+																		validate28.errors =
+																			[
+																				{
+																					instancePath:
+																						instancePath +
+																						'/loadWithIniDirective',
+																					schemaPath:
+																						'#/definitions/PHPExtensionIniDirective/type',
+																					keyword:
+																						'type',
+																					params: {
+																						type: 'string',
+																					},
+																					message:
+																						'must be string',
+																				},
+																			];
+																		return false;
+																	}
+																	if (
+																		!(
+																			data81 ===
+																				'extension' ||
+																			data81 ===
+																				'zend_extension'
+																		)
+																	) {
+																		validate28.errors =
+																			[
+																				{
+																					instancePath:
+																						instancePath +
+																						'/loadWithIniDirective',
+																					schemaPath:
+																						'#/definitions/PHPExtensionIniDirective/enum',
+																					keyword:
+																						'enum',
+																					params: {
+																						allowedValues:
+																							schema37.enum,
+																					},
+																					message:
+																						'must be equal to one of the allowed values',
+																				},
+																			];
+																		return false;
+																	}
+																	var valid42 =
+																		_errs217 ===
+																		errors;
+																} else {
+																	var valid42 = true;
+																}
+																if (valid42) {
+																	if (
+																		data.iniEntries !==
+																		undefined
+																	) {
+																		let data82 =
+																			data.iniEntries;
+																		const _errs220 =
+																			errors;
+																		if (
+																			errors ===
+																			_errs220
+																		) {
+																			if (
+																				data82 &&
+																				typeof data82 ==
+																					'object' &&
+																				!Array.isArray(
+																					data82
+																				)
+																			) {
+																				for (const key27 in data82) {
+																					const _errs223 =
+																						errors;
+																					if (
+																						typeof data82[
+																							key27
+																						] !==
+																						'string'
+																					) {
+																						validate28.errors =
+																							[
+																								{
+																									instancePath:
+																										instancePath +
+																										'/iniEntries/' +
+																										key27
+																											.replace(
+																												/~/g,
+																												'~0'
+																											)
+																											.replace(
+																												/\//g,
+																												'~1'
+																											),
+																									schemaPath:
+																										'#/oneOf/11/properties/iniEntries/additionalProperties/type',
+																									keyword:
+																										'type',
+																									params: {
+																										type: 'string',
+																									},
+																									message:
+																										'must be string',
+																								},
+																							];
+																						return false;
+																					}
+																					var valid47 =
+																						_errs223 ===
+																						errors;
+																					if (
+																						!valid47
+																					) {
+																						break;
+																					}
+																				}
+																			} else {
+																				validate28.errors =
+																					[
+																						{
+																							instancePath:
+																								instancePath +
+																								'/iniEntries',
+																							schemaPath:
+																								'#/oneOf/11/properties/iniEntries/type',
+																							keyword:
+																								'type',
+																							params: {
+																								type: 'object',
+																							},
+																							message:
+																								'must be object',
+																						},
+																					];
+																				return false;
+																			}
+																		}
+																		var valid42 =
+																			_errs220 ===
+																			errors;
+																	} else {
+																		var valid42 = true;
+																	}
+																	if (
+																		valid42
+																	) {
+																		if (
+																			data.extraFiles !==
+																			undefined
+																		) {
+																			const _errs225 =
+																				errors;
+																			if (
+																				!validate18(
+																					data.extraFiles,
+																					{
+																						instancePath:
+																							instancePath +
+																							'/extraFiles',
+																						parentData:
+																							data,
+																						parentDataProperty:
+																							'extraFiles',
+																						rootData,
+																					}
+																				)
+																			) {
+																				vErrors =
+																					vErrors ===
+																					null
+																						? validate18.errors
+																						: vErrors.concat(
+																								validate18.errors
+																							);
+																				errors =
+																					vErrors.length;
+																			}
+																			var valid42 =
+																				_errs225 ===
+																				errors;
+																		} else {
+																			var valid42 = true;
+																		}
+																		if (
+																			valid42
+																		) {
+																			if (
+																				data.extraFilesPath !==
+																				undefined
+																			) {
+																				const _errs226 =
+																					errors;
+																				if (
+																					typeof data.extraFilesPath !==
+																					'string'
+																				) {
+																					validate28.errors =
+																						[
+																							{
+																								instancePath:
+																									instancePath +
+																									'/extraFilesPath',
+																								schemaPath:
+																									'#/oneOf/11/properties/extraFilesPath/type',
+																								keyword:
+																									'type',
+																								params: {
+																									type: 'string',
+																								},
+																								message:
+																									'must be string',
+																							},
+																						];
+																					return false;
+																				}
+																				var valid42 =
+																					_errs226 ===
+																					errors;
+																			} else {
+																				var valid42 = true;
+																			}
+																			if (
+																				valid42
+																			) {
+																				if (
+																					data.env !==
+																					undefined
+																				) {
+																					let data86 =
+																						data.env;
+																					const _errs228 =
+																						errors;
+																					if (
+																						errors ===
+																						_errs228
+																					) {
+																						if (
+																							data86 &&
+																							typeof data86 ==
+																								'object' &&
+																							!Array.isArray(
+																								data86
+																							)
+																						) {
+																							for (const key28 in data86) {
+																								const _errs231 =
+																									errors;
+																								if (
+																									typeof data86[
+																										key28
+																									] !==
+																									'string'
+																								) {
+																									validate28.errors =
+																										[
+																											{
+																												instancePath:
+																													instancePath +
+																													'/env/' +
+																													key28
+																														.replace(
+																															/~/g,
+																															'~0'
+																														)
+																														.replace(
+																															/\//g,
+																															'~1'
+																														),
+																												schemaPath:
+																													'#/oneOf/11/properties/env/additionalProperties/type',
+																												keyword:
+																													'type',
+																												params: {
+																													type: 'string',
+																												},
+																												message:
+																													'must be string',
+																											},
+																										];
+																									return false;
+																								}
+																								var valid48 =
+																									_errs231 ===
+																									errors;
+																								if (
+																									!valid48
+																								) {
+																									break;
+																								}
+																							}
+																						} else {
+																							validate28.errors =
+																								[
+																									{
+																										instancePath:
+																											instancePath +
+																											'/env',
+																										schemaPath:
+																											'#/oneOf/11/properties/env/type',
+																										keyword:
+																											'type',
+																										params: {
+																											type: 'object',
+																										},
+																										message:
+																											'must be object',
+																									},
+																								];
+																							return false;
+																						}
+																					}
+																					var valid42 =
+																						_errs228 ===
+																						errors;
+																				} else {
+																					var valid42 = true;
+																				}
+																				if (
+																					valid42
+																				) {
+																					if (
+																						data.phpVersion !==
+																						undefined
+																					) {
+																						const _errs233 =
+																							errors;
+																						if (
+																							typeof data.phpVersion !==
+																							'string'
+																						) {
+																							validate28.errors =
+																								[
+																									{
+																										instancePath:
+																											instancePath +
+																											'/phpVersion',
+																										schemaPath:
+																											'#/oneOf/11/properties/phpVersion/type',
+																										keyword:
+																											'type',
+																										params: {
+																											type: 'string',
+																										},
+																										message:
+																											'must be string',
+																									},
+																								];
+																							return false;
+																						}
+																						var valid42 =
+																							_errs233 ===
+																							errors;
+																					} else {
+																						var valid42 = true;
+																					}
+																					if (
+																						valid42
+																					) {
+																						if (
+																							data.asyncMode !==
+																							undefined
+																						) {
+																							let data89 =
+																								data.asyncMode;
+																							const _errs235 =
+																								errors;
+																							if (
+																								typeof data89 !==
+																								'string'
+																							) {
+																								validate28.errors =
+																									[
+																										{
+																											instancePath:
+																												instancePath +
+																												'/asyncMode',
+																											schemaPath:
+																												'#/definitions/PHPWasmAsyncMode/type',
+																											keyword:
+																												'type',
+																											params: {
+																												type: 'string',
+																											},
+																											message:
+																												'must be string',
+																										},
+																									];
+																								return false;
+																							}
+																							if (
+																								!(
+																									data89 ===
+																										'jspi' ||
+																									data89 ===
+																										'asyncify'
+																								)
+																							) {
+																								validate28.errors =
+																									[
+																										{
+																											instancePath:
+																												instancePath +
+																												'/asyncMode',
+																											schemaPath:
+																												'#/definitions/PHPWasmAsyncMode/enum',
+																											keyword:
+																												'enum',
+																											params: {
+																												allowedValues:
+																													schema38.enum,
+																											},
+																											message:
+																												'must be equal to one of the allowed values',
+																										},
+																									];
+																								return false;
+																							}
+																							var valid42 =
+																								_errs235 ===
+																								errors;
+																						} else {
+																							var valid42 = true;
+																						}
+																						if (
+																							valid42
+																						) {
+																							if (
+																								data.manifestBaseUrl !==
+																								undefined
+																							) {
+																								const _errs238 =
+																									errors;
+																								if (
+																									typeof data.manifestBaseUrl !==
+																									'string'
+																								) {
+																									validate28.errors =
+																										[
+																											{
+																												instancePath:
+																													instancePath +
+																													'/manifestBaseUrl',
+																												schemaPath:
+																													'#/oneOf/11/properties/manifestBaseUrl/type',
+																												keyword:
+																													'type',
+																												params: {
+																													type: 'string',
+																												},
+																												message:
+																													'must be string',
+																											},
+																										];
+																									return false;
+																								}
+																								var valid42 =
+																									_errs238 ===
+																									errors;
+																							} else {
+																								var valid42 = true;
+																							}
+																							if (
+																								valid42
+																							) {
+																								if (
+																									data.extensionDir !==
+																									undefined
+																								) {
+																									const _errs240 =
+																										errors;
+																									if (
+																										typeof data.extensionDir !==
+																										'string'
+																									) {
+																										validate28.errors =
+																											[
+																												{
+																													instancePath:
+																														instancePath +
+																														'/extensionDir',
+																													schemaPath:
+																														'#/oneOf/11/properties/extensionDir/type',
+																													keyword:
+																														'type',
+																													params: {
+																														type: 'string',
+																													},
+																													message:
+																														'must be string',
+																												},
+																											];
+																										return false;
+																									}
+																									var valid42 =
+																										_errs240 ===
+																										errors;
+																								} else {
+																									var valid42 = true;
+																								}
+																							}
+																						}
+																					}
+																				}
+																			}
+																		}
+																	}
+																}
+															}
+														}
 													}
 												}
 											}
@@ -13338,9 +14183,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'mkdir') {
-						const _errs212 = errors;
-						if (errors === _errs212) {
+					} else if (tag0 === 'login') {
+						const _errs242 = errors;
+						if (errors === _errs242) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -13348,10 +14193,8 @@ function validate28(
 							) {
 								let missing13;
 								if (
-									(data.path === undefined &&
-										(missing13 = 'path')) ||
-									(data.step === undefined &&
-										(missing13 = 'step'))
+									data.step === undefined &&
+									(missing13 = 'step')
 								) {
 									validate28.errors = [
 										{
@@ -13369,13 +14212,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs214 = errors;
-									for (const key27 in data) {
+									const _errs244 = errors;
+									for (const key29 in data) {
 										if (
 											!(
-												key27 === 'progress' ||
-												key27 === 'step' ||
-												key27 === 'path'
+												key29 === 'progress' ||
+												key29 === 'step' ||
+												key29 === 'username' ||
+												key29 === 'password'
 											)
 										) {
 											validate28.errors = [
@@ -13387,7 +14231,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key27,
+															key29,
 													},
 													message:
 														'must NOT have additional properties',
@@ -13397,23 +14241,23 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs214 === errors) {
+									if (_errs244 === errors) {
 										if (data.progress !== undefined) {
-											let data79 = data.progress;
-											const _errs215 = errors;
-											if (errors === _errs215) {
+											let data92 = data.progress;
+											const _errs245 = errors;
+											if (errors === _errs245) {
 												if (
-													data79 &&
-													typeof data79 == 'object' &&
-													!Array.isArray(data79)
+													data92 &&
+													typeof data92 == 'object' &&
+													!Array.isArray(data92)
 												) {
-													const _errs217 = errors;
-													for (const key28 in data79) {
+													const _errs247 = errors;
+													for (const key30 in data92) {
 														if (
 															!(
-																key28 ===
+																key30 ===
 																	'weight' ||
-																key28 ===
+																key30 ===
 																	'caption'
 															)
 														) {
@@ -13429,7 +14273,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key28,
+																				key30,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -13439,21 +14283,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs217 === errors) {
+													if (_errs247 === errors) {
 														if (
-															data79.weight !==
+															data92.weight !==
 															undefined
 														) {
-															let data80 =
-																data79.weight;
-															const _errs218 =
+															let data93 =
+																data92.weight;
+															const _errs248 =
 																errors;
 															if (
 																!(
-																	typeof data80 ==
+																	typeof data93 ==
 																		'number' &&
 																	isFinite(
-																		data80
+																		data93
 																	)
 																)
 															) {
@@ -13476,21 +14320,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid46 =
-																_errs218 ===
+															var valid52 =
+																_errs248 ===
 																errors;
 														} else {
-															var valid46 = true;
+															var valid52 = true;
 														}
-														if (valid46) {
+														if (valid52) {
 															if (
-																data79.caption !==
+																data92.caption !==
 																undefined
 															) {
-																const _errs220 =
+																const _errs250 =
 																	errors;
 																if (
-																	typeof data79.caption !==
+																	typeof data92.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -13501,641 +14345,6 @@ function validate28(
 																					'/progress/caption',
 																				schemaPath:
 																					'#/oneOf/12/properties/progress/properties/caption/type',
-																				keyword:
-																					'type',
-																				params: {
-																					type: 'string',
-																				},
-																				message:
-																					'must be string',
-																			},
-																		];
-																	return false;
-																}
-																var valid46 =
-																	_errs220 ===
-																	errors;
-															} else {
-																var valid46 = true;
-															}
-														}
-													}
-												} else {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/progress',
-															schemaPath:
-																'#/oneOf/12/properties/progress/type',
-															keyword: 'type',
-															params: {
-																type: 'object',
-															},
-															message:
-																'must be object',
-														},
-													];
-													return false;
-												}
-											}
-											var valid45 = _errs215 === errors;
-										} else {
-											var valid45 = true;
-										}
-										if (valid45) {
-											if (data.step !== undefined) {
-												let data82 = data.step;
-												const _errs222 = errors;
-												if (
-													typeof data82 !== 'string'
-												) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/12/properties/step/type',
-															keyword: 'type',
-															params: {
-																type: 'string',
-															},
-															message:
-																'must be string',
-														},
-													];
-													return false;
-												}
-												if ('mkdir' !== data82) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/12/properties/step/const',
-															keyword: 'const',
-															params: {
-																allowedValue:
-																	'mkdir',
-															},
-															message:
-																'must be equal to constant',
-														},
-													];
-													return false;
-												}
-												var valid45 =
-													_errs222 === errors;
-											} else {
-												var valid45 = true;
-											}
-											if (valid45) {
-												if (data.path !== undefined) {
-													const _errs224 = errors;
-													if (
-														typeof data.path !==
-														'string'
-													) {
-														validate28.errors = [
-															{
-																instancePath:
-																	instancePath +
-																	'/path',
-																schemaPath:
-																	'#/oneOf/12/properties/path/type',
-																keyword: 'type',
-																params: {
-																	type: 'string',
-																},
-																message:
-																	'must be string',
-															},
-														];
-														return false;
-													}
-													var valid45 =
-														_errs224 === errors;
-												} else {
-													var valid45 = true;
-												}
-											}
-										}
-									}
-								}
-							} else {
-								validate28.errors = [
-									{
-										instancePath,
-										schemaPath: '#/oneOf/12/type',
-										keyword: 'type',
-										params: { type: 'object' },
-										message: 'must be object',
-									},
-								];
-								return false;
-							}
-						}
-					} else if (tag0 === 'mv') {
-						const _errs226 = errors;
-						if (errors === _errs226) {
-							if (
-								data &&
-								typeof data == 'object' &&
-								!Array.isArray(data)
-							) {
-								let missing14;
-								if (
-									(data.fromPath === undefined &&
-										(missing14 = 'fromPath')) ||
-									(data.step === undefined &&
-										(missing14 = 'step')) ||
-									(data.toPath === undefined &&
-										(missing14 = 'toPath'))
-								) {
-									validate28.errors = [
-										{
-											instancePath,
-											schemaPath: '#/oneOf/13/required',
-											keyword: 'required',
-											params: {
-												missingProperty: missing14,
-											},
-											message:
-												"must have required property '" +
-												missing14 +
-												"'",
-										},
-									];
-									return false;
-								} else {
-									const _errs228 = errors;
-									for (const key29 in data) {
-										if (
-											!(
-												key29 === 'progress' ||
-												key29 === 'step' ||
-												key29 === 'fromPath' ||
-												key29 === 'toPath'
-											)
-										) {
-											validate28.errors = [
-												{
-													instancePath,
-													schemaPath:
-														'#/oneOf/13/additionalProperties',
-													keyword:
-														'additionalProperties',
-													params: {
-														additionalProperty:
-															key29,
-													},
-													message:
-														'must NOT have additional properties',
-												},
-											];
-											return false;
-											break;
-										}
-									}
-									if (_errs228 === errors) {
-										if (data.progress !== undefined) {
-											let data84 = data.progress;
-											const _errs229 = errors;
-											if (errors === _errs229) {
-												if (
-													data84 &&
-													typeof data84 == 'object' &&
-													!Array.isArray(data84)
-												) {
-													const _errs231 = errors;
-													for (const key30 in data84) {
-														if (
-															!(
-																key30 ===
-																	'weight' ||
-																key30 ===
-																	'caption'
-															)
-														) {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/progress',
-																		schemaPath:
-																			'#/oneOf/13/properties/progress/additionalProperties',
-																		keyword:
-																			'additionalProperties',
-																		params: {
-																			additionalProperty:
-																				key30,
-																		},
-																		message:
-																			'must NOT have additional properties',
-																	},
-																];
-															return false;
-															break;
-														}
-													}
-													if (_errs231 === errors) {
-														if (
-															data84.weight !==
-															undefined
-														) {
-															let data85 =
-																data84.weight;
-															const _errs232 =
-																errors;
-															if (
-																!(
-																	typeof data85 ==
-																		'number' &&
-																	isFinite(
-																		data85
-																	)
-																)
-															) {
-																validate28.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/progress/weight',
-																			schemaPath:
-																				'#/oneOf/13/properties/progress/properties/weight/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'number',
-																			},
-																			message:
-																				'must be number',
-																		},
-																	];
-																return false;
-															}
-															var valid49 =
-																_errs232 ===
-																errors;
-														} else {
-															var valid49 = true;
-														}
-														if (valid49) {
-															if (
-																data84.caption !==
-																undefined
-															) {
-																const _errs234 =
-																	errors;
-																if (
-																	typeof data84.caption !==
-																	'string'
-																) {
-																	validate28.errors =
-																		[
-																			{
-																				instancePath:
-																					instancePath +
-																					'/progress/caption',
-																				schemaPath:
-																					'#/oneOf/13/properties/progress/properties/caption/type',
-																				keyword:
-																					'type',
-																				params: {
-																					type: 'string',
-																				},
-																				message:
-																					'must be string',
-																			},
-																		];
-																	return false;
-																}
-																var valid49 =
-																	_errs234 ===
-																	errors;
-															} else {
-																var valid49 = true;
-															}
-														}
-													}
-												} else {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/progress',
-															schemaPath:
-																'#/oneOf/13/properties/progress/type',
-															keyword: 'type',
-															params: {
-																type: 'object',
-															},
-															message:
-																'must be object',
-														},
-													];
-													return false;
-												}
-											}
-											var valid48 = _errs229 === errors;
-										} else {
-											var valid48 = true;
-										}
-										if (valid48) {
-											if (data.step !== undefined) {
-												let data87 = data.step;
-												const _errs236 = errors;
-												if (
-													typeof data87 !== 'string'
-												) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/13/properties/step/type',
-															keyword: 'type',
-															params: {
-																type: 'string',
-															},
-															message:
-																'must be string',
-														},
-													];
-													return false;
-												}
-												if ('mv' !== data87) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/13/properties/step/const',
-															keyword: 'const',
-															params: {
-																allowedValue:
-																	'mv',
-															},
-															message:
-																'must be equal to constant',
-														},
-													];
-													return false;
-												}
-												var valid48 =
-													_errs236 === errors;
-											} else {
-												var valid48 = true;
-											}
-											if (valid48) {
-												if (
-													data.fromPath !== undefined
-												) {
-													const _errs238 = errors;
-													if (
-														typeof data.fromPath !==
-														'string'
-													) {
-														validate28.errors = [
-															{
-																instancePath:
-																	instancePath +
-																	'/fromPath',
-																schemaPath:
-																	'#/oneOf/13/properties/fromPath/type',
-																keyword: 'type',
-																params: {
-																	type: 'string',
-																},
-																message:
-																	'must be string',
-															},
-														];
-														return false;
-													}
-													var valid48 =
-														_errs238 === errors;
-												} else {
-													var valid48 = true;
-												}
-												if (valid48) {
-													if (
-														data.toPath !==
-														undefined
-													) {
-														const _errs240 = errors;
-														if (
-															typeof data.toPath !==
-															'string'
-														) {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/toPath',
-																		schemaPath:
-																			'#/oneOf/13/properties/toPath/type',
-																		keyword:
-																			'type',
-																		params: {
-																			type: 'string',
-																		},
-																		message:
-																			'must be string',
-																	},
-																];
-															return false;
-														}
-														var valid48 =
-															_errs240 === errors;
-													} else {
-														var valid48 = true;
-													}
-												}
-											}
-										}
-									}
-								}
-							} else {
-								validate28.errors = [
-									{
-										instancePath,
-										schemaPath: '#/oneOf/13/type',
-										keyword: 'type',
-										params: { type: 'object' },
-										message: 'must be object',
-									},
-								];
-								return false;
-							}
-						}
-					} else if (tag0 === 'resetData') {
-						const _errs242 = errors;
-						if (errors === _errs242) {
-							if (
-								data &&
-								typeof data == 'object' &&
-								!Array.isArray(data)
-							) {
-								let missing15;
-								if (
-									data.step === undefined &&
-									(missing15 = 'step')
-								) {
-									validate28.errors = [
-										{
-											instancePath,
-											schemaPath: '#/oneOf/14/required',
-											keyword: 'required',
-											params: {
-												missingProperty: missing15,
-											},
-											message:
-												"must have required property '" +
-												missing15 +
-												"'",
-										},
-									];
-									return false;
-								} else {
-									const _errs244 = errors;
-									for (const key31 in data) {
-										if (
-											!(
-												key31 === 'progress' ||
-												key31 === 'step'
-											)
-										) {
-											validate28.errors = [
-												{
-													instancePath,
-													schemaPath:
-														'#/oneOf/14/additionalProperties',
-													keyword:
-														'additionalProperties',
-													params: {
-														additionalProperty:
-															key31,
-													},
-													message:
-														'must NOT have additional properties',
-												},
-											];
-											return false;
-											break;
-										}
-									}
-									if (_errs244 === errors) {
-										if (data.progress !== undefined) {
-											let data90 = data.progress;
-											const _errs245 = errors;
-											if (errors === _errs245) {
-												if (
-													data90 &&
-													typeof data90 == 'object' &&
-													!Array.isArray(data90)
-												) {
-													const _errs247 = errors;
-													for (const key32 in data90) {
-														if (
-															!(
-																key32 ===
-																	'weight' ||
-																key32 ===
-																	'caption'
-															)
-														) {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/progress',
-																		schemaPath:
-																			'#/oneOf/14/properties/progress/additionalProperties',
-																		keyword:
-																			'additionalProperties',
-																		params: {
-																			additionalProperty:
-																				key32,
-																		},
-																		message:
-																			'must NOT have additional properties',
-																	},
-																];
-															return false;
-															break;
-														}
-													}
-													if (_errs247 === errors) {
-														if (
-															data90.weight !==
-															undefined
-														) {
-															let data91 =
-																data90.weight;
-															const _errs248 =
-																errors;
-															if (
-																!(
-																	typeof data91 ==
-																		'number' &&
-																	isFinite(
-																		data91
-																	)
-																)
-															) {
-																validate28.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/progress/weight',
-																			schemaPath:
-																				'#/oneOf/14/properties/progress/properties/weight/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'number',
-																			},
-																			message:
-																				'must be number',
-																		},
-																	];
-																return false;
-															}
-															var valid52 =
-																_errs248 ===
-																errors;
-														} else {
-															var valid52 = true;
-														}
-														if (valid52) {
-															if (
-																data90.caption !==
-																undefined
-															) {
-																const _errs250 =
-																	errors;
-																if (
-																	typeof data90.caption !==
-																	'string'
-																) {
-																	validate28.errors =
-																		[
-																			{
-																				instancePath:
-																					instancePath +
-																					'/progress/caption',
-																				schemaPath:
-																					'#/oneOf/14/properties/progress/properties/caption/type',
 																				keyword:
 																					'type',
 																				params: {
@@ -14162,7 +14371,7 @@ function validate28(
 																instancePath +
 																'/progress',
 															schemaPath:
-																'#/oneOf/14/properties/progress/type',
+																'#/oneOf/12/properties/progress/type',
 															keyword: 'type',
 															params: {
 																type: 'object',
@@ -14180,10 +14389,649 @@ function validate28(
 										}
 										if (valid51) {
 											if (data.step !== undefined) {
-												let data93 = data.step;
+												let data95 = data.step;
 												const _errs252 = errors;
 												if (
-													typeof data93 !== 'string'
+													typeof data95 !== 'string'
+												) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/12/properties/step/type',
+															keyword: 'type',
+															params: {
+																type: 'string',
+															},
+															message:
+																'must be string',
+														},
+													];
+													return false;
+												}
+												if ('login' !== data95) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/12/properties/step/const',
+															keyword: 'const',
+															params: {
+																allowedValue:
+																	'login',
+															},
+															message:
+																'must be equal to constant',
+														},
+													];
+													return false;
+												}
+												var valid51 =
+													_errs252 === errors;
+											} else {
+												var valid51 = true;
+											}
+											if (valid51) {
+												if (
+													data.username !== undefined
+												) {
+													const _errs254 = errors;
+													if (
+														typeof data.username !==
+														'string'
+													) {
+														validate28.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/username',
+																schemaPath:
+																	'#/oneOf/12/properties/username/type',
+																keyword: 'type',
+																params: {
+																	type: 'string',
+																},
+																message:
+																	'must be string',
+															},
+														];
+														return false;
+													}
+													var valid51 =
+														_errs254 === errors;
+												} else {
+													var valid51 = true;
+												}
+												if (valid51) {
+													if (
+														data.password !==
+														undefined
+													) {
+														const _errs256 = errors;
+														if (
+															typeof data.password !==
+															'string'
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/password',
+																		schemaPath:
+																			'#/oneOf/12/properties/password/type',
+																		keyword:
+																			'type',
+																		params: {
+																			type: 'string',
+																		},
+																		message:
+																			'must be string',
+																	},
+																];
+															return false;
+														}
+														var valid51 =
+															_errs256 === errors;
+													} else {
+														var valid51 = true;
+													}
+												}
+											}
+										}
+									}
+								}
+							} else {
+								validate28.errors = [
+									{
+										instancePath,
+										schemaPath: '#/oneOf/12/type',
+										keyword: 'type',
+										params: { type: 'object' },
+										message: 'must be object',
+									},
+								];
+								return false;
+							}
+						}
+					} else if (tag0 === 'mkdir') {
+						const _errs258 = errors;
+						if (errors === _errs258) {
+							if (
+								data &&
+								typeof data == 'object' &&
+								!Array.isArray(data)
+							) {
+								let missing14;
+								if (
+									(data.path === undefined &&
+										(missing14 = 'path')) ||
+									(data.step === undefined &&
+										(missing14 = 'step'))
+								) {
+									validate28.errors = [
+										{
+											instancePath,
+											schemaPath: '#/oneOf/13/required',
+											keyword: 'required',
+											params: {
+												missingProperty: missing14,
+											},
+											message:
+												"must have required property '" +
+												missing14 +
+												"'",
+										},
+									];
+									return false;
+								} else {
+									const _errs260 = errors;
+									for (const key31 in data) {
+										if (
+											!(
+												key31 === 'progress' ||
+												key31 === 'step' ||
+												key31 === 'path'
+											)
+										) {
+											validate28.errors = [
+												{
+													instancePath,
+													schemaPath:
+														'#/oneOf/13/additionalProperties',
+													keyword:
+														'additionalProperties',
+													params: {
+														additionalProperty:
+															key31,
+													},
+													message:
+														'must NOT have additional properties',
+												},
+											];
+											return false;
+											break;
+										}
+									}
+									if (_errs260 === errors) {
+										if (data.progress !== undefined) {
+											let data98 = data.progress;
+											const _errs261 = errors;
+											if (errors === _errs261) {
+												if (
+													data98 &&
+													typeof data98 == 'object' &&
+													!Array.isArray(data98)
+												) {
+													const _errs263 = errors;
+													for (const key32 in data98) {
+														if (
+															!(
+																key32 ===
+																	'weight' ||
+																key32 ===
+																	'caption'
+															)
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/progress',
+																		schemaPath:
+																			'#/oneOf/13/properties/progress/additionalProperties',
+																		keyword:
+																			'additionalProperties',
+																		params: {
+																			additionalProperty:
+																				key32,
+																		},
+																		message:
+																			'must NOT have additional properties',
+																	},
+																];
+															return false;
+															break;
+														}
+													}
+													if (_errs263 === errors) {
+														if (
+															data98.weight !==
+															undefined
+														) {
+															let data99 =
+																data98.weight;
+															const _errs264 =
+																errors;
+															if (
+																!(
+																	typeof data99 ==
+																		'number' &&
+																	isFinite(
+																		data99
+																	)
+																)
+															) {
+																validate28.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/progress/weight',
+																			schemaPath:
+																				'#/oneOf/13/properties/progress/properties/weight/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'number',
+																			},
+																			message:
+																				'must be number',
+																		},
+																	];
+																return false;
+															}
+															var valid55 =
+																_errs264 ===
+																errors;
+														} else {
+															var valid55 = true;
+														}
+														if (valid55) {
+															if (
+																data98.caption !==
+																undefined
+															) {
+																const _errs266 =
+																	errors;
+																if (
+																	typeof data98.caption !==
+																	'string'
+																) {
+																	validate28.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/progress/caption',
+																				schemaPath:
+																					'#/oneOf/13/properties/progress/properties/caption/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'string',
+																				},
+																				message:
+																					'must be string',
+																			},
+																		];
+																	return false;
+																}
+																var valid55 =
+																	_errs266 ===
+																	errors;
+															} else {
+																var valid55 = true;
+															}
+														}
+													}
+												} else {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/progress',
+															schemaPath:
+																'#/oneOf/13/properties/progress/type',
+															keyword: 'type',
+															params: {
+																type: 'object',
+															},
+															message:
+																'must be object',
+														},
+													];
+													return false;
+												}
+											}
+											var valid54 = _errs261 === errors;
+										} else {
+											var valid54 = true;
+										}
+										if (valid54) {
+											if (data.step !== undefined) {
+												let data101 = data.step;
+												const _errs268 = errors;
+												if (
+													typeof data101 !== 'string'
+												) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/13/properties/step/type',
+															keyword: 'type',
+															params: {
+																type: 'string',
+															},
+															message:
+																'must be string',
+														},
+													];
+													return false;
+												}
+												if ('mkdir' !== data101) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/13/properties/step/const',
+															keyword: 'const',
+															params: {
+																allowedValue:
+																	'mkdir',
+															},
+															message:
+																'must be equal to constant',
+														},
+													];
+													return false;
+												}
+												var valid54 =
+													_errs268 === errors;
+											} else {
+												var valid54 = true;
+											}
+											if (valid54) {
+												if (data.path !== undefined) {
+													const _errs270 = errors;
+													if (
+														typeof data.path !==
+														'string'
+													) {
+														validate28.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/path',
+																schemaPath:
+																	'#/oneOf/13/properties/path/type',
+																keyword: 'type',
+																params: {
+																	type: 'string',
+																},
+																message:
+																	'must be string',
+															},
+														];
+														return false;
+													}
+													var valid54 =
+														_errs270 === errors;
+												} else {
+													var valid54 = true;
+												}
+											}
+										}
+									}
+								}
+							} else {
+								validate28.errors = [
+									{
+										instancePath,
+										schemaPath: '#/oneOf/13/type',
+										keyword: 'type',
+										params: { type: 'object' },
+										message: 'must be object',
+									},
+								];
+								return false;
+							}
+						}
+					} else if (tag0 === 'mv') {
+						const _errs272 = errors;
+						if (errors === _errs272) {
+							if (
+								data &&
+								typeof data == 'object' &&
+								!Array.isArray(data)
+							) {
+								let missing15;
+								if (
+									(data.fromPath === undefined &&
+										(missing15 = 'fromPath')) ||
+									(data.step === undefined &&
+										(missing15 = 'step')) ||
+									(data.toPath === undefined &&
+										(missing15 = 'toPath'))
+								) {
+									validate28.errors = [
+										{
+											instancePath,
+											schemaPath: '#/oneOf/14/required',
+											keyword: 'required',
+											params: {
+												missingProperty: missing15,
+											},
+											message:
+												"must have required property '" +
+												missing15 +
+												"'",
+										},
+									];
+									return false;
+								} else {
+									const _errs274 = errors;
+									for (const key33 in data) {
+										if (
+											!(
+												key33 === 'progress' ||
+												key33 === 'step' ||
+												key33 === 'fromPath' ||
+												key33 === 'toPath'
+											)
+										) {
+											validate28.errors = [
+												{
+													instancePath,
+													schemaPath:
+														'#/oneOf/14/additionalProperties',
+													keyword:
+														'additionalProperties',
+													params: {
+														additionalProperty:
+															key33,
+													},
+													message:
+														'must NOT have additional properties',
+												},
+											];
+											return false;
+											break;
+										}
+									}
+									if (_errs274 === errors) {
+										if (data.progress !== undefined) {
+											let data103 = data.progress;
+											const _errs275 = errors;
+											if (errors === _errs275) {
+												if (
+													data103 &&
+													typeof data103 ==
+														'object' &&
+													!Array.isArray(data103)
+												) {
+													const _errs277 = errors;
+													for (const key34 in data103) {
+														if (
+															!(
+																key34 ===
+																	'weight' ||
+																key34 ===
+																	'caption'
+															)
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/progress',
+																		schemaPath:
+																			'#/oneOf/14/properties/progress/additionalProperties',
+																		keyword:
+																			'additionalProperties',
+																		params: {
+																			additionalProperty:
+																				key34,
+																		},
+																		message:
+																			'must NOT have additional properties',
+																	},
+																];
+															return false;
+															break;
+														}
+													}
+													if (_errs277 === errors) {
+														if (
+															data103.weight !==
+															undefined
+														) {
+															let data104 =
+																data103.weight;
+															const _errs278 =
+																errors;
+															if (
+																!(
+																	typeof data104 ==
+																		'number' &&
+																	isFinite(
+																		data104
+																	)
+																)
+															) {
+																validate28.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/progress/weight',
+																			schemaPath:
+																				'#/oneOf/14/properties/progress/properties/weight/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'number',
+																			},
+																			message:
+																				'must be number',
+																		},
+																	];
+																return false;
+															}
+															var valid58 =
+																_errs278 ===
+																errors;
+														} else {
+															var valid58 = true;
+														}
+														if (valid58) {
+															if (
+																data103.caption !==
+																undefined
+															) {
+																const _errs280 =
+																	errors;
+																if (
+																	typeof data103.caption !==
+																	'string'
+																) {
+																	validate28.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/progress/caption',
+																				schemaPath:
+																					'#/oneOf/14/properties/progress/properties/caption/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'string',
+																				},
+																				message:
+																					'must be string',
+																			},
+																		];
+																	return false;
+																}
+																var valid58 =
+																	_errs280 ===
+																	errors;
+															} else {
+																var valid58 = true;
+															}
+														}
+													}
+												} else {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/progress',
+															schemaPath:
+																'#/oneOf/14/properties/progress/type',
+															keyword: 'type',
+															params: {
+																type: 'object',
+															},
+															message:
+																'must be object',
+														},
+													];
+													return false;
+												}
+											}
+											var valid57 = _errs275 === errors;
+										} else {
+											var valid57 = true;
+										}
+										if (valid57) {
+											if (data.step !== undefined) {
+												let data106 = data.step;
+												const _errs282 = errors;
+												if (
+													typeof data106 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14202,7 +15050,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('resetData' !== data93) {
+												if ('mv' !== data106) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14213,7 +15061,7 @@ function validate28(
 															keyword: 'const',
 															params: {
 																allowedValue:
-																	'resetData',
+																	'mv',
 															},
 															message:
 																'must be equal to constant',
@@ -14221,10 +15069,77 @@ function validate28(
 													];
 													return false;
 												}
-												var valid51 =
-													_errs252 === errors;
+												var valid57 =
+													_errs282 === errors;
 											} else {
-												var valid51 = true;
+												var valid57 = true;
+											}
+											if (valid57) {
+												if (
+													data.fromPath !== undefined
+												) {
+													const _errs284 = errors;
+													if (
+														typeof data.fromPath !==
+														'string'
+													) {
+														validate28.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/fromPath',
+																schemaPath:
+																	'#/oneOf/14/properties/fromPath/type',
+																keyword: 'type',
+																params: {
+																	type: 'string',
+																},
+																message:
+																	'must be string',
+															},
+														];
+														return false;
+													}
+													var valid57 =
+														_errs284 === errors;
+												} else {
+													var valid57 = true;
+												}
+												if (valid57) {
+													if (
+														data.toPath !==
+														undefined
+													) {
+														const _errs286 = errors;
+														if (
+															typeof data.toPath !==
+															'string'
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/toPath',
+																		schemaPath:
+																			'#/oneOf/14/properties/toPath/type',
+																		keyword:
+																			'type',
+																		params: {
+																			type: 'string',
+																		},
+																		message:
+																			'must be string',
+																	},
+																];
+															return false;
+														}
+														var valid57 =
+															_errs286 === errors;
+													} else {
+														var valid57 = true;
+													}
+												}
 											}
 										}
 									}
@@ -14242,9 +15157,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'request') {
-						const _errs254 = errors;
-						if (errors === _errs254) {
+					} else if (tag0 === 'resetData') {
+						const _errs288 = errors;
+						if (errors === _errs288) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14252,10 +15167,8 @@ function validate28(
 							) {
 								let missing16;
 								if (
-									(data.request === undefined &&
-										(missing16 = 'request')) ||
-									(data.step === undefined &&
-										(missing16 = 'step'))
+									data.step === undefined &&
+									(missing16 = 'step')
 								) {
 									validate28.errors = [
 										{
@@ -14273,13 +15186,12 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs256 = errors;
-									for (const key33 in data) {
+									const _errs290 = errors;
+									for (const key35 in data) {
 										if (
 											!(
-												key33 === 'progress' ||
-												key33 === 'step' ||
-												key33 === 'request'
+												key35 === 'progress' ||
+												key35 === 'step'
 											)
 										) {
 											validate28.errors = [
@@ -14291,7 +15203,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key33,
+															key35,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14301,23 +15213,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs256 === errors) {
+									if (_errs290 === errors) {
 										if (data.progress !== undefined) {
-											let data94 = data.progress;
-											const _errs257 = errors;
-											if (errors === _errs257) {
+											let data109 = data.progress;
+											const _errs291 = errors;
+											if (errors === _errs291) {
 												if (
-													data94 &&
-													typeof data94 == 'object' &&
-													!Array.isArray(data94)
+													data109 &&
+													typeof data109 ==
+														'object' &&
+													!Array.isArray(data109)
 												) {
-													const _errs259 = errors;
-													for (const key34 in data94) {
+													const _errs293 = errors;
+													for (const key36 in data109) {
 														if (
 															!(
-																key34 ===
+																key36 ===
 																	'weight' ||
-																key34 ===
+																key36 ===
 																	'caption'
 															)
 														) {
@@ -14333,7 +15246,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key34,
+																				key36,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14343,21 +15256,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs259 === errors) {
+													if (_errs293 === errors) {
 														if (
-															data94.weight !==
+															data109.weight !==
 															undefined
 														) {
-															let data95 =
-																data94.weight;
-															const _errs260 =
+															let data110 =
+																data109.weight;
+															const _errs294 =
 																errors;
 															if (
 																!(
-																	typeof data95 ==
+																	typeof data110 ==
 																		'number' &&
 																	isFinite(
-																		data95
+																		data110
 																	)
 																)
 															) {
@@ -14380,21 +15293,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid55 =
-																_errs260 ===
+															var valid61 =
+																_errs294 ===
 																errors;
 														} else {
-															var valid55 = true;
+															var valid61 = true;
 														}
-														if (valid55) {
+														if (valid61) {
 															if (
-																data94.caption !==
+																data109.caption !==
 																undefined
 															) {
-																const _errs262 =
+																const _errs296 =
 																	errors;
 																if (
-																	typeof data94.caption !==
+																	typeof data109.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -14416,11 +15329,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid55 =
-																	_errs262 ===
+																var valid61 =
+																	_errs296 ===
 																	errors;
 															} else {
-																var valid55 = true;
+																var valid61 = true;
 															}
 														}
 													}
@@ -14443,16 +15356,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid54 = _errs257 === errors;
+											var valid60 = _errs291 === errors;
 										} else {
-											var valid54 = true;
+											var valid60 = true;
 										}
-										if (valid54) {
+										if (valid60) {
 											if (data.step !== undefined) {
-												let data97 = data.step;
-												const _errs264 = errors;
+												let data112 = data.step;
+												const _errs298 = errors;
 												if (
-													typeof data97 !== 'string'
+													typeof data112 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14471,7 +15384,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('request' !== data97) {
+												if ('resetData' !== data112) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14482,7 +15395,7 @@ function validate28(
 															keyword: 'const',
 															params: {
 																allowedValue:
-																	'request',
+																	'resetData',
 															},
 															message:
 																'must be equal to constant',
@@ -14490,44 +15403,10 @@ function validate28(
 													];
 													return false;
 												}
-												var valid54 =
-													_errs264 === errors;
+												var valid60 =
+													_errs298 === errors;
 											} else {
-												var valid54 = true;
-											}
-											if (valid54) {
-												if (
-													data.request !== undefined
-												) {
-													const _errs266 = errors;
-													if (
-														!validate37(
-															data.request,
-															{
-																instancePath:
-																	instancePath +
-																	'/request',
-																parentData:
-																	data,
-																parentDataProperty:
-																	'request',
-																rootData,
-															}
-														)
-													) {
-														vErrors =
-															vErrors === null
-																? validate37.errors
-																: vErrors.concat(
-																		validate37.errors
-																	);
-														errors = vErrors.length;
-													}
-													var valid54 =
-														_errs266 === errors;
-												} else {
-													var valid54 = true;
-												}
+												var valid60 = true;
 											}
 										}
 									}
@@ -14545,9 +15424,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'rm') {
-						const _errs267 = errors;
-						if (errors === _errs267) {
+					} else if (tag0 === 'request') {
+						const _errs300 = errors;
+						if (errors === _errs300) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14555,8 +15434,8 @@ function validate28(
 							) {
 								let missing17;
 								if (
-									(data.path === undefined &&
-										(missing17 = 'path')) ||
+									(data.request === undefined &&
+										(missing17 = 'request')) ||
 									(data.step === undefined &&
 										(missing17 = 'step'))
 								) {
@@ -14576,13 +15455,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs269 = errors;
-									for (const key35 in data) {
+									const _errs302 = errors;
+									for (const key37 in data) {
 										if (
 											!(
-												key35 === 'progress' ||
-												key35 === 'step' ||
-												key35 === 'path'
+												key37 === 'progress' ||
+												key37 === 'step' ||
+												key37 === 'request'
 											)
 										) {
 											validate28.errors = [
@@ -14594,7 +15473,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key35,
+															key37,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14604,23 +15483,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs269 === errors) {
+									if (_errs302 === errors) {
 										if (data.progress !== undefined) {
-											let data99 = data.progress;
-											const _errs270 = errors;
-											if (errors === _errs270) {
+											let data113 = data.progress;
+											const _errs303 = errors;
+											if (errors === _errs303) {
 												if (
-													data99 &&
-													typeof data99 == 'object' &&
-													!Array.isArray(data99)
+													data113 &&
+													typeof data113 ==
+														'object' &&
+													!Array.isArray(data113)
 												) {
-													const _errs272 = errors;
-													for (const key36 in data99) {
+													const _errs305 = errors;
+													for (const key38 in data113) {
 														if (
 															!(
-																key36 ===
+																key38 ===
 																	'weight' ||
-																key36 ===
+																key38 ===
 																	'caption'
 															)
 														) {
@@ -14636,7 +15516,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key36,
+																				key38,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14646,21 +15526,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs272 === errors) {
+													if (_errs305 === errors) {
 														if (
-															data99.weight !==
+															data113.weight !==
 															undefined
 														) {
-															let data100 =
-																data99.weight;
-															const _errs273 =
+															let data114 =
+																data113.weight;
+															const _errs306 =
 																errors;
 															if (
 																!(
-																	typeof data100 ==
+																	typeof data114 ==
 																		'number' &&
 																	isFinite(
-																		data100
+																		data114
 																	)
 																)
 															) {
@@ -14683,21 +15563,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid58 =
-																_errs273 ===
+															var valid64 =
+																_errs306 ===
 																errors;
 														} else {
-															var valid58 = true;
+															var valid64 = true;
 														}
-														if (valid58) {
+														if (valid64) {
 															if (
-																data99.caption !==
+																data113.caption !==
 																undefined
 															) {
-																const _errs275 =
+																const _errs308 =
 																	errors;
 																if (
-																	typeof data99.caption !==
+																	typeof data113.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -14719,11 +15599,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid58 =
-																	_errs275 ===
+																var valid64 =
+																	_errs308 ===
 																	errors;
 															} else {
-																var valid58 = true;
+																var valid64 = true;
 															}
 														}
 													}
@@ -14746,16 +15626,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid57 = _errs270 === errors;
+											var valid63 = _errs303 === errors;
 										} else {
-											var valid57 = true;
+											var valid63 = true;
 										}
-										if (valid57) {
+										if (valid63) {
 											if (data.step !== undefined) {
-												let data102 = data.step;
-												const _errs277 = errors;
+												let data116 = data.step;
+												const _errs310 = errors;
 												if (
-													typeof data102 !== 'string'
+													typeof data116 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -14774,7 +15654,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('rm' !== data102) {
+												if ('request' !== data116) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -14785,7 +15665,7 @@ function validate28(
 															keyword: 'const',
 															params: {
 																allowedValue:
-																	'rm',
+																	'request',
 															},
 															message:
 																'must be equal to constant',
@@ -14793,39 +15673,43 @@ function validate28(
 													];
 													return false;
 												}
-												var valid57 =
-													_errs277 === errors;
+												var valid63 =
+													_errs310 === errors;
 											} else {
-												var valid57 = true;
+												var valid63 = true;
 											}
-											if (valid57) {
-												if (data.path !== undefined) {
-													const _errs279 = errors;
+											if (valid63) {
+												if (
+													data.request !== undefined
+												) {
+													const _errs312 = errors;
 													if (
-														typeof data.path !==
-														'string'
-													) {
-														validate28.errors = [
+														!validate39(
+															data.request,
 															{
 																instancePath:
 																	instancePath +
-																	'/path',
-																schemaPath:
-																	'#/oneOf/16/properties/path/type',
-																keyword: 'type',
-																params: {
-																	type: 'string',
-																},
-																message:
-																	'must be string',
-															},
-														];
-														return false;
+																	'/request',
+																parentData:
+																	data,
+																parentDataProperty:
+																	'request',
+																rootData,
+															}
+														)
+													) {
+														vErrors =
+															vErrors === null
+																? validate39.errors
+																: vErrors.concat(
+																		validate39.errors
+																	);
+														errors = vErrors.length;
 													}
-													var valid57 =
-														_errs279 === errors;
+													var valid63 =
+														_errs312 === errors;
 												} else {
-													var valid57 = true;
+													var valid63 = true;
 												}
 											}
 										}
@@ -14844,9 +15728,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'rmdir') {
-						const _errs281 = errors;
-						if (errors === _errs281) {
+					} else if (tag0 === 'rm') {
+						const _errs313 = errors;
+						if (errors === _errs313) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -14875,13 +15759,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs283 = errors;
-									for (const key37 in data) {
+									const _errs315 = errors;
+									for (const key39 in data) {
 										if (
 											!(
-												key37 === 'progress' ||
-												key37 === 'step' ||
-												key37 === 'path'
+												key39 === 'progress' ||
+												key39 === 'step' ||
+												key39 === 'path'
 											)
 										) {
 											validate28.errors = [
@@ -14893,7 +15777,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key37,
+															key39,
 													},
 													message:
 														'must NOT have additional properties',
@@ -14903,24 +15787,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs283 === errors) {
+									if (_errs315 === errors) {
 										if (data.progress !== undefined) {
-											let data104 = data.progress;
-											const _errs284 = errors;
-											if (errors === _errs284) {
+											let data118 = data.progress;
+											const _errs316 = errors;
+											if (errors === _errs316) {
 												if (
-													data104 &&
-													typeof data104 ==
+													data118 &&
+													typeof data118 ==
 														'object' &&
-													!Array.isArray(data104)
+													!Array.isArray(data118)
 												) {
-													const _errs286 = errors;
-													for (const key38 in data104) {
+													const _errs318 = errors;
+													for (const key40 in data118) {
 														if (
 															!(
-																key38 ===
+																key40 ===
 																	'weight' ||
-																key38 ===
+																key40 ===
 																	'caption'
 															)
 														) {
@@ -14936,7 +15820,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key38,
+																				key40,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -14946,21 +15830,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs286 === errors) {
+													if (_errs318 === errors) {
 														if (
-															data104.weight !==
+															data118.weight !==
 															undefined
 														) {
-															let data105 =
-																data104.weight;
-															const _errs287 =
+															let data119 =
+																data118.weight;
+															const _errs319 =
 																errors;
 															if (
 																!(
-																	typeof data105 ==
+																	typeof data119 ==
 																		'number' &&
 																	isFinite(
-																		data105
+																		data119
 																	)
 																)
 															) {
@@ -14983,21 +15867,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid61 =
-																_errs287 ===
+															var valid67 =
+																_errs319 ===
 																errors;
 														} else {
-															var valid61 = true;
+															var valid67 = true;
 														}
-														if (valid61) {
+														if (valid67) {
 															if (
-																data104.caption !==
+																data118.caption !==
 																undefined
 															) {
-																const _errs289 =
+																const _errs321 =
 																	errors;
 																if (
-																	typeof data104.caption !==
+																	typeof data118.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15019,11 +15903,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid61 =
-																	_errs289 ===
+																var valid67 =
+																	_errs321 ===
 																	errors;
 															} else {
-																var valid61 = true;
+																var valid67 = true;
 															}
 														}
 													}
@@ -15046,16 +15930,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid60 = _errs284 === errors;
+											var valid66 = _errs316 === errors;
 										} else {
-											var valid60 = true;
+											var valid66 = true;
 										}
-										if (valid60) {
+										if (valid66) {
 											if (data.step !== undefined) {
-												let data107 = data.step;
-												const _errs291 = errors;
+												let data121 = data.step;
+												const _errs323 = errors;
 												if (
-													typeof data107 !== 'string'
+													typeof data121 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15074,7 +15958,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('rmdir' !== data107) {
+												if ('rm' !== data121) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -15085,7 +15969,7 @@ function validate28(
 															keyword: 'const',
 															params: {
 																allowedValue:
-																	'rmdir',
+																	'rm',
 															},
 															message:
 																'must be equal to constant',
@@ -15093,14 +15977,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid60 =
-													_errs291 === errors;
+												var valid66 =
+													_errs323 === errors;
 											} else {
-												var valid60 = true;
+												var valid66 = true;
 											}
-											if (valid60) {
+											if (valid66) {
 												if (data.path !== undefined) {
-													const _errs293 = errors;
+													const _errs325 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -15122,10 +16006,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid60 =
-														_errs293 === errors;
+													var valid66 =
+														_errs325 === errors;
 												} else {
-													var valid60 = true;
+													var valid66 = true;
 												}
 											}
 										}
@@ -15144,9 +16028,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'runPHP') {
-						const _errs295 = errors;
-						if (errors === _errs295) {
+					} else if (tag0 === 'rmdir') {
+						const _errs327 = errors;
+						if (errors === _errs327) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -15154,8 +16038,8 @@ function validate28(
 							) {
 								let missing19;
 								if (
-									(data.code === undefined &&
-										(missing19 = 'code')) ||
+									(data.path === undefined &&
+										(missing19 = 'path')) ||
 									(data.step === undefined &&
 										(missing19 = 'step'))
 								) {
@@ -15175,13 +16059,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs297 = errors;
-									for (const key39 in data) {
+									const _errs329 = errors;
+									for (const key41 in data) {
 										if (
 											!(
-												key39 === 'progress' ||
-												key39 === 'step' ||
-												key39 === 'code'
+												key41 === 'progress' ||
+												key41 === 'step' ||
+												key41 === 'path'
 											)
 										) {
 											validate28.errors = [
@@ -15193,7 +16077,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key39,
+															key41,
 													},
 													message:
 														'must NOT have additional properties',
@@ -15203,24 +16087,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs297 === errors) {
+									if (_errs329 === errors) {
 										if (data.progress !== undefined) {
-											let data109 = data.progress;
-											const _errs298 = errors;
-											if (errors === _errs298) {
+											let data123 = data.progress;
+											const _errs330 = errors;
+											if (errors === _errs330) {
 												if (
-													data109 &&
-													typeof data109 ==
+													data123 &&
+													typeof data123 ==
 														'object' &&
-													!Array.isArray(data109)
+													!Array.isArray(data123)
 												) {
-													const _errs300 = errors;
-													for (const key40 in data109) {
+													const _errs332 = errors;
+													for (const key42 in data123) {
 														if (
 															!(
-																key40 ===
+																key42 ===
 																	'weight' ||
-																key40 ===
+																key42 ===
 																	'caption'
 															)
 														) {
@@ -15236,7 +16120,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key40,
+																				key42,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -15246,21 +16130,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs300 === errors) {
+													if (_errs332 === errors) {
 														if (
-															data109.weight !==
+															data123.weight !==
 															undefined
 														) {
-															let data110 =
-																data109.weight;
-															const _errs301 =
+															let data124 =
+																data123.weight;
+															const _errs333 =
 																errors;
 															if (
 																!(
-																	typeof data110 ==
+																	typeof data124 ==
 																		'number' &&
 																	isFinite(
-																		data110
+																		data124
 																	)
 																)
 															) {
@@ -15283,21 +16167,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid64 =
-																_errs301 ===
+															var valid70 =
+																_errs333 ===
 																errors;
 														} else {
-															var valid64 = true;
+															var valid70 = true;
 														}
-														if (valid64) {
+														if (valid70) {
 															if (
-																data109.caption !==
+																data123.caption !==
 																undefined
 															) {
-																const _errs303 =
+																const _errs335 =
 																	errors;
 																if (
-																	typeof data109.caption !==
+																	typeof data123.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -15319,11 +16203,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid64 =
-																	_errs303 ===
+																var valid70 =
+																	_errs335 ===
 																	errors;
 															} else {
-																var valid64 = true;
+																var valid70 = true;
 															}
 														}
 													}
@@ -15346,16 +16230,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid63 = _errs298 === errors;
+											var valid69 = _errs330 === errors;
 										} else {
-											var valid63 = true;
+											var valid69 = true;
 										}
-										if (valid63) {
+										if (valid69) {
 											if (data.step !== undefined) {
-												let data112 = data.step;
-												const _errs305 = errors;
+												let data126 = data.step;
+												const _errs337 = errors;
 												if (
-													typeof data112 !== 'string'
+													typeof data126 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -15374,7 +16258,7 @@ function validate28(
 													];
 													return false;
 												}
-												if ('runPHP' !== data112) {
+												if ('rmdir' !== data126) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -15382,6 +16266,306 @@ function validate28(
 																'/step',
 															schemaPath:
 																'#/oneOf/18/properties/step/const',
+															keyword: 'const',
+															params: {
+																allowedValue:
+																	'rmdir',
+															},
+															message:
+																'must be equal to constant',
+														},
+													];
+													return false;
+												}
+												var valid69 =
+													_errs337 === errors;
+											} else {
+												var valid69 = true;
+											}
+											if (valid69) {
+												if (data.path !== undefined) {
+													const _errs339 = errors;
+													if (
+														typeof data.path !==
+														'string'
+													) {
+														validate28.errors = [
+															{
+																instancePath:
+																	instancePath +
+																	'/path',
+																schemaPath:
+																	'#/oneOf/18/properties/path/type',
+																keyword: 'type',
+																params: {
+																	type: 'string',
+																},
+																message:
+																	'must be string',
+															},
+														];
+														return false;
+													}
+													var valid69 =
+														_errs339 === errors;
+												} else {
+													var valid69 = true;
+												}
+											}
+										}
+									}
+								}
+							} else {
+								validate28.errors = [
+									{
+										instancePath,
+										schemaPath: '#/oneOf/18/type',
+										keyword: 'type',
+										params: { type: 'object' },
+										message: 'must be object',
+									},
+								];
+								return false;
+							}
+						}
+					} else if (tag0 === 'runPHP') {
+						const _errs341 = errors;
+						if (errors === _errs341) {
+							if (
+								data &&
+								typeof data == 'object' &&
+								!Array.isArray(data)
+							) {
+								let missing20;
+								if (
+									(data.code === undefined &&
+										(missing20 = 'code')) ||
+									(data.step === undefined &&
+										(missing20 = 'step'))
+								) {
+									validate28.errors = [
+										{
+											instancePath,
+											schemaPath: '#/oneOf/19/required',
+											keyword: 'required',
+											params: {
+												missingProperty: missing20,
+											},
+											message:
+												"must have required property '" +
+												missing20 +
+												"'",
+										},
+									];
+									return false;
+								} else {
+									const _errs343 = errors;
+									for (const key43 in data) {
+										if (
+											!(
+												key43 === 'progress' ||
+												key43 === 'step' ||
+												key43 === 'code'
+											)
+										) {
+											validate28.errors = [
+												{
+													instancePath,
+													schemaPath:
+														'#/oneOf/19/additionalProperties',
+													keyword:
+														'additionalProperties',
+													params: {
+														additionalProperty:
+															key43,
+													},
+													message:
+														'must NOT have additional properties',
+												},
+											];
+											return false;
+											break;
+										}
+									}
+									if (_errs343 === errors) {
+										if (data.progress !== undefined) {
+											let data128 = data.progress;
+											const _errs344 = errors;
+											if (errors === _errs344) {
+												if (
+													data128 &&
+													typeof data128 ==
+														'object' &&
+													!Array.isArray(data128)
+												) {
+													const _errs346 = errors;
+													for (const key44 in data128) {
+														if (
+															!(
+																key44 ===
+																	'weight' ||
+																key44 ===
+																	'caption'
+															)
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/progress',
+																		schemaPath:
+																			'#/oneOf/19/properties/progress/additionalProperties',
+																		keyword:
+																			'additionalProperties',
+																		params: {
+																			additionalProperty:
+																				key44,
+																		},
+																		message:
+																			'must NOT have additional properties',
+																	},
+																];
+															return false;
+															break;
+														}
+													}
+													if (_errs346 === errors) {
+														if (
+															data128.weight !==
+															undefined
+														) {
+															let data129 =
+																data128.weight;
+															const _errs347 =
+																errors;
+															if (
+																!(
+																	typeof data129 ==
+																		'number' &&
+																	isFinite(
+																		data129
+																	)
+																)
+															) {
+																validate28.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/progress/weight',
+																			schemaPath:
+																				'#/oneOf/19/properties/progress/properties/weight/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'number',
+																			},
+																			message:
+																				'must be number',
+																		},
+																	];
+																return false;
+															}
+															var valid73 =
+																_errs347 ===
+																errors;
+														} else {
+															var valid73 = true;
+														}
+														if (valid73) {
+															if (
+																data128.caption !==
+																undefined
+															) {
+																const _errs349 =
+																	errors;
+																if (
+																	typeof data128.caption !==
+																	'string'
+																) {
+																	validate28.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/progress/caption',
+																				schemaPath:
+																					'#/oneOf/19/properties/progress/properties/caption/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'string',
+																				},
+																				message:
+																					'must be string',
+																			},
+																		];
+																	return false;
+																}
+																var valid73 =
+																	_errs349 ===
+																	errors;
+															} else {
+																var valid73 = true;
+															}
+														}
+													}
+												} else {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/progress',
+															schemaPath:
+																'#/oneOf/19/properties/progress/type',
+															keyword: 'type',
+															params: {
+																type: 'object',
+															},
+															message:
+																'must be object',
+														},
+													];
+													return false;
+												}
+											}
+											var valid72 = _errs344 === errors;
+										} else {
+											var valid72 = true;
+										}
+										if (valid72) {
+											if (data.step !== undefined) {
+												let data131 = data.step;
+												const _errs351 = errors;
+												if (
+													typeof data131 !== 'string'
+												) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/19/properties/step/type',
+															keyword: 'type',
+															params: {
+																type: 'string',
+															},
+															message:
+																'must be string',
+														},
+													];
+													return false;
+												}
+												if ('runPHP' !== data131) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/19/properties/step/const',
 															keyword: 'const',
 															params: {
 																allowedValue:
@@ -15393,20 +16577,20 @@ function validate28(
 													];
 													return false;
 												}
-												var valid63 =
-													_errs305 === errors;
+												var valid72 =
+													_errs351 === errors;
 											} else {
-												var valid63 = true;
+												var valid72 = true;
 											}
-											if (valid63) {
+											if (valid72) {
 												if (data.code !== undefined) {
-													let data113 = data.code;
-													const _errs307 = errors;
-													const _errs308 = errors;
-													let valid65 = false;
-													const _errs309 = errors;
+													let data132 = data.code;
+													const _errs353 = errors;
+													const _errs354 = errors;
+													let valid74 = false;
+													const _errs355 = errors;
 													if (
-														typeof data113 !==
+														typeof data132 !==
 														'string'
 													) {
 														const err2 = {
@@ -15414,7 +16598,7 @@ function validate28(
 																instancePath +
 																'/code',
 															schemaPath:
-																'#/oneOf/18/properties/code/anyOf/0/type',
+																'#/oneOf/19/properties/code/anyOf/0/type',
 															keyword: 'type',
 															params: {
 																type: 'string',
@@ -15430,31 +16614,31 @@ function validate28(
 														errors++;
 													}
 													var _valid2 =
-														_errs309 === errors;
-													valid65 =
-														valid65 || _valid2;
-													if (!valid65) {
-														const _errs311 = errors;
+														_errs355 === errors;
+													valid74 =
+														valid74 || _valid2;
+													if (!valid74) {
+														const _errs357 = errors;
 														if (
-															errors === _errs311
+															errors === _errs357
 														) {
 															if (
-																data113 &&
-																typeof data113 ==
+																data132 &&
+																typeof data132 ==
 																	'object' &&
 																!Array.isArray(
-																	data113
+																	data132
 																)
 															) {
-																let missing20;
+																let missing21;
 																if (
-																	(data113.filename ===
+																	(data132.filename ===
 																		undefined &&
-																		(missing20 =
+																		(missing21 =
 																			'filename')) ||
-																	(data113.content ===
+																	(data132.content ===
 																		undefined &&
-																		(missing20 =
+																		(missing21 =
 																			'content'))
 																) {
 																	const err3 =
@@ -15463,16 +16647,16 @@ function validate28(
 																				instancePath +
 																				'/code',
 																			schemaPath:
-																				'#/oneOf/18/properties/code/anyOf/1/required',
+																				'#/oneOf/19/properties/code/anyOf/1/required',
 																			keyword:
 																				'required',
 																			params: {
 																				missingProperty:
-																					missing20,
+																					missing21,
 																			},
 																			message:
 																				"must have required property '" +
-																				missing20 +
+																				missing21 +
 																				"'",
 																		};
 																	if (
@@ -15490,14 +16674,14 @@ function validate28(
 																	}
 																	errors++;
 																} else {
-																	const _errs313 =
+																	const _errs359 =
 																		errors;
-																	for (const key41 in data113) {
+																	for (const key45 in data132) {
 																		if (
 																			!(
-																				key41 ===
+																				key45 ===
 																					'filename' ||
-																				key41 ===
+																				key45 ===
 																					'content'
 																			)
 																		) {
@@ -15507,12 +16691,12 @@ function validate28(
 																						instancePath +
 																						'/code',
 																					schemaPath:
-																						'#/oneOf/18/properties/code/anyOf/1/additionalProperties',
+																						'#/oneOf/19/properties/code/anyOf/1/additionalProperties',
 																					keyword:
 																						'additionalProperties',
 																					params: {
 																						additionalProperty:
-																							key41,
+																							key45,
 																					},
 																					message:
 																						'must NOT have additional properties',
@@ -15535,17 +16719,17 @@ function validate28(
 																		}
 																	}
 																	if (
-																		_errs313 ===
+																		_errs359 ===
 																		errors
 																	) {
 																		if (
-																			data113.filename !==
+																			data132.filename !==
 																			undefined
 																		) {
-																			const _errs314 =
+																			const _errs360 =
 																				errors;
 																			if (
-																				typeof data113.filename !==
+																				typeof data132.filename !==
 																				'string'
 																			) {
 																				const err5 =
@@ -15554,7 +16738,7 @@ function validate28(
 																							instancePath +
 																							'/code/filename',
 																						schemaPath:
-																							'#/oneOf/18/properties/code/anyOf/1/properties/filename/type',
+																							'#/oneOf/19/properties/code/anyOf/1/properties/filename/type',
 																						keyword:
 																							'type',
 																						params: {
@@ -15578,23 +16762,23 @@ function validate28(
 																				}
 																				errors++;
 																			}
-																			var valid66 =
-																				_errs314 ===
+																			var valid75 =
+																				_errs360 ===
 																				errors;
 																		} else {
-																			var valid66 = true;
+																			var valid75 = true;
 																		}
 																		if (
-																			valid66
+																			valid75
 																		) {
 																			if (
-																				data113.content !==
+																				data132.content !==
 																				undefined
 																			) {
-																				const _errs316 =
+																				const _errs362 =
 																					errors;
 																				if (
-																					typeof data113.content !==
+																					typeof data132.content !==
 																					'string'
 																				) {
 																					const err6 =
@@ -15603,7 +16787,7 @@ function validate28(
 																								instancePath +
 																								'/code/content',
 																							schemaPath:
-																								'#/oneOf/18/properties/code/anyOf/1/properties/content/type',
+																								'#/oneOf/19/properties/code/anyOf/1/properties/content/type',
 																							keyword:
 																								'type',
 																							params: {
@@ -15627,11 +16811,11 @@ function validate28(
 																					}
 																					errors++;
 																				}
-																				var valid66 =
-																					_errs316 ===
+																				var valid75 =
+																					_errs362 ===
 																					errors;
 																			} else {
-																				var valid66 = true;
+																				var valid75 = true;
 																			}
 																		}
 																	}
@@ -15642,7 +16826,7 @@ function validate28(
 																		instancePath +
 																		'/code',
 																	schemaPath:
-																		'#/oneOf/18/properties/code/anyOf/1/type',
+																		'#/oneOf/19/properties/code/anyOf/1/type',
 																	keyword:
 																		'type',
 																	params: {
@@ -15667,17 +16851,17 @@ function validate28(
 															}
 														}
 														var _valid2 =
-															_errs311 === errors;
-														valid65 =
-															valid65 || _valid2;
+															_errs357 === errors;
+														valid74 =
+															valid74 || _valid2;
 													}
-													if (!valid65) {
+													if (!valid74) {
 														const err8 = {
 															instancePath:
 																instancePath +
 																'/code',
 															schemaPath:
-																'#/oneOf/18/properties/code/anyOf',
+																'#/oneOf/19/properties/code/anyOf',
 															keyword: 'anyOf',
 															params: {},
 															message:
@@ -15693,327 +16877,20 @@ function validate28(
 															vErrors;
 														return false;
 													} else {
-														errors = _errs308;
+														errors = _errs354;
 														if (vErrors !== null) {
-															if (_errs308) {
+															if (_errs354) {
 																vErrors.length =
-																	_errs308;
+																	_errs354;
 															} else {
 																vErrors = null;
 															}
 														}
 													}
-													var valid63 =
-														_errs307 === errors;
+													var valid72 =
+														_errs353 === errors;
 												} else {
-													var valid63 = true;
-												}
-											}
-										}
-									}
-								}
-							} else {
-								validate28.errors = [
-									{
-										instancePath,
-										schemaPath: '#/oneOf/18/type',
-										keyword: 'type',
-										params: { type: 'object' },
-										message: 'must be object',
-									},
-								];
-								return false;
-							}
-						}
-					} else if (tag0 === 'runPHPWithOptions') {
-						const _errs318 = errors;
-						if (errors === _errs318) {
-							if (
-								data &&
-								typeof data == 'object' &&
-								!Array.isArray(data)
-							) {
-								let missing21;
-								if (
-									(data.options === undefined &&
-										(missing21 = 'options')) ||
-									(data.step === undefined &&
-										(missing21 = 'step'))
-								) {
-									validate28.errors = [
-										{
-											instancePath,
-											schemaPath: '#/oneOf/19/required',
-											keyword: 'required',
-											params: {
-												missingProperty: missing21,
-											},
-											message:
-												"must have required property '" +
-												missing21 +
-												"'",
-										},
-									];
-									return false;
-								} else {
-									const _errs320 = errors;
-									for (const key42 in data) {
-										if (
-											!(
-												key42 === 'progress' ||
-												key42 === 'step' ||
-												key42 === 'options'
-											)
-										) {
-											validate28.errors = [
-												{
-													instancePath,
-													schemaPath:
-														'#/oneOf/19/additionalProperties',
-													keyword:
-														'additionalProperties',
-													params: {
-														additionalProperty:
-															key42,
-													},
-													message:
-														'must NOT have additional properties',
-												},
-											];
-											return false;
-											break;
-										}
-									}
-									if (_errs320 === errors) {
-										if (data.progress !== undefined) {
-											let data116 = data.progress;
-											const _errs321 = errors;
-											if (errors === _errs321) {
-												if (
-													data116 &&
-													typeof data116 ==
-														'object' &&
-													!Array.isArray(data116)
-												) {
-													const _errs323 = errors;
-													for (const key43 in data116) {
-														if (
-															!(
-																key43 ===
-																	'weight' ||
-																key43 ===
-																	'caption'
-															)
-														) {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/progress',
-																		schemaPath:
-																			'#/oneOf/19/properties/progress/additionalProperties',
-																		keyword:
-																			'additionalProperties',
-																		params: {
-																			additionalProperty:
-																				key43,
-																		},
-																		message:
-																			'must NOT have additional properties',
-																	},
-																];
-															return false;
-															break;
-														}
-													}
-													if (_errs323 === errors) {
-														if (
-															data116.weight !==
-															undefined
-														) {
-															let data117 =
-																data116.weight;
-															const _errs324 =
-																errors;
-															if (
-																!(
-																	typeof data117 ==
-																		'number' &&
-																	isFinite(
-																		data117
-																	)
-																)
-															) {
-																validate28.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/progress/weight',
-																			schemaPath:
-																				'#/oneOf/19/properties/progress/properties/weight/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'number',
-																			},
-																			message:
-																				'must be number',
-																		},
-																	];
-																return false;
-															}
-															var valid69 =
-																_errs324 ===
-																errors;
-														} else {
-															var valid69 = true;
-														}
-														if (valid69) {
-															if (
-																data116.caption !==
-																undefined
-															) {
-																const _errs326 =
-																	errors;
-																if (
-																	typeof data116.caption !==
-																	'string'
-																) {
-																	validate28.errors =
-																		[
-																			{
-																				instancePath:
-																					instancePath +
-																					'/progress/caption',
-																				schemaPath:
-																					'#/oneOf/19/properties/progress/properties/caption/type',
-																				keyword:
-																					'type',
-																				params: {
-																					type: 'string',
-																				},
-																				message:
-																					'must be string',
-																			},
-																		];
-																	return false;
-																}
-																var valid69 =
-																	_errs326 ===
-																	errors;
-															} else {
-																var valid69 = true;
-															}
-														}
-													}
-												} else {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/progress',
-															schemaPath:
-																'#/oneOf/19/properties/progress/type',
-															keyword: 'type',
-															params: {
-																type: 'object',
-															},
-															message:
-																'must be object',
-														},
-													];
-													return false;
-												}
-											}
-											var valid68 = _errs321 === errors;
-										} else {
-											var valid68 = true;
-										}
-										if (valid68) {
-											if (data.step !== undefined) {
-												let data119 = data.step;
-												const _errs328 = errors;
-												if (
-													typeof data119 !== 'string'
-												) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/19/properties/step/type',
-															keyword: 'type',
-															params: {
-																type: 'string',
-															},
-															message:
-																'must be string',
-														},
-													];
-													return false;
-												}
-												if (
-													'runPHPWithOptions' !==
-													data119
-												) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/19/properties/step/const',
-															keyword: 'const',
-															params: {
-																allowedValue:
-																	'runPHPWithOptions',
-															},
-															message:
-																'must be equal to constant',
-														},
-													];
-													return false;
-												}
-												var valid68 =
-													_errs328 === errors;
-											} else {
-												var valid68 = true;
-											}
-											if (valid68) {
-												if (
-													data.options !== undefined
-												) {
-													const _errs330 = errors;
-													if (
-														!validate39(
-															data.options,
-															{
-																instancePath:
-																	instancePath +
-																	'/options',
-																parentData:
-																	data,
-																parentDataProperty:
-																	'options',
-																rootData,
-															}
-														)
-													) {
-														vErrors =
-															vErrors === null
-																? validate39.errors
-																: vErrors.concat(
-																		validate39.errors
-																	);
-														errors = vErrors.length;
-													}
-													var valid68 =
-														_errs330 === errors;
-												} else {
-													var valid68 = true;
+													var valid72 = true;
 												}
 											}
 										}
@@ -16032,9 +16909,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'runWpInstallationWizard') {
-						const _errs331 = errors;
-						if (errors === _errs331) {
+					} else if (tag0 === 'runPHPWithOptions') {
+						const _errs364 = errors;
+						if (errors === _errs364) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -16063,13 +16940,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs333 = errors;
-									for (const key44 in data) {
+									const _errs366 = errors;
+									for (const key46 in data) {
 										if (
 											!(
-												key44 === 'progress' ||
-												key44 === 'step' ||
-												key44 === 'options'
+												key46 === 'progress' ||
+												key46 === 'step' ||
+												key46 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -16081,7 +16958,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key44,
+															key46,
 													},
 													message:
 														'must NOT have additional properties',
@@ -16091,24 +16968,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs333 === errors) {
+									if (_errs366 === errors) {
 										if (data.progress !== undefined) {
-											let data121 = data.progress;
-											const _errs334 = errors;
-											if (errors === _errs334) {
+											let data135 = data.progress;
+											const _errs367 = errors;
+											if (errors === _errs367) {
 												if (
-													data121 &&
-													typeof data121 ==
+													data135 &&
+													typeof data135 ==
 														'object' &&
-													!Array.isArray(data121)
+													!Array.isArray(data135)
 												) {
-													const _errs336 = errors;
-													for (const key45 in data121) {
+													const _errs369 = errors;
+													for (const key47 in data135) {
 														if (
 															!(
-																key45 ===
+																key47 ===
 																	'weight' ||
-																key45 ===
+																key47 ===
 																	'caption'
 															)
 														) {
@@ -16124,7 +17001,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key45,
+																				key47,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -16134,21 +17011,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs336 === errors) {
+													if (_errs369 === errors) {
 														if (
-															data121.weight !==
+															data135.weight !==
 															undefined
 														) {
-															let data122 =
-																data121.weight;
-															const _errs337 =
+															let data136 =
+																data135.weight;
+															const _errs370 =
 																errors;
 															if (
 																!(
-																	typeof data122 ==
+																	typeof data136 ==
 																		'number' &&
 																	isFinite(
-																		data122
+																		data136
 																	)
 																)
 															) {
@@ -16171,21 +17048,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid72 =
-																_errs337 ===
+															var valid78 =
+																_errs370 ===
 																errors;
 														} else {
-															var valid72 = true;
+															var valid78 = true;
 														}
-														if (valid72) {
+														if (valid78) {
 															if (
-																data121.caption !==
+																data135.caption !==
 																undefined
 															) {
-																const _errs339 =
+																const _errs372 =
 																	errors;
 																if (
-																	typeof data121.caption !==
+																	typeof data135.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -16207,11 +17084,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid72 =
-																	_errs339 ===
+																var valid78 =
+																	_errs372 ===
 																	errors;
 															} else {
-																var valid72 = true;
+																var valid78 = true;
 															}
 														}
 													}
@@ -16234,16 +17111,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid71 = _errs334 === errors;
+											var valid77 = _errs367 === errors;
 										} else {
-											var valid71 = true;
+											var valid77 = true;
 										}
-										if (valid71) {
+										if (valid77) {
 											if (data.step !== undefined) {
-												let data124 = data.step;
-												const _errs341 = errors;
+												let data138 = data.step;
+												const _errs374 = errors;
 												if (
-													typeof data124 !== 'string'
+													typeof data138 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -16263,8 +17140,8 @@ function validate28(
 													return false;
 												}
 												if (
-													'runWpInstallationWizard' !==
-													data124
+													'runPHPWithOptions' !==
+													data138
 												) {
 													validate28.errors = [
 														{
@@ -16276,6 +17153,313 @@ function validate28(
 															keyword: 'const',
 															params: {
 																allowedValue:
+																	'runPHPWithOptions',
+															},
+															message:
+																'must be equal to constant',
+														},
+													];
+													return false;
+												}
+												var valid77 =
+													_errs374 === errors;
+											} else {
+												var valid77 = true;
+											}
+											if (valid77) {
+												if (
+													data.options !== undefined
+												) {
+													const _errs376 = errors;
+													if (
+														!validate41(
+															data.options,
+															{
+																instancePath:
+																	instancePath +
+																	'/options',
+																parentData:
+																	data,
+																parentDataProperty:
+																	'options',
+																rootData,
+															}
+														)
+													) {
+														vErrors =
+															vErrors === null
+																? validate41.errors
+																: vErrors.concat(
+																		validate41.errors
+																	);
+														errors = vErrors.length;
+													}
+													var valid77 =
+														_errs376 === errors;
+												} else {
+													var valid77 = true;
+												}
+											}
+										}
+									}
+								}
+							} else {
+								validate28.errors = [
+									{
+										instancePath,
+										schemaPath: '#/oneOf/20/type',
+										keyword: 'type',
+										params: { type: 'object' },
+										message: 'must be object',
+									},
+								];
+								return false;
+							}
+						}
+					} else if (tag0 === 'runWpInstallationWizard') {
+						const _errs377 = errors;
+						if (errors === _errs377) {
+							if (
+								data &&
+								typeof data == 'object' &&
+								!Array.isArray(data)
+							) {
+								let missing23;
+								if (
+									(data.options === undefined &&
+										(missing23 = 'options')) ||
+									(data.step === undefined &&
+										(missing23 = 'step'))
+								) {
+									validate28.errors = [
+										{
+											instancePath,
+											schemaPath: '#/oneOf/21/required',
+											keyword: 'required',
+											params: {
+												missingProperty: missing23,
+											},
+											message:
+												"must have required property '" +
+												missing23 +
+												"'",
+										},
+									];
+									return false;
+								} else {
+									const _errs379 = errors;
+									for (const key48 in data) {
+										if (
+											!(
+												key48 === 'progress' ||
+												key48 === 'step' ||
+												key48 === 'options'
+											)
+										) {
+											validate28.errors = [
+												{
+													instancePath,
+													schemaPath:
+														'#/oneOf/21/additionalProperties',
+													keyword:
+														'additionalProperties',
+													params: {
+														additionalProperty:
+															key48,
+													},
+													message:
+														'must NOT have additional properties',
+												},
+											];
+											return false;
+											break;
+										}
+									}
+									if (_errs379 === errors) {
+										if (data.progress !== undefined) {
+											let data140 = data.progress;
+											const _errs380 = errors;
+											if (errors === _errs380) {
+												if (
+													data140 &&
+													typeof data140 ==
+														'object' &&
+													!Array.isArray(data140)
+												) {
+													const _errs382 = errors;
+													for (const key49 in data140) {
+														if (
+															!(
+																key49 ===
+																	'weight' ||
+																key49 ===
+																	'caption'
+															)
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/progress',
+																		schemaPath:
+																			'#/oneOf/21/properties/progress/additionalProperties',
+																		keyword:
+																			'additionalProperties',
+																		params: {
+																			additionalProperty:
+																				key49,
+																		},
+																		message:
+																			'must NOT have additional properties',
+																	},
+																];
+															return false;
+															break;
+														}
+													}
+													if (_errs382 === errors) {
+														if (
+															data140.weight !==
+															undefined
+														) {
+															let data141 =
+																data140.weight;
+															const _errs383 =
+																errors;
+															if (
+																!(
+																	typeof data141 ==
+																		'number' &&
+																	isFinite(
+																		data141
+																	)
+																)
+															) {
+																validate28.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/progress/weight',
+																			schemaPath:
+																				'#/oneOf/21/properties/progress/properties/weight/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'number',
+																			},
+																			message:
+																				'must be number',
+																		},
+																	];
+																return false;
+															}
+															var valid81 =
+																_errs383 ===
+																errors;
+														} else {
+															var valid81 = true;
+														}
+														if (valid81) {
+															if (
+																data140.caption !==
+																undefined
+															) {
+																const _errs385 =
+																	errors;
+																if (
+																	typeof data140.caption !==
+																	'string'
+																) {
+																	validate28.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/progress/caption',
+																				schemaPath:
+																					'#/oneOf/21/properties/progress/properties/caption/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'string',
+																				},
+																				message:
+																					'must be string',
+																			},
+																		];
+																	return false;
+																}
+																var valid81 =
+																	_errs385 ===
+																	errors;
+															} else {
+																var valid81 = true;
+															}
+														}
+													}
+												} else {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/progress',
+															schemaPath:
+																'#/oneOf/21/properties/progress/type',
+															keyword: 'type',
+															params: {
+																type: 'object',
+															},
+															message:
+																'must be object',
+														},
+													];
+													return false;
+												}
+											}
+											var valid80 = _errs380 === errors;
+										} else {
+											var valid80 = true;
+										}
+										if (valid80) {
+											if (data.step !== undefined) {
+												let data143 = data.step;
+												const _errs387 = errors;
+												if (
+													typeof data143 !== 'string'
+												) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/21/properties/step/type',
+															keyword: 'type',
+															params: {
+																type: 'string',
+															},
+															message:
+																'must be string',
+														},
+													];
+													return false;
+												}
+												if (
+													'runWpInstallationWizard' !==
+													data143
+												) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/21/properties/step/const',
+															keyword: 'const',
+															params: {
+																allowedValue:
 																	'runWpInstallationWizard',
 															},
 															message:
@@ -16284,35 +17468,35 @@ function validate28(
 													];
 													return false;
 												}
-												var valid71 =
-													_errs341 === errors;
+												var valid80 =
+													_errs387 === errors;
 											} else {
-												var valid71 = true;
+												var valid80 = true;
 											}
-											if (valid71) {
+											if (valid80) {
 												if (
 													data.options !== undefined
 												) {
-													let data125 = data.options;
-													const _errs343 = errors;
-													const _errs344 = errors;
-													if (errors === _errs344) {
+													let data144 = data.options;
+													const _errs389 = errors;
+													const _errs390 = errors;
+													if (errors === _errs390) {
 														if (
-															data125 &&
-															typeof data125 ==
+															data144 &&
+															typeof data144 ==
 																'object' &&
 															!Array.isArray(
-																data125
+																data144
 															)
 														) {
-															const _errs346 =
+															const _errs392 =
 																errors;
-															for (const key46 in data125) {
+															for (const key50 in data144) {
 																if (
 																	!(
-																		key46 ===
+																		key50 ===
 																			'adminUsername' ||
-																		key46 ===
+																		key50 ===
 																			'adminPassword'
 																	)
 																) {
@@ -16328,7 +17512,7 @@ function validate28(
 																					'additionalProperties',
 																				params: {
 																					additionalProperty:
-																						key46,
+																						key50,
 																				},
 																				message:
 																					'must NOT have additional properties',
@@ -16339,17 +17523,17 @@ function validate28(
 																}
 															}
 															if (
-																_errs346 ===
+																_errs392 ===
 																errors
 															) {
 																if (
-																	data125.adminUsername !==
+																	data144.adminUsername !==
 																	undefined
 																) {
-																	const _errs347 =
+																	const _errs393 =
 																		errors;
 																	if (
-																		typeof data125.adminUsername !==
+																		typeof data144.adminUsername !==
 																		'string'
 																	) {
 																		validate28.errors =
@@ -16371,21 +17555,21 @@ function validate28(
 																			];
 																		return false;
 																	}
-																	var valid74 =
-																		_errs347 ===
+																	var valid83 =
+																		_errs393 ===
 																		errors;
 																} else {
-																	var valid74 = true;
+																	var valid83 = true;
 																}
-																if (valid74) {
+																if (valid83) {
 																	if (
-																		data125.adminPassword !==
+																		data144.adminPassword !==
 																		undefined
 																	) {
-																		const _errs349 =
+																		const _errs395 =
 																			errors;
 																		if (
-																			typeof data125.adminPassword !==
+																			typeof data144.adminPassword !==
 																			'string'
 																		) {
 																			validate28.errors =
@@ -16407,11 +17591,11 @@ function validate28(
 																				];
 																			return false;
 																		}
-																		var valid74 =
-																			_errs349 ===
+																		var valid83 =
+																			_errs395 ===
 																			errors;
 																	} else {
-																		var valid74 = true;
+																		var valid83 = true;
 																	}
 																}
 															}
@@ -16436,308 +17620,10 @@ function validate28(
 															return false;
 														}
 													}
-													var valid71 =
-														_errs343 === errors;
+													var valid80 =
+														_errs389 === errors;
 												} else {
-													var valid71 = true;
-												}
-											}
-										}
-									}
-								}
-							} else {
-								validate28.errors = [
-									{
-										instancePath,
-										schemaPath: '#/oneOf/20/type',
-										keyword: 'type',
-										params: { type: 'object' },
-										message: 'must be object',
-									},
-								];
-								return false;
-							}
-						}
-					} else if (tag0 === 'runSql') {
-						const _errs351 = errors;
-						if (errors === _errs351) {
-							if (
-								data &&
-								typeof data == 'object' &&
-								!Array.isArray(data)
-							) {
-								let missing23;
-								if (
-									(data.sql === undefined &&
-										(missing23 = 'sql')) ||
-									(data.step === undefined &&
-										(missing23 = 'step'))
-								) {
-									validate28.errors = [
-										{
-											instancePath,
-											schemaPath: '#/oneOf/21/required',
-											keyword: 'required',
-											params: {
-												missingProperty: missing23,
-											},
-											message:
-												"must have required property '" +
-												missing23 +
-												"'",
-										},
-									];
-									return false;
-								} else {
-									const _errs353 = errors;
-									for (const key47 in data) {
-										if (
-											!(
-												key47 === 'progress' ||
-												key47 === 'step' ||
-												key47 === 'sql'
-											)
-										) {
-											validate28.errors = [
-												{
-													instancePath,
-													schemaPath:
-														'#/oneOf/21/additionalProperties',
-													keyword:
-														'additionalProperties',
-													params: {
-														additionalProperty:
-															key47,
-													},
-													message:
-														'must NOT have additional properties',
-												},
-											];
-											return false;
-											break;
-										}
-									}
-									if (_errs353 === errors) {
-										if (data.progress !== undefined) {
-											let data128 = data.progress;
-											const _errs354 = errors;
-											if (errors === _errs354) {
-												if (
-													data128 &&
-													typeof data128 ==
-														'object' &&
-													!Array.isArray(data128)
-												) {
-													const _errs356 = errors;
-													for (const key48 in data128) {
-														if (
-															!(
-																key48 ===
-																	'weight' ||
-																key48 ===
-																	'caption'
-															)
-														) {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/progress',
-																		schemaPath:
-																			'#/oneOf/21/properties/progress/additionalProperties',
-																		keyword:
-																			'additionalProperties',
-																		params: {
-																			additionalProperty:
-																				key48,
-																		},
-																		message:
-																			'must NOT have additional properties',
-																	},
-																];
-															return false;
-															break;
-														}
-													}
-													if (_errs356 === errors) {
-														if (
-															data128.weight !==
-															undefined
-														) {
-															let data129 =
-																data128.weight;
-															const _errs357 =
-																errors;
-															if (
-																!(
-																	typeof data129 ==
-																		'number' &&
-																	isFinite(
-																		data129
-																	)
-																)
-															) {
-																validate28.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/progress/weight',
-																			schemaPath:
-																				'#/oneOf/21/properties/progress/properties/weight/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'number',
-																			},
-																			message:
-																				'must be number',
-																		},
-																	];
-																return false;
-															}
-															var valid77 =
-																_errs357 ===
-																errors;
-														} else {
-															var valid77 = true;
-														}
-														if (valid77) {
-															if (
-																data128.caption !==
-																undefined
-															) {
-																const _errs359 =
-																	errors;
-																if (
-																	typeof data128.caption !==
-																	'string'
-																) {
-																	validate28.errors =
-																		[
-																			{
-																				instancePath:
-																					instancePath +
-																					'/progress/caption',
-																				schemaPath:
-																					'#/oneOf/21/properties/progress/properties/caption/type',
-																				keyword:
-																					'type',
-																				params: {
-																					type: 'string',
-																				},
-																				message:
-																					'must be string',
-																			},
-																		];
-																	return false;
-																}
-																var valid77 =
-																	_errs359 ===
-																	errors;
-															} else {
-																var valid77 = true;
-															}
-														}
-													}
-												} else {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/progress',
-															schemaPath:
-																'#/oneOf/21/properties/progress/type',
-															keyword: 'type',
-															params: {
-																type: 'object',
-															},
-															message:
-																'must be object',
-														},
-													];
-													return false;
-												}
-											}
-											var valid76 = _errs354 === errors;
-										} else {
-											var valid76 = true;
-										}
-										if (valid76) {
-											if (data.step !== undefined) {
-												let data131 = data.step;
-												const _errs361 = errors;
-												if (
-													typeof data131 !== 'string'
-												) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/21/properties/step/type',
-															keyword: 'type',
-															params: {
-																type: 'string',
-															},
-															message:
-																'must be string',
-														},
-													];
-													return false;
-												}
-												if ('runSql' !== data131) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/21/properties/step/const',
-															keyword: 'const',
-															params: {
-																allowedValue:
-																	'runSql',
-															},
-															message:
-																'must be equal to constant',
-														},
-													];
-													return false;
-												}
-												var valid76 =
-													_errs361 === errors;
-											} else {
-												var valid76 = true;
-											}
-											if (valid76) {
-												if (data.sql !== undefined) {
-													const _errs363 = errors;
-													if (
-														!validate16(data.sql, {
-															instancePath:
-																instancePath +
-																'/sql',
-															parentData: data,
-															parentDataProperty:
-																'sql',
-															rootData,
-														})
-													) {
-														vErrors =
-															vErrors === null
-																? validate16.errors
-																: vErrors.concat(
-																		validate16.errors
-																	);
-														errors = vErrors.length;
-													}
-													var valid76 =
-														_errs363 === errors;
-												} else {
-													var valid76 = true;
+													var valid80 = true;
 												}
 											}
 										}
@@ -16756,9 +17642,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'setSiteOptions') {
-						const _errs364 = errors;
-						if (errors === _errs364) {
+					} else if (tag0 === 'runSql') {
+						const _errs397 = errors;
+						if (errors === _errs397) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -16766,8 +17652,8 @@ function validate28(
 							) {
 								let missing24;
 								if (
-									(data.options === undefined &&
-										(missing24 = 'options')) ||
+									(data.sql === undefined &&
+										(missing24 = 'sql')) ||
 									(data.step === undefined &&
 										(missing24 = 'step'))
 								) {
@@ -16787,13 +17673,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs366 = errors;
-									for (const key49 in data) {
+									const _errs399 = errors;
+									for (const key51 in data) {
 										if (
 											!(
-												key49 === 'progress' ||
-												key49 === 'step' ||
-												key49 === 'options'
+												key51 === 'progress' ||
+												key51 === 'step' ||
+												key51 === 'sql'
 											)
 										) {
 											validate28.errors = [
@@ -16805,7 +17691,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key49,
+															key51,
 													},
 													message:
 														'must NOT have additional properties',
@@ -16815,24 +17701,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs366 === errors) {
+									if (_errs399 === errors) {
 										if (data.progress !== undefined) {
-											let data133 = data.progress;
-											const _errs367 = errors;
-											if (errors === _errs367) {
+											let data147 = data.progress;
+											const _errs400 = errors;
+											if (errors === _errs400) {
 												if (
-													data133 &&
-													typeof data133 ==
+													data147 &&
+													typeof data147 ==
 														'object' &&
-													!Array.isArray(data133)
+													!Array.isArray(data147)
 												) {
-													const _errs369 = errors;
-													for (const key50 in data133) {
+													const _errs402 = errors;
+													for (const key52 in data147) {
 														if (
 															!(
-																key50 ===
+																key52 ===
 																	'weight' ||
-																key50 ===
+																key52 ===
 																	'caption'
 															)
 														) {
@@ -16848,7 +17734,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key50,
+																				key52,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -16858,21 +17744,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs369 === errors) {
+													if (_errs402 === errors) {
 														if (
-															data133.weight !==
+															data147.weight !==
 															undefined
 														) {
-															let data134 =
-																data133.weight;
-															const _errs370 =
+															let data148 =
+																data147.weight;
+															const _errs403 =
 																errors;
 															if (
 																!(
-																	typeof data134 ==
+																	typeof data148 ==
 																		'number' &&
 																	isFinite(
-																		data134
+																		data148
 																	)
 																)
 															) {
@@ -16895,21 +17781,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid80 =
-																_errs370 ===
+															var valid86 =
+																_errs403 ===
 																errors;
 														} else {
-															var valid80 = true;
+															var valid86 = true;
 														}
-														if (valid80) {
+														if (valid86) {
 															if (
-																data133.caption !==
+																data147.caption !==
 																undefined
 															) {
-																const _errs372 =
+																const _errs405 =
 																	errors;
 																if (
-																	typeof data133.caption !==
+																	typeof data147.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -16931,11 +17817,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid80 =
-																	_errs372 ===
+																var valid86 =
+																	_errs405 ===
 																	errors;
 															} else {
-																var valid80 = true;
+																var valid86 = true;
 															}
 														}
 													}
@@ -16958,16 +17844,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid79 = _errs367 === errors;
+											var valid85 = _errs400 === errors;
 										} else {
-											var valid79 = true;
+											var valid85 = true;
 										}
-										if (valid79) {
+										if (valid85) {
 											if (data.step !== undefined) {
-												let data136 = data.step;
-												const _errs374 = errors;
+												let data150 = data.step;
+												const _errs407 = errors;
 												if (
-													typeof data136 !== 'string'
+													typeof data150 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -16986,9 +17872,7 @@ function validate28(
 													];
 													return false;
 												}
-												if (
-													'setSiteOptions' !== data136
-												) {
+												if ('runSql' !== data150) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -16999,7 +17883,7 @@ function validate28(
 															keyword: 'const',
 															params: {
 																allowedValue:
-																	'setSiteOptions',
+																	'runSql',
 															},
 															message:
 																'must be equal to constant',
@@ -17007,61 +17891,37 @@ function validate28(
 													];
 													return false;
 												}
-												var valid79 =
-													_errs374 === errors;
+												var valid85 =
+													_errs407 === errors;
 											} else {
-												var valid79 = true;
+												var valid85 = true;
 											}
-											if (valid79) {
-												if (
-													data.options !== undefined
-												) {
-													let data137 = data.options;
-													const _errs376 = errors;
-													if (errors === _errs376) {
-														if (
-															data137 &&
-															typeof data137 ==
-																'object' &&
-															!Array.isArray(
-																data137
-															)
-														) {
-															for (const key51 in data137) {
-																const _errs379 =
-																	errors;
-																var valid81 =
-																	_errs379 ===
-																	errors;
-																if (!valid81) {
-																	break;
-																}
-															}
-														} else {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/options',
-																		schemaPath:
-																			'#/oneOf/22/properties/options/type',
-																		keyword:
-																			'type',
-																		params: {
-																			type: 'object',
-																		},
-																		message:
-																			'must be object',
-																	},
-																];
-															return false;
-														}
+											if (valid85) {
+												if (data.sql !== undefined) {
+													const _errs409 = errors;
+													if (
+														!validate16(data.sql, {
+															instancePath:
+																instancePath +
+																'/sql',
+															parentData: data,
+															parentDataProperty:
+																'sql',
+															rootData,
+														})
+													) {
+														vErrors =
+															vErrors === null
+																? validate16.errors
+																: vErrors.concat(
+																		validate16.errors
+																	);
+														errors = vErrors.length;
 													}
-													var valid79 =
-														_errs376 === errors;
+													var valid85 =
+														_errs409 === errors;
 												} else {
-													var valid79 = true;
+													var valid85 = true;
 												}
 											}
 										}
@@ -17080,9 +17940,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'unzip') {
-						const _errs380 = errors;
-						if (errors === _errs380) {
+					} else if (tag0 === 'setSiteOptions') {
+						const _errs410 = errors;
+						if (errors === _errs410) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -17090,8 +17950,8 @@ function validate28(
 							) {
 								let missing25;
 								if (
-									(data.extractToPath === undefined &&
-										(missing25 = 'extractToPath')) ||
+									(data.options === undefined &&
+										(missing25 = 'options')) ||
 									(data.step === undefined &&
 										(missing25 = 'step'))
 								) {
@@ -17111,15 +17971,13 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs382 = errors;
-									for (const key52 in data) {
+									const _errs412 = errors;
+									for (const key53 in data) {
 										if (
 											!(
-												key52 === 'progress' ||
-												key52 === 'step' ||
-												key52 === 'zipFile' ||
-												key52 === 'zipPath' ||
-												key52 === 'extractToPath'
+												key53 === 'progress' ||
+												key53 === 'step' ||
+												key53 === 'options'
 											)
 										) {
 											validate28.errors = [
@@ -17131,7 +17989,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key52,
+															key53,
 													},
 													message:
 														'must NOT have additional properties',
@@ -17141,24 +17999,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs382 === errors) {
+									if (_errs412 === errors) {
 										if (data.progress !== undefined) {
-											let data139 = data.progress;
-											const _errs383 = errors;
-											if (errors === _errs383) {
+											let data152 = data.progress;
+											const _errs413 = errors;
+											if (errors === _errs413) {
 												if (
-													data139 &&
-													typeof data139 ==
+													data152 &&
+													typeof data152 ==
 														'object' &&
-													!Array.isArray(data139)
+													!Array.isArray(data152)
 												) {
-													const _errs385 = errors;
-													for (const key53 in data139) {
+													const _errs415 = errors;
+													for (const key54 in data152) {
 														if (
 															!(
-																key53 ===
+																key54 ===
 																	'weight' ||
-																key53 ===
+																key54 ===
 																	'caption'
 															)
 														) {
@@ -17174,7 +18032,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key53,
+																				key54,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -17184,21 +18042,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs385 === errors) {
+													if (_errs415 === errors) {
 														if (
-															data139.weight !==
+															data152.weight !==
 															undefined
 														) {
-															let data140 =
-																data139.weight;
-															const _errs386 =
+															let data153 =
+																data152.weight;
+															const _errs416 =
 																errors;
 															if (
 																!(
-																	typeof data140 ==
+																	typeof data153 ==
 																		'number' &&
 																	isFinite(
-																		data140
+																		data153
 																	)
 																)
 															) {
@@ -17221,21 +18079,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid84 =
-																_errs386 ===
+															var valid89 =
+																_errs416 ===
 																errors;
 														} else {
-															var valid84 = true;
+															var valid89 = true;
 														}
-														if (valid84) {
+														if (valid89) {
 															if (
-																data139.caption !==
+																data152.caption !==
 																undefined
 															) {
-																const _errs388 =
+																const _errs418 =
 																	errors;
 																if (
-																	typeof data139.caption !==
+																	typeof data152.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -17257,11 +18115,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid84 =
-																	_errs388 ===
+																var valid89 =
+																	_errs418 ===
 																	errors;
 															} else {
-																var valid84 = true;
+																var valid89 = true;
 															}
 														}
 													}
@@ -17284,16 +18142,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid83 = _errs383 === errors;
+											var valid88 = _errs413 === errors;
 										} else {
-											var valid83 = true;
+											var valid88 = true;
 										}
-										if (valid83) {
+										if (valid88) {
 											if (data.step !== undefined) {
-												let data142 = data.step;
-												const _errs390 = errors;
+												let data155 = data.step;
+												const _errs420 = errors;
 												if (
-													typeof data142 !== 'string'
+													typeof data155 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -17312,7 +18170,9 @@ function validate28(
 													];
 													return false;
 												}
-												if ('unzip' !== data142) {
+												if (
+													'setSiteOptions' !== data155
+												) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -17320,6 +18180,330 @@ function validate28(
 																'/step',
 															schemaPath:
 																'#/oneOf/23/properties/step/const',
+															keyword: 'const',
+															params: {
+																allowedValue:
+																	'setSiteOptions',
+															},
+															message:
+																'must be equal to constant',
+														},
+													];
+													return false;
+												}
+												var valid88 =
+													_errs420 === errors;
+											} else {
+												var valid88 = true;
+											}
+											if (valid88) {
+												if (
+													data.options !== undefined
+												) {
+													let data156 = data.options;
+													const _errs422 = errors;
+													if (errors === _errs422) {
+														if (
+															data156 &&
+															typeof data156 ==
+																'object' &&
+															!Array.isArray(
+																data156
+															)
+														) {
+															for (const key55 in data156) {
+																const _errs425 =
+																	errors;
+																var valid90 =
+																	_errs425 ===
+																	errors;
+																if (!valid90) {
+																	break;
+																}
+															}
+														} else {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/options',
+																		schemaPath:
+																			'#/oneOf/23/properties/options/type',
+																		keyword:
+																			'type',
+																		params: {
+																			type: 'object',
+																		},
+																		message:
+																			'must be object',
+																	},
+																];
+															return false;
+														}
+													}
+													var valid88 =
+														_errs422 === errors;
+												} else {
+													var valid88 = true;
+												}
+											}
+										}
+									}
+								}
+							} else {
+								validate28.errors = [
+									{
+										instancePath,
+										schemaPath: '#/oneOf/23/type',
+										keyword: 'type',
+										params: { type: 'object' },
+										message: 'must be object',
+									},
+								];
+								return false;
+							}
+						}
+					} else if (tag0 === 'unzip') {
+						const _errs426 = errors;
+						if (errors === _errs426) {
+							if (
+								data &&
+								typeof data == 'object' &&
+								!Array.isArray(data)
+							) {
+								let missing26;
+								if (
+									(data.extractToPath === undefined &&
+										(missing26 = 'extractToPath')) ||
+									(data.step === undefined &&
+										(missing26 = 'step'))
+								) {
+									validate28.errors = [
+										{
+											instancePath,
+											schemaPath: '#/oneOf/24/required',
+											keyword: 'required',
+											params: {
+												missingProperty: missing26,
+											},
+											message:
+												"must have required property '" +
+												missing26 +
+												"'",
+										},
+									];
+									return false;
+								} else {
+									const _errs428 = errors;
+									for (const key56 in data) {
+										if (
+											!(
+												key56 === 'progress' ||
+												key56 === 'step' ||
+												key56 === 'zipFile' ||
+												key56 === 'zipPath' ||
+												key56 === 'extractToPath'
+											)
+										) {
+											validate28.errors = [
+												{
+													instancePath,
+													schemaPath:
+														'#/oneOf/24/additionalProperties',
+													keyword:
+														'additionalProperties',
+													params: {
+														additionalProperty:
+															key56,
+													},
+													message:
+														'must NOT have additional properties',
+												},
+											];
+											return false;
+											break;
+										}
+									}
+									if (_errs428 === errors) {
+										if (data.progress !== undefined) {
+											let data158 = data.progress;
+											const _errs429 = errors;
+											if (errors === _errs429) {
+												if (
+													data158 &&
+													typeof data158 ==
+														'object' &&
+													!Array.isArray(data158)
+												) {
+													const _errs431 = errors;
+													for (const key57 in data158) {
+														if (
+															!(
+																key57 ===
+																	'weight' ||
+																key57 ===
+																	'caption'
+															)
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/progress',
+																		schemaPath:
+																			'#/oneOf/24/properties/progress/additionalProperties',
+																		keyword:
+																			'additionalProperties',
+																		params: {
+																			additionalProperty:
+																				key57,
+																		},
+																		message:
+																			'must NOT have additional properties',
+																	},
+																];
+															return false;
+															break;
+														}
+													}
+													if (_errs431 === errors) {
+														if (
+															data158.weight !==
+															undefined
+														) {
+															let data159 =
+																data158.weight;
+															const _errs432 =
+																errors;
+															if (
+																!(
+																	typeof data159 ==
+																		'number' &&
+																	isFinite(
+																		data159
+																	)
+																)
+															) {
+																validate28.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/progress/weight',
+																			schemaPath:
+																				'#/oneOf/24/properties/progress/properties/weight/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'number',
+																			},
+																			message:
+																				'must be number',
+																		},
+																	];
+																return false;
+															}
+															var valid93 =
+																_errs432 ===
+																errors;
+														} else {
+															var valid93 = true;
+														}
+														if (valid93) {
+															if (
+																data158.caption !==
+																undefined
+															) {
+																const _errs434 =
+																	errors;
+																if (
+																	typeof data158.caption !==
+																	'string'
+																) {
+																	validate28.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/progress/caption',
+																				schemaPath:
+																					'#/oneOf/24/properties/progress/properties/caption/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'string',
+																				},
+																				message:
+																					'must be string',
+																			},
+																		];
+																	return false;
+																}
+																var valid93 =
+																	_errs434 ===
+																	errors;
+															} else {
+																var valid93 = true;
+															}
+														}
+													}
+												} else {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/progress',
+															schemaPath:
+																'#/oneOf/24/properties/progress/type',
+															keyword: 'type',
+															params: {
+																type: 'object',
+															},
+															message:
+																'must be object',
+														},
+													];
+													return false;
+												}
+											}
+											var valid92 = _errs429 === errors;
+										} else {
+											var valid92 = true;
+										}
+										if (valid92) {
+											if (data.step !== undefined) {
+												let data161 = data.step;
+												const _errs436 = errors;
+												if (
+													typeof data161 !== 'string'
+												) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/24/properties/step/type',
+															keyword: 'type',
+															params: {
+																type: 'string',
+															},
+															message:
+																'must be string',
+														},
+													];
+													return false;
+												}
+												if ('unzip' !== data161) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/24/properties/step/const',
 															keyword: 'const',
 															params: {
 																allowedValue:
@@ -17331,16 +18515,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid83 =
-													_errs390 === errors;
+												var valid92 =
+													_errs436 === errors;
 											} else {
-												var valid83 = true;
+												var valid92 = true;
 											}
-											if (valid83) {
+											if (valid92) {
 												if (
 													data.zipFile !== undefined
 												) {
-													const _errs392 = errors;
+													const _errs438 = errors;
 													if (
 														!validate16(
 															data.zipFile,
@@ -17364,17 +18548,17 @@ function validate28(
 																	);
 														errors = vErrors.length;
 													}
-													var valid83 =
-														_errs392 === errors;
+													var valid92 =
+														_errs438 === errors;
 												} else {
-													var valid83 = true;
+													var valid92 = true;
 												}
-												if (valid83) {
+												if (valid92) {
 													if (
 														data.zipPath !==
 														undefined
 													) {
-														const _errs393 = errors;
+														const _errs439 = errors;
 														if (
 															typeof data.zipPath !==
 															'string'
@@ -17386,7 +18570,7 @@ function validate28(
 																			instancePath +
 																			'/zipPath',
 																		schemaPath:
-																			'#/oneOf/23/properties/zipPath/type',
+																			'#/oneOf/24/properties/zipPath/type',
 																		keyword:
 																			'type',
 																		params: {
@@ -17398,17 +18582,17 @@ function validate28(
 																];
 															return false;
 														}
-														var valid83 =
-															_errs393 === errors;
+														var valid92 =
+															_errs439 === errors;
 													} else {
-														var valid83 = true;
+														var valid92 = true;
 													}
-													if (valid83) {
+													if (valid92) {
 														if (
 															data.extractToPath !==
 															undefined
 														) {
-															const _errs395 =
+															const _errs441 =
 																errors;
 															if (
 																typeof data.extractToPath !==
@@ -17421,7 +18605,7 @@ function validate28(
 																				instancePath +
 																				'/extractToPath',
 																			schemaPath:
-																				'#/oneOf/23/properties/extractToPath/type',
+																				'#/oneOf/24/properties/extractToPath/type',
 																			keyword:
 																				'type',
 																			params: {
@@ -17433,379 +18617,12 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid83 =
-																_errs395 ===
+															var valid92 =
+																_errs441 ===
 																errors;
 														} else {
-															var valid83 = true;
+															var valid92 = true;
 														}
-													}
-												}
-											}
-										}
-									}
-								}
-							} else {
-								validate28.errors = [
-									{
-										instancePath,
-										schemaPath: '#/oneOf/23/type',
-										keyword: 'type',
-										params: { type: 'object' },
-										message: 'must be object',
-									},
-								];
-								return false;
-							}
-						}
-					} else if (tag0 === 'updateUserMeta') {
-						const _errs397 = errors;
-						if (errors === _errs397) {
-							if (
-								data &&
-								typeof data == 'object' &&
-								!Array.isArray(data)
-							) {
-								let missing26;
-								if (
-									(data.meta === undefined &&
-										(missing26 = 'meta')) ||
-									(data.step === undefined &&
-										(missing26 = 'step')) ||
-									(data.userId === undefined &&
-										(missing26 = 'userId'))
-								) {
-									validate28.errors = [
-										{
-											instancePath,
-											schemaPath: '#/oneOf/24/required',
-											keyword: 'required',
-											params: {
-												missingProperty: missing26,
-											},
-											message:
-												"must have required property '" +
-												missing26 +
-												"'",
-										},
-									];
-									return false;
-								} else {
-									const _errs399 = errors;
-									for (const key54 in data) {
-										if (
-											!(
-												key54 === 'progress' ||
-												key54 === 'step' ||
-												key54 === 'meta' ||
-												key54 === 'userId'
-											)
-										) {
-											validate28.errors = [
-												{
-													instancePath,
-													schemaPath:
-														'#/oneOf/24/additionalProperties',
-													keyword:
-														'additionalProperties',
-													params: {
-														additionalProperty:
-															key54,
-													},
-													message:
-														'must NOT have additional properties',
-												},
-											];
-											return false;
-											break;
-										}
-									}
-									if (_errs399 === errors) {
-										if (data.progress !== undefined) {
-											let data146 = data.progress;
-											const _errs400 = errors;
-											if (errors === _errs400) {
-												if (
-													data146 &&
-													typeof data146 ==
-														'object' &&
-													!Array.isArray(data146)
-												) {
-													const _errs402 = errors;
-													for (const key55 in data146) {
-														if (
-															!(
-																key55 ===
-																	'weight' ||
-																key55 ===
-																	'caption'
-															)
-														) {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/progress',
-																		schemaPath:
-																			'#/oneOf/24/properties/progress/additionalProperties',
-																		keyword:
-																			'additionalProperties',
-																		params: {
-																			additionalProperty:
-																				key55,
-																		},
-																		message:
-																			'must NOT have additional properties',
-																	},
-																];
-															return false;
-															break;
-														}
-													}
-													if (_errs402 === errors) {
-														if (
-															data146.weight !==
-															undefined
-														) {
-															let data147 =
-																data146.weight;
-															const _errs403 =
-																errors;
-															if (
-																!(
-																	typeof data147 ==
-																		'number' &&
-																	isFinite(
-																		data147
-																	)
-																)
-															) {
-																validate28.errors =
-																	[
-																		{
-																			instancePath:
-																				instancePath +
-																				'/progress/weight',
-																			schemaPath:
-																				'#/oneOf/24/properties/progress/properties/weight/type',
-																			keyword:
-																				'type',
-																			params: {
-																				type: 'number',
-																			},
-																			message:
-																				'must be number',
-																		},
-																	];
-																return false;
-															}
-															var valid87 =
-																_errs403 ===
-																errors;
-														} else {
-															var valid87 = true;
-														}
-														if (valid87) {
-															if (
-																data146.caption !==
-																undefined
-															) {
-																const _errs405 =
-																	errors;
-																if (
-																	typeof data146.caption !==
-																	'string'
-																) {
-																	validate28.errors =
-																		[
-																			{
-																				instancePath:
-																					instancePath +
-																					'/progress/caption',
-																				schemaPath:
-																					'#/oneOf/24/properties/progress/properties/caption/type',
-																				keyword:
-																					'type',
-																				params: {
-																					type: 'string',
-																				},
-																				message:
-																					'must be string',
-																			},
-																		];
-																	return false;
-																}
-																var valid87 =
-																	_errs405 ===
-																	errors;
-															} else {
-																var valid87 = true;
-															}
-														}
-													}
-												} else {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/progress',
-															schemaPath:
-																'#/oneOf/24/properties/progress/type',
-															keyword: 'type',
-															params: {
-																type: 'object',
-															},
-															message:
-																'must be object',
-														},
-													];
-													return false;
-												}
-											}
-											var valid86 = _errs400 === errors;
-										} else {
-											var valid86 = true;
-										}
-										if (valid86) {
-											if (data.step !== undefined) {
-												let data149 = data.step;
-												const _errs407 = errors;
-												if (
-													typeof data149 !== 'string'
-												) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/24/properties/step/type',
-															keyword: 'type',
-															params: {
-																type: 'string',
-															},
-															message:
-																'must be string',
-														},
-													];
-													return false;
-												}
-												if (
-													'updateUserMeta' !== data149
-												) {
-													validate28.errors = [
-														{
-															instancePath:
-																instancePath +
-																'/step',
-															schemaPath:
-																'#/oneOf/24/properties/step/const',
-															keyword: 'const',
-															params: {
-																allowedValue:
-																	'updateUserMeta',
-															},
-															message:
-																'must be equal to constant',
-														},
-													];
-													return false;
-												}
-												var valid86 =
-													_errs407 === errors;
-											} else {
-												var valid86 = true;
-											}
-											if (valid86) {
-												if (data.meta !== undefined) {
-													let data150 = data.meta;
-													const _errs409 = errors;
-													if (errors === _errs409) {
-														if (
-															data150 &&
-															typeof data150 ==
-																'object' &&
-															!Array.isArray(
-																data150
-															)
-														) {
-															for (const key56 in data150) {
-																const _errs412 =
-																	errors;
-																var valid88 =
-																	_errs412 ===
-																	errors;
-																if (!valid88) {
-																	break;
-																}
-															}
-														} else {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/meta',
-																		schemaPath:
-																			'#/oneOf/24/properties/meta/type',
-																		keyword:
-																			'type',
-																		params: {
-																			type: 'object',
-																		},
-																		message:
-																			'must be object',
-																	},
-																];
-															return false;
-														}
-													}
-													var valid86 =
-														_errs409 === errors;
-												} else {
-													var valid86 = true;
-												}
-												if (valid86) {
-													if (
-														data.userId !==
-														undefined
-													) {
-														let data152 =
-															data.userId;
-														const _errs413 = errors;
-														if (
-															!(
-																typeof data152 ==
-																	'number' &&
-																isFinite(
-																	data152
-																)
-															)
-														) {
-															validate28.errors =
-																[
-																	{
-																		instancePath:
-																			instancePath +
-																			'/userId',
-																		schemaPath:
-																			'#/oneOf/24/properties/userId/type',
-																		keyword:
-																			'type',
-																		params: {
-																			type: 'number',
-																		},
-																		message:
-																			'must be number',
-																	},
-																];
-															return false;
-														}
-														var valid86 =
-															_errs413 === errors;
-													} else {
-														var valid86 = true;
 													}
 												}
 											}
@@ -17825,9 +18642,9 @@ function validate28(
 								return false;
 							}
 						}
-					} else if (tag0 === 'writeFile') {
-						const _errs415 = errors;
-						if (errors === _errs415) {
+					} else if (tag0 === 'updateUserMeta') {
+						const _errs443 = errors;
+						if (errors === _errs443) {
 							if (
 								data &&
 								typeof data == 'object' &&
@@ -17835,12 +18652,12 @@ function validate28(
 							) {
 								let missing27;
 								if (
-									(data.data === undefined &&
-										(missing27 = 'data')) ||
-									(data.path === undefined &&
-										(missing27 = 'path')) ||
+									(data.meta === undefined &&
+										(missing27 = 'meta')) ||
 									(data.step === undefined &&
-										(missing27 = 'step'))
+										(missing27 = 'step')) ||
+									(data.userId === undefined &&
+										(missing27 = 'userId'))
 								) {
 									validate28.errors = [
 										{
@@ -17858,14 +18675,14 @@ function validate28(
 									];
 									return false;
 								} else {
-									const _errs417 = errors;
-									for (const key57 in data) {
+									const _errs445 = errors;
+									for (const key58 in data) {
 										if (
 											!(
-												key57 === 'progress' ||
-												key57 === 'step' ||
-												key57 === 'path' ||
-												key57 === 'data'
+												key58 === 'progress' ||
+												key58 === 'step' ||
+												key58 === 'meta' ||
+												key58 === 'userId'
 											)
 										) {
 											validate28.errors = [
@@ -17877,7 +18694,7 @@ function validate28(
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key57,
+															key58,
 													},
 													message:
 														'must NOT have additional properties',
@@ -17887,24 +18704,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs417 === errors) {
+									if (_errs445 === errors) {
 										if (data.progress !== undefined) {
-											let data153 = data.progress;
-											const _errs418 = errors;
-											if (errors === _errs418) {
+											let data165 = data.progress;
+											const _errs446 = errors;
+											if (errors === _errs446) {
 												if (
-													data153 &&
-													typeof data153 ==
+													data165 &&
+													typeof data165 ==
 														'object' &&
-													!Array.isArray(data153)
+													!Array.isArray(data165)
 												) {
-													const _errs420 = errors;
-													for (const key58 in data153) {
+													const _errs448 = errors;
+													for (const key59 in data165) {
 														if (
 															!(
-																key58 ===
+																key59 ===
 																	'weight' ||
-																key58 ===
+																key59 ===
 																	'caption'
 															)
 														) {
@@ -17920,7 +18737,7 @@ function validate28(
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key58,
+																				key59,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -17930,21 +18747,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs420 === errors) {
+													if (_errs448 === errors) {
 														if (
-															data153.weight !==
+															data165.weight !==
 															undefined
 														) {
-															let data154 =
-																data153.weight;
-															const _errs421 =
+															let data166 =
+																data165.weight;
+															const _errs449 =
 																errors;
 															if (
 																!(
-																	typeof data154 ==
+																	typeof data166 ==
 																		'number' &&
 																	isFinite(
-																		data154
+																		data166
 																	)
 																)
 															) {
@@ -17967,21 +18784,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid91 =
-																_errs421 ===
+															var valid96 =
+																_errs449 ===
 																errors;
 														} else {
-															var valid91 = true;
+															var valid96 = true;
 														}
-														if (valid91) {
+														if (valid96) {
 															if (
-																data153.caption !==
+																data165.caption !==
 																undefined
 															) {
-																const _errs423 =
+																const _errs451 =
 																	errors;
 																if (
-																	typeof data153.caption !==
+																	typeof data165.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -18003,11 +18820,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid91 =
-																	_errs423 ===
+																var valid96 =
+																	_errs451 ===
 																	errors;
 															} else {
-																var valid91 = true;
+																var valid96 = true;
 															}
 														}
 													}
@@ -18030,16 +18847,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid90 = _errs418 === errors;
+											var valid95 = _errs446 === errors;
 										} else {
-											var valid90 = true;
+											var valid95 = true;
 										}
-										if (valid90) {
+										if (valid95) {
 											if (data.step !== undefined) {
-												let data156 = data.step;
-												const _errs425 = errors;
+												let data168 = data.step;
+												const _errs453 = errors;
 												if (
-													typeof data156 !== 'string'
+													typeof data168 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -18058,7 +18875,9 @@ function validate28(
 													];
 													return false;
 												}
-												if ('writeFile' !== data156) {
+												if (
+													'updateUserMeta' !== data168
+												) {
 													validate28.errors = [
 														{
 															instancePath:
@@ -18066,6 +18885,371 @@ function validate28(
 																'/step',
 															schemaPath:
 																'#/oneOf/25/properties/step/const',
+															keyword: 'const',
+															params: {
+																allowedValue:
+																	'updateUserMeta',
+															},
+															message:
+																'must be equal to constant',
+														},
+													];
+													return false;
+												}
+												var valid95 =
+													_errs453 === errors;
+											} else {
+												var valid95 = true;
+											}
+											if (valid95) {
+												if (data.meta !== undefined) {
+													let data169 = data.meta;
+													const _errs455 = errors;
+													if (errors === _errs455) {
+														if (
+															data169 &&
+															typeof data169 ==
+																'object' &&
+															!Array.isArray(
+																data169
+															)
+														) {
+															for (const key60 in data169) {
+																const _errs458 =
+																	errors;
+																var valid97 =
+																	_errs458 ===
+																	errors;
+																if (!valid97) {
+																	break;
+																}
+															}
+														} else {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/meta',
+																		schemaPath:
+																			'#/oneOf/25/properties/meta/type',
+																		keyword:
+																			'type',
+																		params: {
+																			type: 'object',
+																		},
+																		message:
+																			'must be object',
+																	},
+																];
+															return false;
+														}
+													}
+													var valid95 =
+														_errs455 === errors;
+												} else {
+													var valid95 = true;
+												}
+												if (valid95) {
+													if (
+														data.userId !==
+														undefined
+													) {
+														let data171 =
+															data.userId;
+														const _errs459 = errors;
+														if (
+															!(
+																typeof data171 ==
+																	'number' &&
+																isFinite(
+																	data171
+																)
+															)
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/userId',
+																		schemaPath:
+																			'#/oneOf/25/properties/userId/type',
+																		keyword:
+																			'type',
+																		params: {
+																			type: 'number',
+																		},
+																		message:
+																			'must be number',
+																	},
+																];
+															return false;
+														}
+														var valid95 =
+															_errs459 === errors;
+													} else {
+														var valid95 = true;
+													}
+												}
+											}
+										}
+									}
+								}
+							} else {
+								validate28.errors = [
+									{
+										instancePath,
+										schemaPath: '#/oneOf/25/type',
+										keyword: 'type',
+										params: { type: 'object' },
+										message: 'must be object',
+									},
+								];
+								return false;
+							}
+						}
+					} else if (tag0 === 'writeFile') {
+						const _errs461 = errors;
+						if (errors === _errs461) {
+							if (
+								data &&
+								typeof data == 'object' &&
+								!Array.isArray(data)
+							) {
+								let missing28;
+								if (
+									(data.data === undefined &&
+										(missing28 = 'data')) ||
+									(data.path === undefined &&
+										(missing28 = 'path')) ||
+									(data.step === undefined &&
+										(missing28 = 'step'))
+								) {
+									validate28.errors = [
+										{
+											instancePath,
+											schemaPath: '#/oneOf/26/required',
+											keyword: 'required',
+											params: {
+												missingProperty: missing28,
+											},
+											message:
+												"must have required property '" +
+												missing28 +
+												"'",
+										},
+									];
+									return false;
+								} else {
+									const _errs463 = errors;
+									for (const key61 in data) {
+										if (
+											!(
+												key61 === 'progress' ||
+												key61 === 'step' ||
+												key61 === 'path' ||
+												key61 === 'data'
+											)
+										) {
+											validate28.errors = [
+												{
+													instancePath,
+													schemaPath:
+														'#/oneOf/26/additionalProperties',
+													keyword:
+														'additionalProperties',
+													params: {
+														additionalProperty:
+															key61,
+													},
+													message:
+														'must NOT have additional properties',
+												},
+											];
+											return false;
+											break;
+										}
+									}
+									if (_errs463 === errors) {
+										if (data.progress !== undefined) {
+											let data172 = data.progress;
+											const _errs464 = errors;
+											if (errors === _errs464) {
+												if (
+													data172 &&
+													typeof data172 ==
+														'object' &&
+													!Array.isArray(data172)
+												) {
+													const _errs466 = errors;
+													for (const key62 in data172) {
+														if (
+															!(
+																key62 ===
+																	'weight' ||
+																key62 ===
+																	'caption'
+															)
+														) {
+															validate28.errors =
+																[
+																	{
+																		instancePath:
+																			instancePath +
+																			'/progress',
+																		schemaPath:
+																			'#/oneOf/26/properties/progress/additionalProperties',
+																		keyword:
+																			'additionalProperties',
+																		params: {
+																			additionalProperty:
+																				key62,
+																		},
+																		message:
+																			'must NOT have additional properties',
+																	},
+																];
+															return false;
+															break;
+														}
+													}
+													if (_errs466 === errors) {
+														if (
+															data172.weight !==
+															undefined
+														) {
+															let data173 =
+																data172.weight;
+															const _errs467 =
+																errors;
+															if (
+																!(
+																	typeof data173 ==
+																		'number' &&
+																	isFinite(
+																		data173
+																	)
+																)
+															) {
+																validate28.errors =
+																	[
+																		{
+																			instancePath:
+																				instancePath +
+																				'/progress/weight',
+																			schemaPath:
+																				'#/oneOf/26/properties/progress/properties/weight/type',
+																			keyword:
+																				'type',
+																			params: {
+																				type: 'number',
+																			},
+																			message:
+																				'must be number',
+																		},
+																	];
+																return false;
+															}
+															var valid100 =
+																_errs467 ===
+																errors;
+														} else {
+															var valid100 = true;
+														}
+														if (valid100) {
+															if (
+																data172.caption !==
+																undefined
+															) {
+																const _errs469 =
+																	errors;
+																if (
+																	typeof data172.caption !==
+																	'string'
+																) {
+																	validate28.errors =
+																		[
+																			{
+																				instancePath:
+																					instancePath +
+																					'/progress/caption',
+																				schemaPath:
+																					'#/oneOf/26/properties/progress/properties/caption/type',
+																				keyword:
+																					'type',
+																				params: {
+																					type: 'string',
+																				},
+																				message:
+																					'must be string',
+																			},
+																		];
+																	return false;
+																}
+																var valid100 =
+																	_errs469 ===
+																	errors;
+															} else {
+																var valid100 = true;
+															}
+														}
+													}
+												} else {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/progress',
+															schemaPath:
+																'#/oneOf/26/properties/progress/type',
+															keyword: 'type',
+															params: {
+																type: 'object',
+															},
+															message:
+																'must be object',
+														},
+													];
+													return false;
+												}
+											}
+											var valid99 = _errs464 === errors;
+										} else {
+											var valid99 = true;
+										}
+										if (valid99) {
+											if (data.step !== undefined) {
+												let data175 = data.step;
+												const _errs471 = errors;
+												if (
+													typeof data175 !== 'string'
+												) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/26/properties/step/type',
+															keyword: 'type',
+															params: {
+																type: 'string',
+															},
+															message:
+																'must be string',
+														},
+													];
+													return false;
+												}
+												if ('writeFile' !== data175) {
+													validate28.errors = [
+														{
+															instancePath:
+																instancePath +
+																'/step',
+															schemaPath:
+																'#/oneOf/26/properties/step/const',
 															keyword: 'const',
 															params: {
 																allowedValue:
@@ -18077,14 +19261,14 @@ function validate28(
 													];
 													return false;
 												}
-												var valid90 =
-													_errs425 === errors;
+												var valid99 =
+													_errs471 === errors;
 											} else {
-												var valid90 = true;
+												var valid99 = true;
 											}
-											if (valid90) {
+											if (valid99) {
 												if (data.path !== undefined) {
-													const _errs427 = errors;
+													const _errs473 = errors;
 													if (
 														typeof data.path !==
 														'string'
@@ -18095,7 +19279,7 @@ function validate28(
 																	instancePath +
 																	'/path',
 																schemaPath:
-																	'#/oneOf/25/properties/path/type',
+																	'#/oneOf/26/properties/path/type',
 																keyword: 'type',
 																params: {
 																	type: 'string',
@@ -18106,23 +19290,23 @@ function validate28(
 														];
 														return false;
 													}
-													var valid90 =
-														_errs427 === errors;
+													var valid99 =
+														_errs473 === errors;
 												} else {
-													var valid90 = true;
+													var valid99 = true;
 												}
-												if (valid90) {
+												if (valid99) {
 													if (
 														data.data !== undefined
 													) {
-														let data158 = data.data;
-														const _errs429 = errors;
-														const _errs430 = errors;
-														let valid92 = false;
-														const _errs431 = errors;
+														let data177 = data.data;
+														const _errs475 = errors;
+														const _errs476 = errors;
+														let valid101 = false;
+														const _errs477 = errors;
 														if (
 															!validate16(
-																data158,
+																data177,
 																{
 																	instancePath:
 																		instancePath +
@@ -18145,14 +19329,14 @@ function validate28(
 																vErrors.length;
 														}
 														var _valid3 =
-															_errs431 === errors;
-														valid92 =
-															valid92 || _valid3;
-														if (!valid92) {
-															const _errs432 =
+															_errs477 === errors;
+														valid101 =
+															valid101 || _valid3;
+														if (!valid101) {
+															const _errs478 =
 																errors;
 															if (
-																typeof data158 !==
+																typeof data177 !==
 																'string'
 															) {
 																const err9 = {
@@ -18160,7 +19344,7 @@ function validate28(
 																		instancePath +
 																		'/data',
 																	schemaPath:
-																		'#/oneOf/25/properties/data/anyOf/1/type',
+																		'#/oneOf/26/properties/data/anyOf/1/type',
 																	keyword:
 																		'type',
 																	params: {
@@ -18184,47 +19368,47 @@ function validate28(
 																errors++;
 															}
 															var _valid3 =
-																_errs432 ===
+																_errs478 ===
 																errors;
-															valid92 =
-																valid92 ||
+															valid101 =
+																valid101 ||
 																_valid3;
-															if (!valid92) {
-																const _errs434 =
+															if (!valid101) {
+																const _errs480 =
 																	errors;
 																if (
 																	errors ===
-																	_errs434
+																	_errs480
 																) {
 																	if (
-																		data158 &&
-																		typeof data158 ==
+																		data177 &&
+																		typeof data177 ==
 																			'object' &&
 																		!Array.isArray(
-																			data158
+																			data177
 																		)
 																	) {
-																		let missing28;
+																		let missing29;
 																		if (
-																			(data158.BYTES_PER_ELEMENT ===
+																			(data177.BYTES_PER_ELEMENT ===
 																				undefined &&
-																				(missing28 =
+																				(missing29 =
 																					'BYTES_PER_ELEMENT')) ||
-																			(data158.buffer ===
+																			(data177.buffer ===
 																				undefined &&
-																				(missing28 =
+																				(missing29 =
 																					'buffer')) ||
-																			(data158.byteLength ===
+																			(data177.byteLength ===
 																				undefined &&
-																				(missing28 =
+																				(missing29 =
 																					'byteLength')) ||
-																			(data158.byteOffset ===
+																			(data177.byteOffset ===
 																				undefined &&
-																				(missing28 =
+																				(missing29 =
 																					'byteOffset')) ||
-																			(data158.length ===
+																			(data177.length ===
 																				undefined &&
-																				(missing28 =
+																				(missing29 =
 																					'length'))
 																		) {
 																			const err10 =
@@ -18233,16 +19417,16 @@ function validate28(
 																						instancePath +
 																						'/data',
 																					schemaPath:
-																						'#/oneOf/25/properties/data/anyOf/2/required',
+																						'#/oneOf/26/properties/data/anyOf/2/required',
 																					keyword:
 																						'required',
 																					params: {
 																						missingProperty:
-																							missing28,
+																							missing29,
 																					},
 																					message:
 																						"must have required property '" +
-																						missing28 +
+																						missing29 +
 																						"'",
 																				};
 																			if (
@@ -18260,35 +19444,35 @@ function validate28(
 																			}
 																			errors++;
 																		} else {
-																			const _errs436 =
+																			const _errs482 =
 																				errors;
-																			for (const key59 in data158) {
+																			for (const key63 in data177) {
 																				if (
 																					!(
-																						key59 ===
+																						key63 ===
 																							'BYTES_PER_ELEMENT' ||
-																						key59 ===
+																						key63 ===
 																							'buffer' ||
-																						key59 ===
+																						key63 ===
 																							'byteLength' ||
-																						key59 ===
+																						key63 ===
 																							'byteOffset' ||
-																						key59 ===
+																						key63 ===
 																							'length'
 																					)
 																				) {
-																					let data159 =
-																						data158[
-																							key59
+																					let data178 =
+																						data177[
+																							key63
 																						];
-																					const _errs437 =
+																					const _errs483 =
 																						errors;
 																					if (
 																						!(
-																							typeof data159 ==
+																							typeof data178 ==
 																								'number' &&
 																							isFinite(
-																								data159
+																								data178
 																							)
 																						)
 																					) {
@@ -18297,7 +19481,7 @@ function validate28(
 																								instancePath:
 																									instancePath +
 																									'/data/' +
-																									key59
+																									key63
 																										.replace(
 																											/~/g,
 																											'~0'
@@ -18307,7 +19491,7 @@ function validate28(
 																											'~1'
 																										),
 																								schemaPath:
-																									'#/oneOf/25/properties/data/anyOf/2/additionalProperties/type',
+																									'#/oneOf/26/properties/data/anyOf/2/additionalProperties/type',
 																								keyword:
 																									'type',
 																								params: {
@@ -18331,34 +19515,34 @@ function validate28(
 																						}
 																						errors++;
 																					}
-																					var valid93 =
-																						_errs437 ===
+																					var valid102 =
+																						_errs483 ===
 																						errors;
 																					if (
-																						!valid93
+																						!valid102
 																					) {
 																						break;
 																					}
 																				}
 																			}
 																			if (
-																				_errs436 ===
+																				_errs482 ===
 																				errors
 																			) {
 																				if (
-																					data158.BYTES_PER_ELEMENT !==
+																					data177.BYTES_PER_ELEMENT !==
 																					undefined
 																				) {
-																					let data160 =
-																						data158.BYTES_PER_ELEMENT;
-																					const _errs439 =
+																					let data179 =
+																						data177.BYTES_PER_ELEMENT;
+																					const _errs485 =
 																						errors;
 																					if (
 																						!(
-																							typeof data160 ==
+																							typeof data179 ==
 																								'number' &&
 																							isFinite(
-																								data160
+																								data179
 																							)
 																						)
 																					) {
@@ -18368,7 +19552,7 @@ function validate28(
 																									instancePath +
 																									'/data/BYTES_PER_ELEMENT',
 																								schemaPath:
-																									'#/oneOf/25/properties/data/anyOf/2/properties/BYTES_PER_ELEMENT/type',
+																									'#/oneOf/26/properties/data/anyOf/2/properties/BYTES_PER_ELEMENT/type',
 																								keyword:
 																									'type',
 																								params: {
@@ -18392,40 +19576,40 @@ function validate28(
 																						}
 																						errors++;
 																					}
-																					var valid94 =
-																						_errs439 ===
+																					var valid103 =
+																						_errs485 ===
 																						errors;
 																				} else {
-																					var valid94 = true;
+																					var valid103 = true;
 																				}
 																				if (
-																					valid94
+																					valid103
 																				) {
 																					if (
-																						data158.buffer !==
+																						data177.buffer !==
 																						undefined
 																					) {
-																						let data161 =
-																							data158.buffer;
-																						const _errs441 =
+																						let data180 =
+																							data177.buffer;
+																						const _errs487 =
 																							errors;
 																						if (
 																							errors ===
-																							_errs441
+																							_errs487
 																						) {
 																							if (
-																								data161 &&
-																								typeof data161 ==
+																								data180 &&
+																								typeof data180 ==
 																									'object' &&
 																								!Array.isArray(
-																									data161
+																									data180
 																								)
 																							) {
-																								let missing29;
+																								let missing30;
 																								if (
-																									data161.byteLength ===
+																									data180.byteLength ===
 																										undefined &&
-																									(missing29 =
+																									(missing30 =
 																										'byteLength')
 																								) {
 																									const err13 =
@@ -18434,16 +19618,16 @@ function validate28(
 																												instancePath +
 																												'/data/buffer',
 																											schemaPath:
-																												'#/oneOf/25/properties/data/anyOf/2/properties/buffer/required',
+																												'#/oneOf/26/properties/data/anyOf/2/properties/buffer/required',
 																											keyword:
 																												'required',
 																											params: {
 																												missingProperty:
-																													missing29,
+																													missing30,
 																											},
 																											message:
 																												"must have required property '" +
-																												missing29 +
+																												missing30 +
 																												"'",
 																										};
 																									if (
@@ -18461,12 +19645,12 @@ function validate28(
 																									}
 																									errors++;
 																								} else {
-																									const _errs443 =
+																									const _errs489 =
 																										errors;
-																									for (const key60 in data161) {
+																									for (const key64 in data180) {
 																										if (
 																											!(
-																												key60 ===
+																												key64 ===
 																												'byteLength'
 																											)
 																										) {
@@ -18476,12 +19660,12 @@ function validate28(
 																														instancePath +
 																														'/data/buffer',
 																													schemaPath:
-																														'#/oneOf/25/properties/data/anyOf/2/properties/buffer/additionalProperties',
+																														'#/oneOf/26/properties/data/anyOf/2/properties/buffer/additionalProperties',
 																													keyword:
 																														'additionalProperties',
 																													params: {
 																														additionalProperty:
-																															key60,
+																															key64,
 																													},
 																													message:
 																														'must NOT have additional properties',
@@ -18504,21 +19688,21 @@ function validate28(
 																										}
 																									}
 																									if (
-																										_errs443 ===
+																										_errs489 ===
 																										errors
 																									) {
 																										if (
-																											data161.byteLength !==
+																											data180.byteLength !==
 																											undefined
 																										) {
-																											let data162 =
-																												data161.byteLength;
+																											let data181 =
+																												data180.byteLength;
 																											if (
 																												!(
-																													typeof data162 ==
+																													typeof data181 ==
 																														'number' &&
 																													isFinite(
-																														data162
+																														data181
 																													)
 																												)
 																											) {
@@ -18528,7 +19712,7 @@ function validate28(
 																															instancePath +
 																															'/data/buffer/byteLength',
 																														schemaPath:
-																															'#/oneOf/25/properties/data/anyOf/2/properties/buffer/properties/byteLength/type',
+																															'#/oneOf/26/properties/data/anyOf/2/properties/buffer/properties/byteLength/type',
 																														keyword:
 																															'type',
 																														params: {
@@ -18562,7 +19746,7 @@ function validate28(
 																											instancePath +
 																											'/data/buffer',
 																										schemaPath:
-																											'#/oneOf/25/properties/data/anyOf/2/properties/buffer/type',
+																											'#/oneOf/26/properties/data/anyOf/2/properties/buffer/type',
 																										keyword:
 																											'type',
 																										params: {
@@ -18587,29 +19771,29 @@ function validate28(
 																								errors++;
 																							}
 																						}
-																						var valid94 =
-																							_errs441 ===
+																						var valid103 =
+																							_errs487 ===
 																							errors;
 																					} else {
-																						var valid94 = true;
+																						var valid103 = true;
 																					}
 																					if (
-																						valid94
+																						valid103
 																					) {
 																						if (
-																							data158.byteLength !==
+																							data177.byteLength !==
 																							undefined
 																						) {
-																							let data163 =
-																								data158.byteLength;
-																							const _errs446 =
+																							let data182 =
+																								data177.byteLength;
+																							const _errs492 =
 																								errors;
 																							if (
 																								!(
-																									typeof data163 ==
+																									typeof data182 ==
 																										'number' &&
 																									isFinite(
-																										data163
+																										data182
 																									)
 																								)
 																							) {
@@ -18619,7 +19803,7 @@ function validate28(
 																											instancePath +
 																											'/data/byteLength',
 																										schemaPath:
-																											'#/oneOf/25/properties/data/anyOf/2/properties/byteLength/type',
+																											'#/oneOf/26/properties/data/anyOf/2/properties/byteLength/type',
 																										keyword:
 																											'type',
 																										params: {
@@ -18643,29 +19827,29 @@ function validate28(
 																								}
 																								errors++;
 																							}
-																							var valid94 =
-																								_errs446 ===
+																							var valid103 =
+																								_errs492 ===
 																								errors;
 																						} else {
-																							var valid94 = true;
+																							var valid103 = true;
 																						}
 																						if (
-																							valid94
+																							valid103
 																						) {
 																							if (
-																								data158.byteOffset !==
+																								data177.byteOffset !==
 																								undefined
 																							) {
-																								let data164 =
-																									data158.byteOffset;
-																								const _errs448 =
+																								let data183 =
+																									data177.byteOffset;
+																								const _errs494 =
 																									errors;
 																								if (
 																									!(
-																										typeof data164 ==
+																										typeof data183 ==
 																											'number' &&
 																										isFinite(
-																											data164
+																											data183
 																										)
 																									)
 																								) {
@@ -18675,7 +19859,7 @@ function validate28(
 																												instancePath +
 																												'/data/byteOffset',
 																											schemaPath:
-																												'#/oneOf/25/properties/data/anyOf/2/properties/byteOffset/type',
+																												'#/oneOf/26/properties/data/anyOf/2/properties/byteOffset/type',
 																											keyword:
 																												'type',
 																											params: {
@@ -18699,29 +19883,29 @@ function validate28(
 																									}
 																									errors++;
 																								}
-																								var valid94 =
-																									_errs448 ===
+																								var valid103 =
+																									_errs494 ===
 																									errors;
 																							} else {
-																								var valid94 = true;
+																								var valid103 = true;
 																							}
 																							if (
-																								valid94
+																								valid103
 																							) {
 																								if (
-																									data158.length !==
+																									data177.length !==
 																									undefined
 																								) {
-																									let data165 =
-																										data158.length;
-																									const _errs450 =
+																									let data184 =
+																										data177.length;
+																									const _errs496 =
 																										errors;
 																									if (
 																										!(
-																											typeof data165 ==
+																											typeof data184 ==
 																												'number' &&
 																											isFinite(
-																												data165
+																												data184
 																											)
 																										)
 																									) {
@@ -18731,7 +19915,7 @@ function validate28(
 																													instancePath +
 																													'/data/length',
 																												schemaPath:
-																													'#/oneOf/25/properties/data/anyOf/2/properties/length/type',
+																													'#/oneOf/26/properties/data/anyOf/2/properties/length/type',
 																												keyword:
 																													'type',
 																												params: {
@@ -18755,11 +19939,11 @@ function validate28(
 																										}
 																										errors++;
 																									}
-																									var valid94 =
-																										_errs450 ===
+																									var valid103 =
+																										_errs496 ===
 																										errors;
 																								} else {
-																									var valid94 = true;
+																									var valid103 = true;
 																								}
 																							}
 																						}
@@ -18774,7 +19958,7 @@ function validate28(
 																					instancePath +
 																					'/data',
 																				schemaPath:
-																					'#/oneOf/25/properties/data/anyOf/2/type',
+																					'#/oneOf/26/properties/data/anyOf/2/type',
 																				keyword:
 																					'type',
 																				params: {
@@ -18800,20 +19984,20 @@ function validate28(
 																	}
 																}
 																var _valid3 =
-																	_errs434 ===
+																	_errs480 ===
 																	errors;
-																valid92 =
-																	valid92 ||
+																valid101 =
+																	valid101 ||
 																	_valid3;
 															}
 														}
-														if (!valid92) {
+														if (!valid101) {
 															const err21 = {
 																instancePath:
 																	instancePath +
 																	'/data',
 																schemaPath:
-																	'#/oneOf/25/properties/data/anyOf',
+																	'#/oneOf/26/properties/data/anyOf',
 																keyword:
 																	'anyOf',
 																params: {},
@@ -18836,23 +20020,23 @@ function validate28(
 																vErrors;
 															return false;
 														} else {
-															errors = _errs430;
+															errors = _errs476;
 															if (
 																vErrors !== null
 															) {
-																if (_errs430) {
+																if (_errs476) {
 																	vErrors.length =
-																		_errs430;
+																		_errs476;
 																} else {
 																	vErrors =
 																		null;
 																}
 															}
 														}
-														var valid90 =
-															_errs429 === errors;
+														var valid99 =
+															_errs475 === errors;
 													} else {
-														var valid90 = true;
+														var valid99 = true;
 													}
 												}
 											}
@@ -18863,7 +20047,7 @@ function validate28(
 								validate28.errors = [
 									{
 										instancePath,
-										schemaPath: '#/oneOf/25/type',
+										schemaPath: '#/oneOf/26/type',
 										keyword: 'type',
 										params: { type: 'object' },
 										message: 'must be object',
@@ -18873,58 +20057,58 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'writeFiles') {
-						const _errs452 = errors;
-						if (errors === _errs452) {
+						const _errs498 = errors;
+						if (errors === _errs498) {
 							if (
 								data &&
 								typeof data == 'object' &&
 								!Array.isArray(data)
 							) {
-								let missing30;
+								let missing31;
 								if (
 									(data.filesTree === undefined &&
-										(missing30 = 'filesTree')) ||
+										(missing31 = 'filesTree')) ||
 									(data.step === undefined &&
-										(missing30 = 'step')) ||
+										(missing31 = 'step')) ||
 									(data.writeToPath === undefined &&
-										(missing30 = 'writeToPath'))
+										(missing31 = 'writeToPath'))
 								) {
 									validate28.errors = [
 										{
 											instancePath,
-											schemaPath: '#/oneOf/26/required',
+											schemaPath: '#/oneOf/27/required',
 											keyword: 'required',
 											params: {
-												missingProperty: missing30,
+												missingProperty: missing31,
 											},
 											message:
 												"must have required property '" +
-												missing30 +
+												missing31 +
 												"'",
 										},
 									];
 									return false;
 								} else {
-									const _errs454 = errors;
-									for (const key61 in data) {
+									const _errs500 = errors;
+									for (const key65 in data) {
 										if (
 											!(
-												key61 === 'progress' ||
-												key61 === 'step' ||
-												key61 === 'writeToPath' ||
-												key61 === 'filesTree'
+												key65 === 'progress' ||
+												key65 === 'step' ||
+												key65 === 'writeToPath' ||
+												key65 === 'filesTree'
 											)
 										) {
 											validate28.errors = [
 												{
 													instancePath,
 													schemaPath:
-														'#/oneOf/26/additionalProperties',
+														'#/oneOf/27/additionalProperties',
 													keyword:
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key61,
+															key65,
 													},
 													message:
 														'must NOT have additional properties',
@@ -18934,24 +20118,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs454 === errors) {
+									if (_errs500 === errors) {
 										if (data.progress !== undefined) {
-											let data166 = data.progress;
-											const _errs455 = errors;
-											if (errors === _errs455) {
+											let data185 = data.progress;
+											const _errs501 = errors;
+											if (errors === _errs501) {
 												if (
-													data166 &&
-													typeof data166 ==
+													data185 &&
+													typeof data185 ==
 														'object' &&
-													!Array.isArray(data166)
+													!Array.isArray(data185)
 												) {
-													const _errs457 = errors;
-													for (const key62 in data166) {
+													const _errs503 = errors;
+													for (const key66 in data185) {
 														if (
 															!(
-																key62 ===
+																key66 ===
 																	'weight' ||
-																key62 ===
+																key66 ===
 																	'caption'
 															)
 														) {
@@ -18962,12 +20146,12 @@ function validate28(
 																			instancePath +
 																			'/progress',
 																		schemaPath:
-																			'#/oneOf/26/properties/progress/additionalProperties',
+																			'#/oneOf/27/properties/progress/additionalProperties',
 																		keyword:
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key62,
+																				key66,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -18977,21 +20161,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs457 === errors) {
+													if (_errs503 === errors) {
 														if (
-															data166.weight !==
+															data185.weight !==
 															undefined
 														) {
-															let data167 =
-																data166.weight;
-															const _errs458 =
+															let data186 =
+																data185.weight;
+															const _errs504 =
 																errors;
 															if (
 																!(
-																	typeof data167 ==
+																	typeof data186 ==
 																		'number' &&
 																	isFinite(
-																		data167
+																		data186
 																	)
 																)
 															) {
@@ -19002,7 +20186,7 @@ function validate28(
 																				instancePath +
 																				'/progress/weight',
 																			schemaPath:
-																				'#/oneOf/26/properties/progress/properties/weight/type',
+																				'#/oneOf/27/properties/progress/properties/weight/type',
 																			keyword:
 																				'type',
 																			params: {
@@ -19014,21 +20198,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid98 =
-																_errs458 ===
+															var valid107 =
+																_errs504 ===
 																errors;
 														} else {
-															var valid98 = true;
+															var valid107 = true;
 														}
-														if (valid98) {
+														if (valid107) {
 															if (
-																data166.caption !==
+																data185.caption !==
 																undefined
 															) {
-																const _errs460 =
+																const _errs506 =
 																	errors;
 																if (
-																	typeof data166.caption !==
+																	typeof data185.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -19038,7 +20222,7 @@ function validate28(
 																					instancePath +
 																					'/progress/caption',
 																				schemaPath:
-																					'#/oneOf/26/properties/progress/properties/caption/type',
+																					'#/oneOf/27/properties/progress/properties/caption/type',
 																				keyword:
 																					'type',
 																				params: {
@@ -19050,11 +20234,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid98 =
-																	_errs460 ===
+																var valid107 =
+																	_errs506 ===
 																	errors;
 															} else {
-																var valid98 = true;
+																var valid107 = true;
 															}
 														}
 													}
@@ -19065,7 +20249,7 @@ function validate28(
 																instancePath +
 																'/progress',
 															schemaPath:
-																'#/oneOf/26/properties/progress/type',
+																'#/oneOf/27/properties/progress/type',
 															keyword: 'type',
 															params: {
 																type: 'object',
@@ -19077,16 +20261,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid97 = _errs455 === errors;
+											var valid106 = _errs501 === errors;
 										} else {
-											var valid97 = true;
+											var valid106 = true;
 										}
-										if (valid97) {
+										if (valid106) {
 											if (data.step !== undefined) {
-												let data169 = data.step;
-												const _errs462 = errors;
+												let data188 = data.step;
+												const _errs508 = errors;
 												if (
-													typeof data169 !== 'string'
+													typeof data188 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -19094,7 +20278,7 @@ function validate28(
 																instancePath +
 																'/step',
 															schemaPath:
-																'#/oneOf/26/properties/step/type',
+																'#/oneOf/27/properties/step/type',
 															keyword: 'type',
 															params: {
 																type: 'string',
@@ -19105,14 +20289,14 @@ function validate28(
 													];
 													return false;
 												}
-												if ('writeFiles' !== data169) {
+												if ('writeFiles' !== data188) {
 													validate28.errors = [
 														{
 															instancePath:
 																instancePath +
 																'/step',
 															schemaPath:
-																'#/oneOf/26/properties/step/const',
+																'#/oneOf/27/properties/step/const',
 															keyword: 'const',
 															params: {
 																allowedValue:
@@ -19124,17 +20308,17 @@ function validate28(
 													];
 													return false;
 												}
-												var valid97 =
-													_errs462 === errors;
+												var valid106 =
+													_errs508 === errors;
 											} else {
-												var valid97 = true;
+												var valid106 = true;
 											}
-											if (valid97) {
+											if (valid106) {
 												if (
 													data.writeToPath !==
 													undefined
 												) {
-													const _errs464 = errors;
+													const _errs510 = errors;
 													if (
 														typeof data.writeToPath !==
 														'string'
@@ -19145,7 +20329,7 @@ function validate28(
 																	instancePath +
 																	'/writeToPath',
 																schemaPath:
-																	'#/oneOf/26/properties/writeToPath/type',
+																	'#/oneOf/27/properties/writeToPath/type',
 																keyword: 'type',
 																params: {
 																	type: 'string',
@@ -19156,17 +20340,17 @@ function validate28(
 														];
 														return false;
 													}
-													var valid97 =
-														_errs464 === errors;
+													var valid106 =
+														_errs510 === errors;
 												} else {
-													var valid97 = true;
+													var valid106 = true;
 												}
-												if (valid97) {
+												if (valid106) {
 													if (
 														data.filesTree !==
 														undefined
 													) {
-														const _errs466 = errors;
+														const _errs512 = errors;
 														if (
 															!validate18(
 																data.filesTree,
@@ -19191,10 +20375,10 @@ function validate28(
 															errors =
 																vErrors.length;
 														}
-														var valid97 =
-															_errs466 === errors;
+														var valid106 =
+															_errs512 === errors;
 													} else {
-														var valid97 = true;
+														var valid106 = true;
 													}
 												}
 											}
@@ -19205,7 +20389,7 @@ function validate28(
 								validate28.errors = [
 									{
 										instancePath,
-										schemaPath: '#/oneOf/26/type',
+										schemaPath: '#/oneOf/27/type',
 										keyword: 'type',
 										params: { type: 'object' },
 										message: 'must be object',
@@ -19215,56 +20399,56 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'wp-cli') {
-						const _errs467 = errors;
-						if (errors === _errs467) {
+						const _errs513 = errors;
+						if (errors === _errs513) {
 							if (
 								data &&
 								typeof data == 'object' &&
 								!Array.isArray(data)
 							) {
-								let missing31;
+								let missing32;
 								if (
 									(data.command === undefined &&
-										(missing31 = 'command')) ||
+										(missing32 = 'command')) ||
 									(data.step === undefined &&
-										(missing31 = 'step'))
+										(missing32 = 'step'))
 								) {
 									validate28.errors = [
 										{
 											instancePath,
-											schemaPath: '#/oneOf/27/required',
+											schemaPath: '#/oneOf/28/required',
 											keyword: 'required',
 											params: {
-												missingProperty: missing31,
+												missingProperty: missing32,
 											},
 											message:
 												"must have required property '" +
-												missing31 +
+												missing32 +
 												"'",
 										},
 									];
 									return false;
 								} else {
-									const _errs469 = errors;
-									for (const key63 in data) {
+									const _errs515 = errors;
+									for (const key67 in data) {
 										if (
 											!(
-												key63 === 'progress' ||
-												key63 === 'step' ||
-												key63 === 'command' ||
-												key63 === 'wpCliPath'
+												key67 === 'progress' ||
+												key67 === 'step' ||
+												key67 === 'command' ||
+												key67 === 'wpCliPath'
 											)
 										) {
 											validate28.errors = [
 												{
 													instancePath,
 													schemaPath:
-														'#/oneOf/27/additionalProperties',
+														'#/oneOf/28/additionalProperties',
 													keyword:
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key63,
+															key67,
 													},
 													message:
 														'must NOT have additional properties',
@@ -19274,24 +20458,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs469 === errors) {
+									if (_errs515 === errors) {
 										if (data.progress !== undefined) {
-											let data172 = data.progress;
-											const _errs470 = errors;
-											if (errors === _errs470) {
+											let data191 = data.progress;
+											const _errs516 = errors;
+											if (errors === _errs516) {
 												if (
-													data172 &&
-													typeof data172 ==
+													data191 &&
+													typeof data191 ==
 														'object' &&
-													!Array.isArray(data172)
+													!Array.isArray(data191)
 												) {
-													const _errs472 = errors;
-													for (const key64 in data172) {
+													const _errs518 = errors;
+													for (const key68 in data191) {
 														if (
 															!(
-																key64 ===
+																key68 ===
 																	'weight' ||
-																key64 ===
+																key68 ===
 																	'caption'
 															)
 														) {
@@ -19302,12 +20486,12 @@ function validate28(
 																			instancePath +
 																			'/progress',
 																		schemaPath:
-																			'#/oneOf/27/properties/progress/additionalProperties',
+																			'#/oneOf/28/properties/progress/additionalProperties',
 																		keyword:
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key64,
+																				key68,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -19317,21 +20501,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs472 === errors) {
+													if (_errs518 === errors) {
 														if (
-															data172.weight !==
+															data191.weight !==
 															undefined
 														) {
-															let data173 =
-																data172.weight;
-															const _errs473 =
+															let data192 =
+																data191.weight;
+															const _errs519 =
 																errors;
 															if (
 																!(
-																	typeof data173 ==
+																	typeof data192 ==
 																		'number' &&
 																	isFinite(
-																		data173
+																		data192
 																	)
 																)
 															) {
@@ -19342,7 +20526,7 @@ function validate28(
 																				instancePath +
 																				'/progress/weight',
 																			schemaPath:
-																				'#/oneOf/27/properties/progress/properties/weight/type',
+																				'#/oneOf/28/properties/progress/properties/weight/type',
 																			keyword:
 																				'type',
 																			params: {
@@ -19354,21 +20538,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid101 =
-																_errs473 ===
+															var valid110 =
+																_errs519 ===
 																errors;
 														} else {
-															var valid101 = true;
+															var valid110 = true;
 														}
-														if (valid101) {
+														if (valid110) {
 															if (
-																data172.caption !==
+																data191.caption !==
 																undefined
 															) {
-																const _errs475 =
+																const _errs521 =
 																	errors;
 																if (
-																	typeof data172.caption !==
+																	typeof data191.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -19378,7 +20562,7 @@ function validate28(
 																					instancePath +
 																					'/progress/caption',
 																				schemaPath:
-																					'#/oneOf/27/properties/progress/properties/caption/type',
+																					'#/oneOf/28/properties/progress/properties/caption/type',
 																				keyword:
 																					'type',
 																				params: {
@@ -19390,11 +20574,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid101 =
-																	_errs475 ===
+																var valid110 =
+																	_errs521 ===
 																	errors;
 															} else {
-																var valid101 = true;
+																var valid110 = true;
 															}
 														}
 													}
@@ -19405,7 +20589,7 @@ function validate28(
 																instancePath +
 																'/progress',
 															schemaPath:
-																'#/oneOf/27/properties/progress/type',
+																'#/oneOf/28/properties/progress/type',
 															keyword: 'type',
 															params: {
 																type: 'object',
@@ -19417,16 +20601,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid100 = _errs470 === errors;
+											var valid109 = _errs516 === errors;
 										} else {
-											var valid100 = true;
+											var valid109 = true;
 										}
-										if (valid100) {
+										if (valid109) {
 											if (data.step !== undefined) {
-												let data175 = data.step;
-												const _errs477 = errors;
+												let data194 = data.step;
+												const _errs523 = errors;
 												if (
-													typeof data175 !== 'string'
+													typeof data194 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -19434,7 +20618,7 @@ function validate28(
 																instancePath +
 																'/step',
 															schemaPath:
-																'#/oneOf/27/properties/step/type',
+																'#/oneOf/28/properties/step/type',
 															keyword: 'type',
 															params: {
 																type: 'string',
@@ -19445,14 +20629,14 @@ function validate28(
 													];
 													return false;
 												}
-												if ('wp-cli' !== data175) {
+												if ('wp-cli' !== data194) {
 													validate28.errors = [
 														{
 															instancePath:
 																instancePath +
 																'/step',
 															schemaPath:
-																'#/oneOf/27/properties/step/const',
+																'#/oneOf/28/properties/step/const',
 															keyword: 'const',
 															params: {
 																allowedValue:
@@ -19464,22 +20648,22 @@ function validate28(
 													];
 													return false;
 												}
-												var valid100 =
-													_errs477 === errors;
+												var valid109 =
+													_errs523 === errors;
 											} else {
-												var valid100 = true;
+												var valid109 = true;
 											}
-											if (valid100) {
+											if (valid109) {
 												if (
 													data.command !== undefined
 												) {
-													let data176 = data.command;
-													const _errs479 = errors;
-													const _errs480 = errors;
-													let valid102 = false;
-													const _errs481 = errors;
+													let data195 = data.command;
+													const _errs525 = errors;
+													const _errs526 = errors;
+													let valid111 = false;
+													const _errs527 = errors;
 													if (
-														typeof data176 !==
+														typeof data195 !==
 														'string'
 													) {
 														const err22 = {
@@ -19487,7 +20671,7 @@ function validate28(
 																instancePath +
 																'/command',
 															schemaPath:
-																'#/oneOf/27/properties/command/anyOf/0/type',
+																'#/oneOf/28/properties/command/anyOf/0/type',
 															keyword: 'type',
 															params: {
 																type: 'string',
@@ -19503,31 +20687,31 @@ function validate28(
 														errors++;
 													}
 													var _valid4 =
-														_errs481 === errors;
-													valid102 =
-														valid102 || _valid4;
-													if (!valid102) {
-														const _errs483 = errors;
+														_errs527 === errors;
+													valid111 =
+														valid111 || _valid4;
+													if (!valid111) {
+														const _errs529 = errors;
 														if (
-															errors === _errs483
+															errors === _errs529
 														) {
 															if (
 																Array.isArray(
-																	data176
+																	data195
 																)
 															) {
-																var valid103 = true;
+																var valid112 = true;
 																const len0 =
-																	data176.length;
+																	data195.length;
 																for (
 																	let i0 = 0;
 																	i0 < len0;
 																	i0++
 																) {
-																	const _errs485 =
+																	const _errs531 =
 																		errors;
 																	if (
-																		typeof data176[
+																		typeof data195[
 																			i0
 																		] !==
 																		'string'
@@ -19539,7 +20723,7 @@ function validate28(
 																					'/command/' +
 																					i0,
 																				schemaPath:
-																					'#/oneOf/27/properties/command/anyOf/1/items/type',
+																					'#/oneOf/28/properties/command/anyOf/1/items/type',
 																				keyword:
 																					'type',
 																				params: {
@@ -19563,11 +20747,11 @@ function validate28(
 																		}
 																		errors++;
 																	}
-																	var valid103 =
-																		_errs485 ===
+																	var valid112 =
+																		_errs531 ===
 																		errors;
 																	if (
-																		!valid103
+																		!valid112
 																	) {
 																		break;
 																	}
@@ -19578,7 +20762,7 @@ function validate28(
 																		instancePath +
 																		'/command',
 																	schemaPath:
-																		'#/oneOf/27/properties/command/anyOf/1/type',
+																		'#/oneOf/28/properties/command/anyOf/1/type',
 																	keyword:
 																		'type',
 																	params: {
@@ -19603,17 +20787,17 @@ function validate28(
 															}
 														}
 														var _valid4 =
-															_errs483 === errors;
-														valid102 =
-															valid102 || _valid4;
+															_errs529 === errors;
+														valid111 =
+															valid111 || _valid4;
 													}
-													if (!valid102) {
+													if (!valid111) {
 														const err25 = {
 															instancePath:
 																instancePath +
 																'/command',
 															schemaPath:
-																'#/oneOf/27/properties/command/anyOf',
+																'#/oneOf/28/properties/command/anyOf',
 															keyword: 'anyOf',
 															params: {},
 															message:
@@ -19629,27 +20813,27 @@ function validate28(
 															vErrors;
 														return false;
 													} else {
-														errors = _errs480;
+														errors = _errs526;
 														if (vErrors !== null) {
-															if (_errs480) {
+															if (_errs526) {
 																vErrors.length =
-																	_errs480;
+																	_errs526;
 															} else {
 																vErrors = null;
 															}
 														}
 													}
-													var valid100 =
-														_errs479 === errors;
+													var valid109 =
+														_errs525 === errors;
 												} else {
-													var valid100 = true;
+													var valid109 = true;
 												}
-												if (valid100) {
+												if (valid109) {
 													if (
 														data.wpCliPath !==
 														undefined
 													) {
-														const _errs487 = errors;
+														const _errs533 = errors;
 														if (
 															typeof data.wpCliPath !==
 															'string'
@@ -19661,7 +20845,7 @@ function validate28(
 																			instancePath +
 																			'/wpCliPath',
 																		schemaPath:
-																			'#/oneOf/27/properties/wpCliPath/type',
+																			'#/oneOf/28/properties/wpCliPath/type',
 																		keyword:
 																			'type',
 																		params: {
@@ -19673,10 +20857,10 @@ function validate28(
 																];
 															return false;
 														}
-														var valid100 =
-															_errs487 === errors;
+														var valid109 =
+															_errs533 === errors;
 													} else {
-														var valid100 = true;
+														var valid109 = true;
 													}
 												}
 											}
@@ -19687,7 +20871,7 @@ function validate28(
 								validate28.errors = [
 									{
 										instancePath,
-										schemaPath: '#/oneOf/27/type',
+										schemaPath: '#/oneOf/28/type',
 										keyword: 'type',
 										params: { type: 'object' },
 										message: 'must be object',
@@ -19697,55 +20881,55 @@ function validate28(
 							}
 						}
 					} else if (tag0 === 'setSiteLanguage') {
-						const _errs489 = errors;
-						if (errors === _errs489) {
+						const _errs535 = errors;
+						if (errors === _errs535) {
 							if (
 								data &&
 								typeof data == 'object' &&
 								!Array.isArray(data)
 							) {
-								let missing32;
+								let missing33;
 								if (
 									(data.language === undefined &&
-										(missing32 = 'language')) ||
+										(missing33 = 'language')) ||
 									(data.step === undefined &&
-										(missing32 = 'step'))
+										(missing33 = 'step'))
 								) {
 									validate28.errors = [
 										{
 											instancePath,
-											schemaPath: '#/oneOf/28/required',
+											schemaPath: '#/oneOf/29/required',
 											keyword: 'required',
 											params: {
-												missingProperty: missing32,
+												missingProperty: missing33,
 											},
 											message:
 												"must have required property '" +
-												missing32 +
+												missing33 +
 												"'",
 										},
 									];
 									return false;
 								} else {
-									const _errs491 = errors;
-									for (const key65 in data) {
+									const _errs537 = errors;
+									for (const key69 in data) {
 										if (
 											!(
-												key65 === 'progress' ||
-												key65 === 'step' ||
-												key65 === 'language'
+												key69 === 'progress' ||
+												key69 === 'step' ||
+												key69 === 'language'
 											)
 										) {
 											validate28.errors = [
 												{
 													instancePath,
 													schemaPath:
-														'#/oneOf/28/additionalProperties',
+														'#/oneOf/29/additionalProperties',
 													keyword:
 														'additionalProperties',
 													params: {
 														additionalProperty:
-															key65,
+															key69,
 													},
 													message:
 														'must NOT have additional properties',
@@ -19755,24 +20939,24 @@ function validate28(
 											break;
 										}
 									}
-									if (_errs491 === errors) {
+									if (_errs537 === errors) {
 										if (data.progress !== undefined) {
-											let data179 = data.progress;
-											const _errs492 = errors;
-											if (errors === _errs492) {
+											let data198 = data.progress;
+											const _errs538 = errors;
+											if (errors === _errs538) {
 												if (
-													data179 &&
-													typeof data179 ==
+													data198 &&
+													typeof data198 ==
 														'object' &&
-													!Array.isArray(data179)
+													!Array.isArray(data198)
 												) {
-													const _errs494 = errors;
-													for (const key66 in data179) {
+													const _errs540 = errors;
+													for (const key70 in data198) {
 														if (
 															!(
-																key66 ===
+																key70 ===
 																	'weight' ||
-																key66 ===
+																key70 ===
 																	'caption'
 															)
 														) {
@@ -19783,12 +20967,12 @@ function validate28(
 																			instancePath +
 																			'/progress',
 																		schemaPath:
-																			'#/oneOf/28/properties/progress/additionalProperties',
+																			'#/oneOf/29/properties/progress/additionalProperties',
 																		keyword:
 																			'additionalProperties',
 																		params: {
 																			additionalProperty:
-																				key66,
+																				key70,
 																		},
 																		message:
 																			'must NOT have additional properties',
@@ -19798,21 +20982,21 @@ function validate28(
 															break;
 														}
 													}
-													if (_errs494 === errors) {
+													if (_errs540 === errors) {
 														if (
-															data179.weight !==
+															data198.weight !==
 															undefined
 														) {
-															let data180 =
-																data179.weight;
-															const _errs495 =
+															let data199 =
+																data198.weight;
+															const _errs541 =
 																errors;
 															if (
 																!(
-																	typeof data180 ==
+																	typeof data199 ==
 																		'number' &&
 																	isFinite(
-																		data180
+																		data199
 																	)
 																)
 															) {
@@ -19823,7 +21007,7 @@ function validate28(
 																				instancePath +
 																				'/progress/weight',
 																			schemaPath:
-																				'#/oneOf/28/properties/progress/properties/weight/type',
+																				'#/oneOf/29/properties/progress/properties/weight/type',
 																			keyword:
 																				'type',
 																			params: {
@@ -19835,21 +21019,21 @@ function validate28(
 																	];
 																return false;
 															}
-															var valid106 =
-																_errs495 ===
+															var valid115 =
+																_errs541 ===
 																errors;
 														} else {
-															var valid106 = true;
+															var valid115 = true;
 														}
-														if (valid106) {
+														if (valid115) {
 															if (
-																data179.caption !==
+																data198.caption !==
 																undefined
 															) {
-																const _errs497 =
+																const _errs543 =
 																	errors;
 																if (
-																	typeof data179.caption !==
+																	typeof data198.caption !==
 																	'string'
 																) {
 																	validate28.errors =
@@ -19859,7 +21043,7 @@ function validate28(
 																					instancePath +
 																					'/progress/caption',
 																				schemaPath:
-																					'#/oneOf/28/properties/progress/properties/caption/type',
+																					'#/oneOf/29/properties/progress/properties/caption/type',
 																				keyword:
 																					'type',
 																				params: {
@@ -19871,11 +21055,11 @@ function validate28(
 																		];
 																	return false;
 																}
-																var valid106 =
-																	_errs497 ===
+																var valid115 =
+																	_errs543 ===
 																	errors;
 															} else {
-																var valid106 = true;
+																var valid115 = true;
 															}
 														}
 													}
@@ -19886,7 +21070,7 @@ function validate28(
 																instancePath +
 																'/progress',
 															schemaPath:
-																'#/oneOf/28/properties/progress/type',
+																'#/oneOf/29/properties/progress/type',
 															keyword: 'type',
 															params: {
 																type: 'object',
@@ -19898,16 +21082,16 @@ function validate28(
 													return false;
 												}
 											}
-											var valid105 = _errs492 === errors;
+											var valid114 = _errs538 === errors;
 										} else {
-											var valid105 = true;
+											var valid114 = true;
 										}
-										if (valid105) {
+										if (valid114) {
 											if (data.step !== undefined) {
-												let data182 = data.step;
-												const _errs499 = errors;
+												let data201 = data.step;
+												const _errs545 = errors;
 												if (
-													typeof data182 !== 'string'
+													typeof data201 !== 'string'
 												) {
 													validate28.errors = [
 														{
@@ -19915,7 +21099,7 @@ function validate28(
 																instancePath +
 																'/step',
 															schemaPath:
-																'#/oneOf/28/properties/step/type',
+																'#/oneOf/29/properties/step/type',
 															keyword: 'type',
 															params: {
 																type: 'string',
@@ -19928,7 +21112,7 @@ function validate28(
 												}
 												if (
 													'setSiteLanguage' !==
-													data182
+													data201
 												) {
 													validate28.errors = [
 														{
@@ -19936,7 +21120,7 @@ function validate28(
 																instancePath +
 																'/step',
 															schemaPath:
-																'#/oneOf/28/properties/step/const',
+																'#/oneOf/29/properties/step/const',
 															keyword: 'const',
 															params: {
 																allowedValue:
@@ -19948,16 +21132,16 @@ function validate28(
 													];
 													return false;
 												}
-												var valid105 =
-													_errs499 === errors;
+												var valid114 =
+													_errs545 === errors;
 											} else {
-												var valid105 = true;
+												var valid114 = true;
 											}
-											if (valid105) {
+											if (valid114) {
 												if (
 													data.language !== undefined
 												) {
-													const _errs501 = errors;
+													const _errs547 = errors;
 													if (
 														typeof data.language !==
 														'string'
@@ -19968,7 +21152,7 @@ function validate28(
 																	instancePath +
 																	'/language',
 																schemaPath:
-																	'#/oneOf/28/properties/language/type',
+																	'#/oneOf/29/properties/language/type',
 																keyword: 'type',
 																params: {
 																	type: 'string',
@@ -19979,10 +21163,10 @@ function validate28(
 														];
 														return false;
 													}
-													var valid105 =
-														_errs501 === errors;
+													var valid114 =
+														_errs547 === errors;
 												} else {
-													var valid105 = true;
+													var valid114 = true;
 												}
 											}
 										}
@@ -19992,7 +21176,7 @@ function validate28(
 								validate28.errors = [
 									{
 										instancePath,
-										schemaPath: '#/oneOf/28/type',
+										schemaPath: '#/oneOf/29/type',
 										keyword: 'type',
 										params: { type: 'object' },
 										message: 'must be object',

--- a/packages/playground/blueprints/public/blueprint-schema.json
+++ b/packages/playground/blueprints/public/blueprint-schema.json
@@ -896,6 +896,87 @@
 						},
 						"step": {
 							"type": "string",
+							"const": "loadPHPExtension"
+						},
+						"source": {
+							"$ref": "#/definitions/FileReference",
+							"description": "The extension `.so` file or a compile-extension `manifest.json`."
+						},
+						"sourceFormat": {
+							"$ref": "#/definitions/PHPExtensionSourceFormat",
+							"description": "Defaults to \"manifest\" for `.json` files and \"so\" otherwise."
+						},
+						"name": {
+							"type": "string",
+							"description": "Required when loading a `.so` file whose filename is not named after the extension."
+						},
+						"loadTiming": {
+							"$ref": "#/definitions/PHPExtensionLoadTiming",
+							"description": "Defaults to \"auto\"."
+						},
+						"loadWithIniDirective": {
+							"$ref": "#/definitions/PHPExtensionIniDirective",
+							"description": "Defaults to \"extension\". Use \"zend_extension\" for extensions like Xdebug."
+						},
+						"iniEntries": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "string"
+							},
+							"description": "Extra `php.ini` entries to write next to the extension."
+						},
+						"extraFiles": {
+							"$ref": "#/definitions/DirectoryReference",
+							"description": "Extra files required by the extension, such as ICU data or shared libraries."
+						},
+						"extraFilesPath": {
+							"type": "string",
+							"description": "Where to write `extraFiles`. Defaults to an extension-specific assets directory."
+						},
+						"env": {
+							"type": "object",
+							"additionalProperties": {
+								"type": "string"
+							},
+							"description": "Runtime environment variables needed by the extension."
+						},
+						"phpVersion": {
+							"type": "string",
+							"description": "Overrides manifest artifact selection. Defaults to the running PHP version."
+						},
+						"asyncMode": {
+							"$ref": "#/definitions/PHPWasmAsyncMode",
+							"description": "Overrides manifest artifact selection. Defaults to the running async mode."
+						},
+						"manifestBaseUrl": {
+							"type": "string",
+							"description": "Base URL for relative artifact paths in an inline or bundled manifest."
+						},
+						"extensionDir": {
+							"type": "string",
+							"description": "Where to install the extension `.so` and `.ini` files."
+						}
+					},
+					"required": ["source", "step"]
+				},
+				{
+					"type": "object",
+					"additionalProperties": false,
+					"properties": {
+						"progress": {
+							"type": "object",
+							"properties": {
+								"weight": {
+									"type": "number"
+								},
+								"caption": {
+									"type": "string"
+								}
+							},
+							"additionalProperties": false
+						},
+						"step": {
+							"type": "string",
 							"const": "login"
 						},
 						"username": {
@@ -1503,6 +1584,22 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"PHPExtensionSourceFormat": {
+			"type": "string",
+			"enum": ["so", "manifest"]
+		},
+		"PHPExtensionLoadTiming": {
+			"type": "string",
+			"enum": ["before-php-startup", "after-php-startup", "auto"]
+		},
+		"PHPExtensionIniDirective": {
+			"type": "string",
+			"enum": ["extension", "zend_extension"]
+		},
+		"PHPWasmAsyncMode": {
+			"type": "string",
+			"enum": ["jspi", "asyncify"]
 		},
 		"PHPRequest": {
 			"type": "object",

--- a/packages/playground/blueprints/src/lib/steps/handlers.ts
+++ b/packages/playground/blueprints/src/lib/steps/handlers.ts
@@ -20,6 +20,7 @@ export { exportWXR } from './export-wxr';
 export { unzip } from './unzip';
 export { installPlugin } from './install-plugin';
 export { installTheme } from './install-theme';
+export { loadPHPExtension } from './load-php-extension';
 export { login } from './login';
 export { resetData } from './reset-data';
 export { runWpInstallationWizard } from './run-wp-installation-wizard';

--- a/packages/playground/blueprints/src/lib/steps/index.ts
+++ b/packages/playground/blueprints/src/lib/steps/index.ts
@@ -36,6 +36,7 @@ import type { EnableMultisiteStep } from './enable-multisite';
 import type { WPCLIStep } from './wp-cli';
 import type { ResetDataStep } from './reset-data';
 import type { SetSiteLanguageStep } from './set-site-language';
+import type { LoadPHPExtensionStep } from './load-php-extension';
 
 export type Step = GenericStep<FileReference, DirectoryReference>;
 export type StepDefinition = Step & {
@@ -63,6 +64,7 @@ export type GenericStep<FileResource, DirectoryResource> =
 	| ImportWordPressFilesStep<FileResource>
 	| InstallPluginStep<FileResource, DirectoryResource>
 	| InstallThemeStep<FileResource, DirectoryResource>
+	| LoadPHPExtensionStep<FileResource, DirectoryResource>
 	| LoginStep
 	| MkdirStep
 	| MvStep
@@ -96,6 +98,7 @@ export type {
 	InstallPluginOptions,
 	InstallThemeStep,
 	InstallThemeOptions,
+	LoadPHPExtensionStep,
 	LoginStep,
 	MkdirStep,
 	MvStep,
@@ -127,7 +130,7 @@ export type StepProgress = {
 
 export type StepHandler<
 	S extends GenericStep<File, Directory>,
-	Return = any
+	Return = any,
 > = (
 	/**
 	 * A PHP instance or Playground client.

--- a/packages/playground/blueprints/src/lib/steps/load-php-extension.spec.ts
+++ b/packages/playground/blueprints/src/lib/steps/load-php-extension.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	PHP_EXTENSION_PRELOAD_DIR,
+	PHP_EXTENSIONS_DIR,
+} from '@php-wasm/universal';
+import { loadPHPExtension } from './load-php-extension';
+
+const PHP_INI_PATH = '/internal/shared/php.ini';
+
+describe('loadPHPExtension Blueprint step', () => {
+	it('loads a direct .so resource and a directory resource for extra files', async () => {
+		const php = createFakePHP();
+		const soBytes = new Uint8Array([1, 2, 3]);
+
+		await loadPHPExtension(php as any, {
+			source: new File([soBytes], 'example.so'),
+			extraFiles: {
+				name: 'example-assets',
+				files: {
+					'data.txt': 'sidecar',
+				},
+			},
+			extraFilesPath: '/internal/shared/example-assets',
+		});
+
+		expect(php.files.get(`${PHP_EXTENSIONS_DIR}/example.so`)).toEqual(
+			soBytes
+		);
+		expect(php.files.get(`${PHP_EXTENSIONS_DIR}/example.ini`)).toBe(
+			`extension=${PHP_EXTENSIONS_DIR}/example.so`
+		);
+		expect(
+			String(php.files.get(`${PHP_EXTENSION_PRELOAD_DIR}/example.php`))
+		).toContain("dl('example.so')");
+		expect(php.files.get('/internal/shared/example-assets/data.txt')).toBe(
+			'sidecar'
+		);
+	});
+});
+
+function createFakePHP() {
+	const files = new Map<string, string | Uint8Array>([
+		[PHP_INI_PATH, 'memory_limit=256M\n'],
+	]);
+	const directories = new Set<string>(['/internal', '/internal/shared']);
+
+	return {
+		files,
+		directories,
+		async fileExists(path: string) {
+			return files.has(path) || directories.has(path);
+		},
+		async mkdir(path: string) {
+			directories.add(path);
+		},
+		async mkdirTree(path: string) {
+			directories.add(path);
+		},
+		async writeFile(path: string, data: string | Uint8Array) {
+			files.set(path, data);
+		},
+		async readFileAsText(path: string) {
+			const value = files.get(path);
+			if (value instanceof Uint8Array) {
+				return new TextDecoder().decode(value);
+			}
+			return value ?? '';
+		},
+	};
+}

--- a/packages/playground/blueprints/src/lib/steps/load-php-extension.ts
+++ b/packages/playground/blueprints/src/lib/steps/load-php-extension.ts
@@ -1,0 +1,123 @@
+import {
+	loadPHPExtension as loadPHPExtensionFromSource,
+	type LoadedPHPExtension,
+	type PHPExtensionIniDirective,
+	type PHPExtensionLoadTiming,
+	type PHPExtensionSourceFormat,
+	type PHPWasmAsyncMode,
+} from '@php-wasm/universal';
+import type { StepHandler } from '.';
+import type { Directory } from '../v1/resources';
+
+type SourceFile = File & { sourceUrl?: string };
+
+/**
+ * @inheritDoc loadPHPExtension
+ * @example
+ *
+ * <code>
+ * {
+ * 		"step": "loadPHPExtension",
+ * 		"source": {
+ * 			"resource": "url",
+ * 			"url": "https://example.com/extensions/example/manifest.json"
+ * 		},
+ * 		"sourceFormat": "manifest"
+ * }
+ * </code>
+ */
+export interface LoadPHPExtensionStep<FileResource, DirectoryResource> {
+	step: 'loadPHPExtension';
+	/** The extension `.so` file or a compile-extension `manifest.json`. */
+	source: FileResource;
+	/** Defaults to "manifest" for `.json` files and "so" otherwise. */
+	sourceFormat?: PHPExtensionSourceFormat;
+	/** Required when loading a `.so` file whose filename is not named after the extension. */
+	name?: string;
+	/** Defaults to "auto". */
+	loadTiming?: PHPExtensionLoadTiming;
+	/** Defaults to "extension". Use "zend_extension" for extensions like Xdebug. */
+	loadWithIniDirective?: PHPExtensionIniDirective;
+	/** Extra `php.ini` entries to write next to the extension. */
+	iniEntries?: Record<string, string>;
+	/** Extra files required by the extension, such as ICU data or shared libraries. */
+	extraFiles?: DirectoryResource;
+	/** Where to write `extraFiles`. Defaults to an extension-specific assets directory. */
+	extraFilesPath?: string;
+	/** Runtime environment variables needed by the extension. */
+	env?: Record<string, string>;
+	/** Overrides manifest artifact selection. Defaults to the running PHP version. */
+	phpVersion?: string;
+	/** Overrides manifest artifact selection. Defaults to the running async mode. */
+	asyncMode?: PHPWasmAsyncMode;
+	/** Base URL for relative artifact paths in an inline or bundled manifest. */
+	manifestBaseUrl?: string;
+	/** Where to install the extension `.so` and `.ini` files. */
+	extensionDir?: string;
+}
+
+export const loadPHPExtension: StepHandler<
+	LoadPHPExtensionStep<File, Directory>,
+	Promise<LoadedPHPExtension>
+> = async (
+	playground,
+	{
+		source,
+		sourceFormat,
+		name,
+		loadTiming,
+		loadWithIniDirective,
+		iniEntries,
+		extraFiles,
+		extraFilesPath,
+		env,
+		phpVersion,
+		asyncMode,
+		manifestBaseUrl,
+		extensionDir,
+	}
+) => {
+	const format = sourceFormat ?? inferSourceFormat(source);
+	const bytes = new Uint8Array(await source.arrayBuffer());
+
+	return await loadPHPExtensionFromSource(playground, {
+		source:
+			format === 'manifest'
+				? {
+						format,
+						manifest: JSON.parse(new TextDecoder().decode(bytes)),
+						baseUrl: manifestBaseUrl ?? getSourceUrl(source),
+					}
+				: {
+						format,
+						name: name ?? inferExtensionName(source),
+						bytes,
+					},
+		name,
+		loadTiming,
+		loadWithIniDirective,
+		iniEntries,
+		extraFiles: extraFiles
+			? {
+					targetPath: extraFilesPath,
+					files: extraFiles.files,
+				}
+			: undefined,
+		env,
+		phpVersion,
+		asyncMode,
+		extensionDir,
+	});
+};
+
+function inferSourceFormat(source: File): PHPExtensionSourceFormat {
+	return source.name.endsWith('.json') ? 'manifest' : 'so';
+}
+
+function inferExtensionName(source: File): string | undefined {
+	return source.name.endsWith('.so') ? source.name.slice(0, -3) : undefined;
+}
+
+function getSourceUrl(source: SourceFile): string | undefined {
+	return source.sourceUrl;
+}

--- a/packages/playground/blueprints/src/lib/v1/resources.spec.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.spec.ts
@@ -6,6 +6,7 @@ import {
 	rewriteGithubProxyUrl,
 	ZipResource,
 	Resource,
+	isResourceReference,
 } from './resources';
 import { expect, describe, it, vi, beforeEach, afterEach } from 'vitest';
 import { StreamedFile } from '@php-wasm/stream-compression';
@@ -44,6 +45,20 @@ describe('UrlResource', () => {
 		expect(resource.getURL()).toBe(
 			'https://raw.githubusercontent.com/adamziel/blueprints/f49382e89099806a8eede4feba41a9a7ab89bcfe/blueprints%2Fbeta-rc%2Fblueprint.json'
 		);
+	});
+});
+
+describe('isResourceReference', () => {
+	it('recognizes literal directory resources', () => {
+		expect(
+			isResourceReference({
+				resource: 'literal:directory',
+				name: 'assets',
+				files: {
+					'data.txt': 'sidecar',
+				},
+			})
+		).toBe(true);
 	});
 });
 

--- a/packages/playground/blueprints/src/lib/v1/resources.ts
+++ b/packages/playground/blueprints/src/lib/v1/resources.ts
@@ -59,6 +59,7 @@ export type { FileTree };
 export const ResourceTypes = [
 	'vfs',
 	'literal',
+	'literal:directory',
 	'wordpress.org/themes',
 	'wordpress.org/plugins',
 	'url',
@@ -562,7 +563,12 @@ export abstract class FetchResource extends Resource<File> {
 					response.headers.get('content-disposition') || ''
 				) ||
 				encodeURIComponent(url);
-			return new File([await response.arrayBuffer()], filename);
+			const file = new File([await response.arrayBuffer()], filename);
+			Object.defineProperty(file, 'sourceUrl', {
+				value: url,
+				enumerable: false,
+			});
+			return file;
 		} catch (e) {
 			throw new ResourceDownloadError(
 				`Could not download "${url}".\n\n` +


### PR DESCRIPTION
## What it does

Adds a `loadPHPExtension` Blueprint step on top of the runtime extension loader from #3566. Blueprints can now load either a direct `.so` resource or a compile-extension `manifest.json` resource, plus optional sidecar files through `extraFiles`.

This is the middle PR in the stack: #3566 runtime loader → this Blueprint step → #3567 compiler tools.

## Rationale

The runtime PR gives Playground a shared `loadPHPExtension()` API, but extenders also need a declarative Blueprint entry point. Keeping this in a stacked PR makes the runtime API reviewable on its own while preserving the same loading path for Blueprint users.

## Implementation

The step resolves `source` as a normal Blueprint file resource, infers `sourceFormat` from `.json` vs `.so`, then calls `@php-wasm/universal`:

```json
{
  "step": "loadPHPExtension",
  "source": {
    "resource": "url",
    "url": "https://example.com/extensions/example/manifest.json"
  },
  "sourceFormat": "manifest"
}
```

`literal:directory` is now recognized as a directory resource so `extraFiles` can carry data files or dependency assets. URL resources retain a non-enumerable `sourceUrl` so relative manifest artifacts can be resolved from the manifest URL.

## Testing instructions

```bash
npx nx typecheck playground-blueprints
npx nx build:blueprint-schema playground-blueprints
cd packages/playground/blueprints
npx vitest run src/lib/steps/load-php-extension.spec.ts --config vite.config.ts
npx vitest run src/lib/v1/resources.spec.ts --config vite.config.ts -t "recognizes literal directory resources"
```