### PR TITLE
Stabilize legacy WordPress boot CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,6 +508,7 @@ jobs:
               run: node packages/playground/wordpress/tests/download-legacy-wp-zips.mjs /tmp/legacy-wordpress-zips
             - name: Save legacy WordPress ZIP cache
               if: steps.legacy-wp-zip-cache.outputs.cache-hit != 'true'
+              continue-on-error: true
               uses: actions/cache/save@v4
               with:
                   path: /tmp/legacy-wordpress-zips

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,7 +517,7 @@ jobs:
               run: |
                   node packages/playground/wordpress/tests/serve-legacy-wp-zips.mjs /tmp/legacy-wordpress-zips 5410 > /tmp/legacy-wordpress-zips.log 2>&1 &
                   timeout=30; elapsed=0
-                  until curl -s -o /dev/null http://127.0.0.1:5410/wordpress-6.2.zip 2>/dev/null; do
+                  until curl -s -o /dev/null "http://127.0.0.1:5410/https://wordpress.org/wordpress-6.2.zip" 2>/dev/null; do
                     sleep 1
                     elapsed=$((elapsed + 1))
                     if [ $elapsed -ge $timeout ]; then
@@ -527,6 +527,8 @@ jobs:
                     fi
                   done
             - name: Start dev server
+              env:
+                  CORS_PROXY_URL: http://127.0.0.1:5410/
               run: |
                   npm run dev > /tmp/playground-dev.log 2>&1 &
                   timeout=120; elapsed=0
@@ -540,8 +542,6 @@ jobs:
                     fi
                   done
             - name: Test legacy WordPress version boot
-              env:
-                  LEGACY_WP_ZIP_BASE_URL: http://127.0.0.1:5410/
               run: node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
 
     # Redis extension tests - verifies the php-redis extension loads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,22 +502,22 @@ jobs:
               uses: actions/cache/restore@v4
               with:
                   path: /tmp/legacy-wordpress-zips
-                  key: legacy-wordpress-zips-v1-${{ hashFiles('packages/playground/wordpress/tests/legacy-wp-versions.mjs') }}
+                  key: legacy-wordpress-zips-v1-${{ hashFiles('packages/playground/wordpress/tests/legacy-wp-version-boot/matrix.mjs') }}
                   restore-keys: legacy-wordpress-zips-v1-
             - name: Download legacy WordPress ZIPs
-              run: node packages/playground/wordpress/tests/download-legacy-wp-zips.mjs /tmp/legacy-wordpress-zips
+              run: node packages/playground/wordpress/tests/legacy-wp-version-boot/download-zips.mjs /tmp/legacy-wordpress-zips
             - name: Save legacy WordPress ZIP cache
               if: steps.legacy-wp-zip-cache.outputs.cache-hit != 'true'
               continue-on-error: true
               uses: actions/cache/save@v4
               with:
                   path: /tmp/legacy-wordpress-zips
-                  key: legacy-wordpress-zips-v1-${{ hashFiles('packages/playground/wordpress/tests/legacy-wp-versions.mjs') }}
+                  key: legacy-wordpress-zips-v1-${{ hashFiles('packages/playground/wordpress/tests/legacy-wp-version-boot/matrix.mjs') }}
             - name: Serve legacy WordPress ZIP cache
               run: |
-                  node packages/playground/wordpress/tests/serve-legacy-wp-zips.mjs /tmp/legacy-wordpress-zips 5410 > /tmp/legacy-wordpress-zips.log 2>&1 &
+                  node packages/playground/wordpress/tests/legacy-wp-version-boot/serve-zips.mjs /tmp/legacy-wordpress-zips 5410 > /tmp/legacy-wordpress-zips.log 2>&1 &
                   timeout=30; elapsed=0
-                  until curl -s -o /dev/null "http://127.0.0.1:5410/https://wordpress.org/wordpress-6.2.zip" 2>/dev/null; do
+                  until curl --fail --silent --output /dev/null "http://127.0.0.1:5410/https://wordpress.org/wordpress-6.2.zip" 2>/dev/null; do
                     sleep 1
                     elapsed=$((elapsed + 1))
                     if [ $elapsed -ge $timeout ]; then
@@ -542,7 +542,7 @@ jobs:
                     fi
                   done
             - name: Test legacy WordPress version boot
-              run: node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+              run: node packages/playground/wordpress/tests/legacy-wp-version-boot/test.mjs
 
     # Redis extension tests - verifies the php-redis extension loads
     # and provides the expected API, and can connect to a real Redis server.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,44 @@ jobs:
                   submodules: true
             - uses: ./.github/actions/prepare-playground
             - name: Install Playwright Browser
-              run: npx playwright install chromium --with-deps
+              run: |
+                  for attempt in 1 2 3; do
+                    if npx playwright install chromium --with-deps; then
+                      exit 0
+                    fi
+                    if [ "$attempt" -eq 3 ]; then
+                      exit 1
+                    fi
+                    sleep "$((attempt * 15))"
+                  done
+            - name: Restore legacy WordPress ZIP cache
+              id: legacy-wp-zip-cache
+              uses: actions/cache/restore@v4
+              with:
+                  path: /tmp/legacy-wordpress-zips
+                  key: legacy-wordpress-zips-v1-${{ hashFiles('packages/playground/wordpress/tests/legacy-wp-versions.mjs') }}
+                  restore-keys: legacy-wordpress-zips-v1-
+            - name: Download legacy WordPress ZIPs
+              run: node packages/playground/wordpress/tests/download-legacy-wp-zips.mjs /tmp/legacy-wordpress-zips
+            - name: Save legacy WordPress ZIP cache
+              if: steps.legacy-wp-zip-cache.outputs.cache-hit != 'true'
+              uses: actions/cache/save@v4
+              with:
+                  path: /tmp/legacy-wordpress-zips
+                  key: legacy-wordpress-zips-v1-${{ hashFiles('packages/playground/wordpress/tests/legacy-wp-versions.mjs') }}
+            - name: Serve legacy WordPress ZIP cache
+              run: |
+                  node packages/playground/wordpress/tests/serve-legacy-wp-zips.mjs /tmp/legacy-wordpress-zips 5410 > /tmp/legacy-wordpress-zips.log 2>&1 &
+                  timeout=30; elapsed=0
+                  until curl -s -o /dev/null http://127.0.0.1:5410/wordpress-6.2.zip 2>/dev/null; do
+                    sleep 1
+                    elapsed=$((elapsed + 1))
+                    if [ $elapsed -ge $timeout ]; then
+                      echo "Legacy WordPress ZIP server failed to start within ${timeout}s"
+                      cat /tmp/legacy-wordpress-zips.log | tail -50
+                      exit 1
+                    fi
+                  done
             - name: Start dev server
               run: |
                   npm run dev > /tmp/playground-dev.log 2>&1 &
