### PR TITLE
[Website] Validate input in standalone PR previewer pages

### DIFF
--- a/packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts
+++ b/packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts
@@ -45,6 +45,24 @@ test('wordpress.html: a numeric PR is forwarded to plugin-proxy', async ({
 	expect(capturedUrl).toContain('pr=12345');
 });
 
+test('wordpress.html: whitespace around the PR value is trimmed', async ({
+	page,
+}) => {
+	let capturedUrl = '';
+	await page.route('**/plugin-proxy.php*', (route) => {
+		capturedUrl = route.request().url();
+		return route.fulfill({
+			status: 400,
+			contentType: 'application/json',
+			body: JSON.stringify({ error: 'artifact_expired' }),
+		});
+	});
+	await page.goto('./wordpress.html');
+	await submit(page, '  12345\n');
+	await expect(page.locator('#error')).toContainText('artifact has expired');
+	expect(capturedUrl).toContain('pr=12345');
+});
+
 test('gutenberg.html: pasting a wordpress-develop PR URL points to the WordPress previewer', async ({
 	page,
 }) => {
@@ -86,7 +104,9 @@ test('gutenberg.html: ?pr= URL param is extracted before reaching plugin-proxy',
 				'https://github.com/WordPress/gutenberg/pull/78937'
 			)
 	);
-	await expect(page.locator('#error')).toBeVisible();
+	await expect(page.locator('#error')).toContainText(
+		'does not exist or GitHub CI did not finish'
+	);
 	expect(capturedUrl).toContain('repo=gutenberg');
 	expect(capturedUrl).toContain('pr=78937');
 	expect(capturedUrl).not.toContain('github.com');

--- a/packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts
+++ b/packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+
+async function submit(page: Page, value: string) {
+	await page.locator('#pr-number').fill(value);
+	await page.locator('#submit').click();
+}
+
+test('wordpress.html: pasting a Gutenberg PR URL points to the Gutenberg previewer', async ({
+	page,
+}) => {
+	await page.goto('./wordpress.html');
+	await submit(page, 'https://github.com/WordPress/gutenberg/pull/78937');
+	await expect(
+		page.getByRole('link', { name: 'Gutenberg PR previewer' })
+	).toHaveAttribute('href', './gutenberg.html');
+});
+
+test('wordpress.html: non-PR input shows a wordpress-develop-specific error', async ({
+	page,
+}) => {
+	await page.goto('./wordpress.html');
+	await submit(page, 'not-a-pr');
+	await expect(page.locator('#error')).toHaveText(
+		'Please enter a valid wordpress-develop PR number or URL.'
+	);
+});
+
+test('wordpress.html: a numeric PR is forwarded to plugin-proxy', async ({
+	page,
+}) => {
+	let capturedUrl = '';
+	await page.route('**/plugin-proxy.php*', (route) => {
+		capturedUrl = route.request().url();
+		return route.fulfill({
+			status: 400,
+			contentType: 'application/json',
+			body: JSON.stringify({ error: 'artifact_expired' }),
+		});
+	});
+	await page.goto('./wordpress.html');
+	await submit(page, '12345');
+	await expect(page.locator('#error')).toContainText('artifact has expired');
+	expect(capturedUrl).toContain('repo=wordpress-develop');
+	expect(capturedUrl).toContain('pr=12345');
+});
+
+test('gutenberg.html: pasting a wordpress-develop PR URL points to the WordPress previewer', async ({
+	page,
+}) => {
+	await page.goto('./gutenberg.html');
+	await submit(
+		page,
+		'https://github.com/WordPress/wordpress-develop/pull/9999'
+	);
+	await expect(
+		page.getByRole('link', { name: 'WordPress PR previewer' })
+	).toHaveAttribute('href', './wordpress.html');
+});
+
+test('gutenberg.html: non-PR input shows a gutenberg-specific error', async ({
+	page,
+}) => {
+	await page.goto('./gutenberg.html');
+	await submit(page, 'oh-no');
+	await expect(page.locator('#error')).toHaveText(
+		'Please enter a valid gutenberg PR number or URL.'
+	);
+});
+
+test('gutenberg.html: ?pr= URL param is extracted before reaching plugin-proxy', async ({
+	page,
+}) => {
+	let capturedUrl = '';
+	await page.route('**/plugin-proxy.php*', (route) => {
+		capturedUrl = route.request().url();
+		return route.fulfill({
+			status: 400,
+			contentType: 'application/json',
+			body: JSON.stringify({ error: 'no_ci_runs' }),
+		});
+	});
+	await page.goto(
+		'./gutenberg.html?pr=' +
+			encodeURIComponent(
+				'https://github.com/WordPress/gutenberg/pull/78937'
+			)
+	);
+	await expect(page.locator('#error')).toBeVisible();
+	expect(capturedUrl).toContain('repo=gutenberg');
+	expect(capturedUrl).toContain('pr=78937');
+	expect(capturedUrl).not.toContain('github.com');
+});

--- a/packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts
+++ b/packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts
@@ -26,6 +26,19 @@ test('wordpress.html: non-PR input shows a wordpress-develop-specific error', as
 	);
 });
 
