### PR TITLE
Handle browser refresh in Playground iframe

### DIFF
--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -17,7 +17,10 @@ import {
 	useAppDispatch,
 	useAppSelector,
 } from '../../lib/state/redux/store';
-import { removeClientInfo } from '../../lib/state/redux/slice-clients';
+import {
+	removeClientInfo,
+	selectClientInfoBySiteSlug,
+} from '../../lib/state/redux/slice-clients';
 import { bootSiteClient } from '../../lib/state/redux/boot-site-client';
 import { selectSiteBySlug } from '../../lib/state/redux/slice-sites';
 import {
@@ -42,6 +45,7 @@ import {
 } from './blueprint-install';
 import type { BlueprintInstallPreview } from './blueprint-install';
 import { isAllowedBlueprintUrl } from '../../lib/blueprint-url';
+import { useBrowserRefreshShortcut } from '../../lib/hooks/use-browser-refresh-shortcut';
 // @ts-ignore
 import { corsProxyUrl } from 'virtual:cors-proxy-url';
 
@@ -854,6 +858,9 @@ export const JustViewport = function JustViewport({
 	const internalIframeRef = useRef<HTMLIFrameElement>(null);
 	const iframeRef = externalIframeRef || internalIframeRef;
 	const site = useAppSelector((state) => selectSiteBySlug(state, siteSlug))!;
+	const clientInfo = useAppSelector((state) =>
+		selectClientInfoBySiteSlug(state, siteSlug)
+	);
 
 	const dispatch = useAppDispatch();
 	const runtimeConfigString = JSON.stringify(
@@ -885,6 +892,11 @@ export const JustViewport = function JustViewport({
 	const errorDetails = useAppSelector(selectActiveSiteErrorDetails);
 	const activeSiteSlug = useAppSelector((state) => state.ui.activeSite?.slug);
 	const showOverlay = error && activeSiteSlug === siteSlug;
+	useBrowserRefreshShortcut({
+		client: clientInfo?.client,
+		enabled: activeSiteSlug === siteSlug,
+		iframeRef,
+	});
 
 	return (
 		<>

--- a/packages/playground/personal-wp/src/lib/hooks/use-browser-refresh-shortcut.ts
+++ b/packages/playground/personal-wp/src/lib/hooks/use-browser-refresh-shortcut.ts
@@ -1,0 +1,132 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+import type { PlaygroundClient } from '@wp-playground/remote';
+import { logger } from '@php-wasm/logger';
+
+const PLAYGROUND_REFRESH_RELAY_TYPE = 'playground-refresh';
+
+export function useBrowserRefreshShortcut({
+	client,
+	enabled = true,
+	iframeRef,
+}: {
+	client?: PlaygroundClient;
+	enabled?: boolean;
+	iframeRef: RefObject<HTMLIFrameElement>;
+}) {
+	useEffect(() => {
+		if (!enabled || !client) {
+			return;
+		}
+		const playground = client;
+
+		function handleKeyDown(event: KeyboardEvent) {
+			if (!isBrowserRefreshShortcut(event)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			void reloadPlaygroundClient(playground).catch((error) =>
+				logger.error(error)
+			);
+		}
+
+		window.addEventListener('keydown', handleKeyDown, true);
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown, true);
+		};
+	}, [client, enabled]);
+
+	useEffect(() => {
+		if (!enabled || !client) {
+			return;
+		}
+		const playground = client;
+
+		function handleMessage(event: MessageEvent) {
+			if (
+				event.origin !== window.location.origin ||
+				!isPlaygroundRefreshMessage(event.data) ||
+				!isMessageFromIframeTree(event, iframeRef.current)
+			) {
+				return;
+			}
+
+			void reloadPlaygroundClient(playground).catch((error) =>
+				logger.error(error)
+			);
+		}
+
+		window.addEventListener('message', handleMessage);
+		return () => {
+			window.removeEventListener('message', handleMessage);
+		};
+	}, [client, enabled, iframeRef]);
+}
+
+async function reloadPlaygroundClient(client: PlaygroundClient) {
+	await client.goTo(await client.getCurrentURL());
+}
+
+export function isBrowserRefreshShortcut(
+	event: Pick<
+		KeyboardEvent,
+		| 'altKey'
+		| 'ctrlKey'
+		| 'defaultPrevented'
+		| 'isComposing'
+		| 'key'
+		| 'metaKey'
+		| 'repeat'
+	>
+): boolean {
+	return (
+		!event.defaultPrevented &&
+		!event.altKey &&
+		!event.isComposing &&
+		!event.repeat &&
+		event.key.toLowerCase() === 'r' &&
+		(event.metaKey || event.ctrlKey)
+	);
+}
+
+function isPlaygroundRefreshMessage(data: unknown): boolean {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		(data as { type?: unknown }).type === 'relay' &&
+		(data as { relayType?: unknown }).relayType ===
+			PLAYGROUND_REFRESH_RELAY_TYPE
+	);
+}
+
+function isMessageFromIframeTree(
+	event: MessageEvent,
+	iframe: HTMLIFrameElement | null
+): boolean {
+	if (!iframe?.contentWindow || !event.source) {
+		return false;
+	}
+	if (event.source === iframe.contentWindow) {
+		return true;
+	}
+	return isDescendantWindow(iframe.contentWindow, event.source);
+}
+
+function isDescendantWindow(
+	root: Window,
+	candidate: MessageEventSource
+): boolean {
+	try {
+		for (let i = 0; i < root.frames.length; i++) {
+			const child = root.frames[i];
+			if (child === candidate || isDescendantWindow(child, candidate)) {
+				return true;
+			}
+		}
+	} catch {
+		// Cross-origin descendants are not inspectable and are not accepted.
+	}
+	return false;
+}

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -562,6 +562,7 @@ export async function bootPlaygroundRemote() {
 		phpRemoteApi,
 		phpWorkerApi
 	);
+	setupBrowserRefreshShortcut(() => reloadWordPressFrame(phpRemoteApi));
 
 	/*
 	 * An assertion to make sure Playground Client is compatible
@@ -622,6 +623,48 @@ function detectDocumentIsolationPolicySuport(): Promise<boolean> {
 
 function getOrigin(url: string) {
 	return new URL(url, 'https://example.com').origin;
+}
+
+function setupBrowserRefreshShortcut(reload: () => Promise<void>) {
+	window.addEventListener(
+		'keydown',
+		(event) => {
+			if (!isBrowserRefreshShortcut(event)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			void reload().catch((error) => logger.error(error));
+		},
+		true
+	);
+}
+
+async function reloadWordPressFrame(playground: PHPRemoteApi) {
+	await playground.goTo(await playground.getCurrentURL());
+}
+
+function isBrowserRefreshShortcut(
+	event: Pick<
+		KeyboardEvent,
+		| 'altKey'
+		| 'ctrlKey'
+		| 'defaultPrevented'
+		| 'isComposing'
+		| 'key'
+		| 'metaKey'
+		| 'repeat'
+	>
+): boolean {
+	return (
+		!event.defaultPrevented &&
+		!event.altKey &&
+		!event.isComposing &&
+		!event.repeat &&
+		event.key.toLowerCase() === 'r' &&
+		(event.metaKey || event.ctrlKey)
+	);
 }
 
 /**

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground-php52.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground-php52.php
@@ -69,6 +69,44 @@ function _pg52_dummy_transports() {
 	return array('Dummy');
 }
 
+// Ask the embedding Playground shell to reload only the WordPress iframe.
+add_action('wp_head', '_pg52_reload_iframe_on_browser_refresh_shortcut');
+add_action('admin_head', '_pg52_reload_iframe_on_browser_refresh_shortcut');
+add_action('login_head', '_pg52_reload_iframe_on_browser_refresh_shortcut');
+function _pg52_reload_iframe_on_browser_refresh_shortcut() {
+	?>
+	<script>
+		(function () {
+			function isRefreshShortcut(event) {
+				var key = event.key || '';
+				return !event.defaultPrevented &&
+					!event.altKey &&
+					!event.isComposing &&
+					!event.repeat &&
+					key.toLowerCase() === 'r' &&
+					(event.metaKey || event.ctrlKey);
+			}
+
+			window.addEventListener('keydown', function (event) {
+				if (!isRefreshShortcut(event) || window.parent === window) {
+					return;
+				}
+
+				event.preventDefault();
+				event.stopPropagation();
+				window.parent.postMessage(
+					{
+						type: 'relay',
+						relayType: 'playground-refresh'
+					},
+					'*'
+				);
+			}, true);
+		})();
+	</script>
+	<?php
+}
+
 // Disable WP Cron on legacy WordPress only. On PHP 5.2 the HTTP API
 // is stubbed with Wp_Http_Dummy (see above), so every spawn-cron
 // request would return false and WordPress would quietly retry

--- a/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
+++ b/packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php
@@ -190,6 +190,46 @@ add_action('wp_head', 'playground_report_url_to_parent');
 add_action('admin_head', 'playground_report_url_to_parent');
 
 /**
+ * Asks the embedding Playground shell to reload only the WordPress iframe.
+ */
+function playground_reload_iframe_on_browser_refresh_shortcut() {
+	?>
+	<script>
+		(function () {
+			function isRefreshShortcut(event) {
+				var key = event.key || '';
+				return !event.defaultPrevented &&
+					!event.altKey &&
+					!event.isComposing &&
+					!event.repeat &&
+					key.toLowerCase() === 'r' &&
+					(event.metaKey || event.ctrlKey);
+			}
+
+			window.addEventListener('keydown', function (event) {
+				if (!isRefreshShortcut(event) || window.parent === window) {
+					return;
+				}
+
+				event.preventDefault();
+				event.stopPropagation();
+				window.parent.postMessage(
+					{
+						type: 'relay',
+						relayType: 'playground-refresh'
+					},
+					'*'
+				);
+			}, true);
+		})();
+	</script>
+	<?php
+}
+add_action('wp_head', 'playground_reload_iframe_on_browser_refresh_shortcut');
+add_action('admin_head', 'playground_reload_iframe_on_browser_refresh_shortcut');
+add_action('login_head', 'playground_reload_iframe_on_browser_refresh_shortcut');
+
+/**
  * The default WordPress requests transports have been disabled
  * at this point. However, the Requests class requires at least
  * one working transport or else it throws warnings and acts up.

--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -9,7 +9,10 @@ import {
 	useAppDispatch,
 	useAppSelector,
 } from '../../lib/state/redux/store';
-import { removeClientInfo } from '../../lib/state/redux/slice-clients';
+import {
+	removeClientInfo,
+	selectClientInfoBySiteSlug,
+} from '../../lib/state/redux/slice-clients';
 import { bootSiteClient } from '../../lib/state/redux/boot-site-client';
 import {
 	selectSiteBySlug,
@@ -18,6 +21,7 @@ import {
 } from '../../lib/state/redux/slice-sites';
 import classNames from 'classnames';
 import { SiteErrorModal } from '../site-error-modal';
+import { useBrowserRefreshShortcut } from '../../lib/hooks/use-browser-refresh-shortcut';
 
 export const supportedDisplayModes = [
 	'browser-full-screen',
@@ -201,6 +205,9 @@ export const JustViewport = function JustViewport({
 }) {
 	const iframeRef = useRef<HTMLIFrameElement>(null);
 	const site = useAppSelector((state) => selectSiteBySlug(state, siteSlug))!;
+	const clientInfo = useAppSelector((state) =>
+		selectClientInfoBySiteSlug(state, siteSlug)
+	);
 
 	const dispatch = useAppDispatch();
 	const runtimeConfigString = JSON.stringify(
@@ -230,6 +237,11 @@ export const JustViewport = function JustViewport({
 	const errorDetails = useAppSelector(selectActiveSiteErrorDetails);
 	const activeSiteSlug = useAppSelector((state) => state.ui.activeSite?.slug);
 	const showOverlay = error && activeSiteSlug === siteSlug;
+	useBrowserRefreshShortcut({
+		client: clientInfo?.client,
+		enabled: activeSiteSlug === siteSlug,
+		iframeRef,
+	});
 
 	return (
 		<>

--- a/packages/playground/website/src/lib/hooks/use-browser-refresh-shortcut.ts
+++ b/packages/playground/website/src/lib/hooks/use-browser-refresh-shortcut.ts
@@ -1,0 +1,132 @@
+import { useEffect } from 'react';
+import type { RefObject } from 'react';
+import type { PlaygroundClient } from '@wp-playground/remote';
+import { logger } from '@php-wasm/logger';
+
+const PLAYGROUND_REFRESH_RELAY_TYPE = 'playground-refresh';
+
+export function useBrowserRefreshShortcut({
+	client,
+	enabled = true,
+	iframeRef,
+}: {
+	client?: PlaygroundClient;
+	enabled?: boolean;
+	iframeRef: RefObject<HTMLIFrameElement>;
+}) {
+	useEffect(() => {
+		if (!enabled || !client) {
+			return;
+		}
+		const playground = client;
+
+		function handleKeyDown(event: KeyboardEvent) {
+			if (!isBrowserRefreshShortcut(event)) {
+				return;
+			}
+
+			event.preventDefault();
+			event.stopPropagation();
+			void reloadPlaygroundClient(playground).catch((error) =>
+				logger.error(error)
+			);
+		}
+
+		window.addEventListener('keydown', handleKeyDown, true);
+		return () => {
+			window.removeEventListener('keydown', handleKeyDown, true);
+		};
+	}, [client, enabled]);
+
+	useEffect(() => {
+		if (!enabled || !client) {
+			return;
+		}
+		const playground = client;
+
+		function handleMessage(event: MessageEvent) {
+			if (
+				event.origin !== window.location.origin ||
+				!isPlaygroundRefreshMessage(event.data) ||
+				!isMessageFromIframeTree(event, iframeRef.current)
+			) {
+				return;
+			}
+
+			void reloadPlaygroundClient(playground).catch((error) =>
+				logger.error(error)
+			);
+		}
+
+		window.addEventListener('message', handleMessage);
+		return () => {
+			window.removeEventListener('message', handleMessage);
+		};
+	}, [client, enabled, iframeRef]);
+}
+
+async function reloadPlaygroundClient(client: PlaygroundClient) {
+	await client.goTo(await client.getCurrentURL());
+}
+
+export function isBrowserRefreshShortcut(
+	event: Pick<
+		KeyboardEvent,
+		| 'altKey'
+		| 'ctrlKey'
+		| 'defaultPrevented'
+		| 'isComposing'
+		| 'key'
+		| 'metaKey'
+		| 'repeat'
+	>
+): boolean {
+	return (
+		!event.defaultPrevented &&
+		!event.altKey &&
+		!event.isComposing &&
+		!event.repeat &&
+		event.key.toLowerCase() === 'r' &&
+		(event.metaKey || event.ctrlKey)
+	);
+}
+
+function isPlaygroundRefreshMessage(data: unknown): boolean {
+	return (
+		typeof data === 'object' &&
+		data !== null &&
+		(data as { type?: unknown }).type === 'relay' &&
+		(data as { relayType?: unknown }).relayType ===
+			PLAYGROUND_REFRESH_RELAY_TYPE
+	);
+}
+
+function isMessageFromIframeTree(
+	event: MessageEvent,
+	iframe: HTMLIFrameElement | null
+): boolean {
+	if (!iframe?.contentWindow || !event.source) {
+		return false;
+	}
+	if (event.source === iframe.contentWindow) {
+		return true;
+	}
+	return isDescendantWindow(iframe.contentWindow, event.source);
+}
+
+function isDescendantWindow(
+	root: Window,
+	candidate: MessageEventSource
+): boolean {
+	try {
+		for (let i = 0; i < root.frames.length; i++) {
+			const child = root.frames[i];
+			if (child === candidate || isDescendantWindow(child, candidate)) {
+				return true;
+			}
+		}
+	} catch {
+		// Cross-origin descendants are not inspectable and are not accepted.
+	}
+	return false;
+}


### PR DESCRIPTION
## Motivation for the change, related issues

Pressing Cmd+R or Ctrl+R while using Playground currently reloads the entire shell. That is especially disruptive for temporary Playgrounds and Personal WP, where the expected browser behavior is to refresh the current WordPress page without tearing down the embedding app.

## Implementation details

- Add active viewport shortcut handling in both the regular website and Personal WP.
- Reload the current WordPress page through `PlaygroundClient.getCurrentURL()` and `goTo()` so only the inner WordPress iframe refreshes.
- Add a remote-wrapper listener for the case where focus is on the `remote.html` document itself.
- Relay refresh shortcuts from WordPress pages back to the embedding shell via the Playground mu-plugin, including the PHP 5.2 variant.

The mu-plugin piece is needed because the focused document owns the keyboard event. In the normal usage path the frame tree is:

`Playground shell -> remote.html -> WordPress iframe`

When focus is inside wp-admin, the site editor, the login screen, or the front end, the browser dispatches Cmd+R or Ctrl+R to the WordPress document. That keydown event does not bubble out to `remote.html` or to the outer Playground shell, so listeners attached only in those wrappers would miss the shortcut exactly where users most often press refresh. Document-Isolation-Policy can also make it unreliable for the wrapper to reach into the WordPress frame and attach a listener from the outside.

The mu-plugin is the existing bridge for WordPress-page scripts. It listens inside the WordPress document, prevents the browser-level page reload, and relays a `playground-refresh` message back to the shell. Without it, iframe-only refresh would work when focus is in Playground chrome, but not when focus is inside WordPress.

Existing Personal WP sites receive this on the next runtime boot without mutating the persisted site files. The web-specific Playground mu-plugin is written to `/internal/shared/mu-plugins/1-playground-web.php` during boot, before the persisted `/wordpress` OPFS mount is applied. `/internal/shared` is runtime-owned storage, so updating this source file updates the bridge script for both new and existing Personal WP sites once they load the new Playground runtime.

## Testing Instructions (or ideally a Blueprint)

- `NX_ISOLATE_PLUGINS=false NX_DAEMON=false NPM_CONFIG_CACHE=/tmp/npm-cache NX_CACHE_DIRECTORY=/tmp/nx-cache npm exec nx run playground-website:typecheck`
- `NX_ISOLATE_PLUGINS=false NX_DAEMON=false NPM_CONFIG_CACHE=/tmp/npm-cache NX_CACHE_DIRECTORY=/tmp/nx-cache npm exec nx run playground-personal-wp:typecheck`
- `NX_ISOLATE_PLUGINS=false NX_DAEMON=false NPM_CONFIG_CACHE=/tmp/npm-cache NX_CACHE_DIRECTORY=/tmp/nx-cache npm exec nx run playground-remote:typecheck`
- `ESLINT_USE_FLAT_CONFIG=false ./node_modules/.bin/eslint packages/playground/website/src/lib/hooks/use-browser-refresh-shortcut.ts packages/playground/website/src/components/playground-viewport/index.tsx packages/playground/personal-wp/src/lib/hooks/use-browser-refresh-shortcut.ts packages/playground/personal-wp/src/components/playground-viewport/index.tsx packages/playground/remote/src/lib/boot-playground-remote.ts`
- `php -l packages/playground/remote/src/lib/playground-mu-plugin/0-playground.php`
- `php -l packages/playground/remote/src/lib/playground-mu-plugin/0-playground-php52.php`

Manual smoke test:

1. Open the Playground website or Personal WP app.
2. Focus the outer Playground UI and press Cmd+R on macOS or Ctrl+R on Windows/Linux.
3. Confirm only the WordPress iframe reloads and the outer shell stays loaded.
4. Click inside the WordPress iframe, including wp-admin or the login page, and press the same shortcut.
5. Confirm the same iframe-only reload happens from inside the focused WordPress document.