### PR TITLE
Expand Playground troubleshooting docs and translated guides

### DIFF
--- a/packages/docs/site/docs/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/docs/blueprints/02-using-blueprints.md
@@ -81,6 +81,21 @@ Playground also supports Base64-encoded Blueprints. Base64 is useful when a plat
 
 To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
 
+#### URIError: URI malformed
+
+If a Playground link fails with `URIError: URI malformed`, the encoded
+Blueprint fragment is usually malformed. Common causes include an invalid `%`
+escape, a fragment that was encoded twice, or JSON pasted into the URL without
+encoding.
+
+Rebuild the link from the original Blueprint object and encode it once:
+
+```js
+const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
+```
+
+If another tool changes URL fragments, use a Base64-encoded Blueprint instead.
+
 :::tip
 In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`.
 
@@ -110,6 +125,15 @@ Note that the Blueprint must be publicly accessible and served with [the correct
 ```
 Access-Control-Allow-Origin: *
 ```
+
+When a Blueprint URL fails with `BlueprintFetchError`, check these details:
+
+- The URL must return a JSON file or a Blueprint ZIP bundle, not an HTML page.
+- GitHub URLs should use `raw.githubusercontent.com`, not `github.com/.../blob/...`.
+- GitLab URLs should use the raw file URL, not a `/-/blob/` page.
+- The file must be reachable without login, cookies, VPN access, or a temporary browser session.
+- Draft releases, expired CI artifacts, and temporary tunnel URLs can stop working even if the Blueprint was valid earlier.
+- If you host the file yourself, configure CORS so `https://playground.wordpress.net` can fetch it.
 
 #### Blueprint Bundles
 

--- a/packages/docs/site/docs/blueprints/03-data-format.md
+++ b/packages/docs/site/docs/blueprints/03-data-format.md
@@ -115,3 +115,73 @@ Arguably the most powerful property, `steps` allows you to configure the Playgro
 	]
 }
 ```
+
+## Common property placement mistakes
+
+Blueprint validation errors often come from putting a valid property in the
+wrong object.
+
+### Activate a plugin or theme
+
+`activate` belongs inside `options`, not inside `pluginData`, `themeData`, or
+directly on the step.
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "gutenberg"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+### Install plugins with the shorthand
+
+The `plugins` shorthand is a top-level Blueprint property. Do not put it inside
+`preferredVersions`.
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["gutenberg"]
+}
+```
+
+### Use one plugin install shape
+
+For an `installPlugin` step, use `pluginData`. Do not mix `pluginData` with
+older examples or custom objects such as `pluginZipFile`.
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+The `wordpress.org/plugins` resource needs a separate `slug`. Do not write the
+slug into the `resource` value, such as `"wordpress.org/plugins/woocommerce"`.
+
+### Keep `preferredVersions` limited to versions
+
+`preferredVersions` only accepts `php` and `wp`. Use `features` for networking,
+`plugins` or `installPlugin` for plugins, and `steps` for ordered setup tasks.
+
+### Use explicit steps when order matters
+
+Shorthands such as `plugins`, `login`, `siteOptions`, and `constants` are
+expanded before the `steps` array. If one action must happen before another,
+write both actions as explicit steps in the order you need.

--- a/packages/docs/site/docs/blueprints/04-resources.md
+++ b/packages/docs/site/docs/blueprints/04-resources.md
@@ -9,7 +9,7 @@ description: A technical reference for "Resource References." Learn how to use e
 
 <div class="callout callout-info">
 
-Blueprints steps such as [`installPlugin`](/blueprints/steps#InstallPluginStep) or [`installTheme`](/blueprints/steps#InstallThemeStep) require a location of the plugin or theme to be installed.
+Blueprint steps such as [`installPlugin`](/blueprints/steps) or [`installTheme`](/blueprints/steps) require a location of the plugin or theme to be installed.
 
 That location can be defined as [a `URL` resource](#urlreference) of the `.zip` file containing the theme or plugin. It can also be defined as a [`wordpress.org/plugins`](#corepluginreference) or [`wordpress.org/themes`](#corethemereference) resource for those plugins/themes published in the official WordPress directories.
 
@@ -41,13 +41,26 @@ To use the `URLReference` resource, you need to provide the URL of the file. For
 }
 ```
 
-The resource `url` type works really in combination with blueprint steps such as [`installPlugin`](/blueprints/steps#InstallPluginStep) or
-[`installTheme`](http://localhost:3000/wordpress-playground/blueprints/steps#InstallThemeStep).
+The `url` resource works with Blueprint steps such as [`installPlugin`](/blueprints/steps) or
+[`installTheme`](/blueprints/steps).
 These steps require a `ResourceType` to define the location of the plugin or the theme to install.
 
-With a `"resource": "url"` we can define the location of a `.zip` containing the plugin/theme. Use this for built ZIP artifacts hosted on a publicly accessible URL that does not require authentication, such as a release asset or a CI artifact direct-download URL.
+With a `"resource": "url"` we can define the location of a `.zip` containing the plugin/theme. Use this for built ZIP artifacts hosted on a publicly accessible URL that does not require authentication, such as a release asset. CI artifact direct-download URLs can work, but they are often short-lived or restricted.
 
 For source code stored in a Git repository, prefer [`git:directory`](/blueprints/steps/resources#gitdirectoryreference). It can fetch a repository subdirectory from a branch, tag, or commit without requiring a ZIP archive.
+
+Before using a `url` resource, verify that the URL:
+
+- Downloads the file directly. It must not return an HTML page, redirect warning, login page, repository file viewer, or proxy error page.
+- Is available without cookies, authentication, a VPN, or a temporary browser session.
+- Sends CORS headers that allow Playground to fetch it.
+- Points to the expected file type. `installPlugin` and `installTheme` need a plugin or theme ZIP archive unless you use another resource type.
+- Will remain available. Temporary tunnel URLs, draft release assets, and short-lived CI artifacts can expire.
+- Is a real ZIP archive when the step expects a ZIP. Very small downloads often mean the server returned an HTML error page instead of the archive.
+
+For GitHub source code, do not point `url` at a repository page or a generated
+ZIP from a branch when you can use `git:directory`. Use `url` for built ZIP
+artifacts and `git:directory` for source directories.
 
 ### GitDirectoryReference
 
@@ -88,7 +101,7 @@ type GitDirectoryReference = {
 - Playground automatically detects providers like GitHub and GitLab.
 - Repository URLs may include or omit a trailing `.git` suffix. Extra trailing slashes are ignored.
 - It handles CORS-proxied fetches and sparse checkouts, so you can use URLs that point to specific subdirectories or branches.
-- This resource can be used with steps like [`installPlugin`](/blueprints/steps#InstallPluginStep) and [`installTheme`](/blueprints/steps#InstallThemeStep).
+- This resource can be used with steps like [`installPlugin`](/blueprints/steps) and [`installTheme`](/blueprints/steps).
 - Set `".git": true` to include a `.git` folder containing packfiles and refs so Git-aware tooling can detect the checkout. This currently mirrors a shallow clone of the selected ref.
 - The folder name is derived from the URL by default (e.g. `https-github-com-WordPress-block-development-examples-HEAD-at-plugins-data-basics-59c8f8`). Use `options.targetFolderName` in the step to override it, as shown in the example above.
 

--- a/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/docs/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -1,113 +1,491 @@
 ---
 title: Troubleshoot and debug
 slug: /blueprints/troubleshoot-and-debug
-description: A guide with tips and tools to help you troubleshoot and debug your Blueprints, from common issues to browser tools.
+description: A searchable guide to common Blueprint errors, including fetch failures, validation errors, PHP failures, and plugin activation issues.
 ---
 
 # Troubleshoot and debug Blueprints
 
-When you build Blueprints, you might run into issues. Here are tips and tools to help you debug them:
+Blueprint errors usually point to one of three places:
 
-## Review Common gotchas
+- The Blueprint JSON is invalid.
+- Playground could not fetch the Blueprint or one of its resources.
+- A Blueprint step ran, but WordPress, PHP, WP-CLI, or a plugin failed.
 
-- Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you’d need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('wordpress/wp-load.php'); REST_OF_YOUR_CODE"`.
+Start with the exact error name shown by Playground, then use the matching
+section below.
 
-## Common Issues and Solutions
+## Quick checklist
 
-### Invalid Blueprint After Opening a Link
+- Paste the Blueprint into the [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to validate the JSON schema.
+- If the Blueprint is loaded from a URL, open that URL directly in a private browser window and confirm it downloads valid JSON or a Blueprint ZIP bundle.
+- If a step fails, note the step number in `BlueprintStepExecutionError`. The failed step is usually the item at that position after Blueprint shorthands have been expanded.
+- Open browser developer tools and check the Console and Network tabs for download, CORS, PHP, or plugin activation details.
+- For plugin/theme activation failures, check the Playground **Logs** panel or the browser console for PHP warnings and fatal errors.
 
-If Playground reports `Invalid blueprint`, read the detailed error message. It includes the underlying JSON parsing error when one is available.
+## InvalidBlueprintError
 
-If the message says the input still contains `%XX` escapes after decoding, the URL fragment was likely double-encoded. Rebuild the link from the original Blueprint object and encode it once with `encodeURIComponent(JSON.stringify(blueprint))`, or use Base64. Do not encode a fragment that is already encoded.
+`InvalidBlueprintError` means the Blueprint does not match the
+[Blueprint data format](/blueprints/data-format). The error output usually
+contains paths such as `/steps/2/pluginData` or `/preferredVersions`.
 
-### WP-CLI: Error Establishing a Database Connection on Mounted Sites
+### Unexpected property `activate`
 
-When using `wp-cli` with a mounted Playground site (e.g., via `--mount-before-install`), you might encounter an "Error establishing a database connection." This happens because WordPress Playground loads the SQLite database integration plugin from its internal files by default, not from the mounted directory, meaning it's not persisted for external `wp-cli` calls.
-
-To resolve this, you need to explicitly install and configure the SQLite database integration plugin within your Blueprint.
-
-**Solution:** Add the following steps to your Blueprint:
+`activate` belongs inside `options`, not directly on the step or inside
+`pluginData`.
 
 ```json
 {
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+### Unexpected property `plugins` in `preferredVersions`
+
+`preferredVersions` only accepts `php` and `wp`. Install plugins with the
+top-level `plugins` shorthand or with an explicit `installPlugin` step.
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
 	"plugins": ["sqlite-database-integration"]
 }
 ```
 
-**Example Usage:**
+### Missing `slug`, `url`, `path`, or `files`
 
-To test this locally, combine the Blueprint with your Playground CLI command:
+The resource object is incomplete or uses the wrong shape. Common fixes:
+
+- WordPress.org plugin: `{ "resource": "wordpress.org/plugins", "slug": "akismet" }`
+- ZIP URL: `{ "resource": "url", "url": "https://example.com/plugin.zip" }`
+- Git directory: `{ "resource": "git:directory", "url": "https://github.com/org/repo", "ref": "trunk", "refType": "branch" }`
+
+See [Resources References](/blueprints/steps/resources) for all supported
+resource shapes.
+
+### Mixed plugin install properties
+
+Use `pluginData` for `installPlugin`. Do not provide both `pluginData` and
+older examples or custom objects such as `pluginZipFile`.
+
+The WordPress.org plugin resource also needs a separate `slug`:
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	}
+}
+```
+
+Do not write `"resource": "wordpress.org/plugins/woocommerce"`.
+
+## BlueprintFetchError
+
+`BlueprintFetchError` means Playground could not load the file passed to
+`?blueprint-url=`.
+
+Check that the URL:
+
+- Is public and does not require cookies, login, a temporary session, or a VPN.
+- Returns HTTP 200 when opened directly.
+- Serves valid JSON or a ZIP bundle with `blueprint.json` inside it.
+- Sends `Access-Control-Allow-Origin: *` or another header that allows
+  `https://playground.wordpress.net`.
+- Uses a raw file URL, not a repository HTML page.
+
+For GitHub, use `raw.githubusercontent.com` URLs instead of `github.com/.../blob/...`.
+For GitLab, use the raw file URL instead of a `/-/blob/` page.
+
+```text
+# Good
+https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/welcome/blueprint.json
+
+# Not a raw JSON response
+https://github.com/WordPress/blueprints/blob/trunk/blueprints/welcome/blueprint.json
+```
+
+Temporary tunnel URLs, local development URLs, and draft release assets often
+fail because the browser cannot reach them or because they do not allow
+cross-origin requests. Move the Blueprint to a public host with CORS enabled.
+
+### Blueprint file is neither a valid JSON nor a ZIP file
+
+This means Playground received a response, but the response was not a Blueprint.
+The URL may have returned an HTML page, 404 page, repository file viewer, proxy
+warning, login page, or corrupted ZIP.
+
+Open the URL directly and check that:
+
+- JSON URLs return valid Blueprint JSON.
+- ZIP bundle URLs download a real ZIP archive.
+- Blueprint bundles contain `blueprint.json` at the root of the ZIP.
+- The response is not a small HTML or text error page.
+
+### URIError: URI malformed
+
+`URIError: URI malformed` usually points to a broken encoded Blueprint fragment
+in the URL, not to a failed Blueprint step. Check for invalid `%` escapes,
+double-encoded fragments, or raw JSON pasted after `#`. Rebuild the link from
+the original Blueprint and encode it once, or use Base64. See
+[Encoded Blueprint fragments](/blueprints/using-blueprints).
+
+## ResourceDownloadError
+
+`ResourceDownloadError` means the Blueprint loaded, but a step could not download
+a resource such as a plugin ZIP, theme ZIP, WXR file, or imported site archive.
+
+Confirm the resource URL:
+
+- Downloads the actual file, not an HTML page, redirect warning, or expired artifact.
+- Is public and does not require authentication.
+- Allows cross-origin requests.
+- Is the direct file URL. Some release pages and CI artifact pages are human pages, not direct downloads.
+- Still exists. Temporary links and CI artifacts can expire.
+
+For source code in a Git repository, prefer a
+[`git:directory` resource](/blueprints/steps/resources#gitdirectoryreference).
+Use a `url` resource for built ZIP artifacts that are already publicly
+downloadable.
+
+## BlueprintStepExecutionError
+
+`BlueprintStepExecutionError` means a specific step failed after the Blueprint
+started running. The message includes a step number:
+
+```text
+BlueprintStepExecutionError: Error when executing the blueprint step #4
+```
+
+Use that number to inspect the matching step. If your Blueprint uses shorthands
+such as `plugins`, `login`, `siteOptions`, or `constants`, Playground expands
+them into steps before running the Blueprint. Use explicit `steps` when the
+order matters.
+
+URL query parameters such as `?plugin=...`, `?theme=...`, `?php=...`,
+`?wp=...`, and `?networking=yes` also create an implicit Blueprint. Errors from
+those URLs are still Blueprint execution errors, and the generated steps affect
+the reported step number.
+
+## PHP.run() failed with exit code 255
+
+Exit code `255` usually means PHP hit a fatal error. Look for the first
+`Fatal error`, `Uncaught`, or `TypeError` line in the output. The large HTML
+error page around it is usually WordPress's generic critical error screen.
+
+To make the output more useful while debugging, enable WordPress debug constants
+near the beginning of the Blueprint:
+
+```json
+{
+	"step": "defineWpConfigConsts",
+	"consts": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"WP_DISABLE_FATAL_ERROR_HANDLER": true
+	}
+}
+```
+
+Then rerun the Blueprint and check the Playground **Logs** panel or browser
+console.
+
+## PHP.run() failed with exit code 1
+
+Exit code `1` often appears when WP-CLI or WordPress returns an application
+error. Read the `Stderr` section first. It usually names the unsupported
+argument, missing resource, or command-specific failure.
+
+Some WP-CLI commands behave differently in Playground because WordPress runs in
+WebAssembly with SQLite. Keep commands small and test them individually before
+adding a long chain to a Blueprint.
+
+## Undefined constant `ABSPATH`
+
+This usually happens in a `runPHP` step that calls WordPress APIs without first
+loading WordPress.
+
+Add `wp-load.php` before any WordPress function, constant, option, or plugin API:
+
+```json
+{
+	"step": "runPHP",
+	"code": "<?php require '/wordpress/wp-load.php'; update_option('blogname', 'Demo site');"
+}
+```
+
+## Plugin could not be activated
+
+Plugin activation errors usually come from the plugin itself, not from the
+Blueprint runner. Common causes:
+
+- The plugin requires a newer PHP version or WordPress version.
+- The plugin has a fatal error on activation.
+- The plugin depends on another plugin that is not installed or activated.
+- The plugin performs a redirect or prints unexpected output during activation.
+- The plugin ZIP extracts to a folder or main file name different from the path the step is activating.
+
+If the error says the current PHP or WordPress version does not meet minimum
+requirements, set `preferredVersions`:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	}
+}
+```
+
+### WordPress exited with exit code 0
+
+Activation can fail even when WordPress exits with code `0`. This usually means
+WordPress returned an activation error response rather than a PHP process crash.
+When the message says `Inspect the "debug" logs`, check the Playground **Logs**
+panel, browser console, or CLI output.
+
+Look for PHP warnings, redirects or output printed during activation, missing
+dependency plugins, or plugin minimum PHP/WordPress requirements.
+
+### Current PHP or WordPress version does not meet minimum requirements
+
+Version mismatch errors often include text like:
+
+```text
+Current PHP version (7.4.33) does not meet minimum requirements. The plugin requires PHP 8.0.
+```
+
+or:
+
+```text
+Current WordPress version (6.9.4) does not meet minimum requirements. The plugin requires WordPress 7.0.
+```
+
+Set `preferredVersions` to a compatible PHP and WordPress version, or use a
+plugin/theme release that supports the versions available in Playground.
+
+If the error is:
+
+```text
+Failed to download WordPress 6.9.0 (HTTP 404)
+```
+
+the requested WordPress build is not available. Use `latest`, a supported
+released version, or a supported beta/nightly value.
+
+If the error says `Plugin file does not exist`, inspect the installed folder
+name. For ZIP URLs with unusual folder names, set `targetFolderName`:
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "url",
+		"url": "https://example.com/my-plugin.zip"
+	},
+	"options": {
+		"activate": true,
+		"targetFolderName": "my-plugin"
+	}
+}
+```
+
+If the plugin has dependencies, install and activate those dependencies first
+with explicit steps.
+
+## Theme could not be activated
+
+Theme activation failures usually mean the theme folder name is wrong, the
+theme ZIP extracted to an unexpected directory, or the theme code caused a
+WordPress/PHP error.
+
+Use `installTheme` with `options.activate` when installing a theme:
+
+```json
+{
+	"step": "installTheme",
+	"themeData": {
+		"resource": "wordpress.org/themes",
+		"slug": "twentytwentyfour"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+If you use a standalone `activateTheme` step, pass the folder name inside
+`wp-content/themes`, not a full URL or ZIP filename.
+
+## Could not write to a file
+
+Errors like this mean the parent directory does not exist:
+
+```text
+Could not write to "/wordpress/wp-content/plugins/example/index.php":
+There is no such file or directory OR the parent directory does not exist.
+```
+
+Create the directory first with `mkdir`, or use `writeFiles` with a
+`literal:directory` resource.
+
+```json
+[
+	{
+		"step": "mkdir",
+		"path": "/wordpress/wp-content/plugins/example"
+	},
+	{
+		"step": "writeFile",
+		"path": "/wordpress/wp-content/plugins/example/index.php",
+		"data": "<?php /* Plugin Name: Example */"
+	}
+]
+```
+
+## Could not unzip file
+
+This usually means the file is not a valid ZIP archive. The URL may have
+returned an HTML page, an error response, a login page, or a truncated file.
+
+If the output says `Could not unzip file. Error code: 19`, verify the download
+is a ZIP archive. A small file size often means the server returned an HTML
+error page instead of the archive.
+
+Open the URL directly and confirm the browser downloads a ZIP. If you are using
+a GitHub or CI artifact, use a direct-download URL and make sure the release or
+artifact is public.
+
+## WP-CLI command pitfalls
+
+The `wp-cli` step runs WP-CLI inside Playground. It is useful for setup tasks,
+but not every command or shell feature behaves like a local terminal.
+
+Common fixes:
+
+- Use the step name `"wp-cli"`, not `"wpcli"` or `"cli"`.
+- Keep commands focused. Prefer multiple `wp-cli` steps over one complex shell command.
+- Avoid shell substitutions such as `$(...)` in shared Blueprints. Use `runPHP` for logic that needs WordPress APIs.
+- Check parameter names against the WP-CLI command you are using. For example, command-specific parameters may differ between `wp post list`, `wp post delete`, and plugin-provided commands.
+- If a plugin-provided WP-CLI command fails with a plugin stack trace, the fix usually belongs in that plugin or in the input data passed to the command.
+- If a command fails with `unknown --post_type parameter` or `unknown --format parameter`, check whether the flags belong to a different command in the pipeline.
+- If a plugin command fails with `Unsupported argument type passed to WP_CLI::error_to_string(): 'NULL'`, confirm the plugin is active, the imported data exists, and the command input points to a valid resource.
+
+## WP-CLI: Error establishing a database connection on mounted sites
+
+When using `wp-cli` with a mounted Playground site, for example via
+`--mount-before-install`, you might encounter an "Error establishing a database
+connection." This happens because WordPress Playground loads the SQLite database
+integration plugin from its internal files by default, not from the mounted
+directory.
+
+Add the SQLite integration plugin to the mounted WordPress site explicitly:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}
+```
+
+Then run the Blueprint with the mounted site:
 
 ```bash
 mkdir wordpress
-# Ensure your blueprint with the above steps is saved as, for example, './blueprint.json'
 npx @wp-playground/cli server --mount-before-install=wordpress:/wordpress --blueprint=./blueprint.json
-cd wordpress
-wp post list
 ```
 
-This will ensure the SQLite plugin is installed correctly and configured within your mounted WordPress site, allowing `wp-cli` commands to function correctly.
+## Debugging tools
 
-## Blueprints Builder
+### Blueprints editor
 
-You can use an in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to build, validate, and preview your Blueprints in the browser.
+Use the in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html)
+to build, validate, and preview Blueprints.
 
 :::danger Caution
 
-The editor is under development and the embedded Playground sometimes fails to load. To get around it, refresh the page. We're aware of that, and are working to improve the experience.
+The editor is under development and the embedded Playground sometimes fails to
+load. To get around it, refresh the page.
 
 :::
 
-## Check for the Filesystem and Database
+### Filesystem and database inspection
 
-Some blueprint steps (such as [`writeFile`](/blueprints/steps#WriteFileStep)) alter the internal Filesystem structure of the Playground instance and some others (such as [`runSql`](/blueprints/steps#runSql)) alter the internal WordPress database.
+Some Blueprint steps, such as [`writeFile`](/blueprints/steps),
+alter the internal filesystem. Others, such as
+[`runSql`](/blueprints/steps), alter the database.
 
-To check the final internal filesystem structure and database (after the blueprint steps have been applied) we can leverage some WordPress plugins that provide a SQL manager and a file explorer such as [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and [`WPide`](https://wordpress.org/plugins/wpide/) (you can see them in action from https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide)
+To inspect the final state, install plugins such as
+[`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and
+[`WPide`](https://wordpress.org/plugins/wpide/). You can see them in action at
+https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide.
 
-:::tip
+You can also inspect a Playground instance from the browser console through
+`window.playground`:
 
-There are a bunch of methods we can launch from the console of any WordPress Playground instance to inspect the internals of that instance. They're exposed as part of `window.playground` object (see [Developers > JavaScript API > Debugging and testing](/developers/apis/javascript-api/#debugging-and-testing)). Some examples:
-
+```js
+await playground.isDir('/wordpress/wp-content/plugins');
+await playground.listFiles('/wordpress/wp-content/plugins');
 ```
-> await playground.isDir("/wordpress/wp-content/plugins")
-true
-> await playground.listFiles("/wordpress/wp-content/plugins")
-(3) ['hello.php', 'index.php', 'WordPress-Importer-master']
-```
 
-Full list of methods we can use is available [here](/api/client/interface/PlaygroundClient)
+See the full [PlaygroundClient API](/api/client/interface/PlaygroundClient).
 
-:::
+### Browser console and network requests
 
-## Check for errors in the browser console
+Open browser developer tools to check JavaScript errors, PHP debug logs, and
+failed network requests. In Chrome, Firefox, and Edge, press
+`Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
 
-If your Blueprint isn’t running as expected, open the browser developer tools to check for any errors.
+:::caution Safari
 
-To open the developer tools in Chrome, Firefox, Safari\*, and Edge: press `Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
-
-:::caution
-
-If you haven't yet, enable the Develop menu: go to **Safari > Settings... > Advanced** and check **Show features for web developers**.
+If you have not enabled the Develop menu, go to **Safari > Settings... >
+Advanced** and check **Show features for web developers**.
 
 :::
 
-The developer tools window allows you to inspect network requests, view console logs, debug JavaScript, and examine the DOM and CSS styles applied to your webpage. This is crucial for diagnosing and fixing issues with Blueprints.
+### Custom error logging
 
-## Log your own error messages
-
-You can `error_log` your own error messages through [`runPHP` step](/blueprints/steps#RunPHPStep) (see [blueprint example](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) and check them from the ["View Logs" option](/web-instance#playground-options-menu) or from the browser's console.
+You can write your own messages with `error_log()` in a
+[`runPHP` step](/blueprints/steps), then check the Playground
+**Logs** panel or the browser console.
 
 ![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
 :::info
-When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance.
+When you download your Playground instance as a ZIP through the
+["Download as zip"](/web-instance) option, the archive
+also includes `debug.log`.
 :::
 
 ## Ask for help
 
-The community is here to help! If you have questions or comments, [open a new issue](https://github.com/adamziel/blueprints/issues) in this repository. Remember to include the following details:
+If you need help, [open an issue](https://github.com/WordPress/wordpress-playground/issues)
+and include:
 
-- The Blueprint you’re trying to run.
-- The error message you’re seeing, if any.
-- The full output from the browser developer tools.
-- Any other relevant information that might help us understand the issue: OS, browser version, etc.
+- The Blueprint JSON or the public Blueprint URL.
+- The exact error message.
+- The failing step number, if shown.
+- Browser, operating system, and whether you used the website, JavaScript API, or CLI.
+- Relevant console, network, or CLI output.

--- a/packages/docs/site/docs/main/troubleshooting.md
+++ b/packages/docs/site/docs/main/troubleshooting.md
@@ -1,0 +1,174 @@
+---
+title: Troubleshooting
+slug: /troubleshooting
+description: Diagnose common WordPress Playground website errors, including boot failures, SQLite issues, browser storage, and saved Playground recovery.
+---
+
+# Troubleshooting WordPress Playground
+
+This page covers errors from the Playground website itself, saved Playgrounds,
+browser storage, and WordPress boot. For Blueprint-specific errors, see
+[Troubleshoot and debug Blueprints](/blueprints/troubleshoot-and-debug).
+
+## Playground looks broken
+
+Try these first:
+
+- Use the reload button inside the Playground toolbar instead of refreshing the browser tab. Browser refresh starts the whole Playground app again.
+- Open the same URL in a private window to rule out saved-site or browser-storage state.
+- Disable browser extensions that block JavaScript, WebAssembly, storage, workers, or network requests.
+- Check browser developer tools for Console and Network errors.
+- If the URL includes `?site-slug=...`, try removing that query parameter to start a fresh unsaved Playground.
+
+## A clean site says the MySQL extension is missing
+
+You may see a WordPress error page like this:
+
+```text
+Your PHP installation appears to be missing the MySQL extension which is required by WordPress.
+```
+
+In Playground, this usually means WordPress did not load the SQLite integration
+that lets WordPress run without MySQL. Playground runs WordPress in WebAssembly
+and uses SQLite instead of a MySQL server.
+
+Try these steps:
+
+- Start a fresh unsaved Playground at https://playground.wordpress.net/ to confirm the public site can boot.
+- If the URL includes a saved site, remove `?site-slug=...` and load a new temporary site.
+- If this happened after importing a ZIP, confirm the import did not include a custom `wp-content/db.php` that overrides Playground's SQLite setup.
+- If this happened in the CLI, do not use `--skip-sqlite-setup` unless you provide your own database integration.
+- If this happened with a Blueprint, see the [Blueprint troubleshooting page](/blueprints/troubleshoot-and-debug).
+
+If you are writing a Blueprint and need to add the SQLite integration plugin,
+`plugins` goes at the top level:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}
+```
+
+## Error connecting to the SQLite database
+
+This means Playground loaded the SQLite integration, but WordPress still could
+not connect to the database.
+
+Common causes:
+
+- A saved Playground's browser storage is stale or incomplete.
+- An imported site ZIP contains an incompatible database file or database drop-in.
+- A mounted local directory is missing files that WordPress needs.
+- Browser storage was cleared, evicted, or blocked.
+
+Recommended recovery:
+
+1. Start a fresh unsaved Playground without `site-slug`.
+2. If the fresh site works, the issue is tied to the saved site or imported archive.
+3. Export any accessible files from the broken saved site using the File Browser or local directory copy, if available.
+4. Re-import the site into a new Playground, or rebuild it from its Blueprint.
+
+## NotAllowedError
+
+`NotAllowedError` usually means the browser blocked an operation that requires
+user permission or a supported browser context. In Playground, this often
+relates to saved sites or local directory access.
+
+You may see this exact message:
+
+```text
+The request is not allowed by the user agent or the platform in the current context.
+```
+
+Try:
+
+- Open Playground in a normal top-level browser tab, not inside a restricted iframe.
+- Reopen the site from the Playground **Saved Playgrounds** panel.
+- If the site was saved to a local directory, import or save the directory again.
+- Confirm the browser supports the file or storage API being used. Chrome and Edge generally have the broadest local directory support.
+- Check whether private browsing mode, enterprise policy, or browser settings block storage access.
+
+## NoModificationAllowedError
+
+`NoModificationAllowedError` means the browser or filesystem refused a write.
+This can happen when a saved local directory became read-only, permission was
+lost, or browser storage is unavailable.
+
+You may see this exact message:
+
+```text
+An attempt was made to write to a file or directory which could not be modified due to the state of the underlying filesystem.
+```
+
+Try:
+
+- Save a copy to a different local directory.
+- Check that the target folder still exists and is writable.
+- Avoid system-protected folders or synced folders that temporarily lock files.
+- Start a fresh unsaved Playground if you only need a temporary test site.
+- Use [Playground CLI](/developers/local-development/wp-playground-cli) for local development that needs reliable filesystem persistence.
+
+## Saved Playground cannot reload
+
+Saved Playgrounds are stored in browser storage or in a local directory you
+selected. They are not hosted on a remote server.
+
+If a saved Playground cannot reload:
+
+- Confirm you are using the same browser and browser profile where it was saved.
+- Check whether browser data was cleared or storage was disabled.
+- If the site was saved to a local directory, confirm the directory still exists and has not moved.
+- If the URL includes `?site-slug=...`, remove it to start a fresh unsaved site.
+- Recreate the saved site from its original Blueprint or import ZIP if storage was lost.
+
+## Browser storage and persistence
+
+An unsaved Playground is temporary. A browser refresh, tab close, storage
+cleanup, or browser profile change can remove its state.
+
+Use the **Save** button before doing meaningful work. For longer-running local
+development, prefer the [Playground CLI](/developers/local-development/wp-playground-cli),
+which persists site files on disk.
+
+:::tip
+The refresh button inside the Playground toolbar reloads WordPress while keeping
+the current Playground runtime. The browser refresh button reloads the full app
+and can discard unsaved changes.
+:::
+
+## When to start fresh
+
+Start a fresh unsaved Playground when:
+
+- You only need to test whether the public Playground site is working.
+- The URL points to a saved `site-slug` that no longer loads.
+- You are debugging whether an error comes from Playground itself or from a plugin, theme, Blueprint, or imported site.
+- Browser storage or local directory access is suspected to be broken.
+
+Use this URL for a clean site:
+
+```text
+https://playground.wordpress.net/
+```
+
+## Report a Playground issue
+
+If the problem reproduces on a fresh unsaved Playground, please
+[open an issue](https://github.com/WordPress/wordpress-playground/issues) and
+include:
+
+- The full Playground URL.
+- The browser and operating system.
+- Whether you used a saved site, imported ZIP, Blueprint, local directory, or CLI.
+- The exact error name and message.
+- Console and Network details from browser developer tools.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
@@ -1,25 +1,20 @@
 ---
 title: Usar Blueprints
 slug: /blueprints/using-blueprints
-description: Descubre las diferentes formas de usar Blueprints, incluso mediante fragmento de URL, parámetro de consulta, paquetes y la API de JavaScript.
+description: Descubre las distintas formas de usar Blueprints, incluso mediante fragmentos de URL, parámetros de consulta, paquetes y la API de JavaScript.
 ---
 
-<!--
-title: Using Blueprints
-description: Discover the different ways to use Blueprints, including via URL fragment, query parameter, bundles, and the JavaScript API.
--->
+<!-- title: Using Blueprints -->
 
-<!--
-# Using Blueprints
--->
+<!-- description: Discover the different ways to use Blueprints, including via URL fragment, query parameter, bundles, and the JavaScript API. -->
+
+<!-- # Using Blueprints -->
 
 # Usar Blueprints
 
-<!--
-You can use Blueprints in one of the following ways:
--->
+<!-- You can use Blueprints in one of the following ways: -->
 
-Puedes usar Blueprints de una de las siguientes formas:
+Puedes usar Blueprints de una de estas formas:
 
 <!--
 - By passing them as a URL fragment to the Playground.
@@ -28,28 +23,25 @@ Puedes usar Blueprints de una de las siguientes formas:
 - By using the JavaScript API.
 -->
 
-- Pasándolos como fragmento de URL al Playground.
+- Pasándolos como un fragmento de URL al Playground.
 - Cargándolos desde una URL con el parámetro `blueprint-url`.
 - Usando paquetes de Blueprint (archivos ZIP o directorios).
 - Usando la API de JavaScript.
 
-<!--
-## URL Fragment
--->
+<!-- ## URL Fragment -->
 
-## Fragmento de URL {#url-fragment}
+## Fragmento de URL
 
-<!--
-The easiest way to start using Blueprints is to paste one into the URL "fragment" on WordPress Playground website, e.g. `https://playground.wordpress.net/#{"preferredVersions...`.
--->
+<!-- The easiest way to start using Blueprints is to paste one into the URL "fragment" on WordPress Playground website, e.g. `https://playground.wordpress.net/#{"preferredVersions...`. -->
 
-La forma más sencilla de empezar a usar Blueprints es pegar uno en el "fragmento" de URL del sitio de WordPress Playground, por ejemplo `https://playground.wordpress.net/#{"preferredVersions...`.
+La forma más sencilla de empezar a usar Blueprints es pegar uno en el
+"fragmento" de la URL en el sitio de WordPress Playground, por ejemplo
+`https://playground.wordpress.net/#{"preferredVersions...`.
 
-<!--
-For example, to create a Playground with specific versions of WordPress and PHP you would use the following Blueprint:
--->
+<!-- For example, to create a Playground with specific versions of WordPress and PHP you would use the following Blueprint: -->
 
-Por ejemplo, para crear un Playground con versiones específicas de WordPress y PHP, usarías el siguiente Blueprint:
+Por ejemplo, para crear un Playground con versiones específicas de WordPress y
+PHP, usarías el siguiente Blueprint:
 
 ```json
 {
@@ -66,17 +58,18 @@ And then you would go to
 `https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
 -->
 
-Luego irías a
+Y después irías a
 `https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
 
-:::tip
-
 <!--
+:::tip
 In Javascript, you can get a compact version of any blueprint JSON with [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) and [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
 Example:
 -->
 
-En JavaScript, puedes obtener una versión compacta de cualquier JSON de Blueprint con [`JSON.stringify`](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) y [`JSON.parse`](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
+:::tip
+En JavaScript, puedes obtener una versión compacta de cualquier JSON de
+Blueprint con [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) y [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
 Ejemplo:
 
 ```js
@@ -94,11 +87,10 @@ const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
 
 :::
 
-<!--
-You won't have to paste links to follow along. We'll use code examples with a "Try it out" button that will automatically run the examples for you:
--->
+<!-- You won't have to paste links to follow along. We'll use code examples with a "Try it out" button that will automatically run the examples for you: -->
 
-No tendrás que pegar enlaces para seguir el tutorial. Usaremos ejemplos de código con un botón "Pruébalo" que ejecutará automáticamente los ejemplos por ti:
+No tendrás que pegar enlaces para seguir la guía. Usaremos ejemplos de código
+con un botón "Try it out" que ejecutará automáticamente los ejemplos por ti:
 
 import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
 
@@ -109,17 +101,15 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 	}
 }} />
 
-<!--
-### Encoded Blueprint fragments
--->
+<!-- ### Encoded Blueprint fragments -->
 
 ### Fragmentos de Blueprint codificados
 
-<!--
-When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`:
--->
+<!-- When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`: -->
 
-Cuando crees enlaces de Playground desde JavaScript o herramientas de automatización, codifica el JSON minificado una sola vez con `encodeURIComponent()` y añádelo después de `#`:
+Cuando crees enlaces de Playground desde JavaScript o herramientas de
+automatización, codifica el JSON minificado una vez con `encodeURIComponent()`
+y añádelo después de `#`:
 
 ```js
 const blueprint = {
@@ -132,27 +122,58 @@ const blueprint = {
 const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
 ```
 
-<!--
-Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
--->
+<!-- Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`. -->
 
-Playground también admite Blueprints codificados en Base64. Base64 es útil cuando una plataforma modifica fragmentos JSON o cuando quieres un enlace compacto y fácil de copiar. Por ejemplo, este es el Blueprint anterior en formato Base64: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+Playground también admite Blueprints codificados en Base64. Base64 es útil
+cuando una plataforma modifica fragmentos JSON o cuando quieres un enlace
+compacto y fácil de copiar. Por ejemplo, este es el Blueprint anterior en
+formato Base64: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
 
-<!--
-To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
--->
+<!-- To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19 -->
 
 Para ejecutarlo, ve a https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
 
-:::tip
+<!-- #### URIError: URI malformed -->
+
+#### URIError: URI malformed
 
 <!--
-In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`.
-
-Example:
+If a Playground link fails with `URIError: URI malformed`, the encoded
+Blueprint fragment is usually malformed. Common causes include an invalid `%`
+escape, a fragment that was encoded twice, or JSON pasted into the URL without
+encoding.
 -->
 
-En JavaScript, puedes convertir cualquier JSON de Blueprint a [formato Base64](https://developer.mozilla.org/es/docs/Glossary/Base64#javascript_support) con la función global `btoa()`.
+Si un enlace de Playground falla con `URIError: URI malformed`, el fragmento de
+Blueprint codificado suele estar mal formado. Las causas comunes incluyen un
+escape `%` inválido, un fragmento codificado dos veces o JSON pegado en la URL
+sin codificar.
+
+<!-- Rebuild the link from the original Blueprint object and encode it once: -->
+
+Reconstruye el enlace desde el objeto Blueprint original y codifícalo una sola
+vez:
+
+```js
+const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
+```
+
+<!-- If another tool changes URL fragments, use a Base64-encoded Blueprint instead. -->
+
+Si otra herramienta cambia los fragmentos de URL, usa en su lugar un Blueprint
+codificado en Base64.
+
+<!--
+:::tip
+In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`.
+-->
+
+:::tip
+En JavaScript, puedes obtener cualquier JSON de Blueprint en
+[formato Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support)
+con la función global `btoa()`.
+
+<!-- Example: -->
 
 Ejemplo:
 
@@ -169,55 +190,72 @@ const minifiedBlueprintJson = btoa(blueprintJson); // eyIkc2NoZW1hIjogImh0dHBzOi
 
 :::
 
-<!--
-### Load Blueprint from a URL
--->
+<!-- ### Load Blueprint from a URL -->
 
-### Cargar Blueprint desde una URL
+### Cargar un Blueprint desde una URL
 
-<!--
-When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this:
--->
+<!-- When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this: -->
 
-Cuando tu Blueprint sea demasiado difícil de manejar, puedes cargarlo mediante el parámetro de consulta `?blueprint-url` en la URL, así:
+Cuando tu Blueprint sea demasiado grande, puedes cargarlo mediante el parámetro
+de consulta `?blueprint-url` en la URL, así:
+
+<!-- [https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json) -->
 
 [https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
 
-<!--
-Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
--->
+<!-- Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin): -->
 
-Ten en cuenta que el Blueprint debe ser accesible públicamente y servirse con [el encabezado `Access-Control-Allow-Origin` correcto](https://developer.mozilla.org/es/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
+Ten en cuenta que el Blueprint debe ser accesible públicamente y servirse con
+el [encabezado `Access-Control-Allow-Origin` correcto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
 
 ```
 Access-Control-Allow-Origin: *
 ```
 
+<!-- When a Blueprint URL fails with `BlueprintFetchError`, check these details: -->
+
+Cuando una URL de Blueprint falle con `BlueprintFetchError`, revisa estos
+detalles:
+
 <!--
-#### Blueprint Bundles
+- The URL must return a JSON file or a Blueprint ZIP bundle, not an HTML page.
+- GitHub URLs should use `raw.githubusercontent.com`, not `github.com/.../blob/...`.
+- GitLab URLs should use the raw file URL, not a `/-/blob/` page.
+- The file must be reachable without login, cookies, VPN access, or a temporary browser session.
+- Draft releases, expired CI artifacts, and temporary tunnel URLs can stop working even if the Blueprint was valid earlier.
+- If you host the file yourself, configure CORS so `https://playground.wordpress.net` can fetch it.
 -->
+
+- La URL debe devolver un archivo JSON o un paquete ZIP de Blueprint, no una página HTML.
+- Las URL de GitHub deben usar `raw.githubusercontent.com`, no `github.com/.../blob/...`.
+- Las URL de GitLab deben usar la URL del archivo sin procesar, no una página `/-/blob/`.
+- El archivo debe ser accesible sin inicio de sesión, cookies, VPN o una sesión temporal del navegador.
+- Las releases en borrador, los artifacts de CI expirados y las URL temporales de túnel pueden dejar de funcionar aunque el Blueprint fuera válido antes.
+- Si alojas el archivo, configura CORS para que `https://playground.wordpress.net` pueda obtenerlo.
+
+<!-- #### Blueprint Bundles -->
 
 #### Paquetes de Blueprint
 
-<!--
-The `?blueprint-url` parameter now also supports Blueprint bundles in ZIP format. A Blueprint bundle is a ZIP file that contains a `blueprint.json` file at the root level, along with any additional resources referenced by the Blueprint.
--->
+<!-- The `?blueprint-url` parameter now also supports Blueprint bundles in ZIP format. A Blueprint bundle is a ZIP file that contains a `blueprint.json` file at the root level, along with any additional resources referenced by the Blueprint. -->
 
-El parámetro `?blueprint-url` ahora también admite paquetes de Blueprint en formato ZIP. Un paquete de Blueprint es un archivo ZIP que contiene un archivo `blueprint.json` en el nivel raíz, junto con cualquier recurso adicional al que haga referencia el Blueprint.
+El parámetro `?blueprint-url` ahora también admite paquetes de Blueprint en
+formato ZIP. Un paquete de Blueprint es un archivo ZIP que contiene un archivo
+`blueprint.json` en el nivel raíz, junto con cualquier recurso adicional
+referenciado por el Blueprint.
 
-<!--
-For example, you can load a Blueprint bundle like this:
--->
+<!-- For example, you can load a Blueprint bundle like this: -->
 
 Por ejemplo, puedes cargar un paquete de Blueprint así:
 
+<!-- [https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip](https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip) -->
+
 [https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip](https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip)
 
-<!--
-When using a Blueprint bundle, you can reference bundled resources using the `bundled` resource type:
--->
+<!-- When using a Blueprint bundle, you can reference bundled resources using the `bundled` resource type: -->
 
-Al usar un paquete de Blueprint, puedes referenciar recursos incluidos en el paquete con el tipo de recurso `bundled`:
+Cuando uses un paquete de Blueprint, puedes referenciar recursos incluidos en
+el paquete con el tipo de recurso `bundled`:
 
 ```json
 {
@@ -235,23 +273,20 @@ Al usar un paquete de Blueprint, puedes referenciar recursos incluidos en el paq
 }
 ```
 
-<!--
-For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation.
--->
+<!-- For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation. -->
 
-Para obtener más información sobre los paquetes de Blueprint, consulta la documentación de [Paquetes de Blueprint](/blueprints/bundles).
+Para más información sobre los paquetes de Blueprint, consulta la documentación
+de [Paquetes de Blueprint](/blueprints/bundles).
 
-<!--
-## JavaScript API
--->
+<!-- ## JavaScript API -->
 
-## API de JavaScript {#javascript-api}
+## API de JavaScript
 
-<!--
-You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen:
--->
+<!-- You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen: -->
 
-También puedes usar Blueprints con la API de JavaScript mediante la función `startPlaygroundWeb()` del paquete `@wp-playground/client`. Aquí tienes un ejemplo pequeño y autónomo que puedes ejecutar en JSFiddle o CodePen:
+También puedes usar Blueprints con la API de JavaScript mediante la función
+`startPlaygroundWeb()` del paquete `@wp-playground/client`. Este es un ejemplo
+pequeño y autónomo que puedes ejecutar en JSFiddle o CodePen:
 
 ```html
 <iframe id="wp-playground" style="width: 1200px; height: 800px"></iframe>

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/03-data-format.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/03-data-format.md
@@ -1,0 +1,297 @@
+---
+sidebar_position: 1
+title: Formato de datos de Blueprint
+slug: /blueprints/data-format
+description: Una visión general del formato de datos de Blueprint. Aprende sobre propiedades clave como landingPage, preferredVersions y steps.
+---
+
+<!-- title: Blueprint data Format -->
+
+<!-- description: An overview of the Blueprint data format. Learn about key properties like landingPage, preferredVersions, and steps. -->
+
+<!-- # Blueprint data format -->
+
+# Formato de datos de Blueprint
+
+<!-- A Blueprint JSON file can have many different properties that will be used to define your Playground instance. The most important properties are detailed below. -->
+
+Un archivo JSON de Blueprint puede tener muchas propiedades diferentes que se
+usarán para definir tu instancia de Playground. Las propiedades más importantes
+se detallan a continuación.
+
+<!-- Here's an example that uses many of them: -->
+
+Este es un ejemplo que usa muchas de ellas:
+
+import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
+
+<BlueprintExample blueprint={{
+	"landingPage": "/wp-admin/",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	},
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		}
+	]
+}} />
+
+<!-- ## JSON schema -->
+
+## Esquema JSON
+
+<!-- JSON files can be tedious to write and easy to get wrong. To help with that, Playground provides a [JSON schema](https://playground.wordpress.net/blueprint-schema.json) file that you can use to get auto-completion and validation in your editor. Just set the `$schema` property to the following: -->
+
+Los archivos JSON pueden ser tediosos de escribir y fáciles de equivocarse.
+Para ayudar con eso, Playground proporciona un archivo de
+[esquema JSON](https://playground.wordpress.net/blueprint-schema.json) que
+puedes usar para obtener autocompletado y validación en tu editor. Solo tienes
+que definir la propiedad `$schema` así:
+
+```js
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+}
+```
+
+<!-- ## Landing page -->
+
+## Página de destino
+
+<!-- The `landingPage` property tells Playground which URL to navigate to after the Blueprint has been run. This is a great tool, especially when creating theme or plugin demos. Often, you will want to start Playground in the Site Editor or have a specific post open in the Post Editor. Make sure you use a relative path. -->
+
+La propiedad `landingPage` indica a Playground a qué URL navegar después de que
+se haya ejecutado el Blueprint. Es una gran herramienta, especialmente al crear
+demos de temas o plugins. A menudo querrás iniciar Playground en el Editor del
+sitio o abrir una entrada específica en el Editor de entradas. Asegúrate de usar
+una ruta relativa.
+
+```js
+{
+	"landingPage": "/wp-admin/site-editor.php",
+}
+```
+
+<!-- ## Preferred versions -->
+
+## Versiones preferidas
+
+<!-- The `preferredVersions` property declares your preferred PHP and WordPress versions. It can contain the following properties: -->
+
+La propiedad `preferredVersions` declara tus versiones preferidas de PHP y
+WordPress. Puede contener las siguientes propiedades:
+
+<!--
+- `php` (string): Loads the specified PHP version. Accepts `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5`, or `latest`. Minor versions like `7.4.1` are not supported.
+- `wp` (string): Loads the specified WordPress version. Accepts the last seven major WordPress versions. As of April 28, 2026, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7`, `6.8`, or `6.9`. You can also use the generic values `latest`, `beta`, or `nightly` (alias `trunk`). `beta` resolves to the most recent Beta or Release Candidate of an active release cycle; `nightly`/`trunk` builds straight from the WordPress development branch.
+-->
+
+- `php` (string): Carga la versión de PHP especificada. Acepta `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5` o `latest`. Las versiones menores como `7.4.1` no son compatibles.
+- `wp` (string): Carga la versión de WordPress especificada. Acepta las últimas siete versiones principales de WordPress. Al 28 de abril de 2026, son `6.3`, `6.4`, `6.5`, `6.6`, `6.7`, `6.8` o `6.9`. También puedes usar los valores genéricos `latest`, `beta` o `nightly` (alias `trunk`). `beta` se resuelve a la Beta o Release Candidate más reciente de un ciclo de lanzamiento activo; `nightly`/`trunk` se compila directamente desde la rama de desarrollo de WordPress.
+
+```js
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.7"
+	},
+}
+```
+
+<!-- ## Features -->
+
+## Características
+
+<!-- You can use the `features` property to turn on or off certain features of the Playground instance. It can contain the following properties: -->
+
+Puedes usar la propiedad `features` para activar o desactivar ciertas
+características de la instancia de Playground. Puede contener las siguientes
+propiedades:
+
+<!-- - `networking`: Defaults to `true`. Enables or disables the networking support for Playground. If enabled, [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) and similar WordPress functions will actually use `fetch()` to make HTTP requests. If disabled, they will immediately fail instead. You will need this property enabled if you want the user to be able to install plugins or themes. -->
+
+- `networking`: Su valor predeterminado es `true`. Activa o desactiva el soporte de red para Playground. Si está activado, [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) y funciones similares de WordPress usarán realmente `fetch()` para hacer solicitudes HTTP. Si está desactivado, fallarán de inmediato. Necesitarás esta propiedad activada si quieres que la persona usuaria pueda instalar plugins o temas.
+
+```js
+{
+	"features": {
+		"networking": false
+	},
+}
+```
+
+<!-- ## Extra libraries -->
+
+## Bibliotecas adicionales
+
+<!-- You can preload extra libraries into the Playground instance. The following libraries are supported: -->
+
+Puedes precargar bibliotecas adicionales en la instancia de Playground. Las
+siguientes bibliotecas son compatibles:
+
+<!-- - `wp-cli`: Enables WP-CLI support for Playground. If included, WP-CLI will be installed during boot. If not included, you will get an error message when trying to run WP-CLI commands using the JS API. WP-CLI will be installed by default if the blueprint contains any `wp-cli` steps. -->
+
+- `wp-cli`: Activa el soporte de WP-CLI para Playground. Si se incluye, WP-CLI se instalará durante el arranque. Si no se incluye, recibirás un mensaje de error al intentar ejecutar comandos WP-CLI con la API JS. WP-CLI se instalará de forma predeterminada si el Blueprint contiene cualquier etapa `wp-cli`.
+
+```js
+{
+	"extraLibraries": [ "wp-cli" ],
+}
+```
+
+<!-- ## Steps -->
+
+## Etapas
+
+<!-- Arguably the most powerful property, `steps` allows you to configure the Playground instance with preinstalled themes, plugins, demo content, and more. The following example logs the user in with a dedicated username and password. It then installs and activates the Gutenberg plugin. [Learn more about steps](/blueprints/steps). -->
+
+Probablemente la propiedad más potente, `steps` te permite configurar la
+instancia de Playground con temas, plugins, contenido de demo y mucho más ya
+instalado. El siguiente ejemplo inicia sesión con un nombre de usuario y una
+contraseña dedicados. Luego instala y activa el plugin Gutenberg.
+[Aprende más sobre las etapas](/blueprints/steps).
+
+```js
+{
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "gutenberg"
+			}
+		},
+	]
+}
+```
+
+<!-- ## Common property placement mistakes -->
+
+## Errores comunes de ubicación de propiedades
+
+<!--
+Blueprint validation errors often come from putting a valid property in the
+wrong object.
+-->
+
+Los errores de validación de Blueprint a menudo aparecen al colocar una
+propiedad válida en el objeto equivocado.
+
+<!-- ### Activate a plugin or theme -->
+
+### Activar un plugin o tema
+
+<!--
+`activate` belongs inside `options`, not inside `pluginData`, `themeData`, or
+directly on the step.
+-->
+
+`activate` debe estar dentro de `options`, no dentro de `pluginData`,
+`themeData` ni directamente en la etapa.
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "gutenberg"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!-- ### Install plugins with the shorthand -->
+
+### Instalar plugins con el atajo
+
+<!--
+The `plugins` shorthand is a top-level Blueprint property. Do not put it inside
+`preferredVersions`.
+-->
+
+El atajo `plugins` es una propiedad de nivel superior de Blueprint. No lo
+coloques dentro de `preferredVersions`.
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["gutenberg"]
+}
+```
+
+<!-- ### Use one plugin install shape -->
+
+### Usar una sola forma de instalación de plugin
+
+<!--
+For an `installPlugin` step, use `pluginData`. Do not mix `pluginData` with
+older examples or custom objects such as `pluginZipFile`.
+-->
+
+Para una etapa `installPlugin`, usa `pluginData`. No mezcles `pluginData` con
+ejemplos antiguos u objetos personalizados como `pluginZipFile`.
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!--
+The `wordpress.org/plugins` resource needs a separate `slug`. Do not write the
+slug into the `resource` value, such as `"wordpress.org/plugins/woocommerce"`.
+-->
+
+El recurso `wordpress.org/plugins` necesita un `slug` separado. No escribas el
+slug dentro del valor de `resource`, como `"wordpress.org/plugins/woocommerce"`.
+
+<!-- ### Keep `preferredVersions` limited to versions -->
+
+### Mantener `preferredVersions` limitado a versiones
+
+<!--
+`preferredVersions` only accepts `php` and `wp`. Use `features` for networking,
+`plugins` or `installPlugin` for plugins, and `steps` for ordered setup tasks.
+-->
+
+`preferredVersions` solo acepta `php` y `wp`. Usa `features` para networking,
+`plugins` o `installPlugin` para plugins, y `steps` para tareas de configuración
+ordenadas.
+
+<!-- ### Use explicit steps when order matters -->
+
+### Usar etapas explícitas cuando importa el orden
+
+<!--
+Shorthands such as `plugins`, `login`, `siteOptions`, and `constants` are
+expanded before the `steps` array. If one action must happen before another,
+write both actions as explicit steps in the order you need.
+-->
+
+Atajos como `plugins`, `login`, `siteOptions` y `constants` se expanden antes
+del array `steps`. Si una acción debe ocurrir antes que otra, escribe ambas
+acciones como etapas explícitas en el orden que necesitas.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/04-resources.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/04-resources.md
@@ -1,0 +1,357 @@
+---
+slug: /blueprints/steps/resources
+description: Una referencia técnica para "Referencias de recursos". Aprende a usar archivos externos para temas, plugins y contenido.
+---
+
+<!-- description: A technical reference for "Resource References." Learn how to use external files for themes, plugins, and content. -->
+
+<!-- # Resources References -->
+
+# Referencias de recursos
+
+<!-- "Resource References" allow you use external files in Blueprints -->
+
+Las "Referencias de recursos" te permiten usar archivos externos en Blueprints
+
+<div class="callout callout-info">
+
+<!-- Blueprint steps such as [`installPlugin`](/blueprints/steps) or [`installTheme`](/blueprints/steps) require a location of the plugin or theme to be installed. -->
+
+Las etapas de Blueprint como [`installPlugin`](/blueprints/steps) o [`installTheme`](/blueprints/steps) requieren una ubicación del plugin o tema que se va a instalar.
+
+<!-- That location can be defined as [a `URL` resource](#urlreference) of the `.zip` file containing the theme or plugin. It can also be defined as a [`wordpress.org/plugins`](#corepluginreference) or [`wordpress.org/themes`](#corethemereference) resource for those plugins/themes published in the official WordPress directories. -->
+
+Esa ubicación puede definirse como un [recurso `URL`](#urlreference) del archivo `.zip` que contiene el tema o plugin. También puede definirse como un recurso [`wordpress.org/plugins`](#corepluginreference) o [`wordpress.org/themes`](#corethemereference) para esos plugins/temas publicados en los directorios oficiales de WordPress.
+
+</div>
+
+<!-- The following resource references are available: -->
+
+Están disponibles las siguientes referencias de recursos:
+
+import TOCInline from '@theme/TOCInline';
+
+<TOCInline toc={toc} />
+
+<!-- ### URLReference -->
+
+### URLReference
+
+<!-- The `URLReference` resource is used to reference files that are stored on a remote server. The `URLReference` resource is defined as follows: -->
+
+El recurso `URLReference` se usa para referenciar archivos almacenados en un
+servidor remoto. El recurso `URLReference` se define así:
+
+```typescript
+type URLReference = {
+	resource: 'url';
+	url: string;
+};
+```
+
+<!-- To use the `URLReference` resource, you need to provide the URL of the file. For example, to reference a file named "index.html" that is stored on a remote server, you can create a `URLReference` as follows: -->
+
+Para usar el recurso `URLReference`, debes proporcionar la URL del archivo. Por
+ejemplo, para referenciar un archivo llamado "index.html" almacenado en un
+servidor remoto, puedes crear un `URLReference` así:
+
+```json
+{
+	"resource": "url",
+	"url": "https://example.com/index.html"
+}
+```
+
+<!--
+The `url` resource works with Blueprint steps such as [`installPlugin`](/blueprints/steps) or
+[`installTheme`](/blueprints/steps).
+These steps require a `ResourceType` to define the location of the plugin or the theme to install.
+-->
+
+El recurso `url` funciona con etapas de Blueprint como [`installPlugin`](/blueprints/steps) o
+[`installTheme`](/blueprints/steps).
+Estas etapas requieren un `ResourceType` para definir la ubicación del plugin o
+tema que se instalará.
+
+<!-- With a `"resource": "url"` we can define the location of a `.zip` containing the plugin/theme. Use this for built ZIP artifacts hosted on a publicly accessible URL that does not require authentication, such as a release asset. CI artifact direct-download URLs can work, but they are often short-lived or restricted. -->
+
+Con `"resource": "url"` podemos definir la ubicación de un `.zip` que contiene
+el plugin/tema. Usa esto para artifacts ZIP ya creados y alojados en una URL
+públicamente accesible que no requiera autenticación, como un asset de release.
+Las URL de descarga directa de artifacts de CI pueden funcionar, pero a menudo
+son de corta duración o están restringidas.
+
+<!-- For source code stored in a Git repository, prefer [`git:directory`](/blueprints/steps/resources#gitdirectoryreference). It can fetch a repository subdirectory from a branch, tag, or commit without requiring a ZIP archive. -->
+
+Para código fuente almacenado en un repositorio Git, prefiere
+[`git:directory`](/blueprints/steps/resources#gitdirectoryreference). Puede
+obtener un subdirectorio del repositorio desde una rama, etiqueta o commit sin
+requerir un archivo ZIP.
+
+<!-- Before using a `url` resource, verify that the URL: -->
+
+Antes de usar un recurso `url`, verifica que la URL:
+
+<!--
+- Downloads the file directly. It must not return an HTML page, redirect warning, login page, repository file viewer, or proxy error page.
+- Is available without cookies, authentication, a VPN, or a temporary browser session.
+- Sends CORS headers that allow Playground to fetch it.
+- Points to the expected file type. `installPlugin` and `installTheme` need a plugin or theme ZIP archive unless you use another resource type.
+- Will remain available. Temporary tunnel URLs, draft release assets, and short-lived CI artifacts can expire.
+- Is a real ZIP archive when the step expects a ZIP. Very small downloads often mean the server returned an HTML error page instead of the archive.
+-->
+
+- Descargue el archivo directamente. No debe devolver una página HTML, aviso de redirección, página de inicio de sesión, visor de archivo de repositorio o página de error de proxy.
+- Esté disponible sin cookies, autenticación, VPN o una sesión temporal del navegador.
+- Envíe encabezados CORS que permitan que Playground la obtenga.
+- Apunte al tipo de archivo esperado. `installPlugin` e `installTheme` necesitan un archivo ZIP de plugin o tema, a menos que uses otro tipo de recurso.
+- Permanezca disponible. Las URL temporales de túnel, los assets de release en borrador y los artifacts de CI de corta duración pueden expirar.
+- Sea un archivo ZIP real cuando la etapa espere un ZIP. Las descargas muy pequeñas a menudo significan que el servidor devolvió una página HTML de error en lugar del archivo.
+
+<!--
+For GitHub source code, do not point `url` at a repository page or a generated
+ZIP from a branch when you can use `git:directory`. Use `url` for built ZIP
+artifacts and `git:directory` for source directories.
+-->
+
+Para código fuente de GitHub, no apuntes `url` a una página del repositorio ni
+a un ZIP generado desde una rama cuando puedes usar `git:directory`. Usa `url`
+para artifacts ZIP creados y `git:directory` para directorios de código fuente.
+
+<!-- ### GitDirectoryReference -->
+
+### GitDirectoryReference
+
+<!-- The `GitDirectoryReference` resource is used to reference a directory inside a Git repository. This is useful when a plugin or theme lives in a subfolder of a repo, or when you want to install from a specific branch, tag, or commit. -->
+
+El recurso `GitDirectoryReference` se usa para referenciar un directorio dentro
+de un repositorio Git. Esto es útil cuando un plugin o tema vive en una
+subcarpeta de un repositorio, o cuando quieres instalar desde una rama, etiqueta
+o commit específico.
+
+```typescript
+type GitDirectoryReference = {
+	resource: 'git:directory';
+	url: string; // Repository URL (https://, ssh git@..., etc.)
+	path?: string; // Optional subdirectory inside the repository
+	ref?: string; // Branch, tag, or commit SHA (defaults to HEAD)
+	refType?: 'branch' | 'tag' | 'commit'; // Hint for resolving the ref
+	'.git'?: boolean; // Experimental: include a .git directory with fetched metadata
+};
+```
+
+<!-- **Example:** -->
+
+**Ejemplo:**
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "git:directory",
+		"url": "https://github.com/WordPress/block-development-examples",
+		"ref": "HEAD",
+		"path": "plugins/data-basics-59c8f8"
+	},
+	"options": {
+		"activate": true,
+		"targetFolderName": "data-basics"
+	}
+}
+```
+
+<!-- **Notes:** -->
+
+**Notas:**
+
+<!--
+- When using a branch or tag name for `ref`, you must specify `refType` (e.g. `"refType": "branch"`). Without it, only `HEAD` is reliably resolved.
+- Playground automatically detects providers like GitHub and GitLab.
+- Repository URLs may include or omit a trailing `.git` suffix. Extra trailing slashes are ignored.
+- It handles CORS-proxied fetches and sparse checkouts, so you can use URLs that point to specific subdirectories or branches.
+- This resource can be used with steps like [`installPlugin`](/blueprints/steps) and [`installTheme`](/blueprints/steps).
+- Set `".git": true` to include a `.git` folder containing packfiles and refs so Git-aware tooling can detect the checkout. This currently mirrors a shallow clone of the selected ref.
+- The folder name is derived from the URL by default (e.g. `https-github-com-WordPress-block-development-examples-HEAD-at-plugins-data-basics-59c8f8`). Use `options.targetFolderName` in the step to override it, as shown in the example above.
+-->
+
+- Al usar un nombre de rama o etiqueta para `ref`, debes especificar `refType` (por ejemplo, `"refType": "branch"`). Sin eso, solo `HEAD` se resuelve de forma fiable.
+- Playground detecta automáticamente proveedores como GitHub y GitLab.
+- Las URL de repositorio pueden incluir u omitir el sufijo final `.git`. Las barras finales extra se ignoran.
+- Maneja solicitudes con proxy CORS y checkouts dispersos, por lo que puedes usar URL que apuntan a subdirectorios o ramas específicos.
+- Este recurso puede usarse con etapas como [`installPlugin`](/blueprints/steps) e [`installTheme`](/blueprints/steps).
+- Define `".git": true` para incluir una carpeta `.git` que contenga packfiles y refs, de modo que herramientas compatibles con Git puedan detectar el checkout. Actualmente esto refleja un clon superficial del ref seleccionado.
+- El nombre de la carpeta se deriva de la URL por defecto (por ejemplo, `https-github-com-WordPress-block-development-examples-HEAD-at-plugins-data-basics-59c8f8`). Usa `options.targetFolderName` en la etapa para sobrescribirlo, como se muestra en el ejemplo anterior.
+
+<!-- ### CoreThemeReference -->
+
+### CoreThemeReference
+
+<!-- The _CoreThemeReference_ resource is used to reference WordPress core themes. The _CoreThemeReference_ resource is defined as follows: -->
+
+El recurso _CoreThemeReference_ se usa para referenciar temas principales de
+WordPress. El recurso _CoreThemeReference_ se define así:
+
+```typescript
+type CoreThemeReference = {
+	resource: 'wordpress.org/themes';
+	slug: string;
+	version?: string;
+};
+```
+
+<!-- To use the _CoreThemeReference_ resource, you need to provide the slug of the theme. For example, to reference the "Twenty Twenty-One" theme, you can create a _CoreThemeReference_ as follows: -->
+
+Para usar el recurso _CoreThemeReference_, debes proporcionar el slug del tema.
+Por ejemplo, para referenciar el tema "Twenty Twenty-One", puedes crear un
+_CoreThemeReference_ así:
+
+```json
+{
+	"resource": "wordpress.org/themes",
+	"slug": "twentytwentyone"
+}
+```
+
+<!-- ### CorePluginReference -->
+
+### CorePluginReference
+
+<!-- The _CorePluginReference_ resource is used to reference WordPress core plugins. The _CorePluginReference_ resource is defined as follows: -->
+
+El recurso _CorePluginReference_ se usa para referenciar plugins principales de
+WordPress. El recurso _CorePluginReference_ se define así:
+
+```typescript
+type CorePluginReference = {
+	resource: 'wordpress.org/plugins';
+	slug: string;
+	version?: string;
+};
+```
+
+<!-- To use the _CorePluginReference_ resource, you need to provide the slug of the plugin. For example, to reference the "Akismet" plugin, you can create a _CorePluginReference_ as follows: -->
+
+Para usar el recurso _CorePluginReference_, debes proporcionar el slug del
+plugin. Por ejemplo, para referenciar el plugin "Akismet", puedes crear un
+_CorePluginReference_ así:
+
+```json
+{
+	"resource": "wordpress.org/plugins",
+	"slug": "akismet"
+}
+```
+
+<!-- ### VFSReference -->
+
+### VFSReference
+
+<!-- The _VFSReference_ resource is used to reference files that are stored in a virtual file system (VFS). The VFS is a file system that is stored in memory and can be used to store files that are not part of the file system of the operating system. The _VFSReference_ resource is defined as follows: -->
+
+El recurso _VFSReference_ se usa para referenciar archivos almacenados en un
+sistema de archivos virtual (VFS). El VFS es un sistema de archivos almacenado
+en memoria y puede usarse para almacenar archivos que no forman parte del
+sistema de archivos del sistema operativo. El recurso _VFSReference_ se define
+así:
+
+```typescript
+type VFSReference = {
+	resource: 'vfs';
+	path: string;
+};
+```
+
+<!-- To use the _VFSReference_ resource, you need to provide the path to the file in the VFS. For example, to reference a file named "index.html" that is stored in the root of the VFS, you can create a _VFSReference_ as follows: -->
+
+Para usar el recurso _VFSReference_, debes proporcionar la ruta al archivo en
+el VFS. Por ejemplo, para referenciar un archivo llamado "index.html" almacenado
+en la raíz del VFS, puedes crear un _VFSReference_ así:
+
+```json
+{
+	"resource": "vfs",
+	"path": "/index.html"
+}
+```
+
+<!-- ### LiteralReference -->
+
+### LiteralReference
+
+<!-- The _LiteralReference_ resource is used to reference files that are stored as literals in the code. The _LiteralReference_ resource is defined as follows: -->
+
+El recurso _LiteralReference_ se usa para referenciar archivos almacenados como
+literales en el código. El recurso _LiteralReference_ se define así:
+
+```typescript
+type LiteralReference = {
+	resource: 'literal';
+	name: string;
+	contents: string | Uint8Array;
+};
+```
+
+<!-- To use the _LiteralReference_ resource, you need to provide the name of the file and its contents. For example, to reference a file named "index.html" that contains the text "Hello, World!", you can create a _LiteralReference_ as follows: -->
+
+Para usar el recurso _LiteralReference_, debes proporcionar el nombre del
+archivo y su contenido. Por ejemplo, para referenciar un archivo llamado
+"index.html" que contiene el texto "Hello, World!", puedes crear un
+_LiteralReference_ así:
+
+```json
+{
+	"resource": "literal",
+	"name": "index.html",
+	"contents": "Hello, World!"
+}
+```
+
+<!-- ### BundledReference -->
+
+### BundledReference
+
+<!-- The `BundledReference` resource is used to reference files that are bundled with the Blueprint itself. This is particularly useful for creating self-contained Blueprint bundles that include all necessary resources. The `BundledReference` resource is defined as follows: -->
+
+El recurso `BundledReference` se usa para referenciar archivos incluidos en el
+propio Blueprint. Esto es especialmente útil para crear paquetes de Blueprint
+autocontenidos que incluyen todos los recursos necesarios. El recurso
+`BundledReference` se define así:
+
+```typescript
+type BundledReference = {
+	resource: 'bundled';
+	path: string;
+};
+```
+
+<!-- To use the `BundledReference` resource, you need to provide the relative path to the file within the bundle. For example, to reference a file named "plugin.php" that is bundled with the Blueprint, you can create a `BundledReference` as follows: -->
+
+Para usar `BundledReference`, debes proporcionar la ruta relativa al archivo
+dentro del paquete. Por ejemplo, para referenciar un archivo llamado
+"plugin.php" incluido con el Blueprint, puedes crear un `BundledReference` así:
+
+```json
+{
+	"resource": "bundled",
+	"path": "plugin.php"
+}
+```
+
+<!-- Blueprint bundles can be distributed in various formats, including: -->
+
+Los paquetes de Blueprint pueden distribuirse en varios formatos, incluidos:
+
+<!--
+- ZIP files with a top-level `blueprint.json` file
+- Directories containing a `blueprint.json` file and related resources
+- Remote URLs where the Blueprint and its resources are hosted together
+-->
+
+- Archivos ZIP con un archivo `blueprint.json` de nivel superior
+- Directorios que contienen un archivo `blueprint.json` y recursos relacionados
+- URL remotas donde el Blueprint y sus recursos están alojados juntos
+
+<!-- For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation. -->
+
+Para más información sobre paquetes de Blueprint, consulta la documentación de
+[Paquetes de Blueprint](/blueprints/bundles).

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -1,263 +1,946 @@
 ---
 title: Solucionar problemas y depurar
 slug: /blueprints/troubleshoot-and-debug
-description: Una guía con consejos y herramientas para ayudarte a solucionar problemas y depurar tus Blueprints, desde problemas comunes hasta herramientas del navegador.
+description: Una guía fácil de buscar para errores comunes de Blueprint, incluidas fallas de carga, errores de validación, fallas de PHP y problemas de activación de plugins.
 ---
 
-<!--
-title: Troubleshoot and debug
-description: A guide with tips and tools to help you troubleshoot and debug your Blueprints, from common issues to browser tools.
--->
+<!-- title: Troubleshoot and debug -->
 
-<!--
-# Troubleshoot and debug Blueprints
--->
+<!-- description: A searchable guide to common Blueprint errors, including fetch failures, validation errors, PHP failures, and plugin activation issues. -->
+
+<!-- # Troubleshoot and debug Blueprints -->
 
 # Solucionar problemas y depurar Blueprints
 
-<!--
-When you build Blueprints, you might run into issues. Here are tips and tools to help you debug them:
--->
+<!-- Blueprint errors usually point to one of three places: -->
 
-Cuando creas Blueprints, puedes encontrarte con problemas. Aquí tienes consejos y herramientas para ayudarte a depurarlos:
+Los errores de Blueprint suelen apuntar a uno de estos tres lugares:
 
 <!--
-## Review Common gotchas
+- The Blueprint JSON is invalid.
+- Playground could not fetch the Blueprint or one of its resources.
+- A Blueprint step ran, but WordPress, PHP, WP-CLI, or a plugin failed.
 -->
 
-## Revisa problemas comunes
+- El JSON del Blueprint no es válido.
+- Playground no pudo obtener el Blueprint o uno de sus recursos.
+- Una etapa del Blueprint se ejecutó, pero falló WordPress, PHP, WP-CLI o un plugin.
 
 <!--
-- Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you’d need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('wordpress/wp-load.php'); REST_OF_YOUR_CODE"`.
+Start with the exact error name shown by Playground, then use the matching
+section below.
 -->
 
-- Requiere `wp-load`: para ejecutar una función PHP de WordPress usando el paso `runPHP`, tendrás que requerir [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). Por eso, el valor de la clave `code` debe empezar con `"<?php require_once('wordpress/wp-load.php'); RESTO_DE_TU_CÓDIGO"`.
+Empieza con el nombre exacto del error que muestra Playground y usa la sección
+correspondiente a continuación.
+
+<!-- ## Quick checklist -->
+
+## Lista de verificación rápida
 
 <!--
-## Common Issues and Solutions
+- Paste the Blueprint into the [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to validate the JSON schema.
+- If the Blueprint is loaded from a URL, open that URL directly in a private browser window and confirm it downloads valid JSON or a Blueprint ZIP bundle.
+- If a step fails, note the step number in `BlueprintStepExecutionError`. The failed step is usually the item at that position after Blueprint shorthands have been expanded.
+- Open browser developer tools and check the Console and Network tabs for download, CORS, PHP, or plugin activation details.
+- For plugin/theme activation failures, check the Playground **Logs** panel or the browser console for PHP warnings and fatal errors.
 -->
 
-## Problemas comunes y soluciones
+- Pega el Blueprint en el [editor de Blueprints](https://playground.wordpress.net/builder/builder.html) para validar el esquema JSON.
+- Si el Blueprint se carga desde una URL, abre esa URL directamente en una ventana privada del navegador y confirma que descarga JSON válido o un paquete ZIP de Blueprint.
+- Si falla una etapa, anota el número de etapa en `BlueprintStepExecutionError`. La etapa fallida suele ser el elemento en esa posición después de que se hayan expandido los atajos de Blueprint.
+- Abre las herramientas de desarrollo del navegador y revisa las pestañas Console y Network para ver detalles de descarga, CORS, PHP o activación de plugins.
+- Para fallas de activación de plugin/tema, revisa el panel **Logs** de Playground o la consola del navegador para ver advertencias y errores fatales de PHP.
+
+<!-- ## InvalidBlueprintError -->
+
+## InvalidBlueprintError
 
 <!--
-### Invalid Blueprint After Opening a Link
+`InvalidBlueprintError` means the Blueprint does not match the
+[Blueprint data format](/blueprints/data-format). The error output usually
+contains paths such as `/steps/2/pluginData` or `/preferredVersions`.
 -->
 
-### Blueprint no válido después de abrir un enlace
+`InvalidBlueprintError` significa que el Blueprint no coincide con el
+[formato de datos de Blueprint](/blueprints/data-format). La salida del error
+suele contener rutas como `/steps/2/pluginData` o `/preferredVersions`.
+
+<!-- ### Unexpected property `activate` -->
+
+### Propiedad inesperada `activate`
 
 <!--
-If Playground reports `Invalid blueprint`, read the detailed error message. It includes the underlying JSON parsing error when one is available.
+`activate` belongs inside `options`, not directly on the step or inside
+`pluginData`.
 -->
 
-Si Playground informa `Invalid blueprint`, lee el mensaje de error detallado. Incluye el error de análisis JSON subyacente cuando está disponible.
-
-<!--
-If the message says the input still contains `%XX` escapes after decoding, the URL fragment was likely double-encoded. Rebuild the link from the original Blueprint object and encode it once with `encodeURIComponent(JSON.stringify(blueprint))`, or use Base64. Do not encode a fragment that is already encoded.
--->
-
-Si el mensaje dice que la entrada todavía contiene secuencias de escape `%XX` después de decodificarla, es probable que el fragmento de URL se haya codificado dos veces. Reconstruye el enlace a partir del objeto Blueprint original y codifícalo una sola vez con `encodeURIComponent(JSON.stringify(blueprint))`, o usa Base64. No codifiques un fragmento que ya esté codificado.
-
-<!--
-### WP-CLI: Error Establishing a Database Connection on Mounted Sites
--->
-
-### WP-CLI: error al establecer una conexión con la base de datos en sitios montados {#wp-cli-error-establishing-a-database-connection-on-mounted-sites}
-
-<!--
-When using `wp-cli` with a mounted Playground site (e.g., via `--mount-before-install`), you might encounter an "Error establishing a database connection." This happens because WordPress Playground loads the SQLite database integration plugin from its internal files by default, not from the mounted directory, meaning it's not persisted for external `wp-cli` calls.
--->
-
-Al usar `wp-cli` con un sitio Playground montado (por ejemplo, mediante `--mount-before-install`), puedes encontrar un mensaje de "Error establishing a database connection". Esto ocurre porque WordPress Playground carga por defecto el plugin de integración de base de datos SQLite desde sus archivos internos, no desde el directorio montado, lo que significa que no se conserva para llamadas externas de `wp-cli`.
-
-<!--
-To resolve this, you need to explicitly install and configure the SQLite database integration plugin within your Blueprint.
--->
-
-Para resolverlo, debes instalar y configurar explícitamente el plugin de integración de base de datos SQLite dentro de tu Blueprint.
-
-<!--
-**Solution:** Add the following steps to your Blueprint:
--->
-
-**Solución:** añade los siguientes pasos a tu Blueprint:
+`activate` debe estar dentro de `options`, no directamente en la etapa ni dentro
+de `pluginData`.
 
 ```json
 {
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!-- ### Unexpected property `plugins` in `preferredVersions` -->
+
+### Propiedad inesperada `plugins` en `preferredVersions`
+
+<!--
+`preferredVersions` only accepts `php` and `wp`. Install plugins with the
+top-level `plugins` shorthand or with an explicit `installPlugin` step.
+-->
+
+`preferredVersions` solo acepta `php` y `wp`. Instala plugins con el atajo
+`plugins` de nivel superior o con una etapa explícita `installPlugin`.
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
 	"plugins": ["sqlite-database-integration"]
 }
 ```
 
+<!-- ### Missing `slug`, `url`, `path`, or `files` -->
+
+### Falta `slug`, `url`, `path` o `files`
+
+<!-- The resource object is incomplete or uses the wrong shape. Common fixes: -->
+
+El objeto de recurso está incompleto o usa la forma incorrecta. Correcciones
+comunes:
+
 <!--
-**Example Usage:**
+- WordPress.org plugin: `{ "resource": "wordpress.org/plugins", "slug": "akismet" }`
+- ZIP URL: `{ "resource": "url", "url": "https://example.com/plugin.zip" }`
+- Git directory: `{ "resource": "git:directory", "url": "https://github.com/org/repo", "ref": "trunk", "refType": "branch" }`
 -->
 
-**Ejemplo de uso:**
+- Plugin de WordPress.org: `{ "resource": "wordpress.org/plugins", "slug": "akismet" }`
+- URL de ZIP: `{ "resource": "url", "url": "https://example.com/plugin.zip" }`
+- Directorio Git: `{ "resource": "git:directory", "url": "https://github.com/org/repo", "ref": "trunk", "refType": "branch" }`
 
 <!--
-To test this locally, combine the Blueprint with your Playground CLI command:
+See [Resources References](/blueprints/steps/resources) for all supported
+resource shapes.
 -->
 
-Para probarlo localmente, combina el Blueprint con tu comando de Playground CLI:
+Consulta [Referencias de recursos](/blueprints/steps/resources) para ver todas
+las formas de recurso compatibles.
 
-```bash
-mkdir wordpress
-# Ensure your blueprint with the above steps is saved as, for example, './blueprint.json'
-npx @wp-playground/cli server --mount-before-install=wordpress:/wordpress --blueprint=./blueprint.json
-cd wordpress
-wp post list
+<!-- ### Mixed plugin install properties -->
+
+### Propiedades mixtas de instalación de plugin
+
+<!--
+Use `pluginData` for `installPlugin`. Do not provide both `pluginData` and
+older examples or custom objects such as `pluginZipFile`.
+-->
+
+Usa `pluginData` para `installPlugin`. No proporciones `pluginData` junto con
+ejemplos antiguos u objetos personalizados como `pluginZipFile`.
+
+<!-- The WordPress.org plugin resource also needs a separate `slug`: -->
+
+El recurso de plugin de WordPress.org también necesita un `slug` separado:
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	}
+}
+```
+
+<!-- Do not write `"resource": "wordpress.org/plugins/woocommerce"`. -->
+
+No escribas `"resource": "wordpress.org/plugins/woocommerce"`.
+
+<!-- ## BlueprintFetchError -->
+
+## BlueprintFetchError
+
+<!--
+`BlueprintFetchError` means Playground could not load the file passed to
+`?blueprint-url=`.
+-->
+
+`BlueprintFetchError` significa que Playground no pudo cargar el archivo pasado
+a `?blueprint-url=`.
+
+<!-- Check that the URL: -->
+
+Comprueba que la URL:
+
+<!--
+- Is public and does not require cookies, login, a temporary session, or a VPN.
+- Returns HTTP 200 when opened directly.
+- Serves valid JSON or a ZIP bundle with `blueprint.json` inside it.
+- Sends `Access-Control-Allow-Origin: *` or another header that allows
+  `https://playground.wordpress.net`.
+- Uses a raw file URL, not a repository HTML page.
+-->
+
+- Sea pública y no requiera cookies, inicio de sesión, una sesión temporal o una VPN.
+- Devuelva HTTP 200 al abrirse directamente.
+- Sirva JSON válido o un paquete ZIP con `blueprint.json` dentro.
+- Envíe `Access-Control-Allow-Origin: *` u otro encabezado que permita
+  `https://playground.wordpress.net`.
+- Use una URL de archivo sin procesar, no una página HTML de repositorio.
+
+<!--
+For GitHub, use `raw.githubusercontent.com` URLs instead of `github.com/.../blob/...`.
+For GitLab, use the raw file URL instead of a `/-/blob/` page.
+-->
+
+Para GitHub, usa URL de `raw.githubusercontent.com` en lugar de `github.com/.../blob/...`.
+Para GitLab, usa la URL del archivo sin procesar en lugar de una página `/-/blob/`.
+
+```text
+# Good
+https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/welcome/blueprint.json
+
+# Not a raw JSON response
+https://github.com/WordPress/blueprints/blob/trunk/blueprints/welcome/blueprint.json
 ```
 
 <!--
-This will ensure the SQLite plugin is installed correctly and configured within your mounted WordPress site, allowing `wp-cli` commands to function correctly.
+Temporary tunnel URLs, local development URLs, and draft release assets often
+fail because the browser cannot reach them or because they do not allow
+cross-origin requests. Move the Blueprint to a public host with CORS enabled.
 -->
 
-Esto garantiza que el plugin SQLite se instale correctamente y se configure dentro de tu sitio WordPress montado, lo que permite que los comandos `wp-cli` funcionen correctamente.
+Las URL temporales de túnel, las URL de desarrollo local y los assets de release
+en borrador suelen fallar porque el navegador no puede acceder a ellos o porque
+no permiten solicitudes de origen cruzado. Mueve el Blueprint a un alojamiento
+público con CORS activado.
+
+<!-- ### Blueprint file is neither a valid JSON nor a ZIP file -->
+
+### El archivo de Blueprint no es JSON válido ni un archivo ZIP
 
 <!--
-## Blueprints Builder
+This means Playground received a response, but the response was not a Blueprint.
+The URL may have returned an HTML page, 404 page, repository file viewer, proxy
+warning, login page, or corrupted ZIP.
 -->
 
-## Constructor de Blueprints
+Esto significa que Playground recibió una respuesta, pero la respuesta no era
+un Blueprint. La URL puede haber devuelto una página HTML, una página 404, un
+visor de archivo de repositorio, una advertencia de proxy, una página de inicio
+de sesión o un ZIP corrupto.
+
+<!-- Open the URL directly and check that: -->
+
+Abre la URL directamente y comprueba que:
 
 <!--
-You can use an in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to build, validate, and preview your Blueprints in the browser.
+- JSON URLs return valid Blueprint JSON.
+- ZIP bundle URLs download a real ZIP archive.
+- Blueprint bundles contain `blueprint.json` at the root of the ZIP.
+- The response is not a small HTML or text error page.
 -->
 
-Puedes usar un [editor de Blueprints](https://playground.wordpress.net/builder/builder.html) en el navegador para crear, validar y previsualizar tus Blueprints.
+- Las URL JSON devuelvan JSON de Blueprint válido.
+- Las URL de paquete ZIP descarguen un archivo ZIP real.
+- Los paquetes de Blueprint contengan `blueprint.json` en la raíz del ZIP.
+- La respuesta no sea una pequeña página HTML o de texto de error.
+
+<!-- ### URIError: URI malformed -->
+
+### URIError: URI malformed
+
+<!--
+`URIError: URI malformed` usually points to a broken encoded Blueprint fragment
+in the URL, not to a failed Blueprint step. Check for invalid `%` escapes,
+double-encoded fragments, or raw JSON pasted after `#`. Rebuild the link from
+the original Blueprint and encode it once, or use Base64. See
+[Encoded Blueprint fragments](/blueprints/using-blueprints).
+-->
+
+`URIError: URI malformed` suele indicar un fragmento de Blueprint codificado
+incorrectamente en la URL, no una etapa de Blueprint fallida. Revisa escapes
+`%` inválidos, fragmentos codificados dos veces o JSON sin procesar pegado
+después de `#`. Reconstruye el enlace desde el Blueprint original y codifícalo
+una vez, o usa Base64. Consulta
+[Fragmentos de Blueprint codificados](/blueprints/using-blueprints).
+
+<!-- ## ResourceDownloadError -->
+
+## ResourceDownloadError
+
+<!--
+`ResourceDownloadError` means the Blueprint loaded, but a step could not download
+a resource such as a plugin ZIP, theme ZIP, WXR file, or imported site archive.
+-->
+
+`ResourceDownloadError` significa que el Blueprint cargó, pero una etapa no
+pudo descargar un recurso como un ZIP de plugin, ZIP de tema, archivo WXR o
+archivo de sitio importado.
+
+<!-- Confirm the resource URL: -->
+
+Confirma que la URL del recurso:
+
+<!--
+- Downloads the actual file, not an HTML page, redirect warning, or expired artifact.
+- Is public and does not require authentication.
+- Allows cross-origin requests.
+- Is the direct file URL. Some release pages and CI artifact pages are human pages, not direct downloads.
+- Still exists. Temporary links and CI artifacts can expire.
+-->
+
+- Descarga el archivo real, no una página HTML, advertencia de redirección o artifact expirado.
+- Es pública y no requiere autenticación.
+- Permite solicitudes de origen cruzado.
+- Es la URL directa del archivo. Algunas páginas de release y páginas de artifacts de CI son páginas para personas, no descargas directas.
+- Todavía existe. Los enlaces temporales y los artifacts de CI pueden expirar.
+
+<!--
+For source code in a Git repository, prefer a
+[`git:directory` resource](/blueprints/steps/resources#gitdirectoryreference).
+Use a `url` resource for built ZIP artifacts that are already publicly
+downloadable.
+-->
+
+Para código fuente en un repositorio Git, prefiere un
+[recurso `git:directory`](/blueprints/steps/resources#gitdirectoryreference).
+Usa un recurso `url` para artifacts ZIP ya creados que estén disponibles
+públicamente para descarga.
+
+<!-- ## BlueprintStepExecutionError -->
+
+## BlueprintStepExecutionError
+
+<!--
+`BlueprintStepExecutionError` means a specific step failed after the Blueprint
+started running. The message includes a step number:
+-->
+
+`BlueprintStepExecutionError` significa que una etapa específica falló después
+de que el Blueprint empezó a ejecutarse. El mensaje incluye un número de etapa:
+
+```text
+BlueprintStepExecutionError: Error when executing the blueprint step #4
+```
+
+<!--
+Use that number to inspect the matching step. If your Blueprint uses shorthands
+such as `plugins`, `login`, `siteOptions`, or `constants`, Playground expands
+them into steps before running the Blueprint. Use explicit `steps` when the
+order matters.
+-->
+
+Usa ese número para inspeccionar la etapa correspondiente. Si tu Blueprint usa
+atajos como `plugins`, `login`, `siteOptions` o `constants`, Playground los
+expande en etapas antes de ejecutar el Blueprint. Usa `steps` explícitas cuando
+el orden importe.
+
+<!--
+URL query parameters such as `?plugin=...`, `?theme=...`, `?php=...`,
+`?wp=...`, and `?networking=yes` also create an implicit Blueprint. Errors from
+those URLs are still Blueprint execution errors, and the generated steps affect
+the reported step number.
+-->
+
+Los parámetros de consulta de URL como `?plugin=...`, `?theme=...`, `?php=...`,
+`?wp=...` y `?networking=yes` también crean un Blueprint implícito. Los errores
+de esas URL siguen siendo errores de ejecución de Blueprint, y las etapas
+generadas afectan al número de etapa informado.
+
+<!-- ## PHP.run() failed with exit code 255 -->
+
+## PHP.run() failed with exit code 255
+
+<!--
+Exit code `255` usually means PHP hit a fatal error. Look for the first
+`Fatal error`, `Uncaught`, or `TypeError` line in the output. The large HTML
+error page around it is usually WordPress's generic critical error screen.
+-->
+
+El código de salida `255` suele significar que PHP encontró un error fatal.
+Busca la primera línea `Fatal error`, `Uncaught` o `TypeError` en la salida. La
+gran página HTML de error que la rodea suele ser la pantalla genérica de error
+crítico de WordPress.
+
+<!--
+To make the output more useful while debugging, enable WordPress debug constants
+near the beginning of the Blueprint:
+-->
+
+Para hacer que la salida sea más útil durante la depuración, activa las
+constantes de depuración de WordPress cerca del inicio del Blueprint:
+
+```json
+{
+	"step": "defineWpConfigConsts",
+	"consts": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"WP_DISABLE_FATAL_ERROR_HANDLER": true
+	}
+}
+```
+
+<!--
+Then rerun the Blueprint and check the Playground **Logs** panel or browser
+console.
+-->
+
+Después vuelve a ejecutar el Blueprint y revisa el panel **Logs** de Playground
+o la consola del navegador.
+
+<!-- ## PHP.run() failed with exit code 1 -->
+
+## PHP.run() failed with exit code 1
+
+<!--
+Exit code `1` often appears when WP-CLI or WordPress returns an application
+error. Read the `Stderr` section first. It usually names the unsupported
+argument, missing resource, or command-specific failure.
+-->
+
+El código de salida `1` aparece a menudo cuando WP-CLI o WordPress devuelve un
+error de aplicación. Lee primero la sección `Stderr`. Normalmente indica el
+argumento no compatible, el recurso faltante o la falla específica del comando.
+
+<!--
+Some WP-CLI commands behave differently in Playground because WordPress runs in
+WebAssembly with SQLite. Keep commands small and test them individually before
+adding a long chain to a Blueprint.
+-->
+
+Algunos comandos WP-CLI se comportan de forma diferente en Playground porque
+WordPress se ejecuta en WebAssembly con SQLite. Mantén los comandos pequeños y
+pruébalos individualmente antes de añadir una cadena larga a un Blueprint.
+
+<!-- ## Undefined constant `ABSPATH` -->
+
+## Undefined constant `ABSPATH`
+
+<!--
+This usually happens in a `runPHP` step that calls WordPress APIs without first
+loading WordPress.
+-->
+
+Esto suele ocurrir en una etapa `runPHP` que llama a API de WordPress sin
+cargar primero WordPress.
+
+<!-- Add `wp-load.php` before any WordPress function, constant, option, or plugin API: -->
+
+Añade `wp-load.php` antes de cualquier función, constante, opción o API de
+plugin de WordPress:
+
+```json
+{
+	"step": "runPHP",
+	"code": "<?php require '/wordpress/wp-load.php'; update_option('blogname', 'Demo site');"
+}
+```
+
+<!-- ## Plugin could not be activated -->
+
+## Plugin could not be activated
+
+<!--
+Plugin activation errors usually come from the plugin itself, not from the
+Blueprint runner. Common causes:
+-->
+
+Los errores de activación de plugins suelen venir del propio plugin, no del
+ejecutor de Blueprints. Causas comunes:
+
+<!--
+- The plugin requires a newer PHP version or WordPress version.
+- The plugin has a fatal error on activation.
+- The plugin depends on another plugin that is not installed or activated.
+- The plugin performs a redirect or prints unexpected output during activation.
+- The plugin ZIP extracts to a folder or main file name different from the path the step is activating.
+-->
+
+- El plugin requiere una versión más reciente de PHP o WordPress.
+- El plugin tiene un error fatal durante la activación.
+- El plugin depende de otro plugin que no está instalado o activado.
+- El plugin realiza una redirección o imprime una salida inesperada durante la activación.
+- El ZIP del plugin se extrae a una carpeta o archivo principal con un nombre distinto de la ruta que la etapa está activando.
+
+<!--
+If the error says the current PHP or WordPress version does not meet minimum
+requirements, set `preferredVersions`:
+-->
+
+Si el error dice que la versión actual de PHP o WordPress no cumple los
+requisitos mínimos, define `preferredVersions`:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	}
+}
+```
+
+<!-- ### WordPress exited with exit code 0 -->
+
+### WordPress exited with exit code 0
+
+<!--
+Activation can fail even when WordPress exits with code `0`. This usually means
+WordPress returned an activation error response rather than a PHP process crash.
+When the message says `Inspect the "debug" logs`, check the Playground **Logs**
+panel, browser console, or CLI output.
+-->
+
+La activación puede fallar aunque WordPress salga con código `0`. Esto suele
+significar que WordPress devolvió una respuesta de error de activación en lugar
+de una caída del proceso PHP. Cuando el mensaje diga `Inspect the "debug" logs`,
+revisa el panel **Logs** de Playground, la consola del navegador o la salida de
+la CLI.
+
+<!--
+Look for PHP warnings, redirects or output printed during activation, missing
+dependency plugins, or plugin minimum PHP/WordPress requirements.
+-->
+
+Busca advertencias de PHP, redirecciones o salida impresa durante la activación,
+plugins de dependencia ausentes o requisitos mínimos de PHP/WordPress del plugin.
+
+<!-- ### Current PHP or WordPress version does not meet minimum requirements -->
+
+### Current PHP or WordPress version does not meet minimum requirements
+
+<!-- Version mismatch errors often include text like: -->
+
+Los errores de incompatibilidad de versión suelen incluir texto como:
+
+```text
+Current PHP version (7.4.33) does not meet minimum requirements. The plugin requires PHP 8.0.
+```
+
+<!-- or: -->
+
+o:
+
+```text
+Current WordPress version (6.9.4) does not meet minimum requirements. The plugin requires WordPress 7.0.
+```
+
+<!--
+Set `preferredVersions` to a compatible PHP and WordPress version, or use a
+plugin/theme release that supports the versions available in Playground.
+-->
+
+Define `preferredVersions` con una versión compatible de PHP y WordPress, o usa
+una release del plugin/tema que sea compatible con las versiones disponibles en
+Playground.
+
+<!-- If the error is: -->
+
+Si el error es:
+
+```text
+Failed to download WordPress 6.9.0 (HTTP 404)
+```
+
+<!--
+the requested WordPress build is not available. Use `latest`, a supported
+released version, or a supported beta/nightly value.
+-->
+
+la compilación de WordPress solicitada no está disponible. Usa `latest`, una
+versión publicada compatible o un valor beta/nightly compatible.
+
+<!--
+If the error says `Plugin file does not exist`, inspect the installed folder
+name. For ZIP URLs with unusual folder names, set `targetFolderName`:
+-->
+
+Si el error dice `Plugin file does not exist`, inspecciona el nombre de la
+carpeta instalada. Para URL ZIP con nombres de carpeta inusuales, define
+`targetFolderName`:
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "url",
+		"url": "https://example.com/my-plugin.zip"
+	},
+	"options": {
+		"activate": true,
+		"targetFolderName": "my-plugin"
+	}
+}
+```
+
+<!--
+If the plugin has dependencies, install and activate those dependencies first
+with explicit steps.
+-->
+
+Si el plugin tiene dependencias, instala y activa esas dependencias primero con
+etapas explícitas.
+
+<!-- ## Theme could not be activated -->
+
+## Theme could not be activated
+
+<!--
+Theme activation failures usually mean the theme folder name is wrong, the
+theme ZIP extracted to an unexpected directory, or the theme code caused a
+WordPress/PHP error.
+-->
+
+Las fallas de activación de temas suelen significar que el nombre de la carpeta
+del tema es incorrecto, que el ZIP del tema se extrajo a un directorio
+inesperado o que el código del tema causó un error de WordPress/PHP.
+
+<!-- Use `installTheme` with `options.activate` when installing a theme: -->
+
+Usa `installTheme` con `options.activate` al instalar un tema:
+
+```json
+{
+	"step": "installTheme",
+	"themeData": {
+		"resource": "wordpress.org/themes",
+		"slug": "twentytwentyfour"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!--
+If you use a standalone `activateTheme` step, pass the folder name inside
+`wp-content/themes`, not a full URL or ZIP filename.
+-->
+
+Si usas una etapa independiente `activateTheme`, pasa el nombre de la carpeta
+dentro de `wp-content/themes`, no una URL completa ni el nombre del archivo ZIP.
+
+<!-- ## Could not write to a file -->
+
+## Could not write to a file
+
+<!-- Errors like this mean the parent directory does not exist: -->
+
+Errores como este significan que el directorio padre no existe:
+
+```text
+Could not write to "/wordpress/wp-content/plugins/example/index.php":
+There is no such file or directory OR the parent directory does not exist.
+```
+
+<!--
+Create the directory first with `mkdir`, or use `writeFiles` with a
+`literal:directory` resource.
+-->
+
+Crea primero el directorio con `mkdir` o usa `writeFiles` con un recurso
+`literal:directory`.
+
+```json
+[
+	{
+		"step": "mkdir",
+		"path": "/wordpress/wp-content/plugins/example"
+	},
+	{
+		"step": "writeFile",
+		"path": "/wordpress/wp-content/plugins/example/index.php",
+		"data": "<?php /* Plugin Name: Example */"
+	}
+]
+```
+
+<!-- ## Could not unzip file -->
+
+## Could not unzip file
+
+<!--
+This usually means the file is not a valid ZIP archive. The URL may have
+returned an HTML page, an error response, a login page, or a truncated file.
+-->
+
+Esto suele significar que el archivo no es un archivo ZIP válido. La URL puede
+haber devuelto una página HTML, una respuesta de error, una página de inicio de
+sesión o un archivo truncado.
+
+<!--
+If the output says `Could not unzip file. Error code: 19`, verify the download
+is a ZIP archive. A small file size often means the server returned an HTML
+error page instead of the archive.
+-->
+
+Si la salida dice `Could not unzip file. Error code: 19`, verifica que la
+descarga sea un archivo ZIP. Un tamaño de archivo pequeño a menudo significa que
+el servidor devolvió una página HTML de error en lugar del archivo.
+
+<!--
+Open the URL directly and confirm the browser downloads a ZIP. If you are using
+a GitHub or CI artifact, use a direct-download URL and make sure the release or
+artifact is public.
+-->
+
+Abre la URL directamente y confirma que el navegador descarga un ZIP. Si estás
+usando un artifact de GitHub o de CI, usa una URL de descarga directa y asegúrate
+de que la release o el artifact sea público.
+
+<!-- ## WP-CLI command pitfalls -->
+
+## Problemas comunes con comandos WP-CLI
+
+<!--
+The `wp-cli` step runs WP-CLI inside Playground. It is useful for setup tasks,
+but not every command or shell feature behaves like a local terminal.
+-->
+
+La etapa `wp-cli` ejecuta WP-CLI dentro de Playground. Es útil para tareas de
+configuración, pero no todos los comandos o características del shell se
+comportan como en una terminal local.
+
+<!-- Common fixes: -->
+
+Correcciones comunes:
+
+<!--
+- Use the step name `"wp-cli"`, not `"wpcli"` or `"cli"`.
+- Keep commands focused. Prefer multiple `wp-cli` steps over one complex shell command.
+- Avoid shell substitutions such as `$(...)` in shared Blueprints. Use `runPHP` for logic that needs WordPress APIs.
+- Check parameter names against the WP-CLI command you are using. For example, command-specific parameters may differ between `wp post list`, `wp post delete`, and plugin-provided commands.
+- If a plugin-provided WP-CLI command fails with a plugin stack trace, the fix usually belongs in that plugin or in the input data passed to the command.
+- If a command fails with `unknown --post_type parameter` or `unknown --format parameter`, check whether the flags belong to a different command in the pipeline.
+- If a plugin command fails with `Unsupported argument type passed to WP_CLI::error_to_string(): 'NULL'`, confirm the plugin is active, the imported data exists, and the command input points to a valid resource.
+-->
+
+- Usa el nombre de etapa `"wp-cli"`, no `"wpcli"` ni `"cli"`.
+- Mantén los comandos enfocados. Prefiere varias etapas `wp-cli` en lugar de un comando de shell complejo.
+- Evita sustituciones de shell como `$(...)` en Blueprints compartidos. Usa `runPHP` para lógica que necesite API de WordPress.
+- Revisa los nombres de parámetros contra el comando WP-CLI que estás usando. Por ejemplo, los parámetros específicos de cada comando pueden diferir entre `wp post list`, `wp post delete` y comandos proporcionados por plugins.
+- Si un comando WP-CLI proporcionado por un plugin falla con un stack trace del plugin, la corrección suele estar en ese plugin o en los datos de entrada pasados al comando.
+- Si un comando falla con `unknown --post_type parameter` o `unknown --format parameter`, revisa si las flags pertenecen a otro comando en el pipeline.
+- Si un comando de plugin falla con `Unsupported argument type passed to WP_CLI::error_to_string(): 'NULL'`, confirma que el plugin esté activo, que los datos importados existan y que la entrada del comando apunte a un recurso válido.
+
+<!-- ## WP-CLI: Error establishing a database connection on mounted sites -->
+
+## WP-CLI: Error establishing a database connection en sitios montados {#wp-cli-error-establishing-a-database-connection-on-mounted-sites}
+
+<!--
+When using `wp-cli` with a mounted Playground site, for example via
+`--mount-before-install`, you might encounter an "Error establishing a database
+connection." This happens because WordPress Playground loads the SQLite database
+integration plugin from its internal files by default, not from the mounted
+directory.
+-->
+
+Al usar `wp-cli` con un sitio Playground montado, por ejemplo mediante
+`--mount-before-install`, podrías encontrar "Error establishing a database
+connection." Esto ocurre porque WordPress Playground carga el plugin de
+integración de base de datos SQLite desde sus archivos internos por defecto, no
+desde el directorio montado.
+
+<!-- Add the SQLite integration plugin to the mounted WordPress site explicitly: -->
+
+Añade explícitamente el plugin de integración SQLite al sitio WordPress montado:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}
+```
+
+<!-- Then run the Blueprint with the mounted site: -->
+
+Después ejecuta el Blueprint con el sitio montado:
+
+```bash
+mkdir wordpress
+npx @wp-playground/cli server --mount-before-install=wordpress:/wordpress --blueprint=./blueprint.json
+```
+
+<!-- ## Debugging tools -->
+
+## Herramientas de depuración
+
+<!-- ### Blueprints editor -->
+
+### Editor de Blueprints
+
+<!--
+Use the in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html)
+to build, validate, and preview Blueprints.
+-->
+
+Usa el [editor de Blueprints](https://playground.wordpress.net/builder/builder.html)
+en el navegador para crear, validar y previsualizar Blueprints.
+
+<!-- :::danger Caution -->
 
 :::danger Precaución
 
 <!--
-The editor is under development and the embedded Playground sometimes fails to load. To get around it, refresh the page. We're aware of that, and are working to improve the experience.
+The editor is under development and the embedded Playground sometimes fails to
+load. To get around it, refresh the page.
 -->
 
-El editor está en desarrollo y el Playground incrustado a veces no carga. Para solucionarlo, actualiza la página. Somos conscientes de ello y estamos trabajando para mejorar la experiencia.
+El editor está en desarrollo y el Playground incrustado a veces falla al
+cargar. Para evitarlo, actualiza la página.
 
 :::
 
-<!--
-## Check for the Filesystem and Database
--->
+<!-- ### Filesystem and database inspection -->
 
-## Revisa el sistema de archivos y la base de datos
+### Inspección del sistema de archivos y la base de datos
 
 <!--
-Some blueprint steps (such as [`writeFile`](/blueprints/steps#WriteFileStep)) alter the internal Filesystem structure of the Playground instance and some others (such as [`runSql`](/blueprints/steps#runSql)) alter the internal WordPress database.
+Some Blueprint steps, such as [`writeFile`](/blueprints/steps),
+alter the internal filesystem. Others, such as
+[`runSql`](/blueprints/steps), alter the database.
 -->
 
-Algunos pasos de Blueprint (como [`writeFile`](/blueprints/steps#WriteFileStep)) modifican la estructura interna del sistema de archivos de la instancia de Playground, y otros (como [`runSql`](/blueprints/steps#runSql)) modifican la base de datos interna de WordPress.
+Algunas etapas de Blueprint, como [`writeFile`](/blueprints/steps), modifican
+el sistema de archivos interno. Otras, como [`runSql`](/blueprints/steps),
+modifican la base de datos.
 
 <!--
-To check the final internal filesystem structure and database (after the blueprint steps have been applied) we can leverage some WordPress plugins that provide a SQL manager and a file explorer such as [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and [`WPide`](https://wordpress.org/plugins/wpide/) (you can see them in action from https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide)
+To inspect the final state, install plugins such as
+[`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and
+[`WPide`](https://wordpress.org/plugins/wpide/). You can see them in action at
+https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide.
 -->
 
-Para revisar la estructura final del sistema de archivos interno y la base de datos (después de aplicar los pasos del Blueprint), podemos usar algunos plugins de WordPress que proporcionan un gestor SQL y un explorador de archivos, como [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) y [`WPide`](https://wordpress.org/plugins/wpide/) (puedes verlos en acción desde https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide).
-
-:::tip
+Para inspeccionar el estado final, instala plugins como
+[`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) y
+[`WPide`](https://wordpress.org/plugins/wpide/). Puedes verlos en acción en
+https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide.
 
 <!--
-There are a bunch of methods we can launch from the console of any WordPress Playground instance to inspect the internals of that instance. They're exposed as part of `window.playground` object (see [Developers > JavaScript API > Debugging and testing](/developers/apis/javascript-api/#debugging-and-testing)). Some examples:
+You can also inspect a Playground instance from the browser console through
+`window.playground`:
 -->
 
-Hay varios métodos que podemos ejecutar desde la consola de cualquier instancia de WordPress Playground para inspeccionar sus partes internas. Están expuestos como parte del objeto `window.playground` (consulta [Desarrolladores > API de JavaScript > Depuración y pruebas](/developers/apis/javascript-api/#debugging-and-testing)). Algunos ejemplos:
+También puedes inspeccionar una instancia de Playground desde la consola del
+navegador mediante `window.playground`:
 
+```js
+await playground.isDir('/wordpress/wp-content/plugins');
+await playground.listFiles('/wordpress/wp-content/plugins');
 ```
-> await playground.isDir("/wordpress/wp-content/plugins")
-true
-> await playground.listFiles("/wordpress/wp-content/plugins")
-(3) ['hello.php', 'index.php', 'WordPress-Importer-master']
-```
+
+<!-- See the full [PlaygroundClient API](/api/client/interface/PlaygroundClient). -->
+
+Consulta la [API PlaygroundClient](/api/client/interface/PlaygroundClient) completa.
+
+<!-- ### Browser console and network requests -->
+
+### Consola del navegador y solicitudes de red
 
 <!--
-Full list of methods we can use is available [here](/api/client/interface/PlaygroundClient)
+Open browser developer tools to check JavaScript errors, PHP debug logs, and
+failed network requests. In Chrome, Firefox, and Edge, press
+`Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
 -->
 
-La lista completa de métodos que podemos usar está disponible [aquí](/api/client/interface/PlaygroundClient).
+Abre las herramientas de desarrollo del navegador para revisar errores de
+JavaScript, logs de depuración de PHP y solicitudes de red fallidas. En Chrome,
+Firefox y Edge, presiona `Ctrl + Shift + I` en Windows/Linux o
+`Cmd + Option + I` en macOS.
+
+<!-- :::caution Safari -->
+
+:::caution Safari
+
+<!--
+If you have not enabled the Develop menu, go to **Safari > Settings... >
+Advanced** and check **Show features for web developers**.
+-->
+
+Si no has activado el menú Develop, ve a **Safari > Settings... > Advanced** y
+marca **Show features for web developers**.
 
 :::
 
-<!--
-## Check for errors in the browser console
--->
+<!-- ### Custom error logging -->
 
-## Revisa errores en la consola del navegador
+### Registro de errores personalizado
 
 <!--
-If your Blueprint isn’t running as expected, open the browser developer tools to check for any errors.
+You can write your own messages with `error_log()` in a
+[`runPHP` step](/blueprints/steps), then check the Playground
+**Logs** panel or the browser console.
 -->
 
-Si tu Blueprint no se está ejecutando como esperas, abre las herramientas de desarrollo del navegador para comprobar si hay errores.
+Puedes escribir tus propios mensajes con `error_log()` en una etapa
+[`runPHP`](/blueprints/steps) y luego revisar el panel **Logs** de Playground o
+la consola del navegador.
+
+<!-- ![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp) -->
+
+![Captura de errores de log](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
 <!--
-To open the developer tools in Chrome, Firefox, Safari\*, and Edge: press `Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
--->
-
-Para abrir las herramientas de desarrollo en Chrome, Firefox, Safari\* y Edge: pulsa `Ctrl + Shift + I` en Windows/Linux o `Cmd + Option + I` en macOS.
-
-:::caution
-
-<!--
-If you haven't yet, enable the Develop menu: go to **Safari > Settings... > Advanced** and check **Show features for web developers**.
--->
-
-Si aún no lo has hecho, activa el menú Desarrollo: ve a **Safari > Configuración... > Avanzado** y marca **Mostrar funciones para desarrolladores web**.
-
+:::info
+When you download your Playground instance as a ZIP through the
+["Download as zip"](/web-instance) option, the archive
+also includes `debug.log`.
 :::
-
-<!--
-The developer tools window allows you to inspect network requests, view console logs, debug JavaScript, and examine the DOM and CSS styles applied to your webpage. This is crucial for diagnosing and fixing issues with Blueprints.
 -->
-
-La ventana de herramientas de desarrollo te permite inspeccionar solicitudes de red, ver registros de consola, depurar JavaScript y examinar el DOM y los estilos CSS aplicados a tu página. Esto es clave para diagnosticar y corregir problemas con Blueprints.
-
-<!--
-## Log your own error messages
--->
-
-## Registra tus propios mensajes de error
-
-<!--
-You can `error_log` your own error messages through [`runPHP` step](/blueprints/steps#RunPHPStep) (see [blueprint example](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) and check them from the ["View Logs" option](/web-instance#playground-options-menu) or from the browser's console.
--->
-
-Puedes registrar tus propios mensajes de error con `error_log` mediante el [paso `runPHP`](/blueprints/steps#RunPHPStep) (consulta el [ejemplo de Blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) y la [demo en vivo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) y revisarlos desde la opción ["View Logs"](/web-instance#playground-options-menu) o desde la consola del navegador.
-
-<!--
-![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
--->
-
-![Captura de errores de registro](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
 :::info
-
-<!--
-When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance.
--->
-
-Cuando descargas tu instancia de Playground como un `zip` mediante la opción ["Download as zip"](/web-instance#playground-options-menu), también descargas el archivo `debug.log`, que contiene todos los registros de tu instancia de Playground.
-
+Cuando descargas tu instancia de Playground como ZIP mediante la opción
+["Download as zip"](/web-instance), el archivo también incluye `debug.log`.
 :::
 
-<!--
-## Ask for help
--->
+<!-- ## Ask for help -->
 
-## Pide ayuda
+## Pedir ayuda
 
 <!--
-The community is here to help! If you have questions or comments, [open a new issue](https://github.com/adamziel/blueprints/issues) in this repository. Remember to include the following details:
+If you need help, [open an issue](https://github.com/WordPress/wordpress-playground/issues)
+and include:
 -->
 
-La comunidad está aquí para ayudar. Si tienes preguntas o comentarios, [abre un nuevo issue](https://github.com/adamziel/blueprints/issues) en este repositorio. Recuerda incluir los siguientes detalles:
+Si necesitas ayuda, [abre un issue](https://github.com/WordPress/wordpress-playground/issues)
+e incluye:
 
 <!--
-- The Blueprint you’re trying to run.
-- The error message you’re seeing, if any.
-- The full output from the browser developer tools.
-- Any other relevant information that might help us understand the issue: OS, browser version, etc.
+- The Blueprint JSON or the public Blueprint URL.
+- The exact error message.
+- The failing step number, if shown.
+- Browser, operating system, and whether you used the website, JavaScript API, or CLI.
+- Relevant console, network, or CLI output.
 -->
 
-- El Blueprint que intentas ejecutar.
-- El mensaje de error que ves, si lo hay.
-- La salida completa de las herramientas de desarrollo del navegador.
-- Cualquier otra información relevante que pueda ayudarnos a entender el problema: sistema operativo, versión del navegador, etc.
+- El JSON del Blueprint o la URL pública del Blueprint.
+- El mensaje de error exacto.
+- El número de etapa fallida, si se muestra.
+- Navegador, sistema operativo y si usaste el sitio web, la API JavaScript o la CLI.
+- Salida relevante de consola, red o CLI.

--- a/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/troubleshooting.md
+++ b/packages/docs/site/i18n/es/docusaurus-plugin-content-docs/current/main/troubleshooting.md
@@ -1,0 +1,360 @@
+---
+title: Solución de problemas
+slug: /troubleshooting
+description: Diagnostica errores comunes del sitio de WordPress Playground, incluidas fallas de arranque, problemas de SQLite, almacenamiento del navegador y recuperación de Playgrounds guardados.
+---
+
+<!-- title: Troubleshooting -->
+
+<!-- description: Diagnose common WordPress Playground website errors, including boot failures, SQLite issues, browser storage, and saved Playground recovery. -->
+
+<!-- # Troubleshooting WordPress Playground -->
+
+# Solución de problemas de WordPress Playground
+
+<!--
+This page covers errors from the Playground website itself, saved Playgrounds,
+browser storage, and WordPress boot. For Blueprint-specific errors, see
+[Troubleshoot and debug Blueprints](/blueprints/troubleshoot-and-debug).
+-->
+
+Esta página cubre errores del propio sitio de Playground, Playgrounds guardados,
+almacenamiento del navegador y arranque de WordPress. Para errores específicos
+de Blueprint, consulta
+[Solucionar problemas y depurar Blueprints](/blueprints/troubleshoot-and-debug).
+
+<!-- ## Playground looks broken -->
+
+## Playground parece roto
+
+<!-- Try these first: -->
+
+Prueba esto primero:
+
+<!--
+- Use the reload button inside the Playground toolbar instead of refreshing the browser tab. Browser refresh starts the whole Playground app again.
+- Open the same URL in a private window to rule out saved-site or browser-storage state.
+- Disable browser extensions that block JavaScript, WebAssembly, storage, workers, or network requests.
+- Check browser developer tools for Console and Network errors.
+- If the URL includes `?site-slug=...`, try removing that query parameter to start a fresh unsaved Playground.
+-->
+
+- Usa el botón de recarga dentro de la barra de herramientas de Playground en lugar de actualizar la pestaña del navegador. La actualización del navegador inicia toda la aplicación de Playground de nuevo.
+- Abre la misma URL en una ventana privada para descartar el estado de un sitio guardado o del almacenamiento del navegador.
+- Desactiva extensiones del navegador que bloqueen JavaScript, WebAssembly, almacenamiento, workers o solicitudes de red.
+- Revisa las herramientas de desarrollo del navegador para ver errores en Console y Network.
+- Si la URL incluye `?site-slug=...`, prueba a quitar ese parámetro de consulta para iniciar un Playground nuevo sin guardar.
+
+<!-- ## A clean site says the MySQL extension is missing -->
+
+## Un sitio limpio dice que falta la extensión MySQL
+
+<!-- You may see a WordPress error page like this: -->
+
+Puedes ver una página de error de WordPress como esta:
+
+```text
+Your PHP installation appears to be missing the MySQL extension which is required by WordPress.
+```
+
+<!--
+In Playground, this usually means WordPress did not load the SQLite integration
+that lets WordPress run without MySQL. Playground runs WordPress in WebAssembly
+and uses SQLite instead of a MySQL server.
+-->
+
+En Playground, esto suele significar que WordPress no cargó la integración
+SQLite que permite ejecutar WordPress sin MySQL. Playground ejecuta WordPress en
+WebAssembly y usa SQLite en lugar de un servidor MySQL.
+
+<!-- Try these steps: -->
+
+Prueba estos pasos:
+
+<!--
+- Start a fresh unsaved Playground at https://playground.wordpress.net/ to confirm the public site can boot.
+- If the URL includes a saved site, remove `?site-slug=...` and load a new temporary site.
+- If this happened after importing a ZIP, confirm the import did not include a custom `wp-content/db.php` that overrides Playground's SQLite setup.
+- If this happened in the CLI, do not use `--skip-sqlite-setup` unless you provide your own database integration.
+- If this happened with a Blueprint, see the [Blueprint troubleshooting page](/blueprints/troubleshoot-and-debug).
+-->
+
+- Inicia un Playground nuevo sin guardar en https://playground.wordpress.net/ para confirmar que el sitio público puede arrancar.
+- Si la URL incluye un sitio guardado, elimina `?site-slug=...` y carga un sitio temporal nuevo.
+- Si esto ocurrió después de importar un ZIP, confirma que la importación no incluyó un `wp-content/db.php` personalizado que sobrescriba la configuración SQLite de Playground.
+- Si esto ocurrió en la CLI, no uses `--skip-sqlite-setup` a menos que proporciones tu propia integración de base de datos.
+- Si esto ocurrió con un Blueprint, consulta la [página de solución de problemas de Blueprint](/blueprints/troubleshoot-and-debug).
+
+<!--
+If you are writing a Blueprint and need to add the SQLite integration plugin,
+`plugins` goes at the top level:
+-->
+
+Si estás escribiendo un Blueprint y necesitas añadir el plugin de integración
+SQLite, `plugins` va en el nivel superior:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}
+```
+
+<!-- ## Error connecting to the SQLite database -->
+
+## Error connecting to the SQLite database
+
+<!--
+This means Playground loaded the SQLite integration, but WordPress still could
+not connect to the database.
+-->
+
+Esto significa que Playground cargó la integración SQLite, pero WordPress aún
+no pudo conectarse a la base de datos.
+
+<!-- Common causes: -->
+
+Causas comunes:
+
+<!--
+- A saved Playground's browser storage is stale or incomplete.
+- An imported site ZIP contains an incompatible database file or database drop-in.
+- A mounted local directory is missing files that WordPress needs.
+- Browser storage was cleared, evicted, or blocked.
+-->
+
+- El almacenamiento del navegador de un Playground guardado está obsoleto o incompleto.
+- Un ZIP de sitio importado contiene un archivo de base de datos o drop-in de base de datos incompatible.
+- A un directorio local montado le faltan archivos que WordPress necesita.
+- El almacenamiento del navegador fue borrado, desalojado o bloqueado.
+
+<!-- Recommended recovery: -->
+
+Recuperación recomendada:
+
+<!--
+1. Start a fresh unsaved Playground without `site-slug`.
+2. If the fresh site works, the issue is tied to the saved site or imported archive.
+3. Export any accessible files from the broken saved site using the File Browser or local directory copy, if available.
+4. Re-import the site into a new Playground, or rebuild it from its Blueprint.
+-->
+
+1. Inicia un Playground nuevo sin guardar y sin `site-slug`.
+2. Si el sitio nuevo funciona, el problema está ligado al sitio guardado o al archivo importado.
+3. Exporta cualquier archivo accesible desde el sitio guardado roto usando el Navegador de archivos o una copia del directorio local, si está disponible.
+4. Vuelve a importar el sitio en un nuevo Playground o reconstruyelo desde su Blueprint.
+
+<!-- ## NotAllowedError -->
+
+## NotAllowedError
+
+<!--
+`NotAllowedError` usually means the browser blocked an operation that requires
+user permission or a supported browser context. In Playground, this often
+relates to saved sites or local directory access.
+-->
+
+`NotAllowedError` suele significar que el navegador bloqueó una operación que
+requiere permiso del usuario o un contexto de navegador compatible. En
+Playground, esto a menudo está relacionado con sitios guardados o acceso a
+directorios locales.
+
+<!-- You may see this exact message: -->
+
+Puedes ver este mensaje exacto:
+
+```text
+The request is not allowed by the user agent or the platform in the current context.
+```
+
+<!-- Try: -->
+
+Prueba:
+
+<!--
+- Open Playground in a normal top-level browser tab, not inside a restricted iframe.
+- Reopen the site from the Playground **Saved Playgrounds** panel.
+- If the site was saved to a local directory, import or save the directory again.
+- Confirm the browser supports the file or storage API being used. Chrome and Edge generally have the broadest local directory support.
+- Check whether private browsing mode, enterprise policy, or browser settings block storage access.
+-->
+
+- Abrir Playground en una pestaña normal de nivel superior del navegador, no dentro de un iframe restringido.
+- Volver a abrir el sitio desde el panel **Saved Playgrounds** de Playground.
+- Si el sitio se guardó en un directorio local, importar o guardar el directorio de nuevo.
+- Confirmar que el navegador admite la API de archivos o almacenamiento que se está usando. Chrome y Edge suelen tener el soporte más amplio para directorios locales.
+- Revisar si el modo de navegación privada, una política empresarial o la configuración del navegador bloquean el acceso al almacenamiento.
+
+<!-- ## NoModificationAllowedError -->
+
+## NoModificationAllowedError
+
+<!--
+`NoModificationAllowedError` means the browser or filesystem refused a write.
+This can happen when a saved local directory became read-only, permission was
+lost, or browser storage is unavailable.
+-->
+
+`NoModificationAllowedError` significa que el navegador o el sistema de archivos
+rechazó una escritura. Esto puede ocurrir cuando un directorio local guardado se
+volvió de solo lectura, se perdió el permiso o el almacenamiento del navegador
+no está disponible.
+
+<!-- You may see this exact message: -->
+
+Puedes ver este mensaje exacto:
+
+```text
+An attempt was made to write to a file or directory which could not be modified due to the state of the underlying filesystem.
+```
+
+<!-- Try: -->
+
+Prueba:
+
+<!--
+- Save a copy to a different local directory.
+- Check that the target folder still exists and is writable.
+- Avoid system-protected folders or synced folders that temporarily lock files.
+- Start a fresh unsaved Playground if you only need a temporary test site.
+- Use [Playground CLI](/developers/local-development/wp-playground-cli) for local development that needs reliable filesystem persistence.
+-->
+
+- Guardar una copia en otro directorio local.
+- Comprobar que la carpeta de destino aún exista y sea escribible.
+- Evitar carpetas protegidas del sistema o carpetas sincronizadas que bloqueen archivos temporalmente.
+- Iniciar un Playground nuevo sin guardar si solo necesitas un sitio de prueba temporal.
+- Usar [Playground CLI](/developers/local-development/wp-playground-cli) para desarrollo local que necesite persistencia fiable del sistema de archivos.
+
+<!-- ## Saved Playground cannot reload -->
+
+## Un Playground guardado no puede recargarse
+
+<!--
+Saved Playgrounds are stored in browser storage or in a local directory you
+selected. They are not hosted on a remote server.
+-->
+
+Los Playgrounds guardados se almacenan en el almacenamiento del navegador o en
+un directorio local que seleccionaste. No están alojados en un servidor remoto.
+
+<!-- If a saved Playground cannot reload: -->
+
+Si un Playground guardado no puede recargarse:
+
+<!--
+- Confirm you are using the same browser and browser profile where it was saved.
+- Check whether browser data was cleared or storage was disabled.
+- If the site was saved to a local directory, confirm the directory still exists and has not moved.
+- If the URL includes `?site-slug=...`, remove it to start a fresh unsaved site.
+- Recreate the saved site from its original Blueprint or import ZIP if storage was lost.
+-->
+
+- Confirma que estás usando el mismo navegador y perfil de navegador donde se guardó.
+- Revisa si los datos del navegador se borraron o si el almacenamiento se desactivó.
+- Si el sitio se guardó en un directorio local, confirma que el directorio todavía existe y no se ha movido.
+- Si la URL incluye `?site-slug=...`, quítalo para iniciar un sitio nuevo sin guardar.
+- Recrea el sitio guardado desde su Blueprint original o ZIP de importación si se perdió el almacenamiento.
+
+<!-- ## Browser storage and persistence -->
+
+## Almacenamiento del navegador y persistencia
+
+<!--
+An unsaved Playground is temporary. A browser refresh, tab close, storage
+cleanup, or browser profile change can remove its state.
+-->
+
+Un Playground sin guardar es temporal. Una actualización del navegador, cerrar
+la pestaña, limpiar el almacenamiento o cambiar de perfil del navegador puede
+eliminar su estado.
+
+<!--
+Use the **Save** button before doing meaningful work. For longer-running local
+development, prefer the [Playground CLI](/developers/local-development/wp-playground-cli),
+which persists site files on disk.
+-->
+
+Usa el botón **Save** antes de hacer trabajo importante. Para desarrollo local
+de mayor duración, prefiere [Playground CLI](/developers/local-development/wp-playground-cli),
+que persiste los archivos del sitio en disco.
+
+<!--
+:::tip
+The refresh button inside the Playground toolbar reloads WordPress while keeping
+the current Playground runtime. The browser refresh button reloads the full app
+and can discard unsaved changes.
+:::
+-->
+
+:::tip
+El botón de recarga dentro de la barra de herramientas de Playground recarga
+WordPress mientras mantiene el runtime actual de Playground. El botón de
+actualizar del navegador recarga toda la aplicación y puede descartar cambios
+no guardados.
+:::
+
+<!-- ## When to start fresh -->
+
+## Cuándo empezar de nuevo
+
+<!-- Start a fresh unsaved Playground when: -->
+
+Inicia un Playground nuevo sin guardar cuando:
+
+<!--
+- You only need to test whether the public Playground site is working.
+- The URL points to a saved `site-slug` that no longer loads.
+- You are debugging whether an error comes from Playground itself or from a plugin, theme, Blueprint, or imported site.
+- Browser storage or local directory access is suspected to be broken.
+-->
+
+- Solo necesitas probar si el sitio público de Playground funciona.
+- La URL apunta a un `site-slug` guardado que ya no carga.
+- Estás depurando si un error proviene del propio Playground o de un plugin, tema, Blueprint o sitio importado.
+- Se sospecha que el almacenamiento del navegador o el acceso al directorio local está roto.
+
+<!-- Use this URL for a clean site: -->
+
+Usa esta URL para un sitio limpio:
+
+```text
+https://playground.wordpress.net/
+```
+
+<!-- ## Report a Playground issue -->
+
+## Informar de un problema de Playground
+
+<!--
+If the problem reproduces on a fresh unsaved Playground, please
+[open an issue](https://github.com/WordPress/wordpress-playground/issues) and
+include:
+-->
+
+Si el problema se reproduce en un Playground nuevo sin guardar,
+[abre un issue](https://github.com/WordPress/wordpress-playground/issues) e
+incluye:
+
+<!--
+- The full Playground URL.
+- The browser and operating system.
+- Whether you used a saved site, imported ZIP, Blueprint, local directory, or CLI.
+- The exact error name and message.
+- Console and Network details from browser developer tools.
+-->
+
+- La URL completa de Playground.
+- El navegador y el sistema operativo.
+- Si usaste un sitio guardado, ZIP importado, Blueprint, directorio local o CLI.
+- El nombre y el mensaje exactos del error.
+- Detalles de Console y Network de las herramientas de desarrollo del navegador.

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
@@ -1,25 +1,20 @@
 ---
 title: Utiliser les Blueprints
 slug: /blueprints/using-blueprints
-description: Découvrez les différentes façons d’utiliser les Blueprints, notamment avec un fragment d’URL, un paramètre de requête, des paquets et l’API JavaScript.
+description: Découvrez les différentes façons d’utiliser les Blueprints, notamment avec un fragment d’URL, un paramètre de requête, des bundles et l’API JavaScript.
 ---
 
-<!--
-title: Using Blueprints
-description: Discover the different ways to use Blueprints, including via URL fragment, query parameter, bundles, and the JavaScript API.
--->
+<!-- title: Using Blueprints -->
 
-<!--
-# Using Blueprints
--->
+<!-- description: Discover the different ways to use Blueprints, including via URL fragment, query parameter, bundles, and the JavaScript API. -->
+
+<!-- # Using Blueprints -->
 
 # Utiliser les Blueprints
 
-<!--
-You can use Blueprints in one of the following ways:
--->
+<!-- You can use Blueprints in one of the following ways: -->
 
-Vous pouvez utiliser les Blueprints de l’une des façons suivantes :
+Vous pouvez utiliser les Blueprints de l’une des manières suivantes :
 
 <!--
 - By passing them as a URL fragment to the Playground.
@@ -30,26 +25,23 @@ Vous pouvez utiliser les Blueprints de l’une des façons suivantes :
 
 - En les passant comme fragment d’URL au Playground.
 - En les chargeant depuis une URL avec le paramètre `blueprint-url`.
-- En utilisant des paquets Blueprint (fichiers ZIP ou répertoires).
+- En utilisant des bundles de Blueprint (fichiers ZIP ou répertoires).
 - En utilisant l’API JavaScript.
 
-<!--
-## URL Fragment
--->
+<!-- ## URL Fragment -->
 
-## Fragment d’URL {#url-fragment}
+## Fragment d’URL
 
-<!--
-The easiest way to start using Blueprints is to paste one into the URL "fragment" on WordPress Playground website, e.g. `https://playground.wordpress.net/#{"preferredVersions...`.
--->
+<!-- The easiest way to start using Blueprints is to paste one into the URL "fragment" on WordPress Playground website, e.g. `https://playground.wordpress.net/#{"preferredVersions...`. -->
 
-La façon la plus simple de commencer à utiliser les Blueprints est d’en coller un dans le « fragment » d’URL du site WordPress Playground, par exemple `https://playground.wordpress.net/#{"preferredVersions...`.
+La façon la plus simple de commencer avec les Blueprints consiste à en coller
+un dans le "fragment" de l’URL sur le site WordPress Playground, par exemple
+`https://playground.wordpress.net/#{"preferredVersions...`.
 
-<!--
-For example, to create a Playground with specific versions of WordPress and PHP you would use the following Blueprint:
--->
+<!-- For example, to create a Playground with specific versions of WordPress and PHP you would use the following Blueprint: -->
 
-Par exemple, pour créer un Playground avec des versions spécifiques de WordPress et de PHP, vous utiliseriez le Blueprint suivant :
+Par exemple, pour créer un Playground avec des versions précises de WordPress
+et de PHP, vous utiliseriez le Blueprint suivant :
 
 ```json
 {
@@ -66,18 +58,19 @@ And then you would go to
 `https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
 -->
 
-Vous iriez ensuite à
+Puis vous iriez sur
 `https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
 
-:::tip
-
 <!--
+:::tip
 In Javascript, you can get a compact version of any blueprint JSON with [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) and [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
 Example:
 -->
 
-En JavaScript, vous pouvez obtenir une version compacte de n’importe quel JSON de Blueprint avec [`JSON.stringify`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) et [`JSON.parse`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
-Exemple :
+:::tip
+En JavaScript, vous pouvez obtenir une version compacte de n’importe quel JSON
+de Blueprint avec [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) et [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
+Exemple :
 
 ```js
 const blueprintJson = `{
@@ -94,11 +87,11 @@ const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
 
 :::
 
-<!--
-You won't have to paste links to follow along. We'll use code examples with a "Try it out" button that will automatically run the examples for you:
--->
+<!-- You won't have to paste links to follow along. We'll use code examples with a "Try it out" button that will automatically run the examples for you: -->
 
-Vous n’aurez pas besoin de coller de liens pour suivre. Nous utiliserons des exemples de code avec un bouton « Essayer » qui exécutera automatiquement les exemples pour vous :
+Vous n’aurez pas à coller de liens pour suivre. Nous utiliserons des exemples
+de code avec un bouton "Try it out" qui exécutera automatiquement les exemples
+pour vous :
 
 import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
 
@@ -109,17 +102,15 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 	}
 }} />
 
-<!--
-### Encoded Blueprint fragments
--->
+<!-- ### Encoded Blueprint fragments -->
 
 ### Fragments de Blueprint encodés
 
-<!--
-When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`:
--->
+<!-- When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`: -->
 
-Lorsque vous créez des liens Playground depuis JavaScript ou des outils d’automatisation, encodez le JSON minifié une seule fois avec `encodeURIComponent()` et ajoutez-le après `#` :
+Lorsque vous créez des liens Playground depuis JavaScript ou des outils
+d’automatisation, encodez une seule fois le JSON minifié avec
+`encodeURIComponent()` et ajoutez-le après `#` :
 
 ```js
 const blueprint = {
@@ -132,29 +123,60 @@ const blueprint = {
 const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
 ```
 
-<!--
-Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
--->
+<!-- Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`. -->
 
-Playground prend également en charge les Blueprints encodés en Base64. Base64 est utile lorsqu’une plateforme modifie les fragments JSON ou lorsque vous voulez un lien compact et facile à copier. Par exemple, voici le Blueprint ci-dessus au format Base64 : `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+Playground prend aussi en charge les Blueprints encodés en Base64. Base64 est
+utile lorsqu’une plateforme modifie les fragments JSON ou lorsque vous voulez
+un lien compact et facile à copier. Par exemple, voici le Blueprint ci-dessus au
+format Base64 : `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
 
-<!--
-To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
--->
+<!-- To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19 -->
 
 Pour l’exécuter, allez sur https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
 
-:::tip
+<!-- #### URIError: URI malformed -->
+
+#### URIError: URI malformed
 
 <!--
-In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`.
-
-Example:
+If a Playground link fails with `URIError: URI malformed`, the encoded
+Blueprint fragment is usually malformed. Common causes include an invalid `%`
+escape, a fragment that was encoded twice, or JSON pasted into the URL without
+encoding.
 -->
 
-En JavaScript, vous pouvez convertir n’importe quel JSON de Blueprint au [format Base64](https://developer.mozilla.org/fr/docs/Glossary/Base64#javascript_support) avec la fonction globale `btoa()`.
+Si un lien Playground échoue avec `URIError: URI malformed`, le fragment de
+Blueprint encodé est généralement mal formé. Les causes courantes incluent un
+échappement `%` invalide, un fragment encodé deux fois ou du JSON collé dans
+l’URL sans encodage.
 
-Exemple :
+<!-- Rebuild the link from the original Blueprint object and encode it once: -->
+
+Reconstruisez le lien depuis l’objet Blueprint d’origine et encodez-le une seule
+fois :
+
+```js
+const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
+```
+
+<!-- If another tool changes URL fragments, use a Base64-encoded Blueprint instead. -->
+
+Si un autre outil modifie les fragments d’URL, utilisez plutôt un Blueprint
+encodé en Base64.
+
+<!--
+:::tip
+In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`.
+-->
+
+:::tip
+En JavaScript, vous pouvez obtenir n’importe quel JSON de Blueprint au
+[format Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support)
+avec la fonction globale `btoa()`.
+
+<!-- Example: -->
+
+Exemple :
 
 ```js
 const blueprintJson = `{
@@ -169,55 +191,72 @@ const minifiedBlueprintJson = btoa(blueprintJson); // eyIkc2NoZW1hIjogImh0dHBzOi
 
 :::
 
-<!--
-### Load Blueprint from a URL
--->
+<!-- ### Load Blueprint from a URL -->
 
 ### Charger un Blueprint depuis une URL
 
-<!--
-When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this:
--->
+<!-- When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this: -->
 
-Lorsque votre Blueprint devient trop difficile à gérer, vous pouvez le charger avec le paramètre de requête `?blueprint-url` dans l’URL, comme ceci :
+Quand votre Blueprint devient trop volumineux, vous pouvez le charger avec le
+paramètre de requête `?blueprint-url` dans l’URL, comme ceci :
+
+<!-- [https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json) -->
 
 [https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
 
-<!--
-Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
--->
+<!-- Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin): -->
 
-Notez que le Blueprint doit être accessible publiquement et servi avec [le bon en-tête `Access-Control-Allow-Origin`](https://developer.mozilla.org/fr/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin) :
+Notez que le Blueprint doit être accessible publiquement et servi avec le
+[bon en-tête `Access-Control-Allow-Origin`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin) :
 
 ```
 Access-Control-Allow-Origin: *
 ```
 
-<!--
-#### Blueprint Bundles
--->
+<!-- When a Blueprint URL fails with `BlueprintFetchError`, check these details: -->
 
-#### Paquets Blueprint
-
-<!--
-The `?blueprint-url` parameter now also supports Blueprint bundles in ZIP format. A Blueprint bundle is a ZIP file that contains a `blueprint.json` file at the root level, along with any additional resources referenced by the Blueprint.
--->
-
-Le paramètre `?blueprint-url` prend désormais aussi en charge les paquets Blueprint au format ZIP. Un paquet Blueprint est un fichier ZIP qui contient un fichier `blueprint.json` à la racine, ainsi que toutes les ressources supplémentaires référencées par le Blueprint.
+Lorsqu’une URL de Blueprint échoue avec `BlueprintFetchError`, vérifiez ces
+points :
 
 <!--
-For example, you can load a Blueprint bundle like this:
+- The URL must return a JSON file or a Blueprint ZIP bundle, not an HTML page.
+- GitHub URLs should use `raw.githubusercontent.com`, not `github.com/.../blob/...`.
+- GitLab URLs should use the raw file URL, not a `/-/blob/` page.
+- The file must be reachable without login, cookies, VPN access, or a temporary browser session.
+- Draft releases, expired CI artifacts, and temporary tunnel URLs can stop working even if the Blueprint was valid earlier.
+- If you host the file yourself, configure CORS so `https://playground.wordpress.net` can fetch it.
 -->
 
-Par exemple, vous pouvez charger un paquet Blueprint comme ceci :
+- L’URL doit renvoyer un fichier JSON ou un bundle ZIP de Blueprint, pas une page HTML.
+- Les URL GitHub doivent utiliser `raw.githubusercontent.com`, pas `github.com/.../blob/...`.
+- Les URL GitLab doivent utiliser l’URL du fichier brut, pas une page `/-/blob/`.
+- Le fichier doit être accessible sans connexion, cookies, VPN ni session temporaire du navigateur.
+- Les releases en brouillon, les artifacts CI expirés et les URL temporaires de tunnel peuvent cesser de fonctionner même si le Blueprint était valide auparavant.
+- Si vous hébergez le fichier vous-même, configurez CORS pour que `https://playground.wordpress.net` puisse le récupérer.
+
+<!-- #### Blueprint Bundles -->
+
+#### Bundles de Blueprint
+
+<!-- The `?blueprint-url` parameter now also supports Blueprint bundles in ZIP format. A Blueprint bundle is a ZIP file that contains a `blueprint.json` file at the root level, along with any additional resources referenced by the Blueprint. -->
+
+Le paramètre `?blueprint-url` prend maintenant aussi en charge les bundles de
+Blueprint au format ZIP. Un bundle de Blueprint est un fichier ZIP qui contient
+un fichier `blueprint.json` à la racine, avec les ressources supplémentaires
+référencées par le Blueprint.
+
+<!-- For example, you can load a Blueprint bundle like this: -->
+
+Par exemple, vous pouvez charger un bundle de Blueprint comme ceci :
+
+<!-- [https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip](https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip) -->
 
 [https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip](https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip)
 
-<!--
-When using a Blueprint bundle, you can reference bundled resources using the `bundled` resource type:
--->
+<!-- When using a Blueprint bundle, you can reference bundled resources using the `bundled` resource type: -->
 
-Lorsque vous utilisez un paquet Blueprint, vous pouvez référencer les ressources incluses avec le type de ressource `bundled` :
+Lorsque vous utilisez un bundle de Blueprint, vous pouvez référencer les
+ressources incluses avec le type de ressource `bundled` :
 
 ```json
 {
@@ -235,23 +274,20 @@ Lorsque vous utilisez un paquet Blueprint, vous pouvez référencer les ressourc
 }
 ```
 
-<!--
-For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation.
--->
+<!-- For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation. -->
 
-Pour en savoir plus sur les paquets Blueprint, consultez la documentation [Paquets Blueprint](/blueprints/bundles).
+Pour plus d’informations sur les bundles de Blueprint, consultez la
+documentation des [Bundles de Blueprint](/blueprints/bundles).
 
-<!--
-## JavaScript API
--->
+<!-- ## JavaScript API -->
 
-## API JavaScript {#javascript-api}
+## API JavaScript
 
-<!--
-You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen:
--->
+<!-- You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen: -->
 
-Vous pouvez aussi utiliser les Blueprints avec l’API JavaScript grâce à la fonction `startPlaygroundWeb()` du paquet `@wp-playground/client`. Voici un petit exemple autonome que vous pouvez exécuter sur JSFiddle ou CodePen :
+Vous pouvez aussi utiliser les Blueprints avec l’API JavaScript grâce à la
+fonction `startPlaygroundWeb()` du paquet `@wp-playground/client`. Voici un
+petit exemple autonome que vous pouvez exécuter sur JSFiddle ou CodePen :
 
 ```html
 <iframe id="wp-playground" style="width: 1200px; height: 800px"></iframe>

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/03-data-format.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/03-data-format.md
@@ -1,0 +1,299 @@
+---
+sidebar_position: 1
+title: Format des données Blueprint
+slug: /blueprints/data-format
+description: Vue d’ensemble du format de données Blueprint. Découvrez les propriétés clés comme landingPage, preferredVersions et steps.
+---
+
+<!-- title: Blueprint data Format -->
+
+<!-- description: An overview of the Blueprint data format. Learn about key properties like landingPage, preferredVersions, and steps. -->
+
+<!-- # Blueprint data format -->
+
+# Format des données Blueprint
+
+<!-- A Blueprint JSON file can have many different properties that will be used to define your Playground instance. The most important properties are detailed below. -->
+
+Un fichier JSON de Blueprint peut contenir de nombreuses propriétés différentes
+qui seront utilisées pour définir votre instance Playground. Les propriétés les
+plus importantes sont détaillées ci-dessous.
+
+<!-- Here's an example that uses many of them: -->
+
+Voici un exemple qui en utilise plusieurs :
+
+import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
+
+<BlueprintExample blueprint={{
+	"landingPage": "/wp-admin/",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	},
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		}
+	]
+}} />
+
+<!-- ## JSON schema -->
+
+## Schéma JSON
+
+<!-- JSON files can be tedious to write and easy to get wrong. To help with that, Playground provides a [JSON schema](https://playground.wordpress.net/blueprint-schema.json) file that you can use to get auto-completion and validation in your editor. Just set the `$schema` property to the following: -->
+
+Les fichiers JSON peuvent être fastidieux à écrire et il est facile de s’y
+tromper. Pour vous aider, Playground fournit un fichier
+[schéma JSON](https://playground.wordpress.net/blueprint-schema.json) que vous
+pouvez utiliser pour obtenir l’autocomplétion et la validation dans votre
+éditeur. Définissez simplement la propriété `$schema` comme suit :
+
+```js
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+}
+```
+
+<!-- ## Landing page -->
+
+## Page d’arrivée
+
+<!-- The `landingPage` property tells Playground which URL to navigate to after the Blueprint has been run. This is a great tool, especially when creating theme or plugin demos. Often, you will want to start Playground in the Site Editor or have a specific post open in the Post Editor. Make sure you use a relative path. -->
+
+La propriété `landingPage` indique à Playground vers quelle URL naviguer après
+l’exécution du Blueprint. C’est un excellent outil, en particulier lors de la
+création de démos de thèmes ou d’extensions. Souvent, vous voudrez démarrer
+Playground dans l’éditeur de site ou ouvrir un article précis dans l’éditeur
+d’articles. Assurez-vous d’utiliser un chemin relatif.
+
+```js
+{
+	"landingPage": "/wp-admin/site-editor.php",
+}
+```
+
+<!-- ## Preferred versions -->
+
+## Versions préférées
+
+<!-- The `preferredVersions` property declares your preferred PHP and WordPress versions. It can contain the following properties: -->
+
+La propriété `preferredVersions` déclare vos versions préférées de PHP et de
+WordPress. Elle peut contenir les propriétés suivantes :
+
+<!--
+- `php` (string): Loads the specified PHP version. Accepts `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5`, or `latest`. Minor versions like `7.4.1` are not supported.
+- `wp` (string): Loads the specified WordPress version. Accepts the last seven major WordPress versions. As of April 28, 2026, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7`, `6.8`, or `6.9`. You can also use the generic values `latest`, `beta`, or `nightly` (alias `trunk`). `beta` resolves to the most recent Beta or Release Candidate of an active release cycle; `nightly`/`trunk` builds straight from the WordPress development branch.
+-->
+
+- `php` (string) : charge la version PHP indiquée. Accepte `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5` ou `latest`. Les versions mineures comme `7.4.1` ne sont pas prises en charge.
+- `wp` (string) : charge la version WordPress indiquée. Accepte les sept dernières versions majeures de WordPress. Au 28 avril 2026, il s’agit de `6.3`, `6.4`, `6.5`, `6.6`, `6.7`, `6.8` ou `6.9`. Vous pouvez aussi utiliser les valeurs génériques `latest`, `beta` ou `nightly` (alias `trunk`). `beta` correspond à la bêta ou Release Candidate la plus récente d’un cycle de publication actif ; `nightly`/`trunk` est construit directement depuis la branche de développement de WordPress.
+
+```js
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.7"
+	},
+}
+```
+
+<!-- ## Features -->
+
+## Fonctionnalités
+
+<!-- You can use the `features` property to turn on or off certain features of the Playground instance. It can contain the following properties: -->
+
+Vous pouvez utiliser la propriété `features` pour activer ou désactiver
+certaines fonctionnalités de l’instance Playground. Elle peut contenir les
+propriétés suivantes :
+
+<!-- - `networking`: Defaults to `true`. Enables or disables the networking support for Playground. If enabled, [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) and similar WordPress functions will actually use `fetch()` to make HTTP requests. If disabled, they will immediately fail instead. You will need this property enabled if you want the user to be able to install plugins or themes. -->
+
+- `networking` : vaut `true` par défaut. Active ou désactive la prise en charge réseau de Playground. Si elle est activée, [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) et les fonctions WordPress similaires utiliseront réellement `fetch()` pour effectuer des requêtes HTTP. Si elle est désactivée, elles échoueront immédiatement. Cette propriété doit être activée si vous voulez que l’utilisateur puisse installer des extensions ou des thèmes.
+
+```js
+{
+	"features": {
+		"networking": false
+	},
+}
+```
+
+<!-- ## Extra libraries -->
+
+## Bibliothèques supplémentaires
+
+<!-- You can preload extra libraries into the Playground instance. The following libraries are supported: -->
+
+Vous pouvez précharger des bibliothèques supplémentaires dans l’instance
+Playground. Les bibliothèques suivantes sont prises en charge :
+
+<!-- - `wp-cli`: Enables WP-CLI support for Playground. If included, WP-CLI will be installed during boot. If not included, you will get an error message when trying to run WP-CLI commands using the JS API. WP-CLI will be installed by default if the blueprint contains any `wp-cli` steps. -->
+
+- `wp-cli` : active la prise en charge de WP-CLI pour Playground. Si elle est incluse, WP-CLI sera installé pendant le démarrage. Si elle n’est pas incluse, vous obtiendrez un message d’erreur en essayant d’exécuter des commandes WP-CLI avec l’API JS. WP-CLI sera installé par défaut si le Blueprint contient des étapes `wp-cli`.
+
+```js
+{
+	"extraLibraries": [ "wp-cli" ],
+}
+```
+
+<!-- ## Steps -->
+
+## Étapes
+
+<!-- Arguably the most powerful property, `steps` allows you to configure the Playground instance with preinstalled themes, plugins, demo content, and more. The following example logs the user in with a dedicated username and password. It then installs and activates the Gutenberg plugin. [Learn more about steps](/blueprints/steps). -->
+
+Sans doute la propriété la plus puissante, `steps` vous permet de configurer
+l’instance Playground avec des thèmes, des extensions, du contenu de démo
+préinstallés, et plus encore. L’exemple suivant connecte l’utilisateur avec un
+nom d’utilisateur et un mot de passe dédiés. Il installe et active ensuite
+l’extension Gutenberg. [En savoir plus sur les étapes](/blueprints/steps).
+
+```js
+{
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		},
+		{
+			"step": "installPlugin",
+			"pluginData": {
+				"resource": "wordpress.org/plugins",
+				"slug": "gutenberg"
+			}
+		},
+	]
+}
+```
+
+<!-- ## Common property placement mistakes -->
+
+## Erreurs courantes de placement des propriétés
+
+<!--
+Blueprint validation errors often come from putting a valid property in the
+wrong object.
+-->
+
+Les erreurs de validation de Blueprint viennent souvent d’une propriété valide
+placée dans le mauvais objet.
+
+<!-- ### Activate a plugin or theme -->
+
+### Activer une extension ou un thème
+
+<!--
+`activate` belongs inside `options`, not inside `pluginData`, `themeData`, or
+directly on the step.
+-->
+
+`activate` doit se trouver dans `options`, pas dans `pluginData`, `themeData` ni
+directement sur l’étape.
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "gutenberg"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!-- ### Install plugins with the shorthand -->
+
+### Installer des extensions avec le raccourci
+
+<!--
+The `plugins` shorthand is a top-level Blueprint property. Do not put it inside
+`preferredVersions`.
+-->
+
+Le raccourci `plugins` est une propriété de premier niveau du Blueprint. Ne le
+placez pas dans `preferredVersions`.
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["gutenberg"]
+}
+```
+
+<!-- ### Use one plugin install shape -->
+
+### Utiliser une seule forme d’installation d’extension
+
+<!--
+For an `installPlugin` step, use `pluginData`. Do not mix `pluginData` with
+older examples or custom objects such as `pluginZipFile`.
+-->
+
+Pour une étape `installPlugin`, utilisez `pluginData`. Ne mélangez pas
+`pluginData` avec d’anciens exemples ou des objets personnalisés comme
+`pluginZipFile`.
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!--
+The `wordpress.org/plugins` resource needs a separate `slug`. Do not write the
+slug into the `resource` value, such as `"wordpress.org/plugins/woocommerce"`.
+-->
+
+La ressource `wordpress.org/plugins` nécessite un `slug` séparé. N’écrivez pas
+le slug dans la valeur `resource`, comme `"wordpress.org/plugins/woocommerce"`.
+
+<!-- ### Keep `preferredVersions` limited to versions -->
+
+### Limiter `preferredVersions` aux versions
+
+<!--
+`preferredVersions` only accepts `php` and `wp`. Use `features` for networking,
+`plugins` or `installPlugin` for plugins, and `steps` for ordered setup tasks.
+-->
+
+`preferredVersions` accepte uniquement `php` et `wp`. Utilisez `features` pour
+le réseau, `plugins` ou `installPlugin` pour les extensions, et `steps` pour les
+tâches de configuration ordonnées.
+
+<!-- ### Use explicit steps when order matters -->
+
+### Utiliser des étapes explicites lorsque l’ordre compte
+
+<!--
+Shorthands such as `plugins`, `login`, `siteOptions`, and `constants` are
+expanded before the `steps` array. If one action must happen before another,
+write both actions as explicit steps in the order you need.
+-->
+
+Les raccourcis comme `plugins`, `login`, `siteOptions` et `constants` sont
+développés avant le tableau `steps`. Si une action doit avoir lieu avant une
+autre, écrivez les deux actions sous forme d’étapes explicites dans l’ordre
+nécessaire.

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/04-resources.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/04-resources.md
@@ -1,0 +1,368 @@
+---
+slug: /blueprints/steps/resources
+description: Une référence technique pour les « Resource References ». Découvrez comment utiliser des fichiers externes pour les thèmes, les extensions et le contenu.
+---
+
+<!-- description: A technical reference for "Resource References." Learn how to use external files for themes, plugins, and content. -->
+
+<!-- # Resources References -->
+
+# Références de ressources
+
+<!-- "Resource References" allow you use external files in Blueprints -->
+
+Les « Resource References » vous permettent d’utiliser des fichiers externes
+dans les Blueprints.
+
+<div class="callout callout-info">
+
+<!-- Blueprint steps such as [`installPlugin`](/blueprints/steps) or [`installTheme`](/blueprints/steps) require a location of the plugin or theme to be installed. -->
+
+Les étapes de Blueprint comme [`installPlugin`](/blueprints/steps) ou
+[`installTheme`](/blueprints/steps) nécessitent l’emplacement de l’extension ou
+du thème à installer.
+
+<!-- That location can be defined as [a `URL` resource](#urlreference) of the `.zip` file containing the theme or plugin. It can also be defined as a [`wordpress.org/plugins`](#corepluginreference) or [`wordpress.org/themes`](#corethemereference) resource for those plugins/themes published in the official WordPress directories. -->
+
+Cet emplacement peut être défini comme une ressource [`URL`](#urlreference) du
+fichier `.zip` contenant le thème ou l’extension. Il peut aussi être défini
+comme une ressource [`wordpress.org/plugins`](#corepluginreference) ou
+[`wordpress.org/themes`](#corethemereference) pour les extensions/thèmes publiés
+dans les répertoires officiels WordPress.
+
+</div>
+
+<!-- The following resource references are available: -->
+
+Les références de ressources suivantes sont disponibles :
+
+import TOCInline from '@theme/TOCInline';
+
+<TOCInline toc={toc} />
+
+<!-- ### URLReference -->
+
+### URLReference
+
+<!-- The `URLReference` resource is used to reference files that are stored on a remote server. The `URLReference` resource is defined as follows: -->
+
+La ressource `URLReference` sert à référencer des fichiers stockés sur un
+serveur distant. La ressource `URLReference` est définie comme suit :
+
+```typescript
+type URLReference = {
+	resource: 'url';
+	url: string;
+};
+```
+
+<!-- To use the `URLReference` resource, you need to provide the URL of the file. For example, to reference a file named "index.html" that is stored on a remote server, you can create a `URLReference` as follows: -->
+
+Pour utiliser la ressource `URLReference`, vous devez fournir l’URL du fichier.
+Par exemple, pour référencer un fichier nommé "index.html" stocké sur un
+serveur distant, vous pouvez créer une `URLReference` comme suit :
+
+```json
+{
+	"resource": "url",
+	"url": "https://example.com/index.html"
+}
+```
+
+<!--
+The `url` resource works with Blueprint steps such as [`installPlugin`](/blueprints/steps) or
+[`installTheme`](/blueprints/steps).
+These steps require a `ResourceType` to define the location of the plugin or the theme to install.
+-->
+
+La ressource `url` fonctionne avec des étapes de Blueprint comme
+[`installPlugin`](/blueprints/steps) ou [`installTheme`](/blueprints/steps).
+Ces étapes nécessitent un `ResourceType` pour définir l’emplacement de
+l’extension ou du thème à installer.
+
+<!-- With a `"resource": "url"` we can define the location of a `.zip` containing the plugin/theme. Use this for built ZIP artifacts hosted on a publicly accessible URL that does not require authentication, such as a release asset. CI artifact direct-download URLs can work, but they are often short-lived or restricted. -->
+
+Avec `"resource": "url"`, nous pouvons définir l’emplacement d’un `.zip`
+contenant l’extension/le thème. Utilisez cette option pour des artifacts ZIP
+construits hébergés sur une URL accessible publiquement qui ne nécessite pas
+d’authentification, comme un asset de release. Les URL de téléchargement direct
+d’artifacts CI peuvent fonctionner, mais elles sont souvent de courte durée ou
+restreintes.
+
+<!-- For source code stored in a Git repository, prefer [`git:directory`](/blueprints/steps/resources#gitdirectoryreference). It can fetch a repository subdirectory from a branch, tag, or commit without requiring a ZIP archive. -->
+
+Pour du code source stocké dans un dépôt Git, préférez
+[`git:directory`](/blueprints/steps/resources#gitdirectoryreference). Cette
+ressource peut récupérer un sous-répertoire de dépôt depuis une branche, une
+étiquette ou un commit sans nécessiter d’archive ZIP.
+
+<!-- Before using a `url` resource, verify that the URL: -->
+
+Avant d’utiliser une ressource `url`, vérifiez que l’URL :
+
+<!--
+- Downloads the file directly. It must not return an HTML page, redirect warning, login page, repository file viewer, or proxy error page.
+- Is available without cookies, authentication, a VPN, or a temporary browser session.
+- Sends CORS headers that allow Playground to fetch it.
+- Points to the expected file type. `installPlugin` and `installTheme` need a plugin or theme ZIP archive unless you use another resource type.
+- Will remain available. Temporary tunnel URLs, draft release assets, and short-lived CI artifacts can expire.
+- Is a real ZIP archive when the step expects a ZIP. Very small downloads often mean the server returned an HTML error page instead of the archive.
+-->
+
+- Télécharge directement le fichier. Elle ne doit pas renvoyer une page HTML, un avertissement de redirection, une page de connexion, un aperçu de fichier de dépôt ni une page d’erreur de proxy.
+- Est disponible sans cookies, authentification, VPN ni session temporaire de navigateur.
+- Envoie des en-têtes CORS qui autorisent Playground à la récupérer.
+- Pointe vers le type de fichier attendu. `installPlugin` et `installTheme` nécessitent une archive ZIP d’extension ou de thème, sauf si vous utilisez un autre type de ressource.
+- Restera disponible. Les URL de tunnel temporaires, les assets de release en brouillon et les artifacts CI de courte durée peuvent expirer.
+- Est une véritable archive ZIP lorsque l’étape attend un ZIP. Les téléchargements très petits signifient souvent que le serveur a renvoyé une page d’erreur HTML au lieu de l’archive.
+
+<!--
+For GitHub source code, do not point `url` at a repository page or a generated
+ZIP from a branch when you can use `git:directory`. Use `url` for built ZIP
+artifacts and `git:directory` for source directories.
+-->
+
+Pour du code source GitHub, ne faites pas pointer `url` vers une page de dépôt
+ou un ZIP généré depuis une branche lorsque vous pouvez utiliser
+`git:directory`. Utilisez `url` pour des artifacts ZIP construits et
+`git:directory` pour des répertoires de source.
+
+<!-- ### GitDirectoryReference -->
+
+### GitDirectoryReference
+
+<!-- The `GitDirectoryReference` resource is used to reference a directory inside a Git repository. This is useful when a plugin or theme lives in a subfolder of a repo, or when you want to install from a specific branch, tag, or commit. -->
+
+La ressource `GitDirectoryReference` sert à référencer un répertoire dans un
+dépôt Git. C’est utile lorsqu’une extension ou un thème se trouve dans un
+sous-dossier d’un dépôt, ou lorsque vous voulez installer depuis une branche,
+une étiquette ou un commit précis.
+
+```typescript
+type GitDirectoryReference = {
+	resource: 'git:directory';
+	url: string; // Repository URL (https://, ssh git@..., etc.)
+	path?: string; // Optional subdirectory inside the repository
+	ref?: string; // Branch, tag, or commit SHA (defaults to HEAD)
+	refType?: 'branch' | 'tag' | 'commit'; // Hint for resolving the ref
+	'.git'?: boolean; // Experimental: include a .git directory with fetched metadata
+};
+```
+
+<!-- **Example:** -->
+
+**Exemple :**
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "git:directory",
+		"url": "https://github.com/WordPress/block-development-examples",
+		"ref": "HEAD",
+		"path": "plugins/data-basics-59c8f8"
+	},
+	"options": {
+		"activate": true,
+		"targetFolderName": "data-basics"
+	}
+}
+```
+
+<!-- **Notes:** -->
+
+**Notes :**
+
+<!--
+- When using a branch or tag name for `ref`, you must specify `refType` (e.g. `"refType": "branch"`). Without it, only `HEAD` is reliably resolved.
+- Playground automatically detects providers like GitHub and GitLab.
+- Repository URLs may include or omit a trailing `.git` suffix. Extra trailing slashes are ignored.
+- It handles CORS-proxied fetches and sparse checkouts, so you can use URLs that point to specific subdirectories or branches.
+- This resource can be used with steps like [`installPlugin`](/blueprints/steps) and [`installTheme`](/blueprints/steps).
+- Set `".git": true` to include a `.git` folder containing packfiles and refs so Git-aware tooling can detect the checkout. This currently mirrors a shallow clone of the selected ref.
+- The folder name is derived from the URL by default (e.g. `https-github-com-WordPress-block-development-examples-HEAD-at-plugins-data-basics-59c8f8`). Use `options.targetFolderName` in the step to override it, as shown in the example above.
+-->
+
+- Lorsque vous utilisez un nom de branche ou d’étiquette pour `ref`, vous devez indiquer `refType` (par exemple `"refType": "branch"`). Sans cela, seul `HEAD` est résolu de façon fiable.
+- Playground détecte automatiquement les fournisseurs comme GitHub et GitLab.
+- Les URL de dépôt peuvent inclure ou omettre un suffixe final `.git`. Les barres obliques finales supplémentaires sont ignorées.
+- Cette ressource gère les récupérations via proxy CORS et les sparse checkouts ; vous pouvez donc utiliser des URL qui pointent vers des sous-répertoires ou branches précis.
+- Cette ressource peut être utilisée avec des étapes comme [`installPlugin`](/blueprints/steps) et [`installTheme`](/blueprints/steps).
+- Définissez `".git": true` pour inclure un dossier `.git` contenant les packfiles et les refs afin que les outils sensibles à Git puissent détecter le checkout. Cela reflète actuellement un clone superficiel de la ref sélectionnée.
+- Le nom du dossier est dérivé de l’URL par défaut (par exemple `https-github-com-WordPress-block-development-examples-HEAD-at-plugins-data-basics-59c8f8`). Utilisez `options.targetFolderName` dans l’étape pour le remplacer, comme dans l’exemple ci-dessus.
+
+<!-- ### CoreThemeReference -->
+
+### CoreThemeReference
+
+<!-- The _CoreThemeReference_ resource is used to reference WordPress core themes. The _CoreThemeReference_ resource is defined as follows: -->
+
+La ressource _CoreThemeReference_ sert à référencer les thèmes du cœur
+WordPress. La ressource _CoreThemeReference_ est définie comme suit :
+
+```typescript
+type CoreThemeReference = {
+	resource: 'wordpress.org/themes';
+	slug: string;
+	version?: string;
+};
+```
+
+<!-- To use the _CoreThemeReference_ resource, you need to provide the slug of the theme. For example, to reference the "Twenty Twenty-One" theme, you can create a _CoreThemeReference_ as follows: -->
+
+Pour utiliser la ressource _CoreThemeReference_, vous devez fournir le slug du
+thème. Par exemple, pour référencer le thème "Twenty Twenty-One", vous pouvez
+créer une _CoreThemeReference_ comme suit :
+
+```json
+{
+	"resource": "wordpress.org/themes",
+	"slug": "twentytwentyone"
+}
+```
+
+<!-- ### CorePluginReference -->
+
+### CorePluginReference
+
+<!-- The _CorePluginReference_ resource is used to reference WordPress core plugins. The _CorePluginReference_ resource is defined as follows: -->
+
+La ressource _CorePluginReference_ sert à référencer les extensions du cœur
+WordPress. La ressource _CorePluginReference_ est définie comme suit :
+
+```typescript
+type CorePluginReference = {
+	resource: 'wordpress.org/plugins';
+	slug: string;
+	version?: string;
+};
+```
+
+<!-- To use the _CorePluginReference_ resource, you need to provide the slug of the plugin. For example, to reference the "Akismet" plugin, you can create a _CorePluginReference_ as follows: -->
+
+Pour utiliser la ressource _CorePluginReference_, vous devez fournir le slug de
+l’extension. Par exemple, pour référencer l’extension "Akismet", vous pouvez
+créer une _CorePluginReference_ comme suit :
+
+```json
+{
+	"resource": "wordpress.org/plugins",
+	"slug": "akismet"
+}
+```
+
+<!-- ### VFSReference -->
+
+### VFSReference
+
+<!-- The _VFSReference_ resource is used to reference files that are stored in a virtual file system (VFS). The VFS is a file system that is stored in memory and can be used to store files that are not part of the file system of the operating system. The _VFSReference_ resource is defined as follows: -->
+
+La ressource _VFSReference_ sert à référencer des fichiers stockés dans un
+système de fichiers virtuel (VFS). Le VFS est un système de fichiers stocké en
+mémoire qui peut servir à stocker des fichiers ne faisant pas partie du système
+de fichiers du système d’exploitation. La ressource _VFSReference_ est définie
+comme suit :
+
+```typescript
+type VFSReference = {
+	resource: 'vfs';
+	path: string;
+};
+```
+
+<!-- To use the _VFSReference_ resource, you need to provide the path to the file in the VFS. For example, to reference a file named "index.html" that is stored in the root of the VFS, you can create a _VFSReference_ as follows: -->
+
+Pour utiliser la ressource _VFSReference_, vous devez fournir le chemin vers le
+fichier dans le VFS. Par exemple, pour référencer un fichier nommé "index.html"
+stocké à la racine du VFS, vous pouvez créer une _VFSReference_ comme suit :
+
+```json
+{
+	"resource": "vfs",
+	"path": "/index.html"
+}
+```
+
+<!-- ### LiteralReference -->
+
+### LiteralReference
+
+<!-- The _LiteralReference_ resource is used to reference files that are stored as literals in the code. The _LiteralReference_ resource is defined as follows: -->
+
+La ressource _LiteralReference_ sert à référencer des fichiers stockés comme
+littéraux dans le code. La ressource _LiteralReference_ est définie comme suit :
+
+```typescript
+type LiteralReference = {
+	resource: 'literal';
+	name: string;
+	contents: string | Uint8Array;
+};
+```
+
+<!-- To use the _LiteralReference_ resource, you need to provide the name of the file and its contents. For example, to reference a file named "index.html" that contains the text "Hello, World!", you can create a _LiteralReference_ as follows: -->
+
+Pour utiliser la ressource _LiteralReference_, vous devez fournir le nom du
+fichier et son contenu. Par exemple, pour référencer un fichier nommé
+"index.html" qui contient le texte "Hello, World!", vous pouvez créer une
+_LiteralReference_ comme suit :
+
+```json
+{
+	"resource": "literal",
+	"name": "index.html",
+	"contents": "Hello, World!"
+}
+```
+
+<!-- ### BundledReference -->
+
+### BundledReference
+
+<!-- The `BundledReference` resource is used to reference files that are bundled with the Blueprint itself. This is particularly useful for creating self-contained Blueprint bundles that include all necessary resources. The `BundledReference` resource is defined as follows: -->
+
+La ressource `BundledReference` sert à référencer des fichiers inclus avec le
+Blueprint lui-même. C’est particulièrement utile pour créer des bundles de
+Blueprint autonomes qui incluent toutes les ressources nécessaires. La ressource
+`BundledReference` est définie comme suit :
+
+```typescript
+type BundledReference = {
+	resource: 'bundled';
+	path: string;
+};
+```
+
+<!-- To use the `BundledReference` resource, you need to provide the relative path to the file within the bundle. For example, to reference a file named "plugin.php" that is bundled with the Blueprint, you can create a `BundledReference` as follows: -->
+
+Pour utiliser la ressource `BundledReference`, vous devez fournir le chemin
+relatif vers le fichier dans le bundle. Par exemple, pour référencer un fichier
+nommé "plugin.php" inclus avec le Blueprint, vous pouvez créer une
+`BundledReference` comme suit :
+
+```json
+{
+	"resource": "bundled",
+	"path": "plugin.php"
+}
+```
+
+<!-- Blueprint bundles can be distributed in various formats, including: -->
+
+Les bundles de Blueprint peuvent être distribués dans différents formats,
+notamment :
+
+<!--
+- ZIP files with a top-level `blueprint.json` file
+- Directories containing a `blueprint.json` file and related resources
+- Remote URLs where the Blueprint and its resources are hosted together
+-->
+
+- Des fichiers ZIP avec un fichier `blueprint.json` au premier niveau.
+- Des répertoires contenant un fichier `blueprint.json` et les ressources associées.
+- Des URL distantes où le Blueprint et ses ressources sont hébergés ensemble.
+
+<!-- For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation. -->
+
+Pour plus d’informations sur les bundles de Blueprint, consultez la
+documentation des [Blueprint Bundles](/blueprints/bundles).

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -1,263 +1,955 @@
 ---
 title: Dépanner et déboguer
 slug: /blueprints/troubleshoot-and-debug
-description: Un guide avec des conseils et des outils pour vous aider à dépanner et déboguer vos Blueprints, des problèmes courants aux outils du navigateur.
+description: Un guide consultable des erreurs courantes de Blueprint, notamment les échecs de récupération, les erreurs de validation, les échecs PHP et les problèmes d’activation d’extensions.
 ---
 
-<!--
-title: Troubleshoot and debug
-description: A guide with tips and tools to help you troubleshoot and debug your Blueprints, from common issues to browser tools.
--->
+<!-- title: Troubleshoot and debug -->
 
-<!--
-# Troubleshoot and debug Blueprints
--->
+<!-- description: A searchable guide to common Blueprint errors, including fetch failures, validation errors, PHP failures, and plugin activation issues. -->
+
+<!-- # Troubleshoot and debug Blueprints -->
 
 # Dépanner et déboguer les Blueprints
 
-<!--
-When you build Blueprints, you might run into issues. Here are tips and tools to help you debug them:
--->
+<!-- Blueprint errors usually point to one of three places: -->
 
-Lorsque vous créez des Blueprints, vous pouvez rencontrer des problèmes. Voici des conseils et des outils pour vous aider à les déboguer :
+Les erreurs de Blueprint pointent généralement vers l’un de ces trois endroits :
 
 <!--
-## Review Common gotchas
+- The Blueprint JSON is invalid.
+- Playground could not fetch the Blueprint or one of its resources.
+- A Blueprint step ran, but WordPress, PHP, WP-CLI, or a plugin failed.
 -->
 
-## Vérifier les pièges courants
+- Le JSON du Blueprint n’est pas valide.
+- Playground n’a pas pu récupérer le Blueprint ou l’une de ses ressources.
+- Une étape du Blueprint s’est exécutée, mais WordPress, PHP, WP-CLI ou une extension a échoué.
 
 <!--
-- Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you’d need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('wordpress/wp-load.php'); REST_OF_YOUR_CODE"`.
+Start with the exact error name shown by Playground, then use the matching
+section below.
 -->
 
-- Requérir `wp-load` : pour exécuter une fonction PHP de WordPress avec l’étape `runPHP`, vous devez requérir [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). La valeur de la clé `code` doit donc commencer par `"<?php require_once('wordpress/wp-load.php'); LE_RESTE_DE_VOTRE_CODE"`.
+Commencez par le nom d’erreur exact affiché par Playground, puis utilisez la
+section correspondante ci-dessous.
+
+<!-- ## Quick checklist -->
+
+## Liste de vérification rapide
 
 <!--
-## Common Issues and Solutions
+- Paste the Blueprint into the [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to validate the JSON schema.
+- If the Blueprint is loaded from a URL, open that URL directly in a private browser window and confirm it downloads valid JSON or a Blueprint ZIP bundle.
+- If a step fails, note the step number in `BlueprintStepExecutionError`. The failed step is usually the item at that position after Blueprint shorthands have been expanded.
+- Open browser developer tools and check the Console and Network tabs for download, CORS, PHP, or plugin activation details.
+- For plugin/theme activation failures, check the Playground **Logs** panel or the browser console for PHP warnings and fatal errors.
 -->
 
-## Problèmes courants et solutions
+- Collez le Blueprint dans l’[éditeur de Blueprints](https://playground.wordpress.net/builder/builder.html) pour valider le schéma JSON.
+- Si le Blueprint est chargé depuis une URL, ouvrez cette URL directement dans une fenêtre de navigation privée et confirmez qu’elle télécharge du JSON valide ou un bundle ZIP de Blueprint.
+- Si une étape échoue, notez son numéro dans `BlueprintStepExecutionError`. L’étape échouée est généralement l’élément à cette position après le développement des raccourcis de Blueprint.
+- Ouvrez les outils de développement du navigateur et consultez les onglets Console et Network pour obtenir des détails sur le téléchargement, CORS, PHP ou l’activation d’extensions.
+- Pour les échecs d’activation d’extension ou de thème, consultez le panneau **Logs** de Playground ou la console du navigateur pour les avertissements PHP et les erreurs fatales.
+
+<!-- ## InvalidBlueprintError -->
+
+## InvalidBlueprintError
 
 <!--
-### Invalid Blueprint After Opening a Link
+`InvalidBlueprintError` means the Blueprint does not match the
+[Blueprint data format](/blueprints/data-format). The error output usually
+contains paths such as `/steps/2/pluginData` or `/preferredVersions`.
 -->
 
-### Blueprint non valide après l’ouverture d’un lien
+`InvalidBlueprintError` signifie que le Blueprint ne correspond pas au
+[format de données Blueprint](/blueprints/data-format). La sortie d’erreur
+contient généralement des chemins comme `/steps/2/pluginData` ou
+`/preferredVersions`.
+
+<!-- ### Unexpected property `activate` -->
+
+### Propriété inattendue `activate`
 
 <!--
-If Playground reports `Invalid blueprint`, read the detailed error message. It includes the underlying JSON parsing error when one is available.
+`activate` belongs inside `options`, not directly on the step or inside
+`pluginData`.
 -->
 
-Si Playground indique `Invalid blueprint`, lisez le message d’erreur détaillé. Il inclut l’erreur d’analyse JSON sous-jacente lorsqu’elle est disponible.
-
-<!--
-If the message says the input still contains `%XX` escapes after decoding, the URL fragment was likely double-encoded. Rebuild the link from the original Blueprint object and encode it once with `encodeURIComponent(JSON.stringify(blueprint))`, or use Base64. Do not encode a fragment that is already encoded.
--->
-
-Si le message indique que l’entrée contient encore des échappements `%XX` après le décodage, le fragment d’URL a probablement été encodé deux fois. Reconstruisez le lien depuis l’objet Blueprint d’origine et encodez-le une seule fois avec `encodeURIComponent(JSON.stringify(blueprint))`, ou utilisez Base64. N’encodez pas un fragment qui est déjà encodé.
-
-<!--
-### WP-CLI: Error Establishing a Database Connection on Mounted Sites
--->
-
-### WP-CLI : erreur lors de l’établissement d’une connexion à la base de données sur les sites montés {#wp-cli-error-establishing-a-database-connection-on-mounted-sites}
-
-<!--
-When using `wp-cli` with a mounted Playground site (e.g., via `--mount-before-install`), you might encounter an "Error establishing a database connection." This happens because WordPress Playground loads the SQLite database integration plugin from its internal files by default, not from the mounted directory, meaning it's not persisted for external `wp-cli` calls.
--->
-
-Lorsque vous utilisez `wp-cli` avec un site Playground monté (par exemple avec `--mount-before-install`), vous pouvez rencontrer une erreur « Error establishing a database connection ». Cela se produit parce que WordPress Playground charge par défaut l’extension d’intégration de base de données SQLite depuis ses fichiers internes, et non depuis le répertoire monté, ce qui signifie qu’elle n’est pas conservée pour les appels externes à `wp-cli`.
-
-<!--
-To resolve this, you need to explicitly install and configure the SQLite database integration plugin within your Blueprint.
--->
-
-Pour résoudre ce problème, vous devez installer et configurer explicitement l’extension d’intégration de base de données SQLite dans votre Blueprint.
-
-<!--
-**Solution:** Add the following steps to your Blueprint:
--->
-
-**Solution :** ajoutez les étapes suivantes à votre Blueprint :
+`activate` doit se trouver dans `options`, pas directement sur l’étape ni dans
+`pluginData`.
 
 ```json
 {
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!-- ### Unexpected property `plugins` in `preferredVersions` -->
+
+### Propriété inattendue `plugins` dans `preferredVersions`
+
+<!--
+`preferredVersions` only accepts `php` and `wp`. Install plugins with the
+top-level `plugins` shorthand or with an explicit `installPlugin` step.
+-->
+
+`preferredVersions` accepte uniquement `php` et `wp`. Installez les extensions
+avec le raccourci de premier niveau `plugins` ou avec une étape explicite
+`installPlugin`.
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
 	"plugins": ["sqlite-database-integration"]
 }
 ```
 
+<!-- ### Missing `slug`, `url`, `path`, or `files` -->
+
+### `slug`, `url`, `path` ou `files` manquant
+
+<!-- The resource object is incomplete or uses the wrong shape. Common fixes: -->
+
+L’objet de ressource est incomplet ou utilise une forme incorrecte. Corrections
+courantes :
+
 <!--
-**Example Usage:**
+- WordPress.org plugin: `{ "resource": "wordpress.org/plugins", "slug": "akismet" }`
+- ZIP URL: `{ "resource": "url", "url": "https://example.com/plugin.zip" }`
+- Git directory: `{ "resource": "git:directory", "url": "https://github.com/org/repo", "ref": "trunk", "refType": "branch" }`
 -->
 
-**Exemple d’utilisation :**
+- Extension WordPress.org : `{ "resource": "wordpress.org/plugins", "slug": "akismet" }`
+- URL ZIP : `{ "resource": "url", "url": "https://example.com/plugin.zip" }`
+- Répertoire Git : `{ "resource": "git:directory", "url": "https://github.com/org/repo", "ref": "trunk", "refType": "branch" }`
 
 <!--
-To test this locally, combine the Blueprint with your Playground CLI command:
+See [Resources References](/blueprints/steps/resources) for all supported
+resource shapes.
 -->
 
-Pour tester cela localement, combinez le Blueprint avec votre commande Playground CLI :
+Consultez les [références des ressources](/blueprints/steps/resources) pour
+voir toutes les formes de ressource prises en charge.
 
-```bash
-mkdir wordpress
-# Ensure your blueprint with the above steps is saved as, for example, './blueprint.json'
-npx @wp-playground/cli server --mount-before-install=wordpress:/wordpress --blueprint=./blueprint.json
-cd wordpress
-wp post list
+<!-- ### Mixed plugin install properties -->
+
+### Propriétés d’installation d’extension mélangées
+
+<!--
+Use `pluginData` for `installPlugin`. Do not provide both `pluginData` and
+older examples or custom objects such as `pluginZipFile`.
+-->
+
+Utilisez `pluginData` pour `installPlugin`. Ne fournissez pas à la fois
+`pluginData` et d’anciens exemples ou objets personnalisés comme
+`pluginZipFile`.
+
+<!-- The WordPress.org plugin resource also needs a separate `slug`: -->
+
+La ressource d’extension WordPress.org nécessite aussi un `slug` séparé :
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	}
+}
+```
+
+<!-- Do not write `"resource": "wordpress.org/plugins/woocommerce"`. -->
+
+N’écrivez pas `"resource": "wordpress.org/plugins/woocommerce"`.
+
+<!-- ## BlueprintFetchError -->
+
+## BlueprintFetchError
+
+<!--
+`BlueprintFetchError` means Playground could not load the file passed to
+`?blueprint-url=`.
+-->
+
+`BlueprintFetchError` signifie que Playground n’a pas pu charger le fichier
+passé à `?blueprint-url=`.
+
+<!-- Check that the URL: -->
+
+Vérifiez que l’URL :
+
+<!--
+- Is public and does not require cookies, login, a temporary session, or a VPN.
+- Returns HTTP 200 when opened directly.
+- Serves valid JSON or a ZIP bundle with `blueprint.json` inside it.
+- Sends `Access-Control-Allow-Origin: *` or another header that allows
+  `https://playground.wordpress.net`.
+- Uses a raw file URL, not a repository HTML page.
+-->
+
+- Est publique et ne nécessite pas de cookies, de connexion, de session temporaire ni de VPN.
+- Renvoie HTTP 200 lorsqu’elle est ouverte directement.
+- Sert du JSON valide ou un bundle ZIP avec `blueprint.json` à l’intérieur.
+- Envoie `Access-Control-Allow-Origin: *` ou un autre en-tête qui autorise
+  `https://playground.wordpress.net`.
+- Utilise une URL de fichier brut, pas une page HTML de dépôt.
+
+<!--
+For GitHub, use `raw.githubusercontent.com` URLs instead of `github.com/.../blob/...`.
+For GitLab, use the raw file URL instead of a `/-/blob/` page.
+-->
+
+Pour GitHub, utilisez des URL `raw.githubusercontent.com` au lieu de
+`github.com/.../blob/...`. Pour GitLab, utilisez l’URL de fichier brut au lieu
+d’une page `/-/blob/`.
+
+```text
+# Good
+https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/welcome/blueprint.json
+
+# Not a raw JSON response
+https://github.com/WordPress/blueprints/blob/trunk/blueprints/welcome/blueprint.json
 ```
 
 <!--
-This will ensure the SQLite plugin is installed correctly and configured within your mounted WordPress site, allowing `wp-cli` commands to function correctly.
+Temporary tunnel URLs, local development URLs, and draft release assets often
+fail because the browser cannot reach them or because they do not allow
+cross-origin requests. Move the Blueprint to a public host with CORS enabled.
 -->
 
-Cela garantit que l’extension SQLite est installée correctement et configurée dans votre site WordPress monté, ce qui permet aux commandes `wp-cli` de fonctionner correctement.
+Les URL de tunnel temporaires, les URL de développement local et les assets de
+release en brouillon échouent souvent parce que le navigateur ne peut pas les
+atteindre ou parce qu’ils n’autorisent pas les requêtes cross-origin. Déplacez
+le Blueprint vers un hébergeur public avec CORS activé.
+
+<!-- ### Blueprint file is neither a valid JSON nor a ZIP file -->
+
+### Blueprint file is neither a valid JSON nor a ZIP file
 
 <!--
-## Blueprints Builder
+This means Playground received a response, but the response was not a Blueprint.
+The URL may have returned an HTML page, 404 page, repository file viewer, proxy
+warning, login page, or corrupted ZIP.
 -->
 
-## Générateur de Blueprints
+Cela signifie que Playground a reçu une réponse, mais que cette réponse n’était
+pas un Blueprint. L’URL a pu renvoyer une page HTML, une page 404, un aperçu de
+fichier de dépôt, un avertissement de proxy, une page de connexion ou un ZIP
+corrompu.
+
+<!-- Open the URL directly and check that: -->
+
+Ouvrez l’URL directement et vérifiez que :
 
 <!--
-You can use an in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to build, validate, and preview your Blueprints in the browser.
+- JSON URLs return valid Blueprint JSON.
+- ZIP bundle URLs download a real ZIP archive.
+- Blueprint bundles contain `blueprint.json` at the root of the ZIP.
+- The response is not a small HTML or text error page.
 -->
 
-Vous pouvez utiliser un [éditeur de Blueprints](https://playground.wordpress.net/builder/builder.html) dans le navigateur pour créer, valider et prévisualiser vos Blueprints.
+- Les URL JSON renvoient du JSON de Blueprint valide.
+- Les URL de bundle ZIP téléchargent une véritable archive ZIP.
+- Les bundles de Blueprint contiennent `blueprint.json` à la racine du ZIP.
+- La réponse n’est pas une petite page d’erreur HTML ou texte.
+
+<!-- ### URIError: URI malformed -->
+
+### URIError: URI malformed
+
+<!--
+`URIError: URI malformed` usually points to a broken encoded Blueprint fragment
+in the URL, not to a failed Blueprint step. Check for invalid `%` escapes,
+double-encoded fragments, or raw JSON pasted after `#`. Rebuild the link from
+the original Blueprint and encode it once, or use Base64. See
+[Encoded Blueprint fragments](/blueprints/using-blueprints).
+-->
+
+`URIError: URI malformed` indique généralement un fragment de Blueprint encodé
+cassé dans l’URL, pas une étape de Blueprint échouée. Vérifiez les échappements
+`%` invalides, les fragments doublement encodés ou le JSON brut collé après
+`#`. Reconstruisez le lien depuis le Blueprint d’origine et encodez-le une
+seule fois, ou utilisez Base64. Consultez les
+[fragments de Blueprint encodés](/blueprints/using-blueprints).
+
+<!-- ## ResourceDownloadError -->
+
+## ResourceDownloadError
+
+<!--
+`ResourceDownloadError` means the Blueprint loaded, but a step could not download
+a resource such as a plugin ZIP, theme ZIP, WXR file, or imported site archive.
+-->
+
+`ResourceDownloadError` signifie que le Blueprint s’est chargé, mais qu’une
+étape n’a pas pu télécharger une ressource comme un ZIP d’extension, un ZIP de
+thème, un fichier WXR ou une archive de site importée.
+
+<!-- Confirm the resource URL: -->
+
+Confirmez que l’URL de la ressource :
+
+<!--
+- Downloads the actual file, not an HTML page, redirect warning, or expired artifact.
+- Is public and does not require authentication.
+- Allows cross-origin requests.
+- Is the direct file URL. Some release pages and CI artifact pages are human pages, not direct downloads.
+- Still exists. Temporary links and CI artifacts can expire.
+-->
+
+- Télécharge le fichier réel, pas une page HTML, un avertissement de redirection ou un artifact expiré.
+- Est publique et ne nécessite pas d’authentification.
+- Autorise les requêtes cross-origin.
+- Est l’URL directe du fichier. Certaines pages de release et pages d’artifacts CI sont des pages destinées aux humains, pas des téléchargements directs.
+- Existe encore. Les liens temporaires et les artifacts CI peuvent expirer.
+
+<!--
+For source code in a Git repository, prefer a
+[`git:directory` resource](/blueprints/steps/resources#gitdirectoryreference).
+Use a `url` resource for built ZIP artifacts that are already publicly
+downloadable.
+-->
+
+Pour du code source dans un dépôt Git, préférez une
+[ressource `git:directory`](/blueprints/steps/resources#gitdirectoryreference).
+Utilisez une ressource `url` pour des artifacts ZIP construits qui sont déjà
+téléchargeables publiquement.
+
+<!-- ## BlueprintStepExecutionError -->
+
+## BlueprintStepExecutionError
+
+<!--
+`BlueprintStepExecutionError` means a specific step failed after the Blueprint
+started running. The message includes a step number:
+-->
+
+`BlueprintStepExecutionError` signifie qu’une étape précise a échoué après le
+démarrage du Blueprint. Le message inclut un numéro d’étape :
+
+```text
+BlueprintStepExecutionError: Error when executing the blueprint step #4
+```
+
+<!--
+Use that number to inspect the matching step. If your Blueprint uses shorthands
+such as `plugins`, `login`, `siteOptions`, or `constants`, Playground expands
+them into steps before running the Blueprint. Use explicit `steps` when the
+order matters.
+-->
+
+Utilisez ce numéro pour inspecter l’étape correspondante. Si votre Blueprint
+utilise des raccourcis comme `plugins`, `login`, `siteOptions` ou `constants`,
+Playground les développe en étapes avant d’exécuter le Blueprint. Utilisez des
+`steps` explicites lorsque l’ordre compte.
+
+<!--
+URL query parameters such as `?plugin=...`, `?theme=...`, `?php=...`,
+`?wp=...`, and `?networking=yes` also create an implicit Blueprint. Errors from
+those URLs are still Blueprint execution errors, and the generated steps affect
+the reported step number.
+-->
+
+Les paramètres de requête d’URL comme `?plugin=...`, `?theme=...`, `?php=...`,
+`?wp=...` et `?networking=yes` créent aussi un Blueprint implicite. Les erreurs
+issues de ces URL restent des erreurs d’exécution de Blueprint, et les étapes
+générées influencent le numéro d’étape indiqué.
+
+<!-- ## PHP.run() failed with exit code 255 -->
+
+## PHP.run() failed with exit code 255
+
+<!--
+Exit code `255` usually means PHP hit a fatal error. Look for the first
+`Fatal error`, `Uncaught`, or `TypeError` line in the output. The large HTML
+error page around it is usually WordPress's generic critical error screen.
+-->
+
+Le code de sortie `255` signifie généralement que PHP a rencontré une erreur
+fatale. Recherchez la première ligne `Fatal error`, `Uncaught` ou `TypeError`
+dans la sortie. La grande page d’erreur HTML qui l’entoure est généralement
+l’écran générique d’erreur critique de WordPress.
+
+<!--
+To make the output more useful while debugging, enable WordPress debug constants
+near the beginning of the Blueprint:
+-->
+
+Pour rendre la sortie plus utile pendant le débogage, activez les constantes de
+débogage WordPress près du début du Blueprint :
+
+```json
+{
+	"step": "defineWpConfigConsts",
+	"consts": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"WP_DISABLE_FATAL_ERROR_HANDLER": true
+	}
+}
+```
+
+<!--
+Then rerun the Blueprint and check the Playground **Logs** panel or browser
+console.
+-->
+
+Relancez ensuite le Blueprint et consultez le panneau **Logs** de Playground ou
+la console du navigateur.
+
+<!-- ## PHP.run() failed with exit code 1 -->
+
+## PHP.run() failed with exit code 1
+
+<!--
+Exit code `1` often appears when WP-CLI or WordPress returns an application
+error. Read the `Stderr` section first. It usually names the unsupported
+argument, missing resource, or command-specific failure.
+-->
+
+Le code de sortie `1` apparaît souvent lorsque WP-CLI ou WordPress renvoie une
+erreur applicative. Lisez d’abord la section `Stderr`. Elle nomme généralement
+l’argument non pris en charge, la ressource manquante ou l’échec propre à la
+commande.
+
+<!--
+Some WP-CLI commands behave differently in Playground because WordPress runs in
+WebAssembly with SQLite. Keep commands small and test them individually before
+adding a long chain to a Blueprint.
+-->
+
+Certaines commandes WP-CLI se comportent différemment dans Playground parce que
+WordPress s’exécute dans WebAssembly avec SQLite. Gardez les commandes courtes
+et testez-les individuellement avant d’ajouter une longue chaîne à un Blueprint.
+
+<!-- ## Undefined constant `ABSPATH` -->
+
+## Undefined constant `ABSPATH`
+
+<!--
+This usually happens in a `runPHP` step that calls WordPress APIs without first
+loading WordPress.
+-->
+
+Cela se produit généralement dans une étape `runPHP` qui appelle des API
+WordPress sans charger WordPress au préalable.
+
+<!-- Add `wp-load.php` before any WordPress function, constant, option, or plugin API: -->
+
+Ajoutez `wp-load.php` avant toute fonction, constante, option ou API d’extension
+WordPress :
+
+```json
+{
+	"step": "runPHP",
+	"code": "<?php require '/wordpress/wp-load.php'; update_option('blogname', 'Demo site');"
+}
+```
+
+<!-- ## Plugin could not be activated -->
+
+## Plugin could not be activated
+
+<!--
+Plugin activation errors usually come from the plugin itself, not from the
+Blueprint runner. Common causes:
+-->
+
+Les erreurs d’activation d’extensions viennent généralement de l’extension
+elle-même, pas de l’exécuteur de Blueprints. Causes fréquentes :
+
+<!--
+- The plugin requires a newer PHP version or WordPress version.
+- The plugin has a fatal error on activation.
+- The plugin depends on another plugin that is not installed or activated.
+- The plugin performs a redirect or prints unexpected output during activation.
+- The plugin ZIP extracts to a folder or main file name different from the path the step is activating.
+-->
+
+- L’extension nécessite une version plus récente de PHP ou de WordPress.
+- L’extension déclenche une erreur fatale pendant l’activation.
+- L’extension dépend d’une autre extension qui n’est pas installée ou activée.
+- L’extension effectue une redirection ou affiche une sortie inattendue pendant l’activation.
+- Le ZIP de l’extension s’extrait dans un dossier ou un fichier principal dont le nom ne correspond pas au chemin activé par l’étape.
+
+<!--
+If the error says the current PHP or WordPress version does not meet minimum
+requirements, set `preferredVersions`:
+-->
+
+Si l’erreur indique que la version actuelle de PHP ou de WordPress ne respecte
+pas les prérequis minimaux, définissez `preferredVersions` :
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	}
+}
+```
+
+<!-- ### WordPress exited with exit code 0 -->
+
+### WordPress exited with exit code 0
+
+<!--
+Activation can fail even when WordPress exits with code `0`. This usually means
+WordPress returned an activation error response rather than a PHP process crash.
+When the message says `Inspect the "debug" logs`, check the Playground **Logs**
+panel, browser console, or CLI output.
+-->
+
+L’activation peut échouer même quand WordPress se termine avec le code `0`. Cela
+signifie généralement que WordPress a renvoyé une réponse d’erreur d’activation,
+plutôt qu’un plantage du processus PHP. Quand le message indique
+`Inspect the "debug" logs`, consultez le panneau **Logs** de Playground, la
+console du navigateur ou la sortie de la CLI.
+
+<!--
+Look for PHP warnings, redirects or output printed during activation, missing
+dependency plugins, or plugin minimum PHP/WordPress requirements.
+-->
+
+Cherchez des avertissements PHP, des redirections ou une sortie imprimée pendant
+l’activation, des extensions dépendantes manquantes ou des prérequis minimaux
+PHP/WordPress de l’extension.
+
+<!-- ### Current PHP or WordPress version does not meet minimum requirements -->
+
+### Current PHP or WordPress version does not meet minimum requirements
+
+<!-- Version mismatch errors often include text like: -->
+
+Les erreurs d’incompatibilité de version contiennent souvent un texte comme :
+
+```text
+Current PHP version (7.4.33) does not meet minimum requirements. The plugin requires PHP 8.0.
+```
+
+<!-- or: -->
+
+ou :
+
+```text
+Current WordPress version (6.9.4) does not meet minimum requirements. The plugin requires WordPress 7.0.
+```
+
+<!--
+Set `preferredVersions` to a compatible PHP and WordPress version, or use a
+plugin/theme release that supports the versions available in Playground.
+-->
+
+Définissez `preferredVersions` avec une version compatible de PHP et de
+WordPress, ou utilisez une version de l’extension ou du thème compatible avec
+les versions disponibles dans Playground.
+
+<!-- If the error is: -->
+
+Si l’erreur est :
+
+```text
+Failed to download WordPress 6.9.0 (HTTP 404)
+```
+
+<!--
+the requested WordPress build is not available. Use `latest`, a supported
+released version, or a supported beta/nightly value.
+-->
+
+la build WordPress demandée n’est pas disponible. Utilisez `latest`, une version
+publiée prise en charge ou une valeur beta/nightly prise en charge.
+
+<!--
+If the error says `Plugin file does not exist`, inspect the installed folder
+name. For ZIP URLs with unusual folder names, set `targetFolderName`:
+-->
+
+Si l’erreur indique `Plugin file does not exist`, inspectez le nom du dossier
+installé. Pour les URL ZIP dont les noms de dossier sont inhabituels,
+définissez `targetFolderName` :
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "url",
+		"url": "https://example.com/my-plugin.zip"
+	},
+	"options": {
+		"activate": true,
+		"targetFolderName": "my-plugin"
+	}
+}
+```
+
+<!--
+If the plugin has dependencies, install and activate those dependencies first
+with explicit steps.
+-->
+
+Si l’extension a des dépendances, installez et activez d’abord ces dépendances
+avec des étapes explicites.
+
+<!-- ## Theme could not be activated -->
+
+## Theme could not be activated
+
+<!--
+Theme activation failures usually mean the theme folder name is wrong, the
+theme ZIP extracted to an unexpected directory, or the theme code caused a
+WordPress/PHP error.
+-->
+
+Les échecs d’activation de thèmes signifient généralement que le nom du dossier
+du thème est incorrect, que le ZIP du thème s’est extrait dans un répertoire
+inattendu ou que le code du thème a causé une erreur WordPress/PHP.
+
+<!-- Use `installTheme` with `options.activate` when installing a theme: -->
+
+Utilisez `installTheme` avec `options.activate` lors de l’installation d’un
+thème :
+
+```json
+{
+	"step": "installTheme",
+	"themeData": {
+		"resource": "wordpress.org/themes",
+		"slug": "twentytwentyfour"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!--
+If you use a standalone `activateTheme` step, pass the folder name inside
+`wp-content/themes`, not a full URL or ZIP filename.
+-->
+
+Si vous utilisez une étape `activateTheme` autonome, fournissez le nom du
+dossier dans `wp-content/themes`, pas une URL complète ni un nom de fichier ZIP.
+
+<!-- ## Could not write to a file -->
+
+## Could not write to a file
+
+<!-- Errors like this mean the parent directory does not exist: -->
+
+Les erreurs comme celle-ci signifient que le répertoire parent n’existe pas :
+
+```text
+Could not write to "/wordpress/wp-content/plugins/example/index.php":
+There is no such file or directory OR the parent directory does not exist.
+```
+
+<!--
+Create the directory first with `mkdir`, or use `writeFiles` with a
+`literal:directory` resource.
+-->
+
+Créez d’abord le répertoire avec `mkdir`, ou utilisez `writeFiles` avec une
+ressource `literal:directory`.
+
+```json
+[
+	{
+		"step": "mkdir",
+		"path": "/wordpress/wp-content/plugins/example"
+	},
+	{
+		"step": "writeFile",
+		"path": "/wordpress/wp-content/plugins/example/index.php",
+		"data": "<?php /* Plugin Name: Example */"
+	}
+]
+```
+
+<!-- ## Could not unzip file -->
+
+## Could not unzip file
+
+<!--
+This usually means the file is not a valid ZIP archive. The URL may have
+returned an HTML page, an error response, a login page, or a truncated file.
+-->
+
+Cela signifie généralement que le fichier n’est pas une archive ZIP valide.
+L’URL peut avoir renvoyé une page HTML, une réponse d’erreur, une page de
+connexion ou un fichier tronqué.
+
+<!--
+If the output says `Could not unzip file. Error code: 19`, verify the download
+is a ZIP archive. A small file size often means the server returned an HTML
+error page instead of the archive.
+-->
+
+Si la sortie indique `Could not unzip file. Error code: 19`, vérifiez que le
+téléchargement est bien une archive ZIP. Une petite taille de fichier signifie
+souvent que le serveur a renvoyé une page d’erreur HTML au lieu de l’archive.
+
+<!--
+Open the URL directly and confirm the browser downloads a ZIP. If you are using
+a GitHub or CI artifact, use a direct-download URL and make sure the release or
+artifact is public.
+-->
+
+Ouvrez l’URL directement et confirmez que le navigateur télécharge un ZIP. Si
+vous utilisez un artefact GitHub ou CI, utilisez une URL de téléchargement
+direct et vérifiez que la release ou l’artefact est public.
+
+<!-- ## WP-CLI command pitfalls -->
+
+## Pièges des commandes WP-CLI
+
+<!--
+The `wp-cli` step runs WP-CLI inside Playground. It is useful for setup tasks,
+but not every command or shell feature behaves like a local terminal.
+-->
+
+L’étape `wp-cli` exécute WP-CLI dans Playground. Elle est utile pour les tâches
+de configuration, mais toutes les commandes ou fonctionnalités du shell ne se
+comportent pas comme dans un terminal local.
+
+<!-- Common fixes: -->
+
+Corrections fréquentes :
+
+<!--
+- Use the step name `"wp-cli"`, not `"wpcli"` or `"cli"`.
+- Keep commands focused. Prefer multiple `wp-cli` steps over one complex shell command.
+- Avoid shell substitutions such as `$(...)` in shared Blueprints. Use `runPHP` for logic that needs WordPress APIs.
+- Check parameter names against the WP-CLI command you are using. For example, command-specific parameters may differ between `wp post list`, `wp post delete`, and plugin-provided commands.
+- If a plugin-provided WP-CLI command fails with a plugin stack trace, the fix usually belongs in that plugin or in the input data passed to the command.
+- If a command fails with `unknown --post_type parameter` or `unknown --format parameter`, check whether the flags belong to a different command in the pipeline.
+- If a plugin command fails with `Unsupported argument type passed to WP_CLI::error_to_string(): 'NULL'`, confirm the plugin is active, the imported data exists, and the command input points to a valid resource.
+-->
+
+- Utilisez le nom d’étape `"wp-cli"`, pas `"wpcli"` ni `"cli"`.
+- Gardez les commandes ciblées. Préférez plusieurs étapes `wp-cli` à une seule commande shell complexe.
+- Évitez les substitutions shell comme `$(...)` dans les Blueprints partagés. Utilisez `runPHP` pour la logique qui nécessite les API WordPress.
+- Vérifiez les noms de paramètres dans la commande WP-CLI que vous utilisez. Par exemple, les paramètres propres à une commande peuvent différer entre `wp post list`, `wp post delete` et les commandes fournies par des extensions.
+- Si une commande WP-CLI fournie par une extension échoue avec une trace de pile de l’extension, la correction se trouve généralement dans cette extension ou dans les données d’entrée transmises à la commande.
+- Si une commande échoue avec `unknown --post_type parameter` ou `unknown --format parameter`, vérifiez si ces options appartiennent à une autre commande du pipeline.
+- Si une commande d’extension échoue avec `Unsupported argument type passed to WP_CLI::error_to_string(): 'NULL'`, confirmez que l’extension est active, que les données importées existent et que l’entrée de la commande pointe vers une ressource valide.
+
+<!-- ## WP-CLI: Error establishing a database connection on mounted sites -->
+
+## WP-CLI: Error establishing a database connection sur les sites montés {#wp-cli-error-establishing-a-database-connection-on-mounted-sites}
+
+<!--
+When using `wp-cli` with a mounted Playground site, for example via
+`--mount-before-install`, you might encounter an "Error establishing a database
+connection." This happens because WordPress Playground loads the SQLite database
+integration plugin from its internal files by default, not from the mounted
+directory.
+-->
+
+Lorsque vous utilisez `wp-cli` avec un site Playground monté, par exemple via
+`--mount-before-install`, vous pouvez rencontrer "Error establishing a database
+connection." Cela se produit parce que WordPress Playground charge par défaut
+l’extension d’intégration de base de données SQLite depuis ses fichiers
+internes, pas depuis le répertoire monté.
+
+<!-- Add the SQLite integration plugin to the mounted WordPress site explicitly: -->
+
+Ajoutez explicitement l’extension d’intégration SQLite au site WordPress monté :
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}
+```
+
+<!-- Then run the Blueprint with the mounted site: -->
+
+Exécutez ensuite le Blueprint avec le site monté :
+
+```bash
+mkdir wordpress
+npx @wp-playground/cli server --mount-before-install=wordpress:/wordpress --blueprint=./blueprint.json
+```
+
+<!-- ## Debugging tools -->
+
+## Outils de débogage
+
+<!-- ### Blueprints editor -->
+
+### Éditeur de Blueprints
+
+<!--
+Use the in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html)
+to build, validate, and preview Blueprints.
+-->
+
+Utilisez l’[éditeur de Blueprints](https://playground.wordpress.net/builder/builder.html)
+dans le navigateur pour créer, valider et prévisualiser des Blueprints.
+
+<!-- :::danger Caution -->
 
 :::danger Attention
 
 <!--
-The editor is under development and the embedded Playground sometimes fails to load. To get around it, refresh the page. We're aware of that, and are working to improve the experience.
+The editor is under development and the embedded Playground sometimes fails to
+load. To get around it, refresh the page.
 -->
 
-L’éditeur est en cours de développement et le Playground intégré ne se charge pas toujours. Pour contourner le problème, actualisez la page. Nous en sommes conscients et travaillons à améliorer l’expérience.
+L’éditeur est en cours de développement et le Playground intégré échoue parfois
+à se charger. Pour contourner le problème, actualisez la page.
 
 :::
 
-<!--
-## Check for the Filesystem and Database
--->
+<!-- ### Filesystem and database inspection -->
 
-## Vérifier le système de fichiers et la base de données
+### Inspection du système de fichiers et de la base de données
 
 <!--
-Some blueprint steps (such as [`writeFile`](/blueprints/steps#WriteFileStep)) alter the internal Filesystem structure of the Playground instance and some others (such as [`runSql`](/blueprints/steps#runSql)) alter the internal WordPress database.
+Some Blueprint steps, such as [`writeFile`](/blueprints/steps),
+alter the internal filesystem. Others, such as
+[`runSql`](/blueprints/steps), alter the database.
 -->
 
-Certaines étapes de Blueprint (comme [`writeFile`](/blueprints/steps#WriteFileStep)) modifient la structure interne du système de fichiers de l’instance Playground, et d’autres (comme [`runSql`](/blueprints/steps#runSql)) modifient la base de données WordPress interne.
+Certaines étapes de Blueprint, comme [`writeFile`](/blueprints/steps),
+modifient le système de fichiers interne. D’autres, comme
+[`runSql`](/blueprints/steps), modifient la base de données.
 
 <!--
-To check the final internal filesystem structure and database (after the blueprint steps have been applied) we can leverage some WordPress plugins that provide a SQL manager and a file explorer such as [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and [`WPide`](https://wordpress.org/plugins/wpide/) (you can see them in action from https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide)
+To inspect the final state, install plugins such as
+[`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and
+[`WPide`](https://wordpress.org/plugins/wpide/). You can see them in action at
+https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide.
 -->
 
-Pour vérifier la structure finale du système de fichiers interne et de la base de données (après l’application des étapes du Blueprint), nous pouvons utiliser des extensions WordPress qui fournissent un gestionnaire SQL et un explorateur de fichiers, comme [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) et [`WPide`](https://wordpress.org/plugins/wpide/) (vous pouvez les voir en action depuis https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide).
-
-:::tip
+Pour inspecter l’état final, installez des extensions comme
+[`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) et
+[`WPide`](https://wordpress.org/plugins/wpide/). Vous pouvez les voir en action
+sur https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide.
 
 <!--
-There are a bunch of methods we can launch from the console of any WordPress Playground instance to inspect the internals of that instance. They're exposed as part of `window.playground` object (see [Developers > JavaScript API > Debugging and testing](/developers/apis/javascript-api/#debugging-and-testing)). Some examples:
+You can also inspect a Playground instance from the browser console through
+`window.playground`:
 -->
 
-Plusieurs méthodes peuvent être lancées depuis la console de n’importe quelle instance WordPress Playground pour en inspecter les éléments internes. Elles sont exposées dans l’objet `window.playground` (voir [Développeurs > API JavaScript > Débogage et tests](/developers/apis/javascript-api/#debugging-and-testing)). Quelques exemples :
+Vous pouvez aussi inspecter une instance Playground depuis la console du
+navigateur via `window.playground` :
 
+```js
+await playground.isDir('/wordpress/wp-content/plugins');
+await playground.listFiles('/wordpress/wp-content/plugins');
 ```
-> await playground.isDir("/wordpress/wp-content/plugins")
-true
-> await playground.listFiles("/wordpress/wp-content/plugins")
-(3) ['hello.php', 'index.php', 'WordPress-Importer-master']
-```
+
+<!-- See the full [PlaygroundClient API](/api/client/interface/PlaygroundClient). -->
+
+Consultez l’[API PlaygroundClient](/api/client/interface/PlaygroundClient)
+complète.
+
+<!-- ### Browser console and network requests -->
+
+### Console du navigateur et requêtes réseau
 
 <!--
-Full list of methods we can use is available [here](/api/client/interface/PlaygroundClient)
+Open browser developer tools to check JavaScript errors, PHP debug logs, and
+failed network requests. In Chrome, Firefox, and Edge, press
+`Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
 -->
 
-La liste complète des méthodes que nous pouvons utiliser est disponible [ici](/api/client/interface/PlaygroundClient).
+Ouvrez les outils de développement du navigateur pour vérifier les erreurs
+JavaScript, les journaux de débogage PHP et les requêtes réseau échouées. Dans
+Chrome, Firefox et Edge, appuyez sur `Ctrl + Shift + I` sous Windows/Linux ou
+sur `Cmd + Option + I` sous macOS.
+
+<!-- :::caution Safari -->
+
+:::caution Safari
+
+<!--
+If you have not enabled the Develop menu, go to **Safari > Settings... >
+Advanced** and check **Show features for web developers**.
+-->
+
+Si vous n’avez pas activé le menu Développement, allez dans
+**Safari > Settings... > Advanced** et cochez
+**Show features for web developers**.
 
 :::
 
-<!--
-## Check for errors in the browser console
--->
+<!-- ### Custom error logging -->
 
-## Vérifier les erreurs dans la console du navigateur
+### Journalisation d’erreurs personnalisée
 
 <!--
-If your Blueprint isn’t running as expected, open the browser developer tools to check for any errors.
+You can write your own messages with `error_log()` in a
+[`runPHP` step](/blueprints/steps), then check the Playground
+**Logs** panel or the browser console.
 -->
 
-Si votre Blueprint ne s’exécute pas comme prévu, ouvrez les outils de développement du navigateur pour vérifier les erreurs.
+Vous pouvez écrire vos propres messages avec `error_log()` dans une étape
+[`runPHP`](/blueprints/steps), puis consulter le panneau **Logs** de Playground
+ou la console du navigateur.
+
+<!-- ![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp) -->
+
+![Capture des erreurs de journal](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
 <!--
-To open the developer tools in Chrome, Firefox, Safari\*, and Edge: press `Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
--->
-
-Pour ouvrir les outils de développement dans Chrome, Firefox, Safari\* et Edge : appuyez sur `Ctrl + Shift + I` sous Windows/Linux ou sur `Cmd + Option + I` sous macOS.
-
-:::caution
-
-<!--
-If you haven't yet, enable the Develop menu: go to **Safari > Settings... > Advanced** and check **Show features for web developers**.
--->
-
-Si ce n’est pas encore fait, activez le menu Développement : allez dans **Safari > Réglages... > Avancé** et cochez **Afficher les fonctionnalités pour les développeurs web**.
-
+:::info
+When you download your Playground instance as a ZIP through the
+["Download as zip"](/web-instance) option, the archive
+also includes `debug.log`.
 :::
-
-<!--
-The developer tools window allows you to inspect network requests, view console logs, debug JavaScript, and examine the DOM and CSS styles applied to your webpage. This is crucial for diagnosing and fixing issues with Blueprints.
 -->
-
-La fenêtre des outils de développement vous permet d’inspecter les requêtes réseau, de consulter les journaux de console, de déboguer JavaScript et d’examiner le DOM ainsi que les styles CSS appliqués à votre page. C’est essentiel pour diagnostiquer et corriger les problèmes avec les Blueprints.
-
-<!--
-## Log your own error messages
--->
-
-## Journaliser vos propres messages d’erreur
-
-<!--
-You can `error_log` your own error messages through [`runPHP` step](/blueprints/steps#RunPHPStep) (see [blueprint example](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) and check them from the ["View Logs" option](/web-instance#playground-options-menu) or from the browser's console.
--->
-
-Vous pouvez journaliser vos propres messages d’erreur avec `error_log` via l’[étape `runPHP`](/blueprints/steps#RunPHPStep) (voir l’[exemple de Blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) et la [démo en direct](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) puis les consulter depuis l’option ["View Logs"](/web-instance#playground-options-menu) ou depuis la console du navigateur.
-
-<!--
-![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
--->
-
-![Capture des erreurs journalisées](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
 :::info
-
-<!--
-When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance.
--->
-
-Lorsque vous téléchargez votre instance Playground sous forme de `zip` avec l’option ["Download as zip"](/web-instance#playground-options-menu), vous téléchargez aussi le fichier `debug.log` qui contient tous les journaux de votre instance Playground.
-
+Lorsque vous téléchargez votre instance Playground sous forme de ZIP via
+l’option ["Download as zip"](/web-instance), l’archive inclut aussi `debug.log`.
 :::
 
-<!--
-## Ask for help
--->
+<!-- ## Ask for help -->
 
 ## Demander de l’aide
 
 <!--
-The community is here to help! If you have questions or comments, [open a new issue](https://github.com/adamziel/blueprints/issues) in this repository. Remember to include the following details:
+If you need help, [open an issue](https://github.com/WordPress/wordpress-playground/issues)
+and include:
 -->
 
-La communauté est là pour aider. Si vous avez des questions ou des commentaires, [ouvrez une nouvelle issue](https://github.com/adamziel/blueprints/issues) dans ce dépôt. Pensez à inclure les informations suivantes :
+Si vous avez besoin d’aide, [ouvrez une issue](https://github.com/WordPress/wordpress-playground/issues)
+et incluez :
 
 <!--
-- The Blueprint you’re trying to run.
-- The error message you’re seeing, if any.
-- The full output from the browser developer tools.
-- Any other relevant information that might help us understand the issue: OS, browser version, etc.
+- The Blueprint JSON or the public Blueprint URL.
+- The exact error message.
+- The failing step number, if shown.
+- Browser, operating system, and whether you used the website, JavaScript API, or CLI.
+- Relevant console, network, or CLI output.
 -->
 
-- Le Blueprint que vous essayez d’exécuter.
-- Le message d’erreur que vous voyez, le cas échéant.
-- La sortie complète des outils de développement du navigateur.
-- Toute autre information pertinente qui pourrait nous aider à comprendre le problème : système d’exploitation, version du navigateur, etc.
+- Le JSON du Blueprint ou l’URL publique du Blueprint.
+- Le message d’erreur exact.
+- Le numéro de l’étape en échec, s’il est affiché.
+- Le navigateur, le système d’exploitation et si vous avez utilisé le site web, l’API JavaScript ou la CLI.
+- La sortie pertinente de la console, du réseau ou de la CLI.

--- a/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/troubleshooting.md
+++ b/packages/docs/site/i18n/fr/docusaurus-plugin-content-docs/current/main/troubleshooting.md
@@ -1,0 +1,363 @@
+---
+title: Dépannage
+slug: /troubleshooting
+description: Diagnostiquer les erreurs courantes du site WordPress Playground, notamment les échecs de démarrage, les problèmes SQLite, le stockage du navigateur et la récupération des Playgrounds enregistrés.
+---
+
+<!-- title: Troubleshooting -->
+
+<!-- description: Diagnose common WordPress Playground website errors, including boot failures, SQLite issues, browser storage, and saved Playground recovery. -->
+
+<!-- # Troubleshooting WordPress Playground -->
+
+# Dépannage de WordPress Playground
+
+<!--
+This page covers errors from the Playground website itself, saved Playgrounds,
+browser storage, and WordPress boot. For Blueprint-specific errors, see
+[Troubleshoot and debug Blueprints](/blueprints/troubleshoot-and-debug).
+-->
+
+Cette page couvre les erreurs du site Playground lui-même, des Playgrounds
+enregistrés, du stockage du navigateur et du démarrage de WordPress. Pour les
+erreurs propres aux Blueprints, consultez
+[Dépanner et déboguer les Blueprints](/blueprints/troubleshoot-and-debug).
+
+<!-- ## Playground looks broken -->
+
+## Playground semble cassé
+
+<!-- Try these first: -->
+
+Essayez d’abord ceci :
+
+<!--
+- Use the reload button inside the Playground toolbar instead of refreshing the browser tab. Browser refresh starts the whole Playground app again.
+- Open the same URL in a private window to rule out saved-site or browser-storage state.
+- Disable browser extensions that block JavaScript, WebAssembly, storage, workers, or network requests.
+- Check browser developer tools for Console and Network errors.
+- If the URL includes `?site-slug=...`, try removing that query parameter to start a fresh unsaved Playground.
+-->
+
+- Utilisez le bouton de rechargement dans la barre d’outils de Playground au lieu d’actualiser l’onglet du navigateur. L’actualisation du navigateur redémarre toute l’application Playground.
+- Ouvrez la même URL dans une fenêtre privée pour écarter un état de site enregistré ou de stockage du navigateur.
+- Désactivez les extensions du navigateur qui bloquent JavaScript, WebAssembly, le stockage, les workers ou les requêtes réseau.
+- Consultez les erreurs de Console et de Network dans les outils de développement du navigateur.
+- Si l’URL inclut `?site-slug=...`, essayez de supprimer ce paramètre de requête pour démarrer un nouveau Playground non enregistré.
+
+<!-- ## A clean site says the MySQL extension is missing -->
+
+## Un site propre indique que l’extension MySQL est manquante
+
+<!-- You may see a WordPress error page like this: -->
+
+Vous pouvez voir une page d’erreur WordPress comme celle-ci :
+
+```text
+Your PHP installation appears to be missing the MySQL extension which is required by WordPress.
+```
+
+<!--
+In Playground, this usually means WordPress did not load the SQLite integration
+that lets WordPress run without MySQL. Playground runs WordPress in WebAssembly
+and uses SQLite instead of a MySQL server.
+-->
+
+Dans Playground, cela signifie généralement que WordPress n’a pas chargé
+l’intégration SQLite qui permet à WordPress de fonctionner sans MySQL.
+Playground exécute WordPress dans WebAssembly et utilise SQLite au lieu d’un
+serveur MySQL.
+
+<!-- Try these steps: -->
+
+Essayez ces étapes :
+
+<!--
+- Start a fresh unsaved Playground at https://playground.wordpress.net/ to confirm the public site can boot.
+- If the URL includes a saved site, remove `?site-slug=...` and load a new temporary site.
+- If this happened after importing a ZIP, confirm the import did not include a custom `wp-content/db.php` that overrides Playground's SQLite setup.
+- If this happened in the CLI, do not use `--skip-sqlite-setup` unless you provide your own database integration.
+- If this happened with a Blueprint, see the [Blueprint troubleshooting page](/blueprints/troubleshoot-and-debug).
+-->
+
+- Démarrez un nouveau Playground non enregistré sur https://playground.wordpress.net/ pour confirmer que le site public peut démarrer.
+- Si l’URL inclut un site enregistré, supprimez `?site-slug=...` et chargez un nouveau site temporaire.
+- Si cela s’est produit après l’importation d’un ZIP, confirmez que l’importation n’incluait pas de `wp-content/db.php` personnalisé qui remplace la configuration SQLite de Playground.
+- Si cela s’est produit dans la CLI, n’utilisez pas `--skip-sqlite-setup` sauf si vous fournissez votre propre intégration de base de données.
+- Si cela s’est produit avec un Blueprint, consultez la [page de dépannage des Blueprints](/blueprints/troubleshoot-and-debug).
+
+<!--
+If you are writing a Blueprint and need to add the SQLite integration plugin,
+`plugins` goes at the top level:
+-->
+
+Si vous écrivez un Blueprint et devez ajouter l’extension d’intégration SQLite,
+`plugins` se place au premier niveau :
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}
+```
+
+<!-- ## Error connecting to the SQLite database -->
+
+## Error connecting to the SQLite database
+
+<!--
+This means Playground loaded the SQLite integration, but WordPress still could
+not connect to the database.
+-->
+
+Cela signifie que Playground a chargé l’intégration SQLite, mais que WordPress
+n’a toujours pas pu se connecter à la base de données.
+
+<!-- Common causes: -->
+
+Causes courantes :
+
+<!--
+- A saved Playground's browser storage is stale or incomplete.
+- An imported site ZIP contains an incompatible database file or database drop-in.
+- A mounted local directory is missing files that WordPress needs.
+- Browser storage was cleared, evicted, or blocked.
+-->
+
+- Le stockage navigateur d’un Playground enregistré est périmé ou incomplet.
+- Un ZIP de site importé contient un fichier de base de données ou un drop-in de base de données incompatible.
+- Il manque à un répertoire local monté des fichiers dont WordPress a besoin.
+- Le stockage du navigateur a été effacé, évincé ou bloqué.
+
+<!-- Recommended recovery: -->
+
+Récupération recommandée :
+
+<!--
+1. Start a fresh unsaved Playground without `site-slug`.
+2. If the fresh site works, the issue is tied to the saved site or imported archive.
+3. Export any accessible files from the broken saved site using the File Browser or local directory copy, if available.
+4. Re-import the site into a new Playground, or rebuild it from its Blueprint.
+-->
+
+1. Démarrez un nouveau Playground non enregistré sans `site-slug`.
+2. Si le nouveau site fonctionne, le problème est lié au site enregistré ou à l’archive importée.
+3. Exportez tous les fichiers accessibles du site enregistré cassé avec le File Browser ou une copie de répertoire local, si disponible.
+4. Réimportez le site dans un nouveau Playground, ou reconstruisez-le à partir de son Blueprint.
+
+<!-- ## NotAllowedError -->
+
+## NotAllowedError
+
+<!--
+`NotAllowedError` usually means the browser blocked an operation that requires
+user permission or a supported browser context. In Playground, this often
+relates to saved sites or local directory access.
+-->
+
+`NotAllowedError` signifie généralement que le navigateur a bloqué une opération
+qui nécessite une autorisation de l’utilisateur ou un contexte de navigateur
+pris en charge. Dans Playground, cela concerne souvent les sites enregistrés ou
+l’accès à un répertoire local.
+
+<!-- You may see this exact message: -->
+
+Vous pouvez voir ce message exact :
+
+```text
+The request is not allowed by the user agent or the platform in the current context.
+```
+
+<!-- Try: -->
+
+Essayez :
+
+<!--
+- Open Playground in a normal top-level browser tab, not inside a restricted iframe.
+- Reopen the site from the Playground **Saved Playgrounds** panel.
+- If the site was saved to a local directory, import or save the directory again.
+- Confirm the browser supports the file or storage API being used. Chrome and Edge generally have the broadest local directory support.
+- Check whether private browsing mode, enterprise policy, or browser settings block storage access.
+-->
+
+- Ouvrez Playground dans un onglet de navigateur normal de premier niveau, pas dans une iframe restreinte.
+- Rouvrez le site depuis le panneau **Saved Playgrounds** de Playground.
+- Si le site a été enregistré dans un répertoire local, importez ou enregistrez de nouveau le répertoire.
+- Confirmez que le navigateur prend en charge l’API de fichier ou de stockage utilisée. Chrome et Edge offrent généralement la prise en charge la plus large des répertoires locaux.
+- Vérifiez si le mode de navigation privée, une politique d’entreprise ou les réglages du navigateur bloquent l’accès au stockage.
+
+<!-- ## NoModificationAllowedError -->
+
+## NoModificationAllowedError
+
+<!--
+`NoModificationAllowedError` means the browser or filesystem refused a write.
+This can happen when a saved local directory became read-only, permission was
+lost, or browser storage is unavailable.
+-->
+
+`NoModificationAllowedError` signifie que le navigateur ou le système de
+fichiers a refusé une écriture. Cela peut arriver lorsqu’un répertoire local
+enregistré est devenu en lecture seule, que l’autorisation a été perdue ou que
+le stockage du navigateur est indisponible.
+
+<!-- You may see this exact message: -->
+
+Vous pouvez voir ce message exact :
+
+```text
+An attempt was made to write to a file or directory which could not be modified due to the state of the underlying filesystem.
+```
+
+<!-- Try: -->
+
+Essayez :
+
+<!--
+- Save a copy to a different local directory.
+- Check that the target folder still exists and is writable.
+- Avoid system-protected folders or synced folders that temporarily lock files.
+- Start a fresh unsaved Playground if you only need a temporary test site.
+- Use [Playground CLI](/developers/local-development/wp-playground-cli) for local development that needs reliable filesystem persistence.
+-->
+
+- Enregistrez une copie dans un autre répertoire local.
+- Vérifiez que le dossier cible existe encore et qu’il est accessible en écriture.
+- Évitez les dossiers protégés par le système ou les dossiers synchronisés qui verrouillent temporairement les fichiers.
+- Démarrez un nouveau Playground non enregistré si vous avez seulement besoin d’un site de test temporaire.
+- Utilisez [Playground CLI](/developers/local-development/wp-playground-cli) pour un développement local qui nécessite une persistance fiable du système de fichiers.
+
+<!-- ## Saved Playground cannot reload -->
+
+## Le Playground enregistré ne peut pas se recharger
+
+<!--
+Saved Playgrounds are stored in browser storage or in a local directory you
+selected. They are not hosted on a remote server.
+-->
+
+Les Playgrounds enregistrés sont stockés dans le stockage du navigateur ou dans
+un répertoire local que vous avez sélectionné. Ils ne sont pas hébergés sur un
+serveur distant.
+
+<!-- If a saved Playground cannot reload: -->
+
+Si un Playground enregistré ne peut pas se recharger :
+
+<!--
+- Confirm you are using the same browser and browser profile where it was saved.
+- Check whether browser data was cleared or storage was disabled.
+- If the site was saved to a local directory, confirm the directory still exists and has not moved.
+- If the URL includes `?site-slug=...`, remove it to start a fresh unsaved site.
+- Recreate the saved site from its original Blueprint or import ZIP if storage was lost.
+-->
+
+- Confirmez que vous utilisez le même navigateur et le même profil de navigateur que lors de son enregistrement.
+- Vérifiez si les données du navigateur ont été effacées ou si le stockage a été désactivé.
+- Si le site a été enregistré dans un répertoire local, confirmez que le répertoire existe toujours et n’a pas été déplacé.
+- Si l’URL inclut `?site-slug=...`, supprimez-le pour démarrer un nouveau site non enregistré.
+- Recréez le site enregistré depuis son Blueprint d’origine ou son ZIP d’importation si le stockage a été perdu.
+
+<!-- ## Browser storage and persistence -->
+
+## Stockage du navigateur et persistance
+
+<!--
+An unsaved Playground is temporary. A browser refresh, tab close, storage
+cleanup, or browser profile change can remove its state.
+-->
+
+Un Playground non enregistré est temporaire. Une actualisation du navigateur, la
+fermeture d’un onglet, le nettoyage du stockage ou un changement de profil de
+navigateur peut supprimer son état.
+
+<!--
+Use the **Save** button before doing meaningful work. For longer-running local
+development, prefer the [Playground CLI](/developers/local-development/wp-playground-cli),
+which persists site files on disk.
+-->
+
+Utilisez le bouton **Save** avant d’effectuer un travail important. Pour un
+développement local plus long, préférez
+[Playground CLI](/developers/local-development/wp-playground-cli), qui conserve
+les fichiers du site sur le disque.
+
+<!--
+:::tip
+The refresh button inside the Playground toolbar reloads WordPress while keeping
+the current Playground runtime. The browser refresh button reloads the full app
+and can discard unsaved changes.
+:::
+-->
+
+:::tip
+Le bouton de rechargement dans la barre d’outils de Playground recharge
+WordPress tout en conservant l’environnement d’exécution actuel de Playground.
+Le bouton d’actualisation du navigateur recharge toute l’application et peut
+perdre les modifications non enregistrées.
+:::
+
+<!-- ## When to start fresh -->
+
+## Quand repartir de zéro
+
+<!-- Start a fresh unsaved Playground when: -->
+
+Démarrez un nouveau Playground non enregistré lorsque :
+
+<!--
+- You only need to test whether the public Playground site is working.
+- The URL points to a saved `site-slug` that no longer loads.
+- You are debugging whether an error comes from Playground itself or from a plugin, theme, Blueprint, or imported site.
+- Browser storage or local directory access is suspected to be broken.
+-->
+
+- Vous voulez seulement tester si le site public Playground fonctionne.
+- L’URL pointe vers un `site-slug` enregistré qui ne se charge plus.
+- Vous cherchez à savoir si une erreur vient de Playground lui-même ou d’une extension, d’un thème, d’un Blueprint ou d’un site importé.
+- Le stockage du navigateur ou l’accès au répertoire local semble cassé.
+
+<!-- Use this URL for a clean site: -->
+
+Utilisez cette URL pour un site propre :
+
+```text
+https://playground.wordpress.net/
+```
+
+<!-- ## Report a Playground issue -->
+
+## Signaler un problème Playground
+
+<!--
+If the problem reproduces on a fresh unsaved Playground, please
+[open an issue](https://github.com/WordPress/wordpress-playground/issues) and
+include:
+-->
+
+Si le problème se reproduit sur un nouveau Playground non enregistré, veuillez
+[ouvrir une issue](https://github.com/WordPress/wordpress-playground/issues) et
+inclure :
+
+<!--
+- The full Playground URL.
+- The browser and operating system.
+- Whether you used a saved site, imported ZIP, Blueprint, local directory, or CLI.
+- The exact error name and message.
+- Console and Network details from browser developer tools.
+-->
+
+- L’URL complète de Playground.
+- Le navigateur et le système d’exploitation.
+- Si vous avez utilisé un site enregistré, un ZIP importé, un Blueprint, un répertoire local ou la CLI.
+- Le nom et le message d’erreur exacts.
+- Les détails de Console et de Network des outils de développement du navigateur.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/02-using-blueprints.md
@@ -1,34 +1,47 @@
 ---
-title: Usando Blueprints
+title: Como usar Blueprints
 slug: /blueprints/using-blueprints
-description: Descubra as diferentes maneiras de usar Blueprints, incluindo via fragmento de URL, parâmetro de consulta, pacotes e API JavaScript.
+description: Conheça as diferentes maneiras de usar Blueprints, inclusive por fragmento de URL, parâmetro de consulta, pacotes e API JavaScript.
 ---
 
-# Usando Blueprints
+<!-- title: Using Blueprints -->
+
+<!-- description: Discover the different ways to use Blueprints, including via URL fragment, query parameter, bundles, and the JavaScript API. -->
+
+<!-- # Using Blueprints -->
+
+# Como usar Blueprints
 
 <!-- You can use Blueprints in one of the following ways: -->
 
 Você pode usar Blueprints de uma das seguintes maneiras:
 
-<!-- -   By passing them as a URL fragment to the Playground. -->
+<!--
+- By passing them as a URL fragment to the Playground.
+- By loading them from a URL using the `blueprint-url` parameter.
+- By using Blueprint bundles (ZIP files or directories).
+- By using the JavaScript API.
+-->
 
 - Passando-os como um fragmento de URL para o Playground.
-    <!-- -   By loading them from a URL using the `blueprint-url` parameter. -->
-- Carregando-os de uma URL usando o parâmetro `blueprint-url`.
-    <!-- -   By using Blueprint bundles (ZIP files or directories). -->
+- Carregando-os a partir de uma URL usando o parâmetro `blueprint-url`.
 - Usando pacotes de Blueprint (arquivos ZIP ou diretórios).
-    <!-- -   By using the JavaScript API. -->
 - Usando a API JavaScript.
 
-## Fragmento de URL {#url-fragment}
+<!-- ## URL Fragment -->
+
+## Fragmento de URL
 
 <!-- The easiest way to start using Blueprints is to paste one into the URL "fragment" on WordPress Playground website, e.g. `https://playground.wordpress.net/#{"preferredVersions...`. -->
 
-A maneira mais fácil de começar a usar Blueprints é colar um no "fragmento" de URL no site do WordPress Playground, por exemplo `https://playground.wordpress.net/#{"preferredVersions...`.
+A maneira mais fácil de começar a usar Blueprints é colar um deles no
+"fragmento" da URL no site do WordPress Playground, por exemplo
+`https://playground.wordpress.net/#{"preferredVersions...`.
 
 <!-- For example, to create a Playground with specific versions of WordPress and PHP you would use the following Blueprint: -->
 
-Por exemplo, para criar um Playground com versões específicas do WordPress e PHP, você usaria o seguinte Blueprint:
+Por exemplo, para criar um Playground com versões específicas do WordPress e do
+PHP, use o seguinte Blueprint:
 
 ```json
 {
@@ -40,19 +53,23 @@ Por exemplo, para criar um Playground com versões específicas do WordPress e P
 }
 ```
 
-<!-- And then you would go to `https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`. -->
+<!--
+And then you would go to
+`https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
+-->
 
-E então você iria para
+E então acesse
 `https://playground.wordpress.net/#{"preferredVersions":{"php":"8.3","wp":"6.5"}}`.
 
+<!--
 :::tip
+In Javascript, you can get a compact version of any blueprint JSON with [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) and [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
+Example:
+-->
 
-<!-- In Javascript, you can get a compact version of any blueprint JSON with [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) and [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) -->
-
-Em Javascript, você pode obter uma versão compacta de qualquer Blueprint JSON com [`JSON.stringify`](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) e [`JSON.parse`](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
-
-<!-- Example: -->
-
+:::tip
+Em JavaScript, você pode obter uma versão compacta de qualquer JSON de Blueprint
+com [`JSON.stringify`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) e [`JSON.parse`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse)
 Exemplo:
 
 ```js
@@ -72,7 +89,8 @@ const playgroundUrl = `https://playground.wordpress.net/#${encodedBlueprint}`;
 
 <!-- You won't have to paste links to follow along. We'll use code examples with a "Try it out" button that will automatically run the examples for you: -->
 
-Você não precisará colar links para acompanhar. Usaremos exemplos de código com um botão "Experimente" que executará automaticamente os exemplos para você:
+Você não precisará colar links para acompanhar. Usaremos exemplos de código com
+um botão "Try it out", que executará automaticamente os exemplos para você:
 
 import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
 
@@ -83,11 +101,15 @@ import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.m
 	}
 }} />
 
+<!-- ### Encoded Blueprint fragments -->
+
 ### Fragmentos de Blueprint codificados
 
 <!-- When you create Playground links from JavaScript or automation tools, encode the minified JSON once with `encodeURIComponent()` and append it after `#`: -->
 
-Ao criar links do Playground a partir de JavaScript ou ferramentas de automação, codifique o JSON minificado uma vez com `encodeURIComponent()` e adicione-o depois de `#`:
+Ao criar links do Playground a partir de JavaScript ou ferramentas de automação,
+codifique o JSON minificado uma vez com `encodeURIComponent()` e adicione-o
+depois de `#`:
 
 ```js
 const blueprint = {
@@ -100,19 +122,55 @@ const blueprint = {
 const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
 ```
 
-<!-- Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: -->
+<!-- Playground also supports Base64-encoded Blueprints. Base64 is useful when a platform modifies JSON fragments or when you want a compact, copyable link. For example, that's the above Blueprint in Base64 format: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`. -->
 
-O Playground também oferece suporte a Blueprints codificados em Base64. Base64 é útil quando uma plataforma modifica fragmentos JSON ou quando você quer um link compacto e fácil de copiar. Por exemplo, este é o Blueprint acima em formato Base64: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
+O Playground também aceita Blueprints codificados em Base64. Base64 é útil
+quando uma plataforma modifica fragmentos JSON ou quando você quer um link
+compacto e fácil de copiar. Por exemplo, este é o Blueprint acima em formato
+Base64: `eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19`.
 
 <!-- To run it, go to https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19 -->
 
 Para executá-lo, acesse https://playground.wordpress.net/#eyIkc2NoZW1hIjogImh0dHBzOi8vcGxheWdyb3VuZC53b3JkcHJlc3MubmV0L2JsdWVwcmludC1zY2hlbWEuanNvbiIsInByZWZlcnJlZFZlcnNpb25zIjogeyJwaHAiOiAiNy40Iiwid3AiOiAiNi41In19
 
+<!-- #### URIError: URI malformed -->
+
+#### URIError: URI malformed
+
+<!--
+If a Playground link fails with `URIError: URI malformed`, the encoded
+Blueprint fragment is usually malformed. Common causes include an invalid `%`
+escape, a fragment that was encoded twice, or JSON pasted into the URL without
+encoding.
+-->
+
+Se um link do Playground falhar com `URIError: URI malformed`, o fragmento de
+Blueprint codificado geralmente está malformado. Causas comuns incluem um escape
+`%` inválido, um fragmento codificado duas vezes ou JSON colado na URL sem
+codificação.
+
+<!-- Rebuild the link from the original Blueprint object and encode it once: -->
+
+Reconstrua o link a partir do objeto Blueprint original e codifique-o uma vez:
+
+```js
+const playgroundUrl = `https://playground.wordpress.net/#${encodeURIComponent(JSON.stringify(blueprint))}`;
+```
+
+<!-- If another tool changes URL fragments, use a Base64-encoded Blueprint instead. -->
+
+Se outra ferramenta alterar fragmentos de URL, use um Blueprint codificado em
+Base64.
+
+<!--
 :::tip
+In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`.
+-->
 
-<!-- In JavaScript, You can get any blueprint JSON in [Base64 format](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support) with global function `btoa()`. -->
-
-Em JavaScript, você pode obter qualquer Blueprint JSON em [formato Base64](https://developer.mozilla.org/pt-BR/docs/Glossary/Base64#javascript_support) com a função global `btoa()`.
+:::tip
+Em JavaScript, você pode obter qualquer JSON de Blueprint no
+[formato Base64](https://developer.mozilla.org/en-US/docs/Glossary/Base64#javascript_support)
+com a função global `btoa()`.
 
 <!-- Example: -->
 
@@ -131,37 +189,72 @@ const minifiedBlueprintJson = btoa(blueprintJson); // eyIkc2NoZW1hIjogImh0dHBzOi
 
 :::
 
+<!-- ### Load Blueprint from a URL -->
+
 ### Carregar Blueprint de uma URL
 
 <!-- When your Blueprint gets too wieldy, you can load it via the `?blueprint-url` query parameter in the URL, like this: -->
 
-Quando seu Blueprint ficar muito grande, você pode carregá-lo através do parâmetro de consulta `?blueprint-url` na URL, assim:
+Quando o Blueprint ficar grande demais, você pode carregá-lo pelo parâmetro de
+consulta `?blueprint-url` na URL, assim:
+
+<!-- [https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json) -->
 
 [https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/adamziel/blueprints/trunk/blueprints/latest-gutenberg/blueprint.json)
 
-<!-- Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin): -->
+<!-- Note that the Blueprint must be publicly accessible and served with [the correct `Access-Control-Allow-Origin` header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin): -->
 
-Observe que o Blueprint deve estar publicamente acessível e servido com [o cabeçalho correto `Access-Control-Allow-Origin`](https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
+Observe que o Blueprint deve estar publicamente acessível e ser servido com o
+[cabeçalho `Access-Control-Allow-Origin` correto](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Origin):
 
 ```
 Access-Control-Allow-Origin: *
 ```
 
+<!-- When a Blueprint URL fails with `BlueprintFetchError`, check these details: -->
+
+Quando uma URL de Blueprint falhar com `BlueprintFetchError`, verifique estes
+detalhes:
+
+<!--
+- The URL must return a JSON file or a Blueprint ZIP bundle, not an HTML page.
+- GitHub URLs should use `raw.githubusercontent.com`, not `github.com/.../blob/...`.
+- GitLab URLs should use the raw file URL, not a `/-/blob/` page.
+- The file must be reachable without login, cookies, VPN access, or a temporary browser session.
+- Draft releases, expired CI artifacts, and temporary tunnel URLs can stop working even if the Blueprint was valid earlier.
+- If you host the file yourself, configure CORS so `https://playground.wordpress.net` can fetch it.
+-->
+
+- A URL deve retornar um arquivo JSON ou um pacote ZIP de Blueprint, não uma página HTML.
+- URLs do GitHub devem usar `raw.githubusercontent.com`, não `github.com/.../blob/...`.
+- URLs do GitLab devem usar a URL de arquivo bruto, não uma página `/-/blob/`.
+- O arquivo deve estar acessível sem login, cookies, VPN ou sessão temporária do navegador.
+- Releases em rascunho, artefatos de CI expirados e URLs temporárias de túnel podem parar de funcionar mesmo que o Blueprint fosse válido antes.
+- Se você hospedar o arquivo, configure CORS para que `https://playground.wordpress.net` possa buscá-lo.
+
+<!-- #### Blueprint Bundles -->
+
 #### Pacotes de Blueprint
 
 <!-- The `?blueprint-url` parameter now also supports Blueprint bundles in ZIP format. A Blueprint bundle is a ZIP file that contains a `blueprint.json` file at the root level, along with any additional resources referenced by the Blueprint. -->
 
-O parâmetro `?blueprint-url` agora também oferece suporte a pacotes de Blueprint em formato ZIP. Um pacote de Blueprint é um arquivo ZIP que contém um arquivo `blueprint.json` no nível raiz, junto com quaisquer recursos adicionais referenciados pelo Blueprint.
+O parâmetro `?blueprint-url` agora também aceita pacotes de Blueprint no formato
+ZIP. Um pacote de Blueprint é um arquivo ZIP que contém um arquivo
+`blueprint.json` no nível raiz, junto com quaisquer recursos adicionais
+referenciados pelo Blueprint.
 
 <!-- For example, you can load a Blueprint bundle like this: -->
 
 Por exemplo, você pode carregar um pacote de Blueprint assim:
 
+<!-- [https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip](https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip) -->
+
 [https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip](https://playground.wordpress.net/?blueprint-url=https://example.com/my-blueprint-bundle.zip)
 
 <!-- When using a Blueprint bundle, you can reference bundled resources using the `bundled` resource type: -->
 
-Ao usar um pacote de Blueprint, você pode referenciar recursos empacotados usando o tipo de recurso `bundled`:
+Ao usar um pacote de Blueprint, você pode referenciar recursos empacotados com
+o tipo de recurso `bundled`:
 
 ```json
 {
@@ -181,13 +274,18 @@ Ao usar um pacote de Blueprint, você pode referenciar recursos empacotados usan
 
 <!-- For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation. -->
 
-Para mais informações sobre pacotes de Blueprint, consulte a documentação de [Pacotes de Blueprint](/blueprints/bundles).
+Para saber mais sobre pacotes de Blueprint, consulte a documentação de
+[Pacotes de Blueprint](/blueprints/bundles).
 
-## API JavaScript {#javascript-api}
+<!-- ## JavaScript API -->
+
+## API JavaScript
 
 <!-- You can also use Blueprints with the JavaScript API using the `startPlaygroundWeb()` function from the `@wp-playground/client` package. Here's a small, self-contained example you can run on JSFiddle or CodePen: -->
 
-Você também pode usar Blueprints com a API JavaScript usando a função `startPlaygroundWeb()` do pacote `@wp-playground/client`. Aqui está um pequeno exemplo independente que você pode executar no JSFiddle ou CodePen:
+Você também pode usar Blueprints com a API JavaScript usando a função
+`startPlaygroundWeb()` do pacote `@wp-playground/client`. Veja um exemplo
+pequeno e independente que você pode executar no JSFiddle ou no CodePen:
 
 ```html
 <iframe id="wp-playground" style="width: 1200px; height: 800px"></iframe>

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/03-data-format.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/03-data-format.md
@@ -2,56 +2,58 @@
 sidebar_position: 1
 title: Formato de dados do Blueprint
 slug: /blueprints/data-format
-description_long: Uma visão geral do formato de dados do Blueprint. Saiba mais sobre propriedades-chave como landingPage, preferredVersions e as etapas.
+description: Uma visão geral do formato de dados do Blueprint. Aprenda sobre propriedades importantes como landingPage, preferredVersions e steps.
 ---
 
-<!--
-# Blueprint data format
+<!-- title: Blueprint data Format -->
 
-A Blueprint JSON file can have many different properties that will be used to define your Playground instance. The most important properties are detailed below.
+<!-- description: An overview of the Blueprint data format. Learn about key properties like landingPage, preferredVersions, and steps. -->
 
-Here's an example that uses many of them:
--->
+<!-- # Blueprint data format -->
 
 # Formato de dados do Blueprint
 
-Um arquivo JSON do Blueprint pode ter muitas propriedades diferentes que serão usadas para definir sua instância do Playground. As propriedades mais importantes estão detalhadas abaixo.
+<!-- A Blueprint JSON file can have many different properties that will be used to define your Playground instance. The most important properties are detailed below. -->
 
-Aqui está um exemplo que usa muitas delas:
+Um arquivo JSON de Blueprint pode ter várias propriedades diferentes que serão
+usadas para definir sua instância do Playground. As propriedades mais
+importantes são detalhadas abaixo.
 
-```js
+<!-- Here's an example that uses many of them: -->
+
+Este é um exemplo que usa várias delas:
+
 import BlueprintExample from '@site/src/components/Blueprints/BlueprintExample.mdx';
 
-<BlueprintExample
-	blueprint={{
-		landingPage: '/wp-admin/',
-		preferredVersions: {
-			php: '8.3',
-			wp: '6.5',
-		},
-		features: {
-			networking: true,
-		},
-		steps: [
-			{
-				step: 'login',
-				username: 'admin',
-				password: 'password',
-			},
-		],
-	}}
-/>;
-```
+<BlueprintExample blueprint={{
+	"landingPage": "/wp-admin/",
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "6.5"
+	},
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin",
+			"password": "password"
+		}
+	]
+}} />
 
-<!--
-## JSON schema
-
-JSON files can be tedious to write and easy to get wrong. To help with that, Playground provides a [JSON schema](https://playground.wordpress.net/blueprint-schema.json) file that you can use to get auto-completion and validation in your editor. Just set the `$schema` property to the following:
--->
+<!-- ## JSON schema -->
 
 ## Esquema JSON
 
-Arquivos JSON podem ser tediosos de escrever e fáceis de cometer erros. Para ajudar com isso, o Playground fornece um arquivo de [esquema JSON](https://playground.wordpress.net/blueprint-schema.json) que você pode usar para obter preenchimento automático e validação no seu editor. Basta definir a propriedade `$schema` para o seguinte:
+<!-- JSON files can be tedious to write and easy to get wrong. To help with that, Playground provides a [JSON schema](https://playground.wordpress.net/blueprint-schema.json) file that you can use to get auto-completion and validation in your editor. Just set the `$schema` property to the following: -->
+
+Arquivos JSON podem ser tediosos de escrever e fáceis de errar. Para ajudar
+com isso, o Playground fornece um arquivo de
+[esquema JSON](https://playground.wordpress.net/blueprint-schema.json) que você
+pode usar para ter preenchimento automático e validação no editor. Basta definir
+a propriedade `$schema` assim:
 
 ```js
 {
@@ -59,15 +61,17 @@ Arquivos JSON podem ser tediosos de escrever e fáceis de cometer erros. Para aj
 }
 ```
 
-<!--
-## Landing page
+<!-- ## Landing page -->
 
-The `landingPage` property tells Playground which URL to navigate to after the Blueprint has been run. This is a great tool, especially when creating theme or plugin demos. Often, you will want to start Playground in the Site Editor or have a specific post open in the Post Editor. Make sure you use a relative path.
--->
+## Página inicial
 
-## Página de destino
+<!-- The `landingPage` property tells Playground which URL to navigate to after the Blueprint has been run. This is a great tool, especially when creating theme or plugin demos. Often, you will want to start Playground in the Site Editor or have a specific post open in the Post Editor. Make sure you use a relative path. -->
 
-A propriedade `landingPage` diz ao Playground para qual URL navegar após o Blueprint ser executado. Esta é uma ótima ferramenta, especialmente ao criar demonstrações de temas ou plugins. Frequentemente, você desejará iniciar o Playground no Editor do Site ou ter uma postagem específica aberta no Editor de Postagens. Certifique-se de usar um caminho relativo.
+A propriedade `landingPage` informa ao Playground para qual URL navegar depois
+que o Blueprint for executado. Ela é uma ótima ferramenta, especialmente ao
+criar demonstrações de temas ou plugins. Muitas vezes, você vai querer iniciar
+o Playground no Editor do site ou abrir um post específico no Editor de posts.
+Use sempre um caminho relativo.
 
 ```js
 {
@@ -75,23 +79,22 @@ A propriedade `landingPage` diz ao Playground para qual URL navegar após o Blue
 }
 ```
 
-<!--
-## Preferred versions
+<!-- ## Preferred versions -->
 
-The `preferredVersions` property declares your preferred PHP and WordPress versions. It can contain the following properties:
--->
+## Versões preferenciais
 
-## Versões preferidas
+<!-- The `preferredVersions` property declares your preferred PHP and WordPress versions. It can contain the following properties: -->
 
-A propriedade `preferredVersions` declara suas versões preferidas de PHP e WordPress. Ela pode conter as seguintes propriedades:
+A propriedade `preferredVersions` declara suas versões preferenciais do PHP e
+do WordPress. Ela pode conter as seguintes propriedades:
 
 <!--
 - `php` (string): Loads the specified PHP version. Accepts `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5`, or `latest`. Minor versions like `7.4.1` are not supported.
-- `wp` (string): Loads the specified WordPress version. Accepts the last six major WordPress versions. As of September 1, 2025, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7` or `6.8`. You can also use the generic values `latest`, `nightly`, or `beta`. To use a pre-release version of WordPress, `beta` will load the latest beta or release candidate versions of a release cycle (Beta or RC).
+- `wp` (string): Loads the specified WordPress version. Accepts the last seven major WordPress versions. As of April 28, 2026, that's `6.3`, `6.4`, `6.5`, `6.6`, `6.7`, `6.8`, or `6.9`. You can also use the generic values `latest`, `beta`, or `nightly` (alias `trunk`). `beta` resolves to the most recent Beta or Release Candidate of an active release cycle; `nightly`/`trunk` builds straight from the WordPress development branch.
 -->
 
-- `php` (string): Carrega a versão PHP especificada. Aceita `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5` ou `latest`. Versões menores como `7.4.1` não são suportadas.
-- `wp` (string): Carrega a versão WordPress especificada. Aceita as últimas seis versões principais do WordPress. A partir de 1º de setembro de 2025, são `6.3`, `6.4`, `6.5`, `6.6`, `6.7` ou `6.8`. Você também pode usar os valores genéricos `latest`, `nightly` ou `beta`. Para usar uma versão pré-lançamento do WordPress, `beta` carregará as versões mais recentes de beta ou candidato a lançamento de um ciclo de lançamento (Beta ou RC).
+- `php` (string): Carrega a versão especificada do PHP. Aceita `7.4`, `8.0`, `8.1`, `8.2`, `8.3`, `8.4`, `8.5` ou `latest`. Versões menores como `7.4.1` não são compatíveis.
+- `wp` (string): Carrega a versão especificada do WordPress. Aceita as últimas sete versões principais do WordPress. Em 28 de abril de 2026, são `6.3`, `6.4`, `6.5`, `6.6`, `6.7`, `6.8` ou `6.9`. Você também pode usar os valores genéricos `latest`, `beta` ou `nightly` (alias `trunk`). `beta` resolve para a versão Beta ou Release Candidate mais recente de um ciclo de lançamento ativo; `nightly`/`trunk` é criado diretamente a partir do branch de desenvolvimento do WordPress.
 
 ```js
 {
@@ -102,21 +105,18 @@ A propriedade `preferredVersions` declara suas versões preferidas de PHP e Word
 }
 ```
 
-<!--
-## Features
-
-You can use the `features` property to turn on or off certain features of the Playground instance. It can contain the following properties:
--->
+<!-- ## Features -->
 
 ## Recursos
 
-Você pode usar a propriedade `features` para ativar ou desativar certos recursos da instância do Playground. Ela pode conter as seguintes propriedades:
+<!-- You can use the `features` property to turn on or off certain features of the Playground instance. It can contain the following properties: -->
 
-<!--
-- `networking`: Defaults to `true`. Enables or disables the networking support for Playground. If enabled, [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) and similar WordPress functions will actually use `fetch()` to make HTTP requests. If disabled, they will immediately fail instead. You will need this property enabled if you want the user to be able to install plugins or themes.
--->
+Você pode usar a propriedade `features` para ativar ou desativar determinados
+recursos da instância do Playground. Ela pode conter as seguintes propriedades:
 
-- `networking`: Padrão `true`. Ativa ou desativa o suporte de rede para o Playground. Se habilitado, [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) e funções WordPress similares usarão `fetch()` para fazer requisições HTTP. Se desabilitado, elas falharão imediatamente. Você precisará desta propriedade habilitada se quiser que o usuário possa instalar plugins ou temas.
+<!-- - `networking`: Defaults to `true`. Enables or disables the networking support for Playground. If enabled, [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) and similar WordPress functions will actually use `fetch()` to make HTTP requests. If disabled, they will immediately fail instead. You will need this property enabled if you want the user to be able to install plugins or themes. -->
+
+- `networking`: O padrão é `true`. Ativa ou desativa o suporte a rede no Playground. Se ativado, [`wp_safe_remote_get`](https://developer.wordpress.org/reference/functions/wp_safe_remote_get/) e funções semelhantes do WordPress usarão `fetch()` para fazer requisições HTTP. Se desativado, elas falharão imediatamente. Você precisará ativar essa propriedade se quiser que a pessoa usuária possa instalar plugins ou temas.
 
 ```js
 {
@@ -126,21 +126,18 @@ Você pode usar a propriedade `features` para ativar ou desativar certos recurso
 }
 ```
 
-<!--
-## Extra libraries
-
-You can preload extra libraries into the Playground instance. The following libraries are supported:
--->
+<!-- ## Extra libraries -->
 
 ## Bibliotecas extras
 
-Você pode pré-carregar bibliotecas extras na instância do Playground. As seguintes bibliotecas são suportadas:
+<!-- You can preload extra libraries into the Playground instance. The following libraries are supported: -->
 
-<!--
-- `wp-cli`: Enables WP-CLI support for Playground. If included, WP-CLI will be installed during boot. If not included, you will get an error message when trying to run WP-CLI commands using the JS API. WP-CLI will be installed by default if the blueprint contains any `wp-cli` steps.
--->
+Você pode pré-carregar bibliotecas extras na instância do Playground. As
+seguintes bibliotecas são compatíveis:
 
-- `wp-cli`: Habilita o suporte WP-CLI para o Playground. Se incluído, WP-CLI será instalado durante a inicialização. Se não incluído, você receberá uma mensagem de erro ao tentar executar comandos WP-CLI usando a API JS. WP-CLI será instalado por padrão se o blueprint contiver algum step `wp-cli`.
+<!-- - `wp-cli`: Enables WP-CLI support for Playground. If included, WP-CLI will be installed during boot. If not included, you will get an error message when trying to run WP-CLI commands using the JS API. WP-CLI will be installed by default if the blueprint contains any `wp-cli` steps. -->
+
+- `wp-cli`: Ativa o suporte a WP-CLI no Playground. Se incluída, a WP-CLI será instalada durante a inicialização. Se não for incluída, você receberá uma mensagem de erro ao tentar executar comandos WP-CLI usando a API JS. A WP-CLI será instalada por padrão se o Blueprint contiver qualquer etapa `wp-cli`.
 
 ```js
 {
@@ -148,15 +145,17 @@ Você pode pré-carregar bibliotecas extras na instância do Playground. As segu
 }
 ```
 
-<!--
-## Steps
-
-Arguably the most powerful property, `steps` allows you to configure the Playground instance with preinstalled themes, plugins, demo content, and more. The following example logs the user in with a dedicated username and password. It then installs and activates the Gutenberg plugin. [Learn more about steps](/blueprints/steps).
--->
+<!-- ## Steps -->
 
 ## Etapas
 
-Potencialmente a propriedade mais poderosa, `steps` permite que você configure a instância do Playground com temas, plugins, conteúdo de demonstração pré-instalados e muito mais. O exemplo a seguir faz login do usuário com um nome de usuário e senha dedicados. Em seguida, instala e ativa o plugin Gutenberg. [Saiba mais sobre steps](/blueprints/steps).
+<!-- Arguably the most powerful property, `steps` allows you to configure the Playground instance with preinstalled themes, plugins, demo content, and more. The following example logs the user in with a dedicated username and password. It then installs and activates the Gutenberg plugin. [Learn more about steps](/blueprints/steps). -->
+
+Provavelmente a propriedade mais poderosa, `steps` permite configurar a
+instância do Playground com temas, plugins, conteúdo de demonstração e muito
+mais pré-instalados. O exemplo a seguir autentica o usuário com um nome de
+usuário e senha dedicados. Em seguida, instala e ativa o plugin Gutenberg.
+[Saiba mais sobre etapas](/blueprints/steps).
 
 ```js
 {
@@ -176,3 +175,122 @@ Potencialmente a propriedade mais poderosa, `steps` permite que você configure 
 	]
 }
 ```
+
+<!-- ## Common property placement mistakes -->
+
+## Erros comuns de posicionamento de propriedades
+
+<!--
+Blueprint validation errors often come from putting a valid property in the
+wrong object.
+-->
+
+Erros de validação de Blueprint geralmente acontecem quando uma propriedade
+válida é colocada no objeto errado.
+
+<!-- ### Activate a plugin or theme -->
+
+### Ativar um plugin ou tema
+
+<!--
+`activate` belongs inside `options`, not inside `pluginData`, `themeData`, or
+directly on the step.
+-->
+
+`activate` deve ficar dentro de `options`, não dentro de `pluginData`,
+`themeData` nem diretamente na etapa.
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "gutenberg"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!-- ### Install plugins with the shorthand -->
+
+### Instalar plugins com o atalho
+
+<!--
+The `plugins` shorthand is a top-level Blueprint property. Do not put it inside
+`preferredVersions`.
+-->
+
+O atalho `plugins` é uma propriedade de nível superior do Blueprint. Não o
+coloque dentro de `preferredVersions`.
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["gutenberg"]
+}
+```
+
+<!-- ### Use one plugin install shape -->
+
+### Usar um único formato de instalação de plugin
+
+<!--
+For an `installPlugin` step, use `pluginData`. Do not mix `pluginData` with
+older examples or custom objects such as `pluginZipFile`.
+-->
+
+Para uma etapa `installPlugin`, use `pluginData`. Não misture `pluginData` com
+exemplos antigos ou objetos personalizados como `pluginZipFile`.
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!--
+The `wordpress.org/plugins` resource needs a separate `slug`. Do not write the
+slug into the `resource` value, such as `"wordpress.org/plugins/woocommerce"`.
+-->
+
+O recurso `wordpress.org/plugins` precisa de um `slug` separado. Não escreva o
+slug no valor de `resource`, como `"wordpress.org/plugins/woocommerce"`.
+
+<!-- ### Keep `preferredVersions` limited to versions -->
+
+### Manter `preferredVersions` limitado a versões
+
+<!--
+`preferredVersions` only accepts `php` and `wp`. Use `features` for networking,
+`plugins` or `installPlugin` for plugins, and `steps` for ordered setup tasks.
+-->
+
+`preferredVersions` aceita somente `php` e `wp`. Use `features` para rede,
+`plugins` ou `installPlugin` para plugins, e `steps` para tarefas de
+configuração ordenadas.
+
+<!-- ### Use explicit steps when order matters -->
+
+### Usar etapas explícitas quando a ordem importa
+
+<!--
+Shorthands such as `plugins`, `login`, `siteOptions`, and `constants` are
+expanded before the `steps` array. If one action must happen before another,
+write both actions as explicit steps in the order you need.
+-->
+
+Atalhos como `plugins`, `login`, `siteOptions` e `constants` são expandidos
+antes do array `steps`. Se uma ação precisa acontecer antes de outra, escreva
+ambas como etapas explícitas na ordem necessária.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/04-resources.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/04-resources.md
@@ -1,25 +1,27 @@
 ---
 slug: /blueprints/steps/resources
-description_long: Uma referência técnica para "Referências de Recursos". Saiba como usar arquivos externos para temas, plugins e conteúdo.
+description: Uma referência técnica para "Referências de recursos". Aprenda a usar arquivos externos para temas, plugins e conteúdo.
 ---
 
-<!-- A technical reference for "Resource References." Learn how to use external files for themes, plugins, and content. -->
+<!-- description: A technical reference for "Resource References." Learn how to use external files for themes, plugins, and content. -->
 
-# Resources References
+<!-- # Resources References -->
+
+# Referências de recursos
 
 <!-- "Resource References" allow you use external files in Blueprints -->
 
-"Referências de Recursos" permitem que você use arquivos externos em Blueprints
+"Referências de recursos" permitem usar arquivos externos em Blueprints.
 
 <div class="callout callout-info">
 
-<!-- Blueprints steps such as [`installPlugin`](/blueprints/steps#InstallPluginStep) or [`installTheme`](/blueprints/steps#InstallThemeStep) require a location of the plugin or theme to be installed.
+<!-- Blueprint steps such as [`installPlugin`](/blueprints/steps) or [`installTheme`](/blueprints/steps) require a location of the plugin or theme to be installed. -->
 
-That location can be defined as [a `URL` resource](#urlreference) of the `.zip` file containing the theme or plugin. It can also be defined as a [`wordpress.org/plugins`](#corepluginreference) or [`wordpress.org/themes`](#corethemereference) resource for those plugins/themes published in the official WordPress directories. -->
+Etapas de Blueprint como [`installPlugin`](/blueprints/steps) ou [`installTheme`](/blueprints/steps) exigem a localização do plugin ou tema que será instalado.
 
-Etapas de Blueprints como [`installPlugin`](/blueprints/steps#InstallPluginStep) ou [`installTheme`](/blueprints/steps#InstallThemeStep) exigem um local do plugin ou tema a ser instalado.
+<!-- That location can be defined as [a `URL` resource](#urlreference) of the `.zip` file containing the theme or plugin. It can also be defined as a [`wordpress.org/plugins`](#corepluginreference) or [`wordpress.org/themes`](#corethemereference) resource for those plugins/themes published in the official WordPress directories. -->
 
-Esse local pode ser definido como um recurso [URL](#urlreference) do arquivo `.zip` contendo o tema ou plugin. Também pode ser definido como um recurso [`wordpress.org/plugins`](#corepluginreference) ou [`wordpress.org/themes`](#corethemereference) para aqueles plugins/temas publicados nos diretórios oficiais do WordPress.
+Essa localização pode ser definida como um [recurso `URL`](#urlreference) do arquivo `.zip` que contém o tema ou plugin. Ela também pode ser definida como um recurso [`wordpress.org/plugins`](#corepluginreference) ou [`wordpress.org/themes`](#corethemereference) para plugins/temas publicados nos diretórios oficiais do WordPress.
 
 </div>
 
@@ -31,11 +33,14 @@ import TOCInline from '@theme/TOCInline';
 
 <TOCInline toc={toc} />
 
+<!-- ### URLReference -->
+
 ### URLReference
 
 <!-- The `URLReference` resource is used to reference files that are stored on a remote server. The `URLReference` resource is defined as follows: -->
 
-O recurso `URLReference` é usado para referenciar arquivos armazenados em um servidor remoto. O recurso `URLReference` é definido da seguinte forma:
+O recurso `URLReference` é usado para referenciar arquivos armazenados em um
+servidor remoto. O recurso `URLReference` é definido assim:
 
 ```typescript
 type URLReference = {
@@ -46,7 +51,9 @@ type URLReference = {
 
 <!-- To use the `URLReference` resource, you need to provide the URL of the file. For example, to reference a file named "index.html" that is stored on a remote server, you can create a `URLReference` as follows: -->
 
-Para usar o recurso `URLReference`, você precisa fornecer a URL do arquivo. Por exemplo, para referenciar um arquivo chamado "index.html" armazenado em um servidor remoto, você pode criar um `URLReference` da seguinte forma:
+Para usar o recurso `URLReference`, você precisa fornecer a URL do arquivo. Por
+exemplo, para referenciar um arquivo chamado "index.html" armazenado em um
+servidor remoto, crie um `URLReference` assim:
 
 ```json
 {
@@ -55,38 +62,87 @@ Para usar o recurso `URLReference`, você precisa fornecer a URL do arquivo. Por
 }
 ```
 
-<!-- The resource `url` type works really in combination with blueprint steps such as [`installPlugin`](/blueprints/steps#InstallPluginStep) or [`installTheme`](/blueprints/steps#InstallThemeStep). These steps require a `ResourceType` to define the location of the plugin or the theme to install.
+<!--
+The `url` resource works with Blueprint steps such as [`installPlugin`](/blueprints/steps) or
+[`installTheme`](/blueprints/steps).
+These steps require a `ResourceType` to define the location of the plugin or the theme to install.
+-->
 
-With a `"resource": "url"` we can define the location of a `.zip` containing the plugin/theme via a URL that can point directly to a GitHub repo. -->
+O recurso `url` funciona com etapas de Blueprint como [`installPlugin`](/blueprints/steps) ou
+[`installTheme`](/blueprints/steps).
+Essas etapas exigem um `ResourceType` para definir a localização do plugin ou
+tema a instalar.
 
-O tipo de recurso `url` funciona realmente em combinação com etapas de blueprint como [`installPlugin`](/blueprints/steps#InstallPluginStep) ou [`installTheme`](/blueprints/steps#InstallThemeStep). Essas etapas exigem um `ResourceType` para definir o local do plugin ou do tema a instalar.
+<!-- With a `"resource": "url"` we can define the location of a `.zip` containing the plugin/theme. Use this for built ZIP artifacts hosted on a publicly accessible URL that does not require authentication, such as a release asset. CI artifact direct-download URLs can work, but they are often short-lived or restricted. -->
 
-Com um `"resource": "url"` podemos definir o local de um `.zip` contendo o plugin/tema via uma URL que pode apontar diretamente para um repositório GitHub.
+Com `"resource": "url"`, podemos definir a localização de um `.zip` que contém
+o plugin/tema. Use isso para artefatos ZIP já criados e hospedados em uma URL
+publicamente acessível que não exija autenticação, como um asset de release.
+URLs de download direto de artefatos de CI podem funcionar, mas costumam ter
+duração curta ou acesso restrito.
 
-:::tip
+<!-- For source code stored in a Git repository, prefer [`git:directory`](/blueprints/steps/resources#gitdirectoryreference). It can fetch a repository subdirectory from a branch, tag, or commit without requiring a ZIP archive. -->
 
-<!-- The Playground project provides a [GitHub Proxy](https://playground.wordpress.net/proxy) that allows you to generate a `.zip` from a repository (or even a folder inside a repo) containing your plugin or theme. This tool is very useful for avoiding CORS issues, among others. -->
+Para código-fonte armazenado em um repositório Git, prefira
+[`git:directory`](/blueprints/steps/resources#gitdirectoryreference). Ele pode
+buscar um subdiretório de repositório a partir de um branch, tag ou commit sem
+exigir um arquivo ZIP.
 
-O projeto Playground fornece um [Proxy GitHub](https://playground.wordpress.net/proxy) que permite gerar um `.zip` a partir de um repositório (ou mesmo uma pasta dentro de um repo) contendo seu plugin ou tema. Essa ferramenta é muito útil para evitar problemas de CORS, entre outros.
-:::
+<!-- Before using a `url` resource, verify that the URL: -->
+
+Antes de usar um recurso `url`, verifique se a URL:
+
+<!--
+- Downloads the file directly. It must not return an HTML page, redirect warning, login page, repository file viewer, or proxy error page.
+- Is available without cookies, authentication, a VPN, or a temporary browser session.
+- Sends CORS headers that allow Playground to fetch it.
+- Points to the expected file type. `installPlugin` and `installTheme` need a plugin or theme ZIP archive unless you use another resource type.
+- Will remain available. Temporary tunnel URLs, draft release assets, and short-lived CI artifacts can expire.
+- Is a real ZIP archive when the step expects a ZIP. Very small downloads often mean the server returned an HTML error page instead of the archive.
+-->
+
+- Baixa o arquivo diretamente. Ela não deve retornar uma página HTML, aviso de redirecionamento, página de login, visualizador de arquivo de repositório ou página de erro de proxy.
+- Está disponível sem cookies, autenticação, VPN ou sessão temporária do navegador.
+- Envia cabeçalhos CORS que permitem que o Playground a busque.
+- Aponta para o tipo de arquivo esperado. `installPlugin` e `installTheme` precisam de um arquivo ZIP de plugin ou tema, a menos que você use outro tipo de recurso.
+- Permanecerá disponível. URLs temporárias de túnel, assets de release em rascunho e artefatos de CI de curta duração podem expirar.
+- É um arquivo ZIP real quando a etapa espera um ZIP. Downloads muito pequenos costumam significar que o servidor retornou uma página HTML de erro em vez do arquivo.
+
+<!--
+For GitHub source code, do not point `url` at a repository page or a generated
+ZIP from a branch when you can use `git:directory`. Use `url` for built ZIP
+artifacts and `git:directory` for source directories.
+-->
+
+Para código-fonte no GitHub, não aponte `url` para uma página de repositório ou
+para um ZIP gerado de um branch quando você puder usar `git:directory`. Use
+`url` para artefatos ZIP criados e `git:directory` para diretórios de código-fonte.
+
+<!-- ### GitDirectoryReference -->
 
 ### GitDirectoryReference
 
 <!-- The `GitDirectoryReference` resource is used to reference a directory inside a Git repository. This is useful when a plugin or theme lives in a subfolder of a repo, or when you want to install from a specific branch, tag, or commit. -->
 
-O recurso `GitDirectoryReference` é usado para referenciar um diretório dentro de um repositório Git. Isso é útil quando um plugin ou tema está em uma subpasta de um repo, ou quando você quer instalar de um branch, tag ou commit específico.
+O recurso `GitDirectoryReference` é usado para referenciar um diretório dentro
+de um repositório Git. Isso é útil quando um plugin ou tema fica em uma subpasta
+de um repositório, ou quando você quer instalar a partir de um branch, tag ou
+commit específico.
 
 ```typescript
 type GitDirectoryReference = {
 	resource: 'git:directory';
 	url: string; // Repository URL (https://, ssh git@..., etc.)
 	path?: string; // Optional subdirectory inside the repository
-	ref?: string; // Optional branch, tag, or commit SHA
+	ref?: string; // Branch, tag, or commit SHA (defaults to HEAD)
+	refType?: 'branch' | 'tag' | 'commit'; // Hint for resolving the ref
 	'.git'?: boolean; // Experimental: include a .git directory with fetched metadata
 };
 ```
 
-**Example:**
+<!-- **Example:** -->
+
+**Exemplo:**
 
 ```json
 {
@@ -98,28 +154,42 @@ type GitDirectoryReference = {
 		"path": "plugins/data-basics-59c8f8"
 	},
 	"options": {
-		"activate": true
+		"activate": true,
+		"targetFolderName": "data-basics"
 	}
 }
 ```
 
-**Notas:**
+<!-- **Notes:** -->
 
-<!-- - Playground automatically detects providers like GitHub and GitLab.
+**Observações:**
+
+<!--
+- When using a branch or tag name for `ref`, you must specify `refType` (e.g. `"refType": "branch"`). Without it, only `HEAD` is reliably resolved.
+- Playground automatically detects providers like GitHub and GitLab.
+- Repository URLs may include or omit a trailing `.git` suffix. Extra trailing slashes are ignored.
 - It handles CORS-proxied fetches and sparse checkouts, so you can use URLs that point to specific subdirectories or branches.
-- This resource can be used with steps like [`installPlugin`](/blueprints/steps#InstallPluginStep) and [`installTheme`](/blueprints/steps#InstallThemeStep).
-- Set `".git": true` to include a `.git` folder containing packfiles and refs so Git-aware tooling can detect the checkout. This currently mirrors a shallow clone of the selected ref. -->
+- This resource can be used with steps like [`installPlugin`](/blueprints/steps) and [`installTheme`](/blueprints/steps).
+- Set `".git": true` to include a `.git` folder containing packfiles and refs so Git-aware tooling can detect the checkout. This currently mirrors a shallow clone of the selected ref.
+- The folder name is derived from the URL by default (e.g. `https-github-com-WordPress-block-development-examples-HEAD-at-plugins-data-basics-59c8f8`). Use `options.targetFolderName` in the step to override it, as shown in the example above.
+-->
 
+- Ao usar um nome de branch ou tag em `ref`, você deve especificar `refType` (por exemplo, `"refType": "branch"`). Sem isso, somente `HEAD` é resolvido de forma confiável.
 - O Playground detecta automaticamente provedores como GitHub e GitLab.
-- Ele lida com buscas através de proxy por CORS e URLs parciais, para que você possa usar URLs que apontam para subdiretórios ou branches específicos.
-- Este recurso pode ser usado como etapas de [`installPlugin`](/blueprints/steps#InstallPluginStep) e [`installTheme`](/blueprints/steps#InstallThemeStep).
-- Defina `".git": true` para incluir uma pasta `.git` contendo packfiles e refs para que ferramentas compatíveis com Git possam detectar a chegada dos arquivos. Atualmente, isso espelha um clone superficial da ref selecionada.
+- URLs de repositório podem incluir ou omitir o sufixo `.git` final. Barras finais extras são ignoradas.
+- Ele lida com buscas via proxy CORS e checkouts esparsos, então você pode usar URLs que apontam para subdiretórios ou branches específicos.
+- Esse recurso pode ser usado com etapas como [`installPlugin`](/blueprints/steps) e [`installTheme`](/blueprints/steps).
+- Defina `".git": true` para incluir uma pasta `.git` contendo packfiles e refs, para que ferramentas cientes de Git possam detectar o checkout. Atualmente, isso espelha um clone raso do ref selecionado.
+- O nome da pasta é derivado da URL por padrão (por exemplo, `https-github-com-WordPress-block-development-examples-HEAD-at-plugins-data-basics-59c8f8`). Use `options.targetFolderName` na etapa para sobrescrevê-lo, como mostrado no exemplo acima.
+
+<!-- ### CoreThemeReference -->
 
 ### CoreThemeReference
 
 <!-- The _CoreThemeReference_ resource is used to reference WordPress core themes. The _CoreThemeReference_ resource is defined as follows: -->
 
-O recurso _CoreThemeReference_ é usado para referenciar temas principais do WordPress. O recurso _CoreThemeReference_ é definido da seguinte forma:
+O recurso _CoreThemeReference_ é usado para referenciar temas principais do
+WordPress. O recurso _CoreThemeReference_ é definido assim:
 
 ```typescript
 type CoreThemeReference = {
@@ -131,7 +201,9 @@ type CoreThemeReference = {
 
 <!-- To use the _CoreThemeReference_ resource, you need to provide the slug of the theme. For example, to reference the "Twenty Twenty-One" theme, you can create a _CoreThemeReference_ as follows: -->
 
-Para usar o recurso _CoreThemeReference_, você precisa fornecer o slug do tema. Por exemplo, para referenciar o tema "Twenty Twenty-One", você pode criar um _CoreThemeReference_ da seguinte forma:
+Para usar o recurso _CoreThemeReference_, você precisa fornecer o slug do tema.
+Por exemplo, para referenciar o tema "Twenty Twenty-One", crie um
+_CoreThemeReference_ assim:
 
 ```json
 {
@@ -140,11 +212,14 @@ Para usar o recurso _CoreThemeReference_, você precisa fornecer o slug do tema.
 }
 ```
 
+<!-- ### CorePluginReference -->
+
 ### CorePluginReference
 
 <!-- The _CorePluginReference_ resource is used to reference WordPress core plugins. The _CorePluginReference_ resource is defined as follows: -->
 
-O recurso _CorePluginReference_ é usado para referenciar plugins principais do WordPress. O recurso _CorePluginReference_ é definido da seguinte forma:
+O recurso _CorePluginReference_ é usado para referenciar plugins principais do
+WordPress. O recurso _CorePluginReference_ é definido assim:
 
 ```typescript
 type CorePluginReference = {
@@ -156,7 +231,9 @@ type CorePluginReference = {
 
 <!-- To use the _CorePluginReference_ resource, you need to provide the slug of the plugin. For example, to reference the "Akismet" plugin, you can create a _CorePluginReference_ as follows: -->
 
-Para usar o recurso _CorePluginReference_, você precisa fornecer o slug do plugin. Por exemplo, para referenciar o plugin "Akismet", você pode criar um _CorePluginReference_ da seguinte forma:
+Para usar o recurso _CorePluginReference_, você precisa fornecer o slug do
+plugin. Por exemplo, para referenciar o plugin "Akismet", crie um
+_CorePluginReference_ assim:
 
 ```json
 {
@@ -165,11 +242,16 @@ Para usar o recurso _CorePluginReference_, você precisa fornecer o slug do plug
 }
 ```
 
+<!-- ### VFSReference -->
+
 ### VFSReference
 
 <!-- The _VFSReference_ resource is used to reference files that are stored in a virtual file system (VFS). The VFS is a file system that is stored in memory and can be used to store files that are not part of the file system of the operating system. The _VFSReference_ resource is defined as follows: -->
 
-O recurso _VFSReference_ é usado para referenciar arquivos armazenados em um sistema de arquivos virtual (VFS). O VFS é um sistema de arquivos armazenado na memória e pode ser usado para armazenar arquivos que não fazem parte do sistema de arquivos do sistema operacional. O recurso _VFSReference_ é definido da seguinte forma:
+O recurso _VFSReference_ é usado para referenciar arquivos armazenados em um
+sistema de arquivos virtual (VFS). O VFS é um sistema de arquivos armazenado em
+memória e pode ser usado para armazenar arquivos que não fazem parte do sistema
+de arquivos do sistema operacional. O recurso _VFSReference_ é definido assim:
 
 ```typescript
 type VFSReference = {
@@ -180,7 +262,9 @@ type VFSReference = {
 
 <!-- To use the _VFSReference_ resource, you need to provide the path to the file in the VFS. For example, to reference a file named "index.html" that is stored in the root of the VFS, you can create a _VFSReference_ as follows: -->
 
-Para usar o recurso _VFSReference_, você precisa fornecer o caminho para o arquivo no VFS. Por exemplo, para referenciar um arquivo chamado "index.html" armazenado na raiz do VFS, você pode criar um _VFSReference_ da seguinte forma:
+Para usar o recurso _VFSReference_, você precisa fornecer o caminho para o
+arquivo no VFS. Por exemplo, para referenciar um arquivo chamado "index.html"
+armazenado na raiz do VFS, crie um _VFSReference_ assim:
 
 ```json
 {
@@ -189,11 +273,14 @@ Para usar o recurso _VFSReference_, você precisa fornecer o caminho para o arqu
 }
 ```
 
+<!-- ### LiteralReference -->
+
 ### LiteralReference
 
 <!-- The _LiteralReference_ resource is used to reference files that are stored as literals in the code. The _LiteralReference_ resource is defined as follows: -->
 
-O recurso _LiteralReference_ é usado para referenciar arquivos armazenados como literais no código. O recurso _LiteralReference_ é definido da seguinte forma:
+O recurso _LiteralReference_ é usado para referenciar arquivos armazenados como
+literais no código. O recurso _LiteralReference_ é definido assim:
 
 ```typescript
 type LiteralReference = {
@@ -205,21 +292,28 @@ type LiteralReference = {
 
 <!-- To use the _LiteralReference_ resource, you need to provide the name of the file and its contents. For example, to reference a file named "index.html" that contains the text "Hello, World!", you can create a _LiteralReference_ as follows: -->
 
-Para usar o recurso _LiteralReference_, você precisa fornecer o nome do arquivo e seu conteúdo. Por exemplo, para referenciar um arquivo chamado "index.html" que contém o texto "Olá, Mundo!", você pode criar um _LiteralReference_ da seguinte forma:
+Para usar o recurso _LiteralReference_, você precisa fornecer o nome do arquivo
+e o conteúdo dele. Por exemplo, para referenciar um arquivo chamado "index.html"
+que contém o texto "Hello, World!", crie um _LiteralReference_ assim:
 
 ```json
 {
 	"resource": "literal",
 	"name": "index.html",
-	"contents": "Olá, Mundo!"
+	"contents": "Hello, World!"
 }
 ```
+
+<!-- ### BundledReference -->
 
 ### BundledReference
 
 <!-- The `BundledReference` resource is used to reference files that are bundled with the Blueprint itself. This is particularly useful for creating self-contained Blueprint bundles that include all necessary resources. The `BundledReference` resource is defined as follows: -->
 
-O recurso `BundledReference` é usado para referenciar arquivos que são agrupados com o próprio Blueprint. Isso é particularmente útil para criar blueprints autocontidos que incluem todos os recursos necessários. O recurso `BundledReference` é definido da seguinte forma:
+O recurso `BundledReference` é usado para referenciar arquivos empacotados com
+o próprio Blueprint. Isso é especialmente útil para criar pacotes de Blueprint
+autocontidos que incluem todos os recursos necessários. O recurso
+`BundledReference` é definido assim:
 
 ```typescript
 type BundledReference = {
@@ -230,7 +324,10 @@ type BundledReference = {
 
 <!-- To use the `BundledReference` resource, you need to provide the relative path to the file within the bundle. For example, to reference a file named "plugin.php" that is bundled with the Blueprint, you can create a `BundledReference` as follows: -->
 
-Para usar o recurso `BundledReference`, você precisa fornecer o caminho relativo para o arquivo dentro do pacote. Por exemplo, para referenciar um arquivo chamado "plugin.php" agrupado com o Blueprint, você pode criar um `BundledReference` da seguinte forma:
+Para usar o `BundledReference`, você precisa fornecer o caminho relativo para o
+arquivo dentro do pacote. Por exemplo, para referenciar um arquivo chamado
+"plugin.php" que está empacotado com o Blueprint, crie um `BundledReference`
+assim:
 
 ```json
 {
@@ -239,18 +336,21 @@ Para usar o recurso `BundledReference`, você precisa fornecer o caminho relativ
 }
 ```
 
-<!-- Blueprint bundles can be distributed in various formats, including:
+<!-- Blueprint bundles can be distributed in various formats, including: -->
 
+Pacotes de Blueprint podem ser distribuídos em vários formatos, incluindo:
+
+<!--
 - ZIP files with a top-level `blueprint.json` file
 - Directories containing a `blueprint.json` file and related resources
 - Remote URLs where the Blueprint and its resources are hosted together
-
-For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation. -->
-
-Os pacotes Blueprint podem ser distribuídos em vários formatos, incluindo:
+-->
 
 - Arquivos ZIP com um arquivo `blueprint.json` no nível superior
 - Diretórios contendo um arquivo `blueprint.json` e recursos relacionados
 - URLs remotas onde o Blueprint e seus recursos estão hospedados juntos
 
-Para mais informações sobre pacotes Blueprint, consulte a documentação de [Pacotes Blueprint](/blueprints/bundles).
+<!-- For more information on Blueprint bundles, see the [Blueprint Bundles](/blueprints/bundles) documentation. -->
+
+Para mais informações sobre pacotes de Blueprint, consulte a documentação de
+[Pacotes de Blueprint](/blueprints/bundles).

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/blueprints/09-troubleshoot-and-debug-blueprints.md
@@ -1,157 +1,942 @@
 ---
-title: Solucionar problemas e depurar
+title: Solução de problemas e depuração
 slug: /blueprints/troubleshoot-and-debug
-description: Um guia com dicas e ferramentas para ajudar você a solucionar problemas e depurar seus Blueprints, desde problemas comuns até ferramentas do navegador.
+description: Um guia pesquisável para erros comuns de Blueprint, incluindo falhas de busca, erros de validação, falhas de PHP e problemas de ativação de plugins.
 ---
 
-<!-- Review Common gotchas -->
+<!-- title: Troubleshoot and debug -->
 
-## Revise os erros comuns
+<!-- description: A searchable guide to common Blueprint errors, including fetch failures, validation errors, PHP failures, and plugin activation issues. -->
 
-<!-- Require `wp-load`: to run a WordPress PHP function using the `runPHP` step, you'd need to require [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). So, the value of the `code` key should start with `"<?php require_once('wordpress/wp-load.php'); REST_OF_YOUR_CODE"`. -->
+<!-- # Troubleshoot and debug Blueprints -->
 
-- Exija `wp-load`: para executar uma função PHP do WordPress usando a etapa `runPHP`, você precisará exigir [wp-load.php](https://github.com/WordPress/WordPress/blob/master/wp-load.php). Portanto, o valor da chave `code` deve começar com `"<?php require_once('wordpress/wp-load.php'); RESTO_DO_SEU_CÓDIGO"`.
+# Solução de problemas e depuração de Blueprints
 
-<!-- Common Issues and Solutions -->
+<!-- Blueprint errors usually point to one of three places: -->
 
-## Problemas e Soluções Comuns
+Erros de Blueprint geralmente apontam para um destes três lugares:
 
-<!-- Invalid Blueprint After Opening a Link -->
+<!--
+- The Blueprint JSON is invalid.
+- Playground could not fetch the Blueprint or one of its resources.
+- A Blueprint step ran, but WordPress, PHP, WP-CLI, or a plugin failed.
+-->
 
-### Blueprint inválido após abrir um link
+- O JSON do Blueprint é inválido.
+- O Playground não conseguiu buscar o Blueprint ou um dos recursos dele.
+- Uma etapa do Blueprint foi executada, mas o WordPress, PHP, WP-CLI ou um plugin falhou.
 
-<!-- If Playground reports `Invalid blueprint`, read the detailed error message. It includes the underlying JSON parsing error when one is available. -->
+<!--
+Start with the exact error name shown by Playground, then use the matching
+section below.
+-->
 
-Se o Playground informar `Invalid blueprint`, leia a mensagem de erro detalhada. Ela inclui o erro de análise JSON subjacente quando ele estiver disponível.
+Comece pelo nome exato do erro mostrado pelo Playground e use a seção
+correspondente abaixo.
 
-<!-- If the message says the input still contains `%XX` escapes after decoding, the URL fragment was likely double-encoded. Rebuild the link from the original Blueprint object and encode it once with `encodeURIComponent(JSON.stringify(blueprint))`, or use Base64. Do not encode a fragment that is already encoded. -->
+<!-- ## Quick checklist -->
 
-Se a mensagem disser que a entrada ainda contém escapes `%XX` após a decodificação, o fragmento de URL provavelmente foi codificado duas vezes. Recrie o link a partir do objeto Blueprint original e codifique-o uma vez com `encodeURIComponent(JSON.stringify(blueprint))`, ou use Base64. Não codifique um fragmento que já está codificado.
+## Lista de verificação rápida
 
-<!-- WP-CLI: Error Establishing a Database Connection on Mounted Sites -->
+<!--
+- Paste the Blueprint into the [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to validate the JSON schema.
+- If the Blueprint is loaded from a URL, open that URL directly in a private browser window and confirm it downloads valid JSON or a Blueprint ZIP bundle.
+- If a step fails, note the step number in `BlueprintStepExecutionError`. The failed step is usually the item at that position after Blueprint shorthands have been expanded.
+- Open browser developer tools and check the Console and Network tabs for download, CORS, PHP, or plugin activation details.
+- For plugin/theme activation failures, check the Playground **Logs** panel or the browser console for PHP warnings and fatal errors.
+-->
 
-### WP-CLI: Erro ao Estabelecer Conexão com Banco de Dados em Sites Montados {#wp-cli-error-establishing-a-database-connection-on-mounted-sites}
+- Cole o Blueprint no [editor de Blueprints](https://playground.wordpress.net/builder/builder.html) para validar o esquema JSON.
+- Se o Blueprint for carregado de uma URL, abra essa URL diretamente em uma janela privativa do navegador e confirme que ela baixa um JSON válido ou um pacote ZIP de Blueprint.
+- Se uma etapa falhar, anote o número da etapa em `BlueprintStepExecutionError`. A etapa com falha normalmente é o item nessa posição depois que os atalhos de Blueprint são expandidos.
+- Abra as ferramentas de desenvolvedor do navegador e verifique as abas Console e Network para detalhes de download, CORS, PHP ou ativação de plugins.
+- Para falhas de ativação de plugin/tema, confira o painel **Logs** do Playground ou o console do navegador para avisos e erros fatais de PHP.
 
-<!-- When using `wp-cli` with a mounted Playground site (e.g., via `--mount-before-install`), you might encounter an "Error establishing a database connection." This happens because WordPress Playground loads the SQLite database integration plugin from its internal files by default, not from the mounted directory, meaning it's not persisted for external `wp-cli` calls. -->
+<!-- ## InvalidBlueprintError -->
 
-Ao usar `wp-cli` com um site Playground montado (por exemplo, via `--mount-before-install`), você pode encontrar um erro "Erro ao estabelecer conexão com banco de dados". Isso acontece porque o WordPress Playground carrega o plugin de integração do banco de dados SQLite a partir de seus arquivos internos por padrão, não do diretório montado, significando que não é persistido para chamadas externas de `wp-cli`.
+## InvalidBlueprintError
 
-<!-- To resolve this, you need to explicitly install and configure the SQLite database integration plugin within your Blueprint. -->
+<!--
+`InvalidBlueprintError` means the Blueprint does not match the
+[Blueprint data format](/blueprints/data-format). The error output usually
+contains paths such as `/steps/2/pluginData` or `/preferredVersions`.
+-->
 
-Para resolver isso, você precisa instalar e configurar explicitamente o plugin de integração do banco de dados SQLite dentro de seu Blueprint.
+`InvalidBlueprintError` significa que o Blueprint não corresponde ao
+[formato de dados do Blueprint](/blueprints/data-format). A saída do erro
+normalmente contém caminhos como `/steps/2/pluginData` ou `/preferredVersions`.
 
-<!-- **Solution:** Add the following steps to your Blueprint: -->
+<!-- ### Unexpected property `activate` -->
 
-**Solução:** Adicione as seguintes etapas ao seu Blueprint:
+### Propriedade inesperada `activate`
 
-<!-- **Example Usage:** To test this locally, combine the Blueprint with your Playground CLI command: -->
+<!--
+`activate` belongs inside `options`, not directly on the step or inside
+`pluginData`.
+-->
 
-**Exemplo de Uso:**
+`activate` deve ficar dentro de `options`, não diretamente na etapa nem dentro
+de `pluginData`.
 
-Para testar isso localmente, combine o Blueprint com seu comando Playground CLI:
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
 
-<!-- This will ensure the SQLite plugin is installed correctly and configured in your mounted WordPress site, allowing `wp-cli` commands to function correctly. -->
+<!-- ### Unexpected property `plugins` in `preferredVersions` -->
 
-Isso garantirá que o plugin SQLite seja instalado corretamente e configurado em seu site WordPress montado, permitindo que comandos `wp-cli` funcionem corretamente.
+### Propriedade inesperada `plugins` em `preferredVersions`
 
-<!-- Blueprints Builder -->
+<!--
+`preferredVersions` only accepts `php` and `wp`. Install plugins with the
+top-level `plugins` shorthand or with an explicit `installPlugin` step.
+-->
 
-## Construtor de Blueprints
+`preferredVersions` aceita somente `php` e `wp`. Instale plugins com o atalho
+`plugins` no nível superior ou com uma etapa explícita `installPlugin`.
 
-<!-- You can use an in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html) to build, validate, and preview your Blueprints in the browser. -->
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"]
+}
+```
 
-Você pode usar um [editor de Blueprints](https://playground.wordpress.net/builder/builder.html) no navegador para criar, validar e visualizar seus Blueprints.
+<!-- ### Missing `slug`, `url`, `path`, or `files` -->
 
-<!-- :::danger Caution The editor is under development and the embedded Playground sometimes fails to load. To get around it, refresh the page. We're aware of that, and are working to improve the experience. ::: -->
+### `slug`, `url`, `path` ou `files` ausente
 
-:::danger Aviso
+<!-- The resource object is incomplete or uses the wrong shape. Common fixes: -->
 
-O editor está em desenvolvimento e o Playground incorporado às vezes falha ao carregar. Para contornar isso, atualize a página. Estamos cientes disso e trabalhando para melhorar a experiência.
+O objeto de recurso está incompleto ou usa o formato errado. Correções comuns:
+
+<!--
+- WordPress.org plugin: `{ "resource": "wordpress.org/plugins", "slug": "akismet" }`
+- ZIP URL: `{ "resource": "url", "url": "https://example.com/plugin.zip" }`
+- Git directory: `{ "resource": "git:directory", "url": "https://github.com/org/repo", "ref": "trunk", "refType": "branch" }`
+-->
+
+- Plugin do WordPress.org: `{ "resource": "wordpress.org/plugins", "slug": "akismet" }`
+- URL de ZIP: `{ "resource": "url", "url": "https://example.com/plugin.zip" }`
+- Diretório Git: `{ "resource": "git:directory", "url": "https://github.com/org/repo", "ref": "trunk", "refType": "branch" }`
+
+<!--
+See [Resources References](/blueprints/steps/resources) for all supported
+resource shapes.
+-->
+
+Consulte [Referências de recursos](/blueprints/steps/resources) para ver todos
+os formatos de recurso compatíveis.
+
+<!-- ### Mixed plugin install properties -->
+
+### Propriedades mistas de instalação de plugin
+
+<!--
+Use `pluginData` for `installPlugin`. Do not provide both `pluginData` and
+older examples or custom objects such as `pluginZipFile`.
+-->
+
+Use `pluginData` para `installPlugin`. Não forneça `pluginData` junto com
+exemplos antigos ou objetos personalizados como `pluginZipFile`.
+
+<!-- The WordPress.org plugin resource also needs a separate `slug`: -->
+
+O recurso de plugin do WordPress.org também precisa de um `slug` separado:
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "wordpress.org/plugins",
+		"slug": "woocommerce"
+	}
+}
+```
+
+<!-- Do not write `"resource": "wordpress.org/plugins/woocommerce"`. -->
+
+Não escreva `"resource": "wordpress.org/plugins/woocommerce"`.
+
+<!-- ## BlueprintFetchError -->
+
+## BlueprintFetchError
+
+<!--
+`BlueprintFetchError` means Playground could not load the file passed to
+`?blueprint-url=`.
+-->
+
+`BlueprintFetchError` significa que o Playground não conseguiu carregar o arquivo
+passado para `?blueprint-url=`.
+
+<!-- Check that the URL: -->
+
+Verifique se a URL:
+
+<!--
+- Is public and does not require cookies, login, a temporary session, or a VPN.
+- Returns HTTP 200 when opened directly.
+- Serves valid JSON or a ZIP bundle with `blueprint.json` inside it.
+- Sends `Access-Control-Allow-Origin: *` or another header that allows
+  `https://playground.wordpress.net`.
+- Uses a raw file URL, not a repository HTML page.
+-->
+
+- É pública e não exige cookies, login, sessão temporária ou VPN.
+- Retorna HTTP 200 quando aberta diretamente.
+- Serve JSON válido ou um pacote ZIP com `blueprint.json` dentro.
+- Envia `Access-Control-Allow-Origin: *` ou outro cabeçalho que permita
+  `https://playground.wordpress.net`.
+- Usa uma URL de arquivo bruto, não uma página HTML de repositório.
+
+<!--
+For GitHub, use `raw.githubusercontent.com` URLs instead of `github.com/.../blob/...`.
+For GitLab, use the raw file URL instead of a `/-/blob/` page.
+-->
+
+Para GitHub, use URLs `raw.githubusercontent.com` em vez de `github.com/.../blob/...`.
+Para GitLab, use a URL de arquivo bruto em vez de uma página `/-/blob/`.
+
+```text
+# Good
+https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/welcome/blueprint.json
+
+# Not a raw JSON response
+https://github.com/WordPress/blueprints/blob/trunk/blueprints/welcome/blueprint.json
+```
+
+<!--
+Temporary tunnel URLs, local development URLs, and draft release assets often
+fail because the browser cannot reach them or because they do not allow
+cross-origin requests. Move the Blueprint to a public host with CORS enabled.
+-->
+
+URLs temporárias de túnel, URLs de desenvolvimento local e assets de lançamento
+em rascunho costumam falhar porque o navegador não consegue acessá-los ou
+porque eles não permitem requisições de origem cruzada. Mova o Blueprint para
+um host público com CORS ativado.
+
+<!-- ### Blueprint file is neither a valid JSON nor a ZIP file -->
+
+### O arquivo de Blueprint não é JSON válido nem arquivo ZIP
+
+<!--
+This means Playground received a response, but the response was not a Blueprint.
+The URL may have returned an HTML page, 404 page, repository file viewer, proxy
+warning, login page, or corrupted ZIP.
+-->
+
+Isso significa que o Playground recebeu uma resposta, mas ela não era um
+Blueprint. A URL pode ter retornado uma página HTML, página 404, visualizador
+de arquivo de repositório, aviso de proxy, página de login ou ZIP corrompido.
+
+<!-- Open the URL directly and check that: -->
+
+Abra a URL diretamente e verifique se:
+
+<!--
+- JSON URLs return valid Blueprint JSON.
+- ZIP bundle URLs download a real ZIP archive.
+- Blueprint bundles contain `blueprint.json` at the root of the ZIP.
+- The response is not a small HTML or text error page.
+-->
+
+- URLs JSON retornam JSON de Blueprint válido.
+- URLs de pacote ZIP baixam um arquivo ZIP real.
+- Pacotes de Blueprint contêm `blueprint.json` na raiz do ZIP.
+- A resposta não é uma pequena página HTML ou texto de erro.
+
+<!-- ### URIError: URI malformed -->
+
+### URIError: URI malformed
+
+<!--
+`URIError: URI malformed` usually points to a broken encoded Blueprint fragment
+in the URL, not to a failed Blueprint step. Check for invalid `%` escapes,
+double-encoded fragments, or raw JSON pasted after `#`. Rebuild the link from
+the original Blueprint and encode it once, or use Base64. See
+[Encoded Blueprint fragments](/blueprints/using-blueprints).
+-->
+
+`URIError: URI malformed` normalmente aponta para um fragmento de Blueprint
+codificado incorretamente na URL, não para uma etapa de Blueprint com falha.
+Verifique escapes `%` inválidos, fragmentos codificados duas vezes ou JSON bruto
+colado depois de `#`. Reconstrua o link a partir do Blueprint original e
+codifique-o uma vez, ou use Base64. Consulte
+[Fragmentos de Blueprint codificados](/blueprints/using-blueprints).
+
+<!-- ## ResourceDownloadError -->
+
+## ResourceDownloadError
+
+<!--
+`ResourceDownloadError` means the Blueprint loaded, but a step could not download
+a resource such as a plugin ZIP, theme ZIP, WXR file, or imported site archive.
+-->
+
+`ResourceDownloadError` significa que o Blueprint carregou, mas uma etapa não
+conseguiu baixar um recurso, como um ZIP de plugin, ZIP de tema, arquivo WXR ou
+arquivo de site importado.
+
+<!-- Confirm the resource URL: -->
+
+Confirme se a URL do recurso:
+
+<!--
+- Downloads the actual file, not an HTML page, redirect warning, or expired artifact.
+- Is public and does not require authentication.
+- Allows cross-origin requests.
+- Is the direct file URL. Some release pages and CI artifact pages are human pages, not direct downloads.
+- Still exists. Temporary links and CI artifacts can expire.
+-->
+
+- Baixa o arquivo real, não uma página HTML, aviso de redirecionamento ou artefato expirado.
+- É pública e não exige autenticação.
+- Permite requisições de origem cruzada.
+- É a URL direta do arquivo. Algumas páginas de release e de artefatos de CI são páginas para pessoas, não downloads diretos.
+- Ainda existe. Links temporários e artefatos de CI podem expirar.
+
+<!--
+For source code in a Git repository, prefer a
+[`git:directory` resource](/blueprints/steps/resources#gitdirectoryreference).
+Use a `url` resource for built ZIP artifacts that are already publicly
+downloadable.
+-->
+
+Para código-fonte em um repositório Git, prefira um
+[recurso `git:directory`](/blueprints/steps/resources#gitdirectoryreference).
+Use um recurso `url` para artefatos ZIP criados e já disponíveis publicamente
+para download.
+
+<!-- ## BlueprintStepExecutionError -->
+
+## BlueprintStepExecutionError
+
+<!--
+`BlueprintStepExecutionError` means a specific step failed after the Blueprint
+started running. The message includes a step number:
+-->
+
+`BlueprintStepExecutionError` significa que uma etapa específica falhou depois
+que o Blueprint começou a ser executado. A mensagem inclui um número de etapa:
+
+```text
+BlueprintStepExecutionError: Error when executing the blueprint step #4
+```
+
+<!--
+Use that number to inspect the matching step. If your Blueprint uses shorthands
+such as `plugins`, `login`, `siteOptions`, or `constants`, Playground expands
+them into steps before running the Blueprint. Use explicit `steps` when the
+order matters.
+-->
+
+Use esse número para inspecionar a etapa correspondente. Se o Blueprint usa
+atalhos como `plugins`, `login`, `siteOptions` ou `constants`, o Playground os
+expande em etapas antes de executar o Blueprint. Use `steps` explícitas quando
+a ordem for importante.
+
+<!--
+URL query parameters such as `?plugin=...`, `?theme=...`, `?php=...`,
+`?wp=...`, and `?networking=yes` also create an implicit Blueprint. Errors from
+those URLs are still Blueprint execution errors, and the generated steps affect
+the reported step number.
+-->
+
+Parâmetros de consulta de URL como `?plugin=...`, `?theme=...`, `?php=...`,
+`?wp=...` e `?networking=yes` também criam um Blueprint implícito. Erros dessas
+URLs ainda são erros de execução de Blueprint, e as etapas geradas afetam o
+número de etapa informado.
+
+<!-- ## PHP.run() failed with exit code 255 -->
+
+## PHP.run() failed with exit code 255
+
+<!--
+Exit code `255` usually means PHP hit a fatal error. Look for the first
+`Fatal error`, `Uncaught`, or `TypeError` line in the output. The large HTML
+error page around it is usually WordPress's generic critical error screen.
+-->
+
+O código de saída `255` normalmente significa que o PHP encontrou um erro fatal.
+Procure a primeira linha `Fatal error`, `Uncaught` ou `TypeError` na saída. A
+grande página HTML de erro ao redor dela costuma ser a tela genérica de erro
+crítico do WordPress.
+
+<!--
+To make the output more useful while debugging, enable WordPress debug constants
+near the beginning of the Blueprint:
+-->
+
+Para tornar a saída mais útil durante a depuração, ative as constantes de
+depuração do WordPress perto do início do Blueprint:
+
+```json
+{
+	"step": "defineWpConfigConsts",
+	"consts": {
+		"WP_DEBUG": true,
+		"WP_DEBUG_LOG": true,
+		"WP_DEBUG_DISPLAY": true,
+		"WP_DISABLE_FATAL_ERROR_HANDLER": true
+	}
+}
+```
+
+<!--
+Then rerun the Blueprint and check the Playground **Logs** panel or browser
+console.
+-->
+
+Depois execute o Blueprint novamente e confira o painel **Logs** do Playground
+ou o console do navegador.
+
+<!-- ## PHP.run() failed with exit code 1 -->
+
+## PHP.run() failed with exit code 1
+
+<!--
+Exit code `1` often appears when WP-CLI or WordPress returns an application
+error. Read the `Stderr` section first. It usually names the unsupported
+argument, missing resource, or command-specific failure.
+-->
+
+O código de saída `1` costuma aparecer quando o WP-CLI ou o WordPress retorna
+um erro da aplicação. Leia primeiro a seção `Stderr`. Ela normalmente informa o
+argumento sem suporte, o recurso ausente ou a falha específica do comando.
+
+<!--
+Some WP-CLI commands behave differently in Playground because WordPress runs in
+WebAssembly with SQLite. Keep commands small and test them individually before
+adding a long chain to a Blueprint.
+-->
+
+Alguns comandos WP-CLI se comportam de forma diferente no Playground porque o
+WordPress é executado em WebAssembly com SQLite. Mantenha os comandos pequenos
+e teste-os individualmente antes de adicionar uma cadeia longa a um Blueprint.
+
+<!-- ## Undefined constant `ABSPATH` -->
+
+## Undefined constant `ABSPATH`
+
+<!--
+This usually happens in a `runPHP` step that calls WordPress APIs without first
+loading WordPress.
+-->
+
+Isso normalmente acontece em uma etapa `runPHP` que chama APIs do WordPress sem
+antes carregar o WordPress.
+
+<!-- Add `wp-load.php` before any WordPress function, constant, option, or plugin API: -->
+
+Adicione `wp-load.php` antes de qualquer função, constante, opção ou API de
+plugin do WordPress:
+
+```json
+{
+	"step": "runPHP",
+	"code": "<?php require '/wordpress/wp-load.php'; update_option('blogname', 'Demo site');"
+}
+```
+
+<!-- ## Plugin could not be activated -->
+
+## Plugin could not be activated
+
+<!--
+Plugin activation errors usually come from the plugin itself, not from the
+Blueprint runner. Common causes:
+-->
+
+Erros de ativação de plugin geralmente vêm do próprio plugin, não do executor
+de Blueprints. Causas comuns:
+
+<!--
+- The plugin requires a newer PHP version or WordPress version.
+- The plugin has a fatal error on activation.
+- The plugin depends on another plugin that is not installed or activated.
+- The plugin performs a redirect or prints unexpected output during activation.
+- The plugin ZIP extracts to a folder or main file name different from the path the step is activating.
+-->
+
+- O plugin exige uma versão mais recente do PHP ou do WordPress.
+- O plugin tem um erro fatal na ativação.
+- O plugin depende de outro plugin que não está instalado ou ativado.
+- O plugin faz um redirecionamento ou imprime uma saída inesperada durante a ativação.
+- O ZIP do plugin é extraído para uma pasta ou arquivo principal com nome diferente do caminho que a etapa está ativando.
+
+<!--
+If the error says the current PHP or WordPress version does not meet minimum
+requirements, set `preferredVersions`:
+-->
+
+Se o erro disser que a versão atual do PHP ou do WordPress não atende aos
+requisitos mínimos, defina `preferredVersions`:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	}
+}
+```
+
+<!-- ### WordPress exited with exit code 0 -->
+
+### WordPress exited with exit code 0
+
+<!--
+Activation can fail even when WordPress exits with code `0`. This usually means
+WordPress returned an activation error response rather than a PHP process crash.
+When the message says `Inspect the "debug" logs`, check the Playground **Logs**
+panel, browser console, or CLI output.
+-->
+
+A ativação pode falhar mesmo quando o WordPress sai com código `0`. Isso
+normalmente significa que o WordPress retornou uma resposta de erro de ativação,
+em vez de uma falha do processo PHP. Quando a mensagem disser
+`Inspect the "debug" logs`, verifique o painel **Logs** do Playground, o console
+do navegador ou a saída da CLI.
+
+<!--
+Look for PHP warnings, redirects or output printed during activation, missing
+dependency plugins, or plugin minimum PHP/WordPress requirements.
+-->
+
+Procure avisos de PHP, redirecionamentos ou saída impressa durante a ativação,
+plugins de dependência ausentes ou requisitos mínimos de PHP/WordPress do plugin.
+
+<!-- ### Current PHP or WordPress version does not meet minimum requirements -->
+
+### Current PHP or WordPress version does not meet minimum requirements
+
+<!-- Version mismatch errors often include text like: -->
+
+Erros de incompatibilidade de versão costumam incluir textos como:
+
+```text
+Current PHP version (7.4.33) does not meet minimum requirements. The plugin requires PHP 8.0.
+```
+
+<!-- or: -->
+
+ou:
+
+```text
+Current WordPress version (6.9.4) does not meet minimum requirements. The plugin requires WordPress 7.0.
+```
+
+<!--
+Set `preferredVersions` to a compatible PHP and WordPress version, or use a
+plugin/theme release that supports the versions available in Playground.
+-->
+
+Defina `preferredVersions` para uma versão compatível de PHP e WordPress, ou
+use uma versão do plugin/tema compatível com as versões disponíveis no Playground.
+
+<!-- If the error is: -->
+
+Se o erro for:
+
+```text
+Failed to download WordPress 6.9.0 (HTTP 404)
+```
+
+<!--
+the requested WordPress build is not available. Use `latest`, a supported
+released version, or a supported beta/nightly value.
+-->
+
+a compilação solicitada do WordPress não está disponível. Use `latest`, uma versão
+lançada compatível ou um valor beta/nightly compatível.
+
+<!--
+If the error says `Plugin file does not exist`, inspect the installed folder
+name. For ZIP URLs with unusual folder names, set `targetFolderName`:
+-->
+
+Se o erro disser `Plugin file does not exist`, inspecione o nome da pasta
+instalada. Para URLs ZIP com nomes de pasta incomuns, defina `targetFolderName`:
+
+```json
+{
+	"step": "installPlugin",
+	"pluginData": {
+		"resource": "url",
+		"url": "https://example.com/my-plugin.zip"
+	},
+	"options": {
+		"activate": true,
+		"targetFolderName": "my-plugin"
+	}
+}
+```
+
+<!--
+If the plugin has dependencies, install and activate those dependencies first
+with explicit steps.
+-->
+
+Se o plugin tiver dependências, instale e ative essas dependências primeiro com
+etapas explícitas.
+
+<!-- ## Theme could not be activated -->
+
+## Theme could not be activated
+
+<!--
+Theme activation failures usually mean the theme folder name is wrong, the
+theme ZIP extracted to an unexpected directory, or the theme code caused a
+WordPress/PHP error.
+-->
+
+Falhas de ativação de tema geralmente significam que o nome da pasta do tema
+está errado, que o ZIP do tema foi extraído para um diretório inesperado ou que
+o código do tema causou um erro do WordPress/PHP.
+
+<!-- Use `installTheme` with `options.activate` when installing a theme: -->
+
+Use `installTheme` com `options.activate` ao instalar um tema:
+
+```json
+{
+	"step": "installTheme",
+	"themeData": {
+		"resource": "wordpress.org/themes",
+		"slug": "twentytwentyfour"
+	},
+	"options": {
+		"activate": true
+	}
+}
+```
+
+<!--
+If you use a standalone `activateTheme` step, pass the folder name inside
+`wp-content/themes`, not a full URL or ZIP filename.
+-->
+
+Se você usar uma etapa independente `activateTheme`, passe o nome da pasta
+dentro de `wp-content/themes`, não uma URL completa ou o nome do arquivo ZIP.
+
+<!-- ## Could not write to a file -->
+
+## Could not write to a file
+
+<!-- Errors like this mean the parent directory does not exist: -->
+
+Erros como este significam que o diretório pai não existe:
+
+```text
+Could not write to "/wordpress/wp-content/plugins/example/index.php":
+There is no such file or directory OR the parent directory does not exist.
+```
+
+<!--
+Create the directory first with `mkdir`, or use `writeFiles` with a
+`literal:directory` resource.
+-->
+
+Crie o diretório primeiro com `mkdir` ou use `writeFiles` com um recurso
+`literal:directory`.
+
+```json
+[
+	{
+		"step": "mkdir",
+		"path": "/wordpress/wp-content/plugins/example"
+	},
+	{
+		"step": "writeFile",
+		"path": "/wordpress/wp-content/plugins/example/index.php",
+		"data": "<?php /* Plugin Name: Example */"
+	}
+]
+```
+
+<!-- ## Could not unzip file -->
+
+## Could not unzip file
+
+<!--
+This usually means the file is not a valid ZIP archive. The URL may have
+returned an HTML page, an error response, a login page, or a truncated file.
+-->
+
+Isso normalmente significa que o arquivo não é um ZIP válido. A URL pode ter
+retornado uma página HTML, uma resposta de erro, uma página de login ou um
+arquivo truncado.
+
+<!--
+If the output says `Could not unzip file. Error code: 19`, verify the download
+is a ZIP archive. A small file size often means the server returned an HTML
+error page instead of the archive.
+-->
+
+Se a saída disser `Could not unzip file. Error code: 19`, verifique se o
+download é um arquivo ZIP. Um tamanho de arquivo pequeno costuma significar que
+o servidor retornou uma página HTML de erro em vez do arquivo.
+
+<!--
+Open the URL directly and confirm the browser downloads a ZIP. If you are using
+a GitHub or CI artifact, use a direct-download URL and make sure the release or
+artifact is public.
+-->
+
+Abra a URL diretamente e confirme que o navegador baixa um ZIP. Se você estiver
+usando um artefato do GitHub ou de CI, use uma URL de download direto e garanta
+que a release ou o artefato seja público.
+
+<!-- ## WP-CLI command pitfalls -->
+
+## Armadilhas de comandos WP-CLI
+
+<!--
+The `wp-cli` step runs WP-CLI inside Playground. It is useful for setup tasks,
+but not every command or shell feature behaves like a local terminal.
+-->
+
+A etapa `wp-cli` executa o WP-CLI dentro do Playground. Ela é útil para tarefas
+de configuração, mas nem todo comando ou recurso de shell se comporta como em
+um terminal local.
+
+<!-- Common fixes: -->
+
+Correções comuns:
+
+<!--
+- Use the step name `"wp-cli"`, not `"wpcli"` or `"cli"`.
+- Keep commands focused. Prefer multiple `wp-cli` steps over one complex shell command.
+- Avoid shell substitutions such as `$(...)` in shared Blueprints. Use `runPHP` for logic that needs WordPress APIs.
+- Check parameter names against the WP-CLI command you are using. For example, command-specific parameters may differ between `wp post list`, `wp post delete`, and plugin-provided commands.
+- If a plugin-provided WP-CLI command fails with a plugin stack trace, the fix usually belongs in that plugin or in the input data passed to the command.
+- If a command fails with `unknown --post_type parameter` or `unknown --format parameter`, check whether the flags belong to a different command in the pipeline.
+- If a plugin command fails with `Unsupported argument type passed to WP_CLI::error_to_string(): 'NULL'`, confirm the plugin is active, the imported data exists, and the command input points to a valid resource.
+-->
+
+- Use o nome de etapa `"wp-cli"`, não `"wpcli"` nem `"cli"`.
+- Mantenha os comandos focados. Prefira várias etapas `wp-cli` em vez de um comando de shell complexo.
+- Evite substituições de shell como `$(...)` em Blueprints compartilhados. Use `runPHP` para lógica que precisa das APIs do WordPress.
+- Confira os nomes dos parâmetros no comando WP-CLI que você está usando. Por exemplo, parâmetros específicos podem diferir entre `wp post list`, `wp post delete` e comandos fornecidos por plugins.
+- Se um comando WP-CLI fornecido por plugin falhar com um stack trace do plugin, a correção normalmente pertence a esse plugin ou aos dados de entrada passados ao comando.
+- Se um comando falhar com `unknown --post_type parameter` ou `unknown --format parameter`, verifique se as flags pertencem a outro comando no pipeline.
+- Se um comando de plugin falhar com `Unsupported argument type passed to WP_CLI::error_to_string(): 'NULL'`, confirme que o plugin está ativo, os dados importados existem e a entrada do comando aponta para um recurso válido.
+
+<!-- ## WP-CLI: Error establishing a database connection on mounted sites -->
+
+## WP-CLI: Error establishing a database connection on mounted sites
+
+<!--
+When using `wp-cli` with a mounted Playground site, for example via
+`--mount-before-install`, you might encounter an "Error establishing a database
+connection." This happens because WordPress Playground loads the SQLite database
+integration plugin from its internal files by default, not from the mounted
+directory.
+-->
+
+Ao usar `wp-cli` com um site Playground montado, por exemplo via
+`--mount-before-install`, você pode encontrar "Error establishing a database
+connection." Isso acontece porque o WordPress Playground carrega o plugin de
+integração de banco de dados SQLite a partir de seus arquivos internos por
+padrão, não do diretório montado.
+
+<!-- Add the SQLite integration plugin to the mounted WordPress site explicitly: -->
+
+Adicione explicitamente o plugin de integração SQLite ao site WordPress montado:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}
+```
+
+<!-- Then run the Blueprint with the mounted site: -->
+
+Depois execute o Blueprint com o site montado:
+
+```bash
+mkdir wordpress
+npx @wp-playground/cli server --mount-before-install=wordpress:/wordpress --blueprint=./blueprint.json
+```
+
+<!-- ## Debugging tools -->
+
+## Ferramentas de depuração
+
+<!-- ### Blueprints editor -->
+
+### Editor de Blueprints
+
+<!--
+Use the in-browser [Blueprints editor](https://playground.wordpress.net/builder/builder.html)
+to build, validate, and preview Blueprints.
+-->
+
+Use o [editor de Blueprints](https://playground.wordpress.net/builder/builder.html)
+no navegador para criar, validar e pré-visualizar Blueprints.
+
+<!-- :::danger Caution -->
+
+:::danger Atenção
+
+<!--
+The editor is under development and the embedded Playground sometimes fails to
+load. To get around it, refresh the page.
+-->
+
+O editor está em desenvolvimento e o Playground incorporado às vezes falha ao
+carregar. Para contornar isso, atualize a página.
 
 :::
 
-<!-- Check for the Filesystem and Database -->
+<!-- ### Filesystem and database inspection -->
 
-## Verificar o Sistema de Arquivos e Banco de Dados
+### Inspeção do sistema de arquivos e do banco de dados
 
-<!-- Some blueprint steps (such as [`writeFile`](/blueprints/steps#WriteFileStep)) alter the internal Filesystem structure of the Playground instance and some others (such as [`runSql`](/blueprints/steps#runSql)) alter the internal WordPress database. -->
+<!--
+Some Blueprint steps, such as [`writeFile`](/blueprints/steps),
+alter the internal filesystem. Others, such as
+[`runSql`](/blueprints/steps), alter the database.
+-->
 
-Algumas etapas de blueprint (como [`writeFile`](/blueprints/steps#WriteFileStep)) alteram a estrutura interna do Sistema de Arquivos da instância Playground e outras (como [`runSql`](/blueprints/steps#runSql)) alteram o banco de dados interno do WordPress.
+Algumas etapas de Blueprint, como [`writeFile`](/blueprints/steps),
+alteram o sistema de arquivos interno. Outras, como
+[`runSql`](/blueprints/steps), alteram o banco de dados.
 
-<!-- To check the final internal filesystem structure and database (after the blueprint steps have been applied) we can leverage some WordPress plugins that provide a SQL manager and a file explorer such as [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and [`WPide`](https://wordpress.org/plugins/wpide/) (you can see them in action from https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide) -->
+<!--
+To inspect the final state, install plugins such as
+[`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) and
+[`WPide`](https://wordpress.org/plugins/wpide/). You can see them in action at
+https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide.
+-->
 
-Para verificar a estrutura final do sistema de arquivos interno e do banco de dados (após as etapas do blueprint terem sido aplicadas), podemos aproveitar alguns plugins WordPress que fornecem um gerenciador SQL e um explorador de arquivos como [`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) e [`WPide`](https://wordpress.org/plugins/wpide/) (você pode vê-los em ação em https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide)
+Para inspecionar o estado final, instale plugins como
+[`SQL Buddy`](https://wordpress.org/plugins/sql-buddy/) e
+[`WPide`](https://wordpress.org/plugins/wpide/). Você pode vê-los em ação em
+https://playground.wordpress.net/?plugin=sql-buddy&plugin=wpide.
 
-<!-- :::tip There are a bunch of methods we can launch from the console of any WordPress Playground instance to inspect the internals of that instance. They're exposed as part of `window.playground` object (see [Developers > JavaScript API > Debugging and testing](/developers/apis/javascript-api/#debugging-and-testing)). Some examples: Full list of methods we can use is available [here](/api/client/interface/PlaygroundClient) ::: -->
+<!--
+You can also inspect a Playground instance from the browser console through
+`window.playground`:
+-->
 
-:::tip
+Você também pode inspecionar uma instância do Playground pelo console do
+navegador usando `window.playground`:
 
-Há vários métodos que podemos lançar a partir do console de qualquer instância do WordPress Playground para inspecionar os internos dessa instância. Eles são expostos como parte do objeto `window.playground` (veja [Desenvolvedores > API JavaScript > Depuração e teste](/developers/apis/javascript-api/#debugging-and-testing)). Alguns exemplos:
+```js
+await playground.isDir('/wordpress/wp-content/plugins');
+await playground.listFiles('/wordpress/wp-content/plugins');
+```
 
-A lista completa de métodos que podemos usar está disponível [aqui](/api/client/interface/PlaygroundClient)
+<!-- See the full [PlaygroundClient API](/api/client/interface/PlaygroundClient). -->
+
+Consulte a [API PlaygroundClient](/api/client/interface/PlaygroundClient) completa.
+
+<!-- ### Browser console and network requests -->
+
+### Console do navegador e requisições de rede
+
+<!--
+Open browser developer tools to check JavaScript errors, PHP debug logs, and
+failed network requests. In Chrome, Firefox, and Edge, press
+`Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS.
+-->
+
+Abra as ferramentas de desenvolvedor do navegador para verificar erros de
+JavaScript, logs de depuração de PHP e requisições de rede com falha. No Chrome,
+Firefox e Edge, pressione `Ctrl + Shift + I` no Windows/Linux ou
+`Cmd + Option + I` no macOS.
+
+<!-- :::caution Safari -->
+
+:::caution Safari
+
+<!--
+If you have not enabled the Develop menu, go to **Safari > Settings... >
+Advanced** and check **Show features for web developers**.
+-->
+
+Se você ainda não ativou o menu Develop, acesse **Safari > Settings... >
+Advanced** e marque **Show features for web developers**.
 
 :::
 
-<!-- Check for errors in the browser console -->
+<!-- ### Custom error logging -->
 
-## Verificar erros no console do navegador
+### Registro de erros personalizado
 
-<!-- If your Blueprint isn't running as expected, open the browser developer tools to check for any errors. -->
+<!--
+You can write your own messages with `error_log()` in a
+[`runPHP` step](/blueprints/steps), then check the Playground
+**Logs** panel or the browser console.
+-->
 
-Se seu Blueprint não está sendo executado conforme esperado, abra as ferramentas de desenvolvedor do navegador para verificar se há erros.
+Você pode gravar suas próprias mensagens com `error_log()` em uma etapa
+[`runPHP`](/blueprints/steps) e depois conferir o painel **Logs** do Playground
+ou o console do navegador.
 
-<!-- To open the developer tools in Chrome, Firefox, Safari*, and Edge: press `Ctrl + Shift + I` on Windows/Linux or `Cmd + Option + I` on macOS. -->
+<!-- ![Log errors snapshot](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp) -->
 
-Para abrir as ferramentas de desenvolvedor no Chrome, Firefox, Safari\* e Edge: pressione `Ctrl + Shift + I` no Windows/Linux ou `Cmd + Option + I` no macOS.
+![Captura de logs de erro](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/blueprints/log-errors.webp)
 
-<!-- :::caution If you haven't yet, enable the Develop menu: go to **Safari > Settings... > Advanced** and check **Show features for web developers**. ::: -->
-
-:::caution
-
-Se você ainda não fez isso, ative o menu Desenvolvimento: vá para **Safari > Configurações... > Avançado** e marque **Mostrar recursos para desenvolvedores da web**.
-
+<!--
+:::info
+When you download your Playground instance as a ZIP through the
+["Download as zip"](/web-instance) option, the archive
+also includes `debug.log`.
 :::
-
-<!-- The developer tools window allows you to inspect network requests, view console logs, debug JavaScript, and examine the DOM and CSS styles applied to your webpage. This is crucial for diagnosing and fixing issues with Blueprints. -->
-
-A janela de ferramentas de desenvolvedor permite inspecionar requisições de rede, visualizar logs do console, depurar JavaScript e examinar o DOM e estilos CSS aplicados à sua página. Isso é crucial para diagnosticar e corrigir problemas com Blueprints.
-
-<!-- Log your own error messages -->
-
-## Registre suas próprias mensagens de erro
-
-<!-- You can `error_log` your own error messages through [`runPHP` step](/blueprints/steps#RunPHPStep) (see [blueprint example](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) and [live demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) and check them from the ["View Logs" option](/web-instance#playground-options-menu) or from the browser's console. -->
-
-Você pode usar `error_log` para suas próprias mensagens de erro através da [etapa `runPHP`](/blueprints/steps#RunPHPStep) (veja [exemplo de blueprint](https://github.com/wordpress/blueprints/blob/trunk/blueprints/reset-data-and-import-content/blueprint.json) e [demo ao vivo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/wordpress/blueprints/trunk/blueprints/reset-data-and-import-content/blueprint.json)) e verifique-os através da opção ["Ver Logs"](/web-instance#playground-options-menu) ou do console do navegador.
-
-<!-- Log errors snapshot -->
-
-![Captura de tela de erros de log](@site/static/img/blueprints/log-errors.webp)
-
-<!-- :::info When you download your Playground instance as a `zip` through the ["Download as zip" option](/web-instance#playground-options-menu) you'll also download the `debug.log` file containing all the logs from your Playground instance. ::: -->
+-->
 
 :::info
-
-Quando você baixa sua instância do Playground como um `zip` através da opção ["Baixar como zip"](/web-instance#playground-options-menu), você também baixa o arquivo `debug.log` contendo todos os logs de sua instância do Playground.
-
+Ao baixar sua instância do Playground como ZIP pela opção
+["Download as zip"](/web-instance), o arquivo também inclui `debug.log`.
 :::
 
-<!-- Ask for help -->
+<!-- ## Ask for help -->
 
 ## Peça ajuda
 
-<!-- The community is here to help! If you have questions or comments, [open a new issue](https://github.com/adamziel/blueprints/issues) in this repository. Remember to include the following details: -->
-
-A comunidade está aqui para ajudar! Se você tem perguntas ou comentários, [abra uma nova issue](https://github.com/adamziel/blueprints/issues) neste repositório. Lembre-se de incluir os seguintes detalhes:
-
 <!--
--   The Blueprint you’re trying to run.
--   The error message you’re seeing, if any.
--   The full output from the browser developer tools.
--   Any other relevant information that might help us understand the issue: OS, browser version, etc.
+If you need help, [open an issue](https://github.com/WordPress/wordpress-playground/issues)
+and include:
 -->
 
-- O Blueprint que você está tentando executar.
-- A mensagem de erro que você está vendo, se houver.
-- A saída completa das ferramentas de desenvolvedor do navegador.
-- Qualquer outra informação relevante que possa nos ajudar a entender o problema: SO, versão do navegador, etc.
+Se você precisar de ajuda, [abra uma issue](https://github.com/WordPress/wordpress-playground/issues)
+e inclua:
+
+<!--
+- The Blueprint JSON or the public Blueprint URL.
+- The exact error message.
+- The failing step number, if shown.
+- Browser, operating system, and whether you used the website, JavaScript API, or CLI.
+- Relevant console, network, or CLI output.
+-->
+
+- O JSON do Blueprint ou a URL pública do Blueprint.
+- A mensagem de erro exata.
+- O número da etapa com falha, se mostrado.
+- Navegador, sistema operacional e se você usou o site, a API JavaScript ou a CLI.
+- Saída relevante do console, da rede ou da CLI.

--- a/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/troubleshooting.md
+++ b/packages/docs/site/i18n/pt-BR/docusaurus-plugin-content-docs/current/main/troubleshooting.md
@@ -1,0 +1,359 @@
+---
+title: Solução de problemas
+slug: /troubleshooting
+description: Diagnostique erros comuns do site do WordPress Playground, incluindo falhas de inicialização, problemas com SQLite, armazenamento do navegador e recuperação de Playgrounds salvos.
+---
+
+<!-- title: Troubleshooting -->
+
+<!-- description: Diagnose common WordPress Playground website errors, including boot failures, SQLite issues, browser storage, and saved Playground recovery. -->
+
+<!-- # Troubleshooting WordPress Playground -->
+
+# Solução de problemas no WordPress Playground
+
+<!--
+This page covers errors from the Playground website itself, saved Playgrounds,
+browser storage, and WordPress boot. For Blueprint-specific errors, see
+[Troubleshoot and debug Blueprints](/blueprints/troubleshoot-and-debug).
+-->
+
+Esta página cobre erros do próprio site do Playground, Playgrounds salvos,
+armazenamento do navegador e inicialização do WordPress. Para erros específicos
+de Blueprint, consulte [Solução de problemas e depuração de Blueprints](/blueprints/troubleshoot-and-debug).
+
+<!-- ## Playground looks broken -->
+
+## O Playground parece quebrado
+
+<!-- Try these first: -->
+
+Tente isto primeiro:
+
+<!--
+- Use the reload button inside the Playground toolbar instead of refreshing the browser tab. Browser refresh starts the whole Playground app again.
+- Open the same URL in a private window to rule out saved-site or browser-storage state.
+- Disable browser extensions that block JavaScript, WebAssembly, storage, workers, or network requests.
+- Check browser developer tools for Console and Network errors.
+- If the URL includes `?site-slug=...`, try removing that query parameter to start a fresh unsaved Playground.
+-->
+
+- Use o botão de recarregar dentro da barra de ferramentas do Playground em vez de atualizar a aba do navegador. A atualização do navegador inicia todo o app do Playground novamente.
+- Abra a mesma URL em uma janela privativa para descartar problemas de estado de site salvo ou armazenamento do navegador.
+- Desative extensões do navegador que bloqueiam JavaScript, WebAssembly, armazenamento, workers ou requisições de rede.
+- Verifique as ferramentas de desenvolvedor do navegador para erros nas abas Console e Network.
+- Se a URL incluir `?site-slug=...`, tente remover esse parâmetro de consulta para iniciar um Playground novo e não salvo.
+
+<!-- ## A clean site says the MySQL extension is missing -->
+
+## Um site limpo diz que a extensão MySQL está ausente
+
+<!-- You may see a WordPress error page like this: -->
+
+Você pode ver uma página de erro do WordPress como esta:
+
+```text
+Your PHP installation appears to be missing the MySQL extension which is required by WordPress.
+```
+
+<!--
+In Playground, this usually means WordPress did not load the SQLite integration
+that lets WordPress run without MySQL. Playground runs WordPress in WebAssembly
+and uses SQLite instead of a MySQL server.
+-->
+
+No Playground, isso geralmente significa que o WordPress não carregou a
+integração SQLite que permite executar o WordPress sem MySQL. O Playground
+executa o WordPress em WebAssembly e usa SQLite em vez de um servidor MySQL.
+
+<!-- Try these steps: -->
+
+Tente estes passos:
+
+<!--
+- Start a fresh unsaved Playground at https://playground.wordpress.net/ to confirm the public site can boot.
+- If the URL includes a saved site, remove `?site-slug=...` and load a new temporary site.
+- If this happened after importing a ZIP, confirm the import did not include a custom `wp-content/db.php` that overrides Playground's SQLite setup.
+- If this happened in the CLI, do not use `--skip-sqlite-setup` unless you provide your own database integration.
+- If this happened with a Blueprint, see the [Blueprint troubleshooting page](/blueprints/troubleshoot-and-debug).
+-->
+
+- Inicie um Playground novo e não salvo em https://playground.wordpress.net/ para confirmar que o site público consegue inicializar.
+- Se a URL incluir um site salvo, remova `?site-slug=...` e carregue um novo site temporário.
+- Se isso aconteceu depois de importar um ZIP, confirme que a importação não incluiu um `wp-content/db.php` personalizado que substitui a configuração SQLite do Playground.
+- Se isso aconteceu na CLI, não use `--skip-sqlite-setup`, a menos que você forneça sua própria integração de banco de dados.
+- Se isso aconteceu com um Blueprint, consulte a [página de solução de problemas de Blueprint](/blueprints/troubleshoot-and-debug).
+
+<!--
+If you are writing a Blueprint and need to add the SQLite integration plugin,
+`plugins` goes at the top level:
+-->
+
+Se você estiver escrevendo um Blueprint e precisar adicionar o plugin de
+integração SQLite, `plugins` fica no nível superior:
+
+```json
+{
+	"preferredVersions": {
+		"php": "8.3",
+		"wp": "latest"
+	},
+	"plugins": ["sqlite-database-integration"],
+	"steps": [
+		{
+			"step": "login",
+			"username": "admin"
+		}
+	]
+}
+```
+
+<!-- ## Error connecting to the SQLite database -->
+
+## Error connecting to the SQLite database
+
+<!--
+This means Playground loaded the SQLite integration, but WordPress still could
+not connect to the database.
+-->
+
+Isso significa que o Playground carregou a integração SQLite, mas o WordPress
+ainda não conseguiu se conectar ao banco de dados.
+
+<!-- Common causes: -->
+
+Causas comuns:
+
+<!--
+- A saved Playground's browser storage is stale or incomplete.
+- An imported site ZIP contains an incompatible database file or database drop-in.
+- A mounted local directory is missing files that WordPress needs.
+- Browser storage was cleared, evicted, or blocked.
+-->
+
+- O armazenamento do navegador de um Playground salvo está desatualizado ou incompleto.
+- Um ZIP de site importado contém um arquivo de banco de dados ou drop-in de banco de dados incompatível.
+- Um diretório local montado não tem arquivos de que o WordPress precisa.
+- O armazenamento do navegador foi limpo, removido ou bloqueado.
+
+<!-- Recommended recovery: -->
+
+Recuperação recomendada:
+
+<!--
+1. Start a fresh unsaved Playground without `site-slug`.
+2. If the fresh site works, the issue is tied to the saved site or imported archive.
+3. Export any accessible files from the broken saved site using the File Browser or local directory copy, if available.
+4. Re-import the site into a new Playground, or rebuild it from its Blueprint.
+-->
+
+1. Inicie um Playground novo e não salvo sem `site-slug`.
+2. Se o site novo funcionar, o problema está ligado ao site salvo ou ao arquivo importado.
+3. Exporte quaisquer arquivos acessíveis do site salvo quebrado usando o Navegador de arquivos ou uma cópia do diretório local, se disponível.
+4. Reimporte o site para um novo Playground ou reconstrua-o a partir do Blueprint.
+
+<!-- ## NotAllowedError -->
+
+## NotAllowedError
+
+<!--
+`NotAllowedError` usually means the browser blocked an operation that requires
+user permission or a supported browser context. In Playground, this often
+relates to saved sites or local directory access.
+-->
+
+`NotAllowedError` geralmente significa que o navegador bloqueou uma operação
+que exige permissão do usuário ou um contexto de navegador compatível. No
+Playground, isso costuma estar relacionado a sites salvos ou acesso a
+diretórios locais.
+
+<!-- You may see this exact message: -->
+
+Você pode ver esta mensagem exata:
+
+```text
+The request is not allowed by the user agent or the platform in the current context.
+```
+
+<!-- Try: -->
+
+Tente:
+
+<!--
+- Open Playground in a normal top-level browser tab, not inside a restricted iframe.
+- Reopen the site from the Playground **Saved Playgrounds** panel.
+- If the site was saved to a local directory, import or save the directory again.
+- Confirm the browser supports the file or storage API being used. Chrome and Edge generally have the broadest local directory support.
+- Check whether private browsing mode, enterprise policy, or browser settings block storage access.
+-->
+
+- Abrir o Playground em uma aba normal de nível superior do navegador, não dentro de um iframe restrito.
+- Reabrir o site pelo painel **Saved Playgrounds** do Playground.
+- Se o site foi salvo em um diretório local, importar ou salvar o diretório novamente.
+- Confirmar que o navegador oferece suporte à API de arquivos ou armazenamento em uso. Chrome e Edge geralmente têm o suporte mais amplo a diretórios locais.
+- Verificar se o modo de navegação privativa, uma política empresarial ou as configurações do navegador bloqueiam acesso ao armazenamento.
+
+<!-- ## NoModificationAllowedError -->
+
+## NoModificationAllowedError
+
+<!--
+`NoModificationAllowedError` means the browser or filesystem refused a write.
+This can happen when a saved local directory became read-only, permission was
+lost, or browser storage is unavailable.
+-->
+
+`NoModificationAllowedError` significa que o navegador ou sistema de arquivos
+recusou uma gravação. Isso pode acontecer quando um diretório local salvo se
+tornou somente leitura, a permissão foi perdida ou o armazenamento do navegador
+está indisponível.
+
+<!-- You may see this exact message: -->
+
+Você pode ver esta mensagem exata:
+
+```text
+An attempt was made to write to a file or directory which could not be modified due to the state of the underlying filesystem.
+```
+
+<!-- Try: -->
+
+Tente:
+
+<!--
+- Save a copy to a different local directory.
+- Check that the target folder still exists and is writable.
+- Avoid system-protected folders or synced folders that temporarily lock files.
+- Start a fresh unsaved Playground if you only need a temporary test site.
+- Use [Playground CLI](/developers/local-development/wp-playground-cli) for local development that needs reliable filesystem persistence.
+-->
+
+- Salvar uma cópia em outro diretório local.
+- Verificar se a pasta de destino ainda existe e é gravável.
+- Evitar pastas protegidas pelo sistema ou pastas sincronizadas que bloqueiam arquivos temporariamente.
+- Iniciar um Playground novo e não salvo se você só precisa de um site temporário de teste.
+- Usar a [Playground CLI](/developers/local-development/wp-playground-cli) para desenvolvimento local que precisa de persistência confiável do sistema de arquivos.
+
+<!-- ## Saved Playground cannot reload -->
+
+## Playground salvo não recarrega
+
+<!--
+Saved Playgrounds are stored in browser storage or in a local directory you
+selected. They are not hosted on a remote server.
+-->
+
+Playgrounds salvos são armazenados no armazenamento do navegador ou em um
+diretório local que você selecionou. Eles não são hospedados em um servidor
+remoto.
+
+<!-- If a saved Playground cannot reload: -->
+
+Se um Playground salvo não recarregar:
+
+<!--
+- Confirm you are using the same browser and browser profile where it was saved.
+- Check whether browser data was cleared or storage was disabled.
+- If the site was saved to a local directory, confirm the directory still exists and has not moved.
+- If the URL includes `?site-slug=...`, remove it to start a fresh unsaved site.
+- Recreate the saved site from its original Blueprint or import ZIP if storage was lost.
+-->
+
+- Confirme que você está usando o mesmo navegador e perfil de navegador em que ele foi salvo.
+- Verifique se os dados do navegador foram limpos ou se o armazenamento foi desativado.
+- Se o site foi salvo em um diretório local, confirme que o diretório ainda existe e não foi movido.
+- Se a URL incluir `?site-slug=...`, remova-o para iniciar um site novo e não salvo.
+- Recrie o site salvo a partir do Blueprint original ou do ZIP de importação se o armazenamento foi perdido.
+
+<!-- ## Browser storage and persistence -->
+
+## Armazenamento do navegador e persistência
+
+<!--
+An unsaved Playground is temporary. A browser refresh, tab close, storage
+cleanup, or browser profile change can remove its state.
+-->
+
+Um Playground não salvo é temporário. Uma atualização do navegador, fechamento
+da aba, limpeza de armazenamento ou troca de perfil do navegador pode remover
+o estado dele.
+
+<!--
+Use the **Save** button before doing meaningful work. For longer-running local
+development, prefer the [Playground CLI](/developers/local-development/wp-playground-cli),
+which persists site files on disk.
+-->
+
+Use o botão **Save** antes de fazer trabalhos importantes. Para desenvolvimento
+local de longa duração, prefira a [Playground CLI](/developers/local-development/wp-playground-cli),
+que persiste os arquivos do site em disco.
+
+<!--
+:::tip
+The refresh button inside the Playground toolbar reloads WordPress while keeping
+the current Playground runtime. The browser refresh button reloads the full app
+and can discard unsaved changes.
+:::
+-->
+
+:::tip
+O botão de atualizar dentro da barra de ferramentas do Playground recarrega o
+WordPress mantendo o runtime atual do Playground. O botão de atualizar do
+navegador recarrega o app inteiro e pode descartar alterações não salvas.
+:::
+
+<!-- ## When to start fresh -->
+
+## Quando começar do zero
+
+<!-- Start a fresh unsaved Playground when: -->
+
+Inicie um Playground novo e não salvo quando:
+
+<!--
+- You only need to test whether the public Playground site is working.
+- The URL points to a saved `site-slug` that no longer loads.
+- You are debugging whether an error comes from Playground itself or from a plugin, theme, Blueprint, or imported site.
+- Browser storage or local directory access is suspected to be broken.
+-->
+
+- Você só precisa testar se o site público do Playground está funcionando.
+- A URL aponta para um `site-slug` salvo que não carrega mais.
+- Você está depurando se um erro vem do próprio Playground ou de um plugin, tema, Blueprint ou site importado.
+- Há suspeita de problema no armazenamento do navegador ou no acesso a diretório local.
+
+<!-- Use this URL for a clean site: -->
+
+Use esta URL para um site limpo:
+
+```text
+https://playground.wordpress.net/
+```
+
+<!-- ## Report a Playground issue -->
+
+## Relatar um problema do Playground
+
+<!--
+If the problem reproduces on a fresh unsaved Playground, please
+[open an issue](https://github.com/WordPress/wordpress-playground/issues) and
+include:
+-->
+
+Se o problema for reproduzido em um Playground novo e não salvo,
+[abra uma issue](https://github.com/WordPress/wordpress-playground/issues) e
+inclua:
+
+<!--
+- The full Playground URL.
+- The browser and operating system.
+- Whether you used a saved site, imported ZIP, Blueprint, local directory, or CLI.
+- The exact error name and message.
+- Console and Network details from browser developer tools.
+-->
+
+- A URL completa do Playground.
+- O navegador e o sistema operacional.
+- Se você usou um site salvo, ZIP importado, Blueprint, diretório local ou CLI.
+- O nome e a mensagem exatos do erro.
+- Detalhes das abas Console e Network das ferramentas de desenvolvedor do navegador.

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -23,6 +23,7 @@ const sidebars = {
 			items: [
 				'main/quick-start-guide',
 				'main/web-instance',
+				'main/troubleshooting',
 				{
 					type: 'category',
 					label: 'About Playground',


### PR DESCRIPTION
## Summary
- Expand the Blueprint troubleshooting page into a search-friendly error playbook covering fetch, execution, activation, schema, resource, and WP-CLI failures.
- Add a new general Playground troubleshooting page at `/troubleshooting` and link it from the docs sidebar.
- Update Blueprint resource, schema, and URL guidance to cover common remote-resource and validation pitfalls.
- Add pt-BR, es, and fr translations for the new and updated docs, with the original English content preserved in HTML comments.

## Testing
- `npm run build:docs` passed.
- `npx nx run docs-site:check-orphan-pages` passed.
- `git diff --check` passed.