### PR TITLE
[Website] Propose AI-generated PR titles and descriptions in the GitHub export form

### DIFF
--- a/packages/playground/website/src/github/ai-settings-state.ts
+++ b/packages/playground/website/src/github/ai-settings-state.ts
@@ -1,0 +1,45 @@
+import { signal } from '@preact/signals-react';
+
+export interface AISettingsState {
+	openAiApiKey?: string;
+	useAiForPrDescription: boolean;
+}
+
+export const AI_SETTINGS_KEY = 'playground-ai-settings';
+
+// Persist the AI settings in localStorage in development mode so that
+// they survive page reloads. In production, keep them in memory only –
+// the same tradeoff made for the GitHub OAuth token in state.ts.
+const shouldPersist = process.env.NODE_ENV === 'development';
+
+function loadAISettings(): AISettingsState {
+	if (shouldPersist) {
+		try {
+			const stored = localStorage.getItem(AI_SETTINGS_KEY);
+			if (stored) {
+				return JSON.parse(stored);
+			}
+		} catch {
+			// Fall through to the defaults below.
+		}
+	}
+	return { useAiForPrDescription: false };
+}
+
+export const aiSettingsState = signal<AISettingsState>(loadAISettings());
+
+export function setAISettings(settings: Partial<AISettingsState>) {
+	const updated = {
+		...aiSettingsState.value,
+		...settings,
+	};
+	aiSettingsState.value = updated;
+
+	if (shouldPersist) {
+		localStorage.setItem(AI_SETTINGS_KEY, JSON.stringify(updated));
+	}
+}
+
+export function getAISettings(): AISettingsState {
+	return aiSettingsState.value;
+}

