### PR TITLE
[Website] Enable full settings editing for autosaved Playgrounds

### DIFF
--- a/packages/playground/website/playwright/e2e/website-ui.spec.ts
+++ b/packages/playground/website/playwright/e2e/website-ui.spec.ts
@@ -810,6 +810,103 @@ test.describe('Default Playground storage', () => {
 		).toBe(true);
 	});
 
+	test('should offer full settings for an autosaved Playground', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.page.goto('./');
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({
+			timeout: 120000,
+		});
+
+		await website.page
+			.getByRole('button', { name: 'Edit Playground settings' })
+			.click();
+
+		await expect(
+			website.page.getByText(
+				'Stored Playgrounds have limited configuration options.'
+			)
+		).toHaveCount(0);
+		await expect(
+			website.page.getByLabel('WordPress version')
+		).toBeEnabled();
+		await expect(website.page.getByLabel('Language')).toBeEnabled();
+		await expect(
+			website.page.getByLabel('Create a multisite network')
+		).toBeEnabled();
+		await expect(
+			website.page.getByText('Apply Settings & Recreate Playground')
+		).toBeVisible();
+	});
+
+	test('should apply settings to an autosaved Playground under the same slug', async ({
+		website,
+		browserName,
+	}) => {
+		test.skip(
+			browserName !== 'chromium',
+			`Saved-by-default Playgrounds rely on OPFS, which is not available in Playwright's ${browserName}.`
+		);
+
+		await website.goto(getUniqueSavedPlaygroundSetupUrl('settings-recreate'));
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		const originalSite = await getActivePlaygroundSite(website.page);
+
+		await website.page
+			.getByRole('button', { name: 'Edit Playground settings' })
+			.click();
+		const phpSelect = website.page.getByLabel('PHP version');
+		const currentPhpVersion = await phpSelect.inputValue();
+		const nextPhpVersion = SupportedPHPVersions.find(
+			(version) => version !== currentPhpVersion
+		)!;
+		await phpSelect.selectOption(nextPhpVersion);
+		await website.page
+			.getByRole('button', {
+				name: 'Apply Settings & Recreate Playground',
+			})
+			.click();
+
+		await expect
+			.poll(() => new URL(website.page.url()).searchParams.get('php'), {
+				timeout: 120000,
+			})
+			.toBe(nextPhpVersion);
+		await expect(
+			website.page.getByRole('button', { name: 'Autosaved' })
+		).toBeVisible({ timeout: 120000 });
+		await expect
+			.poll(() => getActivePlaygroundSite(website.page), {
+				timeout: 120000,
+			})
+			.toMatchObject({
+				slug: originalSite.slug,
+				name: originalSite.name,
+				persistence: 'autosave',
+			});
+		await expect
+			.poll(() =>
+				website.page.evaluate(
+					(slug) =>
+						(window as any).playgroundSites
+							.list()
+							.filter((site: any) => site.slug === slug).length,
+					originalSite.slug
+				)
+			)
+			.toBe(1);
+	});
+
 	test('should show intent-driven creation actions in the overlay', async ({
 		website,
 		browserName,

--- a/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
+++ b/packages/playground/website/src/components/ensure-playground-site/ensure-playground-site-is-selected.tsx
@@ -171,6 +171,19 @@ export function EnsurePlaygroundSiteIsSelected({
 			if (shouldUseTemporarySite) {
 				await sitesAPI.createNewTemporarySite();
 			} else {
+				// Recreating an autosave resets the same slug before routing to
+				// its new setup URL. Keep that pending site selected instead of
+				// treating the route change as a request for another autosave.
+				if (
+					activeSite &&
+					isAutosavedSite(activeSite) &&
+					activeSite.metadata.initialOpfsSyncPending &&
+					getAutosaveFingerprintFromSite(activeSite) ===
+						currentSetupUrlFingerprint
+				) {
+					return;
+				}
+
 				// Offer restore only when the autosave came from the same
 				// setup URL. A different setup URL should create a fresh
 				// Playground even if another autosave exists.

--- a/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/active-site-settings-form.tsx
@@ -1,3 +1,5 @@
+import { isAutosavedSite } from '../../../lib/state/redux/slice-sites';
+import { AutosavedSiteSettingsForm } from './autosaved-site-settings-form';
 import { useActiveSite } from '../../../lib/state/redux/store';
 import { StoredSiteSettingsForm } from './stored-site-settings-form';
 import { TemporarySiteSettingsForm } from './temporary-site-settings-form';
@@ -22,6 +24,24 @@ export function ActiveSiteSettingsForm({
 				/>
 			);
 		case 'opfs':
+			// Autosaved Playgrounds are recoverable unsaved work, so keep the
+			// full setup form available. Explicitly saved OPFS Playgrounds are
+			// user-confirmed artifacts, so they keep the limited stored-site form.
+			if (isAutosavedSite(activeSite)) {
+				return (
+					<AutosavedSiteSettingsForm
+						siteSlug={activeSite.slug}
+						onSubmit={onSubmit}
+					/>
+				);
+			}
+
+			return (
+				<StoredSiteSettingsForm
+					siteSlug={activeSite.slug}
+					onSubmit={onSubmit}
+				/>
+			);
 		case 'local-fs':
 			return (
 				<StoredSiteSettingsForm

--- a/packages/playground/website/src/components/site-manager/site-settings-form/autosaved-site-settings-form.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/autosaved-site-settings-form.tsx
@@ -11,7 +11,14 @@ import {
 	getSiteSettingsFromFormData,
 } from './setup-form-values';
 
-export function TemporarySiteSettingsForm({
+/**
+ * Renders the setup settings form for an autosaved Playground.
+ *
+ * Autosaved Playgrounds represent recoverable unsaved work, so changing setup
+ * fields recreates the same autosaved site instead of creating a second site or
+ * preserving the previous WordPress files.
+ */
+export function AutosavedSiteSettingsForm({
 	siteSlug,
 	onSubmit,
 }: {
@@ -23,10 +30,7 @@ export function TemporarySiteSettingsForm({
 	)!;
 	const sitesAPI = useSitesAPI();
 	const updateSite = async (data: SiteFormData) => {
-		await sitesAPI.createNewTemporarySite(
-			undefined,
-			getSiteSettingsFromFormData(data)
-		);
+		await sitesAPI.recreateAutosavedSite(getSiteSettingsFromFormData(data));
 		onSubmit?.();
 	};
 	const defaultValues = useMemo(
@@ -36,7 +40,7 @@ export function TemporarySiteSettingsForm({
 
 	return (
 		<UnconnectedSiteSettingsForm
-			className="is-temporary-site"
+			className="is-autosaved-site"
 			onSubmit={updateSite}
 			defaultValues={defaultValues}
 			footer={
@@ -48,10 +52,11 @@ export function TemporarySiteSettingsForm({
 				>
 					<p>
 						<b>Destructive action!</b> Applying these settings will
-						reset the WordPress site to its initial state.
+						recreate this autosaved Playground under the same name
+						and replace its current WordPress files.
 					</p>
 					<Button type="submit" variant="primary">
-						Apply Settings & Reset Playground
+						Apply Settings & Recreate Playground
 					</Button>
 				</VStack>
 			}

--- a/packages/playground/website/src/components/site-manager/site-settings-form/index.tsx
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/index.tsx
@@ -1,4 +1,5 @@
 export { ActiveSiteSettingsForm } from './active-site-settings-form';
+export { AutosavedSiteSettingsForm } from './autosaved-site-settings-form';
 export type { SiteFormData } from './unconnected-site-settings-form';
 export { TemporarySiteSettingsForm } from './temporary-site-settings-form';
 export { UnconnectedSiteSettingsForm } from './unconnected-site-settings-form';

--- a/packages/playground/website/src/components/site-manager/site-settings-form/setup-form-values.ts
+++ b/packages/playground/website/src/components/site-manager/site-settings-form/setup-form-values.ts
@@ -1,0 +1,46 @@
+import type { SiteInfo } from '../../../lib/state/redux/slice-sites';
+import type { SiteSettings } from '../../../lib/state/redux/site-management-api-middleware';
+import type { SiteFormData } from './unconnected-site-settings-form';
+
+/**
+ * Returns the setup that should be shown in the settings form.
+ *
+ * Site creation resolves the Blueprint and Query API into
+ * `metadata.runtimeConfiguration`, which records boot settings such as PHP,
+ * WordPress, and networking. Raw setup URL fields that are not part of runtime
+ * configuration, such as `language` and `multisite`, stay in
+ * `originalUrlParams`. The form reads both so it shows the setup that will be
+ * used when recreating a temporary or autosaved Playground.
+ */
+export function getSetupFormDefaultValues(
+	siteInfo: SiteInfo
+): Partial<SiteFormData> {
+	const searchParams = siteInfo.originalUrlParams?.searchParams || {};
+	const runtimeConf = siteInfo.metadata?.runtimeConfiguration || {};
+	const language = searchParams.language;
+	const multisite = searchParams.multisite;
+	return {
+		phpVersion: runtimeConf?.phpVersion as any,
+		wpVersion: runtimeConf?.wpVersion as any,
+		withNetworking: runtimeConf?.networking,
+		language: typeof language === 'string' ? language : '',
+		multisite: multisite === 'yes',
+	};
+}
+
+/**
+ * Converts setup-form values to the settings shape accepted by the site API.
+ *
+ * The form names the networking checkbox `withNetworking` to read naturally in
+ * the UI layer. Site creation and autosave recreation use `networking`, matching
+ * the runtime configuration field stored in site metadata.
+ */
+export function getSiteSettingsFromFormData(data: SiteFormData): SiteSettings {
+	return {
+		phpVersion: data.phpVersion,
+		wpVersion: data.wpVersion,
+		networking: data.withNetworking,
+		language: data.language,
+		multisite: data.multisite,
+	};
+}

--- a/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
@@ -14,7 +14,7 @@ import {
 import { joinPaths } from '@php-wasm/util';
 import { getDirectoryPathForSlug } from './opfs-site-path';
 
-const BUNDLE_DIR_NAME = 'blueprint-bundle';
+export const BUNDLE_DIR_NAME = 'blueprint-bundle';
 
 /**
  * Get the OPFS path for a site's blueprint bundle directory.

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -18,6 +18,7 @@ import {
 import type { AllPHPVersion } from '@php-wasm/universal';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import {
+	BUNDLE_DIR_NAME,
 	loadPersistedBlueprintBundle,
 	loadPersistedBlueprintBundleFromPath,
 } from './opfs-blueprint-bundle-storage';
@@ -183,6 +184,33 @@ class OpfsSiteStorage {
 	}
 
 	/**
+	 * Removes WordPress files from an OPFS-backed site while preserving the
+	 * site metadata file and the editable Blueprint bundle directory.
+	 *
+	 * Autosaved Playgrounds use this before running their edited setup again:
+	 * the Playground keeps the same slug, name, and Blueprint bundle, but
+	 * WordPress must be recreated from that setup instead of reusing files from
+	 * the previous run.
+	 */
+	async resetSiteFiles(slug: string): Promise<void> {
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
+			throw new Error(`Site with slug '${slug}' does not exist.`);
+		}
+		const siteDirectory = await this.root.getDirectoryHandle(siteDirName);
+		const namesToDelete: string[] = [];
+		for await (const [name] of siteDirectory.entries()) {
+			if (name === SITE_METADATA_FILENAME || name === BUNDLE_DIR_NAME) {
+				continue;
+			}
+			namesToDelete.push(name);
+		}
+		for (const name of namesToDelete) {
+			await siteDirectory.removeEntry(name, { recursive: true });
+		}
+	}
+
+	/**
 	 * Finds the directory containing a persisted site's metadata.
 	 *
 	 * A failed save can leave behind an encoded directory without
@@ -225,8 +253,13 @@ async function metadataToStoredFormat(
 		{
 			slug,
 			originalBlueprintSource,
-			// Only store the blueprint declaration if it's NOT a bundle directory.
-			// For bundle directories, the full bundle is stored separately.
+			/**
+			 * Site metadata stores Blueprint declaration JSON, not arbitrary
+			 * bundle files. When the Blueprint source is `opfs-site`, the
+			 * bundle files already live beside the site's WordPress files, so
+			 * metadata points at that OPFS bundle directory instead of
+			 * duplicating the declaration here.
+			 */
 			originalBlueprint:
 				originalBlueprintSource?.type === 'opfs-site'
 					? undefined

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -20,6 +20,7 @@ import {
 	removeSite,
 	pruneAutosavedSites,
 	preserveSite,
+	resetAutosavedSiteSpec,
 	setTemporarySiteSpec,
 	setStoredSiteSpec,
 	deriveSiteNameFromSlug,
@@ -36,6 +37,7 @@ import type { PlaygroundClient } from '@wp-playground/remote';
 import type { AllPHPVersion } from '@php-wasm/universal';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
 import { getSetupUrlFromUrl } from '../playground-identity';
+import { redirectTo } from '../url/router';
 
 export interface SiteSettings {
 	phpVersion?: AllPHPVersion;
@@ -386,6 +388,34 @@ export function createSitesAPI(
 				);
 			}
 			return { slug: site.slug, storage };
+		},
+
+		/**
+		 * Recreates the active autosaved Playground with new setup settings.
+		 *
+		 * Autosaved Playgrounds behave like recoverable unsaved work: changing
+		 * setup settings replaces the current WordPress files under the same
+		 * autosaved slug instead of creating another autosave.
+		 *
+		 * @param settings Optional site settings.
+		 * @throws When no site is selected, the active site is not autosaved, or
+		 *   browser storage cannot be reset.
+		 */
+		async recreateAutosavedSite(settings?: SiteSettings): Promise<void> {
+			const site = selectActiveSite(getState());
+			if (!site) {
+				throw new Error('No active site selected');
+			}
+			if (!isAutosavedSite(site)) {
+				throw new Error(
+					'Only autosaved Playgrounds can be recreated in place.'
+				);
+			}
+			const setupUrl = getSetupUrlForNewSite(settings, {
+				onlySetupParams: true,
+			});
+			await dispatch(resetAutosavedSiteSpec(site.slug, setupUrl));
+			redirectTo(setupUrl.toString());
 		},
 
 		/**

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -29,6 +29,7 @@ import { deriveSlugFromSiteName, getUniqueSiteSlug } from './site-slug';
 import {
 	getAutosavedSitesToPrune,
 	getSitesSortedByRecency,
+	isAutosavedSite,
 	type AutosavedSitesPruneOptions,
 	type SitePersistence,
 } from './site-lifecycle';
@@ -556,6 +557,77 @@ export function setStoredSiteSpec(
 
 		await dispatch(addSite(newSiteInfo));
 		return newSiteInfo;
+	};
+}
+
+/**
+ * Replaces the setup metadata and WordPress files for an autosaved Playground
+ * without changing its slug or display name.
+ *
+ * Autosaves are recoverable unsaved work. Explicitly saved Playgrounds preserve
+ * their WordPress files, so they must not use this reset path.
+ */
+export function resetAutosavedSiteSpec(
+	siteSlug: string,
+	playgroundUrlWithQueryApiArgs: URL
+) {
+	return async (
+		dispatch: PlaygroundDispatch,
+		getState: () => PlaygroundReduxState
+	) => {
+		const site = selectSiteBySlug(getState(), siteSlug);
+		if (!site) {
+			throw new Error(`Site not found: ${siteSlug}`);
+		}
+		if (!isAutosavedSite(site)) {
+			throw new Error(
+				`Cannot reset ${siteSlug}; only autosaved Playgrounds can be recreated in place.`
+			);
+		}
+
+		const resolvedBlueprint = await resolveSiteBlueprintFromUrl(
+			playgroundUrlWithQueryApiArgs
+		);
+		const runtimeConfiguration = (await resolveRuntimeConfiguration(
+			resolvedBlueprint.blueprint
+		))!;
+		// Validate the new setup before deleting the old WordPress files so a
+		// broken Blueprint URL does not destroy the existing autosave.
+		// `isAutosavedSite()` requires OPFS storage; an autosaved site cannot be
+		// selected in a browser session where OPFS storage is unavailable.
+		await opfsSiteStorage!.resetSiteFiles(siteSlug);
+		const now = Date.now();
+		await dispatch(
+			updateSite({
+				slug: siteSlug,
+				changes: {
+					originalUrlParams: getOriginalUrlParams(
+						playgroundUrlWithQueryApiArgs
+					),
+					metadata: {
+						...site.metadata,
+						whenCreated: now,
+						whenLastUsed: now,
+						initialOpfsSyncPending: true,
+						/**
+						 * Recreating an autosaved Playground discards the old
+						 * WordPress files and boots from the updated setup.
+						 * Constants discovered from the previous runtime may no
+						 * longer exist in the recreated site, so they must be
+						 * rediscovered after the first OPFS sync.
+						 */
+						playgroundDefinedConstants: undefined,
+						sourceSetupUrlFingerprint:
+							getAutosaveFingerprintFromURL(
+								playgroundUrlWithQueryApiArgs
+							),
+						originalBlueprint: resolvedBlueprint.blueprint,
+						originalBlueprintSource: resolvedBlueprint.source!,
+						runtimeConfiguration,
+					},
+				},
+			})
+		);
 	};
 }
 


### PR DESCRIPTION
## What it does

Shows the full Playground settings form for autosaved Playgrounds. Applying setup changes recreates the autosaved Playground **in place** under the same slug/name and warns that the current WordPress files will be replaced.

## Rationale

Autosaved Playgrounds are recoverable unsaved work, not deliberate stored artifacts. The settings popover should keep setup fields like `wp`, `php`, `language`, `multisite`, and `networking` editable for that unsaved workflow.

Explicitly saved Playgrounds still use the limited stored-site settings form because changing their creation setup without replacing the saved WordPress files would make the metadata disagree with the preserved site.

## Implementation

Adds `AutosavedSiteSettingsForm`, which reuses `UnconnectedSiteSettingsForm` and calls `playgroundSites.recreateAutosavedSite()` on submit. Shared setup-form helpers keep the temporary and autosaved forms from drifting when they map form fields to setup settings.

`recreateAutosavedSite()` resolves the updated setup URL first, then `resetAutosavedSiteSpec()` clears the autosaved site's WordPress files and updates its metadata. `opfsSiteStorage.resetSiteFiles()` preserves `wp-runtime.json` and the editable Blueprint bundle directory so the site keeps its identity while booting from the updated setup.

The site-selection effect now recognizes the pending recreated autosave by `sourceSetupUrlFingerprint`, so the redirect to the updated setup URL does not create a duplicate autosaved Playground.

## Testing instructions

```bash
git diff --check origin/trunk...HEAD
npx nx typecheck playground-website
npx nx lint playground-website
npx nx test playground-website --testFile=opfs-site-storage.spec.ts
```

GitHub CI run `27161250461` passed for the `playground-website` Playwright coverage added in this PR:

- autosaved Playgrounds expose the full settings form
- applying settings keeps the same autosaved slug and does not create a duplicate autosave
