### PR TITLE
[Docs] Prevent stale PHP snippet script in docs previews

### DIFF
--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import type { ExampleName } from './PhpCodeSnippetLiveExample.examples';
 
-const SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
+// php-code-snippet.js used to be served with a one-year browser cache.
+// Keep this query so docs previews don't reuse stale pre-editable-default copies.
+const SCRIPT_URL =
+	'https://playground.wordpress.net/php-code-snippet.js?v=editable-by-default';
 
 function usePhpSnippetScript() {
 	useEffect(() => {
@@ -23,11 +26,13 @@ function usePhpSnippetExample(name: ExampleName) {
 		let isCurrent = true;
 
 		setHtml(undefined);
-		void import('./PhpCodeSnippetLiveExample.examples').then(({ examples }) => {
-			if (isCurrent) {
-				setHtml(examples[name]);
+		void import('./PhpCodeSnippetLiveExample.examples').then(
+			({ examples }) => {
+				if (isCurrent) {
+					setHtml(examples[name]);
+				}
 			}
-		});
+		);
 
 		return () => {
 			isCurrent = false;

--- a/packages/playground/website-deployment/custom-redirects-lib.php
+++ b/packages/playground/website-deployment/custom-redirects-lib.php
@@ -369,6 +369,7 @@ function playground_get_custom_response_headers( $requested_path ) {
 			$filename,
 			array(
 				'index.js',
+				'php-code-snippet.js',
 				'blueprint-schema.json',
 				'logger.php',
 				'oauth.php',


### PR DESCRIPTION
## What changed

- Kept `<php-snippet>` examples relying on the runtime default: runnable snippets are editable unless `readonly` or `runnable="false"` opts out.
- Added `php-code-snippet.js` to the WP Cloud custom-header path so it is served with no-cache headers going forward.
- Added a cache-busting query for the docs live previews so browsers do not reuse stale one-year-cached copies of `php-code-snippet.js` from before editable-by-default shipped.

## Why

`editable` is already the default in the current snippet runtime. The docs issue can happen when a browser still has an older `php-code-snippet.js` cached; that file is currently served with `Cache-Control: max-age=31536000`. A stale cached script predates the editable-by-default behavior, so the examples look locked even though the current source defaults to editable.

## Testing

- `php -l packages/playground/website-deployment/custom-redirects-lib.php`
- PHP assertion that `/php-code-snippet.js` receives `Access-Control-Allow-Origin: *` and no-cache headers
- `npm exec nx lint docs-site`
- `git diff --check`
