### PR TITLE
Fix @php-wasm/web icu.dat dynamic import path in dist bundle

### DIFF
--- a/packages/php-wasm/web/vite.config.ts
+++ b/packages/php-wasm/web/vite.config.ts
@@ -33,18 +33,19 @@ export default defineConfig({
 		/*
 		 * This transforms rewrite dynamic import paths so they work from the dist output.
 		 *
-		 * Why the '../../../' prefix? Rollup computes the final import path relative to
+		 * Why the '../../' prefix? Rollup computes the final import path relative to
 		 * where the source file was located. Since everything gets bundled into
 		 * index.js at the dist root, we need to "climb out" of the source directory
-		 * structure. Rollup then normalizes '../../../foo' to './foo' in the output.
+		 * structure. Rollup then normalizes '../../foo' to './foo' in the output.
 		 */
 		viteExternalDynamicImports([
 			{
 				// Source: src/lib/extensions/load-extensions.ts
-				// Input:  './lib/extensions/intl/shared/icu.dat'
+				// Input:  './intl/shared/icu.dat'
 				// Output: './shared/icu.dat'
 				regex: /icu\.dat$/,
-				transform: (specifier) => `../../../${specifier}`,
+				transform: (specifier) =>
+					`../../${specifier.split('/').slice(-2).join('/')}`,
 			},
 		]),
 		...viteGlobalExtensions,

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/assets.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/assets.spec.ts
@@ -1,0 +1,61 @@
+const path = require('path');
+const fs = require('fs');
+
+const nodeModulesDir = path.resolve(__dirname, '..', 'node_modules');
+
+const bundleFiles = ['index.js', 'index.cjs'];
+const assetExtensions = ['dat', 'so', 'wasm'];
+const importRegex = new RegExp(
+	`import\\(\\s*["']((?:\\./|\\.\\./)[^"']+\\.(?:${assetExtensions.join(
+		'|'
+	)}))["']\\s*\\)`,
+	'g'
+);
+
+function getInstalledPackages(): Array<{ name: string; dir: string }> {
+	const results: Array<{ name: string; dir: string }> = [];
+	for (const scope of ['@php-wasm', '@wp-playground']) {
+		const scopeDir = path.join(nodeModulesDir, scope);
+		if (!fs.existsSync(scopeDir)) continue;
+		for (const pkg of fs.readdirSync(scopeDir)) {
+			const pkgDir = path.join(scopeDir, pkg);
+			const pkgJsonPath = path.join(pkgDir, 'package.json');
+			if (!fs.existsSync(pkgJsonPath)) continue;
+			const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+			results.push({ name: pkgJson.name, dir: pkgDir });
+		}
+	}
+	return results;
+}
+
+describe('Built package dynamic asset imports', () => {
+	getInstalledPackages().forEach((pkg) => {
+		it(`${pkg.name} dynamic asset imports resolve to files in dist`, () => {
+			for (const bundle of bundleFiles) {
+				const bundlePath = path.join(pkg.dir, bundle);
+				if (!fs.existsSync(bundlePath)) continue;
+
+				const source = fs.readFileSync(bundlePath, 'utf-8');
+				const specs = [...source.matchAll(importRegex)].map(
+					([, spec]) => spec
+				);
+				if (specs.length === 0) continue;
+
+				for (const spec of specs) {
+					const resolved = path.resolve(pkg.dir, spec);
+					expect({
+						bundle: `${pkg.name}/${bundle}`,
+						spec,
+						resolved,
+						exists: fs.existsSync(resolved),
+					}).toEqual({
+						bundle: `${pkg.name}/${bundle}`,
+						spec,
+						resolved,
+						exists: true,
+					});
+				}
+			}
+		});
+	});
+});

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/run-tests.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/run-tests.ts
@@ -35,7 +35,11 @@ if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
 	);
 }
 
