### PR TITLE
Add WordPress 0.7 legacy support

### DIFF
--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -283,6 +283,8 @@ const [setApiReady, setAPIError] = exposeAPI(
  */
 function normalizeWordPressVersion(version: string): string {
 	const legacyVersionMap: Record<string, string> = {
+		'0.7': '0.71-gold',
+		'0.71': '0.71-gold',
 		'1.0': '1.0.2',
 		'1.2': '1.2.2',
 		'1.5': '1.5.2',

--- a/packages/playground/website/src/components/site-manager/site-settings-form/older-wordpress-versions.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/older-wordpress-versions.ts
@@ -63,6 +63,8 @@ export const OlderWordPressVersions = [
 	'1.5',
 	'1.2',
 	'1.0',
+	// WP 0.7 is served by wordpress.org as the 0.71-gold archive.
+	'0.7',
 ] as const;
 
 export type OlderWordPressVersion = (typeof OlderWordPressVersions)[number];

--- a/packages/playground/wordpress/src/legacy-wp/legacy-fixes.ts
+++ b/packages/playground/wordpress/src/legacy-wp/legacy-fixes.ts
@@ -3,7 +3,7 @@
  *
  * Two kinds of patches live here:
  *
- *   * Full source-level rewrites that let WordPress 1.0–2.8 boot on
+ *   * Full source-level rewrites that let WordPress 0.7–2.8 boot on
  *     the PHP 5.2 WASM + SQLite stack. Entry point:
  *     {@link patchWordPressSourceFiles}. Used from legacy-wp/legacy-boot.ts.
  *   * A mysqli-check backport that lets WP 5.0–6.1 boot on SQLite.
@@ -33,6 +33,11 @@
 import type { PHP } from '@php-wasm/universal';
 import { logger } from '@php-wasm/logger';
 import { joinPaths } from '@php-wasm/util';
+import {
+	prepareWp07SourceTree,
+	runWp07PostInstallFixups,
+} from './wp-07-support';
+import { rewriteRelativePhpIncludes } from './relative-paths';
 
 /**
  * Backports WP 6.2's mysqli check to WP 5.0–6.1 on SQLite: the
@@ -90,7 +95,7 @@ export const LEGACY_WP_ERROR_REPORTING_PHP_EXPR = 'E_ALL & ~8192 & ~2048';
  * Patches WordPress source files for legacy version compatibility.
  *
  * Applies all necessary patches to make old WordPress versions
- * (1.0 through 2.8) work with modern PHP and the SQLite integration.
+ * (0.7 through 2.8) work with modern PHP and the SQLite integration.
  *
  * Called from legacy-wp/legacy-boot.ts; legacy boot path only.
  */
@@ -98,6 +103,8 @@ export async function patchWordPressSourceFiles(
 	php: PHP,
 	documentRoot: string
 ) {
+	if (await prepareWp07SourceTree(php, documentRoot)) return;
+
 	await ensureVersionPhp(php, documentRoot);
 	await ensureWpLoadPhp(php, documentRoot);
 
@@ -940,62 +947,13 @@ async function patchWpAdminRelativePaths(php: PHP, documentRoot: string) {
 	// /wordpress instead of the file's own directory. Rewrite every
 	// relative require/include in wp-admin to a dirname(__FILE__)-based
 	// absolute path. Covers WP 1.2 through 3.6.
-	const toDirnameExpr = (relPath: string): string => {
-		let remaining = relPath;
-		let upLevels = 0;
-		while (remaining.startsWith('../')) {
-			upLevels++;
-			remaining = remaining.slice(3);
-		}
-		while (remaining.startsWith('./')) {
-			remaining = remaining.slice(2);
-		}
-		let dirExpr = 'dirname(__FILE__)';
-		for (let i = 0; i < upLevels; i++) {
-			dirExpr = `dirname(${dirExpr})`;
-		}
-		return `${dirExpr} . '/${remaining}'`;
-	};
 	const wpAdminDir = joinPaths(documentRoot, 'wp-admin');
 	if (php.isDir(wpAdminDir)) {
 		for (const file of php.listFiles(wpAdminDir)) {
 			if (!file.endsWith('.php')) continue;
 			const filePath = joinPaths(wpAdminDir, file);
 			const content = php.readFileAsText(filePath);
-			const patched = content
-				.replace(
-					/((?:require|include)(?:_once)?)\s*\(\s*(['"])(\.\.\/[^'"]+)\2\s*\)/g,
-					(_, keyword, _q, path) =>
-						`${keyword}(${toDirnameExpr(path)})`
-				)
-				.replace(
-					/((?:require|include)(?:_once)?)\s*\(\s*(['"])(\.\/[^'"]+)\2\s*\)/g,
-					(_, keyword, _q, path) =>
-						`${keyword}(${toDirnameExpr(path)})`
-				)
-				// Bare filename (e.g. 'admin-header.php'). Restrict to
-				// .php to avoid false positives.
-				.replace(
-					/((?:require|include)(?:_once)?)\s*\(\s*(['"])([a-z][\w-]*\.php)\2\s*\)/g,
-					(_, keyword, _q, path) =>
-						`${keyword}(${toDirnameExpr(path)})`
-				)
-				// Statement form without parentheses (WP 2.0 uses this).
-				.replace(
-					/((?:require|include)(?:_once)?)\s+(['"])(\.\.\/[^'"]+)\2/g,
-					(_, keyword, _q, path) =>
-						`${keyword}(${toDirnameExpr(path)})`
-				)
-				.replace(
-					/((?:require|include)(?:_once)?)\s+(['"])(\.\/[^'"]+)\2/g,
-					(_, keyword, _q, path) =>
-						`${keyword}(${toDirnameExpr(path)})`
-				)
-				.replace(
-					/((?:require|include)(?:_once)?)\s+(['"])([a-z][\w-]*\.php)\2/g,
-					(_, keyword, _q, path) =>
-						`${keyword}(${toDirnameExpr(path)})`
-				)
+			const patched = rewriteRelativePhpIncludes(content)
 				// Drop the leading slash from `ABSPATH . '/wp-...'`.
 				.replace(/ABSPATH\s*\.\s*'\/wp-/g, "ABSPATH . 'wp-");
 			if (patched !== content) {
@@ -1559,6 +1517,9 @@ if (!function_exists('mysqli_close')) {
 /**
  * Post-install fixups for legacy WordPress.
  *
+ * Stage 0 (WP 0.7 only): delegates to the gated b2/cafelog fixups in
+ * wp-07-support.ts because WP 0.7 has b2* tables, not wp_* tables.
+ *
  * Stage 1 (always): boots WordPress and patches data via $wpdb —
  * siteurl/home, admin password, roles/caps, default content.
  *
@@ -1573,6 +1534,8 @@ export async function runPostInstallLegacyFixups(
 	php: PHP,
 	siteUrl: string
 ): Promise<void> {
+	if (await runWp07PostInstallFixups(php)) return;
+
 	let wpVersion: string | null = null;
 	const versionPhp = joinPaths(php.documentRoot, 'wp-includes/version.php');
 	if (php.fileExists(versionPhp)) {

--- a/packages/playground/wordpress/src/legacy-wp/mysql-shims.ts
+++ b/packages/playground/wordpress/src/legacy-wp/mysql-shims.ts
@@ -33,6 +33,9 @@ if (!function_exists('mysql_select_db')) {
 if (!function_exists('mysql_set_charset')) {
 	function mysql_set_charset() { return true; }
 }
+if (!defined('MYSQL_ASSOC')) define('MYSQL_ASSOC', 1);
+if (!defined('MYSQL_NUM')) define('MYSQL_NUM', 2);
+if (!defined('MYSQL_BOTH')) define('MYSQL_BOTH', 3);
 // Functional mysql_* stubs that delegate to $wpdb (SQLite driver).
 $GLOBALS['_mysql_results'] = array();
 $GLOBALS['_mysql_result_id'] = 0;
@@ -96,6 +99,23 @@ if (!function_exists('mysql_fetch_row')) {
 		if ($r['index'] >= count($r['rows'])) return null;
 		$row = $r['rows'][$r['index']++];
 		return array_values((array)$row);
+	}
+}
+if (!function_exists('mysql_fetch_assoc')) {
+	function mysql_fetch_assoc($result) {
+		if (!isset($GLOBALS['_mysql_results'][$result])) return null;
+		$r = &$GLOBALS['_mysql_results'][$result];
+		if ($r['index'] >= count($r['rows'])) return null;
+		return (array)$r['rows'][$r['index']++];
+	}
+}
+if (!function_exists('mysql_fetch_array')) {
+	function mysql_fetch_array($result, $result_type = null) {
+		$row = mysql_fetch_assoc($result);
+		if ($row === null) return null;
+		if ($result_type === MYSQL_ASSOC) return $row;
+		if ($result_type === MYSQL_NUM) return array_values($row);
+		return array_merge(array_values($row), $row);
 	}
 }
 if (!function_exists('mysql_fetch_object')) {

--- a/packages/playground/wordpress/src/legacy-wp/relative-paths.ts
+++ b/packages/playground/wordpress/src/legacy-wp/relative-paths.ts
@@ -1,0 +1,52 @@
+/**
+ * Rewrites relative PHP include/require paths to paths relative to
+ * the file itself. Playground runs PHP requests with CWD set to the
+ * document root, while old WordPress admin scripts assume CWD is the
+ * script directory.
+ *
+ * Each pattern anchors the keyword to a non-word boundary (`(^|[^\w$])`)
+ * so identifiers that merely end in `require`/`include` — e.g.
+ * `my_require_once(...)` — are left untouched. A negative lookbehind
+ * would be cleaner but isn't supported on older Safari, so the boundary
+ * character is captured and re-emitted instead.
+ */
+export function rewriteRelativePhpIncludes(content: string): string {
+	const patterns = [
+		// Parenthesized forms.
+		/(^|[^\w$])((?:require|include)(?:_once)?)\s*\(\s*(['"])(\.\.\/[^'"]+)\3\s*\)/g,
+		/(^|[^\w$])((?:require|include)(?:_once)?)\s*\(\s*(['"])(\.\/[^'"]+)\3\s*\)/g,
+		// Bare filename (e.g. 'admin-header.php'). Restrict to .php to
+		// avoid false positives.
+		/(^|[^\w$])((?:require|include)(?:_once)?)\s*\(\s*(['"])([a-z][\w-]*\.php)\3\s*\)/g,
+		// Statement forms without parentheses (WP 2.0 uses this).
+		/(^|[^\w$])((?:require|include)(?:_once)?)\s+(['"])(\.\.\/[^'"]+)\3/g,
+		/(^|[^\w$])((?:require|include)(?:_once)?)\s+(['"])(\.\/[^'"]+)\3/g,
+		/(^|[^\w$])((?:require|include)(?:_once)?)\s+(['"])([a-z][\w-]*\.php)\3/g,
+	];
+	return patterns.reduce(
+		(text, pattern) =>
+			text.replace(
+				pattern,
+				(_, pre, keyword, _q, path) =>
+					`${pre}${keyword}(${toDirnameExpr(path)})`
+			),
+		content
+	);
+}
+
+function toDirnameExpr(relPath: string): string {
+	let remaining = relPath;
+	let upLevels = 0;
+	while (remaining.startsWith('../')) {
+		upLevels++;
+		remaining = remaining.slice(3);
+	}
+	while (remaining.startsWith('./')) {
+		remaining = remaining.slice(2);
+	}
+	let dirExpr = 'dirname(__FILE__)';
+	for (let i = 0; i < upLevels; i++) {
+		dirExpr = `dirname(${dirExpr})`;
+	}
+	return `${dirExpr} . '/${remaining}'`;
+}

--- a/packages/playground/wordpress/src/legacy-wp/wp-07-support.ts
+++ b/packages/playground/wordpress/src/legacy-wp/wp-07-support.ts
@@ -1,0 +1,593 @@
+/**
+ * WordPress 0.7 compatibility.
+ *
+ * WP 0.71-gold still uses the b2/cafelog file layout: b2config.php,
+ * b2-include/, b2login.php, and b2* database tables. Keep those
+ * adaptations here so the regular legacy WP 1.0+ path stays focused on
+ * WordPress-shaped trees.
+ */
+import type { PHP } from '@php-wasm/universal';
+import { joinPaths } from '@php-wasm/util';
+import { rewriteRelativePhpIncludes } from './relative-paths';
+
+export async function prepareWp07SourceTree(
+	php: PHP,
+	documentRoot: string
+): Promise<boolean> {
+	if (!isWp07SourceTree(php, documentRoot)) return false;
+
+	await ensureWp07CompatibilityDirectories(php, documentRoot);
+	await writeWp07WordPressShims(php, documentRoot);
+	await patchWp07Config(php, documentRoot);
+	await patchWp07BlogHeader(php, documentRoot);
+	await patchWp07WpDb(php, documentRoot);
+	await patchWp07TemplateFunctions(php, documentRoot);
+	await patchWp07AuthAndAdminFiles(php, documentRoot);
+	return true;
+}
+
+export async function runWp07PostInstallFixups(php: PHP): Promise<boolean> {
+	if (!isWp07SourceTree(php, php.documentRoot)) return false;
+
+	await php.run({
+		code: `<?php
+			$db_dir = getenv('DOCUMENT_ROOT') . '/wp-content/database/';
+			if (!is_dir($db_dir)) { @mkdir($db_dir, 0777, true); }
+			$db_path = $db_dir . '.ht.sqlite';
+			$pdo = new PDO('sqlite:' . $db_path);
+			$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+			$now = date('Y-m-d H:i:s');
+
+			$tables_sql = array(
+				'b2posts' => "CREATE TABLE IF NOT EXISTS b2posts (
+					ID INTEGER PRIMARY KEY AUTOINCREMENT,
+					post_author INTEGER NOT NULL DEFAULT 0,
+					post_date TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+					post_content TEXT NOT NULL DEFAULT '',
+					post_title TEXT NOT NULL DEFAULT '',
+					post_category INTEGER NOT NULL DEFAULT 0,
+					post_excerpt TEXT NOT NULL DEFAULT '',
+					post_status TEXT NOT NULL DEFAULT 'publish',
+					comment_status TEXT NOT NULL DEFAULT 'open',
+					ping_status TEXT NOT NULL DEFAULT 'open',
+					post_password TEXT NOT NULL DEFAULT ''
+				)",
+				'b2categories' => "CREATE TABLE IF NOT EXISTS b2categories (
+					cat_ID INTEGER PRIMARY KEY AUTOINCREMENT,
+					cat_name TEXT NOT NULL DEFAULT ''
+				)",
+				'b2comments' => "CREATE TABLE IF NOT EXISTS b2comments (
+					comment_ID INTEGER PRIMARY KEY AUTOINCREMENT,
+					comment_post_ID INTEGER NOT NULL DEFAULT 0,
+					comment_author TEXT NOT NULL DEFAULT '',
+					comment_author_email TEXT NOT NULL DEFAULT '',
+					comment_author_url TEXT NOT NULL DEFAULT '',
+					comment_author_IP TEXT NOT NULL DEFAULT '',
+					comment_date TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+					comment_content TEXT NOT NULL DEFAULT '',
+					comment_karma INTEGER NOT NULL DEFAULT 0
+				)",
+				'b2settings' => "CREATE TABLE IF NOT EXISTS b2settings (
+					ID INTEGER NOT NULL DEFAULT 1,
+					posts_per_page INTEGER NOT NULL DEFAULT 20,
+					what_to_show TEXT NOT NULL DEFAULT 'posts',
+					archive_mode TEXT NOT NULL DEFAULT 'postbypost',
+					time_difference INTEGER NOT NULL DEFAULT 0,
+					AutoBR INTEGER NOT NULL DEFAULT 1,
+					time_format TEXT NOT NULL DEFAULT 'g:i a',
+					date_format TEXT NOT NULL DEFAULT 'n/j/Y',
+					PRIMARY KEY (ID)
+				)",
+				'b2users' => "CREATE TABLE IF NOT EXISTS b2users (
+					ID INTEGER PRIMARY KEY AUTOINCREMENT,
+					user_login TEXT NOT NULL DEFAULT '',
+					user_pass TEXT NOT NULL DEFAULT '',
+					user_firstname TEXT NOT NULL DEFAULT '',
+					user_lastname TEXT NOT NULL DEFAULT '',
+					user_nickname TEXT NOT NULL DEFAULT '',
+					user_icq INTEGER NOT NULL DEFAULT 0,
+					user_email TEXT NOT NULL DEFAULT '',
+					user_url TEXT NOT NULL DEFAULT '',
+					user_ip TEXT NOT NULL DEFAULT '',
+					user_domain TEXT NOT NULL DEFAULT '',
+					user_browser TEXT NOT NULL DEFAULT '',
+					dateYMDhour TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+					user_level INTEGER NOT NULL DEFAULT 0,
+					user_aim TEXT NOT NULL DEFAULT '',
+					user_msn TEXT NOT NULL DEFAULT '',
+					user_yim TEXT NOT NULL DEFAULT '',
+					user_idmode TEXT NOT NULL DEFAULT ''
+				)",
+				'b2links' => "CREATE TABLE IF NOT EXISTS b2links (
+					link_id INTEGER PRIMARY KEY AUTOINCREMENT,
+					link_url TEXT NOT NULL DEFAULT '',
+					link_name TEXT NOT NULL DEFAULT '',
+					link_image TEXT NOT NULL DEFAULT '',
+					link_target TEXT NOT NULL DEFAULT '',
+					link_category INTEGER NOT NULL DEFAULT 0,
+					link_description TEXT NOT NULL DEFAULT '',
+					link_visible TEXT NOT NULL DEFAULT 'Y',
+					link_owner INTEGER NOT NULL DEFAULT 1,
+					link_rating INTEGER NOT NULL DEFAULT 0,
+					link_updated TEXT NOT NULL DEFAULT '0000-00-00 00:00:00',
+					link_rel TEXT NOT NULL DEFAULT '',
+					link_notes TEXT NOT NULL DEFAULT '',
+					link_rss TEXT NOT NULL DEFAULT ''
+				)",
+				'b2linkcategories' => "CREATE TABLE IF NOT EXISTS b2linkcategories (
+					cat_id INTEGER PRIMARY KEY AUTOINCREMENT,
+					cat_name TEXT NOT NULL DEFAULT '',
+					auto_toggle TEXT NOT NULL DEFAULT 'N',
+					show_images TEXT NOT NULL DEFAULT 'Y',
+					show_description TEXT NOT NULL DEFAULT 'N',
+					show_rating TEXT NOT NULL DEFAULT 'Y',
+					show_updated TEXT NOT NULL DEFAULT 'Y',
+					sort_order TEXT NOT NULL DEFAULT 'name',
+					sort_desc TEXT NOT NULL DEFAULT 'ASC',
+					text_before_link TEXT NOT NULL DEFAULT '<li>',
+					text_after_link TEXT NOT NULL DEFAULT '<br />',
+					text_after_all TEXT NOT NULL DEFAULT '</li>',
+					list_limit INTEGER NOT NULL DEFAULT -1
+				)"
+			);
+			foreach ($tables_sql as $sql) {
+				$pdo->exec($sql);
+			}
+
+			if (!$pdo->query("SELECT COUNT(*) FROM b2categories")->fetchColumn()) {
+				$pdo->exec("INSERT INTO b2categories (cat_ID, cat_name) VALUES (1, 'General')");
+			}
+			if (!$pdo->query("SELECT COUNT(*) FROM b2settings")->fetchColumn()) {
+				$pdo->exec("INSERT INTO b2settings (ID, posts_per_page, what_to_show, archive_mode, time_difference, AutoBR, time_format, date_format) VALUES (1, 20, 'posts', 'postbypost', 0, 1, 'g:i a', 'n/j/Y')");
+			}
+			if (!$pdo->query("SELECT COUNT(*) FROM b2users")->fetchColumn()) {
+				$pass = md5('password');
+				$pdo->exec("INSERT INTO b2users (ID, user_login, user_pass, user_nickname, user_email, user_level, dateYMDhour, user_idmode) VALUES (1, 'admin', '{$pass}', 'admin', 'admin@localhost.com', 10, '{$now}', 'nickname')");
+			} else {
+				$pass = md5('password');
+				$pdo->exec("UPDATE b2users SET user_pass = '{$pass}', user_level = 10 WHERE user_login = 'admin'");
+			}
+			if (!$pdo->query("SELECT COUNT(*) FROM b2posts")->fetchColumn()) {
+				$content = 'Welcome to WordPress. This is the first post. Edit or delete it, then start blogging!';
+				$pdo->exec("INSERT INTO b2posts (ID, post_author, post_date, post_content, post_title, post_category, post_excerpt, post_status, comment_status, ping_status, post_password) VALUES (1, 1, '{$now}', '{$content}', 'Hello world!', 1, '', 'publish', 'open', 'open', '')");
+			}
+			if (!$pdo->query("SELECT COUNT(*) FROM b2comments")->fetchColumn()) {
+				$pdo->exec("INSERT INTO b2comments (comment_post_ID, comment_author, comment_author_email, comment_author_url, comment_author_IP, comment_date, comment_content, comment_karma) VALUES (1, 'Mr WordPress', 'mr@wordpress.org', 'http://wordpress.org', '127.0.0.1', '{$now}', 'Hi, this is a comment. To delete a comment, just log in and view the comments for this post.', 0)");
+			}
+			if (!$pdo->query("SELECT COUNT(*) FROM b2linkcategories")->fetchColumn()) {
+				$pdo->exec("INSERT INTO b2linkcategories (cat_id, cat_name) VALUES (1, 'General')");
+			}
+			if (!$pdo->query("SELECT COUNT(*) FROM b2links")->fetchColumn()) {
+				$pdo->exec("INSERT INTO b2links (link_url, link_name, link_category, link_visible, link_owner) VALUES ('http://wordpress.org', 'WordPress', 1, 'Y', 1)");
+			}
+		`,
+		env: {
+			DOCUMENT_ROOT: php.documentRoot,
+		},
+	});
+
+	return true;
+}
+
+function isWp07SourceTree(php: PHP, documentRoot: string): boolean {
+	const configPath = joinPaths(documentRoot, 'b2config.php');
+	const varsPath = joinPaths(documentRoot, 'b2-include/b2vars.php');
+	if (!php.fileExists(configPath) || !php.fileExists(varsPath)) {
+		return false;
+	}
+	return php.readFileAsText(varsPath).includes("$b2_version = '0.71'");
+}
+
+async function ensureWp07CompatibilityDirectories(
+	php: PHP,
+	documentRoot: string
+): Promise<void> {
+	for (const path of [
+		joinPaths(documentRoot, 'wp-includes'),
+		joinPaths(documentRoot, 'wp-content'),
+		joinPaths(documentRoot, 'wp-content/database'),
+	]) {
+		if (!php.isDir(path)) {
+			await php.mkdir(path);
+		}
+	}
+}
+
+async function writeWp07WordPressShims(
+	php: PHP,
+	documentRoot: string
+): Promise<void> {
+	const versionPhpPath = joinPaths(documentRoot, 'wp-includes/version.php');
+	await php.writeFile(
+		versionPhpPath,
+		`<?php
+$wp_version = '0.71';
+$wp_db_version = 71;
+`
+	);
+
+	const wpConfigPath = joinPaths(documentRoot, 'wp-config.php');
+	if (!php.fileExists(wpConfigPath)) {
+		await php.writeFile(
+			wpConfigPath,
+			`<?php require_once dirname(__FILE__) . '/b2config.php';`
+		);
+	}
+
+	const wpLoadPath = joinPaths(documentRoot, 'wp-load.php');
+	if (!php.fileExists(wpLoadPath)) {
+		await php.writeFile(
+			wpLoadPath,
+			`<?php
+if (!defined('ABSPATH')) {
+	define('ABSPATH', dirname(__FILE__) . '/');
+}
+require_once ABSPATH . 'b2config.php';
+`
+		);
+	}
+
+	const postPhpPath = joinPaths(documentRoot, 'wp-admin/post.php');
+	if (!php.fileExists(postPhpPath)) {
+		await php.writeFile(
+			postPhpPath,
+			`<?php require_once dirname(__FILE__) . '/b2edit.php';`
+		);
+	}
+}
+
+async function patchWp07Config(php: PHP, documentRoot: string): Promise<void> {
+	const configPath = joinPaths(documentRoot, 'b2config.php');
+	let config = php.readFileAsText(configPath);
+	const original = config;
+
+	if (!config.includes('pg_wp07_bootstrap')) {
+		config = config.replace(
+			'<?php',
+			`<?php
+if (!defined('ABSPATH')) define('ABSPATH', dirname(__FILE__) . '/'); /* pg_wp07_bootstrap */
+if (!defined('WPINC')) define('WPINC', 'b2-include');
+if (!defined('WP_CONTENT_DIR')) define('WP_CONTENT_DIR', ABSPATH . 'wp-content');
+if (!defined('DB_ENGINE')) define('DB_ENGINE', 'sqlite');
+if (!isset($table_prefix)) $table_prefix = 'b2';
+error_reporting(E_ALL & ~E_NOTICE & ~8192 & ~2048);
+`
+		);
+	}
+
+	config = config
+		.replace(
+			/\$siteurl\s*=\s*'http:\/\/example\.com';[^\n]*/,
+			"$siteurl = defined('WP_SITEURL') ? WP_SITEURL : 'http://localhost'; // pg_wp07_siteurl"
+		)
+		.replace(
+			'$blogname = "my weblog";',
+			'$blogname = "My WordPress Website";'
+		)
+		.replace(
+			'$blogdescription = "babblings !";',
+			'$blogdescription = "Just another WordPress weblog";'
+		)
+		.replace(
+			"$admin_email = 'you@example.com';",
+			"$admin_email = 'admin@localhost.com';"
+		)
+		.replace(
+			"$abspath =  getenv('DOCUMENT_ROOT') . $relpath . '/';",
+			"$abspath = dirname(__FILE__) . '/';"
+		);
+
+	if (config !== original) {
+		await php.writeFile(configPath, config);
+	}
+}
+
+async function patchWp07BlogHeader(
+	php: PHP,
+	documentRoot: string
+): Promise<void> {
+	const blogHeaderPath = joinPaths(documentRoot, 'blog.header.php');
+	let blogHeader = php.readFileAsText(blogHeaderPath);
+	const original = blogHeader;
+
+	blogHeader = blogHeader.replace(
+		`$where .= ' AND (post_status = "publish"';`,
+		`$where .= " AND (post_status = 'publish'";`
+	);
+
+	if (blogHeader !== original) {
+		await php.writeFile(blogHeaderPath, blogHeader);
+	}
+}
+
+async function patchWp07WpDb(php: PHP, documentRoot: string): Promise<void> {
+	const wpDbPath = joinPaths(documentRoot, 'b2-include/wp-db.php');
+	let wpDb = php.readFileAsText(wpDbPath);
+	const original = wpDb;
+
+	wpDb = injectWp07WpdbPolyfills(wpDb);
+	wpDb = wpDb.replace(
+		'$wpdb = new wpdb(DB_USER, DB_PASSWORD, DB_NAME, DB_HOST);',
+		`if (!isset($GLOBALS['wpdb'])) {
+	$GLOBALS['wpdb'] = new wpdb(DB_USER, DB_PASSWORD, DB_NAME, DB_HOST);
+}
+$wpdb = $GLOBALS['wpdb']; /* pg_wp07_preserve_sqlite_loader */`
+	);
+
+	if (wpDb !== original) {
+		await php.writeFile(wpDbPath, wpDb);
+	}
+}
+
+function injectWp07WpdbPolyfills(wpDb: string): string {
+	const polyfills: string[] = [];
+	if (!wpDb.includes('function set_prefix')) {
+		polyfills.push(`
+	function set_prefix($prefix) {
+		$this->prefix = $prefix;
+		$tables = array('posts', 'users', 'categories', 'comments', 'links', 'linkcategories', 'settings', 'options', 'postmeta', 'usermeta', 'terms', 'term_taxonomy', 'term_relationships');
+		foreach ($tables as $table) {
+			$this->$table = $prefix . $table;
+		}
+		return $prefix;
+	}`);
+	}
+	if (!wpDb.includes('function timer_start')) {
+		polyfills.push(`
+	function timer_start() {
+		$this->time_start = microtime(true);
+		return true;
+	}`);
+	}
+	if (!wpDb.includes('function timer_stop')) {
+		polyfills.push(`
+	function timer_stop() {
+		return microtime(true) - $this->time_start;
+	}`);
+	}
+	if (!wpDb.includes('function init_charset')) {
+		polyfills.push(`
+	function init_charset() {
+		if (defined('DB_CHARSET')) $this->charset = DB_CHARSET;
+		if (defined('DB_COLLATE')) $this->collate = DB_COLLATE;
+	}`);
+	}
+	if (!wpDb.includes('function bail')) {
+		polyfills.push(`
+	function bail($message, $error_code = '500') {
+		die($message);
+	}`);
+	}
+	if (!wpDb.includes('function check_connection')) {
+		polyfills.push(`
+	function check_connection($allow_bail = true) {
+		return true;
+	}`);
+	}
+	if (polyfills.length === 0) return wpDb;
+
+	const classEndMatch = wpDb.match(
+		/^(\s*})\s*\n+(\$wpdb|if\s*\(\s*!\s*isset\(\s*\$GLOBALS\['wpdb'\]\s*\))/m
+	);
+	// Fail loudly rather than silently shipping a wpdb missing essential
+	// methods (set_prefix, init_charset, bail, ...), which would fatal far
+	// downstream with a confusing error.
+	if (!classEndMatch || classEndMatch.index === undefined) {
+		throw new Error(
+			'WP 0.7 wpdb polyfill anchor not found; b2-include/wp-db.php layout changed'
+		);
+	}
+
+	const polyfillBlock =
+		'\n\t// Polyfills added by WordPress Playground for WP 0.7.\n' +
+		polyfills.join('\n') +
+		'\n\n';
+	return (
+		wpDb.substring(0, classEndMatch.index) +
+		polyfillBlock +
+		wpDb.substring(classEndMatch.index)
+	);
+}
+
+async function patchWp07TemplateFunctions(
+	php: PHP,
+	documentRoot: string
+): Promise<void> {
+	const templateFunctionsPath = joinPaths(
+		documentRoot,
+		'b2-include/b2template.functions.php'
+	);
+	let templateFunctions = php.readFileAsText(templateFunctionsPath);
+	const original = templateFunctions;
+	if (templateFunctions.includes('pg_wp07_apply_filters')) return;
+
+	templateFunctions = templateFunctions.replace(
+		`function apply_filters($tag, $string) {
+	global $b2_filter;
+	if (isset($b2_filter['all'])) {
+		$b2_filter['all'] = (is_string($b2_filter['all'])) ? array($b2_filter['all']) : $b2_filter['all'];
+		$b2_filter[$tag] = array_merge($b2_filter['all'], $b2_filter[$tag]);
+		$b2_filter[$tag] = array_unique($b2_filter[$tag]);
+	}
+	if (isset($b2_filter[$tag])) {
+		$b2_filter[$tags] = (is_string($b2_filter[$tag])) ? array($b2_filter[$tag]) : $b2_filter[$tag];
+		$functions = $b2_filter[$tag];
+		foreach($functions as $function) {
+			$string = $function($string);
+		}
+	}
+	return $string;
+}`,
+		`function apply_filters($tag, $string) { /* pg_wp07_apply_filters */
+	global $b2_filter;
+	$functions = array();
+	// WP_SQLite_DB uses apply_filters('query'); b2's all filter texturizes SQL.
+	if ($tag != 'query' && isset($b2_filter['all'])) {
+		$all = is_array($b2_filter['all']) ? $b2_filter['all'] : array($b2_filter['all']);
+		$functions = array_merge($functions, $all);
+	}
+	if (isset($b2_filter[$tag])) {
+		$tag_functions = is_array($b2_filter[$tag]) ? $b2_filter[$tag] : array($b2_filter[$tag]);
+		$functions = array_merge($functions, $tag_functions);
+	}
+	$functions = array_unique($functions);
+	foreach($functions as $function) {
+		if (function_exists($function)) {
+			$string = $function($string);
+		}
+	}
+	return $string;
+}`
+	);
+
+	if (templateFunctions !== original) {
+		await php.writeFile(templateFunctionsPath, templateFunctions);
+	}
+}
+
+async function patchWp07AuthAndAdminFiles(
+	php: PHP,
+	documentRoot: string
+): Promise<void> {
+	await patchWp07Login(php, documentRoot);
+	await patchWp07AdminRelativePaths(php, documentRoot);
+	await patchWp07AdminMenuTop(php, documentRoot);
+	await patchWp07AdminAuth(php, documentRoot);
+}
+
+async function patchWp07Login(php: PHP, documentRoot: string): Promise<void> {
+	const loginPath = joinPaths(documentRoot, 'b2login.php');
+	let login = php.readFileAsText(loginPath);
+	const original = login;
+
+	if (!login.includes('pg_wp07_login_auto_login')) {
+		login = login.replace(
+			`switch($action) {`,
+			`${getWp07AutoLoginCookieBootstrap('pg_wp07_login_auto_login')}
+switch($action) {`
+		);
+	}
+
+	if (!login.includes('pg_wp07_logout_guard')) {
+		login = login.replace(
+			`\tsetcookie('wordpressuser');
+\tsetcookie('wordpresspass');`,
+			`\tsetcookie('wordpressuser', '', time() - 31536000);
+\tsetcookie('wordpresspass', '', time() - 31536000);
+\tsetcookie('wordpressblogid', '', time() - 31536000);
+\tsetcookie('wordpressuser', '', time() - 31536000, '/');
+\tsetcookie('wordpresspass', '', time() - 31536000, '/');
+\tsetcookie('wordpressblogid', '', time() - 31536000, '/');
+\tsetcookie('playground_auto_login_already_logged_out', '1', time() + 172800, '/'); /* pg_wp07_logout_guard */`
+		);
+		login = login
+			.replace(
+				`header('Refresh: 0;url=b2login.php');`,
+				`header('Refresh: 0;url=b2login.php?loggedout=1');`
+			)
+			.replace(
+				`header('Location: b2login.php');`,
+				`header('Location: b2login.php?loggedout=1');`
+			);
+	}
+
+	if (login !== original) {
+		await php.writeFile(loginPath, login);
+	}
+}
+
+async function patchWp07AdminRelativePaths(
+	php: PHP,
+	documentRoot: string
+): Promise<void> {
+	const wpAdminDir = joinPaths(documentRoot, 'wp-admin');
+	if (!php.isDir(wpAdminDir)) return;
+
+	for (const file of php.listFiles(wpAdminDir)) {
+		if (!file.endsWith('.php')) continue;
+		const filePath = joinPaths(wpAdminDir, file);
+		const content = php.readFileAsText(filePath);
+		const patched = rewriteRelativePhpIncludes(content);
+		if (patched !== content) {
+			await php.writeFile(filePath, patched);
+		}
+	}
+}
+
+async function patchWp07AdminMenuTop(
+	php: PHP,
+	documentRoot: string
+): Promise<void> {
+	const menuPath = joinPaths(documentRoot, 'wp-admin/b2menutop.php');
+	let menu = php.readFileAsText(menuPath);
+	const original = menu;
+
+	menu = menu
+		.replace(
+			'file("./b2menutop.txt")',
+			`file(dirname(__FILE__) . '/b2menutop.txt')`
+		)
+		.replace(
+			'<a href="http://wordpress.org" rel="external"><span>WordPress</span></a>',
+			'<a href="#" rel="external"><span>WordPress</span></a>'
+		);
+
+	if (menu !== original) {
+		await php.writeFile(menuPath, menu);
+	}
+}
+
+async function patchWp07AdminAuth(
+	php: PHP,
+	documentRoot: string
+): Promise<void> {
+	const authPath = joinPaths(documentRoot, 'wp-admin/b2verifauth.php');
+	let auth = php.readFileAsText(authPath);
+	const original = auth;
+	if (auth.includes('pg_wp07_auto_login')) return;
+
+	auth = auth.replace(
+		"require_once('../b2config.php');",
+		`require_once('../b2config.php');
+${getWp07AutoLoginCookieBootstrap('pg_wp07_auto_login')}`
+	);
+	if (auth !== original) {
+		await php.writeFile(authPath, auth);
+	}
+}
+
+function getWp07AutoLoginCookieBootstrap(marker: string): string {
+	return `
+if (isset($_GET['loggedout']) || isset($HTTP_GET_VARS['loggedout'])) {
+	$_COOKIE['playground_auto_login_already_logged_out'] = '1';
+	unset($_COOKIE['wordpressuser']);
+	unset($_COOKIE['wordpresspass']);
+	unset($_COOKIE['wordpressblogid']);
+	unset($HTTP_COOKIE_VARS['wordpressuser']);
+	unset($HTTP_COOKIE_VARS['wordpresspass']);
+	unset($HTTP_COOKIE_VARS['wordpressblogid']);
+	if (!headers_sent()) {
+		setcookie('playground_auto_login_already_logged_out', '1', time() + 172800, '/');
+	}
+}
+if (
+	defined('PLAYGROUND_AUTO_LOGIN_AS_USER') &&
+	empty($_COOKIE['playground_auto_login_already_logged_out']) &&
+	(!isset($action) || $action != 'logout')
+) {
+	$_pg_wp07_user = PLAYGROUND_AUTO_LOGIN_AS_USER;
+	$_pg_wp07_pass = md5(md5('password'));
+	$_COOKIE['wordpressuser'] = $_pg_wp07_user;
+	$_COOKIE['wordpresspass'] = $_pg_wp07_pass;
+	$_COOKIE['wordpressblogid'] = 1;
+	$HTTP_COOKIE_VARS = $_COOKIE;
+	$GLOBALS['HTTP_COOKIE_VARS'] = $HTTP_COOKIE_VARS;
+	if (!headers_sent()) {
+		$_pg_wp07_exp = time() + 172800;
+		setcookie('wordpressuser', $_pg_wp07_user, $_pg_wp07_exp, '/');
+		setcookie('wordpresspass', $_pg_wp07_pass, $_pg_wp07_exp, '/');
+		setcookie('wordpressblogid', 1, $_pg_wp07_exp, '/');
+	}
+} /* ${marker} */
+`;
+}

--- a/packages/playground/wordpress/src/test/relative-paths.spec.ts
+++ b/packages/playground/wordpress/src/test/relative-paths.spec.ts
@@ -1,0 +1,49 @@
+import { rewriteRelativePhpIncludes } from '../legacy-wp/relative-paths';
+
+describe('Legacy WordPress relative path rewrites', () => {
+	it('rewrites parent and current-directory includes', () => {
+		const rewritten = rewriteRelativePhpIncludes(`<?php
+require_once('../wp-load.php');
+include("./b2header.php");
+`);
+
+		expect(rewritten).toContain(
+			"require_once(dirname(dirname(__FILE__)) . '/wp-load.php')"
+		);
+		expect(rewritten).toContain(
+			"include(dirname(__FILE__) . '/b2header.php')"
+		);
+	});
+
+	it('rewrites bare PHP filenames in function and statement forms', () => {
+		const rewritten = rewriteRelativePhpIncludes(`<?php
+require_once('admin.php');
+include 'admin-footer.php';
+`);
+
+		expect(rewritten).toContain(
+			"require_once(dirname(__FILE__) . '/admin.php')"
+		);
+		expect(rewritten).toContain(
+			"include(dirname(__FILE__) . '/admin-footer.php')"
+		);
+	});
+
+	it('leaves identifiers that merely end in require/include alone', () => {
+		const source = `<?php
+my_require_once('admin.php');
+foo_include('../setup.php');
+`;
+
+		expect(rewriteRelativePhpIncludes(source)).toBe(source);
+	});
+
+	it('keeps non-PHP include paths unchanged', () => {
+		const source = `<?php
+$menu = file('./menu.txt');
+require_once(WPINC . '/functions.php');
+`;
+
+		expect(rewriteRelativePhpIncludes(source)).toBe(source);
+	});
+});

--- a/packages/playground/wordpress/src/test/version-detect.spec.ts
+++ b/packages/playground/wordpress/src/test/version-detect.spec.ts
@@ -24,10 +24,21 @@ describe('Test WP version detection', async () => {
 						await loadNodeRuntime(RecommendedPHPVersion),
 					siteUrl: 'http://playground-domain/',
 					wordPressZip: await getWordPressModule(
-						expectedWordPressVersion
+						expectedWordPressVersion === 'trunk'
+							? undefined
+							: expectedWordPressVersion
 					),
 					sqliteIntegrationPluginZip: await getSqliteDriverModule(),
 				});
+				if (expectedWordPressVersion === 'trunk') {
+					// Avoid live GitHub master.zip; detection only needs
+					// a trunk-style version.php value.
+					const php = await handler.getPrimaryPhp();
+					php.writeFile(
+						`${handler.documentRoot}/wp-includes/version.php`,
+						'<?php $wp_version = "6.6-alpha-57783";'
+					);
+				}
 				const loadedWordPressVersion =
 					await getLoadedWordPressVersion(handler);
 				expect(loadedWordPressVersion).to.equal(

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -2,18 +2,19 @@
  * Tests that legacy and mid-modern WordPress versions boot
  * successfully through Playground's wordpress.org download path:
  *
- *   - WP 1.0 – 4.9 on PHP 5.2 (legacy SQLite driver)
+ *   - WP 0.7 – 4.9 on PHP 5.2 (legacy SQLite driver)
  *   - WP 5.0 – 6.2 on PHP 7.4 (modern SQLite driver)
  *
  * Pre-built bundled WP (6.3+) has its own coverage elsewhere.
  *
- * Each version is exercised through five phases:
+ * Each version is exercised through six phases:
  *
  *   1. Front page loads with "Hello world!"
- *   2. wp-admin dashboard loads (auto-login works)
- *   3. Clicking a post title loads the single post (pretty permalinks)
+ *   2. Clicking a post title loads the single post (pretty permalinks)
+ *   3. wp-admin dashboard loads (auto-login works)
  *   4. Creating a new post page loads (nonces work)
  *   5. Activating a plugin works (Hello Dolly)
+ *   6. Logging out disables automatic re-login where tested
  *
  * All failures are hard errors: the job should honestly reflect the
  * state of legacy WordPress support.
@@ -80,6 +81,7 @@ const WP_VERSIONS = [
 	{ wp: '1.5', php: '5.2' },
 	{ wp: '1.2', php: '5.2' },
 	{ wp: '1.0', php: '5.2' },
+	{ wp: '0.7', php: '5.2' },
 ];
 
 const PORT = 5400;
@@ -129,8 +131,11 @@ async function waitForWPFrame(page, timeoutSeconds, opts = {}) {
  * if found, null otherwise. The returned string is not truncated —
  * callers decide how much to display.
  */
-function findPHPError(body) {
+function findPHPError(body, { includeWarnings = false } = {}) {
 	const errorPatterns = ['Parse error', 'Fatal error', 'database error'];
+	if (includeWarnings) {
+		errorPatterns.push('Warning:');
+	}
 	for (const pattern of errorPatterns) {
 		if (body.includes(pattern)) {
 			const line = body
@@ -317,12 +322,21 @@ function hasAdminIndicator(body) {
 	return ADMIN_INDICATORS.some((ind) => body.includes(ind));
 }
 
-// WP < 2.5 uses post.php for new posts; 2.5+ uses post-new.php.
-// WP 1.0-2.0 render the "new post" form via wp-admin/post.php's
-// default case. WP 2.1 introduced wp-admin/post-new.php and made
-// post.php redirect to edit.php, so the new-post form lives at
-// post-new.php from 2.1 onward (just like modern WordPress).
+/**
+ * Checks whether body text contains the b2-era login form.
+ */
+function hasB2LoginForm(body) {
+	return body.includes('Login:') && body.includes('Password:');
+}
+
+// WP < 2.5 uses older entry points for new posts; 2.5+ uses post-new.php.
+// WP 0.7 renders the form from b2edit.php. WP 1.0-2.0 render it via
+// wp-admin/post.php's default case. WP 2.1 introduced wp-admin/post-new.php.
+const NEW_POST_URL_BY_VERSION = new Map([['0.7', '/wp-admin/b2edit.php']]);
+const ADMIN_AUTO_LOGIN_URL_BY_VERSION = new Map([['0.7', '/b2login.php']]);
 const NEW_POST_URL_VERSIONS = new Set(['1.0', '1.2', '1.5', '2.0']);
+const NO_PLUGIN_SUPPORT_VERSIONS = new Set(['0.7']);
+const LOGOUT_SUPPORT_VERSIONS = new Set(['0.7']);
 
 // Optional filter for local runs: WP_ONLY=6.2,6.1,5.9 to test a subset.
 const WP_ONLY = process.env.WP_ONLY
@@ -371,6 +385,10 @@ const browser = await chromium.launch({
 });
 
 for (const { wp, php } of MATRIX) {
+	// Treat PHP warnings as hard errors only for WP 0.7: it's the newest,
+	// most fragile target where any warning likely signals a broken shim.
+	// Older versions emit benign deprecation/notice noise we don't fail on.
+	const includePHPWarnings = wp === '0.7';
 	const label = `WP ${wp} (PHP ${php})`;
 	process.stdout.write(`${label}... `);
 
@@ -391,6 +409,7 @@ for (const { wp, php } of MATRIX) {
 	let postStatus = null;
 	let newPostStatus = null;
 	let pluginStatus = null;
+	let logoutStatus = null;
 
 	try {
 		await page.goto(url, {
@@ -421,7 +440,9 @@ for (const { wp, php } of MATRIX) {
 				detail: lastError,
 			};
 		} else {
-			const error = findPHPError(wp1.body);
+			const error = findPHPError(wp1.body, {
+				includeWarnings: includePHPWarnings,
+			});
 			if (error) {
 				frontStatus = {
 					status: 'ERROR',
@@ -512,6 +533,8 @@ for (const { wp, php } of MATRIX) {
 		// --- Phase 3: Admin dashboard (auto-login) ---
 		if (frontStatus.status === 'OK' || frontStatus.status === 'PARTIAL') {
 			try {
+				const adminAutoLoginUrl =
+					ADMIN_AUTO_LOGIN_URL_BY_VERSION.get(wp) ?? '/wp-admin/';
 				// Retry once on timeout — modern WP admin occasionally
 				// hangs the first /wp-admin/ load on shared CI runners
 				// (see the long-standing admin-phase flake across runs
@@ -519,19 +542,21 @@ for (const { wp, php } of MATRIX) {
 				// URL bar almost always unblocks it.
 				let wp2 = await navigateViaUrlBar(
 					page,
-					'/wp-admin/',
+					adminAutoLoginUrl,
 					TIMEOUT_S
 				);
 				if (!wp2) {
 					wp2 = await navigateViaUrlBar(
 						page,
-						'/wp-admin/',
+						adminAutoLoginUrl,
 						TIMEOUT_S
 					);
 				}
 				if (
 					wp2 &&
-					!findPHPError(wp2.body) &&
+					!findPHPError(wp2.body, {
+						includeWarnings: includePHPWarnings,
+					}) &&
 					!hasAdminIndicator(wp2.body)
 				) {
 					const settled = await waitForWPFrame(page, 30, {
@@ -544,7 +569,9 @@ for (const { wp, php } of MATRIX) {
 				if (!wp2) {
 					adminStatus = { status: 'TIMEOUT' };
 				} else {
-					const error = findPHPError(wp2.body);
+					const error = findPHPError(wp2.body, {
+						includeWarnings: includePHPWarnings,
+					});
 					if (error) {
 						adminStatus = {
 							status: 'ERROR',
@@ -585,9 +612,11 @@ for (const { wp, php } of MATRIX) {
 		// --- Phase 4: New post page (nonce check) ---
 		if (adminStatus && adminStatus.status === 'OK') {
 			try {
-				const newPostPath = NEW_POST_URL_VERSIONS.has(wp)
-					? '/wp-admin/post.php'
-					: '/wp-admin/post-new.php';
+				const newPostPath =
+					NEW_POST_URL_BY_VERSION.get(wp) ??
+					(NEW_POST_URL_VERSIONS.has(wp)
+						? '/wp-admin/post.php'
+						: '/wp-admin/post-new.php');
 				const consoleStartIndex = consoleErrors.length;
 				const wp3 = await navigateViaUrlBar(page, newPostPath, 30);
 				if (!wp3) {
@@ -611,7 +640,13 @@ for (const { wp, php } of MATRIX) {
 						.innerText({ timeout: 2000 })
 						.catch(() => wp3.body);
 
-					const error = findPHPError(bodyText) || findPHPError(html);
+					const error =
+						findPHPError(bodyText, {
+							includeWarnings: includePHPWarnings,
+						}) ||
+						findPHPError(html, {
+							includeWarnings: includePHPWarnings,
+						});
 
 					const bad =
 						bodyText.includes('Are you sure') ||
@@ -675,7 +710,12 @@ for (const { wp, php } of MATRIX) {
 		}
 
 		// --- Phase 5: Plugin activation ---
-		if (adminStatus && adminStatus.status === 'OK') {
+		if (NO_PLUGIN_SUPPORT_VERSIONS.has(wp)) {
+			pluginStatus = {
+				status: 'SKIP',
+				detail: 'plugins predate this WordPress release',
+			};
+		} else if (adminStatus && adminStatus.status === 'OK') {
 			try {
 				const wp4 = await navigateViaUrlBar(
 					page,
@@ -767,6 +807,75 @@ for (const { wp, php } of MATRIX) {
 		} else {
 			pluginStatus = { status: 'SKIP', detail: 'admin failed' };
 		}
+
+		// --- Phase 6: Logout guard ---
+		if (!LOGOUT_SUPPORT_VERSIONS.has(wp)) {
+			logoutStatus = {
+				status: 'SKIP',
+				detail: 'logout guard not tested for this version',
+			};
+		} else if (adminStatus && adminStatus.status === 'OK') {
+			try {
+				const wp5 = await navigateViaUrlBar(
+					page,
+					'/b2login.php?action=logout',
+					30
+				);
+				if (!wp5) {
+					logoutStatus = { status: 'TIMEOUT' };
+				} else {
+					const error = findPHPError(wp5.body, {
+						includeWarnings: includePHPWarnings,
+					});
+					const wrongPassword = wp5.body.includes(
+						'Error: wrong login/password'
+					);
+					if (error) {
+						logoutStatus = {
+							status: 'ERROR',
+							detail: error,
+							body: wp5.body,
+						};
+					} else if (
+						!hasB2LoginForm(wp5.body) ||
+						wrongPassword ||
+						hasAdminIndicator(wp5.body)
+					) {
+						logoutStatus = {
+							status: 'UNKNOWN',
+							detail: wp5.body.slice(0, 120).replace(/\n/g, ' '),
+							body: wp5.body,
+						};
+					} else {
+						const guardedAdmin = await navigateViaUrlBar(
+							page,
+							'/wp-admin/',
+							30
+						);
+						if (
+							guardedAdmin &&
+							hasB2LoginForm(guardedAdmin.body) &&
+							!hasAdminIndicator(guardedAdmin.body)
+						) {
+							logoutStatus = { status: 'OK' };
+						} else {
+							logoutStatus = {
+								status: guardedAdmin ? 'UNKNOWN' : 'TIMEOUT',
+								detail:
+									guardedAdmin?.body
+										.slice(0, 120)
+										.replace(/\n/g, ' ') || '',
+								body: guardedAdmin?.body,
+							};
+						}
+					}
+				}
+			} catch (e) {
+				logoutStatus = { status: 'CRASH', detail: e.message };
+			}
+		} else {
+			logoutStatus = { status: 'SKIP', detail: 'admin failed' };
+		}
 	} catch (e) {
 		frontStatus = {
 			status: 'CRASH',
@@ -776,6 +885,7 @@ for (const { wp, php } of MATRIX) {
 		postStatus = { status: 'SKIP', detail: 'boot crashed' };
 		newPostStatus = { status: 'SKIP', detail: 'boot crashed' };
 		pluginStatus = { status: 'SKIP', detail: 'boot crashed' };
+		logoutStatus = { status: 'SKIP', detail: 'boot crashed' };
 	}
 
 	const icon = (s) =>
@@ -786,6 +896,7 @@ for (const { wp, php } of MATRIX) {
 		`admin:${icon(adminStatus)}`,
 		`newpost:${icon(newPostStatus)}`,
 		`plugin:${icon(pluginStatus)}`,
+		`logout:${icon(logoutStatus)}`,
 	];
 	console.log(parts.join(' '));
 
@@ -797,6 +908,7 @@ for (const { wp, php } of MATRIX) {
 		admin: adminStatus,
 		newPost: newPostStatus,
 		plugin: pluginStatus,
+		logout: logoutStatus,
 	});
 	await page.close();
 	await context.close();
@@ -804,7 +916,7 @@ for (const { wp, php } of MATRIX) {
 
 await browser.close();
 
-const PHASES = ['front', 'post', 'admin', 'newPost', 'plugin'];
+const PHASES = ['front', 'post', 'admin', 'newPost', 'plugin', 'logout'];
 
 function isPass(status) {
 	return status.status === 'OK' || status.status === 'PARTIAL';

--- a/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
+++ b/packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs
@@ -262,11 +262,11 @@ async function navigateViaUrlBar(page, path, timeoutSeconds = 60) {
  */
 async function waitForPluginActivation(
 	page,
-	previousFrameUrl,
-	previousBody,
-	timeoutSeconds = 60
+	{ previousFrameUrl, previousBody, pluginFile },
+	timeoutSeconds = TIMEOUT_S
 ) {
 	const deadline = Date.now() + timeoutSeconds * 1000;
+	let lastSeen = null;
 	while (Date.now() < deadline) {
 		await page.waitForTimeout(500);
 		for (const frame of page.frames()) {
@@ -275,12 +275,21 @@ async function waitForPluginActivation(
 				const body = await frame
 					.locator('body')
 					.innerText({ timeout: 2000 });
+				lastSeen = { body, frame, frameUrl: frame.url() };
+				const outcome = await readPluginActivationOutcome(
+					frame,
+					body,
+					pluginFile
+				);
+				if (outcome) {
+					return { body, frame, outcome };
+				}
 				const changed =
 					frame.url() !== previousFrameUrl || body !== previousBody;
 				if (!changed) continue;
 				if (
 					body.includes('Plugin activated') ||
-					body.includes('Deactivate') ||
+					(!pluginFile && body.includes('Deactivate')) ||
 					body.includes('Are you sure') ||
 					findPHPError(body)
 				) {
@@ -289,7 +298,69 @@ async function waitForPluginActivation(
 			} catch {}
 		}
 	}
-	return null;
+	return lastSeen ? { ...lastSeen, timedOut: true } : null;
+}
+
+/**
+ * Checks whether the plugins page has reached a conclusive post-activation
+ * state.
+ */
+async function readPluginActivationOutcome(frame, body, pluginFile) {
+	if (findPHPError(body)) return 'error';
+	if (body.includes('Are you sure')) return 'nonce';
+	if (body.includes('Plugin activated')) return 'activated';
+	if (pluginFile) {
+		const hasTargetDeactivateLink = await hasPluginActionLink(
+			frame,
+			pluginFile,
+			'deactivate'
+		);
+		return hasTargetDeactivateLink ? 'activated' : null;
+	}
+	return body.includes('Deactivate') ? 'activated' : null;
+}
+
+async function hasPluginActionLink(frame, pluginFile, action) {
+	for (const pluginFileVariant of [
+		pluginFile,
+		encodeURIComponent(pluginFile),
+	]) {
+		const selector = `a[href*="action=${action}"][href*="${escapeCssAttributeValue(
+			pluginFileVariant
+		)}"]`;
+		if ((await frame.locator(selector).count()) > 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function escapeCssAttributeValue(value) {
+	return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function getPluginFileFromActivationHref(href) {
+	if (!href) return null;
+	try {
+		const url = new URL(href, 'http://playground.test/');
+		return url.searchParams.get('plugin');
+	} catch {
+		return null;
+	}
+}
+
+function getPluginActivationTimeoutDetail(result) {
+	if (!result) return '';
+	const details = [];
+	if (result.frameUrl) {
+		details.push(`last URL: ${result.frameUrl}`);
+	}
+	if (result.body) {
+		details.push(
+			`last body: ${result.body.slice(0, 160).replace(/\s+/g, ' ')}`
+		);
+	}
+	return details.join('; ');
 }
 
 /**
@@ -764,20 +835,32 @@ for (const { wp, php } of MATRIX) {
 							.innerText({ timeout: 2000 })
 							.catch(() => wp4.body);
 						const prevFrameUrl = wp4.frame.url();
-						await activateLink.click({ timeout: 5000 });
-						const wp4b = await waitForPluginActivation(
-							page,
-							prevFrameUrl,
-							bodyBeforeActivation
+						const pluginFile = getPluginFileFromActivationHref(
+							await activateLink
+								.getAttribute('href')
+								.catch(() => null)
 						);
-						if (!wp4b) {
-							pluginStatus = { status: 'TIMEOUT' };
+						await activateLink.click({ timeout: 5000 });
+						const wp4b = await waitForPluginActivation(page, {
+							previousFrameUrl: prevFrameUrl,
+							previousBody: bodyBeforeActivation,
+							pluginFile,
+						});
+						if (!wp4b || wp4b.timedOut) {
+							pluginStatus = {
+								status: 'TIMEOUT',
+								detail: getPluginActivationTimeoutDetail(wp4b),
+							};
 						} else {
 							const error = findPHPError(wp4b.body);
 							const ok =
+								wp4b.outcome === 'activated' ||
 								wp4b.body.includes('Plugin activated') ||
-								wp4b.body.includes('Deactivate');
-							const bad = wp4b.body.includes('Are you sure');
+								(!pluginFile &&
+									wp4b.body.includes('Deactivate'));
+							const bad =
+								wp4b.outcome === 'nonce' ||
+								wp4b.body.includes('Are you sure');
 							if (error) {
 								pluginStatus = {
 									status: 'ERROR',


### PR DESCRIPTION
## Summary
- Add `wp=0.7` support by resolving `0.7`/`0.71` to the `wordpress-0.71-gold.zip` archive and exposing `0.7` in the older WordPress selector.
- Isolate b2/cafelog compatibility in `wp-07-support.ts`, guarded by WP 0.71 source-tree detection.
- Keep WP 0.7 post-install behavior under the existing legacy fixup flow instead of branching in `legacy-boot.ts`.
- Seed the b2 SQLite schema/default content and patch only b2-era files needed for SQLite, rendering, admin auth, and logout.
- Avoid live GitHub `master.zip` in the trunk version-detection unit test.

## Details
WP 0.71-gold predates the WordPress-shaped source tree and installer: it uses `b2config.php`, `b2-include`, b2 tables, and unsuffixed b2 auth cookies. The existing WP 1.0+ legacy path assumes `wp-*` entry points and schema. This PR keeps those b2-specific adaptations in a dedicated support file and no-ops unless the extracted source is the 0.71 tree.

The public UI exposes `0.7`; `0.71` is only accepted as an input alias because wordpress.org serves the 0.7-era build as `0.71-gold`.

## Validation
- [x] `node --check packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs`
- [x] focused Nx lint for touched WordPress/remote/website TypeScript files
- [x] `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" WP_ONLY=0.7 node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs`
- [x] `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" WP_ONLY=0.7,1.0,1.2,2.0,3.6 node packages/playground/wordpress/tests/test-legacy-wp-version-boot.mjs`
- [x] `npm exec nx test playground-wordpress -- --runInBand`
- [x] `npm exec nx build playground-wordpress`
- [x] `npm exec nx build playground-remote`
- [x] `npm exec nx build playground-website`
