### PR TITLE
[Docs] how to use @php-wasm/compile-extension from a downstream repo

### DIFF
--- a/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
@@ -39,8 +39,9 @@ dist/wp_mysql_parser/
 `-- wp_mysql_parser-php8.4-jspi.so
 ```
 
-The manifest records the extension name, artifact matrix, relative `.so` file
-paths, and `sha256` hashes:
+The manifest matches the `PHPExtensionManifest` shape from
+`@php-wasm/universal`. It records the extension name, the artifact matrix,
+and a `sourcePath` for each artifact relative to the manifest URL:
 
 ```json
 {
@@ -49,8 +50,7 @@ paths, and `sha256` hashes:
 	"artifacts": [
 		{
 			"phpVersion": "8.4",
-			"file": "wp_mysql_parser-php8.4-jspi.so",
-			"sha256": "..."
+			"sourcePath": "wp_mysql_parser-php8.4-jspi.so"
 		}
 	]
 }
@@ -58,6 +58,28 @@ paths, and `sha256` hashes:
 
 Host the whole output directory from the same static location. Relative
 artifact paths are resolved from the manifest URL.
+
+### Sidecar files
+
+Pass `--extra-files <hostDir>:<vfsRoot>` to stage data directories, web UI
+assets, ICU data, or anything else the extension needs at runtime. The host
+directory is copied next to the manifest, and each entry is recorded under
+`extraFiles.nodes` with a `vfsPath` relative to `vfsRoot` and a `sourcePath`
+relative to the manifest URL:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./spx-src \
+	--name spx \
+	--php-versions 8.2 \
+	--extra-files ./web-ui:/internal/shared/spx \
+	--out ./dist/spx
+```
+
+Empty directories are recorded as `type: "directory"` nodes so the loader
+creates them before PHP starts. Multiple `--extra-files` entries are
+allowed, but they must agree on `vfsRoot` — the manifest format stores a
+single root per group.
 
 ## Loading in Node.js
 
@@ -83,8 +105,9 @@ const php = new PHP(
 
 Node.js accepts local paths, `file:` URLs, and HTTP(S) URLs for `manifestUrl`.
 The loader selects the artifact whose `phpVersion` matches the runtime,
-verifies `sha256` when present, writes a generated `.ini` file, and starts PHP
-with the extension scan directory configured.
+stages the `.so`, copies any `extraFiles` declared in the manifest, writes a
+generated `.ini` file, and starts PHP with the extension scan directory
+configured.
 
 ## Loading in the browser
 
@@ -124,7 +147,6 @@ await loadWebRuntime('8.4', {
 				format: 'url',
 				name: 'wp_mysql_parser',
 				url: new URL('https://cdn.example.com/wp_mysql_parser-php8.4-jspi.so'),
-				sha256: '...',
 			},
 		},
 	],

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
@@ -137,8 +137,81 @@ Build every PHP version you plan to support. A `.so` built for PHP 8.4 cannot
 be loaded into PHP 8.3. Custom extension artifacts are JSPI-only and must be
 loaded by a JSPI runtime.
 
