### PR TITLE
[E2E] Fix WordPress 7.0 e2e expectations

### DIFF
--- a/packages/playground/website/cypress/e2e/query-api.cy.ts
+++ b/packages/playground/website/cypress/e2e/query-api.cy.ts
@@ -29,7 +29,7 @@ describe('Query API', () => {
 		it('should load WordPress latest by default', () => {
 			cy.visit('/?url=/wp-admin/');
 			const expectedBodyClass =
-				'branch-' + LatestSupportedWordPressVersion.replace('.', '-');
+				'version-' + LatestSupportedWordPressVersion.replace('.', '-');
 			cy.wordPressDocument()
 				.find(`body.${expectedBodyClass}`)
 				.should('exist');

--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -307,7 +307,7 @@ test('wp-cli step should create a post', async ({ website, wordpress }) => {
 	};
 	await website.goto(`/#${JSON.stringify(blueprint)}`);
 	await expect(
-		wordpress.locator('body').locator('[aria-label="“Test post” (Edit)"]')
+		wordpress.locator('body').locator('a').filter({ hasText: 'Test post' })
 	).toBeVisible();
 });
 

--- a/packages/playground/website/playwright/e2e/query-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/query-api.spec.ts
@@ -160,7 +160,7 @@ test('should load WordPress latest by default', async ({
 	await website.goto('./?url=/wp-admin/');
 
 	const expectedBodyClass =
-		'branch-' + LatestSupportedWordPressVersion.replace('.', '-');
+		'version-' + LatestSupportedWordPressVersion.replace('.', '-');
 	await expect(wordpress.locator(`body.${expectedBodyClass}`)).toContainText(
 		'Dashboard'
 	);


### PR DESCRIPTION
## What it does

Updates the e2e assertions affected by the latest WordPress build refresh.

- Latest WordPress checks now assert the exact `version-7-0` body class instead of `branch-7-0`.
- The WP-CLI post creation test now asserts the created post title link instead of the old edit action label.

## Rationale

Commit `2173e11fb` ("Recompile WordPress major and beta versions") made WordPress 7.0 the latest bundled WordPress. WordPress 7.0 renders `body.branch-7.version-7-0`, so `branch-${LatestSupportedWordPressVersion}` is no longer a valid exact-version class.

The post list edit action label also changed from `“Test post” (Edit)` to `Edit “Test post”`. The title link is the behavior the test actually needs: the WP-CLI step created the post and the admin list rendered it.

## Implementation

Use `version-${LatestSupportedWordPressVersion}` for exact latest-version assertions in both Cypress and Playwright.

Use the visible `Test post` title link for the WP-CLI test, which keeps the assertion tied to the created post instead of a WordPress-specific action label format.

## Testing instructions

- `npm run format:uncommitted`
- `git diff --check`
- `PLAYWRIGHT_TEST_BASE_URL=http://127.0.0.1:5400/website-server/ npx playwright test --config=packages/playground/website/playwright/playwright.config.ts --project=chromium packages/playground/website/playwright/e2e/query-api.spec.ts:156 packages/playground/website/playwright/e2e/blueprints.spec.ts:296`
- Chrome MCP: confirmed WordPress 7.0 renders `branch-7 version-7-0` and the WP-CLI blueprint creates a visible `Test post` title link.