### PR TITLE
[php-snippet] Simplify PHP snippet pointer handling

### DIFF
--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -84,6 +84,52 @@ test.describe('php-code-snippet embed', () => {
 		).toHaveCount(0);
 	});
 
+	test('wp=none progress copy says runtime instead of WordPress', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const phpOnly = page.locator('php-snippet[name="just-php.php"]');
+		const withWordPress = page.locator('php-snippet[name="hello.php"]');
+
+		await expect(phpOnly).toBeVisible();
+		await expect(withWordPress).toBeVisible();
+		await expect
+			.poll(() =>
+				phpOnly.evaluate((snippet: any) =>
+					snippet._getRunProgressLabel('Preparing WordPress')
+				)
+			)
+			.toBe('Preparing runtime');
+		await expect
+			.poll(() =>
+				withWordPress.evaluate((snippet: any) =>
+					snippet._getRunProgressLabel('Preparing WordPress')
+				)
+			)
+			.toBe('Preparing WordPress');
+	});
+
+	test('Run button width stays stable across progress labels', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const editable = page.locator('php-snippet[name="scratch.php"]');
+		await expect(editable).toBeVisible();
+		const runButton = editable.locator('.run');
+		const idleBox = await runButton.boundingBox();
+		expect(idleBox).not.toBeNull();
+
+		await editable.evaluate((snippet: any) => {
+			const runButton = snippet.shadowRoot.querySelector('.run');
+			runButton.setAttribute('aria-busy', 'true');
+			snippet._setRunButtonProgress('Preparing runtime', 100);
+		});
+
+		const progressBox = await runButton.boundingBox();
+		expect(progressBox).not.toBeNull();
+		expect(Math.round(progressBox!.width)).toBe(Math.round(idleBox!.width));
+	});
+
 	test('first Run boots the runtime and shows button progress + output', async ({
 		page,
 	}) => {
@@ -217,7 +263,8 @@ test.describe('php-code-snippet embed', () => {
 
 		// Replace the snippet contents with something we can uniquely identify
 		// in the output panel.
-		await textarea.click();
+		await editable.locator('.editor').click();
+		await expect(textarea).toBeFocused();
 		await textarea.evaluate((el: HTMLTextAreaElement) => {
 			el.value = '<?php echo "edited:" . (40 + 2);';
 			el.dispatchEvent(new Event('input', { bubbles: true }));
@@ -300,6 +347,75 @@ test.describe('php-code-snippet embed', () => {
 			'run-count:1'
 		);
 		await expect(runButton).toBeEnabled();
+	});
+
+	test('Run button works while the code editor textarea is focused', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const editable = page.locator('php-snippet[name="scratch.php"]');
+		await expect(editable).toBeVisible();
+
+		await editable.evaluate((snippet: any) => {
+			snippet._testRunCount = 0;
+			snippet._runOnce = async function (code: string) {
+				this._testRunCount += 1;
+				const outputWrap = this.shadowRoot.querySelector('.output');
+				const outputBody =
+					this.shadowRoot.querySelector('.output-body');
+				outputBody.textContent = `run-count:${this._testRunCount}; hasTyped:${code.includes('typed-marker')}`;
+				outputWrap.classList.add('visible');
+			};
+		});
+
+		const editor = editable.locator('.editor');
+		await editor.scrollIntoViewIfNeeded();
+		const editorBox = await editor.boundingBox();
+		expect(editorBox).not.toBeNull();
+		const textarea = editable.locator('textarea.ta');
+		const thirdLineEnd = await textarea.evaluate(
+			(el: HTMLTextAreaElement) => {
+				const lines = el.value.split('\n');
+				return {
+					lineEnd:
+						lines[0].length +
+						1 +
+						lines[1].length +
+						1 +
+						lines[2].length,
+					lineTop:
+						parseFloat(getComputedStyle(el).paddingTop) +
+						parseFloat(getComputedStyle(el).lineHeight) * 2,
+				};
+			}
+		);
+		await page.mouse.click(
+			editorBox!.x + editorBox!.width - 24,
+			editorBox!.y + thirdLineEnd.lineTop + 4
+		);
+
+		await expect(textarea).toBeFocused();
+		await expect
+			.poll(() =>
+				textarea.evaluate(
+					(el: HTMLTextAreaElement) => el.selectionStart
+				)
+			)
+			.toBe(thirdLineEnd.lineEnd);
+		await page.keyboard.type(' // typed-marker');
+
+		const runButton = editable.locator('.run');
+		const runBox = await runButton.boundingBox();
+		expect(runBox).not.toBeNull();
+		await page.mouse.click(
+			runBox!.x + runBox!.width / 2,
+			runBox!.y + runBox!.height / 2
+		);
+
+		await expect(editable.locator('.output-body')).toContainText(
+			'run-count:1; hasTyped:true'
+		);
+		await expect(textarea).toBeFocused({ timeout: 1000 });
 	});
 
 	test('Run button handles repeated mouse clicks after completion', async ({

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -234,7 +234,7 @@ async function bootRuntime({ origin, php, wp, blueprint }, entry) {
 	iframe.title = 'PHP Snippet runtime';
 	iframe.setAttribute('aria-hidden', 'true');
 	iframe.style.cssText =
-		'position:absolute;width:1px;height:1px;border:0;opacity:0;pointer-events:none;left:-9999px;';
+		'position:absolute;width:1px;height:1px;border:0;opacity:0;left:-9999px;';
 	iframe.src = `${origin}/remote.html`;
 	document.body.appendChild(iframe);
 	// wp="none" maps to the Blueprint's declarative
@@ -554,6 +554,7 @@ const TEMPLATE_CSS = `
 	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 	font-size: 13px;
 	color: #57606a;
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -571,20 +572,29 @@ const TEMPLATE_CSS = `
 	font-weight: 500;
 	cursor: pointer;
 	flex-shrink: 0;
-	min-width: 86px;
+	width: 210px;
+	max-width: 100%;
 	justify-content: center;
 }
 .run:hover { background: #1d4ed8; }
 .run[aria-busy="true"] { background: #93c5fd; cursor: progress; }
 .run[aria-busy="true"]:hover { background: #93c5fd; }
 .run-icon { font-size: 10px; }
+.run-label {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
 .run-shortcut {
 	font-size: 11px;
 	font-weight: 400;
 	opacity: 0.82;
+	flex-shrink: 0;
 }
 .run-spinner {
 	display: none;
+	flex-shrink: 0;
 	width: 12px;
 	height: 12px;
 	border: 2px solid rgba(255, 255, 255, 0.45);
@@ -594,6 +604,7 @@ const TEMPLATE_CSS = `
 }
 .run-percent {
 	display: none;
+	flex-shrink: 0;
 	font-size: 12px;
 	font-variant-numeric: tabular-nums;
 }
@@ -640,7 +651,6 @@ pre {
 }
 .editor pre {
 	color: #24292f;
-	pointer-events: none;
 	overflow: hidden;
 	min-height: 1.5em;
 }
@@ -731,7 +741,9 @@ class PhpSnippet extends HTMLElement {
 		this._pendingRun = false;
 		this._isRunning = false;
 		this._rerunRequested = false;
-		this._pointerActivatedRun = false;
+		this._skipNextPointerClick = false;
+		this._lastFocusedEditor = null;
+		this._restoreEditorFocusAfterRun = false;
 		this.shadowRoot.addEventListener('pointerdown', (event) => {
 			const target = event.target;
 			const runButton =
@@ -739,23 +751,33 @@ class PhpSnippet extends HTMLElement {
 			if (!runButton || event.button !== 0) {
 				return;
 			}
-			this._pointerActivatedRun = true;
+			const activeElement =
+				this._lastFocusedEditor || this.shadowRoot.activeElement;
+			event.preventDefault();
+			this._skipNextPointerClick = true;
 			this._run();
-		});
-		this.shadowRoot.addEventListener('pointerup', () => {
-			setTimeout(() => {
-				this._pointerActivatedRun = false;
-			}, 0);
-		});
-		this.shadowRoot.addEventListener('pointercancel', () => {
-			this._pointerActivatedRun = false;
+			if (
+				activeElement instanceof Element &&
+				activeElement.matches('textarea.ta')
+			) {
+				this._restoreEditorFocusAfterRun = true;
+				const restoreEditorFocus = () => this._restoreEditorFocus();
+				document.addEventListener('pointerup', restoreEditorFocus, {
+					once: true,
+				});
+				document.addEventListener('pointercancel', restoreEditorFocus, {
+					once: true,
+				});
+			}
 		});
 		this.shadowRoot.addEventListener('click', (event) => {
 			const target = event.target;
 			if (target instanceof Element && target.closest('.run')) {
-				if (this._pointerActivatedRun && event.detail !== 0) {
-					this._pointerActivatedRun = false;
-					return;
+				if (this._skipNextPointerClick) {
+					this._skipNextPointerClick = false;
+					if (event.detail !== 0) {
+						return;
+					}
 				}
 				this._run();
 			}
@@ -884,6 +906,9 @@ class PhpSnippet extends HTMLElement {
 			this._code = textarea.value;
 			hl.innerHTML = highlightPhp(this._code);
 		};
+		textarea.addEventListener('focus', () => {
+			this._lastFocusedEditor = textarea;
+		});
 		textarea.addEventListener('input', sync);
 		textarea.addEventListener('keydown', (e) => {
 			if (e.key === 'Tab') {
@@ -925,6 +950,10 @@ class PhpSnippet extends HTMLElement {
 			this._isRunning = false;
 			currentBtn.removeAttribute('aria-busy');
 			this._setRunButtonProgress('Run', 0);
+			if (this._restoreEditorFocusAfterRun) {
+				this._restoreEditorFocusAfterRun = false;
+				this._restoreEditorFocus();
+			}
 		}
 	}
 
@@ -947,7 +976,10 @@ class PhpSnippet extends HTMLElement {
 				},
 				({ progress: pct, caption: cap }) => {
 					const rounded = Math.round(pct);
-					this._setRunButtonProgress(cap || 'Loading', rounded);
+					this._setRunButtonProgress(
+						this._getRunProgressLabel(cap || 'Loading'),
+						rounded
+					);
 				}
 			);
 			this._setRunButtonProgress('Running', 100);
@@ -978,6 +1010,28 @@ class PhpSnippet extends HTMLElement {
 		if (runPercent) {
 			runPercent.textContent = Math.round(pct) + '%';
 		}
+	}
+
+	_getRunProgressLabel(label) {
+		if (
+			(this.getAttribute('wp') || DEFAULT_WP) === 'none' &&
+			label === 'Preparing WordPress'
+		) {
+			return 'Preparing runtime';
+		}
+		return label;
+	}
+
+	_restoreEditorFocus() {
+		const editor = this._lastFocusedEditor;
+		if (!(editor instanceof Element) || !editor.isConnected) {
+			return;
+		}
+		requestAnimationFrame(() => {
+			if (editor.isConnected) {
+				editor.focus({ preventScroll: true });
+			}
+		});
 	}
 
 	/*


### PR DESCRIPTION
## What

Updates the PHP snippet embed so pointer runs behave like editor toolbar actions:

- keeps Run activation on `pointerdown`, while suppressing the follow-up pointer click
- restores the focused editor textarea after clicking Run so the caret path stays stable
- keeps the run button width stable while progress copy changes
- uses `Preparing runtime` for `wp="none"` snippets instead of `Preparing WordPress`
- keeps the PHP Code Snippet and WordPress Playground branding links split

## Why

The remaining mouse issue was tied to editor focus: keyboard runs worked reliably, but pointer activation from a focused code editor path could lose the textarea/caret state. The fix preserves that focused editor state while still running immediately from pointer activation.

## Testing

Confirmed the new focused-editor E2E fails on `origin/trunk` before the fix: the snippet runs, but the textarea loses focus after the Run pointer click. With this branch, it passes.

Local checks:

- `PATH=/usr/local/opt/node@22/bin:$PATH corepack npm run format:uncommitted`
- `PATH=/usr/local/opt/node@22/bin:$PATH npx nx lint playground-website`
- `PATH=/usr/local/opt/node@22/bin:$PATH PW_TEST_HTML_REPORT_OPEN=never npx playwright test --config=packages/playground/website/playwright/playwright.config.ts e2e/php-code-snippet.spec.ts --project=chromium --project=webkit -g "wp=none progress copy|Run button width|Run button shows progress|pointer activation|repeated mouse clicks|queues clicks|Ctrl\\+Enter|Run button works while the code editor textarea is focused" --retries=0`
- `PATH=/usr/local/opt/node@22/bin:$PATH PW_TEST_HTML_REPORT_OPEN=never npx playwright test --config=packages/playground/website/playwright/playwright.config.ts e2e/php-code-snippet.spec.ts --project=chromium --project=webkit -g "Run button works while the code editor textarea is focused" --retries=0`

Vite still logs the existing `isomorphic-git` dep-scan warnings during these focused Playwright runs, but the tests pass.
