### PR TITLE
fix(CLI): reset crash on newer Node versions (rmdir → rm).

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -26,7 +26,7 @@ import {
 	runBlueprintV1Steps,
 } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import fs, { existsSync, mkdirSync, readdirSync, rmdirSync } from 'fs';
+import fs, { existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
 import type { Server } from 'http';
 import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
 // @ts-ignore
@@ -1878,7 +1878,7 @@ function expandStartCommandArgs(
 
 		if (existsSync(hostPath) && (args['reset'] as boolean)) {
 			cliOutput.print('Resetting site...');
-			rmdirSync(hostPath, { recursive: true });
+			rmSync(hostPath, { recursive: true, force: true });
 		}
 		mkdirSync(hostPath, { recursive: true });
 		newArgs['mount-before-install'] = [


### PR DESCRIPTION
## Motivation for the change, related issues
Fixes #3538 

## Implementation details
Node.js deprecated the `{ recursive: true }` option of `fs.rmdirSync()` long ago and has since removed it. Replaced the call 
`fs.rmSync(..., { recursive: true, force: true })`, the documented replacement.

## Testing Instructions

On Node 25 

```bash
# 1. Create the site first
npx @wp-playground/cli start --wp=6.9 --php=8.1

# 2. Re-run with --reset
npx @wp-playground/cli start --wp=6.9 --php=8.1 --reset