### PR TITLE
[codex] Fix php-snippet wp none execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ The following contributors merged PRs in this release:
 ### Website
 
 - Embeddable PHP code snippets via &lt;php-snippet&gt;. ([#3528](https://github.com/WordPress/wordpress-playground/pull/3528))
-- &lt;php-snippet&gt; setup blueprints via <template>. ([#3536](https://github.com/WordPress/wordpress-playground/pull/3536))
+- &lt;php-snippet&gt; setup blueprints via &lt;template&gt;. ([#3536](https://github.com/WordPress/wordpress-playground/pull/3536))
 - &lt;php-snippet&gt; – display expected output by default. ([#3557](https://github.com/WordPress/wordpress-playground/pull/3557))
 - Accept encodeURIComponent-produced blueprint URL fragments. ([#3527](https://github.com/WordPress/wordpress-playground/pull/3527))
 - Add AI discoverability: Llms.txt, meta tags, documentation section. ([#3534](https://github.com/WordPress/wordpress-playground/pull/3534))

--- a/packages/docs/site/docs/main/changelog.md
+++ b/packages/docs/site/docs/main/changelog.md
@@ -79,7 +79,7 @@ The following contributors merged PRs in this release:
 ### Website
 
 - Embeddable PHP code snippets via &lt;php-snippet&gt;. ([#3528](https://github.com/WordPress/wordpress-playground/pull/3528))
-- &lt;php-snippet&gt; setup blueprints via <template>. ([#3536](https://github.com/WordPress/wordpress-playground/pull/3536))
+- &lt;php-snippet&gt; setup blueprints via &lt;template&gt;. ([#3536](https://github.com/WordPress/wordpress-playground/pull/3536))
 - &lt;php-snippet&gt; – display expected output by default. ([#3557](https://github.com/WordPress/wordpress-playground/pull/3557))
 - Accept encodeURIComponent-produced blueprint URL fragments. ([#3527](https://github.com/WordPress/wordpress-playground/pull/3527))
 - Add AI discoverability: Llms.txt, meta tags, documentation section. ([#3534](https://github.com/WordPress/wordpress-playground/pull/3534))

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -120,7 +120,11 @@ export class BlueprintsV1Handler {
 		 */
 		const wpMajor = parseFloat(runtimeConfiguration.wpVersion);
 		const isLegacyWpVersion = Number.isFinite(wpMajor) && wpMajor < 5.1;
-		if (runtimeConfiguration.networking && !isLegacyWpVersion) {
+		if (
+			installWordPress &&
+			runtimeConfiguration.networking &&
+			!isLegacyWpVersion
+		) {
 			await playground.prefetchUpdateChecks();
 		}
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
@@ -33,6 +33,7 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 		let endpoint:
 			| {
 					boot(options: Record<string, unknown>): Promise<void>;
+					run(request: Record<string, unknown>): Promise<unknown>;
 			  }
 			| undefined;
 		vi.doMock('@wp-playground/wordpress', () => ({
@@ -78,6 +79,53 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 		});
 
 		expect(mountOpfsIntoPhp).toHaveBeenCalledWith(php, mount);
+	}, 10000);
+
+	it('runs code on the primary PHP runtime when WordPress is skipped', async () => {
+		const run = vi.fn(async () => ({ text: 'ok' }));
+		const php = { run } as unknown as PHP;
+		const requestHandler = {
+			getPrimaryPhp: vi.fn(async () => php),
+		};
+		let endpoint:
+			| {
+					boot(options: Record<string, unknown>): Promise<void>;
+					run(request: Record<string, unknown>): Promise<unknown>;
+			  }
+			| undefined;
+		vi.doMock('@wp-playground/wordpress', () => ({
+			bootWordPress: vi.fn(),
+		}));
+		vi.doMock('@php-wasm/web', () => ({
+			certificateToPEM: vi.fn(),
+			createDirectoryHandleMountHandler: vi.fn(),
+			exposeAPI: vi.fn((api) => {
+				endpoint = api;
+				return [vi.fn(), vi.fn()];
+			}),
+			loadWebRuntime: vi.fn(),
+		}));
+		await import('./playground-worker-endpoint-blueprints-v1');
+		if (!endpoint) {
+			throw new Error('Expected exposeAPI to receive an endpoint');
+		}
+		vi.spyOn(endpoint as any, 'computeSiteUrl').mockReturnValue(
+			'http://playground.test'
+		);
+		vi.spyOn(endpoint as any, 'createRequestHandler').mockResolvedValue(
+			requestHandler
+		);
+
+		await endpoint.boot({
+			scope: 'test',
+			phpVersion: '8.3',
+			shouldInstallWordPress: false,
+			withNetworking: false,
+		});
+		const response = await endpoint.run({ code: '<?php echo "ok";' });
+
+		expect(response).toEqual({ text: 'ok' });
+		expect(run).toHaveBeenCalledWith({ code: '<?php echo "ok";' });
 	}, 10000);
 
 	it('throws a diagnostic error if the worker entrypoint is evaluated twice in the same worker global', async () => {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -160,6 +160,8 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			// OPFS mounts and stop, so the caller gets a usable PHP runtime.
 			if (!shouldInstallWordPress) {
 				const primaryPhp = await requestHandler.getPrimaryPhp();
+				await this.setPrimaryPHP(primaryPhp);
+				this.enablePlainPhpRunMode();
 				for (const mount of mounts) {
 					await endpoint.mountOpfsIntoPhp(primaryPhp, mount);
 				}

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -35,6 +35,7 @@ import type {
 	PathAlias,
 	PHP,
 	PHPRequestHandler,
+	PHPRunOptions,
 } from '@php-wasm/universal';
 import {
 	isLegacyPHPVersion,
@@ -123,6 +124,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 
 	private networkTransport: WordPressFetchNetworkTransport | undefined;
 	private requestHandler: PHPRequestHandler | undefined;
+	private runAsPlainPhp = false;
 
 	protected downloadMonitor: EmscriptenDownloadMonitor;
 	protected memoizedFetch: ReturnType<typeof createMemoizedFetch>;
@@ -419,6 +421,10 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 
 	// NOTE: Version-specific boot methods are implemented in the concrete worker entrypoints
 
+	protected enablePlainPhpRunMode() {
+		this.runAsPlainPhp = true;
+	}
+
 	/**
 	 * @returns WordPress module details, including the static assets directory and default theme.
 	 */
@@ -430,6 +436,17 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				? wpVersionToStaticAssetsDirectory(this.loadedWordPressVersion)
 				: undefined,
 		};
+	}
+
+	override async run(request: PHPRunOptions): Promise<PHPResponse> {
+		if (!this.runAsPlainPhp) {
+			return await super.run(request);
+		}
+		const php = this.__internal_getPHP();
+		if (!php) {
+			throw new Error('Playground worker is not connected to PHP.');
+		}
+		return await php.run(request);
 	}
 
 	async getMinifiedWordPressVersions() {

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -66,6 +66,41 @@ test.describe('php-code-snippet embed', () => {
 		).toHaveCount(0);
 	});
 
+	test('wp=none runs plain PHP without loading WordPress', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		await page.evaluate(() => {
+			const snippet = document.createElement('php-snippet');
+			snippet.setAttribute('name', 'plain-ok.php');
+			snippet.setAttribute('wp', 'none');
+
+			const script = document.createElement('script');
+			script.type = 'application/x-php';
+			script.textContent = `<?php
+echo "ok\\n";
+$loaded = file_exists('/wordpress/wp-load.php') ? 'yes' : 'no';
+echo "wp-load:$loaded\\n";
+`;
+			snippet.append(script);
+			document.body.append(snippet);
+		});
+
+		const snippet = page.locator('php-snippet[name="plain-ok.php"]');
+		await expect(snippet.locator('.run')).toBeVisible();
+		await snippet.locator('.run').click();
+		await expect(snippet.locator('.output')).toBeVisible({
+			timeout: 240_000,
+		});
+		await expect(snippet.locator('.output-body')).toContainText('ok');
+		await expect(snippet.locator('.output-body')).toContainText(
+			'wp-load:no'
+		);
+		await expect(snippet.locator('.output-body')).not.toContainText(
+			'/wordpress/wp-load.php'
+		);
+	});
+
 	test('first Run boots the runtime and shows progress + output', async ({
 		page,
 	}) => {

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -74,6 +74,7 @@ test.describe('php-code-snippet embed', () => {
 			const snippet = document.createElement('php-snippet');
 			snippet.setAttribute('name', 'plain-ok.php');
 			snippet.setAttribute('wp', 'none');
+			snippet.setAttribute('playground-origin', window.location.origin);
 
 			const script = document.createElement('script');
 			script.type = 'application/x-php';


### PR DESCRIPTION
## What it does

Fixes `client.run({ code })` for runtimes booted with `preferredVersions.wp: false`, which is what `<php-snippet wp="none">` uses.

The PHP-only worker path now runs snippets on the primary PHP runtime instead of sending them through the WordPress request-handler pool. That keeps plain PHP snippets from picking up the WordPress bootstrap path that requires `/wordpress/wp-load.php`.

The client boot path also skips WordPress update prefetching when `preferredVersions.wp: false`, because that prefetch helper requires `/wordpress/wp-load.php` by design.

## Rationale

`wp="none"` promises a PHP runtime without WordPress. The runtime boot path already skipped the WordPress download/install, but `run({ code })` still used the request-handler execution path and failed on `/wordpress/wp-load.php`.

The first CI run also exposed an existing docs build issue: a changelog entry used raw `<template>` in MDX. This PR escapes that tag so the docs API reference job can build.

## Implementation

Adds a plain-PHP run mode to the Playground worker endpoint and enables it when the Blueprints v1 boot path receives `shouldInstallWordPress: false`.

Skips `prefetchUpdateChecks()` unless the runtime actually installed WordPress.

Adds regression coverage in two places:

- A worker endpoint unit test verifies that `run({ code })` delegates to the primary PHP runtime after a no-WordPress boot.
- A Playwright test appends a real `<php-snippet wp="none">`, clicks Run, and asserts the output contains `ok` and `wp-load:no`, without `/wordpress/wp-load.php`.

The Playwright test sets `playground-origin` to `window.location.origin` so CI tests this branch's local client/remote build rather than the hosted production runtime.

## Testing instructions

Run the focused checks:

```bash
npm exec nx test playground-remote -- --testFile=playground-worker-endpoint-blueprints-v1.spec.ts
npx playwright test --config=packages/playground/website/playwright/playwright.config.ts packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
```

Local Nx checks could not run in this checkout because `node_modules` is not installed; CI should run the repository checks on the PR.
