### PR TITLE
[Website] Infer PHP for older WordPress URLs

### DIFF
--- a/packages/playground/website/src/components/site-manager/site-settings-form/older-wordpress-versions.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/older-wordpress-versions.ts
@@ -1,4 +1,4 @@
-import type { AllPHPVersion } from '@php-wasm/universal';
+export { getForcedPhpVersionForWordPress } from '../../../lib/wordpress-version-compatibility';
 
 /**
  * WordPress versions that ship as non-minified downloads from
@@ -66,44 +66,6 @@ export const OlderWordPressVersions = [
 ] as const;
 
 export type OlderWordPressVersion = (typeof OlderWordPressVersions)[number];
-
-/**
- * Returns the PHP version a given WordPress release must run on
- * inside Playground, or `null` if any supported modern PHP version
- * will do.
- *
- * - WP < 5.0 (the legacy bucket): only our PHP 5.2 WASM build works.
- *   WP 4.x officially requires PHP 5.2.4+, but Playground's 5.6+
- *   builds have been retired so 5.2 is the only option available
- *   here.
- * - WP 5.0 – 6.2 (the older-but-not-legacy bucket): PHP 7.4 is the
- *   safest single choice — old enough for WP 5.0's PHP 5.2.4 era
- *   code (which runs fine on 7.4) yet new enough that nothing
- *   depends on PHP 5 quirks. PHP 8.x would work for WP 5.6+ but not
- *   reliably for WP 5.0 – 5.5, so we force 7.4 across the whole
- *   bucket.
- * - WP 6.3+ (the minified bucket): returns `null`. The UI lets the
- *   user pick any supported PHP version and we default to the
- *   recommended one.
- */
-export function getForcedPhpVersionForWordPress(
-	wpVersion: string | undefined
-): AllPHPVersion | null {
-	if (!wpVersion) {
-		return null;
-	}
-	const major = parseFloat(wpVersion);
-	if (!Number.isFinite(major)) {
-		return null;
-	}
-	if (major < 5) {
-		return '5.2';
-	}
-	if (major < 6.3) {
-		return '7.4';
-	}
-	return null;
-}
 
 /** True for WP versions that live in the non-minified "older" bucket. */
 export function isOlderWordPressVersion(

--- a/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
+++ b/packages/playground/website/src/lib/state/url/resolve-blueprint-from-url.ts
@@ -12,9 +12,9 @@ import {
 import { OpfsFilesystemBackend } from '@wp-playground/storage';
 import { parseBlueprint, isMcpServerEnabled } from './router';
 import { OverlayFilesystem, InMemoryFilesystem } from '@wp-playground/storage';
-import { RecommendedPHPVersion } from '@wp-playground/common';
 import { logger } from '@php-wasm/logger';
 import { decodeBlueprintHash } from './decode-blueprint-hash';
+import { getDefaultPhpVersionForWordPress } from '../../wordpress-version-compatibility';
 
 export { decodeBlueprintHash };
 
@@ -243,12 +243,12 @@ function applyQueryOverridesToDeclaration(
 	if (!blueprint.preferredVersions) {
 		blueprint.preferredVersions = {} as any;
 	}
+	blueprint.preferredVersions!.wp =
+		query.get('wp') || blueprint.preferredVersions!.wp || 'latest';
 	blueprint.preferredVersions!.php =
 		(query.get('php') as any) ||
 		blueprint.preferredVersions!.php ||
-		RecommendedPHPVersion;
-	blueprint.preferredVersions!.wp =
-		query.get('wp') || blueprint.preferredVersions!.wp || 'latest';
+		getDefaultPhpVersionForWordPress(blueprint.preferredVersions!.wp);
 
 	// Features
 	if (!blueprint.features) {

--- a/packages/playground/website/src/lib/wordpress-version-compatibility.spec.ts
+++ b/packages/playground/website/src/lib/wordpress-version-compatibility.spec.ts
@@ -1,0 +1,15 @@
+import { getDefaultPhpVersionForWordPress } from './wordpress-version-compatibility';
+
+describe('getDefaultPhpVersionForWordPress', () => {
+	it('should infer PHP 5.2 for legacy WordPress versions', () => {
+		expect(getDefaultPhpVersionForWordPress('2.0')).toBe('5.2');
+	});
+
+	it('should infer PHP 7.4 for older non-minified WordPress versions', () => {
+		expect(getDefaultPhpVersionForWordPress('5.9')).toBe('7.4');
+	});
+
+	it('should use the recommended PHP version for modern WordPress versions', () => {
+		expect(getDefaultPhpVersionForWordPress('6.3')).toBe('8.3');
+	});
+});

--- a/packages/playground/website/src/lib/wordpress-version-compatibility.ts
+++ b/packages/playground/website/src/lib/wordpress-version-compatibility.ts
@@ -1,0 +1,49 @@
+import type { AllPHPVersion } from '@php-wasm/universal';
+import { RecommendedPHPVersion } from '@wp-playground/common';
+
+export function getDefaultPhpVersionForWordPress(
+	wpVersion: string | undefined
+): AllPHPVersion {
+	return (
+		getForcedPhpVersionForWordPress(wpVersion) ??
+		(RecommendedPHPVersion as AllPHPVersion)
+	);
+}
+
+/**
+ * Returns the PHP version a given WordPress release must run on
+ * inside Playground, or `null` if any supported modern PHP version
+ * will do.
+ *
+ * - WP < 5.0 (the legacy bucket): only our PHP 5.2 WASM build works.
+ *   WP 4.x officially requires PHP 5.2.4+, but Playground's 5.6+
+ *   builds have been retired so 5.2 is the only option available
+ *   here.
+ * - WP 5.0 – 6.2 (the older-but-not-legacy bucket): PHP 7.4 is the
+ *   safest single choice — old enough for WP 5.0's PHP 5.2.4 era
+ *   code (which runs fine on 7.4) yet new enough that nothing
+ *   depends on PHP 5 quirks. PHP 8.x would work for WP 5.6+ but not
+ *   reliably for WP 5.0 – 5.5, so we force 7.4 across the whole
+ *   bucket.
+ * - WP 6.3+ (the minified bucket): returns `null`. The UI lets the
+ *   user pick any supported PHP version and we default to the
+ *   recommended one.
+ */
+export function getForcedPhpVersionForWordPress(
+	wpVersion: string | undefined
+): AllPHPVersion | null {
+	if (!wpVersion) {
+		return null;
+	}
+	const major = parseFloat(wpVersion);
+	if (!Number.isFinite(major)) {
+		return null;
+	}
+	if (major < 5) {
+		return '5.2';
+	}
+	if (major < 6.3) {
+		return '7.4';
+	}
+	return null;
+}


### PR DESCRIPTION
## What changed

- Infers the default PHP version from the requested WordPress version when URL/runtime query overrides do not specify `php`.
- Moves the existing older-WordPress compatibility mapping into a shared website helper so the settings form and URL resolution use the same source of truth.
- Adds focused unit coverage for the inferred defaults:
  - WP 2.0 -> PHP 5.2
  - WP 5.9 -> PHP 7.4
  - WP 6.3 -> recommended PHP 8.3

## Why

`?wp=2.0` was booting with the recommended PHP version, currently PHP 8.3, instead of the legacy-compatible PHP 5.2 runtime. That skipped the legacy WordPress boot path and crashed with `Error connecting to the SQLite database`.

CI covered `?php=5.2&wp=2.0`, but not the public URL shape where `php` is omitted.

## Testing

- `npm exec nx test playground-website -- --testFile=wordpress-version-compatibility.spec.ts`
- `npm exec nx run playground-website:typecheck`
- `npm exec nx run playground-website:lint`


## Notes for review

@JanJakes I moved the WordPress-version-to-PHP-version helper out of the Site Manager form module intentionally. The regression happened because that compatibility rule only lived in UI code, while URL/runtime resolution still defaulted to the recommended PHP version before considering the requested WordPress version.

Keeping the mapping in `src/lib/wordpress-version-compatibility.ts` gives both the settings UI and URL resolution one shared source of truth without making runtime URL parsing import from `components/site-manager/site-settings-form/older-wordpress-versions.ts`.
