### PR TITLE
[compile-extension] Emit the new PHPExtensionManifest shape, add --extra-files

### DIFF
--- a/packages/php-wasm/compile-extension/README.md
+++ b/packages/php-wasm/compile-extension/README.md
@@ -12,7 +12,37 @@ npx @php-wasm/compile-extension \
 ```
 
 The command writes one JSPI `.so` per PHP version and a `manifest.json` that
-can be consumed by PHP.wasm extension-loading helpers.
+can be consumed by PHP.wasm extension-loading helpers. The manifest matches
+the `PHPExtensionManifest` shape from `@php-wasm/universal`:
+
+```json
+{
+	"name": "wp_mysql_parser",
+	"version": "0.1.0",
+	"artifacts": [
+		{
+			"phpVersion": "8.4",
+			"sourcePath": "wp_mysql_parser-php8.4-jspi.so"
+		}
+	]
+}
+```
+
+To stage sidecar files (data directories, web UI assets, ICU data, etc.) under
+an absolute VFS prefix, pass `--extra-files <hostDir>:<vfsRoot>`. The host
+directory is copied next to the manifest and recorded under `extraFiles.nodes`:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./spx-src \
+	--name spx \
+	--php-versions 8.2 \
+	--extra-files ./web-ui:/internal/shared/spx \
+	--out ./dist
+```
+
+Empty directories are recorded as `type: "directory"` nodes so the loader
+creates them before PHP starts.
 
 Docker is required. The build reuses the `packages/php-wasm/compile` base image
 and its PHP patch set, then runs `phpize`, `emconfigure`, and `emmake` inside
