### PR TITLE
Add saved Playground lifecycle metadata

### DIFF
--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
@@ -1,0 +1,177 @@
+import {
+	RECENT_AUTOSAVE_RESTORE_WINDOW_MS,
+	getAutosavedSitesToPrune,
+	getSitePublicPersistence,
+	getSitesSortedByRecency,
+	isAutosavedSite,
+	wasSiteRecentlyInteractedWith,
+} from './site-lifecycle';
+import type { SiteInfo } from './slice-sites';
+
+describe('autosaved site helpers', () => {
+	it('treats legacy browser-stored sites without persistence metadata as explicit', () => {
+		expect(
+			isAutosavedSite(
+				createSite('legacy', {
+					storage: 'opfs',
+					persistence: undefined,
+				})
+			)
+		).toBe(false);
+	});
+
+	it('only exposes persistence for stored sites', () => {
+		expect(
+			getSitePublicPersistence(
+				createSite('temporary', { storage: 'none' })
+			)
+		).toBeUndefined();
+		expect(
+			getSitePublicPersistence(
+				createSite('autosave', { persistence: 'autosave' })
+			)
+		).toBe('autosave');
+		expect(
+			getSitePublicPersistence(
+				createSite('explicit', { persistence: 'explicit' })
+			)
+		).toBe('explicit');
+		expect(
+			getSitePublicPersistence(
+				createSite('legacy', { persistence: undefined })
+			)
+		).toBe('explicit');
+	});
+
+	it('prunes only autosaved sites older than the latest limit', () => {
+		const sites = [
+			createSite('explicit-old', {
+				storage: 'opfs',
+				persistence: 'explicit',
+				whenCreated: 1,
+			}),
+			createSite('legacy-old', {
+				storage: 'opfs',
+				persistence: undefined,
+				whenCreated: 2,
+			}),
+			createSite('local-old', {
+				storage: 'local-fs',
+				persistence: 'explicit',
+				whenCreated: 3,
+			}),
+			createSite('auto-1', { persistence: 'autosave', whenCreated: 10 }),
+			createSite('auto-2', { persistence: 'autosave', whenCreated: 20 }),
+			createSite('auto-3', { persistence: 'autosave', whenCreated: 30 }),
+			createSite('auto-4', { persistence: 'autosave', whenCreated: 40 }),
+			createSite('auto-5', { persistence: 'autosave', whenCreated: 50 }),
+			createSite('auto-6', { persistence: 'autosave', whenCreated: 60 }),
+		];
+
+		expect(
+			getAutosavedSitesToPrune(sites).map((site) => site.slug)
+		).toEqual(['auto-1']);
+	});
+
+	it('uses whenLastUsed before whenCreated for autosave retention', () => {
+		const sites = [
+			createSite('recently-used-old-site', {
+				persistence: 'autosave',
+				whenCreated: 1,
+				whenLastUsed: 100,
+			}),
+			createSite('newer-unused-site', {
+				persistence: 'autosave',
+				whenCreated: 90,
+			}),
+		];
+
+		expect(
+			getAutosavedSitesToPrune(sites, { limit: 1 }).map(
+				(site) => site.slug
+			)
+		).toEqual(['newer-unused-site']);
+	});
+
+	it('can protect a specific autosaved site from pruning', () => {
+		const sites = [
+			createSite('old-active', {
+				persistence: 'autosave',
+				whenCreated: 1,
+			}),
+			createSite('new-1', { persistence: 'autosave', whenCreated: 10 }),
+			createSite('new-2', { persistence: 'autosave', whenCreated: 20 }),
+		];
+
+		expect(
+			getAutosavedSitesToPrune(sites, {
+				limit: 2,
+				excludeSlugs: ['old-active'],
+			}).map((site) => site.slug)
+		).toEqual(['new-1']);
+	});
+
+	it('only treats recently interacted-with sites as restore candidates', () => {
+		const now = Date.now();
+
+		expect(
+			wasSiteRecentlyInteractedWith(
+				createSite('recent', {
+					persistence: 'autosave',
+					whenLastUsed: now - RECENT_AUTOSAVE_RESTORE_WINDOW_MS + 1,
+				}),
+				now
+			)
+		).toBe(true);
+		expect(
+			wasSiteRecentlyInteractedWith(
+				createSite('stale', {
+					persistence: 'autosave',
+					whenLastUsed: now - RECENT_AUTOSAVE_RESTORE_WINDOW_MS - 1,
+				}),
+				now
+			)
+		).toBe(false);
+	});
+});
+
+describe('site recency helpers', () => {
+	it('sorts sites by recency without mutating the input array', () => {
+		const sites = [
+			createSite('a-old', { whenCreated: 1 }),
+			createSite('b-new', { whenCreated: 2 }),
+		];
+
+		expect(getSitesSortedByRecency(sites).map((site) => site.slug)).toEqual(
+			['b-new', 'a-old']
+		);
+		expect(sites.map((site) => site.slug)).toEqual(['a-old', 'b-new']);
+	});
+});
+
+function createSite(
+	slug: string,
+	metadata: Partial<SiteInfo['metadata']> = {}
+): SiteInfo {
+	return {
+		slug,
+		metadata: {
+			storage: 'opfs',
+			id: slug,
+			name: slug,
+			whenCreated: 0,
+			persistence: 'explicit',
+			runtimeConfiguration: {
+				phpVersion: '8.3',
+				wpVersion: 'latest',
+				intl: false,
+				networking: true,
+				extraLibraries: [],
+				constants: {},
+			},
+			originalBlueprint: {},
+			originalBlueprintSource: { type: 'none' },
+			...metadata,
+		},
+	};
+}

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
@@ -1,0 +1,118 @@
+import type { SiteInfo } from './slice-sites';
+
+/**
+ * Keep a small recovery history without letting invisible autosaves grow OPFS
+ * usage forever. UI that surfaces autosaves should use this same limit so
+ * users can see every autosave retained by pruning.
+ */
+export const MAX_AUTOSAVED_SITES = 5;
+
+/**
+ * Only prompt to restore autosaves from a recently interrupted session. Older
+ * autosaves remain recoverable from the Playgrounds overlay instead.
+ */
+export const RECENT_AUTOSAVE_RESTORE_WINDOW_MS = 15 * 60 * 1000;
+
+/**
+ * Persistence states for stored Playgrounds.
+ */
+export const SitePersistenceTypes = ['autosave', 'explicit'] as const;
+export type SitePersistence = (typeof SitePersistenceTypes)[number];
+
+export type AutosavedSitesPruneOptions = {
+	/**
+	 * Maximum number of autosaved sites to retain.
+	 */
+	limit?: number;
+	/**
+	 * Site slugs to keep even when they would otherwise be pruned.
+	 */
+	excludeSlugs?: string[];
+};
+
+/**
+ * Returns the timestamp used to sort sites by recency.
+ */
+export function getSiteRecencyTimestamp(site: SiteInfo) {
+	return site.metadata.whenLastUsed ?? site.metadata.whenCreated ?? 0;
+}
+
+/**
+ * Returns sites sorted by recency without mutating the input array.
+ */
+export function getSitesSortedByRecency(sites: readonly SiteInfo[]) {
+	return [...sites].sort(
+		(a, b) => getSiteRecencyTimestamp(b) - getSiteRecencyTimestamp(a)
+	);
+}
+
+/**
+ * Indicates whether a site was used within the recent-autosave window.
+ */
+export function wasSiteRecentlyInteractedWith(
+	site: SiteInfo,
+	now = Date.now()
+) {
+	const recencyTimestamp = getSiteRecencyTimestamp(site);
+	return (
+		recencyTimestamp > 0 &&
+		now - recencyTimestamp <= RECENT_AUTOSAVE_RESTORE_WINDOW_MS
+	);
+}
+
+/**
+ * Indicates whether a site is an automatic browser-storage recovery copy.
+ */
+export function isAutosavedSite(site: SiteInfo) {
+	return (
+		site.metadata.storage === 'opfs' &&
+		site.metadata.persistence === 'autosave'
+	);
+}
+
+/**
+ * Indicates whether a site should be treated as explicitly saved.
+ */
+export function isExplicitlySavedSite(site: SiteInfo) {
+	return site.metadata.storage !== 'none' && !isAutosavedSite(site);
+}
+
+/**
+ * Returns the persistence value exposed by the public site-management API.
+ *
+ * Persistence describes a stored Playground, so temporary Playgrounds do not
+ * report a value here.
+ */
+export function getSitePublicPersistence(site: SiteInfo) {
+	if (site.metadata.storage === 'none') {
+		return undefined;
+	}
+	return isAutosavedSite(site) ? 'autosave' : 'explicit';
+}
+
+/**
+ * Returns autosaved sites to delete after honoring the retention limit.
+ */
+export function getAutosavedSitesToPrune(
+	sites: readonly SiteInfo[],
+	{
+		limit = MAX_AUTOSAVED_SITES,
+		excludeSlugs = [],
+	}: AutosavedSitesPruneOptions = {}
+) {
+	const excluded = new Set(excludeSlugs);
+	const autosavedSites = getSitesSortedByRecency(
+		sites.filter(isAutosavedSite)
+	);
+	const retainedSlugs = new Set(
+		autosavedSites
+			.filter((site) => excluded.has(site.slug))
+			.map((site) => site.slug)
+	);
+	for (const site of autosavedSites) {
+		if (retainedSlugs.size < limit) {
+			retainedSlugs.add(site.slug);
+		}
+	}
+	return autosavedSites.filter((site) => !retainedSlugs.has(site.slug));
+}

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -11,8 +11,13 @@ import {
 	setOPFSSitesLoadingState,
 	updateSiteMetadata,
 	removeSite,
+	preserveSite,
 	setTemporarySiteSpec,
 	deriveSiteNameFromSlug,
+	getSitePublicPersistence,
+	isAutosavedSite,
+	type SitePersistence,
+	type SiteStorageType,
 } from './slice-sites';
 import { randomSiteName } from './random-site-name';
 import { persistTemporarySite } from './persist-temporary-site';
