### PR TITLE
[PHP] `@php-wasm/compile-extension` – a workflow for building custom extensions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,6 +409,72 @@ jobs:
                   node-version: 20
             - run: packages/php-wasm/cli/tests/smoke-test.sh
 
+    detect-compile-extension-helper-changes:
+        if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        outputs:
+            changed: ${{ steps.changed.outputs.changed }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 1
+            - id: changed
+              name: Check compile-extension package changes
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                    base_sha="${{ github.event.pull_request.base.sha }}"
+                  else
+                    base_sha="${{ github.event.before }}"
+                  fi
+
+                  if [ -z "$base_sha" ] || [[ "$base_sha" =~ ^0+$ ]]; then
+                    echo "changed=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  git fetch --no-tags --depth=1 origin "$base_sha"
+
+                  if git diff --name-only "$base_sha" "$GITHUB_SHA" -- packages/php-wasm/compile-extension/ | grep -q .; then
+                    echo "changed=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "changed=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+    test-compile-extension-helper:
+        needs: detect-compile-extension-helper-changes
+        if: (github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request') && needs.detect-compile-extension-helper-changes.outputs.changed == 'true'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Free up runner disk space
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  cleanup_path() {
+                    echo "Removing $1"
+                    sudo rm -rf "$1"
+                  }
+
+                  echo "Disk usage before cleanup:"
+                  df -h
+                  cleanup_path /usr/local/lib/android
+                  cleanup_path /usr/share/dotnet
+                  cleanup_path /opt/ghc
+                  cleanup_path /opt/hostedtoolcache/CodeQL
+                  timeout 120s docker system prune -af || true
+                  echo "Disk usage after cleanup:"
+                  df -h
+            - uses: actions/checkout@v4
+              with:
+                  submodules: true
+            - uses: ./.github/actions/prepare-playground
+              with:
+                  node-version: 24
+            - name: Build and load PHP.wasm extension fixtures
+              run: node --expose-gc node_modules/nx/bin/nx affected --target=test-compile-extension-integration --parallel=1 --output-style=stream
+
     test-legacy-wp-version-boot:
         if: github.repository == 'WordPress/wordpress-playground' || github.event_name == 'pull_request'
         runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -13201,6 +13201,10 @@
 			"resolved": "packages/php-wasm/compile",
 			"link": true
 		},
+		"node_modules/@php-wasm/compile-extension": {
+			"resolved": "packages/php-wasm/compile-extension",
+			"link": true
+		},
 		"node_modules/@php-wasm/fs-journal": {
 			"resolved": "packages/php-wasm/fs-journal",
 			"link": true
@@ -53772,6 +53776,21 @@
 			"name": "@php-wasm/compile",
 			"version": "0.1.5",
 			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"packages/php-wasm/compile-extension": {
+			"name": "@php-wasm/compile-extension",
+			"version": "0.1.0",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"php-wasm-compile-extension": "cli.js"
+			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/07-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/07-php-extensions.md
@@ -162,6 +162,11 @@ await loadWebRuntime('8.4', {
 });
 ```
 
+To build your own extension artifacts, see
+[Building PHP extensions](/developers/apis/javascript-api/build-php-extensions)
+and
+[PHP extension dependencies](/developers/apis/javascript-api/php-extension-dependencies).
+
 ## Startup files
 
 PHP loads extensions from `.ini` files it reads during startup. PHP.wasm builds

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
@@ -18,7 +18,6 @@ npx @php-wasm/compile-extension \
 	--source ./wp-mysql-parser \
 	--name wp_mysql_parser \
 	--php-versions 8.4 \
-	--async-modes jspi,asyncify \
 	--out ./dist/wp_mysql_parser
 ```
 
@@ -26,15 +25,17 @@ Docker is required. The helper reuses the PHP.wasm compile image, builds a
 matching PHP source tree, and runs `phpize`, `emconfigure`, and `emmake` with
 the side-module flags expected by PHP.wasm.
 
+Custom extensions are built for JSPI runtimes. The helper does not build
+Asyncify side modules.
+
 ## Output
 
-The output directory contains one artifact for each PHP version and async mode
-plus `manifest.json`:
+The output directory contains one JSPI artifact for each PHP version plus
+`manifest.json`:
 
 ```text
 dist/wp_mysql_parser/
 |-- manifest.json
-|-- wp_mysql_parser-php8.4-asyncify.so
 `-- wp_mysql_parser-php8.4-jspi.so
 ```
 
@@ -48,7 +49,6 @@ paths, and `sha256` hashes:
 	"artifacts": [
 		{
 			"phpVersion": "8.4",
-			"asyncMode": "jspi",
 			"file": "wp_mysql_parser-php8.4-jspi.so",
 			"sha256": "..."
 		}
@@ -82,9 +82,9 @@ const php = new PHP(
 ```
 
 Node.js accepts local paths, `file:` URLs, and HTTP(S) URLs for `manifestUrl`.
-The loader selects the artifact whose `phpVersion` and `asyncMode` match the
-runtime, verifies `sha256` when present, writes a generated `.ini` file, and
-starts PHP with the extension scan directory configured.
+The loader selects the artifact whose `phpVersion` matches the runtime,
+verifies `sha256` when present, writes a generated `.ini` file, and starts PHP
+with the extension scan directory configured.
 
 ## Loading in the browser
 
@@ -133,9 +133,9 @@ await loadWebRuntime('8.4', {
 
 ## Compatibility
 
-Build every PHP version and async mode you plan to support. A `.so` built for
-PHP 8.4 cannot be loaded into PHP 8.3, and a JSPI side module cannot be loaded
-into an Asyncify runtime.
+Build every PHP version you plan to support. A `.so` built for PHP 8.4 cannot
+be loaded into PHP 8.3. Custom extension artifacts are JSPI-only and must be
+loaded by a JSPI runtime.
 
 Extension loading is startup-only. Declare custom extensions in the
 `extensions` option before the runtime is created.

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
@@ -1,0 +1,144 @@
+---
+title: Building PHP extensions
+slug: /developers/apis/javascript-api/build-php-extensions
+description: Build PHP extension source directories into PHP.wasm .so artifacts and manifests.
+---
+
+# Building PHP extensions
+
+Use `@php-wasm/compile-extension` when you have a `phpize` extension source
+directory and want a distributable PHP.wasm `.so` plus a manifest that
+`loadNodeRuntime()` and `loadWebRuntime()` can load before PHP starts.
+
+The source directory must contain a normal PHP extension build recipe, usually
+`config.m4` and the C or C++ files referenced from it.
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./wp-mysql-parser \
+	--name wp_mysql_parser \
+	--php-versions 8.4 \
+	--async-modes jspi,asyncify \
+	--out ./dist/wp_mysql_parser
+```
+
+Docker is required. The helper reuses the PHP.wasm compile image, builds a
+matching PHP source tree, and runs `phpize`, `emconfigure`, and `emmake` with
+the side-module flags expected by PHP.wasm.
+
+## Output
+
+The output directory contains one artifact for each PHP version and async mode
+plus `manifest.json`:
+
+```text
+dist/wp_mysql_parser/
+|-- manifest.json
+|-- wp_mysql_parser-php8.4-asyncify.so
+`-- wp_mysql_parser-php8.4-jspi.so
+```
+
+The manifest records the extension name, artifact matrix, relative `.so` file
+paths, and `sha256` hashes:
+
+```json
+{
+	"name": "wp_mysql_parser",
+	"version": "0.1.0",
+	"artifacts": [
+		{
+			"phpVersion": "8.4",
+			"asyncMode": "jspi",
+			"file": "wp_mysql_parser-php8.4-jspi.so",
+			"sha256": "..."
+		}
+	]
+}
+```
+
+Host the whole output directory from the same static location. Relative
+artifact paths are resolved from the manifest URL.
+
+## Loading in Node.js
+
+Pass the manifest to the startup-time `extensions` option:
+
+```ts
+import { PHP } from '@php-wasm/universal';
+import { loadNodeRuntime } from '@php-wasm/node';
+
+const php = new PHP(
+	await loadNodeRuntime('8.4', {
+		extensions: [
+			{
+				source: {
+					format: 'manifest',
+					manifestUrl: './dist/wp_mysql_parser/manifest.json',
+				},
+			},
+		],
+	})
+);
+```
+
+Node.js accepts local paths, `file:` URLs, and HTTP(S) URLs for `manifestUrl`.
+The loader selects the artifact whose `phpVersion` and `asyncMode` match the
+runtime, verifies `sha256` when present, writes a generated `.ini` file, and
+starts PHP with the extension scan directory configured.
+
+## Loading in the browser
+
+In the browser, host the output directory and pass an absolute URL:
+
+```ts
+import { PHP } from '@php-wasm/universal';
+import { loadWebRuntime } from '@php-wasm/web';
+
+const php = new PHP(
+	await loadWebRuntime('8.4', {
+		extensions: [
+			{
+				source: {
+					format: 'manifest',
+					manifestUrl: new URL('/extensions/wp_mysql_parser/manifest.json', location.href),
+				},
+			},
+		],
+	})
+);
+```
+
+Serve the `.so` artifacts with a static-file server that permits cross-origin
+requests from the page that creates the runtime.
+
+## Direct artifacts
+
+Use a manifest when you publish a matrix. If the caller already picked the
+artifact, use `format: 'url'` instead:
+
+```ts
+await loadWebRuntime('8.4', {
+	extensions: [
+		{
+			source: {
+				format: 'url',
+				name: 'wp_mysql_parser',
+				url: new URL('https://cdn.example.com/wp_mysql_parser-php8.4-jspi.so'),
+				sha256: '...',
+			},
+		},
+	],
+});
+```
+
+## Compatibility
+
+Build every PHP version and async mode you plan to support. A `.so` built for
+PHP 8.4 cannot be loaded into PHP 8.3, and a JSPI side module cannot be loaded
+into an Asyncify runtime.
+
+Extension loading is startup-only. Declare custom extensions in the
+`extensions` option before the runtime is created.
+
+For native dependencies, see
+[PHP extension dependencies](/developers/apis/javascript-api/php-extension-dependencies).

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md
@@ -55,6 +55,35 @@ npx @php-wasm/compile-extension \
 to the final side-module link so dependency archives do not break Autoconf's
 compiler smoke tests.
 
+## Prebuilt static archives
+
+Use `--extra-ldflags` to link prebuilt static archives such as a Rust
+`staticlib`. The helper detects `.a` entries in `--extra-ldflags` and
+force-links them into the final side module with `--whole-archive`.
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./my-rust-extension \
+	--name my_rust_extension \
+	--php-versions 8.4 \
+	--async-modes jspi \
+	--extra-cflags "-I/build/include" \
+	--extra-ldflags "/build/target/wasm32-unknown-emscripten/release/libmy_rust_extension.a"
+```
+
+The extension still needs a small `phpize` wrapper. A common Rust pattern is:
+
+- `config.m4` declares the PHP extension and builds a tiny C shim with
+  `PHP_NEW_EXTENSION`.
+- `_shim.c` defines the PHP module entry and calls exported Rust functions over
+  C ABI.
+- `--extra-ldflags` points at the Rust `staticlib` archive under `/build`.
+
+Do not use `PHP_ADD_LIBRARY_WITH_PATH` for a sibling `.a` archive in
+`config.m4`. PHP's libtool setup can look for a matching `.so`, fail to link
+the archive into the side module, and still leave a build artifact behind. Pass
+static archives through `--extra-ldflags` instead.
+
 ## CMake dependencies
 
 Build CMake dependencies as static archives with Emscripten and store the
@@ -110,6 +139,50 @@ itself is CMake-only or Makefile-only, add a thin `config.m4` wrapper that
 builds the PHP extension and treats the CMake or Make output as dependency
 code.
 
+## Rust build systems
+
+The helper image includes a host `php` CLI because `ext-php-rs` and similar
+build systems often shell out to `php` for version detection. The host CLI is
+only for build scripts. The compiled extension must still link against the
+PHP.wasm headers and side-module ABI.
+
+Rust extensions that use `bindgen` need the same target, sysroot, and Zend
+defines as PHP.wasm. The helper exports `BINDGEN_EXTRA_CLANG_ARGS` with:
+
+```bash
+--target=wasm32-unknown-emscripten \
+--sysroot=$EMSDK_SYSROOT \
+-DZEND_ENABLE_ZVAL_LONG64 \
+-D__x86_64__
+```
+
+If you build the Rust archive outside the helper container, set the same value
+before running `cargo`.
+
+Rust `cc-rs` build scripts also need position-independent objects for side
+module linking. The helper exports target-specific compiler variables including
+`CFLAGS_wasm32_unknown_emscripten=-fPIC` and
+`CXXFLAGS_wasm32_unknown_emscripten=-fPIC`. Without `-fPIC`, the final link can
+fail with an error like:
+
+```text
+R_WASM_MEMORY_ADDR_SLEB cannot be used against symbol ...; recompile with -fPIC
+```
+
+Rust's precompiled `std` for `wasm32-unknown-emscripten` is built with
+unwinding support. That imports a `__cpp_exception` WebAssembly tag that
+PHP.wasm does not export. Build Rust static libraries with `panic=abort` and a
+nightly rebuilt standard library:
+
+```bash
+RUSTFLAGS="-C panic=abort" cargo +nightly build \
+	--release \
+	--target wasm32-unknown-emscripten \
+	-Zbuild-std=std,panic_abort
+```
+
+Link the resulting `lib*.a` with `--extra-ldflags`.
+
 ## Troubleshooting
 
 `configure: error: ... not found`
@@ -135,6 +208,18 @@ for JSPI runtimes and Asyncify artifacts for Asyncify runtimes.
 
 One of the linked libraries is a native host library. Rebuild that dependency
 with Emscripten and link the resulting `.a` file.
+
+`R_WASM_MEMORY_ADDR_SLEB cannot be used against symbol`
+
+A C or C++ object in a static archive was not compiled as position-independent
+code. Rebuild it with `-fPIC`, or make sure Rust `cc-rs` sees
+`CFLAGS_wasm32_unknown_emscripten=-fPIC`.
+
+`__cpp_exception` is undefined when loading a Rust extension
+
+The Rust archive was built against an unwinding `std`. Rebuild it with
+`RUSTFLAGS="-C panic=abort"` and
+`cargo +nightly build -Zbuild-std=std,panic_abort`.
 
 `bad export type for 'stdin'` or another C runtime global
 

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md
@@ -1,0 +1,152 @@
+---
+title: PHP extension dependencies
+slug: /developers/apis/javascript-api/php-extension-dependencies
+description: Link WebAssembly dependencies when building custom PHP.wasm extensions.
+---
+
+# PHP extension dependencies
+
+Custom PHP.wasm extensions can only link WebAssembly code built with the same
+Emscripten toolchain and async mode as the PHP runtime. Native host libraries
+from `/usr/lib`, Homebrew, apt, or npm packages cannot be linked into the final
+`.so`.
+
+Build dependencies as static WebAssembly archives and pass their headers and
+archives to `@php-wasm/compile-extension`.
+
+## Playground-built dependencies
+
+Some libraries already have recipes in `packages/php-wasm/compile`. Build the
+matching async-mode target and pass the mounted path inside the helper
+container:
+
+```bash
+make -C packages/php-wasm/compile libz_jspi
+
+npx @php-wasm/compile-extension \
+	--source ./zlib-probe \
+	--name zlib_probe \
+	--php-versions 8.4 \
+	--async-modes jspi \
+	--extra-cflags "-I/php-wasm-compile/libz/jspi/dist/root/lib/include" \
+	--extra-ldflags "/php-wasm-compile/libz/jspi/dist/root/lib/lib/libz.a"
+```
+
+Use the `jspi` archive for JSPI builds and the `asyncify` archive for Asyncify
+builds.
+
+## Vendored dependencies
+
+If the dependency is not built by Playground, vendor the source under your
+extension directory and build it with Emscripten before the extension is linked.
+Paths from `--source` are available under `/build` inside the helper container:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./external-lib-probe \
+	--name external_lib_probe \
+	--php-versions 8.4 \
+	--async-modes asyncify \
+	--extra-cflags "-I/build/vendor/string-score/install/include" \
+	--extra-ldflags "/build/vendor/string-score/install/lib/libstring_score.a"
+```
+
+`--extra-cflags` is visible during `./configure`. `--extra-ldflags` is applied
+to the final side-module link so dependency archives do not break Autoconf's
+compiler smoke tests.
+
+## CMake dependencies
+
+Build CMake dependencies as static archives with Emscripten and store the
+install tree under the extension source directory:
+
+```bash
+source /root/emsdk/emsdk_env.sh
+
+emcmake cmake \
+	-S vendor/libfoo \
+	-B vendor/libfoo/build \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX="$PWD/vendor/libfoo/install" \
+	-DBUILD_SHARED_LIBS=OFF
+
+emmake cmake --build vendor/libfoo/build --target install
+
+npx @php-wasm/compile-extension \
+	--source . \
+	--name my_extension \
+	--php-versions 8.4 \
+	--async-modes asyncify \
+	--extra-cflags "-I/build/vendor/libfoo/install/include" \
+	--extra-ldflags "/build/vendor/libfoo/install/lib/libfoo.a"
+```
+
+## Makefile dependencies
+
+Force Makefile dependencies to use Emscripten tools:
+
+```bash
+source /root/emsdk/emsdk_env.sh
+
+emmake make -C vendor/libfoo \
+	CC=emcc \
+	CXX=em++ \
+	AR=emar \
+	RANLIB=emranlib \
+	PREFIX="$PWD/vendor/libfoo/install" \
+	install
+
+npx @php-wasm/compile-extension \
+	--source . \
+	--name my_extension \
+	--php-versions 8.4 \
+	--async-modes asyncify \
+	--extra-cflags "-I/build/vendor/libfoo/install/include" \
+	--extra-ldflags "/build/vendor/libfoo/install/lib/libfoo.a"
+```
+
+The final PHP extension still needs a `phpize` build recipe. If the extension
+itself is CMake-only or Makefile-only, add a thin `config.m4` wrapper that
+builds the PHP extension and treats the CMake or Make output as dependency
+code.
+
+## Troubleshooting
+
+`configure: error: ... not found`
+
+The dependency headers or libraries are not visible inside the container. Use
+paths under `/build` for files copied from `--source`, or
+`/php-wasm-compile/<dependency>/<mode>/dist/root/lib` for Playground-built
+dependencies.
+
+`undefined symbol` when loading the extension
+
+The extension references a function that is not exported by the PHP main module
+or was not linked from a WebAssembly dependency archive. Add the dependency
+archive to `--extra-ldflags`, or rebuild the main PHP.wasm runtime if the
+symbol must come from PHP core.
+
+`WebAssembly.LinkError` or startup crashes
+
+Check that the artifact async mode matches the runtime. Build JSPI artifacts
+for JSPI runtimes and Asyncify artifacts for Asyncify runtimes.
+
+`wasm-ld: unknown file type` or `file not recognized`
+
+One of the linked libraries is a native host library. Rebuild that dependency
+with Emscripten and link the resulting `.a` file.
+
+`bad export type for 'stdin'` or another C runtime global
+
+The side module pulled in a dependency object that expects a mutable C runtime
+global the main PHP.wasm module does not export. Rebuild the dependency with
+the unused feature disabled, link a smaller archive that excludes that object,
+or move the dependency into the main PHP.wasm build so the global is provided
+by the runtime.
+
+`phpize` cannot find headers
+
+The helper image builds and installs a minimal matching PHP source tree before
+running `phpize`. If an extension includes headers from optional PHP
+extensions, copy or generate those headers in the Docker layer or include them
+in the extension source.

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md
@@ -7,8 +7,8 @@ description: Link WebAssembly dependencies when building custom PHP.wasm extensi
 # PHP extension dependencies
 
 Custom PHP.wasm extensions can only link WebAssembly code built with the same
-Emscripten toolchain and async mode as the PHP runtime. Native host libraries
-from `/usr/lib`, Homebrew, apt, or npm packages cannot be linked into the final
+Emscripten toolchain and JSPI ABI as the PHP runtime. Native host libraries from
+`/usr/lib`, Homebrew, apt, or npm packages cannot be linked into the final
 `.so`.
 
 Build dependencies as static WebAssembly archives and pass their headers and
@@ -17,8 +17,7 @@ archives to `@php-wasm/compile-extension`.
 ## Playground-built dependencies
 
 Some libraries already have recipes in `packages/php-wasm/compile`. Build the
-matching async-mode target and pass the mounted path inside the helper
-container:
+JSPI target and pass the mounted path inside the helper container:
 
 ```bash
 make -C packages/php-wasm/compile libz_jspi
@@ -27,13 +26,11 @@ npx @php-wasm/compile-extension \
 	--source ./zlib-probe \
 	--name zlib_probe \
 	--php-versions 8.4 \
-	--async-modes jspi \
 	--extra-cflags "-I/php-wasm-compile/libz/jspi/dist/root/lib/include" \
 	--extra-ldflags "/php-wasm-compile/libz/jspi/dist/root/lib/lib/libz.a"
 ```
 
-Use the `jspi` archive for JSPI builds and the `asyncify` archive for Asyncify
-builds.
+Use the `jspi` archive for custom extension builds.
 
 ## Vendored dependencies
 
@@ -46,7 +43,6 @@ npx @php-wasm/compile-extension \
 	--source ./external-lib-probe \
 	--name external_lib_probe \
 	--php-versions 8.4 \
-	--async-modes asyncify \
 	--extra-cflags "-I/build/vendor/string-score/install/include" \
 	--extra-ldflags "/build/vendor/string-score/install/lib/libstring_score.a"
 ```
@@ -66,7 +62,6 @@ npx @php-wasm/compile-extension \
 	--source ./my-rust-extension \
 	--name my_rust_extension \
 	--php-versions 8.4 \
-	--async-modes jspi \
 	--extra-cflags "-I/build/include" \
 	--extra-ldflags "/build/target/wasm32-unknown-emscripten/release/libmy_rust_extension.a"
 ```
@@ -105,7 +100,6 @@ npx @php-wasm/compile-extension \
 	--source . \
 	--name my_extension \
 	--php-versions 8.4 \
-	--async-modes asyncify \
 	--extra-cflags "-I/build/vendor/libfoo/install/include" \
 	--extra-ldflags "/build/vendor/libfoo/install/lib/libfoo.a"
 ```
@@ -129,7 +123,6 @@ npx @php-wasm/compile-extension \
 	--source . \
 	--name my_extension \
 	--php-versions 8.4 \
-	--async-modes asyncify \
 	--extra-cflags "-I/build/vendor/libfoo/install/include" \
 	--extra-ldflags "/build/vendor/libfoo/install/lib/libfoo.a"
 ```
@@ -201,8 +194,8 @@ symbol must come from PHP core.
 
 `WebAssembly.LinkError` or startup crashes
 
-Check that the artifact async mode matches the runtime. Build JSPI artifacts
-for JSPI runtimes and Asyncify artifacts for Asyncify runtimes.
+Check that the extension loads in a JSPI runtime. The custom extension helper
+does not build Asyncify artifacts.
 
 `wasm-ld: unknown file type` or `file not recognized`
 

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -183,6 +183,8 @@ const sidebars = {
 								'developers/apis/javascript-api/blueprint-functions-in-api-client',
 								'developers/apis/javascript-api/mount-data',
 								'developers/apis/javascript-api/php-extensions',
+								'developers/apis/javascript-api/build-php-extensions',
+								'developers/apis/javascript-api/php-extension-dependencies',
 							],
 						},
 					],

--- a/packages/php-wasm/.dockerignore
+++ b/packages/php-wasm/.dockerignore
@@ -1,0 +1,9 @@
+**
+!compile/
+!compile/php/
+!compile/php/php*.patch
+!compile-extension/
+!compile-extension/docker/
+!compile-extension/docker/Dockerfile.ext
+!compile-extension/scripts/
+!compile-extension/scripts/build-in-docker.sh

--- a/packages/php-wasm/compile-extension/.eslintrc.json
+++ b/packages/php-wasm/compile-extension/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+	"extends": ["../../../.eslintrc.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["**/*.ts"],
+			"rules": {
+				"no-console": 0
+			}
+		}
+	]
+}

--- a/packages/php-wasm/compile-extension/README.md
+++ b/packages/php-wasm/compile-extension/README.md
@@ -1,0 +1,247 @@
+# @php-wasm/compile-extension
+
+Builds a PHP extension source directory into PHP.wasm side modules for a PHP
+version and async-mode matrix.
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./ext-src \
+	--name wp_mysql_parser \
+	--php-versions 8.4 \
+	--async-modes jspi,asyncify \
+	--out ./dist
+```
+
+The command writes one `.so` per matrix entry and a `manifest.json` that can be
+consumed by PHP.wasm extension-loading helpers.
+
+Docker is required. The build reuses the `packages/php-wasm/compile` base image
+and its PHP patch set, then runs `phpize`, `emconfigure`, and `emmake` inside
+the container.
+
+## Loading the result
+
+Host the entire output directory somewhere static and pass the manifest URL to
+the runtime through the startup-time `extensions` option:
+
+```ts
+import { loadNodeRuntime } from '@php-wasm/node';
+import { PHP } from '@php-wasm/universal';
+
+const php = new PHP(
+	await loadNodeRuntime('8.4', {
+		extensions: [
+			{
+				source: {
+					format: 'manifest',
+					manifestUrl: 'https://example.com/wp_mysql_parser/manifest.json',
+				},
+			},
+		],
+	})
+);
+```
+
+The loader chooses the artifact whose `phpVersion` and `asyncMode` match the
+running PHP.wasm runtime, downloads it, verifies `sha256` when present, stages
+the `.so`, writes a startup `.ini` file, and registers the extension scan
+directory before PHP starts.
+
+In Node.js, `manifestUrl` may also be a local path:
+
+```ts
+const php = new PHP(
+	await loadNodeRuntime('8.4', {
+		extensions: [
+			{
+				source: {
+					format: 'manifest',
+					manifestUrl: './dist/wp_mysql_parser/manifest.json',
+				},
+			},
+		],
+	})
+);
+```
+
+Pass a direct `.so` URL when the caller chooses the artifact instead of a
+manifest:
+
+```ts
+const php = new PHP(
+	await loadNodeRuntime('8.4', {
+		extensions: [
+			{
+				name: 'wp_mysql_parser',
+				source: {
+					format: 'url',
+					url: 'https://example.com/extensions/wp_mysql_parser-php8.4-jspi.so',
+					sha256: '...',
+				},
+			},
+		],
+	})
+);
+```
+
+Use `loadWithIniDirective: 'zend_extension'` for Zend extensions such as
+Xdebug. Use `extraFiles` and `env` for sidecar files needed by the extension.
+
+## Dependencies
+
+The helper can only link WebAssembly objects built with the same Emscripten
+toolchain and async mode as the PHP runtime. Native host libraries from
+`/usr/lib`, Homebrew, apt, or npm packages cannot be linked into the `.so`.
+
+For dependencies already built by Playground, build the matching target and pass
+the mounted path under `/php-wasm-compile`:
+
+```bash
+make -C packages/php-wasm/compile libz_jspi
+
+npx @php-wasm/compile-extension \
+	--source ./zlib-probe \
+	--name zlib_probe \
+	--php-versions 8.4 \
+	--async-modes jspi \
+	--extra-cflags "-I/php-wasm-compile/libz/jspi/dist/root/lib/include" \
+	--extra-ldflags "/php-wasm-compile/libz/jspi/dist/root/lib/lib/libz.a"
+```
+
+For dependencies that are not in `packages/php-wasm/compile`, either:
+
+- Vendor the dependency source under your extension and build it from
+  `config.m4`, using paths under `/build` after the helper copies `/src`.
+- Build the dependency with Emscripten before running the helper, place the
+  resulting headers and `.a` archive under the extension source directory, and
+  pass `/build/...` paths through `--extra-cflags` and `--extra-ldflags`.
+- Add a Docker layer that builds the dependency with Emscripten, then pass the
+  resulting include and archive paths through `--extra-cflags`,
+  `--extra-ldflags`, and `--config-args`.
+
+For example, if an extension vendors an external library that is not provided by
+Playground and stores its Emscripten build output under
+`vendor/string-score/install`, pass the copied `/build` paths:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./external-lib-probe \
+	--name external_lib_probe \
+	--php-versions 8.4 \
+	--async-modes asyncify \
+	--extra-cflags "-I/build/vendor/string-score/install/include" \
+	--extra-ldflags "/build/vendor/string-score/install/lib/libstring_score.a"
+```
+
+If the dependency uses CMake, build it as a static archive with Emscripten and
+store the install tree under the extension source directory:
+
+```bash
+# Run this inside the same Emscripten toolchain used for the target PHP.wasm
+# version and async mode.
+source /root/emsdk/emsdk_env.sh
+
+emcmake cmake \
+	-S vendor/libfoo \
+	-B vendor/libfoo/build \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DCMAKE_INSTALL_PREFIX="$PWD/vendor/libfoo/install" \
+	-DBUILD_SHARED_LIBS=OFF
+
+emmake cmake --build vendor/libfoo/build --target install
+
+npx @php-wasm/compile-extension \
+	--source . \
+	--name my_extension \
+	--php-versions 8.4 \
+	--async-modes asyncify \
+	--extra-cflags "-I/build/vendor/libfoo/install/include" \
+	--extra-ldflags "/build/vendor/libfoo/install/lib/libfoo.a"
+```
+
+For plain Makefile dependencies, force the Makefile to use Emscripten tools and
+link the resulting archive the same way:
+
+```bash
+source /root/emsdk/emsdk_env.sh
+
+emmake make -C vendor/libfoo \
+	CC=emcc \
+	CXX=em++ \
+	AR=emar \
+	RANLIB=emranlib \
+	PREFIX="$PWD/vendor/libfoo/install" \
+	install
+
+npx @php-wasm/compile-extension \
+	--source . \
+	--name my_extension \
+	--php-versions 8.4 \
+	--async-modes asyncify \
+	--extra-cflags "-I/build/vendor/libfoo/install/include" \
+	--extra-ldflags "/build/vendor/libfoo/install/lib/libfoo.a"
+```
+
+The final PHP extension still needs to be a `phpize` extension with `config.m4`.
+If an extension is CMake-only or Makefile-only and produces the final `.so`
+without `phpize`, add a thin `config.m4` wrapper that builds the PHP extension
+and treats the CMake/Make output as dependency code. A fully custom final build
+script is outside v1.
+
+Keep the dependency async mode aligned with the extension. A `jspi` side module
+must link `jspi` dependency archives; an `asyncify` side module must link
+`asyncify` dependency archives.
+
+`--extra-cflags` is visible during `./configure`. `--extra-ldflags` is applied
+to the final side-module link so dependency archives do not break Autoconf's
+compiler smoke tests. If an extension's `config.m4` insists on link-probing a
+dependency, pass explicit `--config-args` to select the known dependency path or
+patch the extension's build recipe to use the WebAssembly archive directly.
+Static `.a` archives passed via `--extra-ldflags` are force-linked with
+`--whole-archive` so the side module contains the dependency code it needs.
+
+## Troubleshooting
+
+`Could not detect the extension name`
+
+Pass `--name` explicitly, or make sure `config.m4` contains `PHP_ARG_ENABLE`,
+`PHP_ARG_WITH`, or `PHP_NEW_EXTENSION` for the extension.
+
+`configure: error: ... not found`
+
+The dependency headers or libraries are not visible inside the container. Use
+paths under `/build` for files copied from `--source`, or
+`/php-wasm-compile/<dependency>/<mode>/dist/root/lib` for Playground-built
+dependencies.
+
+`undefined symbol` when loading the extension
+
+The extension references a function that is not exported by the PHP main module
+or was not linked from a WebAssembly dependency archive. Add the dependency
+archive to `--extra-ldflags`, or rebuild the main PHP.wasm runtime if the symbol
+must come from PHP core.
+
+`WebAssembly.LinkError` or startup crashes
+
+Check that the artifact async mode matches the runtime. Build `jspi` artifacts
+for JSPI runtimes and `asyncify` artifacts for Asyncify runtimes.
+
+`wasm-ld: unknown file type` or `file not recognized`
+
+One of the linked libraries is a native host library. Rebuild that dependency
+with Emscripten and link the resulting `.a` file.
+
+`bad export type for 'stdin'` or another C runtime global
+
+The side module pulled in a dependency object that expects a mutable C runtime
+global the main PHP.wasm module does not export. Rebuild the dependency with the
+unused feature disabled, link a smaller archive that excludes that object, or
+move the dependency into the main PHP.wasm build so the global is provided by
+the runtime.
+
+`phpize` cannot find headers
+
+The helper image builds and installs a minimal matching PHP source tree before
+running `phpize`. If an extension includes headers from optional PHP extensions,
+copy or generate those headers in the Docker layer or include them in the
+extension source.

--- a/packages/php-wasm/compile-extension/README.md
+++ b/packages/php-wasm/compile-extension/README.md
@@ -133,6 +133,24 @@ npx @php-wasm/compile-extension \
 	--extra-ldflags "/build/vendor/string-score/install/lib/libstring_score.a"
 ```
 
+Prebuilt static archives, including Rust `staticlib` archives, should also be
+passed through `--extra-ldflags`. The helper detects `.a` entries and
+force-links them into the final side module with `--whole-archive`:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./my-rust-extension \
+	--name my_rust_extension \
+	--php-versions 8.4 \
+	--async-modes jspi \
+	--extra-ldflags "/build/target/wasm32-unknown-emscripten/release/libmy_rust_extension.a"
+```
+
+Do not use `PHP_ADD_LIBRARY_WITH_PATH` for sibling `.a` archives in
+`config.m4`. PHP's libtool setup can look for a matching `.so`, fail to link
+the archive into the side module, and still leave a build artifact behind. Use
+`--extra-ldflags` for static archives instead.
+
 If the dependency uses CMake, build it as a static archive with Emscripten and
 store the install tree under the extension source directory:
 
@@ -188,6 +206,21 @@ without `phpize`, add a thin `config.m4` wrapper that builds the PHP extension
 and treats the CMake/Make output as dependency code. A fully custom final build
 script is outside v1.
 
+Rust extensions should wrap the Rust crate with a small `config.m4` and C shim
+that defines the PHP module entry and calls exported Rust functions over C ABI.
+The helper image includes a host `php` CLI for build scripts such as
+`ext-php-rs`, exports `BINDGEN_EXTRA_CLANG_ARGS` for the PHP.wasm target and
+sysroot, and sets `CFLAGS_wasm32_unknown_emscripten=-fPIC` for `cc-rs` build
+scripts. Rust `staticlib` archives must still be built with `panic=abort` and a
+nightly rebuilt standard library:
+
+```bash
+RUSTFLAGS="-C panic=abort" cargo +nightly build \
+	--release \
+	--target wasm32-unknown-emscripten \
+	-Zbuild-std=std,panic_abort
+```
+
 Keep the dependency async mode aligned with the extension. A `jspi` side module
 must link `jspi` dependency archives; an `asyncify` side module must link
 `asyncify` dependency archives.
@@ -230,6 +263,18 @@ for JSPI runtimes and `asyncify` artifacts for Asyncify runtimes.
 
 One of the linked libraries is a native host library. Rebuild that dependency
 with Emscripten and link the resulting `.a` file.
+
+`R_WASM_MEMORY_ADDR_SLEB cannot be used against symbol`
+
+A C or C++ object in a static archive was not compiled as position-independent
+code. Rebuild it with `-fPIC`, or make sure Rust `cc-rs` sees
+`CFLAGS_wasm32_unknown_emscripten=-fPIC`.
+
+`__cpp_exception` is undefined when loading a Rust extension
+
+The Rust archive was built against an unwinding `std`. Rebuild it with
+`RUSTFLAGS="-C panic=abort"` and
+`cargo +nightly build -Zbuild-std=std,panic_abort`.
 
 `bad export type for 'stdin'` or another C runtime global
 

--- a/packages/php-wasm/compile-extension/README.md
+++ b/packages/php-wasm/compile-extension/README.md
@@ -1,19 +1,18 @@
 # @php-wasm/compile-extension
 
-Builds a PHP extension source directory into PHP.wasm side modules for a PHP
-version and async-mode matrix.
+Builds a PHP extension source directory into PHP.wasm JSPI side modules for a
+PHP version matrix.
 
 ```bash
 npx @php-wasm/compile-extension \
 	--source ./ext-src \
 	--name wp_mysql_parser \
 	--php-versions 8.4 \
-	--async-modes jspi,asyncify \
 	--out ./dist
 ```
 
-The command writes one `.so` per matrix entry and a `manifest.json` that can be
-consumed by PHP.wasm extension-loading helpers.
+The command writes one JSPI `.so` per PHP version and a `manifest.json` that
+can be consumed by PHP.wasm extension-loading helpers.
 
 Docker is required. The build reuses the `packages/php-wasm/compile` base image
 and its PHP patch set, then runs `phpize`, `emconfigure`, and `emmake` inside
@@ -42,10 +41,10 @@ const php = new PHP(
 );
 ```
 
-The loader chooses the artifact whose `phpVersion` and `asyncMode` match the
-running PHP.wasm runtime, downloads it, verifies `sha256` when present, stages
-the `.so`, writes a startup `.ini` file, and registers the extension scan
-directory before PHP starts.
+The loader chooses the artifact whose `phpVersion` matches the running
+PHP.wasm runtime, downloads it, verifies `sha256` when present, stages the
+`.so`, writes a startup `.ini` file, and registers the extension scan directory
+before PHP starts.
 
 In Node.js, `manifestUrl` may also be a local path:
 
@@ -90,7 +89,7 @@ Xdebug. Use `extraFiles` and `env` for sidecar files needed by the extension.
 ## Dependencies
 
 The helper can only link WebAssembly objects built with the same Emscripten
-toolchain and async mode as the PHP runtime. Native host libraries from
+toolchain and JSPI ABI as the PHP runtime. Native host libraries from
 `/usr/lib`, Homebrew, apt, or npm packages cannot be linked into the `.so`.
 
 For dependencies already built by Playground, build the matching target and pass
@@ -103,7 +102,6 @@ npx @php-wasm/compile-extension \
 	--source ./zlib-probe \
 	--name zlib_probe \
 	--php-versions 8.4 \
-	--async-modes jspi \
 	--extra-cflags "-I/php-wasm-compile/libz/jspi/dist/root/lib/include" \
 	--extra-ldflags "/php-wasm-compile/libz/jspi/dist/root/lib/lib/libz.a"
 ```
@@ -128,7 +126,6 @@ npx @php-wasm/compile-extension \
 	--source ./external-lib-probe \
 	--name external_lib_probe \
 	--php-versions 8.4 \
-	--async-modes asyncify \
 	--extra-cflags "-I/build/vendor/string-score/install/include" \
 	--extra-ldflags "/build/vendor/string-score/install/lib/libstring_score.a"
 ```
@@ -142,7 +139,6 @@ npx @php-wasm/compile-extension \
 	--source ./my-rust-extension \
 	--name my_rust_extension \
 	--php-versions 8.4 \
-	--async-modes jspi \
 	--extra-ldflags "/build/target/wasm32-unknown-emscripten/release/libmy_rust_extension.a"
 ```
 
@@ -156,7 +152,7 @@ store the install tree under the extension source directory:
 
 ```bash
 # Run this inside the same Emscripten toolchain used for the target PHP.wasm
-# version and async mode.
+# version and JSPI ABI.
 source /root/emsdk/emsdk_env.sh
 
 emcmake cmake \
@@ -172,7 +168,6 @@ npx @php-wasm/compile-extension \
 	--source . \
 	--name my_extension \
 	--php-versions 8.4 \
-	--async-modes asyncify \
 	--extra-cflags "-I/build/vendor/libfoo/install/include" \
 	--extra-ldflags "/build/vendor/libfoo/install/lib/libfoo.a"
 ```
@@ -195,7 +190,6 @@ npx @php-wasm/compile-extension \
 	--source . \
 	--name my_extension \
 	--php-versions 8.4 \
-	--async-modes asyncify \
 	--extra-cflags "-I/build/vendor/libfoo/install/include" \
 	--extra-ldflags "/build/vendor/libfoo/install/lib/libfoo.a"
 ```
@@ -221,9 +215,8 @@ RUSTFLAGS="-C panic=abort" cargo +nightly build \
 	-Zbuild-std=std,panic_abort
 ```
 
-Keep the dependency async mode aligned with the extension. A `jspi` side module
-must link `jspi` dependency archives; an `asyncify` side module must link
-`asyncify` dependency archives.
+Keep dependencies aligned with the custom extension target. Custom extensions
+are JSPI-only, so link `jspi` dependency archives.
 
 `--extra-cflags` is visible during `./configure`. `--extra-ldflags` is applied
 to the final side-module link so dependency archives do not break Autoconf's
@@ -256,8 +249,8 @@ must come from PHP core.
 
 `WebAssembly.LinkError` or startup crashes
 
-Check that the artifact async mode matches the runtime. Build `jspi` artifacts
-for JSPI runtimes and `asyncify` artifacts for Asyncify runtimes.
+Check that the extension loads in a JSPI runtime. The custom extension helper
+does not build Asyncify artifacts.
 
 `wasm-ld: unknown file type` or `file not recognized`
 

--- a/packages/php-wasm/compile-extension/docker/Dockerfile.ext
+++ b/packages/php-wasm/compile-extension/docker/Dockerfile.ext
@@ -1,0 +1,62 @@
+FROM playground-php-wasm:base
+
+ARG PHP_VERSION
+ARG JSPI="no"
+
+RUN apt-get update && apt-get install -y bison
+
+RUN git clone https://github.com/php/php-src.git /root/php-src \
+	--branch php-$PHP_VERSION \
+	--single-branch \
+	--depth 1
+
+RUN cd /root/php-src && ./buildconf --force
+
+COPY ./compile/php/php*.patch /root/
+RUN cd /root && git apply --no-index /root/php${PHP_VERSION:0:3}*.patch -v
+
+RUN source /root/emsdk/emsdk_env.sh && \
+	cd /root/php-src && \
+	emconfigure ./configure \
+	--disable-fiber-asm \
+	--enable-embed \
+	--disable-cgi \
+	--disable-opcache-jit \
+	--disable-opcache \
+	--disable-phpdbg \
+	--without-pcre-jit \
+	--disable-cli \
+	--disable-libxml \
+	--without-libxml \
+	--disable-dom \
+	--disable-xml \
+	--disable-simplexml \
+	--disable-xmlreader \
+	--disable-xmlwriter \
+	--without-sqlite3 \
+	--without-pdo-sqlite \
+	--without-iconv
+
+RUN /root/replace.sh 's/ZEND_USE_ASM_ARITHMETIC 1/ZEND_USE_ASM_ARITHMETIC 0/g' /root/php-src/Zend/zend_operators.h
+RUN /root/replace.sh 's/defined\(__GNUC__\)/0/g' /root/php-src/Zend/zend_multiply.h
+RUN /root/replace.sh 's/defined\(__GNUC__\)/0/g' /root/php-src/Zend/zend_cpuinfo.c
+RUN /root/replace.sh 's/defined\(__clang__\)/0/g' /root/php-src/Zend/zend_cpuinfo.c
+
+RUN source /root/emsdk/emsdk_env.sh && \
+	cd /root/php-src && \
+	emmake make install
+
+RUN mkdir -p /usr/local/include/php/ext/standard && \
+	if [ -f /root/php-src/ext/standard/php_smart_string.h ]; then \
+		cp /root/php-src/ext/standard/*.h /usr/local/include/php/ext/standard/; \
+	else \
+		echo '#include "Zend/zend_smart_string.h"' > /usr/local/include/php/ext/standard/php_smart_string.h; \
+	fi && \
+	if [ -d /root/php-src/ext/random ]; then \
+		cp /root/php-src/ext/random/*.h /usr/local/include/php/ext/standard/; \
+	fi
+
+COPY ./compile-extension/scripts/build-in-docker.sh /usr/local/bin/build-php-wasm-extension
+RUN chmod +x /usr/local/bin/build-php-wasm-extension
+
+ENTRYPOINT ["/usr/local/bin/build-php-wasm-extension"]

--- a/packages/php-wasm/compile-extension/docker/Dockerfile.ext
+++ b/packages/php-wasm/compile-extension/docker/Dockerfile.ext
@@ -3,7 +3,9 @@ FROM playground-php-wasm:base
 ARG PHP_VERSION
 ARG JSPI="no"
 
-RUN apt-get update && apt-get install -y bison
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	bison \
+	php-cli
 
 RUN git clone https://github.com/php/php-src.git /root/php-src \
 	--branch php-$PHP_VERSION \

--- a/packages/php-wasm/compile-extension/package.json
+++ b/packages/php-wasm/compile-extension/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@php-wasm/compile-extension",
 	"version": "0.1.0",
-	"description": "Build PHP.wasm extension side modules across PHP and async-mode matrices",
+	"description": "Build PHP.wasm extension side modules across PHP versions",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/WordPress/wordpress-playground"

--- a/packages/php-wasm/compile-extension/package.json
+++ b/packages/php-wasm/compile-extension/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "@php-wasm/compile-extension",
+	"version": "0.1.0",
+	"description": "Build PHP.wasm extension side modules across PHP and async-mode matrices",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/WordPress/wordpress-playground"
+	},
+	"homepage": "https://developer.wordpress.org/playground",
+	"author": "The WordPress contributors",
+	"publishConfig": {
+		"access": "public",
+		"directory": "../../../dist/packages/php-wasm/compile-extension"
+	},
+	"license": "GPL-2.0-or-later",
+	"type": "module",
+	"main": "./cli.js",
+	"module": "./cli.js",
+	"types": "./cli.d.ts",
+	"bin": {
+		"php-wasm-compile-extension": "./cli.js"
+	},
+	"dependencies": {
+		"yargs": "17.7.2"
+	},
+	"engines": {
+		"node": ">=20.10.0",
+		"npm": ">=10.2.3"
+	}
+}

--- a/packages/php-wasm/compile-extension/project.json
+++ b/packages/php-wasm/compile-extension/project.json
@@ -1,0 +1,96 @@
+{
+	"name": "php-wasm-compile-extension",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/php-wasm/compile-extension/src",
+	"projectType": "library",
+	"tags": ["scope:php-wasm-public", "scope:cli"],
+	"targets": {
+		"build": {
+			"executor": "nx:noop",
+			"dependsOn": ["build:README", "build:docker-assets"]
+		},
+		"build:README": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp packages/php-wasm/compile-extension/README.md dist/packages/php-wasm/compile-extension"
+				]
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:docker-assets": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cp -R packages/php-wasm/compile-extension/docker dist/packages/php-wasm/compile-extension/docker",
+					"cp -R packages/php-wasm/compile-extension/scripts dist/packages/php-wasm/compile-extension/scripts"
+				],
+				"parallel": false
+			},
+			"dependsOn": ["build:package-json"]
+		},
+		"build:package-json": {
+			"executor": "@wp-playground/nx-extensions:package-json",
+			"options": {
+				"tsConfig": "packages/php-wasm/compile-extension/tsconfig.lib.json",
+				"outputPath": "dist/packages/php-wasm/compile-extension",
+				"buildTarget": "php-wasm-compile-extension:build:bundle:production"
+			}
+		},
+		"build:bundle": {
+			"executor": "@nx/vite:build",
+			"outputs": ["{options.outputPath}"],
+			"options": {
+				"outputPath": "dist/packages/php-wasm/compile-extension"
+			},
+			"defaultConfiguration": "production",
+			"configurations": {
+				"development": {
+					"minify": false
+				},
+				"production": {
+					"minify": true
+				}
+			}
+		},
+		"lint": {
+			"executor": "@nx/eslint:lint",
+			"outputs": ["{options.outputFile}"],
+			"options": {
+				"useFlatConfig": false,
+				"lintFilePatterns": [
+					"packages/php-wasm/compile-extension/**/*.ts"
+				],
+				"maxWarnings": 0
+			}
+		},
+		"test": {
+			"executor": "@nx/vitest:test",
+			"outputs": [
+				"{workspaceRoot}/coverage/packages/php-wasm/compile-extension"
+			],
+			"options": {
+				"passWithNoTests": true,
+				"reportsDirectory": "../../../coverage/packages/php-wasm/compile-extension",
+				"typecheck": {
+					"tsconfig": "{projectRoot}/tsconfig.spec.json"
+				}
+			}
+		},
+		"typecheck": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"tsc -p packages/php-wasm/compile-extension/tsconfig.lib.json --noEmit",
+					"tsc -p packages/php-wasm/compile-extension/tsconfig.spec.json --noEmit"
+				]
+			}
+		},
+		"test-compile-extension-integration": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "packages/php-wasm/compile-extension/tests/run-integration-tests.sh"
+			}
+		}
+	}
+}

