### PR TITLE
[Website] Name failed download URL in error modal

### DIFF
--- a/packages/playground/website/playwright/e2e/error-handling.spec.ts
+++ b/packages/playground/website/playwright/e2e/error-handling.spec.ts
@@ -52,8 +52,38 @@ test('should show download error modal when a resource download fails', async ({
 	const body = page.getByText('usually caused by a network problem');
 	await expect(body).toBeVisible();
 
+	const failedFile = page.getByRole('link', {
+		name:
+			'https://downloads.wordpress.org/plugin/' +
+			'hello-dolly.latest-stable.zip',
+	});
+	await expect(failedFile).toBeVisible();
+
 	const reloadButton = page.getByRole('button', {
 		name: 'Reload page',
 	});
 	await expect(reloadButton).toBeVisible();
+});
+
+test('should say when the Blueprint file could not be downloaded', async ({
+	page,
+}) => {
+	const blueprintUrl = 'https://example.com/missing-blueprint.json';
+	await page.addInitScript((urlToFail) => {
+		const originalFetch = window.fetch;
+		window.fetch = function (input: RequestInfo | URL, init?: RequestInit) {
+			const url = input instanceof Request ? input.url : String(input);
+			if (url === urlToFail) {
+				return Promise.reject(new TypeError('Failed to fetch'));
+			}
+			return originalFetch.call(this, input, init);
+		} as typeof fetch;
+	}, blueprintUrl);
+
+	await page.goto(`./?blueprint-url=${encodeURIComponent(blueprintUrl)}`);
+
+	await expect(
+		page.getByText('Blueprint could not be downloaded')
+	).toBeVisible();
+	await expect(page.getByRole('link', { name: blueprintUrl })).toBeVisible();
 });

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { getSiteErrorView } from './get-site-error-view';
+import type { BlueprintSource } from '../../lib/state/url/resolve-blueprint-from-url';
+import type { SiteInfo } from '../../lib/state/redux/slice-sites';
+
+const helpers = {
+	deleteSite: () => {},
+	restartWithoutPr: () => {},
+	reloadWithoutBlueprint: () => {},
+};
+
+describe('getSiteErrorView', () => {
+	it('shows the failed file URL for resource download errors', () => {
+		const url =
+			'https://downloads.wordpress.org/plugin/hello-dolly.latest-stable.zip';
+		const view = getSiteErrorView({
+			error: 'resource-download-failed',
+			site: createSite(),
+			helpers,
+			errorDetails: {
+				url,
+			},
+		});
+
+		expect(renderToStaticMarkup(view.body)).toContain(url);
+	});
+
+	it('says when the entire Blueprint could not be downloaded', () => {
+		const url = 'https://example.com/blueprint.json';
+		const view = getSiteErrorView({
+			error: 'blueprint-fetch-failed',
+			site: createSite({
+				type: 'remote-url',
+				url,
+			}),
+			helpers,
+		});
+
+		expect(view.title).toBe('Blueprint could not be downloaded');
+		expect(renderToStaticMarkup(view.body)).toContain(url);
+	});
+});
+
+function createSite(
+	originalBlueprintSource: BlueprintSource = { type: 'none' }
+): SiteInfo {
+	return {
+		slug: 'test-site',
+		metadata: {
+			name: 'Test site',
+			id: 'test-site',
+			storage: 'none',
+			originalBlueprint: {},
+			originalBlueprintSource,
+			runtimeConfiguration: {
+				phpVersion: '8.3',
+				wpVersion: 'latest',
+				intl: false,
+				networking: true,
+				extraLibraries: [],
+				constants: {},
+			},
+		},
+	} as SiteInfo;
+}

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -61,7 +61,7 @@ export function getSiteErrorView(
 		case 'network-firewall-interference':
 			return networkFirewallInterferenceView(context);
 		case 'resource-download-failed':
-			return resourceDownloadFailedView();
+			return resourceDownloadFailedView(context);
 		case 'site-boot-failed':
 		default:
 			return genericSiteBootFailedView(context);
@@ -145,7 +145,7 @@ function blueprintFetchFailedView({
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	const blueprintUrl = getBlueprintSourceUrl(site);
 	return {
-		title: 'Blueprint could not be loaded',
+		title: 'Blueprint could not be downloaded',
 		isDeveloperError: true,
 		detailSummaryOverride: 'Network error details',
 		body: (
@@ -298,20 +298,30 @@ function directoryHandleUnknownErrorView(): SiteErrorViewConfig {
  * then falls back to pattern matching in the error message.
  */
 function extractTargetUrl(errorDetails: unknown): string | undefined {
-	if (!errorDetails || typeof errorDetails !== 'object') {
+	if (!errorDetails) {
 		return undefined;
 	}
 
-	const details = errorDetails as Record<string, unknown>;
+	if (typeof errorDetails === 'string') {
+		return extractTargetUrlFromMessage(errorDetails);
+	}
+
+	if (typeof errorDetails !== 'object') {
+		return undefined;
+	}
 
 	// Prefer the structured url property if available
+	const details = errorDetails as Record<string, unknown>;
 	if (typeof details.url === 'string' && details.url) {
 		return details.url;
 	}
 
 	// Fall back to pattern matching in the message for backwards compatibility
 	const message = (details.rawMessage || details.message || '') as string;
+	return extractTargetUrlFromMessage(message);
+}
 
+function extractTargetUrlFromMessage(message: string): string | undefined {
 	// "Could not fetch {url}" from FirewallInterferenceError
 	const fetchMatch = message.match(/Could not fetch ([^\s]+)/);
 	if (fetchMatch) {
@@ -468,7 +478,10 @@ function networkFirewallInterferenceView({
 	};
 }
 
-function resourceDownloadFailedView(): SiteErrorViewConfig {
+function resourceDownloadFailedView({
+	errorDetails,
+}: SiteErrorViewContext): SiteErrorViewConfig {
+	const targetUrl = extractTargetUrl(errorDetails);
 	return {
 		title: 'Could not download required files',
 		isDeveloperError: false,
@@ -481,6 +494,19 @@ function resourceDownloadFailedView(): SiteErrorViewConfig {
 					Playground could not download one or more files it needs to
 					run. This is usually caused by a network problem.
 				</p>
+				{targetUrl ? (
+					<p>
+						Failed file:{' '}
+						<a
+							className={css.errorLink}
+							href={targetUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{targetUrl}
+						</a>
+					</p>
+				) : null}
 				<ul className={css.errorList}>
 					<li>Check your internet connection and try again.</li>
 					<li>

--- a/packages/playground/website/src/lib/state/redux/error-utils.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/error-utils.spec.ts
@@ -98,6 +98,14 @@ describe('findDownloadErrorInCauseChain', () => {
 		expect(findDownloadErrorInCauseChain(error)).toBe(error);
 	});
 
+	it('should detect ResourceDownloadError by name', () => {
+		const error = new Error(
+			'Could not download "https://example.com/file.zip"'
+		);
+		error.name = 'ResourceDownloadError';
+		expect(findDownloadErrorInCauseChain(error)).toBe(error);
+	});
+
 	it('should return the first matching error in the chain', () => {
 		const deeper = new TypeError('Load failed');
 		const shallower = new TypeError('Failed to fetch', {

--- a/packages/playground/website/src/lib/state/redux/error-utils.ts
+++ b/packages/playground/website/src/lib/state/redux/error-utils.ts
@@ -61,8 +61,13 @@ const DOWNLOAD_ERROR_PATTERNS = [
  * Error class names that indicate a download/network problem.
  * WebAssembly.CompileError and LinkError occur when the browser tries
  * to compile a non-WASM response (e.g. an HTML error page) as WASM.
+ * ResourceDownloadError is thrown for Blueprint resource fetch failures.
  */
-const DOWNLOAD_ERROR_CLASS_NAMES = ['CompileError', 'LinkError'];
+const DOWNLOAD_ERROR_CLASS_NAMES = [
+	'CompileError',
+	'LinkError',
+	'ResourceDownloadError',
+];
 
 /**
  * Search through an error's cause chain to find a network/download error.

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -60,21 +60,6 @@ const serializeSiteErrorDetails = (
 	details?: unknown
 ): SerializedSiteErrorDetails | undefined => {
 	if (details instanceof BlueprintStepExecutionError) {
-		// Look for a url property in the cause chain
-		let url: string | undefined;
-		let current: unknown = details.cause;
-		while (current && !url) {
-			if (
-				current &&
-				typeof current === 'object' &&
-				'url' in current &&
-				typeof (current as any).url === 'string'
-			) {
-				url = (current as any).url;
-			}
-			current = current instanceof Error ? current.cause : undefined;
-		}
-
 		return {
 			type: 'blueprint-step-error',
 			stepNumber: details.stepNumber,
@@ -87,7 +72,7 @@ const serializeSiteErrorDetails = (
 					: details.message,
 			name: details.name,
 			stack: details.stack,
-			url,
+			url: findUrlInCauseChain(details),
 		};
 	}
 	if (details instanceof Error) {
@@ -95,10 +80,7 @@ const serializeSiteErrorDetails = (
 			message: details.message,
 			name: details.name,
 			stack: details.stack,
-			url:
-				'url' in details && typeof details.url === 'string'
-					? details.url
-					: undefined,
+			url: findUrlInCauseChain(details),
 		};
 	}
 	if (typeof details === 'string') {
@@ -139,6 +121,28 @@ const serializeSiteErrorDetails = (
 		return String(details);
 	}
 };
+
+function findUrlInCauseChain(error: Error): string | undefined {
+	let current: unknown = error;
+	const seen = new Set<Error>();
+	while (current) {
+		if (current instanceof Error) {
+			if (seen.has(current)) {
+				break;
+			}
+			seen.add(current);
+		}
+		if (
+			typeof current === 'object' &&
+			'url' in current &&
+			typeof (current as any).url === 'string'
+		) {
+			return (current as any).url;
+		}
+		current = current instanceof Error ? current.cause : undefined;
+	}
+	return undefined;
+}
 
 export interface UIState {
 	activeSite?: {


### PR DESCRIPTION
## What it does

Shows the URL of the file Playground failed to download in the download-error modal.

If Playground fails while fetching the Blueprint itself, the modal now says `Blueprint could not be downloaded` and keeps showing the Blueprint URL.

<img width="2400" height="2214" alt="-Users-cloudnik-conductor-workspaces-wordpress-playground-denver-v1- context-download-error-file-url" src="https://github.com/user-attachments/assets/f4f084f9-59f8-4d5c-8ee5-806a3c89a62d" />

<img width="2400" height="2214" alt="-Users-cloudnik-conductor-workspaces-wordpress-playground-denver-v1- context-blueprint-download-error" src="https://github.com/user-attachments/assets/88ce044d-248f-4a11-8cb4-cd0ed43038d7" />


## Rationale

The old `Could not download required files` modal explained likely network causes, but did not identify the failed resource. That made it hard to tell whether the blocked file was a plugin, theme, WordPress asset, or the Blueprint itself.

## Implementation

`resource-download-failed` now receives the serialized error details and renders a `Failed file` link when a URL is available. Error detail serialization now looks through the error cause chain for `url`, so wrapped download errors still preserve the resource URL.

`ResourceDownloadError` is also recognized as a download failure, covering failed HTTP responses as well as fetch exceptions.

## Testing instructions

Automated checks run:

```bash
npx nx test playground-website --runInBand
npx nx typecheck playground-website
npx nx lint playground-website
```

I also attempted the focused Playwright file:

```bash
npx playwright test --config=packages/playground/website/playwright/playwright.config.ts error-handling.spec.ts --project=chromium
```

That could not start because another process was already listening on the shared CORS proxy port `127.0.0.1:5263`.
