### PR TITLE
Add Blueprint editor shortcut to the "Start a new Playground" panel

### DIFF
--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -34,9 +34,7 @@ import {
 	setSiteSlugToRename,
 	setSiteSlugToDelete,
 	setSiteSlugToSave,
-	remountSiteInfoPanel,
 } from '../../lib/state/redux/slice-ui';
-import { setSiteLastTab } from '../site-manager/site-info-panel';
 import { useSitesAPI } from '../../lib/state/redux/site-management-api-middleware';
 import { WordPressIcon } from '@wp-playground/components';
 import useFetch from '../../lib/hooks/use-fetch';
@@ -94,9 +92,6 @@ export function SavedPlaygroundsOverlay({
 	initialViewMode = 'main',
 }: SavedPlaygroundsOverlayProps) {
 	const offline = useAppSelector((state) => state.ui.offline);
-	const siteManagerIsOpen = useAppSelector(
-		(state) => state.ui.siteManagerIsOpen
-	);
 	const storedSites = useAppSelector(selectSortedSites).filter(
 		(site) => site.metadata.storage !== 'none'
 	);
@@ -376,14 +371,8 @@ export function SavedPlaygroundsOverlay({
 			title: 'Blueprint editor',
 			icon: code,
 			onClick: () => {
-				if (activeSite) {
-					setSiteLastTab(activeSite.slug, 'blueprint');
-				}
-				if (siteManagerIsOpen) {
-					dispatch(remountSiteInfoPanel());
-				}
 				dispatch(setSiteManagerOpen(true));
-				dispatch(setSiteManagerSection('site-details'));
+				dispatch(setSiteManagerSection('blueprint'));
 				onClose();
 			},
 			disabled: false,

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -290,6 +290,7 @@ export function SavedPlaygroundsOverlay({
 	 */
 	function previewBlueprint(blueprintPath: BlueprintsIndexEntry['path']) {
 		dispatch(setSiteManagerOpen(false));
+		dispatch(setSiteManagerSection('site-details'));
 		redirectTo(
 			PlaygroundRoute.newSite({
 				query: {
@@ -306,6 +307,7 @@ export function SavedPlaygroundsOverlay({
 
 	function createVanillaSite() {
 		dispatch(setSiteManagerOpen(false));
+		dispatch(setSiteManagerSection('site-details'));
 		// "New Playground" means start fresh. The URL change makes the
 		// selected-site guard handle this as an in-app new-site navigation.
 		redirectTo(PlaygroundRoute.newSite());

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -6,7 +6,7 @@ import {
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
-import { moreVertical, plus, upload, link } from '@wordpress/icons';
+import { moreVertical, plus, upload, link, code } from '@wordpress/icons';
 import { Icon } from '@wordpress/icons';
 import { GitHubIcon } from '../../github/github';
 import { useState, useEffect, useRef } from 'react';
@@ -34,7 +34,9 @@ import {
 	setSiteSlugToRename,
 	setSiteSlugToDelete,
 	setSiteSlugToSave,
+	remountSiteInfoPanel,
 } from '../../lib/state/redux/slice-ui';
+import { setSiteLastTab } from '../site-manager/site-info-panel';
 import { useSitesAPI } from '../../lib/state/redux/site-management-api-middleware';
 import { WordPressIcon } from '@wp-playground/components';
 import useFetch from '../../lib/hooks/use-fetch';
@@ -92,6 +94,9 @@ export function SavedPlaygroundsOverlay({
 	initialViewMode = 'main',
 }: SavedPlaygroundsOverlayProps) {
 	const offline = useAppSelector((state) => state.ui.offline);
+	const siteManagerIsOpen = useAppSelector(
+		(state) => state.ui.siteManagerIsOpen
+	);
 	const storedSites = useAppSelector(selectSortedSites).filter(
 		(site) => site.metadata.storage !== 'none'
 	);
@@ -363,6 +368,23 @@ export function SavedPlaygroundsOverlay({
 			icon: upload,
 			onClick: () => {
 				zipFileInputRef.current?.click();
+			},
+			disabled: false,
+		},
+		{
+			id: 'blueprint-editor',
+			title: 'Blueprint editor',
+			icon: code,
+			onClick: () => {
+				if (activeSite) {
+					setSiteLastTab(activeSite.slug, 'blueprint');
+				}
+				if (siteManagerIsOpen) {
+					dispatch(remountSiteInfoPanel());
+				}
+				dispatch(setSiteManagerOpen(true));
+				dispatch(setSiteManagerSection('site-details'));
+				onClose();
 			},
 			disabled: false,
 		},

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -85,6 +85,7 @@
 }
 
 .creationButton {
+	flex: 1;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -480,7 +481,6 @@
 
 @media (max-width: 900px) {
 	.creationRow {
-		flex-wrap: wrap;
 		justify-content: center;
 	}
 

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -24,9 +24,6 @@ export const SiteManager = forwardRef<
 	const activeSiteManagerSection = useAppSelector(
 		(state) => state.ui.siteManagerSection
 	);
-	const siteInfoPanelKey = useAppSelector(
-		(state) => state.ui.siteInfoPanelKey
-	);
 
 	// Load saved width from localStorage or use default
 	const [siteInfoWidth, setSiteInfoWidth] = useState<number>(() => {
@@ -72,15 +69,21 @@ export const SiteManager = forwardRef<
 				/>
 			);
 			break;
+		case 'blueprint':
 		default:
-		case 'site-details':
+		case 'site-details': {
+			const initialTab =
+				activeSiteManagerSection === 'blueprint'
+					? 'blueprint'
+					: undefined;
 			activePanel = activeSite ? (
 				fullScreenSections ? (
 					<SiteInfoPanel
-						key={`${activeSite?.slug}-${siteInfoPanelKey}`}
+						key={`${activeSite?.slug}-${activeSiteManagerSection}`}
 						className={css.siteManagerSiteInfo}
 						site={activeSite}
 						mobileUi={fullScreenSections}
+						initialTab={initialTab}
 					/>
 				) : (
 					<ResizableBox
@@ -104,15 +107,17 @@ export const SiteManager = forwardRef<
 						}}
 					>
 						<SiteInfoPanel
-							key={`${activeSite?.slug}-${siteInfoPanelKey}`}
+							key={`${activeSite?.slug}-${activeSiteManagerSection}`}
 							className={css.siteManagerSiteInfo}
 							site={activeSite}
 							mobileUi={fullScreenSections}
+							initialTab={initialTab}
 						/>
 					</ResizableBox>
 				)
 			) : null;
 			break;
+		}
 	}
 
 	// If the site manager is open but there's no active panel,

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -24,6 +24,9 @@ export const SiteManager = forwardRef<
 	const activeSiteManagerSection = useAppSelector(
 		(state) => state.ui.siteManagerSection
 	);
+	const siteInfoPanelKey = useAppSelector(
+		(state) => state.ui.siteInfoPanelKey
+	);
 
 	// Load saved width from localStorage or use default
 	const [siteInfoWidth, setSiteInfoWidth] = useState<number>(() => {
@@ -74,7 +77,7 @@ export const SiteManager = forwardRef<
 			activePanel = activeSite ? (
 				fullScreenSections ? (
 					<SiteInfoPanel
-						key={activeSite?.slug}
+						key={`${activeSite?.slug}-${siteInfoPanelKey}`}
 						className={css.siteManagerSiteInfo}
 						site={activeSite}
 						mobileUi={fullScreenSections}
@@ -101,6 +104,7 @@ export const SiteManager = forwardRef<
 						}}
 					>
 						<SiteInfoPanel
+							key={`${activeSite?.slug}-${siteInfoPanelKey}`}
 							className={css.siteManagerSiteInfo}
 							site={activeSite}
 							mobileUi={fullScreenSections}

--- a/packages/playground/website/src/components/site-manager/index.tsx
+++ b/packages/playground/website/src/components/site-manager/index.tsx
@@ -72,10 +72,12 @@ export const SiteManager = forwardRef<
 		case 'blueprint':
 		default:
 		case 'site-details': {
-			const initialTab =
-				activeSiteManagerSection === 'blueprint'
-					? 'blueprint'
-					: undefined;
+			const STANDARD_SECTIONS = ['site-details', 'blueprints', 'sidebar'];
+			const initialTab = !STANDARD_SECTIONS.includes(
+				activeSiteManagerSection
+			)
+				? activeSiteManagerSection
+				: undefined;
 			activePanel = activeSite ? (
 				fullScreenSections ? (
 					<SiteInfoPanel

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -65,7 +65,7 @@ function getSiteLastTab(siteSlug: string): string | null {
 	}
 }
 
-export function setSiteLastTab(siteSlug: string, tabName: string): void {
+function setSiteLastTab(siteSlug: string, tabName: string): void {
 	try {
 		const stored = localStorage.getItem(LAST_TAB_STORAGE_KEY);
 		const tabs = stored ? JSON.parse(stored) : {};
@@ -81,18 +81,19 @@ export function SiteInfoPanel({
 	site,
 	mobileUi,
 	siteViewHidden,
+	initialTab,
 }: {
 	className: string;
 	site: SiteInfo;
 	mobileUi?: boolean;
 	siteViewHidden?: boolean;
+	initialTab?: string;
 }) {
 	const offline = useAppSelector((state) => state.ui.offline);
 	const dispatch = useAppDispatch();
 	// Load the last active tab for this site
 	const [initialTabName] = useState(() => {
-		const lastTab = getSiteLastTab(site.slug);
-		return lastTab || 'settings';
+		return initialTab || getSiteLastTab(site.slug) || 'settings';
 	});
 
 	// Resolve documentRoot from playground client

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -91,7 +91,7 @@ export function SiteInfoPanel({
 }) {
 	const offline = useAppSelector((state) => state.ui.offline);
 	const dispatch = useAppDispatch();
-	// Load the last active tab for this site
+	// Load the requested tab, restore the last visited one, or default to settings
 	const [initialTabName] = useState(() => {
 		return initialTab || getSiteLastTab(site.slug) || 'settings';
 	});

--- a/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-info-panel/index.tsx
@@ -65,7 +65,7 @@ function getSiteLastTab(siteSlug: string): string | null {
 	}
 }
 
-function setSiteLastTab(siteSlug: string, tabName: string): void {
+export function setSiteLastTab(siteSlug: string, tabName: string): void {
 	try {
 		const stored = localStorage.getItem(LAST_TAB_STORAGE_KEY);
 		const tabs = stored ? JSON.parse(stored) : {};

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -161,6 +161,7 @@ export interface UIState {
 	offline: boolean;
 	siteManagerIsOpen: boolean;
 	siteManagerSection: SiteManagerSection;
+	siteInfoPanelKey: number;
 }
 
 const query = new URL(document.location.href).searchParams;
@@ -203,6 +204,7 @@ const initialState: UIState = {
 		// your entire screen – quite a confusing experience.
 		window.innerWidth >= BREAKPOINTS.tablet,
 	siteManagerSection: 'site-details',
+	siteInfoPanelKey: 0,
 };
 
 const uiSlice = createSlice({
@@ -291,6 +293,9 @@ const uiSlice = createSlice({
 		) => {
 			state.siteSlugToSave = action.payload;
 		},
+		remountSiteInfoPanel: (state) => {
+			state.siteInfoPanelKey++;
+		},
 	},
 });
 
@@ -338,6 +343,7 @@ export const {
 	setSiteSlugToRename,
 	setSiteSlugToDelete,
 	setSiteSlugToSave,
+	remountSiteInfoPanel,
 } = uiSlice.actions;
 
 export default uiSlice.reducer;

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -17,7 +17,11 @@ export type SiteError =
 	| 'network-firewall-interference'
 	| 'resource-download-failed';
 
-export type SiteManagerSection = 'sidebar' | 'site-details' | 'blueprints';
+export type SiteManagerSection =
+	| 'sidebar'
+	| 'site-details'
+	| 'blueprints'
+	| 'blueprint';
 
 export const modalSlugs = {
 	LOG: 'log',
@@ -161,7 +165,6 @@ export interface UIState {
 	offline: boolean;
 	siteManagerIsOpen: boolean;
 	siteManagerSection: SiteManagerSection;
-	siteInfoPanelKey: number;
 }
 
 const query = new URL(document.location.href).searchParams;
@@ -204,7 +207,6 @@ const initialState: UIState = {
 		// your entire screen – quite a confusing experience.
 		window.innerWidth >= BREAKPOINTS.tablet,
 	siteManagerSection: 'site-details',
-	siteInfoPanelKey: 0,
 };
 
 const uiSlice = createSlice({
@@ -293,9 +295,6 @@ const uiSlice = createSlice({
 		) => {
 			state.siteSlugToSave = action.payload;
 		},
-		remountSiteInfoPanel: (state) => {
-			state.siteInfoPanelKey++;
-		},
 	},
 });
 
@@ -343,7 +342,6 @@ export const {
 	setSiteSlugToRename,
 	setSiteSlugToDelete,
 	setSiteSlugToSave,
-	remountSiteInfoPanel,
 } = uiSlice.actions;
 
 export default uiSlice.reducer;


### PR DESCRIPTION
## Motivation for the change, related issues
Users who write blueprints (e.g. with external tools) had no quick way to reach the Blueprint editor from the "Start a new Playground" launch panel. This adds a dedicated shortcut so the editor is discoverable alongside the other launch options.

Closes #3171 

## Implementation details
- Added a "Blueprint editor" button (using the `< >` code icon) as the last entry in the `creationOptions` array in `SavedPlaygroundsOverlay`. Clicking it opens the site manager and sets the section to `'blueprint'`.
- Added `'blueprint'` as a new `SiteManagerSection` value. In `SiteManager`, any section that isn't a standard panel (`site-details`, `blueprints`, `sidebar`) is passed to `SiteInfoPanel` as the `initialTab`, so the panel opens directly on the matching tab.
- `SiteInfoPanel` accepts an optional `initialTab` prop that takes precedence over the last-visited tab when choosing which tab to open on mount.
- The `SiteInfoPanel` key includes the active section (`${slug}-${section}`) so that changing the section remounts the panel — this is what lets `initialTab` take effect when the site manager is already open on another tab.
- Other creation actions (`createVanillaSite`, `previewBlueprint`) reset the section back to `'site-details'` so a freshly created Playground doesn't inadvertently open on the Blueprint tab.
- Adjusted the `.creationRow` layout (`flex: 1` on buttons) so the launch options share rows evenly instead of orphaning the new 7th button on its own line.

## Testing Instructions (or ideally a Blueprint)
1. Open the app and click the "Your Playgrounds" button to open the launch panel.
2. Verify a "Blueprint editor" button with a `< >` icon appears in the "Start a new Playground" row.
3. Click it — the panel should close, the site manager should open, and the Blueprint tab should be active.
4. Repeat with the site manager already open (e.g. on the Settings tab) — clicking "Blueprint editor" should switch directly to the Blueprint tab.
5. Repeat with the site manager closed — opening via the button should land on the Blueprint tab.