### PR TITLE
[Website] URLencode the OPFS directory names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
 				"@types/xml2js": "0.4.14",
 				"@uiw/react-codemirror": "4.23.0",
 				"@wordpress/dataviews": "4.5.0",
+				"@wordpress/url": "4.43.0",
 				"@zip.js/zip.js": "2.7.57",
 				"ajv": "8.12.0",
 				"async-lock": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
 		"@types/xml2js": "0.4.14",
 		"@uiw/react-codemirror": "4.23.0",
 		"@wordpress/dataviews": "4.5.0",
+		"@wordpress/url": "4.43.0",
 		"@zip.js/zip.js": "2.7.57",
 		"ajv": "8.12.0",
 		"async-lock": "1.4.1",

--- a/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
@@ -11,7 +11,8 @@ import {
 	copyFilesystem,
 	type TraversableFilesystemBackend,
 } from '@wp-playground/storage';
-import { getDirectoryPathForSlug } from './opfs-site-storage';
+import { joinPaths } from '@php-wasm/util';
+import { getDirectoryPathForSlug } from './opfs-site-path';
 
 const BUNDLE_DIR_NAME = 'blueprint-bundle';
 
@@ -19,8 +20,7 @@ const BUNDLE_DIR_NAME = 'blueprint-bundle';
  * Get the OPFS path for a site's blueprint bundle directory.
  */
 function getBundlePath(siteSlug: string): string {
-	const sitePath = getDirectoryPathForSlug(siteSlug);
-	return `${sitePath}/${BUNDLE_DIR_NAME}`;
+	return getBundlePathForSitePath(getDirectoryPathForSlug(siteSlug));
 }
 
 /**
@@ -74,4 +74,20 @@ export async function loadPersistedBlueprintBundle(
 	siteSlug: string
 ): Promise<OpfsFilesystemBackend> {
 	return OpfsFilesystemBackend.fromPath(getBundlePath(siteSlug));
+}
+
+/**
+ * Load a persisted blueprint bundle from an already-resolved OPFS site path.
+ *
+ * This is used when a saved site's directory name is the legacy lossy form, so
+ * recomputing the path from the slug would point at the newer encoded location.
+ */
+export async function loadPersistedBlueprintBundleFromPath(
+	sitePath: string
+): Promise<OpfsFilesystemBackend> {
+	return OpfsFilesystemBackend.fromPath(getBundlePathForSitePath(sitePath));
+}
+
+function getBundlePathForSitePath(sitePath: string): string {
+	return joinPaths(sitePath, BUNDLE_DIR_NAME);
 }

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-path.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-path.spec.ts
@@ -1,0 +1,38 @@
+import {
+	getCandidateDirectoryNamesForSlug,
+	getDirectoryNameForSlug,
+} from './opfs-site-path';
+
+describe('getDirectoryNameForSlug', () => {
+	it('keeps existing ASCII slug directory names stable', () => {
+		expect(getDirectoryNameForSlug('demo-site')).toBe('site-demo-site');
+	});
+
+	it('encodes path separators without conflating different slugs', () => {
+		expect(getDirectoryNameForSlug('a/b')).toBe('site-a%2Fb');
+		expect(getDirectoryNameForSlug('a?b')).toBe('site-a%3Fb');
+		expect(getDirectoryNameForSlug('a/b')).not.toBe(
+			getDirectoryNameForSlug('a?b')
+		);
+	});
+
+	it('preserves the full slug through reversible path encoding', () => {
+		const slug = 'Mój Playground 🚀';
+		const directoryName = getDirectoryNameForSlug(slug);
+
+		expect(directoryName).toBe(`site-${encodeURIComponent(slug)}`);
+		expect(decodeURIComponent(directoryName.replace(/^site-/, ''))).toBe(
+			slug
+		);
+	});
+
+	it('checks the encoded directory before the legacy directory', () => {
+		expect(getCandidateDirectoryNamesForSlug('demo-site')).toEqual([
+			'site-demo-site',
+		]);
+		expect(getCandidateDirectoryNamesForSlug('a/b')).toEqual([
+			'site-a%2Fb',
+			'site-a-b',
+		]);
+	});
+});

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-path.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-path.ts
@@ -1,0 +1,48 @@
+import { joinPaths } from '@php-wasm/util';
+
+export const OPFS_SITES_ROOT_PATH = '/sites';
+
+/**
+ * Computes the canonical OPFS path for writing a site slug.
+ *
+ * This does not perform legacy directory lookup. Use the site storage methods
+ * when reading, updating, or deleting an existing site because those operations
+ * need to check older directory names.
+ */
+export function getDirectoryPathForSlug(slug: string) {
+	return joinPaths(OPFS_SITES_ROOT_PATH, getDirectoryNameForSlug(slug));
+}
+
+/**
+ * Returns the OPFS directory name for a site slug.
+ *
+ * The slug itself may contain characters that are fine in a query parameter
+ * but not as an OPFS path segment, such as `/`. Percent-encoding keeps the
+ * mapping reversible instead of collapsing distinct slugs to the same name.
+ */
+export function getDirectoryNameForSlug(slug: string) {
+	return `site-${encodeURIComponent(slug)}`;
+}
+
+/**
+ * Returns the OPFS directory names that may contain the site data for a slug.
+ *
+ * Check the current reversible name first, then the legacy lossy name for sites
+ * saved before slug path encoding was introduced.
+ */
+export function getCandidateDirectoryNamesForSlug(slug: string) {
+	const directoryName = getDirectoryNameForSlug(slug);
+	// When the directory name is not the same as the slug, which happens
+	// for legacy sites stored using the older, unencoded slugs,
+	// return both the new and old directory names.
+	const legacyDirectoryName = `site-${slug}`.replaceAll(
+		/[^a-zA-Z0-9_-]/g,
+		'-'
+	);
+	if (legacyDirectoryName !== directoryName) {
+		return [directoryName, legacyDirectoryName];
+	}
+
+	// Otherwise, return the single directory name.
+	return [directoryName];
+}

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -1,0 +1,192 @@
+import type { SiteMetadata } from '../redux/slice-sites';
+import type { opfsSiteStorage as exportedOpfsSiteStorage } from './opfs-site-storage';
+
+describe('opfsSiteStorage', () => {
+	let opfsRoot: MemoryDirectoryHandle;
+	let storage: NonNullable<typeof exportedOpfsSiteStorage>;
+
+	beforeEach(async () => {
+		vi.resetModules();
+		opfsRoot = new MemoryDirectoryHandle('');
+		vi.stubGlobal('navigator', {
+			storage: {
+				getDirectory: vi.fn(async () => opfsRoot),
+			},
+		});
+		vi.doMock('./opfs-blueprint-bundle-storage', () => ({
+			loadPersistedBlueprintBundle: vi.fn(),
+			loadPersistedBlueprintBundleFromPath: vi.fn(),
+		}));
+		vi.doMock('@wp-playground/blueprints', () => ({
+			getBlueprintDeclaration: vi.fn(async (blueprint) => blueprint),
+		}));
+
+		const module = await import('./opfs-site-storage');
+		storage = module.opfsSiteStorage!;
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('reads legacy site metadata when the encoded directory is incomplete', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await sitesRoot.getDirectoryHandle('site-a%2Fb', { create: true });
+		await writeSiteMetadata(sitesRoot, 'site-a-b', 'a/b');
+
+		const site = await storage.read('a/b');
+
+		expect(site).toMatchObject({
+			slug: 'a/b',
+			metadata: {
+				name: 'Test Playground',
+			},
+		});
+	});
+
+	it('does not create a duplicate when legacy site metadata exists', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await sitesRoot.getDirectoryHandle('site-a%2Fb', { create: true });
+		await writeSiteMetadata(sitesRoot, 'site-a-b', 'a/b');
+
+		await expect(
+			storage.create('a/b', createSiteMetadata())
+		).rejects.toThrow("Site with slug 'a/b' already exists.");
+	});
+
+	it('deletes the legacy site directory when the encoded directory is incomplete', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await sitesRoot.getDirectoryHandle('site-a%2Fb', { create: true });
+		await writeSiteMetadata(sitesRoot, 'site-a-b', 'a/b');
+
+		await storage.delete('a/b');
+
+		await expect(
+			sitesRoot.getDirectoryHandle('site-a-b')
+		).rejects.toMatchObject({ name: 'NotFoundError' });
+		await expect(
+			sitesRoot.getDirectoryHandle('site-a%2Fb')
+		).resolves.toBeDefined();
+	});
+});
+
+async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {
+	return opfsRoot.getDirectoryHandle('sites');
+}
+
+async function writeSiteMetadata(
+	sitesRoot: MemoryDirectoryHandle,
+	directoryName: string,
+	slug: string
+) {
+	const siteDirectory = await sitesRoot.getDirectoryHandle(directoryName, {
+		create: true,
+	});
+	siteDirectory.setFile(
+		'wp-runtime.json',
+		JSON.stringify({
+			slug,
+			...createSiteMetadata(),
+		})
+	);
+}
+
+function createSiteMetadata(): SiteMetadata {
+	return {
+		storage: 'opfs',
+		id: 'test-site-id',
+		name: 'Test Playground',
+		runtimeConfiguration: {
+			phpVersion: '8.3',
+			wpVersion: 'latest',
+			intl: false,
+			networking: true,
+			extraLibraries: [],
+			constants: {},
+		},
+		originalBlueprint: {},
+		originalBlueprintSource: {
+			type: 'none',
+		},
+	};
+}
+
+class MemoryDirectoryHandle {
+	kind = 'directory' as const;
+	name: string;
+	private entries = new Map<
+		string,
+		MemoryDirectoryHandle | MemoryFileHandle
+	>();
+
+	constructor(name: string) {
+		this.name = name;
+	}
+
+	async getDirectoryHandle(
+		name: string,
+		options?: { create?: boolean }
+	): Promise<MemoryDirectoryHandle> {
+		const entry = this.entries.get(name);
+		if (entry instanceof MemoryDirectoryHandle) {
+			return entry;
+		}
+		if (entry) {
+			throw createDomException('TypeMismatchError');
+		}
+		if (options?.create) {
+			const directory = new MemoryDirectoryHandle(name);
+			this.entries.set(name, directory);
+			return directory;
+		}
+		throw createDomException('NotFoundError');
+	}
+
+	async getFileHandle(name: string): Promise<MemoryFileHandle> {
+		const entry = this.entries.get(name);
+		if (entry instanceof MemoryFileHandle) {
+			return entry;
+		}
+		if (entry) {
+			throw createDomException('TypeMismatchError');
+		}
+		throw createDomException('NotFoundError');
+	}
+
+	async removeEntry(name: string) {
+		if (!this.entries.delete(name)) {
+			throw createDomException('NotFoundError');
+		}
+	}
+
+	async *values() {
+		yield* this.entries.values();
+	}
+
+	setFile(name: string, content: string) {
+		this.entries.set(name, new MemoryFileHandle(name, content));
+	}
+}
+
+class MemoryFileHandle {
+	kind = 'file' as const;
+	name: string;
+	private content: string;
+
+	constructor(name: string, content: string) {
+		this.name = name;
+		this.content = content;
+	}
+
+	async getFile() {
+		return {
+			text: async () => this.content,
+		};
+	}
+}
+
+function createDomException(name: string) {
+	const error = new Error(name);
+	error.name = name;
+	return error;
+}

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -8,8 +8,8 @@
 import metadataWorkerUrl from './opfs-site-storage-worker-for-safari?worker&url';
 import type { SiteMetadata } from '../redux/slice-sites';
 import type { SiteInfo } from '../redux/slice-sites';