@@ -28,6 +33,9 @@ export interface SiteSettings {
 	multisite?: boolean;
 }
 
+type PublicSiteStorageType = Exclude<SiteStorageType, 'none'> | 'temporary';
+type SaveSiteResult = { slug: string; storage: SiteStorageType };
+
 /**
  * API for listing, renaming, saving, and opening Playground
  * sites. Used by the MCP bridge, the `window.playgroundSites`
@@ -42,7 +50,8 @@ export interface PlaygroundSitesAPI {
 	list(): Array<{
 		slug: string;
 		name: string;
-		storage: string;
+		storage: PublicSiteStorageType;
+		persistence?: SitePersistence;
 		isActive: boolean;
 	}>;
 
@@ -64,18 +73,39 @@ export interface PlaygroundSitesAPI {
 	rename(newName: string): Promise<void>;
 
 	/**
-	 * Persists the active temporary site to OPFS.
+	 * Saves the active Playground in browser storage when it is temporary.
 	 *
-	 * @param name Optional display name for the saved site.
+	 * Temporary sites are persisted to OPFS. Existing autosaves are marked as
+	 * explicitly saved and returned without changing storage backends.
+	 *
+	 * @param name Optional display name for a temporary site being saved.
 	 * @returns The site's slug and storage type.
 	 * @throws When no site is selected or saving fails.
 	 */
