### PR TITLE
[Website] Handle malformed PR previewer URLs

### DIFF
--- a/packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts
+++ b/packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts
@@ -26,6 +26,19 @@ test('wordpress.html: non-PR input shows a wordpress-develop-specific error', as
 	);
 });
 
+test('wordpress.html: malformed wordpress-develop PR URL shows a validation error', async ({
+	page,
+}) => {
+	await page.goto('./wordpress.html');
+	await submit(
+		page,
+		'https://github.com/WordPress/wordpress-develop/pull/not-a-number'
+	);
+	await expect(page.locator('#error')).toHaveText(
+		'Please enter a valid wordpress-develop PR number or URL.'
+	);
+});
+
 test('wordpress.html: a numeric PR is forwarded to plugin-proxy', async ({
 	page,
 }) => {
@@ -81,6 +94,19 @@ test('gutenberg.html: non-PR input shows a gutenberg-specific error', async ({
 }) => {
 	await page.goto('./gutenberg.html');
 	await submit(page, 'oh-no');
+	await expect(page.locator('#error')).toHaveText(
+		'Please enter a valid gutenberg PR number or URL.'
+	);
+});
+
+test('gutenberg.html: malformed Gutenberg PR URL shows a validation error', async ({
+	page,
+}) => {
+	await page.goto('./gutenberg.html');
+	await submit(
+		page,
+		'https://github.com/WordPress/gutenberg/pull/not-a-number'
+	);
 	await expect(page.locator('#error')).toHaveText(
 		'Please enter a valid gutenberg PR number or URL.'
 	);

--- a/packages/playground/website/public/gutenberg.html
+++ b/packages/playground/website/public/gutenberg.html
@@ -120,12 +120,11 @@
 			prNumber = prNumber.trim();
 
 			// Extract number from a GitHub URL
-			if (
-				prNumber
-					.toLowerCase()
-					.includes('github.com/wordpress/gutenberg/pull')
-			) {
-				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
+			const gutenbergPr = prNumber.match(
+				/github\.com\/wordpress\/gutenberg\/pull\/(\d+)/i
+			);
+			if (gutenbergPr) {
+				prNumber = gutenbergPr[1];
 			}
 
 			if (!/^\d+$/.test(prNumber)) {

--- a/packages/playground/website/public/wordpress.html
+++ b/packages/playground/website/public/wordpress.html
@@ -137,12 +137,11 @@
 			prNumber = prNumber.trim();
 
 			// Extract number from a GitHub URL
-			if (
-				prNumber
-					.toLowerCase()
-					.includes('github.com/wordpress/wordpress-develop/pull')
-			) {
-				prNumber = prNumber.match(/\/pull\/(\d+)/)[1];
+			const wordpressDevelopPr = prNumber.match(
+				/github\.com\/wordpress\/wordpress-develop\/pull\/(\d+)/i
+			);
+			if (wordpressDevelopPr) {
+				prNumber = wordpressDevelopPr[1];
 			}
 
 			if (!/^\d+$/.test(prNumber)) {


### PR DESCRIPTION
## What changed

- Avoid dereferencing a missing regex match when parsing same-repo PR URLs in the standalone previewer pages.
- Let malformed same-repo URLs fall through to the existing validation error state.
- Add Playwright regression coverage for malformed wordpress-develop and Gutenberg PR URLs.

## Testing

- npx prettier --check packages/playground/website/public/wordpress.html packages/playground/website/public/gutenberg.html packages/playground/website/playwright/e2e/standalone-pr-previewers.spec.ts

Stacked on #3748.