### PR TITLE
Bump vulnerable dependencies: ws, express, fast-xml-parser, ajv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,13 +39,13 @@
 				"@wordpress/dataviews": "4.5.0",
 				"@wordpress/url": "4.43.0",
 				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
+				"ajv": "8.18.0",
 				"async-lock": "1.4.1",
 				"classnames": "^2.3.2",
 				"crc-32": "1.2.2",
 				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
+				"express": "4.22.2",
+				"fast-xml-parser": "^5.8.0",
 				"file-saver": "^2.0.5",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"fs-extra": "11.1.1",
@@ -9959,23 +9959,6 @@
 				"resolve": "~1.22.2"
 			}
 		},
-		"node_modules/@microsoft/tsdoc-config/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
 		"node_modules/@modelcontextprotocol/sdk": {
 			"version": "1.27.0",
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.0.tgz",
@@ -10027,22 +10010,6 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
@@ -11175,6 +11142,18 @@
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
+		},
+		"node_modules/@nodable/entities": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+			"integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -14743,23 +14722,6 @@
 				"@types/node": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@rushstack/node-core-library/node_modules/ajv": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.3",
-				"fast-uri": "^3.0.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
@@ -21072,15 +21034,15 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
@@ -22614,9 +22576,9 @@
 			"license": "MIT"
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.4",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+			"version": "1.20.5",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+			"integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "~3.1.2",
@@ -22627,7 +22589,7 @@
 				"http-errors": "~2.0.1",
 				"iconv-lite": "~0.4.24",
 				"on-finished": "~2.4.1",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
 				"unpipe": "~1.0.0"
@@ -22663,6 +22625,21 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"license": "MIT"
+		},
+		"node_modules/body-parser/node_modules/qs": {
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/body-parser/node_modules/raw-body": {
 			"version": "2.5.3",
@@ -28325,14 +28302,14 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
+				"body-parser": "~1.20.5",
 				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "~0.7.1",
@@ -28351,7 +28328,7 @@
 				"parseurl": "~1.3.3",
 				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
 				"send": "~0.19.0",
@@ -28408,6 +28385,21 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
 			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
 			"license": "MIT"
+		},
+		"node_modules/express/node_modules/qs": {
+			"version": "6.15.2",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -28533,9 +28525,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -28544,13 +28536,14 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.5.12",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
-			"integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
+			"version": "5.8.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+			"integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
 			"funding": [
 				{
 					"type": "github",
@@ -28559,9 +28552,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fast-xml-builder": "^1.1.4",
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.2.0",
 				"path-expression-matcher": "^1.5.0",
-				"strnum": "^2.2.3"
+				"strnum": "^2.3.0",
+				"xml-naming": "^0.1.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -49559,9 +49554,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -52714,27 +52709,6 @@
 				"node": ">= 10"
 			}
 		},
-		"node_modules/webpack-bundle-analyzer/node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/webpack-dev-middleware": {
 			"version": "7.4.5",
 			"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.5.tgz",
@@ -52846,15 +52820,6 @@
 				}
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
 		"node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -52865,52 +52830,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/webpack-dev-server/node_modules/express": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/webpack-dev-server/node_modules/http-proxy-middleware": {
@@ -52958,12 +52877,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/webpack-dev-server/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"license": "MIT"
-		},
 		"node_modules/webpack-dev-server/node_modules/open": {
 			"version": "10.2.0",
 			"resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
@@ -52981,12 +52894,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/webpack-dev-server/node_modules/path-to-regexp": {
-			"version": "0.1.13",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
-			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
-			"license": "MIT"
 		},
 		"node_modules/webpack-merge": {
 			"version": "6.0.1",
@@ -53509,9 +53416,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -53592,6 +53499,21 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/xml2js": {
@@ -54267,7 +54189,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.27.0",
-				"ws": "^8.18.0",
+				"ws": "^8.21.0",
 				"zod": "^4.3"
 			},
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -97,13 +97,13 @@
 		"@wordpress/dataviews": "4.5.0",
 		"@wordpress/url": "4.43.0",
 		"@zip.js/zip.js": "2.7.57",
-		"ajv": "8.12.0",
+		"ajv": "8.18.0",
 		"async-lock": "1.4.1",
 		"classnames": "^2.3.2",
 		"crc-32": "1.2.2",
 		"diff3": "0.0.4",
-		"express": "4.22.0",
-		"fast-xml-parser": "^5.5.1",
+		"express": "4.22.2",
+		"fast-xml-parser": "^5.8.0",
 		"file-saver": "^2.0.5",
 		"fs-ext-extra-prebuilt": "2.2.7",
 		"fs-extra": "11.1.1",
@@ -225,7 +225,8 @@
 		"form-data": "^4.0.4",
 		"lodash": "^4.17.23",
 		"glob": "^9.3.0",
-		"webpackbar": "^7.0.0"
+		"webpackbar": "^7.0.0",
+		"ws": "^8.21.0"
 	},
 	"workspaces": [
 		"packages/nx-extensions",

--- a/packages/playground/mcp/package.json
+++ b/packages/playground/mcp/package.json
@@ -37,7 +37,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.0",
-		"ws": "^8.18.0",
+		"ws": "^8.21.0",
 		"zod": "^4.3"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Fixes Dependabot alerts by bumping the minimum required versions:

| Package | Dep | From | To | Fixes |
|---------|-----|------|----|-------|
| `@wp-playground/mcp` | `ws` | `^8.18.0` | `^8.21.0` | #224 |
| root | `express` | `4.22.0` | `4.22.2` | #228, #89, #110 |
| root | `fast-xml-parser` | `^5.5.1` | `^5.8.0` | #206, #205 |
| root | `ajv` | `8.12.0` | `8.18.0` | #121 |

`ws` is added to the `overrides` section (not `dependencies`) in the root `package.json` to force `^8.21.0` across all transitive consumers. This is necessary because `@module-federation/dts-plugin` and `webpack-dev-server` pin `ws` to exactly `8.18.0`, which would otherwise win as the hoisted version despite `@wp-playground/mcp` requesting `^8.21.0`.