### PR TITLE
[Docs] Document wp-now migration to Playground CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,4 +210,4 @@ A worthy mention is Wasm Labs’s closed-source [WordPress in the browser](https
 
 [WordPress Playground](https://github.com/WordPress/wordpress-playground) is a WordPress.org project started and led by [Adam Zielinski](https://github.com/adamziel).
 
-[Playground tools](https://github.com/WordPress/playground-tools) like `wp-now` or the interactive code block are maintained by their authors in the [playground-tools monorepo](https://github.com/WordPress/playground-tools).
+[Playground tools](https://github.com/WordPress/playground-tools) like the interactive code block are maintained by their authors in the [playground-tools monorepo](https://github.com/WordPress/playground-tools).

--- a/packages/docs/site/docs/developers/05-local-development/01-wp-now.md
+++ b/packages/docs/site/docs/developers/05-local-development/01-wp-now.md
@@ -14,48 +14,29 @@ The NPM package @wp-now/wp-now is deprecated and won't receive updates in the fu
 
 # wp-now NPM package
 
-[wp-now](https://www.npmjs.com/package/@wp-now/wp-now) is a command-line tool designed to simplify the process of running WordPress locally. It provides a quick and easy way to set up a local WordPress environment with minimal configuration.
+[`@wp-now/wp-now`](https://www.npmjs.com/package/@wp-now/wp-now) is deprecated.
+Use [Playground CLI](/developers/local-development/wp-playground-cli) instead.
+It uses the same WordPress Playground runtime and is maintained in the main
+WordPress Playground repository.
 
-Key Features:
+## Migrate to Playground CLI
 
-- **Command-line Interface**: Easy to use for developers comfortable with CLI.
-- **Quick Setup**: Set up a local WordPress environment in seconds.
-- **Customizable**: Allows for configuration to suit specific development needs.
+The familiar wp-now workflow maps to the Playground CLI `start` command:
 
-[`@wp-now/wp-now`](https://www.npmjs.com/package/@wp-now/wp-now) is a CLI tool to spin up a WordPress site with a single command. Similarly to the [VS Code extension](/developers/local-development/vscode-extension), it uses a portable WebAssembly version of PHP and SQLite. No Docker, MySQL, or Apache are required.
+| wp-now                                                  | Playground CLI                                                     |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| `npx @wp-now/wp-now start`                              | `npx @wp-playground/cli@latest start`                              |
+| `npx @wp-now/wp-now start --path=./plugin`              | `npx @wp-playground/cli@latest start --path=./plugin`              |
+| `npx @wp-now/wp-now start --wp=6.8 --php=8.3`           | `npx @wp-playground/cli@latest start --wp=6.8 --php=8.3`           |
+| `npx @wp-now/wp-now start --blueprint=./blueprint.json` | `npx @wp-playground/cli@latest start --blueprint=./blueprint.json` |
+| `npx @wp-now/wp-now start --skip-browser`               | `npx @wp-playground/cli@latest start --skip-browser`               |
+| `npx @wp-now/wp-now start --reset`                      | `npx @wp-playground/cli@latest start --reset`                      |
 
-<div class="callout callout-info">
+`@wp-playground/cli start` automatically detects whether the selected directory
+is a plugin, theme, `wp-content` directory, or WordPress installation. It also
+persists sites in `~/.wordpress-playground/sites/<path-hash>/`.
 
-**Documentation**
-
-`wp-now` is maintained in a different GitHub repository, [Playground Tools](https://github.com/WordPress/playground-tools/). You can find the latest documentation in the [dedicated README file](https://github.com/WordPress/playground-tools/blob/trunk/packages/wp-now/README.md).
-
-</div>
-
-## Launch wp-now in a plugin or theme directory
-
-Navigate to your plugin or theme directory and start `wp-now` with the following commands:
-
-```bash
-cd my-plugin-or-theme-directory
-npx @wp-now/wp-now start
-```
-
-## Launch wp-now in the `wp-content` directory with options
-
-You can also start `wp-now` from any `wp-content` folder. The following example passes parameters for changing the PHP and WordPress versions and loading a blueprint file.
-
-```bash
-cd my-wordpress-folder/wp-content
-npx @wp-now/wp-now start --wp=6.4 --php=8.3 --blueprint=path/to/blueprint.json
-```
-
-## Install wp-now globally
-
-Alternatively, you can install `@wp-now/wp-now` globally to load it from any directory:
-
-```bash
-npm install -g @wp-now/wp-now
-cd my-plugin-or-theme-directory
-wp-now start
-```
+For manual mounts, automation, or CI workflows, use the lower-level
+`@wp-playground/cli server` command. See the
+[Playground CLI documentation](/developers/local-development/wp-playground-cli)
+for details.

--- a/packages/docs/site/docs/developers/05-local-development/01-wp-now.md
+++ b/packages/docs/site/docs/developers/05-local-development/01-wp-now.md
@@ -26,15 +26,17 @@ The familiar wp-now workflow maps to the Playground CLI `start` command:
 | wp-now                                                  | Playground CLI                                                     |
 | ------------------------------------------------------- | ------------------------------------------------------------------ |
 | `npx @wp-now/wp-now start`                              | `npx @wp-playground/cli@latest start`                              |
-| `npx @wp-now/wp-now start --path=./plugin`              | `npx @wp-playground/cli@latest start --path=./plugin`              |
+| `npx @wp-now/wp-now start --path=./plugin`              | `cd ./plugin && npx @wp-playground/cli@latest start`               |
 | `npx @wp-now/wp-now start --wp=6.8 --php=8.3`           | `npx @wp-playground/cli@latest start --wp=6.8 --php=8.3`           |
 | `npx @wp-now/wp-now start --blueprint=./blueprint.json` | `npx @wp-playground/cli@latest start --blueprint=./blueprint.json` |
 | `npx @wp-now/wp-now start --skip-browser`               | `npx @wp-playground/cli@latest start --skip-browser`               |
 | `npx @wp-now/wp-now start --reset`                      | `npx @wp-playground/cli@latest start --reset`                      |
 
 `@wp-playground/cli start` automatically detects whether the selected directory
-is a plugin, theme, `wp-content` directory, or WordPress installation. It also
-persists sites in `~/.wordpress-playground/sites/<path-hash>/`.
+is a plugin, theme, `wp-content` directory, or WordPress installation. When it
+manages the WordPress root directory, it persists the site in
+`~/.wordpress-playground/sites/<path-hash>/`. If the selected directory is a full
+WordPress installation, that directory becomes the persistent store instead.
 
 For manual mounts, automation, or CI workflows, use the lower-level
 `@wp-playground/cli server` command. See the

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -62,18 +62,22 @@ command:
 | `npx @wp-now/wp-now start --skip-browser`               | `npx @wp-playground/cli@latest start --skip-browser`               |
 | `npx @wp-now/wp-now start --reset`                      | `npx @wp-playground/cli@latest start --reset`                      |
 
-The main difference is persistence. `wp-now` implicitly associated persistent
-sites with local paths. `@wp-playground/cli start` persists sites in
-`~/.wordpress-playground/sites/<path-hash>/` when it manages the WordPress root
-directory. If the selected directory is a full WordPress installation, or you
-explicitly mount `/wordpress`, that directory becomes the persistent store
-instead.
+The main workflow change is where the saved site lives:
 
-`start --path=./plugin` works for mounting another directory, but the managed
-persistent site is keyed to the command's current working directory. For the
-closest wp-now-style migration, `cd` into the project directory before running
-`start`. Use `server` when you need manual control over mounts, storage, or
-automation.
+- With `wp-now`, `--path=./plugin` picked the project and the saved site.
+- With Playground CLI, `start` saves the site for the current directory. For
+  the closest match, `cd` into the project first, then run `start`.
+- When Playground CLI creates WordPress for you, it keeps the WordPress files
+  in `~/.wordpress-playground/sites/<path-hash>/`.
+- If you run it on a full WordPress directory, or mount a directory at
+  `/wordpress`, that directory is the WordPress site. Changes are written
+  there.
+- `start --path=./plugin` still mounts that folder, but it does not make
+  `./plugin` the saved site. The saved site still belongs to the directory
+  where you ran the command.
+
+Use `start` for the familiar wp-now-style flow. Use `server` only when you want
+to spell out mounts, storage, or automation yourself.
 
 ### Using `server` (Advanced)
 

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -48,6 +48,28 @@ npx @wp-playground/cli@latest start
 - Opens browser automatically
 - Auto-mounts the project by default
 
+## Migrating from wp-now
+
+The deprecated `@wp-now/wp-now` package maps most directly to the `start`
+command:
+
+| wp-now                                                  | Playground CLI                                                     |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| `npx @wp-now/wp-now start`                              | `npx @wp-playground/cli@latest start`                              |
+| `npx @wp-now/wp-now start --path=./plugin`              | `npx @wp-playground/cli@latest start --path=./plugin`              |
+| `npx @wp-now/wp-now start --wp=6.8 --php=8.3`           | `npx @wp-playground/cli@latest start --wp=6.8 --php=8.3`           |
+| `npx @wp-now/wp-now start --blueprint=./blueprint.json` | `npx @wp-playground/cli@latest start --blueprint=./blueprint.json` |
+| `npx @wp-now/wp-now start --skip-browser`               | `npx @wp-playground/cli@latest start --skip-browser`               |
+| `npx @wp-now/wp-now start --reset`                      | `npx @wp-playground/cli@latest start --reset`                      |
+
+The main difference is persistence. `wp-now` implicitly associated persistent
+sites with local paths. `@wp-playground/cli start` persists sites in
+`~/.wordpress-playground/sites/<path-hash>/`. The lower-level `server` command
+uses temporary storage unless you explicitly mount persistent directories.
+
+Use `start` for the familiar wp-now-style workflow. Use `server` when you need
+manual control over mounts, storage, or automation.
+
 ### Using `server` (Advanced)
 
 The `server` command provides full control over configuration:

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -56,7 +56,7 @@ command:
 | wp-now                                                  | Playground CLI                                                     |
 | ------------------------------------------------------- | ------------------------------------------------------------------ |
 | `npx @wp-now/wp-now start`                              | `npx @wp-playground/cli@latest start`                              |
-| `npx @wp-now/wp-now start --path=./plugin`              | `npx @wp-playground/cli@latest start --path=./plugin`              |
+| `npx @wp-now/wp-now start --path=./plugin`              | `cd ./plugin && npx @wp-playground/cli@latest start`               |
 | `npx @wp-now/wp-now start --wp=6.8 --php=8.3`           | `npx @wp-playground/cli@latest start --wp=6.8 --php=8.3`           |
 | `npx @wp-now/wp-now start --blueprint=./blueprint.json` | `npx @wp-playground/cli@latest start --blueprint=./blueprint.json` |
 | `npx @wp-now/wp-now start --skip-browser`               | `npx @wp-playground/cli@latest start --skip-browser`               |
@@ -64,11 +64,16 @@ command:
 
 The main difference is persistence. `wp-now` implicitly associated persistent
 sites with local paths. `@wp-playground/cli start` persists sites in
-`~/.wordpress-playground/sites/<path-hash>/`. The lower-level `server` command
-uses temporary storage unless you explicitly mount persistent directories.
+`~/.wordpress-playground/sites/<path-hash>/` when it manages the WordPress root
+directory. If the selected directory is a full WordPress installation, or you
+explicitly mount `/wordpress`, that directory becomes the persistent store
+instead.
 
-Use `start` for the familiar wp-now-style workflow. Use `server` when you need
-manual control over mounts, storage, or automation.
+`start --path=./plugin` works for mounting another directory, but the managed
+persistent site is keyed to the command's current working directory. For the
+closest wp-now-style migration, `cd` into the project directory before running
+`start`. Use `server` when you need manual control over mounts, storage, or
+automation.
 
 ### Using `server` (Advanced)
 
@@ -80,7 +85,12 @@ npx @wp-playground/cli@latest server
 
 ![Playground CLI in Action](https://raw.githubusercontent.com/WordPress/wordpress-playground/refs/heads/trunk/packages/docs/site/static/img/developers/npx-wp-playground-server.gif)
 
-**Automatic site persistence:** By default, the `start` command keeps your WordPress site persistent across sessions. Your files and database are stored in `~/.wordpress-playground/sites/<path-hash>/`, where `<path-hash>` is derived from your project directory. This means you can stop and restart the CLI without losing your work.
+**Automatic site persistence:** When the `start` command manages the WordPress
+root directory, it keeps your WordPress site persistent across sessions. Your
+files and database are stored in `~/.wordpress-playground/sites/<path-hash>/`,
+where `<path-hash>` is derived from the command's current working directory. If
+you start from a full WordPress installation, or explicitly mount `/wordpress`,
+that mounted directory becomes the persistent store instead.
 
 This is useful when:
 
@@ -218,7 +228,8 @@ npx @wp-playground/cli@latest server --mount=./wp-content:/wordpress/wp-content
 
 ### Data Persistence in `start` mode
 
-Running in `start` mode, Playground CLI **automatically persists** your WordPress site in a dedicated directory:
+When `start` manages the WordPress root directory, Playground CLI
+**automatically persists** your WordPress site in a dedicated directory:
 
 ```
 ~/.wordpress-playground/sites/<path-hash>/
@@ -227,18 +238,23 @@ Running in `start` mode, Playground CLI **automatically persists** your WordPres
 └── tmp/              # Temporary PHP files
 ```
 
-The `<path-hash>` is derived from your project directory path. This ensures isolation between different projects while persisting changes automatically.
+The `<path-hash>` is derived from the command's current working directory.
+This ensures isolation between different projects when you run `start` from each
+project directory.
 
 #### Persistence behavior
 
-- **Default (no explicit mount)**: WordPress files and database persist in `~/.wordpress-playground/sites/<path-hash>/`. Changes survive between CLI restarts.
-- **Explicit `/wordpress` mount**: If you provide a mount path for `/wordpress`, automatic persistence is skipped. Your mount configuration takes precedence.
+- **Default (no WordPress root mount)**: WordPress files and database persist in `~/.wordpress-playground/sites/<path-hash>/`. Changes survive between CLI restarts.
+- **Full WordPress directory or explicit `/wordpress` mount**: Automatic persistence in `~/.wordpress-playground/sites/<path-hash>/` is skipped. The mounted WordPress directory is the persistent store.
 
 The database location depends on your configuration:
 
 - **Default (automatic persistence)**:
     - Database: `~/.wordpress-playground/sites/<path-hash>/wordpress/wp-content/database/.ht.sqlite`
     - **Persisted automatically** between sessions
+- **Full WordPress directory or explicit `/wordpress` mount**:
+    - Database: Follows the mounted WordPress directory
+    - **Persisted in that mounted directory**
 
 #### Resetting a persisted site
 
@@ -258,18 +274,26 @@ to your unique WordPress setup. With the Playground CLI, you can use the followi
 - **`run-blueprint`**: Executes a Blueprint file without starting a web server.
 - **`build-snapshot`**: Builds a ZIP snapshot of a WordPress site based on a Blueprint.
 
-The `start` command has a dedicated argument:
+The `start` command supports these common optional arguments. Run
+`npx @wp-playground/cli@latest start --help` for the full list:
 
+- `--path=<path>`: Path to the project directory. Defaults to the current working directory.
+- `--wp=<version>`: WordPress version to use. Defaults to the latest.
+- `--php=<version>`: PHP version to use. Defaults to PHP 8.3.
+- `--port=<port>`: The port number for the server to listen on. Defaults to 9400 when available.
+- `--blueprint=<path>`: The path to a JSON Blueprint file to execute.
+- `--login`: Automatically log the user in as an administrator. Defaults to true.
+- `--skip-browser`: Do not open the site in your default browser.
 - `--reset`: Delete the stored site and start fresh. Defaults to false.
+- `--no-auto-mount`: Disable automatic project detection.
 
-The `server` command supports the following optional arguments:
+The `server` command supports these common optional arguments. Run `npx @wp-playground/cli@latest server --help` for the full list:
 
 - `--port=<port>`: The port number for the server to listen on. Defaults to 9400.
 - `--version`: Show version number.
-- `--outfile`: When building, write to this output file.
 - `--site-url=<url>`: Site URL to use for WordPress. Defaults to `http://127.0.0.1:{port}`.
 - `--wp=<version>`: The version of WordPress to use. Defaults to the latest.
-- `--php=<version>`: PHP version to use. Choices: `8.5`, `8.4`, `8.3`, `8.2`, `8.1`, `8.0`, `7.4`. Defaults to `8.5`.
+- `--php=<version>`: PHP version to use. Choices: `8.5`, `8.4`, `8.3`, `8.2`, `8.1`, `8.0`, `7.4`. Defaults to `8.3`.
 - `--auto-mount[=<path>]`: Automatically mount a directory. If no path is provided, mounts the current working directory. You can mount a WordPress directory, a plugin directory, a theme directory, a wp-content directory, or any directory containing PHP and HTML files.
 - `--mount=<mapping>`: Manually mount a directory (can be used multiple times). Format: `"/host/path:/vfs/path"`.
 - `--mount-before-install`: Mount a directory to the PHP runtime before WordPress installation (can be used multiple times). Format: `"/host/path:/vfs/path"`.

--- a/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
+++ b/packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md
@@ -109,7 +109,7 @@ The `--reset` flag works only with `start`. For `server`, manually delete the pe
 By default, the CLI loads the latest stable version of WordPress and PHP 8.3 due to its improved performance. To specify your preferred versions, you can use the flag `--wp=<version>` and `--php=<version>`:
 
 ```bash
-npx @wp-playground/cli@latest server --wp=6.8 --php=8.3
+npx @wp-playground/cli@latest server --wp=6.8 --php=8.4
 ```
 
 ### Loading Blueprints

--- a/packages/docs/site/docs/main/contributing/code.md
+++ b/packages/docs/site/docs/main/contributing/code.md
@@ -81,12 +81,13 @@ We handle code formatting and linting automatically. Relax, type away, and let t
 
 ### Running a local Multisite
 
-WordPress Multisite has a few [restrictions when run locally](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/#restrictions). If you plan to test a Multisite network using Playground's `enableMultisite` step, make sure you either change `wp-now`'s default port or set a local test domain running via HTTPS.
+WordPress Multisite has a few [restrictions when run locally](https://developer.wordpress.org/advanced-administration/multisite/prepare-network/#restrictions). If you plan to test a Multisite network using Playground's `enableMultisite` step, make sure you either change Playground CLI's default port or set a local test domain running via HTTPS.
 
-To change `wp-now`'s default port to the one supported by WordPress Multisite, run it using the `--port=80` flag:
+To change Playground CLI's default port to the one supported by WordPress
+Multisite, run it using the `--port=80` flag:
 
 ```bash
-npx @wp-now/wp-now start --port=80
+npx @wp-playground/cli@latest start --port=80
 ```
 
 There are a few ways to set up a local test domain, including editing your `hosts` file. If you're unsure how to do that, we suggest installing [Laravel Valet](https://laravel.com/docs/11.x/valet) and then running the following command:

--- a/packages/playground/cli/README.md
+++ b/packages/playground/cli/README.md
@@ -105,7 +105,7 @@ command:
 | wp-now                                                  | Playground CLI                                                     |
 | ------------------------------------------------------- | ------------------------------------------------------------------ |
 | `npx @wp-now/wp-now start`                              | `npx @wp-playground/cli@latest start`                              |
-| `npx @wp-now/wp-now start --path=./plugin`              | `npx @wp-playground/cli@latest start --path=./plugin`              |
+| `npx @wp-now/wp-now start --path=./plugin`              | `cd ./plugin && npx @wp-playground/cli@latest start`               |
 | `npx @wp-now/wp-now start --wp=6.8 --php=8.3`           | `npx @wp-playground/cli@latest start --wp=6.8 --php=8.3`           |
 | `npx @wp-now/wp-now start --blueprint=./blueprint.json` | `npx @wp-playground/cli@latest start --blueprint=./blueprint.json` |
 | `npx @wp-now/wp-now start --skip-browser`               | `npx @wp-playground/cli@latest start --skip-browser`               |
@@ -115,10 +115,18 @@ The main mental model change is storage:
 
 - `wp-now` implicitly associated persistent sites with local paths.
 - `@wp-playground/cli start` persists sites in
-  `~/.wordpress-playground/sites/<path-hash>/`.
+  `~/.wordpress-playground/sites/<path-hash>/` when it manages the WordPress
+  root directory. If the selected directory is a full WordPress installation,
+  or you explicitly mount `/wordpress`, that directory becomes the persistent
+  store instead.
 - `@wp-playground/cli server` is lower-level and temporary by default. Use
   `--mount`, `--mount-before-install`, or `--auto-mount` when you need explicit
   filesystem behavior.
+
+`start --path=./plugin` works for mounting another directory, but the managed
+persistent site is keyed to the command's current working directory. For the
+closest wp-now-style migration, `cd` into the project directory before running
+`start`.
 
 Use `start` for the familiar wp-now-style experience. Use `server` when you need
 to describe the virtual filesystem yourself.
@@ -134,7 +142,7 @@ to your unique WordPress setup. With the Playground CLI, you can use the followi
 - **`build-snapshot`**: Builds a ZIP snapshot of a WordPress site based on a Blueprint.
 - **`php`**: Runs a PHP script.
 
-The `start` command supports the following optional arguments:
+The `start` command supports these common optional arguments. Run `npx @wp-playground/cli@latest start --help` for the full list:
 
 - `--path=<path>`: Path to the project directory. Defaults to the current working directory.
 - `--wp=<version>`: WordPress version to use. Defaults to the latest.
@@ -146,10 +154,9 @@ The `start` command supports the following optional arguments:
 - `--reset`: Delete the stored site directory and start fresh.
 - `--no-auto-mount`: Disable automatic project detection.
 
-The `server` command supports the following optional arguments:
+The `server` command supports these common optional arguments. Run `npx @wp-playground/cli@latest server --help` for the full list:
 
 - `--port=<port>`: The port number for the server to listen on. Defaults to 9400.
-- `--outfile`: When building, write to this output file.
 - `--wp=<version>`: The version of WordPress to use. Defaults to the latest.
 - `--php=<version>`: PHP version to use. Defaults to PHP 8.3.
 - `--auto-mount`: Automatically mount the current directory (plugin, theme, wp-content, etc.).

--- a/packages/playground/cli/README.md
+++ b/packages/playground/cli/README.md
@@ -1,12 +1,15 @@
 # WordPress Playground CLI
 
-`@wp-playground/cli` streamlines the process of setting up a local WordPress environment for development and testing. It utilizes WordPress Playground to set up a new WordPress environment seamlessly. As with its predecessor `wp-now`, you can switch between PHP and WordPress versions only with a flag.
+`@wp-playground/cli` runs WordPress locally with WordPress Playground. It is
+the recommended replacement for the deprecated `@wp-now/wp-now` package: no
+Docker, MySQL, or Apache are required.
 
 # Table of contents
 
 - [Requirements](#requirements)
 - [Quickstart](#quickstart)
 - [Usage](#usage)
+- [Migrating from wp-now](#migrating-from-wp-now)
 - [Working with Blueprints](#working-with-blueprints)
 - [Contributing](#contributing)
 
@@ -16,45 +19,70 @@ The Playground CLI requires Node.js 20.18 or higher, which is the recommended Lo
 
 ## Quickstart
 
-Running the Playground CLI is as simple as going to your plugin or theme directory and running the following command:
+For most local development workflows, use the `start` command:
 
 ```bash
 cd my-plugin-or-theme-directory
-npx @wp-playground/cli server --auto-mount
+npx @wp-playground/cli@latest start
 ```
 
-The flag `--auto-mount` will figure out if the project folder is a plugin or a theme for you. For more advanced mounting options, see the [Mounting Local Directories](#mounting-local-directories) section.
+`start` automatically detects whether the current directory is a plugin, theme,
+`wp-content` directory, or WordPress installation. It also persists the site
+between runs and opens the browser by default.
+
+Use `server` when you need explicit, low-level control over mounts, storage, or
+CI setup:
+
+```bash
+npx @wp-playground/cli@latest server --auto-mount
+```
 
 ## Usage
 
 You don't have to install `@wp-playground/cli`, you can run it directly with `npx`. This is the recommended way to use the CLI and requires no permanent installation. To run a vanilla WordPress website, you can run the command:
 
 ```bash
-npx @wp-playground/cli@latest server
+npx @wp-playground/cli@latest start
 ```
-
-> **_NOTE:_** You can also use the `@wp-playground/cli@latest` to load the latest version of playground.
 
 ### Choosing a WordPress Version
 
-By default, the CLI loads the latest stable version of WordPress and PHP 8.0 due to its improved performance. To specify your preferred versions, you can use the flag `--wp=<version>` and `--php=<version>`:
+By default, the CLI loads the latest stable version of WordPress and PHP 8.3 due to its improved performance. To specify your preferred versions, you can use the flag `--wp=<version>` and `--php=<version>`:
 
 ```bash
- npx @wp-playground/cli@latest server --wp=6.8 --php=8.4
+npx @wp-playground/cli@latest start --wp=6.8 --php=8.3
 ```
+
+### `start` and `server`
+
+Playground CLI includes two commands for running WordPress locally:
+
+- **`start`**: Recommended for day-to-day development. It auto-detects the
+  project type, persists the site in `~/.wordpress-playground/sites/<path-hash>/`,
+  enables login, and opens the browser.
+- **`server`**: Advanced mode for explicit mounts, automation, and CI. Unless
+  you mount persistent storage yourself, `server` uses temporary directories
+  that are removed after they become stale.
 
 ### Mounting local Directories
 
 `@wp-playground/cli` operates by mounting your local project files into a virtualized WordPress environment. This allows you to work on your plugin or theme with a live WordPress instance without any complex setup. You can do this automatically or manually.
 
+The easiest option is automatic mounting:
+
+```bash
+cd my-plugin-or-theme-directory
+npx @wp-playground/cli@latest server --auto-mount
+```
+
 For full control, you can manually mount a local directory to a specific path inside the virtual WordPress installation. For example, to mount your current project folder into the plugins directory, use the `--mount` flag:
 
 ```shell
 cd my-plugin-or-theme-directory
-npx @wp-playground/cli@latest server --mount=.:/wordpress/wp-content/plugins/
+npx @wp-playground/cli@latest server --mount=.:/wordpress/wp-content/plugins/my-plugin
 ```
 
-Another helpful flag is `--mount-before-install` allows the users to create a site in a local filesystem instead of in the Virtual File System.
+Another helpful flag is `--mount-before-install`. It lets you mount files before WordPress is installed, which is useful when the mounted directory already contains a WordPress site:
 
 ```shell
 npx @wp-playground/cli@latest server --mount-before-install=./my-local-site:/wordpress
@@ -62,32 +90,73 @@ npx @wp-playground/cli@latest server --mount-before-install=./my-local-site:/wor
 
 ### Automatic Mounting with `--auto-mount`
 
-The `--auto-mount` flag is the easiest way to get started. It inspects the current directory and automatically mounts it to the correct location in the virtual WordPress site. These are the supported directory types and how they are detected:
+The `--auto-mount` flag inspects the selected directory and mounts it to the correct location in the virtual WordPress site. These are the supported directory types and how they are detected:
 
 - **Plugin Mode**: Presence of a PHP file with `Plugin Name:` in its header.
 - **Theme Mode**: Presence of a style.css file with `Theme Name:` in its header.
-- **wp-content Mode**: Presence of plugins and themes subdirectories.
+- **wp-content Mode**: Presence of plugins, themes, mu-plugins, or uploads subdirectories.
 - **WordPress Mode**: Presence of a complete WordPress installation. The directory will be mounted to the root `/wordpress` folder.
+
+## Migrating from wp-now
+
+The deprecated `@wp-now/wp-now` package maps most directly to the `start`
+command:
+
+| wp-now                                                  | Playground CLI                                                     |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| `npx @wp-now/wp-now start`                              | `npx @wp-playground/cli@latest start`                              |
+| `npx @wp-now/wp-now start --path=./plugin`              | `npx @wp-playground/cli@latest start --path=./plugin`              |
+| `npx @wp-now/wp-now start --wp=6.8 --php=8.3`           | `npx @wp-playground/cli@latest start --wp=6.8 --php=8.3`           |
+| `npx @wp-now/wp-now start --blueprint=./blueprint.json` | `npx @wp-playground/cli@latest start --blueprint=./blueprint.json` |
+| `npx @wp-now/wp-now start --skip-browser`               | `npx @wp-playground/cli@latest start --skip-browser`               |
+| `npx @wp-now/wp-now start --reset`                      | `npx @wp-playground/cli@latest start --reset`                      |
+
+The main mental model change is storage:
+
+- `wp-now` implicitly associated persistent sites with local paths.
+- `@wp-playground/cli start` persists sites in
+  `~/.wordpress-playground/sites/<path-hash>/`.
+- `@wp-playground/cli server` is lower-level and temporary by default. Use
+  `--mount`, `--mount-before-install`, or `--auto-mount` when you need explicit
+  filesystem behavior.
+
+Use `start` for the familiar wp-now-style experience. Use `server` when you need
+to describe the virtual filesystem yourself.
 
 ## Command and Arguments
 
 Playground CLI is simple, configurable, and unopinionated. You can set it up according
 to your unique WordPress setup. With the Playground CLI, you can use the following top-level commands:
 
-- **`server`**: (Default) Starts a local WordPress server.
+- **`start`**: Starts a local WordPress server with automatic project detection, site persistence, and browser opening.
+- **`server`**: Starts a local WordPress server with full manual control over configuration.
 - **`run-blueprint`**: Executes a Blueprint file without starting a web server.
 - **`build-snapshot`**: Builds a ZIP snapshot of a WordPress site based on a Blueprint.
+- **`php`**: Runs a PHP script.
+
+The `start` command supports the following optional arguments:
+
+- `--path=<path>`: Path to the project directory. Defaults to the current working directory.
+- `--wp=<version>`: WordPress version to use. Defaults to the latest.
+- `--php=<version>`: PHP version to use. Defaults to PHP 8.3.
+- `--port=<port>`: The port number for the server to listen on. Defaults to 9400 when available.
+- `--blueprint=<path>`: The path to a JSON Blueprint file to execute.
+- `--login`: Automatically log the user in as an administrator. Defaults to true.
+- `--skip-browser`: Do not open the site in your default browser.
+- `--reset`: Delete the stored site directory and start fresh.
+- `--no-auto-mount`: Disable automatic project detection.
 
 The `server` command supports the following optional arguments:
 
 - `--port=<port>`: The port number for the server to listen on. Defaults to 9400.
 - `--outfile`: When building, write to this output file.
 - `--wp=<version>`: The version of WordPress to use. Defaults to the latest.
+- `--php=<version>`: PHP version to use. Defaults to PHP 8.3.
 - `--auto-mount`: Automatically mount the current directory (plugin, theme, wp-content, etc.).
-- `--mount=<mapping>`: Manually mount a directory (can be used multiple times). Format: /host/path:/vfs/path
-- `--mount-before-install`: Mount a directory to the PHP runtime before WordPress installation (can be used multiple times). Format: `"/host/path:/vfs/path"`.
-- `--mount-dir`: Mount a directory to the PHP runtime (can be used multiple times). Format: `"/host/path"` `"/vfs/path"`.
-- `--mount-dir-before-install`: Mount a directory before WordPress installation (can be used multiple times). Format: `"/host/path"` `"/vfs/path"`
+- `--mount=<mapping>`: Manually mount a directory (can be used multiple times). Format: `/host/path:/vfs/path`.
+- `--mount-before-install`: Mount a directory to the PHP runtime before WordPress installation (can be used multiple times). Format: `/host/path:/vfs/path`.
+- `--mount-dir`: Mount a directory to the PHP runtime (can be used multiple times). Format: `"/host/path" "/vfs/path"`.
+- `--mount-dir-before-install`: Mount a directory before WordPress installation (can be used multiple times). Format: `"/host/path" "/vfs/path"`.
 - `--blueprint=<path>`: The path to a JSON Blueprint file to execute.
 - `--blueprint-may-read-adjacent-files`: Consent flag: Allow "bundled" resources in a local blueprint to read files in the same directory as the blueprint file.
 - `--login`: Automatically log the user in as an administrator.

--- a/packages/playground/cli/README.md
+++ b/packages/playground/cli/README.md
@@ -111,25 +111,22 @@ command:
 | `npx @wp-now/wp-now start --skip-browser`               | `npx @wp-playground/cli@latest start --skip-browser`               |
 | `npx @wp-now/wp-now start --reset`                      | `npx @wp-playground/cli@latest start --reset`                      |
 
-The main mental model change is storage:
+The main workflow change is where the saved site lives:
 
-- `wp-now` implicitly associated persistent sites with local paths.
-- `@wp-playground/cli start` persists sites in
-  `~/.wordpress-playground/sites/<path-hash>/` when it manages the WordPress
-  root directory. If the selected directory is a full WordPress installation,
-  or you explicitly mount `/wordpress`, that directory becomes the persistent
-  store instead.
-- `@wp-playground/cli server` is lower-level and temporary by default. Use
-  `--mount`, `--mount-before-install`, or `--auto-mount` when you need explicit
-  filesystem behavior.
+- With `wp-now`, `--path=./plugin` picked the project and the saved site.
+- With Playground CLI, `start` saves the site for the current directory. For
+  the closest match, `cd` into the project first, then run `start`.
+- When Playground CLI creates WordPress for you, it keeps the WordPress files
+  in `~/.wordpress-playground/sites/<path-hash>/`.
+- If you run it on a full WordPress directory, or mount a directory at
+  `/wordpress`, that directory is the WordPress site. Changes are written
+  there.
+- `start --path=./plugin` still mounts that folder, but it does not make
+  `./plugin` the saved site. The saved site still belongs to the directory
+  where you ran the command.
 
-`start --path=./plugin` works for mounting another directory, but the managed
-persistent site is keyed to the command's current working directory. For the
-closest wp-now-style migration, `cd` into the project directory before running
-`start`.
-
-Use `start` for the familiar wp-now-style experience. Use `server` when you need
-to describe the virtual filesystem yourself.
+Use `start` for the familiar wp-now-style flow. Use `server` only when you want
+to spell out mounts, storage, or automation yourself.
 
 ## Command and Arguments
 

--- a/packages/playground/cli/README.md
+++ b/packages/playground/cli/README.md
@@ -50,7 +50,7 @@ npx @wp-playground/cli@latest start
 By default, the CLI loads the latest stable version of WordPress and PHP 8.3 due to its improved performance. To specify your preferred versions, you can use the flag `--wp=<version>` and `--php=<version>`:
 
 ```bash
-npx @wp-playground/cli@latest start --wp=6.8 --php=8.3
+npx @wp-playground/cli@latest start --wp=6.8 --php=8.4
 ```
 
 ### `start` and `server`


### PR DESCRIPTION
## What it does

Documents the migration path from deprecated `@wp-now/wp-now` usage to `@wp-playground/cli`.

## Rationale

The wp-now deprecation checklist calls for a clear migration guide before publishing the deprecation warning. The CLI docs already introduced `start`, but the npm README and wp-now page still did not clearly map common wp-now commands to Playground CLI.

## Implementation

- Updates the Playground CLI README to lead with `start` for wp-now-style usage.
- Adds command mappings for `start`, `--path`, `--wp`, `--php`, `--blueprint`, `--skip-browser`, and `--reset`.
- Explains persistence differences between wp-now, `@wp-playground/cli start`, and `server`.
- Reworks the wp-now docs page to point users to Playground CLI instead of teaching new wp-now usage.
- Removes remaining source-doc references that recommended wp-now for local Multisite setup.

## Testing instructions

- Ran `git diff --check`.
- Ran `npx --yes prettier@3.6.2 --check README.md packages/playground/cli/README.md packages/docs/site/docs/developers/05-local-development/01-wp-now.md packages/docs/site/docs/developers/05-local-development/04-wp-playground-cli.md packages/docs/site/docs/main/contributing/code.md`.

Note: the repository commit hook attempted `npm run format:uncommitted`, but this checkout does not have Nx modules installed, so the hook printed `Could not find Nx modules in this workspace`. The commit still completed, and the targeted Prettier check passed.
