### PR TITLE
Start Playground CLI workers lazily

### DIFF
--- a/packages/php-wasm/universal/src/lib/index.ts
+++ b/packages/php-wasm/universal/src/lib/index.ts
@@ -137,7 +137,10 @@ export * from './file-lock-interval-tree';
 
 export type { Remote } from './comlink-sync';
 
-export { createObjectPoolProxy } from './object-pool-proxy';
+export {
+	createObjectPoolProxy,
+	createLazyObjectPoolProxy,
+} from './object-pool-proxy';
 export type { Pooled } from './object-pool-proxy';
 
 export * from './process-id-allocator';

--- a/packages/php-wasm/universal/src/lib/object-pool-proxy.ts
+++ b/packages/php-wasm/universal/src/lib/object-pool-proxy.ts
@@ -48,14 +48,14 @@ export function createObjectPoolProxy<T extends object>(
 	const freeInstances: T[] = [...instances];
 	const waitQueue: Array<(instance: T) => void> = [];
 
-	function acquire(): Promise<T> {
+	function acquire(): Promise<AcquiredInstance<T>> {
 		const free = freeInstances.shift();
 		if (free !== undefined) {
-			return Promise.resolve(free);
+			return Promise.resolve(wrapAcquiredInstance(free, release));
 		}
 		return new Promise<T>((resolve) => {
 			waitQueue.push(resolve);
-		});
+		}).then((instance) => wrapAcquiredInstance(instance, release));
 	}
 
 	function release(instance: T): void {
@@ -67,19 +67,91 @@ export function createObjectPoolProxy<T extends object>(
 		}
 	}
 
