### PR TITLE
fix(php-wasm/web): do not build a request body stream for HEAD in tcpOverFetch

### DIFF
--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -640,7 +640,13 @@ export class RawBytesFetch {
 			headersEndIndex + 4 /* Skip \r\n\r\n */
 		);
 		let outboundBodyStream: ReadableStream<Uint8Array> | undefined;
-		if (parsedHeaders.method !== 'GET') {
+		// GET and HEAD are forbidden by the Fetch spec from carrying a request
+		// body. Building a ReadableStream for HEAD and then passing it to
+		// `new Request(url, { method: 'HEAD', body: stream })` raises
+		// `TypeError: Failed to construct 'Request': Request with GET/HEAD
+		// method cannot have body.` which surfaces as an uncaught promise
+		// rejection here and corrupts the cURL call that emitted the HEAD.
+		if (parsedHeaders.method !== 'GET' && parsedHeaders.method !== 'HEAD') {
 			const requestBytesReader = requestBytesStream.getReader();
 			let seenBytes = bodyBytes.length;
 			let last5Bytes = bodyBytes.slice(-6);

--- a/packages/php-wasm/web/src/test/tcp-over-fetch-websocket.spec.ts
+++ b/packages/php-wasm/web/src/test/tcp-over-fetch-websocket.spec.ts
@@ -787,6 +787,29 @@ describe('RawBytesFetch', () => {
 		expect(decodedRequestBody).toEqual(encodedBodyBytes);
 	});
 
+	it('parseHttpRequest should not build a body stream for HEAD requests', async () => {
+		// The Fetch spec forbids GET and HEAD from carrying a request body, so
+		// `new Request(url, { method: 'HEAD', body: stream })` throws
+		// `TypeError: Failed to construct 'Request': Request with GET/HEAD
+		// method cannot have body.` Curl with CURLOPT_NOBODY emits HEAD over
+		// tcpOverFetch as part of size-prechecks and redirect follow-ups, so
+		// we must mirror the GET case and leave outboundBodyStream undefined.
+		const requestBytes = `HEAD /probe HTTP/1.1\r\nHost: example.com\r\n\r\n`;
+		const { request } = await RawBytesFetch.parseHttpRequest(
+			new ReadableStream({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode(requestBytes));
+					controller.close();
+				},
+			}),
+			'example.com',
+			'http'
+		);
+		expect(request.method).toEqual('HEAD');
+		expect(request.url).toEqual('http://example.com/probe');
+		expect(request.body).toBeNull();
+	});
+
 	it('parseHttpRequest should handle a path and query string', async () => {
 		const requestBytes = `GET /core/version-check/1.7/?channel=beta HTTP/1.1\r\nHost: playground.internal\r\n\r\n`;
 		const { request } = await RawBytesFetch.parseHttpRequest(


### PR DESCRIPTION
Closes #3631

## Problem

`RawBytesFetch.parseHttpRequest()` in `packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts` (line 643) builds an outbound `ReadableStream` body for **every** parsed request whose method is not exactly `'GET'`, then constructs:

```ts
new Request(url.toString(), {
    method: parsedHeaders.method,
    headers: parsedHeaders.headers,
    body: outboundBodyStream,
    duplex: outboundBodyStream ? 'half' : undefined,
});
```

The Fetch spec forbids GET and HEAD from carrying a request body, so for HEAD this raises:

```
TypeError: Failed to construct 'Request': Request with GET/HEAD method cannot have body.
```

That exception surfaces as an **uncaught** promise rejection at the top of `parseHttpRequest` (`tcp-over-fetch-websocket.ts:736` in the current minified bundle). Whatever cURL call emitted the HEAD probe is left in a half-state — the GET request that follows still completes but the buffered bytes ride on top of corrupted internal state.

## Where this trips in practice

[Moodle Playground](https://github.com/ateeducacion/moodle-playground) (a Moodle build that uses `@php-wasm/web`) reports that downloads through **Moodle's built-in URL downloader repository** (`repository_url`) all silently fail because Moodle's cURL emits HEAD whenever `CURLOPT_NOBODY` is set — a common path used for cheap size pre-checks and during redirect follow-ups. Local form-upload paths are unaffected because they never traverse `tcpOverFetch`.

Console excerpt from the bug report:

```
Uncaught (in promise) TypeError: Failed to construct 'Request': Request with GET/HEAD method cannot have body.
    at _L.parseHttpRequest (tcp-over-fetch-websocket.ts:736:19)
    at async nt.fetchOverTLS (tcp-over-fetch-websocket.ts:329:4)
```

Downstream tracking:

- [ateeducacion/moodle-playground#93](https://github.com/ateeducacion/moodle-playground/pull/93) (merged) — temporary downstream esbuild-string-replace patch against the published `@php-wasm/web` bundle, to be removed once this PR lands and `@php-wasm/web` is bumped.

## Fix

Mirror the GET branch and also exclude HEAD from the body-building path. One-line change in `tcp-over-fetch-websocket.ts`:

```diff
-		if (parsedHeaders.method !== 'GET') {
+		// GET and HEAD are forbidden by the Fetch spec from carrying a request body.
+		if (parsedHeaders.method !== 'GET' && parsedHeaders.method !== 'HEAD') {
```

## Tests

Added a `parseHttpRequest should not build a body stream for HEAD requests` case in `packages/php-wasm/web/src/test/tcp-over-fetch-websocket.spec.ts`, mirroring the existing GET-shaped tests in the same `describe('RawBytesFetch', ...)` block. Without the fix, the assertion `expect(request.body).toBeNull()` fails because `new Request('http://host/probe', { method: 'HEAD', body: <stream> })` throws before the assertion runs.

Local CI not run here (the fork is shallow); please rely on the action workflow.

## Manual verification

Reproduced the URL-downloader regression in Moodle Playground, confirmed it still fails on `WordPress/wordpress-playground@trunk`, then verified it goes away after rebuilding `@php-wasm/web` with this patch applied. The chrome-devtools test was the built-in **URL downloader** Moodle repository (`<img class="fp-repo-icon" src=".../repository_url/.../icon">`): pasting a remote image URL into the file picker now downloads and renders correctly, whereas before this fix it produced a broken-thumbnail icon and a 404 from `draftfile.php`.