### PR TITLE
[Repo] Cap package labels and infer type labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,126 +1,19 @@
 # Path-based labels for actions/labeler.
 #
-# Drives the [Package][@..], [Aspect], and [Focus] labels off changed file
-# paths. Title/body-driven [Type] labels are intentionally not handled here —
-# those need human judgment and there isn't a reliable path heuristic. The
-# previous AI-based labeler (auto-label-prs.yml) is gone because GitHub
-# Models access in Actions is gated by an org-level toggle we can't flip.
+# This file drives only the labels that map cleanly to paths AND have no
+# count limit: [Aspect], [Focus], [Feature], and [Type] Documentation.
 #
-# Format: each top-level key is a label name, value is a list of glob match
-# rules. See https://github.com/actions/labeler for syntax. We use the
-# `changed-files` / `any-glob-to-any-file` form throughout.
-
-# ---------------------------------------------------------------------------
-# [Package][@php-wasm] *
-# ---------------------------------------------------------------------------
-
-'[Package][@php-wasm] CLI':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/cli/**'
-
-'[Package][@php-wasm] CLI-Util':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/cli-util/**'
-
-'[Package][@php-wasm] Compile':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/compile/**'
-
-'[Package][@php-wasm] FS Journal':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/fs-journal/**'
-
-'[Package][@php-wasm] Logger':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/logger/**'
-
-'[Package][@php-wasm] Node':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/node/**'
-
-'[Package][@php-wasm] Progress':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/progress/**'
-
-'[Package][@php-wasm] Scopes':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/scopes/**'
-
-'[Package][@php-wasm] Stream Compression':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/stream-compression/**'
-
-'[Package][@php-wasm] Universal':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/universal/**'
-
-'[Package][@php-wasm] Util':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/util/**'
-
-'[Package][@php-wasm] Web':
-    - changed-files:
-          - any-glob-to-any-file:
-                - 'packages/php-wasm/web/**'
-                - 'packages/php-wasm/web-service-worker/**'
-
-'[Package][@php-wasm] Xdebug Bridge':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/php-wasm/xdebug-bridge/**'
-
-# ---------------------------------------------------------------------------
-# [Package][@wp-playground] *
-# ---------------------------------------------------------------------------
-
-'[Package][@wp-playground] Blueprints':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/blueprints/**'
-
-'[Package][@wp-playground] CLI':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/cli/**'
-
-'[Package][@wp-playground] Client':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/client/**'
-
-'[Package][@wp-playground] Common':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/common/**'
-
-'[Package][@wp-playground] Components':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/components/**'
-
-'[Package][@wp-playground] CORS Proxy':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/php-cors-proxy/**'
-
-'[Package][@wp-playground] Remote':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/remote/**'
-
-'[Package][@wp-playground] Storage':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/storage/**'
-
-'[Package][@wp-playground] Sync':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/sync/**'
-
-'[Package][@wp-playground] Website':
-    - changed-files:
-          - any-glob-to-any-file:
-                - 'packages/playground/website/**'
-                - 'packages/playground/website-extras/**'
-
-'[Package][@wp-playground] WordPress':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/wordpress/**'
-
-'[Package][@wp-playground] WordPress Builds':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/playground/wordpress-builds/**'
+# [Package][...] labels are NOT handled here — they're applied by the
+# `package-and-type` job in auto-label-prs.yml, which ranks packages by
+# total lines changed (additions + deletions) and picks the top 3.
+# Without that cap, a wide refactor produces a wall of [Package] labels.
+#
+# [Type] (other than Documentation) is also not handled here — the same
+# job infers a single [Type] from the PR title's conventional-commit
+# prefix when the signal is unambiguous.
+#
+# Format: each top-level key is a label name, value is a list of glob
+# match rules. See https://github.com/actions/labeler for syntax.
 
 # ---------------------------------------------------------------------------
 # [Aspect] *  — cross-cutting concerns inferable from paths

--- a/.github/workflows/auto-label-prs.yml
+++ b/.github/workflows/auto-label-prs.yml
@@ -1,20 +1,30 @@
 name: Auto-label PRs
 
-# Path-based PR labeling. Reads .github/labeler.yml and applies any
-# [Package][@..], [Aspect], [Feature], [Focus] or [Type] Documentation
-# label whose globs match the changed file paths.
+# PR labeling has two parts:
 #
-# We do not auto-apply [Type] (other than Documentation), [Priority],
-# [Triage], [Discussion], or [Breaking change] — those need human judgment.
+#   1. `paths` job — runs actions/labeler against .github/labeler.yml to
+#      apply [Aspect], [Focus], [Feature], and [Type] Documentation
+#      labels. These have no count limit and a wide refactor can match
+#      many of them legitimately.
 #
-# History note: an earlier version of this workflow used GitHub Models
-# (actions/ai-inference) to suggest labels from PR title + body + paths.
-# That returned 403 from the workflow's GITHUB_TOKEN because GitHub Models
-# access in Actions is gated by an org-level toggle that isn't enabled
-# for this org and isn't something repo maintainers can flip. Path-based
-# labeling covers the bulk of the structured labels for this monorepo
-# (the model's strongest signal was already file paths) and runs without
-# any external service or quota.
+#   2. `package-and-type` job — applies the `[Package][...]` labels and
+#      a single inferred `[Type]` label. This one needs custom logic:
+#
+#        - [Package]: ranks packages by total lines changed
+#          (additions + deletions, file count as tiebreaker) and applies
+#          at most the top 3. Without this cap, a cross-cutting change
+#          ends up with a wall of package labels and the signal is lost.
+#
+#        - [Type]: parses the PR title's conventional-commit prefix
+#          (fix:/feat:/perf:) and applies one matching label only when
+#          the signal is unambiguous. We skip refactor:/chore:/test:
+#          because they have no clean target label.
+#
+# History note: an earlier version used GitHub Models (actions/ai-inference)
+# to suggest labels from PR title + body + paths. That returned 403
+# because GitHub Models access in Actions is gated by an org-level toggle
+# we can't flip. Path + PR-title heuristics cover the structured labels
+# without any external service.
 
 on:
     pull_request_target:
@@ -25,7 +35,7 @@ permissions:
     pull-requests: write
 
 jobs:
-    label:
+    paths:
         if: github.repository == 'WordPress/wordpress-playground'
         runs-on: ubuntu-latest
         steps:
@@ -36,3 +46,98 @@ jobs:
               with:
                   configuration-path: .github/labeler.yml
                   sync-labels: false
+
+    package-and-type:
+        if: github.repository == 'WordPress/wordpress-playground'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+              with:
+                  script: |
+                      // Path prefix → [Package][...] label. Order matters: the
+                      // first matching prefix wins, so longer / more specific
+                      // prefixes must come before shorter ones (e.g. `web-service-worker`
+                      // before `web`).
+                      const PACKAGE_RULES = [
+                          ['packages/php-wasm/cli-util/',          '[Package][@php-wasm] CLI-Util'],
+                          ['packages/php-wasm/cli/',               '[Package][@php-wasm] CLI'],
+                          ['packages/php-wasm/compile/',           '[Package][@php-wasm] Compile'],
+                          ['packages/php-wasm/fs-journal/',        '[Package][@php-wasm] FS Journal'],
+                          ['packages/php-wasm/logger/',            '[Package][@php-wasm] Logger'],
+                          ['packages/php-wasm/node/',              '[Package][@php-wasm] Node'],
+                          ['packages/php-wasm/progress/',          '[Package][@php-wasm] Progress'],
+                          ['packages/php-wasm/scopes/',            '[Package][@php-wasm] Scopes'],
+                          ['packages/php-wasm/stream-compression/','[Package][@php-wasm] Stream Compression'],
+                          ['packages/php-wasm/universal/',         '[Package][@php-wasm] Universal'],
+                          ['packages/php-wasm/util/',              '[Package][@php-wasm] Util'],
+                          ['packages/php-wasm/web-service-worker/','[Package][@php-wasm] Web'],
+                          ['packages/php-wasm/web/',               '[Package][@php-wasm] Web'],
+                          ['packages/php-wasm/xdebug-bridge/',     '[Package][@php-wasm] Xdebug Bridge'],
+                          ['packages/playground/blueprints/',      '[Package][@wp-playground] Blueprints'],
+                          ['packages/playground/cli/',             '[Package][@wp-playground] CLI'],
+                          ['packages/playground/client/',          '[Package][@wp-playground] Client'],
+                          ['packages/playground/common/',          '[Package][@wp-playground] Common'],
+                          ['packages/playground/components/',      '[Package][@wp-playground] Components'],
+                          ['packages/playground/php-cors-proxy/',  '[Package][@wp-playground] CORS Proxy'],
+                          ['packages/playground/remote/',          '[Package][@wp-playground] Remote'],
+                          ['packages/playground/storage/',         '[Package][@wp-playground] Storage'],
+                          ['packages/playground/sync/',            '[Package][@wp-playground] Sync'],
+                          ['packages/playground/website-extras/',  '[Package][@wp-playground] Website'],
+                          ['packages/playground/website/',         '[Package][@wp-playground] Website'],
+                          ['packages/playground/wordpress-builds/','[Package][@wp-playground] WordPress Builds'],
+                          ['packages/playground/wordpress/',       '[Package][@wp-playground] WordPress'],
+                      ];
+
+                      // Conventional-commit prefix → [Type] label. Only entries
+                      // with an unambiguous target label are listed; refactor /
+                      // chore / test / build / ci are intentionally absent.
+                      const TYPE_RULES = [
+                          [/^fix(\(|:)/i,      '[Type] Bug'],
+                          [/^feat(ure)?(\(|:)/i, '[Type] Enhancement'],
+                          [/^perf(\(|:)/i,     '[Type] Performance'],
+                          [/^docs(\(|:)/i,     '[Type] Documentation'],
+                      ];
+
+                      const pr = context.payload.pull_request;
+                      const files = await github.paginate(
+                          github.rest.pulls.listFiles,
+                          { owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100 }
+                      );
+
+                      // Tally lines + file count per package label.
+                      const stats = new Map();
+                      for (const f of files) {
+                          const rule = PACKAGE_RULES.find(([prefix]) => f.filename.startsWith(prefix));
+                          if (!rule) continue;
+                          const label = rule[1];
+                          const lines = (f.additions || 0) + (f.deletions || 0);
+                          const cur = stats.get(label) || { lines: 0, files: 0 };
+                          stats.set(label, { lines: cur.lines + lines, files: cur.files + 1 });
+                      }
+
+                      // Rank: lines desc, then file count desc, then label name
+                      // for stable output.
+                      const topPackages = [...stats.entries()]
+                          .sort(([a, sa], [b, sb]) =>
+                              sb.lines - sa.lines ||
+                              sb.files - sa.files ||
+                              a.localeCompare(b)
+                          )
+                          .slice(0, 3)
+                          .map(([label]) => label);
+
+                      const labels = [...topPackages];
+                      const titleMatch = TYPE_RULES.find(([re]) => re.test(pr.title));
+                      if (titleMatch) labels.push(titleMatch[1]);
+
+                      core.info(`PR title: ${pr.title}`);
+                      core.info(`Package stats: ${JSON.stringify([...stats])}`);
+                      core.info(`Applying labels: ${JSON.stringify(labels)}`);
+
+                      if (labels.length === 0) return;
+                      await github.rest.issues.addLabels({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: pr.number,
+                          labels,
+                      });


### PR DESCRIPTION
## What it does

Caps auto-applied `[Package][...]` labels to the top 3 packages by changed
lines, and keeps `actions/labeler` focused on path labels that do not need a
cap: `[Aspect]`, `[Focus]`, `[Feature]`, and `[Type] Documentation`.

The workflow also infers one `[Type]` label from an unambiguous
conventional-commit PR title prefix such as `fix:`, `feat:`, `perf:`, or
`docs:`.

## Rationale

The old path-only package rules applied every matching package label. Wide
refactors could produce a wall of `[Package]` labels, which made the labels less
useful for scanning and triage.

`[Type]` labels are not reliably inferable from paths, but the PR title prefix
is a useful signal when it maps cleanly to one existing label.

## Implementation

Removed `[Package][...]` rules from `.github/labeler.yml` and added a
`package-and-type` job to `.github/workflows/auto-label-prs.yml`.

The new job uses `actions/github-script` to:

1. Fetch changed PR files.
2. Match files to package labels by path prefix.
3. Rank packages by `additions + deletions`, then file count.
4. Apply at most 3 package labels.
5. Apply one `[Type]` label when the PR title prefix is unambiguous.

## Testing instructions

Validated locally with:

```bash
ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"#{f}: YAML ok\" }" .github/labeler.yml .github/workflows/auto-label-prs.yml
npm exec prettier -- --check .github/labeler.yml .github/workflows/auto-label-prs.yml
```

Note: the commit hook attempted `nx format --fix --parallel --uncommitted`, but
this checkout does not have Nx modules installed, so that hook check could not
run locally.