+The helper supports PHP `7.4` and `8.0` through `8.5`. Pass the matrix as a
+comma-separated list:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./wp-mysql-parser \
+	--name wp_mysql_parser \
+	--php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
+	--out ./dist/wp_mysql_parser
+```
+
 Extension loading is startup-only. Declare custom extensions in the
 `extensions` option before the runtime is created.
+
+## Using the helper from a downstream repository
+
+`@php-wasm/compile-extension` is not yet published to npm. Until it is, run it
+from a checkout of `WordPress/wordpress-playground`. CI jobs that build a
+single extension only need a few packages from the monorepo, so a
+sparse-checkout keeps the clone small and the install step fast.
+
+Example GitHub Actions step that pulls just the packages the helper needs to
+build a JSPI side module for PHP `8.0` through `8.5`:
+
+```yaml
+- name: Check out wordpress-playground
+  uses: actions/checkout@v4
+  with:
+      repository: WordPress/wordpress-playground
+      ref: trunk
+      path: wordpress-playground
+      sparse-checkout-cone-mode: false
+      sparse-checkout: |
+          /package.json
+          /package-lock.json
+          /nx.json
+          /tsconfig.base.json
+          /packages/meta/
+          /packages/nx-extensions/
+          /packages/php-wasm/cli-util/
+          /packages/php-wasm/compile-extension/
+          /packages/php-wasm/compile/
+          /packages/php-wasm/fs-journal/
+          /packages/php-wasm/logger/
+          /packages/php-wasm/node/
+          /packages/php-wasm/node-builds/8-0/
+          /packages/php-wasm/node-builds/8-1/
+          /packages/php-wasm/node-builds/8-2/
+          /packages/php-wasm/node-builds/8-3/
+          /packages/php-wasm/node-builds/8-4/
+          /packages/php-wasm/node-builds/8-5/
+          /packages/php-wasm/progress/
+          /packages/php-wasm/scopes/
+          /packages/php-wasm/stream-compression/
+          /packages/php-wasm/universal/
+          /packages/php-wasm/util/
+
+- name: Install Playground deps
+  working-directory: wordpress-playground
+  run: npm ci --ignore-scripts
+```
+
+Trim the `node-builds` lines to the PHP versions the matrix actually builds.
+The helper resolves headers and side-module link inputs from
+`packages/php-wasm/compile`, so include that package even when the build
+itself runs inside the helper's Docker image.
+
+Once `npm ci` finishes, run the helper against the extension source from the
+downstream repository. The `--source` directory and any vendored archives
+listed in `--extra-ldflags` are copied into the container under `/build`, so
+the helper does not need to live in the same checkout as the extension.
+
+When you build the matrix in CI, prefer `max-parallel: 1` for the WASM lanes.
+Parallel Docker builds on hosted runners frequently hit apt-mirror flakes
+during the base image build.
 
 For native dependencies, see
 [PHP extension dependencies](/developers/apis/javascript-api/php-extension-dependencies).

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
@@ -151,85 +151,26 @@ npx @php-wasm/compile-extension \
 Extension loading is startup-only. Declare custom extensions in the
 `extensions` option before the runtime is created.
 
-## Using the helper from a downstream repository
+## Running the helper in CI
 
-`@php-wasm/compile-extension` is not yet published to npm. Until it is, run it
-from a checkout of `WordPress/wordpress-playground`. CI jobs that build a
-single extension only need a few packages from the monorepo, so a
-sparse-checkout keeps the clone small and the install step fast.
-
-Example GitHub Actions step that pulls just the packages the helper needs to
-build a JSPI side module for PHP `8.0` through `8.5`:
+The helper is published as `@php-wasm/compile-extension` on npm and only
+needs Docker and Node. A typical GitHub Actions job:
 
 ```yaml
-- name: Check out wordpress-playground
-  uses: actions/checkout@v4
+- uses: actions/checkout@v4
+
+- uses: actions/setup-node@v4
   with:
-    repository: WordPress/wordpress-playground
-    ref: trunk
-    path: wordpress-playground
-    sparse-checkout-cone-mode: false
-    sparse-checkout: |
-      /package.json
-      /package-lock.json
-      /nx.json
-      /tsconfig.base.json
-      /packages/meta/
-      /packages/nx-extensions/
-      /packages/php-wasm/cli-util/
-      /packages/php-wasm/compile-extension/
-      /packages/php-wasm/compile/
-      /packages/php-wasm/fs-journal/
-      /packages/php-wasm/logger/
-      /packages/php-wasm/node/
-      /packages/php-wasm/node-builds/8-0/
-      /packages/php-wasm/node-builds/8-1/
-      /packages/php-wasm/node-builds/8-2/
-      /packages/php-wasm/node-builds/8-3/
-      /packages/php-wasm/node-builds/8-4/
-      /packages/php-wasm/node-builds/8-5/
-      /packages/php-wasm/progress/
-      /packages/php-wasm/scopes/
-      /packages/php-wasm/stream-compression/
-      /packages/php-wasm/universal/
-      /packages/php-wasm/util/
+    node-version: '24'
 
