### PR TITLE
Fix personal-wp e2e stability

### DIFF
--- a/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
@@ -90,6 +90,8 @@ test('should navigate within WordPress from Site Tools shortcuts', async ({
 	).toBeVisible();
 
 	await website.page.getByRole('button', { name: 'Homepage' }).click();
-	await expect(website.page).toHaveURL(/\/$/);
-	await expect(wordpress.locator('p.wp-block-site-title')).toBeVisible();
+	await expect(website.page).toHaveURL(/\/my-apps\/$/);
+	await expect(
+		wordpress.locator('a[href$="/my-apps/?recipes"]')
+	).toBeVisible();
 });


### PR DESCRIPTION
## What?

Updates the Personal WP e2e expectation for the Site Tools "Homepage" shortcut. The shortcut now lands on `/my-apps/`, so the test waits for that URL and asserts on the specific My Apps recipes link href instead of a broad accessible-name regex.

## Why?

The failure started after the external default Personal WP blueprint behavior changed, not from a repo-local Personal WP code change:

- Last passing `test-e2e-personal-wp`: run `26067147338`, commit `8ffc6ccf3`, created `2026-05-18 23:47 UTC`.
- First failing `test-e2e-personal-wp`: run `26087160245`, commit `f9ee7a990`, created `2026-05-19 09:00 UTC`.
- The boundary WordPress Playground commit only touched unrelated OAuth website code.
- The default Personal WP blueprint installs `akirk/my-apps@main` at runtime, and [`akirk/my-apps#78`](https://github.com/akirk/my-apps/pull/78) changed the default root URL behavior so `/` redirects to `/my-apps/`.

That redirect explains the hard failure where clicking Homepage no longer leaves WordPress at `/` with the site-title block visible.

## Testing

- `npm exec nx -- run playground-personal-wp:typecheck`
- `npm run format:uncommitted`
- `git diff --check`

Not run locally: Personal WP Playwright e2e, because the local Chromium browser is not installed and we intentionally skipped installing Playwright browsers on this machine. CI should validate the browser e2e coverage.