### PR TITLE
Relay WordPress page titles during navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
 				"classnames": "^2.3.2",
 				"crc-32": "1.2.2",
 				"diff3": "0.0.4",
-				"dompurify": "3.4.7",
 				"express": "4.22.2",
 				"fast-xml-parser": "^5.8.0",
 				"file-saver": "^2.0.5",
@@ -16260,13 +16259,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/trusted-types": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -26585,15 +26577,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domhandler?sponsor=1"
-			}
-		},
-		"node_modules/dompurify": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
-			"integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
-			"license": "(MPL-2.0 OR Apache-2.0)",
-			"optionalDependencies": {
-				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/domutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
 				"classnames": "^2.3.2",
 				"crc-32": "1.2.2",
 				"diff3": "0.0.4",
+				"dompurify": "3.4.7",
 				"express": "4.22.2",
 				"fast-xml-parser": "^5.8.0",
 				"file-saver": "^2.0.5",
@@ -16259,6 +16260,13 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/@types/unist": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -26577,6 +26585,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.4.7",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+			"integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
 			}
 		},
 		"node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
 		"classnames": "^2.3.2",
 		"crc-32": "1.2.2",
 		"diff3": "0.0.4",
+		"dompurify": "3.4.7",
 		"express": "4.22.2",
 		"fast-xml-parser": "^5.8.0",
 		"file-saver": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
 		"classnames": "^2.3.2",
 		"crc-32": "1.2.2",
 		"diff3": "0.0.4",
-		"dompurify": "3.4.7",
 		"express": "4.22.2",
 		"fast-xml-parser": "^5.8.0",
 		"file-saver": "^2.0.5",

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/01-index.md
@@ -40,6 +40,47 @@ Here's the shortest example of how to use the JavaScript API in a HTML page:
 </script>
 ```
 
+## Custom loading screens
+
+By default, `remote.html` shows a progress bar while Playground boots. To use a
+custom welcome screen, render it in your parent page and keep the Playground
+iframe hidden until loading finishes:
+
+```html
+<section id="loading-screen">
+	<p id="loading-text">Preparing WordPress</p>
+	<progress id="loading-bar" max="100" value="0"></progress>
+</section>
+<iframe id="wp" hidden></iframe>
+<script type="module">
+	import { startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
+
+	const loadingScreen = document.getElementById('loading-screen');
+	const loadingText = document.getElementById('loading-text');
+	const loadingBar = document.getElementById('loading-bar');
+	const iframe = document.getElementById('wp');
+
+	const client = await startPlaygroundWeb({
+		iframe,
+		remoteUrl: `https://playground.wordpress.net/remote.html`,
+		disableProgressBar: true,
+		onProgress({ progress, caption }) {
+			loadingText.textContent = caption;
+			loadingBar.value = progress;
+		},
+		onReady() {
+			loadingScreen.hidden = true;
+			iframe.hidden = false;
+		},
+	});
+</script>
+```
+
+Custom welcome HTML should live in the parent page, not inside the Playground
+remote iframe. This keeps the remote progress UI generic while giving each
+embedding app full control over its loading screen markup, styles, and
+interactions.
+
 <div class="callout callout-info">
 
 **/remote.html is a special URL**

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/01-index.md
@@ -40,47 +40,6 @@ Here's the shortest example of how to use the JavaScript API in a HTML page:
 </script>
 ```
 
-## Custom loading screens
-
-By default, `remote.html` shows a progress bar while Playground boots. To use a custom welcome screen, render it in your parent page and keep the Playground iframe hidden until loading finishes:
-
-```html
-<section id="loading-screen">
-	<p id="loading-text">Preparing WordPress</p>
-	<progress id="loading-bar" max="100" value="0"></progress>
-</section>
-<iframe id="wp" hidden></iframe>
-<script type="module">
-	import { ProgressTracker, startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
-
-	const loadingScreen = document.getElementById('loading-screen');
-	const loadingText = document.getElementById('loading-text');
-	const loadingBar = document.getElementById('loading-bar');
-	const iframe = document.getElementById('wp');
-	const progressTracker = new ProgressTracker();
-
-	progressTracker.addEventListener('progress', (event) => {
-		const { progress, caption } = event.detail;
-		loadingText.textContent = caption;
-		loadingBar.value = progress;
-	});
-
-	progressTracker.addEventListener('done', () => {
-		loadingScreen.hidden = true;
-		iframe.hidden = false;
-	});
-
-	const client = await startPlaygroundWeb({
-		iframe,
-		remoteUrl: `https://playground.wordpress.net/remote.html`,
-		progressTracker,
-		disableProgressBar: true,
-	});
-</script>
-```
-
-Custom welcome HTML should live in the parent page, not inside the Playground remote iframe. This keeps the remote progress UI generic while giving each embedding app full control over its loading screen markup, styles, and interactions. The `progressTracker` and `disableProgressBar` options existed before this change; this pattern is the supported alternative to injecting welcome HTML into the remote progress overlay.
-
 <div class="callout callout-info">
 
 **/remote.html is a special URL**

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/01-index.md
@@ -42,9 +42,7 @@ Here's the shortest example of how to use the JavaScript API in a HTML page:
 
 ## Custom loading screens
 
-By default, `remote.html` shows a progress bar while Playground boots. To use a
-custom welcome screen, render it in your parent page and keep the Playground
-iframe hidden until loading finishes:
+By default, `remote.html` shows a progress bar while Playground boots. To use a custom welcome screen, render it in your parent page and keep the Playground iframe hidden until loading finishes:
 
 ```html
 <section id="loading-screen">
@@ -53,33 +51,35 @@ iframe hidden until loading finishes:
 </section>
 <iframe id="wp" hidden></iframe>
 <script type="module">
