### PR TITLE
fix(cli): propagate runCLI() startup errors instead of swallowing them via process.exit(1)

### DIFF
--- a/packages/playground/cli/src/run-cli.ts
+++ b/packages/playground/cli/src/run-cli.ts
@@ -1829,9 +1829,6 @@ export async function runCLI(args: RunCLIArgs): Promise<RunCLIServer | void> {
 
 			return response;
 		},
-	}).catch((error) => {
-		cliOutput.printError(describeError(error));
-		process.exit(1);
 	});
 
 	if (server && args.command === 'start' && !args.skipBrowser) {

--- a/packages/playground/cli/tests/run-cli.spec.ts
+++ b/packages/playground/cli/tests/run-cli.spec.ts
@@ -2110,35 +2110,31 @@ describe('other run-cli behaviors', () => {
 
 	describe('port in use', () => {
 		test('should error when explicit port is already in use', async () => {
-			const stdoutMessages: string[] = [];
-			const mockStdout = vi
-				.spyOn(process.stdout, 'write')
-				.mockImplementation((chunk) => {
-					stdoutMessages.push(String(chunk));
-					return true;
-				});
-			const mockExit = vi
-				.spyOn(process, 'exit')
-				.mockImplementation(() => undefined as never);
-
 			const port = 12345;
 			const blockingServer = http.createServer();
 			await new Promise<void>((resolve) => {
 				blockingServer.listen(port, () => resolve());
 			});
 
-			try {
-				await runCLI({
-					command: 'server',
-					port,
-				});
-
-				expect(stdoutMessages.join('')).toContain(
-					`Error: listen EADDRINUSE: address already in use :::${port}`
+			const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((
+				code?: any
+			) => {
+				throw new Error(
+					`process.exit unexpectedly called with code ${code}`
 				);
+			}) as any);
+
+			try {
+				await expect(
+					runCLI({
+						command: 'server',
+						port,
+					})
+				).rejects.toThrow(/EADDRINUSE/);
+
+				expect(exitSpy).not.toHaveBeenCalled();
 			} finally {
-				mockExit.mockRestore();
-				mockStdout.mockRestore();
+				exitSpy.mockRestore();
 				blockingServer.close();
 			}
 		});


### PR DESCRIPTION
## Motivation for the change, related issues

`runCLI()` in `packages/playground/cli/src/run-cli.ts` had a `.catch()` on the internal `startServer()` call that swallowed startup errors by printing them and calling `process.exit(1)`:

```js
}).catch((error) => {
    cliOutput.printError(describeError(error));
    process.exit(1);
});
```

This means library callers of `runCLI()` — such as WordPress Studio, which spawns it as a daemon — can never catch or handle startup errors. A non-fatal error (e.g. a port conflict, a transient worker exit race) kills the entire process with no opportunity to retry or report it gracefully.

Fixes #3520 

## Implementation details

Remove the `.catch()` so rejections from `startServer()` propagate naturally through `await` as a rejected promise from `runCLI()`.

The `process.exit(1)` behavior for standalone CLI users is preserved unchanged: `parseOptionsAndRunCLI()` already wraps `runCLI()` in its own `try/catch` that formats the error and exits.

The existing test `should error when explicit port is already in use` was asserting the old broken behavior (error printed to stdout + `process.exit` called). Updated it to assert the correct behavior: `runCLI()` rejects with `EADDRINUSE` and `process.exit` is not called.

**Breaking change:** library callers that previously relied on `runCLI()` never rejecting will now see unhandled rejections on startup failure. This is the correct behavior — callers should handle errors from `runCLI()`.

## Testing Instructions (or ideally a Blueprint)

1. Run the CLI test suite and confirm all tests pass:
   ```bash
   nvm use
   npx nx test-playground-cli playground-cli --testFile=run-cli.spec.ts
   ```

2. Confirm the standalone CLI still exits cleanly on a port conflict:
   ```bash
   # Occupy port 9400
   node -e "require('net').createServer().listen(9400)"
   # In another terminal, try to start the CLI on the same port
   npx nx dev playground-cli server --port=9400
   # Should print the EADDRINUSE error and exit with code 1 — same as before
   ```

3. Confirm library callers can now catch errors:
   ```js
   import { runCLI } from '@wp-playground/cli';

   try {
       await runCLI({ command: 'server', port: 9400 }); // port already in use
   } catch (error) {
       console.log('Caught:', error.message); // now reachable
   }
   ```
