### PR TITLE
[Client] Use wordpressInstallMode for Playground boot

### DIFF
--- a/packages/playground/client/src/blueprints-v1-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.spec.ts
@@ -80,7 +80,6 @@ describe('BlueprintsV1Handler', () => {
 
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
-				shouldBootWordPress: false,
 				wordpressInstallMode: 'do-not-attempt-installing',
 			})
 		);
@@ -100,7 +99,6 @@ describe('BlueprintsV1Handler', () => {
 
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
-				shouldBootWordPress: true,
 				wordpressInstallMode: 'install-from-existing-files-if-needed',
 			})
 		);
@@ -147,60 +145,45 @@ describe('BlueprintsV1Handler', () => {
 		);
 	});
 
-	it('does not install WordPress when boot is explicitly disabled', async () => {
+	it('does not install WordPress when installation is disabled', async () => {
 		const iframe = createIframe();
 		const handler = new BlueprintsV1Handler({
 			iframe,
 			remoteUrl: 'http://example.com/remote.html',
 			blueprint: {},
-			shouldBootWordPress: false,
+			wordpressInstallMode: 'do-not-attempt-installing',
 		});
 
 		await handler.bootPlayground(iframe, createProgressTracker());
 
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
-				shouldBootWordPress: false,
 				wordpressInstallMode: 'do-not-attempt-installing',
 			})
 		);
 		expect(mocks.playground.prefetchUpdateChecks).not.toHaveBeenCalled();
 	});
 
-	it('rejects WordPress installation when boot is disabled', async () => {
+	it('rejects WordPress install mode for PHP-only blueprints', async () => {
 		const iframe = createIframe();
 		const handler = new BlueprintsV1Handler({
 			iframe,
 			remoteUrl: 'http://example.com/remote.html',
-			blueprint: {},
-			shouldBootWordPress: false,
-			shouldInstallWordPress: true,
-		});
-
-		await expect(
-			handler.bootPlayground(iframe, createProgressTracker())
-		).rejects.toThrow(
-			'Conflicting options: WordPress installation was requested, ' +
-				'but WordPress boot was disabled. Pick one.'
-		);
-		expect(mocks.playground.boot).not.toHaveBeenCalled();
-	});
-
-	it('rejects WordPress install mode when boot is disabled', async () => {
-		const iframe = createIframe();
-		const handler = new BlueprintsV1Handler({
-			iframe,
-			remoteUrl: 'http://example.com/remote.html',
-			blueprint: {},
-			shouldBootWordPress: false,
+			blueprint: {
+				preferredVersions: {
+					php: '8.4',
+					wp: false,
+				},
+			},
 			wordpressInstallMode: 'download-and-install',
 		});
 
 		await expect(
 			handler.bootPlayground(iframe, createProgressTracker())
 		).rejects.toThrow(
-			'Conflicting options: WordPress installation was requested, ' +
-				'but WordPress boot was disabled. Pick one.'
+			'Conflicting options: WordPress was requested, ' +
+				'but the Blueprint sets ' +
+				'`preferredVersions.wp: false`. Pick one.'
 		);
 		expect(mocks.playground.boot).not.toHaveBeenCalled();
 	});
@@ -222,7 +205,7 @@ describe('BlueprintsV1Handler', () => {
 		await expect(
 			handler.bootPlayground(iframe, createProgressTracker())
 		).rejects.toThrow(
-			'Conflicting options: WordPress install or boot was requested, ' +
+			'Conflicting options: WordPress was requested, ' +
 				'but the Blueprint sets ' +
 				'`preferredVersions.wp: false`. Pick one.'
 		);

--- a/packages/playground/client/src/blueprints-v1-handler.spec.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.spec.ts
@@ -81,7 +81,7 @@ describe('BlueprintsV1Handler', () => {
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
 				shouldBootWordPress: false,
-				shouldInstallWordPress: false,
+				wordpressInstallMode: 'do-not-attempt-installing',
 			})
 		);
 		expect(mocks.playground.prefetchUpdateChecks).not.toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe('BlueprintsV1Handler', () => {
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
 				shouldBootWordPress: true,
-				shouldInstallWordPress: false,
+				wordpressInstallMode: 'install-from-existing-files-if-needed',
 			})
 		);
 	});
@@ -161,7 +161,7 @@ describe('BlueprintsV1Handler', () => {
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
 				shouldBootWordPress: false,
-				shouldInstallWordPress: false,
+				wordpressInstallMode: 'do-not-attempt-installing',
 			})
 		);
 		expect(mocks.playground.prefetchUpdateChecks).not.toHaveBeenCalled();
