### PR TITLE
[TCP bridge] Fix CURLFile uploads over tcpOverFetch

### DIFF
--- a/packages/php-wasm/web/playwright.config.ts
+++ b/packages/php-wasm/web/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
 	outputDir: './src/test/test-results',
 	testDir: './src/test',
-	testMatch: 'php-dynamic-loading.spec.ts',
+	testMatch: ['php-dynamic-loading.spec.ts', 'php-networking.spec.ts'],
 	fullyParallel: false,
 	forbidOnly: !!process.env['CI'],
 	workers: 1,
@@ -16,6 +16,7 @@ export default defineConfig({
 			name: 'chromium',
 			use: {
 				...devices['Desktop Chrome'],
+				ignoreHTTPSErrors: true,
 			},
 		},
 	],

--- a/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
+++ b/packages/php-wasm/web/src/lib/tcp-over-fetch-websocket.ts
@@ -627,6 +627,9 @@ export class RawBytesFetch {
 
 		const headersBuffer = inputBuffer.slice(0, headersEndIndex);
 		const parsedHeaders = RawBytesFetch.parseRequestHeaders(headersBuffer);
+		const expectsContinue = RawBytesFetch.expectsContinue(
+			parsedHeaders.headers
+		);
 		const terminationMode =
 			parsedHeaders.headers.get('Transfer-Encoding') !== null
 				? 'chunked'
@@ -738,17 +741,20 @@ export class RawBytesFetch {
 		 */
 		const hostname = parsedHeaders.headers.get('Host') ?? host;
 		const url = new URL(parsedHeaders.path, protocol + '://' + hostname);
+		const requestHeaders = RawBytesFetch.normalizeRequestHeadersForFetch(
+			parsedHeaders.headers
+		);
 
 		const request = new Request(url.toString(), {
 			method: parsedHeaders.method,
-			headers: parsedHeaders.headers,
+			headers: requestHeaders,
 			body: outboundBodyStream,
 			// @ts-expect-error duplex is required for streaming request bodies
 			duplex: outboundBodyStream ? 'half' : undefined,
 		});
 		return {
 			request,
-			expectsContinue: parsedHeaders.expectsContinue,
+			expectsContinue,
 		};
 	}
 
@@ -773,15 +779,56 @@ export class RawBytesFetch {
 			}
 		}
 
-		// Strip the Expect header. PHP's curl sends
-		// "Expect: 100-continue" for POST bodies > 1024 bytes
-		// (e.g. CURLFile uploads). The fetch() API does not
-		// support this header and will reject the request.
-		const expectsContinue =
-			headers.get('Expect')?.toLowerCase() === '100-continue';
-		headers.delete('Expect');
+		return { method, path, headers };
+	}
 
-		return { method, path, headers, expectsContinue };
+	private static expectsContinue(headers: Headers) {
+		return headers.get('Expect')?.toLowerCase() === '100-continue';
+	}
+
+	private static normalizeRequestHeadersForFetch(headers: Headers) {
+		const normalizedHeaders = new Headers(headers);
+		/*
+		 * PHP writes a raw HTTP/1.1 request to what it believes is a TCP socket.
+		 * tcpOverFetch parses that byte stream and turns it into a browser
+		 * Request. At that point there are two different network hops involved:
+		 *
+		 * 1. PHP to tcpOverFetch, where HTTP/1.1 framing headers such as
+		 *    Content-Length, Transfer-Encoding, Expect, and Connection are valid.
+		 * 2. Browser fetch to the remote server, where the browser owns request
+		 *    framing, connection management, host selection, and upload streaming.
+		 *
+		 * Forwarding PHP's hop-by-hop headers into fetch mixes those two layers.
+		 * Some of these names are forbidden by the Fetch spec and can make
+		 * `new Request()` or `fetch()` reject. Others are technically accepted
+		 * but stale after tcpOverFetch transforms the request, e.g. after
+		 * responding to Expect: 100-continue or decoding Transfer-Encoding:
+		 * chunked. Content-Length is especially problematic for CURLFile uploads:
+		 * Chromium requires streaming uploads to be sent without caller-supplied
+		 * HTTP/1.1 framing metadata, and forwarding it can make large streamed
+		 * multipart requests fail before the server receives the body.
+		 *
+		 * Keep end-to-end headers such as Content-Type and Authorization, but
+		 * remove headers that describe only the PHP-to-socket hop. The Host header
+		 * is handled above when choosing the target URL because fetch does not
+		 * support Host spoofing.
+		 */
+		for (const header of [
+			'Connection',
+			'Content-Length',
+			'Expect',
+			'Host',
+			'Keep-Alive',
+			'Proxy-Authenticate',
+			'Proxy-Authorization',
+			'TE',
+			'Trailer',
+			'Transfer-Encoding',
+			'Upgrade',
+		]) {
+			normalizedHeaders.delete(header);
+		}
+		return normalizedHeaders;
 	}
 }
 

