### PR TITLE
[Docs] Document PHP snippet embeds

### DIFF
--- a/packages/docs/site/docs/main/guides/index.md
+++ b/packages/docs/site/docs/main/guides/index.md
@@ -11,7 +11,7 @@ In this section we present a selection of guides that will help you to both work
 
 ## [PHP code snippets and embeds](/guides/php-code-snippets)
 
-Embed runnable PHP snippets in any web page with the `<php-snippet>` web component, or share full PHP examples via the standalone PHP Playground at [`playground.wordpress.net/php-playground.html`](https://playground.wordpress.net/php-playground.html). One script tag, lazy-loaded runtime, shared across every snippet on the page.
+Embed editable, runnable PHP and WordPress examples in any web page with the `<php-snippet>` web component. The guide covers custom Blueprints, expected output, pure-PHP snippets, runtime sharing, and the standalone PHP Playground.
 
 ## [WordPress Playground for Everyone](/guides/playground-for-everyone)
 

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -1,185 +1,463 @@
 ---
 title: PHP code snippets and embeds
 slug: /guides/php-code-snippets
-description: Embed runnable PHP code snippets in any web page using the <php-snippet> web component, or share full PHP demos via the standalone PHP Playground.
+description: Embed editable, runnable PHP and WordPress examples in any web page using the <php-snippet> web component.
 sidebar_class_name: navbar-build-item
 ---
 
+import PhpCodeSnippetLiveExample, { PhpCodeSnippetExample } from '@site/src/components/PhpCodeSnippetLiveExample';
+
 # PHP code snippets and embeds
 
-WordPress Playground ships two ready-made ways to put runnable PHP — and the full WordPress runtime — directly into a web page or a shareable URL. No PHP server, no setup, just a browser.
+Use `<php-snippet>` when you want readers to run PHP or WordPress code directly
+from a docs page, tutorial, blog post, or demo. It renders a syntax-highlighted
+code block with a Run button and starts a real Playground runtime only when the
+reader asks for it.
 
-- **[`<php-snippet>` web component](#embedding-with-php-snippet)** — drop one `<script>` tag into your blog post, docs site, or readme to embed multiple runnable PHP snippets that share a single Playground runtime.
-- **[Standalone PHP Playground](#standalone-php-playground)** — a full-page PHP editor at `playground.wordpress.net/php-playground.html` with a shareable URL.
+The runtime is shared across matching snippets on the same page, so a tutorial
+can include several runnable examples without starting WordPress over and over.
 
-## Embedding with `<php-snippet>`
+## Try it
 
-The `<php-snippet>` custom element renders a syntax-highlighted code block with a Run button. Multiple snippets on the same page share a single hidden Playground runtime that is downloaded only when the visitor clicks Run for the first time.
+The example below is editable and runnable. It also uses a Blueprint to install
+a small mu-plugin before the snippet runs, so the PHP code can call a helper
+function that did not exist in the default WordPress install.
 
-### Quick start
+<PhpCodeSnippetLiveExample />
+
+Here is the complete embed:
 
 ```html
-<script
-	type="module"
-	src="https://playground.wordpress.net/php-code-snippet.js"
-></script>
+<script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
+
+<script id="product-card-blueprint" type="application/json">
+	{
+		"steps": [
+			{
+				"step": "writeFile",
+				"path": "/wordpress/wp-content/mu-plugins/product-cards.php",
+				"data": "<?php\nfunction docs_render_product_card(array $product): string {\n    return sprintf(\n        '<article class=\"product-card\"><h3>%s</h3><p>$%0.2f</p></article>',\n        esc_html($product['name']),\n        $product['price']\n    );\n}\n"
+			}
+		]
+	}
+</script>
+
+<php-snippet name="product-card.php" blueprint="product-card-blueprint">
+	<script type="application/x-php">
+		<?php
+		require '/wordpress/wp-load.php';
+
+		$products = [
+		    [ 'name' => 'Canvas Tote', 'price' => 24 ],
+		    [ 'name' => 'Coffee & Code Mug', 'price' => 16.5 ],
+		];
+
+		foreach ( $products as $product ) {
+		    echo docs_render_product_card( $product ) . "\n";
+		}
+	</script>
+	<script type="text/expected-output">
+		<article class="product-card"><h3>Canvas Tote</h3><p>$24.00</p></article>
+		<article class="product-card"><h3>Coffee &amp; Code Mug</h3><p>$16.50</p></article>
+	</script>
+</php-snippet>
+```
+
+Use this pattern when each example should start from the same prepared site:
+helper functions, mu-plugins, options, themes, demo files, or sample content.
+
+## Start with one snippet
+
+For a basic runnable example, add the component script once and place PHP inside
+`<php-snippet>`:
+
+<PhpCodeSnippetExample name="hello" />
+
+```html
+<script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 
 <php-snippet name="hello.php">
 	<script type="application/x-php">
-<?php
-echo "Hello from PHP " . phpversion();
+		<?php
+		echo "Hello from PHP " . phpversion();
+	</script>
+	<script type="text/expected-output">
+		Hello from PHP 8.4.x
 	</script>
 </php-snippet>
 ```
 
-That's the whole integration. The script is around 5 KB gzipped and contains no PHP or WordPress — those are fetched lazily on the first Run click.
+The script itself is small. PHP, WordPress, and the WASM runtime are fetched
+later, after the first Run click. The expected output appears before Run and is
+replaced with the exact PHP version after execution.
 
-### Why a `<script type="application/x-php">` wrapper?
+## Write PHP safely in HTML
 
-Browsers ignore the contents of script tags whose `type` they don't understand. That means you can put PHP code that contains literal `<` characters (HTML strings, generics, comparisons) inside the wrapper without escaping anything.
+Put inline PHP in a `<script type="application/x-php">` child. Browsers ignore
+script tags with unknown types, which means PHP strings can contain HTML without
+escaping every `<` character.
 
-If your snippet has no characters that need escaping, you can put the code directly inside `<php-snippet>`:
-
-```html
-<php-snippet name="add.php">
-	&lt;?php echo 1 + 2;
-</php-snippet>
-```
-
-You can also load the code from a separate file:
+<PhpCodeSnippetExample name="htmlApi" />
 
 ```html
-<php-snippet name="lazy-load.php" src="./snippets/lazy-load.php"></php-snippet>
-```
-
-### WordPress is available
-
-Each snippet runs inside a real WordPress installation. `require '/wordpress/wp-load.php'` brings in the core APIs:
-
-```html
-<php-snippet name="lazy-load-images.php">
+<php-snippet name="html-api.php">
 	<script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
+		<?php
+		require '/wordpress/wp-load.php';
 
-$html = '<article>
-    <img src="hero.jpg" alt="Hero">
-    <img src="inline.jpg" alt="Inline">
-</article>';
+		$html = '<img src="hero.jpg" alt="Hero">';
+		$tags = new WP_HTML_Tag_Processor( $html );
 
-$tags = new WP_HTML_Tag_Processor( $html );
-while ( $tags->next_tag( 'img' ) ) {
-    $tags->set_attribute( 'loading', 'lazy' );
-    $tags->add_class( 'responsive' );
-}
+		if ( $tags->next_tag( 'img' ) ) {
+		    $tags->set_attribute( 'loading', 'lazy' );
+		}
 
-echo $tags->get_updated_html();
+		echo $tags->get_updated_html();
+	</script>
+	<script type="text/expected-output">
+		<img src="hero.jpg" alt="Hero" loading="lazy">
 	</script>
 </php-snippet>
 ```
 
-### How runtime sharing works
+Very short snippets can also be written as text, as long as PHP opening tags are
+escaped:
 
-The first time a visitor clicks Run on **any** snippet on the page, the component:
-
-1. Lazy-loads the Playground client (`https://playground.wordpress.net/client/index.js`),
-2. Creates one hidden iframe pointing at `https://playground.wordpress.net/remote.html`,
-3. Boots PHP and WordPress inside it.
-
-Every later Run — on the same snippet or any other — calls `client.run({ code })` against that same runtime. No additional downloads, no extra processes. A page with five snippets pays the runtime cost once.
-
-While the boot is in progress, every snippet that has its Run clicked shows the same staged progress bar (download → install → ready) drawn from the live progress events Playground emits internally.
-
-### Sharing a blueprint across snippets
-
-If several snippets need the same baseline — a mu-plugin, a couple of files, a configured option — drop a single `<script type="application/json">` on the page that contains a JSON [Blueprint](/blueprints/), and point each snippet at it with a `blueprint` attribute:
+<PhpCodeSnippetExample name="sum" />
 
 ```html
-<script id="toolkit" type="application/json">
-{
-  "steps": [
-    {
-      "step": "writeFile",
-      "path": "/wordpress/wp-content/mu-plugins/toolkit.php",
-      "data": "<?php\nfunction toolkit_say($s) { return strtoupper($s); }"
-    }
-  ]
-}
+<php-snippet name="sum.php" expected-output="42"> &lt;?php echo 20 + 22; </php-snippet>
+```
+
+## Use WordPress APIs
+
+Snippets run in a real WordPress installation by default. Load WordPress with
+`require '/wordpress/wp-load.php'`, then call core APIs as usual.
+
+<PhpCodeSnippetExample name="siteTitle" />
+
+```html
+<php-snippet name="site-title.php">
+	<script type="application/x-php">
+		<?php
+		require '/wordpress/wp-load.php';
+
+		update_option( 'blogname', 'Snippet Docs' );
+		echo get_bloginfo( 'name' );
+	</script>
+	<script type="text/expected-output">
+		Snippet Docs
+	</script>
+</php-snippet>
+```
+
+If your example is pure PHP and does not need WordPress, use `wp="none"` to skip
+the WordPress download and boot step:
+
+<PhpCodeSnippetExample name="purePhp" />
+
+```html
+<php-snippet name="pure-php.php" wp="none">
+	<script type="application/x-php">
+		<?php
+		echo "WordPress installed: ";
+		echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
+	</script>
+	<script type="text/expected-output">
+		WordPress installed: no
+	</script>
+</php-snippet>
+```
+
+## Edit examples in place
+
+Runnable snippets are editable by default. The edited code is kept only in the
+current page session; refreshing restores the original snippet.
+
+<PhpCodeSnippetExample name="scratch" />
+
+```html
+<php-snippet name="scratch.php">
+	<script type="application/x-php">
+		<?php
+		$numbers = range( 1, 5 );
+		echo array_sum( $numbers );
+	</script>
+	<script type="text/expected-output">
+		15
+	</script>
+</php-snippet>
+```
+
+Editable snippets also run with `Ctrl+Enter` or `Cmd+Enter` while the editor is
+focused.
+
+Use `readonly` for runnable examples that should be copied or run as-is:
+
+<PhpCodeSnippetExample name="readOnly" />
+
+```html
+<php-snippet name="reference.php" readonly>
+	<script type="application/x-php">
+		<?php
+		echo "This example can run, but the code is locked.";
+	</script>
+	<script type="text/expected-output">
+		This example can run, but the code is locked.
+	</script>
+</php-snippet>
+```
+
+`editable="false"` works as a compatibility alias for `readonly`.
+
+## Show output before Run
+
+Use expected output when you want the result visible immediately. The placeholder
+is replaced with real runtime output after the reader clicks Run.
+
+<PhpCodeSnippetExample name="precomputed" />
+
+```html
+<php-snippet name="precomputed.php">
+	<script type="application/x-php">
+		<?php
+		echo "2 + 2 = " . ( 2 + 2 );
+	</script>
+	<script type="text/expected-output">
+		2 + 2 = 4
+	</script>
+</php-snippet>
+```
+
+For one-line output, use the `expected-output` attribute:
+
+<PhpCodeSnippetExample name="oneLine" />
+
+```html
+<php-snippet name="one-line.php" expected-output="Ready">
+	<script type="application/x-php">
+		<?php echo "Ready";
+	</script>
+</php-snippet>
+```
+
+## Prepare a site with a Blueprint
+
+Use `blueprint` when snippets need setup before the PHP code runs. Put a JSON
+[Blueprint](/blueprints/) in the page and point snippets at it by id or CSS
+selector.
+
+<PhpCodeSnippetExample name="greeting" />
+
+```html
+<script id="setup-blueprint" type="application/json">
+	{
+		"steps": [
+			{
+				"step": "writeFile",
+				"path": "/wordpress/wp-content/mu-plugins/helpers.php",
+				"data": "<?php\nfunction docs_greet($name) { return 'Hello, ' . $name; }\n"
+			}
+		]
+	}
 </script>
 
-<php-snippet name="a.php" blueprint="toolkit">
-  <script type="application/x-php">
-<?php require '/wordpress/wp-load.php'; echo toolkit_say('hello');
-  </script>
-</php-snippet>
-
-<php-snippet name="b.php" blueprint="toolkit">
-  <script type="application/x-php">
-<?php require '/wordpress/wp-load.php'; echo toolkit_say('world');
-  </script>
-</php-snippet>
-```
-
-Browsers don't execute scripts whose `type` they don't recognize, so the JSON sits inert until the component reads it. The blueprint is JSON-stringified and folded into the runtime cache key, so two snippets with the same `blueprint` share one runtime boot. Two snippets with different `blueprint` values get separate runtimes — usually what you want.
-
-The `blueprint` attribute accepts either an id or any CSS selector. Any element will do — `<script type="application/json">` is recommended because the HTML parser treats its contents as raw text, so a literal `<?php` inside the JSON is harmless. A `<template>` works too, but its content is parsed as HTML, and the `<?` in `<?php` is treated as the start of a bogus comment that runs to the next `>`. That can swallow the closing `</template>` and quietly break the page. If you do use a `<template>`, escape `<` as `\u003c` in the JSON.
-
-### Editable snippets
-
-Add the `editable` attribute and visitors can tweak the code before clicking Run. The keystrokes go into a transparent textarea overlaid on the highlighted code, so the syntax colors update as they type.
-
-```html
-<php-snippet name="scratch.php" editable>
+<php-snippet name="greeting.php" blueprint="setup-blueprint">
 	<script type="application/x-php">
-<?php
-$nums = range(1, 10);
-echo "Sum: " . array_sum($nums);
+		<?php
+		require '/wordpress/wp-load.php';
+		echo docs_greet( 'Ada' );
+	</script>
+	<script type="text/expected-output">
+		Hello, Ada
 	</script>
 </php-snippet>
 ```
 
-Useful for "now you try" sections in tutorials, or for letting readers experiment with their own values. Edits live only in the page — there's no persistence — so a refresh resets the snippet to its initial code.
+The selector form is useful when generated markup cannot guarantee simple ids:
 
-### Attributes
+<PhpCodeSnippetExample name="withSelector" />
 
-| Attribute            | Default                              | Purpose                                       |
-| -------------------- | ------------------------------------ | --------------------------------------------- |
-| `name`               | `snippet.php`                        | Filename label shown in the snippet header    |
-| `php`                | `8.4`                                | PHP version (see [supported versions][php])   |
-| `wp`                 | `latest`                             | WordPress version                             |
-| `src`                | —                                    | Load PHP from a URL instead of inline         |
-| `editable`           | (off)                                | Let visitors edit the code before running     |
-| `blueprint`          | —                                    | Id or CSS selector of a `<script type="application/json">` (or `<template>`) containing a JSON Blueprint to run before the snippet |
-| `playground-origin`  | `https://playground.wordpress.net`   | Override the runtime origin (local dev, etc.) |
+```html
+<php-snippet blueprint="#setup-blueprint" name="with-selector.php">
+	<script type="application/x-php">
+		<?php
+		require '/wordpress/wp-load.php';
+		echo docs_greet( 'Grace' );
+	</script>
+	<script type="text/expected-output">
+		Hello, Grace
+	</script>
+</php-snippet>
+```
 
-Snippets that share the same `php`, `wp`, and `playground-origin` values share one runtime; mixing different versions on the same page boots a separate runtime per combination.
+Prefer `<script type="application/json">` for Blueprints. Its contents are raw
+text, so embedded PHP strings such as `<?php` are safe. A `<template>` can work,
+but its contents are parsed as HTML; if you use one, escape `<` in embedded PHP
+strings as `\u003c`.
 
-[php]: /developers/apis/query-api/#available-options
+## Load PHP from another file
+
+Use `src` when the PHP source should live in a separate file:
+
+```html
+<php-snippet name="external-example.php" src="/snippets/external-example.php" expected-output="Loaded from an external file"></php-snippet>
+```
+
+The URL resolves from the page that contains the snippet. If the file is hosted
+on another origin, serve it with an `Access-Control-Allow-Origin` header that
+allows the documentation page.
+
+`src` loads only the snippet body. Use a Blueprint when you need support files,
+plugins, options, or other setup before the snippet runs. The `expected-output`
+attribute is still useful with `src` when you already know what the external PHP
+file prints.
+
+## Pin PHP or WordPress versions
+
+The default PHP version is `8.4`, and the default WordPress version is `latest`.
+Set `php` or `wp` when the example depends on a specific version.
+
+<PhpCodeSnippetExample name="enum" />
+
+```html
+<php-snippet name="enum.php" php="8.4">
+	<script type="application/x-php">
+		<?php
+		enum Status {
+		    case Draft;
+		    case Published;
+		}
+
+		echo Status::Published->name;
+	</script>
+	<script type="text/expected-output">
+		Published
+	</script>
+</php-snippet>
+```
+
+<PhpCodeSnippetExample name="wpVersion" />
+
+```html
+<php-snippet name="wp-version.php" wp="6.8">
+	<script type="application/x-php">
+		<?php
+		require '/wordpress/wp-load.php';
+		echo get_bloginfo( 'version' );
+	</script>
+	<script type="text/expected-output">
+		6.8
+	</script>
+</php-snippet>
+```
+
+See the [Query API reference](/developers/apis/query-api/#available-options)
+for available PHP and WordPress versions.
+
+## Show code without running it
+
+Set `runnable="false"` for fragments that should be highlighted but not
+executed, such as incomplete examples or code that depends on external services.
+
+<PhpCodeSnippetExample name="illustration" />
+
+```html
+<php-snippet name="illustration.php" runnable="false">
+	<script type="application/x-php">
+		<?php
+		// This fragment is shown for discussion, not execution.
+		add_filter( 'the_content', 'docs_filter_content' );
+	</script>
+</php-snippet>
+```
+
+## Self-host the runtime
+
+Most pages should use the hosted runtime from `https://playground.wordpress.net`.
+Set `playground-origin` when developing Playground itself, testing a self-hosted
+deployment, or pinning examples to infrastructure you control.
+
+```html
+<php-snippet name="local-runtime.php" playground-origin="http://localhost:5400">
+	<script type="application/x-php">
+		<?php
+		echo phpversion();
+	</script>
+	<script type="text/expected-output">
+		8.4.x
+	</script>
+</php-snippet>
+```
+
+## Runtime sharing
+
+The first Run click on a page:
+
+1. Loads the Playground client.
+2. Creates a hidden iframe pointed at `remote.html`.
+3. Boots PHP, and WordPress unless the snippet uses `wp="none"`.
+4. Runs the snippet code and writes stdout into the output panel.
+
+Later runs reuse an existing runtime when `playground-origin`, `php`, `wp`, and
+the resolved Blueprint JSON all match. This keeps related snippets fast while
+still isolating examples that need different setup.
+
+## Security and CSP
+
+Snippet PHP runs inside the Playground runtime iframe, not in the parent page.
+The parent page still loads the web component script and creates the hidden
+runtime iframe.
+
+If your site has a Content Security Policy, allow:
+
+- The module script from `https://playground.wordpress.net`.
+- The hidden iframe from the same origin.
+- Network requests for the PHP, WordPress, and Playground runtime assets.
+
+For stricter environments, self-host the snippet script and use
+`playground-origin` to point snippets at your deployment.
 
 ## Standalone PHP Playground
 
-For full-page editing or sharing a one-off snippet via URL, use the standalone PHP Playground at:
+Use the standalone PHP Playground when you want a full-page editor, a shareable
+URL, or an iframe instead of inline examples:
 
 > [playground.wordpress.net/php-playground.html](https://playground.wordpress.net/php-playground.html)
 
-It's a side-by-side editor and preview with PHP and WordPress version selectors. The current code, PHP version, and WordPress version are encoded into the URL fragment, so you can share a working example by copying the URL.
-
-You can embed it in any page with an iframe:
+You can embed it directly:
 
 ```html
-<iframe
-	src="https://playground.wordpress.net/php-playground.html#eyJjb2RlIjoiPD9waHBcblxuZWNobyBcIkkgYW0gYSBjb2RlIHNuaXBwZXQhXCI7XG4iLCJwaHAiOiI4LjQifQ=="
-	width="100%"
-	height="600"
-></iframe>
+<iframe src="https://playground.wordpress.net/php-playground.html#eyJjb2RlIjoiPD9waHBcblxuZWNobyBcIkkgYW0gYSBjb2RlIHNuaXBwZXQhXCI7XG4iLCJwaHAiOiI4LjQifQ==" width="100%" height="600"></iframe>
 ```
 
-The fragment is a base64-encoded JSON payload of `{ code, php, wp }`.
+The URL fragment is a base64-encoded JSON payload with `code`, `php`, and `wp`
+fields.
 
-### Standalone PHP Playground `<iframe>` vs. `<php-snippet>` — which should I use?
+## Which embed should you use?
 
-| Use case                                                          | Pick                |
-| ----------------------------------------------------------------- | ------------------- |
-| Multiple read-only runnable examples in a docs page or blog post  | `<php-snippet>`     |
-| Customizations, e.g. read-only code vs editable code  | `<php-snippet>`     |
-| A single code example you don't want to load foreign scripts on your site | Standalone PHP Playground |
+| Use case                                              | Use                             |
+| ----------------------------------------------------- | ------------------------------- |
+| Several runnable examples in one article              | `<php-snippet>`                 |
+| A tutorial step where readers should edit code inline | `<php-snippet>`                 |
+| Shared setup across examples                          | `<php-snippet blueprint="...">` |
+| A pure PHP language example                           | `<php-snippet wp="none">`       |
+| A runnable example that should not be edited          | `<php-snippet readonly>`        |
+| A single full-page editor with a shareable URL        | Standalone PHP Playground       |
+| A complete WordPress site preview                     | Standard Playground iframe      |
+
+## Troubleshooting
+
+If the snippet does not render, check that the module script loaded and that the
+browser supports custom elements.
+
+If Run never finishes, open DevTools and check failed requests for `remote.html`,
+PHP `.wasm` files, WordPress zip files, Blueprint resources, or cross-origin
+`src` files.
+
+If a Blueprint-backed snippet cannot find helper functions, confirm the
+`blueprint` attribute points to the right element and that the JSON is valid.
+
+If output differs from the expected placeholder, trust the runtime output. The
+placeholder is static documentation; Run executes the current code against the
+selected PHP, WordPress, and Blueprint setup.

--- a/packages/docs/site/docs/main/guides/php-code-snippets.md
+++ b/packages/docs/site/docs/main/guides/php-code-snippets.md
@@ -36,7 +36,7 @@ Here is the complete embed:
 			{
 				"step": "writeFile",
 				"path": "/wordpress/wp-content/mu-plugins/product-cards.php",
-				"data": "<?php\nfunction docs_render_product_card(array $product): string {\n    return sprintf(\n        '<article class=\"product-card\"><h3>%s</h3><p>$%0.2f</p></article>',\n        esc_html($product['name']),\n        $product['price']\n    );\n}\n"
+				"data": "<?php\nfunction docs_render_product_card( array $product ): string {\n\treturn sprintf(\n\t\t'<article class=\"product-card\"><h3>%s</h3><p>$%0.2f</p></article>',\n\t\tesc_html( $product['name'] ),\n\t\t$product['price']\n\t);\n}\n"
 			}
 		]
 	}
@@ -48,12 +48,18 @@ Here is the complete embed:
 		require '/wordpress/wp-load.php';
 
 		$products = [
-		    [ 'name' => 'Canvas Tote', 'price' => 24 ],
-		    [ 'name' => 'Coffee & Code Mug', 'price' => 16.5 ],
+			[
+				'name'  => 'Canvas Tote',
+				'price' => 24,
+			],
+			[
+				'name'  => 'Coffee & Code Mug',
+				'price' => 16.5,
+			],
 		];
 
 		foreach ( $products as $product ) {
-		    echo docs_render_product_card( $product ) . "\n";
+			echo docs_render_product_card( $product ) . "\n";
 		}
 	</script>
 	<script type="text/expected-output">
@@ -79,7 +85,7 @@ For a basic runnable example, add the component script once and place PHP inside
 <php-snippet name="hello.php">
 	<script type="application/x-php">
 		<?php
-		echo "Hello from PHP " . phpversion();
+		echo 'Hello from PHP ' . phpversion();
 	</script>
 	<script type="text/expected-output">
 		Hello from PHP 8.4.x
@@ -109,7 +115,7 @@ escaping every `<` character.
 		$tags = new WP_HTML_Tag_Processor( $html );
 
 		if ( $tags->next_tag( 'img' ) ) {
-		    $tags->set_attribute( 'loading', 'lazy' );
+			$tags->set_attribute( 'loading', 'lazy' );
 		}
 
 		echo $tags->get_updated_html();
@@ -160,7 +166,7 @@ the WordPress download and boot step:
 <php-snippet name="pure-php.php" wp="none">
 	<script type="application/x-php">
 		<?php
-		echo "WordPress installed: ";
+		echo 'WordPress installed: ';
 		echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
 	</script>
 	<script type="text/expected-output">
@@ -200,7 +206,7 @@ Use `readonly` for runnable examples that should be copied or run as-is:
 <php-snippet name="reference.php" readonly>
 	<script type="application/x-php">
 		<?php
-		echo "This example can run, but the code is locked.";
+		echo 'This example can run, but the code is locked.';
 	</script>
 	<script type="text/expected-output">
 		This example can run, but the code is locked.
@@ -221,7 +227,7 @@ is replaced with real runtime output after the reader clicks Run.
 <php-snippet name="precomputed.php">
 	<script type="application/x-php">
 		<?php
-		echo "2 + 2 = " . ( 2 + 2 );
+		echo '2 + 2 = ' . ( 2 + 2 );
 	</script>
 	<script type="text/expected-output">
 		2 + 2 = 4
@@ -236,7 +242,8 @@ For one-line output, use the `expected-output` attribute:
 ```html
 <php-snippet name="one-line.php" expected-output="Ready">
 	<script type="application/x-php">
-		<?php echo "Ready";
+		<?php
+		echo 'Ready';
 	</script>
 </php-snippet>
 ```
@@ -256,7 +263,7 @@ selector.
 			{
 				"step": "writeFile",
 				"path": "/wordpress/wp-content/mu-plugins/helpers.php",
-				"data": "<?php\nfunction docs_greet($name) { return 'Hello, ' . $name; }\n"
+				"data": "<?php\nfunction docs_greet( $name ) {\n\treturn 'Hello, ' . $name;\n}\n"
 			}
 		]
 	}
@@ -325,8 +332,8 @@ Set `php` or `wp` when the example depends on a specific version.
 	<script type="application/x-php">
 		<?php
 		enum Status {
-		    case Draft;
-		    case Published;
+			case Draft;
+			case Published;
 		}
 
 		echo Status::Published->name;

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
@@ -1,0 +1,200 @@
+export const examples = {
+	full: String.raw`<script id="product-card-blueprint" type="application/json">
+{
+  "steps": [
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/product-cards.php",
+      "data": "<?php\nfunction docs_render_product_card( array $product ): string {\n\treturn sprintf(\n\t\t'<article class=\"product-card\"><h3>%s</h3><p>$%0.2f</p></article>',\n\t\tesc_html( $product['name'] ),\n\t\t$product['price']\n\t);\n}\n"
+    }
+  ]
+}
+</script>
+
+<php-snippet name="product-card.php" blueprint="product-card-blueprint">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+$products = [
+	[
+		'name'  => 'Canvas Tote',
+		'price' => 24,
+	],
+	[
+		'name'  => 'Coffee & Code Mug',
+		'price' => 16.5,
+	],
+];
+
+foreach ( $products as $product ) {
+	echo docs_render_product_card( $product ) . "\n";
+}
+  </script>
+  <script type="text/expected-output">
+<article class="product-card"><h3>Canvas Tote</h3><p>$24.00</p></article>
+<article class="product-card"><h3>Coffee &amp; Code Mug</h3><p>$16.50</p></article>
+  </script>
+</php-snippet>`,
+	hello: String.raw`<php-snippet name="hello.php">
+  <script type="application/x-php">
+<?php
+echo 'Hello from PHP ' . phpversion();
+  </script>
+  <script type="text/expected-output">
+Hello from PHP 8.4.x
+  </script>
+</php-snippet>`,
+	htmlApi: String.raw`<php-snippet name="html-api.php">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+$html = '<img src="hero.jpg" alt="Hero">';
+$tags = new WP_HTML_Tag_Processor( $html );
+
+if ( $tags->next_tag( 'img' ) ) {
+	$tags->set_attribute( 'loading', 'lazy' );
+}
+
+echo $tags->get_updated_html();
+  </script>
+  <script type="text/expected-output">
+<img src="hero.jpg" alt="Hero" loading="lazy">
+  </script>
+</php-snippet>`,
+	sum: String.raw`<php-snippet name="sum.php" expected-output="42">&lt;?php echo 20 + 22;</php-snippet>`,
+	siteTitle: String.raw`<php-snippet name="site-title.php">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+update_option( 'blogname', 'Snippet Docs' );
+echo get_bloginfo( 'name' );
+  </script>
+  <script type="text/expected-output">
+Snippet Docs
+  </script>
+</php-snippet>`,
+	purePhp: String.raw`<php-snippet name="pure-php.php" wp="none">
+  <script type="application/x-php">
+<?php
+echo 'WordPress installed: ';
+echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
+  </script>
+  <script type="text/expected-output">
+WordPress installed: no
+  </script>
+</php-snippet>`,
+	scratch: String.raw`<php-snippet name="scratch.php">
+  <script type="application/x-php">
+<?php
+$numbers = range( 1, 5 );
+echo array_sum( $numbers );
+  </script>
+  <script type="text/expected-output">
+15
+ </script>
+</php-snippet>`,
+	readOnly: String.raw`<php-snippet name="reference.php" readonly>
+  <script type="application/x-php">
+<?php
+echo 'This example can run, but the code is locked.';
+  </script>
+  <script type="text/expected-output">
+This example can run, but the code is locked.
+  </script>
+</php-snippet>`,
+	precomputed: String.raw`<php-snippet name="precomputed.php">
+  <script type="application/x-php">
+<?php
+echo '2 + 2 = ' . ( 2 + 2 );
+  </script>
+  <script type="text/expected-output">
+2 + 2 = 4
+  </script>
+</php-snippet>`,
+	oneLine: String.raw`<php-snippet name="one-line.php" expected-output="Ready">
+  <script type="application/x-php">
+<?php
+echo 'Ready';
+  </script>
+</php-snippet>`,
+	greeting: String.raw`<script id="setup-blueprint-preview" type="application/json">
+{
+  "steps": [
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/helpers.php",
+      "data": "<?php\nfunction docs_greet( $name ) {\n\treturn 'Hello, ' . $name;\n}\n"
+    }
+  ]
+}
+</script>
+
+<php-snippet name="greeting.php" blueprint="setup-blueprint-preview">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+echo docs_greet( 'Ada' );
+  </script>
+  <script type="text/expected-output">
+Hello, Ada
+  </script>
+</php-snippet>`,
+	withSelector: String.raw`<script id="setup-blueprint-selector-preview" type="application/json">
+{
+  "steps": [
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/helpers.php",
+      "data": "<?php\nfunction docs_greet( $name ) {\n\treturn 'Hello, ' . $name;\n}\n"
+    }
+  ]
+}
+</script>
+
+<php-snippet blueprint="#setup-blueprint-selector-preview" name="with-selector.php">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+echo docs_greet( 'Grace' );
+  </script>
+  <script type="text/expected-output">
+Hello, Grace
+  </script>
+</php-snippet>`,
+	enum: String.raw`<php-snippet name="enum.php" php="8.4">
+  <script type="application/x-php">
+<?php
+enum Status {
+	case Draft;
+	case Published;
+}
+
+echo Status::Published->name;
+  </script>
+  <script type="text/expected-output">
+Published
+  </script>
+</php-snippet>`,
+	wpVersion: String.raw`<php-snippet name="wp-version.php" wp="6.8">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+echo get_bloginfo( 'version' );
+  </script>
+  <script type="text/expected-output">
+6.8
+  </script>
+</php-snippet>`,
+	illustration: String.raw`<php-snippet name="illustration.php" runnable="false">
+  <script type="application/x-php">
+<?php
+// This fragment is shown for discussion, not execution.
+add_filter( 'the_content', 'docs_filter_content' );
+  </script>
+</php-snippet>`,
+} as const;
+
+export type ExampleName = keyof typeof examples;

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
@@ -9,7 +9,7 @@ const examples = {
     {
       "step": "writeFile",
       "path": "/wordpress/wp-content/mu-plugins/product-cards.php",
-      "data": "<?php\nfunction docs_render_product_card(array $product): string {\n    return sprintf(\n        '<article class=\"product-card\"><h3>%s</h3><p>$%0.2f</p></article>',\n        esc_html($product['name']),\n        $product['price']\n    );\n}\n"
+      "data": "<?php\nfunction docs_render_product_card( array $product ): string {\n\treturn sprintf(\n\t\t'<article class=\"product-card\"><h3>%s</h3><p>$%0.2f</p></article>',\n\t\tesc_html( $product['name'] ),\n\t\t$product['price']\n\t);\n}\n"
     }
   ]
 }
