### PR TITLE
Fix Personal WP Site Tools during boot

### DIFF
--- a/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
@@ -60,14 +60,14 @@ test('should close the Site Tools panel with its close button', async ({
 
 	await website.ensureSiteToolsIsOpen();
 	await expect(
-		website.page.getByRole('link', { name: /App Launcher/ })
+		website.page.getByRole('button', { name: /App Launcher/ })
 	).toBeVisible();
 
 	await website.page
 		.getByRole('button', { name: /Close Site Tools/ })
 		.click();
 	await expect(
-		website.page.getByRole('link', { name: /App Launcher/ })
+		website.page.getByRole('button', { name: /App Launcher/ })
 	).not.toBeVisible();
 });
 

--- a/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
+++ b/packages/playground/personal-wp/playwright/e2e/ui.spec.ts
@@ -30,8 +30,8 @@ test('should show app, backup, and troubleshooting tools', async ({
 		})
 	).toBeVisible();
 	await expect(
-		website.page.getByRole('link', { name: /App Launcher/ })
-	).toHaveAttribute('href', /blueprint-url=data%3Aapplication%2Fjson/);
+		website.page.getByRole('button', { name: /App Launcher/ })
+	).toBeVisible();
 	await expect(
 		website.page.getByRole('heading', { name: 'Backup' })
 	).toBeVisible();

--- a/packages/playground/personal-wp/src/components/layout/style.module.css
+++ b/packages/playground/personal-wp/src/components/layout/style.module.css
@@ -41,6 +41,7 @@ body {
 
 .site-manager-wrapper {
 	position: relative;
+	/* Keep Site Tools above the boot/loading overlay in the site view. */
 	z-index: 30;
 	max-width: var(--site-manager-open-max-width);
 	@media (max-width: 875px) {

--- a/packages/playground/personal-wp/src/components/layout/style.module.css
+++ b/packages/playground/personal-wp/src/components/layout/style.module.css
@@ -40,6 +40,8 @@ body {
 }
 
 .site-manager-wrapper {
+	position: relative;
+	z-index: 30;
 	max-width: var(--site-manager-open-max-width);
 	@media (max-width: 875px) {
 		min-width: 0;

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -27,10 +27,14 @@ import {
 	refreshMainTabStatus,
 	requestRemoteBlueprintInstall,
 	setInstallBlueprintRequestCallback,
+	setUserBlueprintInstallCallback,
 } from '../../lib/state/redux/tab-coordinator';
 import classNames from 'classnames';
 import { SiteErrorModal } from '../site-error-modal';
-import { setSiteManagerOpen } from '../../lib/state/redux/slice-ui';
+import {
+	setBlueprintInstallMessage,
+	setSiteManagerOpen,
+} from '../../lib/state/redux/slice-ui';
 import { playgroundLogo } from '@wp-playground/components';
 import { isAppBasePath } from '../../lib/state/url/app-base-url';
 import Button from '../button';
@@ -980,17 +984,31 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 		}
 	}, []);
 
+	const setBlueprintInstallStatus = useCallback(
+		(message: string | null) => {
+			setInstallingBlueprint(message);
+			dispatch(setBlueprintInstallMessage(message));
+		},
+		[dispatch]
+	);
+
 	const scheduleInstallBannerReset = useCallback(() => {
 		clearInstallBannerResetTimeout();
 		installBannerResetTimeoutRef.current = setTimeout(() => {
 			installBannerResetTimeoutRef.current = null;
-			setInstallingBlueprint(null);
+			setBlueprintInstallStatus(null);
 		}, 3000);
-	}, [clearInstallBannerResetTimeout]);
+	}, [clearInstallBannerResetTimeout, setBlueprintInstallStatus]);
 
 	useEffect(() => {
 		return clearInstallBannerResetTimeout;
 	}, [clearInstallBannerResetTimeout]);
+
+	useEffect(() => {
+		return () => {
+			dispatch(setBlueprintInstallMessage(null));
+		};
+	}, [dispatch]);
 
 	useEffect(() => {
 		setIsBooting(true);
@@ -1059,20 +1077,20 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			const allowNavigation = options.allowNavigation ?? true;
 			clearInstallBannerResetTimeout();
 			try {
-				setInstallingBlueprint('Installing\u2026');
+				setBlueprintInstallStatus('Installing\u2026');
 				const { blueprint, declaration } =
 					await resolveBlueprintForInstallExecution(
 						blueprintUrl,
 						corsProxyUrl
 					);
 				const title = declaration.meta?.title || 'app';
-				setInstallingBlueprint(`Installing ${title}\u2026`);
+				setBlueprintInstallStatus(`Installing ${title}\u2026`);
 
 				const progress = new ProgressTracker();
 				progress.addEventListener('progress', ((e: CustomEvent) => {
 					const caption = e.detail?.caption;
 					if (caption) {
-						setInstallingBlueprint(caption);
+						setBlueprintInstallStatus(caption);
 					}
 				}) as EventListener);
 
@@ -1089,28 +1107,35 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 					)
 				);
 				if (allowNavigation && declaration.landingPage) {
+					setBlueprintInstallStatus('Opening app\u2026');
 					await playground.goTo(declaration.landingPage);
 				}
 			} catch (e) {
 				logger.error('Failed to apply blueprint:', e);
-				setInstallingBlueprint('Installation failed');
+				setBlueprintInstallStatus('Installation failed');
 				scheduleInstallBannerReset();
 				return {
 					status: 'error',
 					error: getErrorMessage(e),
 				};
 			}
