### PR TITLE
[CLI] Support staged PHP.wasm side modules

### DIFF
--- a/packages/php-wasm/compile-extension/src/manifest.ts
+++ b/packages/php-wasm/compile-extension/src/manifest.ts
@@ -38,8 +38,9 @@ export interface ExtensionManifest {
 	/**
 	 * The first directive of the generated startup `.ini` file. Defaults to
 	 * `extension`; use `zend_extension` for Zend extensions like Xdebug.
+	 * Use `false` to stage the `.so` without registering it in php.ini.
 	 */
-	loadWithIniDirective?: 'extension' | 'zend_extension';
+	loadWithIniDirective?: 'extension' | 'zend_extension' | false;
 	/** Additional `key=value` lines for the generated startup `.ini` file. */
 	iniEntries?: Record<string, string>;
 	/** Environment variables added before the extension is loaded. */

--- a/packages/php-wasm/node/README.md
+++ b/packages/php-wasm/node/README.md
@@ -63,6 +63,9 @@ URL. Relative local paths are resolved from the current working directory.
 Relative artifact files in the manifest are resolved against the manifest
 location.
 
+Set `loadWithIniDirective: false` to stage a Wasm artifact without registering
+it in php.ini.
+
 External extensions are only supported when the Node.js runtime has JSPI
 available. Asyncify support is limited to the bundled extensions shipped with
 this package.

--- a/packages/php-wasm/node/src/test/with-php-extensions.spec.ts
+++ b/packages/php-wasm/node/src/test/with-php-extensions.spec.ts
@@ -105,6 +105,54 @@ describe('withPHPExtensions', () => {
 		).rejects.toThrow('External PHP extensions require JSPI');
 	});
 