--- a/packages/php-wasm/compile-extension/scripts/build-in-docker.sh
+++ b/packages/php-wasm/compile-extension/scripts/build-in-docker.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d /src ]; then
+	echo "Missing /src extension source mount." >&2
+	exit 1
+fi
+
+if [ -z "${EXTENSION_NAME:-}" ]; then
+	echo "Missing EXTENSION_NAME." >&2
+	exit 1
+fi
+
+ASYNC_MODE="${ASYNC_MODE:-asyncify}"
+OPTIMIZE="${OPTIMIZE:-2}"
+ARTIFACT_FILENAME="${ARTIFACT_FILENAME:-${EXTENSION_NAME}-php${PHP_VERSION_SHORT:-unknown}-${ASYNC_MODE}.so}"
+MAKE_JOBS="${MAKE_JOBS:-$(nproc)}"
+USER_EXTRA_CFLAGS="${EXTRA_CFLAGS:-}"
+USER_EXTRA_LDFLAGS="${EXTRA_LDFLAGS:-}"
+unset EXTRA_CFLAGS EXTRA_LDFLAGS
+
+rm -rf /build
+mkdir -p /build /out
+cp -R /src/. /build/
+cd /build
+
+phpize .
+source /root/emsdk/emsdk_env.sh
+
+BASE_CFLAGS="-DZEND_ENABLE_ZVAL_LONG64 -D__x86_64__ -fPIC -O${OPTIMIZE}"
+BASE_LDFLAGS="-sSIDE_MODULE=1 -sWASM_BIGINT -fPIC -O${OPTIMIZE}"
+ASYNC_FLAGS=""
+
+if [ "$ASYNC_MODE" = "jspi" ]; then
+	ASYNC_FLAGS="-sSUPPORT_LONGJMP=wasm -fwasm-exceptions -sJSPI"
+elif [ "$ASYNC_MODE" = "asyncify" ]; then
+	ASYNC_FLAGS="-sASYNCIFY=1 -sASYNCIFY_ADVISE"
+else
+	echo "Unsupported ASYNC_MODE: ${ASYNC_MODE}" >&2
+	exit 1
+fi
+
+EXTRA_LINK_FLAGS=""
+EXTRA_STATIC_ARCHIVES=""
+for flag in $USER_EXTRA_LDFLAGS; do
+	if [[ "$flag" == *.a ]]; then
+		EXTRA_STATIC_ARCHIVES="${EXTRA_STATIC_ARCHIVES} ${flag}"
+	else
+		EXTRA_LINK_FLAGS="${EXTRA_LINK_FLAGS} ${flag}"
+	fi
+done
+
+export CFLAGS="${BASE_CFLAGS} ${USER_EXTRA_CFLAGS}"
+export CXXFLAGS="${BASE_CFLAGS} ${USER_EXTRA_CFLAGS}"
+CONFIGURE_LDFLAGS="${BASE_LDFLAGS} ${ASYNC_FLAGS}"
+BUILD_LDFLAGS="${CONFIGURE_LDFLAGS}${EXTRA_LINK_FLAGS}"
+export LDFLAGS="${CONFIGURE_LDFLAGS}"
+# The libtool patch below injects EMCC_FLAGS into the final archive command.
+# Keep dependency archives out of LDFLAGS so libtool does not drop or duplicate them.
+export EMCC_FLAGS="${BUILD_LDFLAGS}"
+export EMCC_STATIC_ARCHIVES="${EXTRA_STATIC_ARCHIVES}"
+
+configure_args=("--host=i386-unknown-freebsd" "--enable-${EXTENSION_NAME}" "--disable-static" "--enable-shared")
+config_args_count="${CONFIG_ARGS_COUNT:-0}"
+for ((i = 0; i < config_args_count; i++)); do
+	arg_name="CONFIG_ARG_${i}"
+	configure_args+=("${!arg_name}")
+done
+
+if ! emconfigure ./configure "${configure_args[@]}"; then
+	if [ -f config.log ]; then
+		cat config.log >&2
+	fi
+	exit 1
+fi
+
+if [ -f libtool ]; then
+	if [ -n "$EMCC_STATIC_ARCHIVES" ]; then
+		/root/replace.sh 's|^archive_cmds="\\\$CC|archive_cmds="emcc \\\$EMCC_FLAGS -shared --whole-archive \\\$EMCC_STATIC_ARCHIVES --no-whole-archive|' libtool || true
+	else
+		/root/replace.sh 's|^archive_cmds="\\\$CC|archive_cmds="emcc \\\$EMCC_FLAGS|' libtool || true
+	fi
+fi
+
+emmake make -j"${MAKE_JOBS}"
+
+module_path="modules/${EXTENSION_NAME}.so"
+if [ ! -f "$module_path" ]; then
+	module_path="$(find modules -maxdepth 1 -name '*.so' -print -quit)"
+fi
+
+if [ -z "$module_path" ] || [ ! -f "$module_path" ]; then
+	echo "Could not find a built .so under /build/modules." >&2
+	exit 1
+fi
+
+if [ -x /root/emsdk/upstream/bin/wasm-opt ]; then
+	/root/emsdk/upstream/bin/wasm-opt -Oz \
+		--enable-bulk-memory \
+		--enable-nontrapping-float-to-int \
+		--enable-sign-ext \
+		--enable-mutable-globals \
+		--enable-exception-handling \
+		"$module_path" \
+		-o "$module_path"
+fi
+
+mkdir -p /out
+cp "$module_path" "/out/${ARTIFACT_FILENAME}"

