### PR TITLE
Wait for personal-wp address bar readiness

### DIFF
--- a/packages/playground/personal-wp/playwright/personal-wp-page.ts
+++ b/packages/playground/personal-wp/playwright/personal-wp-page.ts
@@ -12,6 +12,11 @@ export class PersonalWPPage {
 		await expect(this.wordpress().locator('body')).not.toBeEmpty();
 	}
 
+	async waitForReady() {
+		await this.waitForNestedIframes();
+		await expect(this.addressBar()).toHaveValue(/^\//);
+	}
+
 	wordpress() {
 		return this.page
 			.frameLocator(
@@ -23,7 +28,7 @@ export class PersonalWPPage {
 	async goto(url: string, options?: Parameters<Page['goto']>[1]) {
 		const originalGoto = this.page.goto.bind(this.page);
 		const response = await originalGoto(url, options);
-		await this.waitForNestedIframes();
+		await this.waitForReady();
 		return response;
 	}
 


### PR DESCRIPTION
## Summary
- Make the personal-wp Playwright page helper wait for the toolbar address bar to contain a WordPress path after the nested WordPress iframe body has loaded.
- This avoids the flaky race where the address bar update handler can run before `BrowserChrome` has re-rendered with live `clientInfo`.
- Scope is limited to personal-wp Playwright readiness. Database/MySQL fixes and PR #3588 saved-site SQLite work are intentionally out of scope.

## Validation
- PASS: `npm exec nx lint playground-personal-wp`
- PASS: `npm exec nx typecheck playground-personal-wp`
- BLOCKED LOCALLY: `npm exec nx run playground-personal-wp:e2e:playwright -- packages/playground/personal-wp/playwright/e2e/ui.spec.ts`
  - The default Playwright web server could not start because this environment does not have a `php` binary for `playground-php-cors-proxy:start`.
  - Retried against directly started Vite servers with `CORS_PROXY_URL=`; Playwright reached Chromium launch, but Chromium could not start because `libatk-1.0.so.0` is missing.
  - No Playwright assertions executed locally. CI should perform the actual e2e validation.