### PR TITLE
[Client] Restore bundled type declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,21 @@ jobs:
             - name: Build packages, start local registry, and run integration tests
               run: packages/playground/test-built-npm-packages/run-tests.sh
 
+    test-playground-client-types-rollup:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  submodules: true
+            - uses: ./.github/actions/prepare-playground
+              with:
+                  node-version: 22
+            - name: Verify bundled client declarations
+              run: |
+                  npm exec -- nx run playground-client:test:rollup-declarations
+                  npm pack --dry-run dist/packages/playground/client
+
     test-running-unbuilt-playground-cli:
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -22,7 +22,13 @@ console.log(response.text);
 
 Loading the client from `https://playground.wordpress.net/client/index.js` keeps it in sync with the remote Playground runtime. The client and the iframe communicate over an internal protocol, and backwards compatibility is guaranteed by serving a matching client and remote from the same deployment.
 
-The npm package is still published for build tools and TypeScript users. TypeScript is highly recommended as this package ships with comprehensive types – hit ctrl+space in your IDE after `client.` and you'll see all the available methods.
+## npm package
+
+The npm package exists for projects that want to install `@wp-playground/client` through a package manager, bundle it with their application, or use its TypeScript declarations locally.
+
+Prefer the direct `https://playground.wordpress.net/client/index.js` import for browser applications that use the hosted Playground runtime. An npm-installed client can drift from the `remote.html` it controls, and that may expose protocol mismatches between the parent page and iframe. If you use the npm package, make sure the client and remote runtime are versioned together.
+
+The npm package ships comprehensive types for the client API. In TypeScript, your editor can show the available methods after `client.`.
 
 ## TypeScript declarations
 

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -1,9 +1,11 @@
 # Playground Client
 
