### PR TITLE
Refine Your Playgrounds overlay for autosaves

### DIFF
--- a/packages/playground/website/playwright/e2e/blueprints.spec.ts
+++ b/packages/playground/website/playwright/e2e/blueprints.spec.ts
@@ -114,12 +114,13 @@ test('?blueprint-url=... should work with simple blueprints', async ({
 		browserName === 'webkit',
 		'This test is flaky in WebKit. It seems like a GitHub CI issue rather than an actual flakiness since it is reliable locally.'
 	);
-	await website.goto('/');
-	const websiteUrl = page.url();
-	const blueprintUrl = encodeURIComponent(
-		`${websiteUrl}test-fixtures/blueprint/blueprint-simple.json`
+	await website.goto('./?storage=temp');
+	const websiteUrl = new URL(
+		'test-fixtures/blueprint/blueprint-simple.json',
+		page.url()
 	);
-	await website.goto(`/?blueprint-url=${blueprintUrl}`);
+	const blueprintUrl = encodeURIComponent(websiteUrl.href);
+	await website.goto(`./?storage=temp&blueprint-url=${blueprintUrl}`);
 	await expect(wordpress.locator('body')).toContainText(
 		'PREFACE TO PYGMALION'
 	);
@@ -130,11 +131,11 @@ test('?blueprint-url=... should accept data URLs', async ({
 	website,
 	wordpress,
 }) => {
-	await website.goto('/');
+	await website.goto('./?storage=temp');
 	const blueprintUrl = encodeURIComponent(
 		`data:application/json;base64,eyJsYW5kaW5nUGFnZSI6Ii9weWdtYWxpb24udHh0Iiwic3RlcHMiOlt7InN0ZXAiOiJ3cml0ZUZpbGUiLCJwYXRoIjoiL3dvcmRwcmVzcy9weWdtYWxpb24udHh0IiwiZGF0YSI6IlBSRUZBQ0UgVE8gUFlHTUFMSU9OIn1dfQ==`
 	);
-	await website.goto(`/?blueprint-url=${blueprintUrl}`);
+	await website.goto(`./?storage=temp&blueprint-url=${blueprintUrl}`);
 	await expect(wordpress.locator('body')).toContainText(
 		'PREFACE TO PYGMALION'
 	);
@@ -145,12 +146,13 @@ test('?blueprint-url=... should work with ZIP bundles', async ({
 	website,
 	wordpress,
 }) => {
-	await website.goto('/');
-	const websiteUrl = page.url();
-	const blueprintUrl = encodeURIComponent(
-		`${websiteUrl}test-fixtures/blueprint/blueprint.zip`
+	await website.goto('./?storage=temp');
+	const websiteUrl = new URL(
+		'test-fixtures/blueprint/blueprint.zip',
+		page.url()
 	);
-	await website.goto(`/?blueprint-url=${blueprintUrl}`);
+	const blueprintUrl = encodeURIComponent(websiteUrl.href);
+	await website.goto(`./?storage=temp&blueprint-url=${blueprintUrl}`);
 	await expect(wordpress.locator('body')).toContainText(
 		'PREFACE TO PYGMALION'
 	);
@@ -161,12 +163,13 @@ test('?blueprint-url=... should work with JSON blueprints referring bundled reso
 	website,
 	wordpress,
 }) => {
-	await website.goto('/');
-	const websiteUrl = page.url();
-	const blueprintUrl = encodeURIComponent(
-		`${websiteUrl}test-fixtures/blueprint/blueprint-with-bundled-resources.json`
+	await website.goto('./?storage=temp');
+	const websiteUrl = new URL(
+		'test-fixtures/blueprint/blueprint-with-bundled-resources.json',
+		page.url()
 	);
-	await website.goto(`/?blueprint-url=${blueprintUrl}`);
+	const blueprintUrl = encodeURIComponent(websiteUrl.href);
+	await website.goto(`./?storage=temp&blueprint-url=${blueprintUrl}`);
 	await expect(wordpress.locator('body')).toContainText(
 		'PREFACE TO PYGMALION'
 	);

--- a/packages/playground/website/playwright/e2e/client-side-media.spec.ts
+++ b/packages/playground/website/playwright/e2e/client-side-media.spec.ts
@@ -68,7 +68,9 @@ test('Post editor should be cross-origin isolated with SharedArrayBuffer availab
 	website,
 	wordpress,
 }) => {
-	await website.goto(`./#${JSON.stringify(clientSideMediaBlueprint)}`);
+	await website.goto(
+		`./?storage=temp#${JSON.stringify(clientSideMediaBlueprint)}`
+	);
 
 	// Wait for the block editor to fully load. The editor header is visible in both
 	// fullscreen and non-fullscreen modes.
@@ -96,7 +98,9 @@ test('Gutenberg should report client-side media processing as enabled', async ({
 	website,
 	wordpress,
 }) => {
-	await website.goto(`./#${JSON.stringify(clientSideMediaBlueprint)}`);
+	await website.goto(
+		`./?storage=temp#${JSON.stringify(clientSideMediaBlueprint)}`
+	);
 
 	await expect(
 		wordpress.locator('.edit-post-header, .editor-header')

--- a/packages/playground/website/playwright/e2e/deployment.spec.ts
+++ b/packages/playground/website/playwright/e2e/deployment.spec.ts
@@ -15,6 +15,7 @@ const url = new URL(`http://localhost:${port}`);
 // disable auto-login, the old Playground build encounters
 // a boot error.
 url.searchParams.set('login', 'no');
+url.searchParams.set('storage', 'temp');
 // Specify the theme so we can assert against expected default content.
 // This theme is also what the reference screenshots are based on.
 url.searchParams.set('theme', 'twentytwentyfour');

--- a/packages/playground/website/playwright/e2e/error-handling.spec.ts
+++ b/packages/playground/website/playwright/e2e/error-handling.spec.ts
@@ -44,7 +44,7 @@ test('should show download error modal when a resource download fails', async ({
 	// fetches the zip from downloads.wordpress.org via the CORS
 	// proxy, triggering the resource-download-failed error through
 	// the normal pipeline.
-	await page.goto('./?plugin=hello-dolly');
+	await page.goto('./?storage=temp&plugin=hello-dolly');
 
 	const title = page.getByText('Could not download required files');
 	await expect(title).toBeVisible();

--- a/packages/playground/website/playwright/e2e/opfs.spec.ts
+++ b/packages/playground/website/playwright/e2e/opfs.spec.ts
@@ -97,7 +97,8 @@ test('should switch between sites', async ({ website, browserName }) => {
 	await website.ensureSiteManagerIsOpen();
 
 	// Save the temporary site using the modal
-	await saveSiteViaModal(website.page);
+	const firstSiteName = 'Switching Test Site';
+	await saveSiteViaModal(website.page, { customName: firstSiteName });
 
 	await expect(website.page.getByLabel('Playground title')).not.toContainText(
 		'Unsaved Playground',
@@ -106,19 +107,46 @@ test('should switch between sites', async ({ website, browserName }) => {
 			timeout: 90000,
 		}
 	);
+	await expect(website.page.getByLabel('Playground title')).toContainText(
+		firstSiteName
+	);
 
 	// Open the saved playgrounds overlay to switch sites
 	await website.openSavedPlaygroundsOverlay();
 
-	// Click on Temporary Playground in the overlay's site list
+	// Start another saved Playground, then switch back to the first one.
+	await website.page.getByRole('button', { name: 'New Playground' }).click();
+	await website.waitForNestedIframes();
+	await website.ensureSiteManagerIsOpen();
+
+	await expect(website.page.getByLabel('Playground title')).not.toContainText(
+		firstSiteName
+	);
+	await expect(
+		website.page.getByText('Autosaved in this browser')
+	).toBeVisible({ timeout: 120000 });
+	await expect
+		.poll(() =>
+			website.page.evaluate(() => {
+				const activeSite = (window as any).playgroundSites
+					.list()
+					.find((site: any) => site.isActive);
+				return activeSite
+					? `${activeSite.storage}:${activeSite.persistence}`
+					: null;
+			})
+		)
+		.toBe('opfs:autosave');
+
+	await website.openSavedPlaygroundsOverlay();
 	await website.page
 		.locator('[class*="siteRowContent"]')
-		.filter({ hasText: 'Unsaved Playground' })
+		.filter({ hasText: firstSiteName })
 		.click();
+	await website.ensureSiteManagerIsOpen();
 
-	// The overlay closes and site manager opens with the selected site
 	await expect(website.page.getByLabel('Playground title')).toContainText(
-		'Unsaved Playground'
+		firstSiteName
 	);
 });
 
@@ -170,11 +198,9 @@ test('should preserve PHP constants when saving a temporary site to OPFS', async
 	// Open the saved playgrounds overlay to switch sites
 	await website.openSavedPlaygroundsOverlay();
 
-	// Switch to Temporary Playground
-	await website.page
-		.locator('[class*="siteRowContent"]')
-		.filter({ hasText: 'Unsaved Playground' })
-		.click();
+	// Create another Playground, then switch back.
+	await website.page.getByRole('button', { name: 'New Playground' }).click();
+	await website.waitForNestedIframes();
 
 	// Open the overlay again to switch back to the stored site
 	await website.openSavedPlaygroundsOverlay();
@@ -472,7 +498,7 @@ test('should display OPFS storage option as selected by default', async ({
 	await dialog.getByRole('button', { name: 'Cancel' }).click();
 });
 
-test('should import ZIP into temporary site when a saved site exists', async ({
+test('should import ZIP into a new saved site when a saved site exists', async ({
 	website,
 	wordpress,
 	browserName,
@@ -537,11 +563,13 @@ test('should import ZIP into temporary site when a saved site exists', async ({
 		buffer: zipBuffer,
 	});
 
-	// The import should switch us to a temporary playground.
-	// Wait for the site title to show "Temporary Playground"
-	await expect(website.page.getByLabel('Playground title')).toContainText(
-		'Unsaved Playground',
+	// The import should switch us to a new saved Playground by default.
+	await expect(website.page.getByLabel('Playground title')).not.toContainText(
+		savedSiteName,
 		{ timeout: 30000 }
+	);
+	await expect(website.page.getByLabel('Playground title')).not.toContainText(
+		'Unsaved Playground'
 	);
 
 	// Now verify the saved site still has the original content.
@@ -552,16 +580,17 @@ test('should import ZIP into temporary site when a saved site exists', async ({
 		.locator('[class*="siteRowContent"]')
 		.filter({ hasText: savedSiteName })
 		.click();
+	await website.ensureSiteManagerIsOpen();
 
 	// Wait for the saved site to load - this verifies the saved site wasn't overwritten
-	// by the ZIP import (which went to a temporary site instead)
+	// by the ZIP import (which went to a new saved site instead)
 	await expect(website.page.getByLabel('Playground title')).toContainText(
 		savedSiteName,
 		{ timeout: 30000 }
 	);
 });
 
-test('should create temporary site when importing ZIP while on a saved site with no existing temporary site', async ({
+test('should create a saved site when importing ZIP while on a saved site with no existing temporary site', async ({
 	website,
 	wordpress,
 	browserName,
@@ -619,14 +648,10 @@ test('should create temporary site when importing ZIP while on a saved site with
 	// Open the saved playgrounds overlay
 	await website.openSavedPlaygroundsOverlay();
 
-	// Verify there's no "Temporary Playground" in the list initially
-	// (the temporary site row should show but clicking it would create one)
-	const tempPlaygroundRow = website.page
-		.locator('[class*="siteRowContent"]')
-		.filter({ hasText: 'Unsaved Playground' });
-
-	// The row exists but it's for creating a new temporary playground
-	await expect(tempPlaygroundRow).toBeVisible();
+	const importZipButton = website.page.getByRole('button', {
+		name: 'Import a .zip',
+	});
+	await expect(importZipButton).toBeVisible();
 
 	// Create a test ZIP
 	const importedMarker = 'FRESH_IMPORT_MARKER_BBBBB';
@@ -649,11 +674,13 @@ test('should create temporary site when importing ZIP while on a saved site with
 		buffer: zipBuffer,
 	});
 
-	// The import should trigger creation of a new temporary site.
-	// Wait for the site title to show "Temporary Playground"
-	await expect(website.page.getByLabel('Playground title')).toContainText(
-		'Unsaved Playground',
+	// The import should trigger creation of a new saved site by default.
+	await expect(website.page.getByLabel('Playground title')).not.toContainText(
+		savedSiteName,
 		{ timeout: 30000 }
+	);
+	await expect(website.page.getByLabel('Playground title')).not.toContainText(
+		'Unsaved Playground'
 	);
 
 	// Verify the saved site is still intact by switching to it
@@ -663,9 +690,10 @@ test('should create temporary site when importing ZIP while on a saved site with
 		.locator('[class*="siteRowContent"]')
 		.filter({ hasText: savedSiteName })
 		.click();
+	await website.ensureSiteManagerIsOpen();
 
 	// Wait for the saved site to load - this verifies the saved site wasn't overwritten
-	// by the ZIP import (which went to a temporary site instead)
+	// by the ZIP import (which went to a new saved site instead)
 	await expect(website.page.getByLabel('Playground title')).toContainText(
 		savedSiteName,
 		{ timeout: 30000 }

--- a/packages/playground/website/playwright/e2e/shutdown-loopback-prefetch.spec.ts
+++ b/packages/playground/website/playwright/e2e/shutdown-loopback-prefetch.spec.ts
@@ -72,7 +72,7 @@ add_action( 'shutdown', function() {
 	// Navigate without waiting for nested iframes. We only need the boot
 	// process to run prefetchUpdateChecks(); we don't need wp-admin to render.
 	await website.page.goto(
-		`./?networking=yes&url=/wp-admin/#${JSON.stringify(blueprint)}`
+		`./?storage=temp&networking=yes&url=/wp-admin/#${JSON.stringify(blueprint)}`
 	);
 
 	// Wait for the playground client to be available (set before prefetch runs).
@@ -114,7 +114,8 @@ echo (string) get_option('${optName}', '');
 	expect(parsed.kind).toBe('wp_error');
 	if (parsed.kind === 'wp_error') {
 		expect(parsed.code).toBe('http_request_block');
-		expect(parsed.message).toBe('Loopback requests are not to be pre-fetched');
+		expect(parsed.message).toBe(
+			'Loopback requests are not to be pre-fetched'
+		);
 	}
 });
-

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../playground-fixtures.ts';
 import type { Blueprint } from '@wp-playground/blueprints';
+import type { Page } from '@playwright/test';
 
 // We can't import the SupportedPHPVersions versions directly from the remote package
 // because of ESModules vs CommonJS incompatibilities. Let's just import the
@@ -9,10 +10,70 @@ import { SupportedPHPVersions } from '../../../../php-wasm/universal/src/lib/sup
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import * as MinifiedWordPressVersions from '../../../wordpress-builds/src/wordpress/wp-versions.json';
 
+/**
+ * Returns a setup URL that cannot accidentally reuse another test's autosave.
+ */
+function getUniqueSavedPlaygroundSetupUrl(
+	label: string,
+	params: Record<string, string> = {}
+) {
+	const searchParams = new URLSearchParams({
+		name: `${label}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+		...params,
+	});
+	return `./?${searchParams}`;
+}
+
+/**
+ * Runs PHP and flushes OPFS before assertions that depend on persisted changes.
+ */
+async function runPHPAndFlushOpfs(page: Page, code: string) {
+	await expect
+		.poll(
+			() =>
+				page.evaluate(async (phpCode: string) => {
+					try {
+						const playground = (window as any).playground;
+						await playground.run({ code: phpCode });
+						await playground.flushOpfs('/wordpress');
+						return 'ok';
+					} catch (error) {
+						return String(
+							error instanceof Error ? error.message : error
+						);
+					}
+				}, code),
+			{ timeout: 120000 }
+		)
+		.toBe('ok');
+}
+
+function updateBlogNameCode(blogName: string) {
+	return `<?php
+require_once '/wordpress/wp-load.php';
+update_option('blogname', ${JSON.stringify(blogName)});
+	`;
+}
+
+/**
+ * Returns the active site exposed by the site-management browser API.
+ */
+async function getActivePlaygroundSite(page: Page) {
+	return page.evaluate(() =>
+		(window as any).playgroundSites
+			.list()
+			.find((site: any) => site.isActive)
+	);
+}
+
+function escapeRegExp(text: string) {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 test('should reflect the URL update from the navigation bar in the WordPress site', async ({
 	website,
 }) => {
-	await website.goto('./?url=/wp-admin/');
+	await website.goto('./?storage=temp&url=/wp-admin/');
 	await website.ensureSiteManagerIsClosed();
 	await expect(website.page.locator('input[value="/wp-admin/"]')).toHaveValue(
 		'/wp-admin/'
@@ -27,7 +88,7 @@ test('should correctly load /wp-admin without the trailing slash', async ({
 		browserName === 'webkit',
 		'This test is flaky in WebKit. It seems like a GitHub CI issue rather than an actual flakiness since it is reliable locally.'
 	);
-	await website.goto('./?url=/wp-admin');
+	await website.goto('./?storage=temp&url=/wp-admin');
 	await website.ensureSiteManagerIsClosed();
 	await expect(website.page.locator('input[value="/wp-admin/"]')).toHaveValue(
 		'/wp-admin/'
@@ -36,7 +97,7 @@ test('should correctly load /wp-admin without the trailing slash', async ({
 
 SupportedPHPVersions.forEach(async (version) => {
 	test(`should switch PHP version to ${version}`, async ({ website }) => {
-		await website.goto(`./`);
+		await website.goto('./?storage=temp');
 		await website.ensureSiteManagerIsOpen();
 		await website.page.getByLabel('PHP version').selectOption(version);
 		await website.page
@@ -58,7 +119,7 @@ Object.keys(MinifiedWordPressVersions)
 		test(`should switch WordPress version to ${version}`, async ({
 			website,
 		}) => {
-			await website.goto('./');
+			await website.goto('./?storage=temp');
 			await website.ensureSiteManagerIsOpen();
 			await website.page
 				.getByLabel('WordPress version')
@@ -76,7 +137,7 @@ Object.keys(MinifiedWordPressVersions)
 	});
 
 test('should display networking as active by default', async ({ website }) => {
-	await website.goto('./');
+	await website.goto('./?storage=temp');
 	await website.ensureSiteManagerIsOpen();
 	await expect(website.page.getByLabel('Network access')).toBeChecked();
 });
@@ -84,13 +145,13 @@ test('should display networking as active by default', async ({ website }) => {
 test('should display networking as active when networking is enabled', async ({
 	website,
 }) => {
-	await website.goto('./?networking=yes');
+	await website.goto('./?storage=temp&networking=yes');
 	await website.ensureSiteManagerIsOpen();
 	await expect(website.page.getByLabel('Network access')).toBeChecked();
 });
 
 test('should enable networking when requested', async ({ website }) => {
-	await website.goto('./');
+	await website.goto('./?storage=temp');
 
 	await website.ensureSiteManagerIsOpen();
 	await website.page.getByLabel('Network access').check();
@@ -102,7 +163,7 @@ test('should enable networking when requested', async ({ website }) => {
 });
 
 test('should disable networking when requested', async ({ website }) => {
-	await website.goto('./?networking=yes');
+	await website.goto('./?storage=temp&networking=yes');
 
 	await website.ensureSiteManagerIsOpen();
 	await website.page.getByLabel('Network access').uncheck();
@@ -128,7 +189,7 @@ test('should display PHP output even when a fatal error is hit', async ({
 			},
 		],
 	};
-	await website.goto(`./#${JSON.stringify(blueprint)}`);
+	await website.goto(`./?storage=temp#${JSON.stringify(blueprint)}`);
 
 	await expect(wordpress.locator('body')).toContainText(
 		'This is a fatal error'
@@ -139,9 +200,16 @@ test('should keep query arguments when updating settings', async ({
 	website,
 	wordpress,
 }) => {
-	await website.goto('./?url=/wp-admin/&php=8.0&wp=6.6');
+	await website.goto(
+		'./?storage=temp&url=/wp-admin/&php=8.0&wp=6.6&networking=no'
+	);
 
-	expect(website.page.url()).toContain('?url=%2Fwp-admin%2F&php=8.0&wp=6.6');
+	const initialParams = new URL(website.page.url()).searchParams;
+	expect(initialParams.get('storage')).toBe('temp');
+	expect(initialParams.get('url')).toBe('/wp-admin/');
+	expect(initialParams.get('php')).toBe('8.0');
+	expect(initialParams.get('wp')).toBe('6.6');
+	expect(initialParams.get('networking')).toBe('no');
 	expect(
 		await wordpress.locator('body').evaluate((body) => body.baseURI)
 	).toMatch('/wp-admin/');
@@ -151,9 +219,12 @@ test('should keep query arguments when updating settings', async ({
 	await website.page.getByText('Apply Settings & Reset Playground').click();
 	await website.waitForNestedIframes();
 
-	expect(website.page.url()).toMatch(
-		'?url=%2Fwp-admin%2F&php=8.0&wp=6.6&networking=yes'
-	);
+	const updatedParams = new URL(website.page.url()).searchParams;
+	expect(updatedParams.get('storage')).toBe('temp');
+	expect(updatedParams.get('url')).toBe('/wp-admin/');
+	expect(updatedParams.get('php')).toBe('8.0');
+	expect(updatedParams.get('wp')).toBe('6.6');
+	expect(updatedParams.get('networking')).toBe('yes');
 	expect(
 		await wordpress.locator('body').evaluate((body) => body.baseURI)
 	).toMatch('/wp-admin/');
@@ -163,7 +234,7 @@ test('should edit a file in the code editor and see changes in the viewport', as
 	website,
 	wordpress,
 }) => {
-	await website.goto('./');
+	await website.goto('./?storage=temp');
 
 	// Open site manager
 	await website.ensureSiteManagerIsOpen();
@@ -243,7 +314,7 @@ test('should edit a blueprint in the blueprint editor and recreate the playgroun
 	website,
 	wordpress,
 }) => {
-	await website.goto('./');
+	await website.goto('./?storage=temp');
 
 	// Open site manager
 	await website.ensureSiteManagerIsOpen();
@@ -331,7 +402,7 @@ test('should copy blueprint link to clipboard when share button is clicked', asy
 	// Grant clipboard permissions
 	await context.grantPermissions(['clipboard-read', 'clipboard-write']);
 
-	await website.goto('./');
+	await website.goto('./?storage=temp');
 
 	// Open site manager
 	await website.ensureSiteManagerIsOpen();
@@ -377,7 +448,8 @@ test('should copy blueprint link to clipboard when share button is clicked', asy
 			Uint8Array.from(atob(base64Part), (c) => c.charCodeAt(0))
 		)
 	);
-	expect(decodedBlueprint).toHaveProperty('landingPage');
+	expect(decodedBlueprint).toHaveProperty('steps');
+	expect(Array.isArray(decodedBlueprint.steps)).toBe(true);
 });
 
 test('should make every Site Manager tab reachable on mobile', async ({
@@ -416,7 +488,7 @@ test('should make every Site Manager tab reachable on mobile', async ({
 
 test.describe('Database panel', () => {
 	test.beforeEach(async ({ website }) => {
-		await website.goto('./');
+		await website.goto('./?storage=temp');
 		await website.ensureSiteManagerIsOpen();
 
 		// Navigate to Database tab
@@ -607,7 +679,7 @@ test.describe('Database panel', () => {
 			.getByRole('link', { name: 'SQL' })
 			.click();
 		await newPage.waitForLoadState();
-		await newPage.locator('.CodeMirror').click();
+		await newPage.locator('.CodeMirror.cm-s-default').click();
 		await newPage.keyboard.type('SHOW TABLES');
 		await newPage.getByRole('button', { name: 'Go' }).click();
 		await newPage.waitForLoadState();
@@ -617,9 +689,591 @@ test.describe('Database panel', () => {
 	});
 });
 
-// Test saving playgrounds by default and when the "can-save" URL parameter is set to "no".
-test.describe('Save Status Indicator', () => {
-	test('should show "Unsaved" status for temporary playgrounds', async ({
+// Test browser-saved Playgrounds by default and explicit temporary opt-outs.
+test.describe('Default Playground storage', () => {
+	test.describe.configure({ mode: 'serial' });
+
+	test('should create and finish autosaving a Playground from the root URL', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.page.addInitScript(() => {
+			(window as any).__saveStatusSamples = [];
+			let installed = false;
+			const sampleStatus = () => {
+				const statusButton = [
+					...document.querySelectorAll('[role="status"], button'),
+				].find((node) => {
+					const label = (node.textContent || '').trim();
+					return (
+						label === 'Autosaving' ||
+						label === 'Saving' ||
+						label === 'Autosaved' ||
+						label === 'Saved Playground' ||
+						label === 'Unsaved'
+					);
+				});
+				if (!statusButton) {
+					return;
+				}
+				(window as any).__saveStatusSamples.push({
+					text: (statusButton.textContent || '').trim(),
+					ariaLabel: statusButton.getAttribute('aria-label'),
+					color: getComputedStyle(statusButton).color,
+				});
+			};
+			const installObserver = () => {
+				if (installed) {
+					return;
+				}
+				if (!document.documentElement) {
+					requestAnimationFrame(installObserver);
+					return;
+				}
+				installed = true;
+				new MutationObserver(sampleStatus).observe(
+					document.documentElement,
+					{
+						attributes: true,
+						characterData: true,
+						childList: true,
+						subtree: true,
+					}
+				);
+				window.setInterval(sampleStatus, 25);
+				sampleStatus();
+			};
+			installObserver();
+		});
+		await website.page.goto('./');
+		await expect(
+			website.page.getByRole('button', { name: /Site Manager/ })
+		).toBeVisible();
+		await website.ensureSiteManagerIsClosed();
+
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({
+			timeout: 120000,
+		});
+		expect(new URL(website.page.url()).searchParams.get('site-slug')).toBe(
+			null
+		);
+		await expect(
+			website.page.getByText(/Autosaving|Finalizing autosave/)
+		).toHaveCount(0);
+		await expect(
+			website.page.getByRole('button', { name: 'Unsaved' })
+		).toHaveCount(0);
+		const saveStatusSamples = await website.page.evaluate(() =>
+			((window as any).__saveStatusSamples || []).filter(
+				(
+					sample: {
+						text: string;
+						ariaLabel: string | null;
+						color: string;
+					},
+					index: number,
+					all: {
+						text: string;
+						ariaLabel: string | null;
+						color: string;
+					}[]
+				) => {
+					const previous = all[index - 1];
+					return (
+						!previous ||
+						previous.text !== sample.text ||
+						previous.ariaLabel !== sample.ariaLabel ||
+						previous.color !== sample.color
+					);
+				}
+			)
+		);
+		const autosavingIndex = saveStatusSamples.findIndex(
+			({ text }) => text === 'Autosaving'
+		);
+		const autosavedIndex = saveStatusSamples.findIndex(
+			({ text }) => text === 'Autosaved'
+		);
+		expect(autosavingIndex).toBeGreaterThan(-1);
+		expect(autosavedIndex).toBeGreaterThan(autosavingIndex);
+		expect(
+			saveStatusSamples.some(({ ariaLabel }) =>
+				/^Autosaving [1-9]\d*%$/.test(ariaLabel ?? '')
+			)
+		).toBe(true);
+	});
+
+	test('should show intent-driven creation actions in the overlay', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(
+			getUniqueSavedPlaygroundSetupUrl('creation-actions')
+		);
+		const siteSlugBeforeGitHubImport = new URL(
+			website.page.url()
+		).searchParams.get('site-slug');
+		await website.openSavedPlaygroundsOverlay();
+		await expect(
+			website.page.getByRole('button', { name: 'New Playground' })
+		).toBeVisible();
+		await expect(
+			website.page.getByRole('button', {
+				name: 'Preview a WordPress PR',
+			})
+		).toBeVisible();
+		await expect(
+			website.page.getByRole('button', {
+				name: 'Preview a Gutenberg PR',
+			})
+		).toBeVisible();
+		await expect(
+			website.page.getByRole('button', { name: 'Import from GitHub' })
+		).toBeVisible();
+		await expect(
+			website.page.getByRole('button', {
+				name: 'Open a Blueprint URL',
+			})
+		).toBeVisible();
+		await expect(
+			website.page.getByRole('button', { name: 'Import a .zip' })
+		).toBeVisible();
+		await expect(
+			website.page.getByRole('button', { name: 'Unsaved Playground' })
+		).toHaveCount(0);
+
+		await website.page
+			.getByRole('button', { name: 'Import from GitHub' })
+			.click();
+		await expect(
+			website.page.getByRole('dialog', { name: 'Import from GitHub' })
+		).toBeVisible();
+		expect(new URL(website.page.url()).searchParams.get('site-slug')).toBe(
+			siteSlugBeforeGitHubImport
+		);
+	});
+
+	test('should treat New Playground as an explicit fresh start', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('explicit-new'));
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		const firstSite = await getActivePlaygroundSite(website.page);
+
+		await website.openSavedPlaygroundsOverlay();
+		await website.page
+			.getByRole('button', { name: 'New Playground' })
+			.click();
+		const overlay = website.page
+			.locator('[class*="overlay"]')
+			.filter({ hasText: 'Playground' });
+		await expect(overlay).not.toBeVisible({ timeout: 1000 });
+		await expect
+			.poll(() => getActivePlaygroundSite(website.page), {
+				timeout: 120000,
+			})
+			.not.toMatchObject({ slug: firstSite.slug });
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		const firstBlankSite = await getActivePlaygroundSite(website.page);
+
+		await website.openSavedPlaygroundsOverlay();
+		await website.page
+			.getByRole('button', { name: 'New Playground' })
+			.click();
+		await expect(overlay).not.toBeVisible({ timeout: 1000 });
+		await expect
+			.poll(() => getActivePlaygroundSite(website.page), {
+				timeout: 120000,
+			})
+			.not.toMatchObject({ slug: firstBlankSite.slug });
+		await expect(
+			website.page.getByText('Recent autosave available')
+		).toHaveCount(0);
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+
+		await website.openSavedPlaygroundsOverlay();
+		await website.page.evaluate(() => {
+			(window as any).__siteSwitchStatusSamples = [];
+			const sampleStatus = () => {
+				const status = [
+					...document.querySelectorAll('[role="status"], button'),
+				]
+					.map((node) => (node.textContent || '').trim())
+					.find((text) =>
+						[
+							'Autosaving',
+							'Saving',
+							'Autosaved',
+							'Saved Playground',
+							'Unsaved',
+						].includes(text)
+					);
+				if (status) {
+					(window as any).__siteSwitchStatusSamples.push(status);
+				}
+			};
+			const observer = new MutationObserver(sampleStatus);
+			observer.observe(document.documentElement, {
+				attributes: true,
+				characterData: true,
+				childList: true,
+				subtree: true,
+			});
+			(window as any).__siteSwitchStatusObserver = observer;
+			(window as any).__siteSwitchStatusInterval = window.setInterval(
+				sampleStatus,
+				25
+			);
+			sampleStatus();
+		});
+		await website.page
+			.getByRole('button', {
+				name: new RegExp(`^${escapeRegExp(firstSite.name)}`),
+			})
+			.click();
+		await expect(overlay).not.toBeVisible({ timeout: 1000 });
+		await expect
+			.poll(() => getActivePlaygroundSite(website.page), {
+				timeout: 120000,
+			})
+			.toMatchObject({ slug: firstSite.slug });
+		const switchStatusSamples = await website.page.evaluate(() => {
+			window.clearInterval((window as any).__siteSwitchStatusInterval);
+			(window as any).__siteSwitchStatusObserver?.disconnect();
+			return (window as any).__siteSwitchStatusSamples;
+		});
+		expect(switchStatusSamples).not.toContain('Autosaving');
+	});
+
+	test('should show autosave browser storage details in the Site Manager by default', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('storage-details'));
+		await website.ensureSiteManagerIsOpen();
+
+		await expect(
+			website.page.getByText('Autosaved in this browser')
+		).toBeVisible();
+		await expect(
+			website.page.getByText(
+				'Removed after 5 newer autosaves unless saved.'
+			)
+		).toBeVisible();
+		const siteInfoPanel = website.page.locator(
+			'section[class*="site-info-panel"]'
+		);
+		await expect(
+			siteInfoPanel.getByRole('button', { name: 'Store permanently' })
+		).toBeVisible();
+		await expect(
+			website.page.getByText(
+				'This is an Unsaved Playground. Your changes will be lost on page refresh.'
+			)
+		).toHaveCount(0);
+	});
+
+	test('should promote a default autosaved Playground when kept', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('promote'));
+		await website.ensureSiteManagerIsClosed();
+		const statusButton = website.page.getByRole('button', {
+			name: 'Autosaved',
+		});
+		await expect(statusButton).toBeVisible({ timeout: 120000 });
+		await statusButton.click();
+		await website.page
+			.getByRole('button', { name: 'Store permanently' })
+			.click();
+
+		await expect
+			.poll(() =>
+				website.page.evaluate(() => {
+					const sites = (window as any).playgroundSites.list();
+					return sites.find((site: any) => site.isActive)
+						?.persistence;
+				})
+			)
+			.toBe('explicit');
+		await expect(
+			website.page.getByText(/Autosaved|Autosaving|Finalizing autosave/)
+		).toHaveCount(0);
+		await expect(
+			website.page.getByText(/Saved Playground|Saving|Finalizing save/)
+		).toBeVisible();
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toHaveCount(0);
+	});
+
+	test('should persist WordPress changes after refreshing the default Playground', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('restore'));
+		expect(new URL(website.page.url()).searchParams.get('site-slug')).toBe(
+			null
+		);
+
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+
+		const expectedBlogName = `Saved Playground ${Date.now()}`;
+		await runPHPAndFlushOpfs(
+			website.page,
+			updateBlogNameCode(expectedBlogName)
+		);
+
+		await website.page.reload();
+		await expect(
+			website.page.getByText('Recent autosave available')
+		).toBeVisible();
+		await expect(
+			website.page.getByText(
+				/Another Playground was created .* from the same URL\./
+			)
+		).toBeVisible();
+		await website.waitForNestedIframes();
+		await expect(
+			website.page.getByRole('button', { name: 'Unsaved' })
+		).toBeVisible();
+		await website.page
+			.getByRole('button', { name: 'Restore Autosave' })
+			.click();
+		await website.waitForNestedIframes();
+		await expect
+			.poll(() =>
+				new URL(website.page.url()).searchParams.get('site-slug')
+			)
+			.toBeTruthy();
+
+		const blogName = await website.page.evaluate(async () => {
+			const playground = (window as any).playground;
+			const result = await playground.run({
+				code: `<?php
+require_once '/wordpress/wp-load.php';
+echo get_option('blogname');
+`,
+			});
+			return result.text;
+		});
+		expect(blogName).toBe(expectedBlogName);
+	});
+
+	test('should start fresh from a setup URL when an autosave exists', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		const setupName = `fresh-${Date.now()}-${Math.random()
+			.toString(36)
+			.slice(2)}`;
+		await website.goto(`./?php=8.3&name=${setupName}&random=first`);
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+
+		const firstBlogName = `Restored Playground ${Date.now()}`;
+		await runPHPAndFlushOpfs(
+			website.page,
+			updateBlogNameCode(firstBlogName)
+		);
+
+		await website.page.goto(`./?php=8.3&name=${setupName}&cb=cache-buster`);
+		await expect(
+			website.page.getByText('Recent autosave available')
+		).toBeVisible();
+		await website.waitForNestedIframes();
+		await expect(
+			website.page.getByRole('button', { name: 'Unsaved' })
+		).toBeVisible();
+		expect(new URL(website.page.url()).searchParams.get('site-slug')).toBe(
+			null
+		);
+		await expect
+			.poll(() =>
+				website.page.evaluate(() => {
+					const activeSite = (window as any).playgroundSites
+						.list()
+						.find((site: any) => site.isActive);
+					return {
+						storage: activeSite?.storage,
+						persistence: activeSite?.persistence,
+					};
+				})
+			)
+			.toEqual({ storage: 'temporary', persistence: undefined });
+
+		const freshBlogName = await website.page.evaluate(async () => {
+			const playground = (window as any).playground;
+			const result = await playground.run({
+				code: `<?php
+require_once '/wordpress/wp-load.php';
+echo get_option('blogname');
+`,
+			});
+			return result.text;
+		});
+		expect(freshBlogName).not.toBe(firstBlogName);
+
+		const iframeToken = `keep-running-${Date.now()}`;
+		await website.page
+			.locator(
+				'#playground-viewport:visible,.playground-viewport:visible'
+			)
+			.evaluate((iframe: HTMLIFrameElement, token) => {
+				(iframe.contentWindow as any).__playgroundIframeToken = token;
+			}, iframeToken);
+
+		await website.page.evaluate(() => {
+			(window as any).__keepNewStatusSamples = [];
+			const sampleStatus = () => {
+				const status = [
+					...document.querySelectorAll('[role="status"], button'),
+				]
+					.map((node) => (node.textContent || '').trim())
+					.find((text) =>
+						[
+							'Autosaving',
+							'Saving',
+							'Autosaved',
+							'Saved Playground',
+							'Unsaved',
+						].includes(text)
+					);
+				if (status) {
+					(window as any).__keepNewStatusSamples.push(status);
+				}
+			};
+			const observer = new MutationObserver(sampleStatus);
+			observer.observe(document.documentElement, {
+				attributes: true,
+				characterData: true,
+				childList: true,
+				subtree: true,
+			});
+			(window as any).__keepNewStatusObserver = observer;
+			(window as any).__keepNewStatusInterval = window.setInterval(
+				sampleStatus,
+				25
+			);
+			sampleStatus();
+		});
+		await website.page.getByRole('button', { name: 'No, thanks' }).click();
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		const keepNewStatusSamples = await website.page.evaluate(() => {
+			window.clearInterval((window as any).__keepNewStatusInterval);
+			(window as any).__keepNewStatusObserver?.disconnect();
+			return (window as any).__keepNewStatusSamples;
+		});
+		expect(keepNewStatusSamples).toContain('Autosaving');
+		expect(keepNewStatusSamples).not.toContain('Saving');
+		await expect
+			.poll(() =>
+				website.page.evaluate(() => {
+					const activeSite = (window as any).playgroundSites
+						.list()
+						.find((site: any) => site.isActive);
+					return {
+						storage: activeSite?.storage,
+						persistence: activeSite?.persistence,
+					};
+				})
+			)
+			.toEqual({ storage: 'opfs', persistence: 'autosave' });
+		await expect
+			.poll(() =>
+				website.page
+					.locator(
+						'#playground-viewport:visible,.playground-viewport:visible'
+					)
+					.evaluate(
+						(iframe: HTMLIFrameElement) =>
+							(iframe.contentWindow as any)
+								.__playgroundIframeToken
+					)
+			)
+			.toBe(iframeToken);
+	});
+
+	test('should fall back to an unsaved Playground when browser storage is unavailable', async ({
+		website,
+	}) => {
+		await website.page.addInitScript(() => {
+			Object.defineProperty(navigator.storage, 'getDirectory', {
+				value: undefined,
+				configurable: true,
+			});
+			Object.defineProperty(window, 'showDirectoryPicker', {
+				value: undefined,
+				configurable: true,
+			});
+		});
+
+		await website.goto('./');
+		await website.ensureSiteManagerIsClosed();
+
+		expect(new URL(website.page.url()).searchParams.get('site-slug')).toBe(
+			null
+		);
+		await expect(
+			website.page.getByRole('button', { name: 'Unsaved' })
+		).toBeVisible();
+		await website.page.getByRole('button', { name: 'Unsaved' }).click();
+		await expect(
+			website.page.getByRole('button', { name: 'Store permanently' })
+		).toHaveCount(0);
+	});
+
+	test('should show "Unsaved" status for storage=temp Playgrounds', async ({
 		website,
 	}) => {
 		await website.goto('./?storage=temp');
@@ -630,9 +1284,40 @@ test.describe('Save Status Indicator', () => {
 		});
 		await expect(indicator).toBeVisible();
 		await expect(indicator).toHaveCount(1);
+		await indicator.click();
+		const popoverDescription = website.page.getByText(
+			'This Playground is not stored anywhere. Changes are lost when this page is refreshed or closed.'
+		);
+		await expect(popoverDescription).toBeVisible();
+		await indicator.click();
+		await expect(popoverDescription).toHaveCount(0);
+		await indicator.click();
+		await expect(popoverDescription).toBeVisible();
+		const storePermanentlyButton = website.page.getByRole('button', {
+			name: 'Store permanently',
+		});
+		const canStorePermanently = await website.page.evaluate(async () => {
+			try {
+				await navigator.storage.getDirectory();
+				return true;
+			} catch {
+				return Boolean((window as any).showDirectoryPicker);
+			}
+		});
+		if (canStorePermanently) {
+			await storePermanentlyButton.click();
+			await expect(
+				website.page.getByRole('dialog', { name: 'Save Playground' })
+			).toBeVisible();
+		} else {
+			await expect(storePermanentlyButton).toHaveCount(0);
+		}
+		expect(new URL(website.page.url()).searchParams.get('storage')).toBe(
+			'temp'
+		);
 	});
 
-	test('should see save playground message in the Site Manager', async ({
+	test('should see save playground message in the Site Manager for storage=temp Playgrounds', async ({
 		website,
 	}) => {
 		await website.goto('./?storage=temp');
@@ -743,7 +1428,7 @@ test.describe('Save Status Indicator', () => {
 test('should not include Google Analytics when VITE_GOOGLE_ANALYTICS_ID is not set', async ({
 	website,
 }) => {
-	await website.goto('./');
+	await website.goto('./?storage=temp');
 	const gtmScripts = await website.page
 		.locator('script[src*="googletagmanager.com"]')
 		.count();

--- a/packages/playground/website/playwright/website-page.ts
+++ b/packages/playground/website/playwright/website-page.ts
@@ -69,9 +69,12 @@ export class WebsitePage {
 		).not.toBeVisible();
 	}
 
+	/**
+	 * Opens the Your Playgrounds overlay and waits for its content to render.
+	 */
 	async openSavedPlaygroundsOverlay() {
 		await this.page
-			.getByRole('button', { name: 'Saved Playgrounds' })
+			.getByRole('button', { name: 'Your Playgrounds' })
 			.click();
 		await expect(
 			this.page

--- a/packages/playground/website/src/components/blueprint-url-modal/index.tsx
+++ b/packages/playground/website/src/components/blueprint-url-modal/index.tsx
@@ -15,6 +15,12 @@ export function BlueprintUrlModal() {
 
 	const closeModal = () => dispatch(setActiveModal(null));
 
+	/**
+	 * Opens the submitted Blueprint URL as a fresh Playground that may be autosaved.
+	 *
+	 * Intentionally uses `newSite()` instead of `newTemporarySite()` so
+	 * in-app Blueprint runs follow the default browser autosave policy.
+	 */
 	const handleSubmit = () => {
 		const trimmed = url.trim();
 		if (!trimmed) {
@@ -23,7 +29,7 @@ export function BlueprintUrlModal() {
 		dispatch(setSiteManagerOpen(false));
 		closeModal();
 		redirectTo(
-			PlaygroundRoute.newTemporarySite({
+			PlaygroundRoute.newSite({
 				query: {
 					'blueprint-url': trimmed,
 				},

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -98,7 +98,7 @@ export default function BrowserChrome({
 					<div className={css.toolbarButtons}>
 						<Button
 							variant="browser-chrome"
-							aria-label="Saved Playgrounds"
+							aria-label="Your Playgrounds"
 							onClick={() => setIsPlaygroundsOverlayOpen(true)}
 							aria-expanded={isPlaygroundsOverlayOpen}
 							className={css.savedPlaygroundsButton}

--- a/packages/playground/website/src/components/browser-chrome/style.module.css
+++ b/packages/playground/website/src/components/browser-chrome/style.module.css
@@ -99,6 +99,10 @@ body.is-embedded .fake-window-wrapper {
 	border: none;
 	cursor: pointer;
 	flex-shrink: 0;
+	color: #fff;
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 16px;
 }
 
 .saved-playgrounds-button svg {

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -6,7 +6,7 @@ import {
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
-import { moreVertical, upload, link } from '@wordpress/icons';
+import { moreVertical, plus, upload, link } from '@wordpress/icons';
 import { Icon } from '@wordpress/icons';
 import { GitHubIcon } from '../../github/github';
 import { useDispatch } from 'react-redux';
@@ -22,6 +22,9 @@ import {
 import type { PlaygroundDispatch } from '../../lib/state/redux/store';
 import type { SiteLogo, SiteInfo } from '../../lib/state/redux/slice-sites';
 import {
+	isAutosavedSite,
+	isExplicitlySavedSite,
+	MAX_AUTOSAVED_SITES,
 	selectSortedSites,
 	selectTemporarySite,
 } from '../../lib/state/redux/slice-sites';
@@ -43,6 +46,11 @@ import {
 	OverlayBody,
 	OverlaySection,
 } from '../overlay';
+
+/**
+ * Maximum explicitly saved Playgrounds to show before collapsing the list.
+ */
+const MAX_VISIBLE_SAVED_SITES = 8;
 
 type BlueprintsIndexEntry = {
 	title: string;
@@ -77,6 +85,9 @@ function GridIcon({ size = 20 }: { size?: number }) {
 	);
 }
 
+/**
+ * Displays saved Playgrounds, recent autosaves, and entry points for new sites.
+ */
 export function SavedPlaygroundsOverlay({
 	onClose,
 	initialViewMode = 'main',
@@ -85,6 +96,10 @@ export function SavedPlaygroundsOverlay({
 	const storedSites = useAppSelector(selectSortedSites).filter(
 		(site) => site.metadata.storage !== 'none'
 	);
+	const explicitlySavedSites = storedSites.filter(isExplicitlySavedSite);
+	const autosavedSites = storedSites
+		.filter(isAutosavedSite)
+		.slice(0, MAX_AUTOSAVED_SITES);
 	const temporarySite = useAppSelector(selectTemporarySite);
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
@@ -96,12 +111,19 @@ export function SavedPlaygroundsOverlay({
 	const [viewMode, setViewMode] = useState<OverlayViewMode>(initialViewMode);
 	const [searchQuery, setSearchQuery] = useState('');
 	const [selectedTag, setSelectedTag] = useState<string | null>(null);
+	const [showAllSavedSites, setShowAllSavedSites] = useState(false);
 	const [pendingZipFile, setPendingZipFile] = useState<File | null>(null);
-
-	const isTemporarySite = activeSite?.metadata.storage === 'none';
+	const [pendingZipTargetSlug, setPendingZipTargetSlug] = useState<
+		string | null
+	>(null);
 
 	useEffect(() => {
-		if (!pendingZipFile || !isTemporarySite || !playground) {
+		if (
+			!pendingZipFile ||
+			!playground ||
+			!activeSite ||
+			activeSite.slug !== pendingZipTargetSlug
+		) {
 			return;
 		}
 
@@ -124,19 +146,31 @@ export function SavedPlaygroundsOverlay({
 				);
 			} finally {
 				setPendingZipFile(null);
+				setPendingZipTargetSlug(null);
 				if (zipFileInputRef.current) {
 					zipFileInputRef.current.value = '';
 				}
 			}
 		};
 		doImport();
-	}, [pendingZipFile, isTemporarySite, playground, onClose]);
+	}, [pendingZipFile, pendingZipTargetSlug, activeSite, playground, onClose]);
 
-	async function switchToTemporarySite() {
-		if (temporarySite) {
-			await sitesAPI.setActiveSite(temporarySite.slug);
-		} else {
-			redirectTo(PlaygroundRoute.newTemporarySite());
+	/**
+	 * Creates or selects a target Playground before importing a zip archive.
+	 *
+	 * Imports prefer a new OPFS-backed site so the result survives a refresh.
+	 * If that cannot be created, the import falls back to an existing or new
+	 * temporary site.
+	 */
+	async function createSiteForImport() {
+		try {
+			return await sitesAPI.createNewSavedSite();
+		} catch {
+			if (temporarySite) {
+				await sitesAPI.setActiveSite(temporarySite.slug);
+				return temporarySite.slug;
+			}
+			return await sitesAPI.createNewTemporarySite();
 		}
 	}
 
@@ -144,37 +178,18 @@ export function SavedPlaygroundsOverlay({
 		const file = e.target.files?.[0];
 		if (!file) return;
 
-		if (!isTemporarySite) {
-			setPendingZipFile(file);
-			switchToTemporarySite();
-			return;
-		}
-
-		if (!playground) {
-			alert(
-				'No active Playground to import into. Please create one first.'
-			);
-			return;
-		}
-
 		try {
-			await importWordPressFiles(playground, { wordPressFilesZip: file });
-			setTimeout(async () => {
-				await playground.goTo('/');
-			}, 200);
-			alert(
-				'File imported! This Playground instance has been updated and will refresh shortly.'
-			);
-			onClose();
+			const targetSlug = await createSiteForImport();
+			setPendingZipTargetSlug(targetSlug);
+			setPendingZipFile(file);
 		} catch (error) {
 			logger.error(error);
 			alert(
-				'Unable to import file. Is it a valid WordPress Playground export?'
+				'No active Playground to import into. Please create one first.'
 			);
-		}
-
-		if (zipFileInputRef.current) {
-			zipFileInputRef.current.value = '';
+			if (zipFileInputRef.current) {
+				zipFileInputRef.current.value = '';
+			}
 		}
 	};
 
@@ -228,20 +243,12 @@ export function SavedPlaygroundsOverlay({
 		return matchesSearch && matchesTag;
 	});
 
-	const onSiteClick = async (slug: string) => {
-		await sitesAPI.setActiveSite(slug);
+	const onSiteClick = (slug: string) => {
 		dispatch(setSiteManagerSection('site-details'));
 		onClose();
-	};
-
-	const onTemporaryPlaygroundClick = async () => {
-		if (temporarySite) {
-			await sitesAPI.setActiveSite(temporarySite.slug);
-			dispatch(setSiteManagerSection('site-details'));
-			onClose();
-		} else {
-			createVanillaSite();
-		}
+		void sitesAPI.setActiveSite(slug).catch((error) => {
+			logger.error('Error opening saved Playground', error);
+		});
 	};
 
 	const getLogoDataURL = (logo: SiteLogo): string => {
@@ -260,10 +267,31 @@ export function SavedPlaygroundsOverlay({
 		closeMenu();
 	};
 
+	const handleKeepSite = async (site: SiteInfo, closeMenu?: () => void) => {
+		await sitesAPI.keep(site.slug);
+		closeMenu?.();
+	};
+
+	const getStoredSiteDetails = (site: SiteInfo) => {
+		if (isAutosavedSite(site)) {
+			return 'Recovery copy';
+		}
+		if (site.metadata.storage === 'local-fs') {
+			return 'Saved in a local directory';
+		}
+		return 'Saved in this browser';
+	};
+
+	/**
+	 * Opens the selected Blueprint as a fresh Playground that may be autosaved.
+	 *
+	 * Intentionally uses `newSite()` instead of `newTemporarySite()` so
+	 * in-app Blueprint previews follow the default browser autosave policy.
+	 */
 	function previewBlueprint(blueprintPath: BlueprintsIndexEntry['path']) {
 		dispatch(setSiteManagerOpen(false));
 		redirectTo(
-			PlaygroundRoute.newTemporarySite({
+			PlaygroundRoute.newSite({
 				query: {
 					name: 'Blueprint preview',
 					'blueprint-url': `https://raw.githubusercontent.com/WordPress/blueprints/trunk/${blueprintPath.replace(
@@ -278,21 +306,24 @@ export function SavedPlaygroundsOverlay({
 
 	function createVanillaSite() {
 		dispatch(setSiteManagerOpen(false));
-		redirectTo(PlaygroundRoute.newTemporarySite());
+		// "New Playground" means start fresh. The URL change makes the
+		// selected-site guard handle this as an in-app new-site navigation.
+		redirectTo(PlaygroundRoute.newSite());
 		onClose();
 	}
 
 	const creationOptions = [
 		{
 			id: 'vanilla',
-			title: 'Vanilla WordPress',
-			iconComponent: <WordPressIcon />,
+			title: 'New Playground',
+			icon: plus,
+			iconSize: 56,
 			onClick: createVanillaSite,
 			disabled: false,
 		},
 		{
 			id: 'wp-pr',
-			title: 'WordPress PR',
+			title: 'Preview a WordPress PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
 				modalDispatch(setActiveModal(modalSlugs.PREVIEW_PR_WP));
@@ -301,7 +332,7 @@ export function SavedPlaygroundsOverlay({
 		},
 		{
 			id: 'gutenberg-pr',
-			title: 'Gutenberg PR',
+			title: 'Preview a Gutenberg PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
 				modalDispatch(setActiveModal(modalSlugs.PREVIEW_PR_GUTENBERG));
@@ -310,19 +341,16 @@ export function SavedPlaygroundsOverlay({
 		},
 		{
 			id: 'github',
-			title: 'From GitHub',
+			title: 'Import from GitHub',
 			iconComponent: GitHubIcon,
 			onClick: () => {
-				if (!isTemporarySite) {
-					switchToTemporarySite();
-				}
 				modalDispatch(setActiveModal(modalSlugs.GITHUB_IMPORT));
 			},
 			disabled: offline,
 		},
 		{
 			id: 'blueprint-url',
-			title: 'Blueprint URL',
+			title: 'Open a Blueprint URL',
 			icon: link,
 			onClick: () => {
 				modalDispatch(setActiveModal(modalSlugs.BLUEPRINT_URL));
@@ -331,7 +359,7 @@ export function SavedPlaygroundsOverlay({
 		},
 		{
 			id: 'zip',
-			title: 'Import .zip',
+			title: 'Import a .zip',
 			icon: upload,
 			onClick: () => {
 				zipFileInputRef.current?.click();
@@ -339,6 +367,160 @@ export function SavedPlaygroundsOverlay({
 			disabled: false,
 		},
 	];
+
+	const visibleSavedSites = showAllSavedSites
+		? explicitlySavedSites
+		: explicitlySavedSites.slice(0, MAX_VISIBLE_SAVED_SITES);
+	const hiddenSavedSitesCount =
+		explicitlySavedSites.length - visibleSavedSites.length;
+
+	function formatSiteCreatedDate(site: SiteInfo) {
+		return site.metadata.whenCreated
+			? new Date(site.metadata.whenCreated).toLocaleDateString(
+					undefined,
+					{
+						year: 'numeric',
+						month: 'short',
+						day: 'numeric',
+					}
+				)
+			: undefined;
+	}
+
+	function renderSiteRow(site: SiteInfo) {
+		const isSelected = site.slug === activeSite?.slug;
+		const isAutosave = isAutosavedSite(site);
+		const createdDate = formatSiteCreatedDate(site);
+
+		return (
+			<div
+				key={site.slug}
+				className={classNames(css.siteRow, {
+					[css.siteRowSelected]: isSelected,
+				})}
+			>
+				<button
+					className={css.siteRowContent}
+					onClick={() => onSiteClick(site.slug)}
+				>
+					<div className={css.siteRowLogo}>
+						{site.metadata.logo ? (
+							<img
+								src={getLogoDataURL(site.metadata.logo)}
+								alt=""
+							/>
+						) : (
+							<WordPressIcon />
+						)}
+					</div>
+					<div className={css.siteRowInfo}>
+						<span className={css.siteRowName}>
+							{site.metadata.name}
+						</span>
+						<span className={css.siteRowDate}>
+							{getStoredSiteDetails(site)}
+							{createdDate ? ` - Created ${createdDate}` : ''}
+						</span>
+					</div>
+				</button>
+				<div className={css.siteRowActions}>
+					{isAutosave && (
+						<button
+							type="button"
+							className={css.keepButton}
+							onClick={() => handleKeepSite(site)}
+							title="Store this Playground permanently so it is not pruned from recent autosaves."
+						>
+							Store permanently
+						</button>
+					)}
+					<DropdownMenu
+						icon={moreVertical}
+						label="Site actions"
+						className={css.siteRowMenu}
+						popoverProps={{
+							placement: 'bottom-end',
+						}}
+					>
+						{({ onClose: closeMenu }) => (
+							<>
+								<MenuGroup>
+									{isAutosave && (
+										<MenuItem
+											onClick={() =>
+												handleKeepSite(site, closeMenu)
+											}
+										>
+											Store permanently
+										</MenuItem>
+									)}
+									<MenuItem
+										onClick={() =>
+											handleRenameSite(site, closeMenu)
+										}
+									>
+										Rename
+									</MenuItem>
+								</MenuGroup>
+								<MenuGroup>
+									<MenuItem
+										className={css.dangerMenuItem}
+										onClick={() =>
+											handleDeleteSite(site, closeMenu)
+										}
+									>
+										Delete
+									</MenuItem>
+								</MenuGroup>
+							</>
+						)}
+					</DropdownMenu>
+				</div>
+			</div>
+		);
+	}
+
+	function renderSavedPlaygroundsSection() {
+		if (explicitlySavedSites.length === 0) {
+			return null;
+		}
+
+		return (
+			<OverlaySection title="Saved Playgrounds">
+				<div className={css.sitesList}>
+					{visibleSavedSites.map(renderSiteRow)}
+				</div>
+				{hiddenSavedSitesCount > 0 && (
+					<button
+						type="button"
+						className={css.showMoreButton}
+						onClick={() => setShowAllSavedSites(!showAllSavedSites)}
+					>
+						{showAllSavedSites
+							? 'Show fewer saved Playgrounds'
+							: `Show ${hiddenSavedSitesCount} more saved Playgrounds`}
+					</button>
+				)}
+			</OverlaySection>
+		);
+	}
+
+	function renderAutosavesSection() {
+		if (autosavedSites.length === 0) {
+			return null;
+		}
+
+		return (
+			<OverlaySection
+				title={`Last ${MAX_AUTOSAVED_SITES} autosaves`}
+				description="Older autosaves are deleted automatically. Use Store permanently to keep one."
+			>
+				<div className={css.sitesList}>
+					{autosavedSites.map(renderSiteRow)}
+				</div>
+			</OverlaySection>
+		);
+	}
 
 	if (viewMode === 'blueprints') {
 		return (
@@ -525,25 +707,45 @@ export function SavedPlaygroundsOverlay({
 			<OverlayBody>
 				<OverlaySection title="Start a new Playground">
 					<div className={css.creationRow}>
-						{creationOptions.map((option) => (
-							<button
-								key={option.id}
-								className={css.creationButton}
-								onClick={option.onClick}
-								disabled={option.disabled}
-							>
-								<span className={css.creationIcon}>
-									{'iconComponent' in option ? (
-										option.iconComponent
-									) : (
-										<Icon icon={option.icon} size={24} />
+						{creationOptions.map((option) => {
+							const hasIcon =
+								'iconComponent' in option || 'icon' in option;
+							return (
+								<button
+									key={option.id}
+									className={css.creationButton}
+									onClick={option.onClick}
+									disabled={option.disabled}
+								>
+									{hasIcon && (
+										<span
+											className={classNames(
+												css.creationIcon,
+												option.id === 'vanilla'
+													? css.newPlaygroundIcon
+													: undefined
+											)}
+										>
+											{'iconComponent' in option ? (
+												option.iconComponent
+											) : 'icon' in option ? (
+												<Icon
+													icon={option.icon!}
+													size={
+														'iconSize' in option
+															? option.iconSize
+															: 24
+													}
+												/>
+											) : null}
+										</span>
 									)}
-								</span>
-								<span className={css.creationTitle}>
-									{option.title}
-								</span>
-							</button>
-						))}
+									<span className={css.creationTitle}>
+										{option.title}
+									</span>
+								</button>
+							);
+						})}
 					</div>
 				</OverlaySection>
 
@@ -612,134 +814,8 @@ export function SavedPlaygroundsOverlay({
 					)}
 				</OverlaySection>
 
-				<OverlaySection title="Your Playgrounds">
-					<div className={css.sitesList}>
-						<div
-							className={classNames(css.siteRow, {
-								[css.siteRowSelected]:
-									temporarySite?.slug === activeSite?.slug,
-							})}
-						>
-							<button
-								className={css.siteRowContent}
-								onClick={onTemporaryPlaygroundClick}
-							>
-								<div className={css.siteRowLogo}>
-									{temporarySite?.metadata.logo ? (
-										<img
-											src={getLogoDataURL(
-												temporarySite.metadata.logo
-											)}
-											alt=""
-										/>
-									) : (
-										<WordPressIcon />
-									)}
-								</div>
-								<div className={css.siteRowInfo}>
-									<span className={css.siteRowName}>
-										Unsaved Playground
-									</span>
-									<span className={css.siteRowDate}>
-										Not saved to browser storage
-									</span>
-								</div>
-							</button>
-						</div>
-						{storedSites.map((site) => {
-							const isSelected = site.slug === activeSite?.slug;
-							return (
-								<div
-									key={site.slug}
-									className={classNames(css.siteRow, {
-										[css.siteRowSelected]: isSelected,
-									})}
-								>
-									<button
-										className={css.siteRowContent}
-										onClick={() => onSiteClick(site.slug)}
-									>
-										<div className={css.siteRowLogo}>
-											{site.metadata.logo ? (
-												<img
-													src={getLogoDataURL(
-														site.metadata.logo
-													)}
-													alt=""
-												/>
-											) : (
-												<WordPressIcon />
-											)}
-										</div>
-										<div className={css.siteRowInfo}>
-											<span className={css.siteRowName}>
-												{site.metadata.name}
-											</span>
-											{site.metadata.whenCreated && (
-												<span
-													className={css.siteRowDate}
-												>
-													Created{' '}
-													{new Date(
-														site.metadata
-															.whenCreated
-													).toLocaleDateString(
-														undefined,
-														{
-															year: 'numeric',
-															month: 'short',
-															day: 'numeric',
-														}
-													)}
-												</span>
-											)}
-										</div>
-									</button>
-									<DropdownMenu
-										icon={moreVertical}
-										label="Site actions"
-										className={css.siteRowMenu}
-										popoverProps={{
-											placement: 'bottom-end',
-										}}
-									>
-										{({ onClose: closeMenu }) => (
-											<>
-												<MenuGroup>
-													<MenuItem
-														onClick={() =>
-															handleRenameSite(
-																site,
-																closeMenu
-															)
-														}
-													>
-														Rename
-													</MenuItem>
-												</MenuGroup>
-												<MenuGroup>
-													<MenuItem
-														className={
-															css.dangerMenuItem
-														}
-														onClick={() =>
-															handleDeleteSite(
-																site,
-																closeMenu
-															)
-														}
-													>
-														Delete
-													</MenuItem>
-												</MenuGroup>
-											</>
-										)}
-									</DropdownMenu>
-								</div>
-							);
-						})}
-					</div>
-				</OverlaySection>
+				{renderAutosavesSection()}
+				{renderSavedPlaygroundsSection()}
 			</OverlayBody>
 		</Overlay>
 	);

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -116,14 +116,24 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 32px;
-	height: 32px;
+	width: 58px;
+	height: 58px;
 }
 
 .creationIcon :global(svg) {
 	fill: #fff;
 	width: 28px;
 	height: 28px;
+}
+
+.newPlaygroundIcon {
+	width: 58px;
+	height: 58px;
+}
+
+.newPlaygroundIcon :global(svg) {
+	width: 56px;
+	height: 56px;
 }
 
 .creationTitle {
@@ -289,12 +299,16 @@
 	display: flex;
 	flex-direction: column;
 	gap: 2px;
+	min-width: 0;
 }
 
 .siteRowName {
 	font-size: clamp(14px, 1.4vw, 15px);
 	font-weight: 500;
 	color: #fff;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .siteRowDate {
@@ -304,6 +318,14 @@
 
 .siteRowMenu {
 	margin-right: 12px;
+}
+
+.siteRowActions {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	flex-shrink: 0;
+	padding-right: 8px;
 }
 
 .siteRowMenu button {
@@ -321,6 +343,44 @@
 
 .dangerMenuItem:hover {
 	background: rgba(220, 38, 38, 0.1) !important;
+}
+
+.keepButton {
+	background: #3858e9;
+	border: 1px solid #6c84ff;
+	border-radius: 4px;
+	color: #fff;
+	cursor: pointer;
+	font: inherit;
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1;
+	padding: 8px 12px;
+	white-space: nowrap;
+}
+
+.keepButton:hover {
+	background: #4f6df0;
+	border-color: #8fa1ff;
+}
+
+.showMoreButton {
+	align-items: center;
+	background: transparent;
+	border: 1px solid #3c4349;
+	border-radius: 4px;
+	color: #dcdcde;
+	cursor: pointer;
+	display: inline-flex;
+	font: inherit;
+	font-size: 13px;
+	margin-top: 12px;
+	padding: 8px 12px;
+}
+
+.showMoreButton:hover {
+	background: #2c3338;
+	color: #fff;
 }
 
 /* Loading state */
@@ -519,6 +579,14 @@
 
 	.siteRowContent {
 		padding: 12px 16px;
+	}
+
+	.siteRowActions {
+		padding-right: 4px;
+	}
+
+	.keepButton {
+		padding: 7px 10px;
 	}
 
 	.siteRowLogo {

--- a/packages/playground/website/src/components/site-manager/blueprints-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/blueprints-panel/index.tsx
@@ -61,10 +61,16 @@ export function BlueprintsPanel({
 		});
 	}
 
+	/**
+	 * Opens the selected Blueprint as a fresh Playground that may be autosaved.
+	 *
+	 * Intentionally uses `newSite()` instead of `newTemporarySite()` so
+	 * in-app Blueprint previews follow the default browser autosave policy.
+	 */
 	function previewBlueprint(blueprintPath: BlueprintsIndexEntry['path']) {
 		dispatch(setSiteManagerOpen(false));
 		redirectTo(
-			PlaygroundRoute.newTemporarySite({
+			PlaygroundRoute.newSite({
 				query: {
 					name: 'Blueprint preview',
 					// Explicitly do not use joinPaths() here as it normalizes the input and


### PR DESCRIPTION
## What it does

Refines the Your Playgrounds overlay for the default autosave flow.

The overlay now separates opening existing Playgrounds from explicit creation
actions, and the E2E helpers/tests cover the autosave-first creation and restore
paths.

## Rationale

The overlay is the highest-churn UI piece in the original save-by-default PR.
Keeping it in its own PR lets reviewers evaluate the creation flow and test
coverage without re-reviewing the persistence foundation.

## Implementation

Updates the overlay component, supporting browser chrome styles, blueprint entry
points, and Playwright coverage for the default storage behavior.

This is stacked on `feature/default-autosave-ux` because the overlay presents
the autosave state and actions introduced there.

## Testing instructions

```bash
npm exec nx run playground-website:typecheck
npm exec -- nx run playground-website:e2e:playwright -- --project=chromium --grep "Default Playground storage" --retries=0 --workers=1 --max-failures=1
```
