### PR TITLE
Keep PHP-next build assets writable after Docker extraction

### DIFF
--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -378,6 +378,12 @@ await asyncSpawn(
 );
 /* eslint-enable prettier/prettier */
 
+const copyTerminfoCommand =
+	getArg('WITH_CLI_SAPI') === 'yes'
+		? ' && cp /root/lib/share/terminfo/x/xterm /output/terminfo/x'
+		: '';
+const restoreOutputOwnershipCommand = getRestoreOutputOwnershipCommand();
+
 // Extract the PHP WASM module
 await asyncSpawn(
 	'docker',
@@ -393,14 +399,33 @@ await asyncSpawn(
 		// they don't work without running cp through shell.
 		'sh',
 		'-c',
-		`cp -rf /root/output/* /output && mkdir -p /output/terminfo/x ${
-			getArg('WITH_CLI_SAPI') === 'yes'
-				? '&& cp /root/lib/share/terminfo/x/xterm /output/terminfo/x'
-				: ''
-		}`,
+		`cp -rf /root/output/* /output && ` +
+			`mkdir -p /output/terminfo/x` +
+			copyTerminfoCommand +
+			restoreOutputOwnershipCommand,
 	],
 	{ cwd: sourceDir, stdio: 'inherit' }
 );
+
+/**
+ * build.js copies artifacts from a root Docker container. On Linux, those
+ * bind-mounted files become root-owned on the host. Restore them to the host
+ * owner so later Node steps and local cleanups can edit generated artifacts.
+ */
+function getRestoreOutputOwnershipCommand() {
+	if (
+		typeof process.getuid !== 'function' ||
+		typeof process.getgid !== 'function'
+	) {
+		return '';
+	}
+	const uid = process.getuid();
+	const gid = process.getgid();
+	if (uid === 0) {
+		return '';
+	}
+	return ` && chown -R ${uid}:${gid} /output`;
+}
 
 function asyncSpawn(...args) {
 	console.log('Running', args[0], args[1].join(' '), '...');

--- a/packages/php-wasm/compile/sync-php-next-assets.mjs
+++ b/packages/php-wasm/compile/sync-php-next-assets.mjs
@@ -21,12 +21,14 @@ if (ifMissing && fs.existsSync(path.join(targetDir, 'index.js'))) {
 }
 
 try {
-	run('git', [
-		'fetch',
-		remote,
-		`+refs/heads/${branch}:${remoteRef}`,
-		'--depth=1',
-	]);
+	verifyRemoteBranchExists();
+	run(
+		'git',
+		['fetch', remote, `+refs/heads/${branch}:${remoteRef}`, '--depth=1'],
+		{
+			inheritStdio: !optional,
+		}
+	);
 	fs.rmSync(targetDir, { recursive: true, force: true });
 	fs.mkdirSync(targetDir, { recursive: true });
 	await extractGitArchive(remoteRef, targetDir);
@@ -81,11 +83,53 @@ function extractGitArchive(ref, outputDir) {
 	});
 }
 
-function run(command, commandArgs) {
+/**
+ * Check the publishing branch before git fetch so optional local dev sync can
+ * explain a missing PHP-next branch without dumping git's fatal stderr.
+ */
+function verifyRemoteBranchExists() {
+	const result = spawnSync(
+		'git',
+		['ls-remote', '--exit-code', '--heads', remote, branch],
+		{
+			cwd: projectRoot,
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'pipe'],
+		}
+	);
+	if (result.error) {
+		throw new Error(`git failed to start: ${result.error.message}`, {
+			cause: result.error,
+		});
+	}
+	if (result.status === 0) {
+		return;
+	}
+	if (result.status === 2) {
+		throw new Error(
+			`PHP next assets branch ${branch} does not exist on ${remote}. ` +
+				'Run the Refresh PHP Next workflow to publish it.'
+		);
+	}
+	const output = formatCommandOutput(result);
+	throw new Error(
+		output
+			? `Could not query PHP next assets branch ${branch} ` +
+					`on ${remote}: ${output}`
+			: `Could not query PHP next assets branch ${branch} on ${remote}: ` +
+					`git ls-remote exited with code ${result.status}`
+	);
+}
+
+function run(command, commandArgs, options = {}) {
 	console.log('Running', command, commandArgs.join(' '), '...');
 	const result = spawnSync(command, commandArgs, {
 		cwd: projectRoot,
-		stdio: 'inherit',
+		encoding: 'utf8',
+		stdio:
+			options.inheritStdio === false
+				? ['ignore', 'pipe', 'pipe']
+				: 'inherit',
 	});
 	if (result.error) {
 		throw new Error(`${command} failed to start: ${result.error.message}`, {
@@ -93,6 +137,15 @@ function run(command, commandArgs) {
 		});
 	}
 	if (result.status !== 0) {
-		throw new Error(`${command} exited with code ${result.status}`);
+		const output = formatCommandOutput(result);
+		throw new Error(
+			output
+				? `${command} exited with code ${result.status}: ${output}`
+				: `${command} exited with code ${result.status}`
+		);
 	}
+}
+
+function formatCommandOutput(result) {
+	return [result.stderr, result.stdout].filter(Boolean).join('\n').trim();
 }


### PR DESCRIPTION
## Summary

- restore host ownership after Docker extracts PHP build artifacts, so follow-up Node steps can edit generated files
- preflight the `php-next-builds` branch before syncing assets, giving optional local dev sync a clear skip message instead of raw git missing-ref output

## Root cause

The PHP-next refresh workflow builds artifacts in Docker, then `build-php-next-web.mjs` patches the generated browser loaders from Node. On Linux, the Docker extraction left those files owned by root, so patching failed with `EACCES` before the workflow could publish `php-next-builds`. With that branch absent, local dev startup hit a noisy optional fetch miss.

## Testing

- `node --check packages/php-wasm/compile/build.js`
- `node --check packages/php-wasm/compile/sync-php-next-assets.mjs`
- `npx prettier --check packages/php-wasm/compile/build.js packages/php-wasm/compile/sync-php-next-assets.mjs`
- `git diff --check`
- `PHP_NEXT_ASSETS_DIR=.context/php-next-sync-test node packages/php-wasm/compile/sync-php-next-assets.mjs --optional --if-missing`
- synced from a temporary local `php-next-builds` remote and verified extracted files
- sanity-checked the Docker `chown` command against a local `php-wasm` image
