### PR TITLE
Preserve request host in PWA manifests

### DIFF
--- a/packages/playground/personal-wp/public/dynamic-manifest.json.php
+++ b/packages/playground/personal-wp/public/dynamic-manifest.json.php
@@ -38,19 +38,20 @@ function getManifestId($start_url) {
     return $path . ($query ? '?' . http_build_query($query) : '');
 }
 
-function getTrustedBaseUrl($fallback_host) {
+function getRequestBaseUrl($fallback_host) {
     $http_host = $_SERVER['HTTP_HOST'] ?? $fallback_host;
-    $hostname = strtolower(parse_url('http://' . $http_host, PHP_URL_HOST) ?? '');
-    $allowed_hosts = [ $fallback_host, 'localhost', '127.0.0.1', '::1' ];
+    $has_valid_http_host =
+        is_string($http_host) &&
+        preg_match('/^(\[[0-9a-f:.]+\]|[a-z0-9.-]+)(:\d+)?$/i', $http_host);
 
-    if (!in_array($hostname, $allowed_hosts, true)) {
+    if (!$has_valid_http_host) {
         $http_host = $fallback_host;
     }
 
     return (isHttps() ? 'https://' : 'http://') . $http_host;
 }
 
-$base_url = getTrustedBaseUrl('my.wordpress.net');
+$base_url = getRequestBaseUrl('my.wordpress.net');
 $start_url = $base_url . ($_GET ? '/?' . http_build_query($_GET) : '/');
 
 $app_name = $_GET['app_name'] ?? 'My WordPress';

--- a/packages/playground/personal-wp/src/lib/pwa-manifest.spec.ts
+++ b/packages/playground/personal-wp/src/lib/pwa-manifest.spec.ts
@@ -57,7 +57,14 @@ describe('PWA manifest configuration', () => {
 		expect(php).toContain("unset($query['random']);");
 		expect(php).toContain('"id" => getManifestId($start_url)');
 		expect(php).toContain('"scope" => $base_url . "/"');
-		expect(php).toContain("getTrustedBaseUrl('my.wordpress.net')");
+		expect(php).toContain('function getRequestBaseUrl($fallback_host)');
+		expect(php).toContain(
+			"$http_host = $_SERVER['HTTP_HOST'] ?? $fallback_host;"
+		);
+		expect(php).toContain(
+			"$base_url = getRequestBaseUrl('my.wordpress.net');"
+		);
+		expect(php).not.toContain('allowed_hosts');
 		expect(php).toContain(" : '/'");
 		expect(php).not.toContain('"shortcuts" =>');
 		expect(php).toContain(

--- a/packages/playground/website/public/dynamic-manifest.json.php
+++ b/packages/playground/website/public/dynamic-manifest.json.php
@@ -44,19 +44,20 @@ function getShortcutUrl($base_url, $wordpress_url) {
 	return $base_url . '/?' . http_build_query($query);
 }
 
-function getTrustedBaseUrl($fallback_host) {
+function getRequestBaseUrl($fallback_host) {
     $http_host = $_SERVER['HTTP_HOST'] ?? $fallback_host;
-    $hostname = strtolower(parse_url('http://' . $http_host, PHP_URL_HOST) ?? '');
-    $allowed_hosts = [ $fallback_host, 'localhost', '127.0.0.1', '::1' ];
+    $has_valid_http_host =
+        is_string($http_host) &&
+        preg_match('/^(\[[0-9a-f:.]+\]|[a-z0-9.-]+)(:\d+)?$/i', $http_host);
 
-    if (!in_array($hostname, $allowed_hosts, true)) {
+    if (!$has_valid_http_host) {
         $http_host = $fallback_host;
     }
 
     return (isHttps() ? 'https://' : 'http://') . $http_host;
 }
 
-$base_url = getTrustedBaseUrl('playground.wordpress.net');
+$base_url = getRequestBaseUrl('playground.wordpress.net');
 $start_url = $base_url . ($_GET ? '/?' . http_build_query($_GET) : '/');
 
 $app_name = $_GET['app_name'] ?? 'WordPress Playground';

--- a/packages/playground/website/src/lib/pwa-manifest.spec.ts
+++ b/packages/playground/website/src/lib/pwa-manifest.spec.ts
@@ -66,7 +66,14 @@ describe('PWA manifest configuration', () => {
 		expect(php).toContain("unset($query['random']);");
 		expect(php).toContain('"id" => getManifestId($start_url)');
 		expect(php).toContain('"scope" => $base_url . "/"');
-		expect(php).toContain("getTrustedBaseUrl('playground.wordpress.net')");
+		expect(php).toContain('function getRequestBaseUrl($fallback_host)');
+		expect(php).toContain(
+			"$http_host = $_SERVER['HTTP_HOST'] ?? $fallback_host;"
+		);
+		expect(php).toContain(
+			"$base_url = getRequestBaseUrl('playground.wordpress.net');"
+		);
+		expect(php).not.toContain('allowed_hosts');
 		expect(php).toContain(
 			'function getShortcutUrl($base_url, $wordpress_url)'
 		);


### PR DESCRIPTION
## Summary
- Replace the dynamic manifest host allowlist with request-host handling for valid `HTTP_HOST` values.
- Keep canonical fallbacks for missing or malformed hosts.
- Update PWA manifest specs to assert the request-host behavior and absence of a hard-coded allowlist.

Stacked on #3742.

## Testing
- `npm exec nx test playground-website`
- `npm exec nx test playground-personal-wp`

Note: I could not run `php -l` locally because `php` is not installed in this workspace.