### PR TITLE
[Website] Open GitHub import before creating a new Playground

### DIFF
--- a/packages/playground/website/src/components/layout/index.tsx
+++ b/packages/playground/website/src/components/layout/index.tsx
@@ -188,10 +188,16 @@ function Modals() {
 				<PreviewPRModal target="gutenberg" />
 			</LazyModal>
 		);
-	} else if (currentModal === modalSlugs.GITHUB_IMPORT) {
+	} else if (
+		currentModal === modalSlugs.GITHUB_IMPORT ||
+		currentModal === modalSlugs.GITHUB_IMPORT_NEW_SITE
+	) {
 		return (
 			<LazyModal>
 				<GithubImportModal
+					createNewSiteBeforeImport={
+						currentModal === modalSlugs.GITHUB_IMPORT_NEW_SITE
+					}
 					onImported={({
 						url,
 						path,

--- a/packages/playground/website/src/github/github-import-form/form.tsx
+++ b/packages/playground/website/src/github/github-import-form/form.tsx
@@ -20,6 +20,7 @@ import { logger } from '@php-wasm/logger';
 
 export interface GitHubImportFormProps {
 	playground: PlaygroundClient;
+	getPlaygroundBeforeImport?: () => Promise<PlaygroundClient>;
 	onImported: (details: {
 		url: string;
 		urlInformation: GitHubURLInformation;
@@ -42,6 +43,7 @@ function getClient() {
 
 export default function GitHubImportForm({
 	playground,
+	getPlaygroundBeforeImport,
 	onImported,
 }: GitHubImportFormProps) {
 	const [errors, setErrors] = useState<Record<string, string>>({});
@@ -140,13 +142,17 @@ export default function GitHubImportForm({
 						setImportProgress({ ...progress }),
 				}
 			);
+			const targetPlayground = getPlaygroundBeforeImport
+				? await getPlaygroundBeforeImport()
+				: playground;
 			await importFromGitHub(
-				playground,
+				targetPlayground,
 				ghFiles,
 				contentType!,
 				relativeRepoPath,
 				pluginOrThemeName
 			);
+			targetPlayground.goTo('/');
 			onImported({
 				url: newUrl,
 				urlInformation: urlInformation!,

--- a/packages/playground/website/src/github/github-import-form/modal.tsx
+++ b/packages/playground/website/src/github/github-import-form/modal.tsx
@@ -2,31 +2,61 @@ import type { GitHubImportFormProps } from './form';
 import GitHubImportForm from './form';
 import { usePlaygroundClient } from '../../lib/use-playground-client';
 import { setActiveModal } from '../../lib/state/redux/slice-ui';
-import type { PlaygroundDispatch } from '../../lib/state/redux/store';
+import { selectTemporarySite } from '../../lib/state/redux/slice-sites';
+import {
+	type PlaygroundDispatch,
+	useAppSelector,
+} from '../../lib/state/redux/store';
+import { useSitesAPI } from '../../lib/state/redux/site-management-api-middleware';
 import { useDispatch } from 'react-redux';
 import { Modal } from '../../components/modal';
 
 interface GithubImportModalProps {
 	defaultOpen?: boolean;
+	createNewSiteBeforeImport?: boolean;
 	onImported?: GitHubImportFormProps['onImported'];
 }
 export function GithubImportModal({
 	defaultOpen,
+	createNewSiteBeforeImport,
 	onImported,
 }: GithubImportModalProps) {
 	const dispatch: PlaygroundDispatch = useDispatch();
 	const playground = usePlaygroundClient();
+	const sitesAPI = useSitesAPI();
+	const temporarySite = useAppSelector(selectTemporarySite);
 
 	const closeModal = () => {
 		dispatch(setActiveModal(null));
 	};
+
+	const createSiteForImport = async () => {
+		try {
+			await sitesAPI.createNewTemporarySite();
+			await sitesAPI.saveInBrowser();
+		} catch {
+			if (temporarySite) {
+				await sitesAPI.setActiveSite(temporarySite.slug);
+			} else {
+				await sitesAPI.createNewTemporarySite();
+			}
+		}
+		const client = sitesAPI.getClient();
+		if (!client) {
+			throw new Error('No active Playground to import into.');
+		}
+		return client;
+	};
+
 	return (
 		<Modal title="Import from GitHub" onRequestClose={closeModal}>
 			<GitHubImportForm
 				playground={playground!}
+				getPlaygroundBeforeImport={
+					createNewSiteBeforeImport ? createSiteForImport : undefined
+				}
 				onClose={closeModal}
 				onImported={(details) => {
-					playground!.goTo('/');
 					// eslint-disable-next-line no-alert
 					alert(
 						'Import finished! Your Playground site has been updated.'

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -24,6 +24,7 @@ export const modalSlugs = {
 	ERROR_REPORT: 'error-report',
 	START_ERROR: 'start-error',
 	GITHUB_IMPORT: 'github-import',
+	GITHUB_IMPORT_NEW_SITE: 'github-import-new-site',
 	GITHUB_EXPORT: 'github-export',
 	GITHUB_PRIVATE_REPO_AUTH: 'github-private-repo-auth',
 	PREVIEW_PR_WP: 'preview-pr-wordpress',


### PR DESCRIPTION
## What it does

Changes the saved Playgrounds overlay so choosing **Import from GitHub** opens the GitHub import modal first. A new Playground is created only after the user submits the import form.

## Rationale

The previous flow created a new Playground before the user picked a repository. Canceling the modal left behind an unused site, and failures in the GitHub form could create storage churn before any import work was needed.

## Implementation

Adds a `github-import-new-site` modal mode that passes `getPlaygroundBeforeImport` into `GitHubImportForm`. On submit, the modal creates a new temporary Playground, saves it in browser storage, imports the selected GitHub files into that Playground, and navigates it to `/`.

If creating the browser-stored site fails, the modal falls back to the current temporary site or creates a temporary site so import still has a target.

## Testing instructions

Ran:

```bash
npm exec nx run playground-website:typecheck
```

Manual check:

1. Open the saved Playgrounds overlay.
2. Click **Import from GitHub**.
3. Dismiss the modal and verify no new Playground was created.
4. Reopen it, submit an import, and verify the imported site opens after completion.