### PR TITLE
[Website] Fix site manager pane gap at medium widths

### DIFF
--- a/packages/playground/website/src/components/layout/style.module.css
+++ b/packages/playground/website/src/components/layout/style.module.css
@@ -91,6 +91,7 @@ body {
 
 .site-view {
 	position: relative;
+	box-sizing: border-box;
 	flex: 1 1 auto;
 	min-width: var(--site-view-min-width);
 	height: 100dvh;
@@ -143,6 +144,10 @@ body {
 			100vw - (2 * var(--site-manager-border-width)) -
 				var(--site-manager-site-list-width)
 		);
+	}
+	.site-manager-wrapper + .site-view {
+		border-top-width: var(--site-manager-border-width);
+		border-left-width: var(--site-manager-border-width);
 	}
 	.site-manager-wrapper-exit-active + .site-view {
 		display: block;


### PR DESCRIPTION
## What it does

Fixes the medium-width site manager layout so the left settings pane and right WordPress preview stay visually separated at widths like `1078px`.


Screenshot at `1078 × 627`:

![Site manager panes separated at 1078px](https://gist.githubusercontent.com/adamziel/db2d14735df95e79abef01c8dda723b0/raw/43d6b01c8de6af389af909371fef1229cd0f8c35/pr-3698-pane-gap.png)

## Rationale

At this breakpoint, the preview kept its right/bottom frame but lost the top/left gutter. That made the two panes look merged instead of matching the separated card treatment used at nearby breakpoints.

## Implementation

- Adds `box-sizing: border-box` to `.site-view` so its frame stays inside the available flex width.
- Restores the preview's top and left `--site-manager-border-width` inside the existing `max-width: 1126px` breakpoint.

## Testing instructions

1. Run `npm run dev`.
2. Open `http://127.0.0.1:5400/website-server/`.
3. Resize the viewport to `1078 × 627` and open the site manager.
4. Verify the two panes have a dark gutter between them and rounded edges.

Checked locally with:

```bash
git diff --check origin/trunk...HEAD
npx nx lint playground-website
```