-- name: Install Playground deps
-  working-directory: wordpress-playground
-  run: npm ci --ignore-scripts
+- name: Build the extension matrix
+  run: |
+    npx --yes @php-wasm/compile-extension \
+      --source ./my-extension \
+      --name my_extension \
+      --php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
+      --out ./dist/my-extension
 ```
-
-Adjust the `node-builds` lines to the PHP versions the matrix builds. Add
-`/packages/php-wasm/node-builds/7-4/` when the matrix includes PHP `7.4`, and
-drop entries for versions you do not need. The helper resolves headers and
-side-module link inputs from `packages/php-wasm/compile`, so keep that
-package included even when the build itself runs inside the helper's Docker
-image.
-
-Run the helper from the `wordpress-playground` checkout. `npm ci
---ignore-scripts` does not build the package's bin script, so until
-`@php-wasm/compile-extension` is published to npm, invoke the CLI source
-directly through Node's type-stripping flags:
-
-```bash
-cd wordpress-playground
-
-node \
-	--experimental-strip-types \
-	--experimental-transform-types \
-	--disable-warning=ExperimentalWarning \
-	--import "$PWD/packages/meta/src/node-es-module-loader/register.mts" \
-	./packages/php-wasm/compile-extension/src/cli.ts \
-	--source ../my-extension \
-	--name my_extension \
-	--php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
-	--out ../my-extension/dist
-```
-
-`--source` and any archives listed in `--extra-ldflags` are copied into the
-container under `/build`, so the extension source does not need to live
-inside the `wordpress-playground` checkout. Pass a relative or absolute path
-that points at the extension directory in the downstream repository.
 
 When you build the matrix in GitHub Actions, set `strategy.max-parallel: 1`
 on the WASM job. Parallel Docker builds on hosted runners frequently hit

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md
@@ -165,53 +165,75 @@ build a JSPI side module for PHP `8.0` through `8.5`:
 - name: Check out wordpress-playground
   uses: actions/checkout@v4
   with:
-      repository: WordPress/wordpress-playground
-      ref: trunk
-      path: wordpress-playground
-      sparse-checkout-cone-mode: false
-      sparse-checkout: |
-          /package.json
-          /package-lock.json
-          /nx.json
-          /tsconfig.base.json
-          /packages/meta/
-          /packages/nx-extensions/
-          /packages/php-wasm/cli-util/
-          /packages/php-wasm/compile-extension/
-          /packages/php-wasm/compile/
-          /packages/php-wasm/fs-journal/
-          /packages/php-wasm/logger/
-          /packages/php-wasm/node/
-          /packages/php-wasm/node-builds/8-0/
-          /packages/php-wasm/node-builds/8-1/
-          /packages/php-wasm/node-builds/8-2/
-          /packages/php-wasm/node-builds/8-3/
-          /packages/php-wasm/node-builds/8-4/
-          /packages/php-wasm/node-builds/8-5/
-          /packages/php-wasm/progress/
-          /packages/php-wasm/scopes/
-          /packages/php-wasm/stream-compression/
-          /packages/php-wasm/universal/
-          /packages/php-wasm/util/
+    repository: WordPress/wordpress-playground
+    ref: trunk
+    path: wordpress-playground
+    sparse-checkout-cone-mode: false
+    sparse-checkout: |
+      /package.json
+      /package-lock.json
+      /nx.json
+      /tsconfig.base.json
+      /packages/meta/
+      /packages/nx-extensions/
+      /packages/php-wasm/cli-util/
+      /packages/php-wasm/compile-extension/
+      /packages/php-wasm/compile/
+      /packages/php-wasm/fs-journal/
+      /packages/php-wasm/logger/
+      /packages/php-wasm/node/
+      /packages/php-wasm/node-builds/8-0/
+      /packages/php-wasm/node-builds/8-1/
+      /packages/php-wasm/node-builds/8-2/
+      /packages/php-wasm/node-builds/8-3/
+      /packages/php-wasm/node-builds/8-4/
+      /packages/php-wasm/node-builds/8-5/
+      /packages/php-wasm/progress/
+      /packages/php-wasm/scopes/
+      /packages/php-wasm/stream-compression/
+      /packages/php-wasm/universal/
+      /packages/php-wasm/util/
 
 - name: Install Playground deps
   working-directory: wordpress-playground
   run: npm ci --ignore-scripts
 ```
 
