### PR TITLE
Split Playground CLI worker spawning out of the runner

### DIFF
--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -21,7 +21,7 @@ import { rootCertificates } from 'tls';
 import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
 import { mountResources } from '../mounts';
 import { logger } from '@php-wasm/logger';
-import { spawnWorkerThread } from '../run-cli';
+import { spawnWorkerThread } from '../spawn-worker-thread';
 
 import type { Mount } from '@php-wasm/cli-util';
 

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -47,7 +47,8 @@ import { existsSync } from 'fs';
 import path from 'path';
 import { rootCertificates } from 'tls';
 import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
-import { type RunCLIArgs, spawnWorkerThread } from '../run-cli';
+import { type RunCLIArgs } from '../run-cli';
+import { spawnWorkerThread } from '../spawn-worker-thread';
 import type {
 	PhpIniOptions,
 	PHPInstanceCreatedHook,

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1,5 +1,4 @@
 import { errorLogPath, logger, LogSeverity } from '@php-wasm/logger';
-import { ProcessIdAllocator } from '@php-wasm/universal';
 import {
 	createObjectPoolProxy,
 	type Pooled,
@@ -28,7 +27,7 @@ import {
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import fs, { existsSync, mkdirSync, readdirSync, rmSync } from 'fs';
 import type { Server } from 'http';
-import { MessageChannel as NodeMessageChannel, Worker } from 'worker_threads';
+import { MessageChannel as NodeMessageChannel } from 'worker_threads';
 // @ts-ignore
 import {
 	expandAutoMounts,
@@ -84,11 +83,7 @@ import {
 	PHPMYADMIN_INSTALL_PATH,
 } from '@wp-playground/tools';
 import { jspi } from 'wasm-feature-detect';
-
-// Inlined worker URLs for static analysis by downstream bundlers
-// These are replaced at build time by the Vite plugin in vite.config.ts
-declare const __WORKER_V1_URL__: string;
-declare const __WORKER_V2_URL__: string;
+import { spawnWorkerThread, type SpawnedWorker } from './spawn-worker-thread';
 
 export const LogVerbosity = {
 	Quiet: { name: 'quiet', severity: LogSeverity.Fatal },
@@ -1955,90 +1950,7 @@ function expandStartCommandArgs(
 	return newArgs as RunCLIArgs;
 }
 
-const processIdAllocator = new ProcessIdAllocator();
-
-export type SpawnedWorker = {
-	processId: number;
-	worker: Worker;
-	phpPort: NodeMessagePort;
-};
-
-/**
- * A statically analyzable function that spawns a worker thread of a given type.
- *
- * **Important:** This function builds to code that has the worker URL hardcoded
- * inline, e.g. `new Worker(new URL('./worker-thread-v1.js', import.meta.url))`.
- * This allows the downstream consumers to statically analyze the code, recognize
- * it uses workers, create new entrypoints, and rewrite the new Worker() calls.
- *
- * @param workerType
- * @returns
- */
-export function spawnWorkerThread(
-	workerType: 'v1' | 'v2',
-	{ onExit }: { onExit?: (code: number) => void } = {}
-) {
-	/**
-	 * When running the CLI from source via `node cli.ts`, the Vite-provided
-	 * __WORKER_V1_URL__ and __WORKER_V2_URL__ are undefined. Let's set them to
-	 * the correct paths.
-	 */
-	if (typeof __WORKER_V1_URL__ === 'undefined') {
-		// @ts-expect-error
-		globalThis['__WORKER_V1_URL__'] = './blueprints-v1/worker-thread-v1.ts';
-	}
-	if (typeof __WORKER_V2_URL__ === 'undefined') {
-		// @ts-expect-error
-		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
-	}
-	let worker: Worker;
-	if (workerType === 'v1') {
-		worker = new Worker(new URL(__WORKER_V1_URL__, import.meta.url));
-	} else {
-		worker = new Worker(new URL(__WORKER_V2_URL__, import.meta.url));
-	}
-
-	return new Promise<SpawnedWorker>((resolve, reject) => {
-		const processId = processIdAllocator.claim();
-
-		worker.once('message', function (message: any) {
-			// Let the worker confirm it has initialized.
-			// We could use the 'online' event to detect start of JS execution,
-			// but that would miss initialization errors.
-			if (message.command === 'worker-script-initialized') {
-				resolve({
-					processId,
-					worker,
-					phpPort: message.phpPort,
-				});
-			}
-		});
-		worker.once('error', function (e: Error) {
-			processIdAllocator.release(processId);
-
-			console.error(e);
-			const originalMessage =
-				e?.message || (e ? String(e) : 'unknown error');
-			const error = new Error(
-				`Worker failed to load. Original error: ${originalMessage}`,
-				{ cause: e }
-			);
-			reject(error);
-		});
-		let spawned = false;
-		worker.once('spawn', () => {
-			spawned = true;
-		});
-		worker.once('exit', (code) => {
-			processIdAllocator.release(processId);
-
-			if (!spawned) {
-				reject(new Error(`Worker exited before spawning: ${code}`));
-			}
-			onExit?.(code);
-		});
-	});
-}
+export { spawnWorkerThread, type SpawnedWorker } from './spawn-worker-thread';
 
 /**
  * Expose the file lock manager API on a MessagePort and return it.

--- a/packages/playground/cli/src/spawn-worker-thread.ts
+++ b/packages/playground/cli/src/spawn-worker-thread.ts
@@ -1,0 +1,91 @@
+import { ProcessIdAllocator } from '@php-wasm/universal';
+import { Worker } from 'worker_threads';
+import type { MessagePort as NodeMessagePort } from 'worker_threads';
+
+// Inlined worker URLs for static analysis by downstream bundlers.
+// These are replaced at build time by the Vite plugin in vite.config.ts.
+declare const __WORKER_V1_URL__: string;
+declare const __WORKER_V2_URL__: string;
+
+const processIdAllocator = new ProcessIdAllocator();
+
+export type SpawnedWorker = {
+	processId: number;
+	worker: Worker;
+	phpPort: NodeMessagePort;
+};
+
+/**
+ * A statically analyzable function that spawns a worker thread of a given type.
+ *
+ * **Important:** This function builds to code that has the worker URL hardcoded
+ * inline, e.g. `new Worker(new URL('./worker-thread-v1.js', import.meta.url))`.
+ * This allows the downstream consumers to statically analyze the code, recognize
+ * it uses workers, create new entrypoints, and rewrite the new Worker() calls.
+ *
+ */
+export function spawnWorkerThread(
+	workerType: 'v1' | 'v2',
+	{ onExit }: { onExit?: (code: number) => void } = {}
+) {
+	/*
+	 * Built CLI bundles replace these constants with compiled worker URLs.
+	 * Source runs do not pass through Vite, so provide the TypeScript worker
+	 * paths here instead of forcing worker modules to import the full CLI runner.
+	 */
+	if (typeof __WORKER_V1_URL__ === 'undefined') {
+		// @ts-expect-error
+		globalThis['__WORKER_V1_URL__'] = './blueprints-v1/worker-thread-v1.ts';
+	}
+	if (typeof __WORKER_V2_URL__ === 'undefined') {
+		// @ts-expect-error
+		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
+	}
+	let worker: Worker;
+	if (workerType === 'v1') {
+		worker = new Worker(new URL(__WORKER_V1_URL__, import.meta.url));
+	} else {
+		worker = new Worker(new URL(__WORKER_V2_URL__, import.meta.url));
+	}
+
+	return new Promise<SpawnedWorker>((resolve, reject) => {
+		const processId = processIdAllocator.claim();
+
+		worker.once('message', function (message: any) {
+			// Let the worker confirm it has initialized.
+			// We could use the 'online' event to detect start of JS execution,
+			// but that would miss initialization errors.
+			if (message.command === 'worker-script-initialized') {
+				resolve({
+					processId,
+					worker,
+					phpPort: message.phpPort,
+				});
+			}
+		});
+		worker.once('error', function (e: Error) {
+			processIdAllocator.release(processId);
+
+			console.error(e);
+			const originalMessage =
+				e?.message || (e ? String(e) : 'unknown error');
+			const error = new Error(
+				`Worker failed to load. Original error: ${originalMessage}`,
+				{ cause: e }
+			);
+			reject(error);
+		});
+		let spawned = false;
+		worker.once('spawn', () => {
+			spawned = true;
+		});
+		worker.once('exit', (code) => {
+			processIdAllocator.release(processId);
+
+			if (!spawned) {
+				reject(new Error(`Worker exited before spawning: ${code}`));
+			}
+			onExit?.(code);
+		});
+	});
+}


### PR DESCRIPTION
## What changed

Moves the Playground CLI worker-spawning helper out of `run-cli.ts` and into a small `spawn-worker-thread.ts` module.

The v1/v2 worker entrypoints now import that focused helper directly instead of importing the full CLI runner just to spawn nested PHP workers.

## Why

The Studio performance exploration showed worker startup retaining avoidable JS heap because worker entrypoints pulled in the monolithic CLI runner. Keeping the spawn helper separate makes the worker bundle smaller while preserving the statically analyzable `new Worker(new URL(...))` shape downstream bundlers rely on.

## Notes for Studio reviewers

Pinging @brandonpayton, @mho22, and @frederik for WordPress Studio context.

## Validation

- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run playground-cli:typecheck`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run playground-cli:build:bundle:production`
- Attempted `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run playground-cli:test-playground-cli --testFile=worker-thread-events.spec.ts`, but it failed before collecting tests with an existing Vite/isomorphic-git deep import resolution error: `Missing "./src/models/GitPktLine.js" specifier in "isomorphic-git" package`.



## Impact measurement

Local warm-start benchmark against `origin/trunk` (source CLI, Node v24.14.1 JSPI, PHP 8.4, WP 6.8, `--workers=6`, already-installed mounted site, 3 rounds, median):

- Ready RSS: `1775.4 MiB -> 1517.2 MiB`, saving `258.2 MiB` (`14.5%`).
- Server ready time: `2808.7 ms -> 2499.3 ms`, saving `309 ms` (`11.0%`).

Verdict: worthwhile. This is a low-risk code split with a measurable memory and startup improvement.
