### PR TITLE
Share compiled PHP WASM module across Node CLI workers

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -2529,6 +2529,12 @@ RUN set -euxo pipefail; \
 		# wrapper function.
 		/root/replace.sh $'s/ENVIRONMENT_IS_([A-Z]+)\s*=[^;]*;/ENVIRONMENT_IS_$1=RuntimeName==="$1";/g' /root/output/php.js; \
 		/root/replace.sh 's/var ENV\s*=\s*\{/var ENV = PHPLoader.ENV || {/g' /root/output/php.js; \
+	# Allow runtimes to provide already-compiled dynamic side modules.
+		# Emscripten's loader already accepts WebAssembly.Module objects in
+		# loadWebAssemblyModule(). This hook exposes that path without monkeypatching
+		# the global WebAssembly constructors.
+		/root/replace.sh 's/var preloadedWasm\s*=\s*\{\};/var preloadedWasm = Module["preloadedWasm"] || {};/g' /root/output/php.js; \
+		/root/replace-across-lines.sh 's/var preloaded = preloadedWasm\[libName\];\s*if \(preloaded\) \{\s*return flags\.loadAsync \? Promise\.resolve\(preloaded\) : preloaded;\s*\}/var preloaded = preloadedWasm[libName];\n    if (preloaded) {\n      if (preloaded instanceof WebAssembly.Module) {\n        return loadWebAssemblyModule(preloaded, flags, libName, localScope, handle);\n      }\n      return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;\n    }/s' /root/output/php.js; \
 	# Provide the JSPI longjmp tag for web side modules.
 		# Existing web JSPI binaries do not export __c_longjmp, so the dynamic
 		# linker would otherwise synthesize a JS function stub for a tag import.

--- a/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/asyncify/php_5_2.js
@@ -1358,7 +1358,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4836,8 +4836,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
+++ b/packages/php-wasm/node-builds/5-2/jspi/php_5_2.js
@@ -1324,7 +1324,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4794,8 +4794,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/7-4/asyncify/php_7_4.js
+++ b/packages/php-wasm/node-builds/7-4/asyncify/php_7_4.js
@@ -1358,7 +1358,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4836,8 +4836,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/7-4/jspi/php_7_4.js
+++ b/packages/php-wasm/node-builds/7-4/jspi/php_7_4.js
@@ -1195,7 +1195,7 @@ var registerWasmPlugin = () => {
   preloadPlugins.push(wasmPlugin);
 };
 