+	return createObjectPoolProxyFromAcquire(acquire);
+}
+
+/**
+ * Creates a pool proxy that starts with a small ready set and creates more
+ * instances only when all ready instances are already checked out.
+ */
+export function createLazyObjectPoolProxy<T extends object>(
+	initialInstances: T[],
+	createInstance: () => Promise<T>,
+	maxInstances: number
+): Pooled<T> {
+	if (initialInstances.length === 0) {
+		throw new Error('At least one instance is required');
+	}
+	if (maxInstances < initialInstances.length) {
+		throw new Error('maxInstances cannot be smaller than initialInstances');
+	}
+
+	const freeInstances: T[] = [...initialInstances];
+	const waitQueue: Array<(instance: T) => void> = [];
+	let instanceCount = initialInstances.length;
+
+	async function acquire(): Promise<AcquiredInstance<T>> {
+		const free = freeInstances.shift();
+		if (free !== undefined) {
+			return wrapAcquiredInstance(free, release);
+		}
+		if (instanceCount < maxInstances) {
+			instanceCount++;
+			try {
+				return wrapAcquiredInstance(await createInstance(), release);
+			} catch (e) {
+				instanceCount--;
+				throw e;
+			}
+		}
+		return new Promise<T>((resolve) => {
+			waitQueue.push(resolve);
+		}).then((instance) => wrapAcquiredInstance(instance, release));
+	}
+
+	function release(instance: T): void {
+		const waiter = waitQueue.shift();
+		if (waiter) {
+			waiter(instance);
+		} else {
+			freeInstances.push(instance);
+		}
+	}
+
+	return createObjectPoolProxyFromAcquire(acquire);
+}
+
+type AcquiredInstance<T extends object> = {
+	instance: T;
+	release: () => void;
+};
+
+function wrapAcquiredInstance<T extends object>(
+	instance: T,
+	release: (instance: T) => void
+): AcquiredInstance<T> {
+	return {
+		instance,
+		release: () => release(instance),
+	};
+}
+
+function createObjectPoolProxyFromAcquire<T extends object>(
+	acquire: () => Promise<AcquiredInstance<T>>
+): Pooled<T> {
 	function withInstance<R>(fn: (instance: T) => R | Promise<R>): Promise<R> {
-		return acquire().then((instance) => {
+		return acquire().then(({ instance, release }) => {
 			const releaseWhenComplete = (value: R): R => {
 				// `.finished` means this is a streamed response class.
 				// Keep the instance checked out until streaming settles.
 				const finished = (value as any)?.finished;
 				if (finished && typeof finished.then === 'function') {
 					Promise.resolve(finished).then(
-						() => release(instance),
-						() => release(instance)
+						() => release(),
+						() => release()
 					);
 				} else {
-					release(instance);
+					release();
 				}
 				return value;
 			};
@@ -88,14 +160,14 @@ export function createObjectPoolProxy<T extends object>(
 			try {
 				result = fn(instance);
 			} catch (e) {
-				release(instance);
+				release();
 				throw e;
 			}
 			if (result != null && typeof (result as any).then === 'function') {
 				return (result as Promise<R>).then(
 					(val) => releaseWhenComplete(val),
 					(err) => {
-						release(instance);
+						release();
 						throw err;
 					}
 				);

--- a/packages/php-wasm/universal/src/test/object-pool-proxy.spec.ts
+++ b/packages/php-wasm/universal/src/test/object-pool-proxy.spec.ts
@@ -1,4 +1,7 @@
-import { createObjectPoolProxy } from '../lib/object-pool-proxy';
+import {
+	createLazyObjectPoolProxy,
+	createObjectPoolProxy,
+} from '../lib/object-pool-proxy';
 
 describe('createPoolProxy', () => {
 	it('throws if no instances are provided', () => {
@@ -248,5 +251,41 @@ describe('createPoolProxy', () => {
 		const second = await proxy.value;
 
 		expect([first, second].sort()).toEqual(['a', 'b']);
+	});
+	it('creates lazy instances only when the ready instances are busy', async () => {
+		let releaseFirst!: () => void;
+		const first = {
+			run: vi.fn(
+				() =>
+					new Promise<string>((resolve) => {
+						releaseFirst = () => resolve('first');
+					})
+			),
+		};
+		const second = {
+			run: vi.fn(async () => 'second'),
+		};
+		const createInstance = vi.fn(async () => second);
+		const proxy = createLazyObjectPoolProxy([first], createInstance, 2);
+
+		const firstResult = proxy.run();
+		const secondResult = proxy.run();
+
+		expect(createInstance).toHaveBeenCalledTimes(1);
+		expect(await secondResult).toBe('second');
+		releaseFirst();
+		expect(await firstResult).toBe('first');
+	});
+
+	it('rejects lazy pools whose maximum is below the ready instance count', () => {
+		expect(() =>
+			createLazyObjectPoolProxy(
+				[{ run: vi.fn() }],
+				async () => ({
+					run: vi.fn(),
+				}),
+				0
+			)
+		).toThrow('maxInstances cannot be smaller than initialInstances');
 	});
 });

--- a/packages/playground/cli/src/cli-output.ts
+++ b/packages/playground/cli/src/cli-output.ts
@@ -219,12 +219,19 @@ export class CLIOutput extends BaseCLIOutput {
 	 * Note: The exact wording "WordPress is running on" is checked by
 	 * CI tests, so changes to this string will break test assertions.
 	 */
-	printReady(url: string, workerCount: number): void {
+	printReady(
+		url: string,
+		workerCount: number,
+		{ capacity = false }: { capacity?: boolean } = {}
+	): void {
 		if (this.isQuiet) return;
 
 		const workerLabel = workerCount === 1 ? 'worker' : 'workers';
+		const workerDescription = capacity
+			? `${workerCount} ${workerLabel} capacity`
+			: `${workerCount} ${workerLabel}`;
 		this.writeStream.write(
-			`\n${this.green('Ready!')} WordPress is running on ${this.bold(url)} ${this.dim(`(${workerCount} ${workerLabel})`)}\n\n`
+			`\n${this.green('Ready!')} WordPress is running on ${this.bold(url)} ${this.dim(`(${workerDescription})`)}\n\n`
 		);
 	}
 

--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1,7 +1,7 @@
 import { errorLogPath, logger, LogSeverity } from '@php-wasm/logger';
 import { ProcessIdAllocator } from '@php-wasm/universal';
 import {
-	createObjectPoolProxy,
+	createLazyObjectPoolProxy,
 	type Pooled,
 	type PHPRequest,
 	type PathAlias,
@@ -1544,14 +1544,13 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 			};
 
 			try {
-				const promisesToBoot = [];
 				const workerType = handler.getWorkerType();
-				for (
-					let workerIndex = 0;
-					workerIndex < targetWorkerCount;
-					workerIndex++
-				) {
-					const promiseToBoot = spawnWorkerThread(workerType, {
+				let nextWorkerIndex = 0;
+				const bootWorker = async (): Promise<
+					RemoteAPI<PlaygroundCliWorker>
+				> => {
+					const workerIndex = nextWorkerIndex++;
+					const spawnResult = await spawnWorkerThread(workerType, {
 						onExit: (exitCode: number) => {
 							// We are already disposing, so worker exit is expected
 							// and does not need to be logged.
@@ -1568,55 +1567,39 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 							);
 							// @TODO: Should we respawn the worker if it exited with an error and the CLI is not shutting down?
 						},
-					}).then(
-						async (
-							spawnResult: SpawnedWorker
-						): Promise<
-							[SpawnedWorker, RemoteAPI<PlaygroundCliWorker>]
-						> => {
-							// Remember the worker process before booting the Playground
-							// so we can clean it up if there is an error during boot.
-							spawnedWorkers.push(spawnResult);
+					});
 
-							const fileLockManagerPort =
-								await exposeFileLockManager(fileLockManager);
-							const playgroundApi =
-								await handler.bootRequestHandler({
-									worker: spawnResult,
-									fileLockManagerPort,
-									nativeInternalDirPath,
-								});
+					// Remember the worker process before booting the Playground
+					// so we can clean it up if there is an error during boot.
+					spawnedWorkers.push(spawnResult);
 
-							workerToPlaygroundMap.set(
-								spawnResult,
-								playgroundApi
-							);
+					const fileLockManagerPort =
+						await exposeFileLockManager(fileLockManager);
+					const playgroundApi = await handler.bootRequestHandler({
+						worker: spawnResult,
+						fileLockManagerPort,
+						nativeInternalDirPath,
+					});
 
-							return [spawnResult, playgroundApi];
-						}
-					);
-
-					promisesToBoot.push(promiseToBoot);
-
-					// TODO: Remove this workaround after we remove the inherent race
-					// from @wp-playground/wordpress's bootRequestHandler() function.
-					if (workerIndex === 0) {
-						// Wait for the first worker to boot to avoid a race condition
-						// with writing initial PHP files in bootRequestHandler().
-						// This is the race condition:
-						// https://github.com/WordPress/wordpress-playground/blob/e758ee0893d199416a2d740195815234584b1b44/packages/playground/wordpress/src/boot.ts#L416-L426
-						// Multiple workers may detect that .boot-files-written does not exist
-						// and proceed to try to write initial boot files.
-						await promiseToBoot;
+					if (wordPressReady && workerType === 'v1') {
+						await playgroundApi.mountAfterWordPressInstall(
+							args['mount'] || []
+						);
 					}
-				}
 
-				await Promise.all(promisesToBoot);
-				playgroundPool = createObjectPoolProxy(
-					spawnedWorkers.map(
-						(spawnedWorker) =>
-							workerToPlaygroundMap.get(spawnedWorker)!
-					)
+					workerToPlaygroundMap.set(spawnResult, playgroundApi);
+
+					return playgroundApi;
+				};
+
+				// Boot only the first request worker up front. This preserves
+				// the existing single-writer WordPress boot behavior while
+				// leaving the rest of --workers as lazy capacity.
+				const firstPlayground = await bootWorker();
+				playgroundPool = createLazyObjectPoolProxy(
+					[firstPlayground],
+					bootWorker,
+					targetWorkerCount
 				);
 
 				// NOTE: Using a free-standing block to isolate initial boot vars
@@ -1726,7 +1709,9 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 				}
 
 				cliOutput.finishProgress();
-				cliOutput.printReady(serverUrl, targetWorkerCount);
+				cliOutput.printReady(serverUrl, targetWorkerCount, {
+					capacity: true,
+				});
 
 				if (args.phpmyadmin) {
 					const phpMyAdminPath = path.join(


### PR DESCRIPTION
## Summary

- boot only the first Playground CLI request worker before WordPress startup
- keep `--workers` as request capacity and start additional workers only when the pool is busy
- apply post-install mounts to lazily-created Blueprint v1 workers and label the ready message as worker capacity

@brandonpayton @mho22 @frederik — this is the lazy worker capacity exploration split into its own draft PR for Playground CLI / Studio startup memory review.

## Testing

- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run playground-cli:typecheck`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run playground-cli:build:bundle:production`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run playground-cli:test-playground-cli --testFile=run-cli.spec.ts`



## Impact measurement

Local warm-start benchmark against `origin/trunk` (source CLI, Node v24.14.1 JSPI, PHP 8.4, WP 6.8, `--workers=6`, already-installed mounted site, 3 rounds, median):

- Ready RSS: `1775.4 MiB -> 778.2 MiB`, saving `997.2 MiB` (`56.2%`).
- Server ready time: `2808.7 ms -> 2311.5 ms`, saving `497 ms` (`17.7%`).

Verdict: clearly worthwhile. This is the largest immediate CLI memory win, with the main review risk being lifecycle/request-latency behavior from deferring workers.
