### PR TITLE
Add release code name for WordPress version 7.0

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-release-names.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/wordpress-release-names.ts
@@ -57,6 +57,7 @@ export const WordPressReleaseNames: Record<string, string> = {
 	'6.7': 'Rollins',
 	'6.8': 'Cecil',
 	'6.9': 'Gene',
+	'7.0': 'Armstrong',
 };
 
 /**


### PR DESCRIPTION
See: https://wordpress.org/news/2026/05/armstrong/

## Motivation for the change, related issues
I like seeing the jazzer when I select the theme

## Implementation details

I added a line like the other lines

## Testing Instructions (or ideally a Blueprint)
