### PR TITLE
Use server cache policy for PHP snippet script

### DIFF
--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
@@ -1,10 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import type { ExampleName } from './PhpCodeSnippetLiveExample.examples';
 
-// php-code-snippet.js used to be served with a one-year browser cache.
-// Keep this query so docs previews don't reuse stale pre-editable-default copies.
-const SCRIPT_URL =
-	'https://playground.wordpress.net/php-code-snippet.js?v=editable-by-default';
+const SCRIPT_URL = 'https://playground.wordpress.net/php-code-snippet.js';
 
 function usePhpSnippetScript() {
 	useEffect(() => {


### PR DESCRIPTION
## What changed

Removes the docs-side query-string cache buster from the PHP snippet script URL.

## Why

`php-code-snippet.js` is now covered by the deployment cache policy in `packages/playground/website-deployment/custom-redirects-lib.php`, which serves it with `Cache-Control: max-age=0, no-cache, no-store, must-revalidate`. That makes the server the source of truth for cache behavior instead of requiring docs code to carry a manual or computed cache-busting query.

## Validation

- `npm exec nx lint docs-site`
- `git diff --check`
