### PR TITLE
Bypass PHP for known remote WordPress assets

### DIFF
--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -473,6 +473,30 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 	return workerResponse;
 }
 
+/**
+ * Serve known minified-build assets before involving PHP.
+ *
+ * ## Why this runs before convertFetchEventToPHPRequest()
+ *
+ * Minified WordPress builds intentionally omit many static assets from the
+ * in-memory filesystem. The removed paths are listed in
+ * `wordpress-remote-asset-paths`, so a matching request is known up front
+ * to end in a PHP 404 and a remote-host fallback. Fetching it here avoids
+ * spending a PHP worker turn on work whose outcome is already known.
+ *
+ * ## Request methods
+ *
+ * Only GET and HEAD are safe to short-circuit. Other methods may have
+ * WordPress or plugin semantics even if their path resembles a static
+ * asset, so they keep using the PHP request path.
+ *
+ * ## Scope details
+ *
+ * `getScopedWpDetails()` reads the loaded WordPress version and the remote
+ * asset list reported by the worker that owns this scope. If the scope is
+ * not a minified WordPress build, or if the asset path is not listed, this
+ * function returns `undefined` and the existing PHP path remains unchanged.
+ */
 async function serveKnownRemoteAsset(
 	event: FetchEvent,
 	scope: string,
@@ -493,6 +517,19 @@ async function serveKnownRemoteAsset(
 	return fetchRemoteStaticAsset(request);
 }
 
+/**
+ * Fetches a WordPress static asset from the remote host.
+ *
+ * This is shared by the known-asset fast path and the existing PHP 404
+ * fallback. Both paths intentionally use `fetch()` rather than `fetchFresh()`
+ * because these requests are normal WordPress asset requests and should keep
+ * WordPress' own HTTP caching behavior.
+ *
+ * Playground.WordPress.net occasionally fails static asset requests with a
+ * TypeError that may represent an HTTP/2 protocol error. Keep the historical
+ * randomized single retry so both the fast path and fallback path handle that
+ * transient failure the same way.
+ */
 function fetchRemoteStaticAsset(request: Request) {
 	return fetch(request).catch((e) => {
 		if (e?.name === 'TypeError') {

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -674,7 +674,11 @@ async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {
 			},
 			scope
 		);
-		scopeToWpModule[scope] = await awaitReply(self, requestId);
+		const details: WPModuleDetails = await awaitReply(self, requestId);
+		scopeToWpModule[scope] = {
+			...details,
+			remoteAssetPathSet: new Set(details.remoteAssetPaths),
+		};
 	}
 	return scopeToWpModule[scope];
 }

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -116,6 +116,10 @@ import {
 } from '@php-wasm/web-service-worker';
 import { wordPressRewriteRules } from '@wp-playground/wordpress';
 import { reportServiceWorkerMetrics } from '@php-wasm/logger';
+import {
+	resolveKnownRemoteAssetUrl,
+	type WPModuleDetails,
+} from './src/lib/known-remote-asset';
 
 import {
 	cacheFirstFetch,
@@ -387,6 +391,15 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 		return emptyHtml(scope);
 	}
 
+	const knownRemoteAssetResponse = await serveKnownRemoteAsset(
+		event,
+		scope,
+		unscopedUrl
+	);
+	if (knownRemoteAssetResponse) {
+		return knownRemoteAssetResponse;
+	}
+
 	const workerResponse = await convertFetchEventToPHPRequest(event);
 
 	if (
@@ -431,22 +444,7 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 		 * request to the remote server as it is and let WordPress manage its
 		 * own HTTP caching.
 		 */
-		return fetch(request).catch((e) => {
-			if (e?.name === 'TypeError') {
-				// This could be an ERR_HTTP2_PROTOCOL_ERROR that sometimes
-				// happen on playground.wordpress.net. Let's add a randomized
-				// delay and retry once
-				return new Promise((resolve) => {
-					setTimeout(
-						() => resolve(fetch(request)),
-						Math.random() * 1500
-					);
-				}) as Promise<Response>;
-			}
-
-			// Otherwise let's just re-throw the error
-			throw e;
-		});
+		return fetchRemoteStaticAsset(request);
 	}
 
 	// Path the block-editor.js file to ensure the site editor's iframe
@@ -473,6 +471,41 @@ async function handleScopedRequest(event: FetchEvent, scope: string) {
 	}
 
 	return workerResponse;
+}
+
+async function serveKnownRemoteAsset(
+	event: FetchEvent,
+	scope: string,
+	unscopedUrl: URL
+) {
+	if (!['GET', 'HEAD'].includes(event.request.method)) {
+		return undefined;
+	}
+	const details = await getScopedWpDetails(scope);
+	const remoteAssetUrl = resolveKnownRemoteAssetUrl(unscopedUrl, details);
+	if (!remoteAssetUrl) {
+		return undefined;
+	}
+	const request = await cloneRequest(event.request, {
+		url: remoteAssetUrl,
+		credentials: 'omit',
+	});
+	return fetchRemoteStaticAsset(request);
+}
+
+function fetchRemoteStaticAsset(request: Request) {
+	return fetch(request).catch((e) => {
+		if (e?.name === 'TypeError') {
+			// This could be an ERR_HTTP2_PROTOCOL_ERROR that sometimes
+			// happen on playground.wordpress.net. Let's add a randomized
+			// delay and retry once
+			return new Promise((resolve) => {
+				setTimeout(() => resolve(fetch(request)), Math.random() * 1500);
+			}) as Promise<Response>;
+		}
+
+		throw e;
+	});
 }
 
 reportServiceWorkerMetrics(self);
@@ -594,10 +627,6 @@ function emptyHtml(scope: string) {
 		}
 	);
 }
