### PR TITLE
[Sites API] Add isReady() to wait for active site readiness

### DIFF
--- a/packages/docs/site/docs/developers/06-apis/sites-api/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/sites-api/01-index.md
@@ -6,33 +6,11 @@ description: Manage Playground sites from JavaScript — list, create, persist, 
 
 The Sites API is a JavaScript API exposed by [playground.wordpress.net](https://playground.wordpress.net) for managing the saved WordPress sites in the site manager sidebar. Use it to list and switch between sites, spin up a new temporary site with a specific PHP or WordPress version, persist a temporary site to OPFS or the local filesystem, or change PHP version and networking on a saved site.
 
-The API is reached via the `window.playgroundSites` global.
+The API is reached via the `window.playgroundSites` global. Note that `window.playgroundSites` is not assigned during initial page load — wait for it to appear, then call [`isReady()`](#isready) before making any API calls.
 
 :::info
 The Sites API ships with the Playground website application, not with the `@wp-playground/client` library. It is exposed on the top-level page (`/`), not on `/remote.html`. If you embed Playground via `startPlaygroundWeb` into your own page, your iframe won't expose `window.playgroundSites` to the parent — use the [JavaScript API](/developers/apis/javascript-api/) for direct control instead.
 :::
-
-## Wait until the API is ready
-
-`window.playgroundSites` is not assigned during initial page load. Once it appears, call `isReady()` to wait for the active site to finish booting:
-
-```javascript
-await new Promise((resolve) => {
-	const id = setInterval(() => {
-		if (window.playgroundSites) {
-			clearInterval(id);
-			resolve();
-		}
-	}, 50);
-});
-await window.playgroundSites.isReady();
-```
-
-`isReady()` resolves once the active site's `PlaygroundClient` is ready for API calls — mirroring the [`isReady()` method](/developers/apis/javascript-api/playground-api-client) on the client itself. It rejects if the site fails to boot.
-
-```typescript
-isReady(): Promise<void>;
-```
 
 ## Quick start
 
@@ -111,6 +89,28 @@ Returns the [`PlaygroundClient`](/developers/apis/javascript-api/playground-api-
 
 ```typescript
 getClient(): PlaygroundClient | undefined;
+```
+
+### `isReady()`
+
+Resolves once the active site is fully booted and its `PlaygroundClient` is ready for API calls — mirroring the [`isReady()` method](/developers/apis/javascript-api/playground-api-client) on the client itself. Rejects if the site fails to boot.
+
+For scripts that run before the page has finished loading, wait for `window.playgroundSites` to appear first:
+
+```javascript
+await new Promise((resolve) => {
+	const id = setInterval(() => {
+		if (window.playgroundSites) {
+			clearInterval(id);
+			resolve();
+		}
+	}, 50);
+});
+await window.playgroundSites.isReady();
+```
+
+```typescript
+isReady(): Promise<void>;
 ```
 
 ## Persisting a temporary site

--- a/packages/docs/site/docs/developers/06-apis/sites-api/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/sites-api/01-index.md
@@ -14,20 +14,25 @@ The Sites API ships with the Playground website application, not with the `@wp-p
 
 ## Wait until the API is ready
 
-`window.playgroundSites` is not assigned during initial page load. Poll for `getClient()` to know when it's safe to call:
+`window.playgroundSites` is not assigned during initial page load. Once it appears, call `isReady()` to wait for the active site to finish booting:
 
 ```javascript
 await new Promise((resolve) => {
 	const id = setInterval(() => {
-		if (window.playgroundSites?.getClient()) {
+		if (window.playgroundSites) {
 			clearInterval(id);
 			resolve();
 		}
 	}, 50);
 });
+await window.playgroundSites.isReady();
 ```
 
-Once the active site has booted, `getClient()` returns a `PlaygroundClient` and the rest of the API is ready.
+`isReady()` resolves once the active site's `PlaygroundClient` is ready for API calls — mirroring the [`isReady()` method](/developers/apis/javascript-api/playground-api-client) on the client itself. It rejects if the site fails to boot.
+
+```typescript
+isReady(): Promise<void>;
+```
 
 ## Quick start
 

--- a/packages/playground/website/playwright/e2e/sites-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/sites-api.spec.ts
@@ -101,3 +101,60 @@ test('playgroundSites.isReady() resolves once the active site is ready', async (
 	});
 	expect(ready).toBe(true);
 });
+
+test('playgroundSites.isReady() waits when the client is not in the store yet', async ({
+	page,
+}) => {
+	// Install a setter on window.playgroundSites BEFORE the app runs.
+	// The setter captures the moment of exposure and snapshots the client
+	// state so we can prove the test really hit the "not yet ready" path.
+	await page.addInitScript(() => {
+		let api: any;
+		Object.defineProperty(window, 'playgroundSites', {
+			configurable: true,
+			get() {
+				return api;
+			},
+			set(v) {
+				api = v;
+				let clientAtExposure: unknown = 'missing';
+				try {
+					clientAtExposure = v?.getClient();
+				} catch (e) {
+					clientAtExposure = `THREW:${(e as Error).message}`;
+				}
+				(window as any).__sitesApiExposure = {
+					hadClientAtExposure:
+						clientAtExposure != null &&
+						typeof clientAtExposure !== 'string',
+					exposureSnapshot: String(clientAtExposure),
+				};
+			},
+		});
+	});
+	await page.goto('./');
+	await page.waitForFunction(() => Boolean((window as any).playgroundSites));
+
+	const result = await page.evaluate(async () => {
+		const api = (window as any).playgroundSites;
+		const exposure = (window as any).__sitesApiExposure;
+		const t0 = performance.now();
+		await api.isReady();
+		const isReadyMs = performance.now() - t0;
+		const clientAfter = api.getClient();
+		return {
+			hadClientAtExposure: exposure?.hadClientAtExposure,
+			exposureSnapshot: exposure?.exposureSnapshot,
+			isReadyMs,
+			hasClientAfter: clientAfter != null,
+		};
+	});
+
+	// The test is only meaningful if we actually caught the unready window.
+	expect(result.hadClientAtExposure).toBe(false);
+	// After isReady() resolves, the client must be present.
+	expect(result.hasClientAfter).toBe(true);
+	// And isReady() must not have returned instantly — it had to wait for
+	// the boot to finish.
+	expect(result.isReadyMs).toBeGreaterThan(50);
+});

--- a/packages/playground/website/playwright/e2e/sites-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/sites-api.spec.ts
@@ -84,3 +84,20 @@ test('playgroundSites.getClient() returns a playground client', async ({
 	});
 	expect(hasClient).toBe(true);
 });
+
+test('playgroundSites.isReady() resolves once the active site is ready', async ({
+	website,
+}) => {
+	await website.goto('./');
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites)
+	);
+
+	const ready = await website.page.evaluate(async () => {
+		await (window as any).playgroundSites.isReady();
+		// After isReady() resolves, getClient() must return a usable client.
+		const client = (window as any).playgroundSites.getClient();
+		return client != null;
+	});
+	expect(ready).toBe(true);
+});

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -207,55 +207,52 @@ export function createSitesAPI(
 		},
 
 		async isReady() {
-			const state = getState();
-			const site = selectActiveSite(state);
-			if (!site) {
-				throw new Error('No active site selected');
-			}
-			const existingError = selectActiveSiteError(state);
-			if (existingError) {
-				const details = selectActiveSiteErrorDetails(state);
-				throw new Error(siteErrorMessage(existingError, details));
-			}
-			let client = selectClientBySiteSlug(state, site.slug);
-			if (!client) {
-				client = await new Promise<PlaygroundClient>(
-					(resolve, reject) => {
+			// Wait until the store reaches a "settled" state for the active
+			// site: either a client has been added for it, or boot failed
+			// with an error. This also covers the early window after
+			// `window.playgroundSites` is exposed but before
+			// `EnsurePlaygroundSiteIsSelected` has had a chance to set an
+			// active site — we simply wait for one to appear.
+			const isSettled = (state: PlaygroundReduxState) => {
+				const site = selectActiveSite(state);
+				if (!site) {
+					return false;
+				}
+				if (selectActiveSiteError(state)) {
+					return true;
+				}
+				return Boolean(selectClientBySiteSlug(state, site.slug));
+			};
+
+			let settledState = getState();
+			if (!isSettled(settledState)) {
+				settledState = await new Promise<PlaygroundReduxState>(
+					(resolve) => {
 						const unsubscribe = startListening({
-							predicate: (action) =>
-								(addClientInfo.match(action) &&
-									action.payload.siteSlug === site.slug) ||
-								setActiveSiteError.match(action),
-							effect: (action, listenerApi) => {
+							predicate: (_action, currentState) =>
+								isSettled(currentState),
+							effect: (_action, listenerApi) => {
 								unsubscribe();
-								if (setActiveSiteError.match(action)) {
-									reject(
-										new Error(
-											siteErrorMessage(
-												action.payload.error,
-												action.payload.details
-											)
-										)
-									);
-									return;
-								}
-								const c = selectClientBySiteSlug(
-									listenerApi.getState(),
-									site.slug
-								);
-								if (c) {
-									resolve(c);
-								} else {
-									reject(
-										new Error(
-											'Client unavailable after boot.'
-										)
-									);
-								}
+								resolve(listenerApi.getState());
 							},
 						});
 					}
 				);
+			}
+
+			const error = selectActiveSiteError(settledState);
+			if (error) {
+				throw new Error(
+					siteErrorMessage(
+						error,
+						selectActiveSiteErrorDetails(settledState)
+					)
+				);
+			}
+			const site = selectActiveSite(settledState)!;
+			const client = selectClientBySiteSlug(settledState, site.slug);
+			if (!client) {
+				throw new Error('Client unavailable after boot.');
 			}
 			await client.isReady();
 		},

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -2,7 +2,14 @@ import { useMemo } from 'react';
 import { useStore } from 'react-redux';
 import { createListenerMiddleware } from '@reduxjs/toolkit';
 import type { PlaygroundReduxState, PlaygroundDispatch } from './store';
-import { selectActiveSite, setActiveSite, useAppDispatch } from './store';
+import {
+	selectActiveSite,
+	selectActiveSiteError,
+	selectActiveSiteErrorDetails,
+	setActiveSite,
+	useAppDispatch,
+} from './store';
+import type { SerializedSiteErrorDetails, SiteError } from './slice-ui';
 import { setActiveSiteError } from './slice-ui';
 import { addClientInfo } from './slice-clients';
 import {
@@ -55,6 +62,15 @@ export interface PlaygroundSitesAPI {
 	getClient(): PlaygroundClient | undefined;
 
 	/**
+	 * Resolves once the active site is fully booted and its
+	 * PlaygroundClient is ready for API calls. Mirrors the
+	 * `isReady()` method on the PlaygroundClient itself.
+	 *
+	 * @throws When no site is selected or the site fails to boot.
+	 */
+	isReady(): Promise<void>;
+
+	/**
 	 * Renames the active site.
 	 *
 	 * @param newName The new display name.
@@ -70,7 +86,9 @@ export interface PlaygroundSitesAPI {
 	 * @returns The site's slug and storage type.
 	 * @throws When no site is selected or saving fails.
 	 */
-	saveInBrowser(name?: string): Promise<{ slug: string; storage: string }>;
+	saveInBrowser(
+		name?: string
+	): Promise<{ slug: string; storage: 'opfs' | 'local-fs' }>;
 
 	/**
 	 * Persists the active temporary site to a local directory.
@@ -84,7 +102,7 @@ export interface PlaygroundSitesAPI {
 	saveToLocalFileSystem(
 		name?: string,
 		localFsHandle?: FileSystemDirectoryHandle
-	): Promise<{ slug: string; storage: string }>;
+	): Promise<{ slug: string; storage: 'opfs' | 'local-fs' }>;
 
 	/**
 	 * Changes the PHP version for the active site and reboots it.
@@ -146,6 +164,16 @@ declare global {
 	}
 }
 
+function siteErrorMessage(
+	error: SiteError,
+	details: SerializedSiteErrorDetails | undefined
+): string {
+	if (typeof details === 'string') {
+		return details;
+	}
+	return details?.message ?? error;
+}
+
 export function createSitesAPI(
 	getState: () => PlaygroundReduxState,
 	dispatch: PlaygroundDispatch
@@ -176,6 +204,60 @@ export function createSitesAPI(
 				throw new Error('No active site selected');
 			}
 			return selectClientBySiteSlug(getState(), site.slug);
+		},
+
+		async isReady() {
+			const state = getState();
+			const site = selectActiveSite(state);
+			if (!site) {
+				throw new Error('No active site selected');
+			}
+			const existingError = selectActiveSiteError(state);
+			if (existingError) {
+				const details = selectActiveSiteErrorDetails(state);
+				throw new Error(siteErrorMessage(existingError, details));
+			}
+			let client = selectClientBySiteSlug(state, site.slug);
+			if (!client) {
+				client = await new Promise<PlaygroundClient>(
+					(resolve, reject) => {
+						const unsubscribe = startListening({
+							predicate: (action) =>
+								(addClientInfo.match(action) &&
+									action.payload.siteSlug === site.slug) ||
+								setActiveSiteError.match(action),
+							effect: (action, listenerApi) => {
+								unsubscribe();
+								if (setActiveSiteError.match(action)) {
+									reject(
+										new Error(
+											siteErrorMessage(
+												action.payload.error,
+												action.payload.details
+											)
+										)
+									);
+									return;
+								}
+								const c = selectClientBySiteSlug(
+									listenerApi.getState(),
+									site.slug
+								);
+								if (c) {
+									resolve(c);
+								} else {
+									reject(
+										new Error(
+											'Client unavailable after boot.'
+										)
+									);
+								}
+							},
+						});
+					}
+				);
+			}
+			await client.isReady();
 		},
 
 		async rename(newName: string) {
@@ -211,7 +293,12 @@ export function createSitesAPI(
 				})
 			);
 			const updatedSite = selectSiteBySlug(getState(), site.slug);
-			const storage = updatedSite?.metadata.storage ?? 'none';
+			const storage = updatedSite?.metadata.storage;
+			if (storage !== 'opfs' && storage !== 'local-fs') {
+				throw new Error(
+					`Site ${site.slug} was not persisted (storage: ${storage}).`
+				);
+			}
 			return { slug: site.slug, storage };
 		},
 
@@ -234,7 +321,12 @@ export function createSitesAPI(
 				})
 			);
 			const updatedSite = selectSiteBySlug(getState(), site.slug);
-			const storage = updatedSite?.metadata.storage ?? 'none';
+			const storage = updatedSite?.metadata.storage;
+			if (storage !== 'opfs' && storage !== 'local-fs') {
+				throw new Error(
+					`Site ${site.slug} was not persisted (storage: ${storage}).`
+				);
+			}
 			return { slug: site.slug, storage };
 		},
 
@@ -319,13 +411,14 @@ export function createSitesAPI(
 					effect: (action) => {
 						unsubscribe();
 						if (setActiveSiteError.match(action)) {
-							const details = action.payload.details;
-							const message =
-								typeof details === 'string'
-									? details
-									: (details?.message ??
-										action.payload.error);
-							reject(new Error(message));
+							reject(
+								new Error(
+									siteErrorMessage(
+										action.payload.error,
+										action.payload.details
+									)
+								)
+							);
 						} else {
 							resolve();
 						}


### PR DESCRIPTION
## What is this PR doing?

Adds an `isReady()` method to the Sites API (`window.playgroundSites`) that resolves once the active site is fully booted and its `PlaygroundClient` is available for API calls. Also adds full Sites API documentation.

## Motivation for the change, related issues

Without `isReady()`, scripts using `window.playgroundSites` had no reliable way to wait for the active site to finish booting. `getClient()` returns `undefined` until the site is ready, so callers had to poll or guess timing. This is especially tricky because `window.playgroundSites` itself is assigned early in page load — before the active site has booted — so even detecting when the object exists isn't enough.

## Implementation details

### `isReady()` on the Sites API

The implementation watches the Redux store for a "settled" state: either a `PlaygroundClient` has been added for the active site, or boot failed with an error. It uses RTK's `startListening` to subscribe to state changes without polling, resolves when settled, and then delegates to `client.isReady()` (mirroring the method on `PlaygroundClient` itself).

The implementation also handles the early window where `window.playgroundSites` is exposed but `EnsurePlaygroundSiteIsSelected` hasn't yet set an active site — it waits for one to appear before checking client readiness.

When boot fails, it throws with a descriptive error extracted from the Redux error state (using a new `siteErrorMessage` helper that replaces inline logic in two places).

### Type improvements

- `saveInBrowser` and `saveToLocalFileSystem` now return `{ slug: string; storage: 'opfs' | 'local-fs' }` instead of `string` — the code already validated storage was one of these values, the types now reflect that.

### Documentation

Adds a new [Sites API](/developers/apis/sites-api) doc page covering all methods, storage types, and usage patterns. Updates the API index page to list the Sites API alongside the existing Query, Blueprints, and JavaScript APIs.

## Testing Instructions

Run the new E2E tests:

```bash
npx nx e2e playground-website --grep "isReady"
```

Two scenarios are covered:
1. **Happy path** — `isReady()` resolves, and `getClient()` returns a usable client immediately after.
2. **Race condition** — a `defineProperty` setter on `window.playgroundSites` proves the test caught the window when the client wasn't in the store yet; `isReady()` still resolves correctly and takes >50ms (i.e., it actually waited).

For manual verification, open [playground.wordpress.net](https://playground.wordpress.net) and run in DevTools:

```javascript
await window.playgroundSites.isReady();
console.log(window.playgroundSites.getClient()); // PlaygroundClient object
```