### PR TITLE
[PHP] Don't call prefetchUpdateChecks() when WordPress is disabled

### DIFF
--- a/packages/playground/client/src/blueprints-v1-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.spec.ts
@@ -64,8 +64,9 @@ describe('BlueprintsV1Handler', () => {
 	});
 
 	it('does not prefetch WordPress updates for PHP-only blueprints', async () => {
+		const iframe = createIframe();
 		const handler = new BlueprintsV1Handler({
-			iframe: createIframe(),
+			iframe,
 			remoteUrl: 'http://example.com/remote.html',
 			blueprint: {
 				preferredVersions: {
@@ -75,7 +76,7 @@ describe('BlueprintsV1Handler', () => {
 			},
 		});
 
-		await handler.bootPlayground(createIframe(), createProgressTracker());
+		await handler.bootPlayground(iframe, createProgressTracker());
 
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -86,13 +87,14 @@ describe('BlueprintsV1Handler', () => {
 	});
 
 	it('prefetches WordPress updates when WordPress is installed', async () => {
+		const iframe = createIframe();
 		const handler = new BlueprintsV1Handler({
-			iframe: createIframe(),
+			iframe,
 			remoteUrl: 'http://example.com/remote.html',
 			blueprint: {},
 		});
 
-		await handler.bootPlayground(createIframe(), createProgressTracker());
+		await handler.bootPlayground(iframe, createProgressTracker());
 
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/packages/playground/client/src/blueprints-v1-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.spec.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProgressTracker } from '@php-wasm/progress';
+import { BlueprintsV1Handler } from './blueprints-v1-handler';
+
+const mocks = vi.hoisted(() => {
+	return {
+		playground: {
+			boot: vi.fn(),
+			isConnected: vi.fn(),
+			isReady: vi.fn(),
+			onDownloadProgress: vi.fn(),
+			prefetchUpdateChecks: vi.fn(),
+		},
+		compileBlueprintV1: vi.fn(),
+		isBlueprintBundle: vi.fn(),
+		runBlueprintV1Steps: vi.fn(),
+		resolveRuntimeConfiguration: vi.fn(),
+		createBlueprintReflection: vi.fn(),
+		consumeAPI: vi.fn(),
+		collectPhpLogs: vi.fn(),
+	};
+});
+
+vi.mock('@php-wasm/logger', () => ({
+	collectPhpLogs: mocks.collectPhpLogs,
+	logger: {},
+}));
+
+vi.mock('@php-wasm/universal', () => ({
+	consumeAPI: mocks.consumeAPI,
+}));
+
+vi.mock('.', () => ({
+	BlueprintReflection: {
+		create: mocks.createBlueprintReflection,
+	},
+	compileBlueprintV1: mocks.compileBlueprintV1,
+	isBlueprintBundle: mocks.isBlueprintBundle,
+	runBlueprintV1Steps: mocks.runBlueprintV1Steps,
+	resolveRuntimeConfiguration: mocks.resolveRuntimeConfiguration,
+}));
+
+describe('BlueprintsV1Handler', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.playground.boot.mockResolvedValue(undefined);
+		mocks.playground.isConnected.mockResolvedValue(undefined);
+		mocks.playground.isReady.mockResolvedValue(undefined);
+		mocks.playground.onDownloadProgress.mockResolvedValue(undefined);
+		mocks.playground.prefetchUpdateChecks.mockResolvedValue(undefined);
+		mocks.compileBlueprintV1.mockResolvedValue([]);
+		mocks.isBlueprintBundle.mockReturnValue(false);
+		mocks.runBlueprintV1Steps.mockResolvedValue(undefined);
+		mocks.resolveRuntimeConfiguration.mockResolvedValue({
+			phpVersion: '8.4',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+		});
+		mocks.createBlueprintReflection.mockResolvedValue({
+			getVersion: () => 1,
+		});
+		mocks.consumeAPI.mockReturnValue(mocks.playground);
+	});
+
+	it('does not prefetch WordPress updates for PHP-only blueprints', async () => {
+		const handler = new BlueprintsV1Handler({
+			iframe: createIframe(),
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint: {
+				preferredVersions: {
+					php: '8.4',
+					wp: false,
+				},
+			},
+		});
+
+		await handler.bootPlayground(createIframe(), createProgressTracker());
+
+		expect(mocks.playground.boot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				shouldInstallWordPress: false,
+			})
+		);
+		expect(mocks.playground.prefetchUpdateChecks).not.toHaveBeenCalled();
+	});
+
+	it('prefetches WordPress updates when WordPress is installed', async () => {
+		const handler = new BlueprintsV1Handler({
+			iframe: createIframe(),
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint: {},
+		});
+
+		await handler.bootPlayground(createIframe(), createProgressTracker());
+
+		expect(mocks.playground.boot).toHaveBeenCalledWith(
+			expect.objectContaining({
+				shouldInstallWordPress: true,
+			})
+		);
+		expect(mocks.playground.prefetchUpdateChecks).toHaveBeenCalledTimes(1);
+	});
+});
+
+function createIframe() {
+	return {
+		contentWindow: {},
+		ownerDocument: {
+			defaultView: {},
+		},
+	} as HTMLIFrameElement;
+}
+
+function createProgressTracker() {
+	const child = {
+		finish: vi.fn(),
+		loadingListener: vi.fn(),
+	};
+	return {
+		pipe: vi.fn(),
+		stage: vi.fn(() => child),
+	} as unknown as ProgressTracker;
+}

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -120,7 +120,14 @@ export class BlueprintsV1Handler {
 		 */
 		const wpMajor = parseFloat(runtimeConfiguration.wpVersion);
 		const isLegacyWpVersion = Number.isFinite(wpMajor) && wpMajor < 5.1;
-		if (runtimeConfiguration.networking && !isLegacyWpVersion) {
+		// Prefetch only makes sense when WordPress is actually installed.
+		// In PHP-only mode (`preferredVersions.wp: false`), wp-load.php
+		// doesn't exist and the prefetch crashes the runtime.
+		if (
+			runtimeConfiguration.networking &&
+			!isLegacyWpVersion &&
+			installWordPress
+		) {
 			await playground.prefetchUpdateChecks();
 		}
 

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -13,6 +13,8 @@ import type { Page } from '@playwright/test';
  */
 
 const DEMO_URL = './php-code-snippet-demo.html';
+const CLIENT_INDEX_SOURCE = `${process.cwd()}/packages/playground/client/src/index.ts`;
+const TOOLKIT_AUTOLOAD_SOURCE = `${process.cwd()}/packages/playground/website/public/php-toolkit-autoload.txt`;
 const pageErrors = new WeakMap<Page, string[]>();
 
 test.describe('php-code-snippet embed', () => {
@@ -235,12 +237,8 @@ test.describe('php-code-snippet embed', () => {
 		const snippet = page.locator('php-snippet[name="quickstart.php"]');
 
 		await expect(snippet).toBeVisible();
-		const localClientUrl = new URL('/client/index.js', page.url()).href;
-		const localClientResponse = await page.request.get(localClientUrl);
-		test.skip(
-			!localClientResponse.ok(),
-			'This regression test needs the deploy layout that serves /client/index.js.'
-		);
+		await ensurePlaygroundClientIsServed(page);
+		await ensureToolkitAutoloadIsServed(page);
 		await snippet.evaluate((element) => {
 			element.setAttribute('playground-origin', window.location.origin);
 		});
@@ -291,3 +289,32 @@ test.describe('php-code-snippet embed', () => {
 		).toHaveCount(1);
 	});
 });
+
+async function ensurePlaygroundClientIsServed(page: Page) {
+	const clientUrl = new URL('/client/index.js', page.url()).href;
+	const response = await page.request.get(clientUrl);
+	if (response.ok()) {
+		return;
+	}
+
+	const sourceUrl = new URL(`/@fs${CLIENT_INDEX_SOURCE}`, page.url()).href;
+	await page.route(clientUrl, async (route) => {
+		const response = await page.request.get(sourceUrl);
+		await route.fulfill({ response });
+	});
+}
+
+async function ensureToolkitAutoloadIsServed(page: Page) {
+	const autoloadUrl = new URL('/php-toolkit-autoload.txt', page.url()).href;
+	const response = await page.request.get(autoloadUrl);
+	if (response.ok()) {
+		return;
+	}
+
+	await page.route(autoloadUrl, async (route) => {
+		await route.fulfill({
+			path: TOOLKIT_AUTOLOAD_SOURCE,
+			contentType: 'text/plain',
+		});
+	});
+}

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -42,6 +42,7 @@ test.describe('php-code-snippet embed', () => {
 			'scratch.php',
 			'precomputed.php',
 			'just-php.php',
+			'quickstart.php',
 		]) {
 			const snippet = page.locator(`php-snippet[name="${name}"]`);
 			await expect(snippet).toBeVisible();
@@ -224,6 +225,43 @@ test.describe('php-code-snippet embed', () => {
 		});
 		await expect(editable.locator('.output-body')).toContainText(
 			'edited:42'
+		);
+	});
+
+	test('wp="none" + blueprint installs a PHP toolkit usable from the snippet', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const snippet = page.locator('php-snippet[name="quickstart.php"]');
+
+		await expect(snippet).toBeVisible();
+		const localClientUrl = new URL('/client/index.js', page.url()).href;
+		const localClientResponse = await page.request.get(localClientUrl);
+		test.skip(
+			!localClientResponse.ok(),
+			'This regression test needs the deploy layout that serves /client/index.js.'
+		);
+		await snippet.evaluate((element) => {
+			element.setAttribute('playground-origin', window.location.origin);
+		});
+		// The snippet ships with an expected-output script that pre-fills the
+		// output panel. Wait for the real run to execute by watching the
+		// progress bar appear and then disappear.
+		await snippet.locator('.run').click();
+		await expect(snippet.locator('.progress')).toBeVisible({
+			timeout: 30_000,
+		});
+		await expect(snippet.locator('.progress')).toBeHidden({
+			timeout: 240_000,
+		});
+
+		const body = snippet.locator('.output-body');
+		await expect(body).not.toHaveClass(/error/);
+		await expect(body).toContainText(
+			'<img src="hero.jpg" alt="Hero shot" loading="lazy">'
+		);
+		await expect(body).toContainText(
+			'<img src="diagram.png" alt="" loading="eager">'
 		);
 	});
 

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -210,6 +210,56 @@
 			</script>
 		</php-snippet>
 
+		<h2>8a. Pure PHP toolkit (no WordPress)</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			Uses <code>wp="none"</code> together with a blueprint that installs
+			a tiny PHP toolkit at <code>/tmp/php-toolkit</code>. The snippet
+			boots PHP only, autoloads the toolkit, and uses
+			<code>WP_HTML_Tag_Processor</code> outside of WordPress.
+		</p>
+
+		<script id="toolkit-setup" type="application/json">
+			{
+				"steps": [
+					{ "step": "mkdir", "path": "/tmp/php-toolkit/vendor" },
+					{
+						"step": "writeFile",
+						"path": "/tmp/php-toolkit/vendor/autoload.php",
+						"data": "<?php\nclass WP_HTML_Tag_Processor {\n    private $html;\n    private $offset = 0;\n    private $tag_start = -1;\n    private $tag_end = -1;\n    private $attrs = [];\n    public function __construct($html) { $this->html = $html; }\n    public function next_tag($name) {\n        $name = strtolower($name);\n        $len = strlen($this->html);\n        while ($this->offset < $len) {\n            $lt = strpos($this->html, '<', $this->offset);\n            if ($lt === false) return false;\n            if (substr($this->html, $lt, 4) === '<!--') {\n                $e = strpos($this->html, '-->', $lt + 4);\n                $this->offset = $e === false ? $len : $e + 3;\n                continue;\n            }\n            $nx = isset($this->html[$lt + 1]) ? $this->html[$lt + 1] : '';\n            if ($nx === '/' || $nx === '!' || $nx === '?') { $this->offset = $lt + 1; continue; }\n            $en = $lt + 1;\n            while ($en < $len && ctype_alnum($this->html[$en])) $en++;\n            $tag = strtolower(substr($this->html, $lt + 1, $en - $lt - 1));\n            $gt = strpos($this->html, '>', $en);\n            if ($gt === false) return false;\n            $this->offset = $gt + 1;\n            if ($tag !== $name) continue;\n            $this->tag_start = $lt;\n            $this->tag_end = $gt;\n            $this->attrs = [];\n            $attr_str = substr($this->html, $en, $gt - $en);\n            preg_match_all('/([a-zA-Z_:][a-zA-Z0-9:_.-]*)\\\\s*=\\\\s*\"([^\"]*)\"/', $attr_str, $m, PREG_SET_ORDER);\n            foreach ($m as $a) $this->attrs[strtolower($a[1])] = $a[2];\n            return true;\n        }\n        return false;\n    }\n    public function get_attribute($name) {\n        $k = strtolower($name);\n        return array_key_exists($k, $this->attrs) ? $this->attrs[$k] : null;\n    }\n    public function set_attribute($name, $value) {\n        $tag_str = substr($this->html, $this->tag_start, $this->tag_end - $this->tag_start + 1);\n        $self_close = '';\n        $body = substr($tag_str, 1, -1);\n        if (substr($body, -1) === '/') { $self_close = ' /'; $body = substr($body, 0, -1); }\n        $body = rtrim($body);\n        $k = strtolower($name);\n        $attr_pat = '/\\\\s+' . preg_quote($name, '/') . '\\\\s*=\\\\s*\"[^\"]*\"/i';\n        if (array_key_exists($k, $this->attrs)) {\n            $body = preg_replace($attr_pat, ' ' . $name . '=\"' . htmlspecialchars($value, ENT_QUOTES) . '\"', $body, 1);\n        } else {\n            $body .= ' ' . $name . '=\"' . htmlspecialchars($value, ENT_QUOTES) . '\"';\n        }\n        $new_tag = '<' . $body . $self_close . '>';\n        $delta = strlen($new_tag) - strlen($tag_str);\n        $this->html = substr($this->html, 0, $this->tag_start) . $new_tag . substr($this->html, $this->tag_end + 1);\n        $this->tag_end += $delta;\n        $this->offset += $delta;\n        $this->attrs[$k] = $value;\n    }\n    public function get_updated_html() { return $this->html; }\n}\n"
+					}
+				]
+			}
+		</script>
+
+		<php-snippet wp="none" blueprint="toolkit-setup" name="quickstart.php">
+			<script type="application/x-php">
+				<?php
+				require '/tmp/php-toolkit/vendor/autoload.php';
+
+				$html = '<article>
+					<img src="hero.jpg" alt="Hero shot">
+					<p>Welcome to the site.</p>
+					<img src="diagram.png" alt="" loading="eager">
+				</article>';
+
+				$tags = new WP_HTML_Tag_Processor( $html );
+				while ( $tags->next_tag( 'img' ) ) {
+					if ( null === $tags->get_attribute( 'loading' ) ) {
+						$tags->set_attribute( 'loading', 'lazy' );
+					}
+				}
+
+				echo $tags->get_updated_html();
+			</script>
+			<script type="text/expected-output">
+				<article>
+					<img src="hero.jpg" alt="Hero shot" loading="lazy">
+					<p>Welcome to the site.</p>
+					<img src="diagram.png" alt="" loading="eager">
+				</article>
+			</script>
+		</php-snippet>
+
 		<h2>8. Read-only illustration</h2>
 		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
 			This snippet is syntax-highlighted but is not meant to execute.

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -210,7 +210,7 @@
 			</script>
 		</php-snippet>
 
-		<h2>8a. Pure PHP toolkit (no WordPress)</h2>
+		<h2>8. Pure PHP toolkit (no WordPress)</h2>
 		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
 			Uses <code>wp="none"</code> together with a blueprint that installs
 			a tiny PHP toolkit at <code>/tmp/php-toolkit</code>. The snippet
@@ -225,7 +225,10 @@
 					{
 						"step": "writeFile",
 						"path": "/tmp/php-toolkit/vendor/autoload.php",
-						"data": "<?php\nclass WP_HTML_Tag_Processor {\n    private $html;\n    private $offset = 0;\n    private $tag_start = -1;\n    private $tag_end = -1;\n    private $attrs = [];\n    public function __construct($html) { $this->html = $html; }\n    public function next_tag($name) {\n        $name = strtolower($name);\n        $len = strlen($this->html);\n        while ($this->offset < $len) {\n            $lt = strpos($this->html, '<', $this->offset);\n            if ($lt === false) return false;\n            if (substr($this->html, $lt, 4) === '<!--') {\n                $e = strpos($this->html, '-->', $lt + 4);\n                $this->offset = $e === false ? $len : $e + 3;\n                continue;\n            }\n            $nx = isset($this->html[$lt + 1]) ? $this->html[$lt + 1] : '';\n            if ($nx === '/' || $nx === '!' || $nx === '?') { $this->offset = $lt + 1; continue; }\n            $en = $lt + 1;\n            while ($en < $len && ctype_alnum($this->html[$en])) $en++;\n            $tag = strtolower(substr($this->html, $lt + 1, $en - $lt - 1));\n            $gt = strpos($this->html, '>', $en);\n            if ($gt === false) return false;\n            $this->offset = $gt + 1;\n            if ($tag !== $name) continue;\n            $this->tag_start = $lt;\n            $this->tag_end = $gt;\n            $this->attrs = [];\n            $attr_str = substr($this->html, $en, $gt - $en);\n            preg_match_all('/([a-zA-Z_:][a-zA-Z0-9:_.-]*)\\\\s*=\\\\s*\"([^\"]*)\"/', $attr_str, $m, PREG_SET_ORDER);\n            foreach ($m as $a) $this->attrs[strtolower($a[1])] = $a[2];\n            return true;\n        }\n        return false;\n    }\n    public function get_attribute($name) {\n        $k = strtolower($name);\n        return array_key_exists($k, $this->attrs) ? $this->attrs[$k] : null;\n    }\n    public function set_attribute($name, $value) {\n        $tag_str = substr($this->html, $this->tag_start, $this->tag_end - $this->tag_start + 1);\n        $self_close = '';\n        $body = substr($tag_str, 1, -1);\n        if (substr($body, -1) === '/') { $self_close = ' /'; $body = substr($body, 0, -1); }\n        $body = rtrim($body);\n        $k = strtolower($name);\n        $attr_pat = '/\\\\s+' . preg_quote($name, '/') . '\\\\s*=\\\\s*\"[^\"]*\"/i';\n        if (array_key_exists($k, $this->attrs)) {\n            $body = preg_replace($attr_pat, ' ' . $name . '=\"' . htmlspecialchars($value, ENT_QUOTES) . '\"', $body, 1);\n        } else {\n            $body .= ' ' . $name . '=\"' . htmlspecialchars($value, ENT_QUOTES) . '\"';\n        }\n        $new_tag = '<' . $body . $self_close . '>';\n        $delta = strlen($new_tag) - strlen($tag_str);\n        $this->html = substr($this->html, 0, $this->tag_start) . $new_tag . substr($this->html, $this->tag_end + 1);\n        $this->tag_end += $delta;\n        $this->offset += $delta;\n        $this->attrs[$k] = $value;\n    }\n    public function get_updated_html() { return $this->html; }\n}\n"
+						"data": {
+							"resource": "url",
+							"url": "/php-toolkit-autoload.txt"
+						}
 					}
 				]
 			}
