### PR TITLE
[CI] Avoid azure.archive.ubuntu.com apt failures in CI

### DIFF
--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -10,6 +10,18 @@ inputs:
 runs:
     using: 'composite'
     steps:
+        - name: Use non-Azure apt mirror
+          shell: bash
+          # GitHub-hosted runners default to azure.archive.ubuntu.com, which
+          # has had repeated DNS resolution failures. Switch to the canonical
+          # archive.ubuntu.com mirror to avoid transient `apt-get` breakage
+          # in steps like `playwright install --with-deps`.
+          run: |
+              sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' /etc/apt/sources.list || true
+              if [ -d /etc/apt/sources.list.d ]; then
+                sudo find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} +
+              fi
+              sudo apt-get update -y || true
         - name: Fetch trunk
           shell: bash
           run: git fetch origin trunk --depth=1 --recurse-submodules

--- a/.github/actions/prepare-playground/action.yml
+++ b/.github/actions/prepare-playground/action.yml
@@ -11,17 +11,24 @@ runs:
     using: 'composite'
     steps:
         - name: Use non-Azure apt mirror
+          if: runner.os == 'Linux'
           shell: bash
           # GitHub-hosted runners default to azure.archive.ubuntu.com, which
           # has had repeated DNS resolution failures. Switch to the canonical
           # archive.ubuntu.com mirror to avoid transient `apt-get` breakage
           # in steps like `playwright install --with-deps`.
           run: |
-              sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' /etc/apt/sources.list || true
+              if ! command -v apt-get >/dev/null 2>&1; then
+                echo "Skipping apt mirror rewrite because apt-get is unavailable."
+                exit 0
+              fi
+              if [ -f /etc/apt/sources.list ]; then
+                sudo sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' /etc/apt/sources.list
+              fi
               if [ -d /etc/apt/sources.list.d ]; then
                 sudo find /etc/apt/sources.list.d -type f \( -name '*.list' -o -name '*.sources' \) -exec sed -i 's|azure\.archive\.ubuntu\.com|archive.ubuntu.com|g' {} +
               fi
-              sudo apt-get update -y || true
+              sudo apt-get update -o Acquire::Retries=3
         - name: Fetch trunk
           shell: bash
           run: git fetch origin trunk --depth=1 --recurse-submodules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,13 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browser
