### PR TITLE
[PHP] Limit external extensions to JSPI

### DIFF
--- a/packages/docs/site/docs/developers/05-local-development/03-php-wasm-node.md
+++ b/packages/docs/site/docs/developers/05-local-development/03-php-wasm-node.md
@@ -45,7 +45,7 @@ const php = new PHP(
 );
 ```
 
-The same array can load external `.so` artifacts from a manifest:
+The same array can load external JSPI `.so` artifacts from a manifest:
 
 ```javascript
 const php = new PHP(
@@ -61,6 +61,9 @@ const php = new PHP(
 	})
 );
 ```
+
+External extensions require JSPI. Asyncify support is limited to the bundled
+extensions shipped with the PHP.wasm packages.
 
 See [Loading PHP extensions](/developers/apis/javascript-api/php-extensions)
 for manifest format, browser usage, sidecar files, and compatibility notes.

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/07-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/07-php-extensions.md
@@ -48,7 +48,7 @@ because it also supports external extensions.
 ## External extensions
 
 An external extension needs a WebAssembly `.so` built for the same PHP version
-and async mode as the PHP.wasm runtime. Publish the artifact with a manifest:
+as the PHP.wasm JSPI runtime. Publish the artifact with a manifest:
 
 ```json
 {
@@ -57,7 +57,6 @@ and async mode as the PHP.wasm runtime. Publish the artifact with a manifest:
 	"artifacts": [
 		{
 			"phpVersion": "8.4",
-			"asyncMode": "jspi",
 			"file": "wp_mysql_parser-php8.4-jspi.so",
 			"sha256": "..."
 		}
@@ -91,6 +90,10 @@ const php = new PHP(
 
 Node.js applies the same local-path support to direct artifact URLs and inline
 manifest `baseUrl` values.
+
+External extensions are only supported when JSPI is available. Asyncify support
+is limited to the bundled extensions shipped with the PHP.wasm packages, such
+as `intl`, `xdebug`, `redis`, and `memcached`.
 
 In the browser, pass an absolute URL or construct one with the base URL you want:
 

--- a/packages/php-wasm/node/README.md
+++ b/packages/php-wasm/node/README.md
@@ -41,7 +41,7 @@ const php = new PHP(
 ```
 
 `@php-wasm/node` ships `intl`, `xdebug`, `redis`, and `memcached`. It can also
-load external `.so` artifacts from a manifest:
+load external JSPI `.so` artifacts from a manifest:
 
 ```js
 const php = new PHP(
@@ -62,6 +62,10 @@ In Node.js, `manifestUrl` may be a local path, a `file:` URL, or an HTTP(S)
 URL. Relative local paths are resolved from the current working directory.
 Relative artifact files in the manifest are resolved against the manifest
 location.
+
+External extensions are only supported when the Node.js runtime has JSPI
+available. Asyncify support is limited to the bundled extensions shipped with
+this package.
 
 The older `withIntl`, `withXdebug`, `withRedis`, and `withMemcached` loader
 options still work, but new code should use `extensions`.

--- a/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
+++ b/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
@@ -3,7 +3,6 @@ import type {
 	EmscriptenOptions,
 	PHPExtensionInstallOptions,
 	ResolvedPHPExtension,
-	PHPWasmAsyncMode,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
 import {
@@ -21,6 +20,8 @@ import {
 	fetchNodeExtensionResource,
 	normalizeNodeExtensionSource,
 } from './node-extension-resources';
+
+type PHPWasmAsyncMode = 'jspi' | 'asyncify';
 
 export interface PathMapping {
 	hostPath: string;
@@ -41,8 +42,8 @@ export type BuiltInPHPExtensionName = 'intl' | 'xdebug' | 'redis' | 'memcached';
 /**
  * External PHP extension source that can be installed before PHP starts.
  *
- * The runtime supplies the active PHP version and async mode before resolving
- * the source, so callers only provide the artifact source and install options.
+ * External sources are supported in JSPI runtimes only. Asyncify support is
+ * limited to bundled extensions shipped with this package.
  */
 export type RuntimePHPExtensionSource = PHPExtensionInstallOptions;
 
@@ -114,7 +115,8 @@ export async function withPHPExtensions(
  * 1. An external source supplied by the caller: bytes, a URL, or a manifest.
  *    Node normalizes local paths into `file:` URLs and uses
  *    `fetchNodeExtensionResource()` so local files and remote artifacts go
- *    through the same resolver.
+ *    through the same resolver. External sources are rejected for Asyncify
+ *    runtimes.
  * 2. A built-in extension name: `intl`, `redis`, `memcached`, or `xdebug`.
  *    The Node package already knows where those artifacts live and adds any
  *    extra startup state they require, such as ICU data for `intl` or Xdebug
@@ -137,11 +139,15 @@ async function resolveRuntimePHPExtension(
 	 * manifest, URL, or byte source as one of the bundled extensions.
 	 */
 	if (typeof extension === 'object' && 'source' in extension) {
+		if (asyncMode === 'asyncify') {
+			throw new Error(
+				'External PHP extensions require JSPI. Asyncify is only supported for PHP.wasm bundled extensions.'
+			);
+		}
 		return await resolvePHPExtension({
 			...extension,
 			source: normalizeNodeExtensionSource(extension.source),
 			phpVersion: version,
-			asyncMode,
 			fetch: extension.fetch ?? fetchNodeExtensionResource,
 		});
 	}
@@ -170,7 +176,6 @@ async function resolveRuntimePHPExtension(
 					bytes: soBytes,
 				},
 				phpVersion: version,
-				asyncMode,
 				env: {
 					ICU_DATA: '/internal/shared',
 				},
@@ -192,7 +197,6 @@ async function resolveRuntimePHPExtension(
 					bytes: new Uint8Array(fs.readFileSync(extensionPath)),
 				},
 				phpVersion: version,
-				asyncMode,
 			});
 		}
 		case 'memcached': {
@@ -204,7 +208,6 @@ async function resolveRuntimePHPExtension(
 					bytes: new Uint8Array(fs.readFileSync(extensionPath)),
 				},
 				phpVersion: version,
-				asyncMode,
 			});
 		}
 		case 'xdebug': {
@@ -219,7 +222,6 @@ async function resolveRuntimePHPExtension(
 					bytes: new Uint8Array(fs.readFileSync(filePath)),
 				},
 				phpVersion: version,
-				asyncMode,
 				loadWithIniDirective: 'zend_extension',
 				iniEntries: {
 					'xdebug.mode': 'debug,develop',

--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -33,7 +33,7 @@ export interface PHPLoaderOptions {
 	 * PHP extensions to install before the runtime starts.
 	 *
 	 * Use built-in names such as `intl`, `xdebug`, `redis`, and `memcached`,
-	 * or pass an external extension source such as a manifest.
+	 * or pass an external JSPI extension source such as a manifest.
 	 */
 	extensions?: PHPExtension[];
 	/**

--- a/packages/php-wasm/node/src/test/with-php-extensions.spec.ts
+++ b/packages/php-wasm/node/src/test/with-php-extensions.spec.ts
@@ -20,7 +20,6 @@ describe('withPHPExtensions', () => {
 					artifacts: [
 						{
 							phpVersion: '8.4',
-							asyncMode: 'jspi',
 							file: 'example.so',
 						},
 					],
@@ -49,6 +48,20 @@ describe('withPHPExtensions', () => {
 		} finally {
 			await rm(tempDir, { recursive: true, force: true });
 		}
+	});
+
+	it('rejects external extension sources for Asyncify runtimes', async () => {
+		await expect(
+			withPHPExtensions('8.4', 'asyncify', {}, [
+				{
+					name: 'example',
+					source: {
+						format: 'so',
+						bytes: new Uint8Array([1, 2, 3]),
+					},
+				},
+			])
+		).rejects.toThrow('External PHP extensions require JSPI');
 	});
 
 	it('treats drive-letter-shaped strings as local paths, not URL schemes', () => {

--- a/packages/php-wasm/universal/README.md
+++ b/packages/php-wasm/universal/README.md
@@ -10,8 +10,9 @@ staging primitives.
 
 ## PHP extension manifests
 
-External PHP extensions are loaded before PHP starts. A manifest lets a package
-publish one extension name with artifacts for the PHP and async-mode matrix:
+External PHP extensions are loaded before PHP starts. They are supported in
+JSPI runtimes only. A manifest lets a package publish one extension name with
+artifacts for the PHP version matrix:
 
 ```json
 {
@@ -20,7 +21,6 @@ publish one extension name with artifacts for the PHP and async-mode matrix:
 	"artifacts": [
 		{
 			"phpVersion": "8.4",
-			"asyncMode": "jspi",
 			"file": "wp_mysql_parser-php8.4-jspi.so",
 			"sha256": "..."
 		}
@@ -31,6 +31,9 @@ publish one extension name with artifacts for the PHP and async-mode matrix:
 `file` may be absolute, or relative to the manifest URL. If you pass an inline
 manifest instead of `manifestUrl`, pass `baseUrl` to choose where relative
 artifact files are resolved from.
+
+Asyncify extension loading is reserved for bundled extensions shipped with the
+PHP.wasm packages, such as `intl`, `xdebug`, `redis`, and `memcached`.
 
 ## Lower-level extension staging
 
@@ -44,7 +47,6 @@ import { resolvePHPExtension, withResolvedPHPExtensions } from '@php-wasm/univer
 
 const extension = await resolvePHPExtension({
 	phpVersion: '8.4',
-	asyncMode: 'jspi',
 	source: {
 		format: 'manifest',
 		manifestUrl: new URL('https://cdn.example.com/wp_mysql_parser/manifest.json'),
@@ -59,7 +61,6 @@ Direct bytes skip URL resolution:
 ```ts
 await resolvePHPExtension({
 	phpVersion: '8.4',
-	asyncMode: 'jspi',
 	name: 'wp_mysql_parser',
 	source: { format: 'so', bytes },
 });

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -111,7 +111,6 @@ export type {
 	PHPExtensionManifest,
 	PHPExtensionManifestArtifact,
 	PHPExtensionSource,
-	PHPWasmAsyncMode,
 	ResolvePHPExtensionOptions,
 } from './load-extension';
 

--- a/packages/php-wasm/universal/src/lib/load-extension.spec.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.spec.ts
@@ -11,7 +11,6 @@ describe('resolvePHPExtension', () => {
 				bytes: new Uint8Array([1, 2, 3]),
 			},
 			phpVersion: '8.4',
-			asyncMode: 'jspi',
 		});
 
 		expect(extension.soPath).toBe(`${PHP_EXTENSIONS_DIR}/example.so`);
@@ -28,7 +27,6 @@ describe('resolvePHPExtension', () => {
 				bytes: new Uint8Array([1, 2, 3]),
 			},
 			phpVersion: '8.4',
-			asyncMode: 'jspi',
 			loadWithIniDirective: 'zend_extension',
 		});
 
@@ -46,7 +44,6 @@ describe('resolvePHPExtension', () => {
 					bytes: new Uint8Array([1, 2, 3]),
 				},
 				phpVersion: '8.4',
-				asyncMode: 'jspi',
 			})
 		).rejects.toThrow('Invalid PHP extension name');
 	});
@@ -59,7 +56,6 @@ describe('resolvePHPExtension', () => {
 					url: './example.so',
 				},
 				phpVersion: '8.4',
-				asyncMode: 'jspi',
 				fetch: async () => new Response(new Uint8Array([1, 2, 3])),
 			})
 		).rejects.toThrow('source.url must be an absolute URL');
@@ -73,7 +69,6 @@ describe('resolvePHPExtension', () => {
 				manifestUrl: 'https://example.com/extensions/manifest.json',
 			},
 			phpVersion: '8.4',
-			asyncMode: 'asyncify',
 			fetch: async (url) => {
 				const requestUrl = String(url);
 				if (requestUrl.endsWith('/manifest.json')) {
@@ -83,13 +78,12 @@ describe('resolvePHPExtension', () => {
 						artifacts: [
 							{
 								phpVersion: '8.4',
-								asyncMode: 'asyncify',
-								file: 'example-php8.4-asyncify.so',
+								file: 'example-php8.4-jspi.so',
 							},
 						],
 					});
 				}
-				if (requestUrl.endsWith('/example-php8.4-asyncify.so')) {
+				if (requestUrl.endsWith('/example-php8.4-jspi.so')) {
 					return new Response(artifactBytes);
 				}
 				return new Response('Not found', { status: 404 });
@@ -97,5 +91,28 @@ describe('resolvePHPExtension', () => {
 		});
 
 		expect(extension.soBytes).toEqual(artifactBytes);
+	});
+
+	it('rejects asyncMode in external manifests', async () => {
+		await expect(
+			resolvePHPExtension({
+				source: {
+					format: 'manifest',
+					manifest: {
+						name: 'example',
+						artifacts: [
+							{
+								phpVersion: '8.4',
+								asyncMode: 'asyncify',
+								file: 'example-php8.4-asyncify.so',
+							},
+						],
+					} as any,
+					baseUrl: 'https://example.com/extensions/',
+				},
+				phpVersion: '8.4',
+				fetch: async () => new Response(new Uint8Array([1, 2, 3])),
+			})
+		).rejects.toThrow('Extension manifests do not use asyncMode');
 	});
 });

--- a/packages/php-wasm/universal/src/lib/load-extension.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.ts
@@ -47,7 +47,6 @@
  *   "artifacts": [
  *     {
  *       "phpVersion": "8.4",
- *       "asyncMode": "jspi",
  *       "file": "wp_mysql_parser-php8.4-jspi.so"
  *     }
  *   ]
@@ -72,14 +71,6 @@ import type { FileTree } from './write-files';
 export const PHP_EXTENSIONS_DIR = '/internal/shared/extensions';
 
 /**
- * Async mode used by the PHP.wasm build that will load the extension.
- *
- * Extension side modules must be compiled for the same mode as the main PHP
- * module.
- */
-export type PHPWasmAsyncMode = 'jspi' | 'asyncify';
-
-/**
  * The php.ini directive used to load the extension.
  *
  * Use `extension` for regular PHP extensions and `zend_extension` for Zend
@@ -97,11 +88,6 @@ export interface PHPExtensionManifestArtifact {
 	phpVersion: string;
 
 	/**
-	 * PHP.wasm async mode the artifact was compiled against.
-	 */
-	asyncMode: PHPWasmAsyncMode;
-
-	/**
 	 * Relative to the manifest URL/base URL, or an absolute URL.
 	 */
 	file: string;
@@ -117,7 +103,7 @@ export interface PHPExtensionManifestArtifact {
  *
  * A manifest lets callers publish a matrix of `.so` files and lets
  * `resolvePHPExtension()` select the artifact that matches the current PHP
- * version and async mode.
+ * version. External extension artifacts are JSPI-only.
  */
 export interface PHPExtensionManifest {
 	name: string;
@@ -258,7 +244,6 @@ export interface PHPExtensionInstallOptions {
  */
 export type ResolvePHPExtensionOptions = PHPExtensionInstallOptions & {
 	phpVersion: string;
-	asyncMode: PHPWasmAsyncMode;
 };
 
 /**
@@ -437,9 +422,10 @@ export function installPHPExtensionFilesSync(
  *
  * Direct byte sources are already available, URL sources are fetched as a
  * single artifact, and manifest sources first choose the artifact matching the
- * active PHP version and async mode. Manifests are validated here because they
- * may come from user-provided URLs and their `name`/`file` values later decide
- * what gets written into the PHP virtual filesystem.
+ * active PHP version. External extension artifacts are JSPI-only, so the
+ * manifest does not expose an async-mode selector. Manifests are validated
+ * here because they may come from user-provided URLs and their `name`/`file`
+ * values later decide what gets written into the PHP virtual filesystem.
  */
 async function resolvePHPExtensionSource(
 	options: ResolvePHPExtensionOptions,
@@ -536,11 +522,14 @@ async function resolvePHPExtensionSource(
 		if (
 			!artifact ||
 			typeof artifact.phpVersion !== 'string' ||
-			(artifact.asyncMode !== 'jspi' &&
-				artifact.asyncMode !== 'asyncify') ||
 			typeof artifact.file !== 'string'
 		) {
 			throw new Error('Extension manifest contains an invalid artifact.');
+		}
+		if ('asyncMode' in artifact) {
+			throw new Error(
+				'Extension manifests do not use asyncMode. External PHP extensions require JSPI.'
+			);
 		}
 	}
 	const baseUrl =
@@ -548,13 +537,11 @@ async function resolvePHPExtensionSource(
 			? new URL(String(source.baseUrl))
 			: manifestUrl;
 	const artifact = manifest.artifacts.find(
-		(candidate) =>
-			candidate.phpVersion === options.phpVersion &&
-			candidate.asyncMode === options.asyncMode
+		(candidate) => candidate.phpVersion === options.phpVersion
 	);
 	if (!artifact) {
 		throw new Error(
-			`No extension artifact found for PHP ${options.phpVersion} ${options.asyncMode}.`
+			`No extension artifact found for PHP ${options.phpVersion}.`
 		);
 	}
 	if (!baseUrl) {

--- a/packages/php-wasm/web/README.md
+++ b/packages/php-wasm/web/README.md
@@ -57,7 +57,7 @@ const php = new PHP(
 ```
 
 `@php-wasm/web` ships the `intl` extension. Browser builds can also load
-external `.so` artifacts from a manifest:
+external JSPI `.so` artifacts from a manifest:
 
 ```js
 const php = new PHP(
@@ -76,6 +76,9 @@ const php = new PHP(
 
 In browser runtimes, pass an HTTP(S) URL or a `URL` object. Relative artifact
 files in the manifest are resolved against the manifest URL.
+
+External extensions are only supported when JSPI is available. Asyncify support
+is limited to the bundled `intl` extension shipped with this package.
 
 ## Usage with bundlers
 

--- a/packages/php-wasm/web/src/lib/extensions/load-extensions.ts
+++ b/packages/php-wasm/web/src/lib/extensions/load-extensions.ts
@@ -3,7 +3,6 @@ import type {
 	EmscriptenOptions,
 	PHPExtensionInstallOptions,
 	ResolvedPHPExtension,
-	PHPWasmAsyncMode,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
 import {
@@ -11,6 +10,8 @@ import {
 	resolvePHPExtension,
 } from '@php-wasm/universal';
 import { getIntlExtensionModule } from './intl/get-intl-extension-module';
+
+type PHPWasmAsyncMode = 'jspi' | 'asyncify';
 
 /**
  * Built-in PHP extensions shipped with `@php-wasm/web`.
@@ -20,9 +21,8 @@ export type BuiltInPHPWebExtensionName = 'intl';
 /**
  * External PHP extension source that can be installed before PHP starts.
  *
- * The runtime supplies the active PHP version and async mode before
- * resolving the source, so callers only provide the artifact source and
- * install options.
+ * External sources are supported in JSPI runtimes only. Asyncify support is
+ * limited to bundled extensions shipped with this package.
  */
 export type RuntimePHPWebExtensionSource = PHPExtensionInstallOptions;
 
@@ -75,10 +75,10 @@ export async function withPHPExtensions(
  * Resolves one Web runtime extension request before PHP starts.
  *
  * Web has two extension sources. External extensions already describe their
- * own artifact source, so this passes the active PHP version and async mode to
- * the universal resolver. Built-in `intl` is different: its `.so` and ICU data
- * are bundled assets that must both be fetched and staged before PHP reads the
- * generated `intl.ini`.
+ * own artifact source, so this passes the active PHP version to the universal
+ * resolver after rejecting external Asyncify requests. Built-in `intl` is
+ * different: its `.so` and ICU data are bundled assets that must both be
+ * fetched and staged before PHP reads the generated `intl.ini`.
  */
 async function resolveRuntimePHPWebExtension(
 	version: SupportedPHPVersion,
@@ -93,10 +93,14 @@ async function resolveRuntimePHPWebExtension(
 	 * extension.
 	 */
 	if (typeof extension === 'object' && 'source' in extension) {
+		if (asyncMode === 'asyncify') {
+			throw new Error(
+				'External PHP extensions require JSPI. Asyncify is only supported for PHP.wasm bundled extensions.'
+			);
+		}
 		return await resolvePHPExtension({
 			...extension,
 			phpVersion: version,
-			asyncMode,
 		});
 	}
 
@@ -131,7 +135,6 @@ async function resolveRuntimePHPWebExtension(
 			bytes: new Uint8Array(extensionBytes),
 		},
 		phpVersion: version,
-		asyncMode,
 		env: {
 			ICU_DATA: '/internal/shared',
 		},

--- a/packages/php-wasm/web/src/lib/load-runtime.ts
+++ b/packages/php-wasm/web/src/lib/load-runtime.ts
@@ -25,8 +25,8 @@ export interface LoaderOptions {
 	/**
 	 * PHP extensions to install before the runtime starts.
 	 *
-	 * Use built-in names such as `intl`, or pass an external extension source
-	 * such as a manifest.
+	 * Use built-in names such as `intl`, or pass an external JSPI extension
+	 * source such as a manifest.
 	 */
 	extensions?: PHPWebExtension[];
 	/**


### PR DESCRIPTION
## What it does

Limits external PHP extension loading to JSPI runtimes in the extension API added by #3566:

```json
{
	"phpVersion": "8.4",
	"file": "extension-php8.4-jspi.so"
}
```

Bundled extensions shipped with the PHP.wasm packages still support Asyncify. `intl`, `xdebug`, `redis`, and `memcached` continue to use the artifact selected by their versioned packages.

## Rationale

External Asyncify side modules would require Playground to support and document an Asyncify artifact matrix for third-party extensions. That is a larger compatibility surface than #3566 needs.

Bundled extensions are different because their Asyncify artifacts are built, shipped, and tested with this repo.

## Implementation

`resolvePHPExtension()` no longer accepts `asyncMode`. External manifests select artifacts by `phpVersion` only and reject manifest entries that still include `asyncMode`.

Node and Web extension wrappers reject external extension sources when the runtime is using Asyncify. Bundled extension paths still go through the same staging resolver after their versioned packages choose the matching JSPI or Asyncify `.so`.

## Testing instructions

```bash
npm exec nx -- test php-wasm-universal --testFile=load-extension.spec.ts
npm exec nx -- run php-wasm-node:test-group-4-asyncify --testFiles=with-php-extensions.spec.ts
npm exec nx -- typecheck php-wasm-universal
npm exec nx -- typecheck php-wasm-node
npm exec nx -- typecheck php-wasm-web
npm exec nx -- lint php-wasm-universal
npm exec nx -- lint php-wasm-node
npm exec nx -- lint php-wasm-web
```
