### PR TITLE
[Web] Decline TLS session resumption for shared curl handles

### DIFF
--- a/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
+++ b/packages/php-wasm/web/src/lib/tls/1_2/connection.ts
@@ -1208,14 +1208,18 @@ class MessageEncoder {
 			.filter((x): x is Uint8Array => x !== undefined);
 		const extensions = concatUint8Arrays(extensionsParts);
 
+		// This TLS bridge does not implement session resumption or session
+		// caching. Returning an empty session id advertises that clients must
+		// use a full handshake even when curl shares its TLS session cache.
+		const sessionId = new Uint8Array();
 		const body = new Uint8Array([
 			// Version field – 0x03, 0x03 means TLS 1.2
 			...TLS_Version_1_2,
 
 			...serverRandom,
 
-			clientHello.session_id.length,
-			...clientHello.session_id,
+			sessionId.length,
+			...sessionId,
 
 			...as2Bytes(CipherSuites.TLS1_CK_ECDHE_RSA_WITH_AES_128_GCM_SHA256),
 

--- a/packages/php-wasm/web/src/test/php-networking.spec.ts
+++ b/packages/php-wasm/web/src/test/php-networking.spec.ts
@@ -14,6 +14,7 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 	let mockServer: http.Server;
 	let corsProxyServer: http2.Http2SecureServer;
 	let serverUrl: string;
+	let secureServerUrl: string;
 	let corsProxyUrl: string;
 
 	test.beforeAll(async () => {
@@ -103,6 +104,19 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 					return;
 				}
 
+				const url = new URL(req.url!, `https://${req.headers.host}`);
+				let targetPath = url.pathname;
+				try {
+					targetPath = new URL(req.url!.slice(1)).pathname;
+				} catch {
+					// This request was not routed through the CORS proxy.
+				}
+				if (targetPath === '/stats/php/1.0/') {
+					res.setHeader('Content-Type', 'application/json');
+					res.end(JSON.stringify({ '8.3': 50, '8.4': 50 }));
+					return;
+				}
+
 				const chunks: Buffer[] = [];
 				req.on('data', (chunk: Buffer) => chunks.push(chunk));
 				req.on('end', () => {
@@ -125,7 +139,8 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 			corsProxyServer.listen(0, '127.0.0.1', () => resolve());
 		});
 		const corsProxyAddr = corsProxyServer.address() as AddressInfo;
-		corsProxyUrl = `https://127.0.0.1:${corsProxyAddr.port}/`;
+		secureServerUrl = `https://127.0.0.1:${corsProxyAddr.port}`;
+		corsProxyUrl = `${secureServerUrl}/`;
 	});
 
 	test.afterAll(() => {
@@ -253,6 +268,79 @@ test.describe('PHP networking through tcp-over-fetch bridge', () => {
 		test.expect(parsed.code).toBe(200);
 		test.expect(parsed.error).toBe('');
 		test.expect(parsed.has83).toBe(true);
+	});
+
+	test('PHP curl can share the TLS session cache between HTTPS requests', async ({
+		page,
+	}) => {
+		const result = await page.evaluate(async (proxyUrl: string) => {
+			const CAroot = await window.generateCertificate({
+				subject: {
+					commonName: 'TestCA',
+					organizationName: 'Test',
+					countryName: 'US',
+				},
+				basicConstraints: { ca: true },
+			});
+
+			const php = new window.PHP(
+				await window.loadWebRuntime('8.4', {
+					tcpOverFetch: {
+						CAroot,
+						corsProxyUrl: proxyUrl,
+					},
+				})
+			);
+
+			const caBundlePath = '/internal/shared/ca-bundle.crt';
+			php.mkdir('/internal/shared');
+			php.writeFile(
+				caBundlePath,
+				window.certificateToPEM(CAroot.certificate)
+			);
+
+			await window.setPhpIniEntries(php, {
+				allow_url_fopen: '1',
+				disable_functions: '',
+				'openssl.cafile': caBundlePath,
+				'curl.cainfo': caBundlePath,
+			});
+
+			const response = await php.runStream({
+				code: `<?php
+					$share = curl_share_init();
+					curl_share_setopt($share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
+
+					$results = [];
+					for ($i = 0; $i < 2; $i++) {
+						$ch = curl_init('https://remote-server.example/stats/php/1.0/');
+						curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+						curl_setopt($ch, CURLOPT_SHARE, $share);
+						$body = curl_exec($ch);
+						$json = json_decode($body, true);
+						$results[] = [
+							'code' => curl_getinfo($ch, CURLINFO_HTTP_CODE),
+							'error' => curl_error($ch),
+							'has83' => is_array($json) && array_key_exists('8.3', $json),
+						];
+						curl_close($ch);
+					}
+					curl_share_close($share);
+					echo json_encode($results);
+				`,
+			});
+			const text = await response.stdoutText;
+			php.exit();
+			return text;
+		}, corsProxyUrl);
+
+		const parsed = JSON.parse(result);
+		test.expect(parsed).toHaveLength(2);
+		for (const request of parsed) {
+			test.expect(request.code).toBe(200);
+			test.expect(request.error).toBe('');
+			test.expect(request.has83).toBe(true);
+		}
 	});
 
 	test('PHP curl receives decompressed body for brotli-compressed response', async ({

--- a/packages/playground/remote/src/lib/playground-worker-endpoint.ts
+++ b/packages/playground/remote/src/lib/playground-worker-endpoint.ts
@@ -190,13 +190,6 @@ export abstract class PlaygroundWorkerEndpoint extends PHPWorker {
 				CAroot,
 				corsProxyUrl,
 			};
-			phpIniEntries['disable_functions'] = (
-				phpIniEntries['disable_functions'] ?? ''
-			)
-				.split(',')
-				.concat(['curl_share_init'])
-				.filter((n) => n)
-				.join(',');
 		} else {
 			phpIniEntries['allow_url_fopen'] = '0';
 			phpIniEntries['disable_functions'] = (


### PR DESCRIPTION
## What it does

Allows `curl_share_init()` to work with Playground’s browser networking layer.

The TLS bridge now declines TLS session resumption instead of echoing the client’s TLS session id. With that change, shared curl handles can reuse libcurl’s shared TLS cache without triggering OpenSSL handshake errors.

## Rationale

Composer uses `curl_share_init()` to share DNS, cookies, and TLS session cache between curl handles. Playground previously disabled `curl_share_init()` because the second HTTPS request could fail with:

```text
SSL routines:ossl_statem_client_read_transition:unexpected message
```

The issue was not `curl_share_init()` itself. The TypeScript TLS bridge returned the client’s session id in `ServerHello`, which made OpenSSL expect abbreviated session resumption on the next shared handle. Playground’s TLS bridge does not implement resumed handshakes, so the next full handshake looked invalid to OpenSSL.

## Implementation

Changed the TLS `ServerHello` response to use an empty session id:

```ts
const sessionId = new Uint8Array();
```

Why that proves resumption is unavailable: [TLS 1.2 RFC 5246, section 7.4.1.3](https://www.rfc-editor.org/rfc/rfc5246#section-7.4.1.3) defines `ServerHello.session_id` as the server’s session identity. If the client offers a non-empty `ClientHello.session_id` and the server returns the same value, that indicates a resumed session and the peers proceed directly to `Finished`. The same section says an empty `session_id` means the session will not be cached and cannot be resumed.

So the bridge now advertises exactly what it supports: full handshakes only. `curl_share_init()` can still share its TLS cache, but OpenSSL will not try to resume against this fake TLS server.

Also stops disabling `curl_share_init` when Playground browser networking is enabled. No runtime php.ini rewrite is needed: `curl_share_init()` is enabled by default, and the fix is to avoid disabling it in new browser runtimes.

## Testing instructions

Run:

```bash
npm install
npm exec nx e2e php-wasm-web
```

New coverage verifies that PHP can:

1. call `curl_share_init()`
2. share `CURL_LOCK_DATA_SSL_SESSION`
3. perform two HTTPS curl requests through `tcpOverFetch` against a local HTTPS fixture
4. receive successful responses both times

Additional checks run locally:

```bash
npm exec nx run php-wasm-web:typecheck
npm exec nx run playground-remote:typecheck
```

I also attempted the targeted e2e locally:

```bash
npm exec nx run php-wasm-web:e2e -- --grep "PHP curl can share the TLS session cache"
```

That did not start because this checkout is missing the Playwright Chromium binary (`npx playwright install` required), not because the test failed.

