### PR TITLE
[php-snippet] Fix "Progress bar not available" error on code run

### DIFF
--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
 /**
  * E2E tests for the <php-snippet> web component embed.
@@ -12,8 +13,24 @@ import { test, expect } from '@playwright/test';
  */
 
 const DEMO_URL = './php-code-snippet-demo.html';
+const pageErrors = new WeakMap<Page, string[]>();
 
 test.describe('php-code-snippet embed', () => {
+	test.beforeEach(async ({ page }) => {
+		const errors: string[] = [];
+		pageErrors.set(page, errors);
+		page.on('pageerror', (error) => {
+			errors.push(error.message);
+		});
+	});
+
+	test.afterEach(async ({ page }) => {
+		expect(
+			pageErrors.get(page) || [],
+			'<php-snippet> should not emit uncaught browser errors'
+		).toEqual([]);
+	});
+
 	test('renders all snippets with Run buttons', async ({ page }) => {
 		await page.goto(DEMO_URL);
 		for (const name of [

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -242,7 +242,6 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 	const client = await startPlaygroundWeb({
 		iframe,
 		remoteUrl: iframe.src,
-		disableProgressBar: true,
 		progressTracker: entry.tracker,
 		blueprint: {
 			...(blueprint || {}),


### PR DESCRIPTION
## What it does

Fixes `<php-snippet>` runs that reject with `Progress bar not available` after
clicking **Run**.

The snippet embed still shows its own progress UI, and it no longer asks the
hidden `remote.html` iframe to run without an internal progress bar.

## Rationale

`disableProgressBar: true` makes `remote.html` skip creating its progress bar.
The client-side Blueprint handlers still called `progressTracker.pipe(playground)`,
which forwards `setProgress()` and `setLoaded()` over Comlink. In that state the
remote side throws `Progress bar not available`, and the exception surfaces as an
uncaught promise rejection when a snippet boots the runtime.

The runtime iframe is hidden, so keeping `remote.html`'s internal progress bar
does not affect the embed UI. It also keeps the remote progress APIs available
for the client-side boot pipeline.

## Implementation

Removed `disableProgressBar: true` from `php-code-snippet.js`.

## Testing instructions

Validated locally with:

```bash
npm exec nx -- typecheck playground-client
npm exec nx -- typecheck playground-website
npm exec playwright -- test --config=packages/playground/website/playwright/playwright.config.ts php-code-snippet.spec.ts --project=chromium -g "first Run boots"
npm exec prettier -- --check packages/playground/client/src/blueprints-v1-handler.ts packages/playground/client/src/blueprints-v2-handler.ts packages/playground/website/public/php-code-snippet.js packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
git diff --check
```

The PHP snippet Playwright suite now fails on unexpected `pageerror` events, so
uncaught browser exceptions like `Progress bar not available` fail the test even
when the snippet still eventually renders output.
