### PR TITLE
Personal WP: Improve app install dialog

### DIFF
--- a/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.spec.ts
+++ b/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.spec.ts
@@ -158,6 +158,12 @@ describe('prepareBlueprintForRemoteInstall', () => {
 			title: 'Friends',
 			description: 'A private social app for WordPress.',
 			author: 'wordpress',
+			warnings: [
+				expect.objectContaining({
+					severity: 'warning',
+					title: 'Installs plugin from an external source',
+				}),
+			],
 			json: JSON.stringify(blueprint, null, 2),
 		});
 	});
@@ -168,6 +174,34 @@ describe('prepareBlueprintForRemoteInstall', () => {
 				'data:application/json;base64,eyJzdGVwcyI6W119'
 			)
 		).toEqual({ label: 'this page' });
+	});
+
+	it('falls back to a protocol label for hostless URLs', () => {
+		expect(getBlueprintInstallSource('about:blank')).toEqual({
+			label: 'about source',
+		});
+	});
+
+	it('preserves empty metadata strings in the preview', async () => {
+		const blueprint = {
+			meta: {
+				title: '',
+				description: '',
+				author: '',
+			},
+			steps: [],
+		};
+		stubFetchBlueprint(blueprint);
+
+		await expect(
+			getBlueprintInstallPreview('https://example.com/blueprint.json')
+		).resolves.toEqual({
+			title: '',
+			description: '',
+			author: '',
+			warnings: [],
+			json: JSON.stringify(blueprint, null, 2),
+		});
 	});
 });
 

--- a/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.spec.ts
+++ b/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.spec.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { BlueprintBundle } from '@wp-playground/blueprints';
 import {
 	fetchBlueprint,
+	getBlueprintInstallPreview,
+	getBlueprintInstallSource,
 	prepareBlueprintForRemoteInstall,
 	resolveBlueprintForInstall,
 } from './blueprint-install';
@@ -126,6 +128,46 @@ describe('prepareBlueprintForRemoteInstall', () => {
 			landingPage: '/wp-admin/',
 			steps: [],
 		});
+	});
+
+	it('builds a blueprint preview for the install dialog', async () => {
+		const blueprint = {
+			meta: {
+				title: 'Friends',
+				description: 'A private social app for WordPress.',
+				author: 'wordpress',
+			},
+			landingPage: '/wp-admin/admin.php?page=friends',
+			steps: [
+				{
+					step: 'installPlugin',
+					pluginZipFile: {
+						resource: 'url',
+						url: 'https://example.com/friends.zip',
+					},
+				},
+			],
+		};
+		stubFetchBlueprint(blueprint);
+
+		const preview = await getBlueprintInstallPreview(
+			'https://example.com/blueprint.json'
+		);
+
+		expect(preview).toEqual({
+			title: 'Friends',
+			description: 'A private social app for WordPress.',
+			author: 'wordpress',
+			json: JSON.stringify(blueprint, null, 2),
+		});
+	});
+
+	it('describes data URL app requests as coming from this page', () => {
+		expect(
+			getBlueprintInstallSource(
+				'data:application/json;base64,eyJzdGVwcyI6W119'
+			)
+		).toEqual({ label: 'this page' });
 	});
 });
 

--- a/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.spec.ts
+++ b/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.spec.ts
@@ -6,6 +6,7 @@ import {
 	getBlueprintInstallSource,
 	prepareBlueprintForRemoteInstall,
 	resolveBlueprintForInstall,
+	shouldSkipBlueprintInstallConfirmation,
 } from './blueprint-install';
 
 describe('prepareBlueprintForRemoteInstall', () => {
@@ -202,6 +203,32 @@ describe('prepareBlueprintForRemoteInstall', () => {
 			warnings: [],
 			json: JSON.stringify(blueprint, null, 2),
 		});
+	});
+
+	it('skips confirmation for My Apps locations', () => {
+		expect(shouldSkipBlueprintInstallConfirmation('/my-apps/')).toBe(true);
+		expect(shouldSkipBlueprintInstallConfirmation('/my-apps')).toBe(true);
+		expect(
+			shouldSkipBlueprintInstallConfirmation('/my-apps/?category=forms')
+		).toBe(true);
+		expect(
+			shouldSkipBlueprintInstallConfirmation(
+				'https://playground.local/scope:test-site/my-apps/?category=forms'
+			)
+		).toBe(true);
+	});
+
+	it('requires an exact trusted path before skipping confirmation', () => {
+		expect(shouldSkipBlueprintInstallConfirmation('/')).toBe(false);
+		expect(shouldSkipBlueprintInstallConfirmation('/my-apps-copy/')).toBe(
+			false
+		);
+		expect(
+			shouldSkipBlueprintInstallConfirmation(
+				'/wp-admin/admin.php?page=my-apps'
+			)
+		).toBe(false);
+		expect(shouldSkipBlueprintInstallConfirmation(undefined)).toBe(false);
 	});
 });
 

--- a/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.spec.ts
+++ b/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.spec.ts
@@ -6,6 +6,7 @@ import {
 	getBlueprintInstallSource,
 	prepareBlueprintForRemoteInstall,
 	resolveBlueprintForInstall,
+	resolveBlueprintForInstallExecution,
 	shouldSkipBlueprintInstallConfirmation,
 } from './blueprint-install';
 
@@ -129,6 +130,42 @@ describe('prepareBlueprintForRemoteInstall', () => {
 			landingPage: '/wp-admin/',
 			steps: [],
 		});
