### PR TITLE
Enable live memory OPcache for wasm SAPI

### DIFF
--- a/packages/php-wasm/compile/php/Dockerfile
+++ b/packages/php-wasm/compile/php/Dockerfile
@@ -91,6 +91,9 @@ RUN if [ "$WITH_OPCACHE" = "yes" ]; \
 		fi; \
 		# Force OPcache to be built as a static extension. OPcache is always built as a shared extension.
 		/root/replace.sh 's/ext_shared=yes/ext_shared=no/g' /root/php-src/ext/opcache/config.m4; \
+		# The wasm SAPI is request-oriented like cli-server, but PHP upstream does not
+		# know about it. Without this, OPcache registers functions but never starts.
+		perl -0pi -e 's/"ngx-php",\s*\n\s*NULL/"ngx-php",\n\t\t"wasm",\n\t\tNULL/' /root/php-src/ext/opcache/ZendAccelerator.c; \
 		# Add the opcache_module.c to the list of files to build for PHP < 8.5.0.
 		# PHP 8.5 made OPcache a non-optional part of PHP https://wiki.php.net/rfc/make_opcache_required
 		if [[ "${PHP_VERSION:0:1}" -lt "8" || ("${PHP_VERSION:0:1}" -eq "8" && "${PHP_VERSION:2:1}" -le "4") ]]; then \

--- a/packages/php-wasm/universal/src/lib/php.ts
+++ b/packages/php-wasm/universal/src/lib/php.ts
@@ -57,7 +57,10 @@ export const PHP_INI_PATH = '/internal/shared/php.ini';
 const AUTO_PREPEND_SCRIPT = '/internal/shared/auto_prepend_file.php';
 
 export const USE_OPCACHE = true;
-const OPCACHE_FILE_FOLDER = '/internal/shared/opcache';
+// Studio profiling showed 32/6 keeps warm OPcache hits while avoiding
+// the extra growth caused by the previous 64/8 arena.
+const OPCACHE_MEMORY_CONSUMPTION = 32;
+const OPCACHE_INTERNED_STRINGS_BUFFER = 6;
 
 type MountObject = {
 	mountHandler: MountHandler;
@@ -277,14 +280,14 @@ export class PHP implements Disposable {
 						'opcache.enable = 1',
 						'opcache.enable_cli = 1',
 						'opcache.jit = 0',
-						'opcache.interned_strings_buffer = 8',
+						`opcache.interned_strings_buffer = ${OPCACHE_INTERNED_STRINGS_BUFFER}`,
 						'opcache.max_accelerated_files = 1000',
-						'opcache.memory_consumption = 64',
+						`opcache.memory_consumption = ${OPCACHE_MEMORY_CONSUMPTION}`,
 						'opcache.max_wasted_percentage = 5',
-						'opcache.file_cache = ' + OPCACHE_FILE_FOLDER,
-						// Always enable the file cache.
-						'opcache.file_cache_only = 1',
-						'opcache.file_cache_consistency_checks = 1',
+						// Use live OPcache memory instead of the serialized file cache.
+						'opcache.file_cache =',
+						'opcache.file_cache_only = 0',
+						'opcache.file_cache_consistency_checks = 0',
 					]
 				: [];
 
@@ -302,10 +305,6 @@ export class PHP implements Disposable {
 					'opcache.file_cache_consistency_checks = 1'
 				);
 			}*/
-
-			if (!this.fileExists(OPCACHE_FILE_FOLDER)) {
-				this.mkdir(OPCACHE_FILE_FOLDER);
-			}
 
 			this.writeFile(
 				PHP_INI_PATH,


### PR DESCRIPTION
## What

- Allow PHP OPcache to start for the Playground `wasm` SAPI when PHP binaries are rebuilt with OPcache.
- Switch the default OPcache settings from file-cache-only mode to live memory caching.
- Use the smaller memory arena from the Studio performance exploration: 32 MB OPcache memory and 6 MB interned strings.

## Why

The Studio export showed that live OPcache can improve warm WordPress request times, but upstream PHP does not include the custom `wasm` SAPI in OPcache's supported-SAPI list. The ini defaults were also forcing file-cache-only mode, which avoids allocating a live shared-memory cache.

@brandonpayton @mho22 @frederik — please take a look from the WordPress Studio side.

## Testing

- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run php-wasm-universal:typecheck`
- `PATH="$HOME/.nvm/versions/node/v22.22.2/bin:$PATH" npx nx run php-wasm-universal:test:vite`

## Not run

- Full PHP rebuild matrix.
- Runtime benchmarking against regenerated PHP artifacts.

The Dockerfile change affects generated PHP binaries, so this should stay draft until the relevant PHP artifacts are rebuilt and validated.



## Impact measurement

This PR requires regenerated PHP artifacts before the main OPcache claim is meaningful: the Dockerfile patch makes OPcache start for the custom `wasm` SAPI, but the current committed PHP binaries were not rebuilt from this branch.

Studio rebuilt-PHP data for the `32/6` live-memory OPcache configuration:

- Six-worker steady RSS: `875.77 MiB -> 694.02 MiB`, saving `181.75 MiB` (`20.8%`).
- Six-worker peak RSS: `1007.62 MiB -> 827.68 MiB`, saving `179.94 MiB`.
- Warm WordPress PHP load: `244 ms -> 93 ms`, saving `151 ms` (`61.9%`).

Verdict: potentially worthwhile, but only after rebuilt PHP artifacts prove OPcache starts for `wasm` and pass workload validation. Without that rebuild, this is a red-herring/risk rather than a proven runtime improvement.
