### PR TITLE
[Website] Redesign My Playgrounds overlay

### DIFF
--- a/packages/playground/website/src/components/overlay/index.tsx
+++ b/packages/playground/website/src/components/overlay/index.tsx
@@ -29,9 +29,15 @@ interface OverlayProps {
 	children: ReactNode;
 	onClose: () => void;
 	className?: string;
+	contentClassName?: string;
 }
 
-export function Overlay({ children, onClose, className }: OverlayProps) {
+export function Overlay({
+	children,
+	onClose,
+	className,
+	contentClassName,
+}: OverlayProps) {
 	const handleKeyDown = useCallback(
 		(event: KeyboardEvent) => {
 			if (event.key === 'Escape') {
@@ -54,7 +60,10 @@ export function Overlay({ children, onClose, className }: OverlayProps) {
 
 	return (
 		<div className={classNames(css.overlay, className)}>
-			<VStack className={css.fullscreenContent} spacing={0}>
+			<VStack
+				className={classNames(css.fullscreenContent, contentClassName)}
+				spacing={0}
+			>
 				{children}
 			</VStack>
 		</div>

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -6,7 +6,7 @@ import {
 	MenuGroup,
 	MenuItem,
 } from '@wordpress/components';
-import { moreVertical, plus, upload, link } from '@wordpress/icons';
+import { moreVertical, upload, link, close } from '@wordpress/icons';
 import { Icon } from '@wordpress/icons';
 import { GitHubIcon } from '../../github/github';
 import { useState, useEffect, useRef } from 'react';
@@ -21,8 +21,6 @@ import {
 import type { SiteLogo, SiteInfo } from '../../lib/state/redux/slice-sites';
 import {
 	isAutosavedSite,
-	isExplicitlySavedSite,
-	MAX_AUTOSAVED_SITES,
 	selectSortedSites,
 	selectTemporarySite,
 } from '../../lib/state/redux/slice-sites';
@@ -76,14 +74,6 @@ function PullRequestIcon() {
 	);
 }
 
-function GridIcon({ size = 20 }: { size?: number }) {
-	return (
-		<svg width={size} height={size} viewBox="0 0 16 16" fill="currentColor">
-			<path d="M1 2a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V2zM1 7a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V7zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1V7zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1V7zM1 12a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1v-2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1v-2zm5 0a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1v2a1 1 0 0 1-1 1h-2a1 1 0 0 1-1-1v-2z" />
-		</svg>
-	);
-}
-
 /**
  * Displays saved Playgrounds, recent autosaves, and entry points for new sites.
  */
@@ -95,10 +85,6 @@ export function SavedPlaygroundsOverlay({
 	const storedSites = useAppSelector(selectSortedSites).filter(
 		(site) => site.metadata.storage !== 'none'
 	);
-	const explicitlySavedSites = storedSites.filter(isExplicitlySavedSite);
-	const autosavedSites = storedSites
-		.filter(isAutosavedSite)
-		.slice(0, MAX_AUTOSAVED_SITES);
 	const temporarySite = useAppSelector(selectTemporarySite);
 	const activeSite = useActiveSite();
 	const dispatch = useAppDispatch();
@@ -206,8 +192,6 @@ export function SavedPlaygroundsOverlay({
 			}))
 		: [];
 
-	const previewBlueprints = allBlueprints.slice(0, 5);
-
 	const tagCounts = new Map<string, number>();
 	allBlueprints.forEach((b) => {
 		(b.categories || []).forEach((tag) => {
@@ -273,13 +257,19 @@ export function SavedPlaygroundsOverlay({
 	};
 
 	const getStoredSiteDetails = (site: SiteInfo) => {
+		const createdDate = formatSiteCreatedDate(site);
+		if (site.metadata.storage === 'none') {
+			return 'Not saved to browser storage';
+		}
 		if (isAutosavedSite(site)) {
-			return 'Recovery copy';
+			return createdDate
+				? `Recovery copy - Created ${createdDate}`
+				: 'Recovery copy';
 		}
 		if (site.metadata.storage === 'local-fs') {
 			return 'Saved in a local directory';
 		}
-		return 'Saved in this browser';
+		return createdDate ? `Created ${createdDate}` : 'Saved in this browser';
 	};
 
 	/**
@@ -315,15 +305,16 @@ export function SavedPlaygroundsOverlay({
 	const creationOptions = [
 		{
 			id: 'vanilla',
-			title: 'New Playground',
-			icon: plus,
-			iconSize: 56,
+			title: 'Vanilla WordPress',
+			ariaLabel: 'New Playground',
+			iconComponent: <WordPressIcon />,
 			onClick: createVanillaSite,
 			disabled: false,
 		},
 		{
 			id: 'wp-pr',
-			title: 'Preview a WordPress PR',
+			title: 'WordPress PR',
+			ariaLabel: 'Preview a WordPress PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.PREVIEW_PR_WP));
@@ -332,7 +323,8 @@ export function SavedPlaygroundsOverlay({
 		},
 		{
 			id: 'gutenberg-pr',
-			title: 'Preview a Gutenberg PR',
+			title: 'Gutenberg PR',
+			ariaLabel: 'Preview a Gutenberg PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.PREVIEW_PR_GUTENBERG));
@@ -341,7 +333,8 @@ export function SavedPlaygroundsOverlay({
 		},
 		{
 			id: 'github',
-			title: 'Import from GitHub',
+			title: 'From GitHub',
+			ariaLabel: 'Import from GitHub',
 			iconComponent: GitHubIcon,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.GITHUB_IMPORT));
@@ -350,7 +343,8 @@ export function SavedPlaygroundsOverlay({
 		},
 		{
 			id: 'blueprint-url',
-			title: 'Open a Blueprint URL',
+			title: 'Blueprint URL',
+			ariaLabel: 'Open a Blueprint URL',
 			icon: link,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.BLUEPRINT_URL));
@@ -359,7 +353,8 @@ export function SavedPlaygroundsOverlay({
 		},
 		{
 			id: 'zip',
-			title: 'Import a .zip',
+			title: 'Import .zip',
+			ariaLabel: 'Import a .zip',
 			icon: upload,
 			onClick: () => {
 				zipFileInputRef.current?.click();
@@ -368,11 +363,11 @@ export function SavedPlaygroundsOverlay({
 		},
 	];
 
-	const visibleSavedSites = showAllSavedSites
-		? explicitlySavedSites
-		: explicitlySavedSites.slice(0, MAX_VISIBLE_SAVED_SITES);
+	const visibleStoredSites = showAllSavedSites
+		? storedSites
+		: storedSites.slice(0, MAX_VISIBLE_SAVED_SITES);
 	const hiddenSavedSitesCount =
-		explicitlySavedSites.length - visibleSavedSites.length;
+		storedSites.length - visibleStoredSites.length;
 
 	function formatSiteCreatedDate(site: SiteInfo) {
 		return site.metadata.whenCreated
@@ -390,7 +385,7 @@ export function SavedPlaygroundsOverlay({
 	function renderSiteRow(site: SiteInfo) {
 		const isSelected = site.slug === activeSite?.slug;
 		const isAutosave = isAutosavedSite(site);
-		const createdDate = formatSiteCreatedDate(site);
+		const isStoredSite = site.metadata.storage !== 'none';
 
 		return (
 			<div
@@ -419,80 +414,102 @@ export function SavedPlaygroundsOverlay({
 						</span>
 						<span className={css.siteRowDate}>
 							{getStoredSiteDetails(site)}
-							{createdDate ? ` - Created ${createdDate}` : ''}
 						</span>
 					</div>
 				</button>
-				<div className={css.siteRowActions}>
-					{isAutosave && (
-						<button
-							type="button"
-							className={css.keepButton}
-							onClick={() => openSaveModalForSite(site)}
-							title="Store this Playground permanently so it is not pruned from recent autosaves."
+				{isStoredSite && (
+					<div className={css.siteRowActions}>
+						{isAutosave && (
+							<button
+								type="button"
+								className={css.keepButton}
+								onClick={() => openSaveModalForSite(site)}
+								title="Store this Playground permanently so it is not pruned from recent autosaves."
+							>
+								Store permanently
+							</button>
+						)}
+						<DropdownMenu
+							icon={moreVertical}
+							label="Site actions"
+							className={css.siteRowMenu}
+							popoverProps={{
+								placement: 'bottom-end',
+							}}
 						>
-							Store permanently
-						</button>
-					)}
-					<DropdownMenu
-						icon={moreVertical}
-						label="Site actions"
-						className={css.siteRowMenu}
-						popoverProps={{
-							placement: 'bottom-end',
-						}}
-					>
-						{({ onClose: closeMenu }) => (
-							<>
-								<MenuGroup>
-									{isAutosave && (
+							{({ onClose: closeMenu }) => (
+								<>
+									<MenuGroup>
+										{isAutosave && (
+											<MenuItem
+												onClick={() =>
+													openSaveModalForSite(
+														site,
+														closeMenu
+													)
+												}
+											>
+												Store permanently
+											</MenuItem>
+										)}
 										<MenuItem
 											onClick={() =>
-												openSaveModalForSite(
+												handleRenameSite(
 													site,
 													closeMenu
 												)
 											}
 										>
-											Store permanently
+											Rename
 										</MenuItem>
-									)}
-									<MenuItem
-										onClick={() =>
-											handleRenameSite(site, closeMenu)
-										}
-									>
-										Rename
-									</MenuItem>
-								</MenuGroup>
-								<MenuGroup>
-									<MenuItem
-										className={css.dangerMenuItem}
-										onClick={() =>
-											handleDeleteSite(site, closeMenu)
-										}
-									>
-										Delete
-									</MenuItem>
-								</MenuGroup>
-							</>
-						)}
-					</DropdownMenu>
-				</div>
+									</MenuGroup>
+									<MenuGroup>
+										<MenuItem
+											className={css.dangerMenuItem}
+											onClick={() =>
+												handleDeleteSite(
+													site,
+													closeMenu
+												)
+											}
+										>
+											Delete
+										</MenuItem>
+									</MenuGroup>
+								</>
+							)}
+						</DropdownMenu>
+					</div>
+				)}
 			</div>
 		);
 	}
 
-	function renderSavedPlaygroundsSection() {
-		if (explicitlySavedSites.length === 0) {
-			return null;
-		}
+	function renderYourPlaygroundsSection() {
+		const visibleSites = [
+			...(temporarySite ? [temporarySite] : []),
+			...visibleStoredSites,
+		];
 
 		return (
-			<OverlaySection title="Saved Playgrounds">
-				<div className={css.sitesList}>
-					{visibleSavedSites.map(renderSiteRow)}
-				</div>
+			<OverlaySection
+				title="Your Playgrounds"
+				className={css.playgroundsSection}
+			>
+				{visibleSites.length === 0 ? (
+					<p className={css.emptyMessage}>
+						No Playgrounds available yet.
+					</p>
+				) : (
+					<div
+						className={classNames(
+							css.sitesList,
+							css.playgroundsList
+						)}
+					>
+						{visibleSites.map(renderSiteRow)}
+					</div>
+				)}
 				{hiddenSavedSitesCount > 0 && (
 					<button
 						type="button"
@@ -500,34 +517,21 @@ export function SavedPlaygroundsOverlay({
 						onClick={() => setShowAllSavedSites(!showAllSavedSites)}
 					>
 						{showAllSavedSites
-							? 'Show fewer saved Playgrounds'
-							: `Show ${hiddenSavedSitesCount} more saved Playgrounds`}
+							? 'Show fewer Playgrounds'
+							: `Show ${hiddenSavedSitesCount} more Playgrounds`}
 					</button>
 				)}
 			</OverlaySection>
 		);
 	}
 
-	function renderAutosavesSection() {
-		if (autosavedSites.length === 0) {
-			return null;
-		}
-
-		return (
-			<OverlaySection
-				title={`Last ${MAX_AUTOSAVED_SITES} autosaves`}
-				description="Older autosaves are deleted automatically. Use Store permanently to keep one."
-			>
-				<div className={css.sitesList}>
-					{autosavedSites.map(renderSiteRow)}
-				</div>
-			</OverlaySection>
-		);
-	}
-
 	if (viewMode === 'blueprints') {
 		return (
-			<Overlay onClose={onClose}>
+			<Overlay
+				onClose={onClose}
+				className={css.playgroundsOverlay}
+				contentClassName={css.playgroundsContent}
+			>
 				<OverlayHeader
 					onClose={onClose}
 					onBack={() => {
@@ -698,7 +702,11 @@ export function SavedPlaygroundsOverlay({
 	}
 
 	return (
-		<Overlay onClose={onClose}>
+		<Overlay
+			onClose={onClose}
+			className={css.playgroundsOverlay}
+			contentClassName={css.playgroundsContent}
+		>
 			<input
 				type="file"
 				ref={zipFileInputRef}
@@ -706,53 +714,70 @@ export function SavedPlaygroundsOverlay({
 				accept=".zip,application/zip"
 				style={{ display: 'none' }}
 			/>
-			<OverlayHeader onClose={onClose} />
-			<OverlayBody>
-				<OverlaySection title="Start a new Playground">
-					<div className={css.creationRow}>
-						{creationOptions.map((option) => {
-							const hasIcon =
-								'iconComponent' in option || 'icon' in option;
-							return (
-								<button
-									key={option.id}
-									className={css.creationButton}
-									onClick={option.onClick}
-									disabled={option.disabled}
-								>
-									{hasIcon && (
-										<span
-											className={classNames(
-												css.creationIcon,
-												option.id === 'vanilla'
-													? css.newPlaygroundIcon
-													: undefined
-											)}
-										>
-											{'iconComponent' in option ? (
-												option.iconComponent
-											) : 'icon' in option ? (
-												<Icon
-													icon={option.icon!}
-													size={
-														'iconSize' in option
-															? option.iconSize
-															: 24
-													}
-												/>
-											) : null}
+			<button
+				type="button"
+				className={css.playgroundsCloseButton}
+				aria-label="Close"
+				onClick={onClose}
+			>
+				<Icon icon={close} size={28} />
+			</button>
+			<OverlayBody className={css.playgroundsBody}>
+				<div className={css.playgroundsColumns}>
+					{renderYourPlaygroundsSection()}
+					<OverlaySection
+						title="Start a new Playground"
+						className={css.playgroundsSection}
+					>
+						<div className={css.creationRow}>
+							{creationOptions.map((option) => {
+								const hasIcon =
+									'iconComponent' in option ||
+									'icon' in option;
+								return (
+									<button
+										key={option.id}
+										className={css.creationButton}
+										aria-label={option.ariaLabel}
+										onClick={option.onClick}
+										disabled={option.disabled}
+									>
+										{hasIcon && (
+											<span
+												className={classNames(
+													css.creationIcon,
+													option.id === 'vanilla'
+														? css.newPlaygroundIcon
+														: undefined
+												)}
+											>
+												{'iconComponent' in option ? (
+													option.iconComponent
+												) : 'icon' in option ? (
+													<Icon
+														icon={option.icon!}
+														size={24}
+													/>
+												) : null}
+											</span>
+										)}
+										<span className={css.creationTitle}>
+											{option.title}
 										</span>
-									)}
-									<span className={css.creationTitle}>
-										{option.title}
-									</span>
-								</button>
-							);
-						})}
-					</div>
-				</OverlaySection>
+									</button>
+								);
+							})}
+						</div>
+					</OverlaySection>
+				</div>
 
-				<OverlaySection title="Start from a Blueprint">
+				<OverlaySection
+					title="Start from a Blueprint"
+					className={classNames(
+						css.playgroundsSection,
+						css.blueprintsSection
+					)}
+				>
 					{blueprintsLoading ? (
 						<div className={css.loadingContainer}>
 							<Spinner />
@@ -763,7 +788,7 @@ export function SavedPlaygroundsOverlay({
 						</p>
 					) : (
 						<div className={css.blueprintsRow}>
-							{previewBlueprints.map((blueprint) => (
+							{allBlueprints.map((blueprint) => (
 								<button
 									key={blueprint.path}
 									className={css.blueprintPreviewCard}
@@ -797,28 +822,9 @@ export function SavedPlaygroundsOverlay({
 									</span>
 								</button>
 							))}
-							<button
-								className={css.blueprintPreviewCard}
-								onClick={() => setViewMode('blueprints')}
-							>
-								<div
-									className={classNames(
-										css.blueprintPreviewThumbnail,
-										css.viewAllThumbnail
-									)}
-								>
-									<GridIcon size={50} />
-								</div>
-								<span className={css.blueprintPreviewTitle}>
-									View all {allBlueprints.length} blueprints
-								</span>
-							</button>
 						</div>
 					)}
 				</OverlaySection>
-
-				{renderAutosavesSection()}
-				{renderSavedPlaygroundsSection()}
 			</OverlayBody>
 		</Overlay>
 	);

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -45,9 +45,9 @@ import {
 } from '../overlay';
 
 /**
- * Maximum explicitly saved Playgrounds to show before collapsing the list.
+ * Maximum stored Playgrounds to show before collapsing the list.
  */
-const MAX_VISIBLE_SAVED_SITES = 8;
+const MAX_VISIBLE_STORED_SITES = 8;
 
 type BlueprintsIndexEntry = {
 	title: string;
@@ -95,7 +95,7 @@ export function SavedPlaygroundsOverlay({
 	const [viewMode, setViewMode] = useState<OverlayViewMode>(initialViewMode);
 	const [searchQuery, setSearchQuery] = useState('');
 	const [selectedTag, setSelectedTag] = useState<string | null>(null);
-	const [showAllSavedSites, setShowAllSavedSites] = useState(false);
+	const [showAllStoredSites, setShowAllStoredSites] = useState(false);
 	const [pendingZipFile, setPendingZipFile] = useState<File | null>(null);
 	const [pendingZipTargetSlug, setPendingZipTargetSlug] = useState<
 		string | null
@@ -306,7 +306,6 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'vanilla',
 			title: 'Vanilla WordPress',
-			ariaLabel: 'New Playground',
 			iconComponent: <WordPressIcon />,
 			onClick: createVanillaSite,
 			disabled: false,
@@ -314,7 +313,6 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'wp-pr',
 			title: 'WordPress PR',
-			ariaLabel: 'Preview a WordPress PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.PREVIEW_PR_WP));
@@ -324,7 +322,6 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'gutenberg-pr',
 			title: 'Gutenberg PR',
-			ariaLabel: 'Preview a Gutenberg PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.PREVIEW_PR_GUTENBERG));
@@ -334,7 +331,6 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'github',
 			title: 'From GitHub',
-			ariaLabel: 'Import from GitHub',
 			iconComponent: GitHubIcon,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.GITHUB_IMPORT));
@@ -344,7 +340,6 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'blueprint-url',
 			title: 'Blueprint URL',
-			ariaLabel: 'Open a Blueprint URL',
 			icon: link,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.BLUEPRINT_URL));
@@ -354,7 +349,6 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'zip',
 			title: 'Import .zip',
-			ariaLabel: 'Import a .zip',
 			icon: upload,
 			onClick: () => {
 				zipFileInputRef.current?.click();
@@ -363,10 +357,10 @@ export function SavedPlaygroundsOverlay({
 		},
 	];
 
-	const visibleStoredSites = showAllSavedSites
+	const visibleStoredSites = showAllStoredSites
 		? storedSites
-		: storedSites.slice(0, MAX_VISIBLE_SAVED_SITES);
-	const hiddenSavedSitesCount =
+		: storedSites.slice(0, MAX_VISIBLE_STORED_SITES);
+	const hiddenStoredSitesCount =
 		storedSites.length - visibleStoredSites.length;
 
 	function formatSiteCreatedDate(site: SiteInfo) {
@@ -510,15 +504,17 @@ export function SavedPlaygroundsOverlay({
 						{visibleSites.map(renderSiteRow)}
 					</div>
 				)}
-				{hiddenSavedSitesCount > 0 && (
+				{hiddenStoredSitesCount > 0 && (
 					<button
 						type="button"
 						className={css.showMoreButton}
-						onClick={() => setShowAllSavedSites(!showAllSavedSites)}
+						onClick={() =>
+							setShowAllStoredSites(!showAllStoredSites)
+						}
 					>
-						{showAllSavedSites
+						{showAllStoredSites
 							? 'Show fewer Playgrounds'
-							: `Show ${hiddenSavedSitesCount} more Playgrounds`}
+							: `Show ${hiddenStoredSitesCount} more Playgrounds`}
 					</button>
 				)}
 			</OverlaySection>
@@ -738,7 +734,6 @@ export function SavedPlaygroundsOverlay({
 									<button
 										key={option.id}
 										className={css.creationButton}
-										aria-label={option.ariaLabel}
 										onClick={option.onClick}
 										disabled={option.disabled}
 									>

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -257,10 +257,10 @@ export function SavedPlaygroundsOverlay({
 	};
 
 	const getStoredSiteDetails = (site: SiteInfo) => {
-		const createdDate = formatSiteCreatedDate(site);
 		if (site.metadata.storage === 'none') {
 			return 'Not saved to browser storage';
 		}
+		const createdDate = formatSiteCreatedDate(site);
 		if (isAutosavedSite(site)) {
 			return createdDate
 				? `Recovery copy - Created ${createdDate}`

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/index.tsx
@@ -306,6 +306,7 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'vanilla',
 			title: 'Vanilla WordPress',
+			ariaLabel: 'Vanilla WordPress - New Playground',
 			iconComponent: <WordPressIcon />,
 			onClick: createVanillaSite,
 			disabled: false,
@@ -313,6 +314,7 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'wp-pr',
 			title: 'WordPress PR',
+			ariaLabel: 'WordPress PR - Preview a WordPress PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.PREVIEW_PR_WP));
@@ -322,6 +324,7 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'gutenberg-pr',
 			title: 'Gutenberg PR',
+			ariaLabel: 'Gutenberg PR - Preview a Gutenberg PR',
 			iconComponent: <PullRequestIcon />,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.PREVIEW_PR_GUTENBERG));
@@ -331,6 +334,7 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'github',
 			title: 'From GitHub',
+			ariaLabel: 'From GitHub - Import from GitHub',
 			iconComponent: GitHubIcon,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.GITHUB_IMPORT));
@@ -340,6 +344,7 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'blueprint-url',
 			title: 'Blueprint URL',
+			ariaLabel: 'Blueprint URL - Open a Blueprint URL',
 			icon: link,
 			onClick: () => {
 				dispatch(setActiveModal(modalSlugs.BLUEPRINT_URL));
@@ -349,6 +354,7 @@ export function SavedPlaygroundsOverlay({
 		{
 			id: 'zip',
 			title: 'Import .zip',
+			ariaLabel: 'Import .zip - Import a .zip',
 			icon: upload,
 			onClick: () => {
 				zipFileInputRef.current?.click();
@@ -734,6 +740,7 @@ export function SavedPlaygroundsOverlay({
 									<button
 										key={option.id}
 										className={css.creationButton}
+										aria-label={option.ariaLabel}
 										onClick={option.onClick}
 										disabled={option.disabled}
 									>

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -585,7 +585,9 @@
 }
 
 .playgroundsOverlay.playgroundsOverlay {
-	top: 50px;
+	--playgrounds-overlay-top: 50px;
+	--playgrounds-close-button-offset: 20px;
+	top: var(--playgrounds-overlay-top);
 }
 
 .playgroundsContent.playgroundsContent {
@@ -608,7 +610,9 @@
 	padding: 4px;
 	position: fixed;
 	right: 24px;
-	top: 70px;
+	top: calc(
+		var(--playgrounds-overlay-top) + var(--playgrounds-close-button-offset)
+	);
 	z-index: 101;
 }
 
@@ -791,10 +795,7 @@
 
 @media (max-width: 500px) {
 	.playgroundsOverlay.playgroundsOverlay {
-		top: 96px;
-	}
-
-	.playgroundsCloseButton {
-		top: 112px;
+		--playgrounds-overlay-top: 96px;
+		--playgrounds-close-button-offset: 16px;
 	}
 }

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -211,17 +211,6 @@
 	height: 40px;
 }
 
-/* View all thumbnail modifier */
-.viewAllThumbnail {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
-.viewAllThumbnail svg {
-	fill: #fff;
-}
-
 /* Sites list - vertical rows */
 .sitesList {
 	display: flex;
@@ -592,5 +581,236 @@
 	.siteRowLogo {
 		width: 36px;
 		height: 36px;
+	}
+}
+
+.playgroundsOverlay.playgroundsOverlay {
+	top: 50px;
+}
+
+.playgroundsContent.playgroundsContent {
+	max-width: none;
+}
+
+.playgroundsBody.playgroundsBody {
+	padding: 72px 24px 70px;
+}
+
+.playgroundsCloseButton {
+	align-items: center;
+	background: transparent;
+	border: none;
+	border-radius: 4px;
+	color: #949494;
+	cursor: pointer;
+	display: flex;
+	justify-content: center;
+	padding: 4px;
+	position: fixed;
+	right: 24px;
+	top: 70px;
+	z-index: 101;
+}
+
+.playgroundsCloseButton:hover {
+	background: rgba(255, 255, 255, 0.1);
+	color: #fff;
+}
+
+.playgroundsCloseButton svg {
+	fill: currentColor;
+}
+
+.playgroundsColumns {
+	align-items: start;
+	column-gap: clamp(48px, 9.5vw, 137px);
+	display: grid;
+	grid-template-columns: minmax(420px, 710px) minmax(420px, 492px);
+	margin-bottom: 96px;
+	max-width: 1339px;
+}
+
+.playgroundsSection {
+	margin-bottom: 0;
+}
+
+.playgroundsSection h2 {
+	font-size: clamp(24px, 2.2vw, 28px) !important;
+	line-height: 1.2 !important;
+	margin-bottom: 18px !important;
+}
+
+.playgroundsList .siteRowContent {
+	min-height: 88px;
+	padding: 20px 24px;
+}
+
+.playgroundsList .siteRowSelected .siteRowContent {
+	padding-left: 21px;
+}
+
+.playgroundsList .siteRowLogo {
+	height: 50px;
+	width: 50px;
+}
+
+.playgroundsList .siteRowLogo svg {
+	height: 31px;
+	width: 31px;
+}
+
+.playgroundsList .siteRowName {
+	font-size: 20px;
+	font-weight: 600;
+}
+
+.playgroundsList .siteRowDate {
+	font-size: 16px;
+}
+
+.playgroundsList .siteRowMenu {
+	margin-right: 16px;
+}
+
+.playgroundsSection .creationRow {
+	display: grid;
+	gap: 14px;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.playgroundsSection .creationButton {
+	min-height: 112px;
+	min-width: 0;
+	padding: 14px 10px;
+}
+
+.playgroundsSection .creationIcon {
+	height: 42px;
+	width: 42px;
+}
+
+.playgroundsSection .creationIcon :global(svg) {
+	height: 32px;
+	width: 32px;
+}
+
+.playgroundsSection .newPlaygroundIcon :global(svg) {
+	height: 36px;
+	width: 36px;
+}
+
+.playgroundsSection .creationTitle {
+	font-size: 18px;
+	font-weight: 600;
+	line-height: 1.25;
+}
+
+.blueprintsSection .blueprintsRow {
+	display: grid;
+	gap: 24px 20px;
+	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+	overflow-x: hidden;
+	padding: 0 8px 16px 0;
+	scrollbar-color: #3c4349 transparent;
+	scrollbar-width: thin;
+}
+
+.blueprintsSection .blueprintsRow::-webkit-scrollbar {
+	width: 8px;
+}
+
+.blueprintsSection .blueprintsRow::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.blueprintsSection .blueprintsRow::-webkit-scrollbar-thumb {
+	background: #3c4349;
+	border-radius: 8px;
+}
+
+.blueprintsSection .blueprintPreviewCard {
+	min-width: 0;
+}
+
+.blueprintsSection .blueprintPreviewTitle {
+	font-size: 18px;
+	line-height: 1.25;
+}
+
+.blueprintsSection .blueprintPreviewThumbnail {
+	border-radius: 8px;
+}
+
+@media (max-width: 1050px) {
+	.playgroundsColumns {
+		column-gap: 48px;
+		grid-template-columns: minmax(380px, 1fr) minmax(360px, 440px);
+	}
+
+	.playgroundsSection .creationTitle {
+		font-size: 16px;
+	}
+}
+
+@media (max-width: 875px) {
+	.playgroundsBody.playgroundsBody {
+		padding-top: 48px;
+	}
+
+	.playgroundsColumns {
+		gap: 48px;
+		grid-template-columns: 1fr;
+		margin-bottom: 64px;
+	}
+
+	.playgroundsSection .creationRow {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.blueprintsSection .blueprintsRow {
+		gap: 8px;
+		grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+	}
+}
+
+@media (max-width: 640px) {
+	.playgroundsBody.playgroundsBody {
+		padding: 32px 20px 48px;
+	}
+
+	.playgroundsList .siteRowContent {
+		min-height: 76px;
+		padding: 14px 16px;
+	}
+
+	.playgroundsList .siteRowSelected .siteRowContent {
+		padding-left: 13px;
+	}
+
+	.playgroundsList .siteRowLogo {
+		height: 40px;
+		width: 40px;
+	}
+
+	.playgroundsList .siteRowName {
+		font-size: 16px;
+	}
+
+	.playgroundsList .siteRowDate {
+		font-size: 13px;
+	}
+
+	.playgroundsSection .creationRow {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (max-width: 500px) {
+	.playgroundsOverlay.playgroundsOverlay {
+		top: 96px;
+	}
+
+	.playgroundsCloseButton {
+		top: 112px;
 	}
 }

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -587,6 +587,9 @@
 .playgroundsOverlay.playgroundsOverlay {
 	--playgrounds-overlay-top: 50px;
 	--playgrounds-close-button-offset: 20px;
+	--playgrounds-body-top-padding: calc(
+		var(--playgrounds-close-button-offset) + 52px
+	);
 	top: var(--playgrounds-overlay-top);
 }
 
@@ -595,7 +598,7 @@
 }
 
 .playgroundsBody.playgroundsBody {
-	padding: 72px 24px 70px;
+	padding: var(--playgrounds-body-top-padding) 24px 70px;
 }
 
 .playgroundsCloseButton {
@@ -741,10 +744,6 @@
 }
 
 @media (max-width: 875px) {
-	.playgroundsBody.playgroundsBody {
-		padding-top: 48px;
-	}
-
 	.playgroundsColumns {
 		gap: 48px;
 		grid-template-columns: 1fr;
@@ -763,7 +762,7 @@
 
 @media (max-width: 640px) {
 	.playgroundsBody.playgroundsBody {
-		padding: 32px 20px 48px;
+		padding: var(--playgrounds-body-top-padding) 20px 48px;
 	}
 
 	.playgroundsList .siteRowContent {

--- a/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
+++ b/packages/playground/website/src/components/saved-playgrounds-overlay/style.module.css
@@ -709,23 +709,7 @@
 	display: grid;
 	gap: 24px 20px;
 	grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-	overflow-x: hidden;
 	padding: 0 8px 16px 0;
-	scrollbar-color: #3c4349 transparent;
-	scrollbar-width: thin;
-}
-
-.blueprintsSection .blueprintsRow::-webkit-scrollbar {
-	width: 8px;
-}
-
-.blueprintsSection .blueprintsRow::-webkit-scrollbar-track {
-	background: transparent;
-}
-
-.blueprintsSection .blueprintsRow::-webkit-scrollbar-thumb {
-	background: #3c4349;
-	border-radius: 8px;
 }
 
 .blueprintsSection .blueprintPreviewCard {


### PR DESCRIPTION
## What changed

- Redesigns the My Playgrounds overlay into a wider modal that sits below the existing top navigation.
- Keeps saved and temporary playgrounds in a left column, with quick actions for starting new playgrounds on the right.
- Moves Blueprints into a full-width section at the bottom and renders every blueprint card while letting the whole modal scroll.
- Restores the visible close button in the modal chrome.

## Why

This brings the overlay closer to the supplied mockup without changing the top navigation, and keeps all Blueprints reachable without adding a nested scrolling region.

## Screenshots

### Before

<img src="https://gist.githubusercontent.com/adamziel/0996e9339d29768cdb3ac6c7bbee9156/raw/51370dc61481f52b7796a542c1e01c9067de7fdd/pr-before-my-playgrounds.svg" alt="Before: previous My Playgrounds modal" width="720">

### After

<img src="https://gist.githubusercontent.com/adamziel/0996e9339d29768cdb3ac6c7bbee9156/raw/53bd2cc356e5af88668c509dc4108aabe00e9e33/pr-after-my-playgrounds.svg" alt="After: redesigned My Playgrounds modal" width="720">

## Testing

- `npm exec nx run playground-website:typecheck`
- `npm exec nx run playground-website:lint`
