### PR TITLE
[Website] Fix Site Manager tabs overflowing on mobile

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -387,12 +387,18 @@ test('should make every Site Manager tab reachable on mobile', async ({
 	await website.goto('./');
 	await website.ensureSiteManagerIsOpen();
 
-	const tabList = website.page.locator('.components-tab-panel__tabs');
+	const siteManager = website.page.locator(
+		'section[class*="site-info-panel"]'
+	);
+	await expect(siteManager).toBeVisible();
+
+	const tabList = siteManager.locator('.components-tab-panel__tabs');
 	await expect(tabList).toBeVisible();
-	const logsTab = website.page.getByRole('tab', { name: 'Logs' });
+
+	const logsTab = siteManager.getByRole('tab', { name: 'Logs' });
 	await expect(logsTab).toHaveCount(1);
 
-	const tabListState = await tabList.evaluate((element) => {
+	await tabList.evaluate((element) => {
 		const logsTab = Array.from(
 			element.querySelectorAll<HTMLElement>('[role="tab"]')
 		).find((tab) => tab.textContent?.trim() === 'Logs');
@@ -401,24 +407,9 @@ test('should make every Site Manager tab reachable on mobile', async ({
 		}
 
 		logsTab.scrollIntoView({ block: 'nearest', inline: 'end' });
-
-		return {
-			clientWidth: element.clientWidth,
-			overflowX: getComputedStyle(element).overflowX,
-			scrollLeft: element.scrollLeft,
-			scrollWidth: element.scrollWidth,
-			logsTabRight: logsTab.getBoundingClientRect().right,
-			viewportWidth: window.innerWidth,
-		};
 	});
 
-	expect(tabListState.overflowX).toBe('auto');
-	expect(tabListState.scrollWidth).toBeGreaterThan(tabListState.clientWidth);
-	expect(tabListState.scrollLeft).toBeGreaterThan(0);
-	expect(tabListState.logsTabRight).toBeLessThanOrEqual(
-		tabListState.viewportWidth + 1
-	);
-
+	await expect(logsTab).toBeInViewport();
 	await logsTab.click();
 	await expect(logsTab).toHaveAttribute('aria-selected', 'true');
 });

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -380,6 +380,49 @@ test('should copy blueprint link to clipboard when share button is clicked', asy
 	expect(decodedBlueprint).toHaveProperty('landingPage');
 });
 
+test('should make every Site Manager tab reachable on mobile', async ({
+	website,
+}) => {
+	await website.page.setViewportSize({ width: 390, height: 844 });
+	await website.goto('./');
+	await website.ensureSiteManagerIsOpen();
+
+	const tabList = website.page.locator('.components-tab-panel__tabs');
+	await expect(tabList).toBeVisible();
+	const logsTab = website.page.getByRole('tab', { name: 'Logs' });
+	await expect(logsTab).toHaveCount(1);
+
+	const tabListState = await tabList.evaluate((element) => {
+		const logsTab = Array.from(
+			element.querySelectorAll<HTMLElement>('[role="tab"]')
+		).find((tab) => tab.textContent?.trim() === 'Logs');
+		if (!logsTab) {
+			throw new Error('Logs tab not found');
+		}
+
+		logsTab.scrollIntoView({ block: 'nearest', inline: 'end' });
+
+		return {
+			clientWidth: element.clientWidth,
+			overflowX: getComputedStyle(element).overflowX,
+			scrollLeft: element.scrollLeft,
+			scrollWidth: element.scrollWidth,
+			logsTabRight: logsTab.getBoundingClientRect().right,
+			viewportWidth: window.innerWidth,
+		};
+	});
+
+	expect(tabListState.overflowX).toBe('auto');
+	expect(tabListState.scrollWidth).toBeGreaterThan(tabListState.clientWidth);
+	expect(tabListState.scrollLeft).toBeGreaterThan(0);
+	expect(tabListState.logsTabRight).toBeLessThanOrEqual(
+		tabListState.viewportWidth + 1
+	);
+
+	await logsTab.click();
+	await expect(logsTab).toHaveAttribute('aria-selected', 'true');
+});
+
 test.describe('Database panel', () => {
 	test.beforeEach(async ({ website }) => {
 		await website.goto('./');

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -32,6 +32,7 @@
 		border-bottom: 1px solid var(--color-gray-200);
 		max-width: 100%;
 		overflow-x: auto;
+		overflow-y: hidden;
 		-webkit-overflow-scrolling: touch;
 	}
 	& :global(.components-tab-panel__tabs-item) {

--- a/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/style.module.css
@@ -30,10 +30,15 @@
 	& :global(.components-tab-panel__tabs) {
 		--wp-components-color-accent: var(--color-gray-900);
 		border-bottom: 1px solid var(--color-gray-200);
+		max-width: 100%;
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
 	}
 	& :global(.components-tab-panel__tabs-item) {
+		flex: 0 0 auto;
 		padding-left: var(--padding-size);
 		padding-right: var(--padding-size);
+		white-space: nowrap;
 	}
 	& :global(.components-tab-panel__tab-content) {
 		display: flex;


### PR DESCRIPTION
## What?
Fixes the Site Manager tab row on narrow screens so all tabs remain reachable, including the Logs tab.

## Why?
On mobile-width viewports, the Site Manager tab row can overflow horizontally without becoming scrollable. This makes later tabs such as Logs inaccessible.

## How?
- Allows the Site Manager tab row to scroll horizontally when needed.
- Prevents tab labels from shrinking or wrapping.
- Adds an E2E test that verifies the Logs tab is reachable and selectable on a 390px-wide viewport.

## Before

<img width="758" height="1670" alt="Playground-Before" src="https://github.com/user-attachments/assets/0cf2a2d6-9cd7-4070-b8c2-f3aa26c7be1d" />

## After

<img width="748" height="1634" alt="Playground After" src="https://github.com/user-attachments/assets/531a1679-8004-4a28-8d1c-c71c9e75176d" />

## Testing
- `npx playwright test --config=packages/playground/website/playwright/playwright.config.ts --project=chromium -g "should make every Site Manager tab reachable on mobile"`
- `git diff --check`

## Related
Related to #3148