### PR TITLE
Polish PHP snippet run UI

### DIFF
--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -5,8 +5,8 @@ import type { Page } from '@playwright/test';
  * E2E tests for the <php-snippet> web component embed.
  * Verifies that:
  *   - the demo page renders three snippets,
- *   - clicking Run on the first shows a real progress bar with a caption
- *     and percent that advance toward 100,
+ *   - clicking Run on the first shows real button progress that advances
+ *     toward 100,
  *   - the first snippet executes and shows PHP output,
  *   - subsequent snippets reuse the same Playground runtime (much faster
  *     than the first boot) and produce their own output.
@@ -52,9 +52,17 @@ test.describe('php-code-snippet embed', () => {
 			await expect(snippet.locator('.powered-by')).toContainText(
 				'PHP Code Snippet powered by WordPress Playground'
 			);
-			await expect(snippet.locator('.powered-by a')).toHaveAttribute(
+			await expect(
+				snippet.locator('.powered-by a').nth(0)
+			).toHaveAttribute(
 				'href',
 				'https://playground.wordpress.net/php-code-snippet-demo.html'
+			);
+			await expect(
+				snippet.locator('.powered-by a').nth(1)
+			).toHaveAttribute('href', 'https://wordpress.org/playground/');
+			await expect(snippet.locator('.run-shortcut')).toContainText(
+				/Ctrl\+Enter|Cmd\+Enter/
 			);
 		}
 	});
@@ -76,29 +84,31 @@ test.describe('php-code-snippet embed', () => {
 		).toHaveCount(0);
 	});
 
