### PR TITLE
[Website] Preserve stored boot settings when modifying settings of an autosaved Playground

### DIFF
--- a/packages/playground/website/playwright/e2e/sites-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/sites-api.spec.ts
@@ -153,6 +153,56 @@ test('playgroundSites.createNewSavedSite() creates unique slugs for repeated Blu
 	expect(secondSite.name).not.toBe(firstSite.name);
 });
 
+test('playgroundSites.recreateAutosavedSite() preserves stored setup params', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	const blueprint = {
+		steps: [
+			{
+				step: 'writeFile',
+				path: '/wordpress/preserved-setup.txt',
+				data: 'preserved setup',
+			},
+		],
+	};
+	const setupParams = new URLSearchParams({
+		storage: 'temp',
+		php: '8.3',
+	});
+
+	await website.goto(`./?${setupParams}#${JSON.stringify(blueprint)}`);
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+
+	const result = await website.page.evaluate(async () => {
+		const api = (window as any).playgroundSites;
+		await api.autosaveTemporarySite();
+		const activeSite = api.list().find((site: any) => site.isActive);
+
+		// The bug only reproduces once the visible URL no longer contains the
+		// original setup params. This mirrors reopening the autosaved site from
+		// the stored-site route.
+		window.history.pushState({}, '', `./?site-slug=${activeSite.slug}`);
+		await api.recreateAutosavedSite({ phpVersion: '8.4' });
+
+		return window.location.href;
+	});
+
+	const recreatedUrl = new URL(result);
+	expect(recreatedUrl.searchParams.get('site-slug')).toBe(null);
+	expect(recreatedUrl.searchParams.get('php')).toBe('8.4');
+	expect(decodeURIComponent(recreatedUrl.hash.slice(1))).toBe(
+		JSON.stringify(blueprint)
+	);
+});
+
 test('playgroundSites.createNewSavedSite() creates an explicit OPFS site by default', async ({
 	website,
 	browserName,

--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -40,13 +40,19 @@ import {
 import { StringEditorModal } from './string-editor-modal';
 import { useBlueprintUrlHash } from '../../lib/hooks/use-blueprint-url-hash';
 import { useDebouncedCallback } from '../../lib/hooks/use-debounced-callback';
-import { removeClientInfo } from '../../lib/state/redux/slice-clients';
+import {
+	removeClientInfo,
+	selectClientInfoBySiteSlug,
+} from '../../lib/state/redux/slice-clients';
 import {
 	isAutosavedSite,
 	type SiteInfo,
 	updateSite,
 } from '../../lib/state/redux/slice-sites';
-import { useAppDispatch } from '../../lib/state/redux/store';
+import {
+	useAppDispatch,
+	useAppSelector,
+} from '../../lib/state/redux/store';
 import { opfsSiteStorage } from '../../lib/state/opfs/opfs-site-storage';
 import styles from './blueprint-bundle-editor.module.css';
 import hideRootStyles from './hide-root.module.css';
@@ -322,6 +328,9 @@ export const BlueprintBundleEditor = forwardRef<
 	// Store the CodeMirror EditorView for string editor operations
 	const cmViewRef = useRef<EditorView | null>(null);
 	const dispatch = useAppDispatch();
+	const playgroundClient = useAppSelector((state) =>
+		site ? selectClientInfoBySiteSlug(state, site.slug)?.client : undefined
+	);
 
 	// Save file to filesystem
 	const saveFile = useDebouncedCallback(
@@ -402,9 +411,12 @@ export const BlueprintBundleEditor = forwardRef<
 				bundle as any
 			);
 			if (isAutosaved) {
+				await playgroundClient?.unmountOpfs('/wordpress');
+				dispatch(removeClientInfo(site.slug));
 				await opfsSiteStorage!.resetSiteFiles(site.slug);
+			} else {
+				dispatch(removeClientInfo(site.slug));
 			}
-			dispatch(removeClientInfo(site.slug));
 			await dispatch(
 				updateSite({
 					slug: site.slug,
@@ -442,7 +454,7 @@ export const BlueprintBundleEditor = forwardRef<
 		} finally {
 			setIsRecreating(false);
 		}
-	}, [dispatch, filesystem, readOnly, site]);
+	}, [dispatch, filesystem, playgroundClient, readOnly, site]);
 
 	// autorun token hook
 	useEffect(() => {

--- a/packages/playground/website/src/lib/state/playground-identity.spec.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.spec.ts
@@ -4,6 +4,7 @@ import {
 	getAutosaveFingerprintFromURL,
 	getAutosaveFingerprintFromSite,
 	getRuntimeBootFingerprint,
+	getSetupUrlFromSite,
 	getSetupUrlFromUrl,
 } from './playground-identity';
 
@@ -113,6 +114,33 @@ describe('getSetupUrlFromUrl', () => {
 
 		expect(setupUrl.toString()).toBe(
 			'https://playground.test/?php=8.3&php-extension=https%3A%2F%2Fexample.com%2Fext.json&plugin=a&plugin=b#blueprint'
+		);
+	});
+});
+
+describe('getSetupUrlFromSite', () => {
+	it('uses the stored site setup instead of the current browser route', () => {
+		const site = {
+			slug: 'test-site',
+			originalUrlParams: {
+				searchParams: {
+					plugin: ['a', 'b'],
+					theme: 'twentytwentyfive',
+					php: '8.3',
+					modal: 'site-manager',
+				},
+				hash: '#blueprint',
+			},
+			metadata: {},
+		} as unknown as SiteInfo;
+
+		const setupUrl = getSetupUrlFromSite(
+			site,
+			'https://playground.test/?site-slug=test-site&php=8.4#current'
+		);
+
+		expect(setupUrl.toString()).toBe(
+			'https://playground.test/?plugin=a&plugin=b&theme=twentytwentyfive&php=8.3#blueprint'
 		);
 	});
 });

--- a/packages/playground/website/src/lib/state/playground-identity.spec.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.spec.ts
@@ -139,9 +139,14 @@ describe('getSetupUrlFromSite', () => {
 			'https://playground.test/?site-slug=test-site&php=8.4#current'
 		);
 
-		expect(setupUrl.toString()).toBe(
-			'https://playground.test/?plugin=a&plugin=b&theme=twentytwentyfive&php=8.3#blueprint'
+		expect(`${setupUrl.origin}${setupUrl.pathname}`).toBe(
+			'https://playground.test/'
 		);
+		expect(setupUrl.searchParams.getAll('plugin')).toEqual(['a', 'b']);
+		expect(setupUrl.searchParams.get('theme')).toBe('twentytwentyfive');
+		expect(setupUrl.searchParams.get('php')).toBe('8.3');
+		expect(setupUrl.searchParams.has('modal')).toBe(false);
+		expect(setupUrl.hash).toBe('#blueprint');
 	});
 });
 

