### PR TITLE
[Docs] Document Symfony apps in Playground without WordPress

### DIFF
--- a/packages/docs/site/docs/main/guides/index.md
+++ b/packages/docs/site/docs/main/guides/index.md
@@ -13,6 +13,10 @@ In this section we present a selection of guides that will help you to both work
 
 Embed editable, runnable PHP and WordPress examples in any web page with the `<php-snippet>` web component. The guide covers custom Blueprints, expected output, pure-PHP snippets, runtime sharing, and the standalone PHP Playground.
 
+## [Run PHP frameworks in Playground](/guides/php-frameworks)
+
+Use Playground as a generic browser-based PHP runtime. This guide shows how to skip the WordPress download, load a bundled Symfony app with a Blueprint, and run it from a `<php-snippet>`.
+
 ## [WordPress Playground for Everyone](/guides/playground-for-everyone)
 
 Think Playground is only for developers? Think again. This guide shows how WordPress Playground helps beginners, site owners, and everyday users experiment safely — no technical expertise required.

--- a/packages/docs/site/docs/main/guides/php-frameworks.md
+++ b/packages/docs/site/docs/main/guides/php-frameworks.md
@@ -1,0 +1,149 @@
+---
+title: Run PHP frameworks in Playground
+slug: /guides/php-frameworks
+description: Use WordPress Playground as a browser-based PHP runtime for frameworks and apps that are not WordPress.
+sidebar_class_name: navbar-build-item
+---
+
+import { PhpCodeSnippetExample } from '@site/src/components/PhpCodeSnippetLiveExample';
+
+# Run PHP frameworks in Playground
+
+WordPress Playground is also a browser-based PHP runtime. WordPress is the
+most common app it boots, but a Blueprint can skip the WordPress download,
+write any PHP files into the virtual filesystem, and run a framework such as
+Symfony.
+
+This guide shows the shape of that setup. Use it when you want a shareable demo,
+a docs example, or a quick compatibility check for a PHP app that does not need
+a server, database, Node.js, Sass, or a local Composer install.
+
+## What changes when you skip WordPress
+
+Set `preferredVersions.wp` to `false` in a Blueprint, or `wp="none"` on a
+`<php-snippet>`. Playground still downloads PHP, mounts a writable filesystem,
+runs Blueprint steps, and supports networking when `features.networking` is
+`true`. It just does not download or boot WordPress.
+
+That makes Playground useful for generic PHP examples:
+
+- PHP libraries that need a real filesystem.
+- Framework demos that can run behind `public/index.php`.
+- Documentation snippets that should execute in the browser.
+- Reproducible bug reports for PHP code that is not WordPress-specific.
+
+## Try a Symfony app
+
+The example below uses a Blueprint to download and unzip a bundled Symfony app,
+then a `<php-snippet>` boots the Symfony kernel and renders the dashboard route.
+The snippet prints the Symfony response status, the page title, and whether a
+WordPress install exists.
+
+<PhpCodeSnippetExample name="symfonyBlueprint" />
+
+Here is the complete embed:
+
+```html
+<script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
+
+<script id="symfony-blueprint" type="application/json">
+	{
+		"features": {
+			"networking": true
+		},
+		"steps": [
+			{
+				"step": "unzip",
+				"zipFile": {
+					"resource": "url",
+					"url": "https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/symfony-package-radar/symfony-package-radar.zip"
+				},
+				"extractToPath": "/wordpress"
+			}
+		]
+	}
+</script>
+
+<php-snippet name="run-symfony.php" wp="none" blueprint="symfony-blueprint">
+	<script type="application/x-php">
+		<?php
+		require '/wordpress/symfony-package-radar/vendor/autoload.php';
+
+		use App\Kernel;
+		use Symfony\Component\HttpFoundation\Request;
+
+		$kernel = new Kernel( 'prod', false );
+		$request = Request::create( '/' );
+		$response = $kernel->handle( $request );
+
+		preg_match( '/<h1>(.*?)<\/h1>/', $response->getContent(), $match );
+
+		echo 'HTTP ' . $response->getStatusCode() . PHP_EOL;
+		echo 'Symfony page: ' . html_entity_decode( $match[1] ?? 'unknown' ) . PHP_EOL;
+		echo 'WordPress installed: ';
+		echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
+
+		$kernel->terminate( $request, $response );
+	</script>
+	<script type="text/expected-output">
+		HTTP 200
+		Symfony page: Package Radar
+		WordPress installed: no
+	</script>
+</php-snippet>
+```
+
+The same app is also available as a full Playground page:
+
+[Open the Symfony Package Radar demo](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fblueprints%2Ftrunk%2Fblueprints%2Fsymfony-package-radar%2Fblueprint.json)
+
+## Package the app as a ZIP
+
+For framework demos, prefer a ZIP that already contains `vendor/`. That keeps
+the Playground startup path short and avoids asking every visitor to wait for
+Composer, Git, and package registry downloads.
+
+A small Blueprint can then install the app with one step:
+
+```json
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/symfony-package-radar/public/index.php",
+	"preferredVersions": {
+		"php": "8.4",
+		"wp": false
+	},
+	"features": {
+		"networking": true
+	},
+	"steps": [
+		{
+			"step": "unzip",
+			"zipFile": {
+				"resource": "bundled",
+				"path": "./symfony-package-radar.zip"
+			},
+			"extractToPath": "/wordpress"
+		}
+	]
+}
+```
+
+Use `bundled` resources when the ZIP ships next to `blueprint.json`, or use a
+`url` resource when the ZIP is hosted separately. See [Blueprint bundles](/blueprints/bundles)
+for packaging details.
+
+## Keep the demo browser-friendly
+
+A Playground-hosted framework demo works best when it:
+
+- Does not require a long-running background process.
+- Stores generated files under the virtual filesystem.
+- Avoids native extensions that are not compiled into PHP.wasm.
+- Avoids frontend build steps at runtime.
+- Keeps network calls optional or resilient, because browsers may require CORS
+  proxying for third-party services.
+
+Those constraints still leave plenty of room for real framework behavior:
+controllers, routing, dependency injection, templates, forms, HTTP clients, and
+plain PHP libraries all work when their PHP dependencies are available.

