### PR TITLE
Fix PHP next assets publishing

### DIFF
--- a/.github/workflows/refresh-php-next.yml
+++ b/.github/workflows/refresh-php-next.yml
@@ -6,9 +6,9 @@ on:
             php_ref:
                 description: 'php-src ref to build (defaults to php-src development branch)'
                 required: false
-    # Refresh PHP next binaries every day at 6am UTC.
+    # Refresh PHP next binaries every 4 days at 6am UTC.
     schedule:
-        - cron: '0 6 * * *'
+        - cron: '0 6 */4 * *'
 
 concurrency:
     group: refresh-php-next
@@ -68,6 +68,7 @@ jobs:
                   trap 'rm -rf "$publish_dir"' EXIT
                   cp -a packages/playground/website/public/php-next/. "$publish_dir/"
 
+                  git reset --hard HEAD
                   git switch --orphan php-next-publish
                   git rm -rf . || true
                   git clean -fdx


### PR DESCRIPTION
## What changed
- Refresh PHP next every four days instead of daily.
- Reset tracked build-side effects before switching to the orphan assets branch used to publish PHP-next binaries.

## Why
The PHP-next build currently succeeds, but publishing fails because the build updates `packages/php-wasm/supported-php-versions.mjs`. That dirty tracked file prevents `git switch --orphan` from creating the `php-next-builds` publishing branch, leaving deploys unable to sync PHP-next assets.

## Validation
- `git diff --check`
- Parsed `.github/workflows/refresh-php-next.yml` as YAML
- Reproduced the publish sequence in a temporary git repository with a dirty tracked file
