### PR TITLE
Improve Personal WP loading resilience

### DIFF
--- a/packages/php-wasm/progress/src/lib/emscripten-download-monitor.ts
+++ b/packages/php-wasm/progress/src/lib/emscripten-download-monitor.ts
@@ -86,6 +86,9 @@ export class EmscriptenDownloadMonitor extends EventTarget {
 				detail: {
 					loaded: sumValues(this.#progress),
 					total: sumValues(this.#assetsSizes),
+					fileName,
+					fileLoaded: loaded,
+					fileTotal: fileSize,
 				},
 			})
 		);
@@ -107,6 +110,18 @@ export interface DownloadProgress {
 	 * The length number of bytes to load.
 	 */
 	total: number;
+	/**
+	 * The file that emitted this progress update.
+	 */
+	fileName?: string;
+	/**
+	 * The number of bytes loaded for the current file.
+	 */
+	fileLoaded?: number;
+	/**
+	 * The length number of bytes to load for the current file.
+	 */
+	fileTotal?: number;
 }
 
 /**

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -96,6 +96,7 @@ export class BlueprintsV1Handler {
 				setProgressCaption(
 					progressTracker,
 					formatRuntimeDownloadCaption(
+						runtimeDownload.label,
 						runtimeDownload.loaded,
 						runtimeDownload.total,
 						stalledForMs
@@ -105,35 +106,54 @@ export class BlueprintsV1Handler {
 		};
 		await playground.onDownloadProgress((event: any) => {
 			downloadProgress.loadingListener(event);
-			const { loaded, total } = event.detail || {};
+			const {
+				loaded,
+				total,
+				fileName,
+				fileLoaded = loaded,
+				fileTotal = total,
+			} = event.detail || {};
 			if (
 				typeof loaded !== 'number' ||
 				typeof total !== 'number' ||
 				total <= 0
 			) {
-				setProgressCaption(
-					progressTracker,
-					'Downloading runtime assets'
-				);
+				setProgressCaption(progressTracker, getDownloadLabel(fileName));
 				return;
 			}
-			runtimeDownload = { loaded, total, updatedAt: Date.now() };
+			runtimeDownload = {
+				label: getDownloadLabel(fileName),
+				loaded: fileLoaded,
+				total: fileTotal,
+				updatedAt: Date.now(),
+			};
 			if (loaded >= total) {
 				stopRuntimeDownloadHeartbeat();
 				setProgressCaption(
 					progressTracker,
-					`Compiling runtime assets (100%, ${formatBytes(total)} downloaded)`
+					getCompletedDownloadCaption(runtimeDownload.label, total)
 				);
 				return;
 			}
 			const percent = Math.max(
 				0,
-				Math.min(99, Math.floor((loaded / total) * 100))
+				Math.min(
+					99,
+					Math.floor(
+						(runtimeDownload.loaded / runtimeDownload.total) * 100
+					)
+				)
 			);
 			ensureRuntimeDownloadHeartbeat();
 			setProgressCaption(
 				progressTracker,
-				formatRuntimeDownloadCaption(loaded, total, 0, percent)
+				formatRuntimeDownloadCaption(
+					runtimeDownload.label,
+					runtimeDownload.loaded,
+					runtimeDownload.total,
+					0,
+					percent
+				)
 			);
 		});
 		await playground.addEventListener?.('boot.progress', (event: any) => {
@@ -304,6 +324,7 @@ type WordPressInstallMode = NonNullable<
 >;
 
 interface RuntimeDownloadProgress {
+	label: string;
 	loaded: number;
 	total: number;
 	updatedAt: number;
@@ -317,6 +338,7 @@ function setProgressCaption(
 }
 
 function formatRuntimeDownloadCaption(
+	label: string,
 	loaded: number,
 	total: number,
 	stalledForMs: number,
@@ -326,9 +348,32 @@ function formatRuntimeDownloadCaption(
 		stalledForMs >= 5000
 			? `, no data for ${Math.floor(
 					stalledForMs / 1000
-				)}s; interrupted downloads restart`
+				)}s; waiting to resume`
 			: '';
-	return `Downloading runtime assets ${percent}% (${formatBytes(loaded)} / ${formatBytes(total)}${stalledSuffix})`;
+	return `${label} ${percent}% (${formatBytes(loaded)} / ${formatBytes(total)}${stalledSuffix})`;
+}
+
+function getDownloadLabel(fileName?: string): string {
+	if (!fileName) {
+		return 'Downloading files';
+	}
+	if (fileName.endsWith('.wasm') || fileName.startsWith('php_')) {
+		return 'Downloading PHP runtime';
+	}
+	if (fileName.includes('wordpress')) {
+		return 'Downloading WordPress';
+	}
+	if (fileName.includes('sqlite')) {
+		return 'Downloading SQLite integration';
+	}
+	return `Downloading ${fileName}`;
+}
+
+function getCompletedDownloadCaption(label: string, total: number): string {
+	if (label === 'Downloading PHP runtime') {
+		return `Compiling PHP runtime (100%, ${formatBytes(total)} downloaded)`;
+	}
+	return `Preparing downloaded files (100%, ${formatBytes(total)} downloaded)`;
 }
 
 function formatBytes(bytes: number): string {

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -324,7 +324,9 @@ function formatRuntimeDownloadCaption(
 ): string {
 	const stalledSuffix =
 		stalledForMs >= 5000
-			? `, no data for ${Math.floor(stalledForMs / 1000)}s`
+			? `, no data for ${Math.floor(
+					stalledForMs / 1000
+				)}s; interrupted downloads restart`
 			: '';
 	return `Downloading runtime assets ${percent}% (${formatBytes(loaded)} / ${formatBytes(total)}${stalledSuffix})`;
 }

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -68,6 +68,41 @@ export class BlueprintsV1Handler {
 			? ['intl']
 			: [];
 		extensions.push(...(this.options.extensions || []));
+		let runtimeDownload: RuntimeDownloadProgress | undefined;
+		let runtimeDownloadHeartbeat:
+			| ReturnType<typeof setInterval>
+			| undefined;
+		const stopRuntimeDownloadHeartbeat = () => {
+			if (runtimeDownloadHeartbeat) {
+				clearInterval(runtimeDownloadHeartbeat);
+				runtimeDownloadHeartbeat = undefined;
+			}
+		};
+		const ensureRuntimeDownloadHeartbeat = () => {
+			if (runtimeDownloadHeartbeat) {
+				return;
+			}
+			runtimeDownloadHeartbeat = setInterval(() => {
+				if (
+					!runtimeDownload ||
+					runtimeDownload.loaded >= runtimeDownload.total
+				) {
+					return;
+				}
+				const stalledForMs = Date.now() - runtimeDownload.updatedAt;
+				if (stalledForMs < 5000) {
+					return;
+				}
+				setProgressCaption(
+					progressTracker,
+					formatRuntimeDownloadCaption(
+						runtimeDownload.loaded,
+						runtimeDownload.total,
+						stalledForMs
+					)
+				);
+			}, 1000);
+		};
 		await playground.onDownloadProgress((event: any) => {
 			downloadProgress.loadingListener(event);
 			const { loaded, total } = event.detail || {};
@@ -82,7 +117,9 @@ export class BlueprintsV1Handler {
 				);
 				return;
 			}
+			runtimeDownload = { loaded, total, updatedAt: Date.now() };
 			if (loaded >= total) {
+				stopRuntimeDownloadHeartbeat();
 				setProgressCaption(
 					progressTracker,
 					`Compiling runtime assets (100%, ${formatBytes(total)} downloaded)`
@@ -93,9 +130,10 @@ export class BlueprintsV1Handler {
 				0,
 				Math.min(99, Math.floor((loaded / total) * 100))
 			);
+			ensureRuntimeDownloadHeartbeat();
 			setProgressCaption(
 				progressTracker,
-				`Downloading runtime assets ${percent}% (${formatBytes(loaded)} / ${formatBytes(total)})`
+				formatRuntimeDownloadCaption(loaded, total, 0, percent)
 			);
 		});
 		await playground.addEventListener?.('boot.progress', (event: any) => {
@@ -150,6 +188,7 @@ export class BlueprintsV1Handler {
 		);
 		await playground.isReady();
 		downloadProgress.finish();
+		stopRuntimeDownloadHeartbeat();
 
 		setProgressCaption(progressTracker, 'Connecting Playground client');
 		collectPhpLogs(logger, playground);
@@ -264,11 +303,30 @@ type WordPressInstallMode = NonNullable<
 	StartPlaygroundOptions['wordpressInstallMode']
 >;
 
+interface RuntimeDownloadProgress {
+	loaded: number;
+	total: number;
+	updatedAt: number;
+}
+
 function setProgressCaption(
 	progressTracker: ProgressTracker,
 	caption: string
 ): void {
 	progressTracker.setCaption?.(caption);
+}
+
+function formatRuntimeDownloadCaption(
+	loaded: number,
+	total: number,
+	stalledForMs: number,
+	percent = Math.max(0, Math.min(99, Math.floor((loaded / total) * 100)))
+): string {
+	const stalledSuffix =
+		stalledForMs >= 5000
+			? `, no data for ${Math.floor(stalledForMs / 1000)}s`
+			: '';
+	return `Downloading runtime assets ${percent}% (${formatBytes(loaded)} / ${formatBytes(total)}${stalledSuffix})`;
 }
 
 function formatBytes(bytes: number): string {

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -69,6 +69,11 @@ export class BlueprintsV1Handler {
 			: [];
 		extensions.push(...(this.options.extensions || []));
 		await playground.onDownloadProgress(downloadProgress.loadingListener);
+		await playground.addEventListener?.('boot.progress', (event: any) => {
+			if (typeof event.caption === 'string') {
+				setProgressCaption(progressTracker, event.caption);
+			}
+		});
 		// Blueprint's `preferredVersions.wp: false` is the declarative way to
 		// opt out of WordPress. Bundles carry their declaration inside a JSON
 		// file we haven't read here, so we only honor the flag for inline

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -51,7 +51,15 @@ export class BlueprintsV1Handler {
 			iframe.contentWindow!,
 			iframe.ownerDocument!.defaultView!
 		) as PlaygroundClient;
+		setProgressCaption(
+			progressTracker,
+			'Waiting for remote Playground runtime'
+		);
 		await playground.isConnected();
+		setProgressCaption(
+			progressTracker,
+			'Resolving Playground runtime versions'
+		);
 		progressTracker.pipe(playground);
 
 		const runtimeConfiguration =
@@ -88,6 +96,7 @@ export class BlueprintsV1Handler {
 					'`preferredVersions.wp: false`. Pick one.'
 			);
 		}
+		setProgressCaption(progressTracker, 'Booting PHP and WordPress');
 		await playground.boot({
 			mounts,
 			sapiName,
@@ -101,12 +110,18 @@ export class BlueprintsV1Handler {
 			sqliteDriverVersion,
 			pathAliases,
 		});
+		setProgressCaption(
+			progressTracker,
+			'Waiting for WordPress to be ready'
+		);
 		await playground.isReady();
 		downloadProgress.finish();
 
+		setProgressCaption(progressTracker, 'Connecting Playground client');
 		collectPhpLogs(logger, playground);
 		onClientConnected?.(playground);
 
+		setProgressCaption(progressTracker, 'Preparing blueprint steps');
 		const reflection = await BlueprintReflection.create(blueprint);
 		if (reflection.getVersion() === 1) {
 			const compiled = await compileBlueprintV1(blueprint, {
@@ -116,6 +131,7 @@ export class BlueprintsV1Handler {
 				corsProxy,
 				gitAdditionalHeadersCallback,
 			});
+			setProgressCaption(progressTracker, 'Running blueprint steps');
 			await runBlueprintV1Steps(compiled, playground);
 		}
 
@@ -213,3 +229,10 @@ async function isWpAdminLandingPage(blueprint: BlueprintV1): Promise<boolean> {
 type WordPressInstallMode = NonNullable<
 	StartPlaygroundOptions['wordpressInstallMode']
 >;
+
+function setProgressCaption(
+	progressTracker: ProgressTracker,
+	caption: string
+): void {
+	progressTracker.setCaption?.(caption);
+}

--- a/packages/playground/client/src/blueprints-v1-handler.ts
+++ b/packages/playground/client/src/blueprints-v1-handler.ts
@@ -68,7 +68,36 @@ export class BlueprintsV1Handler {
 			? ['intl']
 			: [];
 		extensions.push(...(this.options.extensions || []));
-		await playground.onDownloadProgress(downloadProgress.loadingListener);
+		await playground.onDownloadProgress((event: any) => {
+			downloadProgress.loadingListener(event);
+			const { loaded, total } = event.detail || {};
+			if (
+				typeof loaded !== 'number' ||
+				typeof total !== 'number' ||
+				total <= 0
+			) {
+				setProgressCaption(
+					progressTracker,
+					'Downloading runtime assets'
+				);
+				return;
+			}
+			if (loaded >= total) {
+				setProgressCaption(
+					progressTracker,
+					`Compiling runtime assets (100%, ${formatBytes(total)} downloaded)`
+				);
+				return;
+			}
+			const percent = Math.max(
+				0,
+				Math.min(99, Math.floor((loaded / total) * 100))
+			);
+			setProgressCaption(
+				progressTracker,
+				`Downloading runtime assets ${percent}% (${formatBytes(loaded)} / ${formatBytes(total)})`
+			);
+		});
 		await playground.addEventListener?.('boot.progress', (event: any) => {
 			if (typeof event.caption === 'string') {
 				setProgressCaption(progressTracker, event.caption);
@@ -240,4 +269,16 @@ function setProgressCaption(
 	caption: string
 ): void {
 	progressTracker.setCaption?.(caption);
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) {
+		return `${bytes} B`;
+	}
+	const megabytes = bytes / 1024 / 1024;
+	if (megabytes >= 1) {
+		return `${megabytes.toFixed(1)} MB`;
+	}
+	const kilobytes = bytes / 1024;
+	return `${kilobytes.toFixed(0)} KB`;
 }

--- a/packages/playground/client/src/index.ts
+++ b/packages/playground/client/src/index.ts
@@ -156,12 +156,13 @@ export async function startPlaygroundWeb(
 			? 'v2'
 			: 'v1',
 	});
-	progressTracker.setCaption('Preparing WordPress');
+	progressTracker.setCaption('Loading Playground iframe');
 
 	await new Promise((resolve) => {
 		iframe.src = remoteUrl;
 		iframe.addEventListener('load', resolve, false);
 	});
+	progressTracker.setCaption('Connecting to Playground runtime');
 
 	const handler = options.experimentalBlueprintsV2Runner
 		? new BlueprintsV2Handler(options)

--- a/packages/playground/personal-wp/index.html
+++ b/packages/playground/personal-wp/index.html
@@ -21,6 +21,66 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 		<link rel="stylesheet" href="/src/styles.css" />
+		<style>
+			html,
+			body,
+			#root {
+				width: 100%;
+				height: 100%;
+				margin: 0;
+				background: #fff;
+				color: #1e1e1e;
+				color-scheme: light;
+			}
+			#initial-loading-screen {
+				position: fixed;
+				inset: 0;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				background: #fff;
+				color: #1e1e1e;
+				font-family:
+					-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+					sans-serif;
+			}
+			#initial-loading-screen .initial-loading-content {
+				width: min(420px, calc(100% - 48px));
+			}
+			#initial-loading-screen .initial-loading-title {
+				margin: 0 0 10px;
+				font-size: 18px;
+				font-weight: 500;
+				line-height: 1.3;
+			}
+			#initial-loading-screen .initial-loading-caption {
+				margin: 0 0 14px;
+				color: #50575e;
+				font-size: 13px;
+				line-height: 1.4;
+			}
+			#initial-loading-screen .initial-loading-track {
+				height: 4px;
+				overflow: hidden;
+				border-radius: 999px;
+				background: #e0e0e0;
+			}
+			#initial-loading-screen .initial-loading-bar {
+				width: 42%;
+				height: 100%;
+				border-radius: inherit;
+				background: #3858e9;
+				animation: initial-loading 1.2s ease-in-out infinite;
+			}
+			@keyframes initial-loading {
+				0% {
+					transform: translateX(-120%);
+				}
+				100% {
+					transform: translateX(260%);
+				}
+			}
+		</style>
 		<script>
 			/**
 			 * Dynamically create <link rel="manifest" /> to enable using Playground with
@@ -243,6 +303,17 @@
 		</script>
 
 		<main id="root" aria-label="WordPress Playground">
+			<div id="initial-loading-screen" role="status" aria-live="polite">
+				<div class="initial-loading-content">
+					<p class="initial-loading-title">Loading My WordPress</p>
+					<p class="initial-loading-caption">
+						Preparing the app shell...
+					</p>
+					<div class="initial-loading-track">
+						<div class="initial-loading-bar"></div>
+					</div>
+				</div>
+			</div>
 			<script>
 				const query = new URLSearchParams(window.location.search);
 				const shouldLazyLoadPlayground =
@@ -264,7 +335,7 @@
 
 					const root = document.getElementById('root');
 					root.classList.add('lazy-loading');
-					root.appendChild(initiator);
+					root.replaceChildren(initiator);
 				}
 			</script>
 		</main>

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -870,9 +870,8 @@ function getCardStageCss(): string {
   .habit-label.done { color: var(--ink); text-decoration: line-through; text-decoration-color: var(--ink-faint); }
   .habit-streak { font-size: 10px; color: var(--ink-faint); }
 
-  /* Boot progress: checkmarks fill in over time, regardless of expansion
-     state, so opening the card late shows progress already made. Timings
-     are a visual narrative, not real progress. */
+  /* Boot progress: synced to the actual runtime boot caption via
+     LoadingScreenHtml[data-boot-step]. */
   .boot-step .habit-check::after {
     content: '✓';
     position: absolute; inset: 0;
@@ -880,41 +879,50 @@ function getCardStageCss(): string {
     color: var(--accent-on); font-size: 10px; font-weight: 600;
     opacity: 0;
   }
-  .boot-step .habit-check {
-    animation: boot-fill 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  .boot-step .habit-check,
+  .boot-step .habit-check::after,
+  .boot-step .habit-label { transition: 0.2s ease-out; }
+  :host([data-boot-step="1"]) .boot-step.bs1 .habit-check,
+  :host([data-boot-step="2"]) .boot-step.bs1 .habit-check,
+  :host([data-boot-step="2"]) .boot-step.bs2 .habit-check,
+  :host([data-boot-step="3"]) .boot-step.bs1 .habit-check,
+  :host([data-boot-step="3"]) .boot-step.bs2 .habit-check,
+  :host([data-boot-step="3"]) .boot-step.bs3 .habit-check,
+  :host([data-boot-step="4"]) .boot-step.bs1 .habit-check,
+  :host([data-boot-step="4"]) .boot-step.bs2 .habit-check,
+  :host([data-boot-step="4"]) .boot-step.bs3 .habit-check,
+  :host([data-boot-step="4"]) .boot-step.bs4 .habit-check,
+  :host([data-boot-step="5"]) .boot-step .habit-check {
+    background: var(--accent); border-color: var(--accent);
   }
-  .boot-step .habit-check::after {
-    animation: boot-mark 0.3s ease-out forwards;
+  :host([data-boot-step="1"]) .boot-step.bs1 .habit-check::after,
+  :host([data-boot-step="2"]) .boot-step.bs1 .habit-check::after,
+  :host([data-boot-step="2"]) .boot-step.bs2 .habit-check::after,
+  :host([data-boot-step="3"]) .boot-step.bs1 .habit-check::after,
+  :host([data-boot-step="3"]) .boot-step.bs2 .habit-check::after,
+  :host([data-boot-step="3"]) .boot-step.bs3 .habit-check::after,
+  :host([data-boot-step="4"]) .boot-step.bs1 .habit-check::after,
+  :host([data-boot-step="4"]) .boot-step.bs2 .habit-check::after,
+  :host([data-boot-step="4"]) .boot-step.bs3 .habit-check::after,
+  :host([data-boot-step="4"]) .boot-step.bs4 .habit-check::after,
+  :host([data-boot-step="5"]) .boot-step .habit-check::after {
+    opacity: 1;
   }
-  .boot-step .habit-label {
-    animation: boot-strike 0.3s ease-out forwards;
+  :host([data-boot-step="1"]) .boot-step.bs1 .habit-label,
+  :host([data-boot-step="2"]) .boot-step.bs1 .habit-label,
+  :host([data-boot-step="2"]) .boot-step.bs2 .habit-label,
+  :host([data-boot-step="3"]) .boot-step.bs1 .habit-label,
+  :host([data-boot-step="3"]) .boot-step.bs2 .habit-label,
+  :host([data-boot-step="3"]) .boot-step.bs3 .habit-label,
+  :host([data-boot-step="4"]) .boot-step.bs1 .habit-label,
+  :host([data-boot-step="4"]) .boot-step.bs2 .habit-label,
+  :host([data-boot-step="4"]) .boot-step.bs3 .habit-label,
+  :host([data-boot-step="4"]) .boot-step.bs4 .habit-label,
+  :host([data-boot-step="5"]) .boot-step .habit-label {
+    color: var(--ink);
+    text-decoration: line-through;
+    text-decoration-color: var(--ink-faint);
   }
-  @keyframes boot-fill {
-    to { background: var(--accent); border-color: var(--accent); }
-  }
-  @keyframes boot-mark { to { opacity: 1; } }
-  @keyframes boot-strike {
-    to {
-      color: var(--ink);
-      text-decoration: line-through;
-      text-decoration-color: var(--ink-faint);
-    }
-  }
-  .boot-step.bs1 .habit-check,
-  .boot-step.bs1 .habit-check::after,
-  .boot-step.bs1 .habit-label { animation-delay: 1s; }
-  .boot-step.bs2 .habit-check,
-  .boot-step.bs2 .habit-check::after,
-  .boot-step.bs2 .habit-label { animation-delay: 3s; }
-  .boot-step.bs3 .habit-check,
-  .boot-step.bs3 .habit-check::after,
-  .boot-step.bs3 .habit-label { animation-delay: 6s; }
-  .boot-step.bs4 .habit-check,
-  .boot-step.bs4 .habit-check::after,
-  .boot-step.bs4 .habit-label { animation-delay: 9s; }
-  .boot-step.bs5 .habit-check,
-  .boot-step.bs5 .habit-check::after,
-  .boot-step.bs5 .habit-label { animation-delay: 12s; }
 
   /* Backups wiki */
   .wiki-term { font-size: 15px; font-weight: 600; color: var(--ink); margin-bottom: 2px; }
@@ -1512,6 +1520,7 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 				<LoadingScreen
 					html={loadingScreenHtml}
 					progress={bootProgress}
+					bootStep={getBootChecklistStep(bootProgress)}
 					onInteract={handleLoadingInteract}
 					showReadyButton={showReadyButton}
 					onStart={() => setIsBooting(false)}
@@ -1556,12 +1565,14 @@ function getInitialBootProgress(): ProgressDetails {
 function LoadingScreen({
 	html,
 	progress,
+	bootStep,
 	onInteract,
 	showReadyButton,
 	onStart,
 }: {
 	html: string;
 	progress: ProgressDetails;
+	bootStep: number;
 	onInteract: () => void;
 	showReadyButton: boolean;
 	onStart: () => void;
@@ -1583,7 +1594,7 @@ function LoadingScreen({
 			onTouchStart={onInteract}
 			onWheel={onInteract}
 		>
-			<LoadingScreenHtml html={html} />
+			<LoadingScreenHtml html={html} bootStep={bootStep} />
 			<LoadingProgress
 				progress={progress}
 				showReadyButton={showReadyButton}
@@ -1595,8 +1606,10 @@ function LoadingScreen({
 
 const LoadingScreenHtml = memo(function LoadingScreenHtml({
 	html,
+	bootStep,
 }: {
 	html: string;
+	bootStep: number;
 }) {
 	const hostRef = useRef<HTMLDivElement>(null);
 	const renderedHtmlRef = useRef<string | null>(null);
@@ -1615,8 +1628,56 @@ const LoadingScreenHtml = memo(function LoadingScreenHtml({
 		renderedHtmlRef.current = html;
 	}, [html]);
 
+	useLayoutEffect(() => {
+		hostRef.current?.setAttribute('data-boot-step', String(bootStep));
+	}, [bootStep]);
+
 	return <div ref={hostRef} className={css.loadingScreenHtml} />;
 });
+
+function getBootChecklistStep(progress: ProgressDetails): number {
+	if (progress.progress >= 100) {
+		return 5;
+	}
+	const caption = progress.caption.toLowerCase();
+	if (
+		caption.includes('finalizing') ||
+		caption.includes('runtime ready') ||
+		caption.includes('wordpress boot complete') ||
+		caption.includes('waiting for wordpress to be ready') ||
+		caption.includes('connecting playground client')
+	) {
+		return 5;
+	}
+	if (
+		caption.includes('database') ||
+		caption.includes('sqlite') ||
+		caption.includes('wp-config') ||
+		caption.includes('wordpress constants') ||
+		caption.includes('existing wordpress installation')
+	) {
+		return 4;
+	}
+	if (
+		caption.includes('wordpress download') ||
+		caption.includes('extracting wordpress') ||
+		caption.includes('wordpress files') ||
+		caption.includes('wordpress installer')
+	) {
+		return 3;
+	}
+	if (caption.includes('php runtime')) {
+		return 2;
+	}
+	if (
+		caption.includes('playground') ||
+		caption.includes('wasm') ||
+		caption.includes('iframe')
+	) {
+		return 1;
+	}
+	return 0;
+}
 
 function getSanitizedLoadingScreenNodes(html: string): Node[] {
 	const doc = new DOMParser().parseFromString(html, 'text/html');

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1,4 +1,12 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+	memo,
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 import type { KeyboardEvent, RefObject } from 'react';
 import {
 	type BlueprintV1Declaration,
@@ -1541,7 +1549,7 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 function getInitialBootProgress(): ProgressDetails {
 	return {
 		progress: 0,
-		caption: 'Preparing WordPress',
+		caption: 'Loading Playground iframe',
 	};
 }
 
@@ -1593,7 +1601,7 @@ const LoadingScreenHtml = memo(function LoadingScreenHtml({
 	const hostRef = useRef<HTMLDivElement>(null);
 	const renderedHtmlRef = useRef<string | null>(null);
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		if (renderedHtmlRef.current === html) {
 			return;
 		}

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1657,10 +1657,7 @@ function LoadingProgress({
 						className={css.loadingProgressCaption}
 						aria-live="polite"
 					>
-						{progress.caption}
-					</div>
-					<div className={css.loadingProgressDetail}>
-						{Math.round(progressValue)}%
+						{progress.caption} · {Math.round(progressValue)}%
 					</div>
 					<div className={css.loadingProgressTrack}>
 						<div

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1659,6 +1659,9 @@ function LoadingProgress({
 					>
 						{progress.caption}
 					</div>
+					<div className={css.loadingProgressDetail}>
+						{Math.round(progressValue)}%
+					</div>
 					<div className={css.loadingProgressTrack}>
 						<div
 							className={css.loadingProgressBar}

--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -1726,7 +1726,15 @@ function LoadingProgress({
 						className={css.loadingProgressCaption}
 						aria-live="polite"
 					>
-						{progress.caption} · {Math.round(progressValue)}%
+						<span
+							className={css.loadingProgressCaptionText}
+							title={progress.caption}
+						>
+							{progress.caption}
+						</span>
+						<span className={css.loadingProgressPercent}>
+							{Math.round(progressValue)}%
+						</span>
 					</div>
 					<div className={css.loadingProgressTrack}>
 						<div

--- a/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
+++ b/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
@@ -63,12 +63,18 @@
 
 .loading-progress-caption {
 	margin-bottom: 8px;
-	overflow: hidden;
 	font-size: 13px;
 	font-weight: 500;
 	line-height: 1.3;
-	text-overflow: ellipsis;
-	white-space: nowrap;
+	overflow-wrap: anywhere;
+}
+
+.loading-progress-detail {
+	margin: -3px 0 8px;
+	color: #50575e;
+	font-size: 11px;
+	font-weight: 500;
+	line-height: 1.3;
 }
 
 .loading-progress-track {
@@ -116,6 +122,10 @@
 
 	.loading-progress-track {
 		background: #3c434a;
+	}
+
+	.loading-progress-detail {
+		color: #c3c4c7;
 	}
 }
 

--- a/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
+++ b/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
@@ -36,6 +36,8 @@
 	z-index: 10;
 	overflow: hidden;
 	background: #fff;
+	color-scheme: light;
+	color: #1e1e1e;
 }
 
 .loading-screen-html {
@@ -96,25 +98,9 @@
 	cursor: pointer;
 }
 
-.loading-ready-button:hover {
+.loading-ready-button:hover,
+.loading-ready-button:focus-visible {
 	background: #2145e6;
-}
-
-@media (prefers-color-scheme: dark) {
-	.loading-screen {
-		background: #111;
-	}
-
-	.loading-progress {
-		border-color: rgba(255, 255, 255, 0.14);
-		background: rgba(30, 30, 30, 0.88);
-		box-shadow: 0 8px 28px rgba(0, 0, 0, 0.3);
-		color: #f0f0f1;
-	}
-
-	.loading-progress-track {
-		background: #3c434a;
-	}
 }
 
 /* Sidebar latch — tab on the bottom-left edge */

--- a/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
+++ b/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
@@ -64,11 +64,27 @@
 }
 
 .loading-progress-caption {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	gap: 10px;
+	align-items: baseline;
+	min-height: 17px;
 	margin-bottom: 8px;
 	font-size: 13px;
 	font-weight: 500;
 	line-height: 1.3;
-	overflow-wrap: anywhere;
+}
+
+.loading-progress-caption-text {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.loading-progress-percent {
+	font-variant-numeric: tabular-nums;
+	color: #50575e;
 }
 
 .loading-progress-track {

--- a/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
+++ b/packages/playground/personal-wp/src/components/playground-viewport/style.module.css
@@ -69,14 +69,6 @@
 	overflow-wrap: anywhere;
 }
 
-.loading-progress-detail {
-	margin: -3px 0 8px;
-	color: #50575e;
-	font-size: 11px;
-	font-weight: 500;
-	line-height: 1.3;
-}
-
 .loading-progress-track {
 	height: 4px;
 	overflow: hidden;
@@ -122,10 +114,6 @@
 
 	.loading-progress-track {
 		background: #3c434a;
-	}
-
-	.loading-progress-detail {
-		color: #c3c4c7;
 	}
 }
 

--- a/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/boot-site-client.ts
@@ -81,6 +81,11 @@ export function bootSiteClient(
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
 	) => {
+		const reportBootProgress = (progress: number, caption: string) => {
+			onProgress?.({ progress, caption });
+		};
+
+		reportBootProgress(1, 'Reading site settings');
 		signal.onabort = () => {
 			destroyTabCoordinator();
 			dispatch(removeClientInfo(siteSlug));
@@ -94,6 +99,7 @@ export function bootSiteClient(
 
 		let mountDescriptor = undefined;
 		if (site.metadata.storage === 'opfs') {
+			reportBootProgress(3, 'Preparing browser storage');
 			mountDescriptor = {
 				device: {
 					type: 'opfs',
@@ -105,6 +111,7 @@ export function bootSiteClient(
 				mountpoint: '/wordpress',
 			} as const;
 		} else if (site.metadata.storage === 'local-fs') {
+			reportBootProgress(3, 'Loading local folder access');
 			let localDirectoryHandle;
 			try {
 				localDirectoryHandle = await loadDirectoryHandle(site.slug);
@@ -130,6 +137,7 @@ export function bootSiteClient(
 		let isWordPressInstalled = false;
 		if (mountDescriptor) {
 			try {
+				reportBootProgress(6, 'Checking existing WordPress files');
 				isWordPressInstalled = await playgroundAvailableInOpfs(
 					await directoryHandleFromMountDevice(mountDescriptor.device)
 				);
@@ -153,10 +161,17 @@ export function bootSiteClient(
 				return;
 			}
 		}
+		reportBootProgress(
+			8,
+			isWordPressInstalled
+				? 'Found existing WordPress files'
+				: 'No existing WordPress install found'
+		);
 
 		// Only one tab may run the Personal WP runtime at a time. Other tabs
 		// preserve their iframe and observe the browser-managed main-tab locks.
 		if (site.metadata.storage !== 'none') {
+			reportBootProgress(10, 'Checking for another open tab');
 			const tabInfo = await initTabCoordinator(site.slug, {
 				onMainTabStatusChange: (mainTabStatus) => {
 					if (!selectClientInfoBySiteSlug(getState(), site.slug)) {
@@ -176,6 +191,7 @@ export function bootSiteClient(
 			});
 
 			if (tabInfo.isDependentMode) {
+				reportBootProgress(14, 'Connecting to the main tab');
 				bootDependentModeClient({
 					siteSlug: site.slug,
 					iframe,
@@ -192,6 +208,7 @@ export function bootSiteClient(
 			}
 		}
 
+		reportBootProgress(16, 'Preparing boot blueprint');
 		let blueprint: Blueprint;
 		if (isWordPressInstalled) {
 			blueprint = {
@@ -256,6 +273,10 @@ export function bootSiteClient(
 				: isWordPressInstalled
 					? 'install-from-existing-files-if-needed'
 					: 'download-and-install';
+		reportBootProgress(
+			18,
+			getWordPressInstallModeCaption(wordpressInstallMode)
+		);
 
 		let playground: PlaygroundClient | undefined = undefined;
 		const progressTracker = new ProgressTracker();
@@ -264,14 +285,16 @@ export function bootSiteClient(
 			(event: ProgressTrackerEvent) => {
 				onProgress?.({
 					progress: event.detail.progress,
-					caption: event.detail.caption,
+					caption: `Playground runtime: ${event.detail.caption}`,
 				});
 			}
 		);
 		progressTracker.addEventListener('done', () => {
+			reportBootProgress(100, 'WordPress runtime is ready');
 			onReady?.();
 		});
 		try {
+			reportBootProgress(20, 'Starting Playground runtime');
 			await startPlaygroundWeb({
 				iframe: iframe!,
 				remoteUrl: getRemoteUrl().toString(),
@@ -287,6 +310,7 @@ export function bootSiteClient(
 				// Intercept the Playground client even if the
 				// Blueprint fails.
 				onClientConnected: (playgroundClient) => {
+					reportBootProgress(88, 'Connected to Playground client');
 					playground = (window as any)['playground'] =
 						playgroundClient;
 				},
@@ -302,6 +326,7 @@ export function bootSiteClient(
 				corsProxy: corsProxyUrl,
 			});
 		} catch (e) {
+			reportBootProgress(100, 'Boot failed');
 			logger.error(e);
 			const firewallError = findFirewallErrorInCauseChain(e);
 			if (
@@ -357,8 +382,10 @@ export function bootSiteClient(
 			return;
 		}
 
+		reportBootProgress(92, 'Setting up browser message relay');
 		setupPostMessageRelay(iframe, document.location.origin);
 
+		reportBootProgress(94, 'Registering active WordPress client');
 		dispatch(
 			addClientInfo({
 				siteSlug: site.slug,
@@ -404,6 +431,7 @@ export function bootSiteClient(
 
 		// Clear URL blueprint after successful boot
 		if (hasUrlBlueprint) {
+			reportBootProgress(96, 'Cleaning up launch URL');
 			dispatch(setBlueprintResolvedFromUrl(null));
 			if (clearUrlAfterBlueprintApplied) {
 				const cleanUrl = new URL(window.location.href);
@@ -421,6 +449,7 @@ export function bootSiteClient(
 			destroyTabCoordinator();
 			dispatch(removeClientInfo(site.slug));
 		};
+		reportBootProgress(100, 'WordPress is ready');
 	};
 }
 
@@ -482,6 +511,22 @@ type BootUsageStatsMetadata = Pick<
 	SiteMetadata,
 	'lastUsageStatsReturningVisitDate'
 >;
+
+function getWordPressInstallModeCaption(
+	wordpressInstallMode:
+		| 'do-not-attempt-installing'
+		| 'install-from-existing-files-if-needed'
+		| 'download-and-install'
+): string {
+	switch (wordpressInstallMode) {
+		case 'do-not-attempt-installing':
+			return 'Skipping WordPress installation';
+		case 'install-from-existing-files-if-needed':
+			return 'Booting from existing WordPress files';
+		case 'download-and-install':
+			return 'Downloading and installing WordPress';
+	}
+}
 
 function bootDependentModeClient({
 	siteSlug,

--- a/packages/playground/personal-wp/src/styles.css
+++ b/packages/playground/personal-wp/src/styles.css
@@ -157,6 +157,9 @@ body {
 	margin: 0;
 	padding: 0;
 	height: 100%;
+	background: #fff;
+	color: #1e1e1e;
+	color-scheme: light;
 	/* The same font settings as in wp-admin */
 	font-size: 13px;
 	font-family:
@@ -228,6 +231,8 @@ h4 {
 #root {
 	height: 100%;
 	width: 100%;
+	background: #fff;
+	color: #1e1e1e;
 }
 
 #root.lazy-loading {

--- a/packages/playground/remote/service-worker.ts
+++ b/packages/playground/remote/service-worker.ts
@@ -339,6 +339,13 @@ self.addEventListener('fetch', (event) => {
 		return;
 	}
 
+	// Deliberate partial requests are used to resume stalled runtime downloads.
+	// Do not strip their Range header or cache the 206 Partial Content response.
+	if (event.request.headers.has('range')) {
+		event.respondWith(fetch(event.request));
+		return;
+	}
+
 	// Use cache first strategy to serve regular static assets.
 	return event.respondWith(cacheFirstFetch(event.request));
 });

--- a/packages/playground/remote/src/lib/offline-mode-cache.ts
+++ b/packages/playground/remote/src/lib/offline-mode-cache.ts
@@ -166,6 +166,14 @@ export async function hasCachedResponse(
 	return !!cachedResponse;
 }
 
+export async function putCachedResponse(
+	url: string,
+	response: Response
+): Promise<void> {
+	const offlineModeCache = await promisedOfflineModeCache;
+	await offlineModeCache.put(url, response);
+}
+
 export function shouldCacheUrl(url: URL) {
 	if (url.href.includes('wordpress-static.zip')) {
 		return true;

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -81,6 +81,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 				withNetworking,
 				phpVersion: phpVersion!,
 				pathAliases,
+				onProgress: reportBootProgress,
 			});
 
 			this.requestedWordPressVersion =

--- a/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint-blueprints-v1.ts
@@ -64,7 +64,14 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 					? 'install-from-existing-files-if-needed'
 					: 'download-and-install');
 			const siteUrl = this.computeSiteUrl(scope);
+			const reportBootProgress = (caption: string) => {
+				this.dispatchEvent({
+					type: 'boot.progress',
+					caption,
+				});
+			};
 
+			reportBootProgress('Creating Playground request handler');
 			const requestHandler = await this.createRequestHandler({
 				siteUrl,
 				sapiName,
@@ -88,6 +95,7 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			const wpDetails = getWordPressModuleDetails(wpVersion);
 			let wordPressRequest: Promise<Response> | null = null;
 			if (resolvedWordPressInstallMode === 'download-and-install') {
+				reportBootProgress('Preparing WordPress download');
 				if (this.requestedWordPressVersion!.startsWith('http')) {
 					wordPressRequest = this.downloadMonitor
 						.monitorFetch(
@@ -161,11 +169,14 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			// PHP-only mode: the caller asked us to skip WordPress boot entirely.
 			// Apply mounts and stop, so the caller gets a usable PHP runtime.
 			if (resolvedWordPressInstallMode === 'do-not-attempt-installing') {
+				reportBootProgress('Creating PHP runtime');
 				const primaryPhp = await requestHandler.getPrimaryPhp();
 				for (const mount of mounts) {
+					reportBootProgress('Mounting WordPress files');
 					await endpoint.mountOpfsIntoPhp(primaryPhp, mount);
 				}
 				this.__internal_setRequestHandler(requestHandler);
+				reportBootProgress('PHP runtime ready');
 				setApiReady();
 				return;
 			}
@@ -184,10 +195,12 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 			this.downloadMonitor.expectAssets({
 				[sqliteDriverModuleDetails.url]: sqliteDriverModuleDetails.size,
 			});
+			reportBootProgress('Preparing SQLite integration download');
 			const sqliteIntegrationRequest = this.downloadMonitor.monitorFetch(
 				fetch(sqliteDriverModuleDetails.url)
 			);
 
+			reportBootProgress('Booting WordPress');
 			await bootWordPress(requestHandler, {
 				siteUrl,
 				phpVersion,
@@ -233,13 +246,16 @@ class PlaygroundWorkerEndpointBlueprintsV1 extends PlaygroundWorkerEndpoint {
 						}
 					},
 				},
+				onProgress: reportBootProgress,
 			});
 
+			reportBootProgress('Finalizing WordPress runtime');
 			await this.finalizeAfterBoot(
 				requestHandler,
 				withNetworking,
 				knownRemoteAssetPaths
 			);
+			reportBootProgress('WordPress runtime ready');
 			setApiReady();
 		} catch (e) {
 			setAPIError(e as Error);

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -25,6 +25,7 @@ import {
 	backfillStaticFilesRemovedFromMinifiedBuild,
 	hasCachedStaticFilesRemovedFromMinifiedBuild,
 } from './worker-utils';
+import { hasCachedResponse } from './offline-mode-cache';
 /* @ts-ignore */
 import transportFetch from './playground-mu-plugin/playground-includes/wp_http_fetch.php?raw';
 /* @ts-ignore */
@@ -230,7 +231,11 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 							imports: any,
 							receiveInstance: any
 						) => {
-							onProgress?.('Downloading PHP runtime');
+							onProgress?.(
+								(await hasCachedResponse(wasmUrl))
+									? 'Loading cached PHP runtime'
+									: 'Downloading PHP runtime'
+							);
 							const response = await this.memoizedFetch(wasmUrl, {
 								credentials: 'same-origin',
 							});

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -25,7 +25,7 @@ import {
 	backfillStaticFilesRemovedFromMinifiedBuild,
 	hasCachedStaticFilesRemovedFromMinifiedBuild,
 } from './worker-utils';
-import { hasCachedResponse } from './offline-mode-cache';
+import { hasCachedResponse, putCachedResponse } from './offline-mode-cache';
 /* @ts-ignore */
 import transportFetch from './playground-mu-plugin/playground-includes/wp_http_fetch.php?raw';
 /* @ts-ignore */
@@ -215,15 +215,17 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 			phpVersion,
 			createPhpRuntime: async () => {
 				let wasmUrl = '';
+				let wasmTotalSize = 0;
 				onProgress?.('Loading PHP runtime module');
 				return await loadWebRuntime(phpVersion, {
 					extensions,
 					tcpOverFetch,
 					onPhpLoaderModuleLoaded: (phpLoaderModule) => {
 						wasmUrl = phpLoaderModule.dependencyFilename;
+						wasmTotalSize = phpLoaderModule.dependenciesTotalSize;
 						onProgress?.('Preparing PHP runtime download');
 						this.downloadMonitor.expectAssets({
-							[wasmUrl]: phpLoaderModule.dependenciesTotalSize,
+							[wasmUrl]: wasmTotalSize,
 						});
 					},
 					emscriptenOptions: {
@@ -236,9 +238,22 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 									? 'Loading cached PHP runtime'
 									: 'Downloading PHP runtime'
 							);
-							const response = await this.memoizedFetch(wasmUrl, {
-								credentials: 'same-origin',
-							});
+							const response =
+								await this.downloadMonitor.monitorFetch(
+									fetchWithInMemoryResume(
+										wasmUrl,
+										{
+											credentials: 'same-origin',
+										},
+										{
+											expectedTotal: wasmTotalSize,
+											onResume: (offset) =>
+												onProgress?.(
+													`Resuming PHP runtime download at ${formatBytes(offset)}`
+												),
+										}
+									)
+								);
 							onProgress?.('Streaming and compiling PHP runtime');
 							const wasm = await WebAssembly.instantiateStreaming(
 								response as Response,
@@ -593,6 +608,162 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		this.unmounts[options.mountpoint] = unmount;
 		this.opfsMounts[options.mountpoint] = opfsMount;
 	}
+}
+
+async function fetchWithInMemoryResume(
+	url: string,
+	init: RequestInit,
+	options: {
+		expectedTotal: number;
+		onResume?: (offset: number) => void;
+		stallTimeoutMs?: number;
+		maxRetries?: number;
+	}
+): Promise<Response> {
+	const stallTimeoutMs = options.stallTimeoutMs ?? 15000;
+	const maxRetries = options.maxRetries ?? 10;
+	const firstFetch = await fetchRuntimeChunk(url, init, 0);
+	const responseHeaders = new Headers(firstFetch.response.headers);
+	responseHeaders.set('content-length', `${options.expectedTotal}`);
+
+	const responseInit = {
+		status: firstFetch.response.status,
+		statusText: firstFetch.response.statusText,
+		headers: responseHeaders,
+	};
+	const body = new ReadableStream<Uint8Array>({
+		async start(controller) {
+			let loaded = 0;
+			let retries = 0;
+			let chunkFetch = firstFetch;
+
+			while (loaded < options.expectedTotal) {
+				const reader = chunkFetch.response.body?.getReader();
+				if (!reader) {
+					controller.error(
+						new Error('PHP runtime response has no body')
+					);
+					return;
+				}
+				try {
+					while (true) {
+						const { done, value } = await readWithTimeout(
+							reader,
+							stallTimeoutMs,
+							chunkFetch.abort
+						);
+						if (done) {
+							break;
+						}
+						if (value) {
+							loaded += value.byteLength;
+							controller.enqueue(value);
+						}
+					}
+				} catch (error) {
+					if (loaded >= options.expectedTotal) {
+						break;
+					}
+					if (++retries > maxRetries) {
+						controller.error(error);
+						return;
+					}
+					options.onResume?.(loaded);
+					chunkFetch = await fetchRuntimeChunk(url, init, loaded);
+					continue;
+				}
+
+				if (loaded >= options.expectedTotal) {
+					break;
+				}
+				if (++retries > maxRetries) {
+					controller.error(
+						new Error(
+							`PHP runtime download ended early at ${loaded} bytes`
+						)
+					);
+					return;
+				}
+				options.onResume?.(loaded);
+				chunkFetch = await fetchRuntimeChunk(url, init, loaded);
+			}
+
+			controller.close();
+		},
+	});
+	const [runtimeBody, cacheBody] = body.tee();
+	const response = new Response(runtimeBody, responseInit);
+	putCachedResponse(url, new Response(cacheBody, responseInit)).catch(
+		(error) => logger.warn('Failed to cache PHP runtime response', error)
+	);
+	Object.defineProperty(response, 'url', {
+		value: url,
+	});
+	return response;
+}
+
+async function fetchRuntimeChunk(
+	url: string,
+	init: RequestInit,
+	offset: number
+): Promise<{ response: Response; abort: () => void }> {
+	const abortController = new AbortController();
+	const headers = new Headers(init.headers);
+	if (offset > 0) {
+		headers.set('range', `bytes=${offset}-`);
+	}
+	const response = await fetch(url, {
+		...init,
+		headers,
+		signal: abortController.signal,
+	});
+	if (offset > 0 && response.status !== 206) {
+		throw new Error(
+			`Cannot resume PHP runtime download because the server returned HTTP ${response.status}`
+		);
+	}
+	if (offset === 0 && !response.ok) {
+		throw new Error(
+			`Failed to download PHP runtime: HTTP ${response.status}`
+		);
+	}
+	return {
+		response,
+		abort: () => abortController.abort(),
+	};
+}
+
+function readWithTimeout(
+	reader: ReadableStreamDefaultReader<Uint8Array>,
+	timeoutMs: number,
+	abort: () => void
+): Promise<ReadableStreamReadResult<Uint8Array>> {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+	return Promise.race([
+		reader.read(),
+		new Promise<ReadableStreamReadResult<Uint8Array>>((_, reject) => {
+			timeout = setTimeout(() => {
+				abort();
+				reject(new Error('PHP runtime download stalled'));
+			}, timeoutMs);
+		}),
+	]).finally(() => {
+		if (timeout) {
+			clearTimeout(timeout);
+		}
+	});
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) {
+		return `${bytes} B`;
+	}
+	const megabytes = bytes / 1024 / 1024;
+	if (megabytes >= 1) {
+		return `${megabytes.toFixed(1)} MB`;
+	}
+	const kilobytes = bytes / 1024;
+	return `${kilobytes.toFixed(0)} KB`;
 }
 
 function createNullPrototypeRecord<T>() {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -14,7 +14,6 @@ import {
 	createDirectoryHandleMountHandler,
 	loadWebRuntime,
 } from '@php-wasm/web';
-import { createMemoizedFetch } from '@wp-playground/common';
 import { directoryHandleFromMountDevice } from '@wp-playground/storage';
 import {
 	LatestMinifiedWordPressVersion,
@@ -127,15 +126,11 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 	private requestHandler: PHPRequestHandler | undefined;
 
 	protected downloadMonitor: EmscriptenDownloadMonitor;
-	protected memoizedFetch: ReturnType<typeof createMemoizedFetch>;
 
 	constructor(monitor: EmscriptenDownloadMonitor) {
 		super(undefined, monitor);
 
 		this.downloadMonitor = monitor;
-		const monitoredFetch = (input: RequestInfo | URL, init?: RequestInit) =>
-			this.downloadMonitor.monitorFetch(fetch(input, init));
-		this.memoizedFetch = createMemoizedFetch(monitoredFetch);
 	}
 
 	protected computeSiteUrl(scope: string) {

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -234,11 +234,12 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 							const response = await this.memoizedFetch(wasmUrl, {
 								credentials: 'same-origin',
 							});
-							onProgress?.('Instantiating PHP runtime');
+							onProgress?.('Streaming and compiling PHP runtime');
 							const wasm = await WebAssembly.instantiateStreaming(
 								response as Response,
 								imports
 							);
+							onProgress?.('Attaching PHP runtime');
 							receiveInstance(wasm.instance, wasm.module);
 							return {} as any;
 						},

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -152,6 +152,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		withNetworking,
 		phpVersion,
 		pathAliases,
+		onProgress,
 	}: {
 		siteUrl: string;
 		sapiName: string;
@@ -161,6 +162,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		withNetworking: boolean;
 		phpVersion: AllPHPVersion;
 		pathAliases?: PathAlias[];
+		onProgress?: (caption: string) => void;
 	}) {
 		const phpIniEntries: Record<string, string> = {
 			'openssl.cafile': '/internal/shared/ca-bundle.crt',
@@ -172,9 +174,11 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 		if (withNetworking) {
 			// @TODO: Is it fine this is only set in this code branch? That
 			//        makes sense and all, but the previous worker always created the transport.
+			onProgress?.('Preparing network transport');
 			this.networkTransport = new WordPressFetchNetworkTransport({
 				corsProxyUrl,
 			});
+			onProgress?.('Generating networking certificate');
 			const CAroot = await generateCertificate({
 				subject: {
 					commonName: 'WordPressPlaygroundCA',
@@ -191,6 +195,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				corsProxyUrl,
 			};
 		} else {
+			onProgress?.('Disabling network transport');
 			phpIniEntries['allow_url_fopen'] = '0';
 			phpIniEntries['disable_functions'] = (
 				phpIniEntries['disable_functions'] ?? ''
@@ -203,16 +208,19 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 
 		const parsedSiteUrl = new URL(siteUrl);
 		const isLegacyPhp = isLegacyPHPVersion(phpVersion);
+		onProgress?.('Creating PHP request handler');
 		const requestHandler = await bootRequestHandler({
 			siteUrl,
 			phpVersion,
 			createPhpRuntime: async () => {
 				let wasmUrl = '';
+				onProgress?.('Loading PHP runtime module');
 				return await loadWebRuntime(phpVersion, {
 					extensions,
 					tcpOverFetch,
 					onPhpLoaderModuleLoaded: (phpLoaderModule) => {
 						wasmUrl = phpLoaderModule.dependencyFilename;
+						onProgress?.('Preparing PHP runtime download');
 						this.downloadMonitor.expectAssets({
 							[wasmUrl]: phpLoaderModule.dependenciesTotalSize,
 						});
@@ -222,9 +230,11 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 							imports: any,
 							receiveInstance: any
 						) => {
+							onProgress?.('Downloading PHP runtime');
 							const response = await this.memoizedFetch(wasmUrl, {
 								credentials: 'same-origin',
 							});
+							onProgress?.('Instantiating PHP runtime');
 							const wasm = await WebAssembly.instantiateStreaming(
 								response as Response,
 								imports
@@ -236,6 +246,11 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				});
 			},
 			onPHPInstanceCreated: async (php: PHP, { isPrimary }) => {
+				onProgress?.(
+					isPrimary
+						? 'Creating primary PHP instance'
+						: 'Creating secondary PHP instance'
+				);
 				if (!isPrimary) {
 					const pathsToShareBetweenPhpInstances = [
 						'/tmp',
@@ -261,6 +276,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 					);
 				}
 				if (withNetworking) {
+					onProgress?.('Setting up PHP network transport');
 					await this.networkTransport!.setupMessageHandler(php);
 				}
 			},
@@ -315,6 +331,7 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 			},
 		});
 
+		onProgress?.('Connecting primary PHP runtime');
 		const primaryPhp = await requestHandler.getPrimaryPhp();
 		primaryPhp.requestHandler ??= requestHandler;
 		await this.setPrimaryPHP(primaryPhp);

--- a/packages/playground/wordpress/src/boot.ts
+++ b/packages/playground/wordpress/src/boot.ts
@@ -202,6 +202,8 @@ export interface BootWordPressOptions {
 	 * and WP_SITEURL constants in WordPress.
 	 */
 	siteUrl: string;
+	/** Called when WordPress boot advances to a new high-level step. */
+	onProgress?: (caption: string) => void;
 }
 
 /**
@@ -227,16 +229,20 @@ export async function bootWordPress(
 		return bootLegacyWordPress(requestHandler, options);
 	}
 
+	options.onProgress?.('Creating PHP runtime');
 	const php = await requestHandler.getPrimaryPhp();
 	if (options.hooks?.beforeWordPressFiles) {
+		options.onProgress?.('Mounting WordPress files');
 		await options.hooks.beforeWordPressFiles(php);
 	}
 
 	if (options.wordPressZip) {
+		options.onProgress?.('Extracting WordPress files');
 		await unzipWordPress(php, await options.wordPressZip);
 	}
 
 	if (options.constants) {
+		options.onProgress?.('Defining WordPress constants');
 		for (const key in options.constants) {
 			php.defineConstant(key, options.constants[key]);
 		}
@@ -255,9 +261,11 @@ export async function bootWordPress(
 	 * them. This is needed because some WordPress backups and exports may not
 	 * include definitions for some of the necessary constants.
 	 */
+	options.onProgress?.('Preparing wp-config.php');
 	await ensureWpConfig(php, requestHandler.documentRoot);
 	// Run "before database" hooks to mount/copy more files in
 	if (options.hooks?.beforeDatabaseSetup) {
+		options.onProgress?.('Preparing database files');
 		await options.hooks.beforeDatabaseSetup(php);
 	}
 
@@ -266,6 +274,7 @@ export async function bootWordPress(
 	let usesSqlite = false;
 	if (options.sqliteIntegrationPluginZip) {
 		usesSqlite = true;
+		options.onProgress?.('Installing SQLite integration');
 		await preloadSqliteIntegration(
 			php,
 			await options.sqliteIntegrationPluginZip,
@@ -284,12 +293,14 @@ export async function bootWordPress(
 		)
 	) {
 		// Check database prerequisites before attempting installation
+		options.onProgress?.('Checking database prerequisites');
 		await assertDatabasePrerequisites(requestHandler, {
 			usesSqlite,
 			hasCustomDatabasePath,
 		});
 		// Install WordPress if it's not installed.
 		try {
+			options.onProgress?.('Running WordPress installer');
 			await installWordPress(php);
 		} catch (error) {
 			// If installation failed, check if it's a database issue
@@ -302,17 +313,21 @@ export async function bootWordPress(
 		}
 		// Validate the database connection after installation (skip if user provided custom DB path)
 		if (!hasCustomDatabasePath) {
+			options.onProgress?.('Validating database connection');
 			await assertValidDatabaseConnection(requestHandler);
 		}
 	} else if ('install-from-existing-files-if-needed' === installationMode) {
 		// Check database prerequisites before attempting installation
+		options.onProgress?.('Checking database prerequisites');
 		await assertDatabasePrerequisites(requestHandler, {
 			usesSqlite,
 			hasCustomDatabasePath,
 		});
+		options.onProgress?.('Checking existing WordPress installation');
 		if (!(await isWordPressInstalled(php))) {
 			// Install WordPress if it's not installed.
 			try {
+				options.onProgress?.('Running WordPress installer');
 				await installWordPress(php);
 			} catch (error) {
 				// If installation failed, check if it's a database issue
@@ -326,10 +341,12 @@ export async function bootWordPress(
 		}
 		// Validate the database connection after installation (skip if user provided custom DB path)
 		if (!hasCustomDatabasePath) {
+			options.onProgress?.('Validating database connection');
 			await assertValidDatabaseConnection(requestHandler);
 		}
 	}
 
+	options.onProgress?.('WordPress boot complete');
 	return requestHandler;
 }
 


### PR DESCRIPTION
## What?

This PR improves Personal WP's loading experience on slow or unreliable connections. It was split out from the desktop relay prototype so the loading/network resilience work can be reviewed independently.

## What users see

Personal WP now gives earlier and more specific feedback during boot:

- An immediate preloading screen appears before React finishes loading, avoiding the blank/black/white screen gap.
- The boot checklist follows real Playground runtime progress instead of staying on a vague repeated message.
- The progress line stays visually stable instead of jumping between one and two lines.
- PHP runtime downloads show percentage and transferred bytes, for example `Downloading PHP runtime 88% (17.9 MB / 20.3 MB)`.
- If no bytes arrive for several seconds, the progress line says so, for example `no data for 12s; waiting to resume`.
- Later boots can show when the PHP runtime is already available from the build-versioned cache.

## How this helps repeated attempts

The large PHP WebAssembly runtime must be fully available before WordPress can finish booting. Previously, if that download stalled near the end, the user saw little actionable information and a reload often meant starting the same large download again.

With this PR:

1. The page keeps already received bytes in memory while it remains open.
2. If the PHP runtime response stalls, the loader retries with a `Range` request from the last received byte.
3. When the resumed download completes, the assembled full response is stored in the normal Playground CacheStorage cache for the current build.
4. A later reload can use the cached PHP runtime instead of downloading it again.

This does not persist partial downloads across a page reload. The benefit is that a stalled first attempt can recover while the page is still open, and once it completes successfully, future attempts for the same build can reuse the cached full runtime.

## Implementation notes

- Adds per-file download metadata to `EmscriptenDownloadMonitor` events (`fileName`, `fileLoaded`, `fileTotal`).
- Uses those per-file details to label downloads more accurately instead of using a generic "runtime assets" caption.
- Adds an in-memory resumable fetch path for the PHP runtime download.
- Lets deliberate `Range` requests pass through the service worker without trying to cache partial `206` responses.
- Writes the reassembled full runtime response into the existing build-versioned offline cache.

## What is not included?

This intentionally excludes the desktop relay/viewer work. There is no `relay.php`, desktop viewer/connect UI, tunnel host, relay URL rewriter, or desktop traffic diagnostics in this PR.

## Testing

```bash
npm exec nx typecheck php-wasm-progress
npm exec nx typecheck playground-client
npm exec nx typecheck playground-remote
npm exec nx typecheck playground-personal-wp
```