-
-type WPModuleDetails = {
-	staticAssetsDirectory?: string;
-};
 
 const scopeToWpModule: Record<string, WPModuleDetails> = {};
 async function getScopedWpDetails(scope: string): Promise<WPModuleDetails> {

--- a/packages/playground/remote/src/lib/known-remote-asset.spec.ts
+++ b/packages/playground/remote/src/lib/known-remote-asset.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { resolveKnownRemoteAssetUrl } from './known-remote-asset';
+
+describe('resolveKnownRemoteAssetUrl', () => {
+	it('resolves a listed WordPress asset to the static assets directory', () => {
+		const url = resolveKnownRemoteAssetUrl(
+			new URL(
+				'http://127.0.0.1:5400/wp-includes/css/dist/block-library/style.min.css?ver=6.8'
+			),
+			{
+				staticAssetsDirectory: 'wp-6.8',
+				remoteAssetPaths: [
+					'/wp-includes/css/dist/block-library/style.min.css',
+				],
+			}
+		);
+
+		expect(url?.toString()).toBe(
+			'http://127.0.0.1:5400/wp-6.8/wp-includes/css/dist/block-library/style.min.css?ver=6.8'
+		);
+	});
+
+	it('does not resolve assets that are not listed as remote assets', () => {
+		const url = resolveKnownRemoteAssetUrl(
+			new URL('http://127.0.0.1:5400/wp-includes/js/jquery/jquery.js'),
+			{
+				staticAssetsDirectory: 'wp-6.8',
+				remoteAssetPaths: ['/wp-includes/js/dist/editor.min.js'],
+			}
+		);
+
+		expect(url).toBeUndefined();
+	});
+
+	it('does not resolve assets without a static assets directory', () => {
+		const url = resolveKnownRemoteAssetUrl(
+			new URL('http://127.0.0.1:5400/wp-includes/js/dist/editor.min.js'),
+			{
+				remoteAssetPaths: ['/wp-includes/js/dist/editor.min.js'],
+			}
+		);
+
+		expect(url).toBeUndefined();
+	});
+
+	it('does not resolve the front page to a remote asset', () => {
+		const url = resolveKnownRemoteAssetUrl(
+			new URL('http://127.0.0.1:5400/'),
+			{
+				staticAssetsDirectory: 'wp-6.8',
+				remoteAssetPaths: ['/'],
+			}
+		);
+
+		expect(url).toBeUndefined();
+	});
+});

--- a/packages/playground/remote/src/lib/known-remote-asset.ts
+++ b/packages/playground/remote/src/lib/known-remote-asset.ts
@@ -29,6 +29,10 @@ export type WPModuleDetails = {
 	 * WordPress rewrite rules are applied.
 	 */
 	remoteAssetPaths?: string[];
+	/**
+	 * Service-worker-only membership cache derived from `remoteAssetPaths`.
+	 */
+	remoteAssetPathSet?: Set<string>;
 };
 
 /**
@@ -57,8 +61,9 @@ export type WPModuleDetails = {
  */
 export function resolveKnownRemoteAssetUrl(
 	unscopedUrl: URL,
-	{ staticAssetsDirectory, remoteAssetPaths }: WPModuleDetails
+	details: WPModuleDetails
 ) {
+	const { staticAssetsDirectory, remoteAssetPaths } = details;
 	if (!staticAssetsDirectory || !remoteAssetPaths?.length) {
 		return undefined;
 	}
@@ -68,7 +73,10 @@ export function resolveKnownRemoteAssetUrl(
 		wordPressRewriteRules
 	);
 	const normalizedPath = joinPaths('/', siteRelativePath);
-	if (normalizedPath === '/' || !remoteAssetPaths.includes(normalizedPath)) {
+	if (
+		normalizedPath === '/' ||
+		!hasRemoteAssetPath(details, normalizedPath)
+	) {
 		return undefined;
 	}
 
@@ -76,7 +84,18 @@ export function resolveKnownRemoteAssetUrl(
 	remoteAssetUrl.pathname = joinPaths(
 		'/',
 		staticAssetsDirectory,
-		siteRelativePath
+		normalizedPath.substring(1)
 	);
 	return remoteAssetUrl;
+}
+
+function hasRemoteAssetPath(
+	{ remoteAssetPaths, remoteAssetPathSet }: WPModuleDetails,
+	normalizedPath: string
+) {
+	return (
+		remoteAssetPathSet?.has(normalizedPath) ??
+		remoteAssetPaths?.includes(normalizedPath) ??
+		false
+	);
 }

--- a/packages/playground/remote/src/lib/known-remote-asset.ts
+++ b/packages/playground/remote/src/lib/known-remote-asset.ts
@@ -2,11 +2,59 @@ import { joinPaths } from '@php-wasm/util';
 import { applyRewriteRules } from '@php-wasm/universal';
 import { wordPressRewriteRules } from '@wp-playground/wordpress';
 
+/**
+ * Describes the WordPress build currently served inside a Playground scope.
+ *
+ * ## Static assets in minified WordPress builds
+ *
+ * Playground boots faster by shipping minified WordPress builds without many
+ * CSS files, JS files, images, fonts, and other static assets. Each minified
+ * build includes a `wordpress-remote-asset-paths` file that lists the assets
+ * removed from the in-memory WordPress filesystem.
+ *
+ * The service worker can use that list to recognize requests that would
+ * otherwise go through PHP, produce a 404, and only then fall back to the
+ * remote static assets directory.
+ */
 export type WPModuleDetails = {
+	/**
+	 * Directory on the Playground.WordPress.net static host that matches the
+	 * loaded WordPress version, e.g. `wp-6.8`.
+	 */
 	staticAssetsDirectory?: string;
+	/**
+	 * Site-relative paths removed from the minified WordPress filesystem.
+	 *
+	 * Entries are normalized to begin with `/`, matching request paths after
+	 * WordPress rewrite rules are applied.
+	 */
 	remoteAssetPaths?: string[];
 };
 
+/**
+ * Returns a remote static asset URL for a known minified-build asset.
+ *
+ * ## Why this exists
+ *
+ * Requests for assets listed in `wordpress-remote-asset-paths` are guaranteed
+ * to be absent from the minified WordPress filesystem. Without this shortcut,
+ * the service worker would forward the request to PHP first, wait for a PHP
+ * 404, and only then fetch the file from the static assets directory.
+ *
+ * ## Path matching
+ *
+ * WordPress may request pretty URLs or index routes that need to pass through
+ * the same rewrite rules used by the PHP request handler. Apply those rewrite
+ * rules before checking `remoteAssetPaths` so both paths are compared in the
+ * same shape.
+ *
+ * ## Safety
+ *
+ * Only paths explicitly listed in `remoteAssetPaths` are rewritten. Unlisted
+ * files still go through PHP, preserving behavior for dynamic routes and files
+ * created or modified by the user. The root path is rejected even if an empty
+ * line or malformed entry made it into the asset list.
+ */
 export function resolveKnownRemoteAssetUrl(
 	unscopedUrl: URL,
 	{ staticAssetsDirectory, remoteAssetPaths }: WPModuleDetails

--- a/packages/playground/remote/src/lib/known-remote-asset.ts
+++ b/packages/playground/remote/src/lib/known-remote-asset.ts
@@ -1,0 +1,34 @@
+import { joinPaths } from '@php-wasm/util';
+import { applyRewriteRules } from '@php-wasm/universal';
+import { wordPressRewriteRules } from '@wp-playground/wordpress';
+
+export type WPModuleDetails = {
+	staticAssetsDirectory?: string;
+	remoteAssetPaths?: string[];
+};
+
+export function resolveKnownRemoteAssetUrl(
+	unscopedUrl: URL,
+	{ staticAssetsDirectory, remoteAssetPaths }: WPModuleDetails
+) {
+	if (!staticAssetsDirectory || !remoteAssetPaths?.length) {
+		return undefined;
+	}
+
+	const siteRelativePath = applyRewriteRules(
+		unscopedUrl.pathname,
+		wordPressRewriteRules
+	);
+	const normalizedPath = joinPaths('/', siteRelativePath);
+	if (normalizedPath === '/' || !remoteAssetPaths.includes(normalizedPath)) {
+		return undefined;
+	}
+
+	const remoteAssetUrl = new URL(unscopedUrl);
+	remoteAssetUrl.pathname = joinPaths(
+		'/',
+		staticAssetsDirectory,
+		siteRelativePath
+	);
+	return remoteAssetUrl;
+}

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -58,6 +58,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			// eslint-disable-next-line @typescript-eslint/no-this-alias
 			const endpoint = this;
 			this.knownRemoteAssetPaths = new Set<string>();
+			this.knownAbsentRemoteAssetPaths = new Set<string>();
 			const resolvedWordPressInstallMode: WordPressInstallMode =
 				wordpressInstallMode ??
 				(shouldInstallWordPress === false
@@ -238,7 +239,8 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			await this.finalizeAfterBoot(
 				requestHandler,
 				withNetworking,
-				this.knownRemoteAssetPaths
+				this.knownRemoteAssetPaths,
+				this.knownAbsentRemoteAssetPaths
 			);
 			setApiReady();
 		} catch (e) {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -57,7 +57,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 		try {
 			// eslint-disable-next-line @typescript-eslint/no-this-alias
 			const endpoint = this;
-			const knownRemoteAssetPaths = new Set<string>();
+			this.knownRemoteAssetPaths = new Set<string>();
 			const resolvedWordPressInstallMode: WordPressInstallMode =
 				wordpressInstallMode ??
 				(shouldInstallWordPress === false
@@ -69,7 +69,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				siteUrl,
 				sapiName,
 				corsProxyUrl,
-				knownRemoteAssetPaths,
+				knownRemoteAssetPaths: this.knownRemoteAssetPaths,
 				extensions,
 				withNetworking,
 				phpVersion: phpVersion!,
@@ -238,7 +238,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			await this.finalizeAfterBoot(
 				requestHandler,
 				withNetworking,
-				knownRemoteAssetPaths
+				this.knownRemoteAssetPaths
 			);
 			setApiReady();
 		} catch (e) {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
@@ -38,13 +38,13 @@ class PlaygroundWorkerEndpointV2 extends PlaygroundWorkerEndpoint {
 		this.requestedWordPressVersion = wpVersion;
 
 		try {
-			const knownRemoteAssetPaths = new Set<string>();
+			this.knownRemoteAssetPaths = new Set<string>();
 			const siteUrl = this.computeSiteUrl(scope);
 			const requestHandler = await this.createRequestHandler({
 				siteUrl,
 				sapiName,
 				corsProxyUrl,
-				knownRemoteAssetPaths,
+				knownRemoteAssetPaths: this.knownRemoteAssetPaths,
 				extensions,
 				withNetworking,
 				phpVersion: phpVersion!,
@@ -74,7 +74,7 @@ class PlaygroundWorkerEndpointV2 extends PlaygroundWorkerEndpoint {
 			await this.finalizeAfterBoot(
 				requestHandler,
 				withNetworking,
-				knownRemoteAssetPaths
+				this.knownRemoteAssetPaths
 			);
 			setApiReady();
 		} catch (e) {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v2.ts
@@ -39,6 +39,7 @@ class PlaygroundWorkerEndpointV2 extends PlaygroundWorkerEndpoint {
 
 		try {
 			this.knownRemoteAssetPaths = new Set<string>();
+			this.knownAbsentRemoteAssetPaths = new Set<string>();
 			const siteUrl = this.computeSiteUrl(scope);
 			const requestHandler = await this.createRequestHandler({
 				siteUrl,
@@ -74,7 +75,8 @@ class PlaygroundWorkerEndpointV2 extends PlaygroundWorkerEndpoint {
 			await this.finalizeAfterBoot(
 				requestHandler,
 				withNetworking,
-				this.knownRemoteAssetPaths
+				this.knownRemoteAssetPaths,
+				this.knownAbsentRemoteAssetPaths
 			);
 			setApiReady();
 		} catch (e) {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
@@ -276,6 +276,20 @@ describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 		expect(endpoint.opfsMounts['/wordpress']).toBeUndefined();
 		expect(endpoint.unmounts['/wordpress']).toBeUndefined();
 	});
+
+	it('reports known remote WordPress asset paths', async () => {
+		const endpoint = await createEndpoint({});
+		endpoint.loadedWordPressVersion = '6.8';
+		endpoint.knownRemoteAssetPaths = new Set([
+			'/wp-includes/js/dist/editor.min.js',
+		]);
+
+		await expect(endpoint.getWordPressModuleDetails()).resolves.toEqual(
+			expect.objectContaining({
+				remoteAssetPaths: ['/wp-includes/js/dist/editor.min.js'],
+			})
+		);
+	});
 });
 
 async function createEndpoint(
@@ -300,6 +314,11 @@ async function createEndpoint(
 		}): Promise<void>;
 		flushOpfs(mountpoint: string): Promise<void>;
 		unmountOpfs(mountpoint: string): Promise<void>;
+		getWordPressModuleDetails(): Promise<{
+			remoteAssetPaths: string[];
+		}>;
+		loadedWordPressVersion?: string;
+		knownRemoteAssetPaths: Set<string>;
 		opfsMounts: typeof opfsMounts;
 		unmounts: typeof unmounts;
 	};

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
@@ -294,8 +294,13 @@ describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 				(path: string) =>
 					path === '/wordpress/wordpress-remote-asset-paths'
 			),
-			readFileAsText: vi.fn(
-				() => 'wp-includes/js/local.js\nwp-includes/js/remote.js\n'
+			readFileAsText: vi.fn(() =>
+				[
+					'  /wp-includes/js/local.js\r',
+					'wp-includes/js/remote.js',
+					'  ',
+					'',
+				].join('\n')
 			),
 		};
 		const requestHandler = {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.spec.ts
@@ -277,10 +277,65 @@ describe('PlaygroundWorkerEndpoint OPFS flushing', () => {
 		expect(endpoint.unmounts['/wordpress']).toBeUndefined();
 	});
 
+	it('does not report remote asset paths that already exist after boot', async () => {
+		const endpoint = await createEndpoint({});
+		endpoint.requestedWordPressVersion = '6.8';
+		const knownRemoteAssetPaths = new Set<string>();
+		const knownAbsentRemoteAssetPaths = new Set<string>();
+		endpoint.knownAbsentRemoteAssetPaths = knownAbsentRemoteAssetPaths;
+		const primaryPhp = {
+			fileExists: vi.fn((path: string) =>
+				[
+					'/wordpress/wordpress-remote-asset-paths',
+					'/wordpress/wp-includes/js/local.js',
+				].includes(path)
+			),
+			isFile: vi.fn(
+				(path: string) =>
+					path === '/wordpress/wordpress-remote-asset-paths'
+			),
+			readFileAsText: vi.fn(
+				() => 'wp-includes/js/local.js\nwp-includes/js/remote.js\n'
+			),
+		};
+		const requestHandler = {
+			documentRoot: '/wordpress',
+			getPrimaryPhp: vi.fn(async () => primaryPhp),
+			instanceManager: {
+				acquirePHPInstance: vi.fn(async () => ({
+					php: {
+						run: vi.fn(async () => ({ text: '6.8' })),
+					},
+					reap: vi.fn(),
+				})),
+			},
+		};
+
+		await endpoint.finalizeAfterBoot(
+			requestHandler,
+			false,
+			knownRemoteAssetPaths,
+			knownAbsentRemoteAssetPaths
+		);
+
+		expect(Array.from(knownRemoteAssetPaths)).toEqual([
+			'/wp-includes/js/local.js',
+			'/wp-includes/js/remote.js',
+		]);
+		expect(Array.from(knownAbsentRemoteAssetPaths)).toEqual([
+			'/wp-includes/js/remote.js',
+		]);
+		await expect(endpoint.getWordPressModuleDetails()).resolves.toEqual(
+			expect.objectContaining({
+				remoteAssetPaths: ['/wp-includes/js/remote.js'],
+			})
+		);
+	});
+
 	it('reports known remote WordPress asset paths', async () => {
 		const endpoint = await createEndpoint({});
 		endpoint.loadedWordPressVersion = '6.8';
-		endpoint.knownRemoteAssetPaths = new Set([
+		endpoint.knownAbsentRemoteAssetPaths = new Set([
 			'/wp-includes/js/dist/editor.min.js',
 		]);
 
@@ -317,8 +372,15 @@ async function createEndpoint(
 		getWordPressModuleDetails(): Promise<{
 			remoteAssetPaths: string[];
 		}>;
+		finalizeAfterBoot(
+			requestHandler: any,
+			withNetworking: boolean,
+			knownRemoteAssetPaths: Set<string>,
+			knownAbsentRemoteAssetPaths: Set<string>
+		): Promise<void>;
 		loadedWordPressVersion?: string;
-		knownRemoteAssetPaths: Set<string>;
+		requestedWordPressVersion?: string;
+		knownAbsentRemoteAssetPaths: Set<string>;
 		opfsMounts: typeof opfsMounts;
 		unmounts: typeof unmounts;
 	};

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -125,6 +125,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 
 	private networkTransport: WordPressFetchNetworkTransport | undefined;
 	private requestHandler: PHPRequestHandler | undefined;
+	protected knownRemoteAssetPaths = new Set<string>();
 
 	protected downloadMonitor: EmscriptenDownloadMonitor;
 	protected memoizedFetch: ReturnType<typeof createMemoizedFetch>;
@@ -388,10 +389,11 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		if (primaryPhp.isFile(remoteAssetListPath)) {
 			const remoteAssetPaths = primaryPhp
 				.readFileAsText(remoteAssetListPath)
-				.split('\n');
-			remoteAssetPaths.forEach((wpRelativePath: string) =>
-				knownRemoteAssetPaths.add(joinPaths('/', wpRelativePath))
-			);
+				.split('\n')
+				.filter(Boolean);
+			remoteAssetPaths.forEach((wpRelativePath: string) => {
+				knownRemoteAssetPaths.add(joinPaths('/', wpRelativePath));
+			});
 		}
 
 		this.__internal_setRequestHandler(requestHandler);
@@ -426,6 +428,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 			staticAssetsDirectory: this.loadedWordPressVersion
 				? wpVersionToStaticAssetsDirectory(this.loadedWordPressVersion)
 				: undefined,
+			remoteAssetPaths: Array.from(this.knownRemoteAssetPaths),
 		};
 	}
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -126,21 +126,22 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 	private networkTransport: WordPressFetchNetworkTransport | undefined;
 	private requestHandler: PHPRequestHandler | undefined;
 	/**
-	 * Paths removed from the currently loaded minified WordPress build.
+	 * Paths listed in the currently loaded WordPress build's remote asset list.
 	 *
-	 * ## Lifecycle
-	 *
-	 * Each boot starts with a fresh set. `finalizeAfterBoot()` populates it
-	 * from `/wordpress/wordpress-remote-asset-paths`, fetching that list first
-	 * when a stored WordPress build does not already include it.
-	 *
-	 * ## Service worker handoff
-	 *
-	 * The service worker cannot read the PHP filesystem directly. Exposing this
-	 * set through `getWordPressModuleDetails()` lets it skip PHP for assets that
-	 * are known to be absent from the minified filesystem.
+	 * `getFileNotFoundAction()` uses this set only after PHP has confirmed a
+	 * path is absent, so it is safe to keep every listed path here.
 	 */
 	protected knownRemoteAssetPaths = new Set<string>();
+
+	/**
+	 * Remote asset paths that were still absent from the PHP filesystem after
+	 * boot and Blueprint execution completed.
+	 *
+	 * The service worker cannot read the PHP filesystem directly. Exposing only
+	 * the absent subset through `getWordPressModuleDetails()` lets it skip PHP
+	 * without overriding files that are already present in the site.
+	 */
+	protected knownAbsentRemoteAssetPaths = new Set<string>();
 
 	protected downloadMonitor: EmscriptenDownloadMonitor;
 	protected memoizedFetch: ReturnType<typeof createMemoizedFetch>;
@@ -345,7 +346,8 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 	protected async finalizeAfterBoot(
 		requestHandler: any,
 		withNetworking: boolean,
-		knownRemoteAssetPaths: Set<string>
+		knownRemoteAssetPaths: Set<string>,
+		knownAbsentRemoteAssetPaths: Set<string>
 	) {
 		const primaryPhp = await requestHandler.getPrimaryPhp();
 		primaryPhp.requestHandler ??= requestHandler;
@@ -410,17 +412,29 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 
 		if (primaryPhp.isFile(remoteAssetListPath)) {
 			/**
-			 * Keep the list in memory for the service worker and normalize every
-			 * entry to a site-relative absolute path. Empty lines must be ignored:
+			 * Keep the list in memory and normalize every entry to a
+			 * site-relative absolute path. Empty lines must be ignored:
 			 * otherwise they would normalize to `/`, making the front page look
 			 * like a remote static asset.
+			 *
+			 * Only expose paths that are absent after boot to the service worker.
+			 * If a Blueprint or a stored site already supplied one of these files,
+			 * the PHP request path must keep serving that local copy.
 			 */
 			const remoteAssetPaths = primaryPhp
 				.readFileAsText(remoteAssetListPath)
 				.split('\n')
 				.filter(Boolean);
 			remoteAssetPaths.forEach((wpRelativePath: string) => {
-				knownRemoteAssetPaths.add(joinPaths('/', wpRelativePath));
+				const siteRelativePath = joinPaths('/', wpRelativePath);
+				knownRemoteAssetPaths.add(siteRelativePath);
+				if (
+					!primaryPhp.fileExists(
+						joinPaths(requestHandler.documentRoot, siteRelativePath)
+					)
+				) {
+					knownAbsentRemoteAssetPaths.add(siteRelativePath);
+				}
 			});
 		}
 
@@ -461,7 +475,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 			staticAssetsDirectory: this.loadedWordPressVersion
 				? wpVersionToStaticAssetsDirectory(this.loadedWordPressVersion)
 				: undefined,
-			remoteAssetPaths: Array.from(this.knownRemoteAssetPaths),
+			remoteAssetPaths: Array.from(this.knownAbsentRemoteAssetPaths),
 		};
 	}
 

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -413,8 +413,8 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		if (primaryPhp.isFile(remoteAssetListPath)) {
 			/**
 			 * Keep the list in memory and normalize every entry to a
-			 * site-relative absolute path. Empty lines must be ignored:
-			 * otherwise they would normalize to `/`, making the front page look
+			 * site-relative absolute path. Empty or whitespace-only lines must be
+			 * ignored: otherwise they would normalize to `/`, making the front page look
 			 * like a remote static asset.
 			 *
 			 * Only expose paths that are absent after boot to the service worker.
@@ -424,13 +424,14 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 			const remoteAssetPaths = primaryPhp
 				.readFileAsText(remoteAssetListPath)
 				.split('\n')
+				.map((line: string) => line.trim().replace(/^\/+/, ''))
 				.filter(Boolean);
 			remoteAssetPaths.forEach((wpRelativePath: string) => {
 				const siteRelativePath = joinPaths('/', wpRelativePath);
 				knownRemoteAssetPaths.add(siteRelativePath);
 				if (
 					!primaryPhp.fileExists(
-						joinPaths(requestHandler.documentRoot, siteRelativePath)
+						joinPaths(requestHandler.documentRoot, wpRelativePath)
 					)
 				) {
 					knownAbsentRemoteAssetPaths.add(siteRelativePath);

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -125,6 +125,21 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 
 	private networkTransport: WordPressFetchNetworkTransport | undefined;
 	private requestHandler: PHPRequestHandler | undefined;
+	/**
+	 * Paths removed from the currently loaded minified WordPress build.
+	 *
+	 * ## Lifecycle
+	 *
+	 * Each boot starts with a fresh set. `finalizeAfterBoot()` populates it
+	 * from `/wordpress/wordpress-remote-asset-paths`, fetching that list first
+	 * when a stored WordPress build does not already include it.
+	 *
+	 * ## Service worker handoff
+	 *
+	 * The service worker cannot read the PHP filesystem directly. Exposing this
+	 * set through `getWordPressModuleDetails()` lets it skip PHP for assets that
+	 * are known to be absent from the minified filesystem.
+	 */
 	protected knownRemoteAssetPaths = new Set<string>();
 
 	protected downloadMonitor: EmscriptenDownloadMonitor;
@@ -366,6 +381,13 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 			requestHandler.documentRoot,
 			'wordpress-remote-asset-paths'
 		);
+		/**
+		 * Minified WordPress builds contain a `wordpress-remote-asset-paths`
+		 * file, but WordPress restored from browser storage may come from an
+		 * older archive that did not include it. Fetch the list for the loaded
+		 * WordPress version so remote asset handling stays tied to the version
+		 * actually present in the PHP filesystem.
+		 */
 		if (
 			wpStaticAssetsDir !== undefined &&
 			!primaryPhp.fileExists(remoteAssetListPath)
@@ -387,6 +409,12 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		}
 
 		if (primaryPhp.isFile(remoteAssetListPath)) {
+			/**
+			 * Keep the list in memory for the service worker and normalize every
+			 * entry to a site-relative absolute path. Empty lines must be ignored:
+			 * otherwise they would normalize to `/`, making the front page look
+			 * like a remote static asset.
+			 */
 			const remoteAssetPaths = primaryPhp
 				.readFileAsText(remoteAssetListPath)
 				.split('\n')
@@ -419,7 +447,12 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 	// NOTE: Version-specific boot methods are implemented in the concrete worker entrypoints
 
 	/**
-	 * @returns WordPress module details, including the static assets directory and default theme.
+	 * Returns the WordPress details needed outside the PHP worker.
+	 *
+	 * `staticAssetsDirectory` points at the remote static assets directory for
+	 * the loaded WordPress version. `remoteAssetPaths` lists files removed from
+	 * the minified build so the service worker can serve them without first
+	 * asking PHP to 404.
 	 */
 	async getWordPressModuleDetails() {
 		return {


### PR DESCRIPTION
## What it does

Short-circuits PHP for WordPress static assets that are known to live outside the minified in-memory WordPress build.

When a request path appears in `wordpress-remote-asset-paths`, the service worker fetches it directly from the WordPress static assets directory instead of first converting the request into a PHP request.

## Rationale

Minified WordPress builds intentionally omit many CSS, JS, image, and font files. Today, those requests still go through PHP, return a PHP-side 404, and only then fall back to the remote static assets directory.

The service worker already knows which paths were removed from the minified build, so the PHP round-trip is avoidable.

Local benchmark against `origin/trunk` at `309c44e9e`, using `npm run dev`, Chromium headless, WordPress 6.8, `?storage=temp&wp=6.8`, 5 fresh browser contexts per branch. Numbers are medians.

| Flow | trunk | this branch | Change |
| --- | ---: | ---: | ---: |
| Cold boot to frontend ready | 2818 ms | 2352 ms | -466 ms (-16.5%) |
| Toolbar to `/wp-admin/` | 677 ms | 579 ms | -98 ms (-14.5%) |
| Click Posts list | 401 ms | 271 ms | -130 ms (-32.4%) |
| Toolbar to Plugins | 272 ms | 159 ms | -113 ms (-41.5%) |

## Implementation

`PlaygroundWorkerEndpoint` keeps the known remote asset paths collected during boot and exposes them through `getWordPressModuleDetails()`.

The service worker checks GET and HEAD requests against that path list before calling into PHP:

1. Apply the WordPress rewrite rules to the scoped URL.
2. Check the normalized path against `remoteAssetPaths`.
3. If it matches, rewrite the URL to `staticAssetsDirectory` and fetch it directly.
4. Otherwise, use the existing PHP request path and PHP 404 fallback.

This preserves existing behavior for unlisted paths, dynamic routes, and user-modified files. Empty asset-list entries are ignored, and root requests are never treated as remote assets.

## Testing instructions

```bash
npm exec nx test playground-remote -- --runInBand
npm exec nx typecheck playground-remote
npm exec nx lint playground-remote
```

Benchmark artifacts were saved locally under `.context/benchmarks/first-two-prs/`.