@@ -21,12 +21,18 @@ const examples = {
 require '/wordpress/wp-load.php';
 
 $products = [
-    [ 'name' => 'Canvas Tote', 'price' => 24 ],
-    [ 'name' => 'Coffee & Code Mug', 'price' => 16.5 ],
+	[
+		'name'  => 'Canvas Tote',
+		'price' => 24,
+	],
+	[
+		'name'  => 'Coffee & Code Mug',
+		'price' => 16.5,
+	],
 ];
 
 foreach ( $products as $product ) {
-    echo docs_render_product_card( $product ) . "\n";
+	echo docs_render_product_card( $product ) . "\n";
 }
   </script>
   <script type="text/expected-output">
@@ -37,7 +43,7 @@ foreach ( $products as $product ) {
 	hello: String.raw`<php-snippet name="hello.php">
   <script type="application/x-php">
 <?php
-echo "Hello from PHP " . phpversion();
+echo 'Hello from PHP ' . phpversion();
   </script>
   <script type="text/expected-output">
 Hello from PHP 8.4.x
@@ -52,7 +58,7 @@ $html = '<img src="hero.jpg" alt="Hero">';
 $tags = new WP_HTML_Tag_Processor( $html );
 
 if ( $tags->next_tag( 'img' ) ) {
-    $tags->set_attribute( 'loading', 'lazy' );
+	$tags->set_attribute( 'loading', 'lazy' );
 }
 
 echo $tags->get_updated_html();
@@ -77,7 +83,7 @@ Snippet Docs
 	purePhp: String.raw`<php-snippet name="pure-php.php" wp="none">
   <script type="application/x-php">
 <?php
-echo "WordPress installed: ";
+echo 'WordPress installed: ';
 echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
   </script>
   <script type="text/expected-output">
@@ -97,7 +103,7 @@ echo array_sum( $numbers );
 	readOnly: String.raw`<php-snippet name="reference.php" readonly>
   <script type="application/x-php">
 <?php
-echo "This example can run, but the code is locked.";
+echo 'This example can run, but the code is locked.';
   </script>
   <script type="text/expected-output">
 This example can run, but the code is locked.
@@ -106,7 +112,7 @@ This example can run, but the code is locked.
 	precomputed: String.raw`<php-snippet name="precomputed.php">
   <script type="application/x-php">
 <?php
-echo "2 + 2 = " . ( 2 + 2 );
+echo '2 + 2 = ' . ( 2 + 2 );
   </script>
   <script type="text/expected-output">
 2 + 2 = 4
@@ -114,7 +120,8 @@ echo "2 + 2 = " . ( 2 + 2 );
 </php-snippet>`,
 	oneLine: String.raw`<php-snippet name="one-line.php" expected-output="Ready">
   <script type="application/x-php">
-<?php echo "Ready";
+<?php
+echo 'Ready';
   </script>
 </php-snippet>`,
 	greeting: String.raw`<script id="setup-blueprint-preview" type="application/json">
@@ -123,7 +130,7 @@ echo "2 + 2 = " . ( 2 + 2 );
     {
       "step": "writeFile",
       "path": "/wordpress/wp-content/mu-plugins/helpers.php",
-      "data": "<?php\nfunction docs_greet($name) { return 'Hello, ' . $name; }\n"
+      "data": "<?php\nfunction docs_greet( $name ) {\n\treturn 'Hello, ' . $name;\n}\n"
     }
   ]
 }
