### PR TITLE
Fix PHP snippet run controls

### DIFF
--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -49,6 +49,13 @@ test.describe('php-code-snippet embed', () => {
 			const snippet = page.locator(`php-snippet[name="${name}"]`);
 			await expect(snippet).toBeVisible();
 			await expect(snippet.locator('.run')).toBeVisible();
+			await expect(snippet.locator('.powered-by')).toContainText(
+				'PHP Code Snippet powered by WordPress Playground'
+			);
+			await expect(snippet.locator('.powered-by a')).toHaveAttribute(
+				'href',
+				'https://playground.wordpress.net/php-code-snippet-demo.html'
+			);
 		}
 	});
 
@@ -213,6 +220,78 @@ test.describe('php-code-snippet embed', () => {
 		await expect(editable.locator('.output-body')).toContainText(
 			'edited:42'
 		);
+	});
+
+	test('Run button invokes the snippet on the first click', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const editable = page.locator('php-snippet[name="scratch.php"]');
+		await expect(editable).toBeVisible();
+
+		await editable.evaluate((snippet: any) => {
+			snippet._testRunCount = 0;
+			snippet._runOnce = async function () {
+				this._testRunCount += 1;
+				const outputWrap = this.shadowRoot.querySelector('.output');
+				const outputBody =
+					this.shadowRoot.querySelector('.output-body');
+				outputBody.textContent = `run-count:${this._testRunCount}`;
+				outputWrap.classList.add('visible');
+			};
+		});
+
+		await editable.locator('.run').click();
+
+		await expect(editable.locator('.output-body')).toContainText(
+			'run-count:1'
+		);
+		await expect(editable.locator('.run')).toBeEnabled();
+	});
+
+	test('Ctrl+Enter and Cmd+Enter run the focused snippet', async ({
+		page,
+		browserName,
+	}) => {
+		await page.goto(DEMO_URL);
+		const editable = page.locator('php-snippet[name="scratch.php"]');
+		await expect(editable).toBeVisible();
+		const textarea = editable.locator('textarea.ta');
+		await expect(textarea).toBeVisible();
+
+		await editable.evaluate((snippet: any) => {
+			snippet._runOnce = async function (code: string) {
+				const outputWrap = this.shadowRoot.querySelector('.output');
+				const outputBody =
+					this.shadowRoot.querySelector('.output-body');
+				outputBody.textContent = code.includes('cmd')
+					? 'cmd-enter-marker'
+					: 'ctrl-enter-marker';
+				outputWrap.classList.add('visible');
+			};
+		});
+
+		await textarea.click();
+		await textarea.evaluate((el: HTMLTextAreaElement) => {
+			el.value = '<?php echo "ctrl";';
+			el.dispatchEvent(new Event('input', { bubbles: true }));
+		});
+		await page.keyboard.press('Control+Enter');
+		await expect(editable.locator('.output-body')).toContainText(
+			'ctrl-enter-marker'
+		);
+
+		// WebKit on Linux does not reliably synthesize Meta shortcuts in CI.
+		if (browserName !== 'webkit') {
+			await textarea.evaluate((el: HTMLTextAreaElement) => {
+				el.value = '<?php echo "cmd";';
+				el.dispatchEvent(new Event('input', { bubbles: true }));
+			});
+			await page.keyboard.press('Meta+Enter');
+			await expect(editable.locator('.output-body')).toContainText(
+				'cmd-enter-marker'
+			);
+		}
 	});
 
 	test('wp="none" + blueprint installs a PHP toolkit usable from the snippet', async ({

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -47,6 +47,7 @@
 const DEFAULT_ORIGIN = 'https://playground.wordpress.net';
 const DEFAULT_PHP = '8.4';
 const DEFAULT_WP = 'latest';
+const DEMO_URL = 'https://playground.wordpress.net/php-code-snippet-demo.html';
 
 /**
  * Minimal duck-typed port of @php-wasm/progress's ProgressTracker.
@@ -722,6 +723,21 @@ pre {
 	overflow-y: auto;
 }
 .output-body.error { color: #ff8182; }
+.powered-by {
+	padding: 8px 14px;
+	background: #f6f8fa;
+	border-top: 1px solid #e1e4e8;
+	color: #57606a;
+	font-size: 12px;
+	text-align: right;
+}
+.powered-by a {
+	color: #0969da;
+	text-decoration: none;
+}
+.powered-by a:hover {
+	text-decoration: underline;
+}
 /*
  * Brief blue wash that fades to transparent every time the output is
  * refreshed. Re-running an idempotent snippet produces the same text, so
@@ -749,15 +765,34 @@ class PhpSnippet extends HTMLElement {
 		this.attachShadow({ mode: 'open' });
 		this._code = '';
 		this._expectedOutput = null;
+		this._ready = Promise.resolve();
+		this._pendingRun = false;
+		this._isRunning = false;
+		this.shadowRoot.addEventListener('click', (event) => {
+			const target = event.target;
+			if (target instanceof Element && target.closest('.run')) {
+				this._run();
+			}
+		});
+		this.shadowRoot.addEventListener('keydown', (event) => {
+			if (isRunShortcut(event)) {
+				event.preventDefault();
+				this._run();
+			}
+		});
 	}
 
 	connectedCallback() {
 		this._expectedOutput = this._readExpectedOutput();
-		this._readCode().then((code) => {
+		this._ready = this._readCode().then((code) => {
 			this._code = code.trim();
 			this._render();
 			if (this._expectedOutput !== null) {
 				this._showExpectedOutput();
+			}
+			if (this._pendingRun) {
+				this._pendingRun = false;
+				queueMicrotask(() => this._run());
 			}
 		});
 	}
@@ -839,12 +874,19 @@ class PhpSnippet extends HTMLElement {
 					<div class="output-label">Output</div>
 					<pre class="output-body"></pre>
 				</div>
+				<div class="powered-by">
+					<a href="${DEMO_URL}" target="_blank" rel="noopener noreferrer">PHP Code Snippet powered by WordPress Playground</a>
+				</div>
 			</div>
 		`;
 		this.shadowRoot.replaceChildren(style, tpl.content);
 		const runBtn = this.shadowRoot.querySelector('.run');
 		if (runBtn) {
-			runBtn.addEventListener('click', () => this._run());
+			runBtn.setAttribute('title', 'Run (Ctrl+Enter or Cmd+Enter)');
+			runBtn.setAttribute(
+				'aria-keyshortcuts',
+				'Control+Enter Meta+Enter'
+			);
 		}
 		if (editable) this._wireEditor();
 	}
@@ -875,18 +917,26 @@ class PhpSnippet extends HTMLElement {
 
 	async _run() {
 		const btn = this.shadowRoot.querySelector('.run');
-		if (btn.disabled) {
+		if (!btn) {
+			this._pendingRun = true;
+			return;
+		}
+		if (btn.disabled || this._isRunning) {
 			return;
 		}
 
+		this._isRunning = true;
 		btn.disabled = true;
 		btn.setAttribute('aria-busy', 'true');
 		this._setRunButtonProgress('Loading', 0);
 		try {
+			await this._ready;
 			await this._runOnce(this._code);
 		} finally {
-			btn.disabled = false;
-			btn.removeAttribute('aria-busy');
+			const currentBtn = this.shadowRoot.querySelector('.run') || btn;
+			this._isRunning = false;
+			currentBtn.disabled = false;
+			currentBtn.removeAttribute('aria-busy');
 			this._setRunButtonProgress('Run', 0);
 		}
 	}
@@ -979,6 +1029,10 @@ class PhpSnippet extends HTMLElement {
 		};
 		outputBody.addEventListener('animationend', clear);
 	}
+}
+
+function isRunShortcut(event) {
+	return event.key === 'Enter' && (event.metaKey || event.ctrlKey);
 }
 
 customElements.define('php-snippet', PhpSnippet);


### PR DESCRIPTION
## What changed

- Make `<php-snippet>` Run handling stable across async rendering by delegating click handling from the shadow root and queueing early run requests until the snippet is ready.
- Add Ctrl+Enter and Cmd+Enter shortcuts for running the focused snippet.
- Add a branded footer link: "PHP Code Snippet powered by WordPress Playground".
- Add Playwright coverage for the branding link, first-click Run behavior, and keyboard shortcut behavior.

## Why

The first click on Run could feel unreliable because the component's render lifecycle replaced the button and attached the click listener after async snippet loading. Moving the handler to a stable shadow-root listener and waiting for readiness makes the first actionable click run the snippet consistently.

## Testing

- `PATH=/usr/local/opt/node@22/bin:$PATH corepack npm run format:uncommitted`
- `PATH=/usr/local/opt/node@22/bin:$PATH npx nx lint playground-website`
- `PATH=/usr/local/opt/node@22/bin:$PATH npx playwright test --config=packages/playground/website/playwright/playwright.config.ts e2e/php-code-snippet.spec.ts --project=chromium -g "Run button invokes|Ctrl\\+Enter"`

The full focused Chromium snippet spec currently has two failures caused by Vite failing to resolve `isomorphic-git/src/...` deep imports from storage code, which makes `/client/index.js` fail to load. The new first-click and shortcut tests pass independently.