--- a/packages/playground/website/src/lib/state/playground-identity.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.ts
@@ -74,7 +74,7 @@ export function getSetupUrlFromUrl(url: URL) {
  */
 export function getSetupUrlFromSite(
 	site: SiteInfo,
-	baseUrl: string = window.location.href
+	baseUrl: string | URL
 ) {
 	if (!site.originalUrlParams) {
 		return getSetupUrlFromUrl(new URL(baseUrl));

--- a/packages/playground/website/src/lib/state/playground-identity.ts
+++ b/packages/playground/website/src/lib/state/playground-identity.ts
@@ -65,6 +65,39 @@ export function getSetupUrlFromUrl(url: URL) {
 }
 
 /**
+ * Returns the setup URL stored with a site.
+ *
+ * Stored Playgrounds may be opened from a route like `?site-slug=demo`, which
+ * does not fully describe the setup that created them. Recreating an autosaved
+ * Playground must start from the saved setup params instead of the current
+ * browser URL so Blueprint, plugin, theme, and other setup params are retained.
+ */
+export function getSetupUrlFromSite(
+	site: SiteInfo,
+	baseUrl: string = window.location.href
+) {
+	if (!site.originalUrlParams) {
+		return getSetupUrlFromUrl(new URL(baseUrl));
+	}
+
+	const setupUrl = new URL(baseUrl);
+	setupUrl.search = '';
+	for (const [key, value] of Object.entries(
+		site.originalUrlParams.searchParams ?? {}
+	)) {
+		if (!SETUP_QUERY_PARAMS.has(key)) {
+			continue;
+		}
+		const values = Array.isArray(value) ? value : [value];
+		for (const item of values) {
+			setupUrl.searchParams.append(key, item);
+		}
+	}
+	setupUrl.hash = site.originalUrlParams.hash ?? '';
+	return setupUrl;
+}
+
+/**
  * Returns the autosave fingerprint originally associated with a site.
  *
  * Existing saved sites may not have stored `sourceSetupUrlFingerprint`, so this

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -11,7 +11,7 @@ import {
 } from './store';
 import type { SerializedSiteErrorDetails, SiteError } from './slice-ui';
 import { setActiveSiteError } from './slice-ui';
-import { addClientInfo } from './slice-clients';
+import { addClientInfo, removeClientInfo } from './slice-clients';
 import {
 	selectAllSites,
 	selectSiteBySlug,
@@ -418,6 +418,11 @@ export function createSitesAPI(
 				baseUrl: getSetupUrlFromSite(site, window.location.href),
 				onlySetupParams: true,
 			});
+			await selectClientBySiteSlug(
+				getState(),
+				site.slug
+			)?.unmountOpfs('/wordpress');
+			dispatch(removeClientInfo(site.slug));
 			await dispatch(resetAutosavedSiteSpec(site.slug, setupUrl));
 			redirectTo(setupUrl.toString());
 		},

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -415,7 +415,7 @@ export function createSitesAPI(
 				);
 			}
 			const setupUrl = getSetupUrlForNewSite(settings, {
-				baseUrl: getSetupUrlFromSite(site),
+				baseUrl: getSetupUrlFromSite(site, window.location.href),
 				onlySetupParams: true,
 			});
 			await dispatch(resetAutosavedSiteSpec(site.slug, setupUrl));

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -36,7 +36,10 @@ import { selectClientBySiteSlug } from './slice-clients';
 import type { PlaygroundClient } from '@wp-playground/remote';
 import type { AllPHPVersion } from '@php-wasm/universal';
 import { opfsSiteStorage } from '../opfs/opfs-site-storage';
-import { getSetupUrlFromUrl } from '../playground-identity';
+import {
+	getSetupUrlFromSite,
+	getSetupUrlFromUrl,
+} from '../playground-identity';
 import { redirectTo } from '../url/router';
 
 export interface SiteSettings {
@@ -412,6 +415,7 @@ export function createSitesAPI(
 				);
 			}
 			const setupUrl = getSetupUrlForNewSite(settings, {
+				baseUrl: getSetupUrlFromSite(site),
 				onlySetupParams: true,
 			});
 			await dispatch(resetAutosavedSiteSpec(site.slug, setupUrl));
@@ -562,7 +566,9 @@ export function createSitesAPI(
 			const siteName = requestedSiteSlug
 				? deriveSiteNameFromSlug(requestedSiteSlug)
 				: randomSiteName();
-			const url = getSetupUrlForNewSite(settings);
+			const url = getSetupUrlForNewSite(settings, {
+				baseUrl: new URL(window.location.href),
+			});
 			const newSiteInfo = await dispatch(
 				setTemporarySiteSpec(siteName, url, requestedSiteSlug)
 			);
@@ -602,6 +608,7 @@ export function createSitesAPI(
 				? deriveSiteNameFromSlug(requestedSiteSlug)
 				: randomSiteName();
 			const url = getSetupUrlForNewSite(settings, {
+				baseUrl: new URL(window.location.href),
 				onlySetupParams: true,
 			});
 			const newSiteInfo = await dispatch(
@@ -651,19 +658,22 @@ async function updateSiteNameIfProvided(
  *
  * Temporary sites keep the current query string for backwards compatibility.
  * Saved sites keep only setup params so routing, UI, and lifecycle params do
- * not leak into persisted metadata. Both paths use the same `SiteSettings`
- * mapping so new settings have one query representation.
+ * not leak into persisted metadata. Autosaved site recreation passes the
+ * stored setup URL as the base so changing one setting does not discard
+ * Blueprint, plugin, theme, or other setup params that are absent from the
+ * current browser route. All paths use the same `SiteSettings` mapping so new
+ * settings have one query representation.
  */
 function getSetupUrlForNewSite(
-	settings?: SiteSettings,
+	settings: SiteSettings | undefined,
 	options: {
+		baseUrl: URL;
 		onlySetupParams?: boolean;
-	} = {}
+	}
 ) {
-	const currentUrl = new URL(window.location.href);
 	const url = options.onlySetupParams
-		? getSetupUrlFromUrl(currentUrl)
-		: currentUrl;
+		? getSetupUrlFromUrl(options.baseUrl)
+		: new URL(options.baseUrl.href);
 	if (settings) {
 		if (settings.phpVersion !== undefined) {
 			url.searchParams.set('php', settings.phpVersion);


### PR DESCRIPTION
## What it does

Recreates autosaved Playgrounds from the site’s stored setup URL instead of the current browser route.

Changing settings in the autosaved-site popover now preserves setup params such as `plugin`, `theme`, `blueprint-url`, and Blueprint fragments even when the visible URL is only a stored-site route like `?site-slug=demo`.

## Reproduction

1. Open a Playground with setup params, for example:

   ```text
   /?plugin=gutenberg&theme=twentytwentyfive&php=8.3
   ```

2. Let the site get autosaved.
3. Reopen or switch to that autosaved site so the browser URL is the stored-site route instead of the original setup URL, for example:

   ```text
   /?site-slug=my-autosaved-site
   ```

4. Open the autosaved-site settings and change one setting, such as PHP from 8.3 to 8.4.

Before this patch, autosaved-site recreation used `window.location.href` as the base URL. At step 4 that URL only contains `?site-slug=my-autosaved-site`, not the setup that created the site. Applying the edited setting therefore recreates the autosave from something like:

```text
/?php=8.4
```

instead of:

```text
/?plugin=gutenberg&theme=twentytwentyfive&php=8.4
```

That silently drops unrelated setup state such as plugins, themes, Blueprint URLs/fragments, language, and multisite configuration.

## Rationale

Autosaved Playgrounds keep their original setup in `site.originalUrlParams`. The settings form already reads that stored setup for defaults, but submit rebuilt the setup URL from `window.location.href`. If the address bar no longer contained the original setup params, applying one setting could recreate the autosave without the plugins, themes, or Blueprint that created it.

## Implementation

Added `getSetupUrlFromSite(site, baseUrl)` to rebuild a setup URL from `site.originalUrlParams` while using the current page URL only as the origin/path shell.

`recreateAutosavedSite()` now passes that stored setup URL into `getSetupUrlForNewSite()`, which overlays the edited settings on top of the stored setup before resetting the autosaved site files.

## Testing instructions

```bash
git diff --check origin/trunk...HEAD
npx nx test playground-website --testFile=playground-identity.spec.ts
npx nx typecheck playground-website
npx nx lint playground-website
```