--- a/packages/docs/site/docs/main/guides/php-frameworks.md
+++ b/packages/docs/site/docs/main/guides/php-frameworks.md
@@ -79,20 +79,7 @@ $kernel = new Kernel( 'prod', false );
 $request = Request::create( '/' );
 $response = $kernel->handle( $request );
 
-$processor = WP_HTML_Processor::create_fragment( $response->getContent() );
-$page_title = 'unknown';
-if ( $processor->next_tag( 'H1' ) ) {
-	$page_title = '';
-	while ( $processor->next_token() ) {
-		if ( 'H1' === $processor->get_tag() && $processor->is_tag_closer() ) {
-			break;
-		}
-		if ( '#text' === $processor->get_token_type() ) {
-			$page_title .= $processor->get_modifiable_text();
-		}
-	}
-	$page_title = trim( $page_title );
-}
+$page_title = get_first_h1_text( $response->getContent() );
 
 echo 'HTTP ' . $response->getStatusCode() . PHP_EOL;
 echo 'Symfony page: ' . $page_title . PHP_EOL;
@@ -100,6 +87,25 @@ echo 'WordPress installed: ';
 echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
 
 $kernel->terminate( $request, $response );
+
+function get_first_h1_text( string $html ): string {
+	$processor = WP_HTML_Processor::create_fragment( $html );
+	if ( ! $processor->next_tag( 'H1' ) ) {
+		return 'unknown';
+	}
+
+	$text = '';
+	while ( $processor->next_token() ) {
+		if ( 'H1' === $processor->get_tag() && $processor->is_tag_closer() ) {
+			break;
+		}
+		if ( '#text' === $processor->get_token_type() ) {
+			$text .= $processor->get_modifiable_text();
+		}
+	}
+
+	return trim( $text );
+}
   </script>
   <script type="text/expected-output">
 HTTP 200

--- a/packages/docs/site/docs/main/guides/php-frameworks.md
+++ b/packages/docs/site/docs/main/guides/php-frameworks.md
@@ -36,8 +36,9 @@ That makes Playground useful for generic PHP examples:
 
 The example below uses a Blueprint to download and unzip a bundled Symfony app
 into `/app`. Then a `<php-snippet>` boots the Symfony kernel and renders the
