### PR TITLE
Preview Playground PR builds from artifacts

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -125,6 +125,15 @@ import {
 	purgeEverythingFromPreviousRelease,
 	shouldCacheUrl,
 } from './src/lib/offline-mode-cache';
+import {
+	getPlaygroundPrPreviewFromUrl,
+	mapToPlaygroundPrPreviewUrl,
+	shouldBypassPlaygroundPrPreview,
+	shouldMapToPlaygroundPrPreview,
+} from './src/lib/playground-pr-preview';
+
+const playgroundPrPreview = getPlaygroundPrPreviewFromUrl(self.location.href);
+const playgroundPrPreviewClientIds = new Set<string>();
 
 if (!(self as any).document) {
 	// Workaround: vite translates import.meta.url
@@ -192,7 +201,9 @@ self.addEventListener('activate', function (event) {
 
 		if (shouldCacheUrl(new URL(location.href))) {
 			await purgeEverythingFromPreviousRelease();
-			cacheOfflineModeAssetsForCurrentRelease();
+			cacheOfflineModeAssetsForCurrentRelease(
+				playgroundPrPreview?.basePath
+			);
 		}
 	}
 	event.waitUntil(doActivate());
@@ -207,6 +218,10 @@ self.addEventListener('fetch', (event) => {
 
 	// Don't handle requests to the service worker script itself.
 	if (url.pathname.startsWith(self.location.pathname)) {
+		return;
+	}
+
+	if (shouldBypassPlaygroundPrPreview(url)) {
 		return;
 	}
 
@@ -293,7 +308,12 @@ self.addEventListener('fetch', (event) => {
 		}
 	}
 
-	if (!shouldCacheUrl(new URL(event.request.url))) {
+	const effectiveUrl = getEffectiveStaticAssetUrl(event, url, referrerUrl);
+	if (!effectiveUrl) {
+		return;
+	}
+
+	if (!shouldCacheUrl(effectiveUrl)) {
 		/**
 		 * It's safe to use the regular `fetch` function here.
 		 *
@@ -305,6 +325,11 @@ self.addEventListener('fetch', (event) => {
 		 */
 		return;
 	}
+
+	const effectiveRequest =
+		effectiveUrl.href === url.href
+			? Promise.resolve(event.request)
+			: cloneRequest(event.request, { url: effectiveUrl });
 
 	/**
 	 * Always fetch the fresh version of `/remote.html` and `/` from the network.
@@ -335,13 +360,67 @@ self.addEventListener('fetch', (event) => {
 	 * details.
 	 */
 	if (url.pathname === '/remote.html' || url.pathname === '/') {
-		event.respondWith(networkFirstFetch(event.request));
+		event.respondWith(effectiveRequest.then(networkFirstFetch));
 		return;
 	}
 
 	// Use cache first strategy to serve regular static assets.
-	return event.respondWith(cacheFirstFetch(event.request));
+	return event.respondWith(effectiveRequest.then(cacheFirstFetch));
 });
+
+function getEffectiveStaticAssetUrl(
+	event: FetchEvent,
+	url: URL,
+	referrerUrl?: URL
+): URL | undefined {
+	if (!playgroundPrPreview || url.origin !== self.location.origin) {
+		return url;
+	}
+
+	if (isPreviewNavigationRequest(event.request)) {
+		const clientId = event.resultingClientId || event.clientId;
+		if (isPlaygroundPrPreviewUrl(url)) {
+			if (clientId) {
+				playgroundPrPreviewClientIds.add(clientId);
+			}
+			return mapStaticAssetToPlaygroundPrPreview(url);
+		}
+
+		if (clientId) {
+			playgroundPrPreviewClientIds.delete(clientId);
+		}
+		return url;
+	}
+
+	const isPreviewClient =
+		!!event.clientId && playgroundPrPreviewClientIds.has(event.clientId);
+	const hasPreviewReferrer =
+		!!referrerUrl && isPlaygroundPrPreviewUrl(referrerUrl);
+	if (!isPreviewClient && !hasPreviewReferrer) {
+		return url;
+	}
+
+	return mapStaticAssetToPlaygroundPrPreview(url);
+}
+
+function mapStaticAssetToPlaygroundPrPreview(url: URL): URL | undefined {
+	if (!playgroundPrPreview || !shouldMapToPlaygroundPrPreview(url)) {
+		return undefined;
+	}
+
+	return mapToPlaygroundPrPreviewUrl(url, playgroundPrPreview);
+}
+
+function isPreviewNavigationRequest(request: Request) {
+	return request.mode === 'navigate';
+}
+
+function isPlaygroundPrPreviewUrl(url: URL) {
+	return (
+		url.searchParams.get('playground-pr') === playgroundPrPreview?.pr &&
+		url.searchParams.get('playground-pr-sha') === playgroundPrPreview?.sha
+	);
+}
 
 /**
  * A request to a PHP Worker Thread or to a regular static asset,
@@ -382,8 +461,10 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 		) {
 			resolvedUrl.pathname = `/${staticAssetsDirectory}${resolvedUrl.pathname}`;
 		}
+		const staticAssetUrl =
+			mapStaticAssetToPlaygroundPrPreview(resolvedUrl) || resolvedUrl;
 		const request = await cloneRequest(event.request, {
-			url: resolvedUrl,
+			url: staticAssetUrl,
 			// Omit credentials to avoid causing cache aborts due to presence of
 			// cookies
 			credentials: 'omit',

--- a/packages/playground/remote/src/lib/boot-playground-remote.ts
+++ b/packages/playground/remote/src/lib/boot-playground-remote.ts
@@ -26,6 +26,10 @@ import type { FilesystemOperation } from '@php-wasm/fs-journal';
 import { logger } from '@php-wasm/logger';
 import { PhpWasmError } from '@php-wasm/util';
 import { responseTo } from '@php-wasm/web-service-worker';
+import {
+	getPlaygroundPrPreviewServiceWorkerUrl,
+	playgroundPrPreviewServiceWorkerPath,
+} from './playground-pr-preview';
 
 // Select worker runtime (v1 or v2) based on query parameter
 // @ts-ignore
@@ -47,7 +51,11 @@ function getWorkerUrl(): string {
 	return new URL(selected, origin) + '';
 }
 
-export const serviceWorkerUrl = new URL(serviceWorkerPath, origin);
+export const serviceWorkerUrl = getPlaygroundPrPreviewServiceWorkerUrl(
+	serviceWorkerPath,
+	origin,
+	document.location.href
+);
 
 // Prevent Vite from hot-reloading this file – it would
 // cause bootPlaygroundRemote() to register another web worker
@@ -89,7 +97,9 @@ export async function bootPlaygroundRemote() {
 	}
 
 	const registration = await sw.register(serviceWorkerUrl + '', {
-		type: 'module',
+		...(serviceWorkerUrl.pathname === playgroundPrPreviewServiceWorkerPath
+			? {}
+			: { type: 'module' as const }),
 		// Always bypass HTTP cache when fetching the new Service Worker script:
 		updateViaCache: 'none',
 	});

--- a/packages/playground/remote/src/lib/offline-mode-cache.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.ts
@@ -109,13 +109,17 @@ export async function networkFirstFetch(request: Request): Promise<Response> {
  * file and contain JavaScript, CSS, and other assets required to load the
  * site without making any network requests.
  */
-export async function cacheOfflineModeAssetsForCurrentRelease(): Promise<any> {
+export async function cacheOfflineModeAssetsForCurrentRelease(
+	basePath = '/'
+): Promise<any> {
 	// Get the cache manifest and add all the files to the cache
 	const manifestResponse = await fetchFresh(
-		'/assets-required-for-offline-mode.json'
+		`${basePath}assets-required-for-offline-mode.json`
 	);
 	const requiredOfflineAssetUrls = await manifestResponse.json();
-	const urlsToCache = ['/', ...requiredOfflineAssetUrls];
+	const urlsToCache = ['/', ...requiredOfflineAssetUrls].map((url) =>
+		basePath === '/' ? url : `${basePath}${url.replace(/^\//, '')}`
+	);
 	const websiteRequests = urlsToCache.map(
 		/**
 		 * Ensure the response is not coming from HTTP cache.

--- a/packages/playground/remote/src/lib/playground-pr-preview.spec.ts
+++ b/packages/playground/remote/src/lib/playground-pr-preview.spec.ts
@@ -1,0 +1,80 @@
+import {
+	getPlaygroundPrPreviewFromUrl,
+	getPlaygroundPrPreviewServiceWorkerUrl,
+	mapToPlaygroundPrPreviewUrl,
+	shouldBypassPlaygroundPrPreview,
+	shouldMapToPlaygroundPrPreview,
+} from './playground-pr-preview';
+
+describe('getPlaygroundPrPreviewFromUrl', () => {
+	it('accepts a matching preview service worker URL', () => {
+		expect(
+			getPlaygroundPrPreviewFromUrl(
+				'https://playground.test/playground-pr-preview-sw.js?playground-pr=123&playground-pr-sha=abcdef1'
+			)
+		).toEqual({
+			pr: '123',
+			sha: 'abcdef1',
+			basePath: '/pr-previews/123/abcdef1/',
+		});
+	});
+
+	it('rejects URLs where params and path disagree', () => {
+		expect(
+			getPlaygroundPrPreviewFromUrl(
+				'https://playground.test/pr-previews/123/abcdef1/sw.js?playground-pr=124&playground-pr-sha=abcdef1'
+			)
+		).toBeUndefined();
+	});
+});
+
+describe('getPlaygroundPrPreviewServiceWorkerUrl', () => {
+	it('points preview remote.html pages at the preview service worker', () => {
+		const serviceWorkerUrl = getPlaygroundPrPreviewServiceWorkerUrl(
+			'/sw.js',
+			'https://playground.test',
+			'https://playground.test/remote.html?playground-pr=123&playground-pr-sha=abcdef1'
+		);
+
+		expect(serviceWorkerUrl.toString()).toBe(
+			'https://playground.test/playground-pr-preview-sw.js?playground-pr=123&playground-pr-sha=abcdef1'
+		);
+	});
+});
+
+describe('PR preview URL mapping', () => {
+	const preview = {
+		pr: '123',
+		sha: 'abcdef1',
+		basePath: '/pr-previews/123/abcdef1/',
+	};
+
+	it('maps static root URLs to the preview build path', () => {
+		const mapped = mapToPlaygroundPrPreviewUrl(
+			new URL('https://playground.test/assets/index.js?v=1'),
+			preview
+		);
+
+		expect(mapped.toString()).toBe(
+			'https://playground.test/pr-previews/123/abcdef1/assets/index.js?v=1'
+		);
+	});
+
+	it('does not map dynamic or already-preview URLs', () => {
+		expect(
+			shouldMapToPlaygroundPrPreview(
+				new URL('https://playground.test/plugin-proxy.php')
+			)
+		).toBe(false);
+		expect(
+			shouldMapToPlaygroundPrPreview(
+				new URL('https://playground.test/client/index.js')
+			)
+		).toBe(false);
+		expect(
+			shouldBypassPlaygroundPrPreview(
+				new URL('https://playground.test/pr-previews/123/current.json')
+			)
+		).toBe(true);
+	});
+});

--- a/packages/playground/remote/src/lib/playground-pr-preview.ts
+++ b/packages/playground/remote/src/lib/playground-pr-preview.ts
@@ -1,0 +1,99 @@
+export const playgroundPrParam = 'playground-pr';
+export const playgroundPrShaParam = 'playground-pr-sha';
+export const playgroundPrPreviewServiceWorkerPath =
+	'/playground-pr-preview-sw.js';
+
+export interface PlaygroundPrPreview {
+	pr: string;
+	sha: string;
+	basePath: string;
+}
+
+export function getPlaygroundPrPreviewFromUrl(
+	url: string | URL
+): PlaygroundPrPreview | undefined {
+	const parsedUrl = new URL(url);
+	const pr = parsedUrl.searchParams.get(playgroundPrParam);
+	const sha = parsedUrl.searchParams.get(playgroundPrShaParam);
+	if (!pr || !sha || !isValidPlaygroundPrNumber(pr) || !isValidSha(sha)) {
+		return undefined;
+	}
+
+	if (
+		parsedUrl.pathname !== playgroundPrPreviewServiceWorkerPath &&
+		parsedUrl.pathname !== getPlaygroundPrPreviewServiceWorkerPath(pr, sha)
+	) {
+		return undefined;
+	}
+
+	return {
+		pr,
+		sha,
+		basePath: getPlaygroundPrPreviewBasePath(pr, sha),
+	};
+}
+
+export function getPlaygroundPrPreviewServiceWorkerUrl(
+	serviceWorkerPath: string,
+	origin: string,
+	documentUrl: string | URL
+): URL {
+	const serviceWorkerUrl = new URL(serviceWorkerPath, origin);
+	const documentLocation = new URL(documentUrl);
+	const pr = documentLocation.searchParams.get(playgroundPrParam);
+	const sha = documentLocation.searchParams.get(playgroundPrShaParam);
+
+	if (pr && sha && isValidPlaygroundPrNumber(pr) && isValidSha(sha)) {
+		serviceWorkerUrl.pathname = playgroundPrPreviewServiceWorkerPath;
+		serviceWorkerUrl.searchParams.set(playgroundPrParam, pr);
+		serviceWorkerUrl.searchParams.set(playgroundPrShaParam, sha);
+	}
+
+	return serviceWorkerUrl;
+}
+
+export function shouldBypassPlaygroundPrPreview(url: URL): boolean {
+	return url.pathname.startsWith('/pr-previews/');
+}
+
+export function shouldMapToPlaygroundPrPreview(url: URL): boolean {
+	const { pathname } = url;
+	if (
+		pathname.startsWith('/pr-previews/') ||
+		pathname.startsWith('/scope:') ||
+		pathname.startsWith('/plugin-proxy') ||
+		pathname.startsWith('/client/index.js') ||
+		pathname.startsWith('/proxy/') ||
+		pathname.endsWith('.php')
+	) {
+		return false;
+	}
+
+	return true;
+}
+
+export function mapToPlaygroundPrPreviewUrl(
+	url: URL,
+	preview: PlaygroundPrPreview
+): URL {
+	const previewUrl = new URL(url);
+	const pathWithoutLeadingSlash = url.pathname.replace(/^\//, '');
+	previewUrl.pathname = preview.basePath + pathWithoutLeadingSlash;
+	return previewUrl;
+}
+
+function getPlaygroundPrPreviewBasePath(pr: string, sha: string) {
+	return `/pr-previews/${pr}/${sha}/`;
+}
+
+function getPlaygroundPrPreviewServiceWorkerPath(pr: string, sha: string) {
+	return `${getPlaygroundPrPreviewBasePath(pr, sha)}sw.js`;
+}
+
+function isValidPlaygroundPrNumber(pr: string) {
+	return /^\d+$/.test(pr);
+}
+
+function isValidSha(sha: string) {
+	return /^[a-f0-9]{7,40}$/i.test(sha);
+}

--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -38,6 +38,11 @@ function playground_handle_request() {
 	$original_requested_path = $url['path'];
 	$log( "Requested path: '$original_requested_path'" );
 
+	if ( playground_is_pr_preview_request( $original_requested_path ) ) {
+		playground_handle_pr_preview_request( $original_requested_path );
+		die();
+	}
+
 	//
 	// REWRITES
 	//
@@ -316,14 +321,7 @@ function playground_maybe_set_environment( $requested_path ) {
 	}
 
 	if ( str_ends_with( $requested_path, 'plugin-proxy.php' ) ) {
-		// Define DB_PASSWORD early so Atomic_Persistent_Data can work.
-		__atomic_env_define( 'DB_PASSWORD' );
-		$secrets = new Atomic_Persistent_Data;
-		if ( isset( $secrets->GITHUB_TOKEN ) ) {
-			putenv( "GITHUB_TOKEN={$secrets->GITHUB_TOKEN}" );
-		} else {
-			error_log( 'PLAYGROUND: Missing secrets for plugin-proxy.php' );
-		}
+		playground_maybe_set_github_token_environment( 'plugin-proxy.php' );
 
 		return true;
 	}
@@ -347,10 +345,384 @@ function playground_maybe_set_environment( $requested_path ) {
 	return false;
 }
 
+function playground_maybe_set_github_token_environment( $context ) {
+	if ( getenv( 'GITHUB_TOKEN' ) ) {
+		return true;
+	}
+
+	if ( ! function_exists( '__atomic_env_define' ) || ! class_exists( 'Atomic_Persistent_Data' ) ) {
+		error_log( "PLAYGROUND: Missing GitHub token environment helpers for $context" );
+		return false;
+	}
+
+	// Define DB_PASSWORD early so Atomic_Persistent_Data can work.
+	__atomic_env_define( 'DB_PASSWORD' );
+	$secrets = new Atomic_Persistent_Data;
+	if ( isset( $secrets->GITHUB_TOKEN ) ) {
+		putenv( "GITHUB_TOKEN={$secrets->GITHUB_TOKEN}" );
+		return true;
+	}
+
+	error_log( "PLAYGROUND: Missing secrets for $context" );
+	return false;
+}
+
+function playground_is_pr_preview_request( $requested_path ) {
+	return preg_match( '#^/pr-previews/\d+/(current\.json|[a-f0-9]{7,40}(/.*)?)$#i', $requested_path );
+}
+
+function playground_handle_pr_preview_request( $requested_path ) {
+	playground_maybe_set_github_token_environment( 'Playground PR preview' );
+
+	$match = array();
+	if ( preg_match( '#^/pr-previews/(?<pr>\d+)/current\.json$#', $requested_path, $match ) ) {
+		playground_send_pr_preview_current_json( $match['pr'] );
+		return;
+	}
+
+	if (
+		! preg_match(
+			'#^/pr-previews/(?<pr>\d+)/(?<sha>[a-f0-9]{7,40})(?<path>/.*)?$#i',
+			$requested_path,
+			$match
+		)
+	) {
+		http_response_code( 404 );
+		return;
+	}
+
+	$path = isset( $match['path'] ) && '' !== $match['path'] ? $match['path'] : '/';
+	playground_send_pr_preview_file( $match['pr'], strtolower( $match['sha'] ), $path );
+}
+
+function playground_send_pr_preview_current_json( $pr_number ) {
+	$head_sha = playground_get_pr_preview_head_sha( $pr_number );
+	$artifact = playground_get_pr_preview_artifact( $pr_number, $head_sha );
+
+	header( 'Content-Type: application/json' );
+	header( 'Cache-Control: max-age=0, no-cache, no-store, must-revalidate' );
+	echo json_encode(
+		array(
+			'pr' => $pr_number,
+			'sha' => $head_sha,
+			'artifactName' => $artifact->name,
+			'basePath' => "/pr-previews/$pr_number/$head_sha/",
+		)
+	);
+}
+
+function playground_send_pr_preview_file( $pr_number, $sha, $requested_file ) {
+	$artifact = playground_get_pr_preview_artifact( $pr_number, $sha );
+	$artifact_root = playground_get_pr_preview_artifact_root( $artifact );
+
+	$relative_file = ltrim( $requested_file, '/' );
+	if ( '' === $relative_file ) {
+		$relative_file = 'index.html';
+	}
+	if ( str_contains( $relative_file, '..' ) || str_starts_with( $relative_file, '/' ) ) {
+		http_response_code( 400 );
+		echo 'Invalid PR preview path';
+		return;
+	}
+
+	$resolved_path = realpath( $artifact_root . '/' . $relative_file );
+	if ( is_dir( $resolved_path ) ) {
+		$resolved_path = playground_resolve_to_index_file( $resolved_path );
+	}
+
+	if ( false === $resolved_path || ! str_starts_with( $resolved_path, $artifact_root . '/' ) ) {
+		http_response_code( 404 );
+		echo 'PR preview file not found';
+		return;
+	}
+
+	playground_send_pr_preview_static_file( $resolved_path, $requested_file );
+}
+
+
+function playground_pr_preview_json_error( $status, $error, $extra = array() ) {
+	http_response_code( $status );
+	header( 'Content-Type: application/json' );
+	die( json_encode( array_merge( array( 'error' => $error ), $extra ) ) );
+}
+
+function playground_get_pr_preview_head_sha( $pr_number ) {
+	$response = playground_github_api_request(
+		"https://api.github.com/repos/WordPress/wordpress-playground/pulls/$pr_number"
+	);
+	if ( empty( $response->head->sha ) || ! preg_match( '/^[a-f0-9]{40}$/i', $response->head->sha ) ) {
+		playground_pr_preview_json_error( 404, 'invalid_pr_number' );
+	}
+	return strtolower( $response->head->sha );
+}
+
+function playground_get_pr_preview_artifact( $pr_number, $sha ) {
+	$artifact_name = "playground-pr-preview-$pr_number-$sha";
+	$response = playground_github_api_request(
+		'https://api.github.com/repos/WordPress/wordpress-playground/actions/artifacts?name=' .
+			rawurlencode( $artifact_name )
+	);
+
+	if ( empty( $response->artifacts ) ) {
+		playground_pr_preview_json_error(
+			404,
+			'artifact_not_found',
+			array( 'artifactName' => $artifact_name )
+		);
+	}
+
+	foreach ( $response->artifacts as $artifact ) {
+		if ( $artifact_name === $artifact->name && empty( $artifact->expired ) ) {
+			return $artifact;
+		}
+	}
+
+	playground_pr_preview_json_error( 404, 'artifact_expired' );
+}
+
+function playground_get_pr_preview_artifact_root( $artifact ) {
+	$cache_dir = playground_get_pr_preview_cache_dir();
+	$extract_dir = "$cache_dir/extracted/{$artifact->id}";
+	$marker_file = "$extract_dir/.playground-artifact-ready";
+
+	if ( file_exists( $marker_file ) ) {
+		return playground_find_pr_preview_artifact_root( $extract_dir );
+	}
+
+	if ( ! class_exists( 'ZipArchive' ) ) {
+		playground_pr_preview_json_error( 500, 'zip_extension_missing' );
+	}
+
+	$zip_file = "$cache_dir/downloads/{$artifact->id}.zip";
+	if ( ! file_exists( $zip_file ) ) {
+		playground_download_pr_preview_artifact( $artifact, $zip_file );
+	}
+
+	$tmp_extract_dir = "$extract_dir.tmp." . getmypid();
+	playground_delete_directory( $tmp_extract_dir );
+	mkdir( $tmp_extract_dir, 0777, true );
+	playground_extract_zip_safely( $zip_file, $tmp_extract_dir );
+	rename( $tmp_extract_dir, $extract_dir );
+	touch( $marker_file );
+
+	return playground_find_pr_preview_artifact_root( $extract_dir );
+}
+
+function playground_get_pr_preview_cache_dir() {
+	$cache_dir = sys_get_temp_dir() . '/playground-pr-previews';
+	if ( ! is_dir( "$cache_dir/downloads" ) ) {
+		mkdir( "$cache_dir/downloads", 0777, true );
+	}
+	if ( ! is_dir( "$cache_dir/extracted" ) ) {
+		mkdir( "$cache_dir/extracted", 0777, true );
+	}
+	return $cache_dir;
+}
+
+function playground_download_pr_preview_artifact( $artifact, $zip_file ) {
+	$response = playground_github_api_request( $artifact->archive_download_url, false, false );
+	$download_url = playground_find_header( $response['headers'], 'location' );
+	if ( ! $download_url ) {
+		playground_pr_preview_json_error( 502, 'artifact_redirect_not_present' );
+	}
+
+	$tmp_file = "$zip_file.tmp." . getmypid();
+	$fp = fopen( $tmp_file, 'w' );
+	$ch = curl_init( $download_url );
+	curl_setopt_array(
+		$ch,
+		array(
+			CURLOPT_FILE => $fp,
+			CURLOPT_FOLLOWLOCATION => true,
+			CURLOPT_FAILONERROR => true,
+			CURLOPT_CONNECTTIMEOUT => 30,
+		)
+	);
+	$ok = curl_exec( $ch );
+	$http_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+	curl_close( $ch );
+	fclose( $fp );
+
+	if ( ! $ok || $http_code < 200 || $http_code >= 300 ) {
+		@unlink( $tmp_file );
+		playground_pr_preview_json_error( 502, 'artifact_download_failed' );
+	}
+
+	rename( $tmp_file, $zip_file );
+}
+
+function playground_extract_zip_safely( $zip_file, $target_dir ) {
+	$zip = new ZipArchive();
+	if ( true !== $zip->open( $zip_file ) ) {
+		playground_pr_preview_json_error( 502, 'artifact_zip_invalid' );
+	}
+
+	for ( $i = 0; $i < $zip->numFiles; $i++ ) {
+		$name = $zip->getNameIndex( $i );
+		if ( str_ends_with( $name, '/' ) ) {
+			continue;
+		}
+		if ( str_starts_with( $name, '/' ) || str_contains( $name, '..' ) ) {
+			continue;
+		}
+
+		$target_file = "$target_dir/$name";
+		$target_parent = dirname( $target_file );
+		if ( ! is_dir( $target_parent ) ) {
+			mkdir( $target_parent, 0777, true );
+		}
+
+		copy( "zip://$zip_file#$name", $target_file );
+	}
+
+	$zip->close();
+}
+
+function playground_find_pr_preview_artifact_root( $extract_dir ) {
+	$candidates = array(
+		$extract_dir,
+		"$extract_dir/wasm-wordpress-net",
+		"$extract_dir/dist/packages/playground/wasm-wordpress-net",
+	);
+	foreach ( $candidates as $candidate ) {
+		if ( file_exists( "$candidate/sw.js" ) && file_exists( "$candidate/remote.html" ) ) {
+			return realpath( $candidate );
+		}
+	}
+
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $extract_dir, FilesystemIterator::SKIP_DOTS )
+	);
+	foreach ( $iterator as $file ) {
+		if ( 'sw.js' !== $file->getFilename() ) {
+			continue;
+		}
+		$candidate = dirname( $file->getPathname() );
+		if ( file_exists( "$candidate/remote.html" ) ) {
+			return realpath( $candidate );
+		}
+	}
+
+	playground_pr_preview_json_error( 502, 'artifact_missing_website_build' );
+}
+
+function playground_send_pr_preview_static_file( $resolved_path, $requested_file ) {
+	$filename = basename( $resolved_path );
+	$extension = strtolower( pathinfo( $filename, PATHINFO_EXTENSION ) );
+
+	if ( file_exists( __DIR__ . '/mime-types.php' ) ) {
+		require __DIR__ . '/mime-types.php';
+		if ( isset( $mime_types[ $extension ] ) ) {
+			header( "Content-Type: {$mime_types[$extension]}" );
+		}
+	} else {
+		$fallback_mime_types = array(
+			'css' => 'text/css',
+			'html' => 'text/html',
+			'js' => 'application/javascript',
+			'json' => 'application/json',
+			'wasm' => 'application/wasm',
+		);
+		if ( isset( $fallback_mime_types[ $extension ] ) ) {
+			header( "Content-Type: {$fallback_mime_types[$extension]}" );
+		}
+	}
+
+	$custom_response_headers = playground_get_custom_response_headers(
+		'/pr-previews/1/abcdef1/' . ltrim( $requested_file, '/' )
+	);
+	if ( ! empty( $custom_response_headers ) ) {
+		foreach ( $custom_response_headers as $custom_header ) {
+			header( $custom_header );
+		}
+	}
+	if ( 'sw.js' !== $filename && 'current.json' !== $filename ) {
+		header( 'Cache-Control: public, max-age=31536000, immutable' );
+	}
+
+	if ( 'HEAD' !== $_SERVER['REQUEST_METHOD'] ) {
+		readfile( $resolved_path );
+	}
+}
+
+function playground_github_api_request( $url, $decode = true, $follow_location = true ) {
+	$token = getenv( 'GITHUB_TOKEN' );
+	if ( ! $token ) {
+		playground_pr_preview_json_error( 500, 'github_token_missing' );
+	}
+
+	$ch = curl_init( $url );
+	curl_setopt_array(
+		$ch,
+		array(
+			CURLOPT_RETURNTRANSFER => true,
+			CURLOPT_FOLLOWLOCATION => $follow_location,
+			CURLOPT_HTTPHEADER => array(
+				'Accept: application/vnd.github+json',
+				'Authorization: Bearer ' . $token,
+				'User-Agent: WordPress Playground PR preview',
+				'X-GitHub-Api-Version: 2022-11-28',
+			),
+			CURLOPT_HEADER => true,
+			CURLOPT_CONNECTTIMEOUT => 30,
+		)
+	);
+	$response = curl_exec( $ch );
+	$header_size = curl_getinfo( $ch, CURLINFO_HEADER_SIZE );
+	$http_code = curl_getinfo( $ch, CURLINFO_HTTP_CODE );
+	curl_close( $ch );
+
+	if ( false === $response || $http_code < 200 || $http_code >= 400 ) {
+		playground_pr_preview_json_error( 502, 'github_request_failed' );
+	}
+
+	$headers = explode( "\r\n", trim( substr( $response, 0, $header_size ) ) );
+	$body = substr( $response, $header_size );
+	return array(
+		'body' => $decode ? json_decode( $body ) : $body,
+		'headers' => $headers,
+	)[$decode ? 'body' : null] ?? array( 'body' => $body, 'headers' => $headers );
+}
+
+function playground_find_header( $headers, $name ) {
+	$name = strtolower( $name );
+	foreach ( $headers as $header ) {
+		if ( ! str_contains( $header, ':' ) ) {
+			continue;
+		}
+		$header_name = strtolower( substr( $header, 0, strpos( $header, ':' ) ) );
+		if ( $name === $header_name ) {
+			return trim( substr( $header, strpos( $header, ':' ) + 1 ) );
+		}
+	}
+	return null;
+}
+
+function playground_delete_directory( $dir ) {
+	if ( ! is_dir( $dir ) ) {
+		return;
+	}
+	$files = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $dir, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+	foreach ( $files as $fileinfo ) {
+		$fileinfo->isDir() ? rmdir( $fileinfo->getRealPath() ) : unlink( $fileinfo->getRealPath() );
+	}
+	rmdir( $dir );
+}
+
 function playground_get_custom_response_headers( $requested_path ) {
 	$filename = basename( $requested_path );
 
-	if ( 'iframe-worker.html' === $filename ) {
+	if ( preg_match( '#^/pr-previews/\d+/[a-f0-9]{7,40}/sw\.js$#i', $requested_path ) ) {
+		return array(
+			'Service-Worker-Allowed: /',
+			'Cache-Control: max-age=0, no-cache, no-store, must-revalidate',
+		);
+	} elseif ( preg_match( '#^/pr-previews/\d+/current\.json$#', $requested_path ) ) {
+		return array( 'Cache-Control: max-age=0, no-cache, no-store, must-revalidate' );
+	} elseif ( 'iframe-worker.html' === $filename ) {
 		return array( 'Origin-Agent-Cluster: ?1' );
 	} elseif ( str_ends_with( $filename, 'store.zip' ) ) {
 		// Disable compression so zip file can be read piece by piece

--- a/packages/playground/website-deployment/tests.php
+++ b/packages/playground/website-deployment/tests.php
@@ -1,6 +1,7 @@
 <?php
 
 require __DIR__ . '/cors-proxy-config.php';
+require __DIR__ . '/custom-redirects-lib.php';
 
 function assert_equal($expected, $actual, $message='') {
 	if ($expected !== $actual) {
@@ -65,5 +66,30 @@ assert_throws(
         );
     }
 );
+
+$preview_sw_headers = playground_get_custom_response_headers(
+    '/pr-previews/123/abcdef1234567890abcdef1234567890abcdef12/sw.js'
+);
+assert_equal(
+    1,
+    playground_is_pr_preview_request('/pr-previews/123/current.json'),
+    'PR preview current.json should be handled by the artifact proxy'
+);
+assert_equal(
+    1,
+    playground_is_pr_preview_request('/pr-previews/123/abcdef1/assets/index.js'),
+    'PR preview assets should be handled by the artifact proxy'
+);
+assert_equal(
+    true,
+    in_array('Service-Worker-Allowed: /', $preview_sw_headers, true),
+    'PR preview service worker must be allowed to control the root scope'
+);
+assert_equal(
+    array('Cache-Control: max-age=0, no-cache, no-store, must-revalidate'),
+    playground_get_custom_response_headers('/pr-previews/123/current.json'),
+    'PR preview current.json must not be cached'
+);
+
 
 echo 'All tests passed';

--- a/packages/playground/website/.htaccess
+++ b/packages/playground/website/.htaccess
@@ -10,3 +10,12 @@ Header set Access-Control-Allow-Origin "*"
 Header unset ETag
 Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
 </FilesMatch>
+<FilesMatch "sw\.js">
+Header set Service-Worker-Allowed "/"
+Header unset ETag
+Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+</FilesMatch>
+<FilesMatch "current\.json">
+Header unset ETag
+Header set Cache-Control "max-age=0, no-cache, no-store, must-revalidate"
+</FilesMatch>

--- a/packages/playground/website/public/playground-pr-preview-sw.js
+++ b/packages/playground/website/public/playground-pr-preview-sw.js
@@ -1,0 +1,152 @@
+/* eslint-disable no-restricted-globals */
+/* global importScripts */
+const playgroundPrParam = 'playground-pr';
+const playgroundPrShaParam = 'playground-pr-sha';
+const previewPathPrefix = '/pr-previews/';
+
+const preview = getPreviewFromLocation();
+const previewClientIds = new Set();
+const importedFetchListeners = [];
+const nativeAddEventListener = self.addEventListener.bind(self);
+
+self.addEventListener = function (type, listener, options) {
+	if (type === 'fetch') {
+		importedFetchListeners.push({ listener, options });
+		return;
+	}
+	return nativeAddEventListener(type, listener, options);
+};
+
+try {
+	if (preview) {
+		importScripts(getPreviewUrl('/sw.js').toString());
+	}
+} finally {
+	self.addEventListener = nativeAddEventListener;
+}
+
+nativeAddEventListener('fetch', (event) => {
+	const url = new URL(event.request.url);
+	const mappedUrl = getEffectivePreviewUrl(event, url);
+	if (mappedUrl) {
+		event.respondWith(fetchWithUrl(event.request, mappedUrl));
+		return;
+	}
+
+	for (const { listener } of importedFetchListeners) {
+		if (typeof listener === 'function') {
+			listener.call(self, event);
+		} else if (listener && typeof listener.handleEvent === 'function') {
+			listener.handleEvent(event);
+		}
+	}
+});
+
+function getPreviewFromLocation() {
+	const url = new URL(self.location.href);
+	const pr = url.searchParams.get(playgroundPrParam);
+	const sha = url.searchParams.get(playgroundPrShaParam);
+	if (!/^\d+$/.test(pr || '') || !/^[a-f0-9]{7,40}$/i.test(sha || '')) {
+		return undefined;
+	}
+	return { pr, sha };
+}
+
+function getEffectivePreviewUrl(event, url) {
+	if (!preview || url.origin !== self.location.origin) {
+		return undefined;
+	}
+
+	if (url.pathname.startsWith(previewPathPrefix)) {
+		return undefined;
+	}
+
+	if (isPreviewNavigationRequest(event.request)) {
+		const clientId = event.resultingClientId || event.clientId;
+		if (isPlaygroundPrPreviewUrl(url)) {
+			if (clientId) {
+				previewClientIds.add(clientId);
+			}
+			return shouldMapToPreview(url)
+				? getPreviewUrl(url.pathname)
+				: undefined;
+		}
+
+		if (clientId) {
+			previewClientIds.delete(clientId);
+		}
+		return undefined;
+	}
+
+	let referrerUrl;
+	try {
+		referrerUrl = new URL(event.request.referrer);
+	} catch {
+		// Ignore missing or invalid referrers.
+	}
+
+	const isPreviewClient =
+		!!event.clientId && previewClientIds.has(event.clientId);
+	const hasPreviewReferrer =
+		!!referrerUrl && isPlaygroundPrPreviewUrl(referrerUrl);
+	if (!isPreviewClient && !hasPreviewReferrer) {
+		return undefined;
+	}
+
+	return shouldMapToPreview(url) ? getPreviewUrl(url.pathname) : undefined;
+}
+
+function isPreviewNavigationRequest(request) {
+	return request.mode === 'navigate';
+}
+
+function isPlaygroundPrPreviewUrl(url) {
+	return (
+		url.searchParams.get(playgroundPrParam) === preview?.pr &&
+		url.searchParams.get(playgroundPrShaParam) === preview?.sha
+	);
+}
+
+function shouldMapToPreview(url) {
+	const { pathname } = url;
+	return !(
+		pathname.startsWith(previewPathPrefix) ||
+		pathname.startsWith('/scope:') ||
+		pathname.startsWith('/plugin-proxy') ||
+		pathname.startsWith('/client/index.js') ||
+		pathname.startsWith('/proxy/') ||
+		pathname.endsWith('.php')
+	);
+}
+
+function getPreviewUrl(pathname) {
+	const url = new URL(self.location.origin);
+	const pathWithoutLeadingSlash = pathname.replace(/^\//, '');
+	url.pathname = `${previewPathPrefix}${preview.pr}/${preview.sha}/${pathWithoutLeadingSlash}`;
+	return url;
+}
+
+async function fetchWithUrl(request, url) {
+	const requestWithUrl = await cloneRequestWithUrl(request, url);
+	return fetch(requestWithUrl, { cache: 'no-store' });
+}
+
+async function cloneRequestWithUrl(request, url) {
+	let body;
+	if (!['GET', 'HEAD'].includes(request.method)) {
+		body = await request.clone().arrayBuffer();
+	}
+
+	return new Request(url, {
+		body,
+		method: request.method,
+		headers: request.headers,
+		referrer: request.referrer,
+		referrerPolicy: request.referrerPolicy,
+		mode: request.mode === 'navigate' ? 'same-origin' : request.mode,
+		credentials: request.credentials,
+		cache: 'no-store',
+		redirect: request.redirect,
+		integrity: request.integrity,
+	});
+}

--- a/packages/playground/website/src/lib/config.ts
+++ b/packages/playground/website/src/lib/config.ts
@@ -1,10 +1,24 @@
 // Provided by vite
 import { buildVersion } from 'virtual:website-config';
+import {
+	getPlaygroundPrPreview,
+	playgroundPrParam,
+	playgroundPrShaParam,
+} from './playground-pr-preview';
 export { buildVersion } from 'virtual:website-config';
 
 export function getRemoteUrl() {
 	const remoteUrl = new URL(window.location.origin);
 	remoteUrl.pathname = '/remote.html';
 	remoteUrl.searchParams.set('v', buildVersion);
+
+	const preview = getPlaygroundPrPreview();
+	if (preview) {
+		remoteUrl.searchParams.set(playgroundPrParam, preview.pr);
+		if (preview.sha) {
+			remoteUrl.searchParams.set(playgroundPrShaParam, preview.sha);
+		}
+	}
+
 	return remoteUrl;
 }

--- a/packages/playground/website/src/lib/playground-pr-preview.spec.ts
+++ b/packages/playground/website/src/lib/playground-pr-preview.spec.ts
@@ -1,0 +1,48 @@
+import { getRemoteUrl } from './config';
+import {
+	getPlaygroundPrPreview,
+	playgroundPrParam,
+	playgroundPrShaParam,
+} from './playground-pr-preview';
+
+describe('getPlaygroundPrPreview', () => {
+	it('returns a numeric PR and optional SHA', () => {
+		expect(
+			getPlaygroundPrPreview(
+				'https://playground.test/?playground-pr=123&playground-pr-sha=abcdef1'
+			)
+		).toEqual({ pr: '123', sha: 'abcdef1' });
+	});
+
+	it('ignores invalid preview parameters', () => {
+		expect(
+			getPlaygroundPrPreview('https://playground.test/?playground-pr=abc')
+		).toBeUndefined();
+		expect(
+			getPlaygroundPrPreview(
+				'https://playground.test/?playground-pr=123&playground-pr-sha=not-a-sha'
+			)
+		).toBeUndefined();
+	});
+});
+
+describe('getRemoteUrl', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('preserves Playground PR preview parameters for remote.html', () => {
+		vi.stubGlobal('window', {
+			location: new URL(
+				'https://playground.test/?playground-pr=123&playground-pr-sha=abcdef1'
+			),
+		});
+
+		const remoteUrl = getRemoteUrl();
+		expect(remoteUrl.pathname).toBe('/remote.html');
+		expect(remoteUrl.searchParams.get(playgroundPrParam)).toBe('123');
+		expect(remoteUrl.searchParams.get(playgroundPrShaParam)).toBe(
+			'abcdef1'
+		);
+	});
+});

--- a/packages/playground/website/src/lib/playground-pr-preview.ts
+++ b/packages/playground/website/src/lib/playground-pr-preview.ts
@@ -1,0 +1,126 @@
+export const playgroundPrParam = 'playground-pr';
+export const playgroundPrShaParam = 'playground-pr-sha';
+export const playgroundPrPreviewServiceWorkerPath =
+	'/playground-pr-preview-sw.js';
+
+export interface PlaygroundPrPreview {
+	pr: string;
+	sha?: string;
+}
+
+interface PlaygroundPrPreviewCurrent {
+	sha: string;
+}
+
+export function getPlaygroundPrPreview(
+	url: string | URL = window.location.href
+): PlaygroundPrPreview | undefined {
+	const parsedUrl = new URL(url);
+	const pr = parsedUrl.searchParams.get(playgroundPrParam);
+	if (!pr || !isValidPlaygroundPrNumber(pr)) {
+		return undefined;
+	}
+
+	const sha = parsedUrl.searchParams.get(playgroundPrShaParam) || undefined;
+	if (sha && !isValidPlaygroundPrSha(sha)) {
+		return undefined;
+	}
+
+	return { pr, sha };
+}
+
+export function getPlaygroundPrPreviewBasePath(pr: string, sha: string) {
+	return `/pr-previews/${pr}/${sha}/`;
+}
+
+export async function activatePlaygroundPrPreview(
+	url: string | URL = window.location.href
+): Promise<boolean> {
+	const preview = getPlaygroundPrPreview(url);
+	if (!preview || preview.sha) {
+		return false;
+	}
+
+	const response = await fetch(`/pr-previews/${preview.pr}/current.json`, {
+		cache: 'no-store',
+	});
+	if (!response.ok) {
+		throw new Error(`Preview build for PR ${preview.pr} was not found.`);
+	}
+
+	const responseText = await response.text();
+	let current: PlaygroundPrPreviewCurrent;
+	try {
+		current = JSON.parse(responseText) as PlaygroundPrPreviewCurrent;
+	} catch {
+		throw new Error(`Preview build for PR ${preview.pr} was not found.`);
+	}
+	if (!isValidPlaygroundPrSha(current.sha)) {
+		throw new Error(`Preview build for PR ${preview.pr} is invalid.`);
+	}
+
+	const serviceWorkerUrl = new URL(
+		playgroundPrPreviewServiceWorkerPath,
+		window.location.href
+	);
+	serviceWorkerUrl.searchParams.set(playgroundPrParam, preview.pr);
+	serviceWorkerUrl.searchParams.set(playgroundPrShaParam, current.sha);
+
+	const registration = await navigator.serviceWorker.register(
+		serviceWorkerUrl.toString(),
+		{
+			scope: '/',
+			updateViaCache: 'none',
+		}
+	);
+	try {
+		await registration.update();
+	} catch {
+		// The explicit register() call succeeded, so keep going even if the
+		// browser cannot immediately revalidate the worker script.
+	}
+	await waitForPreviewServiceWorkerActivation(
+		registration,
+		serviceWorkerUrl.toString()
+	);
+
+	const reloadUrl = new URL(url);
+	reloadUrl.searchParams.set(playgroundPrShaParam, current.sha);
+	window.location.replace(reloadUrl.toString());
+	return true;
+}
+
+function isValidPlaygroundPrNumber(pr: string) {
+	return /^\d+$/.test(pr);
+}
+
+function isValidPlaygroundPrSha(sha: string) {
+	return /^[a-f0-9]{7,40}$/i.test(sha);
+}
+
+function waitForPreviewServiceWorkerActivation(
+	registration: ServiceWorkerRegistration,
+	scriptUrl: string
+) {
+	const worker =
+		[
+			registration.installing,
+			registration.waiting,
+			registration.active,
+		].find((candidate) => candidate?.scriptURL === scriptUrl) ||
+		registration.installing ||
+		registration.waiting;
+	if (!worker || worker.state === 'activated') {
+		return Promise.resolve();
+	}
+
+	return new Promise<void>((resolve) => {
+		const resolveIfDone = () => {
+			if (worker.state === 'activated' || worker.state === 'redundant') {
+				resolve();
+			}
+		};
+		worker.addEventListener('statechange', resolveIfDone);
+		resolveIfDone();
+	});
+}

--- a/packages/playground/website/src/main.tsx
+++ b/packages/playground/website/src/main.tsx
@@ -6,14 +6,34 @@ import { Provider } from 'react-redux';
 import store from './lib/state/redux/store';
 import { Layout } from './components/layout';
 import { EnsurePlaygroundSite } from './components/ensure-playground-site';
+import { activatePlaygroundPrPreview } from './lib/playground-pr-preview';
 
 collectWindowErrors(logger);
 
-const root = createRoot(document.getElementById('root')!);
-root.render(
-	<Provider store={store}>
-		<EnsurePlaygroundSite>
-			<Layout />
-		</EnsurePlaygroundSite>
-	</Provider>
-);
+activatePlaygroundPrPreview()
+	.then((activated) => {
+		if (!activated) {
+			renderApp();
+		}
+	})
+	.catch((error) => {
+		logger.error(error);
+		renderPreviewError(error);
+	});
+
+function renderApp() {
+	const root = createRoot(document.getElementById('root')!);
+	root.render(
+		<Provider store={store}>
+			<EnsurePlaygroundSite>
+				<Layout />
+			</EnsurePlaygroundSite>
+		</Provider>
+	);
+}
+
+function renderPreviewError(error: Error) {
+	const root = document.getElementById('root')!;
+	root.textContent =
+		error.message || 'Unable to activate the requested PR preview.';
+}


### PR DESCRIPTION
## What changed

Adds the runtime and server pieces for artifact-backed WordPress Playground PR previews via `?playground-pr=<number>`.

This PR is stacked on top of #3703, which only adds the CI workflow that produces `playground-pr-preview-<pr>-<sha>` artifacts.

This PR adds:

- same-origin `/pr-previews/<pr>/current.json` and `/pr-previews/<pr>/<sha>/...` routing backed by GitHub Actions artifacts
- server-side artifact download/extract/cache logic
- a stable preview bootstrap service worker that maps static requests to the artifact-backed virtual path and imports the PR build's own `sw.js`
- website boot logic for `?playground-pr=<number>`
- remote URL parameter preservation so the iframe registers the same preview service worker
- service-worker preview path mapping/bypass behavior
- tests for preview URL parsing, SW URL selection, path mapping, and PHP routing headers

## Why

This lets maintainers preview Playground PR builds without deploying PR files to production paths. The browser still uses same-origin URLs, which is required for a root-scoped service worker, while the backing files come from GitHub Actions artifacts.

## How to test locally

First, run the CI workflow from #3703 for a PR so the `playground-pr-preview-<pr>-<sha>` artifact exists. Then run a PHP-routed local server with `GITHUB_TOKEN` so `/pr-previews/...` requests execute the artifact proxy instead of falling back to static `index.html`.

## Testing

- `npm exec nx test playground-website -- --run`
- `npm exec nx test playground-remote -- --run`
- `npm exec nx typecheck playground-website`
- `npm exec nx typecheck playground-remote`
- `npm exec nx lint playground-website`
- `npm exec nx lint playground-remote`
- `php packages/playground/website-deployment/tests.php`
- `npm exec nx build playground-website`
