### PR TITLE
[Website] Restore local directory saves for autosaves

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1021,6 +1021,15 @@ test.describe('Default Playground storage', () => {
 		await website.page
 			.getByRole('button', { name: 'Store permanently' })
 			.click();
+		const dialog = website.page.getByRole('dialog', {
+			name: 'Save Playground',
+		});
+		await expect(dialog).toBeVisible();
+		await expect(dialog.getByText('Save in this browser')).toBeVisible();
+		await expect(
+			dialog.getByText('Save to a local directory')
+		).toBeVisible();
+		await dialog.getByRole('button', { name: 'Save' }).click();
 
 		await expect
 			.poll(() =>
@@ -1040,6 +1049,82 @@ test.describe('Default Playground storage', () => {
 		await expect(
 			website.page.getByRole('button', { name: 'Autosaved' })
 		).toHaveCount(0);
+	});
+
+	test('should save a default autosaved Playground to a local directory', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.page.addInitScript(() => {
+			Object.defineProperty(window, 'showDirectoryPicker', {
+				value: async () => {
+					const root = await navigator.storage.getDirectory();
+					const directory = await root.getDirectoryHandle(
+						`e2e-local-save-${Date.now()}`,
+						{ create: true }
+					);
+					(window as any).__e2eLocalDirectory = directory;
+					return directory;
+				},
+				configurable: true,
+			});
+		});
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('local-dir'));
+		await website.ensureSiteManagerIsClosed();
+		const statusButton = website.page.getByRole('button', {
+			name: 'Autosaved',
+		});
+		await expect(statusButton).toBeVisible({ timeout: 120000 });
+
+		await statusButton.click();
+		await website.page
+			.getByRole('button', { name: 'Store permanently' })
+			.click();
+		const dialog = website.page.getByRole('dialog', {
+			name: 'Save Playground',
+		});
+		await expect(dialog).toBeVisible();
+		await expect(
+			dialog.getByText('Save to a local directory (not available)')
+		).toHaveCount(0, { timeout: 30000 });
+		await dialog
+			.getByRole('radio', { name: /Save to a local directory/ })
+			.check({ force: true });
+		await dialog.getByRole('button', { name: 'Choose...' }).click();
+		await dialog.getByRole('button', { name: 'Save' }).click();
+
+		await expect(dialog).not.toBeVisible({ timeout: 90000 });
+		await expect
+			.poll(() =>
+				website.page.evaluate(() => {
+					const sites = (window as any).playgroundSites.list();
+					const activeSite = sites.find((site: any) => site.isActive);
+					return {
+						storage: activeSite?.storage,
+						persistence: activeSite?.persistence,
+					};
+				})
+			)
+			.toEqual({ storage: 'local-fs', persistence: 'explicit' });
+		await expect(website.page.getByText('Saved Playground')).toBeVisible();
+		expect(
+			await website.page.evaluate(async () => {
+				const directory = (window as any)
+					.__e2eLocalDirectory as FileSystemDirectoryHandle;
+				try {
+					await directory.getFileHandle('wp-config.php');
+					return true;
+				} catch {
+					return false;
+				}
+			})
+		).toBe(true);
 	});
 
 	test('should persist WordPress changes after refreshing the default Playground', async ({

--- a/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
+++ b/packages/playground/website/src/components/browser-chrome/save-status-indicator.tsx
@@ -7,10 +7,13 @@ import {
 	useActiveSite,
 	useAppDispatch,
 } from '../../lib/state/redux/store';
-import { modalSlugs, setActiveModal } from '../../lib/state/redux/slice-ui';
+import {
+	modalSlugs,
+	setActiveModal,
+	setSiteSlugToSave,
+} from '../../lib/state/redux/slice-ui';
 import { Icon, Popover } from '@wordpress/components';
 import { backup, check, cautionFilled } from '@wordpress/icons';
-import { logger } from '@php-wasm/logger';
 import {
 	isAutosavedSite,
 	MAX_AUTOSAVED_SITES,
@@ -19,7 +22,6 @@ import {
 import type { ClientInfo, OpfsSync } from '../../lib/state/redux/slice-clients';
 import { isOpfsAvailable } from '../../lib/state/opfs/opfs-site-storage';
 import { useLocalFsAvailability } from '../../lib/hooks/use-local-fs-availability';
-import { useSitesAPI } from '../../lib/state/redux/site-management-api-middleware';
 
 type SaveStatus = 'saved' | 'autosaved' | 'unsaved' | 'saving' | 'error';
 
@@ -27,11 +29,9 @@ export function SaveStatusIndicator() {
 	const clientInfo = useAppSelector(getActiveClientInfo);
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
-	const sitesAPI = useSitesAPI();
 	const statusButtonRef = useRef<HTMLButtonElement>(null);
 	const suppressNextTriggerClickRef = useRef(false);
 	const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-	const [popoverError, setPopoverError] = useState<string>();
 
 	const opfsSync = clientInfo?.opfsSync;
 	const status = getSaveStatus(activeSite, clientInfo);
@@ -40,27 +40,10 @@ export function SaveStatusIndicator() {
 	const canStorePermanently =
 		isOpfsAvailable || localFsAvailability === 'available';
 
-	const handleSaveClick = () => {
-		setPopoverError(undefined);
+	const openSaveModal = () => {
 		setIsPopoverOpen(false);
+		dispatch(setSiteSlugToSave(activeSite?.slug));
 		dispatch(setActiveModal(modalSlugs.SAVE_SITE));
-	};
-
-	const handleKeepClick = async () => {
-		if (!activeSite) {
-			return;
-		}
-		setPopoverError(undefined);
-		try {
-			await sitesAPI.keep(activeSite.slug);
-			setIsPopoverOpen(false);
-		} catch (error) {
-			logger.error(
-				'Error storing autosaved Playground permanently.',
-				error
-			);
-			setPopoverError('Could not store permanently. Please try again.');
-		}
 	};
 
 	const handleTriggerMouseDown = (
@@ -74,7 +57,6 @@ export function SaveStatusIndicator() {
 		event.preventDefault();
 		event.stopPropagation();
 		suppressNextTriggerClickRef.current = true;
-		setPopoverError(undefined);
 		setIsPopoverOpen(false);
 	};
 
@@ -84,7 +66,6 @@ export function SaveStatusIndicator() {
 			suppressNextTriggerClickRef.current = false;
 			return;
 		}
-		setPopoverError(undefined);
 		setIsPopoverOpen((isOpen) => !isOpen);
 	};
 
@@ -133,16 +114,11 @@ export function SaveStatusIndicator() {
 								This Playground is saved in this browser with
 								your recent autosaves. It will be deleted after{' '}
 								{MAX_AUTOSAVED_SITES} newer autosaves unless you
-								store it permanently.
+								store it in this browser or a local directory.
 							</p>
-							{popoverError && (
-								<p className={css.popoverError}>
-									{popoverError}
-								</p>
-							)}
 							<button
 								className={css.primaryAction}
-								onClick={handleKeepClick}
+								onClick={openSaveModal}
 								type="button"
 							>
 								Store permanently
@@ -187,7 +163,7 @@ export function SaveStatusIndicator() {
 		return (
 			<button
 				className={classNames(css.indicator, css.error)}
-				onClick={handleSaveClick}
+				onClick={openSaveModal}
 				type="button"
 			>
 				<Icon icon={cautionFilled} size={18} />
@@ -234,7 +210,7 @@ export function SaveStatusIndicator() {
 						{canStorePermanently && (
 							<button
 								className={css.primaryAction}
-								onClick={handleSaveClick}
+								onClick={openSaveModal}
 								type="button"
 							>
 								Store permanently

--- a/packages/playground/website/src/components/save-site-modal/index.tsx
+++ b/packages/playground/website/src/components/save-site-modal/index.tsx
@@ -15,11 +15,17 @@ import {
 import { Modal } from '../modal';
 import ModalButtons from '../modal/modal-buttons';
 import { useAppDispatch, useAppSelector } from '../../lib/state/redux/store';
-import { setActiveModal } from '../../lib/state/redux/slice-ui';
+import {
+	setActiveModal,
+	setSiteSlugToSave,
+} from '../../lib/state/redux/slice-ui';
 import { useSitesAPI } from '../../lib/state/redux/site-management-api-middleware';
 import { useLocalFsAvailability } from '../../lib/hooks/use-local-fs-availability';
 import { selectClientInfoBySiteSlug } from '../../lib/state/redux/slice-clients';
-import type { SiteStorageType } from '../../lib/state/redux/slice-sites';
+import {
+	isAutosavedSite,
+	type SiteStorageType,
+} from '../../lib/state/redux/slice-sites';
 import { logger } from '@php-wasm/logger';
 import { isOpfsAvailable } from '../../lib/state/opfs/opfs-site-storage';
 
@@ -34,18 +40,23 @@ const helpTextStyle: CSSProperties = {
 export function SaveSiteModal() {
 	const dispatch = useAppDispatch();
 	const sitesAPI = useSitesAPI();
+	const siteSlugToSave = useAppSelector((state) => state.ui.siteSlugToSave);
+	const activeSiteSlug = useAppSelector((state) => state.ui.activeSite?.slug);
+	// The modal may be opened from an inactive autosave in Your Playgrounds.
+	const targetSiteSlug = siteSlugToSave ?? activeSiteSlug;
 	const site = useAppSelector((state) =>
-		state.ui.activeSite?.slug
-			? state.sites.entities[state.ui.activeSite.slug]
-			: undefined
+		targetSiteSlug ? state.sites.entities[targetSiteSlug] : undefined
 	);
 	const clientInfo = useAppSelector((state) =>
-		state.ui.activeSite?.slug
-			? selectClientInfoBySiteSlug(state, state.ui.activeSite.slug)
+		targetSiteSlug
+			? selectClientInfoBySiteSlug(state, targetSiteSlug)
 			: undefined
 	);
 
 	const localFsAvailability = useLocalFsAvailability(clientInfo?.client);
+	const targetIsActive = !!site && site.slug === activeSiteSlug;
+	const localIsAvailable =
+		targetIsActive && localFsAvailability === 'available';
 
 	const initialName = useMemo(() => site?.metadata?.name ?? '', [site]);
 	const [name, setName] = useState(initialName);
@@ -54,7 +65,7 @@ export function SaveSiteModal() {
 			if (isOpfsAvailable) {
 				return 'opfs';
 			}
-			if (localFsAvailability === 'available') {
+			if (localIsAvailable) {
 				return 'local-fs';
 			}
 			return 'opfs';
@@ -68,10 +79,15 @@ export function SaveSiteModal() {
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const nameInputRef = useRef<HTMLInputElement>(null);
+	const nameSiteSlugRef = useRef<string>();
 
 	useEffect(() => {
+		if (nameSiteSlugRef.current === site?.slug) {
+			return;
+		}
+		nameSiteSlugRef.current = site?.slug;
 		setName(initialName);
-	}, [initialName]);
+	}, [initialName, site?.slug]);
 
 	useEffect(() => {
 		// Select the text in the name input when the modal is shown
@@ -89,23 +105,20 @@ export function SaveSiteModal() {
 	}, []);
 
 	useEffect(() => {
-		if (
-			selectedStorage === 'local-fs' &&
-			localFsAvailability !== 'available'
-		) {
+		if (selectedStorage === 'local-fs' && !localIsAvailable) {
 			setSelectedStorage('opfs');
 		}
-	}, [selectedStorage, localFsAvailability]);
+	}, [selectedStorage, localIsAvailable]);
 
 	useEffect(() => {
 		if (
 			selectedStorage === 'opfs' &&
 			!isOpfsAvailable &&
-			localFsAvailability === 'available'
+			localIsAvailable
 		) {
 			setSelectedStorage('local-fs');
 		}
-	}, [selectedStorage, localFsAvailability]);
+	}, [selectedStorage, localIsAvailable]);
 
 	useEffect(() => {
 		setDirectoryHandle(null);
@@ -119,29 +132,29 @@ export function SaveSiteModal() {
 	const savingProgress =
 		saveProgress?.status === 'syncing' ? saveProgress.progress : undefined;
 
-	// Close modal when save completes successfully
-	useEffect(() => {
-		if (
-			isSubmitting &&
-			saveProgress?.status !== 'syncing' &&
-			saveProgress?.status !== 'error' &&
-			site?.metadata?.storage !== 'none'
-		) {
-			dispatch(setActiveModal(null));
-		}
-	}, [isSubmitting, saveProgress?.status, site?.metadata?.storage, dispatch]);
+	const isAutosaved = site && isAutosavedSite(site);
+	const canSaveSite =
+		site && (site.metadata.storage === 'none' || isAutosaved);
+	const closeModal = () => {
+		dispatch(setActiveModal(null));
+		dispatch(setSiteSlugToSave(undefined));
+	};
 
-	if (!site || site.metadata.storage !== 'none') {
+	useEffect(() => {
+		if (site && canSaveSite) {
+			return;
+		}
+		dispatch(setActiveModal(null));
+		dispatch(setSiteSlugToSave(undefined));
+	}, [canSaveSite, dispatch, site]);
+
+	if (!site || !canSaveSite) {
 		return null;
 	}
 
-	const closeModal = () => {
-		dispatch(setActiveModal(null));
-	};
-
-	const localIsAvailable = localFsAvailability === 'available';
-	const localUnavailableMessage =
-		localFsAvailability === 'not-available'
+	const localUnavailableMessage = !targetIsActive
+		? 'Open this Playground to save it to a local directory'
+		: localFsAvailability === 'not-available'
 			? 'Not available in this browser'
 			: 'Not available on this site';
 
@@ -234,8 +247,16 @@ export function SaveSiteModal() {
 			setSubmitError(null);
 
 			if (selectedStorage === 'local-fs') {
+				if (!targetIsActive) {
+					setDirectoryError(
+						'Open this Playground to save it to a local directory.'
+					);
+					setIsSubmitting(false);
+					return;
+				}
 				if (!directoryHandle) {
 					setDirectoryError('Choose a directory to continue.');
+					setIsSubmitting(false);
 					return;
 				}
 				const permission = await ensureWriteAccess(directoryHandle);
@@ -244,6 +265,7 @@ export function SaveSiteModal() {
 					setDirectoryError(
 						'Allow Playground to edit that directory in the browser prompt to continue.'
 					);
+					setIsSubmitting(false);
 					return;
 				}
 				await sitesAPI.saveToLocalFileSystem(
@@ -251,10 +273,14 @@ export function SaveSiteModal() {
 					directoryHandle
 				);
 			} else {
-				await sitesAPI.saveInBrowser(trimmedName);
+				if (isAutosaved) {
+					await sitesAPI.keep(site.slug, trimmedName);
+				} else {
+					await sitesAPI.saveInBrowser(trimmedName);
+				}
 			}
 
-			// Don't close modal here - useEffect will close it when save completes
+			closeModal();
 		} catch (error) {
 			logger.error(error);
 			setSubmitError(
@@ -311,9 +337,9 @@ export function SaveSiteModal() {
 				autoComplete="off"
 			>
 				<p style={{ margin: 0, color: '#1e1e1e' }}>
-					This Playground is temporary and will be lost when you
-					refresh or close this page. Save it to keep your work and
-					find it later in Your Playgrounds.
+					{isAutosaved
+						? 'This Playground is autosaved in this browser and may be removed after newer autosaves. Store it permanently in this browser or save it to a local directory.'
+						: 'This Playground is temporary and will be lost when you refresh or close this page. Save it to keep your work and find it later in Your Playgrounds.'}
 				</p>
 				<TextControl
 					label="Playground name"

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -9,7 +9,6 @@ import {
 import { moreVertical, plus, upload, link } from '@wordpress/icons';
 import { Icon } from '@wordpress/icons';
 import { GitHubIcon } from '../../github/github';
-import { useDispatch } from 'react-redux';
 import { useState, useEffect, useRef } from 'react';
 import { usePlaygroundClient } from '../../lib/use-playground-client';
 import { importWordPressFiles } from '@wp-playground/client';
@@ -19,7 +18,6 @@ import {
 	useAppSelector,
 	useAppDispatch,
 } from '../../lib/state/redux/store';
-import type { PlaygroundDispatch } from '../../lib/state/redux/store';
 import type { SiteLogo, SiteInfo } from '../../lib/state/redux/slice-sites';
 import {
 	isAutosavedSite,
@@ -35,6 +33,7 @@ import {
 	setSiteManagerSection,
 	setSiteSlugToRename,
 	setSiteSlugToDelete,
+	setSiteSlugToSave,
 } from '../../lib/state/redux/slice-ui';
 import { useSitesAPI } from '../../lib/state/redux/site-management-api-middleware';
 import { WordPressIcon } from '@wp-playground/components';
@@ -103,7 +102,6 @@ export function SavedPlaygroundsOverlay({
 	const temporarySite = useAppSelector(selectTemporarySite);
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
-	const modalDispatch: PlaygroundDispatch = useDispatch();
 	const sitesAPI = useSitesAPI();
 	const playground = usePlaygroundClient();
 	const zipFileInputRef = useRef<HTMLInputElement>(null);
@@ -257,19 +255,21 @@ export function SavedPlaygroundsOverlay({
 
 	const handleDeleteSite = (site: SiteInfo, closeMenu: () => void) => {
 		dispatch(setSiteSlugToDelete(site.slug));
-		modalDispatch(setActiveModal(modalSlugs.DELETE_SITE));
+		dispatch(setActiveModal(modalSlugs.DELETE_SITE));
 		closeMenu();
 	};
 
 	const handleRenameSite = (site: SiteInfo, closeMenu: () => void) => {
 		dispatch(setSiteSlugToRename(site.slug));
-		modalDispatch(setActiveModal(modalSlugs.RENAME_SITE));
+		dispatch(setActiveModal(modalSlugs.RENAME_SITE));
 		closeMenu();
 	};
 
-	const handleKeepSite = async (site: SiteInfo, closeMenu?: () => void) => {
-		await sitesAPI.keep(site.slug);
+	const openSaveModalForSite = (site: SiteInfo, closeMenu?: () => void) => {
+		dispatch(setSiteSlugToSave(site.slug));
+		dispatch(setActiveModal(modalSlugs.SAVE_SITE));
 		closeMenu?.();
+		onClose();
 	};
 
 	const getStoredSiteDetails = (site: SiteInfo) => {
@@ -326,7 +326,7 @@ export function SavedPlaygroundsOverlay({
 			title: 'Preview a WordPress PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
-				modalDispatch(setActiveModal(modalSlugs.PREVIEW_PR_WP));
+				dispatch(setActiveModal(modalSlugs.PREVIEW_PR_WP));
 			},
 			disabled: offline,
 		},
@@ -335,7 +335,7 @@ export function SavedPlaygroundsOverlay({
 			title: 'Preview a Gutenberg PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
-				modalDispatch(setActiveModal(modalSlugs.PREVIEW_PR_GUTENBERG));
+				dispatch(setActiveModal(modalSlugs.PREVIEW_PR_GUTENBERG));
 			},
 			disabled: offline,
 		},
@@ -344,7 +344,7 @@ export function SavedPlaygroundsOverlay({
 			title: 'Import from GitHub',
 			iconComponent: GitHubIcon,
 			onClick: () => {
-				modalDispatch(setActiveModal(modalSlugs.GITHUB_IMPORT));
+				dispatch(setActiveModal(modalSlugs.GITHUB_IMPORT));
 			},
 			disabled: offline,
 		},
@@ -353,7 +353,7 @@ export function SavedPlaygroundsOverlay({
 			title: 'Open a Blueprint URL',
 			icon: link,
 			onClick: () => {
-				modalDispatch(setActiveModal(modalSlugs.BLUEPRINT_URL));
+				dispatch(setActiveModal(modalSlugs.BLUEPRINT_URL));
 			},
 			disabled: offline,
 		},
@@ -428,7 +428,7 @@ export function SavedPlaygroundsOverlay({
 						<button
 							type="button"
 							className={css.keepButton}
-							onClick={() => handleKeepSite(site)}
+							onClick={() => openSaveModalForSite(site)}
 							title="Store this Playground permanently so it is not pruned from recent autosaves."
 						>
 							Store permanently
@@ -448,7 +448,10 @@ export function SavedPlaygroundsOverlay({
 									{isAutosave && (
 										<MenuItem
 											onClick={() =>
-												handleKeepSite(site, closeMenu)
+												openSaveModalForSite(
+													site,
+													closeMenu
+												)
 											}
 										>
 											Store permanently

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -9,7 +9,6 @@ import {
 	TabPanel,
 } from '@wordpress/components';
 import { chevronLeft, edit, moreVertical } from '@wordpress/icons';
-import { logger } from '@php-wasm/logger';
 import { getLogoDataURL, WordPressIcon } from '@wp-playground/components';
 import classNames from 'classnames';
 import { lazy, Suspense, useEffect, useState } from 'react';
@@ -26,9 +25,9 @@ import {
 	setSiteManagerOpen,
 	setSiteSlugToDelete,
 	setSiteSlugToRename,
+	setSiteSlugToSave,
 } from '../../../lib/state/redux/slice-ui';
 import { useAppDispatch, useAppSelector } from '../../../lib/state/redux/store';
-import { useSitesAPI } from '../../../lib/state/redux/site-management-api-middleware';
 import { usePlaygroundClientInfo } from '../../../lib/use-playground-client';
 import { SiteLogs } from '../../log-modal';
 import { OfflineNotice } from '../../offline-notice';
@@ -90,13 +89,11 @@ export function SiteInfoPanel({
 }) {
 	const offline = useAppSelector((state) => state.ui.offline);
 	const dispatch = useAppDispatch();
-	const sitesAPI = useSitesAPI();
 	// Load the last active tab for this site
 	const [initialTabName] = useState(() => {
 		const lastTab = getSiteLastTab(site.slug);
 		return lastTab || 'settings';
 	});
-	const [keepSiteError, setKeepSiteError] = useState<string>();
 
 	// Resolve documentRoot from playground client
 	const [documentRoot, setDocumentRoot] = useState<string | null>(null);
@@ -114,17 +111,9 @@ export function SiteInfoPanel({
 		dispatch(setActiveModal(modalSlugs.DELETE_SITE));
 		onClose();
 	};
-	const keepSite = async () => {
-		setKeepSiteError(undefined);
-		try {
-			await sitesAPI.keep(site.slug);
-		} catch (error) {
-			logger.error(
-				'Error storing autosaved Playground permanently.',
-				error
-			);
-			setKeepSiteError('Could not store permanently. Please try again.');
-		}
+	const openSaveModal = () => {
+		dispatch(setSiteSlugToSave(site.slug));
+		dispatch(setActiveModal(modalSlugs.SAVE_SITE));
 	};
 	const clientInfo = useAppSelector((state) =>
 		selectClientInfoBySiteSlug(state, site.slug)
@@ -314,14 +303,12 @@ export function SiteInfoPanel({
 						</FlexItem>
 						{isAutosaved && (
 							<FlexItem className={css.siteInfoHeaderAction}>
-								<Button variant="primary" onClick={keepSite}>
+								<Button
+									variant="primary"
+									onClick={openSaveModal}
+								>
 									Store permanently
 								</Button>
-							</FlexItem>
-						)}
-						{keepSiteError && (
-							<FlexItem className={css.siteInfoHeaderError}>
-								{keepSiteError}
 							</FlexItem>
 						)}
 						{mobileUi ? (

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -217,14 +217,6 @@
 	flex-shrink: 0;
 }
 
-.siteInfoHeaderError {
-	color: #b32d2e;
-	flex-basis: 100%;
-	font-size: 13px;
-	line-height: 18px;
-	text-align: right;
-}
-
 .siteInfoRenameButton {
 	padding: 2px !important;
 	min-height: 24px;

--- a/packages/playground/website/src/components/site-manager/site-persist-button/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-persist-button/index.tsx
@@ -2,7 +2,11 @@ import { useAppSelector, useAppDispatch } from '../../../lib/state/redux/store';
 import css from './style.module.css';
 import { selectClientInfoBySiteSlug } from '../../../lib/state/redux/slice-clients';
 import type { SiteStorageType } from '../../../lib/state/redux/slice-sites';
-import { modalSlugs, setActiveModal } from '../../../lib/state/redux/slice-ui';
+import {
+	modalSlugs,
+	setActiveModal,
+	setSiteSlugToSave,
+} from '../../../lib/state/redux/slice-ui';
 import React from 'react';
 
 export function SitePersistButton({
@@ -19,10 +23,11 @@ export function SitePersistButton({
 	const dispatch = useAppDispatch();
 
 	if (!clientInfo?.opfsSync || clientInfo.opfsSync?.status === 'error') {
-		const handleClick = () => {
+		const openSaveModal = () => {
+			dispatch(setSiteSlugToSave(siteSlug));
 			dispatch(setActiveModal(modalSlugs.SAVE_SITE));
 		};
-		const button = <div onClick={handleClick}>{children}</div>;
+		const button = <div onClick={openSaveModal}>{children}</div>;
 
 		return (
 			<>

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -25,12 +25,11 @@ import type { SiteStorageType } from './slice-sites';
 import { setActiveModal } from './slice-ui';
 
 /**
- * Persists a running temporary Playground into a durable storage backend.
+ * Copies the running Playground into a durable storage backend.
  *
- * The active iframe is the source of truth for the filesystem, so this copies
- * MEMFS into OPFS or a picked local directory before changing the site metadata.
- * Autosave callers can keep the URL and iframe stable while still recording the
- * persisted metadata needed for restore.
+ * Temporary sites need a new storage record before the copy starts. Autosaved
+ * sites already have one, so saving them to a local directory only remounts the
+ * running filesystem and updates the existing metadata after the copy succeeds.
  */
 export function persistTemporarySite(
 	siteSlug: string,
@@ -70,28 +69,33 @@ export function persistTemporarySite(
 			siteInfo = selectSiteBySlug(getState(), siteSlug)!;
 		}
 
-		try {
-			const existingSiteInfo = await opfsSiteStorage?.read(siteInfo.slug);
-			if (existingSiteInfo?.metadata.storage === 'none') {
-				// It is likely we are dealing with the remnants of a failed save
-				// of a temporary site to OPFS. Let's clean up an try again.
-				await opfsSiteStorage?.delete(siteInfo.slug);
+		const isTemporarySite = siteInfo.metadata.storage === 'none';
+		if (isTemporarySite) {
+			try {
+				const existingSiteInfo = await opfsSiteStorage?.read(
+					siteInfo.slug
+				);
+				if (existingSiteInfo?.metadata.storage === 'none') {
+					// It is likely we are dealing with the remnants of a failed save
+					// of a temporary site to OPFS. Let's clean up and try again.
+					await opfsSiteStorage?.delete(siteInfo.slug);
+				}
+			} catch (error: any) {
+				if (error?.name === 'NotFoundError') {
+					// No failed temporary-site placeholder exists, so this save can
+					// continue with a fresh OPFS record.
+				} else {
+					throw error;
+				}
 			}
-		} catch (error: any) {
-			if (error?.name === 'NotFoundError') {
-				// No failed temporary-site placeholder exists, so this save can
-				// continue with a fresh OPFS record.
-			} else {
-				throw error;
-			}
+			await opfsSiteStorage?.create(siteInfo.slug, {
+				...siteInfo.metadata,
+				// The placeholder stays marked as temporary until the copy
+				// succeeds, so a later save can recognize and clean up a failed
+				// attempt.
+				storage: 'none',
+			});
 		}
-		await opfsSiteStorage?.create(siteInfo.slug, {
-			...siteInfo.metadata,
-			// Start with storage type of 'none' to represent a temporary site
-			// that the site is being saved. This will help us distinguish
-			// between successful and failed saves.
-			storage: 'none',
-		});
 
 		// Persist the blueprint bundle if available.
 		// First, check if originalBlueprint is already a filesystem (from clicking "Run Blueprint").
@@ -187,6 +191,19 @@ export function persistTemporarySite(
 			})
 		);
 		try {
+			/**
+			 * Autosaved browser sites already mount OPFS at `/wordpress`.
+			 * We need to unmount it before we can mount a local directory at `/wordpress`.
+			 *
+			 * That works, because all the files we need are available in MEMFS despite the prior
+			 * OPFS mount. The OPFS mount doesn't replace the MEMFS `/wordpress` directory.
+			 * Instead, it attaches a filesystem journal to periodically rewrite all the operations to
+			 * the right OPFS location. Therefore, the files are in MEMFS and are ready to be copied
+			 * to the local filesystem.
+			 */
+			if (await playground.hasOpfsMount(mountDescriptor.mountpoint)) {
+				await playground.unmountOpfs(mountDescriptor.mountpoint);
+			}
 			await playground.mountOpfs(
 				{
 					...mountDescriptor,

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -25,6 +25,7 @@ import {
 	deriveSiteNameFromSlug,
 	getSitePublicPersistence,
 	isAutosavedSite,
+	type SiteInfo,
 	type SitePersistence,
 	type SiteStorageType,
 } from './slice-sites';
@@ -209,12 +210,12 @@ export function createSitesAPI(
 		},
 
 		/**
-		 * Saves the active Playground in browser storage when it is temporary.
+		 * Saves the active temporary or autosaved Playground in browser storage.
 		 *
-		 * Temporary sites are persisted to OPFS. Existing autosaves are marked as
-		 * explicitly saved and returned without changing storage backends.
+		 * Temporary sites are persisted to OPFS. Existing autosaves are kept in
+		 * their current backend and marked as explicitly saved.
 		 *
-		 * @param name Optional display name for a temporary site being saved.
+		 * @param name Optional display name for the saved site.
 		 * @returns The site's slug and storage type.
 		 * @throws When no site is selected or saving fails.
 		 */
@@ -225,7 +226,7 @@ export function createSitesAPI(
 			}
 			if (site.metadata.storage !== 'none') {
 				if (isAutosavedSite(site)) {
-					await dispatch(preserveSite(site.slug));
+					await api.keep(site.slug, name);
 				}
 				return { slug: site.slug, storage: site.metadata.storage };
 			}
@@ -297,33 +298,42 @@ export function createSitesAPI(
 		 *
 		 * This is a metadata-only lifecycle change. It turns an autosaved stored
 		 * Playground into an explicit save so autosave pruning and restore prompts
-		 * no longer treat it as disposable. It does not copy files, change the
-		 * storage backend, rename the Playground, or reboot it. Already-explicit
-		 * stored Playgrounds are left explicit.
+		 * no longer treat it as disposable. It may rename the Playground when the
+		 * caller provides a name, but it does not copy files, change the storage
+		 * backend, or reboot it. Already-explicit stored Playgrounds are left
+		 * explicit.
 		 *
 		 * @param siteSlug Optional slug. Uses the active site when omitted.
+		 * @param name Optional display name to apply before keeping the site.
 		 * @throws When no site is selected, the slug is unknown, or the site is
 		 *   temporary.
 		 */
-		async keep(siteSlug?: string): Promise<void> {
+		async keep(siteSlug?: string, name?: string): Promise<void> {
 			const site = siteSlug
 				? selectSiteBySlug(getState(), siteSlug)
 				: selectActiveSite(getState());
 			if (!site) {
 				throw new Error('No site selected');
 			}
+			if (site.metadata.storage === 'none') {
+				throw new Error(
+					'Cannot keep a temporary site. Autosave it first.'
+				);
+			}
+			await updateSiteNameIfProvided(dispatch, site, name);
 			// "Keeping" an autosave only changes lifecycle metadata. The
 			// filesystem stays in the same storage backend.
 			await dispatch(preserveSite(site.slug));
 		},
 
 		/**
-		 * Saves the active Playground to a local directory when it is temporary.
+		 * Saves the active temporary or autosaved Playground to a local directory.
 		 *
-		 * Existing saved sites are returned without changing storage backends.
-		 * Existing autosaves are marked as explicitly saved first.
+		 * Autosaved browser Playgrounds already have durable metadata, but their
+		 * files still need to be copied from the running iframe into the picked
+		 * local directory.
 		 *
-		 * @param name Optional display name for a temporary site being saved.
+		 * @param name Optional display name for the saved site.
 		 * @param localFsHandle Directory handle. When omitted the
 		 *   browser prompts the user to pick one.
 		 * @returns The site's slug and storage type.
@@ -338,10 +348,16 @@ export function createSitesAPI(
 				throw new Error('No active site selected');
 			}
 			if (site.metadata.storage !== 'none') {
-				if (isAutosavedSite(site)) {
-					await dispatch(preserveSite(site.slug));
+				if (site.metadata.storage === 'local-fs') {
+					await updateSiteNameIfProvided(dispatch, site, name);
+					if (isAutosavedSite(site)) {
+						await dispatch(preserveSite(site.slug));
+					}
+					return { slug: site.slug, storage: site.metadata.storage };
 				}
-				return { slug: site.slug, storage: site.metadata.storage };
+				if (!isAutosavedSite(site)) {
+					return { slug: site.slug, storage: site.metadata.storage };
+				}
 			}
 			await dispatch(
 				persistTemporarySite(site.slug, 'local-fs', {
@@ -565,6 +581,26 @@ export function createSitesAPI(
 		},
 	};
 	return api;
+}
+
+/**
+ * Applies a new display name before a metadata-only save transition.
+ */
+async function updateSiteNameIfProvided(
+	dispatch: PlaygroundDispatch,
+	site: SiteInfo,
+	name?: string
+) {
+	const trimmedName = name?.trim();
+	if (!trimmedName || trimmedName === site.metadata.name) {
+		return;
+	}
+	await dispatch(
+		updateSiteMetadata({
+			slug: site.slug,
+			changes: { name: trimmedName },
+		})
+	);
 }
 
 /**

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -153,6 +153,10 @@ export interface UIState {
 	activeModal: string | null;
 	siteSlugToRename?: string;
 	siteSlugToDelete?: string;
+	/**
+	 * Site the save modal operates on. Defaults to the active site when unset.
+	 */
+	siteSlugToSave?: string;
 	githubAuthRepoUrl?: string;
 	offline: boolean;
 	siteManagerIsOpen: boolean;
@@ -281,6 +285,12 @@ const uiSlice = createSlice({
 		) => {
 			state.siteSlugToDelete = action.payload;
 		},
+		setSiteSlugToSave: (
+			state,
+			action: PayloadAction<string | undefined>
+		) => {
+			state.siteSlugToSave = action.payload;
+		},
 	},
 });
 
@@ -327,6 +337,7 @@ export const {
 	setSiteManagerSection,
 	setSiteSlugToRename,
 	setSiteSlugToDelete,
+	setSiteSlugToSave,
 } = uiSlice.actions;
 
 export default uiSlice.reducer;


### PR DESCRIPTION
## What it does

Restores local-directory saves for autosaved Playgrounds. Clicking `Store permanently` on an autosaved Playground now opens the regular save modal instead of silently keeping the OPFS autosave.

## Rationale

Autosave stores recovery copies in browser storage by default, but users still need the existing choice between browser storage and a picked local directory when they decide to keep a Playground permanently.

## Implementation

The save modal can target a selected autosave, not only the active temporary site. Browser saves keep the autosave metadata explicitly; local-directory saves copy the active iframe filesystem into the picked directory and then update the existing site metadata.

Inactive autosaves can still be kept in browser storage from the modal. Local-directory saves require opening that Playground first because the live iframe is the source of files copied to the directory.

## Testing instructions

- `NX_DAEMON=false npx nx run playground-website:typecheck`
- `NX_DAEMON=false npx nx run playground-website:lint`
- `NX_DAEMON=false npx playwright test --config=packages/playground/website/playwright/playwright.config.ts packages/playground/website/playwright/e2e/website-ui.spec.ts --project=chromium --grep "should (promote a default autosaved Playground when kept|save a default autosaved Playground to a local directory)" --reporter=line`