@@ -175,6 +175,25 @@ describe('BlueprintsV1Handler', () => {
 			blueprint: {},
 			shouldBootWordPress: false,
 			shouldInstallWordPress: true,
+		});
+
+		await expect(
+			handler.bootPlayground(iframe, createProgressTracker())
+		).rejects.toThrow(
+			'Conflicting options: WordPress installation was requested, ' +
+				'but WordPress boot was disabled. Pick one.'
+		);
+		expect(mocks.playground.boot).not.toHaveBeenCalled();
+	});
+
+	it('rejects WordPress install mode when boot is disabled', async () => {
+		const iframe = createIframe();
+		const handler = new BlueprintsV1Handler({
+			iframe,
+			remoteUrl: 'http://example.com/remote.html',
+			blueprint: {},
+			shouldBootWordPress: false,
+			wordpressInstallMode: 'download-and-install',
 		});
 
 		await expect(
@@ -222,7 +241,7 @@ describe('BlueprintsV1Handler', () => {
 
 		expect(mocks.playground.boot).toHaveBeenCalledWith(
 			expect.objectContaining({
-				shouldInstallWordPress: true,
+				wordpressInstallMode: 'download-and-install',
 			})
 		);
 		expect(mocks.playground.prefetchUpdateChecks).toHaveBeenCalledTimes(1);

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -68,9 +68,19 @@ export class BlueprintsV1Handler {
 		const declarativeOptOut =
 			!isBlueprintBundle(blueprint) &&
 			blueprint.preferredVersions?.wp === false;
+		const bootWordPress = shouldBootWordPress ?? !declarativeOptOut;
+		const resolvedWordPressInstallMode = getWordPressInstallMode({
+			bootWordPress,
+			shouldInstallWordPress,
+			wordpressInstallMode,
+		});
 		if (
-			(shouldInstallWordPress === true || shouldBootWordPress === true) &&
-			declarativeOptOut
+			wordpressWasRequestedExplicitly({
+				declarativeOptOut,
+				resolvedWordPressInstallMode,
+				shouldBootWordPress,
+				shouldInstallWordPress,
+			})
 		) {
 			throw new Error(
 				'Conflicting options: WordPress install or boot was requested, ' +
@@ -78,9 +88,10 @@ export class BlueprintsV1Handler {
 					'`preferredVersions.wp: false`. Pick one.'
 			);
 		}
-		const bootWordPress = shouldBootWordPress ?? !declarativeOptOut;
-		const installWordPress = shouldInstallWordPress ?? bootWordPress;
-		if (installWordPress && !bootWordPress) {
+		if (
+			!bootWordPress &&
+			resolvedWordPressInstallMode !== 'do-not-attempt-installing'
+		) {
 			throw new Error(
 				'Conflicting options: WordPress installation was requested, ' +
 					'but WordPress boot was disabled. Pick one.'
@@ -90,9 +101,8 @@ export class BlueprintsV1Handler {
 			mounts,
 			sapiName,
 			scope: scope ?? Math.random().toFixed(16),
-			shouldInstallWordPress: installWordPress,
 			shouldBootWordPress: bootWordPress,
-			wordpressInstallMode,
+			wordpressInstallMode: resolvedWordPressInstallMode,
 			phpVersion: runtimeConfiguration.phpVersion,
 			wpVersion: runtimeConfiguration.wpVersion,
 			extensions,
@@ -143,11 +153,58 @@ export class BlueprintsV1Handler {
 		if (
 			runtimeConfiguration.networking &&
 			!isLegacyWpVersion &&
-			installWordPress
+			resolvedWordPressInstallMode === 'download-and-install'
 		) {
 			await playground.prefetchUpdateChecks();
 		}
 
 		return playground;
 	}
+}
+
+type WordPressInstallMode = NonNullable<
+	StartPlaygroundOptions['wordpressInstallMode']
+>;
+
+function getWordPressInstallMode({
+	bootWordPress,
+	shouldInstallWordPress,
+	wordpressInstallMode,
+}: {
+	bootWordPress: boolean;
+	shouldInstallWordPress?: boolean;
+	wordpressInstallMode?: WordPressInstallMode;
+}): WordPressInstallMode {
+	if (wordpressInstallMode) {
+		return wordpressInstallMode;
+	}
+	if (shouldInstallWordPress === true) {
+		return 'download-and-install';
+	}
+	if (!bootWordPress) {
+		return 'do-not-attempt-installing';
+	}
+	if (shouldInstallWordPress === false) {
+		return 'install-from-existing-files-if-needed';
+	}
+	return 'download-and-install';
+}
+
+function wordpressWasRequestedExplicitly({
+	declarativeOptOut,
+	resolvedWordPressInstallMode,
+	shouldBootWordPress,
+	shouldInstallWordPress,
+}: {
+	declarativeOptOut: boolean;
+	resolvedWordPressInstallMode: WordPressInstallMode;
+	shouldBootWordPress?: boolean;
+	shouldInstallWordPress?: boolean;
+}) {
+	return (
+		declarativeOptOut &&
+		(shouldBootWordPress === true ||
+			shouldInstallWordPress === true ||
+			resolvedWordPressInstallMode !== 'do-not-attempt-installing')
+	);
 }

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -32,7 +32,6 @@ export class BlueprintsV1Handler {
 			sapiName,
 			scope,
 			shouldInstallWordPress,
-			shouldBootWordPress,
 			sqliteDriverVersion,
 			wordpressInstallMode,
 			onClientConnected,
@@ -68,40 +67,29 @@ export class BlueprintsV1Handler {
 		const declarativeOptOut =
 			!isBlueprintBundle(blueprint) &&
 			blueprint.preferredVersions?.wp === false;
-		const bootWordPress = shouldBootWordPress ?? !declarativeOptOut;
-		const resolvedWordPressInstallMode = getWordPressInstallMode({
-			bootWordPress,
-			shouldInstallWordPress,
-			wordpressInstallMode,
-		});
+		const resolvedWordPressInstallMode: WordPressInstallMode =
+			wordpressInstallMode ??
+			(declarativeOptOut
+				? 'do-not-attempt-installing'
+				: shouldInstallWordPress === false
+					? 'install-from-existing-files-if-needed'
+					: 'download-and-install');
 		if (
-			wordpressWasRequestedExplicitly({
-				declarativeOptOut,
-				resolvedWordPressInstallMode,
-				shouldBootWordPress,
-				shouldInstallWordPress,
-			})
+			declarativeOptOut &&
+			(shouldInstallWordPress === true ||
+				(wordpressInstallMode !== undefined &&
+					wordpressInstallMode !== 'do-not-attempt-installing'))
 		) {
 			throw new Error(
-				'Conflicting options: WordPress install or boot was requested, ' +
+				'Conflicting options: WordPress was requested, ' +
 					'but the Blueprint sets ' +
 					'`preferredVersions.wp: false`. Pick one.'
-			);
-		}
-		if (
-			!bootWordPress &&
-			resolvedWordPressInstallMode !== 'do-not-attempt-installing'
-		) {
-			throw new Error(
-				'Conflicting options: WordPress installation was requested, ' +
-					'but WordPress boot was disabled. Pick one.'
 			);
 		}
 		await playground.boot({
 			mounts,
 			sapiName,
 			scope: scope ?? Math.random().toFixed(16),
-			shouldBootWordPress: bootWordPress,
 			wordpressInstallMode: resolvedWordPressInstallMode,
 			phpVersion: runtimeConfiguration.phpVersion,
 			wpVersion: runtimeConfiguration.wpVersion,
@@ -165,46 +153,3 @@ export class BlueprintsV1Handler {
 type WordPressInstallMode = NonNullable<
 	StartPlaygroundOptions['wordpressInstallMode']
 >;
-
-function getWordPressInstallMode({
-	bootWordPress,
-	shouldInstallWordPress,
-	wordpressInstallMode,
-}: {
-	bootWordPress: boolean;
-	shouldInstallWordPress?: boolean;
-	wordpressInstallMode?: WordPressInstallMode;
-}): WordPressInstallMode {
-	if (wordpressInstallMode) {
-		return wordpressInstallMode;
-	}
-	if (shouldInstallWordPress === true) {
-		return 'download-and-install';
-	}
-	if (!bootWordPress) {
-		return 'do-not-attempt-installing';
-	}
-	if (shouldInstallWordPress === false) {
-		return 'install-from-existing-files-if-needed';
-	}
-	return 'download-and-install';
-}
-
-function wordpressWasRequestedExplicitly({
-	declarativeOptOut,
-	resolvedWordPressInstallMode,
-	shouldBootWordPress,
-	shouldInstallWordPress,
-}: {
-	declarativeOptOut: boolean;
-	resolvedWordPressInstallMode: WordPressInstallMode;
-	shouldBootWordPress?: boolean;
-	shouldInstallWordPress?: boolean;
-}) {
-	return (
-		declarativeOptOut &&
-		(shouldBootWordPress === true ||
-			shouldInstallWordPress === true ||
-			resolvedWordPressInstallMode !== 'do-not-attempt-installing')
-	);
-}

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -75,10 +75,11 @@ export interface StartPlaygroundOptions {
 	sapiName?: string;
 	mounts?: Array<MountDescriptor>;
 	/**
-	 * Whether to download/install WordPress files.
+	 * @deprecated Use `wordpressInstallMode` instead.
 	 *
-	 * Set this to `false` when WordPress files are already available, for example
-	 * from `mounts` or a saved site.
+	 * Whether to download/install WordPress files. Set this to `false` when
+	 * WordPress files are already available, for example from `mounts` or a
+	 * saved site.
 	 *
 	 * This option cannot be set to `true` when `shouldBootWordPress` is `false`,
 	 * because installing WordPress requires running the WordPress boot setup.
@@ -87,12 +88,13 @@ export interface StartPlaygroundOptions {
 	/**
 	 * Whether to run WordPress boot setup.
 	 *
-	 * This is separate from `shouldInstallWordPress` because saved sites can boot
-	 * from existing WordPress files without downloading or installing a fresh copy.
+	 * This is separate from `wordpressInstallMode` because saved sites can run
+	 * WordPress boot setup against existing files without downloading a fresh copy.
 	 * Set this to `false` for PHP-only Playgrounds.
 	 *
-	 * If `shouldInstallWordPress` is `false` and this option is `true`, WordPress
-	 * files must already be present, for example via `mounts` or a saved site.
+	 * If `wordpressInstallMode` uses existing files and this option is `true`,
+	 * WordPress files must already be present, for example via `mounts` or a
+	 * saved site.
 	 */
 	shouldBootWordPress?: boolean;
 	/**
@@ -126,7 +128,7 @@ export interface StartPlaygroundOptions {
 	sqliteDriverVersion?: string;
 	/**
 	 * How to handle WordPress installation.
-	 * Defaults to 'install-from-existing-files-if-needed'.
+	 * Defaults to `download-and-install` when WordPress boot is enabled.
 	 */
 	wordpressInstallMode?: WordPressInstallMode;
 	/**

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -80,23 +80,8 @@ export interface StartPlaygroundOptions {
 	 * Whether to download/install WordPress files. Set this to `false` when
 	 * WordPress files are already available, for example from `mounts` or a
 	 * saved site.
-	 *
-	 * This option cannot be set to `true` when `shouldBootWordPress` is `false`,
-	 * because installing WordPress requires running the WordPress boot setup.
 	 */
 	shouldInstallWordPress?: boolean;
-	/**
-	 * Whether to run WordPress boot setup.
-	 *
-	 * This is separate from `wordpressInstallMode` because saved sites can run
-	 * WordPress boot setup against existing files without downloading a fresh copy.
-	 * Set this to `false` for PHP-only Playgrounds.
-	 *
-	 * If `wordpressInstallMode` uses existing files and this option is `true`,
-	 * WordPress files must already be present, for example via `mounts` or a
-	 * saved site.
-	 */
-	shouldBootWordPress?: boolean;
 	/**
 	 * The string prefix used in the site URL served by the currently
 	 * running remote.html. E.g. for a prefix like `/scope:playground/`,
@@ -128,7 +113,7 @@ export interface StartPlaygroundOptions {
 	sqliteDriverVersion?: string;
 	/**
 	 * How to handle WordPress installation.
-	 * Defaults to `download-and-install` when WordPress boot is enabled.
+	 * Defaults to `download-and-install`.
 	 */
 	wordpressInstallMode?: WordPressInstallMode;
 	/**

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -216,8 +216,7 @@ export function bootSiteClient(
 
 		// PHP-only mode: a Blueprint with `preferredVersions.wp: false`
 		// declares it doesn't want WordPress, so honor that even if the
-		// storage layer thinks WP isn't installed yet. Passing `true` here
-		// would conflict with the Blueprint and the handler would throw.
+		// storage layer thinks WP isn't installed yet.
 		const blueprintRequestedNoWordPress =
 			!!blueprint &&
 			!isBlueprintBundle(blueprint) &&
@@ -233,6 +232,12 @@ export function bootSiteClient(
 		const isRecoveryMode = urlBlueprintLandingPage?.includes(
 			'health-check-disable-plugin-hash'
 		);
+		const wordpressInstallMode =
+			blueprintRequestedNoWordPress || isRecoveryMode
+				? 'do-not-attempt-installing'
+				: isWordPressInstalled
+					? 'install-from-existing-files-if-needed'
+					: 'download-and-install';
 
 		let playground: PlaygroundClient | undefined = undefined;
 		try {
@@ -246,11 +251,6 @@ export function bootSiteClient(
 					new URLSearchParams(window.location.search).get(
 						'experimental-blueprints-v2-runner'
 					) === 'yes',
-				// In recovery mode, skip the WordPress install check to avoid
-				// loading WordPress before blueprint steps run.
-				wordpressInstallMode: isRecoveryMode
-					? 'do-not-attempt-installing'
-					: undefined,
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playgroundClient) => {
@@ -265,12 +265,12 @@ export function bootSiteClient(
 							},
 						]
 					: [],
-				shouldInstallWordPress: blueprintRequestedNoWordPress
-					? false
-					: !isWordPressInstalled,
 				shouldBootWordPress: blueprintRequestedNoWordPress
 					? false
 					: undefined,
+				// In recovery mode, skip the WordPress install check to avoid
+				// loading WordPress before blueprint steps run.
+				wordpressInstallMode,
 				corsProxy: corsProxyUrl,
 			});
 		} catch (e) {

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -223,9 +223,9 @@ export function bootSiteClient(
 			blueprint.preferredVersions?.wp === false;
 
 		// Check if we're in recovery mode (Health Check troubleshooting).
-		// Recovery mode uses 'do-not-attempt-installing' to skip the
-		// isWordPressInstalled() check that would load WordPress and crash
-		// due to a broken plugin.
+		// In recovery mode, skip the WordPress install check to avoid
+		// loading WordPress before blueprint steps run. The check would
+		// load WordPress and crash due to a broken plugin.
 		const urlBlueprintLandingPage = hasUrlBlueprint
 			? urlBlueprint.blueprint.landingPage
 			: undefined;
@@ -265,11 +265,6 @@ export function bootSiteClient(
 							},
 						]
 					: [],
-				shouldBootWordPress: blueprintRequestedNoWordPress
-					? false
-					: undefined,
-				// In recovery mode, skip the WordPress install check to avoid
-				// loading WordPress before blueprint steps run.
 				wordpressInstallMode,
 				corsProxy: corsProxyUrl,
 			});

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
@@ -73,12 +73,15 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 			scope: 'test',
 			mounts: [mount as any],
 			phpVersion: '8.3',
-			shouldInstallWordPress: false,
+			wordpressInstallMode: 'install-from-existing-files-if-needed',
 			withNetworking: false,
 		});
 
 		expect(bootWordPress).toHaveBeenCalledTimes(1);
 		expect(bootWordPress.mock.calls[0][1].wordPressZip).toBeUndefined();
+		expect(bootWordPress.mock.calls[0][1].wordpressInstallMode).toBe(
+			'install-from-existing-files-if-needed'
+		);
 		expect(mountOpfsIntoPhp).toHaveBeenCalledWith(php, mount);
 	}, 10000);
 
@@ -165,7 +168,7 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 				scope: 'test',
 				phpVersion: '8.3',
 				shouldBootWordPress: false,
-				shouldInstallWordPress: true,
+				wordpressInstallMode: 'download-and-install',
 				withNetworking: false,
 			})
 		).rejects.toThrow(

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.spec.ts
@@ -131,7 +131,7 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 			scope: 'test',
 			mounts: [mount as any],
 			phpVersion: '8.3',
-			shouldBootWordPress: false,
+			wordpressInstallMode: 'do-not-attempt-installing',
 			withNetworking: false,
 		});
 
@@ -139,44 +139,6 @@ describe('PlaygroundWorkerEndpointBlueprintsV1', () => {
 		expect(mountOpfsIntoPhp).toHaveBeenCalledWith(php, mount);
 		expect(fetch).not.toHaveBeenCalled();
 	}, 10000);
-
-	it('rejects WordPress installation when boot is disabled', async () => {
-		let endpoint:
-			| {
-					boot(options: Record<string, unknown>): Promise<void>;
-			  }
-			| undefined;
-		vi.doMock('@wp-playground/wordpress', () => ({
-			bootWordPress: vi.fn(),
-		}));
-		vi.doMock('@php-wasm/web', () => ({
-			certificateToPEM: vi.fn(),
-			createDirectoryHandleMountHandler: vi.fn(),
-			exposeAPI: vi.fn((api) => {
-				endpoint = api;
-				return [vi.fn(), vi.fn()];
-			}),
-			loadWebRuntime: vi.fn(),
-		}));
-		await import('./playground-worker-endpoint-blueprints-v1');
-		if (!endpoint) {
-			throw new Error('Expected exposeAPI to receive an endpoint');
-		}
-
-		await expect(
-			endpoint.boot({
-				scope: 'test',
-				phpVersion: '8.3',
-				shouldBootWordPress: false,
-				wordpressInstallMode: 'download-and-install',
-				withNetworking: false,
-			})
-		).rejects.toThrow(
-			'Conflicting options: WordPress installation was requested, ' +
-				'but WordPress boot was disabled. Pick one.'
-		);
-		expect(fetch).not.toHaveBeenCalled();
-	});
 
 	it('throws a diagnostic error if the worker entrypoint is evaluated twice in the same worker global', async () => {
 		vi.doMock('@php-wasm/web', () => ({

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -41,7 +41,6 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 		extensions = [],
 		withNetworking = true,
 		shouldInstallWordPress,
-		shouldBootWordPress = true,
 		wordpressInstallMode,
 		corsProxyUrl,
 		pathAliases,
@@ -59,20 +58,11 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			// eslint-disable-next-line @typescript-eslint/no-this-alias
 			const endpoint = this;
 			const knownRemoteAssetPaths = new Set<string>();
-			const resolvedWordPressInstallMode = getWordPressInstallMode({
-				shouldBootWordPress,
-				shouldInstallWordPress,
-				wordpressInstallMode,
-			});
-			if (
-				!shouldBootWordPress &&
-				resolvedWordPressInstallMode !== 'do-not-attempt-installing'
-			) {
-				throw new Error(
-					'Conflicting options: WordPress installation was requested, ' +
-						'but WordPress boot was disabled. Pick one.'
-				);
-			}
+			const resolvedWordPressInstallMode: WordPressInstallMode =
+				wordpressInstallMode ??
+				(shouldInstallWordPress === false
+					? 'install-from-existing-files-if-needed'
+					: 'download-and-install');
 			const siteUrl = this.computeSiteUrl(scope);
 
 			const requestHandler = await this.createRequestHandler({
@@ -170,7 +160,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 
 			// PHP-only mode: the caller asked us to skip WordPress boot entirely.
 			// Apply mounts and stop, so the caller gets a usable PHP runtime.
-			if (!shouldBootWordPress) {
+			if (resolvedWordPressInstallMode === 'do-not-attempt-installing') {
 				const primaryPhp = await requestHandler.getPrimaryPhp();
 				for (const mount of mounts) {
 					await endpoint.mountOpfsIntoPhp(primaryPhp, mount);
@@ -261,30 +251,6 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 type WordPressInstallMode = NonNullable<
 	WorkerBootOptions['wordpressInstallMode']
 >;
-
-function getWordPressInstallMode({
-	shouldBootWordPress,
-	shouldInstallWordPress,
-	wordpressInstallMode,
-}: {
-	shouldBootWordPress: boolean;
-	shouldInstallWordPress?: boolean;
-	wordpressInstallMode?: WordPressInstallMode;
-}): WordPressInstallMode {
-	if (wordpressInstallMode) {
-		return wordpressInstallMode;
-	}
-	if (shouldInstallWordPress === true) {
-		return 'download-and-install';
-	}
-	if (!shouldBootWordPress) {
-		return 'do-not-attempt-installing';
-	}
-	if (shouldInstallWordPress === false) {
-		return 'install-from-existing-files-if-needed';
-	}
-	return 'download-and-install';
-}
 
 const workerGlobal = self as unknown as {
 	__playgroundWorkerEndpointBlueprintsV1?: boolean;

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -42,7 +42,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 		withNetworking = true,
 		shouldInstallWordPress,
 		shouldBootWordPress = true,
-		wordpressInstallMode = 'install-from-existing-files-if-needed',
+		wordpressInstallMode,
 		corsProxyUrl,
 		pathAliases,
 	}: WorkerBootOptions) {
@@ -59,9 +59,15 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			// eslint-disable-next-line @typescript-eslint/no-this-alias
 			const endpoint = this;
 			const knownRemoteAssetPaths = new Set<string>();
-			const installWordPress =
-				shouldInstallWordPress ?? shouldBootWordPress;
-			if (installWordPress && !shouldBootWordPress) {
+			const resolvedWordPressInstallMode = getWordPressInstallMode({
+				shouldBootWordPress,
+				shouldInstallWordPress,
+				wordpressInstallMode,
+			});
+			if (
+				!shouldBootWordPress &&
+				resolvedWordPressInstallMode !== 'do-not-attempt-installing'
+			) {
 				throw new Error(
 					'Conflicting options: WordPress installation was requested, ' +
 						'but WordPress boot was disabled. Pick one.'
@@ -91,7 +97,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 
 			const wpDetails = getWordPressModuleDetails(wpVersion);
 			let wordPressRequest: Promise<Response> | null = null;
-			if (installWordPress) {
+			if (resolvedWordPressInstallMode === 'download-and-install') {
 				if (this.requestedWordPressVersion!.startsWith('http')) {
 					wordPressRequest = this.downloadMonitor
 						.monitorFetch(
@@ -195,32 +201,27 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			await bootWordPress(requestHandler, {
 				siteUrl,
 				phpVersion,
-				constants: installWordPress
-					? {
-							// Disable WP_DEBUG for legacy PHP (< 7) because
-							// old WordPress (< 3.1) doesn't have WP_DEBUG_DISPLAY
-							// and shows all notices when WP_DEBUG is true,
-							// breaking header output and install responses.
-							WP_DEBUG: !isLegacyPhp,
-							WP_DEBUG_LOG: true,
-							WP_DEBUG_DISPLAY: false,
-							AUTH_KEY: randomString(40),
-							SECURE_AUTH_KEY: randomString(40),
-							LOGGED_IN_KEY: randomString(40),
-							NONCE_KEY: randomString(40),
-							AUTH_SALT: randomString(40),
-							SECURE_AUTH_SALT: randomString(40),
-							LOGGED_IN_SALT: randomString(40),
-							NONCE_SALT: randomString(40),
-						}
-					: {},
-				// Passing this even when shouldInstallWordPress is false is counter-intuitive.
-				// Before this line was introduced, `wordpressInstallMode` was always undefined
-				// which defaulted to 'install-from-existing-files'. Using the `-if-needed` variant
-				// saves around 600ms during the boot on a macbook pro so it's worth it.
-				// @TODO: Deprecate the `shouldInstallWordPress` semantics entirely and get the client
-				//        and the Playground website to pass `wordpressInstallMode` directly.
-				wordpressInstallMode,
+				constants:
+					resolvedWordPressInstallMode === 'download-and-install'
+						? {
+								// Disable WP_DEBUG for legacy PHP (< 7) because
+								// old WordPress (< 3.1) doesn't have WP_DEBUG_DISPLAY
+								// and shows all notices when WP_DEBUG is true,
+								// breaking header output and install responses.
+								WP_DEBUG: !isLegacyPhp,
+								WP_DEBUG_LOG: true,
+								WP_DEBUG_DISPLAY: false,
+								AUTH_KEY: randomString(40),
+								SECURE_AUTH_KEY: randomString(40),
+								LOGGED_IN_KEY: randomString(40),
+								NONCE_KEY: randomString(40),
+								AUTH_SALT: randomString(40),
+								SECURE_AUTH_SALT: randomString(40),
+								LOGGED_IN_SALT: randomString(40),
+								NONCE_SALT: randomString(40),
+							}
+						: {},
+				wordpressInstallMode: resolvedWordPressInstallMode,
 				// Do not await the WordPress download or the sqlite integration download.
 				// Let bootWordPress start the PHP runtime download first, and then await
 				// all the ZIP files right before they're used.
@@ -255,6 +256,34 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			throw e as Error;
 		}
 	}
+}
+
+type WordPressInstallMode = NonNullable<
+	WorkerBootOptions['wordpressInstallMode']
+>;
+
+function getWordPressInstallMode({
+	shouldBootWordPress,
+	shouldInstallWordPress,
+	wordpressInstallMode,
+}: {
+	shouldBootWordPress: boolean;
+	shouldInstallWordPress?: boolean;
+	wordpressInstallMode?: WordPressInstallMode;
+}): WordPressInstallMode {
+	if (wordpressInstallMode) {
+		return wordpressInstallMode;
+	}
+	if (shouldInstallWordPress === true) {
+		return 'download-and-install';
+	}
+	if (!shouldBootWordPress) {
+		return 'do-not-attempt-installing';
+	}
+	if (shouldInstallWordPress === false) {
+		return 'install-from-existing-files-if-needed';
+	}
+	return 'download-and-install';
 }
 
 const workerGlobal = self as unknown as {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -79,7 +79,6 @@ export type WorkerBootOptions = {
 	mounts?: Array<MountDescriptor>;
 	/** @deprecated Use `wordpressInstallMode` instead. */
 	shouldInstallWordPress?: boolean;
-	shouldBootWordPress?: boolean;
 	corsProxyUrl?: string;
 	/** When true, skip default WP install and run Blueprints v2 in the worker */
 	experimentalBlueprintsV2Runner?: boolean;
@@ -87,7 +86,7 @@ export type WorkerBootOptions = {
 	blueprint?: BlueprintDeclaration;
 	/**
 	 * How to handle WordPress installation.
-	 * Defaults to `download-and-install` when WordPress boot is enabled.
+	 * Defaults to `download-and-install`.
 	 */
 	wordpressInstallMode?: WordPressInstallMode;
 	/**

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -77,6 +77,7 @@ export type WorkerBootOptions = {
 	extensions?: PHPWebExtension[];
 	withNetworking: boolean;
 	mounts?: Array<MountDescriptor>;
+	/** @deprecated Use `wordpressInstallMode` instead. */
 	shouldInstallWordPress?: boolean;
 	shouldBootWordPress?: boolean;
 	corsProxyUrl?: string;
@@ -86,7 +87,7 @@ export type WorkerBootOptions = {
 	blueprint?: BlueprintDeclaration;
 	/**
 	 * How to handle WordPress installation.
-	 * Defaults to 'install-from-existing-files-if-needed'.
+	 * Defaults to `download-and-install` when WordPress boot is enabled.
 	 */
 	wordpressInstallMode?: WordPressInstallMode;
 	/**

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -195,9 +195,6 @@ export function bootSiteClient(
 							},
 						]
 					: [],
-				shouldBootWordPress: blueprintRequestedNoWordPress
-					? false
-					: undefined,
 				wordpressInstallMode,
 				corsProxy: corsProxyUrl,
 				gitAdditionalHeadersCallback: createGitAuthHeaders(),

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -150,12 +150,16 @@ export function bootSiteClient(
 
 		// PHP-only mode: a Blueprint with `preferredVersions.wp: false`
 		// declares it doesn't want WordPress, so honor that even if the
-		// storage layer thinks WP isn't installed yet. Passing `true` here
-		// would conflict with the Blueprint and the handler would throw.
+		// storage layer thinks WP isn't installed yet.
 		const blueprintRequestedNoWordPress =
 			!!blueprint &&
 			!isBlueprintBundle(blueprint) &&
 			blueprint.preferredVersions?.wp === false;
+		const wordpressInstallMode = blueprintRequestedNoWordPress
+			? 'do-not-attempt-installing'
+			: isWordPressInstalled
+				? 'install-from-existing-files-if-needed'
+				: 'download-and-install';
 
 		let playground: PlaygroundClient | undefined = undefined;
 		try {
@@ -191,12 +195,10 @@ export function bootSiteClient(
 							},
 						]
 					: [],
-				shouldInstallWordPress: blueprintRequestedNoWordPress
-					? false
-					: !isWordPressInstalled,
 				shouldBootWordPress: blueprintRequestedNoWordPress
 					? false
 					: undefined,
+				wordpressInstallMode,
 				corsProxy: corsProxyUrl,
 				gitAdditionalHeadersCallback: createGitAuthHeaders(),
 				pathAliases: [


### PR DESCRIPTION
## What it does

Uses `wordpressInstallMode` as the single boot control for WordPress installation and PHP-only Playground sessions.

**Breaking change:** `shouldBootWordPress` is removed from the client and worker boot options. Use `wordpressInstallMode: 'do-not-attempt-installing'` to skip WordPress boot setup.

## Rationale

`shouldInstallWordPress` and `shouldBootWordPress` split one decision across two booleans and make PHP-only boot paths harder to reason about. `wordpressInstallMode` already names the behavior directly:

- `download-and-install` for fresh WordPress installs
- `install-from-existing-files-if-needed` for saved or mounted WordPress files
- `do-not-attempt-installing` for PHP-only sessions

## Implementation

The Blueprints v1 client resolves a concrete `wordpressInstallMode` before booting the remote worker. Inline Blueprints with `preferredVersions.wp: false` resolve to `do-not-attempt-installing` unless the caller explicitly requested WordPress, in which case the handler throws a conflict error.

Website and Personal WP boot clients now pass `wordpressInstallMode` directly. The remote worker uses that mode to decide whether to download WordPress, run WordPress setup, or stop after mounting a PHP-only runtime.

`shouldInstallWordPress` remains accepted for compatibility, but is deprecated and translated into `wordpressInstallMode`.

## Testing instructions

```bash
npm exec nx -- test playground-client --testFile=blueprints-v1-handler.spec.ts
npm exec nx -- test playground-remote --testFile=playground-worker-endpoint-blueprints-v1.spec.ts
npm exec nx -- run-many -t typecheck --projects=playground-client,playground-remote,playground-website,playground-personal-wp
```