-			setInstallingBlueprint(null);
+			setBlueprintInstallStatus('App installed');
+			scheduleInstallBannerReset();
 			return { status: 'success' };
 		},
-		[clearInstallBannerResetTimeout, playground, scheduleInstallBannerReset]
+		[
+			clearInstallBannerResetTimeout,
+			playground,
+			scheduleInstallBannerReset,
+			setBlueprintInstallStatus,
+		]
 	);
 
 	const applyBlueprintInMainTab = useCallback(
 		async (blueprintUrl: string): Promise<InstallBlueprintResult> => {
 			clearInstallBannerResetTimeout();
 			try {
-				setInstallingBlueprint('Installing in the active tab\u2026');
+				setBlueprintInstallStatus('Installing app\u2026');
 				const install = await prepareBlueprintForRemoteInstall(
 					blueprintUrl,
 					corsProxyUrl
@@ -1120,26 +1145,27 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 					install.blueprintUrl
 				);
 				if (result.status === 'error') {
-					setInstallingBlueprint('Installation failed');
+					setBlueprintInstallStatus('Installation failed');
 					scheduleInstallBannerReset();
 				} else {
 					if (install.landingPage) {
 						if (!playground) {
-							setInstallingBlueprint('Installation failed');
+							setBlueprintInstallStatus('Installation failed');
 							scheduleInstallBannerReset();
 							return {
 								status: 'error',
 								error: 'The app was installed, but this tab could not open it.',
 							};
 						}
-						setInstallingBlueprint('Opening app\u2026');
+						setBlueprintInstallStatus('Opening app\u2026');
 						await playground.goTo(install.landingPage);
 					}
-					setInstallingBlueprint(null);
+					setBlueprintInstallStatus('App installed');
+					scheduleInstallBannerReset();
 				}
 				return result;
 			} catch (e) {
-				setInstallingBlueprint('Installation failed');
+				setBlueprintInstallStatus('Installation failed');
 				scheduleInstallBannerReset();
 				return {
 					status: 'error',
@@ -1151,7 +1177,37 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			clearInstallBannerResetTimeout,
 			playground,
 			scheduleInstallBannerReset,
+			setBlueprintInstallStatus,
 			siteSlug,
+		]
+	);
+
+	const installBlueprintFromUserAction = useCallback(
+		async (blueprintUrl: string): Promise<InstallBlueprintResult> => {
+			if (hasLocalRuntimeClient) {
+				return applyBlueprint(blueprintUrl);
+			}
+			if (!isDependentMode) {
+				return {
+					status: 'error',
+					error: 'Playground is not ready.',
+				};
+			}
+
+			const status = await refreshMainTabStatus();
+			if (status !== 'connected') {
+				return {
+					status: 'error',
+					error: getMainTabUnavailableMessage(status),
+				};
+			}
+			return applyBlueprintInMainTab(blueprintUrl);
+		},
+		[
+			applyBlueprint,
+			applyBlueprintInMainTab,
+			hasLocalRuntimeClient,
+			isDependentMode,
 		]
 	);
 
@@ -1169,6 +1225,13 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			setInstallBlueprintRequestCallback(null);
 		};
 	}, [applyBlueprint, hasLocalRuntimeClient]);
