### PR TITLE
[PHP] Use in-memory OPcache for PHP 8.1-8.4

### DIFF
--- a/packages/php-wasm/node/src/test/php-opcache.spec.ts
+++ b/packages/php-wasm/node/src/test/php-opcache.spec.ts
@@ -43,7 +43,7 @@ describe('PHP OPcache', () => {
 		}
 	});
 
-	it('uses the in-memory cache for PHP 8.1 and newer', async () => {
+	it('uses the in-memory cache for PHP 8.1 through 8.4', async () => {
 		const php81 = new PHP(await loadNodeRuntime('8.1'));
 
 		try {
@@ -52,6 +52,18 @@ describe('PHP OPcache', () => {
 			);
 		} finally {
 			php81.exit();
+		}
+	});
+
+	it('keeps file-cache-only mode for PHP 8.5', async () => {
+		const php85 = new PHP(await loadNodeRuntime('8.5'));
+
+		try {
+			expect(php85.readFileAsText('/internal/shared/php.ini')).toContain(
+				'opcache.file_cache_only = 1'
+			);
+		} finally {
+			php85.exit();
 		}
 	});
 

--- a/packages/php-wasm/node/src/test/php-opcache.spec.ts
+++ b/packages/php-wasm/node/src/test/php-opcache.spec.ts
@@ -26,4 +26,44 @@ describe('PHP OPcache', () => {
 			'<td class="e">Opcode Caching </td><td class="v">Up and Running </td>'
 		);
 	});
+
+	it('uses the in-memory cache with file cache fallback', async () => {
+		expect(php.readFileAsText('/internal/shared/php.ini')).toContain(
+			'opcache.file_cache_only = 0'
+		);
+	});
+
+	it('keeps file-cache-only mode for PHP versions older than 8.1', async () => {
+		const php80 = new PHP(await loadNodeRuntime('8.0'));
+
+		expect(php80.readFileAsText('/internal/shared/php.ini')).toContain(
+			'opcache.file_cache_only = 1'
+		);
+	});
+
+	it('uses the in-memory cache for PHP 8.1 and newer', async () => {
+		const php81 = new PHP(await loadNodeRuntime('8.1'));
+
+		expect(php81.readFileAsText('/internal/shared/php.ini')).toContain(
+			'opcache.file_cache_only = 0'
+		);
+	});
+
+	it('revalidates changed scripts', async () => {
+		php.writeFile('/tmp/opcache-test.php', '<?php echo "first";');
+
+		const firstResponse = await php.runStream({
+			code: '<?php require "/tmp/opcache-test.php";',
+		});
+
+		expect(await firstResponse.stdoutText).toBe('first');
+
+		php.writeFile('/tmp/opcache-test.php', '<?php echo "second";');
+
+		const secondResponse = await php.runStream({
+			code: '<?php require "/tmp/opcache-test.php";',
+		});
+
+		expect(await secondResponse.stdoutText).toBe('second');
+	});
 });

--- a/packages/php-wasm/node/src/test/php-opcache.spec.ts
+++ b/packages/php-wasm/node/src/test/php-opcache.spec.ts
@@ -8,6 +8,10 @@ describe('PHP OPcache', () => {
 		php = new PHP(await loadNodeRuntime(LatestSupportedPHPVersion));
 	});
 