--- a/packages/php-wasm/compile-extension/scripts/build-in-docker.sh
+++ b/packages/php-wasm/compile-extension/scripts/build-in-docker.sh
@@ -58,7 +58,7 @@ export CXX_wasm32_unknown_emscripten="${CXX_wasm32_unknown_emscripten:-em++}"
 export AR_wasm32_unknown_emscripten="${AR_wasm32_unknown_emscripten:-emar}"
 export RANLIB_wasm32_unknown_emscripten="${RANLIB_wasm32_unknown_emscripten:-emranlib}"
 CONFIGURE_LDFLAGS="${BASE_LDFLAGS} ${ASYNC_FLAGS}"
-BUILD_LDFLAGS="${CONFIGURE_LDFLAGS}${EXTRA_LINK_FLAGS}"
+BUILD_LDFLAGS="${CONFIGURE_LDFLAGS} ${EXTRA_LINK_FLAGS}"
 export LDFLAGS="${CONFIGURE_LDFLAGS}"
 # The libtool patch below injects EMCC_FLAGS into the final archive command.
 # Keep dependency archives out of LDFLAGS so libtool does not drop or duplicate them.

--- a/packages/php-wasm/compile-extension/scripts/build-in-docker.sh
+++ b/packages/php-wasm/compile-extension/scripts/build-in-docker.sh
@@ -26,6 +26,7 @@ cd /build
 
 phpize .
 source /root/emsdk/emsdk_env.sh