-dashboard route. The snippet prints the Symfony response status, the page title,
-and whether a WordPress install exists.
+dashboard route. The app's Composer dependencies include the WordPress HTML API,
+so the snippet can read the `<h1>` with `WP_HTML_Processor` without installing or
+booting WordPress.
 
 <PhpCodeSnippetExample name="symfonyBlueprint" />
 
@@ -78,10 +79,23 @@ $kernel = new Kernel( 'prod', false );
 $request = Request::create( '/' );
 $response = $kernel->handle( $request );
 
-preg_match( '/<h1>(.*?)<\/h1>/', $response->getContent(), $match );
+$processor = WP_HTML_Processor::create_fragment( $response->getContent() );
+$page_title = 'unknown';
+if ( $processor->next_tag( 'H1' ) ) {
+	$page_title = '';
+	while ( $processor->next_token() ) {
+		if ( 'H1' === $processor->get_tag() && $processor->is_tag_closer() ) {
+			break;
+		}
+		if ( '#text' === $processor->get_token_type() ) {
+			$page_title .= $processor->get_modifiable_text();
+		}
+	}
+	$page_title = trim( $page_title );
+}
 
 echo 'HTTP ' . $response->getStatusCode() . PHP_EOL;
-echo 'Symfony page: ' . html_entity_decode( $match[1] ?? 'unknown' ) . PHP_EOL;
+echo 'Symfony page: ' . $page_title . PHP_EOL;
 echo 'WordPress installed: ';
 echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
 
@@ -89,7 +103,7 @@ $kernel->terminate( $request, $response );
   </script>
   <script type="text/expected-output">
 HTTP 200
-Symfony page: Package Radar
+Symfony page: Symfony Playground
 WordPress installed: no
   </script>
 </php-snippet>
@@ -105,7 +119,9 @@ The same app is also available as a full Playground page:
 
 For framework demos, prefer a ZIP that already contains `vendor/`. That keeps
 the Playground startup path short and avoids asking every visitor to wait for
-Composer, Git, and package registry downloads.
+Composer, Git, and package registry downloads. The Symfony demo uses that path to
+bundle both Symfony and a Composer-installed copy of the WordPress HTML API; it
+still does not include a WordPress install.
 
 For snippets or CLI runs, a small Blueprint can install the app into `/app` with
 one step:

--- a/packages/docs/site/docs/main/guides/php-frameworks.md
+++ b/packages/docs/site/docs/main/guides/php-frameworks.md
@@ -88,6 +88,11 @@ echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
 
 $kernel->terminate( $request, $response );
 
