### PR TITLE
[website] Use runtime boot fingerprints for iframe reloads

### DIFF
--- a/packages/playground/website/src/components/playground-viewport/index.tsx
+++ b/packages/playground/website/src/components/playground-viewport/index.tsx
@@ -18,6 +18,7 @@ import {
 } from '../../lib/state/redux/slice-sites';
 import classNames from 'classnames';
 import { SiteErrorModal } from '../site-error-modal';
+import { getRuntimeBootFingerprint } from '../../lib/state/playground-identity';
 
 export const supportedDisplayModes = [
 	'browser-full-screen',
@@ -203,7 +204,7 @@ export const JustViewport = function JustViewport({
 	const site = useAppSelector((state) => selectSiteBySlug(state, siteSlug))!;
 
 	const dispatch = useAppDispatch();
-	const runtimeConfigString = JSON.stringify(
+	const runtimeBootFingerprint = getRuntimeBootFingerprint(
 		site.metadata.runtimeConfiguration
 	);
 	useEffect(() => {
@@ -224,7 +225,7 @@ export const JustViewport = function JustViewport({
 			dispatch(removeClientInfo(siteSlug));
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [siteSlug, iframeRef, runtimeConfigString]);
+	}, [siteSlug, iframeRef, runtimeBootFingerprint]);
 
 	const error = useAppSelector(selectActiveSiteError);
 	const errorDetails = useAppSelector(selectActiveSiteErrorDetails);

--- a/packages/playground/website/src/lib/state/playground-identity.spec.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.spec.ts
@@ -1,8 +1,10 @@
-import type { SiteInfo } from '../redux/slice-sites';
+import type { RuntimeConfiguration } from '@wp-playground/blueprints';
+import type { SiteInfo } from './redux/slice-sites';
 import {
 	getAutosaveFingerprintFromURL,
 	getAutosaveFingerprintFromSite,
-} from './setup-url';
+	getRuntimeBootFingerprint,
+} from './playground-identity';
 
 describe('getAutosaveFingerprintFromURL', () => {
 	it('ignores runtime, UI, and cache-busting parameters', () => {
@@ -94,6 +96,73 @@ describe('getAutosaveFingerprintFromURL', () => {
 					'https://playground.test/?theme=twentytwentyfive&plugin=b&plugin=a'
 				)
 			)
+		);
+	});
+});
+
+describe('getRuntimeBootFingerprint', () => {
+	const runtimeConfiguration: RuntimeConfiguration = {
+		phpVersion: '8.3',
+		wpVersion: '6.8',
+		intl: false,
+		networking: false,
+		extraLibraries: [],
+		constants: {},
+	};
+
+	it('changes when iframe boot settings change', () => {
+		expect(
+			getRuntimeBootFingerprint({
+				...runtimeConfiguration,
+				phpVersion: '8.3',
+			})
+		).not.toBe(
+			getRuntimeBootFingerprint({
+				...runtimeConfiguration,
+				phpVersion: '8.4',
+			})
+		);
+
+		expect(
+			getRuntimeBootFingerprint({
+				...runtimeConfiguration,
+				networking: false,
+			})
+		).not.toBe(
+			getRuntimeBootFingerprint({
+				...runtimeConfiguration,
+				networking: true,
+			})
+		);
+
+		expect(
+			getRuntimeBootFingerprint({
+				...runtimeConfiguration,
+				extraLibraries: [],
+			})
+		).not.toBe(
+			getRuntimeBootFingerprint({
+				...runtimeConfiguration,
+				extraLibraries: ['wp-cli'],
+			})
+		);
+	});
+
+	it('changes when PHP constants change', () => {
+		expect(
+			getRuntimeBootFingerprint({
+				...runtimeConfiguration,
+				constants: {
+					WP_DEBUG: true,
+				},
+			})
+		).not.toBe(
+			getRuntimeBootFingerprint({
+				...runtimeConfiguration,
+				constants: {
+					SITE_URL: 'https://playground.test',
+				},
+			})
 		);
 	});
 });

--- a/packages/playground/website/src/lib/state/playground-identity.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.ts
@@ -1,4 +1,5 @@
-import type { SiteInfo } from '../redux/slice-sites';
+import type { RuntimeConfiguration } from '@wp-playground/blueprints';
+import type { SiteInfo } from './redux/slice-sites';
 
 const SETUP_QUERY_PARAMS = new Set([
 	'blueprint',
@@ -48,6 +49,20 @@ export function getAutosaveFingerprintFromSite(site: SiteInfo) {
 			hash: site.originalUrlParams?.hash,
 		})
 	);
+}
+
+/**
+ * Returns the persisted-site runtime fingerprint used to decide whether the
+ * mounted iframe can keep running.
+ *
+ * Unlike the autosave setup fingerprint, this does not describe the original
+ * setup URL. It only tracks runtime options passed into an already selected
+ * site's boot process.
+ */
+export function getRuntimeBootFingerprint(
+	runtimeConfiguration: RuntimeConfiguration
+) {
+	return JSON.stringify(runtimeConfiguration);
 }
 
 /**


### PR DESCRIPTION
## What it does

Adds a named runtime boot fingerprint for selected Playgrounds and uses it to decide when the iframe must be rebooted.

## Rationale

The viewport already needed to reboot when `runtimeConfiguration` changed. Keeping that logic in `playground-identity` makes the reboot trigger explicit and keeps it next to the setup URL fingerprint helpers.

## Implementation

- Renames the setup identity helper to `playground-identity` so it can own more than URL fingerprints.
- Adds `getRuntimeBootFingerprint()` as `JSON.stringify(runtimeConfiguration)`.
- Uses that fingerprint in the viewport effect dependency instead of serializing the runtime config inline.
- Tests that PHP constants are part of the fingerprint, so Blueprints that differ only by constants do not compare equal.

## Testing instructions

```bash
npm exec nx run playground-website:typecheck
npm exec nx test playground-website --testFile=playground-identity.spec.ts
```