-	saveInBrowser(name?: string): Promise<{ slug: string; storage: string }>;
+	saveInBrowser(name?: string): Promise<SaveSiteResult>;
 
 	/**
-	 * Persists the active temporary site to a local directory.
+	 * Keeps an autosaved Playground as a saved Playground.
 	 *
-	 * @param name Optional display name for the saved site.
+	 * This is a metadata-only lifecycle change. It turns an autosaved stored
+	 * Playground into an explicit save so autosave pruning and restore prompts
+	 * no longer treat it as disposable. It does not copy files, change the
+	 * storage backend, rename the Playground, or reboot it. Already-explicit
+	 * stored Playgrounds are left explicit.
+	 *
+	 * @param siteSlug Optional slug. Uses the active site when omitted.
+	 * @throws When no site is selected, the slug is unknown, or the site is
+	 *   temporary.
+	 */
+	keep(siteSlug?: string): Promise<void>;
+
+	/**
+	 * Saves the active Playground to a local directory when it is temporary.
+	 *
+	 * Existing saved sites are returned without changing storage backends.
+	 * Existing autosaves are marked as explicitly saved first.
+	 *
+	 * @param name Optional display name for a temporary site being saved.
 	 * @param localFsHandle Directory handle. When omitted the
 	 *   browser prompts the user to pick one.
 	 * @returns The site's slug and storage type.
@@ -84,7 +114,7 @@ export interface PlaygroundSitesAPI {
 	saveToLocalFileSystem(
 		name?: string,
 		localFsHandle?: FileSystemDirectoryHandle
-	): Promise<{ slug: string; storage: string }>;
+	): Promise<SaveSiteResult>;
 
 	/**
 	 * Changes the PHP version for the active site and reboots it.
@@ -155,10 +185,6 @@ export function createSitesAPI(
 			const state = getState();
 			const allSites = selectAllSites(state);
 			const active = selectActiveSite(state);
-			/**
-			 * We rename storage "none" to "temporary" in the API because the name temporary
-			 * is more descriptive of the actual behavior of these sites.
-			 */
 			return allSites.map((s) => ({
 				slug: s.slug,
 				name: s.metadata.name,
@@ -166,6 +192,7 @@ export function createSitesAPI(
 					s.metadata.storage === 'none'
 						? 'temporary'
 						: s.metadata.storage,
+				persistence: getSitePublicPersistence(s),
 				isActive: s.slug === active?.slug,
 			}));
 		},