@@ -502,6 +539,8 @@ jobs:
                     fi
                   done
             - name: Test legacy WordPress version boot
+              env:
+                  LEGACY_WP_ZIP_BASE_URL: http://127.0.0.1:5410/
               run: node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
 
     # Redis extension tests - verifies the php-redis extension loads

--- a/packages/playground/wordpress/project.json
+++ b/packages/playground/wordpress/project.json
@@ -75,7 +75,7 @@
 			"executor": "nx:run-commands",
 			"options": {
 				"commands": [
-					"node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs"
+					"node packages/playground/wordpress/tests/legacy-wp-version-boot/test.mjs"
 				]
 			}
 		},

--- a/packages/playground/wordpress/src/legacy-wp/legacy-fixes.ts
+++ b/packages/playground/wordpress/src/legacy-wp/legacy-fixes.ts
@@ -26,7 +26,7 @@
  * The balance is delicate: a patch may have been quietly covering
  * more WP versions than it advertises, so tightening a needle or
  * changing the replacement can break one you didn't know about.
- * The boot-smoke suite in `tests/test-legacy-wp-version-boot.mjs`
+ * The boot-smoke suite in `tests/legacy-wp-version-boot/test.mjs`
  * exercises every supported legacy WP version end-to-end; run it
  * before landing changes here.
  */

--- a/packages/playground/wordpress/tests/download-legacy-wp-zips.mjs
+++ b/packages/playground/wordpress/tests/download-legacy-wp-zips.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+import { mkdir, rename, stat, unlink, writeFile } from 'node:fs/promises';
+import { basename, join } from 'node:path';
+import {
+	WP_VERSIONS,
+	getWordPressDownloadFilename,
+	getWordPressDownloadUrl,
+} from './legacy-wp-versions.mjs';
+
+const outputDir = process.argv[2];
+if (!outputDir) {
+	console.error('Usage: download-legacy-wp-zips.mjs <output-dir>');
+	process.exit(1);
+}
+
+await mkdir(outputDir, { recursive: true });
+
+for (const { wp } of WP_VERSIONS) {
+	const filename = getWordPressDownloadFilename(wp);
+	const targetPath = join(outputDir, filename);
+	if (await isCachedZip(targetPath)) {
+		console.log(`Cached ${filename}`);
+		continue;
+	}
+
+	await downloadZipWithRetries(getWordPressDownloadUrl(wp), targetPath);
+}
+
+async function downloadZipWithRetries(url, targetPath) {
+	const filename = basename(targetPath);
+	const attempts = 5;
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		try {
+			console.log(`Downloading ${filename} (${attempt}/${attempts})`);
+			await downloadZip(url, targetPath);
+			return;
+		} catch (error) {
+			await unlink(`${targetPath}.tmp`).catch(() => {});
+			if (attempt === attempts) {
+				throw error;
+			}
+			const delayMs = Math.min(60_000, 5_000 * 2 ** (attempt - 1));
+			console.warn(
+				`Failed to download ${filename}: ${error.message}. ` +
+					`Retrying in ${Math.round(delayMs / 1000)}s.`
+			);
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
+	}
+}
+
+async function downloadZip(url, targetPath) {
+	const response = await fetch(url, {
+		headers: {
+			'User-Agent': 'WordPress Playground CI legacy boot test',
+		},
+	});
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status} from ${url}`);
+	}
+	const body = new Uint8Array(await response.arrayBuffer());
+	if (body.length === 0) {
+		throw new Error(`Empty response from ${url}`);
+	}
+	await writeFile(`${targetPath}.tmp`, body);
+	await rename(`${targetPath}.tmp`, targetPath);
+}
+
+async function isCachedZip(path) {
+	try {
+		const stats = await stat(path);
+		return stats.isFile() && stats.size > 0;
+	} catch {
+		return false;
+	}
+}

--- a/packages/playground/wordpress/tests/legacy-wp-version-boot/download-zips.mjs
+++ b/packages/playground/wordpress/tests/legacy-wp-version-boot/download-zips.mjs
@@ -2,20 +2,20 @@
 import { mkdir, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import {
-	WP_VERSIONS,
+	getLegacyWordPressVersionMatrix,
 	getWordPressDownloadFilename,
 	getWordPressDownloadUrl,
-} from './legacy-wp-versions.mjs';
+} from './matrix.mjs';
 
 const outputDir = process.argv[2];
 if (!outputDir) {
-	console.error('Usage: download-legacy-wp-zips.mjs <output-dir>');
+	console.error('Usage: download-zips.mjs <output-dir>');
 	process.exit(1);
 }
 
 await mkdir(outputDir, { recursive: true });
 
-for (const { wp } of WP_VERSIONS) {
+for (const { wp } of getLegacyWordPressVersionMatrix()) {
 	const filename = getWordPressDownloadFilename(wp);
 	const targetPath = join(outputDir, filename);
 	if (await isCachedZip(targetPath)) {

--- a/packages/playground/wordpress/tests/legacy-wp-version-boot/matrix.mjs
+++ b/packages/playground/wordpress/tests/legacy-wp-version-boot/matrix.mjs
@@ -52,6 +52,18 @@ export const WP_VERSIONS = [
 	{ wp: '1.0', php: '5.2' },
 ];
 
+export function getLegacyWordPressVersionMatrix(wpOnly = process.env.WP_ONLY) {
+	if (!wpOnly) {
+		return WP_VERSIONS;
+	}
+	const requestedVersions = new Set(wpOnly.split(',').map((s) => s.trim()));
+	const matrix = WP_VERSIONS.filter(({ wp }) => requestedVersions.has(wp));
+	if (matrix.length === 0) {
+		throw new Error(`WP_ONLY did not match any tested versions: ${wpOnly}`);
+	}
+	return matrix;
+}
+
 export function getWordPressDownloadUrl(version) {
 	return `https://wordpress.org/${getWordPressDownloadFilename(version)}`;
 }

