### PR TITLE
Escape TinyMCE inline CSS in WP editor init

### DIFF
--- a/packages/playground/wordpress/src/platform-mu-plugins.ts
+++ b/packages/playground/wordpress/src/platform-mu-plugins.ts
@@ -201,12 +201,35 @@ export async function writeCommonPlatformMuPlugins(
 				if (!empty($settings['content_style'])) {
 					$inline_css = $settings['content_style'] . "\\n" . $inline_css;
 				}
-				$settings['content_style'] = $inline_css;
+				$settings['content_style'] =
+					playground_escape_tinymce_content_style_for_wp_editor_serializer($inline_css);
 				$settings['content_css'] = '';
 			}
 			return $settings;
 		}
 		add_filter('tiny_mce_before_init', 'playground_inline_tinymce_content_css');
+
+		// _WP_Editors::_parse_init() wraps strings in double quotes without escaping them.
+		// Encode the CSS as a JavaScript string body before WordPress adds those quotes.
+		function playground_escape_tinymce_content_style_for_wp_editor_serializer($css) {
+			$encoded = json_encode($css);
+			if (
+				is_string($encoded) &&
+				substr($encoded, 0, 1) === chr(34) &&
+				substr($encoded, -1) === chr(34)
+			) {
+				$escaped = substr($encoded, 1, -1);
+			} else {
+				// Fallback: json_encode() can fail on non-UTF-8 CSS bytes.
+				// Escape the bytes that would break _WP_Editors::_parse_init().
+				$escaped = str_replace(
+					array('\\\\', chr(34), "\\r", "\\n", "\\xe2\\x80\\xa8", "\\xe2\\x80\\xa9"),
+					array('\\\\\\\\', '\\\\' . chr(34), '\\\\r', '\\\\n', '\\\\u2028', '\\\\u2029'),
+					$css
+				);
+			}
+			return str_replace('</', '<\\/', $escaped);
+		}
 		`
 	);
 }

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -192,6 +192,16 @@ async function waitForNewPostEditorHtml(frame, timeoutSeconds = 30) {
 }
 
 /**
+ * Checks for the TinyMCE inline-style regression without waiting for
+ * TinyMCE itself to initialize. The bug surfaces as a script parse/init
+ * error while the new-post page loads.
+ */
+function checkTinyMCEInlineStyleErrors(consoleErrors, consoleStartIndex) {
+	const error = findTinyMCEInitError(consoleErrors, consoleStartIndex);
+	return error ? { status: 'ERROR', detail: error } : { status: 'OK' };
+}
+
+/**
  * Navigates inside the Playground via the URL bar and then waits for
  * the WordPress content frame to actually navigate to `path`.
  *
@@ -329,6 +339,20 @@ function captureConsoleErrors(page, consoleErrors) {
 	page.on('console', (msg) => {
 		if (msg.type() === 'error')
 			consoleErrors.push(msg.text().slice(0, 300));
+	});
+	page.on('pageerror', (error) => {
+		consoleErrors.push(error.message.slice(0, 300));
+	});
+}
+
+function findTinyMCEInitError(consoleErrors, startIndex = 0) {
+	return consoleErrors.slice(startIndex).find((message) => {
+		const lower = message.toLowerCase();
+		return (
+			lower.includes('tinymcepreinit') ||
+			lower.includes('truetype') ||
+			lower.includes('content_style')
+		);
 	});
 }
 
@@ -561,6 +585,7 @@ for (const { wp, php } of MATRIX) {
 				const newPostPath = NEW_POST_URL_VERSIONS.has(wp)
 					? '/wp-admin/post.php'
 					: '/wp-admin/post-new.php';
+				const consoleStartIndex = consoleErrors.length;
 				const wp3 = await navigateViaUrlBar(page, newPostPath, 30);
 				if (!wp3) {
 					newPostStatus = { status: 'TIMEOUT' };
@@ -620,7 +645,18 @@ for (const { wp, php } of MATRIX) {
 								: 'permission denied',
 						};
 					} else if (hasEditor) {
-						newPostStatus = { status: 'OK' };
+						const tinyMCEStatus = checkTinyMCEInlineStyleErrors(
+							consoleErrors,
+							consoleStartIndex
+						);
+						if (tinyMCEStatus.status === 'OK') {
+							newPostStatus = { status: 'OK' };
+						} else {
+							newPostStatus = {
+								status: tinyMCEStatus.status,
+								detail: tinyMCEStatus.detail,
+							};
+						}
 					} else {
 						newPostStatus = {
 							status: 'UNKNOWN',


### PR DESCRIPTION
## What changed

Escapes the CSS that Playground inlines into TinyMCE `content_style` through the shared `inline-tinymce-content-css.php` mu-plugin.

The escape path uses PHP's `json_encode()` to produce a JavaScript string body, strips the outer quotes because `_WP_Editors::_parse_init()` adds them itself, and keeps a small PHP 5.2-compatible fallback for unexpected encoder failures.

The legacy WordPress boot suite now also checks the real browser new-post phase for classic TinyMCE bootstrap breakage and fails on `tinyMCEPreInit` / `content_style` / `truetype` JavaScript errors without waiting for TinyMCE itself to initialize.

## Why

`_WP_Editors::_parse_init()` serializes TinyMCE settings by concatenating JavaScript strings without escaping. Playground's inlined editor CSS can contain quotes, backslashes, newlines, and closing script sequences, for example Dashicons CSS with `format("truetype")`. Those characters could break the inline `tinyMCEPreInit` script and leave the classic visual editor uninitialized.

## Validation

- `npm exec nx -- run playground-wordpress:lint`
- `node --check packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs`
- `WP_ONLY=3.2,3.1,3.3,4.0,5.5,5.0,2.6,2.5,2.3,2.2,2.1,2.0,1.0 npm exec nx -- run playground-wordpress:test-legacy-wp-version-boot`

## Notes

The sampled legacy browser matrix and lint pass.