-Trim the `node-builds` lines to the PHP versions the matrix actually builds.
-The helper resolves headers and side-module link inputs from
-`packages/php-wasm/compile`, so include that package even when the build
-itself runs inside the helper's Docker image.
+Adjust the `node-builds` lines to the PHP versions the matrix builds. Add
+`/packages/php-wasm/node-builds/7-4/` when the matrix includes PHP `7.4`, and
+drop entries for versions you do not need. The helper resolves headers and
+side-module link inputs from `packages/php-wasm/compile`, so keep that
+package included even when the build itself runs inside the helper's Docker
+image.
 
-Once `npm ci` finishes, run the helper against the extension source from the
-downstream repository. The `--source` directory and any vendored archives
-listed in `--extra-ldflags` are copied into the container under `/build`, so
-the helper does not need to live in the same checkout as the extension.
+Run the helper from the `wordpress-playground` checkout. `npm ci
+--ignore-scripts` does not build the package's bin script, so until
+`@php-wasm/compile-extension` is published to npm, invoke the CLI source
+directly through Node's type-stripping flags:
 
-When you build the matrix in CI, prefer `max-parallel: 1` for the WASM lanes.
-Parallel Docker builds on hosted runners frequently hit apt-mirror flakes
-during the base image build.
+```bash
+cd wordpress-playground
+
+node \
+	--experimental-strip-types \
+	--experimental-transform-types \
+	--disable-warning=ExperimentalWarning \
+	--import "$PWD/packages/meta/src/node-es-module-loader/register.mts" \
+	./packages/php-wasm/compile-extension/src/cli.ts \
+	--source ../my-extension \
+	--name my_extension \
+	--php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
+	--out ../my-extension/dist
+```
+
+`--source` and any archives listed in `--extra-ldflags` are copied into the
+container under `/build`, so the extension source does not need to live
+inside the `wordpress-playground` checkout. Pass a relative or absolute path
+that points at the extension directory in the downstream repository.
+
+When you build the matrix in GitHub Actions, set `strategy.max-parallel: 1`
+on the WASM job. Parallel Docker builds on hosted runners frequently hit
+apt-mirror flakes during the base image build.
 
 For native dependencies, see
 [PHP extension dependencies](/developers/apis/javascript-api/php-extension-dependencies).

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md
@@ -176,6 +176,30 @@ RUSTFLAGS="-C panic=abort" cargo +nightly build \
 
 Link the resulting `lib*.a` with `--extra-ldflags`.
 
+### PHP version support for `ext-php-rs`
+
+`ext-php-rs` `0.15` depends on PHP 8 Zend APIs and does not compile against
+PHP `7.4` headers. Rust extensions built on top of `ext-php-rs` `0.15` should
+restrict the PHP matrix to `8.0` through `8.5`:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./my-rust-extension \
+	--name my_rust_extension \
+	--php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
+	--extra-ldflags "/build/target/wasm32-unknown-emscripten/release/libmy_rust_extension.a"
+```
+
+The helper itself still supports PHP `7.4`. The limitation is in the Rust
+binding layer, not in the WebAssembly side-module ABI. Hand-written Rust
+extensions that bind Zend directly through `bindgen` can target PHP `7.4` if
+the C ABI shim does the same.
+
+`ext-php-rs` also generates bindings for one PHP version at a time. When you
+build the same Rust crate for several PHP versions, rebuild the staticlib for
+each PHP version with that version's Zend API number visible to the build
+script, and link the matching archive into each `--php-versions` lane.
+
 ## Troubleshooting
 
 `configure: error: ... not found`

--- a/packages/php-wasm/compile-extension/README.md
+++ b/packages/php-wasm/compile-extension/README.md
@@ -50,80 +50,28 @@ Docker is required. The build reuses the `packages/php-wasm/compile` base image
 and its PHP patch set, then runs `phpize`, `emconfigure`, and `emmake` inside
 the container.
 
-## Using the helper from a downstream repository
+## Running in CI
 
-This package is not yet on npm. CI jobs in other repositories should pull a
-sparse checkout of `WordPress/wordpress-playground` and run the helper from
-there:
+The package only needs Docker and Node. A typical GitHub Actions job:
 
 ```yaml
 - uses: actions/checkout@v4
