### PR TITLE
[Docs] Treat docs changelog as CommonMark

### DIFF
--- a/packages/docs/site/bin/refresh-changelog.ts
+++ b/packages/docs/site/bin/refresh-changelog.ts
@@ -14,9 +14,8 @@ const existingFrontmatter = existingContent.match(frontmatterRegex)?.[0] || '';
 // Docusaurus 3 parses `.md` files through the MDX pipeline, so unescaped
 // `{` / `}` in PR titles (e.g. `@php-wasm/{web,node}-5-2`) get read as JSX
 // expressions and crash the SSG with `ReferenceError: web is not defined`.
-// The destination file's frontmatter sets `format: md` as a hint, but that
-// alone has not been enough in practice — escape the braces directly so the
-// content is inert regardless of how Docusaurus parses it.
+// The destination file opts into CommonMark via `mdx.format: md`, but also
+// escape braces so the content stays inert if Docusaurus parses it as MDX.
 const escapedChangelog = changelog.replace(/[{}]/g, (c) => '\\' + c);
 const changelogWithFrontmatter =
 	existingFrontmatter + '\n\n' + escapedChangelog;

--- a/packages/docs/site/docs/main/changelog.md
+++ b/packages/docs/site/docs/main/changelog.md
@@ -1,7 +1,9 @@
 ---
 title: Changelog
 slug: /changelog
-format: md
+hide_table_of_contents: true
+mdx:
+  format: md
 ---
 
 # Changelog


### PR DESCRIPTION
## What it does

Treats the generated docs changelog as plain Markdown instead of MDX. The changelog now uses Docusaurus' `mdx.format: md` frontmatter and hides the table of contents for that generated page.

## Rationale

Docusaurus 3 parses `.md` files as MDX unless told otherwise. That made changelog text like `<template>` compile as JSX and fail the docs build:

```text
Expected a closing tag for `<template>`
```

Switching the changelog page to CommonMark keeps release notes inert, which is what we want for generated changelog content.

## Implementation

Changed the changelog frontmatter from the ineffective top-level `format: md` to:

```yaml
hide_table_of_contents: true
mdx:
  format: md
```

`hide_table_of_contents` avoids a Docusaurus 3.9.2 SSG crash where the theme assumes a `toc` array exists for docs pages. I also updated the changelog refresh script comment so future maintainers see the correct `mdx.format: md` setting.

## Testing instructions

Run:

```bash
PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npm run build:docs
```

The docs build completes successfully. It still prints existing broken-anchor warnings unrelated to this changelog issue.
