### PR TITLE
[Website] Use a stricter style.css exclusion in minified WordPress bundles

### DIFF
--- a/packages/playground/wordpress-builds/build/Dockerfile
+++ b/packages/playground/wordpress-builds/build/Dockerfile
@@ -85,7 +85,7 @@ RUN cd wordpress && \
     find ./ -type f -name '*.css' \
     -not -path '*/wp-includes/blocks/*/*.min.css' \
     -not -path '*/wp-admin/css/view-transitions*.css' \
-    -not -path '*/wp-content/themes/*/style*.css' \
+    -not -path '*/wp-content/themes/*/style.css' \
     -not -path '*/wp-includes/css/dist/block-library/common*.css' \
     -not -path '*/wp-includes/css/wp-block-template-skip-link*.css' \
     -not -path '*/wp-includes/css/wp-embed-template.min.css' \

--- a/packages/playground/wordpress-builds/src/test/wordpress-zip-assets.spec.ts
+++ b/packages/playground/wordpress-builds/src/test/wordpress-zip-assets.spec.ts
@@ -1,26 +1,41 @@
-import { execFileSync } from 'node:child_process';
 import { readdirSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
+import { Uint8ArrayReader, ZipReader } from '@zip.js/zip.js';
 
 const wordpressBuildsDirectory = new URL('../wordpress/', import.meta.url);
 
 describe('WordPress zip assets', () => {
-	it('ships CSS files that WordPress core reads from PHP', () => {
-		for (const zipFile of getWordPressZipFiles()) {
+	it('ships CSS files that WordPress core reads from PHP', async () => {
+		const zipFiles = getWordPressZipFiles();
+		expect(
+			zipFiles.length,
+			'Expected at least one wp-*.zip build artifact'
+		).toBeGreaterThan(0);
+
+		let zipFilesWithViewTransitions = 0;
+
+		for (const zipFile of zipFiles) {
 			const zipPath = fileURLToPath(
 				new URL(`../wordpress/${zipFile}`, import.meta.url)
 			);
-			const files = listZipFiles(zipPath);
+			const files = await listZipFiles(zipPath);
 
 			if (!files.has('wp-includes/view-transitions.php')) {
 				continue;
 			}
 
+			zipFilesWithViewTransitions++;
 			expect(files.has('wp-admin/css/view-transitions.css')).toBe(true);
 			expect(files.has('wp-admin/css/view-transitions.min.css')).toBe(
 				true
 			);
 		}
+
+		expect(
+			zipFilesWithViewTransitions,
+			'Expected at least one WordPress zip with wp-includes/view-transitions.php'
+		).toBeGreaterThan(0);
 	});
 });
 
@@ -30,13 +45,18 @@ function getWordPressZipFiles() {
 	);
 }
 
-function listZipFiles(zipPath: string) {
-	return new Set(
-		execFileSync('unzip', ['-Z', '-1', zipPath], {
-			encoding: 'utf8',
-			maxBuffer: 1024 * 1024 * 8,
-		})
-			.split('\n')
-			.filter(Boolean)
+async function listZipFiles(zipPath: string) {
+	const zipBuffer = await readFile(zipPath);
+	const zipData = new Uint8Array(
+		zipBuffer.buffer,
+		zipBuffer.byteOffset,
+		zipBuffer.byteLength
 	);
+	const reader = new ZipReader(new Uint8ArrayReader(zipData));
+	try {
+		const entries = await reader.getEntries();
+		return new Set(entries.map((entry) => entry.filename));
+	} finally {
+		await reader.close();
+	}
 }


### PR DESCRIPTION
## What it does

Follows up on #3663 by tightening the WordPress zip asset regression test and narrowing the theme CSS retention rule.

## Rationale

The test should fail clearly if the checked-in `wp-*.zip` artifacts disappear or stop including the WordPress core file that needs view transition CSS. It also should not depend on an external `unzip` binary or line-ending parsing.

The Dockerfile only needs to preserve theme `style.css` for PHP-read theme metadata, not every `style*.css` file.

## Implementation

- Reads zip entries with the existing `@zip.js/zip.js` dependency instead of shelling out to `unzip`.
- Adds explicit assertions that at least one `wp-*.zip` artifact exists and that at least one zip includes `wp-includes/view-transitions.php`.
- Narrows the theme CSS exception from `style*.css` to `style.css`.

## Testing instructions

```bash
npm exec nx test playground-wordpress-builds
npm exec nx lint playground-wordpress-builds
```
