### PR TITLE
Lower Node PHP initial wasm memory

### DIFF
--- a/packages/php-wasm/compile/build.js
+++ b/packages/php-wasm/compile/build.js
@@ -368,6 +368,11 @@ await asyncSpawn(
 		'--build-arg',
 		`EMSCRIPTEN_ENVIRONMENT=${platform === 'node' ? 'node' : 'web'}`,
 		'--build-arg',
+		// Keep web builds at the existing 64MB. Node builds can grow
+		// memory and the Studio profile passed at 16.5MB, so 32MB keeps
+		// the measured win with headroom for broader CLI workloads.
+		`INITIAL_MEMORY=${platform === 'node' ? '32MB' : '64MB'}`,
+		'--build-arg',
 		getArg('WITH_JSPI'),
 		'--build-arg',
 		getArg('WITH_OPCACHE'),

--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -132,6 +132,9 @@ ARG WITH_IMAGICK
 # The platform to build for: web or node
 ARG EMSCRIPTEN_ENVIRONMENT=web
 
+# Initial WebAssembly memory for the PHP main module.
+ARG INITIAL_MEMORY=64MB
+
 RUN touch /root/.configure-flags && \
 	touch /root/.emcc-php-wasm-flags && \
 	touch /root/.emcc-php-wasm-sources && \
@@ -2420,7 +2423,7 @@ RUN set -euxo pipefail; \
 	-s EXPORTED_FUNCTIONS="@/root/.exported-functions" \
 	-s WASM_BIGINT=1 \
 	-s MIN_NODE_VERSION=200900 \
-	-s INITIAL_MEMORY=64MB \
+	-s INITIAL_MEMORY=${INITIAL_MEMORY} \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s STACK_SIZE="$STACK_SIZE" \
 	-s ASSERTIONS=0 \


### PR DESCRIPTION
## Summary

- make the PHP main-module `INITIAL_MEMORY` a Docker build arg
- keep web builds at 64MB
- build Node PHP binaries with a smaller 32MB initial memory as a conservative first step toward the Studio profiling result

@brandonpayton @mho22 @frederik — this is the lower Node PHP initial-memory exploration split into its own draft PR. It changes the build inputs only; regenerated PHP artifacts are intentionally not included yet.

## Testing

- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" node --check packages/php-wasm/compile/build.js`
- Not run: PHP binary rebuild matrix. This PR needs rebuilt Node PHP artifacts plus runtime validation before it can become non-draft.



## Impact measurement

This branch changes PHP build inputs only. It does not include regenerated PHP artifacts, so the current PR has no shipped runtime improvement until those artifacts are rebuilt and validated.

Studio rebuild data for the same change, measured after combining with NODEFS extensions and precompiled wasm module sharing:

- All workers ready RSS: `705.7 MiB -> 571.8 MiB`, saving `133.9 MiB`.
- Peak RSS: `842.5 MiB -> 743.5 MiB`, saving `99.0 MiB`.
- Worker external memory at ready: `92.7 MiB -> 21.6 MiB`, saving `71.1 MiB`.

Verdict: worthwhile only with rebuilt PHP artifacts and a PHP matrix validation run. As currently scoped, this is a build-input PR with effectively zero runtime win in the package users install.