@@ -260,7 +263,7 @@
 			</script>
 		</php-snippet>
 
-		<h2>8. Read-only illustration</h2>
+		<h2>9. Read-only illustration</h2>
 		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
 			This snippet is syntax-highlighted but is not meant to execute.
 		</p>

--- a/packages/playground/website/public/php-toolkit-autoload.txt
+++ b/packages/playground/website/public/php-toolkit-autoload.txt
@@ -1,0 +1,95 @@
+<?php
+class WP_HTML_Tag_Processor {
+    private $html;
+    private $offset = 0;
+    private $tag_start = -1;
+    private $tag_end = -1;
+    private $attrs = [];
+
+    public function __construct($html) {
+        $this->html = $html;
+    }
+
+    public function next_tag($name) {
+        $name = strtolower($name);
+        $len = strlen($this->html);
+
+        while ($this->offset < $len) {
+            $lt = strpos($this->html, '<', $this->offset);
+            if ($lt === false) {
+                return false;
+            }
+            if (substr($this->html, $lt, 4) === '<!--') {
+                $e = strpos($this->html, '-->', $lt + 4);
+                $this->offset = $e === false ? $len : $e + 3;
+                continue;
+            }
+
+            $nx = isset($this->html[$lt + 1]) ? $this->html[$lt + 1] : '';
+            if ($nx === '/' || $nx === '!' || $nx === '?') {
+                $this->offset = $lt + 1;
+                continue;
+            }
+
+            $en = $lt + 1;
+            while ($en < $len && ctype_alnum($this->html[$en])) {
+                $en++;
+            }
+            $tag = strtolower(substr($this->html, $lt + 1, $en - $lt - 1));
+            $gt = strpos($this->html, '>', $en);
+            if ($gt === false) {
+                return false;
+            }
+
+            $this->offset = $gt + 1;
+            if ($tag !== $name) {
+                continue;
+            }
+
+            $this->tag_start = $lt;
+            $this->tag_end = $gt;
+            $this->attrs = [];
+            $attr_str = substr($this->html, $en, $gt - $en);
+            preg_match_all('/([a-zA-Z_:][a-zA-Z0-9:_.-]*)\s*=\s*"([^"]*)"/', $attr_str, $m, PREG_SET_ORDER);
+            foreach ($m as $a) {
+                $this->attrs[strtolower($a[1])] = $a[2];
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    public function get_attribute($name) {
+        $k = strtolower($name);
+        return array_key_exists($k, $this->attrs) ? $this->attrs[$k] : null;
+    }
+
+    public function set_attribute($name, $value) {
+        $tag_str = substr($this->html, $this->tag_start, $this->tag_end - $this->tag_start + 1);
+        $self_close = '';
+        $body = substr($tag_str, 1, -1);
+        if (substr($body, -1) === '/') {
+            $self_close = ' /';
+            $body = substr($body, 0, -1);
+        }
+        $body = rtrim($body);
+        $k = strtolower($name);
+        $attr_pat = '/\s+' . preg_quote($name, '/') . '\s*=\s*"[^"]*"/i';
+        if (array_key_exists($k, $this->attrs)) {
+            $body = preg_replace($attr_pat, ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES) . '"', $body, 1);
+        } else {
+            $body .= ' ' . $name . '="' . htmlspecialchars($value, ENT_QUOTES) . '"';
+        }
+        $new_tag = '<' . $body . $self_close . '>';
+        $delta = strlen($new_tag) - strlen($tag_str);
+        $this->html = substr($this->html, 0, $this->tag_start) . $new_tag . substr($this->html, $this->tag_end + 1);
+        $this->tag_end += $delta;
+        $this->offset += $delta;
+        $this->attrs[$k] = $value;
+    }
+
+    public function get_updated_html() {
+        return $this->html;
+    }
+}


### PR DESCRIPTION
## What it does

Fixes `wp="none"` PHP snippets that boot through a Blueprint. PHP-only Blueprints now skip WordPress update prefetching, so the runtime no longer tries to load WordPress files that were intentionally not installed.

The demo page also includes a `quickstart.php` example that installs a tiny `/tmp/php-toolkit/vendor/autoload.php` through a Blueprint and runs `WP_HTML_Tag_Processor` outside WordPress.

## Rationale

`wp="none"` maps to `preferredVersions.wp: false`, which means the runtime boots PHP without a `/wordpress` directory. `BlueprintsV1Handler` still called `prefetchUpdateChecks()` after boot when networking was enabled, and that path expects WordPress to exist.

That made PHP-only snippets fail even when their own code and Blueprint did not require WordPress.

## Implementation

`BlueprintsV1Handler` already computes whether WordPress should be installed:

```ts
const installWordPress = shouldInstallWordPress ?? !declarativeOptOut;
```

This now gates `prefetchUpdateChecks()` as well:

```ts
if (runtimeConfiguration.networking && !isLegacyWpVersion && installWordPress) {
	await playground.prefetchUpdateChecks();
}
```

Added a focused client regression test for both paths: PHP-only Blueprints do not prefetch, while normal WordPress boots still do.

## Testing instructions

```bash
npm exec nx test playground-client --testFile=blueprints-v1-handler.spec.ts
npm exec nx typecheck playground-client
npm exec nx lint playground-client
npm exec nx lint playground-website
```

I also ran the focused `php-code-snippet` Playwright case against the bundled `wasm-wordpress-net` layout in Chromium, where `/client/index.js` is served and the snippet executes successfully.
