### PR TITLE
Avoid redundant WordPress bootstraps during Playground install/start

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
+++ b/packages/playground/cli/src/blueprints-v1/blueprints-v1-handler.ts
@@ -15,7 +15,10 @@ import {
 import { RecommendedPHPVersion, zipDirectory } from '@wp-playground/common';
 import fs from 'fs';
 import path from 'path';
-import { resolveWordPressRelease } from '@wp-playground/wordpress';
+import {
+	type WordPressBootResult,
+	resolveWordPressRelease,
+} from '@wp-playground/wordpress';
 import {
 	CACHE_FOLDER,
 	cachedDownload,
@@ -64,7 +67,7 @@ export class BlueprintsV1Handler {
 	async bootWordPress(
 		playground: Pooled<PlaygroundCliWorker>,
 		workerPostInstallMountsPort: NodeMessagePort
-	) {
+	): Promise<WordPressBootResult> {
 		let wpDetails: any = undefined;
 		let wordPressZip: any = undefined;
 		let preinstalledWpContentPath: string | undefined = undefined;
@@ -134,7 +137,7 @@ export class BlueprintsV1Handler {
 		);
 
 		// TODO: Fix this type issue that requires the cast to unknown
-		await (
+		const bootResult = await (
 			playground as unknown as PlaygroundCliBlueprintV1Worker
 		).bootWordPress(
 			{
@@ -148,6 +151,7 @@ export class BlueprintsV1Handler {
 				sqliteIntegrationPluginZip:
 					await sqliteIntegrationPluginZip?.arrayBuffer(),
 				constants: mergeDefinedConstants(this.args),
+				installOptions: this.args.installOptions,
 			},
 			workerPostInstallMountsPort
 		);
@@ -169,7 +173,7 @@ export class BlueprintsV1Handler {
 			);
 		}
 
-		return playground;
+		return bootResult;
 	}
 
 	async bootRequestHandler({

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -14,6 +14,8 @@ import { sprintf } from '@php-wasm/util';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import {
 	type WordPressInstallMode,
+	type WordPressInstallOptions,
+	getWordPressBootResult,
 	bootRequestHandler,
 	bootWordPress,
 } from '@wp-playground/wordpress';
@@ -37,6 +39,7 @@ export type WorkerBootWordPressOptions = {
 	 * PHP constants to define via php.defineConstant().
 	 */
 	constants?: Record<string, string | number | boolean>;
+	installOptions?: WordPressInstallOptions;
 };
 
 interface WorkerBootRequestHandlerOptions {
@@ -106,10 +109,12 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 			sqliteIntegrationPluginZip,
 			dataSqlPath,
 			constants,
+			installOptions,
 		} = options;
 
 		try {
-			await bootWordPress(this.__internal_getRequestHandler()!, {
+			const requestHandler = this.__internal_getRequestHandler()!;
+			await bootWordPress(requestHandler, {
 				siteUrl,
 				phpVersion,
 				wordpressInstallMode,
@@ -137,7 +142,9 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 				},
 				dataSqlPath,
 				constants,
+				installOptions,
 			});
+			const bootResult = getWordPressBootResult(requestHandler);
 
 			// Notify all workers to apply post-install mounts.
 			const postInstall = consumeAPI<{
@@ -147,6 +154,7 @@ export class PlaygroundCliBlueprintV1Worker extends PHPWorker {
 			postInstall[releaseApiProxy]();
 
 			setApiReady();
+			return bootResult;
 		} catch (e) {
 			setAPIError(e as Error);
 			throw e;

--- a/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
+++ b/packages/playground/cli/src/blueprints-v2/blueprints-v2-handler.ts
@@ -1,4 +1,5 @@
 import type { Pooled, SupportedPHPVersion } from '@php-wasm/universal';
+import type { WordPressBootResult } from '@wp-playground/wordpress';
 import { consumeAPI, type RemoteAPI } from '@php-wasm/universal';
 import type {
 	PlaygroundCliBlueprintV2Worker,
@@ -48,7 +49,7 @@ export class BlueprintsV2Handler {
 	async bootWordPress(
 		playground: Pooled<PlaygroundCliWorker>,
 		workerPostInstallMountsPort: NodeMessagePort
-	) {
+	): Promise<WordPressBootResult> {
 		const workerBootArgs = {
 			command: this.args.command,
 			siteUrl: this.siteUrl,
@@ -60,7 +61,7 @@ export class BlueprintsV2Handler {
 		await (
 			playground as unknown as PlaygroundCliBlueprintV2Worker
 		).bootWordPress(workerBootArgs, workerPostInstallMountsPort);
-		return playground;
+		return { adminCredentialsApplied: false };
 	}
 
 	async bootRequestHandler({

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -20,6 +20,7 @@ import type {
 	BlueprintBundle,
 	BlueprintV1Declaration,
 	BlueprintV2Declaration,
+	CompiledBlueprintV1,
 } from '@wp-playground/blueprints';
 import {
 	compileBlueprintV1,
@@ -65,7 +66,11 @@ import {
 	cleanupStalePlaygroundTempDirs,
 	createPlaygroundCliTempDir,
 } from './temp-dir';
-import { type WordPressInstallMode } from '@wp-playground/wordpress';
+import {
+	type WordPressBootResult,
+	type WordPressInstallMode,
+	type WordPressInstallOptions,
+} from '@wp-playground/wordpress';
 import {
 	type Mount,
 	addXdebugIDEConfig,
@@ -911,6 +916,12 @@ export interface RunCLIArgs {
 	workers?: number | 'auto';
 	'experimental-multi-worker'?: number;
 	wordpressInstallMode?: WordPressInstallMode;
+	installOptions?: WordPressInstallOptionsWithAliases;
+	wordpressInstallOptions?: WordPressInstallOptionsWithAliases;
+	/**
+	 * @deprecated Use installOptions instead. Kept for Studio compatibility.
+	 */
+	studioInstallOptions?: WordPressInstallOptionsWithAliases;
 	/**
 	 * PHP string constants defined via --define flag.
 	 * Set via php.defineConstant(), process-specific only.
@@ -951,10 +962,67 @@ export interface RunCLIArgs {
 	reset?: boolean;
 }
 
+function createMutablePooledProxy<T extends object>(
+	getPool: () => Pooled<T>
+): Pooled<T> {
+	return new Proxy({} as Pooled<T>, {
+		get(_target, prop: string | symbol) {
+			if (prop === 'then') {
+				return undefined;
+			}
+			return new Proxy(function () {}, {
+				apply(_target, _thisArg, args: any[]) {
+					return (getPool() as any)[prop](...args);
+				},
+				get(_target, innerProp) {
+					if (innerProp === 'then') {
+						return (resolve: any, reject: any) =>
+							Promise.resolve((getPool() as any)[prop]).then(
+								resolve,
+								reject
+							);
+					}
+					return undefined;
+				},
+			});
+		},
+	});
+}
+
+function normalizeWordPressInstallOptions(
+	args: RunCLIArgs
+): WordPressInstallOptions | undefined {
+	const options =
+		args.installOptions ??
+		args.wordpressInstallOptions ??
+		args.studioInstallOptions;
+	if (!options) {
+		return undefined;
+	}
+
+	return {
+		siteTitle: options.siteTitle ?? options.weblogTitle,
+		adminUsername: options.adminUsername,
+		adminPassword: options.adminPassword,
+		adminEmail: options.adminEmail,
+	};
+}
+
 // TODO: Maybe we should just be declaring an interface instead of a type union
 export type PlaygroundCliWorker =
 	| PlaygroundCliBlueprintV1Worker
 	| PlaygroundCliBlueprintV2Worker;
+
+type WordPressInstallOptionsWithAliases = WordPressInstallOptions & {
+	/**
+	 * @deprecated Use siteTitle instead.
+	 */
+	weblogTitle?: string;
+};
+
+const defaultWordPressBootResult: WordPressBootResult = {
+	adminCredentialsApplied: false,
+};
 
 export const internalsKeyForTesting = Symbol('playground-cli-testing');
 
@@ -962,12 +1030,14 @@ export interface RunCLIServer extends AsyncDisposable {
 	playground: Pooled<PlaygroundCliWorker>;
 	server: Server;
 	serverUrl: string;
+	wordpressBootResult: WordPressBootResult;
 
 	[Symbol.asyncDispose](): Promise<void>;
 
 	// Provide some details and helpers for automated testing.
 	[internalsKeyForTesting]: {
 		workerThreadCount: number;
+		bootedWorkerCount: () => number;
 	};
 }
 
@@ -1023,6 +1093,11 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	if (args.wordpressInstallMode === undefined) {
 		args.wordpressInstallMode = 'download-and-install';
 	}
+
+	args = {
+		...args,
+		installOptions: normalizeWordPressInstallOptions(args),
+	};
 
 	// Keeping the '--quiet' option to preserve backward compatibility
 	if (args.quiet) {
@@ -1507,14 +1582,12 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			};
 
 			try {
-				const promisesToBoot = [];
 				const workerType = handler.getWorkerType();
-				for (
-					let workerIndex = 0;
-					workerIndex < targetWorkerCount;
-					workerIndex++
-				) {
-					const promiseToBoot = spawnWorkerThread(workerType, {
+				const bootWorker = async (
+					workerIndex: number
+				): Promise<[SpawnedWorker, RemoteAPI<PlaygroundCliWorker>]> => {
+					const startedAt = performance.now();
+					const spawnResult = await spawnWorkerThread(workerType, {
 						onExit: (exitCode: number) => {
 							// We are already disposing, so worker exit is expected
 							// and does not need to be logged.
@@ -1531,55 +1604,44 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 							);
 							// @TODO: Should we respawn the worker if it exited with an error and the CLI is not shutting down?
 						},
-					}).then(
-						async (
-							spawnResult: SpawnedWorker
-						): Promise<
-							[SpawnedWorker, RemoteAPI<PlaygroundCliWorker>]
-						> => {
-							// Remember the worker process before booting the Playground
-							// so we can clean it up if there is an error during boot.
-							spawnedWorkers.push(spawnResult);
+					});
+					if (disposing) {
+						await spawnResult.worker.terminate();
+						throw new Error('Playground CLI is disposing.');
+					}
 
-							const fileLockManagerPort =
-								await exposeFileLockManager(fileLockManager);
-							const playgroundApi =
-								await handler.bootRequestHandler({
-									worker: spawnResult,
-									fileLockManagerPort,
-									nativeInternalDirPath,
-								});
+					// Remember the worker process before booting the Playground
+					// so we can clean it up if there is an error during boot.
+					spawnedWorkers.push(spawnResult);
 
-							workerToPlaygroundMap.set(
-								spawnResult,
-								playgroundApi
-							);
+					const fileLockManagerPort =
+						await exposeFileLockManager(fileLockManager);
+					const playgroundApi = await handler.bootRequestHandler({
+						worker: spawnResult,
+						fileLockManagerPort,
+						nativeInternalDirPath,
+					});
 
-							return [spawnResult, playgroundApi];
-						}
+					workerToPlaygroundMap.set(spawnResult, playgroundApi);
+					logger.debug(
+						`Worker ${workerIndex} request handler booted in ${(
+							performance.now() - startedAt
+						).toFixed(2)}ms`
 					);
 
-					promisesToBoot.push(promiseToBoot);
+					return [spawnResult, playgroundApi];
+				};
 
-					// TODO: Remove this workaround after we remove the inherent race
-					// from @wp-playground/wordpress's bootRequestHandler() function.
-					if (workerIndex === 0) {
-						// Wait for the first worker to boot to avoid a race condition
-						// with writing initial PHP files in bootRequestHandler().
-						// This is the race condition:
-						// https://github.com/WordPress/wordpress-playground/blob/e758ee0893d199416a2d740195815234584b1b44/packages/playground/wordpress/src/boot.ts#L416-L426
-						// Multiple workers may detect that .boot-files-written does not exist
-						// and proceed to try to write initial boot files.
-						await promiseToBoot;
-					}
-				}
-
-				await Promise.all(promisesToBoot);
+				await bootWorker(0);
 				playgroundPool = createObjectPoolProxy(
 					spawnedWorkers.map(
 						(spawnedWorker) =>
 							workerToPlaygroundMap.get(spawnedWorker)!
 					)
+				);
+				let wordpressBootResult = defaultWordPressBootResult;
+				const playgroundForReturn = createMutablePooledProxy(
+					() => playgroundPool
 				);
 
 				// NOTE: Using a free-standing block to isolate initial boot vars
@@ -1611,27 +1673,83 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 						undefined,
 						mainThreadPostInstallMountsPort
 					);
-					await handler.bootWordPress(
+					const bootWordPressStartedAt = performance.now();
+					wordpressBootResult = await handler.bootWordPress(
 						playgroundPool,
 						workerPostInstallMountsPort
 					);
 					mainThreadPostInstallMountsPort.close();
+					logger.debug(
+						`bootWordPress completed in ${(
+							performance.now() - bootWordPressStartedAt
+						).toFixed(2)}ms`
+					);
 
-					wordPressReady = true;
-
+					let compiledBlueprint: CompiledBlueprintV1 | undefined;
 					if (!args['experimental-blueprints-v2-runner']) {
-						const compiledBlueprint = await (
+						compiledBlueprint = await (
 							handler as BlueprintsV1Handler
 						).compileInputBlueprint(
 							args['additional-blueprint-steps'] || []
 						);
+					}
+					const hasPostBootSteps =
+						!!compiledBlueprint || !!args.phpmyadmin;
 
-						if (compiledBlueprint) {
-							await runBlueprintV1Steps(
-								compiledBlueprint,
-								playgroundPool
-							);
-						}
+					const bootSecondaryWorkers = async () => {
+						const startedAt = performance.now();
+						await Promise.all(
+							Array.from(
+								{ length: targetWorkerCount - 1 },
+								(_, workerIndex) => workerIndex + 1
+							).map(async (workerIndex) => {
+								const [, playground] =
+									await bootWorker(workerIndex);
+								await playground.mountAfterWordPressInstall(
+									args['mount'] || []
+								);
+							})
+						);
+						playgroundPool = createObjectPoolProxy(
+							spawnedWorkers.map(
+								(spawnedWorker) =>
+									workerToPlaygroundMap.get(spawnedWorker)!
+							)
+						);
+						logger.debug(
+							`Secondary workers booted in ${(
+								performance.now() - startedAt
+							).toFixed(2)}ms`
+						);
+					};
+					const secondaryWorkersPromise = bootSecondaryWorkers();
+					if (args.command === 'server' && !hasPostBootSteps) {
+						wordPressReady = true;
+						void secondaryWorkersPromise.catch((error) => {
+							if (!disposing) {
+								logger.error(
+									'Failed to boot secondary workers:',
+									error
+								);
+							}
+						});
+					} else {
+						// Blueprint/phpMyAdmin setup should observe the final worker pool,
+						// and requests should wait until that setup is complete.
+						await secondaryWorkersPromise;
+					}
+
+					if (compiledBlueprint) {
+						const blueprintStartedAt = performance.now();
+						await runBlueprintV1Steps(
+							compiledBlueprint,
+							playgroundPool
+						);
+						logger.debug(
+							`Blueprint v1 steps completed in ${(
+								performance.now() - blueprintStartedAt
+							).toFixed(2)}ms`
+						);
 					}
 
 					// If phpMyAdmin is enabled and not already installed, install it.
@@ -1691,6 +1809,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				cliOutput.finishProgress();
 				cliOutput.printReady(serverUrl, targetWorkerCount);
 
+				wordPressReady = true;
+
 				if (args.phpmyadmin) {
 					const phpMyAdminPath = path.join(
 						args.phpmyadmin as string,
@@ -1711,12 +1831,14 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				}
 
 				return {
-					playground: playgroundPool,
+					playground: playgroundForReturn,
 					server,
 					serverUrl,
+					wordpressBootResult,
 					[Symbol.asyncDispose]: disposeCLI,
 					[internalsKeyForTesting]: {
 						workerThreadCount: targetWorkerCount,
+						bootedWorkerCount: () => workerToPlaygroundMap.size,
 					},
 				};
 			} catch (error) {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -169,6 +169,55 @@ describe.each(blueprintVersions)(
 			expect(text).toContain('http://127.0.0.1:9500');
 		});
 
+		test('should expose boot result after multi-worker install credentials', async () => {
+			const adminPassword = 'cli-boot-secret';
+			await using cliServer = await runCLI({
+				...suiteCliArgs,
+				command: 'server',
+				workers: 2,
+				studioInstallOptions: {
+					weblogTitle: 'CLI Install Options',
+					adminUsername: 'cliadmin',
+					adminPassword,
+					adminEmail: 'cliadmin@example.com',
+				},
+			});
+
+			expect(cliServer.wordpressBootResult).toEqual({
+				adminCredentialsApplied: true,
+			});
+			expect(JSON.stringify(cliServer.wordpressBootResult)).not.toContain(
+				adminPassword
+			);
+			expect(cliServer[internalsKeyForTesting].workerThreadCount).toBe(2);
+
+			await cliServer.playground.writeFile(
+				'/wordpress/check-cli-admin.php',
+				`<?php
+						require_once '/wordpress/wp-load.php';
+						$user = get_user_by('login', 'cliadmin');
+						echo json_encode(array(
+							'blogname' => get_option('blogname'),
+							'email' => $user ? $user->user_email : null,
+							'passwordMatches' => $user
+								? wp_check_password('${adminPassword}', $user->user_pass, $user->ID)
+								: false,
+						));
+					`
+			);
+			const response = await fetch(
+				new URL('/check-cli-admin.php', cliServer.serverUrl)
+			);
+			const details = await response.json();
+
+			expect(response.status).toBe(200);
+			expect(details).toEqual({
+				blogname: 'CLI Install Options',
+				email: 'cliadmin@example.com',
+				passwordMatches: true,
+			});
+		}, 120_000);
+
 		test('should set WordPress version', async () => {
 			const { MinifiedWordPressVersionsList } =
 				await import('@wp-playground/wordpress-builds');
@@ -196,10 +245,11 @@ describe.each(blueprintVersions)(
 			expect(text).toContain(oldestSupportedVersion);
 		});
 
-		test('should run blueprint', async () => {
+		test('should run blueprint after secondary workers boot', async () => {
 			await using cliServer = await runCLI({
 				...suiteCliArgs,
 				command: 'server',
+				workers: 2,
 				blueprint: {
 					steps: [
 						{
@@ -211,11 +261,22 @@ describe.each(blueprintVersions)(
 					],
 				},
 			});
+
+			expect(cliServer[internalsKeyForTesting].bootedWorkerCount()).toBe(
+				2
+			);
+
 			const homeUrl = new URL('/', cliServer.serverUrl);
-			const response = await fetch(homeUrl);
-			expect(response.status).toBe(200);
-			const text = await response.text();
-			expect(text).toContain('<title>My Blog Name</title>');
+			const responses = await Promise.all([
+				fetch(homeUrl),
+				fetch(homeUrl),
+				fetch(homeUrl),
+			]);
+			for (const response of responses) {
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain('<title>My Blog Name</title>');
+			}
 		});
 
 		test('should be able to follow external symlinks in primary and secondary PHP instances', async ({

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -152,6 +152,29 @@ export type WordPressInstallMode =
 	| 'install-from-existing-files-if-needed'
 	| 'do-not-attempt-installing';
 
+export interface WordPressInstallOptions {
+	siteTitle?: string;
+	adminUsername?: string;
+	adminPassword?: string;
+	adminEmail?: string;
+}
+
+export interface WordPressBootResult {
+	adminCredentialsApplied: boolean;
+}
+
+const bootResults = new WeakMap<PHPRequestHandler, WordPressBootResult>();
+
+export function getWordPressBootResult(
+	requestHandler: PHPRequestHandler
+): WordPressBootResult {
+	return (
+		bootResults.get(requestHandler) ?? {
+			adminCredentialsApplied: false,
+		}
+	);
+}
+
 export interface BootWordPressOptions {
 	/** PHP version string (e.g. '8.3', '5.2'). */
 	phpVersion?: string;
@@ -202,6 +225,8 @@ export interface BootWordPressOptions {
 	 * and WP_SITEURL constants in WordPress.
 	 */
 	siteUrl: string;
+	/** Values to pass to the standard WordPress installer. */
+	installOptions?: WordPressInstallOptions;
 }
 
 /**
@@ -277,6 +302,9 @@ export async function bootWordPress(
 	const installationMode =
 		options['wordpressInstallMode'] ?? 'download-and-install';
 	const hasCustomDatabasePath = !!options.dataSqlPath;
+	let bootResult: WordPressBootResult = {
+		adminCredentialsApplied: false,
+	};
 
 	if (
 		['download-and-install', 'install-from-existing-files'].includes(
@@ -290,7 +318,16 @@ export async function bootWordPress(
 		});
 		// Install WordPress if it's not installed.
 		try {
-			await installWordPress(php);
+			const finalizeResult = await installWordPress(
+				php,
+				options.installOptions
+			);
+			bootResult = {
+				adminCredentialsApplied: finalizeResult.adminCredentialsApplied,
+			};
+			if (!finalizeResult.databaseConnected && !hasCustomDatabasePath) {
+				throwDatabaseConnectionError(php, requestHandler);
+			}
 		} catch (error) {
 			// If installation failed, check if it's a database issue
 			// to provide a more specific error message (but skip if user provided custom DB path)
@@ -299,10 +336,6 @@ export async function bootWordPress(
 			}
 			// If we get here, the database is valid but installation failed for another reason
 			throw error;
-		}
-		// Validate the database connection after installation (skip if user provided custom DB path)
-		if (!hasCustomDatabasePath) {
-			await assertValidDatabaseConnection(requestHandler);
 		}
 	} else if ('install-from-existing-files-if-needed' === installationMode) {
 		// Check database prerequisites before attempting installation
@@ -313,7 +346,20 @@ export async function bootWordPress(
 		if (!(await isWordPressInstalled(php))) {
 			// Install WordPress if it's not installed.
 			try {
-				await installWordPress(php);
+				const finalizeResult = await installWordPress(
+					php,
+					options.installOptions
+				);
+				bootResult = {
+					adminCredentialsApplied:
+						finalizeResult.adminCredentialsApplied,
+				};
+				if (
+					!finalizeResult.databaseConnected &&
+					!hasCustomDatabasePath
+				) {
+					throwDatabaseConnectionError(php, requestHandler);
+				}
 			} catch (error) {
 				// If installation failed, check if it's a database issue
 				// to provide a more specific error message (but skip if user provided custom DB path)
@@ -323,13 +369,22 @@ export async function bootWordPress(
 				// If we get here, the database is valid but installation failed for another reason
 				throw error;
 			}
-		}
-		// Validate the database connection after installation (skip if user provided custom DB path)
-		if (!hasCustomDatabasePath) {
-			await assertValidDatabaseConnection(requestHandler);
+		} else {
+			const finalizeResult = await finalizeWordPressBoot(
+				php,
+				options.installOptions,
+				{ setPermalinks: false }
+			);
+			bootResult = {
+				adminCredentialsApplied: finalizeResult.adminCredentialsApplied,
+			};
+			if (!finalizeResult.databaseConnected && !hasCustomDatabasePath) {
+				throwDatabaseConnectionError(php, requestHandler);
+			}
 		}
 	}
 
+	bootResults.set(requestHandler, bootResult);
 	return requestHandler;
 }
 
@@ -343,6 +398,13 @@ async function assertValidDatabaseConnection(
 		return;
 	}
 
+	throwDatabaseConnectionError(php, requestHandler);
+}
+
+function throwDatabaseConnectionError(
+	php: PHP,
+	requestHandler: PHPRequestHandler
+): never {
 	if (php.isFile('/internal/shared/preload/0-sqlite.php')) {
 		// The core SQLite integration has been installed, but the database connection is not valid.
 		throw new Error('Error connecting to the SQLite database.');
@@ -539,7 +601,24 @@ export async function isWordPressInstalled(php: PHP) {
  * Without them, the installer may take 60 seconds,
  * 300 seconds, or even more to complete.
  */
-async function installWordPress(php: PHP) {
+async function installWordPress(
+	php: PHP,
+	installOptions?: WordPressInstallOptions
+) {
+	const adminPassword = installOptions?.adminPassword ?? 'password';
+	const requestBody = new URLSearchParams({
+		language: 'en',
+		prefix: 'wp_',
+		weblog_title: installOptions?.siteTitle ?? 'My WordPress Website',
+		user_name: installOptions?.adminUsername ?? 'admin',
+		admin_password: adminPassword,
+		// The installation wizard demands typing the same password twice
+		admin_password2: adminPassword,
+		Submit: 'Install WordPress',
+		pw_weak: '1',
+		admin_email: installOptions?.adminEmail ?? 'admin@localhost.com',
+	});
+	const installerStartedAt = performance.now();
 	const response = await withPHPIniValues(
 		php,
 		{
@@ -550,22 +629,32 @@ async function installWordPress(php: PHP) {
 			await php.request({
 				url: '/wp-admin/install.php?step=2',
 				method: 'POST',
-				body: {
-					language: 'en',
-					prefix: 'wp_',
-					weblog_title: 'My WordPress Website',
-					user_name: 'admin',
-					admin_password: 'password',
-					// The installation wizard demands typing the same password twice
-					admin_password2: 'password',
-					Submit: 'Install WordPress',
-					pw_weak: '1',
-					admin_email: 'admin@localhost.com',
+				headers: {
+					'content-type': 'application/x-www-form-urlencoded',
 				},
+				body: new TextEncoder().encode(requestBody.toString()),
 			})
 	);
+	logger.debug(
+		`WordPress installer request completed in ${(
+			performance.now() - installerStartedAt
+		).toFixed(2)}ms`
+	);
 
-	if (!(await isWordPressInstalled(php))) {
+	const finalizationStartedAt = performance.now();
+	const finalizeResult = await finalizeWordPressBoot(php, installOptions, {
+		setPermalinks: true,
+	});
+
+	logger.debug(
+		`WordPress boot finalization completed in ${(
+			performance.now() - finalizationStartedAt
+		).toFixed(2)}ms; adminCredentialsApplied=${
+			finalizeResult.adminCredentialsApplied
+		}`
+	);
+
+	if (!finalizeResult.installed) {
 		throw new Error(
 			`Failed to install WordPress – installer responded with "${response.text?.substring(
 				0,
@@ -574,36 +663,11 @@ async function installWordPress(php: PHP) {
 		);
 	}
 
-	const defaultedToPrettyPermalinks = await php.run({
-		code: `<?php
-			ob_start();
-			$wp_load = getenv('DOCUMENT_ROOT') . '/wp-load.php';
-			if (!file_exists($wp_load)) {
-				echo '0';
-				exit;
-			}
-			require $wp_load;
-			$nice_permalinks = '/%year%/%monthnum%/%day%/%postname%/';
-			$option_result = update_option(
-				'permalink_structure',
-				$nice_permalinks
-			);
-			ob_clean();
-			if ( get_option( 'permalink_structure' ) === $nice_permalinks ) {
-				echo '1';
-			} else {
-				echo '0';
-			}
-			ob_end_flush();
-		`,
-		env: {
-			DOCUMENT_ROOT: php.documentRoot,
-		},
-	});
-
-	if (defaultedToPrettyPermalinks.text !== '1') {
+	if (!finalizeResult.permalinks) {
 		logger.warn('Failed to default to pretty permalinks after WP install.');
 	}
+
+	return finalizeResult;
 }
 
 export function getFileNotFoundActionForWordPress(
@@ -616,6 +680,183 @@ export function getFileNotFoundActionForWordPress(
 		type: 'internal-redirect',
 		uri: '/index.php',
 	};
+}
+
+interface WordPressBootFinalizationResult extends WordPressBootResult {
+	installed: boolean;
+	permalinks: boolean;
+	databaseConnected: boolean;
+}
+
+async function finalizeWordPressBoot(
+	php: PHP,
+	installOptions: WordPressInstallOptions | undefined,
+	options: { setPermalinks: boolean }
+): Promise<WordPressBootFinalizationResult> {
+	const result = await php.run({
+		code: `<?php
+			ob_start();
+			$wp_load = getenv('DOCUMENT_ROOT') . '/wp-load.php';
+			if (!file_exists($wp_load)) {
+				ob_clean();
+				echo json_encode(array(
+					'installed' => false,
+					'permalinks' => false,
+					'databaseConnected' => false,
+					'adminCredentialsApplied' => false,
+				));
+				exit;
+			}
+
+			require $wp_load;
+
+			$installed = is_blog_installed();
+			$permalinks = false;
+			$database_connected = false;
+			$admin_credentials_applied = false;
+
+			if ($installed) {
+				$install_options = json_decode(
+					getenv('PLAYGROUND_WORDPRESS_INSTALL_OPTIONS') ?: '{}',
+					true
+				);
+				$nice_permalinks = '/%year%/%monthnum%/%day%/%postname%/';
+				if (getenv('PLAYGROUND_SET_PERMALINKS') === '1') {
+					if (
+						is_array($install_options) &&
+						isset($install_options['siteTitle'])
+					) {
+						update_option('blogname', $install_options['siteTitle']);
+					}
+					update_option('permalink_structure', $nice_permalinks);
+				}
+				$permalinks = get_option('permalink_structure') === $nice_permalinks;
+				$database_connected = $wpdb->check_connection(false);
+				if (is_array($install_options)) {
+					$admin_credentials_applied =
+						playground_apply_admin_credentials($install_options);
+				}
+			}
+
+			ob_clean();
+			echo json_encode(array(
+				'installed' => (bool) $installed,
+				'permalinks' => (bool) $permalinks,
+				'databaseConnected' => (bool) $database_connected,
+				'adminCredentialsApplied' => (bool) $admin_credentials_applied,
+			));
+			ob_end_flush();
+
+			function playground_apply_admin_credentials($install_options) {
+				$has_username = isset($install_options['adminUsername']);
+				$has_password = isset($install_options['adminPassword']);
+				$has_email = isset($install_options['adminEmail']);
+				if (!$has_username && !$has_password && !$has_email) {
+					return false;
+				}
+
+				$username = $has_username
+					? sanitize_user($install_options['adminUsername'], true)
+					: 'admin';
+				$user = get_user_by('login', $username);
+				if (
+					!$user &&
+					$has_username &&
+					getenv('PLAYGROUND_ALLOW_ADMIN_INSERT') === '1'
+				) {
+					$user_id = wp_insert_user(array(
+						'user_login' => $username,
+						'user_pass' => $has_password
+							? $install_options['adminPassword']
+							: wp_generate_password(),
+						'user_email' => $has_email
+							? $install_options['adminEmail']
+							: $username . '@localhost.com',
+						'role' => 'administrator',
+					));
+					if (!is_wp_error($user_id)) {
+						$user = get_user_by('id', $user_id);
+					}
+				}
+				if (!$user && $username !== 'admin') {
+					$user = get_user_by('login', 'admin');
+				}
+				if (!$user && $has_email) {
+					$user = get_user_by('email', $install_options['adminEmail']);
+				}
+				if (!$user) {
+					return false;
+				}
+
+				if ($has_password) {
+					wp_set_password($install_options['adminPassword'], $user->ID);
+				}
+
+				$user_data = array('ID' => $user->ID);
+				if ($has_email) {
+					$user_data['user_email'] = $install_options['adminEmail'];
+				}
+				if ($has_username && $user->user_login !== $username) {
+					$user_data['user_login'] = $username;
+					$user_data['user_nicename'] = $username;
+					$user_data['display_name'] = $username;
+				}
+
+				if (count($user_data) > 1) {
+					$update_result = wp_update_user($user_data);
+					if (is_wp_error($update_result)) {
+						return false;
+					}
+				}
+
+				$updated_user = get_user_by('id', $user->ID);
+				if (!$updated_user) {
+					return false;
+				}
+				if ($has_username && $updated_user->user_login !== $username) {
+					return false;
+				}
+				if (
+					$has_email &&
+					$updated_user->user_email !== $install_options['adminEmail']
+				) {
+					return false;
+				}
+				if (
+					$has_password &&
+					!wp_check_password(
+						$install_options['adminPassword'],
+						$updated_user->user_pass,
+						$updated_user->ID
+					)
+				) {
+					return false;
+				}
+
+				return true;
+			}
+		`,
+		env: {
+			DOCUMENT_ROOT: php.documentRoot,
+			PLAYGROUND_SET_PERMALINKS: options.setPermalinks ? '1' : '0',
+			PLAYGROUND_ALLOW_ADMIN_INSERT: options.setPermalinks ? '1' : '0',
+			PLAYGROUND_WORDPRESS_INSTALL_OPTIONS: JSON.stringify(
+				installOptions ?? {}
+			),
+		},
+	});
+
+	try {
+		return JSON.parse(result.text);
+	} catch (error) {
+		throw new Error(
+			`Failed to finalize WordPress boot – received "${result.text?.substring(
+				0,
+				100
+			)}"`,
+			{ cause: error }
+		);
+	}
 }
 
 async function isDatabaseConnectionValid(php: PHP) {

--- a/packages/playground/wordpress/src/index.ts
+++ b/packages/playground/wordpress/src/index.ts
@@ -12,11 +12,14 @@ export {
 	bootWordPress,
 	bootWordPressAndRequestHandler,
 	bootRequestHandler,
+	getWordPressBootResult,
 	getFileNotFoundActionForWordPress,
 } from './boot';
 export type {
 	PhpIniOptions,
 	PHPInstanceCreatedHook,
+	WordPressBootResult,
+	WordPressInstallOptions,
 	WordPressInstallMode,
 } from './boot';
 export { defineWpConfigConstants, ensureWpConfig } from './wp-config';

--- a/packages/playground/wordpress/src/test/install-options.spec.ts
+++ b/packages/playground/wordpress/src/test/install-options.spec.ts
@@ -1,0 +1,187 @@
+import { createNodeFsMountHandler, loadNodeRuntime } from '@php-wasm/node';
+import { RecommendedPHPVersion } from '@wp-playground/common';
+import {
+	getSqliteDriverModule,
+	getWordPressModule,
+} from '@wp-playground/wordpress-builds';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+	bootWordPressAndRequestHandler,
+	getWordPressBootResult,
+} from '../boot';
+import type { PHPRequestHandler } from '@php-wasm/universal';
+
+describe('WordPress install options', () => {
+	it(
+		'keeps the default installed site unchanged',
+		async () => {
+			await using handler = await bootWordPressAndRequestHandler({
+				createPhpRuntime: async () =>
+					await loadNodeRuntime(RecommendedPHPVersion),
+				siteUrl: 'http://playground-domain/',
+				wordPressZip: await getWordPressModule(),
+				sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+			});
+
+			const details = await getSiteDetails(handler, {
+				adminUsername: 'admin',
+				adminPassword: 'password',
+			});
+
+			expect(details.installed).toBe(true);
+			expect(details.blogname).toBe('My WordPress Website');
+			expect(details.adminEmail).toBe('admin@localhost.com');
+			expect(details.passwordMatches).toBe(true);
+			expect(details.permalinkStructure).toBe(
+				'/%year%/%monthnum%/%day%/%postname%/'
+			);
+			expect(getWordPressBootResult(handler)).toEqual({
+				adminCredentialsApplied: false,
+			});
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
+		'passes provided install values to the normal installer request',
+		async () => {
+			const adminPassword = 'not-in-logs-secret';
+			await using handler = await bootWordPressAndRequestHandler({
+				createPhpRuntime: async () =>
+					await loadNodeRuntime(RecommendedPHPVersion),
+				siteUrl: 'http://playground-domain/',
+				wordPressZip: await getWordPressModule(),
+				sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+				installOptions: {
+					siteTitle: 'Installed From Options',
+					adminUsername: 'playgroundadmin',
+					adminPassword,
+					adminEmail: 'playground-admin@example.com',
+				},
+			});
+
+			const details = await getSiteDetails(handler, {
+				adminUsername: 'playgroundadmin',
+				adminPassword,
+			});
+			const bootResult = getWordPressBootResult(handler);
+
+			expect(details.installed).toBe(true);
+			expect(details.blogname).toBe('Installed From Options');
+			expect(details.adminEmail).toBe('playground-admin@example.com');
+			expect(details.passwordMatches).toBe(true);
+			expect(details.permalinkStructure).toBe(
+				'/%year%/%monthnum%/%day%/%postname%/'
+			);
+			expect(bootResult.adminCredentialsApplied).toBe(true);
+			expect(JSON.stringify(bootResult)).not.toContain(adminPassword);
+		},
+		{ timeout: 30_000 }
+	);
+
+	it(
+		'does not rerun the installer for an existing installed site',
+		async () => {
+			const siteDir = mkdtempSync(
+				join(tmpdir(), 'playground-install-options-')
+			);
+
+			try {
+				const firstHandler = await bootWordPressAndRequestHandler({
+					createPhpRuntime: async () =>
+						await loadNodeRuntime(RecommendedPHPVersion),
+					siteUrl: 'http://playground-domain/',
+					wordPressZip: await getWordPressModule(),
+					sqliteIntegrationPluginZip: await getSqliteDriverModule(),
+					hooks: {
+						beforeWordPressFiles: async (php) => {
+							await php.mount(
+								'/wordpress',
+								createNodeFsMountHandler(siteDir)
+							);
+						},
+					},
+					installOptions: {
+						siteTitle: 'Original Site Title',
+					},
+				});
+				await firstHandler[Symbol.asyncDispose]();
+
+				await using secondHandler =
+					await bootWordPressAndRequestHandler({
+						createPhpRuntime: async () =>
+							await loadNodeRuntime(RecommendedPHPVersion),
+						siteUrl: 'http://playground-domain/',
+						sqliteIntegrationPluginZip:
+							await getSqliteDriverModule(),
+						wordpressInstallMode:
+							'install-from-existing-files-if-needed',
+						hooks: {
+							beforeWordPressFiles: async (php) => {
+								await php.mount(
+									'/wordpress',
+									createNodeFsMountHandler(siteDir)
+								);
+							},
+						},
+						installOptions: {
+							siteTitle: 'Should Not Replace Existing Title',
+						},
+					});
+
+				const details = await getSiteDetails(secondHandler, {
+					adminUsername: 'admin',
+					adminPassword: 'password',
+				});
+
+				expect(details.installed).toBe(true);
+				expect(details.blogname).toBe('Original Site Title');
+				expect(details.passwordMatches).toBe(true);
+			} finally {
+				rmSync(siteDir, { recursive: true, force: true });
+			}
+		},
+		{ timeout: 60_000 }
+	);
+});
+
+async function getSiteDetails(
+	handler: PHPRequestHandler,
+	options: {
+		adminUsername: string;
+		adminPassword: string;
+	}
+) {
+	const php = await handler.getPrimaryPhp();
+	const result = await php.run({
+		code: `<?php
+			ob_start();
+			require getenv('DOCUMENT_ROOT') . '/wp-load.php';
+			$user = get_user_by('login', getenv('PLAYGROUND_ADMIN_USERNAME'));
+			$details = array(
+				'installed' => is_blog_installed(),
+				'blogname' => get_option('blogname'),
+				'adminEmail' => $user ? $user->user_email : null,
+				'passwordMatches' => $user
+					? wp_check_password(
+						getenv('PLAYGROUND_ADMIN_PASSWORD'),
+						$user->user_pass,
+						$user->ID
+					)
+					: false,
+				'permalinkStructure' => get_option('permalink_structure'),
+			);
+			ob_clean();
+			echo json_encode($details);
+			ob_end_flush();
+		`,
+		env: {
+			DOCUMENT_ROOT: php.documentRoot,
+			PLAYGROUND_ADMIN_USERNAME: options.adminUsername,
+			PLAYGROUND_ADMIN_PASSWORD: options.adminPassword,
+		},
+	});
+	return JSON.parse(result.text);
+}


### PR DESCRIPTION
## Problem

Playground CLI startup was doing redundant WordPress boot work around install/start, and Studio also needs a trustworthy signal for whether boot already applied requested admin credentials. Recent profiling also showed two distinct remaining costs:

- the normal WordPress installer request is still the largest single cost
- eager multi-worker boot can hide the savings from install-option cleanup

## Implementation

- Adds typed `WordPressInstallOptions` and threads them through `runCLI`, the Blueprint v1 worker payload, and `bootWordPress`.
- Uses `siteTitle` as the canonical install option name, while accepting `weblogTitle` plus `wordpressInstallOptions` / deprecated `studioInstallOptions` aliases at the CLI integration boundary for compatibility.
- Passes site/admin values to the normal `/wp-admin/install.php?step=2` installer POST. This intentionally keeps the standard installer request path and does not shortcut to `wp_install()`.
- Collapses post-install installed-site validation, default permalink setup, DB connection checking, and optional admin credential application into one `php.run()` after the installer request.
- Exposes `wordpressBootResult.adminCredentialsApplied` on the actual `runCLI()` server return value, in addition to lower-level boot metadata, so Studio can skip a redundant fallback mutation when boot already handled credentials.
- Starts only the primary worker before WordPress install, then starts secondary server workers after install. Plain server startup backgrounds secondary workers; server startup with Blueprint/phpMyAdmin post-boot steps waits for secondary workers first so those steps run against the final worker pool. Non-server commands also still wait for all workers before continuing.
- Adds lightweight debug timing spans for worker request-handler boot, `bootWordPress`, installer request, finalization, Blueprint v1 steps, and secondary worker boot.
- Keeps the old separate DB connection assertion path for failure diagnosis/error preservation.

## Compatibility / behavior

- Defaults are unchanged when install options are omitted.
- Existing installed sites are not reinstalled in `install-from-existing-files-if-needed` mode.
- Existing sites can apply provided admin credentials during the existing boot finalization run; `adminCredentialsApplied` is only true when requested credential state verifies afterward.
- This does not introduce DB preseeding, shared WordPress core, direct `wp_install()`, or Defender/ReFS-specific behavior.

## Security

`adminPassword` is not included in the boot result or debug/perf metadata. It is only sent to the installer/finalization paths needed to set credentials.

## Perf notes

These are local Studio profiling measurements from the investigation that motivated this PR, not CI benchmarks, and I have not remeasured the exact latest commit after adding deferred secondary-worker boot:

- Fresh child startup improved from about 21.8s on trunk to about 13.2-13.9s with this patch class, depending on run shape.
- The removed post-install admin/title fallback path accounts for about 1.9s of saved startup work in the measured run.
- With `STUDIO_WORKERS=1`, child startup measured about 9.8s instead of 13.9s with six workers, which is why this PR now defers secondary server workers until after the primary install path.

This is still a cleanup/small-to-medium install-path win rather than a full step-change: the standard `/wp-admin/install.php?step=2` request remains the largest floor, measuring roughly 5.7-6.8s by itself in those profiling runs. A bigger improvement would need a separate, riskier fast-install path such as guarded direct `wp_install()` or DB seeding.

## Tests

- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run playground-cli:typecheck`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec -- vitest run tests/run-cli.spec.ts --config packages/playground/cli/vite.config.ts -t "multi-worker install credentials"`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec -- vitest run tests/run-cli.spec.ts --config packages/playground/cli/vite.config.ts -t "blueprint after secondary"`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec vitest run src/test/install-options.spec.ts -- --config packages/playground/wordpress/vite.config.ts`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run playground-wordpress:lint`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run playground-cli:lint`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run playground-wordpress:build:bundle`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run playground-cli:build:bundle`

Also attempted the broader `playground-wordpress:test:vite` path earlier; the new install-options tests passed, but the existing `version-detect.spec.ts` trunk runtime case still timed out at 30s.