@@ -145,7 +152,7 @@ Hello, Ada
     {
       "step": "writeFile",
       "path": "/wordpress/wp-content/mu-plugins/helpers.php",
-      "data": "<?php\nfunction docs_greet($name) { return 'Hello, ' . $name; }\n"
+      "data": "<?php\nfunction docs_greet( $name ) {\n\treturn 'Hello, ' . $name;\n}\n"
     }
   ]
 }
@@ -165,8 +172,8 @@ Hello, Grace
   <script type="application/x-php">
 <?php
 enum Status {
-    case Draft;
-    case Published;
+	case Draft;
+	case Published;
 }
 
 echo Status::Published->name;

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
@@ -1,207 +1,7 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import type { ExampleName } from './PhpCodeSnippetLiveExample.examples';
 
 const SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
-
-const examples = {
-	full: String.raw`<script id="product-card-blueprint" type="application/json">
-{
-  "steps": [
-    {
-      "step": "writeFile",
-      "path": "/wordpress/wp-content/mu-plugins/product-cards.php",
-      "data": "<?php\nfunction docs_render_product_card( array $product ): string {\n\treturn sprintf(\n\t\t'<article class=\"product-card\"><h3>%s</h3><p>$%0.2f</p></article>',\n\t\tesc_html( $product['name'] ),\n\t\t$product['price']\n\t);\n}\n"
-    }
-  ]
-}
-</script>
-
-<php-snippet name="product-card.php" blueprint="product-card-blueprint">
-  <script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
-
-$products = [
-	[
-		'name'  => 'Canvas Tote',
-		'price' => 24,
-	],
-	[
-		'name'  => 'Coffee & Code Mug',
-		'price' => 16.5,
-	],
-];
-
-foreach ( $products as $product ) {
-	echo docs_render_product_card( $product ) . "\n";
-}
-  </script>
-  <script type="text/expected-output">
-<article class="product-card"><h3>Canvas Tote</h3><p>$24.00</p></article>
-<article class="product-card"><h3>Coffee &amp; Code Mug</h3><p>$16.50</p></article>
-  </script>
-</php-snippet>`,
-	hello: String.raw`<php-snippet name="hello.php">
-  <script type="application/x-php">
-<?php
-echo 'Hello from PHP ' . phpversion();
-  </script>
-  <script type="text/expected-output">
-Hello from PHP 8.4.x
-  </script>
-</php-snippet>`,
-	htmlApi: String.raw`<php-snippet name="html-api.php">
-  <script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
-
-$html = '<img src="hero.jpg" alt="Hero">';
-$tags = new WP_HTML_Tag_Processor( $html );
-
-if ( $tags->next_tag( 'img' ) ) {
-	$tags->set_attribute( 'loading', 'lazy' );
-}
-
-echo $tags->get_updated_html();
-  </script>
-  <script type="text/expected-output">
-<img src="hero.jpg" alt="Hero" loading="lazy">
-  </script>
-</php-snippet>`,
-	sum: String.raw`<php-snippet name="sum.php" expected-output="42">&lt;?php echo 20 + 22;</php-snippet>`,
-	siteTitle: String.raw`<php-snippet name="site-title.php">
-  <script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
-
-update_option( 'blogname', 'Snippet Docs' );
-echo get_bloginfo( 'name' );
-  </script>
-  <script type="text/expected-output">
-Snippet Docs
-  </script>
-</php-snippet>`,
-	purePhp: String.raw`<php-snippet name="pure-php.php" wp="none">
-  <script type="application/x-php">
-<?php
-echo 'WordPress installed: ';
-echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
-  </script>
-  <script type="text/expected-output">
-WordPress installed: no
-  </script>
-</php-snippet>`,
-	scratch: String.raw`<php-snippet name="scratch.php">
-  <script type="application/x-php">
-<?php
-$numbers = range( 1, 5 );
-echo array_sum( $numbers );
-  </script>
-  <script type="text/expected-output">
-15
- </script>
-</php-snippet>`,
-	readOnly: String.raw`<php-snippet name="reference.php" readonly>
-  <script type="application/x-php">
-<?php
-echo 'This example can run, but the code is locked.';
-  </script>
-  <script type="text/expected-output">
-This example can run, but the code is locked.
-  </script>
-</php-snippet>`,
-	precomputed: String.raw`<php-snippet name="precomputed.php">
-  <script type="application/x-php">
-<?php
-echo '2 + 2 = ' . ( 2 + 2 );
-  </script>
-  <script type="text/expected-output">
-2 + 2 = 4
-  </script>
-</php-snippet>`,
-	oneLine: String.raw`<php-snippet name="one-line.php" expected-output="Ready">
-  <script type="application/x-php">
-<?php
-echo 'Ready';
-  </script>
-</php-snippet>`,
-	greeting: String.raw`<script id="setup-blueprint-preview" type="application/json">
-{
-  "steps": [
-    {
-      "step": "writeFile",
-      "path": "/wordpress/wp-content/mu-plugins/helpers.php",
-      "data": "<?php\nfunction docs_greet( $name ) {\n\treturn 'Hello, ' . $name;\n}\n"
-    }
-  ]
-}
-</script>
-
-<php-snippet name="greeting.php" blueprint="setup-blueprint-preview">
-  <script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
-echo docs_greet( 'Ada' );
-  </script>
-  <script type="text/expected-output">
-Hello, Ada
-  </script>
-</php-snippet>`,
-	withSelector: String.raw`<script id="setup-blueprint-selector-preview" type="application/json">
-{
-  "steps": [
-    {
-      "step": "writeFile",
-      "path": "/wordpress/wp-content/mu-plugins/helpers.php",
-      "data": "<?php\nfunction docs_greet( $name ) {\n\treturn 'Hello, ' . $name;\n}\n"
-    }
-  ]
-}
-</script>
-
-<php-snippet blueprint="#setup-blueprint-selector-preview" name="with-selector.php">
-  <script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
-echo docs_greet( 'Grace' );
-  </script>
-  <script type="text/expected-output">
-Hello, Grace
-  </script>
-</php-snippet>`,
-	enum: String.raw`<php-snippet name="enum.php" php="8.4">
-  <script type="application/x-php">
-<?php
-enum Status {
-	case Draft;
-	case Published;
-}
-
-echo Status::Published->name;
-  </script>
-  <script type="text/expected-output">
-Published
-  </script>
-</php-snippet>`,
-	wpVersion: String.raw`<php-snippet name="wp-version.php" wp="6.8">
-  <script type="application/x-php">
-<?php
-require '/wordpress/wp-load.php';
-echo get_bloginfo( 'version' );
-  </script>
-  <script type="text/expected-output">
-6.8
-  </script>
-</php-snippet>`,
-	illustration: String.raw`<php-snippet name="illustration.php" runnable="false">
-  <script type="application/x-php">
-<?php
-// This fragment is shown for discussion, not execution.
-add_filter( 'the_content', 'docs_filter_content' );
-  </script>
-</php-snippet>`,
-} as const;
-
-type ExampleName = keyof typeof examples;
 
 function usePhpSnippetScript() {
 	useEffect(() => {
@@ -216,8 +16,34 @@ function usePhpSnippetScript() {
 	}, []);
 }
 
-function PhpCodeSnippetPreview({ html }: { html: string }) {
+function usePhpSnippetExample(name: ExampleName) {
+	const [html, setHtml] = useState<string>();
+
+	useEffect(() => {
+		let isCurrent = true;
+
+		setHtml(undefined);
+		void import('./PhpCodeSnippetLiveExample.examples').then(({ examples }) => {
+			if (isCurrent) {
+				setHtml(examples[name]);
+			}
+		});
+
+		return () => {
+			isCurrent = false;
+		};
+	}, [name]);
+
+	return html;
+}
+
+function PhpCodeSnippetPreview({ name }: { name: ExampleName }) {
 	usePhpSnippetScript();
+
+	const html = usePhpSnippetExample(name);
+	if (!html) {
+		return null;
+	}
 
 	return (
 		<div
@@ -228,9 +54,9 @@ function PhpCodeSnippetPreview({ html }: { html: string }) {
 }
 
 export function PhpCodeSnippetExample({ name }: { name: ExampleName }) {
-	return <PhpCodeSnippetPreview html={examples[name]} />;
+	return <PhpCodeSnippetPreview name={name} />;
 }
 
 export default function PhpCodeSnippetLiveExample() {
-	return <PhpCodeSnippetPreview html={examples.full} />;
+	return <PhpCodeSnippetPreview name="full" />;
 }

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
@@ -1,0 +1,229 @@
+import React, { useEffect } from 'react';
+
+const SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
+
+const examples = {
+	full: String.raw`<script id="product-card-blueprint" type="application/json">
+{
+  "steps": [
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/product-cards.php",
+      "data": "<?php\nfunction docs_render_product_card(array $product): string {\n    return sprintf(\n        '<article class=\"product-card\"><h3>%s</h3><p>$%0.2f</p></article>',\n        esc_html($product['name']),\n        $product['price']\n    );\n}\n"
+    }
+  ]
+}
+</script>
+
+<php-snippet name="product-card.php" blueprint="product-card-blueprint">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+$products = [
+    [ 'name' => 'Canvas Tote', 'price' => 24 ],
+    [ 'name' => 'Coffee & Code Mug', 'price' => 16.5 ],
+];
+
+foreach ( $products as $product ) {
+    echo docs_render_product_card( $product ) . "\n";
+}
+  </script>
+  <script type="text/expected-output">
+<article class="product-card"><h3>Canvas Tote</h3><p>$24.00</p></article>
+<article class="product-card"><h3>Coffee &amp; Code Mug</h3><p>$16.50</p></article>
+  </script>
+</php-snippet>`,
+	hello: String.raw`<php-snippet name="hello.php">
+  <script type="application/x-php">
+<?php
+echo "Hello from PHP " . phpversion();
+  </script>
+  <script type="text/expected-output">
+Hello from PHP 8.4.x
+  </script>
+</php-snippet>`,
+	htmlApi: String.raw`<php-snippet name="html-api.php">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+$html = '<img src="hero.jpg" alt="Hero">';
+$tags = new WP_HTML_Tag_Processor( $html );
+
+if ( $tags->next_tag( 'img' ) ) {
+    $tags->set_attribute( 'loading', 'lazy' );
+}
+
+echo $tags->get_updated_html();
+  </script>
+  <script type="text/expected-output">
+<img src="hero.jpg" alt="Hero" loading="lazy">
+  </script>
+</php-snippet>`,
+	sum: String.raw`<php-snippet name="sum.php" expected-output="42">&lt;?php echo 20 + 22;</php-snippet>`,
+	siteTitle: String.raw`<php-snippet name="site-title.php">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+
+update_option( 'blogname', 'Snippet Docs' );
+echo get_bloginfo( 'name' );
+  </script>
+  <script type="text/expected-output">
+Snippet Docs
+  </script>
+</php-snippet>`,
+	purePhp: String.raw`<php-snippet name="pure-php.php" wp="none">
+  <script type="application/x-php">
+<?php
+echo "WordPress installed: ";
+echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
+  </script>
+  <script type="text/expected-output">
+WordPress installed: no
+  </script>
+</php-snippet>`,
+	scratch: String.raw`<php-snippet name="scratch.php">
+  <script type="application/x-php">
+<?php
+$numbers = range( 1, 5 );
+echo array_sum( $numbers );
+  </script>
+  <script type="text/expected-output">
+15
+ </script>
+</php-snippet>`,
+	readOnly: String.raw`<php-snippet name="reference.php" readonly>
+  <script type="application/x-php">
+<?php
+echo "This example can run, but the code is locked.";
+  </script>
+  <script type="text/expected-output">
+This example can run, but the code is locked.
+  </script>
+</php-snippet>`,
+	precomputed: String.raw`<php-snippet name="precomputed.php">
+  <script type="application/x-php">
+<?php
+echo "2 + 2 = " . ( 2 + 2 );
+  </script>
+  <script type="text/expected-output">
+2 + 2 = 4
+  </script>
+</php-snippet>`,
+	oneLine: String.raw`<php-snippet name="one-line.php" expected-output="Ready">
+  <script type="application/x-php">
+<?php echo "Ready";
+  </script>
+</php-snippet>`,
+	greeting: String.raw`<script id="setup-blueprint-preview" type="application/json">
+{
+  "steps": [
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/helpers.php",
+      "data": "<?php\nfunction docs_greet($name) { return 'Hello, ' . $name; }\n"
+    }
+  ]
+}
+</script>
+
+<php-snippet name="greeting.php" blueprint="setup-blueprint-preview">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+echo docs_greet( 'Ada' );
+  </script>
+  <script type="text/expected-output">
+Hello, Ada
+  </script>
+</php-snippet>`,
+	withSelector: String.raw`<script id="setup-blueprint-selector-preview" type="application/json">
+{
+  "steps": [
+    {
+      "step": "writeFile",
+      "path": "/wordpress/wp-content/mu-plugins/helpers.php",
+      "data": "<?php\nfunction docs_greet($name) { return 'Hello, ' . $name; }\n"
+    }
+  ]
+}
+</script>
+
+<php-snippet blueprint="#setup-blueprint-selector-preview" name="with-selector.php">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+echo docs_greet( 'Grace' );
+  </script>
+  <script type="text/expected-output">
+Hello, Grace
+  </script>
+</php-snippet>`,
+	enum: String.raw`<php-snippet name="enum.php" php="8.4">
+  <script type="application/x-php">
+<?php
+enum Status {
+    case Draft;
+    case Published;
+}
+
+echo Status::Published->name;
+  </script>
+  <script type="text/expected-output">
+Published
+  </script>
+</php-snippet>`,
+	wpVersion: String.raw`<php-snippet name="wp-version.php" wp="6.8">
+  <script type="application/x-php">
+<?php
+require '/wordpress/wp-load.php';
+echo get_bloginfo( 'version' );
+  </script>
+  <script type="text/expected-output">
+6.8
+  </script>
+</php-snippet>`,
+	illustration: String.raw`<php-snippet name="illustration.php" runnable="false">
+  <script type="application/x-php">
+<?php
+// This fragment is shown for discussion, not execution.
+add_filter( 'the_content', 'docs_filter_content' );
+  </script>
+</php-snippet>`,
+} as const;
+
+type ExampleName = keyof typeof examples;
+
+function usePhpSnippetScript() {
+	useEffect(() => {
+		if (document.querySelector(`script[src="${SCRIPT_URL}"]`)) {
+			return;
+		}
+
+		const script = document.createElement('script');
+		script.type = 'module';
+		script.src = SCRIPT_URL;
+		document.head.appendChild(script);
+	}, []);
+}
+
+function PhpCodeSnippetPreview({ html }: { html: string }) {
+	usePhpSnippetScript();
+
+	return (
+		<div
+			className="php-code-snippet-live-example"
+			dangerouslySetInnerHTML={{ __html: html }}
+		/>
+	);
+}
+
+export function PhpCodeSnippetExample({ name }: { name: ExampleName }) {
+	return <PhpCodeSnippetPreview html={examples[name]} />;
+}
+
+export default function PhpCodeSnippetLiveExample() {
+	return <PhpCodeSnippetPreview html={examples.full} />;
+}

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -37,6 +37,7 @@ test.describe('php-code-snippet embed', () => {
 
 	test('renders all snippets with Run buttons', async ({ page }) => {
 		await page.goto(DEMO_URL);
+		await waitForPhpSnippetDefinition(page);
 		for (const name of [
 			'hello.php',
 			'lazy-load-images.php',
@@ -71,8 +72,14 @@ test.describe('php-code-snippet embed', () => {
 		page,
 	}) => {
 		await page.goto(DEMO_URL);
-		const defaultEditable = page.locator('php-snippet[name="hello.php"]');
-		const readOnly = page.locator('php-snippet[name="reference.php"]');
+		const defaultEditable = await waitForRenderedPhpSnippet(
+			page,
+			'php-snippet[name="hello.php"]'
+		);
+		const readOnly = await waitForRenderedPhpSnippet(
+			page,
+			'php-snippet[name="reference.php"]'
+		);
 
 		await expect(defaultEditable).toBeVisible();
 		await expect(defaultEditable.locator('textarea.ta')).toBeVisible();
@@ -96,7 +103,8 @@ test.describe('php-code-snippet embed', () => {
 			document.body.append(snippet);
 		});
 
-		const editableFalse = page.locator(
+		const editableFalse = await waitForRenderedPhpSnippet(
+			page,
 			'php-snippet[name="editable-false.php"]'
 		);
 		await expect(editableFalse.locator('.run')).toBeVisible();
@@ -730,4 +738,24 @@ async function ensureToolkitAutoloadIsServed(page: Page) {
 			contentType: 'text/plain',
 		});
 	});
+}
+
+async function waitForPhpSnippetDefinition(page: Page) {
+	await page.evaluate(() => customElements.whenDefined('php-snippet'));
+}
+
+async function waitForRenderedPhpSnippet(page: Page, selector: string) {
+	await waitForPhpSnippetDefinition(page);
+	const snippet = page.locator(selector);
+
+	await expect(snippet).toBeVisible();
+	await expect
+		.poll(() =>
+			snippet.evaluate(
+				(element) => element.shadowRoot?.childElementCount ?? 0
+			)
+		)
+		.toBeGreaterThan(0);
+
+	return snippet;
 }

--- a/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
+++ b/packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
@@ -4,7 +4,7 @@ import type { Page } from '@playwright/test';
 /**
  * E2E tests for the <php-snippet> web component embed.
  * Verifies that:
- *   - the demo page renders three snippets,
+ *   - the fixture page renders snippets,
  *   - clicking Run on the first shows real button progress that advances
  *     toward 100,
  *   - the first snippet executes and shows PHP output,
@@ -12,7 +12,9 @@ import type { Page } from '@playwright/test';
  *     than the first boot) and produce their own output.
  */
 
-const DEMO_URL = './php-code-snippet-demo.html';
+const DEMO_URL = './php-code-snippet-e2e.html';
+const DOCS_URL =
+	'https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/';
 const CLIENT_INDEX_SOURCE = `${process.cwd()}/packages/playground/client/src/index.ts`;
 const TOOLKIT_AUTOLOAD_SOURCE = `${process.cwd()}/packages/playground/website/public/php-toolkit-autoload.txt`;
 const pageErrors = new WeakMap<Page, string[]>();
@@ -42,6 +44,7 @@ test.describe('php-code-snippet embed', () => {
 			'greet-alice.php',
 			'greet-bob.php',
 			'scratch.php',
+			'reference.php',
 			'precomputed.php',
 			'just-php.php',
 			'quickstart.php',
@@ -54,10 +57,7 @@ test.describe('php-code-snippet embed', () => {
 			);
 			await expect(
 				snippet.locator('.powered-by a').nth(0)
-			).toHaveAttribute(
-				'href',
-				'https://playground.wordpress.net/php-code-snippet-demo.html'
-			);
+			).toHaveAttribute('href', DOCS_URL);
 			await expect(
 				snippet.locator('.powered-by a').nth(1)
 			).toHaveAttribute('href', 'https://wordpress.org/playground/');
@@ -65,6 +65,43 @@ test.describe('php-code-snippet embed', () => {
 				/Ctrl\+Enter|Cmd\+Enter/
 			);
 		}
+	});
+
+	test('runnable snippets are editable by default unless readonly', async ({
+		page,
+	}) => {
+		await page.goto(DEMO_URL);
+		const defaultEditable = page.locator('php-snippet[name="hello.php"]');
+		const readOnly = page.locator('php-snippet[name="reference.php"]');
+
+		await expect(defaultEditable).toBeVisible();
+		await expect(defaultEditable.locator('textarea.ta')).toBeVisible();
+		await expect(defaultEditable.locator('.editor')).toBeVisible();
+
+		await expect(readOnly).toBeVisible();
+		await expect(readOnly.locator('.run')).toBeVisible();
+		await expect(readOnly.locator('textarea.ta')).toHaveCount(0);
+		await expect(readOnly.locator('pre code')).toContainText(
+			'Reference only'
+		);
+
+		await page.evaluate(() => {
+			const snippet = document.createElement('php-snippet');
+			snippet.setAttribute('name', 'editable-false.php');
+			snippet.setAttribute('editable', 'false');
+			const script = document.createElement('script');
+			script.type = 'application/x-php';
+			script.textContent = '<?php echo "Locked";';
+			snippet.append(script);
+			document.body.append(snippet);
+		});
+
+		const editableFalse = page.locator(
+			'php-snippet[name="editable-false.php"]'
+		);
+		await expect(editableFalse.locator('.run')).toBeVisible();
+		await expect(editableFalse.locator('textarea.ta')).toHaveCount(0);
+		await expect(editableFalse.locator('pre code')).toContainText('Locked');
 	});
 
 	test('runnable=false renders a read-only snippet without Run', async ({

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -3,277 +3,30 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>&lt;php-snippet&gt; demo</title>
-		<style>
-			body {
-				font-family:
-					system-ui,
-					-apple-system,
-					sans-serif;
-				max-width: 880px;
-				margin: 0 auto;
-				padding: 32px 20px 64px;
-				color: #1f2328;
-				line-height: 1.55;
-			}
-			h1 {
-				font-size: 28px;
-				margin: 0 0 8px;
-			}
-			h2 {
-				font-size: 20px;
-				margin: 32px 0 8px;
-			}
-			.lede {
-				color: #57606a;
-				margin: 0 0 24px;
-			}
-			code {
-				background: #eaeef2;
-				padding: 2px 5px;
-				border-radius: 4px;
-				font-size: 0.9em;
-			}
-			.note {
-				background: #ddf4ff;
-				border-left: 4px solid #218bff;
-				padding: 12px 14px;
-				margin: 16px 0;
-				border-radius: 4px;
-				font-size: 14px;
-			}
-		</style>
+		<meta
+			http-equiv="refresh"
+			content="0; url=https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/"
+		/>
+		<link
+			rel="canonical"
+			href="https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/"
+		/>
+		<title>PHP code snippets and embeds</title>
 	</head>
 	<body>
-		<h1>&lt;php-snippet&gt; demo</h1>
-		<p class="lede">
-			Three independent snippets on one page. Click Run on any of them —
-			the PHP &amp; WordPress runtime downloads
-			<strong>once</strong> and is shared across all of them.
+		<p>
+			The <code>&lt;php-snippet&gt;</code> demo is now part of the
+			WordPress Playground documentation:
+			<a
+				href="https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/"
+			>
+				PHP code snippets and embeds </a
+			>.
 		</p>
-
-		<div class="note">
-			Open DevTools → Network and watch: the first Run downloads
-			<code>remote.html</code> + the PHP WASM binary + WordPress. The
-			second and third Runs reuse the same runtime — no extra downloads.
-		</div>
-
-		<h2>1. Pure PHP</h2>
-		<php-snippet name="hello.php">
-			<script type="application/x-php">
-				<?php
-				echo "Hello from PHP " . phpversion() . "\n";
-				echo "Today is " . date('Y-m-d') . "\n";
-				echo str_repeat('-', 30) . "\n";
-
-				$nums = [1, 2, 3, 4, 5];
-				echo "Sum of " . implode(',', $nums) . " = " . array_sum($nums) . "\n";
-			</script>
-		</php-snippet>
-
-		<h2>2. WordPress HTML API</h2>
-		<php-snippet name="lazy-load-images.php">
-			<script type="application/x-php">
-				<?php
-				require '/wordpress/wp-load.php';
-
-				$html = '<article>
-				    <img src="hero.jpg" alt="Hero">
-				    <img src="inline.jpg" alt="Inline">
-				</article>';
-
-				$tags = new WP_HTML_Tag_Processor( $html );
-				while ( $tags->next_tag( 'img' ) ) {
-				    $tags->set_attribute( 'loading', 'lazy' );
-				    $tags->add_class( 'responsive' );
-				}
-
-				echo $tags->get_updated_html();
-			</script>
-		</php-snippet>
-
-		<h2>3. Block parser</h2>
-		<php-snippet name="parse-blocks.php">
-			<script type="application/x-php">
-				<?php
-				require '/wordpress/wp-load.php';
-
-				$post_content = "<!-- wp:paragraph -->
-				<p>Hello, <strong>block editor</strong>!</p>
-				<!-- /wp:paragraph -->
-
-				<!-- wp:list -->
-				<ul><li>One</li><li>Two</li></ul>
-				<!-- /wp:list -->";
-
-				$blocks = parse_blocks( $post_content );
-				foreach ( $blocks as $block ) {
-				    if ( ! empty( $block['blockName'] ) ) {
-				        echo "- " . $block['blockName'] . "\n";
-				    }
-				}
-			</script>
-		</php-snippet>
-
-		<h2>4. Shared blueprint via JSON script</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
-			Two snippets reference the same blueprint by id, so their runtime is
-			booted once with a pre-installed mu-plugin. Using
-			<code>&lt;script type="application/json"&gt;</code> lets the JSON
-			contain literal <code>&lt;?php</code> without escaping.
-		</p>
-
-		<script id="greeter-blueprint" type="application/json">
-			{
-				"steps": [
-					{
-						"step": "writeFile",
-						"path": "/wordpress/wp-content/mu-plugins/greeter.php",
-						"data": "<?php\nfunction greeter_say($name) { return 'Hello, ' . $name . '!'; }"
-					}
-				]
-			}
+		<script>
+			window.location.replace(
+				'https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/'
+			);
 		</script>
-
-		<php-snippet name="greet-alice.php" blueprint="greeter-blueprint">
-			<script type="application/x-php">
-				<?php
-				require '/wordpress/wp-load.php';
-				echo greeter_say('Alice');
-			</script>
-		</php-snippet>
-
-		<php-snippet name="greet-bob.php" blueprint="greeter-blueprint">
-			<script type="application/x-php">
-				<?php
-				require '/wordpress/wp-load.php';
-				echo greeter_say('Bob');
-			</script>
-		</php-snippet>
-
-		<h2>5. Editable</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
-			Type into the snippet, then click Run.
-		</p>
-		<php-snippet name="scratch.php" editable>
-			<script type="application/x-php">
-				<?php
-				$nums = range(1, 10);
-				echo "Sum: " . array_sum($nums) . "\n";
-				echo "Product: " . array_product($nums) . "\n";
-			</script>
-		</php-snippet>
-
-		<h2>6. Expected output</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
-			When <code>expected-output</code> is provided (as an attribute or a
-			<code>&lt;script type="text/expected-output"&gt;</code> child), the
-			snippet displays that text before Run is clicked. Clicking Run still
-			loads the Playground runtime and replaces the placeholder with the
-			real output.
-		</p>
-		<php-snippet name="precomputed.php">
-			<script type="application/x-php">
-				<?php
-				echo "2 + 2 = " . (2 + 2) . "\n";
-				echo "WordPress is awesome.";
-			</script>
-			<script type="text/expected-output">
-				2 + 2 = 4
-				WordPress is awesome.
-			</script>
-		</php-snippet>
-
-		<h2>7. PHP-only (no WordPress)</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
-			<code>wp="none"</code> boots PHP without downloading or installing
-			WordPress. The PHP runtime still loads, but no
-			<code>wp-*.zip</code> request fires — handy for snippets that
-			showcase plain PHP language features without paying the WP boot
-			cost.
-		</p>
-		<php-snippet name="just-php.php" wp="none">
-			<script type="application/x-php">
-				<?php
-				echo "PHP " . phpversion() . "\n";
-				echo "WordPress installed: " . (file_exists('/wordpress/wp-includes/version.php') ? 'yes' : 'no') . "\n";
-
-				// Pure-PHP feature demo: enums (PHP 8.1+).
-				enum Status: string {
-				    case Draft   = 'draft';
-				    case Pending = 'pending';
-				    case Live    = 'live';
-				}
-				foreach (Status::cases() as $status) {
-				    echo "- {$status->name}: {$status->value}\n";
-				}
-			</script>
-		</php-snippet>
-
-		<h2>8. Pure PHP toolkit (no WordPress)</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
-			Uses <code>wp="none"</code> together with a blueprint that installs
-			a tiny PHP toolkit at <code>/tmp/php-toolkit</code>. The snippet
-			boots PHP only, autoloads the toolkit, and uses
-			<code>WP_HTML_Tag_Processor</code> outside of WordPress.
-		</p>
-
-		<script id="toolkit-setup" type="application/json">
-			{
-				"steps": [
-					{ "step": "mkdir", "path": "/tmp/php-toolkit/vendor" },
-					{
-						"step": "writeFile",
-						"path": "/tmp/php-toolkit/vendor/autoload.php",
-						"data": {
-							"resource": "url",
-							"url": "/php-toolkit-autoload.txt"
-						}
-					}
-				]
-			}
-		</script>
-
-		<php-snippet wp="none" blueprint="toolkit-setup" name="quickstart.php">
-			<script type="application/x-php">
-				<?php
-				require '/tmp/php-toolkit/vendor/autoload.php';
-
-				$html = '<article>
-					<img src="hero.jpg" alt="Hero shot">
-					<p>Welcome to the site.</p>
-					<img src="diagram.png" alt="" loading="eager">
-				</article>';
-
-				$tags = new WP_HTML_Tag_Processor( $html );
-				while ( $tags->next_tag( 'img' ) ) {
-					if ( null === $tags->get_attribute( 'loading' ) ) {
-						$tags->set_attribute( 'loading', 'lazy' );
-					}
-				}
-
-				echo $tags->get_updated_html();
-			</script>
-			<script type="text/expected-output">
-				<article>
-					<img src="hero.jpg" alt="Hero shot" loading="lazy">
-					<p>Welcome to the site.</p>
-					<img src="diagram.png" alt="" loading="eager">
-				</article>
-			</script>
-		</php-snippet>
-
-		<h2>9. Read-only illustration</h2>
-		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
-			This snippet is syntax-highlighted but is not meant to execute.
-		</p>
-		<php-snippet name="illustration.php" runnable="false" editable>
-			<script type="application/x-php">
-				<?php
-				echo "Just an illustration";
-			</script>
-		</php-snippet>
-
-		<script type="module" src="./php-code-snippet.js"></script>
 	</body>
 </html>

--- a/packages/playground/website/public/php-code-snippet-demo.html
+++ b/packages/playground/website/public/php-code-snippet-demo.html
@@ -20,8 +20,8 @@
 			<a
 				href="https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/"
 			>
-				PHP code snippets and embeds </a
-			>.
+				PHP code snippets and embeds
+			</a>.
 		</p>
 		<script>
 			window.location.replace(

--- a/packages/playground/website/public/php-code-snippet-e2e.html
+++ b/packages/playground/website/public/php-code-snippet-e2e.html
@@ -1,0 +1,294 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>&lt;php-snippet&gt; demo</title>
+		<style>
+			body {
+				font-family:
+					system-ui,
+					-apple-system,
+					sans-serif;
+				max-width: 880px;
+				margin: 0 auto;
+				padding: 32px 20px 64px;
+				color: #1f2328;
+				line-height: 1.55;
+			}
+			h1 {
+				font-size: 28px;
+				margin: 0 0 8px;
+			}
+			h2 {
+				font-size: 20px;
+				margin: 32px 0 8px;
+			}
+			.lede {
+				color: #57606a;
+				margin: 0 0 24px;
+			}
+			code {
+				background: #eaeef2;
+				padding: 2px 5px;
+				border-radius: 4px;
+				font-size: 0.9em;
+			}
+			.note {
+				background: #ddf4ff;
+				border-left: 4px solid #218bff;
+				padding: 12px 14px;
+				margin: 16px 0;
+				border-radius: 4px;
+				font-size: 14px;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>&lt;php-snippet&gt; demo</h1>
+		<p class="lede">
+			Three independent snippets on one page. Click Run on any of them —
+			the PHP &amp; WordPress runtime downloads
+			<strong>once</strong> and is shared across all of them.
+		</p>
+
+		<div class="note">
+			Open DevTools → Network and watch: the first Run downloads
+			<code>remote.html</code> + the PHP WASM binary + WordPress. The
+			second and third Runs reuse the same runtime — no extra downloads.
+		</div>
+
+		<h2>1. Pure PHP</h2>
+		<php-snippet name="hello.php">
+			<script type="application/x-php">
+				<?php
+				echo "Hello from PHP " . phpversion() . "\n";
+				echo "Today is " . date('Y-m-d') . "\n";
+				echo str_repeat('-', 30) . "\n";
+
+				$nums = [1, 2, 3, 4, 5];
+				echo "Sum of " . implode(',', $nums) . " = " . array_sum($nums) . "\n";
+			</script>
+		</php-snippet>
+
+		<h2>2. WordPress HTML API</h2>
+		<php-snippet name="lazy-load-images.php">
+			<script type="application/x-php">
+				<?php
+				require '/wordpress/wp-load.php';
+
+				$html = '<article>
+				    <img src="hero.jpg" alt="Hero">
+				    <img src="inline.jpg" alt="Inline">
+				</article>';
+
+				$tags = new WP_HTML_Tag_Processor( $html );
+				while ( $tags->next_tag( 'img' ) ) {
+				    $tags->set_attribute( 'loading', 'lazy' );
+				    $tags->add_class( 'responsive' );
+				}
+
+				echo $tags->get_updated_html();
+			</script>
+		</php-snippet>
+
+		<h2>3. Block parser</h2>
+		<php-snippet name="parse-blocks.php">
+			<script type="application/x-php">
+				<?php
+				require '/wordpress/wp-load.php';
+
+				$post_content = "<!-- wp:paragraph -->
+				<p>Hello, <strong>block editor</strong>!</p>
+				<!-- /wp:paragraph -->
+
+				<!-- wp:list -->
+				<ul><li>One</li><li>Two</li></ul>
+				<!-- /wp:list -->";
+
+				$blocks = parse_blocks( $post_content );
+				foreach ( $blocks as $block ) {
+				    if ( ! empty( $block['blockName'] ) ) {
+				        echo "- " . $block['blockName'] . "\n";
+				    }
+				}
+			</script>
+		</php-snippet>
+
+		<h2>4. Shared blueprint via JSON script</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			Two snippets reference the same blueprint by id, so their runtime is
+			booted once with a pre-installed mu-plugin. Using
+			<code>&lt;script type="application/json"&gt;</code> lets the JSON
+			contain literal <code>&lt;?php</code> without escaping.
+		</p>
+
+		<script id="greeter-blueprint" type="application/json">
+			{
+				"steps": [
+					{
+						"step": "writeFile",
+						"path": "/wordpress/wp-content/mu-plugins/greeter.php",
+						"data": "<?php\nfunction greeter_say($name) { return 'Hello, ' . $name . '!'; }"
+					}
+				]
+			}
+		</script>
+
+		<php-snippet name="greet-alice.php" blueprint="greeter-blueprint">
+			<script type="application/x-php">
+				<?php
+				require '/wordpress/wp-load.php';
+				echo greeter_say('Alice');
+			</script>
+		</php-snippet>
+
+		<php-snippet name="greet-bob.php" blueprint="greeter-blueprint">
+			<script type="application/x-php">
+				<?php
+				require '/wordpress/wp-load.php';
+				echo greeter_say('Bob');
+			</script>
+		</php-snippet>
+
+		<h2>5. Editable by default</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			Type into the snippet, then click Run.
+		</p>
+		<php-snippet name="scratch.php">
+			<script type="application/x-php">
+				<?php
+				$nums = range(1, 10);
+				echo "Sum: " . array_sum($nums) . "\n";
+				echo "Product: " . array_product($nums) . "\n";
+			</script>
+		</php-snippet>
+
+		<h2>6. Read-only runnable</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			<code>readonly</code> keeps a runnable snippet from becoming
+			editable.
+		</p>
+		<php-snippet name="reference.php" readonly>
+			<script type="application/x-php">
+				<?php
+				echo "Reference only";
+			</script>
+			<script type="text/expected-output">
+				Reference only
+			</script>
+		</php-snippet>
+
+		<h2>7. Expected output</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			When <code>expected-output</code> is provided (as an attribute or a
+			<code>&lt;script type="text/expected-output"&gt;</code> child), the
+			snippet displays that text before Run is clicked. Clicking Run still
+			loads the Playground runtime and replaces the placeholder with the
+			real output.
+		</p>
+		<php-snippet name="precomputed.php">
+			<script type="application/x-php">
+				<?php
+				echo "2 + 2 = " . (2 + 2) . "\n";
+				echo "WordPress is awesome.";
+			</script>
+			<script type="text/expected-output">
+				2 + 2 = 4
+				WordPress is awesome.
+			</script>
+		</php-snippet>
+
+		<h2>8. PHP-only (no WordPress)</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			<code>wp="none"</code> boots PHP without downloading or installing
+			WordPress. The PHP runtime still loads, but no
+			<code>wp-*.zip</code> request fires — handy for snippets that
+			showcase plain PHP language features without paying the WP boot
+			cost.
+		</p>
+		<php-snippet name="just-php.php" wp="none">
+			<script type="application/x-php">
+				<?php
+				echo "PHP " . phpversion() . "\n";
+				echo "WordPress installed: " . (file_exists('/wordpress/wp-includes/version.php') ? 'yes' : 'no') . "\n";
+
+				// Pure-PHP feature demo: enums (PHP 8.1+).
+				enum Status: string {
+				    case Draft   = 'draft';
+				    case Pending = 'pending';
+				    case Live    = 'live';
+				}
+				foreach (Status::cases() as $status) {
+				    echo "- {$status->name}: {$status->value}\n";
+				}
+			</script>
+		</php-snippet>
+
+		<h2>9. Pure PHP toolkit (no WordPress)</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			Uses <code>wp="none"</code> together with a blueprint that installs
+			a tiny PHP toolkit at <code>/tmp/php-toolkit</code>. The snippet
+			boots PHP only, autoloads the toolkit, and uses
+			<code>WP_HTML_Tag_Processor</code> outside of WordPress.
+		</p>
+
+		<script id="toolkit-setup" type="application/json">
+			{
+				"steps": [
+					{ "step": "mkdir", "path": "/tmp/php-toolkit/vendor" },
+					{
+						"step": "writeFile",
+						"path": "/tmp/php-toolkit/vendor/autoload.php",
+						"data": {
+							"resource": "url",
+							"url": "/php-toolkit-autoload.txt"
+						}
+					}
+				]
+			}
+		</script>
+
+		<php-snippet wp="none" blueprint="toolkit-setup" name="quickstart.php">
+			<script type="application/x-php">
+				<?php
+				require '/tmp/php-toolkit/vendor/autoload.php';
+
+				$html = '<article>
+					<img src="hero.jpg" alt="Hero shot">
+					<p>Welcome to the site.</p>
+					<img src="diagram.png" alt="" loading="eager">
+				</article>';
+
+				$tags = new WP_HTML_Tag_Processor( $html );
+				while ( $tags->next_tag( 'img' ) ) {
+					if ( null === $tags->get_attribute( 'loading' ) ) {
+						$tags->set_attribute( 'loading', 'lazy' );
+					}
+				}
+
+				echo $tags->get_updated_html();
+			</script>
+			<script type="text/expected-output">
+				<article>
+					<img src="hero.jpg" alt="Hero shot" loading="lazy">
+					<p>Welcome to the site.</p>
+					<img src="diagram.png" alt="" loading="eager">
+				</article>
+			</script>
+		</php-snippet>
+
+		<h2>10. Read-only illustration</h2>
+		<p style="margin: 0 0 8px; color: #57606a; font-size: 14px">
+			This snippet is syntax-highlighted but is not meant to execute.
+		</p>
+		<php-snippet name="illustration.php" runnable="false">
+			<script type="application/x-php">
+				<?php
+				echo "Just an illustration";
+			</script>
+		</php-snippet>
+
+		<script type="module" src="./php-code-snippet.js"></script>
+	</body>
+</html>

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -31,9 +31,10 @@
  *   runnable="false"      hide the Run button and render the snippet as a
  *                         read-only, syntax-highlighted code block. Useful for
  *                         illustrative examples that aren't meant to execute.
- *   editable              make the snippet editable; visitors type into a
- *                         transparent textarea overlaid on the highlighted
- *                         code, and Run executes whatever they typed
+ *   readonly              render runnable snippets as read-only code blocks.
+ *                         Snippets are editable by default, and Run executes
+ *                         whatever the reader typed. editable="false" is also
+ *                         accepted as a compatibility alias.
  *   blueprint="toolkit"  CSS-selector-or-id of a JSON Blueprint container
  *                         on the page (a <script type="application/json"> is
  *                         recommended; <template> works too). Snippets that
@@ -47,7 +48,8 @@
 const DEFAULT_ORIGIN = 'https://playground.wordpress.net';
 const DEFAULT_PHP = '8.4';
 const DEFAULT_WP = 'latest';
-const DEMO_URL = 'https://playground.wordpress.net/php-code-snippet-demo.html';
+const DOCS_URL =
+	'https://wordpress.github.io/wordpress-playground/guides/php-code-snippets/';
 const PLAYGROUND_URL = 'https://wordpress.org/playground/';
 
 /**
@@ -847,7 +849,10 @@ class PhpSnippet extends HTMLElement {
 	_render() {
 		const name = this.getAttribute('name') || 'snippet.php';
 		const runnable = this.getAttribute('runnable') !== 'false';
-		const editable = runnable && this.hasAttribute('editable');
+		const editable =
+			runnable &&
+			!this.hasAttribute('readonly') &&
+			this.getAttribute('editable') !== 'false';
 		const runShortcut = getRunShortcutLabel();
 		const style = document.createElement('style');
 		style.textContent = TEMPLATE_CSS;
@@ -880,7 +885,7 @@ class PhpSnippet extends HTMLElement {
 					<pre class="output-body"></pre>
 				</div>
 				<div class="powered-by">
-					<a href="${DEMO_URL}" target="_blank" rel="noopener noreferrer">PHP Code Snippet</a>
+					<a href="${DOCS_URL}" target="_blank" rel="noopener noreferrer">PHP Code Snippet</a>
 					powered by
 					<a href="${PLAYGROUND_URL}" target="_blank" rel="noopener noreferrer">WordPress Playground</a>
 				</div>

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -33,8 +33,11 @@
  *                         illustrative examples that aren't meant to execute.
  *   readonly              render runnable snippets as read-only code blocks.
  *                         Snippets are editable by default, and Run executes
- *                         whatever the reader typed. editable="false" is also
- *                         accepted as a compatibility alias.
+ *                         whatever the reader typed.
+ *   editable              legacy opt-in for editable snippets. Since editing
+ *                         is now the default, this is only needed for older
+ *                         embeds. Set readonly or editable="false" to disable
+ *                         editing.
  *   blueprint="toolkit"  CSS-selector-or-id of a JSON Blueprint container
  *                         on the page (a <script type="application/json"> is
  *                         recommended; <template> works too). Snippets that


### PR DESCRIPTION
## What it does

Turns the `<php-snippet>` demo into a full documentation guide. The guide now starts with a live, Blueprint-backed example, then walks through basic embeds, precomputed output, selector-based snippets, WordPress snippets, pure PHP snippets, and option-by-option usage.

`<php-snippet>` examples are editable by default. Runnable snippets that should stay locked now use `readonly`; `editable="false"` remains supported as a compatibility alias.

The old `/php-code-snippet-demo.html` page redirects to the docs guide, and the component's "PHP Code Snippet" attribution link points there too.

## Rationale

The old demo page was useful for testing but not enough as user-facing documentation. The docs page is now the canonical resource, with rendered examples next to copyable code so readers can see the result before deciding what to reuse.

Editable-by-default snippets make the common documentation case lighter: authors only add an attribute when they intentionally want a read-only runnable example.

## Implementation

Adds a Docusaurus `PhpCodeSnippetLiveExample` component that loads the hosted snippet script and renders examples inline throughout the guide.

Updates `php-code-snippet.js` so runnable snippets render an editor unless `readonly`, `runnable="false"`, or `editable="false"` is present.

Moves the old public demo contents to `php-code-snippet-e2e.html` so Playwright keeps a stable fixture while `/php-code-snippet-demo.html` becomes a redirect.

Updates the guide index copy, snippet fixture, and Playwright expectations for the new docs URL and editability behavior.

## Testing instructions

Ran:

```bash
PATH=/usr/local/Cellar/node@22/22.22.3/bin:$PATH npm --prefix packages/docs/site run typecheck
PATH=/usr/local/Cellar/node@22/22.22.3/bin:$PATH npm exec tsc -- -p packages/playground/website/tsconfig.spec.json --noEmit
PATH=/usr/local/Cellar/node@22/22.22.3/bin:$PATH npm exec prettier -- --check packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx packages/docs/site/docs/main/guides/php-code-snippets.md packages/playground/website/public/php-code-snippet.js packages/playground/website/public/php-code-snippet-e2e.html packages/playground/website/playwright/e2e/php-code-snippet.spec.ts
PATH=/usr/local/Cellar/node@22/22.22.3/bin:$PATH node --check packages/playground/website/public/php-code-snippet.js
git diff --check
```

Also verified the local fixture in a browser:

```text
snippets: 11
upgraded: 11
defaultEditableHello: true
defaultEditableScratch: true
readOnlyEditable: false
readOnlyHasRun: true
illustrationHasRun: false
illustrationEditable: false
```
