### PR TITLE
[Website] Handle OPFS initial sync review feedback

### DIFF
--- a/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.spec.ts
@@ -465,6 +465,55 @@ describe('createDirectoryHandleMountHandler', () => {
 		});
 	});
 
+	it('handles rejected async throttled progress callbacks', async () => {
+		vi.useFakeTimers();
+		const loggerError = vi
+			.spyOn(logger, 'error')
+			.mockImplementation(() => {});
+
+		try {
+			const progressError = new Error('progress failed');
+			const releaseWrite = deferred<void>();
+			let writeCount = 0;
+			const { FS, files } = createFakePhp();
+			const opfsRoot = new MemoryDirectoryHandle('root', () => {
+				writeCount++;
+				if (writeCount === 2) {
+					return releaseWrite.promise;
+				}
+				return undefined;
+			});
+			FS.readdir.mockReturnValue(['.', '..', 'first.txt', 'second.txt']);
+			files.set('/wordpress/first.txt', encode('first'));
+			files.set('/wordpress/second.txt', encode('second'));
+
+			const copyPromise = copyMemfsToOpfs(
+				FS as any,
+				opfsRoot as unknown as FileSystemDirectoryHandle,
+				'/wordpress',
+				async (progress) => {
+					if (progress.files > 0 && progress.files < progress.total) {
+						throw progressError;
+					}
+				}
+			);
+
+			await vi.advanceTimersByTimeAsync(100);
+			expect(loggerError).toHaveBeenCalledWith(
+				'Throttled progress callback failed',
+				{
+					error: progressError,
+				}
+			);
+
+			releaseWrite.resolve();
+			await copyPromise;
+		} finally {
+			loggerError.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
 	it('does not emit stale copy progress after the final progress event', async () => {
 		vi.useFakeTimers();
 

--- a/packages/php-wasm/web/src/lib/directory-handle-mount.ts
+++ b/packages/php-wasm/web/src/lib/directory-handle-mount.ts
@@ -99,12 +99,15 @@ export function createDirectoryHandleMountHandler(
 					}
 				);
 				await options.initialSync.onProgress?.({
-					files: lastProgress?.total ?? 0,
+					files: lastProgress?.files ?? 0,
 					total: lastProgress?.total ?? 0,
 					phase: 'flushing',
 				});
 				void mount.flush().catch((error) => {
-					logger.error(error);
+					logger.error('OPFS flush failed after initial sync', {
+						error,
+						vfsMountPoint,
+					});
 				});
 			} catch (error) {
 				await mount.unmount();
@@ -591,7 +594,15 @@ function throttle<T extends (...args: any[]) => any>(
 			timeoutId = setTimeout(() => {
 				timeoutId = undefined;
 				lastCallTime = Date.now();
-				fn(...pendingArgs!);
+				const args = pendingArgs!;
+				pendingArgs = undefined;
+				try {
+					void Promise.resolve(fn(...args)).catch(
+						logThrottledProgressCallbackError
+					);
+				} catch (error) {
+					logThrottledProgressCallbackError(error);
+				}
 			}, delay);
 		}
 	} as CancelableThrottledFunction<T>;
@@ -605,4 +616,8 @@ function throttle<T extends (...args: any[]) => any>(
 	};
 
 	return throttledCallback;
+}
+
+function logThrottledProgressCallbackError(error: unknown) {
+	logger.error('Throttled progress callback failed', { error });
 }


### PR DESCRIPTION
## What it does

Follows up on #3668 with the small fixes from Copilot review:

- The `flushing` progress event now preserves `lastProgress.files` instead of deriving it from `total`.
- The post-copy `mount.flush()` failure log includes the affected `vfsMountPoint`.
- Rejected async progress callbacks inside `throttle()` are caught and logged with a searchable message.

## Rationale

#3668 made `SyncProgressCallback` async-capable and added a background flush after the initial MEMFS-to-OPFS copy. That left two small rough edges: rejected throttled callbacks could become unhandled promise rejections, and flush failures were hard to tie back to the mount that triggered them.

## Implementation

The throttled callback now snapshots `pendingArgs`, clears it before invoking the callback, and wraps `fn(...args)` in `try` plus `Promise.resolve(...).catch(...)`. Both sync throws and async rejections are logged as `Throttled progress callback failed` with the original error in context.

The final initial-sync flush catch logs `vfsMountPoint`, and the `flushing` progress event keeps the copied-file count semantics intact.

## Testing instructions

```bash
npm exec nx typecheck php-wasm-web
npm exec nx test php-wasm-web --testFile=directory-handle-mount.spec.ts
npm exec nx lint php-wasm-web
```