--- a/packages/playground/wordpress/tests/legacy-wp-version-boot/serve-zips.mjs
+++ b/packages/playground/wordpress/tests/legacy-wp-version-boot/serve-zips.mjs
@@ -3,14 +3,13 @@ import { createReadStream } from 'node:fs';
 import { stat } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { basename, join } from 'node:path';
-import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 
 const directory = process.argv[2];
 const port = Number(process.argv[3] || 5410);
 
 if (!directory || !Number.isInteger(port) || port <= 0) {
-	console.error('Usage: serve-legacy-wp-zips.mjs <directory> [port]');
+	console.error('Usage: serve-zips.mjs <directory> [port]');
 	process.exit(1);
 }
 
@@ -34,10 +33,11 @@ const server = createServer(async (request, response) => {
 	const requestUrl = new URL(request.url ?? '/', 'http://localhost');
 	const proxiedUrl = getProxiedUrl(requestUrl);
 	const filename = basename(
-		proxiedUrl ? new URL(proxiedUrl).pathname : requestUrl.pathname
+		proxiedUrl ? proxiedUrl.pathname : requestUrl.pathname
 	);
 	if (!/^wordpress-[A-Za-z0-9.-]+\.zip$/.test(filename)) {
-		await proxyRequest(request, response, proxiedUrl);
+		response.writeHead(404);
+		response.end('Not found');
 		return;
 	}
 
@@ -71,52 +71,17 @@ const server = createServer(async (request, response) => {
 function getProxiedUrl(requestUrl) {
 	const pathTarget = decodeURIComponent(requestUrl.pathname.slice(1));
 	if (isHttpUrl(pathTarget)) {
-		return `${pathTarget}${requestUrl.search}`;
+		return new URL(`${pathTarget}${requestUrl.search}`);
 	}
 	const searchTarget = requestUrl.search.slice(1);
 	if (isHttpUrl(searchTarget)) {
-		return searchTarget;
+		return new URL(searchTarget);
 	}
 	return null;
 }
 
 function isHttpUrl(url) {
 	return url.startsWith('https://') || url.startsWith('http://');
-}
-
-async function proxyRequest(request, response, proxiedUrl) {
-	if (!proxiedUrl) {
-		response.writeHead(404);
-		response.end('Not found');
-		return;
-	}
-	let upstream;
-	try {
-		upstream = await fetch(proxiedUrl, {
-			method: request.method,
-			headers: {
-				'User-Agent': 'WordPress Playground CI legacy boot test',
-			},
-		});
-	} catch (error) {
-		response.writeHead(502);
-		response.end(`Failed to proxy ${proxiedUrl}: ${error.message}`);
-		return;
-	}
-
-	const headers = {};
-	for (const header of ['content-length', 'content-type']) {
-		const value = upstream.headers.get(header);
-		if (value) {
-			headers[header] = value;
-		}
-	}
-	response.writeHead(upstream.status, headers);
-	if (request.method === 'HEAD' || !upstream.body) {
-		response.end();
-		return;
-	}
-	Readable.fromWeb(upstream.body).pipe(response);
 }
 
 server.listen(port, '127.0.0.1', () => {

--- a/packages/playground/wordpress/tests/legacy-wp-version-boot/serve-zips.mjs
+++ b/packages/playground/wordpress/tests/legacy-wp-version-boot/serve-zips.mjs
@@ -31,10 +31,7 @@ const server = createServer(async (request, response) => {
 	}
 
 	const requestUrl = new URL(request.url ?? '/', 'http://localhost');
-	const proxiedUrl = getProxiedUrl(requestUrl);
-	const filename = basename(
-		proxiedUrl ? proxiedUrl.pathname : requestUrl.pathname
-	);
+	const filename = getRequestedFilename(requestUrl);
 	if (!/^wordpress-[A-Za-z0-9.-]+\.zip$/.test(filename)) {
 		response.writeHead(404);
 		response.end('Not found');
@@ -57,31 +54,32 @@ const server = createServer(async (request, response) => {
 		return;
 	}
 
-	response.writeHead(200, {
-		'Content-Length': stats.size,
-		'Content-Type': 'application/zip',
-	});
+	response.statusCode = 200;
+	response.setHeader('Content-Length', stats.size);
+	response.setHeader('Content-Type', 'application/zip');
 	if (request.method === 'HEAD') {
 		response.end();
 		return;
 	}
-	createReadStream(filePath).pipe(response);
+	const fileStream = createReadStream(filePath);
+	fileStream.on('error', (error) => {
+		if (response.headersSent) {
+			response.destroy(error);
+			return;
+		}
+		response.statusCode = 500;
+		response.removeHeader('Content-Length');
+		response.setHeader('Content-Type', 'text/plain');
+		response.end('Failed to read file');
+	});
+	response.on('error', () => {
+		fileStream.destroy();
+	});
+	fileStream.pipe(response);
 });
 
-function getProxiedUrl(requestUrl) {
-	const pathTarget = decodeURIComponent(requestUrl.pathname.slice(1));
-	if (isHttpUrl(pathTarget)) {
-		return new URL(`${pathTarget}${requestUrl.search}`);
-	}
-	const searchTarget = requestUrl.search.slice(1);
-	if (isHttpUrl(searchTarget)) {
-		return new URL(searchTarget);
-	}
-	return null;
-}
-
-function isHttpUrl(url) {
-	return url.startsWith('https://') || url.startsWith('http://');
+function getRequestedFilename(requestUrl) {
+	return basename(requestUrl.pathname.slice(1) || requestUrl.pathname);
 }
 
 server.listen(port, '127.0.0.1', () => {

--- a/packages/playground/wordpress/tests/legacy-wp-version-boot/test.mjs
+++ b/packages/playground/wordpress/tests/legacy-wp-version-boot/test.mjs
@@ -21,10 +21,10 @@
  * Requires the dev server to be running on port 5400
  * (started by the CI job or manually via `npm run dev`).
  *
- * Usage: node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+ * Usage: node packages/playground/wordpress/tests/legacy-wp-version-boot/test.mjs
  */
 import { chromium } from 'playwright';
-import { WP_VERSIONS } from './legacy-wp-versions.mjs';
+import { getLegacyWordPressVersionMatrix } from './matrix.mjs';
 
 const PORT = 5400;
 const TIMEOUT_S = 120;
@@ -322,12 +322,7 @@ function hasAdminIndicator(body) {
 const NEW_POST_URL_VERSIONS = new Set(['1.0', '1.2', '1.5', '2.0']);
 
 // Optional filter for local runs: WP_ONLY=6.2,6.1,5.9 to test a subset.
-const WP_ONLY = process.env.WP_ONLY
-	? new Set(process.env.WP_ONLY.split(',').map((s) => s.trim()))
-	: null;
-const MATRIX = WP_ONLY
-	? WP_VERSIONS.filter(({ wp }) => WP_ONLY.has(wp))
-	: WP_VERSIONS;
+const MATRIX = getLegacyWordPressVersionMatrix();
 
 /**
  * Captures browser console errors so timeout failures can report context.

--- a/packages/playground/wordpress/tests/legacy-wp-version-boot/test.mjs
+++ b/packages/playground/wordpress/tests/legacy-wp-version-boot/test.mjs
@@ -244,15 +244,16 @@ function getPluginActivationStatus(body) {
 }
 
 function getPluginActivationTimeoutStatus(
-	frameBeforeActivation,
+	beforeUrl,
 	latestFrame,
 	consoleErrors,
-	consoleStartIndex
+	consoleStartIndex,
+	timeoutSeconds = PLUGIN_ACTIVATION_TIMEOUT_S
 ) {
 	const recentErrors = consoleErrors.slice(consoleStartIndex).slice(-3);
 	const detail = [
-		`timed out after ${PLUGIN_ACTIVATION_TIMEOUT_S}s`,
-		`before URL: ${frameBeforeActivation.url}`,
+		`timed out after ${timeoutSeconds}s`,
+		`before URL: ${beforeUrl}`,
 		latestFrame ? `latest URL: ${latestFrame.frame.url()}` : null,
 		recentErrors.length
 			? `recent console errors: ${recentErrors.join(' | ')}`
@@ -743,7 +744,7 @@ for (const { wp, php } of MATRIX) {
 							!isPluginActivationTerminalBody(finalFrame.body)
 						) {
 							pluginStatus = getPluginActivationTimeoutStatus(
-								{ url: prevFrameUrl },
+								prevFrameUrl,
 								finalFrame,
 								consoleErrors,
 								consoleStartIndex

--- a/packages/playground/wordpress/tests/legacy-wp-versions.mjs
+++ b/packages/playground/wordpress/tests/legacy-wp-versions.mjs
@@ -1,0 +1,72 @@
+// Versions that were never released: 1.1, 1.3, 1.4, 2.4.
+// Modern WP (5.0-6.2) is paired with PHP 7.4 because it's the newest
+// PHP the legacy SQLite driver supports and is far enough from the
+// PHP 5.2 leg to make regressions obvious.
+export const WP_VERSIONS = [
+	// Mid-modern WordPress (PHP 7.4).
+	{ wp: '6.2', php: '7.4' },
+	{ wp: '6.1', php: '7.4' },
+	{ wp: '6.0', php: '7.4' },
+	{ wp: '5.9', php: '7.4' },
+	{ wp: '5.8', php: '7.4' },
+	{ wp: '5.7', php: '7.4' },
+	{ wp: '5.6', php: '7.4' },
+	{ wp: '5.5', php: '7.4' },
+	{ wp: '5.4', php: '7.4' },
+	{ wp: '5.3', php: '7.4' },
+	{ wp: '5.2', php: '7.4' },
+	{ wp: '5.1', php: '7.4' },
+	{ wp: '5.0', php: '7.4' },
+	// Legacy WordPress on PHP 5.2 WASM.
+	{ wp: '4.9', php: '5.2' },
+	{ wp: '4.8', php: '5.2' },
+	{ wp: '4.7', php: '5.2' },
+	{ wp: '4.6', php: '5.2' },
+	{ wp: '4.5', php: '5.2' },
+	{ wp: '4.4', php: '5.2' },
+	{ wp: '4.3', php: '5.2' },
+	{ wp: '4.2', php: '5.2' },
+	{ wp: '4.1', php: '5.2' },
+	{ wp: '4.0', php: '5.2' },
+	{ wp: '3.9', php: '5.2' },
+	{ wp: '3.8', php: '5.2' },
+	{ wp: '3.7', php: '5.2' },
+	{ wp: '3.6', php: '5.2' },
+	{ wp: '3.5', php: '5.2' },
+	{ wp: '3.4', php: '5.2' },
+	{ wp: '3.3', php: '5.2' },
+	{ wp: '3.2', php: '5.2' },
+	{ wp: '3.1', php: '5.2' },
+	{ wp: '3.0', php: '5.2' },
+	{ wp: '2.9', php: '5.2' },
+	{ wp: '2.8', php: '5.2' },
+	{ wp: '2.7', php: '5.2' },
+	{ wp: '2.6', php: '5.2' },
+	{ wp: '2.5', php: '5.2' },
+	{ wp: '2.3', php: '5.2' },
+	{ wp: '2.2', php: '5.2' },
+	{ wp: '2.1', php: '5.2' },
+	{ wp: '2.0', php: '5.2' },
+	{ wp: '1.5', php: '5.2' },
+	{ wp: '1.2', php: '5.2' },
+	{ wp: '1.0', php: '5.2' },
+];
+
+export function getWordPressDownloadUrl(version) {
+	return `https://wordpress.org/${getWordPressDownloadFilename(version)}`;
+}
+
+export function getWordPressDownloadFilename(version) {
+	return `wordpress-${normalizeWordPressVersionForDownload(version)}.zip`;
+}
+
+// Versions >= 2.0 work as <major>.<minor> because wordpress.org redirects
+// to the latest patch. Versions < 2.0 need explicit patch versions.
+export function normalizeWordPressVersionForDownload(version) {
+	const legacyVersionMap = {
+		'1.0': '1.0.2',
+		1.2: '1.2.2',
+		1.5: '1.5.2',
+	};
+	return legacyVersionMap[version] ?? version;
+}

--- a/packages/playground/wordpress/tests/serve-legacy-wp-zips.mjs
+++ b/packages/playground/wordpress/tests/serve-legacy-wp-zips.mjs
@@ -3,6 +3,7 @@ import { createReadStream } from 'node:fs';
 import { stat } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { basename, join } from 'node:path';
+import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 
 const directory = process.argv[2];
@@ -30,12 +31,13 @@ const server = createServer(async (request, response) => {
 		return;
 	}
 
+	const requestUrl = new URL(request.url ?? '/', 'http://localhost');
+	const proxiedUrl = getProxiedUrl(requestUrl);
 	const filename = basename(
-		new URL(request.url ?? '/', 'http://localhost').pathname
+		proxiedUrl ? new URL(proxiedUrl).pathname : requestUrl.pathname
 	);
 	if (!/^wordpress-[A-Za-z0-9.-]+\.zip$/.test(filename)) {
-		response.writeHead(404);
-		response.end('Not found');
+		await proxyRequest(request, response, proxiedUrl);
 		return;
 	}
 
@@ -65,6 +67,57 @@ const server = createServer(async (request, response) => {
 	}
 	createReadStream(filePath).pipe(response);
 });
+
+function getProxiedUrl(requestUrl) {
+	const pathTarget = decodeURIComponent(requestUrl.pathname.slice(1));
+	if (isHttpUrl(pathTarget)) {
+		return `${pathTarget}${requestUrl.search}`;
+	}
+	const searchTarget = requestUrl.search.slice(1);
+	if (isHttpUrl(searchTarget)) {
+		return searchTarget;
+	}
+	return null;
+}
+
+function isHttpUrl(url) {
+	return url.startsWith('https://') || url.startsWith('http://');
+}
+
+async function proxyRequest(request, response, proxiedUrl) {
+	if (!proxiedUrl) {
+		response.writeHead(404);
+		response.end('Not found');
+		return;
+	}
+	let upstream;
+	try {
+		upstream = await fetch(proxiedUrl, {
+			method: request.method,
+			headers: {
+				'User-Agent': 'WordPress Playground CI legacy boot test',
+			},
+		});
+	} catch (error) {
+		response.writeHead(502);
+		response.end(`Failed to proxy ${proxiedUrl}: ${error.message}`);
+		return;
+	}
+
+	const headers = {};
+	for (const header of ['content-length', 'content-type']) {
+		const value = upstream.headers.get(header);
+		if (value) {
+			headers[header] = value;
+		}
+	}
+	response.writeHead(upstream.status, headers);
+	if (request.method === 'HEAD' || !upstream.body) {
+		response.end();
+		return;
+	}
+	Readable.fromWeb(upstream.body).pipe(response);
+}
 
 server.listen(port, '127.0.0.1', () => {
 	const script = fileURLToPath(import.meta.url);

--- a/packages/playground/wordpress/tests/serve-legacy-wp-zips.mjs
+++ b/packages/playground/wordpress/tests/serve-legacy-wp-zips.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { basename, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const directory = process.argv[2];
+const port = Number(process.argv[3] || 5410);
+
+if (!directory || !Number.isInteger(port) || port <= 0) {
+	console.error('Usage: serve-legacy-wp-zips.mjs <directory> [port]');
+	process.exit(1);
+}
+
+const server = createServer(async (request, response) => {
+	response.setHeader('Access-Control-Allow-Origin', '*');
+	response.setHeader('Access-Control-Allow-Methods', 'GET, HEAD, OPTIONS');
+	response.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+	if (request.method === 'OPTIONS') {
+		response.writeHead(204);
+		response.end();
+		return;
+	}
+
+	if (request.method !== 'GET' && request.method !== 'HEAD') {
+		response.writeHead(405);
+		response.end('Method not allowed');
+		return;
+	}
+
+	const filename = basename(
+		new URL(request.url ?? '/', 'http://localhost').pathname
+	);
+	if (!/^wordpress-[A-Za-z0-9.-]+\.zip$/.test(filename)) {
+		response.writeHead(404);
+		response.end('Not found');
+		return;
+	}
+
+	const filePath = join(directory, filename);
+	let stats;
+	try {
+		stats = await stat(filePath);
+	} catch {
+		response.writeHead(404);
+		response.end('Not found');
+		return;
+	}
+
+	if (!stats.isFile()) {
+		response.writeHead(404);
+		response.end('Not found');
+		return;
+	}
+
+	response.writeHead(200, {
+		'Content-Length': stats.size,
+		'Content-Type': 'application/zip',
+	});
+	if (request.method === 'HEAD') {
+		response.end();
+		return;
+	}
+	createReadStream(filePath).pipe(response);
+});
+
+server.listen(port, '127.0.0.1', () => {
+	const script = fileURLToPath(import.meta.url);
+	console.log(`${script} serving ${directory} at http://127.0.0.1:${port}/`);
+});

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -1,6 +1,6 @@
 /**
  * Tests that legacy and mid-modern WordPress versions boot
- * successfully through Playground's WordPress ZIP download path:
+ * successfully through Playground's wordpress.org download path:
  *
  *   - WP 1.0 – 4.9 on PHP 5.2 (legacy SQLite driver)
  *   - WP 5.0 – 6.2 on PHP 7.4 (modern SQLite driver)
@@ -24,17 +24,11 @@
  * Usage: node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
  */
 import { chromium } from 'playwright';
-import {
-	WP_VERSIONS,
-	getWordPressDownloadFilename,
-} from './legacy-wp-versions.mjs';
+import { WP_VERSIONS } from './legacy-wp-versions.mjs';
 
 const PORT = 5400;
 const TIMEOUT_S = 120;
 const PLUGIN_ACTIVATION_TIMEOUT_S = 60;
-const LEGACY_WP_ZIP_BASE_URL = normalizeDirectoryUrl(
-	process.env.LEGACY_WP_ZIP_BASE_URL || ''
-);
 const results = [];
 
 /**
@@ -233,24 +227,6 @@ async function waitForPluginActivation(
 	return null;
 }
 
-async function recheckPluginActivation(page, frame) {
-	const currentFrame = await getCurrentWPFrameBody(page);
-	if (currentFrame && isPluginActivationTerminalBody(currentFrame.body)) {
-		return currentFrame;
-	}
-
-	const reloadedFrame = await reloadScopedFrame(
-		frame,
-		`/wp-admin/plugins.php?playground-plugin-check=${Date.now()}`,
-		30
-	);
-	if (reloadedFrame && isPluginActivationTerminalBody(reloadedFrame.body)) {
-		return reloadedFrame;
-	}
-
-	return reloadedFrame || currentFrame;
-}
-
 function getPluginActivationStatus(body) {
 	const error = findPHPError(body);
 	const ok = isPluginActivationComplete(body);
@@ -263,7 +239,7 @@ function getPluginActivationStatus(body) {
 	}
 	return {
 		status: bad ? 'NONCE_FAIL' : 'UNKNOWN',
-		detail: body.slice(0, 120).replace(/\n/g, ' '),
+		detail: summarizeBody(body),
 	};
 }
 
@@ -304,43 +280,8 @@ function isPluginActivationComplete(body) {
 	return body.includes('Plugin activated') || body.includes('Deactivate');
 }
 
-async function getCurrentWPFrameBody(page) {
-	for (const frame of page.frames()) {
-		try {
-			if (!frame.url().includes('scope:')) continue;
-			const body = await frame.locator('body').innerText({
-				timeout: 2000,
-			});
-			return { body, frame };
-		} catch {}
-	}
-	return null;
-}
-
-async function reloadScopedFrame(frame, path, timeoutSeconds) {
-	const url = getScopedUrl(frame.url(), path);
-	if (!url) return null;
-	try {
-		await frame.goto(url, {
-			timeout: timeoutSeconds * 1000,
-			waitUntil: 'domcontentloaded',
-		});
-	} catch {}
-	return waitForWPFrame(frame.page(), timeoutSeconds, {
-		contentPredicate: (body) =>
-			body.includes('Plugins') || isPluginActivationTerminalBody(body),
-	});
-}
-
-function getScopedUrl(frameUrl, path) {
-	const url = new URL(frameUrl);
-	const match = url.pathname.match(/^(\/scope:[^/]+)(?:\/.*)?$/);
-	if (!match) return null;
-	const [pathname, search = ''] = path.split('?');
-	url.pathname = `${match[1]}${pathname}`;
-	url.search = search ? `?${search}` : '';
-	url.hash = '';
-	return url.href;
+function summarizeBody(body) {
+	return body.slice(0, 120).replace(/\n/g, ' ');
 }
 
 /**
@@ -421,27 +362,13 @@ function shouldRetryFrontPageBoot(consoleErrors) {
 	);
 }
 
-function getWordPressVersionQuery(wp) {
-	if (!LEGACY_WP_ZIP_BASE_URL) {
-		return wp;
-	}
-	return new URL(getWordPressDownloadFilename(wp), LEGACY_WP_ZIP_BASE_URL)
-		.href;
-}
-
-function normalizeDirectoryUrl(url) {
-	if (!url) return '';
-	return url.endsWith('/') ? url : `${url}/`;
-}
-
 const browser = await chromium.launch({ headless: true });
 
 for (const { wp, php } of MATRIX) {
 	const label = `WP ${wp} (PHP ${php})`;
 	process.stdout.write(`${label}... `);
 
-	const wpVersionQuery = encodeURIComponent(getWordPressVersionQuery(wp));
-	const url = `http://127.0.0.1:${PORT}/website-server/?php=${php}&wp=${wpVersionQuery}`;
+	const url = `http://127.0.0.1:${PORT}/website-server/?php=${php}&wp=${wp}`;
 
 	// Isolate every version in a fresh browser context so that OPFS
 	// (where Playground persists site state), IndexedDB, localStorage
@@ -798,15 +725,27 @@ for (const { wp, php } of MATRIX) {
 							prevFrameUrl,
 							bodyBeforeActivation
 						);
-						const finalFrame =
-							wp4b ||
-							(await recheckPluginActivation(page, wp4.frame));
+						let finalFrame = wp4b;
+						if (!finalFrame) {
+							finalFrame = await navigateViaUrlBar(
+								page,
+								`/wp-admin/plugins.php?playground-plugin-check=${Date.now()}`,
+								30
+							);
+						}
 						if (
-							!wp4b &&
-							(!finalFrame ||
-								!isPluginActivationTerminalBody(
-									finalFrame.body
-								))
+							finalFrame &&
+							!isPluginActivationTerminalBody(finalFrame.body)
+						) {
+							const settled = await waitForWPFrame(page, 30, {
+								contentPredicate:
+									isPluginActivationTerminalBody,
+							});
+							finalFrame = settled || finalFrame;
+						}
+						if (
+							!finalFrame ||
+							!isPluginActivationTerminalBody(finalFrame.body)
 						) {
 							pluginStatus = getPluginActivationTimeoutStatus(
 								{ url: prevFrameUrl },

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -210,7 +210,7 @@ async function waitForPluginActivation(
 	page,
 	previousFrameUrl,
 	previousBody,
-	timeoutSeconds = 60
+	timeoutSeconds = PLUGIN_ACTIVATION_TIMEOUT_S
 ) {
 	const deadline = Date.now() + timeoutSeconds * 1000;
 	while (Date.now() < deadline) {
@@ -224,18 +224,123 @@ async function waitForPluginActivation(
 				const changed =
 					frame.url() !== previousFrameUrl || body !== previousBody;
 				if (!changed) continue;
-				if (
-					body.includes('Plugin activated') ||
-					body.includes('Deactivate') ||
-					body.includes('Are you sure') ||
-					findPHPError(body)
-				) {
+				if (isPluginActivationTerminalBody(body)) {
 					return { body, frame };
 				}
 			} catch {}
 		}
 	}
 	return null;
+}
+
+async function recheckPluginActivation(page, frame) {
+	const currentFrame = await getCurrentWPFrameBody(page);
+	if (currentFrame && isPluginActivationTerminalBody(currentFrame.body)) {
+		return currentFrame;
+	}
+
+	const reloadedFrame = await reloadScopedFrame(
+		frame,
+		`/wp-admin/plugins.php?playground-plugin-check=${Date.now()}`,
+		30
+	);
+	if (reloadedFrame && isPluginActivationTerminalBody(reloadedFrame.body)) {
+		return reloadedFrame;
+	}
+
+	return reloadedFrame || currentFrame;
+}
+
+function getPluginActivationStatus(body) {
+	const error = findPHPError(body);
+	const ok = isPluginActivationComplete(body);
+	const bad = body.includes('Are you sure');
+	if (error) {
+		return { status: 'ERROR', detail: error };
+	}
+	if (ok) {
+		return { status: 'OK' };
+	}
+	return {
+		status: bad ? 'NONCE_FAIL' : 'UNKNOWN',
+		detail: body.slice(0, 120).replace(/\n/g, ' '),
+	};
+}
+
+function getPluginActivationTimeoutStatus(
+	frameBeforeActivation,
+	latestFrame,
+	consoleErrors,
+	consoleStartIndex
+) {
+	const recentErrors = consoleErrors.slice(consoleStartIndex).slice(-3);
+	const detail = [
+		`timed out after ${PLUGIN_ACTIVATION_TIMEOUT_S}s`,
+		`before URL: ${frameBeforeActivation.url}`,
+		latestFrame ? `latest URL: ${latestFrame.frame.url()}` : null,
+		recentErrors.length
+			? `recent console errors: ${recentErrors.join(' | ')}`
+			: null,
+	]
+		.filter(Boolean)
+		.join('; ');
+
+	return {
+		status: 'TIMEOUT',
+		detail,
+		body: latestFrame?.body,
+	};
+}
+
+function isPluginActivationTerminalBody(body) {
+	return (
+		isPluginActivationComplete(body) ||
+		body.includes('Are you sure') ||
+		!!findPHPError(body)
+	);
+}
+
+function isPluginActivationComplete(body) {
+	return body.includes('Plugin activated') || body.includes('Deactivate');
+}
+
+async function getCurrentWPFrameBody(page) {
+	for (const frame of page.frames()) {
+		try {
+			if (!frame.url().includes('scope:')) continue;
+			const body = await frame.locator('body').innerText({
+				timeout: 2000,
+			});
+			return { body, frame };
+		} catch {}
+	}
+	return null;
+}
+
+async function reloadScopedFrame(frame, path, timeoutSeconds) {
+	const url = getScopedUrl(frame.url(), path);
+	if (!url) return null;
+	try {
+		await frame.goto(url, {
+			timeout: timeoutSeconds * 1000,
+			waitUntil: 'domcontentloaded',
+		});
+	} catch {}
+	return waitForWPFrame(frame.page(), timeoutSeconds, {
+		contentPredicate: (body) =>
+			body.includes('Plugins') || isPluginActivationTerminalBody(body),
+	});
+}
+
+function getScopedUrl(frameUrl, path) {
+	const url = new URL(frameUrl);
+	const match = url.pathname.match(/^(\/scope:[^/]+)(?:\/.*)?$/);
+	if (!match) return null;
+	const [pathname, search = ''] = path.split('?');
+	url.pathname = `${match[1]}${pathname}`;
+	url.search = search ? `?${search}` : '';
+	url.hash = '';
+	return url.href;
 }
 
 /**
@@ -639,6 +744,7 @@ for (const { wp, php } of MATRIX) {
 		// --- Phase 5: Plugin activation ---
 		if (adminStatus && adminStatus.status === 'OK') {
 			try {
+				const consoleStartIndex = consoleErrors.length;
 				const wp4 = await navigateViaUrlBar(
 					page,
 					'/wp-admin/plugins.php',
@@ -692,29 +798,26 @@ for (const { wp, php } of MATRIX) {
 							prevFrameUrl,
 							bodyBeforeActivation
 						);
-						if (!wp4b) {
-							pluginStatus = { status: 'TIMEOUT' };
+						const finalFrame =
+							wp4b ||
+							(await recheckPluginActivation(page, wp4.frame));
+						if (
+							!wp4b &&
+							(!finalFrame ||
+								!isPluginActivationTerminalBody(
+									finalFrame.body
+								))
+						) {
+							pluginStatus = getPluginActivationTimeoutStatus(
+								{ url: prevFrameUrl },
+								finalFrame,
+								consoleErrors,
+								consoleStartIndex
+							);
 						} else {
-							const error = findPHPError(wp4b.body);
-							const ok =
-								wp4b.body.includes('Plugin activated') ||
-								wp4b.body.includes('Deactivate');
-							const bad = wp4b.body.includes('Are you sure');
-							if (error) {
-								pluginStatus = {
-									status: 'ERROR',
-									detail: error,
-								};
-							} else if (ok) {
-								pluginStatus = { status: 'OK' };
-							} else {
-								pluginStatus = {
-									status: bad ? 'NONCE_FAIL' : 'UNKNOWN',
-									detail: wp4b.body
-										.slice(0, 120)
-										.replace(/\n/g, ' '),
-								};
-							}
+							pluginStatus = getPluginActivationStatus(
+								finalFrame.body
+							);
 						}
 					} else {
 						pluginStatus = {

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -1,6 +1,6 @@
 /**
  * Tests that legacy and mid-modern WordPress versions boot
- * successfully through Playground's wordpress.org download path:
+ * successfully through Playground's WordPress ZIP download path:
  *
  *   - WP 1.0 – 4.9 on PHP 5.2 (legacy SQLite driver)
  *   - WP 5.0 – 6.2 on PHP 7.4 (modern SQLite driver)
@@ -24,66 +24,17 @@
  * Usage: node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
  */
 import { chromium } from 'playwright';
-
-// Matrix of (WordPress, PHP) combinations to test.
-// Versions that were never released: 1.1, 1.3, 1.4, 2.4.
-// The web worker normalizes bare versions automatically (1.5 → 1.5.2,
-// 2.0 → 2.0.11, etc.) and resolves them to wordpress.org downloads.
-// Modern WP (5.0–6.2) is paired with PHP 7.4 because it's the newest
-// PHP the legacy SQLite driver supports and is far enough from the
-// PHP 5.2 leg to make regressions obvious.
-const WP_VERSIONS = [
-	// Mid-modern WordPress (PHP 7.4).
-	{ wp: '6.2', php: '7.4' },
-	{ wp: '6.1', php: '7.4' },
-	{ wp: '6.0', php: '7.4' },
-	{ wp: '5.9', php: '7.4' },
-	{ wp: '5.8', php: '7.4' },
-	{ wp: '5.7', php: '7.4' },
-	{ wp: '5.6', php: '7.4' },
-	{ wp: '5.5', php: '7.4' },
-	{ wp: '5.4', php: '7.4' },
-	{ wp: '5.3', php: '7.4' },
-	{ wp: '5.2', php: '7.4' },
-	{ wp: '5.1', php: '7.4' },
-	{ wp: '5.0', php: '7.4' },
-	// Legacy WordPress on PHP 5.2 WASM.
-	{ wp: '4.9', php: '5.2' },
-	{ wp: '4.8', php: '5.2' },
-	{ wp: '4.7', php: '5.2' },
-	{ wp: '4.6', php: '5.2' },
-	{ wp: '4.5', php: '5.2' },
-	{ wp: '4.4', php: '5.2' },
-	{ wp: '4.3', php: '5.2' },
-	{ wp: '4.2', php: '5.2' },
-	{ wp: '4.1', php: '5.2' },
-	{ wp: '4.0', php: '5.2' },
-	{ wp: '3.9', php: '5.2' },
-	{ wp: '3.8', php: '5.2' },
-	{ wp: '3.7', php: '5.2' },
-	{ wp: '3.6', php: '5.2' },
-	{ wp: '3.5', php: '5.2' },
-	{ wp: '3.4', php: '5.2' },
-	{ wp: '3.3', php: '5.2' },
-	{ wp: '3.2', php: '5.2' },
-	{ wp: '3.1', php: '5.2' },
-	{ wp: '3.0', php: '5.2' },
-	{ wp: '2.9', php: '5.2' },
-	{ wp: '2.8', php: '5.2' },
-	{ wp: '2.7', php: '5.2' },
-	{ wp: '2.6', php: '5.2' },
-	{ wp: '2.5', php: '5.2' },
-	{ wp: '2.3', php: '5.2' },
-	{ wp: '2.2', php: '5.2' },
-	{ wp: '2.1', php: '5.2' },
-	{ wp: '2.0', php: '5.2' },
-	{ wp: '1.5', php: '5.2' },
-	{ wp: '1.2', php: '5.2' },
-	{ wp: '1.0', php: '5.2' },
-];
+import {
+	WP_VERSIONS,
+	getWordPressDownloadFilename,
+} from './legacy-wp-versions.mjs';
 
 const PORT = 5400;
 const TIMEOUT_S = 120;
+const PLUGIN_ACTIVATION_TIMEOUT_S = 60;
+const LEGACY_WP_ZIP_BASE_URL = normalizeDirectoryUrl(
+	process.env.LEGACY_WP_ZIP_BASE_URL || ''
+);
 const results = [];
 
 /**
@@ -365,13 +316,27 @@ function shouldRetryFrontPageBoot(consoleErrors) {
 	);
 }
 
+function getWordPressVersionQuery(wp) {
+	if (!LEGACY_WP_ZIP_BASE_URL) {
+		return wp;
+	}
+	return new URL(getWordPressDownloadFilename(wp), LEGACY_WP_ZIP_BASE_URL)
+		.href;
+}
+
+function normalizeDirectoryUrl(url) {
+	if (!url) return '';
+	return url.endsWith('/') ? url : `${url}/`;
+}
+
 const browser = await chromium.launch({ headless: true });
 
 for (const { wp, php } of MATRIX) {
 	const label = `WP ${wp} (PHP ${php})`;
 	process.stdout.write(`${label}... `);
 
-	const url = `http://127.0.0.1:${PORT}/website-server/?php=${php}&wp=${wp}`;
+	const wpVersionQuery = encodeURIComponent(getWordPressVersionQuery(wp));
+	const url = `http://127.0.0.1:${PORT}/website-server/?php=${php}&wp=${wpVersionQuery}`;
 
 	// Isolate every version in a fresh browser context so that OPFS
 	// (where Playground persists site state), IndexedDB, localStorage


### PR DESCRIPTION
## What changed

- Cache legacy WordPress ZIP downloads in GitHub Actions and serve them locally during the boot test.
- Keep `wp=4.9` style query values so Playground still uses the normal dotted-version resolver.
- Retry Playwright browser installation and tolerate Actions cache-save races.
- Keep the plugin activation timeout at 60 seconds, then do one URL-bar recheck before failing with diagnostics.
- Group the legacy boot helpers under `packages/playground/wordpress/tests/legacy-wp-version-boot/`.

## Why

The legacy boot job was frequently failing on transient infrastructure issues: WordPress.org download throttling, occasional Playwright install/network failures, and rare plugin activation timing races. The cache removes most WordPress.org traffic without changing the runtime code path under test.

## Validation

- Local focused run: `WP_ONLY=6.2,4.9 node packages/playground/wordpress/tests/legacy-wp-version-boot/test.mjs`
- Local helper checks: `node --check`, Prettier, filtered ZIP download, and ZIP server smoke tests.
- GitHub Actions is green on the latest commit.
- `test-legacy-wp-version-boot` passed on the latest full run and prior targeted reruns.