+/**
+ * The app's Composer dependencies include the WordPress HTML API, so the
+ * snippet can read the <h1> with WP_HTML_Processor without installing or
+ * booting WordPress.
+ */
 function get_first_h1_text( string $html ): string {
 	$processor = WP_HTML_Processor::create_fragment( $html );
 	if ( ! $processor->next_tag( 'H1' ) ) {

--- a/packages/docs/site/docs/main/guides/php-frameworks.md
+++ b/packages/docs/site/docs/main/guides/php-frameworks.md
@@ -59,7 +59,7 @@ Here is the complete embed:
       "step": "unzip",
       "zipFile": {
         "resource": "url",
-        "url": "https://wordpress.github.io/blueprints/blueprints/symfony-package-radar/symfony-package-radar.zip"
+        "url": "https://wordpress.github.io/blueprints/blueprints/symfony-package-radar/symfony-package-radar.zip?v=html-api-2026-06-08"
       },
       "extractToPath": "/app"
     }

--- a/packages/docs/site/docs/main/guides/php-frameworks.md
+++ b/packages/docs/site/docs/main/guides/php-frameworks.md
@@ -34,68 +34,72 @@ That makes Playground useful for generic PHP examples:
 
 ## Try a Symfony app
 
-The example below uses a Blueprint to download and unzip a bundled Symfony app,
-then a `<php-snippet>` boots the Symfony kernel and renders the dashboard route.
-The snippet prints the Symfony response status, the page title, and whether a
-WordPress install exists.
+The example below uses a Blueprint to download and unzip a bundled Symfony app
+into `/app`. Then a `<php-snippet>` boots the Symfony kernel and renders the
+dashboard route. The snippet prints the Symfony response status, the page title,
+and whether a WordPress install exists.
 
 <PhpCodeSnippetExample name="symfonyBlueprint" />
 
 Here is the complete embed:
 
+<!-- prettier-ignore-start -->
+
 ```html
 <script type="module" src="https://playground.wordpress.net/php-code-snippet.js"></script>
 
 <script id="symfony-blueprint" type="application/json">
-	{
-		"features": {
-			"networking": true
-		},
-		"steps": [
-			{
-				"step": "unzip",
-				"zipFile": {
-					"resource": "url",
-					"url": "https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/symfony-package-radar/symfony-package-radar.zip"
-				},
-				"extractToPath": "/wordpress"
-			}
-		]
-	}
+{
+  "features": {
+    "networking": true
+  },
+  "steps": [
+    {
+      "step": "unzip",
+      "zipFile": {
+        "resource": "url",
+        "url": "https://wordpress.github.io/blueprints/blueprints/symfony-package-radar/symfony-package-radar.zip"
+      },
+      "extractToPath": "/app"
+    }
+  ]
+}
 </script>
 
 <php-snippet name="run-symfony.php" wp="none" blueprint="symfony-blueprint">
-	<script type="application/x-php">
-		<?php
-		require '/wordpress/symfony-package-radar/vendor/autoload.php';
+  <script type="application/x-php">
+<?php
+require '/app/symfony-package-radar/vendor/autoload.php';
 
-		use App\Kernel;
-		use Symfony\Component\HttpFoundation\Request;
+use App\Kernel;
+use Symfony\Component\HttpFoundation\Request;
 
-		$kernel = new Kernel( 'prod', false );
-		$request = Request::create( '/' );
-		$response = $kernel->handle( $request );
+$kernel = new Kernel( 'prod', false );
+$request = Request::create( '/' );
+$response = $kernel->handle( $request );
 
-		preg_match( '/<h1>(.*?)<\/h1>/', $response->getContent(), $match );
+preg_match( '/<h1>(.*?)<\/h1>/', $response->getContent(), $match );
 
-		echo 'HTTP ' . $response->getStatusCode() . PHP_EOL;
-		echo 'Symfony page: ' . html_entity_decode( $match[1] ?? 'unknown' ) . PHP_EOL;
-		echo 'WordPress installed: ';
-		echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
+echo 'HTTP ' . $response->getStatusCode() . PHP_EOL;
+echo 'Symfony page: ' . html_entity_decode( $match[1] ?? 'unknown' ) . PHP_EOL;
+echo 'WordPress installed: ';
+echo file_exists( '/wordpress/wp-load.php' ) ? 'yes' : 'no';
 
-		$kernel->terminate( $request, $response );
-	</script>
-	<script type="text/expected-output">
-		HTTP 200
-		Symfony page: Package Radar
-		WordPress installed: no
-	</script>
+$kernel->terminate( $request, $response );
+  </script>
+  <script type="text/expected-output">
+HTTP 200
+Symfony page: Package Radar
+WordPress installed: no
+  </script>
 </php-snippet>
 ```
 
+<!-- prettier-ignore-end -->
+
 The same app is also available as a full Playground page:
 
-[Open the Symfony Package Radar demo](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FWordPress%2Fblueprints%2Ftrunk%2Fblueprints%2Fsymfony-package-radar%2Fblueprint.json)
+[Open the Symfony Package Radar demo](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fblueprints%2Fblueprints%2Fsymfony-package-radar%2Fblueprint.json)
 
 ## Package the app as a ZIP
 
@@ -103,7 +107,8 @@ For framework demos, prefer a ZIP that already contains `vendor/`. That keeps
 the Playground startup path short and avoids asking every visitor to wait for
 Composer, Git, and package registry downloads.
 
-A small Blueprint can then install the app with one step:
+For snippets or CLI runs, a small Blueprint can install the app into `/app` with
+one step:
 
 ```json
 {
@@ -123,7 +128,7 @@ A small Blueprint can then install the app with one step:
 				"resource": "bundled",
 				"path": "./symfony-package-radar.zip"
 			},
-			"extractToPath": "/wordpress"
+			"extractToPath": "/app"
 		}
 	]
 }
@@ -132,6 +137,10 @@ A small Blueprint can then install the app with one step:
 Use `bundled` resources when the ZIP ships next to `blueprint.json`, or use a
 `url` resource when the ZIP is hosted separately. See [Blueprint bundles](/blueprints/bundles)
 for packaging details.
+
+For a full-page Playground website, use a Blueprint like the gallery demo. It
+adds a tiny router at the Playground document root so the Symfony `public/`
+directory can respond to browser requests.
 
 ## Keep the demo browser-friendly
 

--- a/packages/docs/site/sidebars.js
+++ b/packages/docs/site/sidebars.js
@@ -46,6 +46,7 @@ const sidebars = {
 					},
 					items: [
 						'main/guides/php-code-snippets',
+						'main/guides/php-frameworks',
 						'main/guides/agent-skill-wp-playground',
 						'main/guides/wordpress-native-ios-app',
 						'main/guides/for-plugin-developers',

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
@@ -227,6 +227,11 @@ echo file_exists('/wordpress/wp-load.php') ? 'yes' : 'no';
 
 $kernel->terminate($request, $response);
 
+/**
+ * The app's Composer dependencies include the WordPress HTML API, so the
+ * snippet can read the <h1> with WP_HTML_Processor without installing or
+ * booting WordPress.
+ */
 function get_first_h1_text(string $html): string
 {
     $processor = WP_HTML_Processor::create_fragment($html);

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
@@ -198,9 +198,9 @@ echo get_bloginfo( 'version' );
       "step": "unzip",
       "zipFile": {
         "resource": "url",
-        "url": "https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/symfony-package-radar/symfony-package-radar.zip"
+        "url": "https://wordpress.github.io/blueprints/blueprints/symfony-package-radar/symfony-package-radar.zip"
       },
-      "extractToPath": "/wordpress"
+      "extractToPath": "/app"
     }
   ]
 }
@@ -209,7 +209,7 @@ echo get_bloginfo( 'version' );
 <php-snippet name="run-symfony.php" wp="none" blueprint="symfony-blueprint-preview">
   <script type="application/x-php">
 <?php
-require '/wordpress/symfony-package-radar/vendor/autoload.php';
+require '/app/symfony-package-radar/vendor/autoload.php';
 
 use App\Kernel;
 use Symfony\Component\HttpFoundation\Request;

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
@@ -198,7 +198,7 @@ echo get_bloginfo( 'version' );
       "step": "unzip",
       "zipFile": {
         "resource": "url",
-        "url": "https://wordpress.github.io/blueprints/blueprints/symfony-package-radar/symfony-package-radar.zip"
+        "url": "https://wordpress.github.io/blueprints/blueprints/symfony-package-radar/symfony-package-radar.zip?v=html-api-2026-06-08"
       },
       "extractToPath": "/app"
     }

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
@@ -218,20 +218,7 @@ $kernel = new Kernel('prod', false);
 $request = Request::create('/');
 $response = $kernel->handle($request);
 
-$processor = WP_HTML_Processor::create_fragment($response->getContent());
-$pageTitle = 'unknown';
-if ($processor->next_tag('H1')) {
-    $pageTitle = '';
-    while ($processor->next_token()) {
-        if ('H1' === $processor->get_tag() && $processor->is_tag_closer()) {
-            break;
-        }
-        if ('#text' === $processor->get_token_type()) {
-            $pageTitle .= $processor->get_modifiable_text();
-        }
-    }
-    $pageTitle = trim($pageTitle);
-}
+$pageTitle = get_first_h1_text($response->getContent());
 
 echo 'HTTP ' . $response->getStatusCode() . PHP_EOL;
 echo 'Symfony page: ' . $pageTitle . PHP_EOL;
@@ -239,6 +226,26 @@ echo 'WordPress installed: ';
 echo file_exists('/wordpress/wp-load.php') ? 'yes' : 'no';
 
 $kernel->terminate($request, $response);
+
+function get_first_h1_text(string $html): string
+{
+    $processor = WP_HTML_Processor::create_fragment($html);
+    if (!$processor->next_tag('H1')) {
+        return 'unknown';
+    }
+
+    $text = '';
+    while ($processor->next_token()) {
+        if ('H1' === $processor->get_tag() && $processor->is_tag_closer()) {
+            break;
+        }
+        if ('#text' === $processor->get_token_type()) {
+            $text .= $processor->get_modifiable_text();
+        }
+    }
+
+    return trim($text);
+}
   </script>
   <script type="text/expected-output">
 HTTP 200

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
@@ -218,10 +218,23 @@ $kernel = new Kernel('prod', false);
 $request = Request::create('/');
 $response = $kernel->handle($request);
 
-preg_match('/<h1>(.*?)<\/h1>/', $response->getContent(), $match);
+$processor = WP_HTML_Processor::create_fragment($response->getContent());
+$pageTitle = 'unknown';
+if ($processor->next_tag('H1')) {
+    $pageTitle = '';
+    while ($processor->next_token()) {
+        if ('H1' === $processor->get_tag() && $processor->is_tag_closer()) {
+            break;
+        }
+        if ('#text' === $processor->get_token_type()) {
+            $pageTitle .= $processor->get_modifiable_text();
+        }
+    }
+    $pageTitle = trim($pageTitle);
+}
 
 echo 'HTTP ' . $response->getStatusCode() . PHP_EOL;
-echo 'Symfony page: ' . html_entity_decode($match[1] ?? 'unknown') . PHP_EOL;
+echo 'Symfony page: ' . $pageTitle . PHP_EOL;
 echo 'WordPress installed: ';
 echo file_exists('/wordpress/wp-load.php') ? 'yes' : 'no';
 
@@ -229,7 +242,7 @@ $kernel->terminate($request, $response);
   </script>
   <script type="text/expected-output">
 HTTP 200
-Symfony page: Package Radar
+Symfony page: Symfony Playground
 WordPress installed: no
   </script>
 </php-snippet>`,

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.examples.ts
@@ -188,6 +188,51 @@ echo get_bloginfo( 'version' );
 6.8
   </script>
 </php-snippet>`,
+	symfonyBlueprint: String.raw`<script id="symfony-blueprint-preview" type="application/json">
+{
+  "features": {
+    "networking": true
+  },
+  "steps": [
+    {
+      "step": "unzip",
+      "zipFile": {
+        "resource": "url",
+        "url": "https://raw.githubusercontent.com/WordPress/blueprints/trunk/blueprints/symfony-package-radar/symfony-package-radar.zip"
+      },
+      "extractToPath": "/wordpress"
+    }
+  ]
+}
+</script>
+
+<php-snippet name="run-symfony.php" wp="none" blueprint="symfony-blueprint-preview">
+  <script type="application/x-php">
+<?php
+require '/wordpress/symfony-package-radar/vendor/autoload.php';
+
+use App\Kernel;
+use Symfony\Component\HttpFoundation\Request;
+
+$kernel = new Kernel('prod', false);
+$request = Request::create('/');
+$response = $kernel->handle($request);
+
+preg_match('/<h1>(.*?)<\/h1>/', $response->getContent(), $match);
+
+echo 'HTTP ' . $response->getStatusCode() . PHP_EOL;
+echo 'Symfony page: ' . html_entity_decode($match[1] ?? 'unknown') . PHP_EOL;
+echo 'WordPress installed: ';
+echo file_exists('/wordpress/wp-load.php') ? 'yes' : 'no';
+
+$kernel->terminate($request, $response);
+  </script>
+  <script type="text/expected-output">
+HTTP 200
+Symfony page: Package Radar
+WordPress installed: no
+  </script>
+</php-snippet>`,
 	illustration: String.raw`<php-snippet name="illustration.php" runnable="false">
   <script type="application/x-php">
 <?php

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import type { ExampleName } from './PhpCodeSnippetLiveExample.examples';
 
-// php-code-snippet.js used to be served with a one-year browser cache.
-// Keep this query so docs previews don't reuse stale copies.
+// In dev, load the local Playground website script so docs previews exercise
+// uncommitted php-code-snippet.js changes. Production docs still use the hosted
+// script and keep a query string to avoid stale one-year browser caches.
 const SCRIPT_URL =
-	'https://playground.wordpress.net/php-code-snippet.js?v=selected-text-visible';
+	process.env.NODE_ENV === 'development'
+		? 'http://127.0.0.1:5400/website-server/php-code-snippet.js'
+		: 'https://playground.wordpress.net/php-code-snippet.js?v=selected-text-visible';
 
 function usePhpSnippetScript() {
 	useEffect(() => {

--- a/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
+++ b/packages/docs/site/src/components/PhpCodeSnippetLiveExample.tsx
@@ -2,9 +2,9 @@ import React, { useEffect, useState } from 'react';
 import type { ExampleName } from './PhpCodeSnippetLiveExample.examples';
 
 // php-code-snippet.js used to be served with a one-year browser cache.
-// Keep this query so docs previews don't reuse stale pre-editable-default copies.
+// Keep this query so docs previews don't reuse stale copies.
 const SCRIPT_URL =
-	'https://playground.wordpress.net/php-code-snippet.js?v=editable-by-default';
+	'https://playground.wordpress.net/php-code-snippet.js?v=selected-text-visible';
 
 function usePhpSnippetScript() {
 	useEffect(() => {

--- a/packages/playground/website/public/php-code-snippet.js
+++ b/packages/playground/website/public/php-code-snippet.js
@@ -671,7 +671,7 @@ pre {
 	caret-color: #24292f;
 	overflow: hidden;
 }
-.editor textarea::selection { background: #cfe7ff; color: transparent; }
+.editor textarea::selection { background: #cfe7ff; color: #24292f; }
 .output {
 	display: none;
 	border-top: 1px solid #e1e4e8;


### PR DESCRIPTION
## What it does

Adds a Symfony-focused guide at `/guides/php-frameworks` showing that Playground can run a PHP framework app without downloading WordPress.

![Rendered Symfony Playground docs page](https://gist.githubusercontent.com/adamziel/84e703878ad3de92faa8aaf62bfca6f5/raw/0927c16a0669ed8bec9767ace8557d996c14297e/symfony-doc-page.svg)

The guide embeds a runnable `<php-snippet>` that:

1. starts PHP with `wp="none"`,
2. unzips the bundled Symfony Package Radar demo from the Blueprints gallery,
3. boots the Symfony kernel,
4. renders `/`, and
5. reads the first `<h1>` with Composer-bundled `WP_HTML_Processor`.

The expected output confirms the Symfony route rendered and WordPress was not installed:

```text
HTTP 200
Symfony page: Symfony Playground
WordPress installed: no
```

## Rationale

Playground is usually documented as a WordPress runtime, but its PHP/WASM runtime, filesystem, networking layer, snippets, and Blueprints can also host framework examples. Symfony is a useful proof point because the demo exercises routing, autowired services, Twig rendering, Symfony HttpClient, Composer dependencies, and the WordPress HTML API without Node.js, Sass, a database, or a local Composer install.

## Implementation

- Adds `/guides/php-frameworks` and registers it in the Guides index/sidebar.
- Adds a `symfonyBlueprint` live snippet example backed by the merged `WordPress/blueprints` Symfony ZIP.
- Uses the bundled WordPress HTML API Composer package to parse the Symfony response without installing or booting WordPress.
- Loads the local `php-code-snippet.js` while running the docs site in development, so snippet UI changes can be previewed before deploy.
- Makes selected text visible inside `<php-snippet>` code blocks.

## Testing instructions

1. Run `npm run dev` and `npm run dev:docs`.
2. Open `http://127.0.0.1:3000/wordpress-playground/guides/php-frameworks`.
3. Confirm the Symfony snippet loads `http://127.0.0.1:5400/website-server/php-code-snippet.js` in development.
4. Click **Run** and verify the output is:

   ```text
   HTTP 200
   Symfony page: Symfony Playground
   WordPress installed: no
   ```

Also verified:

```bash
npx nx lint docs-site
npx nx lint playground-website
```