+
+	useEffect(() => {
+		setUserBlueprintInstallCallback(installBlueprintFromUserAction);
+		return () => {
+			setUserBlueprintInstallCallback(null);
+		};
+	}, [installBlueprintFromUserAction]);
 
 	// Handle relay messages from WordPress plugins.
 	useEffect(() => {

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -28,10 +28,12 @@ import {
 } from '../../../lib/health-check-recovery';
 import { getRelativeDate } from '../../../lib/utils/get-relative-date';
 import { opfsSiteStorage } from '../../../lib/state/opfs/opfs-site-storage';
-import { broadcastSiteReset } from '../../../lib/state/redux/tab-coordinator';
+import {
+	broadcastSiteReset,
+	requestBlueprintInstall,
+} from '../../../lib/state/redux/tab-coordinator';
 import { logger } from '@php-wasm/logger';
 import { encodeStringAsBase64 } from '../../../lib/base64';
-import { getAppBaseUrl } from '../../../lib/state/url/app-base-url';
 import css from './style.module.css';
 
 const SiteFileBrowser = lazy(() =>
@@ -95,17 +97,28 @@ const APP_LAUNCHER_BLUEPRINT_URL = blueprintToDataUrl(
 	JSON.stringify(APP_LAUNCHER_BLUEPRINT)
 );
 
-function getAppBlueprintUrl(blueprintUrl: string): string {
-	const url = getAppBaseUrl();
-	url.searchParams.set('blueprint-url', blueprintUrl);
-	return url.toString();
-}
-
 function blueprintToDataUrl(blueprint: string): string {
 	return `data:application/json;base64,${encodeStringAsBase64(blueprint)}`;
 }
 
-function InstallAppsSection() {
+function InstallAppsSection({ siteSlug }: { siteSlug: string }) {
+	const installMessage = useAppSelector(
+		(state) => state.ui.blueprintInstallMessage
+	);
+
+	async function installAppLauncher() {
+		if (installMessage) {
+			return;
+		}
+		const result = await requestBlueprintInstall(
+			siteSlug,
+			APP_LAUNCHER_BLUEPRINT_URL
+		);
+		if (result.status === 'error') {
+			logger.error('Failed to install App Launcher:', result.error);
+		}
+	}
+
 	return (
 		<div className={css.aboutSection}>
 			<h4 className={css.aboutSectionTitle}>
@@ -113,9 +126,11 @@ function InstallAppsSection() {
 			</h4>
 			<div className={css.appsList}>
 				<div className={css.appRow}>
-					<a
+					<button
+						type="button"
 						className={css.appLink}
-						href={getAppBlueprintUrl(APP_LAUNCHER_BLUEPRINT_URL)}
+						onClick={installAppLauncher}
+						disabled={!!installMessage}
 					>
 						<span className={css.appIcon}>
 							<WordPressIcon />
@@ -128,8 +143,13 @@ function InstallAppsSection() {
 								{APP_LAUNCHER_BLUEPRINT.meta.description}
 							</span>
 						</span>
-					</a>
+					</button>
 				</div>
+				{installMessage && (
+					<div className={css.appInstallStatus} role="status">
+						{installMessage}
+					</div>
+				)}
 			</div>
 		</div>
 	);
@@ -409,7 +429,7 @@ function RecoverySection() {
 
 // ── About Tab (composed) ──────────────────────────────────────
 
-function AboutTab() {
+function AboutTab({ siteSlug }: { siteSlug: string }) {
 	const clientInfo = usePlaygroundClientInfo();
 	const isDependentMode = clientInfo?.isDependentMode ?? false;
 
@@ -422,7 +442,7 @@ function AboutTab() {
 				device.
 			</p>
 
-			<InstallAppsSection />
+			<InstallAppsSection siteSlug={siteSlug} />
 			{!isDependentMode && (
 				<>
 					<BackupSection />
@@ -660,7 +680,7 @@ export function SiteInfoPanel({
 									)}
 									hidden={tab.name !== 'about'}
 								>
-									<AboutTab />
+									<AboutTab siteSlug={site.slug} />
 								</div>
 								<div
 									className={classNames(

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -422,9 +422,9 @@ function AboutTab() {
 				device.
 			</p>
 
+			<InstallAppsSection />
 			{!isDependentMode && (
 				<>
-					<InstallAppsSection />
 					<BackupSection />
 					<RecoverySection />
 				</>
@@ -449,11 +449,11 @@ function AboutTab() {
 function DependentTabToolsNotice() {
 	return (
 		<div className={css.dependentTabToolsNotice}>
-			<h4>Tools available in the active tab</h4>
+			<h4>Runtime-only tools</h4>
 			<p>
-				This tab can view and navigate the site. Apps, backups,
-				recovery, and reset controls are shown only in the tab with the
-				active WordPress runtime.
+				This tab can view, navigate, and install apps. Backups,
+				recovery, and reset controls need the tab running the WordPress
+				runtime.
 			</p>
 		</div>
 	);

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -469,7 +469,7 @@ function AboutTab({ siteSlug }: { siteSlug: string }) {
 function DependentTabToolsNotice() {
 	return (
 		<div className={css.dependentTabToolsNotice}>
-			<h4>Runtime-only tools</h4>
+			<h4>Runtime-only: backups, recovery, reset</h4>
 			<p>
 				This tab can view, navigate, and install apps. Backups,
 				recovery, and reset controls need the tab running the WordPress

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/style.module.css
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/style.module.css
@@ -308,16 +308,36 @@
 	display: flex;
 	align-items: center;
 	gap: 10px;
+	width: 100%;
 	padding: 6px 4px;
+	border: 0;
+	background: transparent;
 	flex: 1;
 	min-width: 0;
 	color: inherit;
+	font: inherit;
+	text-align: left;
 	text-decoration: none;
+	cursor: pointer;
 }
 
 .app-link:hover {
 	color: inherit;
 	text-decoration: none;
+}
+
+.app-link:disabled {
+	cursor: default;
+}
+
+.app-install-status {
+	margin: 6px 4px 0;
+	padding: 8px 10px;
+	border-radius: 6px;
+	background: #f0f6fc;
+	color: #1e1e1e;
+	font-size: 12px;
+	line-height: 1.4;
 }
 
 .app-icon {

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-ui.ts
@@ -149,6 +149,7 @@ export interface UIState {
 	offline: boolean;
 	siteManagerIsOpen: boolean;
 	siteManagerSection: SiteManagerSection;
+	blueprintInstallMessage: string | null;
 }
 
 const query = new URL(document.location.href).searchParams;
@@ -186,6 +187,7 @@ const initialState: UIState = {
 		// quite a confusing experience.
 		!isMobile,
 	siteManagerSection: 'site-details',
+	blueprintInstallMessage: null,
 };
 
 const uiSlice = createSlice({
@@ -256,6 +258,12 @@ const uiSlice = createSlice({
 		) => {
 			state.siteManagerSection = action.payload;
 		},
+		setBlueprintInstallMessage: (
+			state,
+			action: PayloadAction<string | null>
+		) => {
+			state.blueprintInstallMessage = action.payload;
+		},
 		setSiteSlugToRename: (
 			state,
 			action: PayloadAction<string | undefined>
@@ -304,6 +312,7 @@ export const {
 	clearActiveSiteError,
 	setGitHubAuthRepoUrl,
 	setOffline,
+	setBlueprintInstallMessage,
 	setSiteManagerOpen,
 	setSiteManagerSection,
 	setSiteSlugToRename,

--- a/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/tab-coordinator.ts
@@ -122,6 +122,9 @@ let backupRequestCallback: (() => Promise<boolean>) | null = null;
 let installBlueprintRequestCallback:
 	| ((blueprintUrl: string) => Promise<InstallBlueprintCommandResult>)
 	| null = null;
+let userBlueprintInstallCallback:
+	| ((blueprintUrl: string) => Promise<InstallBlueprintCommandResult>)
+	| null = null;
 let mainLockRelease: (() => void) | null = null;
 let readyLockRelease: (() => void) | null = null;
 let mainLockRequest: Promise<unknown> | null = null;
@@ -182,6 +185,7 @@ export function destroyTabCoordinator(): void {
 	currentOptions = {};
 	backupRequestCallback = null;
 	installBlueprintRequestCallback = null;
+	userBlueprintInstallCallback = null;
 	clearTitleFlash();
 }
 
@@ -224,6 +228,33 @@ export function setInstallBlueprintRequestCallback(
 		| null
 ): void {
 	installBlueprintRequestCallback = callback;
+}
+
+export function setUserBlueprintInstallCallback(
+	callback:
+		| ((blueprintUrl: string) => Promise<InstallBlueprintCommandResult>)
+		| null
+): void {
+	userBlueprintInstallCallback = callback;
+}
+
+export async function requestBlueprintInstall(
+	siteSlug: string,
+	blueprintUrl: string
+): Promise<InstallBlueprintCommandResult> {
+	if (currentTabInfo?.siteSlug === siteSlug && userBlueprintInstallCallback) {
+		return userBlueprintInstallCallback(blueprintUrl);
+	}
+
+	if (
+		currentTabInfo?.siteSlug === siteSlug &&
+		isCurrentMainTab() &&
+		installBlueprintRequestCallback
+	) {
+		return installBlueprintRequestCallback(blueprintUrl);
+	}
+
+	return requestRemoteBlueprintInstall(siteSlug, blueprintUrl);
 }
 
 export async function requestRemoteBackup(


### PR DESCRIPTION
## What changed

- Keep the Personal WP Site Tools panel above the site view/loading overlay so it remains visible when opened during boot.
- Show app install tools in dependent tabs, since blueprint installs can be relayed instead of requiring the runtime tab.
- Update the dependent-tab notice to describe only backup, recovery, and reset controls as runtime-only.

## Testing

- npm exec nx lint playground-personal-wp
- npm exec nx typecheck playground-personal-wp