+
+- uses: actions/setup-node@v4
   with:
-    repository: WordPress/wordpress-playground
-    ref: trunk
-    path: wordpress-playground
-    sparse-checkout-cone-mode: false
-    sparse-checkout: |
-      /package.json
-      /package-lock.json
-      /nx.json
-      /tsconfig.base.json
-      /packages/meta/
-      /packages/nx-extensions/
-      /packages/php-wasm/cli-util/
-      /packages/php-wasm/compile-extension/
-      /packages/php-wasm/compile/
-      /packages/php-wasm/fs-journal/
-      /packages/php-wasm/logger/
-      /packages/php-wasm/node/
-      /packages/php-wasm/node-builds/8-0/
-      /packages/php-wasm/node-builds/8-1/
-      /packages/php-wasm/node-builds/8-2/
-      /packages/php-wasm/node-builds/8-3/
-      /packages/php-wasm/node-builds/8-4/
-      /packages/php-wasm/node-builds/8-5/
-      /packages/php-wasm/progress/
-      /packages/php-wasm/scopes/
-      /packages/php-wasm/stream-compression/
-      /packages/php-wasm/universal/
-      /packages/php-wasm/util/
+    node-version: '24'
 
-- working-directory: wordpress-playground
-  run: npm ci --ignore-scripts
+- run: |
+    npx --yes @php-wasm/compile-extension \
+      --source ./my-extension \
+      --name my_extension \
+      --php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
+      --out ./dist/my-extension
 ```
 
-Adjust the `node-builds` entries to the matrix. Add
-`/packages/php-wasm/node-builds/7-4/` when the matrix includes PHP `7.4`, and
-drop entries for versions the matrix does not build. Keep
-`packages/php-wasm/compile` even when the build runs inside Docker — the
-helper resolves headers and side-module link inputs from there.
-
-`npm ci --ignore-scripts` skips the package build, so the `cli.js` referenced
-by the bin entry does not exist yet. Run the CLI source directly through
-Node's type-stripping flags:
-
-```bash
-cd wordpress-playground
-
-node \
-	--experimental-strip-types \
-	--experimental-transform-types \
-	--disable-warning=ExperimentalWarning \
-	--import "$PWD/packages/meta/src/node-es-module-loader/register.mts" \
-	./packages/php-wasm/compile-extension/src/cli.ts \
-	--source ../my-extension \
-	--name my_extension \
-	--php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
-	--out ../my-extension/dist
-```
-
-`--source` and any `--extra-ldflags` archive paths are copied into the
-container under `/build`, so the extension does not need to live inside the
-`wordpress-playground` checkout.
-
-In GitHub Actions, set `strategy.max-parallel: 1` on the WASM job. Parallel
-Docker builds on hosted runners often hit apt-mirror flakes during the base
-image build.
+In a matrix workflow, set `strategy.max-parallel: 1` on the WASM job —
+parallel Docker builds on hosted runners often hit apt-mirror flakes during
+the base image build.
 
 ## Loading the result
 

--- a/packages/php-wasm/compile-extension/README.md
+++ b/packages/php-wasm/compile-extension/README.md
@@ -44,9 +44,59 @@ npx @php-wasm/compile-extension \
 Empty directories are recorded as `type: "directory"` nodes so the loader
 creates them before PHP starts.
 
+The supported `--php-versions` are `7.4` and `8.0` through `8.5`.
+
 Docker is required. The build reuses the `packages/php-wasm/compile` base image
 and its PHP patch set, then runs `phpize`, `emconfigure`, and `emmake` inside
 the container.
+
+## Using the helper from a downstream repository
+
+This package is not yet on npm. CI jobs in other repositories should pull a
+sparse checkout of `WordPress/wordpress-playground` and run the helper from
+there:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+      repository: WordPress/wordpress-playground
+      ref: trunk
+      path: wordpress-playground
+      sparse-checkout-cone-mode: false
+      sparse-checkout: |
+          /package.json
+          /package-lock.json
+          /nx.json
+          /tsconfig.base.json
+          /packages/meta/
+          /packages/nx-extensions/
+          /packages/php-wasm/cli-util/
+          /packages/php-wasm/compile-extension/
+          /packages/php-wasm/compile/
+          /packages/php-wasm/fs-journal/
+          /packages/php-wasm/logger/
+          /packages/php-wasm/node/
+          /packages/php-wasm/node-builds/8-0/
+          /packages/php-wasm/node-builds/8-1/
+          /packages/php-wasm/node-builds/8-2/
+          /packages/php-wasm/node-builds/8-3/
+          /packages/php-wasm/node-builds/8-4/
+          /packages/php-wasm/node-builds/8-5/
+          /packages/php-wasm/progress/
+          /packages/php-wasm/scopes/
+          /packages/php-wasm/stream-compression/
+          /packages/php-wasm/universal/
+          /packages/php-wasm/util/
+
+- working-directory: wordpress-playground
+  run: npm ci --ignore-scripts
+```
+
+Trim the `node-builds` entries to the PHP versions the matrix actually builds.
+Keep `packages/php-wasm/compile` even when the build runs inside Docker; the
+helper resolves headers and side-module link inputs from there. Prefer
+`max-parallel: 1` for the WASM lanes — parallel Docker builds on hosted
+runners often hit apt-mirror flakes during the base image build.
 
 ## Loading the result
 
