### PR TITLE
[Personal WP] Install my-apps on existing personal sites

### DIFF
--- a/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
+++ b/packages/playground/personal-wp/src/components/playground-viewport/index.tsx
@@ -20,7 +20,10 @@ import {
 } from '../../lib/state/redux/store';
 import { removeClientInfo } from '../../lib/state/redux/slice-clients';
 import { bootSiteClient } from '../../lib/state/redux/boot-site-client';
-import { selectSiteBySlug } from '../../lib/state/redux/slice-sites';
+import {
+	markSiteMigrationApplied,
+	selectSiteBySlug,
+} from '../../lib/state/redux/slice-sites';
 import {
 	getMainTabUnavailableMessage,
 	markMainTabReady,
@@ -57,6 +60,11 @@ import type {
 	BlueprintInstallUsageStatsRequestSource,
 	BlueprintInstallUsageStatsTrigger,
 } from '../../lib/personalwp/usage-stats';
+import {
+	APP_LAUNCHER_BLUEPRINT_URL,
+	MY_APPS_MIGRATION,
+	hasMyAppsPlugin,
+} from '../../lib/personalwp/my-apps';
 // @ts-ignore
 import { corsProxyUrl } from 'virtual:cors-proxy-url';
 
@@ -986,6 +994,7 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 	const blueprintInstallDialogResolverRef = useRef<
 		((confirmed: boolean) => void) | null
 	>(null);
+	const myAppsMigrationsInProgressRef = useRef<Set<string>>(new Set());
 
 	const clearInstallBannerResetTimeout = useCallback(() => {
 		if (installBannerResetTimeoutRef.current) {
@@ -1160,6 +1169,83 @@ function SeamlessViewport({ siteSlug }: { siteSlug: string }) {
 			site,
 		]
 	);
+	const currentSiteSlug = site?.slug;
+	const currentSiteStorage = site?.metadata.storage;
+	const myAppsMigrationApplied =
+		site?.metadata.appliedMigrations?.[MY_APPS_MIGRATION];
+
+	useEffect(() => {
+		if (
+			!currentSiteSlug ||
+			currentSiteStorage === 'none' ||
+			!hasLocalRuntimeClient ||
+			!playground ||
+			myAppsMigrationApplied ||
+			myAppsMigrationsInProgressRef.current.has(currentSiteSlug)
+		) {
+			return;
+		}
+
+		let cancelled = false;
+		const siteSlugToMigrate = currentSiteSlug;
+		const playgroundClient = playground;
+		myAppsMigrationsInProgressRef.current.add(siteSlugToMigrate);
+
+		async function markMyAppsMigrationApplied() {
+			await dispatch(
+				markSiteMigrationApplied({
+					slug: siteSlugToMigrate,
+					migration: MY_APPS_MIGRATION,
+				})
+			);
+		}
+
+		async function migrateMyAppsPlugin() {
+			try {
+				if (await hasMyAppsPlugin(playgroundClient)) {
+					if (!cancelled) {
+						await markMyAppsMigrationApplied();
+					}
+					return;
+				}
+
+				const result = await applyBlueprint(
+					APP_LAUNCHER_BLUEPRINT_URL,
+					{
+						allowNavigation: false,
+					}
+				);
+				if (
+					!cancelled &&
+					result.status === 'success' &&
+					(await hasMyAppsPlugin(playgroundClient))
+				) {
+					await markMyAppsMigrationApplied();
+				}
+			} catch (error) {
+				logger.error(
+					'Failed to migrate the App Launcher plugin:',
+					error
+				);
+			} finally {
+				myAppsMigrationsInProgressRef.current.delete(siteSlugToMigrate);
+			}
+		}
+
+		void migrateMyAppsPlugin();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		applyBlueprint,
+		currentSiteSlug,
+		currentSiteStorage,
+		dispatch,
+		hasLocalRuntimeClient,
+		myAppsMigrationApplied,
+		playground,
+	]);
 
 	const applyBlueprintInMainTab = useCallback(
 		async (

--- a/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
+++ b/packages/playground/personal-wp/src/components/site-manager/site-info-panel/index.tsx
@@ -33,7 +33,10 @@ import {
 	requestBlueprintInstall,
 } from '../../../lib/state/redux/tab-coordinator';
 import { logger } from '@php-wasm/logger';
-import { encodeStringAsBase64 } from '../../../lib/base64';
+import {
+	APP_LAUNCHER_BLUEPRINT,
+	APP_LAUNCHER_BLUEPRINT_URL,
+} from '../../../lib/personalwp/my-apps';
 import css from './style.module.css';
 
 const SiteFileBrowser = lazy(() =>
@@ -67,39 +70,6 @@ function setSiteLastTab(siteSlug: string, tabName: string): void {
 }
 
 // -- Install Apps ------------------------------------------------------------
-
-const APP_LAUNCHER_BLUEPRINT = {
-	$schema: 'https://playground.wordpress.net/blueprint-schema.json',
-	meta: {
-		title: 'App Launcher',
-		description: 'Install more apps with this app launcher',
-		author: 'Alex Kirk',
-	},
-	login: true,
-	landingPage: '/my-apps/',
-	steps: [
-		{
-			step: 'installPlugin',
-			pluginData: {
-				resource: 'git:directory',
-				url: 'https://github.com/akirk/my-apps',
-				ref: 'main',
-				refType: 'branch',
-			},
-			options: {
-				targetFolderName: 'my-apps',
-			},
-		},
-	],
-};
-
-const APP_LAUNCHER_BLUEPRINT_URL = blueprintToDataUrl(
-	JSON.stringify(APP_LAUNCHER_BLUEPRINT)
-);
-
-function blueprintToDataUrl(blueprint: string): string {
-	return `data:application/json;base64,${encodeStringAsBase64(blueprint)}`;
-}
 
 function InstallAppsSection({ siteSlug }: { siteSlug: string }) {
 	const installMessage = useAppSelector(

--- a/packages/playground/personal-wp/src/lib/personalwp/my-apps.spec.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/my-apps.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	APP_LAUNCHER_BLUEPRINT,
+	APP_LAUNCHER_BLUEPRINT_URL,
+	MY_APPS_PLUGIN_FILE,
+	hasMyAppsPlugin,
+} from './my-apps';
+
+describe('my-apps helpers', () => {
+	it('builds the app launcher blueprint URL', async () => {
+		const response = await fetch(APP_LAUNCHER_BLUEPRINT_URL);
+		const blueprint = await response.json();
+
+		expect(blueprint).toEqual(APP_LAUNCHER_BLUEPRINT);
+	});
+
+	it('checks for the main my-apps plugin file', async () => {
+		const playground = {
+			isFile: vi.fn().mockResolvedValue(true),
+		};
+
+		await expect(hasMyAppsPlugin(playground as never)).resolves.toBe(true);
+		expect(playground.isFile).toHaveBeenCalledWith(MY_APPS_PLUGIN_FILE);
+	});
+});

--- a/packages/playground/personal-wp/src/lib/personalwp/my-apps.ts
+++ b/packages/playground/personal-wp/src/lib/personalwp/my-apps.ts
@@ -1,0 +1,47 @@
+import type { PlaygroundClient } from '@wp-playground/remote';
+import { encodeStringAsBase64 } from '../base64';
+
+export const MY_APPS_PLUGIN_FILE =
+	'/wordpress/wp-content/plugins/my-apps/my-apps.php';
+
+export const MY_APPS_MIGRATION = 'myAppsPluginInstalled';
+
+export const APP_LAUNCHER_BLUEPRINT = {
+	$schema: 'https://playground.wordpress.net/blueprint-schema.json',
+	meta: {
+		title: 'App Launcher',
+		description: 'Install more apps with this app launcher',
+		author: 'Alex Kirk',
+	},
+	login: true,
+	landingPage: '/my-apps/',
+	steps: [
+		{
+			step: 'installPlugin',
+			pluginData: {
+				resource: 'git:directory',
+				url: 'https://github.com/akirk/my-apps',
+				// Personal WP treats my-apps main as a nightly channel.
+				ref: 'main',
+				refType: 'branch',
+			},
+			options: {
+				targetFolderName: 'my-apps',
+			},
+		},
+	],
+};
+
+export const APP_LAUNCHER_BLUEPRINT_URL = blueprintToDataUrl(
+	JSON.stringify(APP_LAUNCHER_BLUEPRINT)
+);
+
+export function blueprintToDataUrl(blueprint: string): string {
+	return `data:application/json;base64,${encodeStringAsBase64(blueprint)}`;
+}
+
+export async function hasMyAppsPlugin(
+	playground: Pick<PlaygroundClient, 'isFile'>
+): Promise<boolean> {
+	return await playground.isFile(MY_APPS_PLUGIN_FILE);
+}

--- a/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.spec.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.spec.ts
@@ -128,6 +128,7 @@ describe('cross-tab-sync', () => {
 				backupHistory: [{ timestamp: 123, filename: 'backup-123.zip' }],
 				lastAccessDate: 999,
 				lastUsageStatsReturningVisitDate: '2026-05-28',
+				appliedMigrations: { myAppsPluginInstalled: 456 },
 			});
 
 			expect(messages).toHaveLength(1);
@@ -143,6 +144,7 @@ describe('cross-tab-sync', () => {
 				backupHistory: [{ timestamp: 123, filename: 'backup-123.zip' }],
 				lastAccessDate: 999,
 				lastUsageStatsReturningVisitDate: '2026-05-28',
+				appliedMigrations: { myAppsPluginInstalled: 456 },
 			});
 			expect(message.senderId).toBeTruthy();
 

--- a/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/cross-tab-sync.ts
@@ -92,6 +92,7 @@ function filterSyncableChanges(
 		'backupHistory',
 		'lastAccessDate',
 		'lastUsageStatsReturningVisitDate',
+		'appliedMigrations',
 	];
 
 	const filtered: Partial<SiteMetadata> = {};

--- a/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/personal-wp/src/lib/state/redux/slice-sites.ts
@@ -93,7 +93,19 @@ const sitesSlice = createSlice({
 			const { slug, metadata } = action.payload;
 			const site = state.entities[slug];
 			if (site) {
-				site.metadata = { ...site.metadata, ...metadata };
+				const appliedMigrations =
+					metadata.appliedMigrations ||
+					site.metadata.appliedMigrations
+						? {
+								...site.metadata.appliedMigrations,
+								...metadata.appliedMigrations,
+							}
+						: undefined;
+				site.metadata = {
+					...site.metadata,
+					...metadata,
+					...(appliedMigrations ? { appliedMigrations } : {}),
+				};
 			}
 		},
 
@@ -168,6 +180,34 @@ export function updateSiteMetadata({
 					metadata: {
 						...storedSite.metadata,
 						...metadata,
+					},
+				},
+			})
+		);
+	};
+}
+
+export function markSiteMigrationApplied({
+	slug,
+	migration,
+	timestamp = Date.now(),
+}: {
+	slug: string;
+	migration: string;
+	timestamp?: number;
+}) {
+	return async (
+		dispatch: PlaygroundDispatch,
+		getState: () => PlaygroundReduxState
+	) => {
+		const storedSite = selectSiteBySlug(getState(), slug);
+		await dispatch(
+			updateSiteMetadata({
+				slug,
+				metadata: {
+					appliedMigrations: {
+						...storedSite.metadata.appliedMigrations,
+						[migration]: timestamp,
 					},
 				},
 			})
@@ -555,6 +595,11 @@ export interface SiteMetadata {
 	 * UTC date of the last returning-visit usage stats event for this site.
 	 */
 	lastUsageStatsReturningVisitDate?: string;
+
+	/**
+	 * Timestamps for one-off migrations applied to this site.
+	 */
+	appliedMigrations?: Record<string, number>;
 }
 
 export const { setOPFSSitesLoadingState, setBlueprintResolvedFromUrl } =


### PR DESCRIPTION
## What?
- Adds a shared Personal WP App Launcher blueprint helper.
- Automatically checks existing personal sites for the my-apps plugin file and installs it when missing.
- Persists a migration marker after the plugin is present and syncs that marker across tabs.

## Why?
Older Personal WP sites predate the default my-apps plugin. This equips those sites without reinstalling when users already have the plugin.

## Testing
- npm exec nx test playground-personal-wp -- --run
- npm exec nx typecheck playground-personal-wp
- npm exec nx lint playground-personal-wp