-import { joinPaths } from '@php-wasm/util';
 import { logger } from '@php-wasm/logger';
+import { joinPaths } from '@php-wasm/util';
 import {
 	type ExtraLibrary,
 	type PHPConstants,
@@ -17,9 +17,20 @@ import {
 } from '@wp-playground/blueprints';
 import type { AllPHPVersion } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import { loadPersistedBlueprintBundle } from './opfs-blueprint-bundle-storage';
+import {
+	loadPersistedBlueprintBundle,
+	loadPersistedBlueprintBundleFromPath,
+} from './opfs-blueprint-bundle-storage';
+import {
+	OPFS_SITES_ROOT_PATH,
+	getCandidateDirectoryNamesForSlug,
+	getDirectoryNameForSlug,
+} from './opfs-site-path';
+export {
+	getDirectoryNameForSlug,
+	getDirectoryPathForSlug,
+} from './opfs-site-path';
 
-const ROOT_PATH = '/sites';
 // TODO: Decide on metadata filename
 const SITE_METADATA_FILENAME = 'wp-runtime.json';
 
@@ -45,7 +56,7 @@ export interface StoredSiteMetadata extends SiteMetadata {
 let opfsSitesRoot: FileSystemDirectoryHandle | undefined = undefined;
 try {
 	opfsSitesRoot = await navigator.storage.getDirectory();
-	for (const path of ROOT_PATH.replace(/^\//, '').split('/')) {
+	for (const path of OPFS_SITES_ROOT_PATH.replace(/^\//, '').split('/')) {
 		opfsSitesRoot = await opfsSitesRoot.getDirectoryHandle(path, {
 			create: true,
 		});
@@ -62,30 +73,28 @@ class OpfsSiteStorage {
 
 	async create(slug: string, metadata: SiteMetadata): Promise<void> {
 		const newSiteDirName = getDirectoryNameForSlug(slug);
-		if (await opfsChildExists(this.root, newSiteDirName)) {
-			const dir = await this.root.getDirectoryHandle(newSiteDirName);
-			if (await opfsChildExists(dir, SITE_METADATA_FILENAME)) {
-				throw new Error(`Site with slug '${slug}' already exists.`);
-			}
+		const existingSiteDirName = await this.findExistingSiteDirName(slug);
+		if (existingSiteDirName) {
+			throw new Error(`Site with slug '${slug}' already exists.`);
 		}
 
 		await this.root.getDirectoryHandle(newSiteDirName, {
 			create: true,
 		});
 		await opfsWriteFile(
-			joinPaths(ROOT_PATH, newSiteDirName, SITE_METADATA_FILENAME),
+			getSiteMetadataPath(newSiteDirName),
 			await metadataToStoredFormat(slug, metadata)
 		);
 	}
 
 	async update(slug: string, metadata: SiteMetadata): Promise<void> {
-		const newSiteDirName = getDirectoryNameForSlug(slug);
-		if (!(await opfsChildExists(this.root, newSiteDirName))) {
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
 			throw new Error(`Site with slug '${slug}' does not exist.`);
 		}
 
 		await opfsWriteFile(
-			joinPaths(ROOT_PATH, newSiteDirName, SITE_METADATA_FILENAME),
+			getSiteMetadataPath(siteDirName),
 			await metadataToStoredFormat(slug, metadata)
 		);
 	}
@@ -112,7 +121,11 @@ class OpfsSiteStorage {
 	}
 
 	async read(slug: string): Promise<SiteInfo | undefined> {
-		return await this.readSite(getDirectoryNameForSlug(slug));
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
+			return undefined;
+		}
+		return await this.readSite(siteDirName);
 	}
 
 	private async readSite(siteDirName: string) {
@@ -135,12 +148,20 @@ class OpfsSiteStorage {
 		//       ^ do not do it implicitly. Require user interaction. Maybe constrain this just
 		//         to the site files import flow.
 		const siteInfo = storedFormatToMetadata(await file.text());
+		const sitePath = joinPaths(OPFS_SITES_ROOT_PATH, siteDirectory.name);
+		const isLegacyDirectoryName =
+			siteDirectory.name !== getDirectoryNameForSlug(siteInfo.slug);
+		if (isLegacyDirectoryName) {
+			(siteInfo.metadata as any)[legacyOpfsPathSymbol] = sitePath;
+		}
+
 		// If the blueprint source points to the bundle directory, load from there.
 		// This allows the site to access bundled resources, not just the JSON declaration.
 		if (siteInfo.metadata.originalBlueprintSource?.type === 'opfs-site') {
 			try {
-				siteInfo.metadata.originalBlueprint =
-					await loadPersistedBlueprintBundle(siteInfo.slug);
+				siteInfo.metadata.originalBlueprint = isLegacyDirectoryName
+					? await loadPersistedBlueprintBundleFromPath(sitePath)
+					: await loadPersistedBlueprintBundle(siteInfo.slug);
 			} catch (error) {
 				logger.error(
 					`Failed to load blueprint bundle for site ${siteInfo.slug}`,
@@ -154,8 +175,35 @@ class OpfsSiteStorage {
 	}
 
 	async delete(slug: string): Promise<void> {
-		const siteDirName = getDirectoryNameForSlug(slug);
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
+			throw new Error(`Site with slug '${slug}' does not exist.`);
+		}
 		await this.root.removeEntry(siteDirName, { recursive: true });
+	}
+
+	/**
+	 * Finds the directory containing a persisted site's metadata.
+	 *
+	 * A failed save can leave behind an encoded directory without
+	 * `wp-runtime.json`. That partial directory must not hide a legacy directory
+	 * that still contains the saved site for the same slug.
+	 */
+	private async findExistingSiteDirName(slug: string) {
+		for (const siteDirName of getCandidateDirectoryNamesForSlug(slug)) {
+			const siteDirectory = await getDirectoryHandleIfExists(
+				this.root,
+				siteDirName
+			);
+			if (
+				siteDirectory &&
+				(await opfsFileExists(siteDirectory, SITE_METADATA_FILENAME))
+			) {
+				return siteDirName;
+			}
+		}
+
+		return undefined;
 	}
 }
 
@@ -165,12 +213,8 @@ export const opfsSiteStorage: OpfsSiteStorage | undefined = opfsSitesRoot
 
 export const isOpfsAvailable = !!opfsSiteStorage;
 
-export function getDirectoryPathForSlug(slug: string) {
-	return joinPaths(ROOT_PATH, getDirectoryNameForSlug(slug));
-}
-
-export function getDirectoryNameForSlug(slug: string) {
-	return `site-${slug}`.replaceAll(/[^a-zA-Z0-9_-]/g, '-');
+function getSiteMetadataPath(siteDirName: string) {
+	return joinPaths(OPFS_SITES_ROOT_PATH, siteDirName, SITE_METADATA_FILENAME);
 }
 
 async function metadataToStoredFormat(
@@ -250,21 +294,35 @@ function storedFormatToMetadata(data: string) {
 	};
 }
 
-async function opfsChildExists(
+async function getDirectoryHandleIfExists(
 	handle: FileSystemDirectoryHandle,
 	name: string
 ) {
 	try {
-		await handle.getDirectoryHandle(name);
+		return await handle.getDirectoryHandle(name);
+	} catch (error) {
+		if (isMissingOpfsEntry(error)) {
+			return undefined;
+		}
+		throw error;
+	}
+}
+
+async function opfsFileExists(handle: FileSystemDirectoryHandle, name: string) {
+	try {
+		await handle.getFileHandle(name);
 		return true;
-	} catch {
-		try {
-			await handle.getFileHandle(name);
-			return true;
-		} catch {
+	} catch (error) {
+		if (isMissingOpfsEntry(error)) {
 			return false;
 		}
+		throw error;
 	}
+}
+
+function isMissingOpfsEntry(error: unknown) {
+	const name = (error as DOMException | undefined)?.name;
+	return name === 'NotFoundError' || name === 'TypeMismatchError';
 }
 
 export async function deleteDirectory(path: string) {

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -368,7 +368,7 @@ export function createSitesAPI(
 				}
 			}
 			const newSiteInfo = await dispatch(
-				setTemporarySiteSpec(siteName, url)
+				setTemporarySiteSpec(siteName, url, requestedSiteSlug)
 			);
 			await api.setActiveSite(newSiteInfo.slug);
 			return newSiteInfo.slug;

--- a/packages/playground/website/src/lib/state/redux/site-slug.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-slug.spec.ts
@@ -1,0 +1,48 @@
+import { deriveSlugFromSiteName, getUniqueSiteSlug } from './site-slug';
+
+describe('site slug helpers', () => {
+	it('derives readable default slugs from site names', () => {
+		expect(deriveSlugFromSiteName(' My WordPress Playground! ')).toBe(
+			'my-wordpress-playground'
+		);
+		expect(deriveSlugFromSiteName(' Mój WordPress Playground! ')).toBe(
+			'moj-wordpress-playground'
+		);
+	});
+
+	it('uses a fallback slug when the site name has no usable characters', () => {
+		expect(deriveSlugFromSiteName('!!!')).toBe('playground');
+	});
+
+	it('appends a suffix to avoid slug collisions', () => {
+		expect(
+			getUniqueSiteSlug('demo-site', {
+				unavailableSlugs: ['demo-site', 'demo-site-2', 'other-site'],
+			})
+		).toBe('demo-site-3');
+	});
+
+	it('does not sanitize explicit slug hints while avoiding collisions', () => {
+		expect(
+			getUniqueSiteSlug('Mój Playground 🚀', {
+				unavailableSlugs: [],
+			})
+		).toBe('Mój Playground 🚀');
+		expect(
+			getUniqueSiteSlug('  spaced slug  ', {
+				unavailableSlugs: [],
+			})
+		).toBe('  spaced slug  ');
+		expect(
+			getUniqueSiteSlug('Mój Playground 🚀', {
+				unavailableSlugs: ['Mój Playground 🚀'],
+			})
+		).toBe('Mój Playground 🚀-2');
+	});
+
+	it('uses a fallback when an explicit slug hint is empty', () => {
+		expect(getUniqueSiteSlug('', { unavailableSlugs: [] })).toBe(
+			'playground'
+		);
+	});
+});

--- a/packages/playground/website/src/lib/state/redux/site-slug.ts
+++ b/packages/playground/website/src/lib/state/redux/site-slug.ts
@@ -1,0 +1,39 @@
+import { cleanForSlug } from '@wordpress/url';
+
+/**
+ * Builds the default site slug used when a caller did not provide one.
+ *
+ * Explicit slug hints bypass this helper so their URL/storage escaping remains
+ * the responsibility of the boundaries that consume them.
+ */
+export function deriveSlugFromSiteName(name: string) {
+	return cleanForSlug(name) || 'playground';
+}
+
+/**
+ * Returns a preferred site slug with a numeric suffix when needed.
+ *
+ * Callers decide whether the preferred slug comes from user-facing text or an
+ * explicit slug hint. This function only handles empty strings and collisions.
+ */
+export function getUniqueSiteSlug(
+	preferredSlug: string,
+	{
+		unavailableSlugs,
+	}: {
+		unavailableSlugs: Iterable<string>;
+	}
+) {
+	const unavailable = new Set(unavailableSlugs);
+	const baseSlug = preferredSlug || 'playground';
+	if (!unavailable.has(baseSlug)) {
+		return baseSlug;
+	}
+	let suffix = 2;
+	let candidate = `${baseSlug}-${suffix}`;
+	while (unavailable.has(candidate)) {
+		suffix++;
+		candidate = `${baseSlug}-${suffix}`;
+	}
+	return candidate;
+}

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -25,6 +25,7 @@ import { logger } from '@php-wasm/logger';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { findFirewallErrorInCauseChain } from './error-utils';
+import { deriveSlugFromSiteName, getUniqueSiteSlug } from './site-slug';
 
 /**
  * The Site model used to represent a site within Playground.
@@ -112,9 +113,6 @@ export const getSitesLoadingState = (state: {
 	sites: ReturnType<typeof sitesSlice.reducer>;
 }) => state.sites.opfsSitesLoadingState;
 
-export function deriveSlugFromSiteName(name: string) {
-	return name.toLowerCase().replaceAll(' ', '-');
-}
 export function deriveSiteNameFromSlug(slug: string) {
 	return slug
 		.replaceAll('-', ' ')
@@ -252,13 +250,13 @@ export function removeSite(slug: string) {
  */
 export function setTemporarySiteSpec(
 	siteName: string,
-	playgroundUrlWithQueryApiArgs: URL
+	playgroundUrlWithQueryApiArgs: URL,
+	preferredSlug?: string
 ) {
 	return async (
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
 	) => {
-		const siteSlug = deriveSlugFromSiteName(siteName);
 		const newSiteUrlParams = {
 			searchParams: parseSearchParams(
 				playgroundUrlWithQueryApiArgs.searchParams
@@ -333,6 +331,17 @@ export function setTemporarySiteSpec(
 				return currentTemporarySite;
 			}
 		}
+
+		const siteSlug = getUniqueSiteSlug(
+			preferredSlug || deriveSlugFromSiteName(siteName),
+			{
+				// Temporary sites are removed before the new one is added, so they
+				// should not force the replacement site to take a numeric suffix.
+				unavailableSlugs: selectAllSites(getState())
+					.filter((site) => site.metadata.storage !== 'none')
+					.map((site) => site.slug),
+			}
+		);
 
 		const sites = getState().sites.entities;
 


### PR DESCRIPTION
## What it does

URLencodes the OPFS directory names for stored Playground sites to distinguish a slug like `a/b` from a slug like `a?b`. Before this PR they would collapse to the same OPFS directory name.

## Testing instructions

```bash
npm exec nx run playground-website:typecheck
npm exec nx run playground-website:lint
npm exec nx test playground-website --testFile=site-slug.spec.ts
npm exec nx test playground-website --testFile=opfs-site-path.spec.ts
npm exec nx test playground-website --testFile=opfs-site-storage.spec.ts
```
