### PR TITLE
[OPFS] Flush OPFS writes after initial directory sync

### DIFF
--- a/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi } from 'vitest';
 import { __private__dont__use, type PHP } from '@php-wasm/universal';
 import { Semaphore } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
-import { journalFSEventsToOpfs } from './directory-handle-mount';
+import {
+	copyMemfsToOpfs,
+	createDirectoryHandleMountHandler,
+	journalFSEventsToOpfs,
+} from './directory-handle-mount';
 
 class MemoryFileHandle {
 	kind = 'file' as const;
@@ -355,9 +359,151 @@ describe('journalFSEventsToOpfs', () => {
 	});
 });
 
+describe('createDirectoryHandleMountHandler', () => {
+	it('flushes changes made while the initial MEMFS to OPFS sync is still running', async () => {
+		let changedDuringInitialSync = false;
+		let mount: { flush(): Promise<void> } | undefined;
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root', () => {
+			if (changedDuringInitialSync) {
+				return;
+			}
+			changedDuringInitialSync = true;
+			files.set('/wordpress/database.sqlite', encode('changed'));
+			FS.write({ path: '/wordpress/database.sqlite' });
+		});
+		files.set('/wordpress/database.sqlite', encode('initial'));
+
+		const mountHandler = createDirectoryHandleMountHandler(
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			{
+				initialSync: {
+					direction: 'memfs-to-opfs',
+				},
+				onMount: (createdMount) => {
+					mount = createdMount;
+				},
+			}
+		);
+
+		await mountHandler(php, FS as any, '/wordpress');
+		await mount!.flush();
+
+		expect(decode(opfsRoot.files.get('database.sqlite')!.bytes)).toBe(
+			'changed'
+		);
+	});
+
+	it('does not block the initial MEMFS to OPFS sync on the final flush', async () => {
+		let mount: { flush(): Promise<void> } | undefined;
+		let changedDuringInitialSync = false;
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root', () => {
+			if (changedDuringInitialSync) {
+				return;
+			}
+			changedDuringInitialSync = true;
+			FS.write({ path: '/wordpress/database.sqlite' });
+		});
+		files.set('/wordpress/database.sqlite', encode('initial'));
+		const releaseSemaphore = await php.semaphore.acquire();
+
+		const mountHandler = createDirectoryHandleMountHandler(
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			{
+				initialSync: {
+					direction: 'memfs-to-opfs',
+				},
+				onMount: (createdMount) => {
+					mount = createdMount;
+				},
+			}
+		);
+
+		await mountHandler(php, FS as any, '/wordpress');
+		releaseSemaphore();
+		await mount!.flush();
+
+		expect(decode(opfsRoot.files.get('database.sqlite')!.bytes)).toBe(
+			'initial'
+		);
+	});
+
+	it('reports a flushing phase after the initial MEMFS to OPFS copy', async () => {
+		const progressEvents: Array<{
+			files: number;
+			total: number;
+			phase?: 'copying' | 'flushing';
+		}> = [];
+		const { FS, files, php } = createFakePhp();
+		const opfsRoot = new MemoryDirectoryHandle('root');
+		files.set('/wordpress/database.sqlite', encode('initial'));
+
+		const mountHandler = createDirectoryHandleMountHandler(
+			opfsRoot as unknown as FileSystemDirectoryHandle,
+			{
+				initialSync: {
+					direction: 'memfs-to-opfs',
+					onProgress: (progress) => {
+						progressEvents.push(progress);
+					},
+				},
+			}
+		);
+
+		await mountHandler(php, FS as any, '/wordpress');
+
+		expect(progressEvents[0]).toEqual({
+			files: 0,
+			total: 1,
+			phase: 'copying',
+		});
+		expect(progressEvents).toContainEqual({
+			files: 1,
+			total: 1,
+			phase: 'flushing',
+		});
+	});
+
+	it('does not emit stale copy progress after the final progress event', async () => {
+		vi.useFakeTimers();
+
+		try {
+			const progressEvents: Array<{ files: number; total: number }> = [];
+			const { FS, files } = createFakePhp();
+			const opfsRoot = new MemoryDirectoryHandle('root');
+			FS.readdir.mockReturnValue(['.', '..', 'first.txt', 'second.txt']);
+			files.set('/wordpress/first.txt', encode('first'));
+			files.set('/wordpress/second.txt', encode('second'));
+
+			await copyMemfsToOpfs(
+				FS as any,
+				opfsRoot as unknown as FileSystemDirectoryHandle,
+				'/wordpress',
+				(progress) => {
+					progressEvents.push(progress);
+				}
+			);
+
+			const progressEventCount = progressEvents.length;
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(progressEvents).toHaveLength(progressEventCount);
+			expect(progressEvents.at(-1)).toEqual({
+				files: 2,
+				total: 2,
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
+
 function createFakePhp() {
 	const files = new Map<string, Uint8Array>();
 	const FS = {
+		mkdirTree: vi.fn(),
+		readdir: vi.fn(() => ['.', '..', 'database.sqlite']),
 		write: vi.fn(),
 		truncate: vi.fn(),
 		unlink: vi.fn(),

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -46,8 +46,12 @@ export type SyncProgress = {
 	files: number;
 	/** The number of all files that need to be synced. */
 	total: number;
+	/** The current stage of the initial sync. */
+	phase?: 'copying' | 'flushing';
 };
-export type SyncProgressCallback = (progress: SyncProgress) => void;
+export type SyncProgressCallback = (
+	progress: SyncProgress
+) => void | Promise<void>;
 
 interface JournalFSEventsToOpfsOptions {
 	maxFlushPasses?: number;
@@ -74,17 +78,40 @@ export function createDirectoryHandleMountHandler(
 			}
 			FSHelpers.mkdir(FS, vfsMountPoint);
 			await copyOpfsToMemfs(FS, handle, vfsMountPoint);
+			const mount = journalFSEventsToOpfs(php, handle, vfsMountPoint);
+			options.onMount?.(mount);
+			return mount.unmount;
 		} else {
-			await copyMemfsToOpfs(
-				FS,
-				handle,
-				vfsMountPoint,
-				options.initialSync.onProgress
-			);
+			const mount = journalFSEventsToOpfs(php, handle, vfsMountPoint);
+			options.onMount?.(mount);
+			let lastProgress: SyncProgress | undefined;
+			try {
+				await copyMemfsToOpfs(
+					FS,
+					handle,
+					vfsMountPoint,
+					async (progress) => {
+						lastProgress = {
+							...progress,
+							phase: 'copying',
+						};
+						await options.initialSync.onProgress?.(lastProgress);
+					}
+				);
+				await options.initialSync.onProgress?.({
+					files: lastProgress?.total ?? 0,
+					total: lastProgress?.total ?? 0,
+					phase: 'flushing',
+				});
+				void mount.flush().catch((error) => {
+					logger.error(error);
+				});
+			} catch (error) {
+				await mount.unmount();
+				throw error;
+			}
+			return mount.unmount;
 		}
-		const mount = journalFSEventsToOpfs(php, handle, vfsMountPoint);
-		options.onMount?.(mount);
-		return mount.unmount;
 	};
 }
 
@@ -195,6 +222,10 @@ export async function copyMemfsToOpfs(
 	// so we report progress. Throttle the progress callback to avoid flooding
 	// the main thread with excessive updates.
 	let numFilesCompleted = 0;
+	await onProgress?.({
+		files: numFilesCompleted,
+		total: filesToCreate.length,
+	});
 	const throttledProgressCallback = onProgress && throttle(onProgress, 100);
 
 	// Limit max concurrent writes because Safari may otherwise encounter
@@ -240,6 +271,11 @@ export async function copyMemfsToOpfs(
 		// to a conflict with writes from the earlier attempt.
 		await Promise.allSettled(concurrentWrites);
 	}
+	throttledProgressCallback?.cancel();
+	await onProgress?.({
+		files: filesToCreate.length,
+		total: filesToCreate.length,
+	});
 }
 
 function isMemfsDir(FS: Emscripten.RootFS, path: string) {
@@ -532,15 +568,21 @@ async function resolveParent(
 	return handle as any;
 }
 
+type CancelableThrottledFunction<T extends (...args: any[]) => any> = T & {
+	cancel(): void;
+};
+
 function throttle<T extends (...args: any[]) => any>(
 	fn: T,
 	debounceMs: number
-): T {
+): CancelableThrottledFunction<T> {
 	let lastCallTime = 0;
 	let timeoutId: ReturnType<typeof setTimeout> | undefined;
 	let pendingArgs: Parameters<T> | undefined;
 
-	return function throttledCallback(...args: Parameters<T>) {
+	const throttledCallback = function throttledCallback(
+		...args: Parameters<T>
+	) {
 		pendingArgs = args;
 
 		const timeSinceLastCall = Date.now() - lastCallTime;
@@ -552,5 +594,15 @@ function throttle<T extends (...args: any[]) => any>(
 				fn(...pendingArgs!);
 			}, delay);
 		}
-	} as T;
+	} as CancelableThrottledFunction<T>;
+
+	throttledCallback.cancel = () => {
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId);
+		}
+		timeoutId = undefined;
+		pendingArgs = undefined;
+	};
+
+	return throttledCallback;
 }


### PR DESCRIPTION
## What it does

Starts the OPFS journal mount before the initial MEMFS-to-OPFS copy finishes, then flushes writes that happen during that copy. It also reports initial copy progress from `0 / total` through the final file count.

## Rationale

A Playground can write files while the first OPFS copy is still running. Without a final journal flush, those writes can be overwritten by the initial copy and disappear from the browser-stored directory.

## Implementation

`createDirectoryHandleMountHandler()` now creates the journal mount before `copyMemfsToOpfs()` for MEMFS-to-OPFS initial syncs. After the copy completes, it schedules `mount.flush()` and logs flush errors instead of blocking mount completion.

`copyMemfsToOpfs()` now emits an initial progress event and cancels the throttled progress callback before sending the final progress event, so stale progress cannot arrive after completion.

## Testing instructions

Ran:

```bash
npm exec nx test php-wasm-web --testFile=directory-handle-mount.spec.ts
```