### PR TITLE
[Website] Use Blueprint titles for new Playground names

### DIFF
--- a/packages/playground/website/playwright/e2e/sites-api.spec.ts
+++ b/packages/playground/website/playwright/e2e/sites-api.spec.ts
@@ -86,6 +86,73 @@ test('playgroundSites.autosaveTemporarySite() persists without disrupting the ta
 	expect(result.sameUrl).toBe(true);
 });
 
+test('playgroundSites.createNewSavedSite() creates unique slugs for repeated Blueprint titles', async ({
+	website,
+	browserName,
+}) => {
+	test.skip(
+		browserName !== 'chromium',
+		`This test relies on OPFS which isn't available in Playwright's flavor of ${browserName}.`
+	);
+
+	const blueprint = {
+		meta: {
+			title: 'Shared Blueprint Name',
+			author: 'wordpress',
+		},
+		steps: [],
+	};
+	await website.goto('./?storage=temp');
+	await website.page.waitForFunction(() =>
+		Boolean((window as any).playgroundSites?.getClient())
+	);
+
+	const result = await website.page.evaluate(async (blueprintToSave) => {
+		window.history.replaceState(
+			null,
+			'',
+			`?storage=temp#${encodeURIComponent(
+				JSON.stringify(blueprintToSave)
+			)}`
+		);
+		const api = (window as any).playgroundSites;
+		const firstSlug = await api.createNewSavedSite(undefined, undefined, {
+			updateUrl: false,
+		});
+		const secondSlug = await api.createNewSavedSite(undefined, undefined, {
+			updateUrl: false,
+		});
+		const sites = api
+			.list()
+			.filter((s: any) => s.slug.startsWith('shared-blueprint-name'));
+		return { firstSlug, secondSlug, sites };
+	}, blueprint);
+
+	expect(result.firstSlug).toBe('shared-blueprint-name');
+	expect(result.secondSlug).toBe('shared-blueprint-name-2');
+	const firstSite = result.sites.find(
+		(site: any) => site.slug === 'shared-blueprint-name'
+	);
+	const secondSite = result.sites.find(
+		(site: any) => site.slug === 'shared-blueprint-name-2'
+	);
+	expect(firstSite).toEqual(
+		expect.objectContaining({
+			name: 'Shared Blueprint Name',
+			storage: 'opfs',
+		})
+	);
+	expect(secondSite).toEqual(
+		expect.objectContaining({
+			name: expect.stringMatching(
+				/^Shared Blueprint Name — [A-Z][a-z]{2} \d{1,2}, \d{2}:\d{2}:\d{2}/
+			),
+			storage: 'opfs',
+		})
+	);
+	expect(secondSite.name).not.toBe(firstSite.name);
+});
+
 test('playgroundSites.createNewSavedSite() creates an explicit OPFS site by default', async ({
 	website,
 	browserName,

--- a/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
+++ b/packages/playground/website/src/lib/state/redux/site-management-api-middleware.ts
@@ -549,8 +549,9 @@ export function createSitesAPI(
 		/**
 		 * Creates a new temporary site and boots it.
 		 *
-		 * @param siteSlug Optional slug hint. A random name is
-		 *   generated when omitted.
+		 * @param requestedSiteSlug Optional slug hint. When omitted, the
+		 *   Blueprint title becomes the site name if available; otherwise a
+		 *   random name is generated.
 		 * @param settings Optional site settings.
 		 * @returns The new site's slug.
 		 */
@@ -576,8 +577,9 @@ export function createSitesAPI(
 		 * autosave. First boot creates the WordPress files from the setup URL,
 		 * then stores that initialized filesystem in OPFS for later boots.
 		 *
-		 * @param requestedSiteSlug Optional slug hint. A random name is
-		 *   generated when omitted.
+		 * @param requestedSiteSlug Optional slug hint. When omitted, the
+		 *   Blueprint title becomes the site name if available; otherwise a
+		 *   random name is generated.
 		 * @param settings Optional site settings.
 		 * @param options Optional persistence, routing, and pruning behavior.
 		 * @returns The new site's slug.

--- a/packages/playground/website/src/lib/state/redux/site-name.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-name.spec.ts
@@ -1,0 +1,140 @@
+import {
+	getDefaultSiteNameFromBlueprint,
+	getSiteNameWithCreationTimeIfDuplicate,
+} from './site-name';
+
+describe('getDefaultSiteNameFromBlueprint', () => {
+	it('uses the v1 Blueprint title when present', () => {
+		expect(
+			getDefaultSiteNameFromBlueprint(
+				{
+					meta: {
+						title: 'WooCommerce Demo Store',
+						author: 'wordpress',
+					},
+					steps: [],
+				},
+				'Random Playground'
+			)
+		).toBe('WooCommerce Demo Store');
+	});
+
+	it('uses the v2 Blueprint name when present', () => {
+		expect(
+			getDefaultSiteNameFromBlueprint(
+				{
+					version: 2,
+					blueprintMeta: {
+						name: 'Magazine Starter Site',
+					},
+				},
+				'Random Playground'
+			)
+		).toBe('Magazine Starter Site');
+	});
+
+	it('falls back when the Blueprint has no title metadata', () => {
+		expect(
+			getDefaultSiteNameFromBlueprint({ steps: [] }, 'Random Playground')
+		).toBe('Random Playground');
+	});
+
+	it('falls back when the Blueprint title is empty', () => {
+		expect(
+			getDefaultSiteNameFromBlueprint(
+				{
+					meta: {
+						title: '   ',
+						author: 'wordpress',
+					},
+					steps: [],
+				},
+				'Random Playground'
+			)
+		).toBe('Random Playground');
+	});
+
+	it('falls back when the v2 Blueprint name is empty', () => {
+		expect(
+			getDefaultSiteNameFromBlueprint(
+				{
+					version: 2,
+					blueprintMeta: {
+						name: '   ',
+					},
+				},
+				'Random Playground'
+			)
+		).toBe('Random Playground');
+	});
+
+	it('falls back when the Blueprint title is not a string', () => {
+		expect(
+			getDefaultSiteNameFromBlueprint(
+				{
+					meta: {
+						title: 42,
+						author: 'wordpress',
+					},
+					steps: [],
+				} as unknown as Parameters<
+					typeof getDefaultSiteNameFromBlueprint
+				>[0],
+				'Random Playground'
+			)
+		).toBe('Random Playground');
+	});
+
+	it('falls back when the v2 Blueprint name is not a string', () => {
+		expect(
+			getDefaultSiteNameFromBlueprint(
+				{
+					version: 2,
+					blueprintMeta: {
+						name: 42,
+					},
+				} as unknown as Parameters<
+					typeof getDefaultSiteNameFromBlueprint
+				>[0],
+				'Random Playground'
+			)
+		).toBe('Random Playground');
+	});
+});
+
+describe('getSiteNameWithCreationTimeIfDuplicate', () => {
+	const createdAt = new Date(2026, 5, 11, 14, 37, 5, 123);
+
+	it('keeps the clean name when no existing Playground uses it', () => {
+		expect(
+			getSiteNameWithCreationTimeIfDuplicate(
+				'WooCommerce Demo Store',
+				[],
+				createdAt
+			)
+		).toBe('WooCommerce Demo Store');
+	});
+
+	it('adds the creation time when the clean name is already used', () => {
+		expect(
+			getSiteNameWithCreationTimeIfDuplicate(
+				'WooCommerce Demo Store',
+				['WooCommerce Demo Store'],
+				createdAt
+			)
+		).toBe('WooCommerce Demo Store — Jun 11, 14:37:05');
+	});
+
+	it('adds milliseconds when the second-level timestamp is already used', () => {
+		expect(
+			getSiteNameWithCreationTimeIfDuplicate(
+				'WooCommerce Demo Store',
+				[
+					'WooCommerce Demo Store',
+					'WooCommerce Demo Store — Jun 11, 14:37:05',
+				],
+				createdAt
+			)
+		).toBe('WooCommerce Demo Store — Jun 11, 14:37:05.123');
+	});
+});

--- a/packages/playground/website/src/lib/state/redux/site-name.ts
+++ b/packages/playground/website/src/lib/state/redux/site-name.ts
@@ -1,0 +1,91 @@
+import type { Blueprint } from '@wp-playground/blueprints';
+
+/**
+ * Returns the display name for a new Playground created without an explicit
+ * slug hint.
+ *
+ * Blueprint authors can provide a human-readable title for galleries,
+ * examples, and share URLs. When that title exists, it is a better default
+ * Playground name than a random fallback because it identifies the setup the
+ * user just opened. Empty or malformed metadata is ignored so invalid optional
+ * title data cannot produce a blank name.
+ */
+export function getDefaultSiteNameFromBlueprint(
+	blueprint: Blueprint | undefined,
+	fallbackName: string
+) {
+	const title = getBlueprintTitle(blueprint)?.trim();
+	return title || fallbackName;
+}
+
+/**
+ * Returns a display name that stays readable when a user creates the same
+ * titled Blueprint more than once.
+ *
+ * The first Playground keeps the clean Blueprint title. Later Playgrounds get
+ * their creation time appended so the list identifies which run is which
+ * without using opaque counters such as "1" or "2".
+ */
+export function getSiteNameWithCreationTimeIfDuplicate(
+	siteName: string,
+	unavailableSiteNames: string[],
+	createdAt: Date
+) {
+	const unavailableNames = new Set(unavailableSiteNames);
+	if (!unavailableNames.has(siteName)) {
+		return siteName;
+	}
+
+	const nameWithTimestamp = `${siteName} — ${formatSiteNameTimestamp(
+		createdAt
+	)}`;
+	if (!unavailableNames.has(nameWithTimestamp)) {
+		return nameWithTimestamp;
+	}
+
+	return `${siteName} — ${formatSiteNameTimestamp(createdAt, {
+		includeMilliseconds: true,
+	})}`;
+}
+
+function formatSiteNameTimestamp(
+	createdAt: Date,
+	options: { includeMilliseconds?: boolean } = {}
+) {
+	const formatted = new Intl.DateTimeFormat('en', {
+		month: 'short',
+		day: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		hourCycle: 'h23',
+	}).format(createdAt);
+
+	if (!options.includeMilliseconds) {
+		return formatted;
+	}
+
+	return `${formatted}.${createdAt
+		.getMilliseconds()
+		.toString()
+		.padStart(3, '0')}`;
+}
+
+function getBlueprintTitle(blueprint: Blueprint | undefined) {
+	if (!blueprint || typeof blueprint !== 'object') {
+		return undefined;
+	}
+
+	if ('meta' in blueprint && typeof blueprint.meta?.title === 'string') {
+		return blueprint.meta.title;
+	}
+
+	if (
+		'blueprintMeta' in blueprint &&
+		typeof blueprint.blueprintMeta?.name === 'string'
+	) {
+		return blueprint.blueprintMeta.name;
+	}
+
+	return undefined;
+}

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -35,6 +35,10 @@ import {
 	type SitePersistence,
 } from './site-lifecycle';
 import { getAutosaveFingerprintFromURL } from '../playground-identity';
+import {
+	getDefaultSiteNameFromBlueprint,
+	getSiteNameWithCreationTimeIfDuplicate,
+} from './site-name';
 export {
 	MAX_AUTOSAVED_SITES,
 	SitePersistenceTypes,
@@ -411,16 +415,18 @@ export function setTemporarySiteSpec(
 			}
 		}
 
-		const siteSlug = getUniqueSiteSlug(
-			preferredSlug || deriveSlugFromSiteName(siteName),
-			{
-				// Temporary sites are removed before the new one is added, so they
-				// should not force the replacement site to take a numeric suffix.
-				unavailableSlugs: selectAllSites(getState())
-					.filter((site) => site.metadata.storage !== 'none')
-					.map((site) => site.slug),
-			}
+		// Temporary sites are removed before the new one is added, so they
+		// should not force the replacement site to take a numeric suffix.
+		const storedSites = selectAllSites(getState()).filter(
+			(site) => site.metadata.storage !== 'none'
 		);
+		const unavailableSlugs = storedSites.map((site) => site.slug);
+		const unavailableNames = storedSites.map((site) => site.metadata.name);
+		const getAvailableSiteSlug = (name: string) =>
+			getUniqueSiteSlug(preferredSlug || deriveSlugFromSiteName(name), {
+				unavailableSlugs,
+			});
+		let siteSlug = getAvailableSiteSlug(siteName);
 
 		const sites = getState().sites.entities;
 
@@ -462,11 +468,25 @@ export function setTemporarySiteSpec(
 				resolvedBlueprint,
 				playgroundUrlWithQueryApiArgs
 			);
+			let displayName = siteName;
+			let slugBaseName = siteName;
+			if (!preferredSlug) {
+				slugBaseName = getDefaultSiteNameFromBlueprint(
+					resolvedBlueprint.blueprint,
+					siteName
+				);
+				displayName = getSiteNameWithCreationTimeIfDuplicate(
+					slugBaseName,
+					unavailableNames,
+					new Date()
+				);
+			}
+			siteSlug = getAvailableSiteSlug(slugBaseName);
 			const newSiteInfo: SiteInfo = {
 				slug: siteSlug,
 				originalUrlParams: newSiteUrlParams,
 				metadata: {
-					name: siteName,
+					name: displayName,
 					id: crypto.randomUUID(),
 					whenCreated: Date.now(),
 					storage: 'none' as const,
@@ -522,10 +542,6 @@ export function setStoredSiteSpec(
 		dispatch: PlaygroundDispatch,
 		getState: () => PlaygroundReduxState
 	) => {
-		const siteSlug = getUniqueSiteSlug(
-			preferredSlug || deriveSlugFromSiteName(siteName),
-			{ unavailableSlugs: selectSiteSlugs(getState()) }
-		);
 		const originalUrlParams = getOriginalUrlParams(
 			playgroundUrlWithQueryApiArgs
 		);
@@ -534,11 +550,29 @@ export function setStoredSiteSpec(
 			playgroundUrlWithQueryApiArgs
 		);
 		const now = Date.now();
+		const sites = selectAllSites(getState());
+		let displayName = siteName;
+		let slugBaseName = siteName;
+		if (!preferredSlug) {
+			slugBaseName = getDefaultSiteNameFromBlueprint(
+				resolvedBlueprint.blueprint,
+				siteName
+			);
+			displayName = getSiteNameWithCreationTimeIfDuplicate(
+				slugBaseName,
+				sites.map((site) => site.metadata.name),
+				new Date(now)
+			);
+		}
+		const siteSlug = getUniqueSiteSlug(
+			preferredSlug || deriveSlugFromSiteName(slugBaseName),
+			{ unavailableSlugs: sites.map((site) => site.slug) }
+		);
 		const newSiteInfo: SiteInfo = {
 			slug: siteSlug,
 			originalUrlParams,
 			metadata: {
-				name: siteName,
+				name: displayName,
 				id: crypto.randomUUID(),
 				whenCreated: now,
 				whenLastUsed: now,


### PR DESCRIPTION
## What changed

- Uses a Blueprint's human-readable title as the default name for newly-created Playgrounds when no explicit slug hint is provided.
- Supports v1 `meta.title` and v2 `blueprintMeta.name` metadata.
- Falls back to the existing random default when title metadata is missing, empty, or malformed.
- Verifies repeated new saved Playgrounds created from the same titled Blueprint get unique slugs.

## Why

A shared Blueprint often already names the setup the user is opening. Using that title makes autosaved and temporary Playgrounds easier to recognize than a random generated name.

## Testing

- `npx nx test playground-website --testFile=site-name.spec.ts`
- `npx nx typecheck playground-website`
- `npx nx lint playground-website`
- `npx playwright test --config=packages/playground/website/playwright/playwright.config.ts packages/playground/website/playwright/e2e/sites-api.spec.ts -g "creates unique slugs for repeated Blueprint titles" --project=chromium`
