### PR TITLE
Document isomorphic packages

### DIFF
--- a/packages/docs/site/docs/developers/23-architecture/01-index.md
+++ b/packages/docs/site/docs/developers/23-architecture/01-index.md
@@ -11,6 +11,7 @@ WordPress Playground consists of the following high-level components:
 - [WebAssembly PHP](/developers/architecture/wasm-php-overview)
 - [Browser bindings](/developers/architecture/browser-concepts)
 - Node.js bindings via [@php-wasm/node](https://npmjs.com/package/@php-wasm/node)
+- [Isomorphic packages](/developers/architecture/isomorphic-packages)
 - [Public API](/developers/apis/)
 
 Visit each section to learn more about the specific parts of the architecture.

--- a/packages/docs/site/docs/developers/23-architecture/19-isomorphic-packages.md
+++ b/packages/docs/site/docs/developers/23-architecture/19-isomorphic-packages.md
@@ -1,0 +1,83 @@
+---
+title: Isomorphic packages
+slug: /developers/architecture/isomorphic-packages
+description: Learn what isomorphic packages are in WordPress Playground, why they matter, and how to avoid browser-only or Node.js-only assumptions.
+---
+
+# Isomorphic packages
+
+Many WordPress Playground packages are designed to be isomorphic, also known as universal. In this context, an isomorphic package can run in more than one JavaScript environment, most commonly the browser and Node.js, without changing its public API.
+
+This matters because Playground is used in many places:
+
+- In the browser at [playground.wordpress.net](https://playground.wordpress.net/).
+- In embedded iframes controlled through the JavaScript API.
+- In Node.js tools such as `@wp-playground/cli`.
+- In build, test, and automation workflows.
+
+When a package stays isomorphic, the same feature can be reused across those environments. For example, code that prepares a Blueprint, validates a PHP version, or talks to a Playground client can be shared by browser apps, CLI tools, tests, and documentation examples.
+
+## Tradeoffs
+
+Isomorphic code is more portable, but it also has to avoid APIs that only exist in one runtime.
+
+Browser-only APIs include:
+
+- `window`
+- `document`
+- `DOMParser`
+- `localStorage`
+- Service Worker APIs
+
+Node.js-only APIs include:
+
+- `fs`
+- `path`
+- `process`
+- `Buffer`
+- Native Node.js streams
+
+Using these APIs directly can make a package harder to reuse. A browser app that imports `fs`, or a Node.js script that imports `document`, will fail unless a bundler, polyfill, or adapter fills the gap.
+
+## Patterns for isomorphic code
+
+Prefer platform-neutral APIs when possible:
+
+- Use `fetch`, `URL`, `URLSearchParams`, `TextEncoder`, and `TextDecoder` when they fit the task.
+- Accept data as arguments instead of reading it from the DOM or file system inside shared code.
+- Put browser-specific or Node.js-specific code behind a small adapter.
+- Keep environment detection near the edge of the package, not scattered through shared logic.
+
+For example, a shared package can accept a file-like object or a URL instead of reading directly from `document.querySelector()` or `fs.readFileSync()`. The browser entry point can collect the file from an input element, while the Node.js entry point can read it from disk and pass the same kind of data to the shared function.
+
+## Examples
+
+An isomorphic helper can build a Playground URL from a Blueprint object because it only needs JavaScript objects and URL APIs:
+
+```ts
+export function blueprintToUrl(blueprint: Record<string, unknown>): string {
+	const url = new URL('https://playground.wordpress.net/');
+	url.searchParams.set('blueprint', JSON.stringify(blueprint));
+	return url.toString();
+}
+```
+
+A browser-specific helper is not isomorphic because it reads from the DOM:
+
+```ts
+export function getBlueprintFromTextarea() {
+	return JSON.parse(document.querySelector('textarea')?.value || '{}');
+}
+```
+
+A Node.js-specific helper is not isomorphic because it reads from the local file system:
+
+```ts
+import { readFileSync } from 'fs';
+
+export function getBlueprintFromFile(filePath: string) {
+	return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+```
+
+Both non-isomorphic examples can still be useful. The key is to keep them in browser or Node.js entry points, and keep the core package logic portable where reuse across Playground environments is expected.

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -202,6 +202,7 @@ const sidebars = {
 						'developers/architecture/wasm-php-javascript-module',
 						'developers/architecture/wasm-php-filesystem',
 						'developers/architecture/wasm-asyncify',
+						'developers/architecture/isomorphic-packages',
 						'developers/architecture/browser-concepts',
 						'developers/architecture/browser-tab-orchestrates-execution',
 						'developers/architecture/browser-iframe-rendering',


### PR DESCRIPTION
## What?
Adds a new Architecture documentation page explaining isomorphic packages in Playground.

## Why?
Issue #505 asks for documentation that explains the benefits and tradeoffs of packages that run in both browser and Node.js environments, with examples of isomorphic and non-isomorphic code.

## Testing Instructions
- Run 
> docusaurus-classic-typescript@0.0.0 check-orphan-pages
> node bin/check-orphan-pages.js


=== Documentation Link Check ===
Total documentation files: 83
Total sidebar entries: 83
Unique sidebar entries: 82

⚠️  Warning: Found 1 duplicate sidebar entry(ies):
  - developers/xdebug/introduction

ℹ️  1 intentionally orphaned documentation page(s) (marked with 'orphan: true'):
  ID: developers/local-development/wp-now
  File: developers/05-local-development/01-wp-now.md


✓ All documentation pages are linked in sidebars or intentionally marked as orphaned!

Fixes #505.