### PR TITLE
Mark tsconfig files as JSONC for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 package-lock.json linguist-generated=true
-tsconfig*.json linguist-language=JSON-with-Comments
+tsconfig.json linguist-language=JSON-with-Comments
+tsconfig.*.json linguist-language=JSON-with-Comments
 packages/docs/site/docs/site/docs/ linguist-documentation=true
 packages/docs/site/static/diagrams.excalidraw linguist-documentation=true
 packages/php-wasm/compile/*/dist linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 package-lock.json linguist-generated=true
+tsconfig*.json linguist-language=JSON-with-Comments
 packages/docs/site/docs/site/docs/ linguist-documentation=true
 packages/docs/site/static/diagrams.excalidraw linguist-documentation=true
 packages/php-wasm/compile/*/dist linguist-vendored


### PR DESCRIPTION
This will help GitHub's syntax highlighting to correctly display
comments in tsconfig files.

For example, note the "invalid" (red) syntax highlighting here:

https://github.com/WordPress/wordpress-playground/blob/ecff23993604adbc991ca6e2b11b64104727a4f2/packages/playground/client/tsconfig.lib.json#L14-L20

## Testing instructions

- Check how the syntax is [highlighted on trunk](https://github.com/sirreal/wordpress-playground/blob/trunk/packages/playground/client/tsconfig.lib.json) and see the "invalid" (red) syntax highlighting
- Check how the syntax is [highlighted on this branch](https://github.com/sirreal/wordpress-playground/blob/tsconfig-linguist-language-json-with-comments/packages/playground/client/tsconfig.lib.json) and see the "valid" (grey) syntax highlighting