### PR TITLE
[Node] Load bundled PHP extensions from NODEFS

### DIFF
--- a/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
+++ b/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
@@ -1,17 +1,20 @@
 import { DEFAULT_IDE_KEY } from '@php-wasm/cli-util';
 import type {
+	Emscripten,
 	EmscriptenOptions,
 	ResolvedInstallOptions,
 	ResolvedPHPExtension,
 	SupportedPHPVersion,
 } from '@php-wasm/universal';
 import {
-	withResolvedPHPExtensions,
+	PHP_EXTENSIONS_DIR,
+	installPHPExtensionFilesSync,
 	resolvePHPExtension,
 	SupportedPHPVersions,
 } from '@php-wasm/universal';
 import fs from 'fs';
 import path from 'path';
+import { dirname, joinPaths } from '@php-wasm/util';
 import { getIntlExtensionModule } from './intl/get-intl-extension-module';
 import { getMemcachedExtensionModule } from './memcached/get-memcached-extension-module';
 import { getRedisExtensionModule } from './redis/get-redis-extension-module';
@@ -107,7 +110,156 @@ export async function withPHPExtensions(
 			resolveRuntimePHPExtension(version, asyncMode, extension)
 		)
 	);
-	return withResolvedPHPExtensions(options, resolvedExtensions);
+	return withResolvedNodePHPExtensions(options, resolvedExtensions);
+}
+
+interface NodeFilesystemPHPExtension {
+	soPath: string;
+	soHostPath: string;
+	iniPath?: string;
+	iniContent?: string;
+	extraFiles?: ResolvedInstallOptions['extraFiles'];
+	env?: Record<string, string>;
+	extensionDir: string;
+}
+
+type ResolvedNodePHPExtension =
+	| ResolvedPHPExtension
+	| NodeFilesystemPHPExtension;
+
+function withResolvedNodePHPExtensions(
+	options: EmscriptenOptions,
+	extensions: ResolvedNodePHPExtension[]
+): EmscriptenOptions {
+	if (!extensions.length) {
+		return options;
+	}
+	const env = { ...options.ENV };
+	for (const extension of extensions) {
+		Object.assign(env, extension.env);
+		if (!extension.iniPath) {
+			continue;
+		}
+		const paths = env['PHP_INI_SCAN_DIR']?.split(':') ?? [];
+		if (!paths.includes(extension.extensionDir)) {
+			paths.push(extension.extensionDir);
+			env['PHP_INI_SCAN_DIR'] = paths.join(':');
+		}
+	}
+	const preRun = options['preRun'] ?? [];
+	return {
+		...options,
+		ENV: env,
+		['preRun']: [
+			...preRun,
+			(phpRuntime: { FS: any }) => {
+				for (const extension of extensions) {
+					if ('soBytes' in extension) {
+						installPHPExtensionFilesSync(phpRuntime.FS, extension);
+					} else {
+						installNodeFilesystemExtensionFilesSync(
+							phpRuntime.FS,
+							extension
+						);
+					}
+				}
+			},
+		],
+	};
+}
+
+function createNodeFilesystemExtension(options: {
+	name: BuiltInPHPExtensionName;
+	hostPath: string;
+	loadWithIniDirective?: 'extension' | 'zend_extension';
+	iniEntries?: Record<string, string>;
+	extraFiles?: ResolvedInstallOptions['extraFiles'];
+	env?: Record<string, string>;
+}): NodeFilesystemPHPExtension {
+	const extensionDir = PHP_EXTENSIONS_DIR;
+	const soPath = joinPaths(extensionDir, `${options.name}.so`);
+	return {
+		soPath,
+		soHostPath: options.hostPath,
+		iniPath: joinPaths(extensionDir, `${options.name}.ini`),
+		iniContent: createExtensionIniContent({
+			directive: options.loadWithIniDirective ?? 'extension',
+			soPath,
+			iniEntries: options.iniEntries,
+		}),
+		extraFiles: options.extraFiles,
+		env: options.env,
+		extensionDir,
+	};
+}
+
+function createExtensionIniContent(options: {
+	directive: 'extension' | 'zend_extension';
+	soPath: string;
+	iniEntries?: Record<string, string>;
+}): string {
+	const lines = [`${options.directive}=${options.soPath}`];
+	for (const [key, value] of Object.entries(options.iniEntries ?? {})) {
+		lines.push(`${key}=${value}`);
+	}
+	return lines.join('\n');
+}
+
+function installNodeFilesystemExtensionFilesSync(
+	FS: Emscripten.RootFS,
+	extension: NodeFilesystemPHPExtension
+) {
+	mountHostFile(FS, extension.soHostPath, extension.soPath);
+	if (extension.iniPath && extension.iniContent !== undefined) {
+		mkdirIfMissing(FS, dirname(extension.iniPath));
+		FS.writeFile(extension.iniPath, extension.iniContent);
+	}
+	if (extension.extraFiles) {
+		const { directories = [], files } = extension.extraFiles;
+		for (const directory of directories) {
+			mkdirIfMissing(FS, directory);
+		}
+		for (const [path, content] of Object.entries(files)) {
+			mkdirIfMissing(FS, dirname(path));
+			FS.writeFile(path, content);
+		}
+	}
+}
+
+function mountHostFile(
+	FS: Emscripten.RootFS,
+	hostPath: string,
+	vfsPath: string
+) {
+	mkdirIfMissing(FS, dirname(vfsPath));
+	if (!fileExists(FS, vfsPath)) {
+		// Emscripten's mount point must exist before NODEFS can replace it.
+		FS.writeFile(vfsPath, '');
+	}
+	FS.mount(
+		FS.filesystems['NODEFS'],
+		{ root: fs.realpathSync(hostPath) },
+		vfsPath
+	);
+}
+
+function mkdirIfMissing(FS: Emscripten.RootFS, path: string) {
+	if (!fileExists(FS, path)) {
+		FS.mkdirTree(path);
+	}
+}
+
+function fileExists(FS: Emscripten.RootFS, path: string): boolean {
+	try {
+		FS.lookupPath(path);
+		return true;
+	} catch (e) {
+		const error = e as Emscripten.FS.ErrnoError;
+		if (error.errno === 44) {
+			return false;
+		}
+		throw e;
+	}
 }
 
 /**
@@ -134,7 +286,7 @@ async function resolveRuntimePHPExtension(
 	version: SupportedPHPVersion,
 	asyncMode: PHPWasmAsyncMode,
 	extension: PHPExtension
-): Promise<ResolvedPHPExtension> {
+): Promise<ResolvedNodePHPExtension> {
 	/*
 	 * External extension requests always carry a `source`. Built-in extension
 	 * requests are either strings or `{ name }` objects. This shape check lets
@@ -161,32 +313,24 @@ async function resolveRuntimePHPExtension(
 	switch (builtIn.name) {
 		case 'intl': {
 			const extensionPath = await getIntlExtensionModule(version);
-			const soBytes = new Uint8Array(fs.readFileSync(extensionPath));
-
 			const dataName = 'icu.dat';
 			const moduleDir =
 				typeof __dirname !== 'undefined'
 					? __dirname
 					: import.meta.dirname;
-			const ICUData = fs.readFileSync(
-				resolveIntlDataPath(moduleDir, dataName)
-			);
-
-			return await resolvePHPExtension({
-				source: {
-					format: 'so',
-					name: 'intl',
-					bytes: soBytes,
-				},
-				phpVersion: version,
+			const dataPath = resolveIntlDataPath(moduleDir, dataName);
+			return createNodeFilesystemExtension({
+				name: 'intl',
+				hostPath: extensionPath,
 				env: {
 					ICU_DATA: '/internal/shared',
 				},
 				extraFiles: {
 					files: {
+						// Keep ICU data in MEMFS so PROXYFS callers can share it.
 						// The Intl extension looks for the hard-coded ICU data name.
 						'/internal/shared/icudt74l.dat': new Uint8Array(
-							ICUData
+							fs.readFileSync(dataPath)
 						),
 					},
 				},
@@ -194,48 +338,38 @@ async function resolveRuntimePHPExtension(
 		}
 		case 'redis': {
 			const extensionPath = await getRedisExtensionModule(version);
-			return await resolvePHPExtension({
-				source: {
-					format: 'so',
-					name: 'redis',
-					bytes: new Uint8Array(fs.readFileSync(extensionPath)),
-				},
-				phpVersion: version,
+			return createNodeFilesystemExtension({
+				name: 'redis',
+				hostPath: extensionPath,
 			});
 		}
 		case 'memcached': {
 			const extensionPath = await getMemcachedExtensionModule(version);
-			return await resolvePHPExtension({
-				source: {
-					format: 'so',
-					name: 'memcached',
-					bytes: new Uint8Array(fs.readFileSync(extensionPath)),
-				},
-				phpVersion: version,
+			return createNodeFilesystemExtension({
+				name: 'memcached',
+				hostPath: extensionPath,
 			});
 		}
 		case 'xdebug': {
 			const xdebugOptions = builtIn.options ?? {};
-			const filePath = await getXdebugExtensionModule(version);
 			const ideKey = xdebugOptions.ideKey || DEFAULT_IDE_KEY;
+			const extensionPath = await getXdebugExtensionModule(version);
+			const iniEntries = {
+				'xdebug.mode': 'debug,develop',
+				'xdebug.start_with_request': 'yes',
+				'xdebug.idekey': `"${ideKey}"`,
+				// Path mapping is only available starting from Xdebug 3.5,
+				// which is used by PHP 8.5+. Previous versions ignore it.
+				'xdebug.path_mapping': 'yes',
+			};
+			const extraFiles = resolveXdebugExtraFiles(version, xdebugOptions);
 
-			return await resolvePHPExtension({
-				source: {
-					format: 'so',
-					name: 'xdebug',
-					bytes: new Uint8Array(fs.readFileSync(filePath)),
-				},
-				phpVersion: version,
+			return createNodeFilesystemExtension({
+				name: 'xdebug',
+				hostPath: extensionPath,
 				loadWithIniDirective: 'zend_extension',
-				iniEntries: {
-					'xdebug.mode': 'debug,develop',
-					'xdebug.start_with_request': 'yes',
-					'xdebug.idekey': `"${ideKey}"`,
-					// Path mapping is only available starting from Xdebug 3.5,
-					// which is used by PHP 8.5+. Previous versions ignore it.
-					'xdebug.path_mapping': 'yes',
-				},
-				extraFiles: resolveXdebugExtraFiles(version, xdebugOptions),
+				iniEntries,
+				extraFiles,
 			});
 		}
 		default:

--- a/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
+++ b/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
@@ -14,6 +14,7 @@ import {
 } from '@php-wasm/universal';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { dirname, joinPaths } from '@php-wasm/util';
 import { getIntlExtensionModule } from './intl/get-intl-extension-module';
 import { getMemcachedExtensionModule } from './memcached/get-memcached-extension-module';
@@ -191,7 +192,7 @@ async function resolveRuntimePHPExtension(
 			const moduleDir =
 				typeof __dirname !== 'undefined'
 					? __dirname
-					: import.meta.dirname;
+					: path.dirname(fileURLToPath(import.meta.url));
 			const dataPath = resolveIntlDataPath(moduleDir, dataName);
 			return createNodeFilesystemExtension({
 				name: 'intl',
@@ -443,16 +444,24 @@ function installNodeFilesystemExtensionFilesSync(
 ) {
 	mountHostFile(FS, extension.soHostPath, extension.soPath);
 	if (extension.iniPath && extension.iniContent !== undefined) {
-		mkdirIfMissing(FS, dirname(extension.iniPath));
+		const iniDir = dirname(extension.iniPath);
+		if (!fileExists(FS, iniDir)) {
+			FS.mkdirTree(iniDir);
+		}
 		FS.writeFile(extension.iniPath, extension.iniContent);
 	}
 	if (extension.extraFiles) {
 		const { directories = [], files } = extension.extraFiles;
 		for (const directory of directories) {
-			mkdirIfMissing(FS, directory);
+			if (!fileExists(FS, directory)) {
+				FS.mkdirTree(directory);
+			}
 		}
 		for (const [path, content] of Object.entries(files)) {
-			mkdirIfMissing(FS, dirname(path));
+			const fileDir = dirname(path);
+			if (!fileExists(FS, fileDir)) {
+				FS.mkdirTree(fileDir);
+			}
 			FS.writeFile(path, content);
 		}
 	}
@@ -471,7 +480,10 @@ function mountHostFile(
 	hostPath: string,
 	vfsPath: string
 ) {
-	mkdirIfMissing(FS, dirname(vfsPath));
+	const mountDir = dirname(vfsPath);
+	if (!fileExists(FS, mountDir)) {
+		FS.mkdirTree(mountDir);
+	}
 	if (!fileExists(FS, vfsPath)) {
 		// Emscripten's mount point must exist before NODEFS can replace it.
 		FS.writeFile(vfsPath, '');
@@ -481,15 +493,6 @@ function mountHostFile(
 		{ root: fs.realpathSync(hostPath) },
 		vfsPath
 	);
-}
-
-/**
- * Ensures a directory exists without failing when it was created earlier.
- */
-function mkdirIfMissing(FS: Emscripten.RootFS, path: string) {
-	if (!fileExists(FS, path)) {
-		FS.mkdirTree(path);
-	}
 }
 
 /**

--- a/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
+++ b/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
@@ -113,6 +113,15 @@ export async function withPHPExtensions(
 	return withResolvedNodePHPExtensions(options, resolvedExtensions);
 }
 
+/**
+ * Describes a bundled Node extension loaded from the host filesystem.
+ *
+ * Bundled extension modules already exist on disk next to the Node package.
+ * Mounting the `.so` file through NODEFS lets PHP see the expected virtual
+ * path without first copying the WebAssembly side module into MEMFS. The
+ * generated `.ini` file and any small sidecar files still live in MEMFS
+ * because PHP reads them as regular startup configuration.
+ */
 interface NodeFilesystemPHPExtension {
 	soPath: string;
 	soHostPath: string;
@@ -126,141 +135,6 @@ interface NodeFilesystemPHPExtension {
 type ResolvedNodePHPExtension =
 	| ResolvedPHPExtension
 	| NodeFilesystemPHPExtension;
-
-function withResolvedNodePHPExtensions(
-	options: EmscriptenOptions,
-	extensions: ResolvedNodePHPExtension[]
-): EmscriptenOptions {
-	if (!extensions.length) {
-		return options;
-	}
-	const env = { ...options.ENV };
-	for (const extension of extensions) {
-		Object.assign(env, extension.env);
-		if (!extension.iniPath) {
-			continue;
-		}
-		const paths = env['PHP_INI_SCAN_DIR']?.split(':') ?? [];
-		if (!paths.includes(extension.extensionDir)) {
-			paths.push(extension.extensionDir);
-			env['PHP_INI_SCAN_DIR'] = paths.join(':');
-		}
-	}
-	const preRun = options['preRun'] ?? [];
-	return {
-		...options,
-		ENV: env,
-		['preRun']: [
-			...preRun,
-			(phpRuntime: { FS: any }) => {
-				for (const extension of extensions) {
-					if ('soBytes' in extension) {
-						installPHPExtensionFilesSync(phpRuntime.FS, extension);
-					} else {
-						installNodeFilesystemExtensionFilesSync(
-							phpRuntime.FS,
-							extension
-						);
-					}
-				}
-			},
-		],
-	};
-}
-
-function createNodeFilesystemExtension(options: {
-	name: BuiltInPHPExtensionName;
-	hostPath: string;
-	loadWithIniDirective?: 'extension' | 'zend_extension';
-	iniEntries?: Record<string, string>;
-	extraFiles?: ResolvedInstallOptions['extraFiles'];
-	env?: Record<string, string>;
-}): NodeFilesystemPHPExtension {
-	const extensionDir = PHP_EXTENSIONS_DIR;
-	const soPath = joinPaths(extensionDir, `${options.name}.so`);
-	return {
-		soPath,
-		soHostPath: options.hostPath,
-		iniPath: joinPaths(extensionDir, `${options.name}.ini`),
-		iniContent: createExtensionIniContent({
-			directive: options.loadWithIniDirective ?? 'extension',
-			soPath,
-			iniEntries: options.iniEntries,
-		}),
-		extraFiles: options.extraFiles,
-		env: options.env,
-		extensionDir,
-	};
-}
-
-function createExtensionIniContent(options: {
-	directive: 'extension' | 'zend_extension';
-	soPath: string;
-	iniEntries?: Record<string, string>;
-}): string {
-	const lines = [`${options.directive}=${options.soPath}`];
-	for (const [key, value] of Object.entries(options.iniEntries ?? {})) {
-		lines.push(`${key}=${value}`);
-	}
-	return lines.join('\n');
-}
-
-function installNodeFilesystemExtensionFilesSync(
-	FS: Emscripten.RootFS,
-	extension: NodeFilesystemPHPExtension
-) {
-	mountHostFile(FS, extension.soHostPath, extension.soPath);
-	if (extension.iniPath && extension.iniContent !== undefined) {
-		mkdirIfMissing(FS, dirname(extension.iniPath));
-		FS.writeFile(extension.iniPath, extension.iniContent);
-	}
-	if (extension.extraFiles) {
-		const { directories = [], files } = extension.extraFiles;
-		for (const directory of directories) {
-			mkdirIfMissing(FS, directory);
-		}
-		for (const [path, content] of Object.entries(files)) {
-			mkdirIfMissing(FS, dirname(path));
-			FS.writeFile(path, content);
-		}
-	}
-}
-
-function mountHostFile(
-	FS: Emscripten.RootFS,
-	hostPath: string,
-	vfsPath: string
-) {
-	mkdirIfMissing(FS, dirname(vfsPath));
-	if (!fileExists(FS, vfsPath)) {
-		// Emscripten's mount point must exist before NODEFS can replace it.
-		FS.writeFile(vfsPath, '');
-	}
-	FS.mount(
-		FS.filesystems['NODEFS'],
-		{ root: fs.realpathSync(hostPath) },
-		vfsPath
-	);
-}
-
-function mkdirIfMissing(FS: Emscripten.RootFS, path: string) {
-	if (!fileExists(FS, path)) {
-		FS.mkdirTree(path);
-	}
-}
-
-function fileExists(FS: Emscripten.RootFS, path: string): boolean {
-	try {
-		FS.lookupPath(path);
-		return true;
-	} catch (e) {
-		const error = e as Emscripten.FS.ErrnoError;
-		if (error.errno === 44) {
-			return false;
-		}
-		throw e;
-	}
-}
 
 /**
  * Resolves one user-facing Node extension request before PHP starts.
@@ -380,6 +254,59 @@ async function resolveRuntimePHPExtension(
 }
 
 /**
+ * Builds a NODEFS-backed descriptor for one bundled extension module.
+ *
+ * The descriptor keeps the host path and the PHP-visible path separate:
+ * `soHostPath` points at the package artifact on disk, while `soPath` is the
+ * path PHP loads from `extension_dir`. The generated `.ini` file is installed
+ * later during Emscripten `preRun`, after the runtime filesystem exists.
+ */
+function createNodeFilesystemExtension(options: {
+	name: BuiltInPHPExtensionName;
+	hostPath: string;
+	loadWithIniDirective?: 'extension' | 'zend_extension';
+	iniEntries?: Record<string, string>;
+	extraFiles?: ResolvedInstallOptions['extraFiles'];
+	env?: Record<string, string>;
+}): NodeFilesystemPHPExtension {
+	const extensionDir = PHP_EXTENSIONS_DIR;
+	const soPath = joinPaths(extensionDir, `${options.name}.so`);
+	return {
+		soPath,
+		soHostPath: options.hostPath,
+		iniPath: joinPaths(extensionDir, `${options.name}.ini`),
+		iniContent: createExtensionIniContent({
+			directive: options.loadWithIniDirective ?? 'extension',
+			soPath,
+			iniEntries: options.iniEntries,
+		}),
+		extraFiles: options.extraFiles,
+		env: options.env,
+		extensionDir,
+	};
+}
+
+/**
+ * Creates the PHP startup configuration for one NODEFS-backed extension.
+ *
+ * Most extensions load with `extension=...`; Xdebug is a Zend extension and
+ * must use `zend_extension=...`. Additional entries are appended in order so
+ * extension-specific configuration remains next to the directive that loads
+ * the module.
+ */
+function createExtensionIniContent(options: {
+	directive: 'extension' | 'zend_extension';
+	soPath: string;
+	iniEntries?: Record<string, string>;
+}): string {
+	const lines = [`${options.directive}=${options.soPath}`];
+	for (const [key, value] of Object.entries(options.iniEntries ?? {})) {
+		lines.push(`${key}=${value}`);
+	}
+	return lines.join('\n');
+}
+
+/**
  * Finds the bundled ICU data file for Node `intl`.
  *
  * The path is different in source tests and in the built package. Source tests
@@ -450,4 +377,137 @@ function resolveXdebugExtraFiles(
 	}
 
 	return { files };
+}
+
+/**
+ * Adds resolved Node extension files to Emscripten startup options.
+ *
+ * Extensions are installed during `preRun` because Emscripten creates the
+ * runtime filesystem only after options are prepared. Existing `preRun`
+ * callbacks are preserved, extension-specific environment variables are
+ * merged, and NODEFS-backed `.ini` directories are appended to
+ * `PHP_INI_SCAN_DIR` so PHP discovers them during startup.
+ */
+function withResolvedNodePHPExtensions(
+	options: EmscriptenOptions,
+	extensions: ResolvedNodePHPExtension[]
+): EmscriptenOptions {
+	if (!extensions.length) {
+		return options;
+	}
+	const env = { ...options.ENV };
+	for (const extension of extensions) {
+		Object.assign(env, extension.env);
+		if (!extension.iniPath) {
+			continue;
+		}
+		const paths = env['PHP_INI_SCAN_DIR']?.split(':') ?? [];
+		if (!paths.includes(extension.extensionDir)) {
+			paths.push(extension.extensionDir);
+			env['PHP_INI_SCAN_DIR'] = paths.join(':');
+		}
+	}
+	const preRun = options['preRun'] ?? [];
+	return {
+		...options,
+		ENV: env,
+		['preRun']: [
+			...preRun,
+			(phpRuntime: { FS: any }) => {
+				for (const extension of extensions) {
+					if ('soBytes' in extension) {
+						installPHPExtensionFilesSync(phpRuntime.FS, extension);
+					} else {
+						installNodeFilesystemExtensionFilesSync(
+							phpRuntime.FS,
+							extension
+						);
+					}
+				}
+			},
+		],
+	};
+}
+
+/**
+ * Installs one NODEFS-backed extension into the runtime filesystem.
+ *
+ * The heavy `.so` module is mounted from the host filesystem. The generated
+ * `.ini` file and sidecar files are written into MEMFS because they are small
+ * startup inputs, and because some of them are virtual paths with no matching
+ * host file.
+ */
+function installNodeFilesystemExtensionFilesSync(
+	FS: Emscripten.RootFS,
+	extension: NodeFilesystemPHPExtension
+) {
+	mountHostFile(FS, extension.soHostPath, extension.soPath);
+	if (extension.iniPath && extension.iniContent !== undefined) {
+		mkdirIfMissing(FS, dirname(extension.iniPath));
+		FS.writeFile(extension.iniPath, extension.iniContent);
+	}
+	if (extension.extraFiles) {
+		const { directories = [], files } = extension.extraFiles;
+		for (const directory of directories) {
+			mkdirIfMissing(FS, directory);
+		}
+		for (const [path, content] of Object.entries(files)) {
+			mkdirIfMissing(FS, dirname(path));
+			FS.writeFile(path, content);
+		}
+	}
+}
+
+/**
+ * Mounts one host file at the PHP-visible virtual filesystem path.
+ *
+ * NODEFS replaces an existing filesystem node with a mount, so the VFS path is
+ * created as an empty file first. The host path is resolved before mounting so
+ * symlinked package artifacts keep working when the package is linked into a
+ * workspace.
+ */
+function mountHostFile(
+	FS: Emscripten.RootFS,
+	hostPath: string,
+	vfsPath: string
+) {
+	mkdirIfMissing(FS, dirname(vfsPath));
+	if (!fileExists(FS, vfsPath)) {
+		// Emscripten's mount point must exist before NODEFS can replace it.
+		FS.writeFile(vfsPath, '');
+	}
+	FS.mount(
+		FS.filesystems['NODEFS'],
+		{ root: fs.realpathSync(hostPath) },
+		vfsPath
+	);
+}
+
+/**
+ * Ensures a directory exists without failing when it was created earlier.
+ */
+function mkdirIfMissing(FS: Emscripten.RootFS, path: string) {
+	if (!fileExists(FS, path)) {
+		FS.mkdirTree(path);
+	}
+}
+
+/**
+ * Indicates whether a path exists in Emscripten's virtual filesystem.
+ *
+ * Emscripten reports a missing path as errno 44 (`ENOENT`) instead of
+ * returning `undefined`, so the helper keeps the expected miss separate from
+ * filesystem errors that should still bubble up.
+ */
+function fileExists(FS: Emscripten.RootFS, path: string): boolean {
+	try {
+		FS.lookupPath(path);
+		return true;
+	} catch (e) {
+		const error = e as Emscripten.FS.ErrnoError;
+		if (error.errno === 44) {
+			return false;
+		}
+		throw e;
+	}
 }

--- a/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
+++ b/packages/php-wasm/node/src/lib/extensions/load-extensions.ts
@@ -272,39 +272,30 @@ function createNodeFilesystemExtension(options: {
 }): NodeFilesystemPHPExtension {
 	const extensionDir = PHP_EXTENSIONS_DIR;
 	const soPath = joinPaths(extensionDir, `${options.name}.so`);
+	const directive = options.loadWithIniDirective ?? 'extension';
+	/*
+	 * PHP only discovers this NODEFS-backed extension through startup
+	 * configuration. Most extensions load with `extension=...`; Xdebug is a
+	 * Zend extension and must use `zend_extension=...`. Additional entries are
+	 * appended in order so extension-specific configuration remains next to the
+	 * directive that loads the module.
+	 */
+	const iniContent = [
+		`${directive}=${soPath}`,
+		...Object.entries(options.iniEntries ?? {}).map(
+			([key, value]) => `${key}=${value}`
+		),
+	].join('\n');
+
 	return {
 		soPath,
 		soHostPath: options.hostPath,
 		iniPath: joinPaths(extensionDir, `${options.name}.ini`),
-		iniContent: createExtensionIniContent({
-			directive: options.loadWithIniDirective ?? 'extension',
-			soPath,
-			iniEntries: options.iniEntries,
-		}),
+		iniContent,
 		extraFiles: options.extraFiles,
 		env: options.env,
 		extensionDir,
 	};
-}
-
-/**
- * Creates the PHP startup configuration for one NODEFS-backed extension.
- *
- * Most extensions load with `extension=...`; Xdebug is a Zend extension and
- * must use `zend_extension=...`. Additional entries are appended in order so
- * extension-specific configuration remains next to the directive that loads
- * the module.
- */
-function createExtensionIniContent(options: {
-	directive: 'extension' | 'zend_extension';
-	soPath: string;
-	iniEntries?: Record<string, string>;
-}): string {
-	const lines = [`${options.directive}=${options.soPath}`];
-	for (const [key, value] of Object.entries(options.iniEntries ?? {})) {
-		lines.push(`${key}=${value}`);
-	}
-	return lines.join('\n');
 }
 
 /**

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/load-bundled-extensions.cjs
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/load-bundled-extensions.cjs
@@ -1,0 +1,55 @@
+const { PHP } = require('@php-wasm/universal');
+const { loadNodeRuntime } = require('@php-wasm/node');
+
+const phpVersion = process.argv[2];
+if (!phpVersion) {
+	throw new Error('PHP version argument is required');
+}
+
+(async () => {
+	const php = new PHP(
+		await loadNodeRuntime(phpVersion, {
+			emscriptenOptions: { processId: 1 },
+			extensions: ['intl', 'xdebug'],
+		})
+	);
+	try {
+		const response = await php.runStream({
+			code: `<?php
+				echo extension_loaded('intl') ? "intl=yes\n" : "intl=no\n";
+				echo extension_loaded('xdebug') ? "xdebug=yes\n" : "xdebug=no\n";
+			`,
+		});
+		const output = await response.stdoutText;
+		if (output !== 'intl=yes\nxdebug=yes\n') {
+			throw new Error(
+				`Unexpected extension output: ${JSON.stringify(output)}`
+			);
+		}
+
+		const intlIni = php.readFileAsText(
+			'/internal/shared/extensions/intl.ini'
+		);
+		if (intlIni !== 'extension=/internal/shared/extensions/intl.so') {
+			throw new Error(`Unexpected intl.ini: ${JSON.stringify(intlIni)}`);
+		}
+
+		const xdebugIni = php.readFileAsText(
+			'/internal/shared/extensions/xdebug.ini'
+		);
+		if (
+			!xdebugIni.startsWith(
+				'zend_extension=/internal/shared/extensions/xdebug.so'
+			)
+		) {
+			throw new Error(
+				`Unexpected xdebug.ini: ${JSON.stringify(xdebugIni)}`
+			);
+		}
+	} finally {
+		php.exit();
+	}
+})().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/commonjs-and-jest/tests/wp.spec.ts
@@ -1,6 +1,7 @@
 const { SupportedPHPVersions } = require('@php-wasm/universal');
 const { getPHPLoaderModule } = require('@php-wasm/node');
 const { runCLI } = require('@wp-playground/cli');
+const { execFileSync } = require('child_process');
 const path = require('path');
 SupportedPHPVersions.forEach((phpVersion: string) => {
 	describe(`PHP ${phpVersion}`, () => {
@@ -22,6 +23,17 @@ SupportedPHPVersions.forEach((phpVersion: string) => {
 			} finally {
 				await cli[Symbol.asyncDispose]();
 			}
+		}, 30000);
+
+		it('bundled PHP extensions should load from installed packages', () => {
+			execFileSync(
+				process.execPath,
+				[
+					path.join(__dirname, 'load-bundled-extensions.cjs'),
+					phpVersion,
+				],
+				{ stdio: 'pipe' }
+			);
 		}, 30000);
 	});
 	/**

--- a/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
+++ b/packages/playground/test-built-npm-packages/es-modules-and-vitest/tests/wp.spec.ts
@@ -5,7 +5,8 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { runCLI } from '@wp-playground/cli';
 import type { SupportedPHPVersion } from '@php-wasm/universal';
-import { SupportedPHPVersions } from '@php-wasm/universal';
+import { PHP, SupportedPHPVersions } from '@php-wasm/universal';
+import { loadNodeRuntime } from '@php-wasm/node';
 
 const phpVersion = process.env.PHP_VERSION as SupportedPHPVersion;
 if (!phpVersion) {
@@ -40,6 +41,47 @@ describe(`PHP ${phpVersion}`, { concurrency: 1 }, () => {
 			}
 		}
 	});
+
+	it(
+		'Should load bundled PHP extensions from installed packages',
+		{ timeout: 30000 },
+		async () => {
+			const php = new PHP(
+				await loadNodeRuntime(phpVersion, {
+					emscriptenOptions: { processId: 1 },
+					extensions: ['intl', 'xdebug'],
+				})
+			);
+			try {
+				const response = await php.runStream({
+					code: `<?php
+					echo extension_loaded('intl') ? "intl=yes\n" : "intl=no\n";
+					echo extension_loaded('xdebug') ? "xdebug=yes\n" : "xdebug=no\n";
+				`,
+				});
+				assert.equal(
+					await response.stdoutText,
+					'intl=yes\nxdebug=yes\n'
+				);
+
+				assert.equal(
+					php.readFileAsText('/internal/shared/extensions/intl.ini'),
+					'extension=/internal/shared/extensions/intl.so'
+				);
+				assert.ok(
+					php
+						.readFileAsText(
+							'/internal/shared/extensions/xdebug.ini'
+						)
+						.startsWith(
+							'zend_extension=/internal/shared/extensions/xdebug.so'
+						)
+				);
+			} finally {
+				php.exit();
+			}
+		}
+	);
 
 	/**
 	 * Verify the built Playground packages ship worker files that have stable names.


### PR DESCRIPTION
## What it does

Loads bundled Node PHP extension `.so` files through Emscripten `NODEFS` instead of copying their bytes into MEMFS before PHP starts.

This covers the bundled `intl`, `redis`, `memcached`, and `xdebug` extensions. External extension sources still use the existing byte-backed installer path.

Generated `.ini` files and sidecar files stay in MEMFS so PHP startup and PROXYFS sharing keep the same behavior.

@brandonpayton @mho22 @frederik — this is one of the Playground CLI/Studio memory explorations split into its own draft PR.

## Rationale

Bundled extension modules already live on disk in `@php-wasm/node`. Copying them into MEMFS duplicates the side-module bytes in memory just so PHP can `dlopen()` them. `NODEFS` lets PHP read the package artifact from the host filesystem while preserving the virtual `extension_dir` path PHP expects.

`intl` ICU data remains in MEMFS because existing runtimes share `/internal/shared` through PROXYFS. Xdebug sidecar maps also stay in MEMFS because they are small generated startup inputs, not host modules.

Targeted six-runtime extension-load benchmark against `origin/trunk` (Node v24.14.1 JSPI, PHP 8.4, `intl,redis,memcached`, `--expose-gc`):

- RSS delta for six loaded runtimes: `817.0 MiB -> 745.5 MiB`, saving `71.5 MiB`.
- External memory: `631.0 MiB -> 594.4 MiB`, saving `36.6 MiB`.
- ArrayBuffers: `246.8 MiB -> 210.2 MiB`, saving `36.6 MiB`.

Full CLI warm-ready RSS was noisy/neutral locally (`1775.4 MiB -> 1799.0 MiB` median), so this should be framed as extension byte/peak memory reduction rather than a server-ready-time improvement. The Studio export showed the stronger process-level version of the same win: workers-ready RSS `824.2 MiB -> 705.7 MiB` and peak RSS `1152.5 MiB -> 842.5 MiB`.

Verdict: worthwhile for extension memory and transient peak reduction; not a reliable warm-ready time PR.

## Implementation

- `withPHPExtensions()` resolves each request into either an external byte-backed extension or a bundled `NodeFilesystemPHPExtension` descriptor.
- During Emscripten `preRun`, byte-backed extensions still use `installPHPExtensionFilesSync()`. Bundled extensions mount the `.so` file through `NODEFS`, then write generated `.ini` and sidecar files into MEMFS.
- `PHP_INI_SCAN_DIR` is extended with the generated extension directory when a bundled extension has an `.ini` file, so PHP discovers it during normal startup.
- The PHP-visible paths remain the same as before: `/internal/shared/extensions/<name>.so` and `/internal/shared/extensions/<name>.ini`.
- The package-artifact paths still come from the existing `@php-wasm/node-<version>` helpers, e.g. `jspi/extensions/intl/intl.so` or `asyncify/extensions/intl/intl.so`; this PR mounts those paths instead of reading their bytes.
- `intl` resolves `icu.dat` from the built `@php-wasm/node/shared/` layout or the source-test layout, using `import.meta.url` for ESM package consumers instead of relying on newer `import.meta.dirname` support.
- Built-package tests now load `intl` and `xdebug` from installed packages in both the ES module and CommonJS integration fixtures.
- The helper docs call out the startup lifecycle, the NODEFS/MEMFS boundary, the `intl`/PROXYFS constraint, and Emscripten's `ENOENT` handling. Helpers are defined after their callers so the main flow stays above the implementation details.

## Testing instructions

Validated with:

- `npm exec -- nx lint php-wasm-node`
- `npm exec -- nx typecheck php-wasm-node`
- `npm exec -- nx run php-wasm-node:test-group-4-asyncify --testFiles=php-dynamic-loading.spec.ts`
- `npm exec -- nx run-many -t build -p php-wasm-node,php-wasm-node-8-4,php-wasm-universal,php-wasm-util,php-wasm-logger,php-wasm-cli-util,php-wasm-stream-compression,php-wasm-progress --parallel=3`
- Manual temp npm-consumer smoke test that copied the built `dist` packages into `node_modules` and loaded PHP 8.4 with `extensions: ['intl', 'xdebug']` through both ESM and CommonJS entrypoints.

Earlier targeted checks:

- `PATH="$HOME/.nvm/versions/node/v24.14.1/bin:$PATH" npx nx run php-wasm-node:test-group-4-jspi --testFiles=php-dynamic-loading.spec.ts`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run php-wasm-node:test-group-4-asyncify --testFiles=php-dynamic-loading.spec.ts`
