### PR TITLE
Bypass CORS proxy for supported AI APIs

### DIFF
--- a/packages/php-wasm/web-service-worker/src/lib/fetch-with-cors-proxy.ts
+++ b/packages/php-wasm/web-service-worker/src/lib/fetch-with-cors-proxy.ts
@@ -2,6 +2,16 @@ import { cloneRequest, supportsReadableStreamBody } from './utils';
 import { FirewallInterferenceError } from './firewall-interference-error';
 
 const CORS_PROXY_HEADER = 'X-Playground-Cors-Proxy';
+const CORS_ENABLED_HOST_REQUEST_HEADERS = new Map([
+	[
+		'api.anthropic.com',
+		{
+			'anthropic-dangerous-direct-browser-access': 'true',
+		},
+	],
+	['api.openai.com', {}],
+	['generativelanguage.googleapis.com', {}],
+]);
 
 export async function fetchWithCorsProxy(
 	input: RequestInfo,
@@ -16,16 +26,15 @@ export async function fetchWithCorsProxy(
 		? new URL(requestObject.url, playgroundUrlObj)
 		: new URL(requestObject.url);
 
-	/**
-	 * Never proxy localhost requests. The remote proxy cannot reach the user's
-	 * localhost, so we must fetch directly to access local APIs.
-	 */
-	const isLocalhost =
-		requestUrlObj.hostname === 'localhost' ||
-		requestUrlObj.hostname === '127.0.0.1' ||
-		requestUrlObj.hostname === '[::1]' ||
-		requestUrlObj.hostname === '::1';
-	if (isLocalhost) {
+	if (isLocalhost(requestUrlObj)) {
+		return await fetch(requestObject);
+	}
+
+	if (isKnownCorsEnabledHost(requestUrlObj)) {
+		requestObject = await addCorsEnabledHostRequestHeaders(
+			requestObject,
+			requestUrlObj
+		);
 		return await fetch(requestObject);
 	}
 
@@ -146,4 +155,41 @@ export async function fetchWithCorsProxy(
 
 		return response;
 	}
+}
+
+function isLocalhost(url: URL) {
+	return (
+		url.hostname === 'localhost' ||
+		url.hostname === '127.0.0.1' ||
+		url.hostname === '[::1]' ||
+		url.hostname === '::1'
+	);
+}
+
+function isKnownCorsEnabledHost(url: URL) {
+	return (
+		url.protocol === 'https:' &&
+		CORS_ENABLED_HOST_REQUEST_HEADERS.has(url.hostname)
+	);
+}
+
+async function addCorsEnabledHostRequestHeaders(
+	request: Request,
+	url: URL
+): Promise<Request> {
+	const headersToAdd = CORS_ENABLED_HOST_REQUEST_HEADERS.get(url.hostname);
+	if (!headersToAdd) {
+		return request;
+	}
+
+	const headers = new Headers(request.headers);
+	for (const [name, value] of Object.entries(headersToAdd)) {
+		if (!headers.has(name)) {
+			headers.set(name, value);
+		}
+	}
+
+	return await cloneRequest(request, {
+		headers,
+	});
 }

--- a/packages/php-wasm/web-service-worker/src/test/fetch-with-cors-proxy.spec.ts
+++ b/packages/php-wasm/web-service-worker/src/test/fetch-with-cors-proxy.spec.ts
@@ -142,6 +142,94 @@ describe('fetchWithCorsProxy', () => {
 		expect(request.url).toBe('http://127.0.0.1:3000/endpoint');
 	});
 
+	it.each([
+		[
+			'https://api.anthropic.com/v1/messages',
+			{
+				'anthropic-dangerous-direct-browser-access': 'true',
+			},
+		],
+		['https://api.openai.com/v1/responses', {}],
+		[
+			'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+			{},
+		],
+	])(
+		'never proxies known CORS-enabled host %s even if direct fetch fails',
+		async (url, expectedHeaders) => {
+			const fetchMock = vi
+				.spyOn(globalThis, 'fetch')
+				.mockRejectedValue(new Error('direct fetch failed'));
+
+			await expect(
+				fetchWithCorsProxy(url, undefined, 'https://proxy.test/?url=')
+			).rejects.toThrow('direct fetch failed');
+
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+			const request = fetchMock.mock.calls[0][0] as Request;
+			expect(request.url).toBe(url);
+			for (const [name, value] of Object.entries(expectedHeaders)) {
+				expect(request.headers.get(name)).toBe(value);
+			}
+			if (url !== 'https://api.anthropic.com/v1/messages') {
+				expect(
+					request.headers.has(
+						'anthropic-dangerous-direct-browser-access'
+					)
+				).toBe(false);
+			}
+		}
+	);
+
+	it('does not overwrite caller-provided CORS-enabled host headers', async () => {
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockRejectedValue(new Error('direct fetch failed'));
+
+		await expect(
+			fetchWithCorsProxy(
+				'https://api.anthropic.com/v1/messages',
+				{
+					headers: {
+						'anthropic-dangerous-direct-browser-access': 'custom',
+					},
+				},
+				'https://proxy.test/?url='
+			)
+		).rejects.toThrow('direct fetch failed');
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const request = fetchMock.mock.calls[0][0] as Request;
+		expect(
+			request.headers.get('anthropic-dangerous-direct-browser-access')
+		).toBe('custom');
+	});
+
+	it('does not treat HTTP URLs as known CORS-enabled hosts', async () => {
+		const corsProxyHeaders = new Headers();
+		corsProxyHeaders.set('X-Playground-Cors-Proxy', 'true');
+		const fetchMock = vi
+			.spyOn(globalThis, 'fetch')
+			.mockRejectedValueOnce(new Error('direct fetch failed'))
+			.mockResolvedValueOnce(
+				new Response('proxied', { headers: corsProxyHeaders })
+			);
+
+		await fetchWithCorsProxy(
+			'http://api.openai.com/v1/responses',
+			undefined,
+			'https://proxy.test/?url='
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		const initialRequest = fetchMock.mock.calls[0][0] as Request;
+		expect(initialRequest.url).toBe('https://api.openai.com/v1/responses');
+		const proxiedRequest = fetchMock.mock.calls[1][0] as Request;
+		expect(proxiedRequest.url).toBe(
+			'https://proxy.test/?url=https://api.openai.com/v1/responses'
+		);
+	});
+
 	it('does not upgrade localhost HTTP to HTTPS when corsProxyUrl is configured', async () => {
 		const fetchMock = vi
 			.spyOn(globalThis, 'fetch')


### PR DESCRIPTION
## Motivation for the change, related issues

Playground rewrites WordPress server-side HTTP requests into browser `fetch()` calls because there is no server-side network stack in the browser runtime. Issue #3493 proposed fixing Anthropic requests by allowing additional request headers in the PHP CORS proxy.

This PR takes a different approach for providers that already support browser CORS: send those requests directly to the provider instead of through Playground's CORS proxy. That means API keys and authentication headers for Anthropic, OpenAI, and Google Gemini do not pass through the Playground-operated proxy when the provider can handle the browser request itself.

This also avoids expanding the proxy header allowlist for these providers, and avoids relying on the proxy to preserve provider CORS response behavior.

Fixes #3493

## Implementation details

Adds a known CORS-enabled host list to `fetchWithCorsProxy` for Anthropic, OpenAI, and Google Gemini. These hosts are fetched directly instead of falling back to the CORS proxy.

Anthropic requires an explicit browser-direct opt-in header, so requests to `api.anthropic.com` get `anthropic-dangerous-direct-browser-access: true` before direct fetch, unless the caller already provided that header. OpenAI and Gemini do not need additional request headers.

No changes are made to the PHP CORS proxy.

## Testing Instructions (or ideally a Blueprint)

Start the dev server with `npm run dev` and ensure WordPress 7.0 is installed. Go to Settings > Connections and add API keys for OpenAI and Anthropic. It should succeed. Look at the Network tab in your Dev Tools and you should successful direct requests to api.openai.com and api.anthropic.com respectively.

Optionally test this on trunk to see that the requests go through the CORS proxy and Anthropic fails.

I didn't have a Google Key ready for testing but it should work the same.

Automated checks run:

```bash
npm exec nx test php-wasm-web-service-worker -- --runInBand
npm exec nx typecheck php-wasm-web-service-worker
git diff --check
```

Manual verification performed while investigating:

- Anthropic preflight returns `Access-Control-Allow-Origin` when `anthropic-dangerous-direct-browser-access` is requested.
- Google Gemini native and OpenAI-compatible API preflights return `Access-Control-Allow-Origin` for Playground origins.