+export EMSDK_SYSROOT="${EMSDK_SYSROOT:-${EMSDK}/upstream/emscripten/cache/sysroot}"
 
 BASE_CFLAGS="-DZEND_ENABLE_ZVAL_LONG64 -D__x86_64__ -fPIC -O${OPTIMIZE}"
 BASE_LDFLAGS="-sSIDE_MODULE=1 -sWASM_BIGINT -fPIC -O${OPTIMIZE}"
@@ -52,6 +53,13 @@ done
 
 export CFLAGS="${BASE_CFLAGS} ${USER_EXTRA_CFLAGS}"
 export CXXFLAGS="${BASE_CFLAGS} ${USER_EXTRA_CFLAGS}"
+export BINDGEN_EXTRA_CLANG_ARGS="--target=wasm32-unknown-emscripten --sysroot=${EMSDK_SYSROOT} -DZEND_ENABLE_ZVAL_LONG64 -D__x86_64__ ${BINDGEN_EXTRA_CLANG_ARGS:-}"
+export CFLAGS_wasm32_unknown_emscripten="-fPIC ${CFLAGS_wasm32_unknown_emscripten:-}"
+export CXXFLAGS_wasm32_unknown_emscripten="-fPIC ${CXXFLAGS_wasm32_unknown_emscripten:-}"
+export CC_wasm32_unknown_emscripten="${CC_wasm32_unknown_emscripten:-emcc}"
+export CXX_wasm32_unknown_emscripten="${CXX_wasm32_unknown_emscripten:-em++}"
+export AR_wasm32_unknown_emscripten="${AR_wasm32_unknown_emscripten:-emar}"
+export RANLIB_wasm32_unknown_emscripten="${RANLIB_wasm32_unknown_emscripten:-emranlib}"
 CONFIGURE_LDFLAGS="${BASE_LDFLAGS} ${ASYNC_FLAGS}"
 BUILD_LDFLAGS="${CONFIGURE_LDFLAGS}${EXTRA_LINK_FLAGS}"
 export LDFLAGS="${CONFIGURE_LDFLAGS}"

--- a/packages/php-wasm/compile-extension/scripts/build-in-docker.sh
+++ b/packages/php-wasm/compile-extension/scripts/build-in-docker.sh
@@ -11,7 +11,7 @@ if [ -z "${EXTENSION_NAME:-}" ]; then
 	exit 1
 fi
 
-ASYNC_MODE="${ASYNC_MODE:-asyncify}"
+ASYNC_MODE="${ASYNC_MODE:-jspi}"
 OPTIMIZE="${OPTIMIZE:-2}"
 ARTIFACT_FILENAME="${ARTIFACT_FILENAME:-${EXTENSION_NAME}-php${PHP_VERSION_SHORT:-unknown}-${ASYNC_MODE}.so}"
 MAKE_JOBS="${MAKE_JOBS:-$(nproc)}"
@@ -30,16 +30,13 @@ export EMSDK_SYSROOT="${EMSDK_SYSROOT:-${EMSDK}/upstream/emscripten/cache/sysroo
 
 BASE_CFLAGS="-DZEND_ENABLE_ZVAL_LONG64 -D__x86_64__ -fPIC -O${OPTIMIZE}"
 BASE_LDFLAGS="-sSIDE_MODULE=1 -sWASM_BIGINT -fPIC -O${OPTIMIZE}"
-ASYNC_FLAGS=""
 
-if [ "$ASYNC_MODE" = "jspi" ]; then
-	ASYNC_FLAGS="-sSUPPORT_LONGJMP=wasm -fwasm-exceptions -sJSPI"
-elif [ "$ASYNC_MODE" = "asyncify" ]; then
-	ASYNC_FLAGS="-sASYNCIFY=1 -sASYNCIFY_ADVISE"
-else
-	echo "Unsupported ASYNC_MODE: ${ASYNC_MODE}" >&2
+if [ "$ASYNC_MODE" != "jspi" ]; then
+	echo "Unsupported ASYNC_MODE: ${ASYNC_MODE}." >&2
+	echo "Custom extensions can only be built for JSPI runtimes." >&2
 	exit 1
 fi
+ASYNC_FLAGS="-sSUPPORT_LONGJMP=wasm -fwasm-exceptions -sJSPI"
 
 EXTRA_LINK_FLAGS=""
 EXTRA_STATIC_ARCHIVES=""

--- a/packages/php-wasm/compile-extension/src/cli.spec.ts
+++ b/packages/php-wasm/compile-extension/src/cli.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeDashPrefixedOptionValues, splitShellWords } from './cli';
+
+describe('normalizeDashPrefixedOptionValues', () => {
+	it('keeps configure and compiler flags as option values', () => {
+		expect(
+			normalizeDashPrefixedOptionValues([
+				'--config-args',
+				'--disable-feature --with-libxml=/opt/libxml2',
+				'--extra-cflags',
+				'-Dsetsockopt=wasm_setsockopt',
+				'--extra-ldflags',
+				'-sERROR_ON_UNDEFINED_SYMBOLS=0',
+			])
+		).toEqual([
+			'--config-args=--disable-feature --with-libxml=/opt/libxml2',
+			'--extra-cflags=-Dsetsockopt=wasm_setsockopt',
+			'--extra-ldflags=-sERROR_ON_UNDEFINED_SYMBOLS=0',
+		]);
+	});
+});
+
+describe('splitShellWords', () => {
+	it('splits plain configure arguments', () => {
+		expect(splitShellWords('--with-libxml=/root/lib --enable-foo')).toEqual(
+			['--with-libxml=/root/lib', '--enable-foo']
+		);
+	});
+
+	it('keeps quoted values together', () => {
+		expect(splitShellWords('--with-name="hello world"')).toEqual([
+			'--with-name=hello world',
+		]);
+	});
+
+	it('throws on unterminated quotes', () => {
+		expect(() => splitShellWords('"oops')).toThrow('Unterminated quote');
+	});
+});

--- a/packages/php-wasm/compile-extension/src/cli.ts
+++ b/packages/php-wasm/compile-extension/src/cli.ts
@@ -11,9 +11,7 @@ import {
 	SupportedExtensionPHPVersions,
 } from './compile';
 import { detectExtensionName } from './detect';
-import type { AsyncMode } from './manifest';
 
