### PR TITLE
[Website] Add saved Playground URL foundations

### DIFF
--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -462,6 +462,10 @@ export interface SiteMetadata {
 	//       For a user, timestamps might be useful to disambiguate identically-named sites.
 	//       For playground, we might choose to sort by most recently used.
 	//whenLastLoaded: number;
+	/**
+	 * Stable fingerprint of the setup URL that created this site, when known.
+	 */
+	sourceSetupUrlFingerprint?: string;
 
 	// @TODO: Accept any string as a php version?
 	runtimeConfiguration: RuntimeConfiguration;

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -1,11 +1,12 @@
-import { parseBlueprint } from './router';
+import { parseBlueprint, PlaygroundRoute } from './router';
 import { decodeBlueprintHash } from './decode-blueprint-hash';
+import type { SiteInfo } from '../redux/slice-sites';
 
 const toBase64 = (s: string) =>
 	typeof btoa === 'function'
 		? btoa(s)
 		: // eslint-disable-next-line @typescript-eslint/no-explicit-any
-		  (globalThis as any).Buffer.from(s, 'utf-8').toString('base64');
+			(globalThis as any).Buffer.from(s, 'utf-8').toString('base64');
 
 // `parseBlueprint` reaches into `window.atob` via the existing
 // `decodeBase64ToString` helper. The default vitest environment for this
@@ -13,7 +14,9 @@ const toBase64 = (s: string) =>
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const g = globalThis as any;
 if (typeof g.window === 'undefined') {
-	g.window = { atob: (s: string) => Buffer.from(s, 'base64').toString('binary') };
+	g.window = {
+		atob: (s: string) => Buffer.from(s, 'base64').toString('binary'),
+	};
 }
 
 describe('decodeBlueprintHash', () => {
@@ -87,7 +90,9 @@ describe('parseBlueprint', () => {
 	});
 
 	it('throws a descriptive error for invalid JSON and includes the underlying message', () => {
-		expect(() => parseBlueprint('{not json')).toThrow(/Invalid blueprint\./);
+		expect(() => parseBlueprint('{not json')).toThrow(
+			/Invalid blueprint\./
+		);
 		expect(() => parseBlueprint('{not json')).toThrow(
 			/Invalid blueprint\.\s+\S/
 		);
@@ -96,5 +101,57 @@ describe('parseBlueprint', () => {
 	it('hints at double-encoding when the input still contains %XX escapes', () => {
 		const halfDecoded = '{"landingPage"%3A"/"}';
 		expect(() => parseBlueprint(halfDecoded)).toThrow(/double-encoded/);
+	});
+});
+
+describe('PlaygroundRoute site creation routes', () => {
+	it('marks new temporary site URLs with storage=temp', () => {
+		const url = PlaygroundRoute.newTemporarySite(
+			{},
+			'https://playground.test/website-server/'
+		);
+		expect(new URL(url).searchParams.get('storage')).toBe('temp');
+	});
+
+	it('does not mark default new site URLs as temporary', () => {
+		const url = PlaygroundRoute.newSite(
+			{},
+			'https://playground.test/website-server/?storage=temp'
+		);
+		expect(new URL(url).searchParams.get('storage')).toBeNull();
+	});
+
+	it('replaces the current setup when creating a new site URL', () => {
+		const url = new URL(
+			PlaygroundRoute.newSite(
+				{
+					query: { php: '8.3' },
+				},
+				'https://playground.test/website-server/?storage=temp&wp=6.6#old'
+			)
+		);
+
+		expect(url.searchParams.get('php')).toBe('8.3');
+		expect(url.searchParams.get('random')).not.toBeNull();
+		expect(url.searchParams.get('storage')).toBeNull();
+		expect(url.searchParams.get('wp')).toBeNull();
+		expect(url.hash).toBe('');
+	});
+
+	it('preserves Query API version settings when selecting a saved site', () => {
+		const url = PlaygroundRoute.site(
+			{
+				slug: 'saved-site',
+				metadata: {
+					storage: 'opfs',
+				},
+			} as unknown as SiteInfo,
+			'https://playground.test/website-server/?url=/wp-admin/&php=8.0&wp=6.6'
+		);
+		const params = new URL(url).searchParams;
+		expect(params.get('site-slug')).toBe('saved-site');
+		expect(params.get('url')).toBe('/wp-admin/');
+		expect(params.get('php')).toBe('8.0');
+		expect(params.get('wp')).toBe('6.6');
 	});
 });

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -58,7 +58,10 @@ export function parseBlueprint(rawData: string) {
  * base64-decode-then-parse error if the input looks base64-shaped,
  * otherwise the plain JSON.parse error.
  */
-function formatInvalidBlueprintError(rawData: string, errors: unknown[]): string {
+function formatInvalidBlueprintError(
+	rawData: string,
+	errors: unknown[]
+): string {
 	const looksLikeBase64 = /^[A-Za-z0-9+/=]+$/.test(rawData.trim());
 	const primary = looksLikeBase64 && errors[1] ? errors[1] : errors[0];
 	const detail =
@@ -75,7 +78,21 @@ function formatInvalidBlueprintError(rawData: string, errors: unknown[]): string
 	return sentences.join('. ') + '.';
 }
 
+/**
+ * Builds navigation targets for Playground site changes.
+ *
+ * The helpers describe user-facing routing intents, such as switching to a
+ * saved Playground or starting a fresh setup. They do not change browser
+ * history themselves; callers navigate to the returned URL.
+ */
 export class PlaygroundRoute {
+	/**
+	 * Builds the navigation target for switching to an existing Playground.
+	 *
+	 * Temporary sites reuse their original setup URL. Stored sites use a
+	 * `site-slug` route while preserving selected query parameters from the
+	 * current URL.
+	 */
 	static site(site: SiteInfo, baseUrl: string = window.location.href) {
 		if (site.metadata.storage === 'none') {
 			return updateUrl(baseUrl, site.originalUrlParams || {});
@@ -85,6 +102,10 @@ export class PlaygroundRoute {
 				'mode',
 				'networking',
 				'login',
+				'php',
+				'wp',
+				'language',
+				'multisite',
 				'url',
 				'page-title',
 				'mcp',
@@ -103,6 +124,13 @@ export class PlaygroundRoute {
 			});
 		}
 	}
+
+	/**
+	 * Get the URL that starts a fresh temporary Playground.
+	 *
+	 * It comes with `?storage=temp` and a random cache busting parameter
+	 * and will not be autosaved regardless of the default browser-storage policy.
+	 */
 	static newTemporarySite(
 		config: {
 			query?: QueryAPIParams;
@@ -117,9 +145,39 @@ export class PlaygroundRoute {
 			{
 				searchParams: {
 					...query,
-					// Ensure a part of the URL is unique so we can still
-					// reload the temporary site even if its configuration
-					// hasn't changed.
+					storage: 'temp',
+					// Repeating the same temporary setup should still
+					// navigate away from the current Playground.
+					random: Math.random().toString(36).substring(2, 15),
+				},
+				hash: config.hash,
+			},
+			'replace'
+		);
+	}
+
+	/**
+	 * Get the URL that starts a fresh autosaved Playground.
+	 *
+	 * It comes with no `?storage` parameter, which allows the default browser-storage
+	 * policy to take effect. It still includes a random cache busting parameter anyway.
+	 */
+	static newSite(
+		config: {
+			query?: QueryAPIParams;
+			hash?: string;
+		} = {},
+		baseUrl: string = window.location.href
+	) {
+		const query =
+			(config.query as Record<string, string | undefined>) || {};
+		return updateUrl(
+			baseUrl,
+			{
+				searchParams: {
+					...query,
+					// Repeating the same setup should still navigate away from
+					// the current Playground.
 					random: Math.random().toString(36).substring(2, 15),
 				},
 				hash: config.hash,

--- a/packages/playground/website/src/lib/state/url/setup-url.spec.ts
+++ b/packages/playground/website/src/lib/state/url/setup-url.spec.ts
@@ -1,0 +1,99 @@
+import type { SiteInfo } from '../redux/slice-sites';
+import {
+	getAutosaveFingerprintFromURL,
+	getAutosaveFingerprintFromSite,
+} from './setup-url';
+
+describe('getAutosaveFingerprintFromURL', () => {
+	it('ignores runtime, UI, and cache-busting parameters', () => {
+		const first = getAutosaveFingerprintFromURL(
+			new URL(
+				'https://playground.test/?php=8.3&wp=6.8&random=abc' +
+					'&modal=save-site&site-slug=demo&_=1&cacheBustWhatever=1#'
+			)
+		);
+		const second = getAutosaveFingerprintFromURL(
+			new URL('https://playground.test/?wp=6.8&php=8.3&cb=2&ts=3&v=4')
+		);
+
+		expect(first).toBe(second);
+	});
+
+	it('keeps setup-affecting parameters distinct', () => {
+		expect(
+			getAutosaveFingerprintFromURL(
+				new URL('https://playground.test/?php=8.3&wp=6.8')
+			)
+		).not.toBe(
+			getAutosaveFingerprintFromURL(
+				new URL('https://playground.test/?php=8.4&wp=6.8')
+			)
+		);
+	});
+
+	it('includes the blueprint fragment', () => {
+		expect(
+			getAutosaveFingerprintFromURL(
+				new URL('https://playground.test/#one')
+			)
+		).not.toBe(
+			getAutosaveFingerprintFromURL(
+				new URL('https://playground.test/#two')
+			)
+		);
+	});
+
+	it('normalizes stored site metadata like URL search parameters', () => {
+		const site = {
+			slug: 'test-site',
+			originalUrlParams: {
+				searchParams: { wp: '6.8', php: '8.3' },
+				hash: '#blueprint',
+			},
+			metadata: {},
+		} as unknown as SiteInfo;
+
+		expect(getAutosaveFingerprintFromSite(site)).toBe(
+			getAutosaveFingerprintFromURL(
+				new URL('https://playground.test/?php=8.3&wp=6.8#blueprint')
+			)
+		);
+	});
+
+	it('normalizes repeated URL parameters like stored metadata arrays', () => {
+		const site = {
+			slug: 'test-site',
+			originalUrlParams: {
+				searchParams: {
+					plugin: ['a', 'b'],
+					theme: 'twentytwentyfive',
+				},
+			},
+			metadata: {},
+		} as unknown as SiteInfo;
+
+		expect(getAutosaveFingerprintFromSite(site)).toBe(
+			getAutosaveFingerprintFromURL(
+				new URL(
+					'https://playground.test/?plugin=a&plugin=b&theme=twentytwentyfive'
+				)
+			)
+		);
+	});
+
+	it('treats repeated setup parameter order as insignificant', () => {
+		expect(
+			getAutosaveFingerprintFromURL(
+				new URL(
+					'https://playground.test/?plugin=a&plugin=b&theme=twentytwentyfive'
+				)
+			)
+		).toBe(
+			getAutosaveFingerprintFromURL(
+				new URL(
+					'https://playground.test/?theme=twentytwentyfive&plugin=b&plugin=a'
+				)
+			)
+		);
+	});
+});

--- a/packages/playground/website/src/lib/state/url/setup-url.ts
+++ b/packages/playground/website/src/lib/state/url/setup-url.ts
@@ -1,0 +1,136 @@
+import type { SiteInfo } from '../redux/slice-sites';
+
+const SETUP_QUERY_PARAMS = new Set([
+	'blueprint',
+	'blueprint-url',
+	'core-pr',
+	'gutenberg-branch',
+	'gutenberg-pr',
+	'import-content',
+	'import-site',
+	'import-wxr',
+	'language',
+	'login',
+	'multisite',
+	'name',
+	'networking',
+	'php',
+	'plugin',
+	'theme',
+	'url',
+	'wp',
+]);
+
+/**
+ * Returns a stable cache key for matching autosaves to setup URLs.
+ *
+ * The fingerprint deliberately ignores routing and lifecycle parameters such as
+ * `site-slug`, `storage`, and `random`, so equivalent setup URLs compare equal.
+ */
+export function getAutosaveFingerprintFromURL(url: URL) {
+	return getAutosaveFingerprintFromParts({
+		searchParams: url.searchParams,
+		hash: url.hash,
+	});
+}
+
+/**
+ * Returns the autosave fingerprint originally associated with a site.
+ *
+ * Existing saved sites may not have stored `sourceSetupUrlFingerprint`, so this
+ * falls back to deriving the fingerprint from their original URL parameters.
+ */
+export function getAutosaveFingerprintFromSite(site: SiteInfo) {
+	return (
+		site.metadata.sourceSetupUrlFingerprint ||
+		getAutosaveFingerprintFromParts({
+			searchParams: site.originalUrlParams?.searchParams,
+			hash: site.originalUrlParams?.hash,
+		})
+	);
+}
+
+/**
+ * Returns a serialized autosave fingerprint from URL parts.
+ *
+ * Callers pass either live `URLSearchParams` from the current URL or the stored
+ * search parameter record from site metadata. Both forms are normalized before
+ * serialization so restore matching can compare them consistently.
+ */
+function getAutosaveFingerprintFromParts({
+	searchParams,
+	hash,
+}: {
+	searchParams?: URLSearchParams | Record<string, string | string[]>;
+	hash?: string;
+}) {
+	const params = normalizeFingerprintParams(searchParams);
+	return JSON.stringify({
+		search: params,
+		hash: normalizeHash(hash),
+	});
+}
+
+/**
+ * Returns autosave-affecting search parameters in deterministic order.
+ *
+ * Routing, UI, and cache-busting parameters are excluded because they do not
+ * change the WordPress site being created. Repeated setup parameters are kept
+ * and sorted by key and value. This means repeated parameters such as
+ * `plugin=a&plugin=b` and `plugin=b&plugin=a` produce the same fingerprint.
+ */
+function normalizeFingerprintParams(
+	searchParams?: URLSearchParams | Record<string, string | string[]>
+) {
+	const params = new URLSearchParams();
+	if (searchParams instanceof URLSearchParams) {
+		for (const [key, value] of searchParams.entries()) {
+			if (!SETUP_QUERY_PARAMS.has(key)) {
+				continue;
+			}
+			params.append(key, value);
+		}
+	} else if (searchParams) {
+		for (const [key, value] of Object.entries(searchParams)) {
+			if (!SETUP_QUERY_PARAMS.has(key)) {
+				continue;
+			}
+			const values = Array.isArray(value) ? value : [value];
+			for (const item of values) {
+				params.append(key, item);
+			}
+		}
+	}
+
+	return Array.from(params.entries())
+		.map(([key, value]) => [key, value] as const)
+		.sort(([keyA, valueA], [keyB, valueB]) => {
+			if (keyA === keyB) {
+				return compareFingerprintPart(valueA, valueB);
+			}
+			return compareFingerprintPart(keyA, keyB);
+		});
+}
+
+/**
+ * Compares fingerprint parts without locale-sensitive collation.
+ *
+ * Fingerprints need the same sort order in every browser and Node.js runtime,
+ * regardless of the user's locale.
+ */
+function compareFingerprintPart(left: string, right: string) {
+	if (left < right) {
+		return -1;
+	}
+	if (left > right) {
+		return 1;
+	}
+	return 0;
+}
+
+/**
+ * Returns the normalized setup fragment without a leading hash marker.
+ */
+function normalizeHash(hash?: string) {
+	return hash?.replace(/^#/, '') || '';
+}


### PR DESCRIPTION
## What it does

Adds the URL routing pieces needed for saved Playgrounds:

- Parses and emits `/website-server/:siteSlug/` routes.
- Preserves setup URL query state while routing to a saved Playground.
- Computes a stable setup URL fingerprint for restore decisions.

## Rationale

Saving Playgrounds needs stable URLs before lifecycle or UI changes can be
reviewed cleanly. This PR keeps that routing work separate from persistence
behavior.

## Implementation

Extends the website URL router and setup URL helpers. The site metadata shape
gets `sourceSetupUrlFingerprint` so later PRs can compare a restored autosave
against the setup URL that created it.

## Testing instructions

```bash
npm exec nx run playground-website:typecheck
npm exec nx test playground-website --testFile=setup-url.spec.ts
```