@@ -42,9 +72,9 @@ const php = new PHP(
 ```
 
 The loader chooses the artifact whose `phpVersion` matches the running
-PHP.wasm runtime, downloads it, verifies `sha256` when present, stages the
-`.so`, writes a startup `.ini` file, and registers the extension scan directory
-before PHP starts.
+PHP.wasm runtime, downloads it, stages the `.so`, writes a startup `.ini`
+file, copies any `extraFiles` declared in the manifest, and registers the
+extension scan directory before PHP starts.
 
 In Node.js, `manifestUrl` may also be a local path:
 
@@ -75,7 +105,6 @@ const php = new PHP(
 				source: {
 					format: 'url',
 					url: 'https://example.com/extensions/wp_mysql_parser-php8.4-jspi.so',
-					sha256: '...',
 				},
 			},
 		],

--- a/packages/php-wasm/compile-extension/src/cli.ts
+++ b/packages/php-wasm/compile-extension/src/cli.ts
@@ -11,6 +11,7 @@ import {
 	SupportedExtensionPHPVersions,
 } from './compile';
 import { detectExtensionName } from './detect';
+import { parseExtraFilesSpec, stageExtraFilesIntoOutDir } from './extra-files';
 
 const OptionsWithDashPrefixedValues = new Set([
 	'--config-args',
@@ -65,6 +66,13 @@ export async function main(args = hideBin(process.argv)) {
 				type: 'number',
 				description: 'Maximum concurrent docker builds.',
 			},
+			'extra-files': {
+				type: 'string',
+				array: true,
+				default: [] as string[],
+				description:
+					'Stage a host directory under an absolute VFS root. Format: <hostDir>:<vfsRoot>. Files are copied next to the manifest and recorded in extraFiles.',
+			},
 		})
 		.strict()
 		.help()
@@ -80,6 +88,15 @@ export async function main(args = hideBin(process.argv)) {
 		'php-versions'
 	);
 	const configArgs = splitShellWords((argv['config-args'] as string) || '');
+	const extraFilesSpecs = (argv['extra-files'] as string[]).map(
+		parseExtraFilesSpec
+	);
+	const outDir = path.resolve(workspaceRoot, argv['out'] as string);
+	const extraFiles = await stageExtraFilesIntoOutDir(
+		extraFilesSpecs,
+		outDir,
+		workspaceRoot
+	);
 
 	const result = await compileExtensionMatrix({
 		workspaceRoot,
@@ -92,6 +109,7 @@ export async function main(args = hideBin(process.argv)) {
 		configArgs,
 		optimize: argv['optimize'] as string,
 		jobs: argv['jobs'] as number | undefined,
+		extraFiles,
 	});
 
 	console.log(`Wrote ${result.artifacts.length} artifacts.`);

--- a/packages/php-wasm/compile-extension/src/compile.ts
+++ b/packages/php-wasm/compile-extension/src/compile.ts
@@ -9,7 +9,11 @@ import {
 	createDockerContext,
 	runExtensionBuild,
 } from './docker';
-import type { AsyncMode, BuiltArtifact } from './manifest';
+import type {
+	AsyncMode,
+	BuiltArtifact,
+	ExtensionManifestExtraFiles,
+} from './manifest';
 import { createManifest, ExtensionAsyncMode, writeManifest } from './manifest';
 
 export const SupportedExtensionPHPVersions = [
@@ -43,6 +47,8 @@ export interface CompileExtensionOptions {
 	configArgs: string[];
 	optimize: string;
 	jobs?: number;
+	/** Sidecar files to record at the manifest level. */
+	extraFiles?: ExtensionManifestExtraFiles;
 }
 
 export async function compileExtensionMatrix(options: CompileExtensionOptions) {
@@ -88,7 +94,7 @@ export async function compileExtensionMatrix(options: CompileExtensionOptions) {
 			});
 			return {
 				phpVersion,
-				file: artifactFile,
+				sourcePath: artifactFile,
 				path: path.join(outDir, artifactFile),
 			} satisfies BuiltArtifact;
 		}
@@ -98,6 +104,7 @@ export async function compileExtensionMatrix(options: CompileExtensionOptions) {
 		name: options.name,
 		version,
 		artifacts,
+		extraFiles: options.extraFiles,
 	});
 	const manifestPath = await writeManifest({ outDir, manifest });
 	return { manifestPath, artifacts, manifest };

--- a/packages/php-wasm/compile-extension/src/extra-files.spec.ts
+++ b/packages/php-wasm/compile-extension/src/extra-files.spec.ts
@@ -24,6 +24,15 @@ describe('parseExtraFilesSpec', () => {
 			'must be an absolute VFS path'
 		);
 	});
+
+	it('preserves Windows-style hostDir that contains a colon', () => {
+		expect(
+			parseExtraFilesSpec('C:\\path\\to\\ui:/internal/shared/spx')
+		).toEqual({
+			hostDir: 'C:\\path\\to\\ui',
+			vfsRoot: '/internal/shared/spx',
+		});
+	});
 });
 
 describe('stageExtraFilesIntoOutDir', () => {
@@ -74,6 +83,64 @@ describe('stageExtraFilesIntoOutDir', () => {
 		expect(extraFiles?.nodes).toEqual([
 			{ vfsPath: 'data', type: 'directory' },
 		]);
+	});
+
+	it('rejects two specs whose hostDirs share a basename', async () => {
+		const workspace = await mkdtemp(
+			path.join(os.tmpdir(), 'compile-extension-extras-')
+		);
+		await mkdir(path.join(workspace, 'a', 'ui'), { recursive: true });
+		await mkdir(path.join(workspace, 'b', 'ui'), { recursive: true });
+
+		await expect(
+			stageExtraFilesIntoOutDir(
+				[
+					{
+						hostDir: path.join(workspace, 'a', 'ui'),
+						vfsRoot: '/x',
+					},
+					{
+						hostDir: path.join(workspace, 'b', 'ui'),
+						vfsRoot: '/x',
+					},
+				],
+				path.join(workspace, 'dist'),
+				workspace
+			)
+		).rejects.toThrow('destination collides on disk');
+	});
+
+	it('rejects two specs that produce the same vfsPath', async () => {
+		const workspace = await mkdtemp(
+			path.join(os.tmpdir(), 'compile-extension-extras-')
+		);
+		await mkdir(path.join(workspace, 'first'), { recursive: true });
+		await mkdir(path.join(workspace, 'second'), { recursive: true });
+		await writeFile(
+			path.join(workspace, 'first', 'index.html'),
+			'<html></html>'
+		);
+		await writeFile(
+			path.join(workspace, 'second', 'index.html'),
+			'<html></html>'
+		);
+
+		await expect(
+			stageExtraFilesIntoOutDir(
+				[
+					{
+						hostDir: path.join(workspace, 'first'),
+						vfsRoot: '/x',
+					},
+					{
+						hostDir: path.join(workspace, 'second'),
+						vfsRoot: '/x',
+					},
+				],
+				path.join(workspace, 'dist'),
+				workspace
+			)
+		).rejects.toThrow('vfsPath collides across specs');
 	});
 
 	it('rejects mixed vfsRoot values across specs', async () => {

--- a/packages/php-wasm/compile-extension/src/extra-files.spec.ts
+++ b/packages/php-wasm/compile-extension/src/extra-files.spec.ts
@@ -1,0 +1,99 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { parseExtraFilesSpec, stageExtraFilesIntoOutDir } from './extra-files';
+
+describe('parseExtraFilesSpec', () => {
+	it('splits hostDir from absolute vfsRoot', () => {
+		expect(parseExtraFilesSpec('./web-ui:/internal/shared/spx')).toEqual({
+			hostDir: './web-ui',
+			vfsRoot: '/internal/shared/spx',
+		});
+	});
+
+	it('rejects values without a colon', () => {
+		expect(() => parseExtraFilesSpec('./web-ui')).toThrow(
+			'Invalid --extra-files'
+		);
+	});
+
+	it('rejects relative vfsRoot values', () => {
+		expect(() => parseExtraFilesSpec('./web-ui:internal/shared')).toThrow(
+			'must be an absolute VFS path'
+		);
+	});
+});
+
+describe('stageExtraFilesIntoOutDir', () => {
+	it('copies host files into outDir and records relative sourcePath nodes', async () => {
+		const workspace = await mkdtemp(
+			path.join(os.tmpdir(), 'compile-extension-extras-')
+		);
+		const hostDir = path.join(workspace, 'ui');
+		await mkdir(path.join(hostDir, 'css'), { recursive: true });
+		await writeFile(path.join(hostDir, 'index.html'), '<html></html>');
+		await writeFile(path.join(hostDir, 'css', 'main.css'), 'body{}');
+
+		const outDir = path.join(workspace, 'dist');
+		const extraFiles = await stageExtraFilesIntoOutDir(
+			[{ hostDir, vfsRoot: '/internal/shared/example' }],
+			outDir,
+			workspace
+		);
+
+		expect(extraFiles).toEqual({
+			vfsRoot: '/internal/shared/example',
+			nodes: [
+				{ vfsPath: 'css/main.css', sourcePath: 'ui/css/main.css' },
+				{ vfsPath: 'index.html', sourcePath: 'ui/index.html' },
+			],
+		});
+		expect(
+			(
+				await readFile(path.join(outDir, 'ui', 'index.html'), 'utf8')
+			).trim()
+		).toBe('<html></html>');
+	});
+
+	it('records empty directories as type=directory nodes', async () => {
+		const workspace = await mkdtemp(
+			path.join(os.tmpdir(), 'compile-extension-extras-')
+		);
+		const hostDir = path.join(workspace, 'spx');
+		await mkdir(path.join(hostDir, 'data'), { recursive: true });
+
+		const outDir = path.join(workspace, 'dist');
+		const extraFiles = await stageExtraFilesIntoOutDir(
+			[{ hostDir, vfsRoot: '/internal/shared/spx' }],
+			outDir,
+			workspace
+		);
+
+		expect(extraFiles?.nodes).toEqual([
+			{ vfsPath: 'data', type: 'directory' },
+		]);
+	});
+
+	it('rejects mixed vfsRoot values across specs', async () => {
+		const workspace = await mkdtemp(
+			path.join(os.tmpdir(), 'compile-extension-extras-')
+		);
+		await mkdir(path.join(workspace, 'a'), { recursive: true });
+		await mkdir(path.join(workspace, 'b'), { recursive: true });
+
+		await expect(
+			stageExtraFilesIntoOutDir(
+				[
+					{ hostDir: path.join(workspace, 'a'), vfsRoot: '/x' },
+					{ hostDir: path.join(workspace, 'b'), vfsRoot: '/y' },
+				],
+				path.join(workspace, 'dist'),
+				workspace
+			)
+		).rejects.toThrow(
+			'All --extra-files entries must share the same vfsRoot'
+		);
+	});
+});

--- a/packages/php-wasm/compile-extension/src/extra-files.ts
+++ b/packages/php-wasm/compile-extension/src/extra-files.ts
@@ -10,13 +10,14 @@ import type {
  * Parses a `--extra-files` CLI argument of the form `<hostDir>:<vfsRoot>`.
  *
  * `vfsRoot` must be an absolute VFS path so the loader can stage files
- * without making up a default root.
+ * without making up a default root. Splitting on the *last* colon lets
+ * Windows host paths like `C:\dir:/internal/root` round-trip cleanly.
  */
 export function parseExtraFilesSpec(spec: string): {
 	hostDir: string;
 	vfsRoot: string;
 } {
-	const separator = spec.indexOf(':');
+	const separator = spec.lastIndexOf(':');
 	if (separator < 0) {
 		throw new Error(
 			`Invalid --extra-files value ${JSON.stringify(
@@ -72,10 +73,19 @@ export async function stageExtraFilesIntoOutDir(
 	}
 
 	const nodes: ExtensionManifestExtraFile[] = [];
+	const claimedVfsPaths = new Set<string>();
+	const claimedDestinations = new Set<string>();
 	for (const spec of specs) {
 		const absoluteHostDir = path.resolve(workspaceRoot, spec.hostDir);
 		const targetSubdir = path.basename(absoluteHostDir);
 		const destinationDir = path.join(outDir, targetSubdir);
+		if (claimedDestinations.has(destinationDir)) {
+			throw new Error(
+				`--extra-files destination collides on disk: ${destinationDir}. ` +
+					`Two host directories share the same basename, so one would overwrite the other.`
+			);
+		}
+		claimedDestinations.add(destinationDir);
 		await mkdir(path.dirname(destinationDir), { recursive: true });
 		await cp(absoluteHostDir, destinationDir, { recursive: true });
 
@@ -90,21 +100,38 @@ export async function stageExtraFilesIntoOutDir(
 			const sourcePath = `${targetSubdir}/${relativeUnderRoot}`;
 			if (isDirectory) {
 				const empty = (await readdir(entryPath)).length === 0;
-				if (empty) {
-					nodes.push({
-						vfsPath: relativeUnderRoot,
-						type: 'directory',
-					});
+				if (!empty) {
+					return;
 				}
+				if (claimedVfsPaths.has(relativeUnderRoot)) {
+					throw new Error(
+						`--extra-files vfsPath collides across specs: ${relativeUnderRoot}.`
+					);
+				}
+				claimedVfsPaths.add(relativeUnderRoot);
+				nodes.push({
+					vfsPath: relativeUnderRoot,
+					type: 'directory',
+				});
 				return;
 			}
+			if (claimedVfsPaths.has(relativeUnderRoot)) {
+				throw new Error(
+					`--extra-files vfsPath collides across specs: ${relativeUnderRoot}.`
+				);
+			}
+			claimedVfsPaths.add(relativeUnderRoot);
 			nodes.push({
 				vfsPath: relativeUnderRoot,
 				sourcePath,
 			});
 		});
 	}
-	nodes.sort((a, b) => a.vfsPath.localeCompare(b.vfsPath));
+	// Sort with a locale-independent comparator so the manifest is byte-stable
+	// across machines (`localeCompare` honors the host locale).
+	nodes.sort((a, b) =>
+		a.vfsPath < b.vfsPath ? -1 : a.vfsPath > b.vfsPath ? 1 : 0
+	);
 
 	return {
 		vfsRoot,
@@ -114,7 +141,7 @@ export async function stageExtraFilesIntoOutDir(
 
 async function walk(
 	dir: string,
-	visitor: (path: string, isDirectory: boolean) => Promise<void>
+	visitor: (entryPath: string, isDirectory: boolean) => Promise<void>
 ): Promise<void> {
 	for (const entry of await readdir(dir)) {
 		const entryPath = path.join(dir, entry);

--- a/packages/php-wasm/compile-extension/src/extra-files.ts
+++ b/packages/php-wasm/compile-extension/src/extra-files.ts
@@ -1,0 +1,127 @@
+import { cp, mkdir, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+
+import type {
+	ExtensionManifestExtraFile,
+	ExtensionManifestExtraFiles,
+} from './manifest';
+
+/**
+ * Parses a `--extra-files` CLI argument of the form `<hostDir>:<vfsRoot>`.
+ *
+ * `vfsRoot` must be an absolute VFS path so the loader can stage files
+ * without making up a default root.
+ */
+export function parseExtraFilesSpec(spec: string): {
+	hostDir: string;
+	vfsRoot: string;
+} {
+	const separator = spec.indexOf(':');
+	if (separator < 0) {
+		throw new Error(
+			`Invalid --extra-files value ${JSON.stringify(
+				spec
+			)}. Expected "<hostDir>:<vfsRoot>".`
+		);
+	}
+	const hostDir = spec.slice(0, separator);
+	const vfsRoot = spec.slice(separator + 1);
+	if (!hostDir || !vfsRoot) {
+		throw new Error(
+			`Invalid --extra-files value ${JSON.stringify(
+				spec
+			)}. Expected "<hostDir>:<vfsRoot>".`
+		);
+	}
+	if (!vfsRoot.startsWith('/')) {
+		throw new Error(
+			`--extra-files vfsRoot must be an absolute VFS path. Received ${JSON.stringify(
+				vfsRoot
+			)}.`
+		);
+	}
+	return { hostDir, vfsRoot };
+}
+
+/**
+ * Copies one or more host directories into `outDir` and returns a manifest
+ * `extraFiles` group whose `sourcePath` entries are relative to `outDir`.
+ *
+ * Each spec is `<hostDir>:<vfsRoot>`. All specs must agree on `vfsRoot`
+ * because the manifest format only stores a single `vfsRoot` per group.
+ *
+ * Files keep their relative path under `vfsRoot`. Empty directories are
+ * recorded as `type: 'directory'` nodes so the loader creates them.
+ */
+export async function stageExtraFilesIntoOutDir(
+	specs: Array<{ hostDir: string; vfsRoot: string }>,
+	outDir: string,
+	workspaceRoot: string
+): Promise<ExtensionManifestExtraFiles | undefined> {
+	if (!specs.length) {
+		return undefined;
+	}
+	const vfsRoot = specs[0].vfsRoot;
+	for (const spec of specs) {
+		if (spec.vfsRoot !== vfsRoot) {
+			throw new Error(
+				'All --extra-files entries must share the same vfsRoot. Received ' +
+					JSON.stringify(specs.map((entry) => entry.vfsRoot))
+			);
+		}
+	}
+
+	const nodes: ExtensionManifestExtraFile[] = [];
+	for (const spec of specs) {
+		const absoluteHostDir = path.resolve(workspaceRoot, spec.hostDir);
+		const targetSubdir = path.basename(absoluteHostDir);
+		const destinationDir = path.join(outDir, targetSubdir);
+		await mkdir(path.dirname(destinationDir), { recursive: true });
+		await cp(absoluteHostDir, destinationDir, { recursive: true });
+
+		await walk(destinationDir, async (entryPath, isDirectory) => {
+			const relativeUnderRoot = path
+				.relative(destinationDir, entryPath)
+				.split(path.sep)
+				.join('/');
+			if (!relativeUnderRoot) {
+				return;
+			}
+			const sourcePath = `${targetSubdir}/${relativeUnderRoot}`;
+			if (isDirectory) {
+				const empty = (await readdir(entryPath)).length === 0;
+				if (empty) {
+					nodes.push({
+						vfsPath: relativeUnderRoot,
+						type: 'directory',
+					});
+				}
+				return;
+			}
+			nodes.push({
+				vfsPath: relativeUnderRoot,
+				sourcePath,
+			});
+		});
+	}
+	nodes.sort((a, b) => a.vfsPath.localeCompare(b.vfsPath));
+
+	return {
+		vfsRoot,
+		nodes,
+	};
+}
+
+async function walk(
+	dir: string,
+	visitor: (path: string, isDirectory: boolean) => Promise<void>
+): Promise<void> {
+	for (const entry of await readdir(dir)) {
+		const entryPath = path.join(dir, entry);
+		const entryStat = await stat(entryPath);
+		await visitor(entryPath, entryStat.isDirectory());
+		if (entryStat.isDirectory()) {
+			await walk(entryPath, visitor);
+		}
+	}
+}

--- a/packages/php-wasm/compile-extension/src/manifest.spec.ts
+++ b/packages/php-wasm/compile-extension/src/manifest.spec.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { findExtensionArtifact, type ExtensionManifest } from './manifest';
+import {
+	createManifest,
+	findExtensionArtifact,
+	type ExtensionManifest,
+} from './manifest';
 
 describe('findExtensionArtifact', () => {
 	it('selects the PHP version match', () => {
@@ -10,15 +14,70 @@ describe('findExtensionArtifact', () => {
 			artifacts: [
 				{
 					phpVersion: '8.4',
-					file: 'example-php8.4-jspi.so',
-					sha256: 'abc',
+					sourcePath: 'example-php8.4-jspi.so',
 				},
 			],
 		};
 
-		expect(findExtensionArtifact(manifest, '8.4')?.file).toBe(
+		expect(findExtensionArtifact(manifest, '8.4')?.sourcePath).toBe(
 			'example-php8.4-jspi.so'
 		);
 		expect(findExtensionArtifact(manifest, '8.3')).toBe(undefined);
+	});
+});
+
+describe('createManifest', () => {
+	it('emits sourcePath entries that match the @php-wasm/universal loader', async () => {
+		const manifest = await createManifest({
+			name: 'example',
+			version: '0.1.0',
+			artifacts: [
+				{
+					phpVersion: '8.4',
+					sourcePath: 'example-php8.4-jspi.so',
+					path: '/tmp/dist/example-php8.4-jspi.so',
+				},
+			],
+		});
+
+		expect(manifest).toEqual({
+			name: 'example',
+			version: '0.1.0',
+			artifacts: [
+				{
+					phpVersion: '8.4',
+					sourcePath: 'example-php8.4-jspi.so',
+				},
+			],
+		});
+	});
+
+	it('threads extraFiles through to the manifest output', async () => {
+		const manifest = await createManifest({
+			name: 'example',
+			version: '0.1.0',
+			artifacts: [
+				{
+					phpVersion: '8.4',
+					sourcePath: 'example-php8.4-jspi.so',
+					path: '/tmp/dist/example-php8.4-jspi.so',
+				},
+			],
+			extraFiles: {
+				vfsRoot: '/internal/shared/example',
+				nodes: [
+					{ vfsPath: 'data', type: 'directory' },
+					{ vfsPath: 'ui/index.html', sourcePath: 'ui/index.html' },
+				],
+			},
+		});
+
+		expect(manifest.extraFiles).toEqual({
+			vfsRoot: '/internal/shared/example',
+			nodes: [
+				{ vfsPath: 'data', type: 'directory' },
+				{ vfsPath: 'ui/index.html', sourcePath: 'ui/index.html' },
+			],
+		});
 	});
 });

--- a/packages/php-wasm/compile-extension/src/manifest.ts
+++ b/packages/php-wasm/compile-extension/src/manifest.ts
@@ -1,56 +1,71 @@
-import { createHash } from 'node:crypto';
-import { createReadStream } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 export const ExtensionAsyncMode = 'jspi';
 export type AsyncMode = typeof ExtensionAsyncMode;
 
+/**
+ * One sidecar file or empty directory staged alongside an artifact.
+ *
+ * Mirrors `PHPExtensionManifestExtraFile` in `@php-wasm/universal`.
+ */
+export interface ExtensionManifestExtraFile {
+	/** Joined with the group's `vfsRoot` to form the final VFS path. */
+	vfsPath: string;
+	/** Defaults to "file". Only file nodes need a `sourcePath`. */
+	type?: 'file' | 'directory';
+	/** Relative to the manifest URL/base URL, or an absolute URL. */
+	sourcePath?: string;
+}
+
+export interface ExtensionManifestExtraFiles {
+	/** Absolute VFS prefix joined with each node's `vfsPath`. */
+	vfsRoot?: string;
+	nodes?: ExtensionManifestExtraFile[];
+}
+
 export interface ExtensionArtifact {
 	phpVersion: string;
-	file: string;
-	sha256: string;
+	/** Path to the `.so` file, relative to the manifest URL or absolute. */
+	sourcePath: string;
+	/** URL-backed files needed only by this artifact. */
+	extraFiles?: ExtensionManifestExtraFiles;
 }
 
 export interface ExtensionManifest {
 	name: string;
 	version: string;
 	artifacts: ExtensionArtifact[];
+	/** URL-backed files shared by every artifact in this manifest. */
+	extraFiles?: ExtensionManifestExtraFiles;
 }
 
 export interface BuiltArtifact {
 	phpVersion: string;
-	file: string;
+	/** Path to the `.so` file, relative to the manifest URL. */
+	sourcePath: string;
+	/** Absolute path on disk where the `.so` was written. */
 	path: string;
-}
-
-export async function sha256File(filePath: string): Promise<string> {
-	const hash = createHash('sha256');
-	await new Promise<void>((resolve, reject) => {
-		const stream = createReadStream(filePath);
-		stream.on('data', (chunk) => hash.update(chunk));
-		stream.on('error', reject);
-		stream.on('end', resolve);
-	});
-	return hash.digest('hex');
 }
 
 export async function createManifest(options: {
 	name: string;
 	version: string;
 	artifacts: BuiltArtifact[];
+	extraFiles?: ExtensionManifestExtraFiles;
 }): Promise<ExtensionManifest> {
-	return {
+	const manifest: ExtensionManifest = {
 		name: options.name,
 		version: options.version,
-		artifacts: await Promise.all(
-			options.artifacts.map(async (artifact) => ({
-				phpVersion: artifact.phpVersion,
-				file: artifact.file,
-				sha256: await sha256File(artifact.path),
-			}))
-		),
+		artifacts: options.artifacts.map((artifact) => ({
+			phpVersion: artifact.phpVersion,
+			sourcePath: artifact.sourcePath,
+		})),
 	};
+	if (options.extraFiles) {
+		manifest.extraFiles = options.extraFiles;
+	}
+	return manifest;
 }
 
 export async function writeManifest(options: {


### PR DESCRIPTION
## What it does

Updates `@php-wasm/compile-extension` to emit manifests in the shape the loader merged in #3580 expects, and adds a `--extra-files <hostDir>:<vfsRoot>` CLI flag for staging sidecar assets (web UIs, data dirs, etc.) alongside the `.so` files.

The package's manifest output now matches `PHPExtensionManifest` from `@php-wasm/universal` exactly:

- `artifacts[i].file` → `artifacts[i].sourcePath`
- `sha256` removed (the loader dropped verification in #3580)
- `extraFiles` with `vfsRoot` + `nodes` is supported at both the top-level and per-artifact

## Why

The loader merged in #3580 validates manifests against a strict schema generated from `PHPExtensionManifest`, and rejects the old shape. Without this update, anything built with the published 3.1.25 fails at runtime with "Invalid PHP extension manifest". This is the prerequisite for stacking an SPX build PR that uses `@php-wasm/compile-extension` to produce the `.so` and the new manifest API to stage SPX's web UI files.

## How to use --extra-files

```bash
npx @php-wasm/compile-extension \
  --source ./spx-src \
  --name spx \
  --php-versions 8.2 \
  --extra-files ./web-ui:/internal/shared/spx \
  --out ./dist
```

`./web-ui` is copied next to the manifest. Each file becomes one node under `extraFiles.nodes` with `vfsPath` relative to `vfsRoot` and `sourcePath` relative to the manifest URL. Empty directories are recorded as `type: "directory"` nodes so the loader creates them before PHP starts.

Multiple `--extra-files` entries are allowed; they must agree on `vfsRoot` because the manifest format stores a single root per group.

## Testing instructions

```bash
npm exec nx -- test php-wasm-compile-extension
npm exec nx -- typecheck php-wasm-compile-extension
npm exec nx -- lint php-wasm-compile-extension
```

The existing integration suite (`tests/run-integration-tests.sh`) keeps working because the loader-side tests already pass `manifestUrl` straight through and use the new manifest shape.