-              run: sudo npx playwright install ${{ matrix.browser }} --with-deps
+              run: |
+                  for i in 1 2 3; do
+                    sudo npx playwright install ${{ matrix.browser }} --with-deps && break
+                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
+                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
+                    sleep 30
+                  done
             - name: Build app for E2E tests
               run: CORS_PROXY_URL=http://127.0.0.1:5263/cors-proxy.php? npx nx e2e:playwright:prepare-app-deploy-and-offline-mode playground-website
             - name: Run Playwright tests - ${{ matrix.browser }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
@@ -288,7 +294,13 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browser
-              run: npx playwright install chromium --with-deps
+              run: |
+                  for i in 1 2 3; do
+                    npx playwright install chromium --with-deps && break
+                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
+                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
+                    sleep 30
+                  done
             - name: Run personal-wp Playwright e2e tests
               run: CI=true npx playwright test --config=packages/playground/personal-wp/playwright/playwright.config.ts --project=chromium
             - uses: actions/upload-artifact@v4
@@ -307,7 +319,13 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browsers
-              run: npx playwright install --with-deps chromium
+              run: |
+                  for i in 1 2 3; do
+                    npx playwright install --with-deps chromium && break
+                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
+                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
+                    sleep 30
+                  done
             - name: Run Playwright tests for components
               run: npx nx e2e playground-components
             - uses: actions/upload-artifact@v4
@@ -328,7 +346,13 @@ jobs:
               with:
                   node-version: '22'
             - name: Install Playwright Browsers
-              run: npx playwright install --with-deps chromium
+              run: |
+                  for i in 1 2 3; do
+                    npx playwright install --with-deps chromium && break
+                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
+                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
+                    sleep 30
+                  done
             - name: Run MCP e2e tests
               run: npx nx test:mcp playground-mcp
             - uses: actions/upload-artifact@v4
@@ -347,7 +371,13 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browsers
-              run: npx playwright install --with-deps chromium
+              run: |
+                  for i in 1 2 3; do
+                    npx playwright install --with-deps chromium && break
+                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
+                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
+                    sleep 30
+                  done
             - name: Verify docs API reference
               run: npx nx run docs-site:api-e2e
             - uses: actions/upload-artifact@v4
@@ -419,7 +449,13 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browser
-              run: npx playwright install chromium --with-deps
+              run: |
+                  for i in 1 2 3; do
+                    npx playwright install chromium --with-deps && break
+                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
+                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
+                    sleep 30
+                  done
             - name: Start dev server
               run: |
                   npm run dev > /tmp/playground-dev.log 2>&1 &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,13 +253,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browser
-              run: |
-                  for i in 1 2 3; do
-                    sudo npx playwright install ${{ matrix.browser }} --with-deps && break
-                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
-                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
-                    sleep 30
-                  done
+              run: sudo npx playwright install ${{ matrix.browser }} --with-deps
             - name: Build app for E2E tests
               run: CORS_PROXY_URL=http://127.0.0.1:5263/cors-proxy.php? npx nx e2e:playwright:prepare-app-deploy-and-offline-mode playground-website
             - name: Run Playwright tests - ${{ matrix.browser }}${{ matrix.shard && format(' (shard {0})', matrix.shard) || '' }}
@@ -294,13 +288,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browser
-              run: |
-                  for i in 1 2 3; do
-                    npx playwright install chromium --with-deps && break
-                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
-                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
-                    sleep 30
-                  done
+              run: npx playwright install chromium --with-deps
             - name: Run personal-wp Playwright e2e tests
               run: CI=true npx playwright test --config=packages/playground/personal-wp/playwright/playwright.config.ts --project=chromium
             - uses: actions/upload-artifact@v4
@@ -319,13 +307,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browsers
-              run: |
-                  for i in 1 2 3; do
-                    npx playwright install --with-deps chromium && break
-                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
-                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
-                    sleep 30
-                  done
+              run: npx playwright install --with-deps chromium
             - name: Run Playwright tests for components
               run: npx nx e2e playground-components
             - uses: actions/upload-artifact@v4
@@ -346,13 +328,7 @@ jobs:
               with:
                   node-version: '22'
             - name: Install Playwright Browsers
-              run: |
-                  for i in 1 2 3; do
-                    npx playwright install --with-deps chromium && break
-                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
-                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
-                    sleep 30
-                  done
+              run: npx playwright install --with-deps chromium
             - name: Run MCP e2e tests
               run: npx nx test:mcp playground-mcp
             - uses: actions/upload-artifact@v4
@@ -371,13 +347,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browsers
-              run: |
-                  for i in 1 2 3; do
-                    npx playwright install --with-deps chromium && break
-                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
-                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
-                    sleep 30
-                  done
+              run: npx playwright install --with-deps chromium
             - name: Verify docs API reference
               run: npx nx run docs-site:api-e2e
             - uses: actions/upload-artifact@v4
@@ -449,13 +419,7 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browser
-              run: |
-                  for i in 1 2 3; do
-                    npx playwright install chromium --with-deps && break
-                    if [ $i -eq 3 ]; then echo "playwright install failed after 3 attempts" >&2; exit 1; fi
-                    echo "playwright install failed (attempt $i), retrying after 30s..." >&2
-                    sleep 30
-                  done
+              run: npx playwright install chromium --with-deps
             - name: Start dev server
               run: |
                   npm run dev > /tmp/playground-dev.log 2>&1 &


### PR DESCRIPTION
## Summary
- switch the shared `prepare-playground` action from `azure.archive.ubuntu.com` to `archive.ubuntu.com`

## Why
GitHub-hosted Ubuntu runners have been failing during `playwright install --with-deps` because the underlying `apt-get` step resolves packages through `azure.archive.ubuntu.com`, and that mirror has been returning intermittent DNS failures. This change moves CI back to the canonical Ubuntu archive instead of relying on the flaky Azure mirror.

## Impact
Jobs that install Playwright system dependencies through `--with-deps` should no longer depend on `azure.archive.ubuntu.com`, which should reduce CI flakes across the Playwright-based jobs on `trunk`.

## Validation
- `git diff --check`
- `npx prettier --check .github/actions/prepare-playground/action.yml .github/workflows/ci.yml`

## Notes
- the local commit hook printed `Could not find Nx modules in this workspace` while running `nx format --fix --parallel --uncommitted`, but the commit completed successfully and the touched files pass Prettier formatting checks.
