### PR TITLE
[Website] Avoid autosave prompts in embedded Playground

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1440,6 +1440,42 @@ echo get_option('blogname');
 		await expect(indicator).toHaveCount(0);
 	});
 
+	test('should not show autosave status in seamless mode', async ({
+		website,
+	}) => {
+		await website.page.goto('./?mode=seamless');
+		await expect(
+			website.page.locator(
+				'#playground-viewport:visible,.playground-viewport:visible'
+			)
+		).toBeVisible();
+
+		await expect(
+			website.page.getByRole('button', { name: /Autosaved|Unsaved/ })
+		).toHaveCount(0);
+	});
+
+	test('should not show autosave status when embedded in an iframe', async ({
+		website,
+	}, testInfo) => {
+		const embeddedUrl = new URL(
+			`./?name=embedded-${Date.now()}`,
+			String(testInfo.project.use.baseURL)
+		).href;
+		await website.page.setContent(
+			`<iframe title="Embedded Playground test" src="${embeddedUrl}"></iframe>`
+		);
+
+		const playgroundFrame = website.page.frameLocator(
+			'iframe[title="Embedded Playground test"]'
+		);
+		await expect(playgroundFrame.locator('body')).toBeVisible();
+
+		await expect(
+			playgroundFrame.getByRole('button', { name: /Autosaved|Unsaved/ })
+		).toHaveCount(0);
+	});
+
 	test('should keep a Playground saved after saving from the restore nudge state', async ({
 		website,
 		browserName,

--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -1462,6 +1462,7 @@ echo get_option('blogname');
 			`./?name=embedded-${Date.now()}`,
 			String(testInfo.project.use.baseURL)
 		).href;
+		await website.page.goto('./', { waitUntil: 'domcontentloaded' });
 		await website.page.setContent(
 			`<iframe title="Embedded Playground test" src="${embeddedUrl}"></iframe>`
 		);
@@ -1469,7 +1470,9 @@ echo get_option('blogname');
 		const playgroundFrame = website.page.frameLocator(
 			'iframe[title="Embedded Playground test"]'
 		);
-		await expect(playgroundFrame.locator('body')).toBeVisible();
+		await expect(
+			playgroundFrame.getByRole('button', { name: /Site Manager/ })
+		).toBeVisible();
 
 		await expect(
 			playgroundFrame.getByRole('button', { name: /Autosaved|Unsaved/ })

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -22,7 +22,7 @@ import {
 	type OverlayViewMode,
 } from '../saved-playgrounds-overlay';
 import { SaveStatusIndicator } from './save-status-indicator';
-import { isSaveDisabledByQueryParam } from '../../lib/state/url/router';
+import { isSiteSavingDisabled } from '../../lib/state/url/router';
 
 const query = new URL(document.location.href).searchParams;
 const overlayParam = query.get('overlay');
@@ -93,7 +93,7 @@ export default function BrowserChrome({
 						/>
 					</div>
 
-					{!isSaveDisabledByQueryParam() && <SaveStatusIndicator />}
+					{!isSiteSavingDisabled() && <SaveStatusIndicator />}
 
 					<div className={css.toolbarButtons}>
 						<Button

--- a/packages/playground/website/src/components/browser-chrome/index.tsx
+++ b/packages/playground/website/src/components/browser-chrome/index.tsx
@@ -27,6 +27,7 @@ import { isSiteSavingDisabled } from '../../lib/state/url/router';
 const query = new URL(document.location.href).searchParams;
 const overlayParam = query.get('overlay');
 const shouldOpenOverlay = overlayParam !== null;
+const isSavingDisabled = isSiteSavingDisabled();
 
 interface BrowserChromeProps {
 	children?: React.ReactNode;
@@ -93,7 +94,7 @@ export default function BrowserChrome({
 						/>
 					</div>
 
-					{!isSiteSavingDisabled() && <SaveStatusIndicator />}
+					{!isSavingDisabled && <SaveStatusIndicator />}
 
 					<div className={css.toolbarButtons}>
 						<Button

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from '@wordpress/components';
 import css from './restore-autosave-nudge.module.css';
 import { useCurrentUrl } from '../../lib/state/url/router-hooks';
-import { isSaveDisabledByQueryParam } from '../../lib/state/url/router';
+import { isSiteSavingDisabled } from '../../lib/state/url/router';
 import { opfsSiteStorage } from '../../lib/state/opfs/opfs-site-storage';
 import {
 	OPFSSitesLoaded,
@@ -34,7 +34,7 @@ import { getRelativeDate } from '../../lib/get-relative-date';
  * It has two routing modes:
  * * When `site-slug` is provided, it loads that site or creates it if missing.
  * * When `site-slug` is missing, it starts from the current setup URL and
- *   creates an autosaved site unless the URL or browser requires a temporary one.
+ *   creates an autosaved site unless the shell requires a temporary one.
  */
 export function EnsurePlaygroundSiteIsSelected({
 	children,
@@ -54,7 +54,7 @@ export function EnsurePlaygroundSiteIsSelected({
 	const requestedSiteObject = useAppSelector((state) =>
 		selectSiteBySlug(state, requestedSiteSlug!)
 	);
-	const isSavingDisabled = isSaveDisabledByQueryParam();
+	const isSavingDisabled = isSiteSavingDisabled(url);
 	const shouldUseTemporarySite =
 		url.searchParams.get('storage') === 'temp' ||
 		isSavingDisabled ||
@@ -119,8 +119,8 @@ export function EnsurePlaygroundSiteIsSelected({
 			// If the site slug is provided, try to load the site.
 			if (requestedSiteSlug) {
 				// If the site does not exist, create it. Saved browser
-				// storage is the default unless the URL explicitly asks for
-				// a temporary site or saving is unavailable.
+				// storage is the default unless this shell should not offer
+				// saving.
 				if (!requestedSiteObject) {
 					logger.log(
 						'The requested site was not found. Creating a new site.'

--- a/packages/playground/website/src/components/site-manager/temporary-site-notice/index.tsx
+++ b/packages/playground/website/src/components/site-manager/temporary-site-notice/index.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import classNames from 'classnames';
 import { usePlaygroundClient } from '../../../lib/use-playground-client';
 import { useActiveSite } from '../../../lib/state/redux/store';
-import { isSaveDisabledByQueryParam } from '../../../lib/state/url/router';
+import { isSiteSavingDisabled } from '../../../lib/state/url/router';
 
 export function TemporarySiteNotice({
 	isDismissible = false,
@@ -17,7 +17,7 @@ export function TemporarySiteNotice({
 	const [isDismissed, setIsDismissed] = useState(false);
 	const site = useActiveSite()!;
 	const playground = usePlaygroundClient(site.slug);
-	if (isDismissed || isSaveDisabledByQueryParam()) {
+	if (isDismissed || isSiteSavingDisabled()) {
 		return null;
 	}
 	return (

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -1,4 +1,4 @@
-import { parseBlueprint, PlaygroundRoute } from './router';
+import { parseBlueprint, PlaygroundRoute, isSiteSavingDisabled } from './router';
 import { decodeBlueprintHash } from './decode-blueprint-hash';
 import type { SiteInfo } from '../redux/slice-sites';
 
@@ -153,5 +153,66 @@ describe('PlaygroundRoute site creation routes', () => {
 		expect(params.get('url')).toBe('/wp-admin/');
 		expect(params.get('php')).toBe('8.0');
 		expect(params.get('wp')).toBe('6.6');
+	});
+});
+
+describe('isSiteSavingDisabled', () => {
+	const topWindow = {};
+	const regularWindow = {
+		self: topWindow,
+		top: topWindow,
+	} as unknown as Window;
+	const embeddedWindow = { self: {}, top: topWindow } as unknown as Window;
+
+	it('allows saving by default', () => {
+		expect(
+			isSiteSavingDisabled(
+				new URL('https://playground.test/'),
+				regularWindow
+			)
+		).toBe(false);
+	});
+
+	it('disables saving when can-save=no', () => {
+		expect(
+			isSiteSavingDisabled(
+				new URL('https://playground.test/?can-save=no'),
+				regularWindow
+			)
+		).toBe(true);
+	});
+
+	it('disables saving in seamless mode', () => {
+		expect(
+			isSiteSavingDisabled(
+				new URL('https://playground.test/?mode=seamless'),
+				regularWindow
+			)
+		).toBe(true);
+	});
+
+	it('disables saving when embedded in another iframe', () => {
+		expect(
+			isSiteSavingDisabled(
+				new URL('https://playground.test/'),
+				embeddedWindow
+			)
+		).toBe(true);
+	});
+
+	it('treats inaccessible iframe parents as embedded', () => {
+		const crossOriginWindow = {
+			self: {},
+			get top() {
+				throw new Error('Cross-origin parent');
+			},
+		} as unknown as Window;
+
+		expect(
+			isSiteSavingDisabled(
+				new URL('https://playground.test/'),
+				crossOriginWindow
+			)
+		).toBe(true);
 	});
 });

--- a/packages/playground/website/src/lib/state/url/router.spec.ts
+++ b/packages/playground/website/src/lib/state/url/router.spec.ts
@@ -1,4 +1,8 @@
-import { parseBlueprint, PlaygroundRoute, isSiteSavingDisabled } from './router';
+import {
+	parseBlueprint,
+	PlaygroundRoute,
+	isSiteSavingDisabled,
+} from './router';
 import { decodeBlueprintHash } from './decode-blueprint-hash';
 import type { SiteInfo } from '../redux/slice-sites';
 
@@ -158,11 +162,16 @@ describe('PlaygroundRoute site creation routes', () => {
 
 describe('isSiteSavingDisabled', () => {
 	const topWindow = {};
-	const regularWindow = {
-		self: topWindow,
-		top: topWindow,
-	} as unknown as Window;
-	const embeddedWindow = { self: {}, top: topWindow } as unknown as Window;
+	const regularWindow = {} as unknown as Window;
+	Object.defineProperties(regularWindow, {
+		self: { value: regularWindow },
+		top: { value: regularWindow },
+	});
+	const embeddedWindow = {} as unknown as Window;
+	Object.defineProperties(embeddedWindow, {
+		self: { value: embeddedWindow },
+		top: { value: topWindow },
+	});
 
 	it('allows saving by default', () => {
 		expect(

--- a/packages/playground/website/src/lib/state/url/router.ts
+++ b/packages/playground/website/src/lib/state/url/router.ts
@@ -192,14 +192,25 @@ export class PlaygroundRoute {
 }
 
 /**
- * Checks if the URL has a query parameter that disables saving.
- *
- * @returns {boolean} True if saving is disabled by the query parameter, false otherwise.
+ * Checks if the current Playground shell should offer browser saving.
  */
-export function isSaveDisabledByQueryParam(): boolean {
+export function isSiteSavingDisabled(
+	url: URL = new URL(document.location.href),
+	win: Window = window
+): boolean {
 	return (
-		new URL(document.location.href).searchParams.get('can-save') === 'no'
+		url.searchParams.get('can-save') === 'no' ||
+		url.searchParams.get('mode') === 'seamless' ||
+		isEmbeddedInAnIframe(win)
 	);
+}
+
+function isEmbeddedInAnIframe(win: Window): boolean {
+	try {
+		return win.self !== win.top;
+	} catch {
+		return true;
+	}
 }
 
 /**


### PR DESCRIPTION
## What changed

Don't offer restoring an autosaved Playground in Playgrounds:

* Embedded in an iframe on another sute
* With `?mode=seamless`
* With `?can-save=no`

There's no way to manage Playgrounds under those circumstances and the user expectation is just getting a fresh Playground instance.

## Screenshots

Before, the browser-saving status/action is visible:

<img width="640" alt="Before: save status visible" src="https://gist.githubusercontent.com/adamziel/c96b73222d10cb9994c6f7206ec48080/raw/4d1a22c05e5c5f30525cc77b0706360b55fafae3/before-save-status.svg" />

After, the save/autosave status is hidden when saving is disabled by the shell:

<img width="640" alt="After: save status hidden" src="https://gist.githubusercontent.com/adamziel/c96b73222d10cb9994c6f7206ec48080/raw/b175b1d8dc5e7809ed7e6840e73a5906a61e3988/after-save-status-hidden.svg" />

## Testing
- `git diff --check HEAD^ HEAD`
- `npm exec -- nx test playground-website -- --testFile=router.spec.ts`
- CI Playwright coverage for the new seamless and embedded-shell cases.

