### PR TITLE
Add saved site creation APIs

### DIFF
--- a/packages/playground/website/playwright/e2e/sites-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/sites-api.spec.ts
@@ -20,7 +20,9 @@ test('playgroundSites.list() returns the active site', async ({ website }) => {
 	const active = sites.find((s: any) => s.isActive);
 	expect(active).toBeTruthy();
 	expect(active.slug).toBeTruthy();
-	expect(active.storage).toBe('temporary');
+	// Storage-specific behavior is covered below. This test only checks that
+	// the list exposes the active Playground through the public API shape.
+	expect(['opfs', 'local-fs', 'temporary']).toContain(active.storage);
 });
 
 test('playgroundSites.saveInBrowser() persists a temporary site', async ({
@@ -32,7 +34,7 @@ test('playgroundSites.saveInBrowser() persists a temporary site', async ({
 		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
 	);
 
-	await website.goto('./');
+	await website.goto('./?storage=temp');
 	await website.page.waitForFunction(() =>
 		Boolean((window as any).playgroundSites?.getClient())
 	);
@@ -42,6 +44,87 @@ test('playgroundSites.saveInBrowser() persists a temporary site', async ({
 	);
 	expect(result.slug).toBeTruthy();
 	expect(result.storage).toBe('opfs');
+});
+
+test('playgroundSites.autosaveTemporarySite() persists without disrupting the tab', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto('./?storage=temp');
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+
+	const result = await website.page.evaluate(async () => {
+		const api = (window as any).playgroundSites;
+		const beforeUrl = window.location.href;
+		const beforeClient = api.getClient();
+		const beforeActive = api.list().find((s: any) => s.isActive);
+		const saveResult = await api.autosaveTemporarySite();
+		const afterActive = api.list().find((s: any) => s.isActive);
+		return {
+			beforeSlug: beforeActive?.slug,
+			saveResult,
+			afterActive,
+			sameClient: beforeClient === api.getClient(),
+			sameUrl: window.location.href === beforeUrl,
+		};
+	});
+
+	// Autosave should promote the active temporary site to browser storage
+	// without changing the visible URL or replacing the running Playground.
+	expect(result.saveResult.slug).toBe(result.beforeSlug);
+	expect(result.saveResult.storage).toBe('opfs');
+	expect(result.afterActive.storage).toBe('opfs');
+	expect(result.afterActive.persistence).toBe('autosave');
+	expect(result.sameClient).toBe(true);
+	expect(result.sameUrl).toBe(true);
+});
+
+test('playgroundSites.createNewSavedSite() creates an explicit OPFS site by default', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	await website.goto('./?storage=temp');
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+
+	const result = await website.page.evaluate(async () => {
+		const api = (window as any).playgroundSites;
+		const beforeUrl = window.location.href;
+		const slug = await api.createNewSavedSite(
+			'api-created-site',
+			{ phpVersion: '8.3' },
+			{ updateUrl: false }
+		);
+		const active = api.list().find((s: any) => s.isActive);
+		return {
+			slug,
+			active,
+			sameUrl: window.location.href === beforeUrl,
+			hasClient: api.getClient() != null,
+		};
+	});
+
+	// The new API creates a saved site record, boots it, and marks it as an
+	// explicit save unless the caller opts into autosave persistence.
+	expect(result.slug).toBe('api-created-site');
+	expect(result.active.slug).toBe('api-created-site');
+	expect(result.active.storage).toBe('opfs');
+	expect(result.active.persistence).toBe('explicit');
+	expect(result.hasClient).toBe(true);
+	expect(result.sameUrl).toBe(true);
 });
 
 test('playgroundSites.rename() renames a saved site', async ({
@@ -60,8 +143,8 @@ test('playgroundSites.rename() renames a saved site', async ({
 
 	const newName = await website.page.evaluate(async () => {
 		const api = (window as any).playgroundSites;
-		await api.saveInBrowser();
 		const name = 'Renamed Via API';
+		await api.saveInBrowser();
 		await api.rename(name);
 		const sites = api.list();
 		const active = sites.find((s: any) => s.isActive);

--- a/packages/playground/website/src/components/site-manager/site-settings-form/temporary-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/temporary-site-settings-form.tsx
@@ -31,15 +31,14 @@ export function TemporarySiteSettingsForm({
 	const defaultValues = useMemo<Partial<SiteFormData>>(() => {
 		const searchParams = siteInfo.originalUrlParams?.searchParams || {};
 		const runtimeConf = siteInfo.metadata?.runtimeConfiguration || {};
+		const language = searchParams.language;
+		const multisite = searchParams.multisite;
 		return {
 			phpVersion: runtimeConf?.phpVersion as any,
 			wpVersion: runtimeConf?.wpVersion as any,
 			withNetworking: runtimeConf?.networking,
-			language: 'language' in searchParams ? searchParams.language : '',
-			multisite:
-				'multisite' in searchParams
-					? searchParams.multisite === 'yes'
-					: false,
+			language: typeof language === 'string' ? language : '',
+			multisite: multisite === 'yes',
 		};
 	}, [siteInfo]);
 

--- a/packages/playground/website/src/lib/state/playground-identity.spec.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.spec.ts
@@ -4,6 +4,7 @@ import {
 	getAutosaveFingerprintFromURL,
 	getAutosaveFingerprintFromSite,
 	getRuntimeBootFingerprint,
+	getSetupUrlFromUrl,
 } from './playground-identity';
 
 describe('getAutosaveFingerprintFromURL', () => {
@@ -96,6 +97,22 @@ describe('getAutosaveFingerprintFromURL', () => {
 					'https://playground.test/?theme=twentytwentyfive&plugin=b&plugin=a'
 				)
 			)
+		);
+	});
+});
+
+describe('getSetupUrlFromUrl', () => {
+	it('keeps setup query params and drops routing and UI params', () => {
+		const setupUrl = getSetupUrlFromUrl(
+			new URL(
+				'https://playground.test/?php=8.3&php-extension=https://example.com/ext.json&plugin=a&plugin=b' +
+					'&site-slug=demo&storage=temp&random=abc&modal=save-site' +
+					'&can-save=no#blueprint'
+			)
+		);
+
+		expect(setupUrl.toString()).toBe(
+			'https://playground.test/?php=8.3&php-extension=https%3A%2F%2Fexample.com%2Fext.json&plugin=a&plugin=b#blueprint'
 		);
 	});
 });

--- a/packages/playground/website/src/lib/state/playground-identity.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.ts
@@ -1,26 +1,36 @@
 import type { RuntimeConfiguration } from '@wp-playground/blueprints';
 import type { SiteInfo } from './redux/slice-sites';
+import type { QueryAPIParams } from './url/router';
 
-const SETUP_QUERY_PARAMS = new Set([
-	'blueprint',
-	'blueprint-url',
-	'core-pr',
-	'gutenberg-branch',
-	'gutenberg-pr',
-	'import-content',
-	'import-site',
-	'import-wxr',
-	'language',
-	'login',
-	'multisite',
-	'name',
-	'networking',
-	'php',
-	'plugin',
-	'theme',
-	'url',
-	'wp',
-]);
+// Query API params that do not affect Playground setup must be named here.
+// This makes typechecking fail when a new query param is added without
+// classifying it as either setup-affecting or setup-irrelevant.
+type NonSetupQueryParam = 'page-title';
+type SetupQueryParam = Exclude<keyof QueryAPIParams, NonSetupQueryParam>;
+
+const SETUP_QUERY_PARAM_KEYS = Object.keys({
+	blueprint: true,
+	'blueprint-url': true,
+	'core-pr': true,
+	'gutenberg-branch': true,
+	'gutenberg-pr': true,
+	'import-content': true,
+	'import-site': true,
+	'import-wxr': true,
+	language: true,
+	login: true,
+	multisite: true,
+	name: true,
+	networking: true,
+	php: true,
+	'php-extension': true,
+	plugin: true,
+	theme: true,
+	url: true,
+	wp: true,
+} satisfies Record<SetupQueryParam, true>) as SetupQueryParam[];
+
+const SETUP_QUERY_PARAMS = new Set<string>(SETUP_QUERY_PARAM_KEYS);
 
 /**
  * Returns a stable cache key for matching autosaves to setup URLs.
@@ -33,6 +43,25 @@ export function getAutosaveFingerprintFromURL(url: URL) {
 		searchParams: url.searchParams,
 		hash: url.hash,
 	});
+}
+
+/**
+ * Returns a URL containing only query parameters that define Playground setup.
+ *
+ * New saved sites use this so routing, UI, and lifecycle query parameters from
+ * the current page do not leak into persisted site metadata. Keeping this on
+ * the same setup-param list as autosave fingerprints gives future setup query
+ * params one place to register.
+ */
+export function getSetupUrlFromUrl(url: URL) {
+	const setupUrl = new URL(url.href);
+	setupUrl.search = '';
+	for (const [key, value] of url.searchParams.entries()) {
+		if (SETUP_QUERY_PARAMS.has(key)) {
+			setupUrl.searchParams.append(key, value);
+		}
+	}
+	return setupUrl;
 }
 
 /**

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -17,9 +17,9 @@ import {
 	isBlueprintBundle,
 } from '@wp-playground/blueprints';
 import { logger } from '@php-wasm/logger';
-import { setupPostMessageRelay } from '@php-wasm/web';
+import { type SyncProgress, setupPostMessageRelay } from '@php-wasm/web';
 import { startPlaygroundWeb } from '@wp-playground/client';
-import type { PlaygroundClient } from '@wp-playground/remote';
+import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
 import { getRemoteUrl } from '../../config';
 import {
 	setActiveModal,
@@ -27,7 +27,11 @@ import {
 	setGitHubAuthRepoUrl,
 } from './slice-ui';
 import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
-import { selectSiteBySlug } from './slice-sites';
+import {
+	isAutosavedSite,
+	selectSiteBySlug,
+	updateSiteMetadata,
+} from './slice-sites';
 // @ts-ignore
 import { corsProxyUrl } from 'virtual:cors-proxy-url';
 import { modalSlugs } from './slice-ui';
@@ -142,7 +146,10 @@ export function bootSiteClient(
 				},
 				extraLibraries: site.metadata.runtimeConfiguration
 					.extraLibraries as any[],
-				constants: site.metadata.runtimeConfiguration.constants,
+				constants: {
+					...site.metadata.runtimeConfiguration.constants,
+					...site.metadata.playgroundDefinedConstants,
+				},
 			};
 		} else {
 			blueprint = site.metadata.originalBlueprint;
@@ -152,7 +159,7 @@ export function bootSiteClient(
 		// declares it doesn't want WordPress, so honor that even if the
 		// storage layer thinks WP isn't installed yet.
 		const blueprintRequestedNoWordPress =
-			!!blueprint &&
+			blueprint &&
 			!isBlueprintBundle(blueprint) &&
 			blueprint.preferredVersions?.wp === false;
 		const wordpressInstallMode = blueprintRequestedNoWordPress
@@ -160,6 +167,30 @@ export function bootSiteClient(
 			: isWordPressInstalled
 				? 'install-from-existing-files-if-needed'
 				: 'download-and-install';
+
+		/**
+		 * On the first boot, we must allow WordPress installation in MEMFS
+		 * so it can get synchronized to OPFS on Save or Autosave.
+		 * Only then, on subsequent boots, we can synchronize WordPress files
+		 * back from OPFS to MEMFS.
+		 */
+		const isFirstOpfsBoot =
+			site.metadata.initialOpfsSyncPending === true &&
+			site.metadata.storage === 'opfs' &&
+			!isWordPressInstalled;
+		const mounts: MountDescriptor[] = [];
+		let mountDescriptorForInitialOpfsSync: typeof mountDescriptor =
+			undefined;
+		if (mountDescriptor) {
+			if (isFirstOpfsBoot) {
+				mountDescriptorForInitialOpfsSync = mountDescriptor;
+			} else {
+				mounts.push({
+					...mountDescriptor,
+					initialSyncDirection: 'opfs-to-memfs',
+				});
+			}
+		}
 
 		let playground: PlaygroundClient | undefined = undefined;
 		try {
@@ -187,14 +218,7 @@ export function bootSiteClient(
 				},
 				// Log Blueprint events
 				onBlueprintValidated: logBlueprintEvents,
-				mounts: mountDescriptor
-					? [
-							{
-								...mountDescriptor,
-								initialSyncDirection: 'opfs-to-memfs',
-							},
-						]
-					: [],
+				mounts,
 				wordpressInstallMode,
 				corsProxy: corsProxyUrl,
 				gitAdditionalHeadersCallback: createGitAuthHeaders(),
@@ -290,19 +314,77 @@ export function bootSiteClient(
 		if (signal.aborted || !playground) {
 			return;
 		}
+		const connectedPlayground = playground as PlaygroundClient;
 
 		setupPostMessageRelay(iframe, document.location.origin);
 
+		const syncOperation = isAutosavedSite(site) ? 'autosave' : 'save';
 		dispatch(
 			addClientInfo({
 				siteSlug: site.slug,
 				url: '/',
-				client: playground,
+				client: connectedPlayground,
 				opfsMountDescriptor: mountDescriptor,
+				opfsSync: mountDescriptorForInitialOpfsSync
+					? {
+							status: 'syncing',
+							operation: syncOperation,
+						}
+					: undefined,
 			})
 		);
+		// `initialOpfsSyncPending` is a recovery flag, not the source of truth.
+		// If OPFS already contains WordPress files, the initial sync either
+		// completed earlier or is no longer needed. Clear the stale flag so
+		// future boots mount OPFS normally.
+		const hasStaleInitialOpfsSyncPendingFlag =
+			site.metadata.initialOpfsSyncPending === true &&
+			site.metadata.storage === 'opfs' &&
+			isWordPressInstalled;
 
-		(playground as PlaygroundClient).onNavigation((url) => {
+		if (mountDescriptorForInitialOpfsSync) {
+			void syncInitialOpfsFilesInBackground({
+				playground: connectedPlayground,
+				mountDescriptor: mountDescriptorForInitialOpfsSync,
+				siteSlug: site.slug,
+				operation: syncOperation,
+				dispatch,
+			});
+		} else {
+			try {
+				const metadataChanges = {
+					...(site.metadata.storage !== 'none'
+						? { whenLastUsed: Date.now() }
+						: {}),
+					...(hasStaleInitialOpfsSyncPendingFlag
+						? { initialOpfsSyncPending: false }
+						: {}),
+				};
+				if (Object.keys(metadataChanges).length > 0) {
+					await dispatch(
+						updateSiteMetadata({
+							slug: site.slug,
+							changes: metadataChanges,
+						})
+					);
+				}
+			} catch (error) {
+				logger.error('Error updating Playground metadata', error);
+				dispatch(
+					updateClientInfo({
+						siteSlug: site.slug,
+						changes: {
+							opfsSync: {
+								status: 'error',
+								operation: syncOperation,
+							},
+						},
+					})
+				);
+			}
+		}
+
+		connectedPlayground.onNavigation((url) => {
 			dispatch(
 				updateClientInfo({
 					siteSlug: site.slug,
@@ -315,6 +397,88 @@ export function bootSiteClient(
 
 		signal.onabort = null;
 	};
+}
+
+/**
+ * Copies files created during a saved site's first boot from MEMFS into OPFS.
+ *
+ * The iframe is already usable when this runs. Redux keeps showing sync
+ * progress until the copy succeeds, then future boots can mount OPFS normally.
+ */
+async function syncInitialOpfsFilesInBackground({
+	playground,
+	mountDescriptor,
+	siteSlug,
+	operation,
+	dispatch,
+}: {
+	playground: PlaygroundClient;
+	mountDescriptor: Omit<MountDescriptor, 'initialSyncDirection'>;
+	siteSlug: string;
+	operation: 'save' | 'autosave';
+	dispatch: PlaygroundDispatch;
+}) {
+	let shouldReportProgress = true;
+	try {
+		await playground.mountOpfs(
+			{
+				...mountDescriptor,
+				initialSyncDirection: 'memfs-to-opfs',
+			},
+			(progress: SyncProgress) => {
+				if (!shouldReportProgress) {
+					return;
+				}
+				dispatch(
+					updateClientInfo({
+						siteSlug,
+						changes: {
+							opfsSync: {
+								status: 'syncing',
+								progress,
+								operation,
+							},
+						},
+					})
+				);
+			}
+		);
+		await dispatch(
+			updateSiteMetadata({
+				slug: siteSlug,
+				changes: {
+					initialOpfsSyncPending: false,
+					whenLastUsed: Date.now(),
+				},
+			})
+		);
+		dispatch(
+			updateClientInfo({
+				siteSlug,
+				changes: {
+					opfsSync: undefined,
+				},
+			})
+		);
+	} catch (error: unknown) {
+		logger.error('Error syncing saved Playground to OPFS', error);
+		dispatch(
+			updateClientInfo({
+				siteSlug,
+				changes: {
+					opfsSync: {
+						status: 'error',
+						operation,
+					},
+				},
+			})
+		);
+		return;
+	} finally {
+		// Progress is reported from a worker. Once the sync settles, ignore any
+		// queued progress message so it cannot overwrite the final UI state.
+		shouldReportProgress = false;
+	}
 }
 
 /**

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -16,6 +16,7 @@ import type store from './store';
 import { selectClientBySiteSlug, updateClientInfo } from './slice-clients';
 import {
 	selectSiteBySlug,
+	type SitePersistence,
 	updateSite,
 	updateSiteMetadata,
 } from './slice-sites';
@@ -23,6 +24,14 @@ import { PlaygroundRoute, redirectTo } from '../url/router';
 import type { SiteStorageType } from './slice-sites';
 import { setActiveModal } from './slice-ui';
 
+/**
+ * Persists a running temporary Playground into a durable storage backend.
+ *
+ * The active iframe is the source of truth for the filesystem, so this copies
+ * MEMFS into OPFS or a picked local directory before changing the site metadata.
+ * Autosave callers can keep the URL and iframe stable while still recording the
+ * persisted metadata needed for restore.
+ */
 export function persistTemporarySite(
 	siteSlug: string,
 	storageType: Extract<SiteStorageType, 'opfs' | 'local-fs'>,
@@ -30,6 +39,8 @@ export function persistTemporarySite(
 		localFsHandle?: FileSystemDirectoryHandle;
 		siteName?: string;
 		skipRenameModal?: boolean;
+		persistence?: SitePersistence;
+		updateUrl?: boolean;
 	} = {}
 ) {
 	return async (
@@ -68,7 +79,8 @@ export function persistTemporarySite(
 			}
 		} catch (error: any) {
 			if (error?.name === 'NotFoundError') {
-				// Do nothing
+				// No failed temporary-site placeholder exists, so this save can
+				// continue with a fresh OPFS record.
 			} else {
 				throw error;
 			}
@@ -107,7 +119,8 @@ export function persistTemporarySite(
 					bundleToPersist = opfsBackend;
 				}
 			} catch {
-				// No autosaved bundle available
+				// The blueprint editor only creates this bundle after editing
+				// without running, so absence is expected for regular saves.
 			}
 		}
 
@@ -118,7 +131,7 @@ export function persistTemporarySite(
 				bundleWasPersisted = true;
 			} catch (error) {
 				logger.error('Failed to persist blueprint bundle', error);
-				// Continue with the save - the bundle is optional
+				// The site filesystem is still useful without the editor bundle.
 			}
 		}
 
@@ -132,42 +145,49 @@ export function persistTemporarySite(
 				mountpoint: '/wordpress',
 			} as const;
 		} else if (storageType === 'local-fs') {
-			let dirHandle = options.localFsHandle;
-			if (!dirHandle) {
+			let dirHandle: FileSystemDirectoryHandle;
+			if (options.localFsHandle) {
+				dirHandle = options.localFsHandle;
+			} else {
 				// Request permission to access the directory.
 				// https://developer.mozilla.org/en-US/docs/Web/API/Window/showDirectoryPicker
-				dirHandle = await (window as any).showDirectoryPicker({
+				dirHandle = (await (window as any).showDirectoryPicker({
 					// By specifying an ID, the browser can remember different directories
 					// for different IDs.If the same ID is used for another picker, the
 					// picker opens in the same directory.
 					id: 'playground-directory',
 					mode: 'readwrite',
-				});
+				})) as FileSystemDirectoryHandle;
 			}
-			await saveDirectoryHandle(siteSlug, dirHandle!);
+			await saveDirectoryHandle(siteSlug, dirHandle);
 
 			mountDescriptor = {
 				device: {
 					type: 'local-fs',
-					handle: dirHandle!,
+					handle: dirHandle,
 				},
 				mountpoint: '/wordpress',
 			} as const;
 		} else {
 			throw new Error(`Unsupported device type: ${storageType}`);
 		}
+		const isAutosave = options.persistence === 'autosave';
+		const syncOperation = isAutosave ? 'autosave' : 'save';
 
 		dispatch(
 			updateClientInfo({
 				siteSlug,
 				changes: {
 					opfsMountDescriptor: mountDescriptor,
-					opfsSync: { status: 'syncing' },
+					opfsSync: {
+						status: 'syncing',
+						operation: syncOperation,
+					},
 				},
 			})
 		);
 		try {
-			await playground!.mountOpfs(
+			await playground.mountOpfs(
 				{
 					...mountDescriptor,
 					initialSyncDirection: 'memfs-to-opfs',
@@ -180,6 +200,7 @@ export function persistTemporarySite(
 								opfsSync: {
 									status: 'syncing',
 									progress,
+									operation: syncOperation,
 								},
 							},
 						})
@@ -203,6 +224,7 @@ export function persistTemporarySite(
 					changes: {
 						opfsSync: {
 							status: 'error',
+							operation: syncOperation,
 						},
 					},
 				})
@@ -210,30 +232,37 @@ export function persistTemporarySite(
 			throw error;
 		}
 
-		await dispatch(
-			updateSite({
-				slug: siteSlug,
-				changes: {
-					originalUrlParams: undefined,
-				},
-			})
-		);
+		// Autosaves stay tied to their source setup URL so restore matching and
+		// boot-time query options can still inspect it. Explicit saves open by
+		// slug, so drop the temporary route params after persistence.
+		if (!isAutosave) {
+			await dispatch(
+				updateSite({
+					slug: siteSlug,
+					changes: {
+						originalUrlParams: undefined,
+					},
+				})
+			);
+		}
 
+		const persistedAt = Date.now();
+		const playgroundDefinedConstants =
+			await getPlaygroundDefinedPHPConstants(playground);
 		await dispatch(
 			updateSiteMetadata({
 				slug: siteSlug,
 				changes: {
 					storage: storageType,
-					// Reset the created date. Mental model: From the perspective of
-					// the storage backend, the site was just created.
-					whenCreated: Date.now(),
-					// Make sure to store the constants we'll want to re-apply
-					// on the next page load.
-					runtimeConfiguration: {
-						...siteInfo.metadata.runtimeConfiguration,
-						constants:
-							await getPlaygroundDefinedPHPConstants(playground),
-					},
+					persistence: options.persistence ?? 'explicit',
+					// The viewport key includes whenCreated. Changing it would
+					// remount the iframe, so autosave keeps the current value
+					// while explicit saves reset the creation time.
+					...(isAutosave ? {} : { whenCreated: persistedAt }),
+					whenLastUsed: persistedAt,
+					// Keep these outside runtimeConfiguration so autosave does not
+					// change the running iframe's boot fingerprint.
+					playgroundDefinedConstants,
 					// If we persisted a blueprint bundle, point to it so we can
 					// load the full bundle (not just the declaration) on next load.
 					...(bundleWasPersisted
@@ -255,16 +284,27 @@ export function persistTemporarySite(
 		 * Comlink. We should make Comlink ignore those.
 		 */
 		// @TODO: ^ Is this fixed now?
-		const updatedState = getState();
-		const updatedSite = selectSiteBySlug(updatedState, siteSlug);
+		const updatedSite = selectSiteBySlug(getState(), siteSlug);
 		const persistentSiteUrl = PlaygroundRoute.site(updatedSite!);
-		redirectTo(persistentSiteUrl);
+		if (options.updateUrl) {
+			redirectTo(persistentSiteUrl);
+		}
 		if (!options.skipRenameModal) {
 			dispatch(setActiveModal('rename-site'));
 		}
 	};
 }
 
+/**
+ * Returns constants registered through Playground's live PHP API.
+ *
+ * Calls to `playground.defineConstant()` are persisted in consts.json after the
+ * iframe has already booted. Examples include `PLAYGROUND_AUTO_LOGIN_AS_USER`
+ * from the login step, `WPLANG` from the language step, and caller-defined
+ * constants such as `WP_DEBUG`. Saved sites need to replay them on reload, but
+ * writing them into `runtimeConfiguration` during autosave would change the
+ * running iframe's boot fingerprint and force an unnecessary reboot.
+ */
 async function getPlaygroundDefinedPHPConstants(playground: PlaygroundClient) {
 	let constants: PHPConstants = {};
 	try {
@@ -272,7 +312,7 @@ async function getPlaygroundDefinedPHPConstants(playground: PlaygroundClient) {
 			await playground.readFileAsText('/internal/shared/consts.json')
 		);
 	} catch {
-		// Do nothing
+		// The file is absent until code defines constants through Playground.
 	}
 	return constants;
 }

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -18,8 +18,10 @@ import {
 	setOPFSSitesLoadingState,
 	updateSiteMetadata,
 	removeSite,
+	pruneAutosavedSites,
 	preserveSite,
 	setTemporarySiteSpec,
+	setStoredSiteSpec,
 	deriveSiteNameFromSlug,
 	getSitePublicPersistence,
 	isAutosavedSite,
@@ -31,6 +33,8 @@ import { persistTemporarySite } from './persist-temporary-site';
 import { selectClientBySiteSlug } from './slice-clients';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import type { AllPHPVersion } from '@php-wasm/universal';
+import { opfsSiteStorage } from '../opfs/opfs-site-storage';
+import { getSetupUrlFromUrl } from '../playground-identity';
 
 export interface SiteSettings {
 	phpVersion?: AllPHPVersion;
@@ -93,6 +97,8 @@ export function createSitesAPI(
 			const state = getState();
 			const allSites = selectAllSites(state);
 			const active = selectActiveSite(state);
+			// Keep the Redux-only "none" sentinel out of the public API;
+			// callers should see the user-facing "temporary" storage state.
 			return allSites.map((s) => ({
 				slug: s.slug,
 				name: s.metadata.name,
@@ -227,6 +233,53 @@ export function createSitesAPI(
 				persistTemporarySite(site.slug, 'opfs', {
 					siteName: name,
 					skipRenameModal: true,
+					updateUrl: true,
+				})
+			);
+			const updatedSite = selectSiteBySlug(getState(), site.slug);
+			const storage = updatedSite?.metadata.storage ?? 'none';
+			return { slug: site.slug, storage };
+		},
+
+		/**
+		 * Autosaves a temporary Playground into browser storage.
+		 *
+		 * Autosave keeps the current browser URL unchanged unless the caller
+		 * asks to route to the new stored site.
+		 *
+		 * @param siteSlug Optional slug. Uses the active site when omitted.
+		 * @param options Optional URL update and pruning behavior.
+		 * @returns The site's slug and storage type.
+		 */
+		async autosaveTemporarySite(
+			siteSlug?: string,
+			options: {
+				updateUrl?: boolean;
+				excludeFromPruning?: string[];
+			} = {}
+		): Promise<SaveSiteResult> {
+			const site = siteSlug
+				? selectSiteBySlug(getState(), siteSlug)
+				: selectActiveSite(getState());
+			if (!site) {
+				throw new Error('No site selected');
+			}
+			if (site.metadata.storage !== 'none') {
+				return { slug: site.slug, storage: site.metadata.storage };
+			}
+			await dispatch(
+				persistTemporarySite(site.slug, 'opfs', {
+					skipRenameModal: true,
+					persistence: 'autosave',
+					updateUrl: options.updateUrl ?? false,
+				})
+			);
+			await dispatch(
+				pruneAutosavedSites({
+					excludeSlugs: [
+						site.slug,
+						...(options.excludeFromPruning ?? []),
+					],
 				})
 			);
 			const updatedSite = selectSiteBySlug(getState(), site.slug);
@@ -295,6 +348,7 @@ export function createSitesAPI(
 					siteName: name,
 					localFsHandle,
 					skipRenameModal: true,
+					updateUrl: true,
 				})
 			);
 			const updatedSite = selectSiteBySlug(getState(), site.slug);
@@ -389,9 +443,13 @@ export function createSitesAPI(
 		 * Switches to a different site and boots it.
 		 *
 		 * @param siteSlug The slug of the site to activate.
+		 * @param options Optional activation behavior.
 		 * @throws When the site is not found or fails to boot.
 		 */
-		async setActiveSite(siteSlug: string): Promise<void> {
+		async setActiveSite(
+			siteSlug: string,
+			options: { updateUrl?: boolean } = {}
+		): Promise<void> {
 			const state = getState();
 			const site = selectSiteBySlug(state, siteSlug);
 			if (!site) {
@@ -427,7 +485,7 @@ export function createSitesAPI(
 					},
 				});
 			});
-			dispatch(setActiveSite(siteSlug));
+			dispatch(setActiveSite(siteSlug, options));
 			await bootPromise;
 		},
 
@@ -446,38 +504,111 @@ export function createSitesAPI(
 			const siteName = requestedSiteSlug
 				? deriveSiteNameFromSlug(requestedSiteSlug)
 				: randomSiteName();
-			const url = new URL(window.location.href);
-			if (settings) {
-				if (settings.phpVersion !== undefined) {
-					url.searchParams.set('php', settings.phpVersion);
-				}
-				if (settings.wpVersion !== undefined) {
-					url.searchParams.set('wp', settings.wpVersion);
-				}
-				if (settings.networking !== undefined) {
-					url.searchParams.set(
-						'networking',
-						settings.networking ? 'yes' : 'no'
-					);
-				}
-				if (settings.language !== undefined) {
-					url.searchParams.set('language', settings.language);
-				}
-				if (settings.multisite !== undefined) {
-					url.searchParams.set(
-						'multisite',
-						settings.multisite ? 'yes' : 'no'
-					);
-				}
-			}
+			const url = getSetupUrlForNewSite(settings);
 			const newSiteInfo = await dispatch(
 				setTemporarySiteSpec(siteName, url, requestedSiteSlug)
 			);
 			await api.setActiveSite(newSiteInfo.slug);
 			return newSiteInfo.slug;
 		},
+
+		/**
+		 * Creates a new browser-stored site and boots it.
+		 *
+		 * The site starts as an explicit save unless the caller marks it as an
+		 * autosave. First boot creates the WordPress files from the setup URL,
+		 * then stores that initialized filesystem in OPFS for later boots.
+		 *
+		 * @param requestedSiteSlug Optional slug hint. A random name is
+		 *   generated when omitted.
+		 * @param settings Optional site settings.
+		 * @param options Optional persistence, routing, and pruning behavior.
+		 * @returns The new site's slug.
+		 */
+		async createNewSavedSite(
+			requestedSiteSlug?: string,
+			settings?: SiteSettings,
+			options: {
+				persistence?: SitePersistence;
+				updateUrl?: boolean;
+				excludeFromPruning?: string[];
+			} = {}
+		): Promise<string> {
+			if (!opfsSiteStorage) {
+				throw new Error(
+					'Cannot create a saved Playground because browser storage is not available.'
+				);
+			}
+			const siteName = requestedSiteSlug
+				? deriveSiteNameFromSlug(requestedSiteSlug)
+				: randomSiteName();
+			const url = getSetupUrlForNewSite(settings, {
+				onlySetupParams: true,
+			});
+			const newSiteInfo = await dispatch(
+				setStoredSiteSpec(siteName, url, requestedSiteSlug, {
+					persistence: options.persistence ?? 'explicit',
+				})
+			);
+			await api.setActiveSite(newSiteInfo.slug, {
+				updateUrl: options.updateUrl,
+			});
+			await dispatch(
+				pruneAutosavedSites({
+					excludeSlugs: [
+						newSiteInfo.slug,
+						...(options.excludeFromPruning ?? []),
+					],
+				})
+			);
+			return newSiteInfo.slug;
+		},
 	};
 	return api;
+}
+
+/**
+ * Returns the setup URL for creating a new site.
+ *
+ * Temporary sites keep the current query string for backwards compatibility.
+ * Saved sites keep only setup params so routing, UI, and lifecycle params do
+ * not leak into persisted metadata. Both paths use the same `SiteSettings`
+ * mapping so new settings have one query representation.
+ */
+function getSetupUrlForNewSite(
+	settings?: SiteSettings,
+	options: {
+		onlySetupParams?: boolean;
+	} = {}
+) {
+	const currentUrl = new URL(window.location.href);
+	const url = options.onlySetupParams
+		? getSetupUrlFromUrl(currentUrl)
+		: currentUrl;
+	if (settings) {
+		if (settings.phpVersion !== undefined) {
+			url.searchParams.set('php', settings.phpVersion);
+		}
+		if (settings.wpVersion !== undefined) {
+			url.searchParams.set('wp', settings.wpVersion);
+		}
+		if (settings.networking !== undefined) {
+			url.searchParams.set(
+				'networking',
+				settings.networking ? 'yes' : 'no'
+			);
+		}
+		if (settings.language !== undefined) {
+			url.searchParams.set('language', settings.language);
+		}
+		if (settings.multisite !== undefined) {
+			url.searchParams.set(
+				'multisite',
+				settings.multisite ? 'yes' : 'no'
+			);
+		}
+	}
+	return url;
 }
 
 /**

--- a/packages/playground/website/src/lib/state/redux/slice-clients.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-clients.ts
@@ -8,9 +8,11 @@ export type OpfsSync =
 	| {
 			status: 'syncing';
 			progress?: SyncProgress;
+			operation?: 'save' | 'autosave';
 	  }
 	| {
 			status: 'error';
+			operation?: 'save' | 'autosave';
 	  };
 
 export interface ClientInfo {

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -32,6 +32,7 @@ import {
 	type AutosavedSitesPruneOptions,
 	type SitePersistence,
 } from './site-lifecycle';
+import { getAutosaveFingerprintFromURL } from '../playground-identity';
 export {
 	MAX_AUTOSAVED_SITES,
 	SitePersistenceTypes,
@@ -48,13 +49,16 @@ export type {
 	SitePersistence,
 } from './site-lifecycle';
 
+const DEFAULT_BLUEPRINT =
+	'https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/welcome/blueprint.json';
+
 /**
  * The Site model used to represent a site within Playground.
  */
 export interface SiteInfo {
 	slug: string;
 	originalUrlParams?: {
-		searchParams?: Record<string, string>;
+		searchParams?: Record<string, string | string[]>;
 		hash?: string;
 	};
 	metadata: SiteMetadata;
@@ -240,6 +244,9 @@ export function updateSite({
 /**
  * Creates a new stored site in OPFS and in the redux state.
  *
+ * The OPFS metadata write must succeed before Redux is updated. Otherwise the
+ * UI would list a saved Playground that cannot survive a reload.
+ *
  * @param siteInfo The site info to add.
  */
 export function addSite(siteInfo: SiteInfo) {
@@ -252,7 +259,12 @@ export function addSite(siteInfo: SiteInfo) {
 				'Cannot add a temporary site. Use setTemporarySiteSpec instead.'
 			);
 		}
-		await opfsSiteStorage?.create(siteInfo.slug, siteInfo.metadata);
+		if (!opfsSiteStorage) {
+			throw new Error(
+				'Cannot add a saved Playground because browser storage is not available.'
+			);
+		}
+		await opfsSiteStorage.create(siteInfo.slug, siteInfo.metadata);
 		dispatch(sitesSlice.actions.addSite(siteInfo));
 	};
 }
@@ -312,7 +324,6 @@ export function pruneAutosavedSites(options: AutosavedSitesPruneOptions = {}) {
 
 /**
  * Creates or reuses a temporary Playground in the redux state.
- *
  */
 export function setTemporarySiteSpec(
 	siteName: string,
@@ -323,12 +334,9 @@ export function setTemporarySiteSpec(
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
 	) => {
-		const newSiteUrlParams = {
-			searchParams: parseSearchParams(
-				playgroundUrlWithQueryApiArgs.searchParams
-			),
-			hash: playgroundUrlWithQueryApiArgs.hash,
-		};
+		const newSiteUrlParams = getOriginalUrlParams(
+			playgroundUrlWithQueryApiArgs
+		);
 
 		const showTemporarySiteError = (params: {
 			error: SiteError;
@@ -343,6 +351,9 @@ export function setTemporarySiteSpec(
 					id: crypto.randomUUID(),
 					whenCreated: Date.now(),
 					storage: 'none' as const,
+					sourceSetupUrlFingerprint: getAutosaveFingerprintFromURL(
+						playgroundUrlWithQueryApiArgs
+					),
 					originalBlueprint: {},
 					originalBlueprintSource: {
 						type: 'none',
@@ -418,15 +429,11 @@ export function setTemporarySiteSpec(
 			}
 		}
 
-		// Then create a new temporary site
-		const defaultBlueprint =
-			'https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/welcome/blueprint.json';
-
 		let resolvedBlueprint: ResolvedBlueprint | undefined = undefined;
 		try {
 			resolvedBlueprint = await resolveBlueprintFromURL(
 				playgroundUrlWithQueryApiArgs,
-				defaultBlueprint
+				DEFAULT_BLUEPRINT
 			);
 		} catch (e) {
 			logger.error(
@@ -449,17 +456,10 @@ export function setTemporarySiteSpec(
 		}
 
 		try {
-			const reflection = await BlueprintReflection.create(
-				resolvedBlueprint.blueprint
+			resolvedBlueprint = await prepareResolvedBlueprint(
+				resolvedBlueprint,
+				playgroundUrlWithQueryApiArgs
 			);
-			if (reflection.getVersion() === 1) {
-				resolvedBlueprint.blueprint = await applyQueryOverrides(
-					resolvedBlueprint.blueprint,
-					playgroundUrlWithQueryApiArgs.searchParams
-				);
-			}
-
-			// Compute the runtime configuration based on the resolved Blueprint:
 			const newSiteInfo: SiteInfo = {
 				slug: siteSlug,
 				originalUrlParams: newSiteUrlParams,
@@ -468,6 +468,9 @@ export function setTemporarySiteSpec(
 					id: crypto.randomUUID(),
 					whenCreated: Date.now(),
 					storage: 'none' as const,
+					sourceSetupUrlFingerprint: getAutosaveFingerprintFromURL(
+						playgroundUrlWithQueryApiArgs
+					),
 					originalBlueprint: resolvedBlueprint.blueprint,
 					originalBlueprintSource: resolvedBlueprint.source!,
 					runtimeConfiguration: await resolveRuntimeConfiguration(
@@ -492,8 +495,128 @@ export function setTemporarySiteSpec(
 	};
 }
 
+/**
+ * Creates the metadata record for a new OPFS-backed Playground.
+ *
+ * This intentionally overlaps with `setTemporarySiteSpec`: both capture the
+ * setup URL, resolve the Blueprint, and derive the runtime configuration.
+ * Stored sites diverge after that by writing OPFS metadata immediately, keeping
+ * more than one site record, and marking the first file sync as pending. Boot
+ * then uses the same setup URL to install WordPress in MEMFS before copying the
+ * initialized files into OPFS.
+ */
+export function setStoredSiteSpec(
+	siteName: string,
+	playgroundUrlWithQueryApiArgs: URL,
+	preferredSlug?: string,
+	options: {
+		/**
+		 * Whether the stored site is an autosave or an explicit user save.
+		 */
+		persistence?: SitePersistence;
+	} = {}
+) {
+	return async (
+		dispatch: PlaygroundDispatch,
+		getState: () => PlaygroundReduxState
+	) => {
+		const siteSlug = getUniqueSiteSlug(
+			preferredSlug || deriveSlugFromSiteName(siteName),
+			{ unavailableSlugs: selectSiteSlugs(getState()) }
+		);
+		const originalUrlParams = getOriginalUrlParams(
+			playgroundUrlWithQueryApiArgs
+		);
+
+		const resolvedBlueprint = await resolveSiteBlueprintFromUrl(
+			playgroundUrlWithQueryApiArgs
+		);
+		const now = Date.now();
+		const newSiteInfo: SiteInfo = {
+			slug: siteSlug,
+			originalUrlParams,
+			metadata: {
+				name: siteName,
+				id: crypto.randomUUID(),
+				whenCreated: now,
+				whenLastUsed: now,
+				persistence: options.persistence ?? 'explicit',
+				storage: 'opfs' as const,
+				initialOpfsSyncPending: true,
+				sourceSetupUrlFingerprint: getAutosaveFingerprintFromURL(
+					playgroundUrlWithQueryApiArgs
+				),
+				originalBlueprint: resolvedBlueprint.blueprint,
+				originalBlueprintSource: resolvedBlueprint.source!,
+				runtimeConfiguration: await resolveRuntimeConfiguration(
+					resolvedBlueprint.blueprint
+				)!,
+			},
+		};
+
+		await dispatch(addSite(newSiteInfo));
+		return newSiteInfo;
+	};
+}
+
+/**
+ * Resolves the Blueprint that should initialize a site created from a URL.
+ *
+ * A URL without Blueprint-specific query args still needs a default Blueprint,
+ * so saved-site creation uses the same welcome Blueprint fallback as temporary
+ * site creation.
+ */
+async function resolveSiteBlueprintFromUrl(playgroundUrlWithQueryApiArgs: URL) {
+	const resolvedBlueprint = await resolveBlueprintFromURL(
+		playgroundUrlWithQueryApiArgs,
+		DEFAULT_BLUEPRINT
+	);
+	return prepareResolvedBlueprint(
+		resolvedBlueprint,
+		playgroundUrlWithQueryApiArgs
+	);
+}
+
+/**
+ * Applies URL query overrides before storing Blueprint v1 declarations.
+ *
+ * `resolveBlueprintFromURL()` loads the Blueprint source, but runtime query
+ * params such as `php`, `wp`, and `networking` still need to be folded into v1
+ * Blueprints so the stored site boots from the same setup the URL requested.
+ */
+async function prepareResolvedBlueprint(
+	resolvedBlueprint: ResolvedBlueprint,
+	playgroundUrlWithQueryApiArgs: URL
+) {
+	const reflection = await BlueprintReflection.create(
+		resolvedBlueprint.blueprint
+	);
+	if (reflection.getVersion() === 1) {
+		resolvedBlueprint.blueprint = await applyQueryOverrides(
+			resolvedBlueprint.blueprint,
+			playgroundUrlWithQueryApiArgs.searchParams
+		);
+	}
+	return resolvedBlueprint;
+}
+
+/**
+ * Returns URL parts saved with a site so it can recreate its setup URL.
+ *
+ * Repeated query params stay as arrays because setup params such as `plugin`
+ * and `php-extension` can appear more than once.
+ */
+function getOriginalUrlParams(
+	url: URL
+): NonNullable<SiteInfo['originalUrlParams']> {
+	return {
+		searchParams: parseSearchParams(url.searchParams),
+		hash: url.hash,
+	};
+}
+
 function parseSearchParams(searchParams: URLSearchParams) {
-	const params: Record<string, any> = {};
+	const params: Record<string, string | string[]> = {};
 	for (const key of searchParams.keys()) {
 		const value = searchParams.getAll(key);
 		params[key] = value.length > 1 ? value : value[0];
@@ -544,6 +667,20 @@ export interface SiteMetadata {
 	 * Stable fingerprint of the setup URL that created this site, when known.
 	 */
 	sourceSetupUrlFingerprint?: string;
+	/**
+	 * Indicates that an OPFS-backed site still needs its first MEMFS-to-OPFS
+	 * file sync.
+	 *
+	 * Sites created with `setStoredSiteSpec` start with metadata only. Their
+	 * first boot must run from the setup URL, then copy initialized files into
+	 * OPFS and clear this flag after a successful sync.
+	 */
+	initialOpfsSyncPending?: boolean;
+	/**
+	 * PHP constants discovered from the running Playground and persisted so
+	 * they can be replayed after reload without changing the live boot config.
+	 */
+	playgroundDefinedConstants?: RuntimeConfiguration['constants'];
 
 	// @TODO: Accept any string as a php version?
 	runtimeConfiguration: RuntimeConfiguration;

--- a/packages/playground/website/src/lib/state/redux/store.ts
+++ b/packages/playground/website/src/lib/state/redux/store.ts
@@ -99,7 +99,10 @@ export const selectActiveSiteErrorDetails = (
 
 export const useActiveSite = () => useAppSelector(selectActiveSite);
 
-export const setActiveSite = (slug: string | undefined) => {
+export const setActiveSite = (
+	slug: string | undefined,
+	options: { updateUrl?: boolean } = {}
+) => {
 	return (
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
@@ -110,7 +113,7 @@ export const setActiveSite = (slug: string | undefined) => {
 			return;
 		}
 		dispatch(__internal_uiSlice.actions.setActiveSite(slug));
-		if (slug) {
+		if (slug && options.updateUrl !== false) {
 			const site = selectSiteBySlug(getState(), slug);
 			redirectTo(PlaygroundRoute.site(site));
 		}

--- a/packages/playground/website/src/lib/state/url/router-hooks.ts
+++ b/packages/playground/website/src/lib/state/url/router-hooks.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 
 export type URLComponents = {
-	searchParams: Record<string, string | undefined>;
+	searchParams: Record<string, string | string[] | undefined>;
 	hash?: string;
 	host?: string;
 	port?: string;

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -6,10 +6,11 @@ export function redirectTo(url: string) {
 	window.history.pushState({}, '', url);
 }
 
-interface QueryAPIParams {
+export interface QueryAPIParams {
 	name?: string;
 	wp?: string;
 	php?: string;
+	'php-extension'?: string[];
 	language?: string;
 	multisite?: 'yes' | 'no';
 	networking?: 'yes' | 'no';
@@ -17,6 +18,9 @@ interface QueryAPIParams {
 	login?: 'yes' | 'no';
 	plugin?: string[];
 	blueprint?: string;
+	'core-pr'?: string;
+	'gutenberg-branch'?: string;
+	'gutenberg-pr'?: string;
 	'import-site'?: string;
 	'import-wxr'?: string;
 	'import-content'?: string;


### PR DESCRIPTION
## What it does

Adds APIs for creating browser-stored Playgrounds directly and for autosaving temporary Playgrounds without disrupting the current tab.

## Rationale

The default autosave flow needs to create OPFS-backed recovery copies, autosave running temporary sites, and prune old recovery copies without forcing user-visible route changes or unnecessary iframe restarts.

## Implementation

- Adds `setStoredSiteSpec()` for creating OPFS-backed site records directly from a setup URL.
- Adds `playgroundSites.createNewSavedSite()` and `playgroundSites.autosaveTemporarySite()`.
- Boots newly-created OPFS sites from the setup URL first, then performs the initial OPFS sync in the background.
- Allows active-site changes and temporary-site persistence to skip URL updates when used by autosave.
- Stores constants discovered from the running iframe as `playgroundDefinedConstants` so they replay after reload without changing the live `runtimeConfiguration` fingerprint.
- Tracks first OPFS sync progress separately for explicit saves and autosaves.
- Updates saved sites' `whenLastUsed` when they boot.

## Testing instructions

```bash
npm exec nx run playground-website:typecheck
npm exec nx run playground-website:lint
npm exec nx test playground-website --testFile=site-lifecycle.spec.ts
npx playwright test --config=packages/playground/website/playwright/playwright.config.ts packages/playground/website/playwright/e2e/sites-api.spec.ts --project=chromium
```