+	afterEach(() => {
+		php.exit();
+	});
+
 	it('should be loaded', async () => {
 		const response = await php.runStream({
 			code: '<?php echo json_encode(get_loaded_extensions());',
@@ -27,26 +31,28 @@ describe('PHP OPcache', () => {
 		);
 	});
 
-	it('uses the in-memory cache with file cache fallback', async () => {
-		expect(php.readFileAsText('/internal/shared/php.ini')).toContain(
-			'opcache.file_cache_only = 0'
-		);
-	});
-
 	it('keeps file-cache-only mode for PHP versions older than 8.1', async () => {
 		const php80 = new PHP(await loadNodeRuntime('8.0'));
 
-		expect(php80.readFileAsText('/internal/shared/php.ini')).toContain(
-			'opcache.file_cache_only = 1'
-		);
+		try {
+			expect(php80.readFileAsText('/internal/shared/php.ini')).toContain(
+				'opcache.file_cache_only = 1'
+			);
+		} finally {
+			php80.exit();
+		}
 	});
 
 	it('uses the in-memory cache for PHP 8.1 and newer', async () => {
 		const php81 = new PHP(await loadNodeRuntime('8.1'));
 
-		expect(php81.readFileAsText('/internal/shared/php.ini')).toContain(
-			'opcache.file_cache_only = 0'
-		);
+		try {
+			expect(php81.readFileAsText('/internal/shared/php.ini')).toContain(
+				'opcache.file_cache_only = 0'
+			);
+		} finally {
+			php81.exit();
+		}
 	});
 
 	it('revalidates changed scripts', async () => {

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -271,6 +271,11 @@ export class PHP implements Disposable {
 		);
 
 		if (!this.fileExists(PHP_INI_PATH)) {
+			const useInMemoryOpcache =
+				runtime.phpVersion.major > 8 ||
+				(runtime.phpVersion.major === 8 &&
+					runtime.phpVersion.minor >= 1);
+
 			const opcacheConfig = USE_OPCACHE
 				? [
 						// OPCache
@@ -283,7 +288,8 @@ export class PHP implements Disposable {
 						'opcache.max_wasted_percentage = 5',
 						'opcache.file_cache = ' + OPCACHE_FILE_FOLDER,
 						// Always enable the file cache.
-						'opcache.file_cache_only = 1',
+						'opcache.file_cache_only = ' +
+							(useInMemoryOpcache ? '0' : '1'),
 						'opcache.file_cache_consistency_checks = 1',
 					]
 				: [];

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -272,9 +272,9 @@ export class PHP implements Disposable {
 
 		if (!this.fileExists(PHP_INI_PATH)) {
 			const useInMemoryOpcache =
-				runtime.phpVersion.major > 8 ||
-				(runtime.phpVersion.major === 8 &&
-					runtime.phpVersion.minor >= 1);
+				runtime.phpVersion.major === 8 &&
+				runtime.phpVersion.minor >= 1 &&
+				runtime.phpVersion.minor <= 4;
 
 			const opcacheConfig = USE_OPCACHE
 				? [
@@ -286,6 +286,7 @@ export class PHP implements Disposable {
 						'opcache.max_accelerated_files = 1000',
 						'opcache.memory_consumption = 64',
 						'opcache.max_wasted_percentage = 5',
+						'opcache.revalidate_freq = 0',
 						'opcache.file_cache = ' + OPCACHE_FILE_FOLDER,
 						// Always enable the file cache.
 						'opcache.file_cache_only = ' +


### PR DESCRIPTION
## What?

Enable normal in-memory OPcache for PHP 8.1 through 8.4 while preserving file-cache-only mode for PHP 7.4, 8.0, and 8.5.

Fixes #3617.

## Why?

Playground currently enables OPcache, but forces `opcache.file_cache_only = 1` for all PHP versions. Local A/B testing showed that stable PHP 8.1-8.4 runtimes pay a large warm request latency tax with file-cache-only mode.

A global flip to `file_cache_only = 0` is not safe: PHP 7.4 and 8.0 crashed in local CLI probes, and CI showed PHP 8.5 still needs the conservative path for runtime rotation and JSPI dynamic-loading coverage. This PR keeps those runtimes conservative and enables the faster in-memory path for PHP 8.1-8.4.

The config also sets `opcache.revalidate_freq = 0` so rewritten scripts are revalidated immediately when in-memory OPcache is enabled.

## Evidence

Same machine, same existing WordPress site, same probe, current behavior vs gated candidate. Values are median warm samples after initial warmup.

| PHP | Current mode | Candidate mode | `/wp-json/` current | `/wp-json/` candidate | Speedup | `/` current | `/` candidate | Speedup |
|---|---|---|---:|---:|---:|---:|---:|---:|
| 7.4 | file-only | file-only | 307.1ms | 304.6ms | 1.0x | 367.2ms | 375.9ms | 1.0x |
| 8.0 | file-only | file-only | 299.7ms | 287.3ms | 1.0x | 350.6ms | 341.7ms | 1.0x |
| 8.1 | file-only | memory + file | 313.5ms | 26.1ms | 12.0x | 374.7ms | 75.1ms | 5.0x |
| 8.2 | file-only | memory + file | 334.1ms | 30.0ms | 11.1x | 396.6ms | 89.5ms | 4.4x |
| 8.3 | file-only | memory + file | 310.5ms | 28.1ms | 11.0x | 387.7ms | 83.2ms | 4.7x |
| 8.4 | file-only | memory + file | 314.4ms | 28.4ms | 11.1x | 376.8ms | 79.9ms | 4.7x |
| 8.5 | file-only | file-only | 357.4ms | n/a | n/a | 405.1ms | n/a | n/a |

A global `opcache.file_cache_only = 0` crashed PHP 7.4 and 8.0 with:

```text
Error: PHP.run() failed with exit code -2
```

For PHP 8.1 through 8.5, a direct edited-script freshness probe passed:

```text
first request: v1
second request: v1
after immediate file edit: v2
delayed request: v2
```

CI follow-up narrowed the gate from PHP 8.1+ to PHP 8.1-8.4 after PHP 8.5 showed failures in JSPI dynamic-loading/PROXYFS and runtime-rotation memory coverage.

## Testing Instructions

```bash
npx nx test-group-5-asyncify php-wasm-node --testFiles=php-opcache.spec.ts
npx nx test-group-5-jspi php-wasm-node --testFiles=php-opcache.spec.ts
npx nx test-group-1-asyncify php-wasm-node --testFiles=php-request-handler.spec.ts
npx nx test-group-5-asyncify php-wasm-node --testFiles=php-opcache.spec.ts,php-dynamic-loading.spec.ts
JSPI=true npx nx test-group-5-jspi php-wasm-node --testFiles=php-opcache.spec.ts,php-dynamic-loading.spec.ts
npx nx test-group-4-asyncify php-wasm-node --testFiles=rotate-php-runtime.spec.ts
JSPI=true npx nx test-group-3-jspi php-wasm-node --testFiles=rotate-php-runtime.spec.ts
JSPI=true npx playwright test --config=packages/php-wasm/web/playwright.config.ts packages/php-wasm/web/src/test/php-dynamic-loading.spec.ts
npx nx typecheck php-wasm-node
npx nx typecheck php-wasm-web
npx nx lint php-wasm-node
npx nx lint php-wasm-web
```

## AI assistance

- **AI assistance:** Yes
- **Tool(s):** OpenCode (GPT-5.5)
- **Used for:** Drafting the gated OPcache change, adding targeted tests, running local validation, triaging CI failures, and collecting A/B performance evidence. Chris reviewed the direction and evidence framing.