-Provides a [PlaygroundClient](https://wordpress.github.io/wordpress-playground/api/client/) that can be used to control a WordPress Playground iframe:
+Provides a [PlaygroundClient](https://wordpress.github.io/wordpress-playground/api/client/) that can be used to control a WordPress Playground iframe.
+
+In browser applications, consume the client over HTTP from the same Playground deployment that serves `remote.html`:
 
 ```ts
-import { startPlaygroundWeb } from '@wp-playground/client';
+import { startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
 
 const client = await startPlaygroundWeb({
 	// An iframe pointing to https://playground.wordpress.net/remote.html:
@@ -18,7 +20,19 @@ const response = await client.run({
 console.log(response.text);
 ```
 
-Using TypeScript is highly recommended as this package ships with comprehensive types – hit ctrl+space in your IDE after `client.` and you'll see all the available methods.
+Loading the client from `https://playground.wordpress.net/client/index.js` keeps it in sync with the remote Playground runtime. The client and the iframe communicate over an internal protocol, and backwards compatibility is guaranteed by serving a matching client and remote from the same deployment.
+
+The npm package is still published for build tools and TypeScript users. TypeScript is highly recommended as this package ships with comprehensive types – hit ctrl+space in your IDE after `client.` and you'll see all the available methods.
+
+## TypeScript declarations
+
+The published npm package ships one bundled declaration file, `index.d.ts`. That file is generated from `src/index.ts` and inlines the Playground and PHP-WASM types that are reachable from the public client API.
+
+This is intentional. `@wp-playground/client` exposes types such as Blueprints, PHP responses, mounts, and filesystem options that are implemented across several packages in this monorepo. Consumers should not need to install or resolve those internal workspace packages just to type-check code that imports `@wp-playground/client`.
+
+The build verifies this by checking that the published package contains a single declaration file and that `index.d.ts` does not import from other packages.
+
+Known limitation: The bundled declarations are not yet guaranteed to pass `skipLibCheck: false` in every TypeScript and DOM library combination. The rollup includes lower-level Playground APIs, and strict declaration checking may still surface environment-specific type issues such as Node `Buffer` references or `File.stream()` compatibility. These issues do not affect the usual `PlaygroundClient` API usage.
 
 Once you have a [PlaygroundClient](https://wordpress.github.io/wordpress-playground/api/client/) instance, you can use it to control the playground:
 

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -4,7 +4,7 @@ Provides a [PlaygroundClient](https://wordpress.github.io/wordpress-playground/a
 
 In browser applications, consume the client over HTTP from the same Playground deployment that serves `remote.html`:
 
-```ts
+```js
 import { startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
 
 const client = await startPlaygroundWeb({

--- a/packages/playground/client/bin/build-rollup-declarations.mjs
+++ b/packages/playground/client/bin/build-rollup-declarations.mjs
@@ -1,0 +1,84 @@
+import { rm, readdir, readFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+
+const packagesDirectory = 'packages';
+const outputDirectory = 'dist/packages/playground/client';
+const outputFile = `${outputDirectory}/index.d.ts`;
+const entryPoint = 'packages/playground/client/src/index.ts';
+const tsconfig = 'packages/playground/client/tsconfig.lib.json';
+const externalPackageNames = ['ajv'];
+
+await removeGeneratedDeclarations(outputDirectory);
+
+const internalPackageNames = await findInternalPackageNames(packagesDirectory);
+const inlinedPackageNames = [
+	...internalPackageNames,
+	...externalPackageNames,
+].sort();
+const result = spawnSync(
+	'npx',
+	[
+		'dts-bundle-generator',
+		'--project',
+		tsconfig,
+		'--external-inlines',
+		...inlinedPackageNames,
+		'-o',
+		outputFile,
+		'--',
+		entryPoint,
+	],
+	{ stdio: 'inherit' }
+);
+
+process.exit(result.status ?? 1);
+
+async function removeGeneratedDeclarations(directory) {
+	const declarationFiles = await findDeclarationFiles(directory);
+	await Promise.all(declarationFiles.map((file) => rm(file)));
+}
+
+async function findInternalPackageNames(directory) {
+	const packageJsonFiles = await findPackageJsonFiles(directory);
+	const names = await Promise.all(
+		packageJsonFiles.map(async (file) => {
+			const packageJson = JSON.parse(await readFile(file, 'utf8'));
+			return packageJson.name;
+		})
+	);
+	return names
+		.filter(
+			(name) =>
+				name?.startsWith('@php-wasm/') ||
+				name?.startsWith('@wp-playground/')
+		)
+		.sort();
+}
+
+async function findPackageJsonFiles(directory) {
+	const entries = await readdir(directory, { withFileTypes: true });
+	const files = await Promise.all(
+		entries.map(async (entry) => {
+			const entryPath = `${directory}/${entry.name}`;
+			if (entry.isDirectory()) {
+				return findPackageJsonFiles(entryPath);
+			}
+			return entry.name === 'package.json' ? [entryPath] : [];
+		})
+	);
+	return files.flat();
+}
+
+async function findDeclarationFiles(directory) {
+	const entries = await readdir(directory, { withFileTypes: true });
+	const files = await Promise.all(
+		entries.map(async (entry) => {
+			const entryPath = `${directory}/${entry.name}`;
+			if (entry.isDirectory()) {
+				return findDeclarationFiles(entryPath);
+			}
+			return entry.name.endsWith('.d.ts') ? [entryPath] : [];
+		})
+	);
+	return files.flat();
+}

--- a/packages/playground/client/bin/check-rollup-declarations.mjs
+++ b/packages/playground/client/bin/check-rollup-declarations.mjs
@@ -1,0 +1,78 @@
+import { readdir, readFile } from 'node:fs/promises';
+
+const packageDirectory = 'dist/packages/playground/client';
+const declarationFile = `${packageDirectory}/index.d.ts`;
+const packageJsonFile = `${packageDirectory}/package.json`;
+const externalImportPattern =
+	/^\s*import\s+(?:[^'"]*\s+from\s+)?['"][^.'"]|^\s*export\s+[^'"]*\s+from\s+['"][^.'"]|import\(\s*['"][^.'"]|^\s*declare module ['"][^.'"]/;
+
+async function main() {
+	const declarationFiles = await findDeclarationFiles(packageDirectory);
+	const packageJson = JSON.parse(await readFile(packageJsonFile, 'utf8'));
+	const unexpectedFiles = declarationFiles.filter(
+		(file) => file !== declarationFile
+	);
+
+	if (!declarationFiles.includes(declarationFile)) {
+		throw new Error(`Missing bundled declaration file: ${declarationFile}`);
+	}
+
+	if (unexpectedFiles.length > 0) {
+		throw new Error(
+			[
+				'Expected the client package to ship one declaration file.',
+				'Unexpected files:',
+				...unexpectedFiles.map((file) => `- ${file}`),
+			].join('\n')
+		);
+	}
+
+	if (packageJson.types !== 'index.d.ts') {
+		throw new Error(
+			`Expected ${packageJsonFile} to declare "types": "index.d.ts".`
+		);
+	}
+
+	if (packageJson.exports?.['.']?.types !== './index.d.ts') {
+		throw new Error(
+			`Expected ${packageJsonFile} to export "./index.d.ts" as its root types.`
+		);
+	}
+
+	const declarations = await readFile(declarationFile, 'utf8');
+	const externalImports = declarations
+		.split('\n')
+		.filter((line) => !line.trimStart().startsWith('*'))
+		.filter((line) => externalImportPattern.test(line));
+
+	if (externalImports.length > 0) {
+		throw new Error(
+			[
+				'Bundled declarations must inline external imports.',
+				`Found an external package reference in ${declarationFile}.`,
+				...externalImports.map((line) => `- ${line.trim()}`),
+			].join('\n')
+		);
+	}
+
+	console.log(`Verified bundled declarations in ${declarationFile}`);
+}
+
+async function findDeclarationFiles(directory) {
+	const entries = await readdir(directory, { withFileTypes: true });
+	const files = await Promise.all(
+		entries.map(async (entry) => {
+			const entryPath = `${directory}/${entry.name}`;
+			if (entry.isDirectory()) {
+				return findDeclarationFiles(entryPath);
+			}
+			return entry.name.endsWith('.d.ts') ? [entryPath] : [];
+		})
+	);
+	return files.flat();
+}
+
+main().catch((error) => {
+	console.error(error.message);
+	process.exit(1);
+});

--- a/packages/playground/client/package.json
+++ b/packages/playground/client/package.json
@@ -17,6 +17,7 @@
 	],
 	"exports": {
 		".": {
+			"types": "./index.d.ts",
 			"import": "./index.js",
 			"require": "./index.cjs"
 		},

--- a/packages/playground/client/project.json
+++ b/packages/playground/client/project.json
@@ -7,7 +7,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:README"]
+			"dependsOn": ["build:rollup-declarations"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -24,21 +24,17 @@
 				"tsConfig": "packages/playground/client/tsconfig.lib.json",
 				"outputPath": "dist/packages/playground/client",
 				"buildTarget": "playground-client:build:bundle:production"
-			},
-			"dependsOn": ["build:rollup-declarations"]
+			}
 		},
 		"build:rollup-declarations": {
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"npx dts-bundle-generator -o packages/playground/client/src/rollup.d.ts -- packages/playground/client/src/index.ts",
-					"rimraf dist/packages/playground/client/lib/*.d.ts",
-					"rimraf dist/packages/playground/client/*.d.ts",
-					"cp packages/playground/client/src/rollup.d.ts dist/packages/playground/client/index.d.ts"
+					"node packages/playground/client/bin/build-rollup-declarations.mjs"
 				],
 				"parallel": false
 			},
-			"dependsOn": ["build:bundle"]
+			"dependsOn": ["build:README"]
 		},
 		"build:bundle": {
 			"executor": "@nx/vite:build",
@@ -96,6 +92,13 @@
 			"executor": "@wp-playground/nx-extensions:assert-built-esm-and-cjs",
 			"options": {
 				"outputPath": "dist/packages/playground/client"
+			},
+			"dependsOn": ["build"]
+		},
+		"test:rollup-declarations": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "node packages/playground/client/bin/check-rollup-declarations.mjs"
 			},
 			"dependsOn": ["build"]
 		},

--- a/packages/playground/client/project.json
+++ b/packages/playground/client/project.json
@@ -7,7 +7,7 @@
 	"targets": {
 		"build": {
 			"executor": "nx:noop",
-			"dependsOn": ["build:rollup-declarations"]
+			"dependsOn": ["build:README", "build:rollup-declarations"]
 		},
 		"build:README": {
 			"executor": "nx:run-commands",
@@ -34,7 +34,7 @@
 				],
 				"parallel": false
 			},
-			"dependsOn": ["build:README"]
+			"dependsOn": ["build:package-json"]
 		},
 		"build:bundle": {
 			"executor": "@nx/vite:build",


### PR DESCRIPTION
## What it does

`@wp-playground/client` stopped publishing the types rollup, making it impossible for TypeScript consumers to get type hints in their IDE.

This PR restores the published `@wp-playground/client` types to a single bundled `index.d.ts` and makes the package point to it via both `types` and `exports["."].types`.

Also, the README now recommends loading the browser client from the same Playground deployment as `remote.html`, e.g. `https://playground.wordpress.net/client/index.js`, so the client and iframe stay protocol-compatible. It still ships the types for the npm package consumers.

cc @sirreal

## Implementation

`build-rollup-declarations.mjs` now runs after the package build, removes generated declarations, and asks `dts-bundle-generator` to inline internal `@wp-playground/*`, `@php-wasm/*`, and `ajv` types.

`test:rollup-declarations` verifies the built package has exactly one `.d.ts`, no external package imports in `index.d.ts`, and package metadata pointing at that file. CI runs that check and `npm pack --dry-run`.

Known caveat: consumers using `skipLibCheck: false` may still see lower-level declaration issues around `Buffer` or `File.stream()`. The README documents that separately from the usual `PlaygroundClient` usage.

## Testing instructions

```bash
npm exec -- nx run playground-client:typecheck
npm exec -- nx run playground-client:test:rollup-declarations
npm pack --dry-run dist/packages/playground/client
```
