### PR TITLE
[Networking] Set curl.cainfo alongside openssl.cafile

### DIFF
--- a/packages/docs/site/docs/main/changelog.md
+++ b/packages/docs/site/docs/main/changelog.md
@@ -79,7 +79,7 @@ The following contributors merged PRs in this release:
 ### Website
 
 - Embeddable PHP code snippets via &lt;php-snippet&gt;. ([#3528](https://github.com/WordPress/wordpress-playground/pull/3528))
-- &lt;php-snippet&gt; setup blueprints via <template>. ([#3536](https://github.com/WordPress/wordpress-playground/pull/3536))
+- &lt;php-snippet&gt; setup blueprints via &lt;template&gt;. ([#3536](https://github.com/WordPress/wordpress-playground/pull/3536))
 - &lt;php-snippet&gt; – display expected output by default. ([#3557](https://github.com/WordPress/wordpress-playground/pull/3557))
 - Accept encodeURIComponent-produced blueprint URL fragments. ([#3527](https://github.com/WordPress/wordpress-playground/pull/3527))
 - Add AI discoverability: Llms.txt, meta tags, documentation section. ([#3534](https://github.com/WordPress/wordpress-playground/pull/3534))

--- a/packages/php-wasm/cli/src/main.ts
+++ b/packages/php-wasm/cli/src/main.ts
@@ -39,7 +39,12 @@ const caBundlePath = new URL('ca-bundle.crt', baseUrl).pathname;
 if (!existsSync(caBundlePath)) {
 	writeFileSync(caBundlePath, rootCertificates.join('\n'));
 }
-args.unshift('-d', `openssl.cafile=${caBundlePath}`);
+args.unshift(
+	'-d',
+	`openssl.cafile=${caBundlePath}`,
+	'-d',
+	`curl.cainfo=${caBundlePath}`
+);
 
 async function run() {
 	const defaultPhpIniPath = new URL('php.ini', baseUrl).pathname;

--- a/packages/php-wasm/cli/tests/curl_test.php
+++ b/packages/php-wasm/cli/tests/curl_test.php
@@ -1,0 +1,26 @@
+<?php
+// Verifies that curl can verify HTTPS peers using the CA bundle that
+// php-wasm-cli installs via the `curl.cainfo` ini entry.
+
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, 'https://api.wordpress.org/stats/php/1.0/');
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_TCP_NODELAY, 0);
+$result = curl_exec($ch);
+$error = curl_error($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+if ($result === false || $code !== 200) {
+    echo "curl test failed! HTTP code: $code, error: $error\n";
+    exit(1);
+}
+
+$json = json_decode($result, true);
+if (!is_array($json) || !array_key_exists('8.3', $json)) {
+    echo "curl test failed! Unexpected response body: " . substr((string) $result, 0, 200) . "\n";
+    exit(1);
+}
+
+echo "curl test passed!\n";
+exit(0);

--- a/packages/php-wasm/cli/tests/smoke-test.sh
+++ b/packages/php-wasm/cli/tests/smoke-test.sh
@@ -19,10 +19,23 @@ output=$(npx nx dev php-wasm-cli -- packages/php-wasm/cli/tests/proc_open_test.p
 # Assert that the output contains the expected success message
 if echo "$output" | grep -q "proc_open test passed!"; then
     echo "Assertion passed: proc_open test output contains expected success message"
-    echo "php-wasm-cli smoke test completed!"
 else
     echo "Assertion failed: Expected output to contain 'proc_open test passed!'"
     echo "Actual output:"
     echo "$output"
+    exit 1
+fi
+
+echo "Running php-wasm-cli smoke test with curl over HTTPS..."
+
+curl_output=$(npx nx dev php-wasm-cli -- packages/php-wasm/cli/tests/curl_test.php 2>&1)
+
+if echo "$curl_output" | grep -q "curl test passed!"; then
+    echo "Assertion passed: curl test output contains expected success message"
+    echo "php-wasm-cli smoke test completed!"
+else
+    echo "Assertion failed: Expected output to contain 'curl test passed!'"
+    echo "Actual output:"
+    echo "$curl_output"
     exit 1
 fi

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -27,7 +27,8 @@
  * class as follows:
  *
  * 1. We generate a self-signed CA certificate and tell PHP to trust it using the
- *    `openssl.cafile` PHP.ini option
+ *    `openssl.cafile` and `curl.cainfo` PHP.ini options (so both PHP streams
+ *    and libcurl validate the MITM cert against the same CA bundle)
  * 2. We create a domain-specific child certificate and sign it with the CA private key.
  * 3. We start accepting raw encrypted bytes, process them as structured TLS records,
  *    and perform the TLS handshake.

--- a/packages/php-wasm/web/src/test/php-networking.spec.ts
+++ b/packages/php-wasm/web/src/test/php-networking.spec.ts
@@ -128,6 +128,63 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 		test.expect(parsed.bodyStart).toBe(longText.slice(0, 50));
 	});
 
+	test('PHP curl can verify HTTPS peers via the curl.cainfo CA bundle', async ({
+		page,
+	}) => {
+		const result = await page.evaluate(async () => {
+			const CAroot = await window.generateCertificate({
+				subject: {
+					commonName: 'TestCA',
+					organizationName: 'Test',
+					countryName: 'US',
+				},
+				basicConstraints: { ca: true },
+			});
+
+			const php = new window.PHP(
+				await window.loadWebRuntime('8.4', {
+					tcpOverFetch: { CAroot },
+				})
+			);
+
+			const caBundlePath = '/internal/shared/ca-bundle.crt';
+			php.mkdir('/internal/shared');
+			php.writeFile(caBundlePath, window.certificateToPEM(CAroot.certificate));
+
+			await window.setPhpIniEntries(php, {
+				allow_url_fopen: '1',
+				disable_functions: '',
+				'openssl.cafile': caBundlePath,
+				'curl.cainfo': caBundlePath,
+			});
+
+			const response = await php.runStream({
+				code: `<?php
+					$ch = curl_init('https://api.wordpress.org/stats/php/1.0/');
+					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+					$body = curl_exec($ch);
+					$error = curl_error($ch);
+					$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+					curl_close($ch);
+					$json = json_decode($body, true);
+					echo json_encode([
+						'code' => $code,
+						'error' => $error,
+						'has83' => is_array($json) && array_key_exists('8.3', $json),
+					]);
+				`,
+			});
+			const text = await response.stdoutText;
+			php.exit();
+			return text;
+		});
+
+		const parsed = JSON.parse(result);
+		test.expect(parsed.code).toBe(200);
+		test.expect(parsed.error).toBe('');
+		test.expect(parsed.has83).toBe(true);
+	});
+
 	test('PHP curl receives decompressed body for brotli-compressed response', async ({
 		page,
 	}) => {

--- a/packages/php-wasm/web/src/test/playwright/browser-globals.ts
+++ b/packages/php-wasm/web/src/test/playwright/browser-globals.ts
@@ -4,7 +4,11 @@ import {
 	proxyFileSystem,
 	setPhpIniEntries,
 } from '@php-wasm/universal';
-import { generateCertificate, loadWebRuntime } from '../../lib';
+import {
+	certificateToPEM,
+	generateCertificate,
+	loadWebRuntime,
+} from '../../lib';
 
 declare global {
 	interface Window {
@@ -14,6 +18,7 @@ declare global {
 		proxyFileSystem: typeof proxyFileSystem;
 		setPhpIniEntries: typeof setPhpIniEntries;
 		generateCertificate: typeof generateCertificate;
+		certificateToPEM: typeof certificateToPEM;
 	}
 }
 
@@ -23,3 +28,4 @@ window.loadWebRuntime = loadWebRuntime;
 window.proxyFileSystem = proxyFileSystem;
 window.setPhpIniEntries = setPhpIniEntries;
 window.generateCertificate = generateCertificate;
+window.certificateToPEM = certificateToPEM;

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -131,6 +131,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 				},
 				phpIniEntries: {
 					'openssl.cafile': '/internal/shared/ca-bundle.crt',
+					'curl.cainfo': '/internal/shared/ca-bundle.crt',
 					allow_url_fopen: '1',
 					disable_functions: '',
 				},

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -229,6 +229,7 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 
 		await setPhpIniEntries(php, {
 			'openssl.cafile': '/internal/shared/ca-bundle.crt',
+			'curl.cainfo': '/internal/shared/ca-bundle.crt',
 			allow_url_fopen: '1',
 			disable_functions: '',
 		});

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -163,6 +163,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 	}) {
 		const phpIniEntries: Record<string, string> = {
 			'openssl.cafile': '/internal/shared/ca-bundle.crt',
+			'curl.cainfo': '/internal/shared/ca-bundle.crt',
 		};
 
 		let tcpOverFetch: TCPOverFetchOptions | undefined = undefined;


### PR DESCRIPTION
PHP's `openssl.cafile` only governs OpenSSL streams (`fopen`, `file_get_contents` over HTTPS). libcurl reads its CA bundle from `curl.cainfo`. We were configuring the former in every entry point but not the latter, so `curl_exec()` against HTTPS URLs fell back to whatever bundle libcurl happened to be compiled with — on the WASM build, that's nothing useful.

This wires `curl.cainfo` to the same `ca-bundle.crt` we already write for OpenSSL in php-wasm-cli, the remote iframe, and both Blueprints v1 and v2 CLI workers.

## Tests

- **Web**: new HTTPS curl test in `packages/php-wasm/web/src/test/php-networking.spec.ts` that writes the tcp-over-fetch CA to `/internal/shared/ca-bundle.crt`, sets both ini entries, and curls `https://api.wordpress.org/stats/php/1.0/`.
- **CLI**: new `curl_test.php` smoke test that curls the same HTTPS endpoint via `npx nx dev php-wasm-cli`.