--- a/packages/php-wasm/web/src/test/php-networking.spec.ts
+++ b/packages/php-wasm/web/src/test/php-networking.spec.ts
@@ -1,13 +1,20 @@
 import test from '@playwright/test';
 import http from 'http';
+import http2 from 'http2';
 import zlib from 'zlib';
 import type { AddressInfo } from 'net';
+import {
+	cleanupCertificate,
+	generateCertificate,
+} from './utils/generate-certificate';
 
 const longText = 'The quick brown fox jumps over the lazy dog. '.repeat(100);
 
 test.describe('PHP networking through tcp-over-fetch bridge', () => {
 	let mockServer: http.Server;
+	let corsProxyServer: http2.Http2SecureServer;
 	let serverUrl: string;
+	let corsProxyUrl: string;
 
 	test.beforeAll(async () => {
 		mockServer = http.createServer((req, res) => {
@@ -50,6 +57,22 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 					res.end(compressed);
 					break;
 				}
+				case '/upload': {
+					const chunks: Buffer[] = [];
+					req.on('data', (chunk: Buffer) => chunks.push(chunk));
+					req.on('end', () => {
+						const body = Buffer.concat(chunks).toString('utf-8');
+						res.setHeader('Content-Type', 'application/json');
+						res.end(
+							JSON.stringify({
+								contentType: req.headers['content-type'] || '',
+								bodyLength: body.length,
+								body,
+							})
+						);
+					});
+					break;
+				}
 				default:
 					res.writeHead(404);
 					res.end('Not Found');
@@ -61,10 +84,54 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 		});
 		const addr = mockServer.address() as AddressInfo;
 		serverUrl = `http://127.0.0.1:${addr.port}`;
+
+		const { cert, key } = await generateCertificate();
+		corsProxyServer = http2.createSecureServer(
+			{ allowHTTP1: true, cert, key },
+			(req, res) => {
+				res.setHeader('Access-Control-Allow-Origin', '*');
+				res.setHeader('Access-Control-Allow-Methods', 'GET, POST');
+				res.setHeader('Access-Control-Allow-Headers', '*');
+				res.setHeader(
+					'Access-Control-Expose-Headers',
+					'X-Playground-Cors-Proxy'
+				);
+				res.setHeader('X-Playground-Cors-Proxy', 'true');
+				if (req.method === 'OPTIONS') {
+					res.writeHead(204);
+					res.end();
+					return;
+				}
+
+				const chunks: Buffer[] = [];
+				req.on('data', (chunk: Buffer) => chunks.push(chunk));
+				req.on('end', () => {
+					const body = Buffer.concat(chunks).toString('utf-8');
+					res.setHeader('Content-Type', 'application/json');
+					res.end(
+						JSON.stringify({
+							contentType:
+								req.headers['x-cors-proxy-content-type'] ||
+								req.headers['content-type'] ||
+								'',
+							bodyLength: body.length,
+							body,
+						})
+					);
+				});
+			}
+		);
+		await new Promise<void>((resolve) => {
+			corsProxyServer.listen(0, '127.0.0.1', () => resolve());
+		});
+		const corsProxyAddr = corsProxyServer.address() as AddressInfo;
+		corsProxyUrl = `https://127.0.0.1:${corsProxyAddr.port}/`;
 	});
 
 	test.afterAll(() => {
 		mockServer?.close();
+		corsProxyServer?.close();
+		cleanupCertificate();
 	});
 
 	test.beforeEach(async ({ page }) => {
@@ -149,7 +216,10 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 
 			const caBundlePath = '/internal/shared/ca-bundle.crt';
 			php.mkdir('/internal/shared');
-			php.writeFile(caBundlePath, window.certificateToPEM(CAroot.certificate));
+			php.writeFile(
+				caBundlePath,
+				window.certificateToPEM(CAroot.certificate)
+			);
 
 			await window.setPhpIniEntries(php, {
 				allow_url_fopen: '1',
@@ -235,5 +305,73 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 		test.expect(parsed.error).toBe('');
 		test.expect(parsed.bodyLength).toBe(longText.length);
 		test.expect(parsed.bodyStart).toBe(longText.slice(0, 50));
+	});
+
+	test('PHP curl can upload a local file via CURLFile', async ({ page }) => {
+		const result = await page.evaluate(async (proxyUrl: string) => {
+			const CAroot = await window.generateCertificate({
+				subject: {
+					commonName: 'TestCA',
+					organizationName: 'Test',
+					countryName: 'US',
+				},
+				basicConstraints: { ca: true },
+			});
+
+			const php = new window.PHP(
+				await window.loadWebRuntime('8.4', {
+					tcpOverFetch: {
+						CAroot,
+						corsProxyUrl: proxyUrl,
+					},
+				})
+			);
+
+			await window.setPhpIniEntries(php, {
+				allow_url_fopen: '1',
+				disable_functions: '',
+			});
+
+			const response = await php.runStream({
+				code: `<?php
+					$fileContents = str_repeat('CURLFile upload payload ', 20000);
+					$tmp = tempnam('/tmp', 'curlfile');
+					file_put_contents($tmp, $fileContents);
+
+					$ch = curl_init('http://remote-server.example/upload');
+					curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+					curl_setopt($ch, CURLOPT_POST, true);
+					curl_setopt($ch, CURLOPT_POSTFIELDS, [
+						'file' => new CURLFile($tmp, 'text/plain', 'payload.txt'),
+						'field1' => 'value1',
+					]);
+
+					$result = curl_exec($ch);
+					echo json_encode([
+						'readableLength' => strlen(file_get_contents($tmp)),
+						'curlError' => curl_error($ch),
+						'httpCode' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
+						'response' => $result,
+					]);
+					curl_close($ch);
+				`,
+			});
+			const text = await response.stdoutText;
+			php.exit();
+			return text;
+		}, corsProxyUrl);
+
+		const parsed = JSON.parse(result);
+		test.expect(parsed).toMatchObject({
+			curlError: '',
+			httpCode: 200,
+		});
+		test.expect(parsed.response).not.toBe('');
+		const response = JSON.parse(parsed.response);
+		test.expect(parsed.readableLength).toBeGreaterThan(400_000);
+		test.expect(response.contentType).toContain('multipart/form-data');
+		test.expect(response.body).toContain('payload.txt');
+		test.expect(response.body).toContain('CURLFile upload payload ');
+		test.expect(response.body).toContain('value1');
 	});
 });

--- a/packages/php-wasm/web/src/test/tcp-over-fetch-websocket.spec.ts
+++ b/packages/php-wasm/web/src/test/tcp-over-fetch-websocket.spec.ts
@@ -954,6 +954,45 @@ describe('RawBytesFetch', () => {
 		expect(request.url).toEqual('https://custom.host.com/api');
 	});
 
+	it('parseHttpRequest should normalize raw HTTP/1.1 headers for fetch', async () => {
+		const body = 'hello=world';
+		const requestBytes =
+			`POST /upload HTTP/1.1\r\n` +
+			`Host: custom.host.com\r\n` +
+			`Connection: keep-alive\r\n` +
+			`Content-Length: ${body.length}\r\n` +
+			`Expect: 100-continue\r\n` +
+			`Authorization: Bearer token\r\n` +
+			`Content-Type: application/x-www-form-urlencoded\r\n` +
+			`\r\n` +
+			body;
+		const { request, expectsContinue } =
+			await RawBytesFetch.parseHttpRequest(
+				new ReadableStream({
+					start(controller) {
+						controller.enqueue(
+							new TextEncoder().encode(requestBytes)
+						);
+						controller.close();
+					},
+				}),
+				'default.host.com',
+				'https'
+			);
+
+		expect(expectsContinue).toBe(true);
+		expect(request.url).toEqual('https://custom.host.com/upload');
+		expect(request.headers.get('authorization')).toEqual('Bearer token');
+		expect(request.headers.get('content-type')).toEqual(
+			'application/x-www-form-urlencoded'
+		);
+		expect(request.headers.has('connection')).toBe(false);
+		expect(request.headers.has('content-length')).toBe(false);
+		expect(request.headers.has('expect')).toBe(false);
+		expect(request.headers.has('host')).toBe(false);
+		expect(await new Response(request.body).text()).toEqual(body);
+	});
+
 	/**
 	 * Regression test: when the full body arrives with the headers
 	 * in a single chunk (small POST bodies without Expect:


### PR DESCRIPTION
## What changed

Fixes CURLFile uploads when PHP runs in the browser through `tcpOverFetch`.

The fetch bridge now:

- preserves the streamed request body instead of buffering it
- strips HTTP/1.1 hop/fetch-owned headers before constructing the browser `Request`
- includes `php-networking.spec.ts` in the `php-wasm-web:e2e` target
- adds a regression test that uploads a local file with `new CURLFile(...)` through an HTTPS HTTP/2 mock CORS proxy and verifies the multipart payload reaches the server

## Root cause

The local PHP file was readable, but the browser fetch bridge forwarded socket-level HTTP/1.1 headers such as `Content-Length`, `Expect`, `Connection`, and `Host`. Those headers describe the PHP-to-socket hop, not the browser-to-server fetch request, and could cause the browser/network layer to fail the streamed request body upload.

The regression test uses HTTPS/H2 for the proxy path because Chromium cannot stream upload bodies to HTTP/1.x endpoints.

## Testing

- `npm exec nx run php-wasm-web:e2e`
- `npm exec nx test php-wasm-web -- --testFile=tcp-over-fetch-websocket.spec.ts`
- `npm exec nx typecheck php-wasm-web`
- `npm exec nx lint php-wasm-web`
- `git diff --check`

Fixes #3340