-	import { startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
+	import { ProgressTracker, startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
 
 	const loadingScreen = document.getElementById('loading-screen');
 	const loadingText = document.getElementById('loading-text');
 	const loadingBar = document.getElementById('loading-bar');
 	const iframe = document.getElementById('wp');
+	const progressTracker = new ProgressTracker();
+
+	progressTracker.addEventListener('progress', (event) => {
+		const { progress, caption } = event.detail;
+		loadingText.textContent = caption;
+		loadingBar.value = progress;
+	});
+
+	progressTracker.addEventListener('done', () => {
+		loadingScreen.hidden = true;
+		iframe.hidden = false;
+	});
 
 	const client = await startPlaygroundWeb({
 		iframe,
 		remoteUrl: `https://playground.wordpress.net/remote.html`,
+		progressTracker,
 		disableProgressBar: true,
-		onProgress({ progress, caption }) {
-			loadingText.textContent = caption;
-			loadingBar.value = progress;
-		},
-		onReady() {
-			loadingScreen.hidden = true;
-			iframe.hidden = false;
-		},
 	});
 </script>
 ```
 
-Custom welcome HTML should live in the parent page, not inside the Playground
-remote iframe. This keeps the remote progress UI generic while giving each
-embedding app full control over its loading screen markup, styles, and
-interactions.
+Custom welcome HTML should live in the parent page, not inside the Playground remote iframe. This keeps the remote progress UI generic while giving each embedding app full control over its loading screen markup, styles, and interactions. The `progressTracker` and `disableProgressBar` options existed before this change; this pattern is the supported alternative to injecting welcome HTML into the remote progress overlay.
 
 <div class="callout callout-info">
 

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -55,12 +55,11 @@ The optional `excludePatterns` use gitignore semantics: matching paths are exclu
 
 ## Custom loading screens
 
-The Playground iframe includes a default progress bar while it boots. Apps that
-need a branded welcome or loading screen should render that UI outside the
-iframe and use the client hooks to keep it in sync with Playground boot
-progress:
+The Playground iframe includes a default progress bar while it boots. Apps that need a branded welcome or loading screen should render that UI outside the iframe and use a `ProgressTracker` to keep it in sync with Playground boot progress:
 
 ```js
+import { ProgressTracker, startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
+
 const loadingScreen = document.getElementById('loading-screen');
 const loadingText = document.getElementById('loading-text');
 const loadingBar = document.getElementById('loading-bar');
@@ -68,25 +67,28 @@ const iframe = document.getElementById('wp');
 
 iframe.hidden = true;
 
+const progressTracker = new ProgressTracker();
+
+progressTracker.addEventListener('progress', (event) => {
+	const { progress, caption } = event.detail;
+	loadingText.textContent = caption;
+	loadingBar.value = progress;
+});
+
+progressTracker.addEventListener('done', () => {
+	loadingScreen.hidden = true;
+	iframe.hidden = false;
+});
+
 const client = await startPlaygroundWeb({
 	iframe,
 	remoteUrl: `https://playground.wordpress.net/remote.html`,
+	progressTracker,
 	disableProgressBar: true,
-	onProgress({ progress, caption }) {
-		loadingText.textContent = caption;
-		loadingBar.value = progress;
-	},
-	onReady() {
-		loadingScreen.hidden = true;
-		iframe.hidden = false;
-	},
 });
 ```
 
-This replaces embedding custom welcome HTML inside the remote progress overlay.
-Keeping the welcome screen in the parent page gives each app full control over
-its markup, styling, and interaction model without coupling it to the
-Playground iframe UI.
+This replaces embedding custom welcome HTML inside the remote progress overlay. Keeping the welcome screen in the parent page gives each app full control over its markup, styling, and interaction model without coupling it to the Playground iframe UI. The `progressTracker` and `disableProgressBar` options existed before this change; this pattern is the supported alternative to injecting welcome HTML into the remote progress overlay.
 
 ## npm package
 

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -53,6 +53,41 @@ const zip = await api.exportSavedSiteAsZip('my-site', {
 
 The optional `excludePatterns` use gitignore semantics: matching paths are excluded, later patterns take precedence, and a leading `!` re-includes a path. When `excludePatterns` is omitted, the ZIP contains the complete saved site.
 
+## Custom loading screens
+
+The Playground iframe includes a default progress bar while it boots. Apps that
+need a branded welcome or loading screen should render that UI outside the
+iframe and use the client hooks to keep it in sync with Playground boot
+progress:
+
+```js
+const loadingScreen = document.getElementById('loading-screen');
+const loadingText = document.getElementById('loading-text');
+const loadingBar = document.getElementById('loading-bar');
+const iframe = document.getElementById('wp');
+
+iframe.hidden = true;
+
+const client = await startPlaygroundWeb({
+	iframe,
+	remoteUrl: `https://playground.wordpress.net/remote.html`,
+	disableProgressBar: true,
+	onProgress({ progress, caption }) {
+		loadingText.textContent = caption;
+		loadingBar.value = progress;
+	},
+	onReady() {
+		loadingScreen.hidden = true;
+		iframe.hidden = false;
+	},
+});
+```
+
+This replaces embedding custom welcome HTML inside the remote progress overlay.
+Keeping the welcome screen in the parent page gives each app full control over
+its markup, styling, and interaction model without coupling it to the
+Playground iframe UI.
+
 ## npm package
 
 The npm package exists for projects that want to install `@wp-playground/client` through a package manager, bundle it with their application, or use its TypeScript declarations locally.

--- a/packages/playground/client/README.md
+++ b/packages/playground/client/README.md
@@ -53,43 +53,6 @@ const zip = await api.exportSavedSiteAsZip('my-site', {
 
 The optional `excludePatterns` use gitignore semantics: matching paths are excluded, later patterns take precedence, and a leading `!` re-includes a path. When `excludePatterns` is omitted, the ZIP contains the complete saved site.
 
-## Custom loading screens
-
-The Playground iframe includes a default progress bar while it boots. Apps that need a branded welcome or loading screen should render that UI outside the iframe and use a `ProgressTracker` to keep it in sync with Playground boot progress:
-
-```js
-import { ProgressTracker, startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
-
-const loadingScreen = document.getElementById('loading-screen');
-const loadingText = document.getElementById('loading-text');
-const loadingBar = document.getElementById('loading-bar');
-const iframe = document.getElementById('wp');
-
-iframe.hidden = true;
-
-const progressTracker = new ProgressTracker();
-
-progressTracker.addEventListener('progress', (event) => {
-	const { progress, caption } = event.detail;
-	loadingText.textContent = caption;
-	loadingBar.value = progress;
-});
-
-progressTracker.addEventListener('done', () => {
-	loadingScreen.hidden = true;
-	iframe.hidden = false;
-});
-
-const client = await startPlaygroundWeb({
-	iframe,
-	remoteUrl: `https://playground.wordpress.net/remote.html`,
-	progressTracker,
-	disableProgressBar: true,
-});
-```
-
-This replaces embedding custom welcome HTML inside the remote progress overlay. Keeping the welcome screen in the parent page gives each app full control over its markup, styling, and interaction model without coupling it to the Playground iframe UI. The `progressTracker` and `disableProgressBar` options existed before this change; this pattern is the supported alternative to injecting welcome HTML into the remote progress overlay.
-
 ## npm package
 
 The npm package exists for projects that want to install `@wp-playground/client` through a package manager, bundle it with their application, or use its TypeScript declarations locally.

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { ProgressTracker } from '@php-wasm/progress';
+import { ProgressTracker } from '@php-wasm/progress';
 import type { BlueprintBundle } from '@wp-playground/blueprints';
 
 const mocks = vi.hoisted(() => {
@@ -118,6 +118,71 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV2Handler).toHaveBeenCalledTimes(1);
 		expect(mocks.BlueprintsV1Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
+	});
+});
+
+describe('startPlaygroundWeb loading hooks', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('reports progress and ready state to outer loading UIs', async () => {
+		const playground = { connected: true };
+		const progressTracker = new ProgressTracker();
+		const onProgress = vi.fn();
+		const onReady = vi.fn();
+		mocks.BlueprintsV1Handler.mockImplementation(() => ({
+			bootPlayground: mocks.bootPlaygroundV1,
+		}));
+		mocks.bootPlaygroundV1.mockImplementation(async () => {
+			progressTracker.set(35);
+			return playground;
+		});
+
+		await expect(
+			startPlaygroundWeb({
+				iframe: createIframe(),
+				remoteUrl: 'http://localhost/remote.html',
+				progressTracker,
+				onProgress,
+				onReady,
+			})
+		).resolves.toBe(playground);
+
+		expect(onProgress).toHaveBeenCalledWith({
+			progress: 0,
+			caption: 'Preparing WordPress',
+		});
+		expect(onProgress).toHaveBeenCalledWith({
+			progress: 35,
+			caption: 'Preparing WordPress',
+		});
+		expect(onProgress).toHaveBeenLastCalledWith({
+			progress: 100,
+			caption: 'Preparing WordPress',
+		});
+		expect(onReady).toHaveBeenCalledTimes(1);
+	});
+
+	it('removes the progress listener after booting', async () => {
+		const progressTracker = new ProgressTracker();
+		const onProgress = vi.fn();
+		mocks.BlueprintsV1Handler.mockImplementation(() => ({
+			bootPlayground: mocks.bootPlaygroundV1,
+		}));
+		mocks.bootPlaygroundV1.mockResolvedValue({ connected: true });
+
+		await startPlaygroundWeb({
+			iframe: createIframe(),
+			remoteUrl: 'http://localhost/remote.html',
+			progressTracker,
+			onProgress,
+		});
+		onProgress.mockClear();
+
+		progressTracker.set(50);
+
+		expect(onProgress).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { ProgressTracker } from '@php-wasm/progress';
-import type { ProgressTrackerEvent } from '@php-wasm/progress';
+import type { ProgressTracker } from '@php-wasm/progress';
 import type { BlueprintBundle } from '@wp-playground/blueprints';
 
 const mocks = vi.hoisted(() => {
@@ -119,58 +118,6 @@ describe('startPlaygroundWeb', () => {
 		expect(mocks.BlueprintsV2Handler).toHaveBeenCalledTimes(1);
 		expect(mocks.BlueprintsV1Handler).not.toHaveBeenCalled();
 		expect(iframe.src).not.toContain('blueprints-runner');
-	});
-});
-
-describe('startPlaygroundWeb loading progress', () => {
-	afterEach(() => {
-		vi.clearAllMocks();
-	});
-
-	it('reports loading progress through the provided tracker', async () => {
-		const playground = { connected: true };
-		const progressTracker = new ProgressTracker();
-		const progressEvents: Array<{ progress: number; caption: string }> = [];
-		const onDone = vi.fn();
-		progressTracker.addEventListener(
-			'progress',
-			(event: ProgressTrackerEvent) => {
-				progressEvents.push({
-					progress: event.detail.progress,
-					caption: event.detail.caption,
-				});
-			}
-		);
-		progressTracker.addEventListener('done', onDone);
-		mocks.BlueprintsV1Handler.mockImplementation(() => ({
-			bootPlayground: mocks.bootPlaygroundV1,
-		}));
-		mocks.bootPlaygroundV1.mockImplementation(async () => {
-			progressTracker.set(35);
-			return playground;
-		});
-
-		await expect(
-			startPlaygroundWeb({
-				iframe: createIframe(),
-				remoteUrl: 'http://localhost/remote.html',
-				progressTracker,
-			})
-		).resolves.toBe(playground);
-
-		expect(progressEvents).toContainEqual({
-			progress: 0,
-			caption: 'Preparing WordPress',
-		});
-		expect(progressEvents).toContainEqual({
-			progress: 35,
-			caption: 'Preparing WordPress',
-		});
-		expect(progressEvents[progressEvents.length - 1]).toEqual({
-			progress: 100,
-			caption: 'Preparing WordPress',
-		});
-		expect(onDone).toHaveBeenCalled();
 	});
 });
 

--- a/packages/playground/client/src/index.spec.ts
+++ b/packages/playground/client/src/index.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ProgressTracker } from '@php-wasm/progress';
+import type { ProgressTrackerEvent } from '@php-wasm/progress';
 import type { BlueprintBundle } from '@wp-playground/blueprints';
 
 const mocks = vi.hoisted(() => {
@@ -121,16 +122,26 @@ describe('startPlaygroundWeb', () => {
 	});
 });
 
-describe('startPlaygroundWeb loading hooks', () => {
+describe('startPlaygroundWeb loading progress', () => {
 	afterEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it('reports progress and ready state to outer loading UIs', async () => {
+	it('reports loading progress through the provided tracker', async () => {
 		const playground = { connected: true };
 		const progressTracker = new ProgressTracker();
-		const onProgress = vi.fn();
-		const onReady = vi.fn();
+		const progressEvents: Array<{ progress: number; caption: string }> = [];
+		const onDone = vi.fn();
+		progressTracker.addEventListener(
+			'progress',
+			(event: ProgressTrackerEvent) => {
+				progressEvents.push({
+					progress: event.detail.progress,
+					caption: event.detail.caption,
+				});
+			}
+		);
+		progressTracker.addEventListener('done', onDone);
 		mocks.BlueprintsV1Handler.mockImplementation(() => ({
 			bootPlayground: mocks.bootPlaygroundV1,
 		}));
@@ -144,45 +155,22 @@ describe('startPlaygroundWeb loading hooks', () => {
 				iframe: createIframe(),
 				remoteUrl: 'http://localhost/remote.html',
 				progressTracker,
-				onProgress,
-				onReady,
 			})
 		).resolves.toBe(playground);
 
-		expect(onProgress).toHaveBeenCalledWith({
+		expect(progressEvents).toContainEqual({
 			progress: 0,
 			caption: 'Preparing WordPress',
 		});
-		expect(onProgress).toHaveBeenCalledWith({
+		expect(progressEvents).toContainEqual({
 			progress: 35,
 			caption: 'Preparing WordPress',
 		});
-		expect(onProgress).toHaveBeenLastCalledWith({
+		expect(progressEvents[progressEvents.length - 1]).toEqual({
 			progress: 100,
 			caption: 'Preparing WordPress',
 		});
-		expect(onReady).toHaveBeenCalledTimes(1);
-	});
-
-	it('removes the progress listener after booting', async () => {
-		const progressTracker = new ProgressTracker();
-		const onProgress = vi.fn();
-		mocks.BlueprintsV1Handler.mockImplementation(() => ({
-			bootPlayground: mocks.bootPlaygroundV1,
-		}));
-		mocks.bootPlaygroundV1.mockResolvedValue({ connected: true });
-
-		await startPlaygroundWeb({
-			iframe: createIframe(),
-			remoteUrl: 'http://localhost/remote.html',
-			progressTracker,
-			onProgress,
-		});
-		onProgress.mockClear();
-
-		progressTracker.set(50);
-
-		expect(onProgress).not.toHaveBeenCalled();
+		expect(onDone).toHaveBeenCalled();
 	});
 });
 

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -25,7 +25,6 @@ export {
 	SupportedPHPVersionsList,
 	LatestSupportedPHPVersion,
 } from '@php-wasm/universal';
-export { ProgressTracker } from '@php-wasm/progress';
 export { phpVar, phpVars } from '@php-wasm/util';
 export type { PlaygroundClient, MountDescriptor, SiteThumbnail };
 

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -41,6 +41,7 @@ import type {
 } from '@wp-playground/blueprints';
 import type { WordPressInstallMode } from '@wp-playground/wordpress';
 import { ProgressTracker } from '@php-wasm/progress';
+import type { ProgressDetails, ProgressTrackerEvent } from '@php-wasm/progress';
 import type {
 	MountDescriptor,
 	PlaygroundClient,
@@ -61,6 +62,16 @@ export interface StartPlaygroundOptions {
 	remoteUrl: string;
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
+	/**
+	 * Called whenever the loading progress changes. Use this to render
+	 * a custom progress UI outside of the Playground iframe.
+	 */
+	onProgress?: (progress: ProgressDetails) => void;
+	/**
+	 * Called after Playground finishes booting and blueprint execution.
+	 * Use this to hide a custom outer loading UI and reveal the iframe.
+	 */
+	onReady?: () => void;
 	blueprint?: BlueprintV1;
 	/**
 	 * PHP extensions to install before the runtime starts.
@@ -120,14 +131,6 @@ export interface StartPlaygroundOptions {
 	 * Defaults to the latest development version.
 	 */
 	sqliteDriverVersion?: string;
-	/**
-	 * HTML to show alongside the progress bar during loading.
-	 * When provided, the progress overlay shows this content
-	 * above the progress indicator. On user interaction the
-	 * content collapses and the progress shrinks to a corner
-	 * pill, then becomes a "ready" button when loading finishes.
-	 */
-	welcomeHtml?: string;
 	/**
 	 * How to handle WordPress installation.
 	 * Defaults to `download-and-install`.
@@ -197,6 +200,12 @@ export async function startPlaygroundWeb(
 	const useBlueprintV2Handler = await shouldUseBlueprintV2Handler(
 		options.blueprint
 	);
+	const onProgressListener = options.onProgress
+		? (event: ProgressTrackerEvent) => options.onProgress?.(event.detail)
+		: undefined;
+	if (onProgressListener) {
+		progressTracker.addEventListener('progress', onProgressListener);
+	}
 
 	const remoteUrlWithoutLegacyRunner = new URL(remoteUrl, remoteOrigin);
 	remoteUrlWithoutLegacyRunner.searchParams.delete('blueprints-runner');
@@ -212,25 +221,24 @@ export async function startPlaygroundWeb(
 
 	await loadIframe(iframe, remoteUrl);
 
-	if (options.welcomeHtml) {
-		const targetOrigin = new URL(remoteUrl).origin;
-		iframe.contentWindow?.postMessage(
-			{
-				type: 'set-welcome-html',
-				html: options.welcomeHtml,
-			},
-			targetOrigin
-		);
-	}
-
 	const handler = useBlueprintV2Handler
 		? new BlueprintsV2Handler(options)
 		: new BlueprintsV1Handler(options as StartPlaygroundOptions);
-	const playground = await handler.bootPlayground(iframe, progressTracker);
+	try {
+		const playground = await handler.bootPlayground(
+			iframe,
+			progressTracker
+		);
 
-	progressTracker.finish();
+		progressTracker.finish();
+		options.onReady?.();
 
-	return playground;
+		return playground;
+	} finally {
+		if (onProgressListener) {
+			progressTracker.removeEventListener('progress', onProgressListener);
+		}
+	}
 }
 
 /**

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -25,6 +25,7 @@ export {
 	SupportedPHPVersionsList,
 	LatestSupportedPHPVersion,
 } from '@php-wasm/universal';
+export { ProgressTracker } from '@php-wasm/progress';
 export { phpVar, phpVars } from '@php-wasm/util';
 export type { PlaygroundClient, MountDescriptor, SiteThumbnail };
 
@@ -41,7 +42,6 @@ import type {
 } from '@wp-playground/blueprints';
 import type { WordPressInstallMode } from '@wp-playground/wordpress';
 import { ProgressTracker } from '@php-wasm/progress';
-import type { ProgressDetails, ProgressTrackerEvent } from '@php-wasm/progress';
 import type {
 	MountDescriptor,
 	PlaygroundClient,
@@ -62,16 +62,6 @@ export interface StartPlaygroundOptions {
 	remoteUrl: string;
 	progressTracker?: ProgressTracker;
 	disableProgressBar?: boolean;
-	/**
-	 * Called whenever the loading progress changes. Use this to render
-	 * a custom progress UI outside of the Playground iframe.
-	 */
-	onProgress?: (progress: ProgressDetails) => void;
-	/**
-	 * Called after Playground finishes booting and blueprint execution.
-	 * Use this to hide a custom outer loading UI and reveal the iframe.
-	 */
-	onReady?: () => void;
 	blueprint?: BlueprintV1;
 	/**
 	 * PHP extensions to install before the runtime starts.
@@ -200,16 +190,6 @@ export async function startPlaygroundWeb(
 	const useBlueprintV2Handler = await shouldUseBlueprintV2Handler(
 		options.blueprint
 	);
-	const onProgressListener = options.onProgress
-		? (event: ProgressTrackerEvent) =>
-				options.onProgress?.({
-					progress: event.detail.progress,
-					caption: event.detail.caption,
-				})
-		: undefined;
-	if (onProgressListener) {
-		progressTracker.addEventListener('progress', onProgressListener);
-	}
 
 	const remoteUrlWithoutLegacyRunner = new URL(remoteUrl, remoteOrigin);
 	remoteUrlWithoutLegacyRunner.searchParams.delete('blueprints-runner');
@@ -228,21 +208,11 @@ export async function startPlaygroundWeb(
 	const handler = useBlueprintV2Handler
 		? new BlueprintsV2Handler(options)
 		: new BlueprintsV1Handler(options as StartPlaygroundOptions);
-	try {
-		const playground = await handler.bootPlayground(
-			iframe,
-			progressTracker
-		);
+	const playground = await handler.bootPlayground(iframe, progressTracker);
 
-		progressTracker.finish();
-		options.onReady?.();
+	progressTracker.finish();
 
-		return playground;
-	} finally {
-		if (onProgressListener) {
-			progressTracker.removeEventListener('progress', onProgressListener);
-		}
-	}
+	return playground;
 }
 
 /**

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -213,12 +213,13 @@ export async function startPlaygroundWeb(
 	await loadIframe(iframe, remoteUrl);
 
 	if (options.welcomeHtml) {
+		const targetOrigin = new URL(remoteUrl).origin;
 		iframe.contentWindow?.postMessage(
 			{
 				type: 'set-welcome-html',
 				html: options.welcomeHtml,
 			},
-			'*'
+			targetOrigin
 		);
 	}
 

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -201,7 +201,11 @@ export async function startPlaygroundWeb(
 		options.blueprint
 	);
 	const onProgressListener = options.onProgress
-		? (event: ProgressTrackerEvent) => options.onProgress?.(event.detail)
+		? (event: ProgressTrackerEvent) =>
+				options.onProgress?.({
+					progress: event.detail.progress,
+					caption: event.detail.caption,
+				})
 		: undefined;
 	if (onProgressListener) {
 		progressTracker.addEventListener('progress', onProgressListener);

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -121,6 +121,14 @@ export interface StartPlaygroundOptions {
 	 */
 	sqliteDriverVersion?: string;
 	/**
+	 * HTML to show alongside the progress bar during loading.
+	 * When provided, the progress overlay shows this content
+	 * above the progress indicator. On user interaction the
+	 * content collapses and the progress shrinks to a corner
+	 * pill, then becomes a "ready" button when loading finishes.
+	 */
+	welcomeHtml?: string;
+	/**
 	 * How to handle WordPress installation.
 	 * Defaults to `download-and-install`.
 	 */
@@ -203,6 +211,16 @@ export async function startPlaygroundWeb(
 	progressTracker.setCaption('Preparing WordPress');
 
 	await loadIframe(iframe, remoteUrl);
+
+	if (options.welcomeHtml) {
+		iframe.contentWindow?.postMessage(
+			{
+				type: 'set-welcome-html',
+				html: options.welcomeHtml,
+			},
+			'*'
+		);
+	}
 
 	const handler = useBlueprintV2Handler
 		? new BlueprintsV2Handler(options)

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -369,7 +369,7 @@ export function bootSiteClient(
 			})
 		);
 
-		(playground as PlaygroundClient).onNavigation((url) => {
+		(playground as PlaygroundClient).onNavigation((url, options) => {
 			dispatch(
 				updateClientInfo({
 					siteSlug: site.slug,
@@ -378,6 +378,9 @@ export function bootSiteClient(
 					},
 				})
 			);
+			if (options?.title) {
+				document.title = options.title;
+			}
 		});
 
 		const bootCompletedAt = Date.now();

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -2,36 +2,6 @@
 <html>
 	<head>
 		<title>WordPress Playground</title>
-		<link
-			rel="preload"
-			as="font"
-			type="font/woff2"
-			href="/fonts/Inter-latin.woff2"
-			crossorigin
-		/>
-		<link
-			rel="preload"
-			as="font"
-			type="font/woff2"
-			href="/fonts/EBGaramond-latin.woff2"
-			crossorigin
-		/>
-		<style>
-			@font-face {
-				font-family: 'Inter';
-				font-style: normal;
-				font-weight: 100 900;
-				font-display: swap;
-				src: url('/fonts/Inter-latin.woff2') format('woff2');
-			}
-			@font-face {
-				font-family: 'EB Garamond';
-				font-style: normal;
-				font-weight: 400 700;
-				font-display: swap;
-				src: url('/fonts/EBGaramond-latin.woff2') format('woff2');
-			}
-		</style>
 		<style>
 			* {
 				box-sizing: border-box;

--- a/packages/playground/remote/remote.html
+++ b/packages/playground/remote/remote.html
@@ -2,6 +2,36 @@
 <html>
 	<head>
 		<title>WordPress Playground</title>
+		<link
+			rel="preload"
+			as="font"
+			type="font/woff2"
+			href="/fonts/Inter-latin.woff2"
+			crossorigin
+		/>
+		<link
+			rel="preload"
+			as="font"
+			type="font/woff2"
+			href="/fonts/EBGaramond-latin.woff2"
+			crossorigin
+		/>
+		<style>
+			@font-face {
+				font-family: 'Inter';
+				font-style: normal;
+				font-weight: 100 900;
+				font-display: swap;
+				src: url('/fonts/Inter-latin.woff2') format('woff2');
+			}
+			@font-face {
+				font-family: 'EB Garamond';
+				font-style: normal;
+				font-weight: 400 700;
+				font-display: swap;
+				src: url('/fonts/EBGaramond-latin.woff2') format('woff2');
+			}
+		</style>
 		<style>
 			* {
 				box-sizing: border-box;

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -73,9 +73,11 @@ export async function bootPlaygroundRemote() {
 
 		// Listen for welcome HTML sent by the parent via postMessage
 		// (avoids passing HTML through URL query params).
+		const expectedParentOrigin = getExpectedParentOrigin();
 		window.addEventListener('message', (event) => {
 			if (
 				event.source === window.parent &&
+				event.origin === expectedParentOrigin &&
 				event.data?.type === 'set-welcome-html' &&
 				typeof event.data.html === 'string'
 			) {
@@ -721,6 +723,17 @@ async function captureSiteThumbnailFromWordPress({
 		iframe.addEventListener('load', onLoad, { once: true });
 		document.body.append(iframe);
 	});
+}
+
+function getExpectedParentOrigin() {
+	if (!document.referrer) {
+		return undefined;
+	}
+	try {
+		return new URL(document.referrer).origin;
+	} catch {
+		return undefined;
+	}
 }
 
 /**

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -70,20 +70,6 @@ export async function bootPlaygroundRemote() {
 	if (hasProgressBar) {
 		bar = new ProgressBar();
 		document.body.prepend(bar.element);
-
-		// Listen for welcome HTML sent by the parent via postMessage
-		// (avoids passing HTML through URL query params).
-		const expectedParentOrigin = getExpectedParentOrigin();
-		window.addEventListener('message', (event) => {
-			if (
-				event.source === window.parent &&
-				event.origin === expectedParentOrigin &&
-				event.data?.type === 'set-welcome-html' &&
-				typeof event.data.html === 'string'
-			) {
-				bar!.setWelcomeHtml(event.data.html);
-			}
-		});
 	}
 	const sw = navigator.serviceWorker;
 	if (!sw) {
@@ -723,17 +709,6 @@ async function captureSiteThumbnailFromWordPress({
 		iframe.addEventListener('load', onLoad, { once: true });
 		document.body.append(iframe);
 	});
-}
-
-function getExpectedParentOrigin() {
-	if (!document.referrer) {
-		return undefined;
-	}
-	try {
-		return new URL(document.referrer).origin;
-	} catch {
-		return undefined;
-	}
 }
 
 /**

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -70,6 +70,18 @@ export async function bootPlaygroundRemote() {
 	if (hasProgressBar) {
 		bar = new ProgressBar();
 		document.body.prepend(bar.element);
+
+		// Listen for welcome HTML sent by the parent via postMessage
+		// (avoids passing HTML through URL query params).
+		window.addEventListener('message', (event) => {
+			if (
+				event.source === window.parent &&
+				event.data?.type === 'set-welcome-html' &&
+				typeof event.data.html === 'string'
+			) {
+				bar!.setWelcomeHtml(event.data.html);
+			}
+		});
 	}
 	const sw = navigator.serviceWorker;
 	if (!sw) {
@@ -223,7 +235,7 @@ export async function bootPlaygroundRemote() {
 					const path = await playground.internalUrlToPath(data.url);
 					if (path !== lastPath) {
 						lastPath = path;
-						fn(path);
+						fn(path, { title: data.title });
 					}
 				} catch {
 					// Ignore JSON parse errors
@@ -265,7 +277,13 @@ export async function bootPlaygroundRemote() {
 					);
 					if (path !== lastPath) {
 						lastPath = path;
-						fn(path);
+						let title: string | undefined;
+						try {
+							title = contentWindow.document?.title || undefined;
+						} catch {
+							// Cross-origin access denied
+						}
+						fn(path, { title });
 					}
 				} catch {
 					// @TODO: The above call can fail if the remote iframe

--- a/packages/playground/remote/src/lib/playground-client.ts
+++ b/packages/playground/remote/src/lib/playground-client.ts
@@ -27,7 +27,9 @@ export interface WebClientMixin extends ProgressReceiver {
 	 * Sets the navigation event listener.
 	 * @param fn The function to be called when a navigation event occurs.
 	 */
-	onNavigation(fn: (url: string) => void): Promise<void>;
+	onNavigation(
+		fn: (url: string, options?: { title?: string }) => void
+	): Promise<void>;
 
 	/**
 	 * Navigates to the requested path.

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -247,7 +247,8 @@ function playground_report_url_to_parent() {
 			window.parent.postMessage(
 				JSON.stringify({
 					type: 'playground-url-change',
-					url: window.location.href
+					url: window.location.href,
+					title: document.title
 				}),
 				'*'
 			);

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -54,15 +54,27 @@ class ProgressBar {
 		for (const node of Array.from(doc.body.childNodes)) {
 			this.welcomeElement.appendChild(document.importNode(node, true));
 		}
-		this.welcomeElement.addEventListener('scroll', () => {
-			this.minimize();
-		});
-		this.welcomeElement.addEventListener('click', () => {
-			this.minimize();
-		});
 		// Insert welcome content before the progress section
 		this.element.insertBefore(this.welcomeElement, this.progressSection);
 		this.element.classList.add(css['overlayWithWelcome']);
+
+		// Listen on the overlay (the actual scroll container and
+		// the element that always sits under the pointer, including
+		// the centered progress pill). Scroll events don't bubble
+		// and don't fire on non-scrolling elements, so the listener
+		// has to live here, not on welcomeElement.
+		//
+		// We also listen for wheel/touchstart/keydown: during WASM
+		// boot the main thread can stall, and these "pre-scroll"
+		// signals queue up and fire as soon as the thread breathes —
+		// minimizing as soon as the user expresses any intent.
+		const onInteract = () => this.minimize();
+		const passive = { passive: true } as AddEventListenerOptions;
+		this.element.addEventListener('scroll', onInteract, passive);
+		this.element.addEventListener('wheel', onInteract, passive);
+		this.element.addEventListener('touchstart', onInteract, passive);
+		this.element.addEventListener('click', onInteract);
+		this.element.addEventListener('keydown', onInteract);
 	}
 
 	setOptions(options: ProgressBarOptions) {

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -48,11 +48,9 @@ class ProgressBar {
 		this.welcomeElement = document.createElement('div');
 		this.welcomeElement.classList.add(css['welcomeContent']);
 		this.welcomeElement.textContent = '';
-		// Parse the HTML string safely: only allow known
-		// tags and strip scripts / event handlers.
-		const doc = new DOMParser().parseFromString(html, 'text/html');
-		for (const node of Array.from(doc.body.childNodes)) {
-			this.welcomeElement.appendChild(document.importNode(node, true));
+		const fragment = sanitizeWelcomeHtml(html);
+		for (const node of Array.from(fragment.childNodes)) {
+			this.welcomeElement.appendChild(node);
 		}
 		// Insert welcome content before the progress section
 		this.element.insertBefore(this.welcomeElement, this.progressSection);
@@ -184,6 +182,106 @@ class ProgressBar {
 
 		wrapper.appendChild(progressBar);
 		return wrapper;
+	}
+}
+
+const allowedWelcomeTags = new Set([
+	'A',
+	'B',
+	'BLOCKQUOTE',
+	'BR',
+	'CODE',
+	'DIV',
+	'EM',
+	'H1',
+	'H2',
+	'H3',
+	'HR',
+	'I',
+	'LI',
+	'OL',
+	'P',
+	'PRE',
+	'SPAN',
+	'STRONG',
+	'UL',
+]);
+const blockedWelcomeTags = new Set([
+	'EMBED',
+	'IFRAME',
+	'MATH',
+	'OBJECT',
+	'SCRIPT',
+	'STYLE',
+	'SVG',
+	'TEMPLATE',
+]);
+const allowedWelcomeAttributes = new Map([
+	['A', new Set(['href', 'rel', 'target', 'title'])],
+]);
+
+function sanitizeWelcomeHtml(html: string) {
+	const doc = new DOMParser().parseFromString(html, 'text/html');
+	const fragment = document.createDocumentFragment();
+	for (const node of Array.from(doc.body.childNodes)) {
+		fragment.appendChild(sanitizeWelcomeNode(node));
+	}
+	return fragment;
+}
+
+function sanitizeWelcomeNode(node: Node): Node {
+	if (node.nodeType === Node.TEXT_NODE) {
+		return document.createTextNode(node.textContent || '');
+	}
+	if (node.nodeType !== Node.ELEMENT_NODE) {
+		return document.createTextNode('');
+	}
+
+	const element = node as Element;
+	if (!allowedWelcomeTags.has(element.tagName)) {
+		const fragment = document.createDocumentFragment();
+		if (blockedWelcomeTags.has(element.tagName)) {
+			return fragment;
+		}
+		for (const child of Array.from(element.childNodes)) {
+			fragment.appendChild(sanitizeWelcomeNode(child));
+		}
+		return fragment;
+	}
+
+	const sanitized = document.createElement(element.tagName.toLowerCase());
+	copyAllowedWelcomeAttributes(element, sanitized);
+	for (const child of Array.from(element.childNodes)) {
+		sanitized.appendChild(sanitizeWelcomeNode(child));
+	}
+	return sanitized;
+}
+
+function copyAllowedWelcomeAttributes(source: Element, target: Element) {
+	const allowedAttributes = allowedWelcomeAttributes.get(source.tagName);
+	if (!allowedAttributes) {
+		return;
+	}
+	for (const { name, value } of Array.from(source.attributes)) {
+		if (!allowedAttributes.has(name.toLowerCase())) {
+			continue;
+		}
+		if (name.toLowerCase() === 'href' && !isSafeWelcomeUrl(value)) {
+			continue;
+		}
+		target.setAttribute(name, value);
+	}
+	if (source.tagName === 'A') {
+		target.setAttribute('rel', 'noopener noreferrer');
+	}
+}
+
+function isSafeWelcomeUrl(url: string) {
+	try {
+		const parsed = new URL(url, document.location.href);
+		return ['http:', 'https:', 'mailto:'].includes(parsed.protocol);
+	} catch {
+		return false;
 	}
 }
 

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -1,6 +1,5 @@
 // @ts-ignore
 import css from './style.module.css';
-import DOMPurify from 'dompurify';
 
 export interface ProgressBarOptions {
 	caption?: string;
@@ -13,75 +12,21 @@ class ProgressBar {
 	element: HTMLDivElement;
 	captionElement: HTMLHeadingElement;
 	statusElement: HTMLDivElement;
-	welcomeElement: HTMLDivElement | null = null;
-	progressSection: HTMLDivElement;
 	caption = 'Preparing WordPress';
 	progress = 0;
 	isIndefinite = false;
 	visible = true;
-	private minimized = false;
 
 	constructor(options: ProgressBarOptions = {}) {
 		this.element = document.createElement('div');
-
-		this.progressSection = document.createElement('div');
-		this.progressSection.classList.add(css['progressSection']);
 		this.captionElement = document.createElement('h1');
 		this.statusElement = document.createElement('div');
 		this.statusElement.setAttribute('role', 'status');
 		this.statusElement.setAttribute('aria-live', 'polite');
 		this.statusElement.setAttribute('aria-atomic', 'true');
-		this.progressSection.appendChild(this.captionElement);
-		this.progressSection.appendChild(this.statusElement);
-		this.element.appendChild(this.progressSection);
-
+		this.element.appendChild(this.captionElement);
+		this.element.appendChild(this.statusElement);
 		this.setOptions(options);
-	}
-
-	/**
-	 * Injects welcome HTML above the progress section.
-	 * Must be called before the progress bar is destroyed.
-	 */
-	setWelcomeHtml(html: string) {
-		if (this.welcomeElement) {
-			return;
-		}
-		this.welcomeElement = document.createElement('div');
-		this.welcomeElement.classList.add(css['welcomeContent']);
-		this.welcomeElement.textContent = '';
-		const fragment = DOMPurify.sanitize(html, {
-			ALLOWED_TAGS: allowedWelcomeTags,
-			ALLOWED_ATTR: allowedWelcomeAttributes,
-			ALLOW_DATA_ATTR: false,
-			RETURN_DOM_FRAGMENT: true,
-		});
-		for (const link of Array.from(fragment.querySelectorAll('a'))) {
-			link.setAttribute('rel', 'noopener noreferrer');
-		}
-		for (const node of Array.from(fragment.childNodes)) {
-			this.welcomeElement.appendChild(node);
-		}
-		// Insert welcome content before the progress section
-		this.element.insertBefore(this.welcomeElement, this.progressSection);
-		this.element.classList.add(css['overlayWithWelcome']);
-
-		// Listen on the overlay (the actual scroll container and
-		// the element that always sits under the pointer, including
-		// the centered progress pill). Scroll events don't bubble
-		// and don't fire on non-scrolling elements, so the listener
-		// has to live here, not on welcomeElement.
-		//
-		// We also listen for wheel/touchstart/keydown: during WASM
-		// boot the main thread can stall, and these "pre-scroll"
-		// signals queue up and fire as soon as the thread breathes —
-		// minimizing as soon as the user expresses any intent.
-		const onInteract = () => this.minimize();
-		const passive = { passive: true } as AddEventListenerOptions;
-		this.element.addEventListener('scroll', onInteract, passive);
-		this.element.addEventListener('wheel', onInteract, passive);
-		this.element.addEventListener('touchstart', onInteract, passive);
-		this.element.addEventListener('click', onInteract);
-		this.element.addEventListener('keydown', onInteract);
 	}
 
 	setOptions(options: ProgressBarOptions) {
@@ -101,35 +46,7 @@ class ProgressBar {
 		this.updateElement();
 	}
 
-	minimize() {
-		if (this.minimized) {
-			return;
-		}
-		this.minimized = true;
-		// Only move the progress section into a corner pill —
-		// the welcome content stays visible and scrollable.
-		this.progressSection.classList.add(css['progressSectionMinimized']);
-	}
-
 	destroy() {
-		if (this.welcomeElement && this.minimized) {
-			// User already interacted — replace the progress
-			// pill with a "ready" button in the corner.
-			this.progressSection.innerHTML = '';
-			const readyButton = document.createElement('button');
-			readyButton.className = css['readyButton'];
-			readyButton.textContent =
-				'\u2713 WordPress is ready \u2014 click to start';
-			readyButton.addEventListener('click', () => {
-				this.element.classList.add(css['isHidden']);
-				setTimeout(() => {
-					this.element.remove();
-				}, 500);
-			});
-			this.progressSection.appendChild(readyButton);
-			return;
-		}
-		// No interaction — dismiss everything immediately.
 		this.setOptions({
 			visible: false,
 		});
@@ -141,9 +58,6 @@ class ProgressBar {
 	updateElement() {
 		this.element.className = '';
 		this.element.classList.add(css['overlay']);
-		if (this.welcomeElement) {
-			this.element.classList.add(css['overlayWithWelcome']);
-		}
 
 		if (!this.visible) {
 			this.element.classList.add(css['isHidden']);
@@ -156,17 +70,17 @@ class ProgressBar {
 		this.statusElement.classList.add(css['visuallyHidden']);
 		this.statusElement.textContent = this.caption;
 
-		const progressBarWrapper = this.progressSection.querySelector(
+		const progressBarWrapper = this.element.querySelector(
 			`.${css['wrapper']}`
 		);
 		if (progressBarWrapper) {
-			this.progressSection.removeChild(progressBarWrapper);
+			this.element.removeChild(progressBarWrapper);
 		}
 
 		if (this.isIndefinite) {
-			this.progressSection.appendChild(this.createProgressIndefinite());
+			this.element.appendChild(this.createProgressIndefinite());
 		} else {
-			this.progressSection.appendChild(this.createProgress());
+			this.element.appendChild(this.createProgress());
 		}
 	}
 
@@ -193,28 +107,5 @@ class ProgressBar {
 		return wrapper;
 	}
 }
-
-const allowedWelcomeTags = [
-	'a',
-	'b',
-	'blockquote',
-	'br',
-	'code',
-	'div',
-	'em',
-	'h1',
-	'h2',
-	'h3',
-	'hr',
-	'i',
-	'li',
-	'ol',
-	'p',
-	'pre',
-	'span',
-	'strong',
-	'ul',
-];
-const allowedWelcomeAttributes = ['href', 'rel', 'target', 'title'];
 
 export default ProgressBar;

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import css from './style.module.css';
+import DOMPurify from 'dompurify';
 
 export interface ProgressBarOptions {
 	caption?: string;
@@ -48,7 +49,15 @@ class ProgressBar {
 		this.welcomeElement = document.createElement('div');
 		this.welcomeElement.classList.add(css['welcomeContent']);
 		this.welcomeElement.textContent = '';
-		const fragment = sanitizeWelcomeHtml(html);
+		const fragment = DOMPurify.sanitize(html, {
+			ALLOWED_TAGS: allowedWelcomeTags,
+			ALLOWED_ATTR: allowedWelcomeAttributes,
+			ALLOW_DATA_ATTR: false,
+			RETURN_DOM_FRAGMENT: true,
+		});
+		for (const link of Array.from(fragment.querySelectorAll('a'))) {
+			link.setAttribute('rel', 'noopener noreferrer');
+		}
 		for (const node of Array.from(fragment.childNodes)) {
 			this.welcomeElement.appendChild(node);
 		}
@@ -185,104 +194,27 @@ class ProgressBar {
 	}
 }
 
-const allowedWelcomeTags = new Set([
-	'A',
-	'B',
-	'BLOCKQUOTE',
-	'BR',
-	'CODE',
-	'DIV',
-	'EM',
-	'H1',
-	'H2',
-	'H3',
-	'HR',
-	'I',
-	'LI',
-	'OL',
-	'P',
-	'PRE',
-	'SPAN',
-	'STRONG',
-	'UL',
-]);
-const blockedWelcomeTags = new Set([
-	'EMBED',
-	'IFRAME',
-	'MATH',
-	'OBJECT',
-	'SCRIPT',
-	'STYLE',
-	'SVG',
-	'TEMPLATE',
-]);
-const allowedWelcomeAttributes = new Map([
-	['A', new Set(['href', 'rel', 'target', 'title'])],
-]);
-
-function sanitizeWelcomeHtml(html: string) {
-	const doc = new DOMParser().parseFromString(html, 'text/html');
-	const fragment = document.createDocumentFragment();
-	for (const node of Array.from(doc.body.childNodes)) {
-		fragment.appendChild(sanitizeWelcomeNode(node));
-	}
-	return fragment;
-}
-
-function sanitizeWelcomeNode(node: Node): Node {
-	if (node.nodeType === Node.TEXT_NODE) {
-		return document.createTextNode(node.textContent || '');
-	}
-	if (node.nodeType !== Node.ELEMENT_NODE) {
-		return document.createTextNode('');
-	}
-
-	const element = node as Element;
-	if (!allowedWelcomeTags.has(element.tagName)) {
-		const fragment = document.createDocumentFragment();
-		if (blockedWelcomeTags.has(element.tagName)) {
-			return fragment;
-		}
-		for (const child of Array.from(element.childNodes)) {
-			fragment.appendChild(sanitizeWelcomeNode(child));
-		}
-		return fragment;
-	}
-
-	const sanitized = document.createElement(element.tagName.toLowerCase());
-	copyAllowedWelcomeAttributes(element, sanitized);
-	for (const child of Array.from(element.childNodes)) {
-		sanitized.appendChild(sanitizeWelcomeNode(child));
-	}
-	return sanitized;
-}
-
-function copyAllowedWelcomeAttributes(source: Element, target: Element) {
-	const allowedAttributes = allowedWelcomeAttributes.get(source.tagName);
-	if (!allowedAttributes) {
-		return;
-	}
-	for (const { name, value } of Array.from(source.attributes)) {
-		if (!allowedAttributes.has(name.toLowerCase())) {
-			continue;
-		}
-		if (name.toLowerCase() === 'href' && !isSafeWelcomeUrl(value)) {
-			continue;
-		}
-		target.setAttribute(name, value);
-	}
-	if (source.tagName === 'A') {
-		target.setAttribute('rel', 'noopener noreferrer');
-	}
-}
-
-function isSafeWelcomeUrl(url: string) {
-	try {
-		const parsed = new URL(url, document.location.href);
-		return ['http:', 'https:', 'mailto:'].includes(parsed.protocol);
-	} catch {
-		return false;
-	}
-}
+const allowedWelcomeTags = [
+	'a',
+	'b',
+	'blockquote',
+	'br',
+	'code',
+	'div',
+	'em',
+	'h1',
+	'h2',
+	'h3',
+	'hr',
+	'i',
+	'li',
+	'ol',
+	'p',
+	'pre',
+	'span',
+	'strong',
+	'ul',
+];
+const allowedWelcomeAttributes = ['href', 'rel', 'target', 'title'];
 
 export default ProgressBar;

--- a/packages/playground/remote/src/lib/progress-bar/index.ts
+++ b/packages/playground/remote/src/lib/progress-bar/index.ts
@@ -12,21 +12,57 @@ class ProgressBar {
 	element: HTMLDivElement;
 	captionElement: HTMLHeadingElement;
 	statusElement: HTMLDivElement;
+	welcomeElement: HTMLDivElement | null = null;
+	progressSection: HTMLDivElement;
 	caption = 'Preparing WordPress';
 	progress = 0;
 	isIndefinite = false;
 	visible = true;
+	private minimized = false;
 
 	constructor(options: ProgressBarOptions = {}) {
 		this.element = document.createElement('div');
+
+		this.progressSection = document.createElement('div');
+		this.progressSection.classList.add(css['progressSection']);
 		this.captionElement = document.createElement('h1');
 		this.statusElement = document.createElement('div');
 		this.statusElement.setAttribute('role', 'status');
 		this.statusElement.setAttribute('aria-live', 'polite');
 		this.statusElement.setAttribute('aria-atomic', 'true');
-		this.element.appendChild(this.captionElement);
-		this.element.appendChild(this.statusElement);
+		this.progressSection.appendChild(this.captionElement);
+		this.progressSection.appendChild(this.statusElement);
+		this.element.appendChild(this.progressSection);
+
 		this.setOptions(options);
+	}
+
+	/**
+	 * Injects welcome HTML above the progress section.
+	 * Must be called before the progress bar is destroyed.
+	 */
+	setWelcomeHtml(html: string) {
+		if (this.welcomeElement) {
+			return;
+		}
+		this.welcomeElement = document.createElement('div');
+		this.welcomeElement.classList.add(css['welcomeContent']);
+		this.welcomeElement.textContent = '';
+		// Parse the HTML string safely: only allow known
+		// tags and strip scripts / event handlers.
+		const doc = new DOMParser().parseFromString(html, 'text/html');
+		for (const node of Array.from(doc.body.childNodes)) {
+			this.welcomeElement.appendChild(document.importNode(node, true));
+		}
+		this.welcomeElement.addEventListener('scroll', () => {
+			this.minimize();
+		});
+		this.welcomeElement.addEventListener('click', () => {
+			this.minimize();
+		});
+		// Insert welcome content before the progress section
+		this.element.insertBefore(this.welcomeElement, this.progressSection);
+		this.element.classList.add(css['overlayWithWelcome']);
 	}
 
 	setOptions(options: ProgressBarOptions) {
@@ -46,7 +82,35 @@ class ProgressBar {
 		this.updateElement();
 	}
 
+	minimize() {
+		if (this.minimized) {
+			return;
+		}
+		this.minimized = true;
+		// Only move the progress section into a corner pill —
+		// the welcome content stays visible and scrollable.
+		this.progressSection.classList.add(css['progressSectionMinimized']);
+	}
+
 	destroy() {
+		if (this.welcomeElement && this.minimized) {
+			// User already interacted — replace the progress
+			// pill with a "ready" button in the corner.
+			this.progressSection.innerHTML = '';
+			const readyButton = document.createElement('button');
+			readyButton.className = css['readyButton'];
+			readyButton.textContent =
+				'\u2713 WordPress is ready \u2014 click to start';
+			readyButton.addEventListener('click', () => {
+				this.element.classList.add(css['isHidden']);
+				setTimeout(() => {
+					this.element.remove();
+				}, 500);
+			});
+			this.progressSection.appendChild(readyButton);
+			return;
+		}
+		// No interaction — dismiss everything immediately.
 		this.setOptions({
 			visible: false,
 		});
@@ -58,6 +122,9 @@ class ProgressBar {
 	updateElement() {
 		this.element.className = '';
 		this.element.classList.add(css['overlay']);
+		if (this.welcomeElement) {
+			this.element.classList.add(css['overlayWithWelcome']);
+		}
 
 		if (!this.visible) {
 			this.element.classList.add(css['isHidden']);
@@ -70,17 +137,17 @@ class ProgressBar {
 		this.statusElement.classList.add(css['visuallyHidden']);
 		this.statusElement.textContent = this.caption;
 
-		const progressBarWrapper = this.element.querySelector(
+		const progressBarWrapper = this.progressSection.querySelector(
 			`.${css['wrapper']}`
 		);
 		if (progressBarWrapper) {
-			this.element.removeChild(progressBarWrapper);
+			this.progressSection.removeChild(progressBarWrapper);
 		}
 
 		if (this.isIndefinite) {
-			this.element.appendChild(this.createProgressIndefinite());
+			this.progressSection.appendChild(this.createProgressIndefinite());
 		} else {
-			this.element.appendChild(this.createProgress());
+			this.progressSection.appendChild(this.createProgress());
 		}
 	}
 

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -7,7 +7,11 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	height: 100%;
+	/* Use dynamic viewport height so the scroll container tracks
+	   the visible area on mobile Safari as its address bar shows
+	   and hides — 100% (= large viewport) otherwise leaves the
+	   last content hidden behind the retracted chrome. */
+	height: 100dvh;
 	justify-content: center;
 	align-items: center;
 	box-sizing: border-box;
@@ -22,9 +26,12 @@
    normally and the progress section stays fixed in the
    center, partially blocking the view so the user has
    to scroll past it — giving us a clear interaction
-   signal. */
+   signal. Override justify-content: with overflow, the
+   default center alignment pushes the top of tall content
+   above the scroll origin, where it cannot be reached. */
 .overlay-with-welcome {
 	overflow-y: auto;
+	justify-content: flex-start;
 }
 
 .overlay.is-hidden {
@@ -41,7 +48,11 @@
 	width: 100%;
 	max-width: 680px;
 	margin: 0 auto;
-	padding: 32px 24px 24px;
+	/* Bottom padding clears the minimized progress pill (bottom: 16px,
+	   ~44px tall, plus shadow) once the user has scrolled — otherwise
+	   the last line of content sits behind it, especially on mobile
+	   where content spans the full width. */
+	padding: 32px 24px 96px;
 	font-family:
 		'Inter',
 		-apple-system,

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -33,46 +33,58 @@
 }
 
 /* Welcome content area — normal flow, scrolls behind
-   the fixed-center progress section */
+   the fixed-center progress section. Typography matches
+   the wordpress.org visual identity: Inter for body/UI,
+   EB Garamond for headings, Blueberry (#3858e9) accent.
+   See https://make.wordpress.org/design/ */
 .welcome-content {
 	width: 100%;
 	max-width: 680px;
 	margin: 0 auto;
 	padding: 32px 24px 24px;
 	font-family:
-		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+		'Inter',
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		Roboto,
+		sans-serif;
 }
 
 .welcome-content h1 {
-	font-size: 1.6rem;
-	font-weight: 700;
+	font-family: 'EB Garamond', Georgia, 'Times New Roman', serif;
+	font-size: 2rem;
+	font-weight: 400;
+	line-height: 1.2;
 	color: #1e1e1e;
-	margin: 0 0 6px 0;
+	margin: 0 0 8px 0;
 }
 
 .welcome-content h2 {
-	font-size: 1.1rem;
-	font-weight: 600;
+	font-family: 'EB Garamond', Georgia, 'Times New Roman', serif;
+	font-size: 1.4rem;
+	font-weight: 400;
+	line-height: 1.3;
 	color: #1e1e1e;
-	margin: 24px 0 8px 0;
+	margin: 28px 0 10px 0;
 }
 
 .welcome-content p {
 	font-size: 0.95rem;
 	line-height: 1.7;
-	color: #3c434a;
+	color: #1e1e1e;
 	margin: 0 0 20px 0;
 }
 
 .welcome-content p.subtitle {
-	color: #757575;
+	color: #656a71;
 	margin: 0 0 24px 0;
 }
 
 .welcome-content ul {
 	font-size: 0.9rem;
 	line-height: 1.6;
-	color: #3c434a;
+	color: #1e1e1e;
 	padding-left: 20px;
 	margin: 0 0 8px 0;
 }
@@ -81,14 +93,17 @@
 	margin-bottom: 8px;
 }
 
-.welcome-content .tip-box {
+/* Use :global so the raw class name in the injected
+   welcomeHtml string matches — CSS modules would
+   otherwise hash .tip-box and break the selector. */
+.welcome-content :global(.tip-box) {
 	padding: 16px 20px;
 	border-radius: 12px;
 	font-size: 0.9rem;
 	line-height: 1.5;
 	color: #1e1e1e;
 	margin-top: 20px;
-	background-color: #f0f7ff;
+	background-color: #eff2ff;
 }
 
 /* Progress section — caption + bar */
@@ -144,26 +159,32 @@
 	max-width: none;
 }
 
-/* Ready button shown after loading completes */
+/* Ready button shown after loading completes.
+   Blueberry (#3858e9) is the wordpress.org brand blue. */
 .ready-button {
 	pointer-events: auto;
 	display: block;
 	padding: 10px 24px;
-	background: #1e7d34;
+	background: #3858e9;
 	color: #fff;
 	border: none;
 	border-radius: 24px;
 	font-family:
-		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+		'Inter',
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		Roboto,
+		sans-serif;
 	font-size: 0.9rem;
-	font-weight: 600;
+	font-weight: 500;
 	cursor: pointer;
 	transition: background 0.15s ease;
 	white-space: nowrap;
 }
 
 .ready-button:hover {
-	background: #156b2b;
+	background: #2a44c4;
 }
 
 .wrapper {
@@ -295,9 +316,13 @@
 		color: #ccc;
 	}
 
-	.welcome-content .tip-box {
+	.welcome-content :global(.tip-box) {
 		background-color: #2a3a4a;
 		color: #e0e0e0;
+	}
+
+	.caption {
+		color: #fff;
 	}
 
 	.overlay-with-welcome .progress-section-minimized {

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -17,9 +17,153 @@
 	transition: opacity ease-in 0.25s;
 }
 
+/* When welcome content is present, the overlay becomes
+   a scrollable container. The welcome content flows
+   normally and the progress section stays fixed in the
+   center, partially blocking the view so the user has
+   to scroll past it — giving us a clear interaction
+   signal. */
+.overlay-with-welcome {
+	overflow-y: auto;
+}
+
 .overlay.is-hidden {
 	opacity: 0;
 	pointer-events: none;
+}
+
+/* Welcome content area — normal flow, scrolls behind
+   the fixed-center progress section */
+.welcome-content {
+	width: 100%;
+	max-width: 680px;
+	margin: 0 auto;
+	padding: 32px 24px 24px;
+	font-family:
+		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.welcome-content h1 {
+	font-size: 1.6rem;
+	font-weight: 700;
+	color: #1e1e1e;
+	margin: 0 0 6px 0;
+}
+
+.welcome-content h2 {
+	font-size: 1.1rem;
+	font-weight: 600;
+	color: #1e1e1e;
+	margin: 24px 0 8px 0;
+}
+
+.welcome-content p {
+	font-size: 0.95rem;
+	line-height: 1.7;
+	color: #3c434a;
+	margin: 0 0 20px 0;
+}
+
+.welcome-content p.subtitle {
+	color: #757575;
+	margin: 0 0 24px 0;
+}
+
+.welcome-content ul {
+	font-size: 0.9rem;
+	line-height: 1.6;
+	color: #3c434a;
+	padding-left: 20px;
+	margin: 0 0 8px 0;
+}
+
+.welcome-content ul li {
+	margin-bottom: 8px;
+}
+
+.welcome-content .tip-box {
+	padding: 16px 20px;
+	border-radius: 12px;
+	font-size: 0.9rem;
+	line-height: 1.5;
+	color: #1e1e1e;
+	margin-top: 20px;
+	background-color: #f0f7ff;
+}
+
+/* Progress section — caption + bar */
+.progress-section {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 16px 32px;
+	transition:
+		top 0.3s ease,
+		left 0.3s ease,
+		right 0.3s ease,
+		bottom 0.3s ease,
+		transform 0.3s ease,
+		padding 0.3s ease,
+		border-radius 0.3s ease,
+		box-shadow 0.3s ease;
+}
+
+/* When welcome content is present, fix the progress section
+   in the center of the viewport so it partially blocks the
+   welcome text. The user must scroll past it to read,
+   giving us a clear interaction signal. */
+.overlay-with-welcome .progress-section {
+	position: fixed;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	background: #fff;
+	border-radius: 16px;
+	box-shadow: 0 2px 16px rgba(0, 0, 0, 0.12);
+	border: 1px solid #e0e0e0;
+	z-index: 6;
+}
+
+.overlay-with-welcome .progress-section-minimized {
+	top: auto;
+	left: auto;
+	bottom: 16px;
+	right: 16px;
+	transform: none;
+	border-radius: 24px;
+	padding: 10px 20px;
+	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
+}
+
+.progress-section-minimized .caption {
+	font-size: 0.85rem;
+}
+
+.progress-section-minimized .wrapper {
+	width: 120px;
+	max-width: none;
+}
+
+/* Ready button shown after loading completes */
+.ready-button {
+	pointer-events: auto;
+	display: block;
+	padding: 10px 24px;
+	background: #1e7d34;
+	color: #fff;
+	border: none;
+	border-radius: 24px;
+	font-family:
+		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+	font-size: 0.9rem;
+	font-weight: 600;
+	cursor: pointer;
+	transition: background 0.15s ease;
+	white-space: nowrap;
+}
+
+.ready-button:hover {
+	background: #156b2b;
 }
 
 .wrapper {
@@ -139,6 +283,31 @@
 	.overlay {
 		background: #1e1e1e;
 		color: #fff;
+	}
+
+	.welcome-content h1,
+	.welcome-content h2 {
+		color: #fff;
+	}
+
+	.welcome-content p,
+	.welcome-content ul {
+		color: #ccc;
+	}
+
+	.welcome-content .tip-box {
+		background-color: #2a3a4a;
+		color: #e0e0e0;
+	}
+
+	.overlay-with-welcome .progress-section-minimized {
+		background: #2c2c2c;
+		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
+	}
+
+	.overlay-with-welcome .progress-section {
+		background: #1e1e1e;
+		border-color: #444;
 	}
 
 	.wrapper {

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -11,6 +11,7 @@
 	   the visible area on mobile Safari as its address bar shows
 	   and hides — 100% (= large viewport) otherwise leaves the
 	   last content hidden behind the retracted chrome. */
+	height: 100vh;
 	height: 100dvh;
 	justify-content: center;
 	align-items: center;

--- a/packages/playground/remote/src/lib/progress-bar/style.module.css
+++ b/packages/playground/remote/src/lib/progress-bar/style.module.css
@@ -7,12 +7,7 @@
 	display: flex;
 	flex-direction: column;
 	width: 100%;
-	/* Use dynamic viewport height so the scroll container tracks
-	   the visible area on mobile Safari as its address bar shows
-	   and hides — 100% (= large viewport) otherwise leaves the
-	   last content hidden behind the retracted chrome. */
-	height: 100vh;
-	height: 100dvh;
+	height: 100%;
 	justify-content: center;
 	align-items: center;
 	box-sizing: border-box;
@@ -22,181 +17,9 @@
 	transition: opacity ease-in 0.25s;
 }
 
-/* When welcome content is present, the overlay becomes
-   a scrollable container. The welcome content flows
-   normally and the progress section stays fixed in the
-   center, partially blocking the view so the user has
-   to scroll past it — giving us a clear interaction
-   signal. Override justify-content: with overflow, the
-   default center alignment pushes the top of tall content
-   above the scroll origin, where it cannot be reached. */
-.overlay-with-welcome {
-	overflow-y: auto;
-	justify-content: flex-start;
-}
-
 .overlay.is-hidden {
 	opacity: 0;
 	pointer-events: none;
-}
-
-/* Welcome content area — normal flow, scrolls behind
-   the fixed-center progress section. Typography matches
-   the wordpress.org visual identity: Inter for body/UI,
-   EB Garamond for headings, Blueberry (#3858e9) accent.
-   See https://make.wordpress.org/design/ */
-.welcome-content {
-	width: 100%;
-	max-width: 680px;
-	margin: 0 auto;
-	/* Bottom padding clears the minimized progress pill (bottom: 16px,
-	   ~44px tall, plus shadow) once the user has scrolled — otherwise
-	   the last line of content sits behind it, especially on mobile
-	   where content spans the full width. */
-	padding: 32px 24px 96px;
-	font-family:
-		'Inter',
-		-apple-system,
-		BlinkMacSystemFont,
-		'Segoe UI',
-		Roboto,
-		sans-serif;
-}
-
-.welcome-content h1 {
-	font-family: 'EB Garamond', Georgia, 'Times New Roman', serif;
-	font-size: 2rem;
-	font-weight: 400;
-	line-height: 1.2;
-	color: #1e1e1e;
-	margin: 0 0 8px 0;
-}
-
-.welcome-content h2 {
-	font-family: 'EB Garamond', Georgia, 'Times New Roman', serif;
-	font-size: 1.4rem;
-	font-weight: 400;
-	line-height: 1.3;
-	color: #1e1e1e;
-	margin: 28px 0 10px 0;
-}
-
-.welcome-content p {
-	font-size: 0.95rem;
-	line-height: 1.7;
-	color: #1e1e1e;
-	margin: 0 0 20px 0;
-}
-
-.welcome-content p.subtitle {
-	color: #656a71;
-	margin: 0 0 24px 0;
-}
-
-.welcome-content ul {
-	font-size: 0.9rem;
-	line-height: 1.6;
-	color: #1e1e1e;
-	padding-left: 20px;
-	margin: 0 0 8px 0;
-}
-
-.welcome-content ul li {
-	margin-bottom: 8px;
-}
-
-/* Use :global so the raw class name in the injected
-   welcomeHtml string matches — CSS modules would
-   otherwise hash .tip-box and break the selector. */
-.welcome-content :global(.tip-box) {
-	padding: 16px 20px;
-	border-radius: 12px;
-	font-size: 0.9rem;
-	line-height: 1.5;
-	color: #1e1e1e;
-	margin-top: 20px;
-	background-color: #eff2ff;
-}
-
-/* Progress section — caption + bar */
-.progress-section {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	padding: 16px 32px;
-	transition:
-		top 0.3s ease,
-		left 0.3s ease,
-		right 0.3s ease,
-		bottom 0.3s ease,
-		transform 0.3s ease,
-		padding 0.3s ease,
-		border-radius 0.3s ease,
-		box-shadow 0.3s ease;
-}
-
-/* When welcome content is present, fix the progress section
-   in the center of the viewport so it partially blocks the
-   welcome text. The user must scroll past it to read,
-   giving us a clear interaction signal. */
-.overlay-with-welcome .progress-section {
-	position: fixed;
-	top: 50%;
-	left: 50%;
-	transform: translate(-50%, -50%);
-	background: #fff;
-	border-radius: 16px;
-	box-shadow: 0 2px 16px rgba(0, 0, 0, 0.12);
-	border: 1px solid #e0e0e0;
-	z-index: 6;
-}
-
-.overlay-with-welcome .progress-section-minimized {
-	top: auto;
-	left: auto;
-	bottom: 16px;
-	right: 16px;
-	transform: none;
-	border-radius: 24px;
-	padding: 10px 20px;
-	box-shadow: 0 2px 12px rgba(0, 0, 0, 0.15);
-}
-
-.progress-section-minimized .caption {
-	font-size: 0.85rem;
-}
-
-.progress-section-minimized .wrapper {
-	width: 120px;
-	max-width: none;
-}
-
-/* Ready button shown after loading completes.
-   Blueberry (#3858e9) is the wordpress.org brand blue. */
-.ready-button {
-	pointer-events: auto;
-	display: block;
-	padding: 10px 24px;
-	background: #3858e9;
-	color: #fff;
-	border: none;
-	border-radius: 24px;
-	font-family:
-		'Inter',
-		-apple-system,
-		BlinkMacSystemFont,
-		'Segoe UI',
-		Roboto,
-		sans-serif;
-	font-size: 0.9rem;
-	font-weight: 500;
-	cursor: pointer;
-	transition: background 0.15s ease;
-	white-space: nowrap;
-}
-
-.ready-button:hover {
-	background: #2a44c4;
 }
 
 .wrapper {
@@ -316,35 +139,6 @@
 	.overlay {
 		background: #1e1e1e;
 		color: #fff;
-	}
-
-	.welcome-content h1,
-	.welcome-content h2 {
-		color: #fff;
-	}
-
-	.welcome-content p,
-	.welcome-content ul {
-		color: #ccc;
-	}
-
-	.welcome-content :global(.tip-box) {
-		background-color: #2a3a4a;
-		color: #e0e0e0;
-	}
-
-	.caption {
-		color: #fff;
-	}
-
-	.overlay-with-welcome .progress-section-minimized {
-		background: #2c2c2c;
-		box-shadow: 0 2px 12px rgba(0, 0, 0, 0.4);
-	}
-
-	.overlay-with-welcome .progress-section {
-		background: #1e1e1e;
-		border-color: #444;
 	}
 
 	.wrapper {

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -9,6 +9,7 @@ import { remoteDevServerHost, remoteDevServerPort } from '../build-config';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 import { copyFileSync, existsSync } from 'fs';
+import { mkdir, readFile, writeFile } from 'fs/promises';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -46,7 +47,84 @@ const plugins = [
 	} as Plugin,
 	...viteGlobalExtensions,
 	buildVersionPlugin('remote-config'),
+	wordpressOrgFontsPlugin(),
 ];
+
+/**
+ * Fetches the Inter + EB Garamond woff2 files served by wordpress.org
+ * (the fonts used across the wp.org site) once, caches them locally,
+ * serves them at `/fonts/*` during dev, and copies them into
+ * `dist/fonts/` on build. The files are not committed to git; they
+ * ship alongside the built assets so the progress overlay matches
+ * the wordpress.org visual identity with no third-party runtime
+ * dependency. See https://make.wordpress.org/design/ for context.
+ */
+function wordpressOrgFontsPlugin(): Plugin {
+	const fonts = [
+		{
+			url: 'https://wordpress.org/wp-content/mu-plugins/pub-sync/global-fonts/Inter/Inter-latin.woff2',
+			filename: 'Inter-latin.woff2',
+		},
+		{
+			url: 'https://wordpress.org/wp-content/mu-plugins/pub-sync/global-fonts/EB-Garamond/EBGaramond-latin.woff2',
+			filename: 'EBGaramond-latin.woff2',
+		},
+	];
+	const cacheDir = path('../../../node_modules/.cache/playground-fonts');
+
+	async function ensureCached() {
+		await mkdir(cacheDir, { recursive: true });
+		await Promise.all(
+			fonts.map(async ({ url, filename }) => {
+				const dest = join(cacheDir, filename);
+				if (existsSync(dest)) return;
+				const res = await fetch(url);
+				if (!res.ok) {
+					throw new Error(
+						`Failed to download font ${url}: ${res.status}`
+					);
+				}
+				await writeFile(dest, Buffer.from(await res.arrayBuffer()));
+			})
+		);
+	}
+
+	return {
+		name: 'wordpress-org-fonts-plugin',
+		async configureServer(server) {
+			const ready = ensureCached();
+			server.middlewares.use('/fonts', async (req, res, next) => {
+				try {
+					await ready;
+					const name = (req.url || '')
+						.replace(/^\/+/, '')
+						.split('?')[0];
+					const match = fonts.find((f) => f.filename === name);
+					if (!match) return next();
+					res.setHeader('Content-Type', 'application/font-woff2');
+					res.setHeader(
+						'Cache-Control',
+						'public, max-age=31536000, immutable'
+					);
+					res.end(await readFile(join(cacheDir, match.filename)));
+				} catch (e) {
+					next(e);
+				}
+			});
+		},
+		async writeBundle({ dir: outputDir }) {
+			if (!outputDir) return;
+			await ensureCached();
+			await mkdir(join(outputDir, 'fonts'), { recursive: true });
+			for (const { filename } of fonts) {
+				copyFileSync(
+					join(cacheDir, filename),
+					join(outputDir, 'fonts', filename)
+				);
+			}
+		},
+	};
+}
 
 export default defineConfig(({ mode }) => {
 	const corsProxyUrl =

--- a/packages/playground/remote/vite.config.ts
+++ b/packages/playground/remote/vite.config.ts
@@ -9,7 +9,6 @@ import { remoteDevServerHost, remoteDevServerPort } from '../build-config';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../../vite-extensions/vite-ts-config-paths';
 import { copyFileSync, existsSync } from 'fs';
-import { mkdir, readFile, writeFile } from 'fs/promises';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { buildVersionPlugin } from '../../vite-extensions/vite-build-version';
 // eslint-disable-next-line @nx/enforce-module-boundaries
@@ -47,84 +46,7 @@ const plugins = [
 	} as Plugin,
 	...viteGlobalExtensions,
 	buildVersionPlugin('remote-config'),
-	wordpressOrgFontsPlugin(),
 ];
-
-/**
- * Fetches the Inter + EB Garamond woff2 files served by wordpress.org
- * (the fonts used across the wp.org site) once, caches them locally,
- * serves them at `/fonts/*` during dev, and copies them into
- * `dist/fonts/` on build. The files are not committed to git; they
- * ship alongside the built assets so the progress overlay matches
- * the wordpress.org visual identity with no third-party runtime
- * dependency. See https://make.wordpress.org/design/ for context.
- */
-function wordpressOrgFontsPlugin(): Plugin {
-	const fonts = [
-		{
-			url: 'https://wordpress.org/wp-content/mu-plugins/pub-sync/global-fonts/Inter/Inter-latin.woff2',
-			filename: 'Inter-latin.woff2',
-		},
-		{
-			url: 'https://wordpress.org/wp-content/mu-plugins/pub-sync/global-fonts/EB-Garamond/EBGaramond-latin.woff2',
-			filename: 'EBGaramond-latin.woff2',
-		},
-	];
-	const cacheDir = path('../../../node_modules/.cache/playground-fonts');
-
-	async function ensureCached() {
-		await mkdir(cacheDir, { recursive: true });
-		await Promise.all(
-			fonts.map(async ({ url, filename }) => {
-				const dest = join(cacheDir, filename);
-				if (existsSync(dest)) return;
-				const res = await fetch(url);
-				if (!res.ok) {
-					throw new Error(
-						`Failed to download font ${url}: ${res.status}`
-					);
-				}
-				await writeFile(dest, Buffer.from(await res.arrayBuffer()));
-			})
-		);
-	}
-
-	return {
-		name: 'wordpress-org-fonts-plugin',
-		async configureServer(server) {
-			const ready = ensureCached();
-			server.middlewares.use('/fonts', async (req, res, next) => {
-				try {
-					await ready;
-					const name = (req.url || '')
-						.replace(/^\/+/, '')
-						.split('?')[0];
-					const match = fonts.find((f) => f.filename === name);
-					if (!match) return next();
-					res.setHeader('Content-Type', 'application/font-woff2');
-					res.setHeader(
-						'Cache-Control',
-						'public, max-age=31536000, immutable'
-					);
-					res.end(await readFile(join(cacheDir, match.filename)));
-				} catch (e) {
-					next(e);
-				}
-			});
-		},
-		async writeBundle({ dir: outputDir }) {
-			if (!outputDir) return;
-			await ensureCached();
-			await mkdir(join(outputDir, 'fonts'), { recursive: true });
-			for (const { filename } of fonts) {
-				copyFileSync(
-					join(cacheDir, filename),
-					join(outputDir, 'fonts', filename)
-				);
-			}
-		},
-	};
-}
 
 export default defineConfig(({ mode }) => {
 	const corsProxyUrl =


### PR DESCRIPTION
## Summary

- Relay the WordPress page title through `onNavigation(url, { title })`.
- Include `document.title` in WordPress iframe URL-change messages.
- Use the relayed title in Personal WP navigation so the parent document title stays in sync.

## Testing

- `npm exec nx typecheck playground-personal-wp`