+test('wordpress.html: malformed wordpress-develop PR URL shows a validation error', async ({
+	page,
+}) => {
+	await page.goto('./wordpress.html');
+	await submit(
+		page,
+		'https://github.com/WordPress/wordpress-develop/pull/not-a-number'
+	);
+	await expect(page.locator('#error')).toHaveText(
+		'Please enter a valid wordpress-develop PR number or URL.'
+	);
+});
+
 test('wordpress.html: a numeric PR is forwarded to plugin-proxy', async ({
 	page,
 }) => {
@@ -81,6 +94,19 @@ test('gutenberg.html: non-PR input shows a gutenberg-specific error', async ({
 }) => {
 	await page.goto('./gutenberg.html');
 	await submit(page, 'oh-no');
+	await expect(page.locator('#error')).toHaveText(
+		'Please enter a valid gutenberg PR number or URL.'
+	);
+});
+
+test('gutenberg.html: malformed Gutenberg PR URL shows a validation error', async ({
+	page,
+}) => {
+	await page.goto('./gutenberg.html');
+	await submit(
+		page,
+		'https://github.com/WordPress/gutenberg/pull/not-a-number'
+	);
 	await expect(page.locator('#error')).toHaveText(
 		'Please enter a valid gutenberg PR number or URL.'
 	);

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -117,6 +117,8 @@
 			submitButton.classList.add('loading');
 			submitButton.disabled = true;
 
+			prNumber = prNumber.trim();
+
 			// Extract number from a GitHub URL
 			if (
 				prNumber
@@ -132,9 +134,14 @@
 						.toLowerCase()
 						.includes('github.com/wordpress/wordpress-develop/pull')
 				) {
-					errorDiv.innerHTML =
-						'This looks like a WordPress Core PR. ' +
-						'Use the <a href="./wordpress.html">WordPress PR previewer</a> instead.';
+					const link = document.createElement('a');
+					link.href = './wordpress.html';
+					link.textContent = 'WordPress PR previewer';
+					errorDiv.replaceChildren(
+						'This looks like a WordPress Core PR. Use the ',
+						link,
+						' instead.'
+					);
 				} else {
 					errorDiv.innerText =
 						'Please enter a valid gutenberg PR number or URL.';

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -120,12 +120,11 @@
 			prNumber = prNumber.trim();
 
 			// Extract number from a GitHub URL
-			if (
-				prNumber
-					.toLowerCase()
-					.includes('github.com/wordpress/gutenberg/pull')
-			) {
-				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
+			const gutenbergPr = prNumber.match(
+				/github\.com\/wordpress\/gutenberg\/pull\/(\d+)/i
+			);
+			if (gutenbergPr) {
+				prNumber = gutenbergPr[1];
 			}
 
 			if (!/^\d+$/.test(prNumber)) {

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 
 <head>
 	<title>Gutenberg PR Previewer</title>
@@ -64,8 +64,8 @@
 	<div id="links">
 		Powered by
 		<a href="https://developer.wordpress.org/playground">
-			WordPress Playground
-		</a>. To build a previewer like this for your repository, check the
+			WordPress Playground </a
+		>. To build a previewer like this for your repository, check the
 		<a
 			target="_blank"
 			href="https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/gutenberg.html"
@@ -108,7 +108,14 @@
 			if (submitting) {
 				return;
 			}
-			let prNumber = document.getElementById('pr-number').value;
+			previewPr(document.getElementById('pr-number').value);
+		});
+
+		async function previewPr(prNumber) {
+			submitting = true;
+			errorDiv.innerText = '';
+			submitButton.classList.add('loading');
+			submitButton.disabled = true;
 
 			// Extract number from a GitHub URL
 			if (
@@ -119,14 +126,24 @@
 				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
 			}
 
-			previewPr(prNumber);
-		});
-
-		async function previewPr(prNumber) {
-			submitting = true;
-			errorDiv.innerText = '';
-			submitButton.classList.add('loading');
-			submitButton.disabled = true;
+			if (!/^\d+$/.test(prNumber)) {
+				if (
+					prNumber
+						.toLowerCase()
+						.includes('github.com/wordpress/wordpress-develop/pull')
+				) {
+					errorDiv.innerHTML =
+						'This looks like a WordPress Core PR. ' +
+						'Use the <a href="./wordpress.html">WordPress PR previewer</a> instead.';
+				} else {
+					errorDiv.innerText =
+						'Please enter a valid gutenberg PR number or URL.';
+				}
+				submitting = false;
+				submitButton.classList.remove('loading');
+				submitButton.disabled = false;
+				return;
+			}
 
 			// Verify that the PR exists and that GitHub CI finished building it
 			const zipArtifactUrl = `/plugin-proxy.php?org=WordPress&repo=gutenberg&workflow=Build%20Gutenberg%20Plugin%20Zip&artifact=gutenberg-plugin&pr=${prNumber}`;
@@ -151,7 +168,7 @@
 						step: 'login',
 						username: 'admin',
 						password: 'password',
-					}
+					},
 				],
 			};
 			// If there's a import-site query parameter, pass that to the blueprint

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 
 <head>
 	<title>Gutenberg PR Previewer</title>
@@ -64,8 +64,8 @@
 	<div id="links">
 		Powered by
 		<a href="https://developer.wordpress.org/playground">
-			WordPress Playground </a
-		>. To build a previewer like this for your repository, check the
+			WordPress Playground
+		</a>. To build a previewer like this for your repository, check the
 		<a
 			target="_blank"
 			href="https://github.com/WordPress/wordpress-playground/blob/trunk/packages/playground/website/public/gutenberg.html"

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -137,12 +137,11 @@
 			prNumber = prNumber.trim();
 
 			// Extract number from a GitHub URL
-			if (
-				prNumber
-					.toLowerCase()
-					.includes('github.com/wordpress/wordpress-develop/pull')
-			) {
-				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
+			const wordpressDevelopPr = prNumber.match(
+				/github\.com\/wordpress\/wordpress-develop\/pull\/(\d+)/i
+			);
+			if (wordpressDevelopPr) {
+				prNumber = wordpressDevelopPr[1];
 			}
 
 			if (!/^\d+$/.test(prNumber)) {

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -143,6 +143,25 @@
 				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
 			}
 
+			if (!/^\d+$/.test(prNumber)) {
+				if (
+					prNumber
+						.toLowerCase()
+						.includes('github.com/wordpress/gutenberg/pull')
+				) {
+					errorDiv.innerHTML =
+						'This looks like a Gutenberg PR. ' +
+						'Use the <a href="./gutenberg.html">Gutenberg PR previewer</a> instead.';
+				} else {
+					errorDiv.innerText =
+						'Please enter a valid wordpress-develop PR number or URL.';
+				}
+				submitting = false;
+				submitButton.classList.remove('loading');
+				submitButton.disabled = false;
+				return;
+			}
+
 			// Verify that the PR exists and that GitHub CI finished building it
 			const zipArtifactUrl = `https://playground.wordpress.net/plugin-proxy.php?org=WordPress&repo=wordpress-develop&workflow=Test%20Build%20Processes&artifact=wordpress-build-${prNumber}&pr=${prNumber}`;
 			// Send the HEAD request to zipArtifactUrl to confirm the PR and the artifact both exist

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -134,6 +134,8 @@
 			submitButton.classList.add('loading');
 			submitButton.disabled = true;
 
+			prNumber = prNumber.trim();
+
 			// Extract number from a GitHub URL
 			if (
 				prNumber
@@ -149,9 +151,14 @@
 						.toLowerCase()
 						.includes('github.com/wordpress/gutenberg/pull')
 				) {
-					errorDiv.innerHTML =
-						'This looks like a Gutenberg PR. ' +
-						'Use the <a href="./gutenberg.html">Gutenberg PR previewer</a> instead.';
+					const link = document.createElement('a');
+					link.href = './gutenberg.html';
+					link.textContent = 'Gutenberg PR previewer';
+					errorDiv.replaceChildren(
+						'This looks like a Gutenberg PR. Use the ',
+						link,
+						' instead.'
+					);
 				} else {
 					errorDiv.innerText =
 						'Please enter a valid wordpress-develop PR number or URL.';


### PR DESCRIPTION
## What changed

- `/wordpress.html` and `/gutenberg.html` now validate the entered PR value before calling `plugin-proxy.php`.
- Pasting a Gutenberg PR URL on `/wordpress.html` (and vice versa) shows a clear message with a link to the correct previewer page.
- Any other non-numeric input shows a repo-specific *"Please enter a valid `<repo>` PR number or URL."* message instead of the generic "unexpected error" surfaced by the backend.
- `/gutenberg.html` now extracts the PR number inside `previewPr()` so the `?pr=<github-url>` entry point gets the same treatment as the form submit path.

## Root cause

The standalone previewers are single-repo pages. Their URL-extraction `if` only matches their own repo path (`wordpress-develop/pull` or `gutenberg/pull`), so a URL pointing at the *other* repo falls through unchanged. The full URL is then forwarded as the `pr=` query value to `plugin-proxy.php`, which appends it to a GitHub API path:

```
/repos/WordPress/wordpress-develop/pulls/https://github.com/WordPress/gutenberg/pull/78937
```

GitHub responds non-2xx, PHP's `file_get_contents` returns `false`, and `PluginDownloader::gitHubRequest()` throws `ApiException('Request failed')`. The catch in `plugin-proxy.php` returns HTTP 400 with `{"error":"Request failed"}`. The client doesn't recognize that error code, falls into the catch-all branch, and renders:

> The PR https://github.com/WordPress/gutenberg/pull/78937 couldn't be previewed due to an unexpected error. Please try again later or file an issue in the WordPress Playground repository.

The actual problem — the user is on the wrong previewer page — is never mentioned, and the original URL is awkwardly embedded in a generic "unexpected error" message.

## Reproduction (before)

1. Open `https://playground.wordpress.net/wordpress.html`.
2. Paste `https://github.com/WordPress/gutenberg/pull/78937`.
3. Click *Go*.
4. Observe the opaque error message above.

After this change, the user instead sees:

> This looks like a Gutenberg PR. Use the [Gutenberg PR previewer](./gutenberg.html) instead.

## Testing

`packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts` adds six cases:

- Pasted Gutenberg URL on `/wordpress.html` → link to `gutenberg.html`.
- Non-PR input on `/wordpress.html` → wordpress-develop-specific message.
- Numeric PR on `/wordpress.html` → request reaches `plugin-proxy.php` with `repo=wordpress-develop&pr=12345`.
- Pasted wordpress-develop URL on `/gutenberg.html` → link to `wordpress.html`.
- Non-PR input on `/gutenberg.html` → gutenberg-specific message.
- `?pr=<gutenberg-url>` on `/gutenberg.html` → URL is extracted to `pr=78937` before reaching `plugin-proxy.php`.

```bash
npx playwright test \
  --config=packages/playground/website/playwright/playwright.config.ts \
  standalone-pr-previewers.spec.ts --project=chromium
```

All 6 tests pass locally on Chromium; Firefox and WebKit run in CI.