### PR TITLE
docs: document local test commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ To run the unit tests for every project, use:
 npm run test
 ```
 
-To run unit tests for one project, pass the project name to Nx:
+To run unit tests for one project, run that project's test target with Nx:
 
 ```bash
 npx nx run playground-website:test
 ```
 
-Some browser tests target the local `playground.test` domain over HTTPS, which requires additional local setup before they can run. Once your local environment is configured for that domain, you can run the Playground website E2E tests with:
+Some browser tests target the local `playground.test` domain over HTTPS, which requires additional local setup before they can run. See the [local Multisite setup instructions](https://wordpress.github.io/wordpress-playground/contributing/code#running-a-local-multisite) for guidance on configuring `playground.test` with HTTPS. Once your local environment is configured for that domain, you can run the Playground website E2E tests with:
 
 ```bash
 npx nx run playground-website:e2e

--- a/README.md
+++ b/README.md
@@ -116,33 +116,6 @@ Any changes you make to `.ts` files will be live-reloaded. Changes to `Dockerfil
 
 From here, the [documentation](https://wordpress.github.io/wordpress-playground/) will help you learn how WordPress Playground works and how to use it to build amazing things!
 
-### Running tests
-
-To run the unit tests for every project, use:
-
-```bash
-npm run test
-```
-
-To run unit tests for one project, run that project's test target with Nx:
-
-```bash
-npx nx run playground-website:test
-```
-
-Some browser tests target the local `playground.test` domain over HTTPS, which requires additional local setup before they can run. See the [local Multisite setup instructions](https://wordpress.github.io/wordpress-playground/contributing/code#running-a-local-multisite) for guidance on configuring `playground.test` with HTTPS. Once your local environment is configured for that domain, you can run the Playground website E2E tests with:
-
-```bash
-npx nx run playground-website:e2e
-```
-
-The Playground website also has Playwright E2E targets:
-
-```bash
-npx nx run playground-website:e2e:playwright
-npx nx run playground-website:e2e:playwright:ci
-```
-
 And here are a few more interesting CLI commands you can run in this repo:
 
 ```bash
@@ -174,6 +147,32 @@ npx nx build playground-client
 npx @php-wasm/cli -v
 PHP=7.4 npx @php-wasm/cli -v
 npx @php-wasm/cli phpcbf
+```
+
+### Running tests
+
+To run the unit tests for every project, use:
+
+```bash
+npm run test
+```
+
+To run unit tests for one project, run that project's test target with Nx:
+
+```bash
+npx nx run playground-website:test
+```
+
+Some browser tests target the local `playground.test` domain over HTTPS, which requires additional local setup before they can run. See the [local Multisite setup instructions](https://wordpress.github.io/wordpress-playground/contributing/code#running-a-local-multisite) for guidance on configuring `playground.test` with HTTPS. Once your local environment is configured for that domain, you can run the Playground website E2E tests with:
+
+```bash
+npx nx run playground-website:e2e
+```
+
+The Playground website also has a Playwright E2E target:
+
+```bash
+npx nx run playground-website:e2e:playwright
 ```
 
 ### Test offline support

--- a/README.md
+++ b/README.md
@@ -116,6 +116,33 @@ Any changes you make to `.ts` files will be live-reloaded. Changes to `Dockerfil
 
 From here, the [documentation](https://wordpress.github.io/wordpress-playground/) will help you learn how WordPress Playground works and how to use it to build amazing things!
 
+### Running tests
+
+To run the unit tests for every project, use:
+
+```bash
+npm run test
+```
+
+To run unit tests for one project, pass the project name to Nx:
+
+```bash
+npx nx run playground-website:test
+```
+
+Some browser tests target the local `playground.test` domain over HTTPS, which requires additional local setup before they can run. Once your local environment is configured for that domain, you can run the Playground website E2E tests with:
+
+```bash
+npx nx run playground-website:e2e
+```
+
+The Playground website also has Playwright E2E targets:
+
+```bash
+npx nx run playground-website:e2e:playwright
+npx nx run playground-website:e2e:playwright:ci
+```
+
 And here are a few more interesting CLI commands you can run in this repo:
 
 ```bash


### PR DESCRIPTION
## Motivation for the change, related issues

Adds the local unit and E2E test commands requested in #1519 to the top-level README.

## Implementation details

The new README section documents:

- running all unit tests with `npm run test`
- running a single Nx project's unit tests with `npx nx run playground-website:test`
- running Playground website Cypress E2E tests with `npx nx run playground-website:e2e`
- running Playground website Playwright E2E targets

It also calls out that browser tests using `playground.test` over HTTPS need additional local setup before they can run.

Closes #1519

## Testing Instructions (or ideally a Blueprint)

This is a README-only documentation change. I verified the documented commands against `package.json` and `packages/playground/website/project.json`.