### PR TITLE
[Website] Isolate legacy WordPress boot tests from saved storage

### DIFF
--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -365,13 +365,16 @@ function shouldRetryFrontPageBoot(consoleErrors) {
 	);
 }
 
-const browser = await chromium.launch({ headless: true });
+const browser = await chromium.launch({
+	headless: true,
+	executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
+});
 
 for (const { wp, php } of MATRIX) {
 	const label = `WP ${wp} (PHP ${php})`;
 	process.stdout.write(`${label}... `);
 
-	const url = `http://127.0.0.1:${PORT}/website-server/?php=${php}&wp=${wp}`;
+	const url = `http://127.0.0.1:${PORT}/website-server/?php=${php}&wp=${wp}&storage=temp`;
 
 	// Isolate every version in a fresh browser context so that OPFS
 	// (where Playground persists site state), IndexedDB, localStorage


### PR DESCRIPTION
## What it does

Runs the legacy WordPress boot matrix with `storage=temp` and lets the test use `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` when CI provides a Chromium binary.

## Rationale

The legacy boot test should validate WordPress/PHP boot behavior, not persistent browser storage. Forcing temporary storage keeps prior OPFS state out of the matrix and makes the test independent of browser persistence defaults.

## Implementation

The test URL now includes `storage=temp` for every WordPress/PHP pair. The Chromium launch options also read `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`, matching CI environments that install a specific browser binary.

## Testing instructions

Run the legacy boot check in CI or locally with the same Playwright browser setup:

```bash
node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
```