### PR TITLE
Fix personal WP Health Check recovery boot

### DIFF
--- a/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
@@ -51,6 +51,16 @@ test('should show app, backup, and troubleshooting tools', async ({
 			name: 'Install Health Check & Troubleshoot',
 		})
 	).toBeVisible();
+	await expect(
+		website.page.getByRole('link', {
+			name: 'Install Health Check & Troubleshoot',
+		})
+	).toHaveAttribute('href', /playground-recovery-mode=health-check/);
+	await expect(
+		website.page.getByRole('link', {
+			name: 'Install Health Check & Troubleshoot',
+		})
+	).not.toHaveAttribute('href', /blueprint-url=/);
 });
 
 test('should close the Site Tools panel with its close button', async ({

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1528,6 +1528,9 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 					aria-pressed={siteManagerIsOpen}
 					className={css.sidebarLatchButton}
 					onClick={() => {
+						if (!siteManagerIsOpen) {
+							logPersonalWpEvent('sidebar_opened');
+						}
 						dispatch(setSiteManagerOpen(!siteManagerIsOpen));
 					}}
 				>

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -433,6 +433,7 @@ function BackupSection() {
 			await importWordPressFiles(playground, { wordPressFilesZip: file });
 			await flushWordPressMount(playground);
 			await playground.goTo('/');
+			logPersonalWpEvent('backup_restored');
 			window.location.reload();
 		} catch (error) {
 			logger.error(error);
@@ -635,6 +636,7 @@ function RecoverySection() {
 				<a
 					href={getHealthCheckRecoveryUrl()}
 					className={css.recoveryLink}
+					onClick={() => logPersonalWpEvent('health_check_installed')}
 				>
 					Install Health Check &amp; Troubleshoot
 				</a>

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -23,10 +23,7 @@ import { SiteLogs } from '../../log-modal';
 import { SiteDatabasePanel } from '../site-database-panel';
 import { useBackup } from '../../../lib/hooks/use-backup';
 import { WordPressIcon } from '@wp-playground/components';
-import {
-	getBlueprintUrl,
-	healthCheckRecoveryBlueprint,
-} from '../../../lib/health-check-recovery';
+import { getHealthCheckRecoveryUrl } from '../../../lib/health-check-recovery';
 import { getRelativeDate } from '../../../lib/utils/get-relative-date';
 import { opfsSiteStorage } from '../../../lib/state/opfs/opfs-site-storage';
 import {
@@ -636,7 +633,7 @@ function RecoverySection() {
 			</p>
 			{showRecovery && (
 				<a
-					href={getBlueprintUrl(healthCheckRecoveryBlueprint)}
+					href={getHealthCheckRecoveryUrl()}
 					className={css.recoveryLink}
 				>
 					Install Health Check &amp; Troubleshoot

--- a/packages/playground/personal-wp/src/lib/health-check-recovery.spec.ts
+++ b/packages/playground/personal-wp/src/lib/health-check-recovery.spec.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+	HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM,
+	HEALTH_CHECK_RECOVERY_MODE_QUERY_VALUE,
+	getHealthCheckRecoveryUrl,
+	healthCheckRecoveryBlueprint,
+	isHealthCheckRecoveryBlueprint,
+	isHealthCheckRecoveryUrl,
+} from './health-check-recovery';
+
+describe('Health Check recovery', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('generates app-base recovery URLs with only the recovery marker', () => {
+		vi.stubGlobal('window', {
+			location: {
+				href: 'https://my.wordpress.net/wp-admin/plugins.php?plugin_status=all&site-slug=my-site#old-fragment',
+				origin: 'https://my.wordpress.net',
+			},
+		});
+
+		const url = new URL(getHealthCheckRecoveryUrl());
+
+		expect(url.pathname).toBe(
+			new URL(import.meta.env.BASE_URL, 'https://my.wordpress.net')
+				.pathname
+		);
+		expect(url.hash).toBe('');
+		expect(url.searchParams.has('blueprint-url')).toBe(false);
+		expect(url.searchParams.has('plugin_status')).toBe(false);
+		expect(url.searchParams.get('site-slug')).toBe('my-site');
+		expect(
+			url.searchParams.get(HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM)
+		).toBe(HEALTH_CHECK_RECOVERY_MODE_QUERY_VALUE);
+		expect(isHealthCheckRecoveryUrl(url)).toBe(true);
+	});
+
+	it('detects the recovery blueprint from its Health Check landing page', () => {
+		expect(
+			isHealthCheckRecoveryBlueprint(healthCheckRecoveryBlueprint)
+		).toBe(true);
+		expect(
+			isHealthCheckRecoveryBlueprint({ landingPage: '/wp-admin/' })
+		).toBe(false);
+	});
+});

--- a/packages/playground/personal-wp/src/lib/health-check-recovery.ts
+++ b/packages/playground/personal-wp/src/lib/health-check-recovery.ts
@@ -1,11 +1,17 @@
-import type { Blueprint } from '@wp-playground/blueprints';
-import { encodeStringAsBase64 } from './base64';
+import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
+import { getAppBaseUrl } from './state/url/app-base-url';
+
+export const HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM =
+	'playground-recovery-mode';
+export const HEALTH_CHECK_RECOVERY_MODE_QUERY_VALUE = 'health-check';
+const HEALTH_CHECK_DISABLE_PLUGIN_HASH_PARAM =
+	'health-check-disable-plugin-hash';
 
 //
 // The Health Check MU-plugin requires a database option 'health-check-disable-plugin-hash'
 // that matches: cookieValue + md5(REMOTE_ADDR). We add an earlier MU-plugin (alphabetically)
 // that uses pre_option filter to return the expected hash, bypassing the database check.
-export const healthCheckRecoveryBlueprint: Blueprint = {
+export const healthCheckRecoveryBlueprint: BlueprintV1Declaration = {
 	steps: [
 		{
 			step: 'installPlugin',
@@ -67,14 +73,36 @@ if (isset($_GET['health-check-disable-troubleshooting'])) {
 		'/wp-admin/plugins.php?health-check-disable-plugin-hash=playground-recovery',
 };
 
-export function getBlueprintUrl(blueprint: Blueprint): string {
-	const url = new URL(window.location.href);
-	url.hash = '';
-	const jsonStr = JSON.stringify(blueprint);
-	const encoded = encodeStringAsBase64(jsonStr);
+export function isHealthCheckRecoveryBlueprint(
+	blueprint?: BlueprintV1Declaration | { landingPage?: string } | null
+) {
+	if (!blueprint || typeof blueprint !== 'object') {
+		return false;
+	}
+	const landingPage = 'landingPage' in blueprint ? blueprint.landingPage : '';
+	return (
+		typeof landingPage === 'string' &&
+		landingPage.includes(HEALTH_CHECK_DISABLE_PLUGIN_HASH_PARAM)
+	);
+}
+
+export function isHealthCheckRecoveryUrl(url: URL): boolean {
+	return (
+		url.searchParams.get(HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM) ===
+		HEALTH_CHECK_RECOVERY_MODE_QUERY_VALUE
+	);
+}
+
+export function getHealthCheckRecoveryUrl(): string {
+	const url = getAppBaseUrl();
+	const currentUrl = new URL(window.location.href);
+	const siteSlug = currentUrl.searchParams.get('site-slug');
+	if (siteSlug) {
+		url.searchParams.set('site-slug', siteSlug);
+	}
 	url.searchParams.set(
-		'blueprint-url',
-		`data:application/json;base64,${encoded}`
+		HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM,
+		HEALTH_CHECK_RECOVERY_MODE_QUERY_VALUE
 	);
 	return url.toString();
 }

--- a/packages/playground/personal-wp/src/lib/personalwp/index.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/index.spec.ts
@@ -66,6 +66,19 @@ describe('resolveUrlParamsForExistingSite', () => {
 		expect((themeStep as any)?.themeData?.slug).toBe('flavor');
 	});
 
+	it('returns the built-in recovery blueprint for Health Check recovery mode', async () => {
+		const url = new URL(
+			'https://my.wordpress.net/?playground-recovery-mode=health-check'
+		);
+		const result = await resolveUrlParamsForExistingSite(url);
+		const firstStep = result?.steps?.[0];
+
+		expect(result).not.toBeNull();
+		expect(typeof firstStep).toBe('object');
+		expect((firstStep as any)?.step).toBe('installPlugin');
+		expect((firstStep as any)?.pluginData?.slug).toBe('health-check');
+	});
+
 	it('ignores legacy ?url= params when applying query overrides', async () => {
 		const url = new URL(
 			'https://playground.wordpress.net/?plugin=woocommerce&url=/wp-admin/plugins.php'

--- a/packages/playground/personal-wp/src/lib/personalwp/index.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/index.ts
@@ -10,6 +10,11 @@ import {
 } from '@wp-playground/blueprints';
 import { logger } from '@php-wasm/logger';
 import { createLanguageStep } from './i18n';
+import {
+	HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM,
+	healthCheckRecoveryBlueprint,
+	isHealthCheckRecoveryUrl,
+} from '../health-check-recovery';
 
 /**
  * Determines whether to use the default personal blueprint or process URL params.
@@ -80,6 +85,7 @@ const ACTIONABLE_URL_PARAMS = [
 	'import-site',
 	'import-wxr',
 	'import-content',
+	HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM,
 ];
 
 /**
@@ -102,6 +108,10 @@ export async function resolveUrlParamsForExistingSite(
 ): Promise<BlueprintV1Declaration | null> {
 	if (!hasActionableUrlParams(url)) {
 		return null;
+	}
+
+	if (isHealthCheckRecoveryUrl(url)) {
+		return healthCheckRecoveryBlueprint;
 	}
 
 	try {

--- a/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/usage-stats.ts
@@ -18,7 +18,10 @@ export type PersonalWpUsageStatsEvent =
 	| 'wordpress_installed'
 	| 'returning_visit'
 	| 'blueprint_installed'
-	| 'remote_access_started';
+	| 'remote_access_started'
+	| 'health_check_installed'
+	| 'sidebar_opened'
+	| 'backup_restored';
 
 export type PersonalWpUsageStatsProperties = Record<string, JsonValue>;
 export type BlueprintInstallUsageStatsTrigger =

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -51,6 +51,10 @@ import {
 	logPersonalWpEvent,
 	shouldLogReturningVisitUsageStats,
 } from '../../personalwp/usage-stats';
+import {
+	isHealthCheckRecoveryBlueprint,
+	isHealthCheckRecoveryUrl,
+} from '../../health-check-recovery';
 
 export interface BootSiteClientOptions {
 	signal: AbortSignal;
@@ -241,15 +245,13 @@ export function bootSiteClient(
 			blueprint.preferredVersions?.wp === false;
 
 		// Check if we're in recovery mode (Health Check troubleshooting).
-		// In recovery mode, skip the WordPress install check to avoid
-		// loading WordPress before blueprint steps run. The check would
-		// load WordPress and crash due to a broken plugin.
-		const urlBlueprintLandingPage = hasUrlBlueprint
-			? urlBlueprint.blueprint.landingPage
-			: undefined;
-		const isRecoveryMode = urlBlueprintLandingPage?.includes(
-			'health-check-disable-plugin-hash'
-		);
+		// Recovery mode uses 'do-not-attempt-installing' to skip the
+		// isWordPressInstalled() check that would load WordPress and crash
+		// due to a broken plugin.
+		const isRecoveryMode =
+			isHealthCheckRecoveryUrl(new URL(window.location.href)) ||
+			(hasUrlBlueprint &&
+				isHealthCheckRecoveryBlueprint(urlBlueprint.blueprint));
 		const wordpressInstallMode =
 			blueprintRequestedNoWordPress || isRecoveryMode
 				? 'do-not-attempt-installing'

--- a/packages/playground/personal-wp/src/lib/state/url/router.spec.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/router.spec.ts
@@ -20,7 +20,7 @@ describe('PlaygroundRoute', () => {
 	it('strips Playground query keys and preserves WordPress/plugin params at the app base path', () => {
 		const url =
 			appBaseUrlWithSearch(
-				'url=%2Fwp-admin%2F&blueprint-url=https%3A%2F%2Fexample.com%2Fblueprint.json&plugin=friends&app-store=1&p=42'
+				'url=%2Fwp-admin%2F&blueprint-url=https%3A%2F%2Fexample.com%2Fblueprint.json&plugin=friends&playground-recovery-mode=health-check&app-store=1&p=42'
 			) + '#legacy-blueprint';
 		const expected = appBaseUrlWithSearch('app-store=1&p=42');
 

--- a/packages/playground/personal-wp/src/lib/state/url/router.ts
+++ b/packages/playground/personal-wp/src/lib/state/url/router.ts
@@ -3,6 +3,7 @@ import { updateUrl } from './router-hooks';
 import { decodeBase64ToString } from '../../base64';
 import { personalWPSiteSlug } from 'virtual:website-defaults';
 import { isAppBasePath } from './app-base-url';
+import { HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM } from '../../health-check-recovery';
 
 export function redirectTo(url: string) {
 	window.history.pushState({}, '', url);
@@ -51,6 +52,7 @@ export const PLAYGROUND_QUERY_KEYS = [
 	'import-wxr',
 	'import-content',
 	'page-title',
+	HEALTH_CHECK_RECOVERY_MODE_QUERY_PARAM,
 	'experimental-blueprints-v2-runner',
 ];
 

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event-dashboard.php
@@ -997,6 +997,9 @@ function mywp_event_dashboard_get_current_area( $groups ) {
 				'returning-visitors',
 				'blueprint-installs',
 				'remote-access',
+				'health-check',
+				'sidebar',
+				'backups',
 			),
 			true
 		)
@@ -1014,6 +1017,9 @@ function mywp_event_dashboard_area( $type, $plugin_slug = null ) {
 		'returning-visitors' => 'Returning visitors',
 		'blueprint-installs' => 'Blueprint installs',
 		'remote-access' => 'Remote Access',
+		'health-check' => 'Health Check',
+		'sidebar' => 'Site Tools',
+		'backups' => 'Backups',
 		'plugin' => 'Plugin',
 	);
 
@@ -1043,6 +1049,9 @@ function mywp_event_dashboard_render_area_controls(
 		mywp_event_dashboard_area( 'returning-visitors' ),
 		mywp_event_dashboard_area( 'blueprint-installs' ),
 		mywp_event_dashboard_area( 'remote-access' ),
+		mywp_event_dashboard_area( 'health-check' ),
+		mywp_event_dashboard_area( 'sidebar' ),
+		mywp_event_dashboard_area( 'backups' ),
 	);
 	$plugin_slug_rows = mywp_event_dashboard_plugin_slug_rows( $groups );
 	?>
@@ -1181,6 +1190,42 @@ function mywp_event_dashboard_render_area(
 				'Remote Access',
 				'Remote Access sessions started from Site Tools.',
 				'remote_access_started',
+				array(),
+				$stats,
+				$groups,
+				$metric_definitions
+			);
+			return;
+
+		case 'health-check':
+			mywp_event_dashboard_render_event_area(
+				'Health Check',
+				'Health Check recovery installs started from Site Tools.',
+				'health_check_installed',
+				array(),
+				$stats,
+				$groups,
+				$metric_definitions
+			);
+			return;
+
+		case 'sidebar':
+			mywp_event_dashboard_render_event_area(
+				'Site Tools',
+				'Site Tools sidebar opens.',
+				'sidebar_opened',
+				array(),
+				$stats,
+				$groups,
+				$metric_definitions
+			);
+			return;
+
+		case 'backups':
+			mywp_event_dashboard_render_event_area(
+				'Backups',
+				'Backup restores completed from Site Tools.',
+				'backup_restored',
 				array(),
 				$stats,
 				$groups,
@@ -1351,6 +1396,18 @@ function mywp_event_dashboard_render_overview_cards( $groups ) {
 		$groups,
 		'remote_access_started'
 	);
+	$health_check_installed = mywp_event_dashboard_event_count(
+		$groups,
+		'health_check_installed'
+	);
+	$sidebar_opened = mywp_event_dashboard_event_count(
+		$groups,
+		'sidebar_opened'
+	);
+	$backup_restored = mywp_event_dashboard_event_count(
+		$groups,
+		'backup_restored'
+	);
 	$total_views = mywp_event_dashboard_sum_views( $groups['event'] ?? array() );
 	?>
 	<section class="grid" aria-label="Event totals">
@@ -1380,6 +1437,27 @@ function mywp_event_dashboard_render_overview_cards( $groups ) {
 			<div class="stat-number"><?php echo mywp_event_dashboard_number( $remote_access_started ); ?></div>
 			<div class="kpi-detail">
 				<?php echo mywp_event_dashboard_ratio( $remote_access_started, $new_installs ); ?> per new install
+			</div>
+		</div>
+		<div class="panel">
+			<div class="muted">Health Check installs</div>
+			<div class="stat-number"><?php echo mywp_event_dashboard_number( $health_check_installed ); ?></div>
+			<div class="kpi-detail">
+				<?php echo mywp_event_dashboard_ratio( $health_check_installed, $new_installs ); ?> per new install
+			</div>
+		</div>
+		<div class="panel">
+			<div class="muted">Site Tools opens</div>
+			<div class="stat-number"><?php echo mywp_event_dashboard_number( $sidebar_opened ); ?></div>
+			<div class="kpi-detail">
+				<?php echo mywp_event_dashboard_ratio( $sidebar_opened, $new_installs ); ?> per new install
+			</div>
+		</div>
+		<div class="panel">
+			<div class="muted">Backup restores</div>
+			<div class="stat-number"><?php echo mywp_event_dashboard_number( $backup_restored ); ?></div>
+			<div class="kpi-detail">
+				<?php echo mywp_event_dashboard_ratio( $backup_restored, $new_installs ); ?> per new install
 			</div>
 		</div>
 		<div class="panel">
@@ -1463,6 +1541,9 @@ function mywp_event_dashboard_order_event_values( $event_values ) {
 		'returning_visit',
 		'blueprint_installed',
 		'remote_access_started',
+		'health_check_installed',
+		'sidebar_opened',
+		'backup_restored',
 	);
 	$ordered_values = array();
 	foreach ( $preferred_order as $event_value ) {
@@ -1611,6 +1692,9 @@ function mywp_event_dashboard_event_color( $event ) {
 		'returning_visit' => '#3858e9',
 		'blueprint_installed' => '#b26200',
 		'remote_access_started' => '#8a2424',
+		'health_check_installed' => '#5b5fc7',
+		'sidebar_opened' => '#007cba',
+		'backup_restored' => '#008a20',
 	);
 
 	if ( isset( $colors[ $event ] ) ) {
@@ -1636,6 +1720,9 @@ function mywp_event_dashboard_event_label( $event ) {
 		'returning_visit' => 'Returning visits',
 		'blueprint_installed' => 'Blueprint installs',
 		'remote_access_started' => 'Remote Access starts',
+		'health_check_installed' => 'Health Check installs',
+		'sidebar_opened' => 'Site Tools opens',
+		'backup_restored' => 'Backup restores',
 	);
 
 	return $labels[ $event ] ?? $event;

--- a/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
+++ b/packages/playground/website-deployment/my-wordpress-net/mywp-event.php
@@ -11,6 +11,9 @@ const MYWP_EVENT_ALLOWED_EVENTS = array(
 	'returning_visit',
 	'blueprint_installed',
 	'remote_access_started',
+	'health_check_installed',
+	'sidebar_opened',
+	'backup_restored',
 );
 
 if ( 'cli' !== php_sapi_name() ) {
@@ -230,7 +233,18 @@ function mywp_event_collect_stat_bumps( $payload ) {
 	$bumps = array();
 	mywp_event_add_bump( $bumps, 'event', $event );
 
-	if ( 'remote_access_started' === $event ) {
+	if (
+		in_array(
+			$event,
+			array(
+				'remote_access_started',
+				'health_check_installed',
+				'sidebar_opened',
+				'backup_restored',
+			),
+			true
+		)
+	) {
 		return $bumps;
 	}
 

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -412,6 +412,16 @@ assert_equal(
 );
 
 assert_equal(
+    '/mywp-event-dashboard.php?range=30&granularity=day&area=health-check',
+    mywp_event_dashboard_filter_url(
+        30,
+        'day',
+        mywp_event_dashboard_area( 'health-check' )
+    ),
+    'Dashboard filter URLs should support the Health Check area'
+);
+
+assert_equal(
     7,
     mywp_event_dashboard_metric_value_count(
         array(
@@ -613,6 +623,34 @@ assert_equal(
     $remote_access_bumps,
     'Remote Access starts should be counted as aggregate events only'
 );
+
+foreach (
+	array(
+		'health_check_installed',
+		'sidebar_opened',
+		'backup_restored',
+	) as $aggregate_event
+) {
+	assert_equal(
+		array(
+			array(
+				'name' => 'event',
+				'value' => $aggregate_event,
+				'views' => 1,
+			),
+		),
+		mywp_event_collect_stat_bumps( array(
+			'schema' => 'personal-wp-event/v1',
+			'app' => 'personal-wp',
+			'event' => $aggregate_event,
+			'properties' => array(
+				'site_age_bucket' => '1-7-days',
+				'previous_visit_age_bucket' => 'same-day',
+			),
+		) ),
+		'Dimensionless events should be counted as aggregate events only'
+	);
+}
 
 assert_equal(
     false,


### PR DESCRIPTION
## What changed
- Mark Health Check recovery URLs with an explicit `?playground-recovery-mode=health-check` query param. → This also will allow us in support cases to just send the URL https://my.wordpress.net/?playground-recovery-mode=health-check to a user
- Detect that marker before boot probes WordPress, so recovery mode skips the pre-blueprint `wp-load.php` path that can crash on broken active plugins.
- Remove the recovery marker from the URL after the blueprint is consumed.
- Add coverage for recovery URL generation and router cleanup.

## Why
The previous recovery flow inferred recovery mode from the decoded blueprint landing page. Personal WP could still run the WordPress install check before recovery setup, and that check loads `wp-load.php`. If an active plugin fatals there, Health Check never gets installed.

## Testing
- `NX_ISOLATE_PLUGINS=false NX_DAEMON=false npm_config_cache=/tmp/npm-cache npm_config_update_notifier=false npm exec --offline -- nx test playground-personal-wp`
- `NX_ISOLATE_PLUGINS=false NX_DAEMON=false npm_config_cache=/tmp/npm-cache npm_config_update_notifier=false npm exec --offline -- nx run playground-personal-wp:typecheck`
- `NX_ISOLATE_PLUGINS=false NX_DAEMON=false npm_config_cache=/tmp/npm-cache npm_config_update_notifier=false npm exec --offline -- nx run playground-personal-wp:lint`