-const DefaultAsyncModes: AsyncMode[] = ['jspi', 'asyncify'];
 const OptionsWithDashPrefixedValues = new Set([
 	'--config-args',
 	'--extra-cflags',
@@ -38,11 +36,6 @@ export async function main(args = hideBin(process.argv)) {
 				type: 'string',
 				default: SupportedExtensionPHPVersions.join(','),
 				description: 'Comma-separated PHP major.minor versions.',
-			},
-			'async-modes': {
-				type: 'string',
-				default: DefaultAsyncModes.join(','),
-				description: 'Comma-separated async modes: jspi,asyncify.',
 			},
 			out: {
 				type: 'string',
@@ -86,7 +79,6 @@ export async function main(args = hideBin(process.argv)) {
 		argv['php-versions'] as string,
 		'php-versions'
 	);
-	const asyncModes = parseAsyncModes(argv['async-modes'] as string);
 	const configArgs = splitShellWords((argv['config-args'] as string) || '');
 
 	const result = await compileExtensionMatrix({
@@ -95,7 +87,6 @@ export async function main(args = hideBin(process.argv)) {
 		outDir: argv['out'] as string,
 		name,
 		phpVersions,
-		asyncModes,
 		extraCflags: argv['extra-cflags'] as string | undefined,
 		extraLdflags: argv['extra-ldflags'] as string | undefined,
 		configArgs,
@@ -141,16 +132,6 @@ function parseCsv(value: string, name: string): string[] {
 		throw new Error(`--${name} must contain at least one value.`);
 	}
 	return values;
-}
-
-function parseAsyncModes(value: string): AsyncMode[] {
-	const modes = parseCsv(value, 'async-modes');
-	for (const mode of modes) {
-		if (mode !== 'jspi' && mode !== 'asyncify') {
-			throw new Error(`Unsupported async mode: ${mode}`);
-		}
-	}
-	return modes as AsyncMode[];
 }
 
 export function splitShellWords(value: string): string[] {

--- a/packages/php-wasm/compile-extension/src/cli.ts
+++ b/packages/php-wasm/compile-extension/src/cli.ts
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+import { existsSync, realpathSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+import {
+	compileExtensionMatrix,
+	SupportedExtensionPHPVersions,
+} from './compile';
+import { detectExtensionName } from './detect';
+import type { AsyncMode } from './manifest';
+
+const DefaultAsyncModes: AsyncMode[] = ['jspi', 'asyncify'];
+const OptionsWithDashPrefixedValues = new Set([
+	'--config-args',
+	'--extra-cflags',
+	'--extra-ldflags',
+]);
+
+export async function main(args = hideBin(process.argv)) {
+	const argv = await yargs(normalizeDashPrefixedOptionValues(args))
+		.scriptName('@php-wasm/compile-extension')
+		.usage('Usage: $0 --source <dir> [options]')
+		.options({
+			source: {
+				type: 'string',
+				demandOption: true,
+				description: 'Extension source directory containing config.m4',
+			},
+			name: {
+				type: 'string',
+				description: 'Extension name. Defaults to parsing config.m4.',
+			},
+			'php-versions': {
+				type: 'string',
+				default: SupportedExtensionPHPVersions.join(','),
+				description: 'Comma-separated PHP major.minor versions.',
+			},
+			'async-modes': {
+				type: 'string',
+				default: DefaultAsyncModes.join(','),
+				description: 'Comma-separated async modes: jspi,asyncify.',
+			},
+			out: {
+				type: 'string',
+				default: './dist',
+				description: 'Output directory.',
+			},
+			'extra-cflags': {
+				type: 'string',
+				description: 'Extra CFLAGS appended to the side-module build.',
+			},
+			'extra-ldflags': {
+				type: 'string',
+				description: 'Extra LDFLAGS appended to the side-module build.',
+			},
+			'config-args': {
+				type: 'string',
+				default: '',
+				description:
+					'Extra ./configure arguments, parsed as shell words.',
+			},
+			optimize: {
+				type: 'string',
+				default: '2',
+				description: 'Optimization level passed as -O<level>.',
+			},
+			jobs: {
+				type: 'number',
+				description: 'Maximum concurrent docker builds.',
+			},
+		})
+		.strict()
+		.help()
+		.parse();
+
+	const workspaceRoot = findWorkspaceRoot(process.cwd());
+	const sourceDir = path.resolve(workspaceRoot, argv['source'] as string);
+	const name =
+		(argv['name'] as string | undefined) ??
+		(await detectExtensionName(sourceDir));
+	const phpVersions = parseCsv(
+		argv['php-versions'] as string,
+		'php-versions'
+	);
+	const asyncModes = parseAsyncModes(argv['async-modes'] as string);
+	const configArgs = splitShellWords((argv['config-args'] as string) || '');
+
+	const result = await compileExtensionMatrix({
+		workspaceRoot,
+		sourceDir,
+		outDir: argv['out'] as string,
+		name,
+		phpVersions,
+		asyncModes,
+		extraCflags: argv['extra-cflags'] as string | undefined,
+		extraLdflags: argv['extra-ldflags'] as string | undefined,
+		configArgs,
+		optimize: argv['optimize'] as string,
+		jobs: argv['jobs'] as number | undefined,
+	});
+
+	console.log(`Wrote ${result.artifacts.length} artifacts.`);
+	console.log(`Wrote ${result.manifestPath}.`);
+}
+
+if (isCliEntrypoint(import.meta.url)) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : error);
+		process.exit(1);
+	});
+}
+
+export function normalizeDashPrefixedOptionValues(args: string[]): string[] {
+	const normalized: string[] = [];
+	for (let i = 0; i < args.length; i++) {
+		const arg = args[i];
+		if (
+			OptionsWithDashPrefixedValues.has(arg) &&
+			i + 1 < args.length &&
+			!args[i + 1].startsWith(`${arg}=`)
+		) {
+			normalized.push(`${arg}=${args[i + 1]}`);
+			i++;
+			continue;
+		}
+		normalized.push(arg);
+	}
+	return normalized;
+}
+
+function parseCsv(value: string, name: string): string[] {
+	const values = value
+		.split(',')
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+	if (values.length === 0) {
+		throw new Error(`--${name} must contain at least one value.`);
+	}
+	return values;
+}
+
+function parseAsyncModes(value: string): AsyncMode[] {
+	const modes = parseCsv(value, 'async-modes');
+	for (const mode of modes) {
+		if (mode !== 'jspi' && mode !== 'asyncify') {
+			throw new Error(`Unsupported async mode: ${mode}`);
+		}
+	}
+	return modes as AsyncMode[];
+}
+
+export function splitShellWords(value: string): string[] {
+	const words: string[] = [];
+	let current = '';
+	let quote: '"' | "'" | null = null;
+	let escaping = false;
+
+	for (const character of value) {
+		if (escaping) {
+			current += character;
+			escaping = false;
+			continue;
+		}
+		if (character === '\\') {
+			escaping = true;
+			continue;
+		}
+		if (quote) {
+			if (character === quote) {
+				quote = null;
+			} else {
+				current += character;
+			}
+			continue;
+		}
+		if (character === '"' || character === "'") {
+			quote = character;
+			continue;
+		}
+		if (/\s/.test(character)) {
+			if (current.length > 0) {
+				words.push(current);
+				current = '';
+			}
+			continue;
+		}
+		current += character;
+	}
+
+	if (escaping) {
+		current += '\\';
+	}
+	if (quote) {
+		throw new Error('Unterminated quote in --config-args.');
+	}
+	if (current.length > 0) {
+		words.push(current);
+	}
+	return words;
+}
+
+function findWorkspaceRoot(startDirectory: string): string {
+	let directory = path.resolve(startDirectory);
+	while (directory !== path.dirname(directory)) {
+		if (
+			existsSync(path.join(directory, 'packages/php-wasm/compile')) &&
+			existsSync(path.join(directory, 'nx.json'))
+		) {
+			return directory;
+		}
+		directory = path.dirname(directory);
+	}
+	return process.cwd();
+}
+
+function isCliEntrypoint(metaUrl: string): boolean {
+	const entrypoint = process.argv[1];
+	if (!entrypoint) {
+		return false;
+	}
+	try {
+		return (
+			realpathSync(entrypoint) === realpathSync(fileURLToPath(metaUrl))
+		);
+	} catch {
+		return path.resolve(entrypoint) === fileURLToPath(metaUrl);
+	}
+}

--- a/packages/php-wasm/compile-extension/src/compile.ts
+++ b/packages/php-wasm/compile-extension/src/compile.ts
@@ -1,0 +1,155 @@
+import { mkdir, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+	assertDockerIsAvailable,
+	buildBaseImage,
+	buildExtensionImage,
+	createDockerContext,
+	runExtensionBuild,
+} from './docker';
+import type { AsyncMode, BuiltArtifact } from './manifest';
+import { createManifest, writeManifest } from './manifest';
+
+export const SupportedExtensionPHPVersions = [
+	'8.5',
+	'8.4',
+	'8.3',
+	'8.2',
+	'8.1',
+	'8.0',
+	'7.4',
+] as const;
+
+const PHP_RELEASE_BY_MINOR: Record<string, string> = {
+	'8.5': '8.5.5',
+	'8.4': '8.4.20',
+	'8.3': '8.3.30',
+	'8.2': '8.2.30',
+	'8.1': '8.1.34',
+	'8.0': '8.0.30',
+	'7.4': '7.4.33',
+};
+
+export interface CompileExtensionOptions {
+	workspaceRoot: string;
+	sourceDir: string;
+	outDir: string;
+	name: string;
+	phpVersions: string[];
+	asyncModes: AsyncMode[];
+	extraCflags?: string;
+	extraLdflags?: string;
+	configArgs: string[];
+	optimize: string;
+	jobs?: number;
+}
+
+export async function compileExtensionMatrix(options: CompileExtensionOptions) {
+	const outDir = path.resolve(options.workspaceRoot, options.outDir);
+	const sourceDir = path.resolve(options.workspaceRoot, options.sourceDir);
+	const context = createDockerContext(options.workspaceRoot);
+	const version = await detectManifestVersion(sourceDir);
+	const matrix = options.phpVersions.flatMap((phpVersion) =>
+		options.asyncModes.map((asyncMode) => ({ phpVersion, asyncMode }))
+	);
+
+	await mkdir(outDir, { recursive: true });
+	await assertDockerIsAvailable();
+	await buildBaseImage(context);
+
+	const artifacts = await mapLimit(
+		matrix,
+		normalizeJobCount(options.jobs, matrix.length),
+		async ({ phpVersion, asyncMode }) => {
+			const phpRelease = resolvePHPRelease(phpVersion);
+			const artifactFile = `${options.name}-php${phpVersion}-${asyncMode}.so`;
+			await buildExtensionImage({
+				...context,
+				phpVersion,
+				phpRelease,
+				asyncMode,
+			});
+			await runExtensionBuild({
+				...context,
+				sourceDir,
+				outDir,
+				name: options.name,
+				phpVersion,
+				phpRelease,
+				asyncMode,
+				artifactFile,
+				optimize: options.optimize,
+				extraCflags: options.extraCflags,
+				extraLdflags: options.extraLdflags,
+				configArgs: options.configArgs,
+			});
+			return {
+				phpVersion,
+				asyncMode,
+				file: artifactFile,
+				path: path.join(outDir, artifactFile),
+			} satisfies BuiltArtifact;
+		}
+	);
+
+	const manifest = await createManifest({
+		name: options.name,
+		version,
+		artifacts,
+	});
+	const manifestPath = await writeManifest({ outDir, manifest });
+	return { manifestPath, artifacts, manifest };
+}
+
+export function resolvePHPRelease(phpVersion: string): string {
+	return PHP_RELEASE_BY_MINOR[phpVersion] ?? phpVersion;
+}
+
+async function detectManifestVersion(sourceDir: string): Promise<string> {
+	try {
+		const packageJson = JSON.parse(
+			await readFile(path.join(sourceDir, 'package.json'), 'utf8')
+		) as { version?: unknown };
+		if (typeof packageJson.version === 'string') {
+			return packageJson.version;
+		}
+	} catch {
+		// Native PHP extension sources usually do not contain package.json.
+	}
+	return '0.0.0';
+}
+
+async function mapLimit<T, R>(
+	items: T[],
+	limit: number,
+	worker: (item: T) => Promise<R>
+): Promise<R[]> {
+	const results: R[] = new Array(items.length) as R[];
+	let nextIndex = 0;
+	const workers = Array.from(
+		{ length: Math.min(limit, items.length) },
+		async () => {
+			while (nextIndex < items.length) {
+				const index = nextIndex++;
+				results[index] = await worker(items[index]);
+			}
+		}
+	);
+	await Promise.all(workers);
+	return results;
+}
+
+function normalizeJobCount(
+	jobs: number | undefined,
+	taskCount: number
+): number {
+	if (taskCount === 0) {
+		return 1;
+	}
+	if (jobs && jobs > 0) {
+		return Math.min(jobs, taskCount);
+	}
+	return Math.min(os.availableParallelism?.() ?? os.cpus().length, taskCount);
+}

--- a/packages/php-wasm/compile-extension/src/compile.ts
+++ b/packages/php-wasm/compile-extension/src/compile.ts
@@ -10,7 +10,7 @@ import {
 	runExtensionBuild,
 } from './docker';
 import type { AsyncMode, BuiltArtifact } from './manifest';
-import { createManifest, writeManifest } from './manifest';
+import { createManifest, ExtensionAsyncMode, writeManifest } from './manifest';
 
 export const SupportedExtensionPHPVersions = [
 	'8.5',
@@ -38,7 +38,6 @@ export interface CompileExtensionOptions {
 	outDir: string;
 	name: string;
 	phpVersions: string[];
-	asyncModes: AsyncMode[];
 	extraCflags?: string;
 	extraLdflags?: string;
 	configArgs: string[];
@@ -51,9 +50,11 @@ export async function compileExtensionMatrix(options: CompileExtensionOptions) {
 	const sourceDir = path.resolve(options.workspaceRoot, options.sourceDir);
 	const context = createDockerContext(options.workspaceRoot);
 	const version = await detectManifestVersion(sourceDir);
-	const matrix = options.phpVersions.flatMap((phpVersion) =>
-		options.asyncModes.map((asyncMode) => ({ phpVersion, asyncMode }))
-	);
+	const matrix: Array<{ phpVersion: string; asyncMode: AsyncMode }> =
+		options.phpVersions.map((phpVersion) => ({
+			phpVersion,
+			asyncMode: ExtensionAsyncMode,
+		}));
 
 	await mkdir(outDir, { recursive: true });
 	await assertDockerIsAvailable();
@@ -87,7 +88,6 @@ export async function compileExtensionMatrix(options: CompileExtensionOptions) {
 			});
 			return {
 				phpVersion,
-				asyncMode,
 				file: artifactFile,
 				path: path.join(outDir, artifactFile),
 			} satisfies BuiltArtifact;

--- a/packages/php-wasm/compile-extension/src/detect.spec.ts
+++ b/packages/php-wasm/compile-extension/src/detect.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectExtensionNameFromConfig } from './detect';
+
+describe('detectExtensionNameFromConfig', () => {
+	it('detects PHP_ARG_ENABLE names', () => {
+		expect(
+			detectExtensionNameFromConfig(
+				'PHP_ARG_ENABLE([wp_mysql_parser], [whether to enable it])'
+			)
+		).toBe('wp_mysql_parser');
+	});
+
+	it('detects PHP_ARG_WITH names', () => {
+		expect(
+			detectExtensionNameFromConfig(
+				'PHP_ARG_WITH(example_ext, for example support)'
+			)
+		).toBe('example_ext');
+	});
+
+	it('falls back to PHP_NEW_EXTENSION names', () => {
+		expect(
+			detectExtensionNameFromConfig(
+				'PHP_NEW_EXTENSION([hello], hello.c, $ext_shared)'
+			)
+		).toBe('hello');
+	});
+});

--- a/packages/php-wasm/compile-extension/src/detect.ts
+++ b/packages/php-wasm/compile-extension/src/detect.ts
@@ -1,0 +1,39 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const EXTENSION_NAME_PATTERNS = [
+	/\bPHP_ARG_ENABLE\(\s*\[?([A-Za-z0-9_]+)\]?/m,
+	/\bPHP_ARG_WITH\(\s*\[?([A-Za-z0-9_]+)\]?/m,
+	/\bPHP_NEW_EXTENSION\(\s*\[?([A-Za-z0-9_]+)\]?/m,
+];
+
+export async function detectExtensionName(sourceDir: string): Promise<string> {
+	const configPath = path.join(sourceDir, 'config.m4');
+	let config: string;
+	try {
+		config = await readFile(configPath, 'utf8');
+	} catch (error) {
+		throw new Error(
+			`Could not read ${configPath}. Pass --name or provide a config.m4 file.`,
+			{ cause: error }
+		);
+	}
+
+	const detected = detectExtensionNameFromConfig(config);
+	if (!detected) {
+		throw new Error(
+			`Could not detect the extension name from ${configPath}. Pass --name explicitly.`
+		);
+	}
+	return detected;
+}
+
+export function detectExtensionNameFromConfig(config: string): string | null {
+	for (const pattern of EXTENSION_NAME_PATTERNS) {
+		const match = pattern.exec(config);
+		if (match?.[1]) {
+			return match[1];
+		}
+	}
+	return null;
+}

--- a/packages/php-wasm/compile-extension/src/docker.ts
+++ b/packages/php-wasm/compile-extension/src/docker.ts
@@ -70,7 +70,7 @@ export async function buildExtensionImage(
 			'--build-arg',
 			`PHP_VERSION=${options.phpRelease}`,
 			'--build-arg',
-			`JSPI=${options.asyncMode === 'jspi' ? 'yes' : 'no'}`,
+			'JSPI=yes',
 		],
 		{
 			cwd: options.phpWasmRoot,

--- a/packages/php-wasm/compile-extension/src/docker.ts
+++ b/packages/php-wasm/compile-extension/src/docker.ts
@@ -1,0 +1,158 @@
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+
+import type { AsyncMode } from './manifest';
+
+export interface DockerBuildContext {
+	workspaceRoot: string;
+	phpWasmRoot: string;
+	compileRoot: string;
+}
+
+export interface DockerImageOptions extends DockerBuildContext {
+	phpVersion: string;
+	phpRelease: string;
+	asyncMode: AsyncMode;
+}
+
+export interface DockerRunOptions extends DockerImageOptions {
+	sourceDir: string;
+	outDir: string;
+	name: string;
+	artifactFile: string;
+	optimize: string;
+	extraCflags?: string;
+	extraLdflags?: string;
+	configArgs: string[];
+}
+
+export function createDockerContext(workspaceRoot: string): DockerBuildContext {
+	const phpWasmRoot = path.join(workspaceRoot, 'packages/php-wasm');
+	return {
+		workspaceRoot,
+		phpWasmRoot,
+		compileRoot: path.join(phpWasmRoot, 'compile'),
+	};
+}
+
+export async function assertDockerIsAvailable(): Promise<void> {
+	try {
+		await runCommand('docker', ['--version'], {
+			stdio: 'ignore',
+		});
+	} catch (error) {
+		throw new Error(
+			'Docker is required to compile PHP.wasm extensions, but the docker command was not found.',
+			{ cause: error }
+		);
+	}
+}
+
+export async function buildBaseImage(context: DockerBuildContext) {
+	await runCommand('make', ['base-image'], {
+		cwd: context.compileRoot,
+	});
+}
+
+export async function buildExtensionImage(
+	options: DockerImageOptions
+): Promise<string> {
+	const imageTag = getExtensionImageTag(options);
+	await runCommand(
+		'docker',
+		[
+			'build',
+			'-f',
+			'compile-extension/docker/Dockerfile.ext',
+			'.',
+			`--tag=${imageTag}`,
+			'--progress=plain',
+			'--build-arg',
+			`PHP_VERSION=${options.phpRelease}`,
+			'--build-arg',
+			`JSPI=${options.asyncMode === 'jspi' ? 'yes' : 'no'}`,
+		],
+		{
+			cwd: options.phpWasmRoot,
+		}
+	);
+	return imageTag;
+}
+
+export async function runExtensionBuild(options: DockerRunOptions) {
+	const imageTag = getExtensionImageTag(options);
+	const runArgs = [
+		'run',
+		'--rm',
+		'-v',
+		`${options.sourceDir}:/src:ro`,
+		'-v',
+		`${options.outDir}:/out`,
+		'-v',
+		`${options.compileRoot}:/php-wasm-compile:ro`,
+		'--env',
+		`EXTENSION_NAME=${options.name}`,
+		'--env',
+		`PHP_VERSION_SHORT=${options.phpVersion}`,
+		'--env',
+		`ASYNC_MODE=${options.asyncMode}`,
+		'--env',
+		`ARTIFACT_FILENAME=${options.artifactFile}`,
+		'--env',
+		`OPTIMIZE=${options.optimize}`,
+		'--env',
+		`CONFIG_ARGS_COUNT=${options.configArgs.length}`,
+	];
+
+	if (options.extraCflags) {
+		runArgs.push('--env', `EXTRA_CFLAGS=${options.extraCflags}`);
+	}
+	if (options.extraLdflags) {
+		runArgs.push('--env', `EXTRA_LDFLAGS=${options.extraLdflags}`);
+	}
+
+	options.configArgs.forEach((arg, index) => {
+		runArgs.push('--env', `CONFIG_ARG_${index}=${arg}`);
+	});
+
+	runArgs.push(imageTag);
+
+	await runCommand('docker', runArgs, {
+		cwd: options.workspaceRoot,
+	});
+}
+
+function getExtensionImageTag(
+	options: Pick<DockerImageOptions, 'phpVersion' | 'asyncMode'>
+) {
+	const phpVersion = options.phpVersion.replaceAll('.', '-');
+	return `playground-php-wasm:compile-extension-php${phpVersion}-${options.asyncMode}`;
+}
+
+interface RunCommandOptions {
+	cwd?: string;
+	stdio?: 'inherit' | 'ignore';
+}
+
+async function runCommand(
+	command: string,
+	args: string[],
+	options: RunCommandOptions = {}
+): Promise<void> {
+	console.log(`Running ${command} ${args.join(' ')}`);
+	await new Promise<void>((resolve, reject) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			stdio: options.stdio ?? 'inherit',
+			env: process.env,
+		});
+		child.on('error', reject);
+		child.on('close', (code) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+			reject(new Error(`${command} exited with code ${code}`));
+		});
+	});
+}

--- a/packages/php-wasm/compile-extension/src/manifest.spec.ts
+++ b/packages/php-wasm/compile-extension/src/manifest.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { findExtensionArtifact, type ExtensionManifest } from './manifest';
 
 describe('findExtensionArtifact', () => {
-	it('selects the PHP and async-mode match', () => {
+	it('selects the PHP version match', () => {
 		const manifest: ExtensionManifest = {
 			name: 'example',
 			version: '0.1.0',

--- a/packages/php-wasm/compile-extension/src/manifest.spec.ts
+++ b/packages/php-wasm/compile-extension/src/manifest.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { findExtensionArtifact, type ExtensionManifest } from './manifest';
+
+describe('findExtensionArtifact', () => {
+	it('selects the PHP and async-mode match', () => {
+		const manifest: ExtensionManifest = {
+			name: 'example',
+			version: '0.1.0',
+			artifacts: [
+				{
+					phpVersion: '8.4',
+					asyncMode: 'jspi',
+					file: 'example-php8.4-jspi.so',
+					sha256: 'abc',
+				},
+			],
+		};
+
+		expect(findExtensionArtifact(manifest, '8.4', 'jspi')?.file).toBe(
+			'example-php8.4-jspi.so'
+		);
+		expect(findExtensionArtifact(manifest, '8.4', 'asyncify')).toBe(
+			undefined
+		);
+	});
+});

--- a/packages/php-wasm/compile-extension/src/manifest.spec.ts
+++ b/packages/php-wasm/compile-extension/src/manifest.spec.ts
@@ -10,18 +10,15 @@ describe('findExtensionArtifact', () => {
 			artifacts: [
 				{
 					phpVersion: '8.4',
-					asyncMode: 'jspi',
 					file: 'example-php8.4-jspi.so',
 					sha256: 'abc',
 				},
 			],
 		};
 
-		expect(findExtensionArtifact(manifest, '8.4', 'jspi')?.file).toBe(
+		expect(findExtensionArtifact(manifest, '8.4')?.file).toBe(
 			'example-php8.4-jspi.so'
 		);
-		expect(findExtensionArtifact(manifest, '8.4', 'asyncify')).toBe(
-			undefined
-		);
+		expect(findExtensionArtifact(manifest, '8.3')).toBe(undefined);
 	});
 });

--- a/packages/php-wasm/compile-extension/src/manifest.ts
+++ b/packages/php-wasm/compile-extension/src/manifest.ts
@@ -1,0 +1,81 @@
+import { createHash } from 'node:crypto';
+import { createReadStream } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export type AsyncMode = 'jspi' | 'asyncify';
+
+export interface ExtensionArtifact {
+	phpVersion: string;
+	asyncMode: AsyncMode;
+	file: string;
+	sha256: string;
+}
+
+export interface ExtensionManifest {
+	name: string;
+	version: string;
+	artifacts: ExtensionArtifact[];
+}
+
+export interface BuiltArtifact {
+	phpVersion: string;
+	asyncMode: AsyncMode;
+	file: string;
+	path: string;
+}
+
+export async function sha256File(filePath: string): Promise<string> {
+	const hash = createHash('sha256');
+	await new Promise<void>((resolve, reject) => {
+		const stream = createReadStream(filePath);
+		stream.on('data', (chunk) => hash.update(chunk));
+		stream.on('error', reject);
+		stream.on('end', resolve);
+	});
+	return hash.digest('hex');
+}
+
+export async function createManifest(options: {
+	name: string;
+	version: string;
+	artifacts: BuiltArtifact[];
+}): Promise<ExtensionManifest> {
+	return {
+		name: options.name,
+		version: options.version,
+		artifacts: await Promise.all(
+			options.artifacts.map(async (artifact) => ({
+				phpVersion: artifact.phpVersion,
+				asyncMode: artifact.asyncMode,
+				file: artifact.file,
+				sha256: await sha256File(artifact.path),
+			}))
+		),
+	};
+}
+
+export async function writeManifest(options: {
+	outDir: string;
+	manifest: ExtensionManifest;
+}): Promise<string> {
+	await mkdir(options.outDir, { recursive: true });
+	const manifestPath = path.join(options.outDir, 'manifest.json');
+	await writeFile(
+		manifestPath,
+		`${JSON.stringify(options.manifest, null, 2)}\n`
+	);
+	return manifestPath;
+}
+
+export function findExtensionArtifact(
+	manifest: ExtensionManifest,
+	phpVersion: string,
+	asyncMode: AsyncMode
+): ExtensionArtifact | undefined {
+	return manifest.artifacts.find(
+		(artifact) =>
+			artifact.phpVersion === phpVersion &&
+			artifact.asyncMode === asyncMode
+	);
+}

--- a/packages/php-wasm/compile-extension/src/manifest.ts
+++ b/packages/php-wasm/compile-extension/src/manifest.ts
@@ -3,11 +3,11 @@ import { createReadStream } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-export type AsyncMode = 'jspi' | 'asyncify';
+export const ExtensionAsyncMode = 'jspi';
+export type AsyncMode = typeof ExtensionAsyncMode;
 
 export interface ExtensionArtifact {
 	phpVersion: string;
-	asyncMode: AsyncMode;
 	file: string;
 	sha256: string;
 }
@@ -20,7 +20,6 @@ export interface ExtensionManifest {
 
 export interface BuiltArtifact {
 	phpVersion: string;
-	asyncMode: AsyncMode;
 	file: string;
 	path: string;
 }
@@ -47,7 +46,6 @@ export async function createManifest(options: {
 		artifacts: await Promise.all(
 			options.artifacts.map(async (artifact) => ({
 				phpVersion: artifact.phpVersion,
-				asyncMode: artifact.asyncMode,
 				file: artifact.file,
 				sha256: await sha256File(artifact.path),
 			}))
@@ -70,12 +68,9 @@ export async function writeManifest(options: {
 
 export function findExtensionArtifact(
 	manifest: ExtensionManifest,
-	phpVersion: string,
-	asyncMode: AsyncMode
+	phpVersion: string
 ): ExtensionArtifact | undefined {
 	return manifest.artifacts.find(
-		(artifact) =>
-			artifact.phpVersion === phpVersion &&
-			artifact.asyncMode === asyncMode
+		(artifact) => artifact.phpVersion === phpVersion
 	);
 }

--- a/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe/config.m4
+++ b/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe/config.m4
@@ -1,0 +1,7 @@
+PHP_ARG_ENABLE([external_lib_probe], [whether to enable external_lib_probe],
+	[AS_HELP_STRING([--enable-external_lib_probe], [Enable external_lib_probe])],
+	[no])
+
+if test "$PHP_EXTERNAL_LIB_PROBE" != "no"; then
+	PHP_NEW_EXTENSION([external_lib_probe], [external_lib_probe.c], [$ext_shared])
+fi

--- a/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe/external_lib_probe.c
+++ b/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe/external_lib_probe.c
@@ -1,0 +1,51 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include <string_score.h>
+
+PHP_FUNCTION(external_lib_probe_score)
+{
+	zend_string *input;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(input)
+	ZEND_PARSE_PARAMETERS_END();
+
+	RETURN_LONG(
+		(zend_long) string_score_weighted_sum(
+			ZSTR_VAL(input),
+			ZSTR_LEN(input)
+		)
+	);
+}
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_external_lib_probe_score, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry external_lib_probe_functions[] = {
+	PHP_FE(external_lib_probe_score, arginfo_external_lib_probe_score)
+	PHP_FE_END
+};
+
+zend_module_entry external_lib_probe_module_entry = {
+	STANDARD_MODULE_HEADER,
+	"external_lib_probe",
+	external_lib_probe_functions,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	"0.1.0",
+	STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_EXTERNAL_LIB_PROBE
+#ifdef ZTS
+ZEND_TSRMLS_CACHE_DEFINE()
+#endif
+ZEND_GET_MODULE(external_lib_probe)
+#endif

--- a/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe/vendor/string-score/string_score.c
+++ b/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe/vendor/string-score/string_score.c
@@ -1,0 +1,12 @@
+#include "string_score.h"
+
+uint32_t string_score_weighted_sum(const char *input, size_t length)
+{
+	uint32_t score = 0;
+
+	for (size_t i = 0; i < length; i++) {
+		score += ((uint32_t) (unsigned char) input[i]) * (uint32_t) (i + 1);
+	}
+
+	return score;
+}

--- a/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe/vendor/string-score/string_score.h
+++ b/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe/vendor/string-score/string_score.h
@@ -1,0 +1,9 @@
+#ifndef STRING_SCORE_H
+#define STRING_SCORE_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+uint32_t string_score_weighted_sum(const char *input, size_t length);
+
+#endif

--- a/packages/php-wasm/compile-extension/tests/fixtures/hello/config.m4
+++ b/packages/php-wasm/compile-extension/tests/fixtures/hello/config.m4
@@ -1,0 +1,7 @@
+PHP_ARG_ENABLE([playground_hello], [whether to enable playground_hello],
+	[AS_HELP_STRING([--enable-playground_hello], [Enable playground_hello])],
+	[no])
+
+if test "$PHP_PLAYGROUND_HELLO" != "no"; then
+	PHP_NEW_EXTENSION([playground_hello], [playground_hello.c], [$ext_shared])
+fi

--- a/packages/php-wasm/compile-extension/tests/fixtures/hello/playground_hello.c
+++ b/packages/php-wasm/compile-extension/tests/fixtures/hello/playground_hello.c
@@ -1,0 +1,38 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+
+PHP_FUNCTION(playground_hello_greet)
+{
+	RETURN_STRING("hello from php-wasm");
+}
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_playground_hello_greet, 0, 0, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry playground_hello_functions[] = {
+	PHP_FE(playground_hello_greet, arginfo_playground_hello_greet)
+	PHP_FE_END
+};
+
+zend_module_entry playground_hello_module_entry = {
+	STANDARD_MODULE_HEADER,
+	"playground_hello",
+	playground_hello_functions,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	"0.1.0",
+	STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_PLAYGROUND_HELLO
+#ifdef ZTS
+ZEND_TSRMLS_CACHE_DEFINE()
+#endif
+ZEND_GET_MODULE(playground_hello)
+#endif

--- a/packages/php-wasm/compile-extension/tests/fixtures/zlib-probe/config.m4
+++ b/packages/php-wasm/compile-extension/tests/fixtures/zlib-probe/config.m4
@@ -1,0 +1,7 @@
+PHP_ARG_ENABLE([zlib_probe], [whether to enable zlib_probe],
+	[AS_HELP_STRING([--enable-zlib_probe], [Enable zlib_probe])],
+	[no])
+
+if test "$PHP_ZLIB_PROBE" != "no"; then
+	PHP_NEW_EXTENSION([zlib_probe], [zlib_probe.c], [$ext_shared])
+fi

--- a/packages/php-wasm/compile-extension/tests/fixtures/zlib-probe/zlib_probe.c
+++ b/packages/php-wasm/compile-extension/tests/fixtures/zlib-probe/zlib_probe.c
@@ -1,0 +1,78 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "php.h"
+#include <zlib.h>
+
+PHP_FUNCTION(zlib_probe_roundtrip)
+{
+	zend_string *input;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(input)
+	ZEND_PARSE_PARAMETERS_END();
+
+	uLong source_length = (uLong) ZSTR_LEN(input);
+	uLong compressed_length = compressBound(source_length);
+	Bytef *compressed = emalloc(compressed_length);
+
+	int status = compress2(
+		compressed,
+		&compressed_length,
+		(const Bytef *) ZSTR_VAL(input),
+		source_length,
+		Z_BEST_SPEED
+	);
+	if (status != Z_OK) {
+		efree(compressed);
+		RETURN_FALSE;
+	}
+
+	zend_string *output = zend_string_alloc(ZSTR_LEN(input), 0);
+	uLong output_length = source_length;
+	status = uncompress(
+		(Bytef *) ZSTR_VAL(output),
+		&output_length,
+		compressed,
+		compressed_length
+	);
+	efree(compressed);
+
+	if (status != Z_OK || output_length != source_length) {
+		zend_string_release(output);
+		RETURN_FALSE;
+	}
+
+	ZSTR_VAL(output)[output_length] = '\0';
+	RETURN_STR(output);
+}
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_zlib_probe_roundtrip, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+static const zend_function_entry zlib_probe_functions[] = {
+	PHP_FE(zlib_probe_roundtrip, arginfo_zlib_probe_roundtrip)
+	PHP_FE_END
+};
+
+zend_module_entry zlib_probe_module_entry = {
+	STANDARD_MODULE_HEADER,
+	"zlib_probe",
+	zlib_probe_functions,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	"0.1.0",
+	STANDARD_MODULE_PROPERTIES
+};
+
+#ifdef COMPILE_DL_ZLIB_PROBE
+#ifdef ZTS
+ZEND_TSRMLS_CACHE_DEFINE()
+#endif
+ZEND_GET_MODULE(zlib_probe)
+#endif

--- a/packages/php-wasm/compile-extension/tests/load-built-extension.mjs
+++ b/packages/php-wasm/compile-extension/tests/load-built-extension.mjs
@@ -1,16 +1,12 @@
 import { loadNodeRuntime } from '@php-wasm/node';
 import { PHP } from '@php-wasm/universal';
 
-const [manifestPath, phpVersion, asyncMode, code, expectedOutput] =
-	process.argv.slice(2);
+const [manifestPath, phpVersion, code, expectedOutput] = process.argv.slice(2);
 
-if (!manifestPath || !phpVersion || !asyncMode || !code) {
+if (!manifestPath || !phpVersion || !code) {
 	throw new Error(
-		'Usage: load-built-extension.mjs <manifest> <php-version> <async-mode> <php-code> <expected-output>'
+		'Usage: load-built-extension.mjs <manifest> <php-version> <php-code> <expected-output>'
 	);
-}
-if (asyncMode !== 'jspi' && asyncMode !== 'asyncify') {
-	throw new Error(`Unsupported async mode: ${asyncMode}`);
 }
 
 const php = new PHP(

--- a/packages/php-wasm/compile-extension/tests/load-built-extension.mjs
+++ b/packages/php-wasm/compile-extension/tests/load-built-extension.mjs
@@ -1,0 +1,43 @@
+import { loadNodeRuntime } from '@php-wasm/node';
+import { PHP } from '@php-wasm/universal';
+
+const [manifestPath, phpVersion, asyncMode, code, expectedOutput] =
+	process.argv.slice(2);
+
+if (!manifestPath || !phpVersion || !asyncMode || !code) {
+	throw new Error(
+		'Usage: load-built-extension.mjs <manifest> <php-version> <async-mode> <php-code> <expected-output>'
+	);
+}
+if (asyncMode !== 'jspi' && asyncMode !== 'asyncify') {
+	throw new Error(`Unsupported async mode: ${asyncMode}`);
+}
+
+const php = new PHP(
+	await loadNodeRuntime(phpVersion, {
+		emscriptenOptions: { processId: 1 },
+		extensions: [
+			{
+				source: {
+					format: 'manifest',
+					manifestUrl: manifestPath,
+				},
+			},
+		],
+	})
+);
+try {
+	const result = await php.run({ code });
+	if (result.errors) {
+		throw new Error(result.errors);
+	}
+	if (result.text !== expectedOutput) {
+		throw new Error(
+			`Expected ${JSON.stringify(expectedOutput)}, got ${JSON.stringify(
+				result.text
+			)}`
+		);
+	}
+} finally {
+	php.exit();
+}

--- a/packages/php-wasm/compile-extension/tests/run-integration-tests.sh
+++ b/packages/php-wasm/compile-extension/tests/run-integration-tests.sh
@@ -12,10 +12,13 @@ if ! command -v docker >/dev/null 2>&1; then
 	exit 1
 fi
 
-if [ "$ASYNC_MODE" = "jspi" ]; then
-	NODE_JSPI_FLAGS=(--experimental-wasm-jspi)
-	node "${NODE_JSPI_FLAGS[@]}" -e "import('wasm-feature-detect').then(async ({ jspi }) => { if (!(await jspi())) process.exit(1); })"
+if [ "$ASYNC_MODE" != "jspi" ]; then
+	echo "Unsupported ASYNC_MODE: ${ASYNC_MODE}." >&2
+	echo "Custom extensions are JSPI-only." >&2
+	exit 1
 fi
+NODE_JSPI_FLAGS=(--experimental-wasm-jspi)
+node "${NODE_JSPI_FLAGS[@]}" -e "import('wasm-feature-detect').then(async ({ jspi }) => { if (!(await jspi())) process.exit(1); })"
 
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
@@ -46,7 +49,6 @@ extension_image_tag() {
 compile_extension() {
 	"${COMPILE_EXTENSION[@]}" \
 		--php-versions "$PHP_VERSION" \
-		--async-modes "$ASYNC_MODE" \
 		--jobs 1 \
 		"$@"
 }
@@ -58,7 +60,6 @@ verify_extension() {
 	"${VERIFY_EXTENSION[@]}" \
 		"$manifest_path" \
 		"$PHP_VERSION" \
-		"$ASYNC_MODE" \
 		"$php_code" \
 		"$expected_output"
 }
@@ -104,22 +105,20 @@ verify_extension \
 	"hello from php-wasm"
 echo "::endgroup::"
 
-if [ "$ASYNC_MODE" = "jspi" ]; then
-	echo "::group::Build and load Redis extension"
-	REDIS_SOURCE="$WORK_DIR/phpredis"
-	prepare_redis_source "$REDIS_SOURCE"
-	compile_extension \
-		--source "$REDIS_SOURCE" \
-		--name redis \
-		--out "$WORK_DIR/redis" \
-		--extra-cflags "-Dsetsockopt=wasm_setsockopt -Dusleep=__wrap_usleep" \
-		--config-args "--disable-redis-session --disable-redis-json --disable-redis-igbinary --disable-redis-msgpack --disable-redis-lzf --disable-redis-zstd --disable-redis-lz4"
-	verify_extension \
-		"$WORK_DIR/redis/manifest.json" \
-		"<?php echo class_exists('Redis') ? get_class(new Redis()) : 'missing';" \
-		"Redis"
-	echo "::endgroup::"
-fi
+echo "::group::Build and load Redis extension"
+REDIS_SOURCE="$WORK_DIR/phpredis"
+prepare_redis_source "$REDIS_SOURCE"
+compile_extension \
+	--source "$REDIS_SOURCE" \
+	--name redis \
+	--out "$WORK_DIR/redis" \
+	--extra-cflags "-Dsetsockopt=wasm_setsockopt -Dusleep=__wrap_usleep" \
+	--config-args "--disable-redis-session --disable-redis-json --disable-redis-igbinary --disable-redis-msgpack --disable-redis-lzf --disable-redis-zstd --disable-redis-lz4"
+verify_extension \
+	"$WORK_DIR/redis/manifest.json" \
+	"<?php echo class_exists('Redis') ? get_class(new Redis()) : 'missing';" \
+	"Redis"
+echo "::endgroup::"
 
 # Some PECL extensions import PHP main-module data globals that are not yet
 # exported in a side-module-compatible shape. ext/calendar is still a real

--- a/packages/php-wasm/compile-extension/tests/run-integration-tests.sh
+++ b/packages/php-wasm/compile-extension/tests/run-integration-tests.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+PHP_VERSION="${PHP_VERSION:-8.4}"
+ASYNC_MODE="${ASYNC_MODE:-jspi}"
+WORK_DIR="${ROOT_DIR}/tmp/compile-extension-integration"
+NODE_JSPI_FLAGS=()
+
+if ! command -v docker >/dev/null 2>&1; then
+	echo "Docker is required for compile-extension integration tests." >&2
+	exit 1
+fi
+
+if [ "$ASYNC_MODE" = "jspi" ]; then
+	NODE_JSPI_FLAGS=(--experimental-wasm-jspi)
+	node "${NODE_JSPI_FLAGS[@]}" -e "import('wasm-feature-detect').then(async ({ jspi }) => { if (!(await jspi())) process.exit(1); })"
+fi
+
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+NODE_TS=(
+	node
+	"${NODE_JSPI_FLAGS[@]}"
+	--experimental-strip-types
+	--experimental-transform-types
+	--disable-warning=ExperimentalWarning
+	--import "${ROOT_DIR}/packages/meta/src/node-es-module-loader/register.mts"
+)
+COMPILE_EXTENSION=(
+	"${NODE_TS[@]}"
+	"${ROOT_DIR}/packages/php-wasm/compile-extension/src/cli.ts"
+)
+VERIFY_EXTENSION=(
+	"${NODE_TS[@]}"
+	"${ROOT_DIR}/packages/php-wasm/compile-extension/tests/load-built-extension.mjs"
+)
+
+extension_image_tag() {
+	local php_version_tag="${PHP_VERSION//./-}"
+	echo "playground-php-wasm:compile-extension-php${php_version_tag}-${ASYNC_MODE}"
+}
+
+compile_extension() {
+	"${COMPILE_EXTENSION[@]}" \
+		--php-versions "$PHP_VERSION" \
+		--async-modes "$ASYNC_MODE" \
+		--jobs 1 \
+		"$@"
+}
+
+verify_extension() {
+	local manifest_path="$1"
+	local php_code="$2"
+	local expected_output="$3"
+	"${VERIFY_EXTENSION[@]}" \
+		"$manifest_path" \
+		"$PHP_VERSION" \
+		"$ASYNC_MODE" \
+		"$php_code" \
+		"$expected_output"
+}
+
+build_string_score_dependency() {
+	local source_dir="$1"
+	docker run --rm \
+		--entrypoint bash \
+		-v "${source_dir}:/src" \
+		"$(extension_image_tag)" \
+		-lc '
+			set -euo pipefail
+			source /root/emsdk/emsdk_env.sh
+			cd /src/vendor/string-score
+			mkdir -p build install/include install/lib
+			emcc -D__x86_64__ -fPIC -O2 -c string_score.c -o build/string_score.o
+			emar rcs install/lib/libstring_score.a build/string_score.o
+			emranlib install/lib/libstring_score.a
+			cp string_score.h install/include/
+			chmod -R a+rwX /src/vendor/string-score
+		'
+}
+
+prepare_redis_source() {
+	local source_dir="$1"
+	git clone https://github.com/phpredis/phpredis.git "$source_dir" \
+		--branch 6.3.0 \
+		--single-branch \
+		--depth 1
+	# WASM32 `long` is 4 bytes, but Playground builds PHP with 64-bit
+	# `zend_long`. phpredis uses this variadic call in command formatting.
+	perl -pi -e 's/va_arg\(ap, long\)/va_arg(ap, zend_long)/g' "$source_dir/library.c"
+}
+
+echo "::group::Build and load simple extension"
+compile_extension \
+	--source packages/php-wasm/compile-extension/tests/fixtures/hello \
+	--name playground_hello \
+	--out "$WORK_DIR/hello"
+verify_extension \
+	"$WORK_DIR/hello/manifest.json" \
+	"<?php echo playground_hello_greet();" \
+	"hello from php-wasm"
+echo "::endgroup::"
+
+if [ "$ASYNC_MODE" = "jspi" ]; then
+	echo "::group::Build and load Redis extension"
+	REDIS_SOURCE="$WORK_DIR/phpredis"
+	prepare_redis_source "$REDIS_SOURCE"
+	compile_extension \
+		--source "$REDIS_SOURCE" \
+		--name redis \
+		--out "$WORK_DIR/redis" \
+		--extra-cflags "-Dsetsockopt=wasm_setsockopt -Dusleep=__wrap_usleep" \
+		--config-args "--disable-redis-session --disable-redis-json --disable-redis-igbinary --disable-redis-msgpack --disable-redis-lzf --disable-redis-zstd --disable-redis-lz4"
+	verify_extension \
+		"$WORK_DIR/redis/manifest.json" \
+		"<?php echo class_exists('Redis') ? get_class(new Redis()) : 'missing';" \
+		"Redis"
+	echo "::endgroup::"
+fi
+
+# Some PECL extensions import PHP main-module data globals that are not yet
+# exported in a side-module-compatible shape. ext/calendar is still a real
+# multi-file phpize extension and gives this helper a non-trivial load test.
+echo "::group::Build and load php-src ext/calendar"
+git clone https://github.com/php/php-src.git "$WORK_DIR/php-src" \
+	--branch php-8.4.20 \
+	--single-branch \
+	--depth 1 \
+	--filter=blob:none \
+	--sparse
+git -C "$WORK_DIR/php-src" sparse-checkout set ext/calendar
+compile_extension \
+	--source "$WORK_DIR/php-src/ext/calendar" \
+	--name calendar \
+	--out "$WORK_DIR/calendar"
+verify_extension \
+	"$WORK_DIR/calendar/manifest.json" \
+	"<?php echo cal_days_in_month(CAL_GREGORIAN, 2, 2024);" \
+	"29"
+echo "::endgroup::"
+
+echo "::group::Build and load zlib-backed extension"
+make -C "$ROOT_DIR/packages/php-wasm/compile" "libz_${ASYNC_MODE}"
+DEPS_ROOT="/php-wasm-compile"
+LIBZ_PREFIX="${DEPS_ROOT}/libz/${ASYNC_MODE}/dist/root/lib"
+compile_extension \
+	--source packages/php-wasm/compile-extension/tests/fixtures/zlib-probe \
+	--name zlib_probe \
+	--out "$WORK_DIR/zlib-probe" \
+	--extra-cflags "-I${LIBZ_PREFIX}/include" \
+	--extra-ldflags "${LIBZ_PREFIX}/lib/libz.a"
+verify_extension \
+	"$WORK_DIR/zlib-probe/manifest.json" \
+	"<?php echo zlib_probe_roundtrip('dependency backed extension');" \
+	"dependency backed extension"
+echo "::endgroup::"
+
+echo "::group::Build and load extension backed by non-Playground library"
+EXTERNAL_SOURCE="$WORK_DIR/external-lib-probe"
+cp -R \
+	"$ROOT_DIR/packages/php-wasm/compile-extension/tests/fixtures/external-lib-probe" \
+	"$EXTERNAL_SOURCE"
+build_string_score_dependency "$EXTERNAL_SOURCE"
+compile_extension \
+	--source "$EXTERNAL_SOURCE" \
+	--name external_lib_probe \
+	--out "$WORK_DIR/external-lib-probe-dist" \
+	--extra-cflags "-I/build/vendor/string-score/install/include" \
+	--extra-ldflags "/build/vendor/string-score/install/lib/libstring_score.a"
+verify_extension \
+	"$WORK_DIR/external-lib-probe-dist/manifest.json" \
+	"<?php echo external_lib_probe_score('wasm');" \
+	"1094"
+echo "::endgroup::"

--- a/packages/php-wasm/compile-extension/tsconfig.json
+++ b/packages/php-wasm/compile-extension/tsconfig.json
@@ -1,0 +1,23 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"module": "ESNext",
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"types": ["vitest"]
+	},
+	"files": [],
+	"include": [],
+	"references": [
+		{
+			"path": "./tsconfig.lib.json"
+		},
+		{
+			"path": "./tsconfig.spec.json"
+		}
+	]
+}

--- a/packages/php-wasm/compile-extension/tsconfig.lib.json
+++ b/packages/php-wasm/compile-extension/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"types": ["node"]
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.spec.ts", "src/**/*.test.ts"]
+}

--- a/packages/php-wasm/compile-extension/tsconfig.spec.json
+++ b/packages/php-wasm/compile-extension/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"module": "ESNext",
+		"types": ["vitest", "node"]
+	},
+	"include": ["src/**/*.spec.ts", "src/**/*.test.ts", "src/**/*.ts"]
+}

--- a/packages/php-wasm/compile-extension/vite.config.ts
+++ b/packages/php-wasm/compile-extension/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
 				'yargs',
 				'yargs/helpers',
 			],
-			input: 'packages/php-wasm/compile-extension/src/cli.ts',
+			input: join(__dirname, 'src/cli.ts'),
 			output: {
 				format: 'esm',
 				entryFileNames: 'cli.js',

--- a/packages/php-wasm/compile-extension/vite.config.ts
+++ b/packages/php-wasm/compile-extension/vite.config.ts
@@ -1,0 +1,62 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vite';
+import dts from 'vite-plugin-dts';
+import { join } from 'path';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import viteGlobalExtensions from '../../vite-extensions/vite-global-extensions';
+
+export default defineConfig({
+	root: __dirname,
+	cacheDir: '../../../node_modules/.vite/php-wasm-compile-extension',
+	plugins: [
+		dts({
+			entryRoot: 'src',
+			tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+			pathsToAliases: false,
+		}),
+		nxViteTsPaths(),
+		...viteGlobalExtensions,
+	],
+	build: {
+		target: 'es2021',
+		sourcemap: true,
+		rollupOptions: {
+			external: [
+				'child_process',
+				'crypto',
+				'fs',
+				'fs/promises',
+				'node:child_process',
+				'node:crypto',
+				'node:fs',
+				'node:fs/promises',
+				'node:os',
+				'node:path',
+				'node:url',
+				'os',
+				'path',
+				'url',
+				'yargs',
+				'yargs/helpers',
+			],
+			input: 'packages/php-wasm/compile-extension/src/cli.ts',
+			output: {
+				format: 'esm',
+				entryFileNames: 'cli.js',
+			},
+		},
+	},
+	test: {
+		globals: true,
+		cache: {
+			dir: '../../../node_modules/.vitest',
+		},
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+		reporters: ['default'],
+	},
+	define: {
+		'process.env': 'process.env',
+	},
+});

--- a/packages/php-wasm/compile/base-image/Dockerfile
+++ b/packages/php-wasm/compile/base-image/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /root
 RUN mkdir lib
 
 RUN set -euxo pipefail;\
+    export DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC; \
     apt-get update; \
     apt-get --no-install-recommends -y install \
     build-essential \
@@ -52,9 +53,20 @@ RUN set -euxo pipefail;\
 # https://github.com/emscripten-core/emscripten/commit/4d16f757adcc801fb3f990ccb6100b747c815650
 #
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN git clone https://github.com/emscripten-core/emsdk.git && \
-    ./emsdk/emsdk install 4.0.19 && \
-    /root/emsdk/emsdk activate 4.0.19
+RUN <<EOF
+    set -euxo pipefail
+    git clone https://github.com/emscripten-core/emsdk.git
+    for attempt in 1 2 3; do
+        if EMSDK_NOTTY=1 EMSDK_USE_CURL=1 ./emsdk/emsdk install --notty 4.0.19; then
+            break
+        fi
+        if [ "$attempt" = "3" ]; then
+            exit 1
+        fi
+        sleep $((attempt * 10))
+    done
+    EMSDK_NOTTY=1 /root/emsdk/emsdk activate --notty 4.0.19
+EOF
 
 RUN mkdir -p /root/lib/lib /root/lib/include /root/lib/share /root/lib/bin
 

--- a/packages/php-wasm/compile/base-image/Dockerfile
+++ b/packages/php-wasm/compile/base-image/Dockerfile
@@ -53,8 +53,7 @@ RUN set -euxo pipefail;\
 # https://github.com/emscripten-core/emscripten/commit/4d16f757adcc801fb3f990ccb6100b747c815650
 #
 RUN ln -s /usr/bin/python3 /usr/bin/python
-RUN <<EOF
-    set -euxo pipefail
+RUN bash -euxo pipefail <<'EOF'
     git clone https://github.com/emscripten-core/emsdk.git
     EMSDK_NOTTY=1 EMSDK_USE_CURL=1 ./emsdk/emsdk install --notty 4.0.19
     EMSDK_NOTTY=1 /root/emsdk/emsdk activate --notty 4.0.19

--- a/packages/php-wasm/compile/base-image/Dockerfile
+++ b/packages/php-wasm/compile/base-image/Dockerfile
@@ -56,15 +56,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 RUN <<EOF
     set -euxo pipefail
     git clone https://github.com/emscripten-core/emsdk.git
-    for attempt in 1 2 3; do
-        if EMSDK_NOTTY=1 EMSDK_USE_CURL=1 ./emsdk/emsdk install --notty 4.0.19; then
-            break
-        fi
-        if [ "$attempt" = "3" ]; then
-            exit 1
-        fi
-        sleep $((attempt * 10))
-    done
+    EMSDK_NOTTY=1 EMSDK_USE_CURL=1 ./emsdk/emsdk install --notty 4.0.19
     EMSDK_NOTTY=1 /root/emsdk/emsdk activate --notty 4.0.19
 EOF
 

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -296,66 +296,48 @@ for (const { wp, php } of MATRIX) {
 		});
 
 		// --- Phase 1: Front page ---
-		// Retry a front-page timeout once. On shared CI runners the first
-		// Vite worker request can occasionally race the dev server's cold
-		// transform and fail before WordPress boots, while a fresh navigation
-		// succeeds. Real PHP/page errors still fail immediately.
-		let wp1 = null;
-		for (let attempt = 0; attempt < 2; attempt++) {
-			if (attempt > 0) {
-				consoleErrors.length = 0;
-				await page.goto(url, {
-					timeout: 180_000,
-					waitUntil: 'domcontentloaded',
-				});
-			}
-			wp1 = await waitForWPFrame(page, TIMEOUT_S);
+		const wp1 = await waitForWPFrame(page, TIMEOUT_S);
 
-			if (!wp1) {
-				const lastError = consoleErrors[consoleErrors.length - 1] || '';
+		if (!wp1) {
+			const lastError = consoleErrors[consoleErrors.length - 1] || '';
+			frontStatus = {
+				status: 'TIMEOUT',
+				detail: lastError,
+			};
+		} else {
+			const error = findPHPError(wp1.body);
+			if (error) {
 				frontStatus = {
-					status: 'TIMEOUT',
-					detail: lastError,
+					status: 'ERROR',
+					detail: error,
+					body: wp1.body,
 				};
 			} else {
-				const error = findPHPError(wp1.body);
-				if (error) {
+				const hasHelloWorld =
+					wp1.body.includes('Hello world') ||
+					wp1.body.includes('Hello World');
+				const hasWP =
+					wp1.body.includes('WordPress') ||
+					wp1.body.includes('My WordPress') ||
+					wp1.body.includes('My Weblog');
+
+				if (hasHelloWorld) {
+					frontStatus = { status: 'OK' };
+				} else if (wp1.body.includes('Not Found') && !hasHelloWorld) {
+					frontStatus = { status: 'NOT_FOUND', body: wp1.body };
+				} else if (hasWP) {
 					frontStatus = {
-						status: 'ERROR',
-						detail: error,
-						body: wp1.body,
+						status: 'PARTIAL',
+						detail: wp1.body.slice(0, 120).replace(/\n/g, ' '),
 					};
 				} else {
-					const hasHelloWorld =
-						wp1.body.includes('Hello world') ||
-						wp1.body.includes('Hello World');
-					const hasWP =
-						wp1.body.includes('WordPress') ||
-						wp1.body.includes('My WordPress') ||
-						wp1.body.includes('My Weblog');
-
-					if (hasHelloWorld) {
-						frontStatus = { status: 'OK' };
-					} else if (
-						wp1.body.includes('Not Found') &&
-						!hasHelloWorld
-					) {
-						frontStatus = { status: 'NOT_FOUND', body: wp1.body };
-					} else if (hasWP) {
-						frontStatus = {
-							status: 'PARTIAL',
-							detail: wp1.body.slice(0, 120).replace(/\n/g, ' '),
-						};
-					} else {
-						frontStatus = {
-							status: 'UNKNOWN',
-							detail: wp1.body.slice(0, 120).replace(/\n/g, ' '),
-							body: wp1.body,
-						};
-					}
+					frontStatus = {
+						status: 'UNKNOWN',
+						detail: wp1.body.slice(0, 120).replace(/\n/g, ' '),
+						body: wp1.body,
+					};
 				}
 			}
-			if (frontStatus.status !== 'TIMEOUT') break;
 		}
 
 		// --- Phase 2: View single post (click "Hello world!") ---

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -296,48 +296,66 @@ for (const { wp, php } of MATRIX) {
 		});
 
 		// --- Phase 1: Front page ---
-		const wp1 = await waitForWPFrame(page, TIMEOUT_S);
+		// Retry a front-page timeout once. On shared CI runners the first
+		// Vite worker request can occasionally race the dev server's cold
+		// transform and fail before WordPress boots, while a fresh navigation
+		// succeeds. Real PHP/page errors still fail immediately.
+		let wp1 = null;
+		for (let attempt = 0; attempt < 2; attempt++) {
+			if (attempt > 0) {
+				consoleErrors.length = 0;
+				await page.goto(url, {
+					timeout: 180_000,
+					waitUntil: 'domcontentloaded',
+				});
+			}
+			wp1 = await waitForWPFrame(page, TIMEOUT_S);
 
-		if (!wp1) {
-			const lastError = consoleErrors[consoleErrors.length - 1] || '';
-			frontStatus = {
-				status: 'TIMEOUT',
-				detail: lastError,
-			};
-		} else {
-			const error = findPHPError(wp1.body);
-			if (error) {
+			if (!wp1) {
+				const lastError = consoleErrors[consoleErrors.length - 1] || '';
 				frontStatus = {
-					status: 'ERROR',
-					detail: error,
-					body: wp1.body,
+					status: 'TIMEOUT',
+					detail: lastError,
 				};
 			} else {
-				const hasHelloWorld =
-					wp1.body.includes('Hello world') ||
-					wp1.body.includes('Hello World');
-				const hasWP =
-					wp1.body.includes('WordPress') ||
-					wp1.body.includes('My WordPress') ||
-					wp1.body.includes('My Weblog');
-
-				if (hasHelloWorld) {
-					frontStatus = { status: 'OK' };
-				} else if (wp1.body.includes('Not Found') && !hasHelloWorld) {
-					frontStatus = { status: 'NOT_FOUND', body: wp1.body };
-				} else if (hasWP) {
+				const error = findPHPError(wp1.body);
+				if (error) {
 					frontStatus = {
-						status: 'PARTIAL',
-						detail: wp1.body.slice(0, 120).replace(/\n/g, ' '),
-					};
-				} else {
-					frontStatus = {
-						status: 'UNKNOWN',
-						detail: wp1.body.slice(0, 120).replace(/\n/g, ' '),
+						status: 'ERROR',
+						detail: error,
 						body: wp1.body,
 					};
+				} else {
+					const hasHelloWorld =
+						wp1.body.includes('Hello world') ||
+						wp1.body.includes('Hello World');
+					const hasWP =
+						wp1.body.includes('WordPress') ||
+						wp1.body.includes('My WordPress') ||
+						wp1.body.includes('My Weblog');
+
+					if (hasHelloWorld) {
+						frontStatus = { status: 'OK' };
+					} else if (
+						wp1.body.includes('Not Found') &&
+						!hasHelloWorld
+					) {
+						frontStatus = { status: 'NOT_FOUND', body: wp1.body };
+					} else if (hasWP) {
+						frontStatus = {
+							status: 'PARTIAL',
+							detail: wp1.body.slice(0, 120).replace(/\n/g, ' '),
+						};
+					} else {
+						frontStatus = {
+							status: 'UNKNOWN',
+							detail: wp1.body.slice(0, 120).replace(/\n/g, ' '),
+							body: wp1.body,
+						};
+					}
 				}
 			}
+			if (frontStatus.status !== 'TIMEOUT') break;
 		}
 
 		// --- Phase 2: View single post (click "Hello world!") ---

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,6 +19,9 @@
 		"paths": {
 			"@php-wasm/cli": ["packages/php-wasm/cli/src/main.ts"],
 			"@php-wasm/cli-util": ["packages/php-wasm/cli-util/src/index.ts"],
+			"@php-wasm/compile-extension": [
+				"packages/php-wasm/compile-extension/src/cli.ts"
+			],
 			"@php-wasm/fs-journal": [
 				"packages/php-wasm/fs-journal/src/index.ts"
 			],


### PR DESCRIPTION
## What it does

Adds `@php-wasm/compile-extension`, a Docker-backed helper for compiling
`phpize` extension source directories into PHP.wasm JSPI side modules.

Developers can now build a custom extension, publish the generated `.so` files
and `manifest.json`, and load them at startup through the `extensions` API.

For example, given a `wp_mysql_parser` extension with a normal `config.m4`:

```bash
npx @php-wasm/compile-extension \
	--source ./wp-mysql-parser \
	--name wp_mysql_parser \
	--php-versions 8.4 \
	--out ./dist/wp_mysql_parser
```

The output is directly loadable by PHP.wasm:

```text
dist/wp_mysql_parser/
|-- manifest.json
`-- wp_mysql_parser-php8.4-jspi.so
```

```ts
import { PHP } from '@php-wasm/universal';
import { loadNodeRuntime } from '@php-wasm/node';

const php = new PHP(
	await loadNodeRuntime('8.4', {
		extensions: [
			{
				source: {
					format: 'manifest',
					manifestUrl: './dist/wp_mysql_parser/manifest.json',
				},
			},
		],
	})
);
```

Rust extensions are supported through the same workflow when the Rust crate is
wrapped as a `phpize` extension:

```bash
RUSTFLAGS="-C panic=abort" cargo +nightly build \
	--release \
	--target wasm32-unknown-emscripten \
	-Zbuild-std=std,panic_abort

npx @php-wasm/compile-extension \
	--source ./my-rust-extension \
	--name my_rust_extension \
	--php-versions 8.4 \
	--extra-ldflags "/build/target/wasm32-unknown-emscripten/release/libmy_rust_extension.a"
```

Rust-specific caveats:

- The final extension still needs a tiny `config.m4` + C shim that exposes the
  PHP module entry and calls Rust over C ABI.
- Custom extension builds are **JSPI-only**. Link JSPI-compatible dependency
  archives and load the result in a JSPI runtime.
- Pass Rust `staticlib` archives through `--extra-ldflags`, not
  `PHP_ADD_LIBRARY_WITH_PATH`.
- `bindgen` needs the PHP.wasm target/sysroot/Zend defines; the helper exports
  `BINDGEN_EXTRA_CLANG_ARGS` for builds run inside the container.
- `cc-rs` needs `-fPIC` for side modules; the helper exports target-specific
  `CFLAGS_wasm32_unknown_emscripten` and `CXXFLAGS_wasm32_unknown_emscripten`.
- Rust `std` must be rebuilt with `panic=abort`; the precompiled
  `wasm32-unknown-emscripten` `std` imports unwinding support PHP.wasm does not
  provide.

## Rationale

Custom extensions should be a real developer workflow, not just a runtime API.
This PR gives developers a documented path from extension source code to
loadable PHP.wasm artifacts, including manifest metadata and `sha256` hashes.

This supersedes #3567 and retargets the work to `trunk`. The docs and examples
match the recent `.so` loading changes: startup-time loading via `extensions`,
PHP-version manifest selection, direct URLs, and generated `.ini` files instead
of post-startup `dl()` or older Blueprint-oriented APIs.

## Implementation

- Adds the `@php-wasm/compile-extension` CLI, Docker build flow, manifest
  generation, and artifact selection helpers.
- Builds custom extensions for JSPI runtimes only. The CLI no longer exposes an
  `--async-modes` matrix, and generated manifests no longer include
  `asyncMode`.
- Documents static archive linking, Rust `staticlib` wrappers, vendored
  libraries, CMake/Make dependencies, and common WebAssembly linking failures.
- Adds unit tests, Docker integration fixtures, and CI coverage for the helper.

## Testing instructions

```bash
npm exec nx test php-wasm-compile-extension
npm exec nx run php-wasm-compile-extension:typecheck
npm exec nx run php-wasm-compile-extension:lint
npm exec nx run php-wasm-compile-extension:build
npm exec nx run docs-site:check-orphan-pages
bash -n packages/php-wasm/compile-extension/scripts/build-in-docker.sh packages/php-wasm/compile-extension/tests/run-integration-tests.sh
git diff --check
PATH="$HOME/.nvm/versions/node/v24.14.0/bin:$PATH" npm exec nx run php-wasm-compile-extension:test-compile-extension-integration
```

The Docker integration needs a Node build with JSPI support; Node 22 reports
JSPI unavailable locally, while Node 24 matches the PR CI job.