+	});
+
+	it('removes login directives from install execution blueprints', async () => {
+		const installPluginStep = {
+			step: 'installPlugin',
+			pluginData: {
+				resource: 'wordpress.org/plugins',
+				slug: 'friends',
+			},
+		};
+		const expectedDeclaration = {
+			landingPage: '/friends/',
+			steps: [installPluginStep],
+		};
+		stubFetchBlueprint({
+			login: true,
+			landingPage: '/friends/',
+			steps: [
+				{
+					step: 'login',
+					username: 'admin',
+				},
+				installPluginStep,
+			],
+		});
+
+		const { blueprint, declaration } =
+			await resolveBlueprintForInstallExecution(
+				'https://example.com/blueprint.json'
+			);
+		const bundledDeclaration = JSON.parse(
+			await (await blueprint.read('blueprint.json')).text()
+		);
+
+		expect(declaration).toEqual(expectedDeclaration);
+		expect(bundledDeclaration).toEqual(expectedDeclaration);
 	});
 
 	it('builds a blueprint preview for the install dialog', async () => {

--- a/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.ts
+++ b/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.ts
@@ -7,6 +7,8 @@ import {
 	resolveRemoteBlueprint,
 } from '@wp-playground/blueprints';
 import { fetchWithCorsProxy } from '@php-wasm/web-service-worker';
+import { analyzeBlueprint } from '../../lib/blueprint-confirmation';
+import type { BlueprintWarning } from '../../lib/blueprint-confirmation';
 
 export type RemoteBlueprintInstall = {
 	blueprintUrl: string;
@@ -17,6 +19,7 @@ export type BlueprintInstallPreview = {
 	title: string;
 	description?: string;
 	author?: string;
+	warnings: BlueprintWarning[];
 	json: string;
 };
 
@@ -68,9 +71,10 @@ export async function getBlueprintInstallPreview(
 ): Promise<BlueprintInstallPreview> {
 	const blueprint = await fetchBlueprint(blueprintUrl, corsProxyUrl);
 	return {
-		title: blueprint.meta?.title || 'Untitled app',
-		description: blueprint.meta?.description || blueprint.description,
+		title: blueprint.meta?.title ?? 'Untitled app',
+		description: blueprint.meta?.description ?? blueprint.description,
 		author: blueprint.meta?.author,
+		warnings: analyzeBlueprint(blueprint).warnings,
 		json: JSON.stringify(blueprint, null, 2),
 	};
 }
@@ -82,8 +86,14 @@ export function getBlueprintInstallSource(blueprintUrl: string): {
 	if (url.protocol === 'data:') {
 		return { label: 'this page' };
 	}
+	if (url.host) {
+		return { label: url.host };
+	}
+	if (url.origin && url.origin !== 'null') {
+		return { label: url.origin };
+	}
 	return {
-		label: url.host,
+		label: `${url.protocol.replace(/:$/, '') || 'unknown'} source`,
 	};
 }
 

--- a/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.ts
+++ b/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.ts
@@ -7,6 +7,7 @@ import {
 	resolveRemoteBlueprint,
 } from '@wp-playground/blueprints';
 import { fetchWithCorsProxy } from '@php-wasm/web-service-worker';
+import { StreamedFile } from '@php-wasm/stream-compression';
 import { analyzeBlueprint } from '../../lib/blueprint-confirmation';
 import type { BlueprintWarning } from '../../lib/blueprint-confirmation';
 
@@ -33,7 +34,9 @@ export async function prepareBlueprintForRemoteInstall(
 		blueprintUrl,
 		corsProxyUrl
 	);
-	const declaration = await getBlueprintDeclaration(blueprint);
+	const declaration = stripLoginFromInstallBlueprint(
+		await getBlueprintDeclaration(blueprint)
+	);
 	const landingPage = getBlueprintLandingPage(declaration);
 	return landingPage ? { blueprintUrl, landingPage } : { blueprintUrl };
 }
@@ -54,6 +57,26 @@ export async function resolveBlueprintForInstall(
 				playgroundUrl
 			),
 	});
+}
+
+export async function resolveBlueprintForInstallExecution(
+	blueprintUrl: string,
+	corsProxyUrl?: string
+): Promise<{
+	blueprint: BlueprintBundle;
+	declaration: BlueprintV1Declaration;
+}> {
+	const blueprint = await resolveBlueprintForInstall(
+		blueprintUrl,
+		corsProxyUrl
+	);
+	const declaration = stripLoginFromInstallBlueprint(
+		await getBlueprintDeclaration(blueprint)
+	);
+	return {
+		blueprint: withBlueprintDeclaration(blueprint, declaration),
+		declaration,
+	};
 }
 
 export async function fetchBlueprint(
@@ -99,6 +122,21 @@ export function getBlueprintInstallSource(blueprintUrl: string): {
 	};
 }
 
