### PR TITLE
[Docs] Document PHP.wasm extension usage

### DIFF
--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -264,10 +264,45 @@ The `server` command supports the following optional arguments:
 - `--internal-cookie-store`: Enable internal cookie handling. When enabled, Playground will manage cookies internally using an HttpCookieStore that persists cookies across requests. When disabled, cookies are handled externally (e.g., by a browser in Node.js environments). Defaults to false.
 - `--phpmyadmin[=<path>]`: Install phpMyAdmin for database management. The phpMyAdmin URL will be printed after boot. Optionally specify a custom URL path (default: `/phpmyadmin`).
 - `--xdebug`: Enable Xdebug. Defaults to false.
+- `--php-extension=<manifest>`: Load a PHP.wasm extension manifest before PHP starts. Accepts local paths, `file:` URLs, and HTTP(S) URLs. Can be used multiple times.
 - `--experimental-devtools`: Enable experimental browser development tools. Defaults to false.
 - `--experimental-unsafe-ide-integration=<ide>`: Set up the Xdebug integration on VS Code (`vscode`) and PhpStorm (`phpstorm`).
 - `--workers=<n|auto>`: Number of request-handling worker threads. Pass a positive integer, or `auto` to use one worker per CPU core (minus one). Defaults to `min(6, cpus-1)`. Useful for multi-client workloads (e.g. parallel e2e suites) that need more than 6 in-flight requests.
 - `--experimental-multi-worker=<number>`: Deprecated. Use `--workers=<n|auto>` instead. The value of this flag is ignored.
+
+### Loading PHP.wasm extensions
+
+Playground CLI can load external PHP.wasm extensions before PHP starts. Pass a
+manifest produced by `@php-wasm/compile-extension`, or a published manifest such
+as the SQLite Database Integration native parser:
+
+```bash
+npx @wp-playground/cli@latest server \
+	--php=8.5 \
+	--php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
+	--blueprint=https://wordpress.github.io/sqlite-database-integration/blueprint.json
+```
+
+For local development, point the flag at a local manifest:
+
+```bash
+npx @wp-playground/cli@latest server \
+	--php=8.5 \
+	--php-extension=./dist/wp_mysql_parser/manifest.json
+```
+
+`--php-extension` is repeatable. The manifest selects the `.so` artifact
+matching the active PHP version and can also stage sidecar files, `.ini`
+settings, and environment variables before startup.
+
+External extensions are JSPI side modules. If your Node.js build does not expose
+JSPI, the CLI rejects the extension request during startup. Use a Node.js build
+with JSPI support when testing custom extensions locally.
+
+See [Loading PHP extensions](/developers/apis/javascript-api/php-extensions)
+and
+[Building PHP extensions](/developers/apis/javascript-api/build-php-extensions)
+for manifest format, compiler helpers, and dependency notes.
 
 <div class="callout callout-warning">
 

--- a/packages/docs/site/docs/developers/06-apis/javascript-api/07-php-extensions.md
+++ b/packages/docs/site/docs/developers/06-apis/javascript-api/07-php-extensions.md
@@ -13,6 +13,15 @@ creates the runtime.
 Use the `extensions` array for both bundled extensions and external `.so`
 artifacts.
 
+Use external PHP.wasm extensions when the code that must be fast or native-like
+is too hot for PHP userland, but you still want to ship it with a Playground
+demo, CLI workflow, or embedded app. The same manifest can be loaded by the
+JavaScript API, the Playground web Query API, and Playground CLI.
+
+External extensions are JSPI side modules. If the browser or Node.js build does
+not expose JSPI, PHP.wasm rejects the extension request instead of starting
+with a partially loaded runtime.
+
 ## Bundled extensions
 
 `@php-wasm/node` ships `intl`, `xdebug`, `redis`, and `memcached`:
@@ -183,10 +192,120 @@ await loadWebRuntime('8.4', {
 });
 ```
 
-To build your own extension artifacts, see
-[Building PHP extensions](/developers/apis/javascript-api/build-php-extensions)
-and
-[PHP extension dependencies](/developers/apis/javascript-api/php-extension-dependencies).
+## Try published PHP.wasm extensions
+
+Two projects publish ready-to-use manifests you can inspect before building
+your own:
+
+- [SQLite Database Integration native extension](https://wordpress.github.io/sqlite-database-integration/native-extension/)
+  publishes `wp_mysql_parser`, a native lexer/parser used by the SQLite
+  Database Integration plugin.
+- [PHP Toolkit Native APIs WASM releases](https://wordpress.github.io/php-toolkit/wp_native_apis-wasm-extension/)
+  publishes `wp_native_apis`, an experimental extension for WordPress native
+  APIs.
+
+To try a published extension in Playground web, pass its manifest URL with the
+`php-extension` Query API parameter. This loads the extension before PHP starts,
+without writing any JavaScript:
+
+```text
+https://playground.wordpress.net/?php=8.5&php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
+```
+
+Use `/latest/manifest.json` for a quick demo. Use one of the pinned manifest
+URLs from the extension release page for reproducible demos, tests, and
+documentation links.
+
+Repeat the parameter to load more than one extension:
+
+```text
+https://playground.wordpress.net/?php=8.5&php-extension=https://example.com/one/manifest.json&php-extension=https://example.com/two/manifest.json
+```
+
+The Query API accepts absolute, root-relative, and page-relative manifest URLs.
+After resolution, the manifest URL must use HTTP(S). For example, if your
+Playground page is served from `https://example.com/tools/`, these are valid:
+
+```text
+?php-extension=https://cdn.example.com/wp_mysql_parser/manifest.json
+?php-extension=/extensions/wp_mysql_parser/manifest.json
+?php-extension=./extensions/wp_mysql_parser/manifest.json
+```
+
+The same manifest-loading path is documented in the
+[Query API reference](/developers/apis/query-api).
+
+The same manifest works in Playground CLI:
+
+```bash
+npx @wp-playground/cli@latest server \
+	--php=8.5 \
+	--php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
+	--blueprint=https://wordpress.github.io/sqlite-database-integration/blueprint.json
+```
+
+When you embed Playground with `@wp-playground/client`, pass the same manifest
+through the `extensions` option:
+
+```html
+<iframe id="wp"></iframe>
+<script type="module">
+	import { startPlaygroundWeb } from 'https://playground.wordpress.net/client/index.js';
+
+	const client = await startPlaygroundWeb({
+		iframe: document.getElementById('wp'),
+		remoteUrl: 'https://playground.wordpress.net/remote.html',
+		extensions: [
+			{
+				source: {
+					format: 'manifest',
+					manifestUrl: 'https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json',
+				},
+			},
+		],
+	});
+
+	await client.isReady();
+</script>
+```
+
+Use the lower-level runtime API when you are building directly on
+`@php-wasm/node` or `@php-wasm/web`:
+
+```ts
+import { PHP } from '@php-wasm/universal';
+import { loadNodeRuntime } from '@php-wasm/node';
+
+const php = new PHP(
+	await loadNodeRuntime('8.5', {
+		extensions: [
+			{
+				source: {
+					format: 'manifest',
+					manifestUrl: 'https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json',
+				},
+			},
+		],
+	})
+);
+```
+
+## Build your own extension
+
+`@php-wasm/compile-extension` turns a normal `phpize` extension directory into
+JSPI `.so` artifacts and a loadable manifest:
+
+```bash
+npx @php-wasm/compile-extension \
+	--source ./wp-mysql-parser \
+	--name wp_mysql_parser \
+	--php-versions 8.0,8.1,8.2,8.3,8.4,8.5 \
+	--out ./dist/wp_mysql_parser
+```
+
+Host the whole output directory from one static location. The manifest lets the
+runtime select the artifact that matches the active PHP version and load it
+before PHP starts.
 
 ## Startup files
 

--- a/packages/docs/site/docs/developers/06-apis/query-api/01-index.md
+++ b/packages/docs/site/docs/developers/06-apis/query-api/01-index.md
@@ -55,11 +55,49 @@ For example, the following code embeds a Playground with a preinstalled Gutenber
 <iframe src="https://playground.wordpress.net/?plugin=gutenberg&url=/wp-admin/post-new.php&mode=seamless"> </iframe>
 ```
 
+## Loading PHP.wasm extensions
+
+Use `php-extension` to load an external PHP.wasm extension manifest before PHP
+starts. This is useful for demos that need native extension performance, such
+as the SQLite Database Integration plugin's `wp_mysql_parser` extension. You do
+not need custom JavaScript for this — the Query API turns each parameter into a
+runtime extension request before Playground boots.
+
+```text
+https://playground.wordpress.net/?php=8.5&php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
+```
+
+Use `/latest/manifest.json` for a quick demo. Use a pinned manifest from the
+extension release page when you need a stable URL for tests or documentation.
+
+You can repeat `php-extension` to load multiple manifests:
+
+```text
+https://playground.wordpress.net/?php-extension=https://example.com/one/manifest.json&php-extension=https://example.com/two/manifest.json
+```
+
+The parameter accepts absolute, root-relative, and page-relative manifest URLs:
+
+```text
+?php-extension=https://cdn.example.com/wp_mysql_parser/manifest.json
+?php-extension=/extensions/wp_mysql_parser/manifest.json
+?php-extension=./extensions/wp_mysql_parser/manifest.json
+```
+
+Relative values are resolved against the current Playground page URL. The
+manifest URL must use HTTP(S) once resolved. `file:` URLs are rejected in the
+browser. For local CLI workflows, use
+the [`--php-extension` flag](/developers/local-development/wp-playground-cli#loading-phpwasm-extensions)
+instead.
+
 <div class="callout callout-info">
 
 **CORS policy**
 
-To import files from a URL, such as a site zip package, they must be served with `Access-Control-Allow-Origin` header set. For reference, see: [Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#the_http_response_headers).
+To import files from a URL, such as a site zip package or PHP extension
+manifest and `.so` artifact, they must be served with the
+`Access-Control-Allow-Origin` header set. For reference, see:
+[Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#the_http_response_headers).
 
 </div>
 


### PR DESCRIPTION
## What changed

- Expands the PHP extension docs with a developer-facing path for published PHP.wasm extension manifests, Playground web Query API usage, `@wp-playground/client`, lower-level runtime loading, and `@php-wasm/compile-extension`.
- Documents the `php-extension` Query API flow with repeatable manifest URLs, pinned-vs-latest guidance, and CORS requirements for manifests and `.so` artifacts.
- Adds Playground CLI docs for `--php-extension`, including remote and local manifest examples plus the JSPI startup requirement.

## Why

Recent PHP.wasm extension work made external JSPI side modules usable from Playground web, CLI, and runtime APIs. The docs now connect those pieces into a single story developers can follow from "try a published native extension" to "build and ship your own manifest".

## Validation

- `npm ci` with Node 22.22.2 and npm 10.9.7
- `npm exec prettier -- --write ...`
- `npm exec nx -- run docs-site:check-orphan-pages`
- `npm run build:docs` — passes; existing broken-anchor warnings remain unrelated to these docs changes
- Local Docusaurus preview at `http://localhost:3000/wordpress-playground/developers/apis/javascript-api/php-extensions#try-published-phpwasm-extensions`