@@ -191,7 +218,7 @@ export function createSitesAPI(
 			await dispatch(
 				updateSiteMetadata({
 					slug: site.slug,
-					changes: { name: newName },
+					changes: { name: newName, persistence: 'explicit' },
 				})
 			);
 		},
@@ -202,6 +229,9 @@ export function createSitesAPI(
 				throw new Error('No active site selected');
 			}
 			if (site.metadata.storage !== 'none') {
+				if (isAutosavedSite(site)) {
+					await dispatch(preserveSite(site.slug));
+				}
 				return { slug: site.slug, storage: site.metadata.storage };
 			}
 			await dispatch(
@@ -215,6 +245,18 @@ export function createSitesAPI(
 			return { slug: site.slug, storage };
 		},
 
+		async keep(siteSlug?: string) {
+			const site = siteSlug
+				? selectSiteBySlug(getState(), siteSlug)
+				: selectActiveSite(getState());
+			if (!site) {
+				throw new Error('No site selected');
+			}
+			// "Keeping" an autosave only changes lifecycle metadata. The
+			// filesystem stays in the same storage backend.
+			await dispatch(preserveSite(site.slug));
+		},
+
 		async saveToLocalFileSystem(
 			name?: string,
 			localFsHandle?: FileSystemDirectoryHandle
@@ -224,6 +266,9 @@ export function createSitesAPI(
 				throw new Error('No active site selected');
 			}
 			if (site.metadata.storage !== 'none') {
+				if (isAutosavedSite(site)) {
+					await dispatch(preserveSite(site.slug));
+				}
 				return { slug: site.slug, storage: site.metadata.storage };
 			}
 			await dispatch(

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -26,6 +26,27 @@ import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { findFirewallErrorInCauseChain } from './error-utils';
 import { deriveSlugFromSiteName, getUniqueSiteSlug } from './site-slug';
+import {
+	getAutosavedSitesToPrune,
+	getSitesSortedByRecency,
+	type AutosavedSitesPruneOptions,
+	type SitePersistence,
+} from './site-lifecycle';
+export {
+	MAX_AUTOSAVED_SITES,
+	SitePersistenceTypes,
+	getAutosavedSitesToPrune,
+	getSiteRecencyTimestamp,
+	getSitesSortedByRecency,
+	getSitePublicPersistence,
+	isAutosavedSite,
+	isExplicitlySavedSite,
+	wasSiteRecentlyInteractedWith,
+} from './site-lifecycle';
+export type {
+	AutosavedSitesPruneOptions,
+	SitePersistence,
+} from './site-lifecycle';
 
 /**
  * The Site model used to represent a site within Playground.
@@ -121,7 +142,7 @@ export function deriveSiteNameFromSlug(slug: string) {
 }
 
 /**
- * Updates the site metadata in the OPFS and in the redux state.
+ * Updates site metadata in redux and, for stored sites, in OPFS.
  */
 export function updateSiteMetadata({
 	slug,
@@ -153,10 +174,38 @@ export function updateSiteMetadata({
 }
 
 /**
- * Updates a site in the OPFS and in the redux state.
+ * Marks a stored Playground as explicitly saved.
  *
- * @param siteInfo The site info to update.
- * @returns
+ * This removes autosaved OPFS Playgrounds from autosave pruning. Temporary
+ * Playgrounds must be saved before they can be preserved.
+ */
+export function preserveSite(slug: string) {
+	return async (
+		dispatch: PlaygroundDispatch,
+		getState: () => PlaygroundReduxState
+	) => {
+		const site = selectSiteBySlug(getState(), slug);
+		if (!site) {
+			throw new Error(`Site not found: ${slug}`);
+		}
+		if (site.metadata.storage === 'none') {
+			throw new Error('Cannot preserve a temporary site. Save it first.');
+		}
+		await dispatch(
+			updateSiteMetadata({
+				slug,
+				changes: {
+					persistence: 'explicit',
+				},
+			})
+		);
+	};
+}
+
+/**
+ * Updates a site in redux and, for stored sites, in OPFS.
+ *
+ * The storage backend cannot be changed through this helper.
  */
 export function updateSite({
 	slug,
@@ -189,10 +238,9 @@ export function updateSite({
 }
 
 /**
- * Creates a new site in the OPFS and in the redux state.
+ * Creates a new stored site in OPFS and in the redux state.
  *
  * @param siteInfo The site info to add.
- * @returns
  */
 export function addSite(siteInfo: SiteInfo) {
 	return async (
@@ -210,10 +258,9 @@ export function addSite(siteInfo: SiteInfo) {
 }
 
 /**
- * Removes a site from the OPFS and from the redux state.
+ * Removes a stored site from OPFS and from the redux state.
  *
- * @param siteInfo The site info to remove.
- * @returns
+ * Temporary sites are rejected because they only exist in redux state.
  */
 export function removeSite(slug: string) {
 	return async (
@@ -243,10 +290,29 @@ export function removeSite(slug: string) {
 }
 
 /**
- * Creates a new site in the OPFS and in the redux state.
+ * Removes autosaved Playgrounds beyond the retention limit.
  *
- * @param siteInfo The site info to add.
- * @returns
+ * Explicitly saved Playgrounds are never pruned. `excludeSlugs` protects
+ * specific autosaves for the current prune pass.
+ */
+export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
+	return async (
+		dispatch: PlaygroundDispatch,
+		getState: () => PlaygroundReduxState
+	) => {
+		const sitesToPrune = getAutosavedSitesToPrune(
+			selectAllSites(getState()),
+			options
+		);
+		for (const site of sitesToPrune) {
+			await dispatch(removeSite(site.slug));
+		}
+	};
+}
+
+/**
+ * Creates or reuses a temporary Playground in the redux state.
+ *
  */
 export function setTemporarySiteSpec(
 	siteName: string,
@@ -467,10 +533,13 @@ export interface SiteMetadata {
 
 	// TODO: The designs show keeping admin username and password. Why do we want that?
 	whenCreated?: number;
-	// TODO: Consider keeping timestamps.
-	//       For a user, timestamps might be useful to disambiguate identically-named sites.
-	//       For playground, we might choose to sort by most recently used.
-	//whenLastLoaded: number;
+	whenLastUsed?: number;
+	/**
+	 * Whether this stored site is an automatic recovery copy or should be
+	 * treated as explicitly saved. Missing means explicit for backwards
+	 * compatibility with existing saved Playgrounds.
+	 */
+	persistence?: SitePersistence;
 	/**
 	 * Stable fingerprint of the setup URL that created this site, when known.
 	 */
@@ -495,11 +564,7 @@ export const {
 
 export const selectSortedSites = createSelector(
 	[selectAllSites],
-	(sites: SiteInfo[]) =>
-		sites.sort(
-			(a, b) =>
-				(b.metadata.whenCreated || 0) - (a.metadata.whenCreated || 0)
-		)
+	(sites: SiteInfo[]) => getSitesSortedByRecency(sites)
 );
 
 export const selectTemporarySite = createSelector(


### PR DESCRIPTION
## What it does

Adds saved-site lifecycle metadata and helpers for explicit saves vs. autosaves.

## Rationale

Default autosave needs to distinguish browser-storage recovery copies from Playgrounds the user explicitly saved, and pruning needs a deterministic recency policy.

## Implementation

- Adds `persistence: 'autosave' | 'explicit'` and `whenLastUsed` metadata.
- Treats legacy saved sites with missing persistence metadata as explicit saves.
- Keeps temporary sites outside the persistence contract exposed by `playgroundSites.list()`.
- Adds helpers for recency sorting, recent interaction checks, autosave pruning, and preserving autosaves.
- Exposes `persistence` through `playgroundSites.list()` for stored sites and adds `playgroundSites.keep()`.

## Testing instructions

```bash
npm exec nx run playground-website:typecheck
npm exec nx test playground-website --testFile=site-lifecycle.spec.ts
```