@@ -246,6 +296,12 @@ RUSTFLAGS="-C panic=abort" cargo +nightly build \
 
 Keep dependencies aligned with the custom extension target. Custom extensions
 are JSPI-only, so link `jspi` dependency archives.
+
+`ext-php-rs` `0.15` depends on PHP 8 Zend APIs and does not compile against
+PHP `7.4` headers, so Rust extensions built on top of `ext-php-rs` `0.15`
+should restrict `--php-versions` to `8.0` through `8.5`. The helper itself
+still supports PHP `7.4` for non-Rust extensions and for Rust extensions that
+bind Zend directly through `bindgen`.
 
 `--extra-cflags` is visible during `./configure`. `--extra-ldflags` is applied
 to the final side-module link so dependency archives do not break Autoconf's

--- a/packages/php-wasm/compile-extension/README.md
+++ b/packages/php-wasm/compile-extension/README.md
@@ -59,44 +59,71 @@ there:
 ```yaml
 - uses: actions/checkout@v4
   with:
-      repository: WordPress/wordpress-playground
-      ref: trunk
-      path: wordpress-playground
-      sparse-checkout-cone-mode: false
-      sparse-checkout: |
-          /package.json
-          /package-lock.json
-          /nx.json
-          /tsconfig.base.json
-          /packages/meta/
-          /packages/nx-extensions/
-          /packages/php-wasm/cli-util/
-          /packages/php-wasm/compile-extension/
-          /packages/php-wasm/compile/
-          /packages/php-wasm/fs-journal/
-          /packages/php-wasm/logger/
-          /packages/php-wasm/node/
-          /packages/php-wasm/node-builds/8-0/
-          /packages/php-wasm/node-builds/8-1/
-          /packages/php-wasm/node-builds/8-2/
-          /packages/php-wasm/node-builds/8-3/
-          /packages/php-wasm/node-builds/8-4/
-          /packages/php-wasm/node-builds/8-5/
-          /packages/php-wasm/progress/
-          /packages/php-wasm/scopes/
-          /packages/php-wasm/stream-compression/
-          /packages/php-wasm/universal/
-          /packages/php-wasm/util/
+    repository: WordPress/wordpress-playground
+    ref: trunk
+    path: wordpress-playground
+    sparse-checkout-cone-mode: false
+    sparse-checkout: |
+      /package.json
+      /package-lock.json
+      /nx.json
+      /tsconfig.base.json
+      /packages/meta/
+      /packages/nx-extensions/
+      /packages/php-wasm/cli-util/
+      /packages/php-wasm/compile-extension/
+      /packages/php-wasm/compile/
+      /packages/php-wasm/fs-journal/
+      /packages/php-wasm/logger/
+      /packages/php-wasm/node/
+      /packages/php-wasm/node-builds/8-0/
+      /packages/php-wasm/node-builds/8-1/
+      /packages/php-wasm/node-builds/8-2/
+      /packages/php-wasm/node-builds/8-3/
+      /packages/php-wasm/node-builds/8-4/
+      /packages/php-wasm/node-builds/8-5/
+      /packages/php-wasm/progress/
+      /packages/php-wasm/scopes/
+      /packages/php-wasm/stream-compression/
+      /packages/php-wasm/universal/
+      /packages/php-wasm/util/
 
 - working-directory: wordpress-playground
   run: npm ci --ignore-scripts
 ```
 
