### PR TITLE
[Website] Rename the selected autosaved Playground from Your Playgrounds

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -865,6 +865,86 @@ test.describe('Default Playground storage', () => {
 		);
 	});
 
+	test('should rename an inactive autosaved Playground without keeping it', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('rename-autosave'));
+		const setup = await website.page.evaluate(async () => {
+			const api = (window as any).playgroundSites;
+			await api.isReady();
+			const suffix = Date.now().toString(36);
+			const targetSlug = `rename-target-${suffix}`;
+			const activeSlug = `rename-active-${suffix}`;
+			await api.createNewSavedSite(targetSlug, undefined, {
+				persistence: 'autosave',
+				updateUrl: false,
+			});
+			await api.createNewSavedSite(activeSlug, undefined, {
+				persistence: 'autosave',
+				updateUrl: false,
+				excludeFromPruning: [targetSlug],
+			});
+			const sites = api.list();
+			const target = sites.find((site: any) => site.slug === targetSlug);
+			const active = sites.find((site: any) => site.slug === activeSlug);
+			return {
+				targetSlug,
+				targetName: target.name,
+				activeSlug,
+				activeName: active.name,
+			};
+		});
+
+		await website.openSavedPlaygroundsOverlay();
+		const targetRow = website.page
+			.locator('[class*="siteRow"]')
+			.filter({ hasText: setup.targetName })
+			.first();
+		await targetRow.getByRole('button', { name: 'Site actions' }).click();
+		await website.page.getByRole('menuitem', { name: 'Rename' }).click();
+
+		const dialog = website.page.getByRole('dialog', {
+			name: 'Rename Playground',
+		});
+		const newName = `Renamed Recovery ${Date.now()}`;
+		await expect(
+			dialog.getByRole('textbox', { name: /name/i })
+		).toHaveValue(setup.targetName);
+		await dialog.getByRole('textbox', { name: /name/i }).fill(newName);
+		await dialog.getByRole('button', { name: 'Rename' }).click();
+		await expect(dialog).not.toBeVisible();
+
+		const sitesAfterRename = await website.page.evaluate(
+			({ targetSlug, activeSlug }) => {
+				const sites = (window as any).playgroundSites.list();
+				return {
+					target: sites.find((site: any) => site.slug === targetSlug),
+					active: sites.find((site: any) => site.slug === activeSlug),
+				};
+			},
+			{
+				targetSlug: setup.targetSlug,
+				activeSlug: setup.activeSlug,
+			}
+		);
+		expect(sitesAfterRename.target).toMatchObject({
+			name: newName,
+			persistence: 'autosave',
+			isActive: false,
+		});
+		expect(sitesAfterRename.active).toMatchObject({
+			name: setup.activeName,
+			persistence: 'autosave',
+			isActive: true,
+		});
+	});
+
 	test('should treat New Playground as an explicit fresh start', async ({
 		website,
 		browserName,

--- a/packages/playground/website/src/components/rename-site-modal/index.tsx
+++ b/packages/playground/website/src/components/rename-site-modal/index.tsx
@@ -43,7 +43,7 @@ export function RenameSiteModal() {
 		try {
 			setIsSubmitting(true);
 			setError(null);
-			await sitesAPI.rename(trimmed);
+			await sitesAPI.rename(trimmed, site.slug);
 			closeModal();
 		} catch (e) {
 			setError(

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -185,16 +185,27 @@ export function createSitesAPI(
 		},
 
 		/**
-		 * Renames the active site.
+		 * Renames a stored site.
+		 *
+		 * Defaults to the active site for callers that rename the current
+		 * Playground. UI that opens a rename modal from a site list must pass
+		 * the target slug because the listed site may not be active.
 		 *
 		 * @param newName The new display name.
-		 * @throws When no site is selected or the site is
+		 * @param siteSlug Optional slug. Uses the active site when omitted.
+		 * @throws When no site is selected, the slug is unknown, or the site is
 		 *   temporary.
 		 */
-		async rename(newName: string): Promise<void> {
-			const site = selectActiveSite(getState());
+		async rename(newName: string, siteSlug?: string): Promise<void> {
+			const site = siteSlug
+				? selectSiteBySlug(getState(), siteSlug)
+				: selectActiveSite(getState());
 			if (!site) {
-				throw new Error('No active site selected');
+				throw new Error(
+					siteSlug
+						? `Site not found: ${siteSlug}`
+						: 'No site selected'
+				);
 			}
 			if (site.metadata.storage === 'none') {
 				throw new Error(
@@ -204,7 +215,7 @@ export function createSitesAPI(
 			await dispatch(
 				updateSiteMetadata({
 					slug: site.slug,
-					changes: { name: newName, persistence: 'explicit' },
+					changes: { name: newName },
 				})
 			);
 		},


### PR DESCRIPTION
## What it does

Fixes renaming autosaved Playgrounds from the Your Playgrounds list. The rename modal now updates the selected row's site instead of whichever Playground is currently active.

## Rationale

The overlay can open the rename modal for an inactive autosave. The modal stored that target slug in Redux, but submitted `playgroundSites.rename(name)` without passing it through. `rename()` then fell back to the active site, so the wrong Playground could be renamed.

`rename()` also marked the target as explicitly saved. That made a renamed autosave move from recovery copies into saved Playgrounds.

## Implementation

`playgroundSites.rename()` now accepts an optional `siteSlug`. Existing callers can still omit it to rename the active Playground. The rename modal passes the selected site's slug, and rename metadata updates now only change `name`.

## Testing instructions

Run:

```bash
NX_DAEMON=false npx nx run playground-website:typecheck
NX_DAEMON=false npx nx run playground-website:lint
NX_DAEMON=false npx playwright test --config=packages/playground/website/playwright/playwright.config.ts packages/playground/website/playwright/e2e/website-ui.spec.ts --project=chromium --grep "should rename an inactive autosaved Playground without keeping it" --reporter=line
NX_DAEMON=false npx playwright test --config=packages/playground/website/playwright/playwright.config.ts packages/playground/website/playwright/e2e/sites-api.spec.ts --project=chromium --grep "playgroundSites.rename\\(\\) renames a saved site" --reporter=line
```
