### PR TITLE
Pin ws so npm release packing succeeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,8 @@ jobs:
             - uses: ./.github/actions/prepare-playground
               with:
                   node-version: 22
+            - name: Validate publish package overrides
+              run: node tools/scripts/check-publish-package-overrides.mjs
             - name: Install Playwright Browsers
               run: npx --yes playwright@1.55.1 install --with-deps chromium
             - name: Build packages, start local registry, and run integration tests

--- a/.github/workflows/publish-npm-packages.yml
+++ b/.github/workflows/publish-npm-packages.yml
@@ -94,6 +94,9 @@ jobs:
 
             - uses: ./.github/actions/prepare-playground
 
+            - name: Validate publish package overrides
+              run: node tools/scripts/check-publish-package-overrides.mjs
+
             - name: Publish NPM packages
               # Version bump, release, tag a new version on GitHub.
               # On non-trunk branches, --no-push avoids pushing the version

--- a/package-lock.json
+++ b/package-lock.json
@@ -54189,7 +54189,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.27.0",
-				"ws": "^8.21.0",
+				"ws": "8.21.0",
 				"zod": "^4.3"
 			},
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
 		"lodash": "^4.17.23",
 		"glob": "^9.3.0",
 		"webpackbar": "^7.0.0",
-		"ws": "^8.21.0"
+		"ws": "8.21.0"
 	},
 	"workspaces": [
 		"packages/nx-extensions",

--- a/packages/playground/mcp/package.json
+++ b/packages/playground/mcp/package.json
@@ -37,7 +37,7 @@
 	},
 	"dependencies": {
 		"@modelcontextprotocol/sdk": "^1.27.0",
-		"ws": "^8.21.0",
+		"ws": "8.21.0",
 		"zod": "^4.3"
 	},
 	"devDependencies": {

--- a/tools/scripts/check-publish-package-overrides.mjs
+++ b/tools/scripts/check-publish-package-overrides.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const rootPackageJson = readJson('package.json');
+const packageLock = readJson('package-lock.json');
+const overrides = rootPackageJson.overrides ?? {};
+const failures = [];
+
+// The release build writes resolved dependency versions into dist package.json files.
+// npm 11 rejects a direct dependency when the root override does not match that
+// resolved version exactly, even if the semver range would resolve correctly.
+// Example: `@wp-playground/mcp` had `ws@^8.21.0` in source, but the dist
+// manifest had `ws@8.21.0`; npm rejected it next to `overrides.ws@^8.21.0`.
+// @see https://github.com/WordPress/wordpress-playground/pull/3745
+for (const packageDir of getWorkspacePackageDirs(rootPackageJson.workspaces ?? [])) {
+	const packageJsonPath = `${packageDir}/package.json`;
+	if (!fs.existsSync(packageJsonPath)) {
+		continue;
+	}
+
+	const packageJson = readJson(packageJsonPath);
+	if (packageJson.private || !packageJson.publishConfig?.directory) {
+		continue;
+	}
+
+	for (const section of ['dependencies', 'optionalDependencies']) {
+		for (const [dependencyName, dependencySpec] of Object.entries(
+			packageJson[section] ?? {}
+		)) {
+			const overrideSpec = overrides[dependencyName];
+			if (typeof overrideSpec !== 'string') {
+				continue;
+			}
+
+			const resolvedVersion = getResolvedVersion(packageDir, dependencyName);
+			if (!resolvedVersion) {
+				failures.push(
+					`${packageJson.name} declares ${dependencyName}, but ` +
+						'package-lock.json does not include a resolved version.'
+				);
+				continue;
+			}
+
+			if (dependencySpec !== resolvedVersion || overrideSpec !== resolvedVersion) {
+				failures.push(
+					`${packageJson.name} declares ${dependencyName}@${dependencySpec} ` +
+						`and the root override is ${dependencyName}@${overrideSpec}, ` +
+						`but the lockfile resolves ${dependencyName}@${resolvedVersion}. ` +
+						'Published package manifests use resolved versions during release, ' +
+						'and npm rejects root overrides that do not exactly match ' +
+						'direct dependencies. Pin both specs to the resolved version, ' +
+						'or remove the root override.'
+				);
+			}
+		}
+	}
+}
+
+if (failures.length > 0) {
+	console.error('Publish package override validation failed:');
+	for (const failure of failures) {
+		console.error(`- ${failure}`);
+	}
+	process.exit(1);
+}
+
+console.log('Publish package override validation passed.');
+
+function readJson(filePath) {
+	return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function getWorkspacePackageDirs(workspaces) {
+	const packageDirs = [];
+	for (const workspace of workspaces) {
+		if (!workspace.endsWith('/*')) {
+			if (fs.existsSync(workspace)) {
+				packageDirs.push(workspace);
+			}
+			continue;
+		}
+
+		const baseDir = workspace.slice(0, -2);
+		if (!fs.existsSync(baseDir)) {
+			continue;
+		}
+
+		for (const entry of fs.readdirSync(baseDir, { withFileTypes: true })) {
+			if (entry.isDirectory()) {
+				packageDirs.push(`${baseDir}/${entry.name}`);
+			}
+		}
+	}
+	return packageDirs;
+}
+
+function getResolvedVersion(packageDir, dependencyName) {
+	const packageLocalPath = `${packageDir}/node_modules/${dependencyName}`;
+	const rootPackagePath = `node_modules/${dependencyName}`;
+	return (
+		packageLock.packages?.[packageLocalPath]?.version ??
+		packageLock.packages?.[rootPackagePath]?.version
+	);
+}


### PR DESCRIPTION
## What it does

Prevents the npm release from failing when a publishable package declares a dependency that is also listed in root `overrides`.

Fixes the npm release failure introduced in WordPress/wordpress-playground#3745:

```
npm 11 rejected packing @wp-playground/mcp:
Override for ws@8.21.0 conflicts with direct dependency
```

For `@wp-playground/mcp`, `ws` is now pinned to the same exact version as the root override:

```json
"ws": "8.21.0"
```

## Rationale

The failed npm release reached `lerna publish`, built `dist/packages/playground/mcp/package.json`, then npm 11 rejected packing it:

```text
Override for ws@8.21.0 conflicts with direct dependency
```

The source package used `^8.21.0`, but the release build writes resolved dependency versions into dist manifests. That produced a direct `ws@8.21.0` dependency next to a root `ws@^8.21.0` override, which npm 11 treats as a conflict even though the range resolves correctly.

## Implementation

Adds `tools/scripts/check-publish-package-overrides.mjs`. The script scans publishable workspace packages and fails when:

1. a package directly depends on a root-overridden dependency, and
2. either the package dependency or the root override does not exactly match the lockfile's resolved version.

The check now runs in:

- `test-built-npm-packages`, so PRs catch this before merge
- `publish-npm-packages.yml`, so the release fails before `lerna publish` mutates versions or tags

## Testing instructions

Run the guard:

```bash
node tools/scripts/check-publish-package-overrides.mjs
```

Expected result with this PR:

```text
Publish package override validation passed.
```

I also temporarily reverted `ws` in the root override and MCP package back to `^8.21.0`; the new guard failed with the expected release-conflict message.