-Trim the `node-builds` entries to the PHP versions the matrix actually builds.
-Keep `packages/php-wasm/compile` even when the build runs inside Docker; the
-helper resolves headers and side-module link inputs from there. Prefer
-`max-parallel: 1` for the WASM lanes — parallel Docker builds on hosted
-runners often hit apt-mirror flakes during the base image build.
+Adjust the `node-builds` entries to the matrix. Add
+`/packages/php-wasm/node-builds/7-4/` when the matrix includes PHP `7.4`, and
+drop entries for versions the matrix does not build. Keep
+`packages/php-wasm/compile` even when the build runs inside Docker — the
+helper resolves headers and side-module link inputs from there.
+
+`npm ci --ignore-scripts` skips the package build, so the `cli.js` referenced
+by the bin entry does not exist yet. Run the CLI source directly through
+Node's type-stripping flags:
+
+```bash
+cd wordpress-playground
+
+node \
+	--experimental-strip-types \
+	--experimental-transform-types \
+	--disable-warning=ExperimentalWarning \
+	--import "$PWD/packages/meta/src/node-es-module-loader/register.mts" \
+	./packages/php-wasm/compile-extension/src/cli.ts \
+	--source ../my-extension \
+	--name my_extension \
+	--php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
+	--out ../my-extension/dist
+```
+
+`--source` and any `--extra-ldflags` archive paths are copied into the
+container under `/build`, so the extension does not need to live inside the
+`wordpress-playground` checkout.
+
+In GitHub Actions, set `strategy.max-parallel: 1` on the WASM job. Parallel
+Docker builds on hosted runners often hit apt-mirror flakes during the base
+image build.
 
 ## Loading the result
 


### PR DESCRIPTION
## Summary

The `@php-wasm/compile-extension` helper isn't on npm yet, so projects that want to build a PHP.wasm side module from their own repo (the `wp_mysql_parser` work in `WordPress/sqlite-database-integration#395` was the trigger) have to pull it out of this monorepo. The path that worked in that PR is a sparse checkout of `WordPress/wordpress-playground` plus `npm ci --ignore-scripts`. This change writes that pattern down so the next person doesn't have to rediscover the package list.

While I was in there, two more things needed clearer docs:

- The supported `--php-versions` matrix (`7.4` and `8.0`–`8.5`) is now stated where readers actually look, with an example invocation that builds the whole matrix.
- Rust extensions built on `ext-php-rs 0.15` can't include PHP `7.4` — the crate depends on PHP 8 Zend APIs and won't compile against PHP 7.4 headers. The helper itself still supports 7.4 for non-Rust extensions and for Rust extensions that bind Zend directly via `bindgen`. The note lives in the Rust-build-systems section so it shows up next to the rest of the Rust gotchas.

Edits land in three places that all describe the same toolkit:

- `packages/docs/site/docs/developers/06-apis/javascript-api/08-build-php-extensions.md`
- `packages/docs/site/docs/developers/06-apis/javascript-api/09-php-extension-dependencies.md`
- `packages/php-wasm/compile-extension/README.md`

Docs only — no source or binary changes.

## Test plan

- [ ] `npm run build:docs` builds without warnings
- [ ] Eyeball the rendered "Building PHP extensions" and "PHP extension dependencies" pages on the local docs server