+	it('stages extension artifacts without adding a php.ini scan dir', async () => {
+		const tempDir = await mkdtemp(
+			path.join(tmpdir(), 'php-wasm-extension-')
+		);
+		try {
+			const extensionBytes = new Uint8Array([1, 2, 3]);
+			await writeFile(
+				path.join(tempDir, 'sqlite_markdown.so'),
+				extensionBytes
+			);
+			await writeFile(
+				path.join(tempDir, 'manifest.json'),
+				JSON.stringify({
+					name: 'sqlite_markdown',
+					artifacts: [
+						{
+							phpVersion: '8.4',
+							sourcePath: 'sqlite_markdown.so',
+						},
+					],
+				})
+			);
+
+			const options = await withPHPExtensions('8.4', 'jspi', {}, [
+				{
+					source: {
+						format: 'manifest',
+						manifestUrl: path.join(tempDir, 'manifest.json'),
+					},
+					loadWithIniDirective: false,
+				},
+			]);
+			const fs = createFakeFS();
+
+			expect(options.ENV?.['PHP_INI_SCAN_DIR']).toBeUndefined();
+			options.onRuntimeInitialized?.({ FS: fs } as any);
+
+			expect(
+				fs.files.get(`${PHP_EXTENSIONS_DIR}/sqlite_markdown.so`)
+			).toEqual(extensionBytes);
+			expect(
+				fs.files.has(`${PHP_EXTENSIONS_DIR}/sqlite_markdown.ini`)
+			).toBe(false);
+		} finally {
+			await rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it('treats drive-letter-shaped strings as local paths, not URL schemes', () => {
 		const source = normalizeNodeExtensionSource({
 			format: 'manifest',

--- a/packages/php-wasm/universal/README.md
+++ b/packages/php-wasm/universal/README.md
@@ -21,16 +21,15 @@ artifacts for the PHP version matrix:
 	"artifacts": [
 		{
 			"phpVersion": "8.4",
-			"file": "wp_mysql_parser-php8.4-jspi.so",
-			"sha256": "..."
+			"sourcePath": "wp_mysql_parser-php8.4-jspi.so"
 		}
 	]
 }
 ```
 
-`file` may be absolute, or relative to the manifest URL. If you pass an inline
-manifest instead of `manifestUrl`, pass `baseUrl` to choose where relative
-artifact files are resolved from.
+`sourcePath` may be absolute, or relative to the manifest URL. If you pass an
+inline manifest instead of `manifestUrl`, pass `baseUrl` to choose where
+relative artifact files are resolved from.
 
 Asyncify extension loading is reserved for bundled extensions shipped with the
 PHP.wasm packages, such as `intl`, `xdebug`, `redis`, and `memcached`.
@@ -40,7 +39,9 @@ PHP.wasm packages, such as `intl`, `xdebug`, `redis`, and `memcached`.
 `resolvePHPExtension()` turns bytes, a direct artifact URL, or a manifest into a
 `ResolvedPHPExtension`. `withResolvedPHPExtensions()` then augments Emscripten
 options so the extension `.so`, generated `.ini`, sidecar files, and environment
-variables are ready before PHP scans its `.ini` files.
+variables are ready before PHP scans its `.ini` files. When
+`loadWithIniDirective` is `false`, the `.so` and sidecar files are still staged
+but no `.ini` file or `PHP_INI_SCAN_DIR` entry is generated.
 
 ```ts
 import { resolvePHPExtension, withResolvedPHPExtensions } from '@php-wasm/universal';

--- a/packages/php-wasm/universal/public/php-extension-manifest-schema-validator.js
+++ b/packages/php-wasm/universal/public/php-extension-manifest-schema-validator.js
@@ -12,9 +12,9 @@ const schema11 = {
 				version: { type: 'string' },
 				mode: { type: 'string', const: 'php-extension' },
 				loadWithIniDirective: {
-					$ref: '#/definitions/PHPExtensionIniDirective',
+					$ref: '#/definitions/PHPExtensionLoadDirective',
 					description:
-						'The first directive of the generated startup `.ini` file. Defaults to `extension`; use `zend_extension` for Zend extensions like Xdebug.',
+						'The first directive of the generated startup `.ini` file. Defaults to `extension`; use `zend_extension` for Zend extensions like Xdebug. Use `false` to stage the `.so` without registering it in php.ini.',
 				},
 				iniEntries: {
 					type: 'object',
@@ -69,6 +69,12 @@ const schema11 = {
 			description:
 				'Extension artifact manifest. Lets callers publish a matrix of `.so` files and lets `resolvePHPExtension()` select the artifact matching the current PHP version. External extension artifacts are JSPI-only.',
 		},
+		PHPExtensionLoadDirective: {
+			anyOf: [
+				{ $ref: '#/definitions/PHPExtensionIniDirective' },
+				{ type: 'boolean', const: false },
+			],
+		},
 		PHPExtensionIniDirective: {
 			type: 'string',
 			enum: ['extension', 'zend_extension'],
@@ -121,9 +127,9 @@ const schema12 = {
 		version: { type: 'string' },
 		mode: { type: 'string', const: 'php-extension' },
 		loadWithIniDirective: {
-			$ref: '#/definitions/PHPExtensionIniDirective',
+			$ref: '#/definitions/PHPExtensionLoadDirective',
 			description:
-				'The first directive of the generated startup `.ini` file. Defaults to `extension`; use `zend_extension` for Zend extensions like Xdebug.',
+				'The first directive of the generated startup `.ini` file. Defaults to `extension`; use `zend_extension` for Zend extensions like Xdebug. Use `false` to stage the `.so` without registering it in php.ini.',
 		},
 		iniEntries: {
 			type: 'object',
@@ -177,13 +183,7 @@ const schema12 = {
 	description:
 		'Extension artifact manifest. Lets callers publish a matrix of `.so` files and lets `resolvePHPExtension()` select the artifact matching the current PHP version. External extension artifacts are JSPI-only.',
 };
-const schema13 = {
-	type: 'string',
-	enum: ['extension', 'zend_extension'],
-	description:
-		'The php.ini directive used to load the extension. Use `extension` for regular PHP extensions and `zend_extension` for Zend extensions like Xdebug.',
-};
-const schema14 = {
+const schema15 = {
 	type: 'object',
 	properties: {
 		vfsRoot: {
@@ -221,6 +221,123 @@ const schema14 = {
 	additionalProperties: false,
 };
 const func2 = Object.prototype.hasOwnProperty;
+const schema13 = {
+	anyOf: [
+		{ $ref: '#/definitions/PHPExtensionIniDirective' },
+		{ type: 'boolean', const: false },
+	],
+};
+const schema14 = {
+	type: 'string',
+	enum: ['extension', 'zend_extension'],
+	description:
+		'The php.ini directive used to load the extension. Use `extension` for regular PHP extensions and `zend_extension` for Zend extensions like Xdebug.',
+};
+function validate12(
+	data,
+	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
+) {
+	let vErrors = null;
+	let errors = 0;
+	const _errs0 = errors;
+	let valid0 = false;
+	const _errs1 = errors;
+	if (typeof data !== 'string') {
+		const err0 = {
+			instancePath,
+			schemaPath: '#/definitions/PHPExtensionIniDirective/type',
+			keyword: 'type',
+			params: { type: 'string' },
+			message: 'must be string',
+		};
+		if (vErrors === null) {
+			vErrors = [err0];
+		} else {
+			vErrors.push(err0);
+		}
+		errors++;
+	}
+	if (!(data === 'extension' || data === 'zend_extension')) {
+		const err1 = {
+			instancePath,
+			schemaPath: '#/definitions/PHPExtensionIniDirective/enum',
+			keyword: 'enum',
+			params: { allowedValues: schema14.enum },
+			message: 'must be equal to one of the allowed values',
+		};
+		if (vErrors === null) {
+			vErrors = [err1];
+		} else {
+			vErrors.push(err1);
+		}
+		errors++;
+	}
+	var _valid0 = _errs1 === errors;
+	valid0 = valid0 || _valid0;
+	if (!valid0) {
+		const _errs4 = errors;
+		if (typeof data !== 'boolean') {
+			const err2 = {
+				instancePath,
+				schemaPath: '#/anyOf/1/type',
+				keyword: 'type',
+				params: { type: 'boolean' },
+				message: 'must be boolean',
+			};
+			if (vErrors === null) {
+				vErrors = [err2];
+			} else {
+				vErrors.push(err2);
+			}
+			errors++;
+		}
+		if (false !== data) {
+			const err3 = {
+				instancePath,
+				schemaPath: '#/anyOf/1/const',
+				keyword: 'const',
+				params: { allowedValue: false },
+				message: 'must be equal to constant',
+			};
+			if (vErrors === null) {
+				vErrors = [err3];
+			} else {
+				vErrors.push(err3);
+			}
+			errors++;
+		}
+		var _valid0 = _errs4 === errors;
+		valid0 = valid0 || _valid0;
+	}
+	if (!valid0) {
+		const err4 = {
+			instancePath,
+			schemaPath: '#/anyOf',
+			keyword: 'anyOf',
+			params: {},
+			message: 'must match a schema in anyOf',
+		};
+		if (vErrors === null) {
+			vErrors = [err4];
+		} else {
+			vErrors.push(err4);
+		}
+		errors++;
+		validate12.errors = vErrors;
+		return false;
+	} else {
+		errors = _errs0;
+		if (vErrors !== null) {
+			if (_errs0) {
+				vErrors.length = _errs0;
+			} else {
+				vErrors = null;
+			}
+		}
+	}
+	validate12.errors = vErrors;
+	return errors === 0;
+}
 function validate11(
 	data,
 	{ instancePath = '', parentData, parentDataProperty, rootData = data } = {}
@@ -341,46 +458,25 @@ function validate11(
 							}
 							if (valid0) {
 								if (data.loadWithIniDirective !== undefined) {
-									let data3 = data.loadWithIniDirective;
 									const _errs8 = errors;
-									if (typeof data3 !== 'string') {
-										validate11.errors = [
-											{
-												instancePath:
-													instancePath +
-													'/loadWithIniDirective',
-												schemaPath:
-													'#/definitions/PHPExtensionIniDirective/type',
-												keyword: 'type',
-												params: { type: 'string' },
-												message: 'must be string',
-											},
-										];
-										return false;
-									}
 									if (
-										!(
-											data3 === 'extension' ||
-											data3 === 'zend_extension'
-										)
+										!validate12(data.loadWithIniDirective, {
+											instancePath:
+												instancePath +
+												'/loadWithIniDirective',
+											parentData: data,
+											parentDataProperty:
+												'loadWithIniDirective',
+											rootData,
+										})
 									) {
-										validate11.errors = [
-											{
-												instancePath:
-													instancePath +
-													'/loadWithIniDirective',
-												schemaPath:
-													'#/definitions/PHPExtensionIniDirective/enum',
-												keyword: 'enum',
-												params: {
-													allowedValues:
-														schema13.enum,
-												},
-												message:
-													'must be equal to one of the allowed values',
-											},
-										];
-										return false;
+										vErrors =
+											vErrors === null
+												? validate12.errors
+												: vErrors.concat(
+														validate12.errors
+													);
+										errors = vErrors.length;
 									}
 									var valid0 = _errs8 === errors;
 								} else {
@@ -389,15 +485,15 @@ function validate11(
 								if (valid0) {
 									if (data.iniEntries !== undefined) {
 										let data4 = data.iniEntries;
-										const _errs11 = errors;
-										if (errors === _errs11) {
+										const _errs9 = errors;
+										if (errors === _errs9) {
 											if (
 												data4 &&
 												typeof data4 == 'object' &&
 												!Array.isArray(data4)
 											) {
 												for (const key1 in data4) {
-													const _errs14 = errors;
+													const _errs12 = errors;
 													if (
 														typeof data4[key1] !==
 														'string'
@@ -428,9 +524,9 @@ function validate11(
 														];
 														return false;
 													}
-													var valid2 =
-														_errs14 === errors;
-													if (!valid2) {
+													var valid1 =
+														_errs12 === errors;
+													if (!valid1) {
 														break;
 													}
 												}
@@ -453,22 +549,22 @@ function validate11(
 												return false;
 											}
 										}
-										var valid0 = _errs11 === errors;
+										var valid0 = _errs9 === errors;
 									} else {
 										var valid0 = true;
 									}
 									if (valid0) {
 										if (data.env !== undefined) {
 											let data6 = data.env;
-											const _errs16 = errors;
-											if (errors === _errs16) {
+											const _errs14 = errors;
+											if (errors === _errs14) {
 												if (
 													data6 &&
 													typeof data6 == 'object' &&
 													!Array.isArray(data6)
 												) {
 													for (const key2 in data6) {
-														const _errs19 = errors;
+														const _errs17 = errors;
 														if (
 															typeof data6[
 																key2
@@ -502,9 +598,9 @@ function validate11(
 																];
 															return false;
 														}
-														var valid3 =
-															_errs19 === errors;
-														if (!valid3) {
+														var valid2 =
+															_errs17 === errors;
+														if (!valid2) {
 															break;
 														}
 													}
@@ -527,7 +623,7 @@ function validate11(
 													return false;
 												}
 											}
-											var valid0 = _errs16 === errors;
+											var valid0 = _errs14 === errors;
 										} else {
 											var valid0 = true;
 										}
@@ -535,7 +631,7 @@ function validate11(
 											if (
 												data.extensionDir !== undefined
 											) {
-												const _errs21 = errors;
+												const _errs19 = errors;
 												if (
 													typeof data.extensionDir !==
 													'string'
@@ -557,7 +653,7 @@ function validate11(
 													];
 													return false;
 												}
-												var valid0 = _errs21 === errors;
+												var valid0 = _errs19 === errors;
 											} else {
 												var valid0 = true;
 											}
@@ -566,12 +662,12 @@ function validate11(
 													data.artifacts !== undefined
 												) {
 													let data9 = data.artifacts;
-													const _errs23 = errors;
-													if (errors === _errs23) {
+													const _errs21 = errors;
+													if (errors === _errs21) {
 														if (
 															Array.isArray(data9)
 														) {
-															var valid4 = true;
+															var valid3 = true;
 															const len0 =
 																data9.length;
 															for (
@@ -581,11 +677,11 @@ function validate11(
 															) {
 																let data10 =
 																	data9[i0];
-																const _errs25 =
+																const _errs23 =
 																	errors;
 																if (
 																	errors ===
-																	_errs25
+																	_errs23
 																) {
 																	if (
 																		data10 &&
@@ -629,7 +725,7 @@ function validate11(
 																				];
 																			return false;
 																		} else {
-																			const _errs27 =
+																			const _errs25 =
 																				errors;
 																			for (const key3 in data10) {
 																				if (
@@ -666,14 +762,14 @@ function validate11(
 																				}
 																			}
 																			if (
-																				_errs27 ===
+																				_errs25 ===
 																				errors
 																			) {
 																				if (
 																					data10.phpVersion !==
 																					undefined
 																				) {
-																					const _errs28 =
+																					const _errs26 =
 																						errors;
 																					if (
 																						typeof data10.phpVersion !==
@@ -700,20 +796,20 @@ function validate11(
 																							];
 																						return false;
 																					}
-																					var valid5 =
-																						_errs28 ===
+																					var valid4 =
+																						_errs26 ===
 																						errors;
 																				} else {
-																					var valid5 = true;
+																					var valid4 = true;
 																				}
 																				if (
-																					valid5
+																					valid4
 																				) {
 																					if (
 																						data10.sourcePath !==
 																						undefined
 																					) {
-																						const _errs30 =
+																						const _errs28 =
 																							errors;
 																						if (
 																							typeof data10.sourcePath !==
@@ -740,14 +836,14 @@ function validate11(
 																								];
 																							return false;
 																						}
-																						var valid5 =
-																							_errs30 ===
+																						var valid4 =
+																							_errs28 ===
 																							errors;
 																					} else {
-																						var valid5 = true;
+																						var valid4 = true;
 																					}
 																					if (
-																						valid5
+																						valid4
 																					) {
 																						if (
 																							data10.extraFiles !==
@@ -755,13 +851,13 @@ function validate11(
 																						) {
 																							let data13 =
 																								data10.extraFiles;
-																							const _errs32 =
+																							const _errs30 =
 																								errors;
-																							const _errs33 =
+																							const _errs31 =
 																								errors;
 																							if (
 																								errors ===
-																								_errs33
+																								_errs31
 																							) {
 																								if (
 																									data13 &&
@@ -771,7 +867,7 @@ function validate11(
 																										data13
 																									)
 																								) {
-																									const _errs35 =
+																									const _errs33 =
 																										errors;
 																									for (const key4 in data13) {
 																										if (
@@ -807,14 +903,14 @@ function validate11(
 																										}
 																									}
 																									if (
-																										_errs35 ===
+																										_errs33 ===
 																										errors
 																									) {
 																										if (
 																											data13.vfsRoot !==
 																											undefined
 																										) {
-																											const _errs36 =
+																											const _errs34 =
 																												errors;
 																											if (
 																												typeof data13.vfsRoot !==
@@ -841,14 +937,14 @@ function validate11(
 																													];
 																												return false;
 																											}
-																											var valid7 =
-																												_errs36 ===
+																											var valid6 =
+																												_errs34 ===
 																												errors;
 																										} else {
-																											var valid7 = true;
+																											var valid6 = true;
 																										}
 																										if (
-																											valid7
+																											valid6
 																										) {
 																											if (
 																												data13.nodes !==
@@ -856,18 +952,18 @@ function validate11(
 																											) {
 																												let data15 =
 																													data13.nodes;
-																												const _errs38 =
+																												const _errs36 =
 																													errors;
 																												if (
 																													errors ===
-																													_errs38
+																													_errs36
 																												) {
 																													if (
 																														Array.isArray(
 																															data15
 																														)
 																													) {
-																														var valid8 = true;
+																														var valid7 = true;
 																														const len1 =
 																															data15.length;
 																														for (
@@ -880,11 +976,11 @@ function validate11(
 																																data15[
 																																	i1
 																																];
-																															const _errs40 =
+																															const _errs38 =
 																																errors;
 																															if (
 																																errors ===
-																																_errs40
+																																_errs38
 																															) {
 																																if (
 																																	data16 &&
@@ -926,7 +1022,7 @@ function validate11(
 																																			];
 																																		return false;
 																																	} else {
-																																		const _errs42 =
+																																		const _errs40 =
 																																			errors;
 																																		for (const key5 in data16) {
 																																			if (
@@ -965,14 +1061,14 @@ function validate11(
 																																			}
 																																		}
 																																		if (
-																																			_errs42 ===
+																																			_errs40 ===
 																																			errors
 																																		) {
 																																			if (
 																																				data16.vfsPath !==
 																																				undefined
 																																			) {
-																																				const _errs43 =
+																																				const _errs41 =
 																																					errors;
 																																				if (
 																																					typeof data16.vfsPath !==
@@ -1001,14 +1097,14 @@ function validate11(
 																																						];
 																																					return false;
 																																				}
-																																				var valid9 =
-																																					_errs43 ===
+																																				var valid8 =
+																																					_errs41 ===
 																																					errors;
 																																			} else {
-																																				var valid9 = true;
+																																				var valid8 = true;
 																																			}
 																																			if (
-																																				valid9
+																																				valid8
 																																			) {
 																																				if (
 																																					data16.type !==
@@ -1016,7 +1112,7 @@ function validate11(
 																																				) {
 																																					let data18 =
 																																						data16.type;
-																																					const _errs45 =
+																																					const _errs43 =
 																																						errors;
 																																					if (
 																																						typeof data18 !==
@@ -1069,7 +1165,7 @@ function validate11(
 																																										'enum',
 																																									params: {
 																																										allowedValues:
-																																											schema14
+																																											schema15
 																																												.properties
 																																												.nodes
 																																												.items
@@ -1083,20 +1179,20 @@ function validate11(
 																																							];
 																																						return false;
 																																					}
-																																					var valid9 =
-																																						_errs45 ===
+																																					var valid8 =
+																																						_errs43 ===
 																																						errors;
 																																				} else {
-																																					var valid9 = true;
+																																					var valid8 = true;
 																																				}
 																																				if (
-																																					valid9
+																																					valid8
 																																				) {
 																																					if (
 																																						data16.sourcePath !==
 																																						undefined
 																																					) {
-																																						const _errs47 =
+																																						const _errs45 =
 																																							errors;
 																																						if (
 																																							typeof data16.sourcePath !==
@@ -1125,11 +1221,11 @@ function validate11(
 																																								];
 																																							return false;
 																																						}
-																																						var valid9 =
-																																							_errs47 ===
+																																						var valid8 =
+																																							_errs45 ===
 																																							errors;
 																																					} else {
-																																						var valid9 = true;
+																																						var valid8 = true;
 																																					}
 																																				}
 																																			}
@@ -1159,11 +1255,11 @@ function validate11(
 																																	return false;
 																																}
 																															}
-																															var valid8 =
-																																_errs40 ===
+																															var valid7 =
+																																_errs38 ===
 																																errors;
 																															if (
-																																!valid8
+																																!valid7
 																															) {
 																																break;
 																															}
@@ -1191,11 +1287,11 @@ function validate11(
 																														return false;
 																													}
 																												}
-																												var valid7 =
-																													_errs38 ===
+																												var valid6 =
+																													_errs36 ===
 																													errors;
 																											} else {
-																												var valid7 = true;
+																												var valid6 = true;
 																											}
 																										}
 																									}
@@ -1222,11 +1318,11 @@ function validate11(
 																									return false;
 																								}
 																							}
-																							var valid5 =
-																								_errs32 ===
+																							var valid4 =
+																								_errs30 ===
 																								errors;
 																						} else {
-																							var valid5 = true;
+																							var valid4 = true;
 																						}
 																					}
 																				}
@@ -1254,10 +1350,10 @@ function validate11(
 																		return false;
 																	}
 																}
-																var valid4 =
-																	_errs25 ===
+																var valid3 =
+																	_errs23 ===
 																	errors;
-																if (!valid4) {
+																if (!valid3) {
 																	break;
 																}
 															}
@@ -1283,7 +1379,7 @@ function validate11(
 														}
 													}
 													var valid0 =
-														_errs23 === errors;
+														_errs21 === errors;
 												} else {
 													var valid0 = true;
 												}
@@ -1294,10 +1390,10 @@ function validate11(
 													) {
 														let data20 =
 															data.extraFiles;
-														const _errs49 = errors;
-														const _errs50 = errors;
+														const _errs47 = errors;
+														const _errs48 = errors;
 														if (
-															errors === _errs50
+															errors === _errs48
 														) {
 															if (
 																data20 &&
@@ -1307,7 +1403,7 @@ function validate11(
 																	data20
 																)
 															) {
-																const _errs52 =
+																const _errs50 =
 																	errors;
 																for (const key6 in data20) {
 																	if (
@@ -1341,14 +1437,14 @@ function validate11(
 																	}
 																}
 																if (
-																	_errs52 ===
+																	_errs50 ===
 																	errors
 																) {
 																	if (
 																		data20.vfsRoot !==
 																		undefined
 																	) {
-																		const _errs53 =
+																		const _errs51 =
 																			errors;
 																		if (
 																			typeof data20.vfsRoot !==
@@ -1373,14 +1469,14 @@ function validate11(
 																				];
 																			return false;
 																		}
-																		var valid11 =
-																			_errs53 ===
+																		var valid10 =
+																			_errs51 ===
 																			errors;
 																	} else {
-																		var valid11 = true;
+																		var valid10 = true;
 																	}
 																	if (
-																		valid11
+																		valid10
 																	) {
 																		if (
 																			data20.nodes !==
@@ -1388,18 +1484,18 @@ function validate11(
 																		) {
 																			let data22 =
 																				data20.nodes;
-																			const _errs55 =
+																			const _errs53 =
 																				errors;
 																			if (
 																				errors ===
-																				_errs55
+																				_errs53
 																			) {
 																				if (
 																					Array.isArray(
 																						data22
 																					)
 																				) {
-																					var valid12 = true;
+																					var valid11 = true;
 																					const len2 =
 																						data22.length;
 																					for (
@@ -1412,11 +1508,11 @@ function validate11(
 																							data22[
 																								i2
 																							];
-																						const _errs57 =
+																						const _errs55 =
 																							errors;
 																						if (
 																							errors ===
-																							_errs57
+																							_errs55
 																						) {
 																							if (
 																								data23 &&
@@ -1456,7 +1552,7 @@ function validate11(
 																										];
 																									return false;
 																								} else {
-																									const _errs59 =
+																									const _errs57 =
 																										errors;
 																									for (const key7 in data23) {
 																										if (
@@ -1493,14 +1589,14 @@ function validate11(
 																										}
 																									}
 																									if (
-																										_errs59 ===
+																										_errs57 ===
 																										errors
 																									) {
 																										if (
 																											data23.vfsPath !==
 																											undefined
 																										) {
-																											const _errs60 =
+																											const _errs58 =
 																												errors;
 																											if (
 																												typeof data23.vfsPath !==
@@ -1527,14 +1623,14 @@ function validate11(
 																													];
 																												return false;
 																											}
-																											var valid13 =
-																												_errs60 ===
+																											var valid12 =
+																												_errs58 ===
 																												errors;
 																										} else {
-																											var valid13 = true;
+																											var valid12 = true;
 																										}
 																										if (
-																											valid13
+																											valid12
 																										) {
 																											if (
 																												data23.type !==
@@ -1542,7 +1638,7 @@ function validate11(
 																											) {
 																												let data25 =
 																													data23.type;
-																												const _errs62 =
+																												const _errs60 =
 																													errors;
 																												if (
 																													typeof data25 !==
@@ -1591,7 +1687,7 @@ function validate11(
 																																	'enum',
 																																params: {
 																																	allowedValues:
-																																		schema14
+																																		schema15
 																																			.properties
 																																			.nodes
 																																			.items
@@ -1605,20 +1701,20 @@ function validate11(
 																														];
 																													return false;
 																												}
-																												var valid13 =
-																													_errs62 ===
+																												var valid12 =
+																													_errs60 ===
 																													errors;
 																											} else {
-																												var valid13 = true;
+																												var valid12 = true;
 																											}
 																											if (
-																												valid13
+																												valid12
 																											) {
 																												if (
 																													data23.sourcePath !==
 																													undefined
 																												) {
-																													const _errs64 =
+																													const _errs62 =
 																														errors;
 																													if (
 																														typeof data23.sourcePath !==
@@ -1645,11 +1741,11 @@ function validate11(
 																															];
 																														return false;
 																													}
-																													var valid13 =
-																														_errs64 ===
+																													var valid12 =
+																														_errs62 ===
 																														errors;
 																												} else {
-																													var valid13 = true;
+																													var valid12 = true;
 																												}
 																											}
 																										}
@@ -1677,11 +1773,11 @@ function validate11(
 																								return false;
 																							}
 																						}
-																						var valid12 =
-																							_errs57 ===
+																						var valid11 =
+																							_errs55 ===
 																							errors;
 																						if (
-																							!valid12
+																							!valid11
 																						) {
 																							break;
 																						}
@@ -1707,11 +1803,11 @@ function validate11(
 																					return false;
 																				}
 																			}
-																			var valid11 =
-																				_errs55 ===
+																			var valid10 =
+																				_errs53 ===
 																				errors;
 																		} else {
-																			var valid11 = true;
+																			var valid10 = true;
 																		}
 																	}
 																}
@@ -1737,7 +1833,7 @@ function validate11(
 															}
 														}
 														var valid0 =
-															_errs49 === errors;
+															_errs47 === errors;
 													} else {
 														var valid0 = true;
 													}

--- a/packages/php-wasm/universal/public/php-extension-manifest-schema.json
+++ b/packages/php-wasm/universal/public/php-extension-manifest-schema.json
@@ -16,8 +16,8 @@
 					"const": "php-extension"
 				},
 				"loadWithIniDirective": {
-					"$ref": "#/definitions/PHPExtensionIniDirective",
-					"description": "The first directive of the generated startup `.ini` file. Defaults to `extension`; use `zend_extension` for Zend extensions like Xdebug."
+					"$ref": "#/definitions/PHPExtensionLoadDirective",
+					"description": "The first directive of the generated startup `.ini` file. Defaults to `extension`; use `zend_extension` for Zend extensions like Xdebug. Use `false` to stage the `.so` without registering it in php.ini."
 				},
 				"iniEntries": {
 					"type": "object",
@@ -67,6 +67,17 @@
 			"required": ["name", "artifacts"],
 			"additionalProperties": false,
 			"description": "Extension artifact manifest. Lets callers publish a matrix of `.so` files and lets `resolvePHPExtension()` select the artifact matching the current PHP version. External extension artifacts are JSPI-only."
+		},
+		"PHPExtensionLoadDirective": {
+			"anyOf": [
+				{
+					"$ref": "#/definitions/PHPExtensionIniDirective"
+				},
+				{
+					"type": "boolean",
+					"const": false
+				}
+			]
 		},
 		"PHPExtensionIniDirective": {
 			"type": "string",

--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -105,6 +105,7 @@ export {
 export type {
 	InstallPHPExtensionFilesOptions,
 	PHPExtensionIniDirective,
+	PHPExtensionLoadDirective,
 	ResolvedInstallOptions,
 	ResolvedPHPExtension,
 	PHPExtensionManifest,

--- a/packages/php-wasm/universal/src/lib/load-extension.spec.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.spec.ts
@@ -35,6 +35,24 @@ describe('resolvePHPExtension', () => {
 		);
 	});
 
+	it('resolves a side module without registering it in php.ini', async () => {
+		const extension = await resolvePHPExtension({
+			source: {
+				format: 'so',
+				name: 'sqlite_markdown',
+				bytes: new Uint8Array([1, 2, 3]),
+			},
+			phpVersion: '8.4',
+			loadWithIniDirective: false,
+		});
+
+		expect(extension.soPath).toBe(
+			`${PHP_EXTENSIONS_DIR}/sqlite_markdown.so`
+		);
+		expect(extension.iniPath).toBeUndefined();
+		expect(extension.iniContent).toBeUndefined();
+	});
+
 	it('explains that direct URL sources require absolute URLs', async () => {
 		await expect(
 			resolvePHPExtension({
@@ -114,6 +132,32 @@ describe('resolvePHPExtension', () => {
 		expect(extension.env).toEqual({
 			SPX_DATA_DIR: '/internal/shared/spx/data',
 		});
+	});
+
+	it('resolves manifest sources without php.ini registration', async () => {
+		const extension = await resolvePHPExtension({
+			source: {
+				format: 'manifest',
+				manifest: {
+					name: 'sqlite_markdown',
+					loadWithIniDirective: false,
+					artifacts: [
+						{
+							phpVersion: '8.4',
+							sourcePath: 'sqlite_markdown.so',
+						},
+					],
+				},
+				baseUrl: 'https://example.com/extensions/',
+			},
+			phpVersion: '8.4',
+			fetch: async () => new Response(new Uint8Array([1, 2, 3])),
+		});
+
+		expect(extension.soPath).toBe(
+			`${PHP_EXTENSIONS_DIR}/sqlite_markdown.so`
+		);
+		expect(extension.iniPath).toBeUndefined();
 	});
 
 	it('rejects manifests that do not match the generated schema validator', async () => {

--- a/packages/php-wasm/universal/src/lib/load-extension.ts
+++ b/packages/php-wasm/universal/src/lib/load-extension.ts
@@ -103,6 +103,7 @@ const MAX_EXTENSION_SIDECAR_FILE_REQUESTS = 5;
  * regular PHP extensions and `zend_extension` for Zend extensions like Xdebug.
  */
 export type PHPExtensionIniDirective = 'extension' | 'zend_extension';
+export type PHPExtensionLoadDirective = PHPExtensionIniDirective | false;
 
 /**
  * Extension artifact manifest. Lets callers publish a matrix of `.so` files
@@ -116,8 +117,9 @@ export interface PHPExtensionManifest {
 	/**
 	 * The first directive of the generated startup `.ini` file. Defaults to
 	 * `extension`; use `zend_extension` for Zend extensions like Xdebug.
+	 * Use `false` to stage the `.so` without registering it in php.ini.
 	 */
-	loadWithIniDirective?: PHPExtensionIniDirective;
+	loadWithIniDirective?: PHPExtensionLoadDirective;
 	/** Additional `key=value` lines for the generated startup `.ini` file. */
 	iniEntries?: Record<string, string>;
 	/** Environment variables added before the extension is loaded. */
@@ -201,7 +203,7 @@ export interface ResolvedInstallOptions {
 	 * extensions need `extension=...`; Zend extensions like Xdebug need
 	 * `zend_extension=...`.
 	 */
-	loadWithIniDirective?: PHPExtensionIniDirective;
+	loadWithIniDirective?: PHPExtensionLoadDirective;
 	/** Additional `key=value` lines for the generated startup `.ini` file. */
 	iniEntries?: Record<string, string>;
 	/**
@@ -236,13 +238,13 @@ export interface ResolvedPHPExtension {
 	/** Compiled extension bytes to write at `soPath`. */
 	soBytes: Uint8Array;
 	/** Absolute VFS path the generated per-extension ini file is staged at. */
-	iniPath: string;
+	iniPath?: string;
 	/**
 	 * Contents of the generated per-extension ini file. The first line is the
 	 * `extension=` or `zend_extension=` directive; remaining lines are the
 	 * caller-supplied `iniEntries`.
 	 */
-	iniContent: string;
+	iniContent?: string;
 	/** Sidecar files staged alongside the extension. Optional. */
 	extraFiles?: ResolvedExtraFiles;
 	/** Environment variables added before PHP startup. */
@@ -278,7 +280,7 @@ export interface InstallPHPExtensionFilesOptions {
 	 * extensions need `extension=...`; Zend extensions like Xdebug need
 	 * `zend_extension=...`.
 	 */
-	loadWithIniDirective?: PHPExtensionIniDirective;
+	loadWithIniDirective?: PHPExtensionLoadDirective;
 	/** Additional `key=value` lines for the generated startup `.ini` file. */
 	iniEntries?: Record<string, string>;
 	/** Sidecar files to write into the PHP VFS before the extension is loaded. */
@@ -314,7 +316,7 @@ export async function resolvePHPExtension(
 	let soBytes: Uint8Array;
 	const files: Record<string, Uint8Array | string> = {};
 	const directories: string[] = [];
-	let manifestLoadWithIniDirective: PHPExtensionIniDirective | undefined;
+	let manifestLoadWithIniDirective: PHPExtensionLoadDirective | undefined;
 	let manifestIniEntries: Record<string, string> | undefined;
 	let manifestEnv: Record<string, string> | undefined;
 	let manifestExtensionDir: string | undefined;
@@ -438,11 +440,13 @@ export async function resolvePHPExtension(
 		...options.iniEntries,
 	};
 	const soPath = joinPaths(extensionDir, `${name}.so`);
-	const iniPath = joinPaths(extensionDir, `${name}.ini`);
-	const iniContent = [
-		`${directive}=${soPath}`,
-		...Object.entries(iniEntries).map(([key, value]) => `${key}=${value}`),
-	].join('\n');
+	const iniFile = createPHPExtensionIniFile({
+		directive,
+		extensionDir,
+		name,
+		soPath,
+		iniEntries,
+	});
 	const env = {
 		...manifestEnv,
 		...options.env,
@@ -451,8 +455,7 @@ export async function resolvePHPExtension(
 	return {
 		soPath,
 		soBytes,
-		iniPath,
-		iniContent,
+		...iniFile,
 		extraFiles: {
 			files,
 			directories,
@@ -479,6 +482,9 @@ export function withResolvedPHPExtensions(
 	const env = { ...options.ENV };
 	for (const extension of extensions) {
 		Object.assign(env, extension.env);
+		if (!extension.iniPath) {
+			continue;
+		}
 		const paths = env['PHP_INI_SCAN_DIR']?.split(':') ?? [];
 		if (!paths.includes(extension.extensionDir)) {
 			paths.push(extension.extensionDir);
@@ -513,16 +519,17 @@ export function installPHPExtensionFilesSync(
 		const extensionDir = options.extensionDir ?? PHP_EXTENSIONS_DIR;
 		const directive = options.loadWithIniDirective ?? 'extension';
 		const soPath = joinPaths(extensionDir, `${options.name}.so`);
+		const iniFile = createPHPExtensionIniFile({
+			directive,
+			extensionDir,
+			name: options.name,
+			soPath,
+			iniEntries: options.iniEntries,
+		});
 		ext = {
 			soPath,
 			soBytes: toUint8Array(options.soBytes),
-			iniPath: joinPaths(extensionDir, `${options.name}.ini`),
-			iniContent: [
-				`${directive}=${soPath}`,
-				...Object.entries(options.iniEntries ?? {}).map(
-					([key, value]) => `${key}=${value}`
-				),
-			].join('\n'),
+			...iniFile,
 			extraFiles: options.extraFiles,
 			env: options.env,
 			extensionDir,
@@ -530,7 +537,9 @@ export function installPHPExtensionFilesSync(
 	}
 	mkdirIfMissing(fs, ext.extensionDir);
 	fs.writeFile(ext.soPath, ext.soBytes);
-	fs.writeFile(ext.iniPath, ext.iniContent);
+	if (ext.iniPath && ext.iniContent !== undefined) {
+		fs.writeFile(ext.iniPath, ext.iniContent);
+	}
 	if (ext.extraFiles) {
 		const { directories = [], files } = ext.extraFiles;
 		for (const directory of directories) {
@@ -542,6 +551,30 @@ export function installPHPExtensionFilesSync(
 		}
 	}
 	return ext;
+}
+
+function createPHPExtensionIniFile(options: {
+	directive: PHPExtensionLoadDirective;
+	extensionDir: string;
+	name: string;
+	soPath: string;
+	iniEntries?: Record<string, string>;
+}): Pick<ResolvedPHPExtension, 'iniPath' | 'iniContent'> {
+	if (options.directive === false) {
+		return {};
+	}
+
+	const lines = [
+		`${options.directive}=${options.soPath}`,
+		...Object.entries(options.iniEntries ?? {}).map(
+			([key, value]) => `${key}=${value}`
+		),
+	];
+
+	return {
+		iniPath: joinPaths(options.extensionDir, `${options.name}.ini`),
+		iniContent: lines.join('\n'),
+	};
 }
 
 function mkdirIfMissing(fs: Emscripten.RootFS, path: string): void {

--- a/packages/playground/cli/README.md
+++ b/packages/playground/cli/README.md
@@ -138,6 +138,24 @@ Add runtime settings such as `iniEntries` and `env` directly to the manifest:
 }
 ```
 
+Set `loadWithIniDirective` to `false` when the artifact is a loadable Wasm
+side module that should be staged before PHP starts but should not be registered
+with `extension=` or `zend_extension=` in php.ini:
+
+```json
+{
+	"name": "sqlite_markdown",
+	"version": "0.1.0",
+	"loadWithIniDirective": false,
+	"artifacts": [
+		{
+			"phpVersion": "8.4",
+			"sourcePath": "sqlite_markdown-php8.4-jspi.so"
+		}
+	]
+}
+```
+
 ## Need some help with the CLI?
 
 With the Playground CLI, you can use the `--help` to get some support about the available commands.


### PR DESCRIPTION
## What it does

Allows a PHP.wasm extension manifest to stage an artifact before PHP starts without adding a `php.ini` load directive.

```json
{
  "name": "sqlite_markdown",
  "loadWithIniDirective": false,
  "artifacts": []
}
```

The extension bytes and sidecar files are still fetched and written into the PHP virtual filesystem, but PHP does not receive an `extension=` or `zend_extension=` entry for that artifact.

## Rationale

Some Wasm side modules are consumed by another runtime component instead of PHP's extension loader. They need the startup-time fetch/staging path from custom PHP.wasm extensions, but registering them through `php.ini` makes PHP try to load them as native PHP extensions.

## Implementation

Adds `PHPExtensionLoadDirective = 'extension' | 'zend_extension' | false` and threads it through manifest resolution, `@php-wasm/node`, and the generated manifest schema.

When `loadWithIniDirective` is `false`:

- the `.so` is staged in `extensionDir`
- manifest and caller-provided sidecar files are staged normally
- no per-extension `.ini` file is generated
- `withResolvedPHPExtensions()` omits that extension from `PHP_INI_SCAN_DIR`

The `@php-wasm/compile-extension` manifest type now accepts the same value, so generated extension manifests can use the single manifest object format.

## Testing instructions

```bash
npm exec -- nx run php-wasm-universal:test:vite --testFile=load-extension.spec.ts
npm exec -- nx run php-wasm-node:test-group-1-jspi --testFiles=with-php-extensions.spec.ts
npm exec -- nx run php-wasm-universal:typecheck
npm exec -- nx run php-wasm-node:typecheck
npm exec -- nx run php-wasm-compile-extension:typecheck
npm exec -- nx run php-wasm-universal:lint
npm exec -- nx run php-wasm-node:lint
npm exec -- nx run php-wasm-compile-extension:lint
git diff --check origin/trunk...HEAD
```
