### PR TITLE
Fix WordPress 7.0 CSS assets in builds

### DIFF
--- a/packages/playground/wordpress-builds/build/Dockerfile
+++ b/packages/playground/wordpress-builds/build/Dockerfile
@@ -84,10 +84,15 @@ RUN cd wordpress && \
 RUN cd wordpress && \
     find ./ -type f -name '*.css' \
     -not -path '*/wp-includes/blocks/*/*.min.css' \
-    -not -path '*/wp-content/themes/*/style.css' \
+    -not -path '*/wp-admin/css/view-transitions*.css' \
+    -not -path '*/wp-content/themes/*/style*.css' \
+    -not -path '*/wp-includes/css/dist/block-library/common*.css' \
+    -not -path '*/wp-includes/css/wp-block-template-skip-link*.css' \
     -not -path '*/wp-includes/css/wp-embed-template.min.css' \
     -delete && \
-    find ./ -type f -name '*-rtl.min.css' -delete && \
+    find ./ -type f -name '*-rtl.min.css' \
+    -not -path '*/wp-includes/css/wp-block-template-skip-link-rtl.min.css' \
+    -delete && \
     # Keep only the JS files that are read by PHP
     find ./ -type f -name '*.js' \
     -not -path '*/wp-includes/blocks/*/*.min.js' \

--- a/packages/playground/wordpress-builds/src/test/wordpress-zip-assets.spec.ts
+++ b/packages/playground/wordpress-builds/src/test/wordpress-zip-assets.spec.ts
@@ -1,0 +1,42 @@
+import { execFileSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const wordpressBuildsDirectory = new URL('../wordpress/', import.meta.url);
+
+describe('WordPress zip assets', () => {
+	it('ships CSS files that WordPress core reads from PHP', () => {
+		for (const zipFile of getWordPressZipFiles()) {
+			const zipPath = fileURLToPath(
+				new URL(`../wordpress/${zipFile}`, import.meta.url)
+			);
+			const files = listZipFiles(zipPath);
+
+			if (!files.has('wp-includes/view-transitions.php')) {
+				continue;
+			}
+
+			expect(files.has('wp-admin/css/view-transitions.css')).toBe(true);
+			expect(files.has('wp-admin/css/view-transitions.min.css')).toBe(
+				true
+			);
+		}
+	});
+});
+
+function getWordPressZipFiles() {
+	return readdirSync(wordpressBuildsDirectory).filter((fileName) =>
+		/^wp-.*\.zip$/.test(fileName)
+	);
+}
+
+function listZipFiles(zipPath: string) {
+	return new Set(
+		execFileSync('unzip', ['-Z', '-1', zipPath], {
+			encoding: 'utf8',
+			maxBuffer: 1024 * 1024 * 8,
+		})
+			.split('\n')
+			.filter(Boolean)
+	);
+}


### PR DESCRIPTION
## What it does

Keeps the CSS files that WordPress 7.0 reads from PHP inside the PHP-facing WordPress build zips. This fixes warnings like:

```text
file_get_contents(/wordpress/wp-admin/css/view-transitions.min.css): Failed to open stream: No such file or directory
```

The generated `wp-7.0.zip` and `wp-beta.zip` artifacts now include `wp-admin/css/view-transitions.css` and `wp-admin/css/view-transitions.min.css`.

## Rationale

WordPress 7.0 added `wp-includes/view-transitions.php`, which calls `file_get_contents(ABSPATH . "wp-admin/css/view-transitions{$affix}.css")`. The Playground build kept that CSS in `wordpress-static.zip`, but removed it from the PHP runtime zip, so PHP could not read it.

A few other small CSS files used by WordPress style inlining are preserved for the same reason.

## Implementation

Updated the WordPress build Dockerfile to preserve PHP-read CSS assets:

- `wp-admin/css/view-transitions*.css`
- `wp-content/themes/*/style*.css`
- `wp-includes/css/dist/block-library/common*.css`
- `wp-includes/css/wp-block-template-skip-link*.css`

Added a regression test that checks any WordPress build zip containing `wp-includes/view-transitions.php` also contains the matching view transition CSS files.

## Testing instructions

```bash
npm exec nx test playground-wordpress-builds
npm exec nx lint playground-wordpress-builds
```

Both pass locally under Node 22.