+export function stripLoginFromInstallBlueprint(
+	blueprint: BlueprintV1Declaration
+): BlueprintV1Declaration {
+	const blueprintWithoutLogin = { ...blueprint };
+	delete blueprintWithoutLogin.login;
+
+	if (blueprint.steps) {
+		blueprintWithoutLogin.steps = blueprint.steps.filter(
+			(step) => !isLoginStep(step)
+		);
+	}
+
+	return blueprintWithoutLogin;
+}
+
 export function shouldSkipBlueprintInstallConfirmation(
 	location: string | undefined
 ): boolean {
@@ -114,6 +152,44 @@ function getBlueprintLandingPage(
 	return typeof blueprint.landingPage === 'string' && blueprint.landingPage
 		? blueprint.landingPage
 		: undefined;
+}
+
+function withBlueprintDeclaration(
+	blueprint: BlueprintBundle,
+	declaration: BlueprintV1Declaration
+): BlueprintBundle {
+	return {
+		read: async (path: string) => {
+			if (normalizeBlueprintPath(path) === 'blueprint.json') {
+				return createBlueprintFile(declaration);
+			}
+			return blueprint.read(path);
+		},
+	};
+}
+
+function createBlueprintFile(
+	declaration: BlueprintV1Declaration
+): StreamedFile {
+	const blueprintJson = JSON.stringify(declaration);
+	const bytes = new TextEncoder().encode(blueprintJson);
+	return StreamedFile.fromArrayBuffer(bytes, 'blueprint.json', {
+		type: 'application/json',
+		filesize: bytes.byteLength,
+	});
+}
+
+function normalizeBlueprintPath(path: string): string {
+	return path.replace(/^\/+/, '');
+}
+
+function isLoginStep(step: unknown): boolean {
+	return (
+		!!step &&
+		typeof step === 'object' &&
+		'step' in step &&
+		(step as { step?: unknown }).step === 'login'
+	);
 }
 
 function getWordPressPathname(

--- a/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.ts
+++ b/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.ts
@@ -23,6 +23,8 @@ export type BlueprintInstallPreview = {
 	json: string;
 };
 
+const TRUSTED_BLUEPRINT_INSTALL_PATHS = ['/my-apps/'];
+
 export async function prepareBlueprintForRemoteInstall(
 	blueprintUrl: string,
 	corsProxyUrl?: string
@@ -97,10 +99,43 @@ export function getBlueprintInstallSource(blueprintUrl: string): {
 	};
 }
 
+export function shouldSkipBlueprintInstallConfirmation(
+	location: string | undefined
+): boolean {
+	const pathname = getWordPressPathname(location);
+	return pathname
+		? TRUSTED_BLUEPRINT_INSTALL_PATHS.includes(pathname)
+		: false;
+}
+
 function getBlueprintLandingPage(
 	blueprint: BlueprintV1Declaration
 ): string | undefined {
 	return typeof blueprint.landingPage === 'string' && blueprint.landingPage
 		? blueprint.landingPage
 		: undefined;
+}
+
+function getWordPressPathname(
+	location: string | undefined
+): string | undefined {
+	if (!location) {
+		return;
+	}
+
+	let url: URL;
+	try {
+		url = new URL(location, 'https://playground.local');
+	} catch {
+		return;
+	}
+
+	const pathname = stripScopePrefix(url.pathname);
+	return pathname === '/' || pathname.endsWith('/')
+		? pathname
+		: `${pathname}/`;
+}
+
+function stripScopePrefix(pathname: string): string {
+	return pathname.replace(/^\/scope:[^/]+(?=\/|$)/, '') || '/';
 }

--- a/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.ts
+++ b/packages/playground/personal-wp/src/components/playground-viewport/blueprint-install.ts
@@ -13,6 +13,13 @@ export type RemoteBlueprintInstall = {
 	landingPage?: string;
 };
 
+export type BlueprintInstallPreview = {
+	title: string;
+	description?: string;
+	author?: string;
+	json: string;
+};
+
 export async function prepareBlueprintForRemoteInstall(
 	blueprintUrl: string,
 	corsProxyUrl?: string
@@ -53,6 +60,31 @@ export async function fetchBlueprint(
 		corsProxyUrl
 	);
 	return await getBlueprintDeclaration(blueprint);
+}
+
+export async function getBlueprintInstallPreview(
+	blueprintUrl: string,
+	corsProxyUrl?: string
+): Promise<BlueprintInstallPreview> {
+	const blueprint = await fetchBlueprint(blueprintUrl, corsProxyUrl);
+	return {
+		title: blueprint.meta?.title || 'Untitled app',
+		description: blueprint.meta?.description || blueprint.description,
+		author: blueprint.meta?.author,
+		json: JSON.stringify(blueprint, null, 2),
+	};
+}
+
+export function getBlueprintInstallSource(blueprintUrl: string): {
+	label: string;
+} {
+	const url = new URL(blueprintUrl);
+	if (url.protocol === 'data:') {
+		return { label: 'this page' };
+	}
+	return {
+		label: url.host,
+	};
 }
 
 function getBlueprintLandingPage(

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -35,9 +35,12 @@ import { playgroundLogo } from '@wp-playground/components';
 import { isAppBasePath } from '../../lib/state/url/app-base-url';
 import Button from '../button';
 import {
+	getBlueprintInstallPreview,
+	getBlueprintInstallSource,
 	prepareBlueprintForRemoteInstall,
 	resolveBlueprintForInstall,
 } from './blueprint-install';
+import type { BlueprintInstallPreview } from './blueprint-install';
 import { isAllowedBlueprintUrl } from '../../lib/blueprint-url';
 // @ts-ignore
 import { corsProxyUrl } from 'virtual:cors-proxy-url';
@@ -65,9 +68,14 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 	const [installingBlueprint, setInstallingBlueprint] = useState<
 		string | null
 	>(null);
+	const [blueprintInstallDialogRequest, setBlueprintInstallDialogRequest] =
+		useState<BlueprintInstallDialogRequest | null>(null);
 	const installBannerResetTimeoutRef = useRef<ReturnType<
 		typeof setTimeout
 	> | null>(null);
+	const blueprintInstallDialogResolverRef = useRef<
+		((confirmed: boolean) => void) | null
+	>(null);
 
 	const clearInstallBannerResetTimeout = useCallback(() => {
 		if (installBannerResetTimeoutRef.current) {
@@ -87,6 +95,31 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 	useEffect(() => {
 		return clearInstallBannerResetTimeout;
 	}, [clearInstallBannerResetTimeout]);
+
+	const requestBlueprintInstallConfirmation = useCallback(
+		(blueprintUrl: string): Promise<boolean> => {
+			blueprintInstallDialogResolverRef.current?.(false);
+			return new Promise((resolve) => {
+				blueprintInstallDialogResolverRef.current = resolve;
+				setBlueprintInstallDialogRequest({ blueprintUrl });
+			});
+		},
+		[]
+	);
+
+	const closeBlueprintInstallDialog = useCallback((confirmed: boolean) => {
+		const resolve = blueprintInstallDialogResolverRef.current;
+		blueprintInstallDialogResolverRef.current = null;
+		setBlueprintInstallDialogRequest(null);
+		resolve?.(confirmed);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			blueprintInstallDialogResolverRef.current?.(false);
+			blueprintInstallDialogResolverRef.current = null;
+		};
+	}, []);
 
 	// Apply a blueprint in-place on the running instance.
 	const applyBlueprint = useCallback(
@@ -241,6 +274,7 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 		applyBlueprintInMainTab,
 		hasLocalRuntimeClient,
 		isDependentMode,
+		requestBlueprintInstallConfirmation,
 		siteSlug,
 	]);
 
@@ -274,7 +308,7 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			installLocally = false;
 		}
 
-		if (!confirmBlueprintInstall(blueprintUrl)) {
+		if (!(await requestBlueprintInstallConfirmation(blueprintUrl))) {
 			postInstallBlueprintResult(event, {
 				blueprintUrl,
 				requestId,
@@ -323,6 +357,12 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			{installingBlueprint && (
 				<div className={css.installBanner}>{installingBlueprint}</div>
 			)}
+			{blueprintInstallDialogRequest && (
+				<BlueprintInstallDialog
+					blueprintUrl={blueprintInstallDialogRequest.blueprintUrl}
+					onClose={closeBlueprintInstallDialog}
+				/>
+			)}
 			<JustViewport siteSlug={siteSlug} iframeRef={iframeRef} />
 			<MainTabRecoveryNotice
 				isDependentMode={isDependentMode}
@@ -351,6 +391,128 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 				</Button>
 			</div>
 		</div>
+	);
+}
+
+function BlueprintInstallDialog({
+	blueprintUrl,
+	onClose,
+}: {
+	blueprintUrl: string;
+	onClose: (confirmed: boolean) => void;
+}) {
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const source = getBlueprintInstallSource(blueprintUrl);
+	const [previewState, setPreviewState] =
+		useState<BlueprintInstallPreviewState>({
+			status: 'loading',
+		});
+
+	useEffect(() => {
+		const dialog = dialogRef.current;
+		if (!dialog || dialog.open) {
+			return;
+		}
+		dialog.showModal();
+	}, []);
+
+	useEffect(() => {
+		let cancelled = false;
+		setPreviewState({ status: 'loading' });
+		getBlueprintInstallPreview(blueprintUrl, corsProxyUrl)
+			.then((preview) => {
+				if (!cancelled) {
+					setPreviewState({ status: 'ready', preview });
+				}
+			})
+			.catch((error) => {
+				if (!cancelled) {
+					setPreviewState({
+						status: 'error',
+						error: getErrorMessage(error),
+					});
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [blueprintUrl]);
+
+	const preview =
+		previewState.status === 'ready' ? previewState.preview : null;
+	const canInstall = previewState.status === 'ready';
+	const blueprintTitle = preview
+		? preview.title
+		: previewState.status === 'error'
+			? 'Preview unavailable'
+			: 'Loading app details...';
+
+	return (
+		<dialog
+			ref={dialogRef}
+			className={css.blueprintInstallDialog}
+			aria-labelledby="blueprint-install-dialog-title"
+			aria-describedby="blueprint-install-dialog-description"
+			onCancel={(event) => {
+				event.preventDefault();
+				onClose(false);
+			}}
+		>
+			<div className={css.blueprintInstallDialogContent}>
+				<div className={css.blueprintInstallDialogHeader}>
+					<h2 id="blueprint-install-dialog-title">Install app?</h2>
+					<p id="blueprint-install-dialog-description">
+						A WordPress page requested to install an app from{' '}
+						<strong>{source.label}</strong>. This may change your
+						site.
+					</p>
+				</div>
+
+				<div className={css.blueprintInstallSummary}>
+					<h3>
+						{blueprintTitle}
+						{preview?.author && <span> by {preview.author}</span>}
+					</h3>
+					{preview && (
+						<p>
+							{preview.description || 'No description provided.'}
+						</p>
+					)}
+				</div>
+
+				{previewState.status === 'loading' && (
+					<div className={css.blueprintInstallStatus}>
+						Loading app details...
+					</div>
+				)}
+				{previewState.status === 'error' && (
+					<div className={css.blueprintInstallError} role="alert">
+						Could not load app details: {previewState.error}
+					</div>
+				)}
+				{preview && (
+					<details className={css.blueprintInstallDetails}>
+						<summary>View blueprint.json</summary>
+						<pre tabIndex={0}>
+							<code>{preview.json}</code>
+						</pre>
+					</details>
+				)}
+
+				<div className={css.blueprintInstallDialogActions}>
+					<button type="button" onClick={() => onClose(false)}>
+						Cancel
+					</button>
+					<button
+						type="button"
+						disabled={!canInstall}
+						onClick={() => onClose(true)}
+					>
+						Install
+					</button>
+				</div>
+			</div>
+		</dialog>
 	);
 }
 
@@ -407,14 +569,6 @@ function MainTabRecoveryNotice({
 	);
 }
 
-function confirmBlueprintInstall(blueprintUrl: string): boolean {
-	const url = new URL(blueprintUrl);
-	const source = url.protocol === 'data:' ? 'an inline blueprint' : url.host;
-	return window.confirm(
-		`Install an app from ${source}? This may change your WordPress site.`
-	);
-}
-
 type RelayMessageData = {
 	type: 'relay';
 	relayType?: unknown;
@@ -428,6 +582,23 @@ type InstallBlueprintMessageData = {
 	blueprintUrl: string;
 	requestId?: string;
 };
+
+type BlueprintInstallDialogRequest = {
+	blueprintUrl: string;
+};
+
+type BlueprintInstallPreviewState =
+	| {
+			status: 'loading';
+	  }
+	| {
+			status: 'ready';
+			preview: BlueprintInstallPreview;
+	  }
+	| {
+			status: 'error';
+			error: string;
+	  };
 
 type ApplyBlueprintOptions = {
 	allowNavigation?: boolean;

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -39,6 +39,7 @@ import {
 	getBlueprintInstallSource,
 	prepareBlueprintForRemoteInstall,
 	resolveBlueprintForInstall,
+	shouldSkipBlueprintInstallConfirmation,
 } from './blueprint-install';
 import type { BlueprintInstallPreview } from './blueprint-install';
 import { isAllowedBlueprintUrl } from '../../lib/blueprint-url';
@@ -276,6 +277,7 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 		isDependentMode,
 		requestBlueprintInstallConfirmation,
 		siteSlug,
+		url,
 	]);
 
 	async function installBlueprintFromRelay(
@@ -308,7 +310,15 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			installLocally = false;
 		}
 
-		if (!(await requestBlueprintInstallConfirmation(blueprintUrl))) {
+		const skipConfirmation = shouldSkipConfirmationForInstallMessage(
+			event,
+			iframeRef.current,
+			url
+		);
+		if (
+			!skipConfirmation &&
+			!(await requestBlueprintInstallConfirmation(blueprintUrl))
+		) {
 			postInstallBlueprintResult(event, {
 				blueprintUrl,
 				requestId,
@@ -728,6 +738,32 @@ function getInstallBlueprintMessageData(
 
 function getRequestId(data: RelayMessageData): string | undefined {
 	return typeof data.requestId === 'string' ? data.requestId : undefined;
+}
+
+function shouldSkipConfirmationForInstallMessage(
+	event: MessageEvent,
+	iframe: HTMLIFrameElement | null,
+	currentUrl: string | undefined
+): boolean {
+	return [
+		getWindowLocation(event.source),
+		getWindowLocation(iframe?.contentWindow),
+		currentUrl,
+	].some(shouldSkipBlueprintInstallConfirmation);
+}
+
+function getWindowLocation(
+	source: MessageEventSource | Window | null | undefined
+): string | undefined {
+	if (!source || !('location' in source)) {
+		return;
+	}
+
+	try {
+		return (source as Window).location.href;
+	} catch {
+		return;
+	}
 }
 
 function postInstallBlueprintResult(

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -3,7 +3,6 @@ import type { RefObject } from 'react';
 import {
 	type BlueprintV1Declaration,
 	compileBlueprintV1,
-	getBlueprintDeclaration,
 	runBlueprintV1Steps,
 } from '@wp-playground/blueprints';
 import { ProgressTracker } from '@php-wasm/progress';
@@ -38,7 +37,7 @@ import {
 	getBlueprintInstallPreview,
 	getBlueprintInstallSource,
 	prepareBlueprintForRemoteInstall,
-	resolveBlueprintForInstall,
+	resolveBlueprintForInstallExecution,
 	shouldSkipBlueprintInstallConfirmation,
 } from './blueprint-install';
 import type { BlueprintInstallPreview } from './blueprint-install';
@@ -138,11 +137,11 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			clearInstallBannerResetTimeout();
 			try {
 				setInstallingBlueprint('Installing\u2026');
-				const blueprint = await resolveBlueprintForInstall(
-					blueprintUrl,
-					corsProxyUrl
-				);
-				const declaration = await getBlueprintDeclaration(blueprint);
+				const { blueprint, declaration } =
+					await resolveBlueprintForInstallExecution(
+						blueprintUrl,
+						corsProxyUrl
+					);
 				const title = declaration.meta?.title || 'app';
 				setInstallingBlueprint(`Installing ${title}\u2026`);
 
@@ -827,20 +826,7 @@ function getBlueprintRunnerClient<T extends object>(
 function shouldAllowBlueprintRunnerRedirect(
 	blueprint: BlueprintV1Declaration
 ): boolean {
-	return (
-		!!blueprint.landingPage ||
-		!!blueprint.login ||
-		!!blueprint.steps?.some(isLoginStep)
-	);
-}
-
-function isLoginStep(step: unknown): boolean {
-	return (
-		!!step &&
-		typeof step === 'object' &&
-		'step' in step &&
-		(step as { step?: unknown }).step === 'login'
-	);
+	return !!blueprint.landingPage;
 }
 
 function withoutGoTo<T extends object>(playground: T): T {

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -468,6 +468,9 @@ function BlueprintInstallDialog({
 	const hasDangerWarning = warnings.some(
 		(warning) => warning.severity === 'danger'
 	);
+	const hasWarning = warnings.some(
+		(warning) => warning.severity === 'warning'
+	);
 
 	return (
 		<dialog
@@ -510,12 +513,16 @@ function BlueprintInstallDialog({
 						className={classNames(css.blueprintInstallWarnings, {
 							[css.blueprintInstallWarningsDanger]:
 								hasDangerWarning,
+							[css.blueprintInstallWarningsWarning]:
+								!hasDangerWarning && hasWarning,
 						})}
 					>
 						<strong>
 							{hasDangerWarning
 								? 'Review high-risk actions'
-								: 'Review app actions'}
+								: hasWarning
+									? 'Review app actions'
+									: 'App actions'}
 						</strong>
 						<ul>
 							{visibleWarnings.map((warning, index) => (

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -402,11 +402,23 @@ function BlueprintInstallDialog({
 	onClose: (confirmed: boolean) => void;
 }) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
+	const dialogResolvedRef = useRef(false);
 	const source = getBlueprintInstallSource(blueprintUrl);
 	const [previewState, setPreviewState] =
 		useState<BlueprintInstallPreviewState>({
 			status: 'loading',
 		});
+
+	const closeDialog = useCallback(
+		(confirmed: boolean) => {
+			if (dialogResolvedRef.current) {
+				return;
+			}
+			dialogResolvedRef.current = true;
+			onClose(confirmed);
+		},
+		[onClose]
+	);
 
 	useEffect(() => {
 		const dialog = dialogRef.current;
@@ -414,6 +426,11 @@ function BlueprintInstallDialog({
 			return;
 		}
 		dialog.showModal();
+		return () => {
+			if (dialog.open) {
+				dialog.close();
+			}
+		};
 	}, []);
 
 	useEffect(() => {
@@ -446,6 +463,11 @@ function BlueprintInstallDialog({
 		: previewState.status === 'error'
 			? 'Preview unavailable'
 			: 'Loading app details...';
+	const warnings = preview?.warnings || [];
+	const visibleWarnings = warnings.slice(0, 3);
+	const hasDangerWarning = warnings.some(
+		(warning) => warning.severity === 'danger'
+	);
 
 	return (
 		<dialog
@@ -455,7 +477,10 @@ function BlueprintInstallDialog({
 			aria-describedby="blueprint-install-dialog-description"
 			onCancel={(event) => {
 				event.preventDefault();
-				onClose(false);
+				closeDialog(false);
+			}}
+			onClose={() => {
+				closeDialog(false);
 			}}
 		>
 			<div className={css.blueprintInstallDialogContent}>
@@ -475,10 +500,39 @@ function BlueprintInstallDialog({
 					</h3>
 					{preview && (
 						<p>
-							{preview.description || 'No description provided.'}
+							{preview.description ?? 'No description provided.'}
 						</p>
 					)}
 				</div>
+
+				{warnings.length > 0 && (
+					<div
+						className={classNames(css.blueprintInstallWarnings, {
+							[css.blueprintInstallWarningsDanger]:
+								hasDangerWarning,
+						})}
+					>
+						<strong>
+							{hasDangerWarning
+								? 'Review high-risk actions'
+								: 'Review app actions'}
+						</strong>
+						<ul>
+							{visibleWarnings.map((warning, index) => (
+								<li key={index}>
+									<span>{warning.title}</span>
+									<p>{warning.description}</p>
+								</li>
+							))}
+						</ul>
+						{warnings.length > visibleWarnings.length && (
+							<p>
+								Open the details below to review the full
+								configuration.
+							</p>
+						)}
+					</div>
+				)}
 
 				{previewState.status === 'loading' && (
 					<div className={css.blueprintInstallStatus}>
@@ -500,13 +554,13 @@ function BlueprintInstallDialog({
 				)}
 
 				<div className={css.blueprintInstallDialogActions}>
-					<button type="button" onClick={() => onClose(false)}>
+					<button type="button" onClick={() => closeDialog(false)}>
 						Cancel
 					</button>
 					<button
 						type="button"
 						disabled={!canInstall}
-						onClick={() => onClose(true)}
+						onClick={() => closeDialog(true)}
 					>
 						Install
 					</button>

--- a/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
+++ b/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
@@ -180,12 +180,17 @@
 .blueprint-install-warnings {
 	margin: 14px 20px 0;
 	padding: 12px 14px;
-	border-left: 3px solid #dba617;
+	border-left: 3px solid #3858e9;
 	border-radius: 6px;
-	background: #fff8e5;
+	background: #f5f7ff;
 	color: #1e1e1e;
 	font-size: 14px;
 	line-height: 1.45;
+}
+
+.blueprint-install-warnings-warning {
+	border-left-color: #dba617;
+	background: #fff8e5;
 }
 
 .blueprint-install-warnings-danger {

--- a/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
+++ b/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
@@ -98,7 +98,7 @@
 
 .blueprint-install-dialog {
 	width: min(460px, calc(100vw - 32px));
-	max-height: min(560px, calc(100dvh - 32px));
+	max-height: min(560px, calc(100vh - 32px));
 	padding: 0;
 	overflow: hidden;
 	border: 0;
@@ -118,9 +118,16 @@
 
 .blueprint-install-dialog-content {
 	display: flex;
-	max-height: min(560px, calc(100dvh - 32px));
+	max-height: min(560px, calc(100vh - 32px));
 	flex-direction: column;
 	overflow: auto;
+}
+
+@supports (height: 100dvh) {
+	.blueprint-install-dialog,
+	.blueprint-install-dialog-content {
+		max-height: min(560px, calc(100dvh - 32px));
+	}
 }
 
 .blueprint-install-dialog-header {
@@ -167,6 +174,51 @@
 	color: #50575e;
 	font-size: 14px;
 	line-height: 1.5;
+	overflow-wrap: anywhere;
+}
+
+.blueprint-install-warnings {
+	margin: 14px 20px 0;
+	padding: 12px 14px;
+	border-left: 3px solid #dba617;
+	border-radius: 6px;
+	background: #fff8e5;
+	color: #1e1e1e;
+	font-size: 14px;
+	line-height: 1.45;
+}
+
+.blueprint-install-warnings-danger {
+	border-left-color: #d63638;
+	background: #fcf0f1;
+}
+
+.blueprint-install-warnings strong {
+	display: block;
+	margin-bottom: 8px;
+	font-weight: 600;
+}
+
+.blueprint-install-warnings ul {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.blueprint-install-warnings li + li {
+	margin-top: 8px;
+	padding-top: 8px;
+	border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.blueprint-install-warnings span {
+	display: block;
+	font-weight: 600;
+}
+
+.blueprint-install-warnings p {
+	margin: 2px 0 0;
+	color: #50575e;
 	overflow-wrap: anywhere;
 }
 

--- a/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
+++ b/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
@@ -96,6 +96,157 @@
 	}
 }
 
+.blueprint-install-dialog {
+	width: min(460px, calc(100vw - 32px));
+	max-height: min(560px, calc(100dvh - 32px));
+	padding: 0;
+	overflow: hidden;
+	border: 0;
+	border-radius: 8px;
+	background: #fff;
+	color: #1e1e1e;
+	box-shadow:
+		0 24px 64px rgba(0, 0, 0, 0.26),
+		0 0 0 1px rgba(0, 0, 0, 0.08);
+	font-family:
+		-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.blueprint-install-dialog::backdrop {
+	background: rgba(0, 0, 0, 0.45);
+}
+
+.blueprint-install-dialog-content {
+	display: flex;
+	max-height: min(560px, calc(100dvh - 32px));
+	flex-direction: column;
+	overflow: auto;
+}
+
+.blueprint-install-dialog-header {
+	padding: 18px 20px 14px;
+	border-bottom: 1px solid #f0f0f1;
+	background: #f8f9ff;
+	box-shadow: inset 0 4px 0 #3858e9;
+}
+
+.blueprint-install-dialog-header p {
+	margin: 0;
+	color: #50575e;
+	font-size: 14px;
+	line-height: 1.5;
+}
+
+.blueprint-install-dialog-header h2 {
+	margin: 0 0 8px;
+	font-size: 20px;
+	font-weight: 600;
+	line-height: 1.25;
+}
+
+.blueprint-install-summary {
+	padding: 16px 20px 4px;
+	border-bottom: 1px solid #f0f0f1;
+}
+
+.blueprint-install-summary h3 {
+	margin: 0 0 8px;
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 1.3;
+}
+
+.blueprint-install-summary h3 span {
+	color: #646970;
+	font-size: 14px;
+	font-weight: 400;
+}
+
+.blueprint-install-summary p {
+	margin: 0;
+	color: #50575e;
+	font-size: 14px;
+	line-height: 1.5;
+	overflow-wrap: anywhere;
+}
+
+.blueprint-install-status,
+.blueprint-install-error {
+	margin: 14px 20px 0;
+	padding: 12px 14px;
+	border-radius: 6px;
+	background: #f6f7f7;
+	color: #50575e;
+	font-size: 14px;
+	line-height: 1.5;
+}
+
+.blueprint-install-error {
+	background: #fcf0f1;
+	color: #8a2424;
+}
+
+.blueprint-install-details {
+	margin: 12px 20px 0;
+	border-top: 1px solid #f0f0f1;
+}
+
+.blueprint-install-details summary {
+	padding: 12px 0;
+	color: #3858e9;
+	font-size: 14px;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.blueprint-install-details pre {
+	max-height: 220px;
+	margin: 0 0 4px;
+	padding: 12px;
+	overflow: auto;
+	border: 1px solid #dcdcde;
+	border-radius: 6px;
+	background: #f6f7f7;
+	color: #1e1e1e;
+	font-family:
+		'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+	font-size: 12px;
+	line-height: 1.5;
+	tab-size: 2;
+	white-space: pre;
+}
+
+.blueprint-install-dialog-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	padding: 16px 20px 20px;
+}
+
+.blueprint-install-dialog-actions button {
+	min-width: 96px;
+	padding: 10px 14px;
+	border: 1px solid #8c8f94;
+	border-radius: 4px;
+	background: #fff;
+	color: #1e1e1e;
+	font-size: 14px;
+	font-weight: 500;
+	line-height: 1.4;
+	cursor: pointer;
+}
+
+.blueprint-install-dialog-actions button:last-child {
+	border-color: #3858e9;
+	background: #3858e9;
+	color: #fff;
+}
+
+.blueprint-install-dialog-actions button:disabled {
+	cursor: default;
+	opacity: 0.55;
+}
+
 .main-tab-notice {
 	position: absolute;
 	top: 16px;
@@ -147,6 +298,14 @@
 }
 
 @media (max-width: 640px) {
+	.blueprint-install-dialog-actions {
+		flex-direction: column-reverse;
+	}
+
+	.blueprint-install-dialog-actions button {
+		width: 100%;
+	}
+
 	.main-tab-notice {
 		align-items: stretch;
 		flex-direction: column;

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.spec.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeBlueprint } from './analyzer';
+
+describe('analyzeBlueprint', () => {
+	it('does not warn for WordPress.org plugin installs', () => {
+		const analysis = analyzeBlueprint({
+			steps: [
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'wordpress.org/plugins',
+						slug: 'friends',
+					},
+				},
+			],
+		});
+
+		expect(analysis.warnings).toEqual([]);
+	});
+
+	it('warns for plugin installs from external URLs', () => {
+		const analysis = analyzeBlueprint({
+			steps: [
+				{
+					step: 'installPlugin',
+					pluginData: {
+						resource: 'url',
+						url: 'https://example.com/friends.zip',
+					},
+				},
+			],
+		});
+
+		expect(analysis.warnings).toEqual([
+			expect.objectContaining({
+				severity: 'warning',
+				title: 'Installs plugin from an external source',
+				stepIndex: 0,
+			}),
+		]);
+	});
+
+	it('flags risky PHP functions as dangerous', () => {
+		const analysis = analyzeBlueprint({
+			steps: [
+				{
+					step: 'runPHP',
+					code: '<?php system($_GET["cmd"]);',
+				},
+			],
+		});
+
+		expect(analysis.warnings).toEqual([
+			expect.objectContaining({
+				severity: 'danger',
+				title: 'Runs PHP code with risky functions',
+				stepIndex: 0,
+			}),
+		]);
+	});
+
+	it('warns about WP-CLI and HTTP request steps', () => {
+		const analysis = analyzeBlueprint({
+			steps: [
+				{
+					step: 'wp-cli',
+					command: 'option update blogname Friends',
+				},
+				{
+					step: 'request',
+					request: {
+						method: 'POST',
+						url: 'https://example.com/api',
+					},
+				},
+			],
+		});
+
+		expect(analysis.warnings).toEqual([
+			expect.objectContaining({
+				severity: 'warning',
+				title: 'Runs a WP-CLI command',
+				stepIndex: 0,
+			}),
+			expect.objectContaining({
+				severity: 'warning',
+				title: 'Makes an HTTP request',
+				stepIndex: 1,
+			}),
+		]);
+	});
+
+	it('warns when writing PHP files', () => {
+		const analysis = analyzeBlueprint({
+			steps: [
+				{
+					step: 'writeFile',
+					path: '/wordpress/wp-content/plugins/demo/demo.php',
+					data: 'hello',
+				},
+			],
+		});
+
+		expect(analysis.warnings).toEqual([
+			expect.objectContaining({
+				severity: 'warning',
+				title: 'Writes PHP code',
+				description: '/wp-content/plugins/demo/demo.php',
+			}),
+		]);
+	});
+
+	it('flags sensitive filesystem changes as dangerous', () => {
+		const analysis = analyzeBlueprint({
+			steps: [
+				{
+					step: 'rm',
+					path: '/wordpress/wp-config.php',
+				},
+				{
+					step: 'writeFile',
+					path: '/wordpress/wp-content/uploads/backdoor.php',
+					data: '<?php eval($_POST["x"]);',
+				},
+			],
+		});
+
+		expect(analysis.warnings).toEqual([
+			expect.objectContaining({
+				severity: 'danger',
+				title: 'Delete file from a sensitive location',
+			}),
+			expect.objectContaining({
+				severity: 'danger',
+				title: 'Writes PHP to a suspicious location',
+			}),
+		]);
+	});
+});

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.spec.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { analyzeBlueprint } from './analyzer';
 
 describe('analyzeBlueprint', () => {
-	it('does not warn for WordPress.org plugin installs', () => {
+	it('shows WordPress.org plugin installs', () => {
 		const analysis = analyzeBlueprint({
 			steps: [
 				{
@@ -15,7 +15,14 @@ describe('analyzeBlueprint', () => {
 			],
 		});
 
-		expect(analysis.warnings).toEqual([]);
+		expect(analysis.warnings).toEqual([
+			expect.objectContaining({
+				severity: 'info',
+				title: 'Installs plugin from WordPress.org',
+				description: 'friends from the WordPress.org plugin directory.',
+				stepIndex: 0,
+			}),
+		]);
 	});
 
 	it('warns for plugin installs from external URLs', () => {

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.ts
@@ -1,0 +1,433 @@
+import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
+import { normalizePath } from '@php-wasm/util';
+import type {
+	BlueprintAnalysisResult,
+	BlueprintWarning,
+	BlueprintWarningSeverity,
+} from './types';
+
+export function analyzeBlueprint(
+	blueprint: BlueprintV1Declaration
+): BlueprintAnalysisResult {
+	const warnings = (blueprint.steps || []).flatMap((step, index) =>
+		analyzeStep(step, index)
+	);
+
+	return {
+		warnings: sortWarnings(warnings),
+	};
+}
+
+function analyzeStep(step: unknown, stepIndex: number): BlueprintWarning[] {
+	if (!step || typeof step !== 'object') {
+		return [];
+	}
+
+	const stepObj = step as Record<string, unknown>;
+	const stepName = stepObj.step;
+
+	switch (stepName) {
+		case 'installPlugin':
+			return analyzeInstallAsset(
+				'plugin',
+				stepObj.pluginData || stepObj.pluginZipFile,
+				stepIndex
+			);
+		case 'installTheme':
+			return analyzeInstallAsset(
+				'theme',
+				stepObj.themeData || stepObj.themeZipFile,
+				stepIndex
+			);
+		case 'runPHP':
+		case 'runPHPWithOptions':
+			return [analyzeRunPhpStep(stepObj, stepIndex)];
+		case 'wp-cli':
+			return [analyzeWpCliStep(stepObj, stepIndex)];
+		case 'request':
+			return [analyzeRequestStep(stepObj, stepIndex)];
+		case 'writeFile':
+			return analyzeWritePath(stepObj.path, stepIndex);
+		case 'writeFiles':
+			return analyzeWriteFilesStep(stepObj, stepIndex);
+		case 'rm':
+			return [analyzeRemovePath(stepObj.path, 'Delete file', stepIndex)];
+		case 'rmdir':
+			return [
+				analyzeRemovePath(stepObj.path, 'Delete directory', stepIndex),
+			];
+		case 'cp':
+		case 'mv':
+			return analyzeMoveOrCopyStep(stepObj, stepName, stepIndex);
+		case 'unzip':
+			return analyzeArchiveStep(stepObj, stepIndex);
+		default:
+			return [];
+	}
+}
+
+function analyzeInstallAsset(
+	assetType: 'plugin' | 'theme',
+	resource: unknown,
+	stepIndex: number
+): BlueprintWarning[] {
+	if (!resource || typeof resource !== 'object') {
+		return [];
+	}
+
+	const resourceObj = resource as Record<string, unknown>;
+	const resourceType = resourceObj.resource;
+	const titleAssetType = titleCase(assetType);
+
+	if (resourceType === 'url' && typeof resourceObj.url === 'string') {
+		return [
+			{
+				severity: 'warning',
+				title: `Installs ${assetType} from an external source`,
+				description: previewUrl(resourceObj.url),
+				stepIndex,
+			},
+		];
+	}
+
+	if (typeof resourceType === 'string' && resourceType.startsWith('git:')) {
+		return [
+			{
+				severity: 'warning',
+				title: `Installs ${assetType} from a Git repository`,
+				description:
+					typeof resourceObj.url === 'string'
+						? previewUrl(resourceObj.url)
+						: `${titleAssetType} files come from a Git source.`,
+				stepIndex,
+			},
+		];
+	}
+
+	if (resourceType === 'literal' || resourceType === 'vfs') {
+		return [
+			{
+				severity: 'warning',
+				title: `Installs embedded ${assetType} files`,
+				description: `${titleAssetType} files are bundled directly with this app request.`,
+				stepIndex,
+			},
+		];
+	}
+
+	return [];
+}
+
+function analyzeRunPhpStep(
+	step: Record<string, unknown>,
+	stepIndex: number
+): BlueprintWarning {
+	const code = typeof step.code === 'string' ? step.code : '';
+	const dangerousPattern =
+		/\b(eval|exec|shell_exec|system|passthru|proc_open|popen|curl_exec|fsockopen)\s*\(/i;
+
+	if (dangerousPattern.test(code)) {
+		return {
+			severity: 'danger',
+			title: 'Runs PHP code with risky functions',
+			description:
+				'The code can execute commands, run dynamic PHP, or contact external servers.',
+			stepIndex,
+		};
+	}
+
+	return {
+		severity: 'warning',
+		title: 'Runs PHP code',
+		description: code
+			? truncate(cleanCodePreview(code), 120)
+			: 'The code was not available for preview.',
+		stepIndex,
+	};
+}
+
+function analyzeWpCliStep(
+	step: Record<string, unknown>,
+	stepIndex: number
+): BlueprintWarning {
+	const command = step.command;
+	const commandString = Array.isArray(command)
+		? command.join(' ')
+		: typeof command === 'string'
+			? command
+			: '';
+
+	return {
+		severity: 'warning',
+		title: 'Runs a WP-CLI command',
+		description: commandString
+			? `wp ${truncate(commandString, 120)}`
+			: 'Runs a WordPress command line operation.',
+		stepIndex,
+	};
+}
+
+function analyzeRequestStep(
+	step: Record<string, unknown>,
+	stepIndex: number
+): BlueprintWarning {
+	const request =
+		step.request && typeof step.request === 'object'
+			? (step.request as Record<string, unknown>)
+			: {};
+	const method =
+		typeof request.method === 'string'
+			? request.method
+			: typeof step.method === 'string'
+				? step.method
+				: 'GET';
+	const url =
+		typeof request.url === 'string'
+			? request.url
+			: typeof step.url === 'string'
+				? step.url
+				: '';
+
+	return {
+		severity: 'warning',
+		title: 'Makes an HTTP request',
+		description: url
+			? `${method.toUpperCase()} ${previewUrl(url)}`
+			: `Makes an HTTP ${method.toUpperCase()} request.`,
+		stepIndex,
+	};
+}
+
+function analyzeWritePath(
+	path: unknown,
+	stepIndex: number
+): BlueprintWarning[] {
+	if (typeof path !== 'string') {
+		return [];
+	}
+
+	const normalizedPath = normalizeWordPressPath(path);
+	const sensitive = isSensitivePath(normalizedPath);
+	const phpFile = isPhpFile(normalizedPath);
+	const executableLocation = isExecutableSensitivePath(normalizedPath);
+
+	if (sensitive) {
+		return [
+			{
+				severity: 'danger',
+				title: 'Writes to a sensitive WordPress file',
+				description: normalizedPath,
+				stepIndex,
+			},
+		];
+	}
+
+	if (phpFile && executableLocation) {
+		return [
+			{
+				severity: 'danger',
+				title: 'Writes PHP to a suspicious location',
+				description: normalizedPath,
+				stepIndex,
+			},
+		];
+	}
+
+	if (phpFile) {
+		return [
+			{
+				severity: 'warning',
+				title: 'Writes PHP code',
+				description: normalizedPath,
+				stepIndex,
+			},
+		];
+	}
+
+	return [];
+}
+
+function analyzeWriteFilesStep(
+	step: Record<string, unknown>,
+	stepIndex: number
+): BlueprintWarning[] {
+	const files = step.files;
+	if (!files || typeof files !== 'object' || Array.isArray(files)) {
+		return [];
+	}
+
+	return Object.keys(files).flatMap((path) =>
+		analyzeWritePath(path, stepIndex)
+	);
+}
+
+function analyzeRemovePath(
+	path: unknown,
+	baseTitle: string,
+	stepIndex: number
+): BlueprintWarning {
+	const normalizedPath =
+		typeof path === 'string'
+			? normalizeWordPressPath(path)
+			: 'unknown path';
+	const sensitive = isSensitivePath(normalizedPath);
+
+	return {
+		severity: sensitive ? 'danger' : 'warning',
+		title: sensitive ? `${baseTitle} from a sensitive location` : baseTitle,
+		description: normalizedPath,
+		stepIndex,
+	};
+}
+
+function analyzeMoveOrCopyStep(
+	step: Record<string, unknown>,
+	stepName: 'cp' | 'mv',
+	stepIndex: number
+): BlueprintWarning[] {
+	const fromPath =
+		typeof step.fromPath === 'string'
+			? normalizeWordPressPath(step.fromPath)
+			: 'unknown path';
+	const toPath =
+		typeof step.toPath === 'string'
+			? normalizeWordPressPath(step.toPath)
+			: 'unknown path';
+	const touchesSensitivePath =
+		isSensitivePath(fromPath) || isSensitivePath(toPath);
+	const writesSuspiciousPhp =
+		isPhpFile(toPath) && isExecutableSensitivePath(toPath);
+
+	if (!touchesSensitivePath && !writesSuspiciousPhp) {
+		return [];
+	}
+
+	return [
+		{
+			severity:
+				touchesSensitivePath || writesSuspiciousPhp
+					? 'danger'
+					: 'warning',
+			title:
+				stepName === 'cp'
+					? 'Copies files to a sensitive location'
+					: 'Moves files to a sensitive location',
+			description: `${fromPath} -> ${toPath}`,
+			stepIndex,
+		},
+	];
+}
+
+function analyzeArchiveStep(
+	step: Record<string, unknown>,
+	stepIndex: number
+): BlueprintWarning[] {
+	const target =
+		typeof step.extractToPath === 'string'
+			? normalizeWordPressPath(step.extractToPath)
+			: '';
+
+	if (
+		!target ||
+		(!isSensitivePath(target) && !isExecutableSensitivePath(target))
+	) {
+		return [];
+	}
+
+	return [
+		{
+			severity: isSensitivePath(target) ? 'danger' : 'warning',
+			title: 'Extracts files to a sensitive location',
+			description: target,
+			stepIndex,
+		},
+	];
+}
+
+function sortWarnings(warnings: BlueprintWarning[]): BlueprintWarning[] {
+	const severityOrder: Record<BlueprintWarningSeverity, number> = {
+		danger: 0,
+		warning: 1,
+	};
+	return [...warnings].sort(
+		(a, b) => severityOrder[a.severity] - severityOrder[b.severity]
+	);
+}
+
+function previewUrl(url: string): string {
+	try {
+		const parsed = new URL(url);
+		return parsed.host ? truncate(parsed.href, 120) : truncate(url, 120);
+	} catch {
+		return truncate(url, 120);
+	}
+}
+
+function cleanCodePreview(code: string): string {
+	return code
+		.replace(/^<\?php\s*/i, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+function normalizeWordPressPath(path: string): string {
+	const normalizedPath = normalizePath(
+		path.startsWith('/') ? path : `/${path}`
+	);
+	return normalizedPath.startsWith('/wordpress/')
+		? normalizedPath.slice('/wordpress'.length)
+		: normalizedPath;
+}
+
+function isSensitivePath(path: string): boolean {
+	const normalizedPath = normalizeWordPressPath(path);
+	return SENSITIVE_PATHS.some(
+		(sensitivePath) =>
+			normalizedPath === sensitivePath ||
+			normalizedPath.startsWith(sensitivePath)
+	);
+}
+
+function isExecutableSensitivePath(path: string): boolean {
+	const normalizedPath = normalizeWordPressPath(path);
+	return EXECUTABLE_SENSITIVE_PATHS.some((sensitivePath) =>
+		normalizedPath.startsWith(sensitivePath)
+	);
+}
+
+function isPhpFile(path: string): boolean {
+	const normalizedPath = path.toLowerCase();
+	return PHP_EXTENSIONS.some((extension) =>
+		normalizedPath.endsWith(extension)
+	);
+}
+
+function titleCase(value: string): string {
+	return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function truncate(value: string, maxLength: number): string {
+	return value.length > maxLength
+		? `${value.slice(0, Math.max(0, maxLength - 3))}...`
+		: value;
+}
+
+const SENSITIVE_PATHS = [
+	'/wp-config.php',
+	'/.htaccess',
+	'/wp-admin/',
+	'/wp-includes/',
+	'/wp-content/db.php',
+	'/wp-content/object-cache.php',
+	'/wp-content/advanced-cache.php',
+	'/wp-content/sunrise.php',
+	'/wp-content/mu-plugins/',
+];
+
+const EXECUTABLE_SENSITIVE_PATHS = [
+	'/wp-content/uploads/',
+	'/wp-content/cache/',
+	'/wp-content/upgrade/',
+];
+
+const PHP_EXTENSIONS = ['.php', '.phtml', '.php5', '.php7', '.phar'];

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/analyzer.ts
@@ -79,6 +79,21 @@ function analyzeInstallAsset(
 	const resourceType = resourceObj.resource;
 	const titleAssetType = titleCase(assetType);
 
+	if (assetType === 'plugin' && resourceType === 'wordpress.org/plugins') {
+		const slug =
+			typeof resourceObj.slug === 'string' ? resourceObj.slug : '';
+		return [
+			{
+				severity: 'info',
+				title: 'Installs plugin from WordPress.org',
+				description: slug
+					? `${slug} from the WordPress.org plugin directory.`
+					: 'Plugin comes from the WordPress.org plugin directory.',
+				stepIndex,
+			},
+		];
+	}
+
 	if (resourceType === 'url' && typeof resourceObj.url === 'string') {
 		return [
 			{
@@ -348,6 +363,7 @@ function sortWarnings(warnings: BlueprintWarning[]): BlueprintWarning[] {
 	const severityOrder: Record<BlueprintWarningSeverity, number> = {
 		danger: 0,
 		warning: 1,
+		info: 2,
 	};
 	return [...warnings].sort(
 		(a, b) => severityOrder[a.severity] - severityOrder[b.severity]

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/index.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/index.ts
@@ -1,0 +1,6 @@
+export { analyzeBlueprint } from './analyzer';
+export type {
+	BlueprintAnalysisResult,
+	BlueprintWarning,
+	BlueprintWarningSeverity,
+} from './types';

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/types.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/types.ts
@@ -1,4 +1,4 @@
-export type BlueprintWarningSeverity = 'warning' | 'danger';
+export type BlueprintWarningSeverity = 'info' | 'warning' | 'danger';
 
 export type BlueprintWarning = {
 	severity: BlueprintWarningSeverity;

--- a/packages/playground/personal-wp/src/lib/blueprint-confirmation/types.ts
+++ b/packages/playground/personal-wp/src/lib/blueprint-confirmation/types.ts
@@ -1,0 +1,12 @@
+export type BlueprintWarningSeverity = 'warning' | 'danger';
+
+export type BlueprintWarning = {
+	severity: BlueprintWarningSeverity;
+	title: string;
+	description: string;
+	stepIndex?: number;
+};
+
+export type BlueprintAnalysisResult = {
+	warnings: BlueprintWarning[];
+};


### PR DESCRIPTION

<img width="1004" height="734" alt="Screenshot 2026-05-16 at 14 05 22" src="https://github.com/user-attachments/assets/07c2e9a6-348c-4dfc-9f39-f0ec21776745" />

## Summary
- replace the install-blueprint postMessage confirm with a native HTML dialog
- show app title, author, and description before installing
- keep blueprint.json available behind a details disclosure
- skip the confirmation when install-blueprint is sent from the trusted My Apps route
- ignore top-level login and login steps while executing install-blueprint requests
- add lightweight app action analysis for WordPress.org plugin installs and risky steps such as external plugin/theme installs, runPHP, WP-CLI, HTTP requests, and sensitive filesystem writes
- surface compact app action and warning panels when the app request includes actions worth reviewing

## Testing
- npm run format:uncommitted
- npm exec nx lint playground-personal-wp
- npm exec nx typecheck playground-personal-wp
- npm exec nx test playground-personal-wp