--- a/packages/playground/website/src/github/generate-pr-description.spec.ts
+++ b/packages/playground/website/src/github/generate-pr-description.spec.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Changeset } from '@wp-playground/storage';
+import { generatePrDescription } from './generate-pr-description';
+
+function makeChangeset(partial: Partial<Changeset> = {}): Changeset {
+	return {
+		create: new Map(),
+		update: new Map(),
+		delete: new Set(),
+		...partial,
+	};
+}
+
+function mockOpenAIResponse(content: string) {
+	return {
+		ok: true,
+		json: async () => ({
+			choices: [
+				{
+					message: { content },
+				},
+			],
+		}),
+	};
+}
+
+describe('generatePrDescription', () => {
+	let fetchMock: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		fetchMock = vi.fn();
+		global.fetch = fetchMock;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('should return null if no API key is provided', async () => {
+		const result = await generatePrDescription(
+			makeChangeset(),
+			undefined,
+			'wp-content'
+		);
+
+		expect(result).toBeNull();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('should return null if the API key is an empty string', async () => {
+		const result = await generatePrDescription(
+			makeChangeset(),
+			'',
+			'wp-content'
+		);
+
+		expect(result).toBeNull();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('should return null if the API key is whitespace only', async () => {
+		const result = await generatePrDescription(
+			makeChangeset(),
+			'   ',
+			'wp-content'
+		);
+
+		expect(result).toBeNull();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('should call the OpenAI API with correct parameters', async () => {
+		const changeset = makeChangeset({
+			create: new Map([['wp-content/file.txt', new Uint8Array()]]),
+			update: new Map([['wp-content/existing.txt', new Uint8Array()]]),
+		});
+
+		fetchMock.mockResolvedValueOnce(
+			mockOpenAIResponse(
+				JSON.stringify({
+					title: 'Update wp-content files',
+					body: 'This PR updates the wp-content directory with new files.',
+				})
+			)
+		);
+
+		const result = await generatePrDescription(
+			changeset,
+			'sk-test-key',
+			'wp-content'
+		);
+
+		expect(result).toEqual({
+			title: 'Update wp-content files',
+			body: 'This PR updates the wp-content directory with new files.',
+		});
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://api.openai.com/v1/chat/completions',
+			expect.objectContaining({
+				method: 'POST',
+				headers: expect.objectContaining({
+					'Content-Type': 'application/json',
+					Authorization: 'Bearer sk-test-key',
+				}),
+			})
+		);
+	});
+
+	it('should only send file paths to the API, never file contents', async () => {
+		const secretContent = new TextEncoder().encode('TOP-SECRET-VALUE');
+		const changeset = makeChangeset({
+			update: new Map([['wp-config.php', secretContent]]),
+		});
+
+		fetchMock.mockResolvedValueOnce(
+			mockOpenAIResponse(
+				JSON.stringify({ title: 'Title', body: 'Body.' })
+			)
+		);
+
+		await generatePrDescription(changeset, 'sk-test-key', 'wp-content');
+
+		const requestBody = fetchMock.mock.calls[0][1]?.body as string;
+		expect(requestBody).toContain('wp-config.php');
+		expect(requestBody).not.toContain('TOP-SECRET-VALUE');
+	});
+
+	it('should return null if the API returns a non-ok status', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			statusText: 'Unauthorized',
+		});
+
+		const result = await generatePrDescription(
+			makeChangeset({
+				create: new Map([['file.txt', new Uint8Array()]]),
+			}),
+			'sk-invalid-key',
+			'plugin'
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it('should return null if the API response is malformed', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: true,
+			json: async () => ({ unexpected: 'format' }),
+		});
+
+		const result = await generatePrDescription(
+			makeChangeset({
+				create: new Map([['file.txt', new Uint8Array()]]),
+			}),
+			'sk-test-key',
+			'plugin'
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it('should return null if fetch throws an error', async () => {
+		fetchMock.mockRejectedValueOnce(new Error('Network error'));
+
+		const result = await generatePrDescription(
+			makeChangeset({
+				create: new Map([['file.txt', new Uint8Array()]]),
+			}),
+			'sk-test-key',
+			'theme'
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it('should handle a plain text response when JSON parsing fails', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockOpenAIResponse(
+				`"Update theme files"\nThis PR updates the theme with new styles.`
+			)
+		);
+
+		const result = await generatePrDescription(
+			makeChangeset({
+				create: new Map([['file.txt', new Uint8Array()]]),
+			}),
+			'sk-test-key',
+			'theme'
+		);
+
+		expect(result).toEqual({
+			title: 'Update theme files',
+			body: 'This PR updates the theme with new styles.',
+		});
+	});
+
+	it('should include the content type context in the prompt', async () => {
+		fetchMock.mockResolvedValueOnce(
+			mockOpenAIResponse(
+				JSON.stringify({
+					title: 'Update plugin code',
+					body: 'Plugin update with improvements.',
+				})
+			)
+		);
+
+		await generatePrDescription(
+			makeChangeset({
+				update: new Map([['my-plugin/plugin.php', new Uint8Array()]]),
+			}),
+			'sk-test-key',
+			'plugin'
+		);
+
+		const callArgs = fetchMock.mock.calls[0][1];
+		const body = JSON.parse(callArgs?.body as string);
+		expect(body.messages[0].content).toContain(
+			'Updating a WordPress plugin'
+		);
+	});
+
+	it('should truncate long file lists in the prompt', async () => {
+		const manyFiles = new Map(
+			Array.from({ length: 25 }, (_, i) => [
+				`wp-content/file-${i}.txt`,
+				new Uint8Array(),
+			])
+		);
+
+		fetchMock.mockResolvedValueOnce(
+			mockOpenAIResponse(
+				JSON.stringify({ title: 'Title', body: 'Body.' })
+			)
+		);
+
+		await generatePrDescription(
+			makeChangeset({ create: manyFiles }),
+			'sk-test-key',
+			'wp-content'
+		);
+
+		const requestBody = fetchMock.mock.calls[0][1]?.body as string;
+		const prompt = JSON.parse(requestBody).messages[0].content;
+		expect(prompt).toContain('25 total, showing first 10');
+		expect(prompt).toContain('... and 15 more');
+		expect(prompt).not.toContain('file-15.txt');
+	});
+});

--- a/packages/playground/website/src/github/generate-pr-description.ts
+++ b/packages/playground/website/src/github/generate-pr-description.ts
@@ -1,0 +1,173 @@
+import type { Changeset } from '@wp-playground/storage';
+import { logger } from '@php-wasm/logger';
+
+export interface PRDescription {
+	title: string;
+	body: string;
+}
+
+type ContentType = 'wp-content' | 'theme' | 'plugin' | 'custom-paths';
+
+/**
+ * Generates a PR title and description using the OpenAI API based on
+ * the files changed in the export.
+ *
+ * Returns null when no API key is provided or when anything goes wrong –
+ * the caller is expected to fall back to its default title and message.
+ * This function must never block or break the export flow.
+ *
+ * @param changeset - The file changes about to be pushed to GitHub.
+ * @param apiKey - The user-provided OpenAI API key.
+ * @param contentType - What kind of content is being exported.
+ */
+export async function generatePrDescription(
+	changeset: Changeset,
+	apiKey: string | undefined,
+	contentType: ContentType
+): Promise<PRDescription | null> {
+	if (!apiKey?.trim()) {
+		return null;
+	}
+
+	try {
+		const summary = summarizeChangeset(changeset, contentType);
+
+		const prompt = `You are a helpful assistant that generates concise GitHub pull request titles and descriptions.
+
+Based on the following changes, generate:
+1. A short, descriptive PR title (under 72 characters)
+2. A brief PR description (2-3 sentences)
+
+Changes:
+${summary}
+
+Respond in JSON format with "title" and "body" fields.`;
+
+		const response = await fetch(
+			'https://api.openai.com/v1/chat/completions',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${apiKey}`,
+				},
+				body: JSON.stringify({
+					model: 'gpt-4o-mini',
+					messages: [
+						{
+							role: 'user',
+							content: prompt,
+						},
+					],
+					temperature: 0.7,
+					max_tokens: 200,
+				}),
+			}
+		);
+
+		if (!response.ok) {
+			logger.warn(
+				`OpenAI API error: ${response.status} ${response.statusText}`
+			);
+			return null;
+		}
+
+		const data = (await response.json()) as {
+			choices: Array<{ message: { content: string } }>;
+		};
+
+		const content = data.choices?.[0]?.message?.content;
+		if (!content) {
+			logger.warn('Unexpected OpenAI response format');
+			return null;
+		}
+
+		const parsed = parsePrDescription(content);
+		if (!parsed) {
+			logger.warn(
+				'Could not parse the OpenAI response into a PR description'
+			);
+		}
+		return parsed;
+	} catch (error) {
+		logger.warn('Error generating the PR description:', error);
+		return null;
+	}
+}
+
+/**
+ * Summarizes a changeset into a short, text-only digest for the AI prompt.
+ * Only file paths are included – never file contents. This keeps the token
+ * count low and avoids sending potentially sensitive data to the API.
+ */
+function summarizeChangeset(
+	changeset: Changeset,
+	contentType: ContentType
+): string {
+	const lines: string[] = [];
+
+	if (contentType === 'theme') {
+		lines.push('Updating a WordPress theme.');
+	} else if (contentType === 'plugin') {
+		lines.push('Updating a WordPress plugin.');
+	} else if (contentType === 'wp-content') {
+		lines.push('Updating WordPress site content (wp-content directory).');
+	} else {
+		lines.push('Updating custom paths in a WordPress installation.');
+	}
+
+	const sections: Array<[string, Iterable<string>, number]> = [
+		['New files', changeset.create.keys(), changeset.create.size],
+		['Modified files', changeset.update.keys(), changeset.update.size],
+		['Deleted files', changeset.delete.values(), changeset.delete.size],
+	];
+	const maxPathsPerSection = 10;
+	for (const [label, paths, total] of sections) {
+		if (total === 0) {
+			continue;
+		}
+		lines.push(
+			`\n${label} (${total} total, showing first ${Math.min(
+				total,
+				maxPathsPerSection
+			)}):`
+		);
+		const shownPaths = Array.from(paths).slice(0, maxPathsPerSection);
+		shownPaths.forEach((path) => lines.push(`  - ${path}`));
+		if (total > maxPathsPerSection) {
+			lines.push(`  ... and ${total - maxPathsPerSection} more`);
+		}
+	}
+
+	return lines.join('\n');
+}
+
+/**
+ * Parses the model output into a title and body. Accepts a JSON object
+ * with "title" and "body" fields, and falls back to treating the first
+ * line as the title and the rest as the body.
+ */
+function parsePrDescription(content: string): PRDescription | null {
+	try {
+		const parsed = JSON.parse(content);
+		const title = (parsed.title || '').trim();
+		const body = (parsed.body || '').trim();
+		if (title && body) {
+			return { title, body };
+		}
+	} catch {
+		const lines = content.split('\n');
+		if (lines.length >= 2) {
+			const title = lines[0].replace(/^["']|["']$/g, '').trim();
+			const body = lines
+				.slice(1)
+				.join('\n')
+				.replace(/^["']|["']$/g, '')
+				.trim();
+			if (title && body) {
+				return { title, body };
+			}
+		}
+	}
+	return null;
+}

--- a/packages/playground/website/src/github/github-export-form/form.tsx
+++ b/packages/playground/website/src/github/github-export-form/form.tsx
@@ -28,6 +28,8 @@ import {
 	mayPush,
 } from '@wp-playground/storage';
 import { oAuthState, setOAuthToken } from '../state';
+import { getAISettings, setAISettings } from '../ai-settings-state';
+import { generatePrDescription } from '../generate-pr-description';
 import { Spinner } from '../../components/spinner';
 import GitHubOAuthGuard from '../github-oauth-guard';
 import type { ContentType } from '../import-from-github';
@@ -83,6 +85,11 @@ export default function GitHubExportForm({
 	allowZipExport = true,
 }: GitHubExportFormProps) {
 	const [pushResult, setPushResult] = useState<PushResult>();
+	const [aiSettings, _setAiSettings] = useState(getAISettings());
+	const updateAiSettings = (settings: Partial<typeof aiSettings>) => {
+		setAISettings(settings);
+		_setAiSettings(getAISettings());
+	};
 	const [formValues, _setFormValues] = useState<ExportFormValues>({
 		repoUrl: '',
 		prNumber: '',
@@ -392,6 +399,23 @@ export default function GitHubExportForm({
 				new Map(Object.entries(ghComparableFiles)),
 				allPlaygroundFiles
 			);
+
+			// Propose an AI-generated PR title and description when the
+			// user opted in. Falls back to the defaults on any failure.
+			if (
+				aiSettings.useAiForPrDescription &&
+				aiSettings.openAiApiKey?.trim()
+			) {
+				const aiResult = await generatePrDescription(
+					changes,
+					aiSettings.openAiApiKey,
+					formValues.contentType
+				);
+				if (aiResult) {
+					prTitle = aiResult.title;
+					commitMessage = aiResult.body;
+				}
+			}
 
 			const pushResult = await pushToGithub(getClient(), {
 				owner: repoDetails.owner,
@@ -752,6 +776,58 @@ export default function GitHubExportForm({
 										</div>
 									)}
 								</div>
+								<div
+									className={`${forms.formGroup} ${forms.formGroupLast}`}
+								>
+									<label>
+										<input
+											type="checkbox"
+											checked={
+												aiSettings.useAiForPrDescription
+											}
+											onChange={(e) =>
+												updateAiSettings({
+													useAiForPrDescription:
+														e.target.checked,
+												})
+											}
+										/>
+										Propose a Pull Request title and
+										description with AI (uses your OpenAI
+										API key).
+									</label>
+								</div>
+								{aiSettings.useAiForPrDescription ? (
+									<div
+										className={`${forms.formGroup} ${forms.formGroupLast}`}
+									>
+										<label>
+											OpenAI API key:
+											<input
+												type="password"
+												className={css.repoInput}
+												value={
+													aiSettings.openAiApiKey ||
+													''
+												}
+												onChange={(e) =>
+													updateAiSettings({
+														openAiApiKey:
+															e.target.value,
+													})
+												}
+												placeholder="sk-..."
+											/>
+										</label>
+										<p className={css.fineprint}>
+											The key never leaves your browser
+											except for a single request to the
+											OpenAI API. Only the list of changed
+											file paths is shared, not the file
+											contents.
+										</p>
+									</div>
+								) : null}
 								{allowZipExport ? (
 									<div
 										className={`${forms.formGroup} ${forms.formGroupLast}`}

--- a/packages/playground/website/src/github/github-export-form/style.module.css
+++ b/packages/playground/website/src/github/github-export-form/style.module.css
@@ -83,3 +83,9 @@
 	width: 40px !important;
 	height: 40px !important;
 }
+
+.fineprint {
+	font-size: 13px;
+	color: #555;
+	margin: 5px 0 0;
+}


### PR DESCRIPTION
## What

- Adds an opt-in checkbox to the "Export to GitHub" form: "Propose a Pull Request title and description with AI (uses your OpenAI API key)".
- When enabled, the user supplies their own OpenAI API key. Before pushing, the export form sends a short summary of the changeset (file paths only — `gpt-4o-mini`) and uses the returned title/description for the PR.
- If the option is off, no key is provided, the request fails, or the response can't be parsed, the form falls back to the existing default title and commit message — the export flow is never blocked.

## Why

Closes #1376. Lets contributors get an AI-assisted PR title/description without leaving Playground, while keeping the feature fully optional and privacy-conscious:
- Only file *paths* are sent to OpenAI, never file contents.
- The API key is held in memory (and in `localStorage` only during local development, mirroring the existing GitHub OAuth token pattern in `state.ts`) and is sent only to `api.openai.com`.

## Testing

- Added `generate-pr-description.spec.ts` covering: missing/empty/whitespace API key (no request made), successful generation, non-ok API responses, malformed responses, fetch errors, plain-text fallback parsing, content-type context in the prompt, truncation of long file lists, and a check that file contents are never included in the request body.
- `npx nx test playground-website` — all tests pass
- `npx nx typecheck playground-website` and `npx nx lint playground-website` pass
- Manually verified in the dev server: with the option off, behavior is unchanged; with it on and a valid key, the generated title/description populate the PR fields; with it on and no/invalid key, it silently falls back to the defaults.