-	test('first Run boots the runtime and shows progress + output', async ({
+	test('first Run boots the runtime and shows button progress + output', async ({
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
 		const first = page.locator('php-snippet').nth(0);
+		const runButton = first.locator('.run');
+		const runSpinner = first.locator('.run-spinner');
+		const runPercent = first.locator('.run-percent');
 
-		await expect(first.locator('.progress')).toBeHidden();
-		await first.locator('.run').click();
+		await expect(first.locator('.progress')).toHaveCount(0);
+		await runButton.click();
 
-		// Progress bar appears with caption + percent text.
-		await expect(first.locator('.progress')).toBeVisible();
-		await expect(first.locator('.caption')).not.toHaveText('');
-		await expect(first.locator('.percent')).toContainText(/%$/);
+		await expect(runButton).toHaveAttribute('aria-busy', /true/);
+		await expect(runSpinner).toBeVisible();
+		await expect(runPercent).toContainText(/%$/);
 
 		// The percent advances past 0 (real progress, not just "0%" forever).
 		await expect
 			.poll(
 				async () =>
 					Number(
-						(
-							(await first.locator('.percent').textContent()) ||
-							'0%'
-						).replace('%', '')
+						((await runPercent.textContent()) || '0%').replace(
+							'%',
+							''
+						)
 					),
 				{ timeout: 120_000, intervals: [500] }
 			)
@@ -112,8 +122,7 @@ test.describe('php-code-snippet embed', () => {
 			'Hello from PHP'
 		);
 
-		// Progress hides once the run finishes.
-		await expect(first.locator('.progress')).toBeHidden();
+		await expect(runButton).not.toHaveAttribute('aria-busy', /true/);
 	});
 
 	test('subsequent snippets reuse the shared runtime', async ({ page }) => {
@@ -222,7 +231,7 @@ test.describe('php-code-snippet embed', () => {
 		);
 	});
 
-	test('Run button invokes the snippet on the first click', async ({
+	test('Run button queues clicks while a snippet is running', async ({
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
@@ -233,6 +242,7 @@ test.describe('php-code-snippet embed', () => {
 			snippet._testRunCount = 0;
 			snippet._runOnce = async function () {
 				this._testRunCount += 1;
+				await new Promise((resolve) => setTimeout(resolve, 100));
 				const outputWrap = this.shadowRoot.querySelector('.output');
 				const outputBody =
 					this.shadowRoot.querySelector('.output-body');
@@ -241,12 +251,16 @@ test.describe('php-code-snippet embed', () => {
 			};
 		});
 
-		await editable.locator('.run').click();
+		const runButton = editable.locator('.run');
+		await runButton.click();
+		await expect(runButton).toHaveAttribute('aria-busy', /true/);
+		await expect(runButton).toBeEnabled();
+		await runButton.click();
 
 		await expect(editable.locator('.output-body')).toContainText(
-			'run-count:1'
+			'run-count:2'
 		);
-		await expect(editable.locator('.run')).toBeEnabled();
+		await expect(runButton).toBeEnabled();
 	});
 
 	test('Ctrl+Enter and Cmd+Enter run the focused snippet', async ({
@@ -294,6 +308,44 @@ test.describe('php-code-snippet embed', () => {
 		}
 	});
 
+	test('output refresh keeps the light result styling', async ({ page }) => {
+		await page.goto(DEMO_URL);
+		const editable = page.locator('php-snippet[name="scratch.php"]');
+		await expect(editable).toBeVisible();
+
+		await editable.evaluate((snippet: any) => {
+			snippet._runOnce = async function () {
+				const outputWrap = this.shadowRoot.querySelector('.output');
+				const outputBody =
+					this.shadowRoot.querySelector('.output-body');
+				outputBody.textContent = 'light-output-marker';
+				outputWrap.classList.add('visible');
+				this._flashOutput(outputBody);
+			};
+		});
+
+		await editable.locator('.run').click();
+		await expect(editable.locator('.output-body')).toContainText(
+			'light-output-marker'
+		);
+
+		const colors = await editable.evaluate((snippet: any) => {
+			const output = snippet.shadowRoot.querySelector('.output');
+			const outputBody = snippet.shadowRoot.querySelector('.output-body');
+			const outputStyles = getComputedStyle(output);
+			const bodyStyles = getComputedStyle(outputBody);
+			return {
+				outputBackground: outputStyles.backgroundColor,
+				bodyBackground: bodyStyles.backgroundColor,
+				bodyColor: bodyStyles.color,
+			};
+		});
+
+		expect(colors.outputBackground).toBe('rgb(255, 255, 255)');
+		expect(colors.bodyBackground).not.toBe('rgb(13, 17, 23)');
+		expect(colors.bodyColor).toBe('rgb(36, 41, 47)');
+	});
+
 	test('wp="none" + blueprint installs a PHP toolkit usable from the snippet', async ({
 		page,
 	}) => {
@@ -307,13 +359,14 @@ test.describe('php-code-snippet embed', () => {
 			element.setAttribute('playground-origin', window.location.origin);
 		});
 		// The snippet ships with an expected-output script that pre-fills the
-		// output panel. Wait for the real run to execute by watching the
-		// progress bar appear and then disappear.
-		await snippet.locator('.run').click();
-		await expect(snippet.locator('.progress')).toBeVisible({
+		// output panel. Wait for the real run to execute by watching the run
+		// button enter and exit its busy state.
+		const runButton = snippet.locator('.run');
+		await runButton.click();
+		await expect(runButton).toHaveAttribute('aria-busy', /true/, {
 			timeout: 30_000,
 		});
-		await expect(snippet.locator('.progress')).toBeHidden({
+		await expect(runButton).not.toHaveAttribute('aria-busy', /true/, {
 			timeout: 240_000,
 		});
 
@@ -340,6 +393,7 @@ test.describe('php-code-snippet embed', () => {
 		const runSpinner = editable.locator('.run-spinner');
 		const runLabel = editable.locator('.run-label');
 		const runPercent = editable.locator('.run-percent');
+		const runShortcut = editable.locator('.run-shortcut');
 
 		await editable.evaluate((snippet: any) => {
 			snippet._runOnce = async function (code: string) {
@@ -362,12 +416,13 @@ test.describe('php-code-snippet embed', () => {
 		});
 
 		await runButton.click();
-		await expect(runButton).toBeDisabled();
+		await expect(runButton).toBeEnabled();
 		await expect(runButton).toHaveAttribute('aria-busy', /true/, {
 			timeout: 30_000,
 		});
 		await expect(runSpinner).toBeVisible();
 		await expect(runPercent).toBeVisible();
+		await expect(runShortcut).toBeHidden();
 		await expect(runLabel).toHaveText('Running');
 		await expect(runPercent).toHaveText('42%');
 		await expect(outputBody).toContainText('slow-run-marker', {
@@ -379,6 +434,7 @@ test.describe('php-code-snippet embed', () => {
 		});
 		await expect(runSpinner).toBeHidden();
 		await expect(runLabel).toHaveText('Run');
+		await expect(runShortcut).toBeVisible();
 
 		await textarea.evaluate((el: HTMLTextAreaElement) => {
 			el.value = '<?php echo "second-run-marker";';
@@ -397,21 +453,22 @@ test.describe('php-code-snippet embed', () => {
 		await page.goto(DEMO_URL);
 		const snippet = page.locator('php-snippet[name="precomputed.php"]');
 
-		await expect(snippet.locator('.progress')).toBeHidden();
+		await expect(snippet.locator('.progress')).toHaveCount(0);
 		await expect(snippet.locator('.output')).toBeVisible();
 		await expect(snippet.locator('.output-body')).toContainText(
 			'2 + 2 = 4'
 		);
 
-		await snippet.locator('.run').click();
-		await expect(snippet.locator('.progress')).toBeVisible();
+		const runButton = snippet.locator('.run');
+		await runButton.click();
+		await expect(runButton).toHaveAttribute('aria-busy', /true/);
 		await expect(snippet.locator('.output')).toBeVisible({
 			timeout: 240_000,
 		});
 		await expect(snippet.locator('.output-body')).toContainText(
 			'WordPress is awesome.'
 		);
-		await expect(snippet.locator('.progress')).toBeHidden();
+		await expect(runButton).not.toHaveAttribute('aria-busy', /true/);
 		await expect(
 			page.locator('iframe[title="PHP Snippet runtime"]')
 		).toHaveCount(1);

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -48,6 +48,7 @@ const DEFAULT_ORIGIN = 'https://playground.wordpress.net';
 const DEFAULT_PHP = '8.4';
 const DEFAULT_WP = 'latest';
 const DEMO_URL = 'https://playground.wordpress.net/php-code-snippet-demo.html';
+const PLAYGROUND_URL = 'https://wordpress.org/playground/';
 
 /**
  * Minimal duck-typed port of @php-wasm/progress's ProgressTracker.
@@ -574,9 +575,14 @@ const TEMPLATE_CSS = `
 	justify-content: center;
 }
 .run:hover { background: #1d4ed8; }
-.run:disabled { background: #93c5fd; cursor: progress; }
-.run:disabled:hover { background: #93c5fd; }
+.run[aria-busy="true"] { background: #93c5fd; cursor: progress; }
+.run[aria-busy="true"]:hover { background: #93c5fd; }
 .run-icon { font-size: 10px; }
+.run-shortcut {
+	font-size: 11px;
+	font-weight: 400;
+	opacity: 0.82;
+}
 .run-spinner {
 	display: none;
 	width: 12px;
@@ -592,55 +598,11 @@ const TEMPLATE_CSS = `
 	font-variant-numeric: tabular-nums;
 }
 .run[aria-busy="true"] .run-icon { display: none; }
+.run[aria-busy="true"] .run-shortcut { display: none; }
 .run[aria-busy="true"] .run-spinner,
 .run[aria-busy="true"] .run-percent { display: inline-block; }
 @keyframes php-snippet-spin {
 	to { transform: rotate(360deg); }
-}
-.progress {
-	display: none;
-	align-items: center;
-	gap: 10px;
-	padding: 8px 14px;
-	background: #f0f4ff;
-	border-bottom: 1px solid #d0d7de;
-	font-size: 13px;
-	color: #444c56;
-}
-.progress.visible { display: flex; }
-.bar {
-	flex: 1;
-	height: 4px;
-	background: #d0d7de;
-	border-radius: 2px;
-	overflow: hidden;
-	position: relative;
-}
-.fill {
-	position: absolute;
-	left: 0;
-	top: 0;
-	bottom: 0;
-	background: #2563eb;
-	border-radius: 2px;
-	width: 0;
-	transition: width 0.2s linear;
-}
-.caption {
-	flex-shrink: 0;
-	font-variant-numeric: tabular-nums;
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-.percent {
-	flex-shrink: 0;
-	font-variant-numeric: tabular-nums;
-	color: #57606a;
-	font-size: 12px;
-	min-width: 36px;
-	text-align: right;
 }
 pre {
 	margin: 0;
@@ -698,8 +660,8 @@ pre {
 .output {
 	display: none;
 	border-top: 1px solid #e1e4e8;
-	background: #0d1117;
-	color: #e6edf3;
+	background: #ffffff;
+	color: #24292f;
 	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 	font-size: 13px;
 	line-height: 1.5;
@@ -707,12 +669,12 @@ pre {
 .output.visible { display: block; }
 .output-label {
 	padding: 6px 14px;
-	background: #161b22;
-	color: #7d8590;
+	background: #f6f8fa;
+	color: #57606a;
 	font-size: 11px;
 	text-transform: uppercase;
 	letter-spacing: 0.05em;
-	border-bottom: 1px solid #30363d;
+	border-bottom: 1px solid #d0d7de;
 }
 .output-body {
 	padding: 14px;
@@ -749,8 +711,8 @@ pre {
 	animation: php-snippet-flash 700ms ease-out;
 }
 @keyframes php-snippet-flash {
-	0%   { background-color: rgba(56, 139, 253, 0.35); }
-	100% { background-color: transparent; }
+	0%   { background-color: #dbeafe; }
+	100% { background-color: #ffffff; }
 }
 @media (prefers-reduced-motion: reduce) {
 	.output-body.flash {
@@ -768,6 +730,7 @@ class PhpSnippet extends HTMLElement {
 		this._ready = Promise.resolve();
 		this._pendingRun = false;
 		this._isRunning = false;
+		this._rerunRequested = false;
 		this.shadowRoot.addEventListener('click', (event) => {
 			const target = event.target;
 			if (target instanceof Element && target.closest('.run')) {
@@ -840,6 +803,7 @@ class PhpSnippet extends HTMLElement {
 		const name = this.getAttribute('name') || 'snippet.php';
 		const runnable = this.getAttribute('runnable') !== 'false';
 		const editable = runnable && this.hasAttribute('editable');
+		const runShortcut = getRunShortcutLabel();
 		const style = document.createElement('style');
 		style.textContent = TEMPLATE_CSS;
 		const codeArea = editable
@@ -859,15 +823,11 @@ class PhpSnippet extends HTMLElement {
 								<span class="run-icon" aria-hidden="true">▶</span>
 								<span class="run-spinner" aria-hidden="true"></span>
 								<span class="run-label">Run</span>
+								<span class="run-shortcut">${runShortcut}</span>
 								<span class="run-percent" aria-hidden="true">0%</span>
 							</button>`
 							: ''
 					}
-				</div>
-				<div class="progress" role="status" aria-live="polite" aria-atomic="true">
-					<span class="caption">Loading…</span>
-					<div class="bar"><div class="fill"></div></div>
-					<span class="percent">0%</span>
 				</div>
 				${codeArea}
 				<div class="output">
@@ -875,14 +835,16 @@ class PhpSnippet extends HTMLElement {
 					<pre class="output-body"></pre>
 				</div>
 				<div class="powered-by">
-					<a href="${DEMO_URL}" target="_blank" rel="noopener noreferrer">PHP Code Snippet powered by WordPress Playground</a>
+					<a href="${DEMO_URL}" target="_blank" rel="noopener noreferrer">PHP Code Snippet</a>
+					powered by
+					<a href="${PLAYGROUND_URL}" target="_blank" rel="noopener noreferrer">WordPress Playground</a>
 				</div>
 			</div>
 		`;
 		this.shadowRoot.replaceChildren(style, tpl.content);
 		const runBtn = this.shadowRoot.querySelector('.run');
 		if (runBtn) {
-			runBtn.setAttribute('title', 'Run (Ctrl+Enter or Cmd+Enter)');
+			runBtn.setAttribute('title', `Run (${runShortcut})`);
 			runBtn.setAttribute(
 				'aria-keyshortcuts',
 				'Control+Enter Meta+Enter'
@@ -921,38 +883,32 @@ class PhpSnippet extends HTMLElement {
 			this._pendingRun = true;
 			return;
 		}
-		if (btn.disabled || this._isRunning) {
+		if (this._isRunning) {
+			this._rerunRequested = true;
+			this._setRunButtonProgress('Queued', 100);
 			return;
 		}
 
 		this._isRunning = true;
-		btn.disabled = true;
 		btn.setAttribute('aria-busy', 'true');
-		this._setRunButtonProgress('Loading', 0);
 		try {
 			await this._ready;
-			await this._runOnce(this._code);
+			do {
+				this._rerunRequested = false;
+				await this._runOnce(this._code);
+			} while (this._rerunRequested);
 		} finally {
 			const currentBtn = this.shadowRoot.querySelector('.run') || btn;
 			this._isRunning = false;
-			currentBtn.disabled = false;
 			currentBtn.removeAttribute('aria-busy');
 			this._setRunButtonProgress('Run', 0);
 		}
 	}
 
 	async _runOnce(code) {
-		const progress = this.shadowRoot.querySelector('.progress');
-		const caption = this.shadowRoot.querySelector('.caption');
-		const fill = this.shadowRoot.querySelector('.fill');
-		const percent = this.shadowRoot.querySelector('.percent');
 		const outputWrap = this.shadowRoot.querySelector('.output');
 		const outputBody = this.shadowRoot.querySelector('.output-body');
 		outputBody.classList.remove('error');
-		caption.textContent = 'Loading runtime…';
-		fill.style.width = '0%';
-		percent.textContent = '0%';
-		progress.classList.add('visible');
 		try {
 			const { blueprint, key: blueprintKey } =
 				resolveSetupBlueprint(this);
@@ -967,19 +923,10 @@ class PhpSnippet extends HTMLElement {
 					blueprintKey,
 				},
 				({ progress: pct, caption: cap }) => {
-					progress.classList.add('visible');
 					const rounded = Math.round(pct);
-					fill.style.width = rounded + '%';
-					percent.textContent = rounded + '%';
 					this._setRunButtonProgress(cap || 'Loading', rounded);
-					if (cap) {
-						caption.textContent = cap;
-					}
 				}
 			);
-			caption.textContent = 'Running…';
-			fill.style.width = '100%';
-			percent.textContent = '100%';
 			this._setRunButtonProgress('Running', 100);
 			const response = await client.run({ code });
 			outputBody.textContent = response.text || '(no output)';
@@ -996,8 +943,6 @@ class PhpSnippet extends HTMLElement {
 			);
 			outputWrap.classList.add('visible');
 			this._flashOutput(outputBody);
-		} finally {
-			progress.classList.remove('visible');
 		}
 	}
 
@@ -1033,6 +978,14 @@ class PhpSnippet extends HTMLElement {
 
 function isRunShortcut(event) {
 	return event.key === 'Enter' && (event.metaKey || event.ctrlKey);
+}
+
+function getRunShortcutLabel() {
+	const platform =
+		navigator.userAgentData && navigator.userAgentData.platform
+			? navigator.userAgentData.platform
+			: navigator.platform || '';
+	return /mac|iphone|ipad|ipod/i.test(platform) ? 'Cmd+Enter' : 'Ctrl+Enter';
 }
 
 customElements.define('php-snippet', PhpSnippet);


### PR DESCRIPTION
## What changed

- Keep the Run button clickable while a snippet is already running and queue one follow-up run instead of dropping the click.
- Show the contextual shortcut directly in the Run button: Cmd+Enter on Apple platforms, Ctrl+Enter elsewhere.
- Remove the separate progress bar below snippets; runtime/setup progress stays in the Run button text and percent.
- Stop forcing a default "Loading" label on every click before runtime progress is known.
- Use light result styling during output refreshes so the refreshed result never flashes to the dark panel.
- Split the footer into two links: "PHP Code Snippet" links to the demo page, and "WordPress Playground" links to wordpress.org/playground.

## Testing

- `PATH=/usr/local/opt/node@22/bin:$PATH corepack npm run format:uncommitted`
- `PATH=/usr/local/opt/node@22/bin:$PATH npx nx lint playground-website`
- `PATH=/usr/local/opt/node@22/bin:$PATH npx playwright test --config=packages/playground/website/playwright/playwright.config.ts e2e/php-code-snippet.spec.ts --project=chromium -g "renders all snippets|first Run boots|queues clicks|Ctrl\\+Enter|output refresh|Run button shows progress"`

The targeted tests pass. The local Vite dev server still logs the existing `isomorphic-git/src/...` dependency-scan errors from storage imports during Playwright startup, but they did not affect these targeted snippet UI tests.
