### PR TITLE
Fix CLI WP debug defaults for WordPress 7.0

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -717,19 +717,21 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 		const isLegacyPhpForDebug = isLegacyPHPVersion(phpVersionForDebug);
 		if (!isLegacyPhpForDebug) {
 			if (!hasDebugDefine('WP_DEBUG')) {
-				define['WP_DEBUG'] = 'true';
+				defineBool['WP_DEBUG'] = true;
 			}
 			if (!hasDebugDefine('WP_DEBUG_LOG')) {
-				define['WP_DEBUG_LOG'] = 'true';
+				defineBool['WP_DEBUG_LOG'] = true;
 			}
 			if (!hasDebugDefine('WP_DEBUG_DISPLAY')) {
-				define['WP_DEBUG_DISPLAY'] = 'false';
+				defineBool['WP_DEBUG_DISPLAY'] = false;
 			}
 		}
 
 		const cliArgs = {
 			...args,
 			define,
+			'define-bool': defineBool,
+			'define-number': defineNumber,
 			command,
 			mount: [
 				...((args['mount'] as Mount[]) || []),
@@ -787,7 +789,7 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 				const messageChain = [];
 				let currentError: Error | undefined = e;
 				do {
-					messageChain.push(currentError.message);
+					messageChain.push(describeError(currentError));
 					currentError = currentError.cause as Error;
 				} while (currentError instanceof Error);
 				console.error(
@@ -808,7 +810,27 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
  */
 function describeError(error: unknown): string {
 	if (error instanceof Error) {
-		return error.message;
+		if (error.message) {
+			return error.message;
+		}
+		if (error.cause !== undefined) {
+			return describeError(error.cause);
+		}
+		const parts = [];
+		if (error.name && error.name !== 'Error') {
+			parts.push(error.name);
+		}
+		const obj = error as Error & Record<string, unknown>;
+		if (obj['errno'] !== undefined) {
+			parts.push(`errno: ${obj['errno']}`);
+		}
+		if (obj['code'] !== undefined) {
+			parts.push(`code: ${obj['code']}`);
+		}
+		if (parts.length > 0) {
+			return parts.join(' — ');
+		}
+		return error.stack || String(error);
 	}
 	if (error && typeof error === 'object') {
 		// Comlink-serialized errors arrive as plain objects like

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -786,12 +786,25 @@ export async function parseOptionsAndRunCLI(argsToParse: string[]) {
 			if (debug) {
 				printDebugDetails(e);
 			} else {
-				const messageChain = [];
+				const messageChain: string[] = [];
+				const seenErrors = new Set<Error>();
 				let currentError: Error | undefined = e;
-				do {
+				for (let depth = 0; currentError && depth < 20; depth++) {
+					if (seenErrors.has(currentError)) {
+						messageChain.push('[Circular error cause]');
+						currentError = undefined;
+						break;
+					}
+					seenErrors.add(currentError);
 					messageChain.push(describeError(currentError));
-					currentError = currentError.cause as Error;
-				} while (currentError instanceof Error);
+					currentError =
+						currentError.cause instanceof Error
+							? currentError.cause
+							: undefined;
+				}
+				if (currentError) {
+					messageChain.push('[Error cause chain truncated]');
+				}
 				console.error(
 					'\x1b[1m' + messageChain.join(' caused by: ') + '\x1b[0m'
 				);
@@ -813,10 +826,7 @@ function describeError(error: unknown): string {
 		if (error.message) {
 			return error.message;
 		}
-		if (error.cause !== undefined) {
-			return describeError(error.cause);
-		}
-		const parts = [];
+		const parts: string[] = [];
 		if (error.name && error.name !== 'Error') {
 			parts.push(error.name);
 		}

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1866,10 +1866,10 @@ describe('other run-cli behaviors', () => {
 
 		test('should override WP_DEBUG constants via --define-bool', async () => {
 			// Confirm default values before confirming they can be overridden.
-			const defaultConstantss = await getConstants([]);
-			expect(defaultConstantss.WP_DEBUG).toBe(true);
-			expect(defaultConstantss.WP_DEBUG_LOG).toBe(true);
-			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe(false);
+			const defaultConstants = await getConstants([]);
+			expect(defaultConstants.WP_DEBUG).toBe(true);
+			expect(defaultConstants.WP_DEBUG_LOG).toBe(true);
+			expect(defaultConstants.WP_DEBUG_DISPLAY).toBe(false);
 
 			const constants = await getConstants([
 				'--define-bool',
@@ -1889,10 +1889,10 @@ describe('other run-cli behaviors', () => {
 
 		test('should override WP_DEBUG constants via --define-number', async () => {
 			// Confirm default values before confirming they can be overridden.
-			const defaultConstantss = await getConstants([]);
-			expect(defaultConstantss.WP_DEBUG).toBe(true);
-			expect(defaultConstantss.WP_DEBUG_LOG).toBe(true);
-			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe(false);
+			const defaultConstants = await getConstants([]);
+			expect(defaultConstants.WP_DEBUG).toBe(true);
+			expect(defaultConstants.WP_DEBUG_LOG).toBe(true);
+			expect(defaultConstants.WP_DEBUG_DISPLAY).toBe(false);
 
 			const constants = await getConstants([
 				'--define-number',
@@ -1912,10 +1912,10 @@ describe('other run-cli behaviors', () => {
 
 		test('should override WP_DEBUG constants via --define', async () => {
 			// Confirm default values before confirming they can be overridden.
-			const defaultConstantss = await getConstants([]);
-			expect(defaultConstantss.WP_DEBUG).toBe(true);
-			expect(defaultConstantss.WP_DEBUG_LOG).toBe(true);
-			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe(false);
+			const defaultConstants = await getConstants([]);
+			expect(defaultConstants.WP_DEBUG).toBe(true);
+			expect(defaultConstants.WP_DEBUG_LOG).toBe(true);
+			expect(defaultConstants.WP_DEBUG_DISPLAY).toBe(false);
 
 			const constants = await getConstants([
 				'--define',

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -1867,9 +1867,9 @@ describe('other run-cli behaviors', () => {
 		test('should override WP_DEBUG constants via --define-bool', async () => {
 			// Confirm default values before confirming they can be overridden.
 			const defaultConstantss = await getConstants([]);
-			expect(defaultConstantss.WP_DEBUG).toBe('true');
-			expect(defaultConstantss.WP_DEBUG_LOG).toBe('true');
-			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe('false');
+			expect(defaultConstantss.WP_DEBUG).toBe(true);
+			expect(defaultConstantss.WP_DEBUG_LOG).toBe(true);
+			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe(false);
 
 			const constants = await getConstants([
 				'--define-bool',
@@ -1890,9 +1890,9 @@ describe('other run-cli behaviors', () => {
 		test('should override WP_DEBUG constants via --define-number', async () => {
 			// Confirm default values before confirming they can be overridden.
 			const defaultConstantss = await getConstants([]);
-			expect(defaultConstantss.WP_DEBUG).toBe('true');
-			expect(defaultConstantss.WP_DEBUG_LOG).toBe('true');
-			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe('false');
+			expect(defaultConstantss.WP_DEBUG).toBe(true);
+			expect(defaultConstantss.WP_DEBUG_LOG).toBe(true);
+			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe(false);
 
 			const constants = await getConstants([
 				'--define-number',
@@ -1913,9 +1913,9 @@ describe('other run-cli behaviors', () => {
 		test('should override WP_DEBUG constants via --define', async () => {
 			// Confirm default values before confirming they can be overridden.
 			const defaultConstantss = await getConstants([]);
-			expect(defaultConstantss.WP_DEBUG).toBe('true');
-			expect(defaultConstantss.WP_DEBUG_LOG).toBe('true');
-			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe('false');
+			expect(defaultConstantss.WP_DEBUG).toBe(true);
+			expect(defaultConstantss.WP_DEBUG_LOG).toBe(true);
+			expect(defaultConstantss.WP_DEBUG_DISPLAY).toBe(false);
 
 			const constants = await getConstants([
 				'--define',


### PR DESCRIPTION
## What changed

- Defaults the CLI `WP_DEBUG`, `WP_DEBUG_LOG`, and `WP_DEBUG_DISPLAY` constants through the boolean define map instead of the string define map.
- Passes the normalized `define-bool` and `define-number` maps through to `runCLI()`.
- Updates the CLI tests to assert the default debug constants are booleans.
- Improves non-debug error formatting for empty-message `Error` objects so failures do not print as a blank `Error:`.

## Why

When the CLI resolved WordPress 7.0 from `https://downloads.w.org/release/wordpress-7.0.zip`, it defaulted `WP_DEBUG_DISPLAY` to the string `false`. PHP treats non-empty strings as truthy, so WordPress displayed SQLite bootstrap errors during early database setup. That output contaminated the CLI database validation response and made the CLI report a SQLite connection failure, while the website path worked because it uses boolean constants.

## Validation

- Confirmed the original CLI smoke path now reaches `Ready! WordPress is running...` with `--wp=7.0 --php=8.4`.
- Ran `npm exec nx run playground-cli:test-playground-cli -- --testFiles=tests/run-cli.spec.ts --testNamePattern="WP_DEBUG constants"`.
- Ran `git diff --check origin/trunk..codex/fix-cli-wp70-debug-constants`.