-const testFiles = ['./tests/deps.spec.ts', './tests/wp.spec.ts'];
+const testFiles = [
+	'./tests/deps.spec.ts',
+	'./tests/wp.spec.ts',
+	'./tests/assets.spec.ts',
+];
 
 for (const phpVersion of SupportedPHPVersions) {
 	console.log(`\nRunning tests for PHP ${phpVersion}...`);

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/assets.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/assets.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const nodeModulesDir = path.resolve(__dirname, '..', 'node_modules');
+
+const bundleFiles = ['index.js', 'index.cjs'];
+const assetExtensions = ['dat', 'so', 'wasm'];
+const importRegex = new RegExp(
+	`import\\(\\s*["']((?:\\./|\\.\\./)[^"']+\\.(?:${assetExtensions.join(
+		'|'
+	)}))["']\\s*\\)`,
+	'g'
+);
+
+function getInstalledPackages(): Array<{ name: string; dir: string }> {
+	const results: Array<{ name: string; dir: string }> = [];
+	for (const scope of ['@php-wasm', '@wp-playground']) {
+		const scopeDir = path.join(nodeModulesDir, scope);
+		if (!fs.existsSync(scopeDir)) continue;
+		for (const pkg of fs.readdirSync(scopeDir)) {
+			const pkgDir = path.join(scopeDir, pkg);
+			const pkgJsonPath = path.join(pkgDir, 'package.json');
+			if (!fs.existsSync(pkgJsonPath)) continue;
+			const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+			results.push({ name: pkgJson.name, dir: pkgDir });
+		}
+	}
+	return results;
+}
+
+describe('Built package dynamic asset imports', () => {
+	getInstalledPackages().forEach((pkg) => {
+		it(`${pkg.name} dynamic asset imports resolve to files in dist`, () => {
+			for (const bundle of bundleFiles) {
+				const bundlePath = path.join(pkg.dir, bundle);
+				if (!fs.existsSync(bundlePath)) continue;
+
+				const source = fs.readFileSync(bundlePath, 'utf-8');
+				const specs = [...source.matchAll(importRegex)].map(
+					([, spec]) => spec
+				);
+				if (specs.length === 0) continue;
+
+				for (const spec of specs) {
+					const resolved = path.resolve(pkg.dir, spec);
+					assert.ok(
+						fs.existsSync(resolved),
+						`import("${spec}") in ${pkg.name}/${bundle} -> ${resolved} does not exist`
+					);
+				}
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Rewrites the `viteExternalDynamicImports` transform in `packages/php-wasm/web/vite.config.ts` so the bundled `index.js` / `index.cjs` resolve `icu.dat` from `./shared/icu.dat` next to the bundle.
- Adds a `test-built-npm-packages` regression spec that walks every installed `@php-wasm/*` and `@wp-playground/*` package, extracts dynamic `import("./...dat|so|wasm")` specs from each `index.js` / `index.cjs`, and asserts they resolve to real files relative to the package directory.

Fixes the downstream Vite consumer error:

```
[plugin:vite:import-analysis] Failed to resolve import "../intl/shared/icu.dat"
from "node_modules/@php-wasm/web/index.js"
```

## Why

PR #3566 ("Support custom PHP.wasm extensions") moved the dynamic `import("icu.dat")` from `src/lib/extensions/intl/with-intl.ts` (3 directories below `src/`) to `src/lib/extensions/load-extensions.ts` (2 directories below). The transform was hard-coded for the deeper location, so after the move Rollup's relative-path normalization leaves a leading `../intl/` segment in the output. The published bundle ends up with `import("../intl/shared/icu.dat")`, which resolves to `node_modules/@php-wasm/intl/shared/icu.dat` — a path that does not exist.

The regression test exists so any future relocation of a dynamic-asset import in the WASM packages can't ship to npm unnoticed.

## Changes by commit

- **`[Tests] Verify dynamic asset imports resolve in built npm packages`** — adds `assets.spec.ts` to both the ESM (`node:test`) and CommonJS (Jest) projects under `packages/playground/test-built-npm-packages/`. Wires the ESM spec into `run-tests.ts`; Jest auto-discovers via `testMatch`. On its own this commit fails CI against current trunk, which is the intended demonstration.
- **`Fix dynamic icu.dat import path in @php-wasm/web bundle`** (to follow) — rewrites the `viteExternalDynamicImports` transform to derive a `./shared/<file>` output regardless of source-file depth under `src/`. Turns the new regression test green.

## Test plan

- [x] Locally: spec fails against the broken (trunk) `@php-wasm/web` bundle — `import("../intl/shared/icu.dat") -> .../@php-wasm/intl/shared/icu.dat does not exist`.
- [x] Locally: spec passes against the rebuilt `@php-wasm/web` bundle after the transform fix.
- [ ] CI `test-built-npm-packages` ES Modules and CommonJS jobs fail on the tests-only commit; turn green after the vite-fix commit lands.
- [ ] Reproduce the downstream Vite consumer's original build against `@php-wasm/web` from this branch's HEAD and confirm it no longer errors.