-var preloadedWasm = {};
+var preloadedWasm = Module["preloadedWasm"] || {};
 
 var PATH = {
   isAbs: path => path.charAt(0) === "/",
@@ -4325,6 +4325,9 @@ var findLibraryFS = (libName, rpath) => {
     // lookup preloaded cache first
     var preloaded = preloadedWasm[libName];
     if (preloaded) {
+      if (preloaded instanceof WebAssembly.Module) {
+        return loadWebAssemblyModule(preloaded, flags, libName, localScope, handle);
+      }
       return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
     }
     // module not preloaded - load lib data and create new module from it

--- a/packages/php-wasm/node-builds/8-0/asyncify/php_8_0.js
+++ b/packages/php-wasm/node-builds/8-0/asyncify/php_8_0.js
@@ -1358,7 +1358,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4836,8 +4836,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/8-0/jspi/php_8_0.js
+++ b/packages/php-wasm/node-builds/8-0/jspi/php_8_0.js
@@ -1195,7 +1195,7 @@ var registerWasmPlugin = () => {
   preloadPlugins.push(wasmPlugin);
 };
 
-var preloadedWasm = {};
+var preloadedWasm = Module["preloadedWasm"] || {};
 
 var PATH = {
   isAbs: path => path.charAt(0) === "/",
@@ -4325,6 +4325,9 @@ var findLibraryFS = (libName, rpath) => {
     // lookup preloaded cache first
     var preloaded = preloadedWasm[libName];
     if (preloaded) {
+      if (preloaded instanceof WebAssembly.Module) {
+        return loadWebAssemblyModule(preloaded, flags, libName, localScope, handle);
+      }
       return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
     }
     // module not preloaded - load lib data and create new module from it

--- a/packages/php-wasm/node-builds/8-1/asyncify/php_8_1.js
+++ b/packages/php-wasm/node-builds/8-1/asyncify/php_8_1.js
@@ -1358,7 +1358,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4836,8 +4836,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/8-1/jspi/php_8_1.js
+++ b/packages/php-wasm/node-builds/8-1/jspi/php_8_1.js
@@ -1195,7 +1195,7 @@ var registerWasmPlugin = () => {
   preloadPlugins.push(wasmPlugin);
 };
 
-var preloadedWasm = {};
+var preloadedWasm = Module["preloadedWasm"] || {};
 
 var PATH = {
   isAbs: path => path.charAt(0) === "/",
@@ -4325,6 +4325,9 @@ var findLibraryFS = (libName, rpath) => {
     // lookup preloaded cache first
     var preloaded = preloadedWasm[libName];
     if (preloaded) {
+      if (preloaded instanceof WebAssembly.Module) {
+        return loadWebAssemblyModule(preloaded, flags, libName, localScope, handle);
+      }
       return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
     }
     // module not preloaded - load lib data and create new module from it

--- a/packages/php-wasm/node-builds/8-2/asyncify/php_8_2.js
+++ b/packages/php-wasm/node-builds/8-2/asyncify/php_8_2.js
@@ -1358,7 +1358,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4836,8 +4836,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/8-2/jspi/php_8_2.js
+++ b/packages/php-wasm/node-builds/8-2/jspi/php_8_2.js
@@ -1195,7 +1195,7 @@ var registerWasmPlugin = () => {
   preloadPlugins.push(wasmPlugin);
 };
 
-var preloadedWasm = {};
+var preloadedWasm = Module["preloadedWasm"] || {};
 
 var PATH = {
   isAbs: path => path.charAt(0) === "/",
@@ -4325,6 +4325,9 @@ var findLibraryFS = (libName, rpath) => {
     // lookup preloaded cache first
     var preloaded = preloadedWasm[libName];
     if (preloaded) {
+      if (preloaded instanceof WebAssembly.Module) {
+        return loadWebAssemblyModule(preloaded, flags, libName, localScope, handle);
+      }
       return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
     }
     // module not preloaded - load lib data and create new module from it

--- a/packages/php-wasm/node-builds/8-3/asyncify/php_8_3.js
+++ b/packages/php-wasm/node-builds/8-3/asyncify/php_8_3.js
@@ -1358,7 +1358,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4836,8 +4836,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/8-3/jspi/php_8_3.js
+++ b/packages/php-wasm/node-builds/8-3/jspi/php_8_3.js
@@ -1195,7 +1195,7 @@ var registerWasmPlugin = () => {
   preloadPlugins.push(wasmPlugin);
 };
 
-var preloadedWasm = {};
+var preloadedWasm = Module["preloadedWasm"] || {};
 
 var PATH = {
   isAbs: path => path.charAt(0) === "/",
@@ -4325,6 +4325,9 @@ var findLibraryFS = (libName, rpath) => {
     // lookup preloaded cache first
     var preloaded = preloadedWasm[libName];
     if (preloaded) {
+      if (preloaded instanceof WebAssembly.Module) {
+        return loadWebAssemblyModule(preloaded, flags, libName, localScope, handle);
+      }
       return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
     }
     // module not preloaded - load lib data and create new module from it

--- a/packages/php-wasm/node-builds/8-4/asyncify/php_8_4.js
+++ b/packages/php-wasm/node-builds/8-4/asyncify/php_8_4.js
@@ -1358,7 +1358,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4836,8 +4836,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/8-4/jspi/php_8_4.js
+++ b/packages/php-wasm/node-builds/8-4/jspi/php_8_4.js
@@ -1195,7 +1195,7 @@ var registerWasmPlugin = () => {
   preloadPlugins.push(wasmPlugin);
 };
 
-var preloadedWasm = {};
+var preloadedWasm = Module["preloadedWasm"] || {};
 
 var PATH = {
   isAbs: path => path.charAt(0) === "/",
@@ -4325,6 +4325,9 @@ var findLibraryFS = (libName, rpath) => {
     // lookup preloaded cache first
     var preloaded = preloadedWasm[libName];
     if (preloaded) {
+      if (preloaded instanceof WebAssembly.Module) {
+        return loadWebAssemblyModule(preloaded, flags, libName, localScope, handle);
+      }
       return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
     }
     // module not preloaded - load lib data and create new module from it

--- a/packages/php-wasm/node-builds/8-5/asyncify/php_8_5.js
+++ b/packages/php-wasm/node-builds/8-5/asyncify/php_8_5.js
@@ -1358,7 +1358,7 @@ export function init(RuntimeName, PHPLoader) {
 		preloadPlugins.push(wasmPlugin);
 	};
 
-	var preloadedWasm = {};
+	var preloadedWasm = Module["preloadedWasm"] || {};
 
 	var PATH = {
 		isAbs: (path) => path.charAt(0) === '/',
@@ -4836,8 +4836,29 @@ export function init(RuntimeName, PHPLoader) {
 		function getExports() {
 			// lookup preloaded cache first
 			var preloaded = preloadedWasm[libName];
+
 			if (preloaded) {
+
+				if (preloaded instanceof WebAssembly.Module) {
+
+					return loadWebAssemblyModule(
+
+						preloaded,
+
+						flags,
+
+						libName,
+
+						localScope,
+
+						handle
+
+					);
+
+				}
+
 				return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
+
 			}
 			// module not preloaded - load lib data and create new module from it
 			if (flags.loadAsync) {

--- a/packages/php-wasm/node-builds/8-5/jspi/php_8_5.js
+++ b/packages/php-wasm/node-builds/8-5/jspi/php_8_5.js
@@ -1195,7 +1195,7 @@ var registerWasmPlugin = () => {
   preloadPlugins.push(wasmPlugin);
 };
 
-var preloadedWasm = {};
+var preloadedWasm = Module["preloadedWasm"] || {};
 
 var PATH = {
   isAbs: path => path.charAt(0) === "/",
@@ -4325,6 +4325,9 @@ var findLibraryFS = (libName, rpath) => {
     // lookup preloaded cache first
     var preloaded = preloadedWasm[libName];
     if (preloaded) {
+      if (preloaded instanceof WebAssembly.Module) {
+        return loadWebAssemblyModule(preloaded, flags, libName, localScope, handle);
+      }
       return flags.loadAsync ? Promise.resolve(preloaded) : preloaded;
     }
     // module not preloaded - load lib data and create new module from it

--- a/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
+++ b/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
@@ -102,12 +102,42 @@ export async function withPHPExtensions(
 		return options;
 	}
 
-	const resolvedExtensions = await Promise.all(
+	const resolvedExtensions = await resolveRuntimePHPExtensions(
+		version,
+		asyncMode,
+		extensions
+	);
+	return withResolvedPHPExtensions(options, resolvedExtensions);
+}
+
+export async function resolveRuntimePHPExtensions(
+	version: SupportedPHPVersion,
+	asyncMode: PHPWasmAsyncMode,
+	extensions: PHPExtension[] = []
+): Promise<ResolvedPHPExtension[]> {
+	return await Promise.all(
 		extensions.map((extension) =>
 			resolveRuntimePHPExtension(version, asyncMode, extension)
 		)
 	);
-	return withResolvedPHPExtensions(options, resolvedExtensions);
+}
+
+export async function compilePHPExtensionWasmModules(
+	version: SupportedPHPVersion,
+	asyncMode: PHPWasmAsyncMode,
+	extensions: PHPExtension[] = []
+) {
+	const resolvedExtensions = await resolveRuntimePHPExtensions(
+		version,
+		asyncMode,
+		extensions
+	);
+	return await Promise.all(
+		resolvedExtensions.map(async ({ soPath, soBytes }) => ({
+			soPath,
+			module: await WebAssembly.compile(soBytes),
+		}))
+	);
 }
 
 /**

--- a/packages/php-wasm/node/src/lib/index.ts
+++ b/packages/php-wasm/node/src/lib/index.ts
@@ -1,6 +1,7 @@
 export * from './get-php-loader-module';
 export * from './networking/with-networking';
 export * from './load-runtime';
+export { compilePHPExtensionWasmModules } from './extensions/load-extensions';
 export * from './use-host-filesystem';
 export * from './node-fs-mount';
 export * from './file-lock-manager-for-posix';

--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -14,7 +14,7 @@ import {
 import type { WasmUserSpaceAPI, WasmUserSpaceContext } from './wasm-user-space';
 import { bindUserSpace } from './wasm-user-space';
 import fs from 'fs';
-import { getPHPLoaderModule } from '.';
+import { getPHPLoaderModule } from './get-php-loader-module';
 import { FileLockManagerForPosix } from './file-lock-manager-for-posix';
 import { FileLockManagerForWindows } from './file-lock-manager-for-windows';
 import { withNetworking } from './networking/with-networking';
@@ -55,7 +55,21 @@ export interface PHPLoaderOptions {
 	withMemcached?: boolean;
 }
 
+export interface PrecompiledPHPSideModule {
+	soPath: string;
+	module: WebAssembly.Module;
+}
+
 export type PHPLoaderOptionsForNode = PHPLoaderOptions & {
+	/**
+	 * A precompiled main PHP WebAssembly module. Supplying this avoids
+	 * reading and compiling the same .wasm file in every Node.js worker.
+	 */
+	precompiledWasmModule?: WebAssembly.Module;
+	/**
+	 * Precompiled dynamic PHP extension side modules, keyed by their bytes.
+	 */
+	precompiledSideModules?: PrecompiledPHPSideModule[];
 	/**
 	 * A file lock manager to coordinate file locks between
 	 * multiple php-wasm instances and other OS processes.
@@ -377,10 +391,54 @@ export async function loadNodeRuntime(
 
 	emscriptenOptions = await withNetworking(emscriptenOptions);
 
-	const phpLoaderModule = await getPHPLoaderModule(phpVersion);
+	if (options.precompiledWasmModule) {
+		emscriptenOptions = {
+			...emscriptenOptions,
+			instantiateWasm(imports, receiveInstance) {
+				Promise.resolve()
+					.then(
+						() =>
+							new WebAssembly.Instance(
+								options.precompiledWasmModule!,
+								imports
+							)
+					)
+					.then((instance) => {
+						receiveInstance(
+							instance,
+							options.precompiledWasmModule!
+						);
+					});
+				return {};
+			},
+		};
+	}
 
+	if (options.precompiledSideModules?.length) {
+		emscriptenOptions = {
+			...emscriptenOptions,
+			preloadedWasm: Object.fromEntries(
+				options.precompiledSideModules.map(({ soPath, module }) => [
+					soPath,
+					module,
+				])
+			),
+		};
+	}
+
+	const phpLoaderModule = await getPHPLoaderModule(phpVersion);
 	const runtimeId = await loadPHPRuntime(phpLoaderModule, emscriptenOptions);
 	return runtimeId;
+}
+
+export async function compileNodeRuntimeWasmModule(
+	phpVersion: AllPHPVersion
+): Promise<WebAssembly.Module> {
+	const phpLoaderModule = await getPHPLoaderModule(phpVersion);
+	const wasmBytes = await fs.promises.readFile(
+		phpLoaderModule.dependencyFilename
+	);
+	return await WebAssembly.compile(wasmBytes);
 }
 
 /**

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -18,7 +18,12 @@ import {
 	bootWordPress,
 } from '@wp-playground/wordpress';
 import { rootCertificates } from 'tls';
-import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
+import {
+	MessageChannel,
+	type MessagePort,
+	parentPort,
+	workerData,
+} from 'worker_threads';
 import { mountResources } from '../mounts';
 import { logger } from '@php-wasm/logger';
 import { spawnWorkerThread } from '../run-cli';
@@ -239,6 +244,10 @@ function createPhpRuntimeFactory(
 			options.phpVersion || RecommendedPHPVersion,
 			{
 				fileLockManager,
+				precompiledWasmModule: (workerData as any)
+					?.precompiledWasmModule,
+				precompiledSideModules: (workerData as any)
+					?.precompiledSideModules,
 				emscriptenOptions: {
 					processId: options.processId,
 					trace: options.trace ? tracePhpWasm : undefined,

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -46,7 +46,12 @@ import {
 import { existsSync } from 'fs';
 import path from 'path';
 import { rootCertificates } from 'tls';
-import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
+import {
+	MessageChannel,
+	type MessagePort,
+	parentPort,
+	workerData,
+} from 'worker_threads';
 import { type RunCLIArgs, spawnWorkerThread } from '../run-cli';
 import type {
 	PhpIniOptions,
@@ -466,6 +471,10 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 				createPhpRuntime: async () => {
 					return await loadNodeRuntime(phpVersion, {
 						fileLockManager: this.fileLockManager!,
+						precompiledWasmModule: (workerData as any)
+							?.precompiledWasmModule,
+						precompiledSideModules: (workerData as any)
+							?.precompiledSideModules,
 						emscriptenOptions: {
 							processId,
 							trace: trace ? tracePhpWasm : undefined,

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -7,6 +7,7 @@ import {
 	type PathAlias,
 	type RemoteAPI,
 	type AllPHPVersion,
+	type SupportedPHPVersion,
 } from '@php-wasm/universal';
 import {
 	PHPResponse,
@@ -20,6 +21,7 @@ import type {
 	BlueprintBundle,
 	BlueprintV1Declaration,
 	BlueprintV2Declaration,
+	CompiledBlueprintV1,
 } from '@wp-playground/blueprints';
 import {
 	compileBlueprintV1,
@@ -28,7 +30,11 @@ import {
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import fs, { existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
 import type { Server } from 'http';
-import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
+import {
+	MessageChannel as NodeMessageChannel,
+	Worker,
+	workerData,
+} from 'worker_threads';
 // @ts-ignore
 import {
 	expandAutoMounts,
@@ -43,7 +49,12 @@ import {
 import { isPortInUse, startServer } from './start-server';
 import type { PlaygroundCliBlueprintV1Worker } from './blueprints-v1/worker-thread-v1';
 import type { PlaygroundCliBlueprintV2Worker } from './blueprints-v2/worker-thread-v2';
-import type { XdebugOptions } from '@php-wasm/node';
+import {
+	compileNodeRuntimeWasmModule,
+	compilePHPExtensionWasmModules,
+	type PrecompiledPHPSideModule,
+	type XdebugOptions,
+} from '@php-wasm/node';
 /* eslint-disable no-console */
 import {
 	AllPHPVersions,
@@ -84,6 +95,7 @@ import {
 	PHPMYADMIN_INSTALL_PATH,
 } from '@wp-playground/tools';
 import { jspi } from 'wasm-feature-detect';
+import { cliExtensionArgsToExtensionsArray } from './php-extensions';
 
 // Inlined worker URLs for static analysis by downstream bundlers
 // These are replaced at build time by the Vite plugin in vite.config.ts
@@ -973,7 +985,35 @@ export interface RunCLIServer extends AsyncDisposable {
 	// Provide some details and helpers for automated testing.
 	[internalsKeyForTesting]: {
 		workerThreadCount: number;
+		bootedWorkerCount: () => number;
 	};
+}
+
+function createMutablePooledProxy<T extends object>(
+	getPool: () => Pooled<T>
+): Pooled<T> {
+	return new Proxy({} as Pooled<T>, {
+		get(_target, prop: string | symbol) {
+			if (prop === 'then') {
+				return undefined;
+			}
+			return new Proxy(function () {}, {
+				apply(_target, _thisArg, args: any[]) {
+					return (getPool() as any)[prop](...args);
+				},
+				get(_target, innerProp) {
+					if (innerProp === 'then') {
+						return (resolve: any, reject: any) =>
+							Promise.resolve((getPool() as any)[prop]).then(
+								resolve,
+								reject
+							);
+					}
+					return undefined;
+				},
+			});
+		},
+	});
 }
 
 // These overloads are declared for convenience so runCLI() can return
@@ -1107,6 +1147,64 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				typeof args.blueprint === 'string' ? args.blueprint : undefined,
 		});
 	}
+
+	const shouldShareWasmModule =
+		process.env['PLAYGROUND_CLI_SHARE_WASM_MODULE'] === '1';
+	let precompiledWasmModulePromise: Promise<WebAssembly.Module> | undefined;
+	let precompiledSideModulesPromise:
+		| Promise<PrecompiledPHPSideModule[]>
+		| undefined;
+	const getPrecompiledWasmModule = () => {
+		if (!shouldShareWasmModule) {
+			return undefined;
+		}
+		if (!precompiledWasmModulePromise) {
+			const startedAt = performance.now();
+			precompiledWasmModulePromise = compileNodeRuntimeWasmModule(
+				args.php || RecommendedPHPVersion
+			).then((module) => {
+				logger.debug(
+					`Compiled shared PHP WASM module in ${(
+						performance.now() - startedAt
+					).toFixed(2)}ms`
+				);
+				return module;
+			});
+		}
+		return precompiledWasmModulePromise;
+	};
+	const getPrecompiledSideModules = () => {
+		if (!shouldShareWasmModule) {
+			return undefined;
+		}
+		if (!precompiledSideModulesPromise) {
+			const startedAt = performance.now();
+			const extensions = cliExtensionArgsToExtensionsArray(args);
+			if (!extensions.length) {
+				precompiledSideModulesPromise = Promise.resolve([]);
+				return precompiledSideModulesPromise;
+			}
+			precompiledSideModulesPromise = jspi()
+				.then((hasJspi) =>
+					compilePHPExtensionWasmModules(
+						(args.php ||
+							RecommendedPHPVersion) as SupportedPHPVersion,
+						hasJspi ? 'jspi' : 'asyncify',
+						extensions
+					)
+				)
+				.then((modules) => {
+					logger.debug(
+						`Compiled ${modules.length} shared PHP extension WASM ` +
+							`module(s) in ${(
+								performance.now() - startedAt
+							).toFixed(2)}ms`
+					);
+					return modules;
+				});
+		}
+		return precompiledSideModulesPromise;
+	};
 
 	const selectedPort = args.command === 'server' ? (args.port ?? 9400) : 0;
 
@@ -1512,14 +1610,18 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			};
 
 			try {
-				const promisesToBoot = [];
 				const workerType = handler.getWorkerType();
-				for (
-					let workerIndex = 0;
-					workerIndex < targetWorkerCount;
-					workerIndex++
-				) {
-					const promiseToBoot = spawnWorkerThread(workerType, {
+				const bootWorker = async (
+					workerIndex: number,
+					options: {
+						precompiledWasmModule?: WebAssembly.Module;
+						precompiledSideModules?: PrecompiledPHPSideModule[];
+					} = {}
+				): Promise<[SpawnedWorker, RemoteAPI<PlaygroundCliWorker>]> => {
+					const startedAt = performance.now();
+					const spawnResult = await spawnWorkerThread(workerType, {
+						precompiledWasmModule: options.precompiledWasmModule,
+						precompiledSideModules: options.precompiledSideModules,
 						onExit: (exitCode: number) => {
 							// We are already disposing, so worker exit is expected
 							// and does not need to be logged.
@@ -1536,55 +1638,43 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 							);
 							// @TODO: Should we respawn the worker if it exited with an error and the CLI is not shutting down?
 						},
-					}).then(
-						async (
-							spawnResult: SpawnedWorker
-						): Promise<
-							[SpawnedWorker, RemoteAPI<PlaygroundCliWorker>]
-						> => {
-							// Remember the worker process before booting the Playground
-							// so we can clean it up if there is an error during boot.
-							spawnedWorkers.push(spawnResult);
+					});
+					if (disposing) {
+						await spawnResult.worker.terminate();
+						throw new Error('Playground CLI is disposing.');
+					}
 
-							const fileLockManagerPort =
-								await exposeFileLockManager(fileLockManager);
-							const playgroundApi =
-								await handler.bootRequestHandler({
-									worker: spawnResult,
-									fileLockManagerPort,
-									nativeInternalDirPath,
-								});
+					// Remember the worker process before booting the Playground
+					// so we can clean it up if there is an error during boot.
+					spawnedWorkers.push(spawnResult);
 
-							workerToPlaygroundMap.set(
-								spawnResult,
-								playgroundApi
-							);
+					const fileLockManagerPort =
+						await exposeFileLockManager(fileLockManager);
+					const playgroundApi = await handler.bootRequestHandler({
+						worker: spawnResult,
+						fileLockManagerPort,
+						nativeInternalDirPath,
+					});
 
-							return [spawnResult, playgroundApi];
-						}
+					workerToPlaygroundMap.set(spawnResult, playgroundApi);
+					logger.debug(
+						`Worker ${workerIndex} request handler booted in ${(
+							performance.now() - startedAt
+						).toFixed(2)}ms`
 					);
 
-					promisesToBoot.push(promiseToBoot);
+					return [spawnResult, playgroundApi];
+				};
 
-					// TODO: Remove this workaround after we remove the inherent race
-					// from @wp-playground/wordpress's bootRequestHandler() function.
-					if (workerIndex === 0) {
-						// Wait for the first worker to boot to avoid a race condition
-						// with writing initial PHP files in bootRequestHandler().
-						// This is the race condition:
-						// https://github.com/WordPress/wordpress-playground/blob/e758ee0893d199416a2d740195815234584b1b44/packages/playground/wordpress/src/boot.ts#L416-L426
-						// Multiple workers may detect that .boot-files-written does not exist
-						// and proceed to try to write initial boot files.
-						await promiseToBoot;
-					}
-				}
-
-				await Promise.all(promisesToBoot);
+				await bootWorker(0);
 				playgroundPool = createObjectPoolProxy(
 					spawnedWorkers.map(
 						(spawnedWorker) =>
 							workerToPlaygroundMap.get(spawnedWorker)!
 					)
+				);
+				const playgroundForReturn = createMutablePooledProxy(
+					() => playgroundPool
 				);
 
 				// NOTE: Using a free-standing block to isolate initial boot vars
@@ -1616,27 +1706,96 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 						undefined,
 						mainThreadPostInstallMountsPort
 					);
+					const bootWordPressStartedAt = performance.now();
 					await handler.bootWordPress(
 						playgroundPool,
 						workerPostInstallMountsPort
 					);
 					mainThreadPostInstallMountsPort.close();
+					logger.debug(
+						`bootWordPress completed in ${(
+							performance.now() - bootWordPressStartedAt
+						).toFixed(2)}ms`
+					);
 
-					wordPressReady = true;
-
+					let compiledBlueprint: CompiledBlueprintV1 | undefined;
 					if (!args['experimental-blueprints-v2-runner']) {
-						const compiledBlueprint = await (
+						compiledBlueprint = await (
 							handler as BlueprintsV1Handler
 						).compileInputBlueprint(
 							args['additional-blueprint-steps'] || []
 						);
+					}
+					const hasPostBootSteps =
+						!!compiledBlueprint || !!args.phpmyadmin;
 
-						if (compiledBlueprint) {
-							await runBlueprintV1Steps(
-								compiledBlueprint,
-								playgroundPool
-							);
-						}
+					const bootSecondaryWorkers = async () => {
+						const startedAt = performance.now();
+						const [secondaryWasmModule, secondarySideModules] =
+							await Promise.all([
+								getPrecompiledWasmModule(),
+								getPrecompiledSideModules(),
+							]);
+						await Promise.all(
+							Array.from(
+								{ length: targetWorkerCount - 1 },
+								(_, workerIndex) => workerIndex + 1
+							).map(async (workerIndex) => {
+								const [, playground] = await bootWorker(
+									workerIndex,
+									{
+										precompiledWasmModule:
+											secondaryWasmModule,
+										precompiledSideModules:
+											secondarySideModules,
+									}
+								);
+								await playground.mountAfterWordPressInstall(
+									args['mount'] || []
+								);
+							})
+						);
+						playgroundPool = createObjectPoolProxy(
+							spawnedWorkers.map(
+								(spawnedWorker) =>
+									workerToPlaygroundMap.get(spawnedWorker)!
+							)
+						);
+						logger.debug(
+							`Secondary workers booted in ${(
+								performance.now() - startedAt
+							).toFixed(2)}ms`
+						);
+					};
+					if (args.command === 'server' && !hasPostBootSteps) {
+						wordPressReady = true;
+						setTimeout(() => {
+							void bootSecondaryWorkers().catch((error) => {
+								if (!disposing) {
+									logger.error(
+										'Failed to boot secondary workers:',
+										error
+									);
+								}
+							});
+						}, 0);
+					} else {
+						// Blueprint/phpMyAdmin setup should observe the final worker pool,
+						// and requests should wait until that setup is complete.
+						await bootSecondaryWorkers();
+					}
+
+					if (compiledBlueprint) {
+						const blueprintStartedAt = performance.now();
+						await runBlueprintV1Steps(
+							compiledBlueprint,
+							playgroundPool
+						);
+						logger.debug(
+							`Blueprint v1 steps completed in ${(
+								performance.now() - blueprintStartedAt
+							).toFixed(2)}ms`
+						);
 					}
 
 					// If phpMyAdmin is enabled and not already installed, install it.
@@ -1696,6 +1855,8 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				cliOutput.finishProgress();
 				cliOutput.printReady(serverUrl, targetWorkerCount);
 
+				wordPressReady = true;
+
 				if (args.phpmyadmin) {
 					const phpMyAdminPath = path.join(
 						args.phpmyadmin as string,
@@ -1716,12 +1877,13 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				}
 
 				return {
-					playground: playgroundPool,
+					playground: playgroundForReturn,
 					server,
 					serverUrl,
 					[Symbol.asyncDispose]: disposeCLI,
 					[internalsKeyForTesting]: {
 						workerThreadCount: targetWorkerCount,
+						bootedWorkerCount: () => workerToPlaygroundMap.size,
 					},
 				};
 			} catch (error) {
@@ -1944,7 +2106,15 @@ export type SpawnedWorker = {
  */
 export function spawnWorkerThread(
 	workerType: 'v1' | 'v2',
-	{ onExit }: { onExit?: (code: number) => void } = {}
+	{
+		onExit,
+		precompiledWasmModule = (workerData as any)?.precompiledWasmModule,
+		precompiledSideModules = (workerData as any)?.precompiledSideModules,
+	}: {
+		onExit?: (code: number) => void;
+		precompiledWasmModule?: WebAssembly.Module;
+		precompiledSideModules?: PrecompiledPHPSideModule[];
+	} = {}
 ) {
 	/**
 	 * When running the CLI from source via `node cli.ts`, the Vite-provided
@@ -1960,10 +2130,20 @@ export function spawnWorkerThread(
 		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
 	}
 	let worker: Worker;
+	const workerOptions =
+		precompiledWasmModule || precompiledSideModules
+			? { workerData: { precompiledWasmModule, precompiledSideModules } }
+			: undefined;
 	if (workerType === 'v1') {
-		worker = new Worker(new URL(__WORKER_V1_URL__, import.meta.url));
+		worker = new Worker(
+			new URL(__WORKER_V1_URL__, import.meta.url),
+			workerOptions
+		);
 	} else {
-		worker = new Worker(new URL(__WORKER_V2_URL__, import.meta.url));
+		worker = new Worker(
+			new URL(__WORKER_V2_URL__, import.meta.url),
+			workerOptions
+		);
 	}
 
 	return new Promise<SpawnedWorker>((resolve, reject) => {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -196,10 +196,11 @@ describe.each(blueprintVersions)(
 			expect(text).toContain(oldestSupportedVersion);
 		});
 
-		test('should run blueprint', async () => {
+		test('should run blueprint after secondary workers boot', async () => {
 			await using cliServer = await runCLI({
 				...suiteCliArgs,
 				command: 'server',
+				workers: 2,
 				blueprint: {
 					steps: [
 						{
@@ -211,11 +212,22 @@ describe.each(blueprintVersions)(
 					],
 				},
 			});
+
+			expect(cliServer[internalsKeyForTesting].bootedWorkerCount()).toBe(
+				2
+			);
+
 			const homeUrl = new URL('/', cliServer.serverUrl);
-			const response = await fetch(homeUrl);
-			expect(response.status).toBe(200);
-			const text = await response.text();
-			expect(text).toContain('<title>My Blog Name</title>');
+			const responses = await Promise.all([
+				fetch(homeUrl),
+				fetch(homeUrl),
+				fetch(homeUrl),
+			]);
+			for (const response of responses) {
+				expect(response.status).toBe(200);
+				const text = await response.text();
+				expect(text).toContain('<title>My Blog Name</title>');
+			}
 		});
 
 		test('should be able to follow external symlinks in primary and secondary PHP instances', async ({


### PR DESCRIPTION
## Problem

Starting multiple Node.js Playground CLI workers makes every worker read and compile the same PHP WASM artifacts. That is wasted startup work and creates transient memory pressure when 6+ workers boot concurrently.

However, sharing compiled modules alone is not enough to make full CLI startup dramatically faster because the normal startup critical path is dominated by primary PHP/WordPress boot. The real startup win comes from not putting secondary workers on that critical path.

## Implementation

- Adds `precompiledWasmModule?: WebAssembly.Module` to `loadNodeRuntime()`.
- Adds `compileNodeRuntimeWasmModule(phpVersion)` for Node callers that want to compile the main PHP WASM once.
- Adds `precompiledSideModules?: PrecompiledPHPSideModule[]` to reuse precompiled dynamic extension modules, too.
- Adds `compilePHPExtensionWasmModules(...)` for Node callers that want to precompile requested PHP extensions once.
- Patches the generated Node PHP loaders to accept `Module["preloadedWasm"]` entries where the value is a `WebAssembly.Module`.
  - This uses Emscripten's existing `loadWebAssemblyModule()` support for module objects.
  - This replaces the earlier prototype that monkeypatched global `WebAssembly.Module` / `WebAssembly.instantiate`.
- Updates the PHP build Dockerfile so regenerated loaders keep the same precompiled-side-module hook.
- Wires an env-gated CLI experiment: `PLAYGROUND_CLI_SHARE_WASM_MODULE=1`.
- Starts only the primary CLI worker before WordPress boot.
- Starts secondary server workers after WordPress boot. Plain server startup backgrounds them; server startup with Blueprint/phpMyAdmin post-boot steps waits for secondary workers first so those steps run against the final worker pool.
- When module sharing is enabled, the shared main and extension modules are compiled for secondary workers only, avoiding extra parent compile work on the primary-ready critical path.
- Nested PHP workers spawned from CLI workers inherit the same structured-cloned `WebAssembly.Module`s.

This shares compiled WASM code for the main module and extension side modules. It does not share PHP linear memory, extension globals, request state, or steady per-worker heap usage.

## Node.js measurements

I measured the source CLI in Node.js. The benchmark starts a server from source in a fresh child process per sample. These are local macOS measurements and are noisy, so treat them as directional.

### Before lazy worker boot, main-module sharing only

Focused worker boot path (`wordpressInstallMode: do-not-attempt-installing`, SQLite skipped, Intl disabled):

| Node.js | Workers | Mode | Samples | Avg startup | Avg RSS at ready |
|---|---:|---|---:|---:|---:|
| 23.11.0 JSPI | 6 | isolated | 3 | 1352 ms | 1483 MiB |
| 23.11.0 JSPI | 6 | shared module | 3 | 1258 ms | 1299 MiB |

Full CLI server startup with normal WordPress install, Node 23.11.0 + JSPI, 6 workers:

| Mode | Samples | Avg startup | Avg RSS at ready |
|---|---:|---:|---:|
| isolated | 2 | 6562 ms | 1417 MiB |
| shared module | 2 | 6047 ms | 1374 MiB |

### With lazy secondary-worker boot and generated-loader sharing for main + extension modules

Focused worker boot path (`wordpressInstallMode: do-not-attempt-installing`, SQLite skipped, Intl enabled), Node 23.11.0 + JSPI, 6 workers:

| Mode | Samples | Avg startup | Avg RSS at ready |
|---|---:|---:|---:|
| isolated primary, lazy secondary | 3 | 1094 ms | 1627 MiB |
| isolated primary, lazy shared secondary | 3 | 1096 ms | 1336 MiB |

Full CLI server startup with normal WordPress install, Node 23.11.0 + JSPI, 6 workers:

| Mode | Samples | Avg startup | Avg RSS at ready |
|---|---:|---:|---:|
| isolated primary, lazy secondary | 2 | 5760 ms | 1769 MiB |
| isolated primary, lazy shared secondary | 2 | 5364 ms | 1532 MiB |

Takeaway: lazy secondary-worker boot is the real startup-path optimization. Module sharing is still useful, but mostly as a secondary/background-worker memory spike optimization. Sharing extension modules through the generated loader gives a clearer RSS win when side modules such as Intl are enabled.

## What this shares, and what it cannot share yet

Shared now:

- Main PHP compiled `WebAssembly.Module` for secondary CLI workers.
- Dynamic extension compiled `WebAssembly.Module`s for secondary CLI workers.
- Existing shared NodeFS directories such as `/wordpress` and `/internal`, including OPcache file-cache contents.

Not shared by this PR:

- The mutable PHP/WASM linear memory of each worker.
- Zend/PHP globals, extension globals, allocator state, request state, stack, or heap.

I explored whether we could split/share the built WASM like OS DLL pages. The current artifacts still use one WebAssembly memory per PHP runtime. Emscripten's dynamic loader allocates side-module static memory into that same main linear memory via `__memory_base`/`getMemory(...)`, and side modules import `GOT.mem.*` globals that are relocated into that per-worker memory.

So compiled code can be shared with `WebAssembly.Module`, but immutable/static data pages cannot be shared between independent PHP workers with the current ABI. A true DLL-like approach would need a different toolchain/runtime strategy, likely multi-memory-aware Emscripten/PHP builds or a threads/shared-memory build, and then a careful separation of read-only data from mutable PHP state.

## Caveats

- This is env-gated because it changes the loader path and needs review across Node versions/bundles.
- `WebAssembly.Module` sharing lowers compile/read duplication for secondary workers. It does not solve steady per-worker PHP memory.
- These local macOS measurements do not capture peak RSS as well as the Windows PoC harness. The Windows harness showed the clearer peak-memory win.
- The full WordPress install path is still dominated by WordPress install work, so this optimization is more visible in worker-heavy startup than in install-heavy startup.

## Validation

- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run php-wasm-node:typecheck`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run playground-cli:typecheck`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run php-wasm-node:lint`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run playground-cli:lint`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run php-wasm-node:build:bundle`
- `PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec nx run playground-cli:build:bundle`
- `PLAYGROUND_CLI_SHARE_WASM_MODULE=1 PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec -- vitest run tests/run-cli.spec.ts --config packages/playground/cli/vite.config.ts -t "Intl extension"`
- `PLAYGROUND_CLI_SHARE_WASM_MODULE=1 PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec -- vitest run tests/run-cli.spec.ts --config packages/playground/cli/vite.config.ts -t "should set PHP version"`
- `PLAYGROUND_CLI_SHARE_WASM_MODULE=1 PATH=/usr/local/opt/node@22/bin:/opt/homebrew/opt/node@22/bin:$PATH npm exec -- vitest run tests/run-cli.spec.ts --config packages/playground/cli/vite.config.ts -t "blueprint after secondary"`
