### PR TITLE
Define mysqli stub before custom db.php guard

### DIFF
--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -419,15 +419,18 @@ export async function preloadSqliteIntegration(
 			phpVar(joinPaths(SQLITE_PLUGIN_FOLDER, 'load.php'))
 		);
 	const dbPhpPath = joinPaths(await php.documentRoot, 'wp-content/db.php');
-	const stopIfDbPhpExists = `<?php
-	// Do not preload this if WordPress comes with a custom db.php file.
-	if(file_exists(${phpVar(dbPhpPath)})) {
-		return;
-	}
-	?>`;
+	const stopIfDbPhpExists = `
+		// Do not preload this if WordPress comes with a custom db.php file.
+		if(file_exists(${phpVar(dbPhpPath)})) {
+			return;
+		}
+		`;
 	const SQLITE_MUPLUGIN_PATH =
 		'/internal/shared/mu-plugins/sqlite-database-integration.php';
-	await php.writeFile(SQLITE_MUPLUGIN_PATH, stopIfDbPhpExists + dbPhp);
+	await php.writeFile(
+		SQLITE_MUPLUGIN_PATH,
+		`<?php${stopIfDbPhpExists}?>` + dbPhp
+	);
 	await php.writeFile(
 		`/internal/shared/preload/0-sqlite.php`,
 		buildModernSqlitePreload(stopIfDbPhpExists, SQLITE_MUPLUGIN_PATH)
@@ -458,20 +461,16 @@ function buildModernSqlitePreload(
 	stopIfDbPhpExists: string,
 	muPluginPath: string
 ): string {
-	return (
-		`<?php
-if(!function_exists('mysqli_connect')) {
-	function mysqli_connect() {}
-}
+	return `<?php
+	if(!function_exists('mysqli_connect')) {
+		function mysqli_connect() {}
+	}
 
-		?>` +
-		stopIfDbPhpExists +
-		`<?php
+	${stopIfDbPhpExists}
 
-${SQLITE_PRELOAD_LOADER_CLASS(`require_once ${phpVar(muPluginPath)};`)}
+	${SQLITE_PRELOAD_LOADER_CLASS(`require_once ${phpVar(muPluginPath)};`)}
 
-		`
-	);
+		`;
 }
 
 /**

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -451,21 +451,24 @@ export async function preloadSqliteIntegration(
 
 /**
  * Builds the 0-sqlite.php preload content for modern PHP (7+).
- * Matches trunk behavior: require_once, simple db.php guard,
- * minimal mysqli_connect stub.
+ * The mysqli_connect stub must load before the custom db.php guard
+ * because WordPress may check for it even when a drop-in handles the DB.
  */
 function buildModernSqlitePreload(
 	stopIfDbPhpExists: string,
 	muPluginPath: string
 ): string {
 	return (
+		`<?php
+if(!function_exists('mysqli_connect')) {
+	function mysqli_connect() {}
+}
+
+		?>` +
 		stopIfDbPhpExists +
 		`<?php
 
 ${SQLITE_PRELOAD_LOADER_CLASS(`require_once ${phpVar(muPluginPath)};`)}
-if(!function_exists('mysqli_connect')) {
-	function mysqli_connect() {}
-}
 
 		`
 	);

--- a/packages/playground/wordpress/src/test/database.spec.ts
+++ b/packages/playground/wordpress/src/test/database.spec.ts
@@ -192,9 +192,7 @@ echo $GLOBALS['@pdo']->query('PRAGMA journal_mode')->fetchColumn();
 			const preload = await php.readFileAsText(
 				'/internal/shared/preload/0-sqlite.php'
 			);
-			const guardPosition = preload.indexOf(
-				'// Do not preload this if WordPress comes with a custom db.php file.'
-			);
+			const guardPosition = preload.search(/if\s*\(\s*file_exists\s*\(/);
 			const stubPosition = preload.indexOf('function mysqli_connect()');
 
 			expect(guardPosition).toBeGreaterThanOrEqual(0);

--- a/packages/playground/wordpress/src/test/database.spec.ts
+++ b/packages/playground/wordpress/src/test/database.spec.ts
@@ -161,6 +161,48 @@ echo $GLOBALS['@pdo']->query('PRAGMA journal_mode')->fetchColumn();
 		}
 	);
 
+	it(
+		'should write the mysqli stub before the custom db.php guard',
+		{ timeout: 30_000 },
+		async () => {
+			const dbStubContent = readFileSync(
+				join(__dirname, 'fixtures/mysql-db-stub.php'),
+				'utf-8'
+			);
+
+			await using handler = await bootWordPressAndRequestHandler({
+				createPhpRuntime: async () =>
+					await loadNodeRuntime(RecommendedPHPVersion),
+				siteUrl: 'http://playground-domain/',
+				wordPressZip: await getWordPressModule(),
+				sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+				wordpressInstallMode: 'do-not-attempt-installing',
+				hooks: {
+					beforeDatabaseSetup: async (php) => {
+						await php.mkdir('/wordpress/wp-content');
+						await php.writeFile(
+							'/wordpress/wp-content/db.php',
+							dbStubContent
+						);
+					},
+				},
+			});
+
+			const php = await handler.getPrimaryPhp();
+			const preload = await php.readFileAsText(
+				'/internal/shared/preload/0-sqlite.php'
+			);
+			const guardPosition = preload.indexOf(
+				'// Do not preload this if WordPress comes with a custom db.php file.'
+			);
+			const stubPosition = preload.indexOf('function mysqli_connect()');
+
+			expect(guardPosition).toBeGreaterThanOrEqual(0);
+			expect(stubPosition).toBeGreaterThanOrEqual(0);
+			expect(stubPosition).toBeLessThan(guardPosition);
+		}
+	);
+
 	it("should fail when the SQLite driver directory exists, but doesn't contain a valid driver", async () => {
 		await expect(async () => {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## What?

Fixes the modern SQLite preload path when a Playground filesystem already contains a custom `wp-content/db.php` drop-in.

Current Playground `.zip` exports exclude the generated `wp-content/db.php`, so this is not primarily about the latest export format. The risky state can still happen with older full-site exports, local-directory/restored filesystems, imported backups, or user-provided database drop-ins that leave `wp-content/db.php` in place before boot.

We noticed this gap while working through the same saved-site / missing-MySQL-extension area as PR #3588, but this PR is not dependent on #3588.

## Root cause

`buildModernSqlitePreload()` generated the preload in this order:

1. custom `wp-content/db.php` guard,
2. SQLite preload loader,
3. minimal `mysqli_connect()` userland stub.

When `wp-content/db.php` already existed, the guard returned before the stub was defined. For WordPress versions where Playground backports the MySQL compatibility check to `function_exists( 'mysqli_connect' )`, WordPress could still report that PHP is missing the MySQL extension even though the custom drop-in owns database access.

## Fix

Define the minimal `mysqli_connect()` stub before the custom `db.php` guard.

The custom drop-in behavior stays the same: if `wp-content/db.php` exists, Playground still skips loading its SQLite preload. The only changed behavior is that WordPress' compatibility check can see `mysqli_connect()` before that early return happens.

## Regression

The first commit adds a focused regression test in `database.spec.ts`. It writes `wp-content/db.php` before database setup and asserts that the generated `/internal/shared/preload/0-sqlite.php` defines `function mysqli_connect()` before the custom `db.php` guard.

On the rebased test-only commit (`38214eee`), CI passed everything except the expected regression failure:

```text
50 passed, 3 skipped, 1 failed
failed: test-unit-asyncify (1/7)
expected 2860 to be less than 7
```

After the fix commit, the same targeted regression passes locally.

## Validation

```text
PATH=/home/ashfame/.nvm/versions/node/v22.22.2/bin:$PATH NX_DAEMON=false npm exec nx run playground-wordpress:test:vite -- --run src/test/database.spec.ts -t "should write the mysqli stub before the custom db.php guard"
PASS
```

I also checked the broader import/export coverage while reviewing this: current export/import tests cover current `zipWpContent()` archives and manifestless current archives, but not every historical export shape. That broader archive-format coverage gap is separate from this PR.
