### PR TITLE
Share precompiled PHP wasm modules across CLI workers

### DIFF
--- a/packages/php-wasm/node/src/lib/load-runtime.ts
+++ b/packages/php-wasm/node/src/lib/load-runtime.ts
@@ -57,6 +57,12 @@ export interface PHPLoaderOptions {
 
 export type PHPLoaderOptionsForNode = PHPLoaderOptions & {
 	/**
+	 * Precompiled PHP WebAssembly module. When provided, the runtime can skip
+	 * compiling the same PHP binary again inside this Node.js process.
+	 */
+	precompiledWasmModule?: WebAssembly.Module;
+
+	/**
 	 * A file lock manager to coordinate file locks between
 	 * multiple php-wasm instances and other OS processes.
 	 */
@@ -357,6 +363,23 @@ export async function loadNodeRuntime(
 			phpRuntime.FS.root.mount.opts.root = '.';
 		},
 	};
+
+	if (options.precompiledWasmModule) {
+		if (emscriptenOptions.instantiateWasm) {
+			throw new Error(
+				'precompiledWasmModule cannot be used with a custom instantiateWasm option.'
+			);
+		}
+		const precompiledWasmModule = options.precompiledWasmModule;
+		emscriptenOptions.instantiateWasm = (imports, receiveInstance) => {
+			WebAssembly.instantiate(precompiledWasmModule, imports).then(
+				(instance) => {
+					receiveInstance(instance, precompiledWasmModule);
+				}
+			);
+			return undefined;
+		};
+	}
 
 	if (isLegacy && requestedExtensions.length) {
 		throw new Error(

--- a/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
+++ b/packages/playground/cli/src/blueprints-v1/worker-thread-v1.ts
@@ -18,12 +18,20 @@ import {
 	bootWordPress,
 } from '@wp-playground/wordpress';
 import { rootCertificates } from 'tls';
-import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
+import {
+	MessageChannel,
+	type MessagePort,
+	parentPort,
+	workerData,
+} from 'worker_threads';
 import { mountResources } from '../mounts';
 import { logger } from '@php-wasm/logger';
 import { spawnWorkerThread } from '../run-cli';
+import type { PlaygroundCliWorkerData } from '../run-cli';
 
 import type { Mount } from '@php-wasm/cli-util';
+
+const playgroundCliWorkerData = (workerData ?? {}) as PlaygroundCliWorkerData;
 
 export type WorkerBootWordPressOptions = {
 	siteUrl: string;
@@ -239,6 +247,8 @@ function createPhpRuntimeFactory(
 			options.phpVersion || RecommendedPHPVersion,
 			{
 				fileLockManager,
+				precompiledWasmModule:
+					playgroundCliWorkerData.precompiledWasmModule,
 				emscriptenOptions: {
 					processId: options.processId,
 					trace: options.trace ? tracePhpWasm : undefined,
@@ -275,7 +285,9 @@ async function createPHPWorker(
 	options: Omit<WorkerBootRequestHandlerOptions, 'processId'>,
 	fileLockManager: FileLockManager
 ) {
-	const spawnedWorker = await spawnWorkerThread('v1');
+	const spawnedWorker = await spawnWorkerThread('v1', {
+		workerData: playgroundCliWorkerData,
+	});
 
 	const handler = consumeAPI<PlaygroundCliBlueprintV1Worker>(
 		spawnedWorker.phpPort

--- a/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
+++ b/packages/playground/cli/src/blueprints-v2/worker-thread-v2.ts
@@ -46,14 +46,25 @@ import {
 import { existsSync } from 'fs';
 import path from 'path';
 import { rootCertificates } from 'tls';
-import { MessageChannel, type MessagePort, parentPort } from 'worker_threads';
-import { type RunCLIArgs, spawnWorkerThread } from '../run-cli';
+import {
+	MessageChannel,
+	type MessagePort,
+	parentPort,
+	workerData,
+} from 'worker_threads';
+import {
+	type PlaygroundCliWorkerData,
+	type RunCLIArgs,
+	spawnWorkerThread,
+} from '../run-cli';
 import type {
 	PhpIniOptions,
 	PHPInstanceCreatedHook,
 } from '@wp-playground/wordpress';
 import { shouldRenderProgress } from '../utils/progress';
 import type { Mount } from '@php-wasm/cli-util';
+
+const playgroundCliWorkerData = (workerData ?? {}) as PlaygroundCliWorkerData;
 
 async function mountResources(php: PHP, mounts: Mount[]) {
 	for (const mount of mounts) {
@@ -466,6 +477,8 @@ export class PlaygroundCliBlueprintV2Worker extends PHPWorker {
 				createPhpRuntime: async () => {
 					return await loadNodeRuntime(phpVersion, {
 						fileLockManager: this.fileLockManager!,
+						precompiledWasmModule:
+							playgroundCliWorkerData.precompiledWasmModule,
 						emscriptenOptions: {
 							processId,
 							trace: trace ? tracePhpWasm : undefined,
@@ -567,7 +580,9 @@ async function createPHPWorker(
 	Omit<SecondaryWorkerBootArgs, 'processId'>,
 	fileLockManager: FileLockManager | RemoteAPI<FileLockManager>
 ) {
-	const spawnedWorker = await spawnWorkerThread('v2');
+	const spawnedWorker = await spawnWorkerThread('v2', {
+		workerData: playgroundCliWorkerData,
+	});
 
 	const handler = consumeAPI<PlaygroundCliBlueprintV2Worker>(
 		spawnedWorker.phpPort

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1546,12 +1546,17 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			try {
 				const promisesToBoot = [];
 				const workerType = handler.getWorkerType();
+				const precompiledWasmModule = await compilePHPWasmModule(
+					args.php || RecommendedPHPVersion
+				);
+				const workerData = { precompiledWasmModule };
 				for (
 					let workerIndex = 0;
 					workerIndex < targetWorkerCount;
 					workerIndex++
 				) {
 					const promiseToBoot = spawnWorkerThread(workerType, {
+						workerData,
 						onExit: (exitCode: number) => {
 							// We are already disposing, so worker exit is expected
 							// and does not need to be logged.
@@ -1840,6 +1845,22 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 	return server;
 }
 
+async function compilePHPWasmModule(
+	phpVersion: AllPHPVersion
+): Promise<WebAssembly.Module> {
+	const { getPHPLoaderModule } = await import('@php-wasm/node');
+	const phpLoaderModule = await getPHPLoaderModule(phpVersion);
+	if (!phpLoaderModule.dependencyFilename) {
+		throw new Error(
+			`Cannot precompile PHP ${phpVersion}: wasm dependency filename is missing.`
+		);
+	}
+	const wasmBytes = await fs.promises.readFile(
+		phpLoaderModule.dependencyFilename
+	);
+	return await WebAssembly.compile(wasmBytes);
+}
+
 /**
  * Transforms CLI args for the `start` command into the `server` command arguments.
  *
@@ -1963,6 +1984,10 @@ export type SpawnedWorker = {
 	phpPort: NodeMessagePort;
 };
 
+export type PlaygroundCliWorkerData = {
+	precompiledWasmModule?: WebAssembly.Module;
+};
+
 /**
  * A statically analyzable function that spawns a worker thread of a given type.
  *
@@ -1976,7 +2001,13 @@ export type SpawnedWorker = {
  */
 export function spawnWorkerThread(
 	workerType: 'v1' | 'v2',
-	{ onExit }: { onExit?: (code: number) => void } = {}
+	{
+		onExit,
+		workerData,
+	}: {
+		onExit?: (code: number) => void;
+		workerData?: PlaygroundCliWorkerData;
+	} = {}
 ) {
 	/**
 	 * When running the CLI from source via `node cli.ts`, the Vite-provided
@@ -1992,10 +2023,17 @@ export function spawnWorkerThread(
 		globalThis['__WORKER_V2_URL__'] = './blueprints-v2/worker-thread-v2.ts';
 	}
 	let worker: Worker;
+	const workerOptions = workerData === undefined ? undefined : { workerData };
 	if (workerType === 'v1') {
-		worker = new Worker(new URL(__WORKER_V1_URL__, import.meta.url));
+		worker = new Worker(
+			new URL(__WORKER_V1_URL__, import.meta.url),
+			workerOptions
+		);
 	} else {
-		worker = new Worker(new URL(__WORKER_V2_URL__, import.meta.url));
+		worker = new Worker(
+			new URL(__WORKER_V2_URL__, import.meta.url),
+			workerOptions
+		);
 	}
 
 	return new Promise<SpawnedWorker>((resolve, reject) => {


### PR DESCRIPTION
## Summary

- compile the selected PHP wasm binary once in the CLI parent process
- pass the structured-cloned `WebAssembly.Module` into request workers and nested PHP workers
- let `loadNodeRuntime()` instantiate a provided precompiled module instead of compiling the same wasm bytes in every worker

@brandonpayton @mho22 @frederik — this is one of the Playground CLI/Studio startup/memory explorations split into its own draft PR.

## Testing

- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run php-wasm-node:typecheck`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run playground-cli:typecheck`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run playground-cli:build:bundle:production`

Note: I also tried `npx nx dev playground-cli php --php=8.4 --wp=6.8 -r 'echo "ok\\n";'`, but source dev mode hit the existing local `isomorphic-git/src/models/GitPktLine.js` resolution issue before exercising this path.



## Impact measurement

Local warm-start benchmark against `origin/trunk` (source CLI, Node v24.14.1 JSPI, PHP 8.4, WP 6.8, `--workers=6`, already-installed mounted site, 3 rounds, median):

- Ready RSS: `1775.4 MiB -> 1517.9 MiB`, saving `257.5 MiB` (`14.5%`).
- Server ready time was neutral/slightly worse locally: `2808.7 ms -> 2881.6 ms` (`+73 ms`).

The Studio synthetic worker test showed the startup mechanism more directly: six-worker peak RSS `413.3 MiB -> 247.8 MiB`, and average worker ready time `304.4 ms -> 36.0 ms`.

Verdict: worthwhile for memory/worker startup. Do not sell this PR as a full CLI ready-time improvement by itself yet.
