### PR TITLE
[Website] Stop booting interrupted browser-stored Playground saves

### DIFF
--- a/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
+++ b/packages/playground/website/src/components/blueprint-editor/BlueprintBundleEditor.tsx
@@ -408,6 +408,9 @@ export const BlueprintBundleEditor = forwardRef<
 				updateSite({
 					slug: site.slug,
 					changes: {
+						...(isAutosaved
+							? { loadedFromStorage: false }
+							: {}),
 						metadata: {
 							...site.metadata,
 							originalBlueprintSource: isAutosaved

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -25,6 +25,16 @@ describe('getSiteErrorView', () => {
 		expect(renderToStaticMarkup(view.body)).toContain(url);
 	});
 
+	it('uses generic browser-storage wording for interrupted initial OPFS syncs', () => {
+		const view = getSiteErrorView({
+			error: 'initial-opfs-sync-interrupted',
+			site: createSite(),
+			helpers,
+		});
+
+		expect(view.title).toBe('Browser storage save was interrupted');
+	});
+
 	it('says when the entire Blueprint could not be downloaded', () => {
 		const url = 'https://example.com/blueprint.json';
 		const view = getSiteErrorView({

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.spec.tsx
@@ -33,6 +33,9 @@ describe('getSiteErrorView', () => {
 		});
 
 		expect(view.title).toBe('Browser storage save was interrupted');
+		expect(renderToStaticMarkup(view.body)).toContain(
+			'the browser-storage save finished'
+		);
 	});
 
 	it('says when the entire Blueprint could not be downloaded', () => {

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -74,7 +74,7 @@ function initialOpfsSyncInterruptedView({
 	helpers,
 }: SiteErrorViewContext): SiteErrorViewConfig {
 	return {
-		title: 'Autosave was interrupted',
+		title: 'Browser storage save was interrupted',
 		isDeveloperError: false,
 		body: (
 			<>

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -58,6 +58,8 @@ export function getSiteErrorView(
 			return blueprintValidationFailedView(context);
 		case 'directory-handle-unknown-error':
 			return directoryHandleUnknownErrorView();
+		case 'initial-opfs-sync-interrupted':
+			return initialOpfsSyncInterruptedView(context);
 		case 'network-firewall-interference':
 			return networkFirewallInterferenceView(context);
 		case 'resource-download-failed':
@@ -66,6 +68,48 @@ export function getSiteErrorView(
 		default:
 			return genericSiteBootFailedView(context);
 	}
+}
+
+function initialOpfsSyncInterruptedView({
+	helpers,
+}: SiteErrorViewContext): SiteErrorViewConfig {
+	return {
+		title: 'Autosave was interrupted',
+		isDeveloperError: false,
+		body: (
+			<>
+				<p className={css.errorLead}>
+					Playground started saving this site to browser storage, but
+					the file copy did not finish.
+				</p>
+				<ul className={css.errorList}>
+					<li>
+						This can happen if the tab was closed or reloaded before
+						autosave finished.
+					</li>
+					<li>
+						It can also happen if the browser interrupted storage,
+						for example because the tab was suspended or storage
+						quota was reached.
+					</li>
+					<li>
+						Playground did not try to repair the stored files
+						because the WordPress copy may be incomplete or
+						corrupted.
+					</li>
+				</ul>
+			</>
+		),
+		actions: [
+			<Button
+				variant="primary"
+				key="reload-tab"
+				onClick={helpers.reloadWithoutBlueprint}
+			>
+				Reload Fresh Playground
+			</Button>,
+		],
+	};
 }
 
 function directoryHandlePermissionsExpiredView(): SiteErrorViewConfig {

--- a/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
+++ b/packages/playground/website/src/components/site-error-modal/get-site-error-view.tsx
@@ -85,7 +85,7 @@ function initialOpfsSyncInterruptedView({
 				<ul className={css.errorList}>
 					<li>
 						This can happen if the tab was closed or reloaded before
-						autosave finished.
+						the browser-storage save finished.
 					</li>
 					<li>
 						It can also happen if the browser interrupted storage,

--- a/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.spec.ts
@@ -1,0 +1,25 @@
+import { isTraversableFilesystemBackend } from './opfs-blueprint-bundle-storage';
+
+vi.mock('@wp-playground/storage', () => ({
+	OpfsFilesystemBackend: {},
+	copyFilesystem: vi.fn(),
+}));
+
+describe('isTraversableFilesystemBackend', () => {
+	it('requires traversal members to be functions', () => {
+		expect(
+			isTraversableFilesystemBackend({
+				read: vi.fn(),
+				listFiles: vi.fn(),
+				isDir: vi.fn(),
+			})
+		).toBe(true);
+		expect(
+			isTraversableFilesystemBackend({
+				read: true,
+				listFiles: [],
+				isDir: 'yes',
+			})
+		).toBe(false);
+	});
+});

--- a/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
@@ -22,9 +22,12 @@ export function isTraversableFilesystemBackend(
 	return (
 		typeof value === 'object' &&
 		value !== null &&
-		'read' in value &&
-		'listFiles' in value &&
-		'isDir' in value
+		typeof (value as Partial<TraversableFilesystemBackend>).read ===
+			'function' &&
+		typeof (value as Partial<TraversableFilesystemBackend>).listFiles ===
+			'function' &&
+		typeof (value as Partial<TraversableFilesystemBackend>).isDir ===
+			'function'
 	);
 }
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-blueprint-bundle-storage.ts
@@ -16,6 +16,18 @@ import { getDirectoryPathForSlug } from './opfs-site-path';
 
 export const BUNDLE_DIR_NAME = 'blueprint-bundle';
 
+export function isTraversableFilesystemBackend(
+	value: unknown
+): value is TraversableFilesystemBackend {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'read' in value &&
+		'listFiles' in value &&
+		'isDir' in value
+	);
+}
+
 /**
  * Get the OPFS path for a site's blueprint bundle directory.
  */

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -4,9 +4,13 @@ import type { opfsSiteStorage as exportedOpfsSiteStorage } from './opfs-site-sto
 describe('opfsSiteStorage', () => {
 	let opfsRoot: MemoryDirectoryHandle;
 	let storage: NonNullable<typeof exportedOpfsSiteStorage>;
+	let loadPersistedBlueprintBundle: ReturnType<typeof vi.fn>;
+	let loadPersistedBlueprintBundleFromPath: ReturnType<typeof vi.fn>;
 
 	beforeEach(async () => {
 		vi.resetModules();
+		loadPersistedBlueprintBundle = vi.fn();
+		loadPersistedBlueprintBundleFromPath = vi.fn();
 		opfsRoot = new MemoryDirectoryHandle('');
 		vi.stubGlobal('navigator', {
 			storage: {
@@ -14,8 +18,8 @@ describe('opfsSiteStorage', () => {
 			},
 		});
 		vi.doMock('./opfs-blueprint-bundle-storage', () => ({
-			loadPersistedBlueprintBundle: vi.fn(),
-			loadPersistedBlueprintBundleFromPath: vi.fn(),
+			loadPersistedBlueprintBundle,
+			loadPersistedBlueprintBundleFromPath,
 		}));
 		vi.doMock('@wp-playground/blueprints', () => ({
 			getBlueprintDeclaration: vi.fn(async (blueprint) => blueprint),
@@ -68,6 +72,22 @@ describe('opfsSiteStorage', () => {
 			sitesRoot.getDirectoryHandle('site-a%2Fb')
 		).resolves.toBeDefined();
 	});
+
+	it('loads persisted Blueprint bundles for stored bundle metadata', async () => {
+		const bundle = { read: vi.fn(), listFiles: vi.fn(), isDir: vi.fn() };
+		loadPersistedBlueprintBundle.mockResolvedValue(bundle);
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		await writeSiteMetadata(sitesRoot, 'site-bundle', 'bundle', {
+			originalBlueprintSource: {
+				type: 'opfs-site',
+			},
+		});
+
+		const site = await storage.read('bundle');
+
+		expect(loadPersistedBlueprintBundle).toHaveBeenCalledWith('bundle');
+		expect(site?.metadata.originalBlueprint).toBe(bundle);
+	});
 });
 
 async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {
@@ -77,7 +97,8 @@ async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {
 async function writeSiteMetadata(
 	sitesRoot: MemoryDirectoryHandle,
 	directoryName: string,
-	slug: string
+	slug: string,
+	metadata: Partial<SiteMetadata> = {}
 ) {
 	const siteDirectory = await sitesRoot.getDirectoryHandle(directoryName, {
 		create: true,
@@ -86,12 +107,14 @@ async function writeSiteMetadata(
 		'wp-runtime.json',
 		JSON.stringify({
 			slug,
-			...createSiteMetadata(),
+			...createSiteMetadata(metadata),
 		})
 	);
 }
 
-function createSiteMetadata(): SiteMetadata {
+function createSiteMetadata(
+	metadata: Partial<SiteMetadata> = {}
+): SiteMetadata {
 	return {
 		storage: 'opfs',
 		id: 'test-site-id',
@@ -108,6 +131,7 @@ function createSiteMetadata(): SiteMetadata {
 		originalBlueprintSource: {
 			type: 'none',
 		},
+		...metadata,
 	};
 }
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -89,26 +89,6 @@ describe('opfsSiteStorage', () => {
 		expect(loadPersistedBlueprintBundle).toHaveBeenCalledWith('bundle');
 		expect(site?.metadata.originalBlueprint).toBe(bundle);
 	});
-
-	it('tracks and clears the initial OPFS sync completion marker', async () => {
-		const sitesRoot = await getSitesRoot(opfsRoot);
-		const siteDirectory = await writeSiteMetadata(
-			sitesRoot,
-			'site-complete',
-			'complete'
-		);
-		siteDirectory.setFile('.wp-playground-initial-opfs-sync-complete', '1');
-
-		await expect(
-			storage.isInitialOpfsSyncComplete('complete')
-		).resolves.toBe(true);
-
-		await storage.resetSiteFiles('complete');
-
-		await expect(
-			storage.isInitialOpfsSyncComplete('complete')
-		).resolves.toBe(false);
-	});
 });
 
 async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {
@@ -131,7 +111,6 @@ async function writeSiteMetadata(
 			...createSiteMetadata(metadata),
 		})
 	);
-	return siteDirectory;
 }
 
 function createSiteMetadata(
@@ -199,18 +178,14 @@ class MemoryDirectoryHandle {
 		throw createDomException('NotFoundError');
 	}
 
-	async removeEntry(name: string) {
-		if (!this.children.delete(name)) {
-			throw createDomException('NotFoundError');
-		}
-	}
-
 	async *values() {
 		yield* this.children.values();
 	}
 
-	async *entries() {
-		yield* this.children.entries();
+	async removeEntry(name: string) {
+		if (!this.children.delete(name)) {
+			throw createDomException('NotFoundError');
+		}
 	}
 
 	setFile(name: string, content: string) {

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.spec.ts
@@ -18,6 +18,7 @@ describe('opfsSiteStorage', () => {
 			},
 		});
 		vi.doMock('./opfs-blueprint-bundle-storage', () => ({
+			BUNDLE_DIR_NAME: 'blueprint-bundle',
 			loadPersistedBlueprintBundle,
 			loadPersistedBlueprintBundleFromPath,
 		}));
@@ -88,6 +89,26 @@ describe('opfsSiteStorage', () => {
 		expect(loadPersistedBlueprintBundle).toHaveBeenCalledWith('bundle');
 		expect(site?.metadata.originalBlueprint).toBe(bundle);
 	});
+
+	it('tracks and clears the initial OPFS sync completion marker', async () => {
+		const sitesRoot = await getSitesRoot(opfsRoot);
+		const siteDirectory = await writeSiteMetadata(
+			sitesRoot,
+			'site-complete',
+			'complete'
+		);
+		siteDirectory.setFile('.wp-playground-initial-opfs-sync-complete', '1');
+
+		await expect(
+			storage.isInitialOpfsSyncComplete('complete')
+		).resolves.toBe(true);
+
+		await storage.resetSiteFiles('complete');
+
+		await expect(
+			storage.isInitialOpfsSyncComplete('complete')
+		).resolves.toBe(false);
+	});
 });
 
 async function getSitesRoot(opfsRoot: MemoryDirectoryHandle) {
@@ -110,6 +131,7 @@ async function writeSiteMetadata(
 			...createSiteMetadata(metadata),
 		})
 	);
+	return siteDirectory;
 }
 
 function createSiteMetadata(
@@ -138,7 +160,7 @@ function createSiteMetadata(
 class MemoryDirectoryHandle {
 	kind = 'directory' as const;
 	name: string;
-	private entries = new Map<
+	private children = new Map<
 		string,
 		MemoryDirectoryHandle | MemoryFileHandle
 	>();
@@ -151,7 +173,7 @@ class MemoryDirectoryHandle {
 		name: string,
 		options?: { create?: boolean }
 	): Promise<MemoryDirectoryHandle> {
-		const entry = this.entries.get(name);
+		const entry = this.children.get(name);
 		if (entry instanceof MemoryDirectoryHandle) {
 			return entry;
 		}
@@ -160,14 +182,14 @@ class MemoryDirectoryHandle {
 		}
 		if (options?.create) {
 			const directory = new MemoryDirectoryHandle(name);
-			this.entries.set(name, directory);
+			this.children.set(name, directory);
 			return directory;
 		}
 		throw createDomException('NotFoundError');
 	}
 
 	async getFileHandle(name: string): Promise<MemoryFileHandle> {
-		const entry = this.entries.get(name);
+		const entry = this.children.get(name);
 		if (entry instanceof MemoryFileHandle) {
 			return entry;
 		}
@@ -178,17 +200,21 @@ class MemoryDirectoryHandle {
 	}
 
 	async removeEntry(name: string) {
-		if (!this.entries.delete(name)) {
+		if (!this.children.delete(name)) {
 			throw createDomException('NotFoundError');
 		}
 	}
 
 	async *values() {
-		yield* this.entries.values();
+		yield* this.children.values();
+	}
+
+	async *entries() {
+		yield* this.children.entries();
 	}
 
 	setFile(name: string, content: string) {
-		this.entries.set(name, new MemoryFileHandle(name, content));
+		this.children.set(name, new MemoryFileHandle(name, content));
 	}
 }
 

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -34,6 +34,8 @@ export {
 
 // TODO: Decide on metadata filename
 const SITE_METADATA_FILENAME = 'wp-runtime.json';
+const INITIAL_OPFS_SYNC_COMPLETE_FILENAME =
+	'.wp-playground-initial-opfs-sync-complete';
 
 // Use a symbol to mark legacy site metadata to avoid serializing it to JSON.
 // @TODO: Remove this backcompat code after 2024-12-01.
@@ -213,6 +215,33 @@ class OpfsSiteStorage {
 		for (const name of namesToDelete) {
 			await siteDirectory.removeEntry(name, { recursive: true });
 		}
+	}
+
+	async markInitialOpfsSyncComplete(slug: string): Promise<void> {
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
+			throw new Error(`Site with slug '${slug}' does not exist.`);
+		}
+		await opfsWriteFile(
+			joinPaths(
+				OPFS_SITES_ROOT_PATH,
+				siteDirName,
+				INITIAL_OPFS_SYNC_COMPLETE_FILENAME
+			),
+			'1'
+		);
+	}
+
+	async isInitialOpfsSyncComplete(slug: string): Promise<boolean> {
+		const siteDirName = await this.findExistingSiteDirName(slug);
+		if (!siteDirName) {
+			throw new Error(`Site with slug '${slug}' does not exist.`);
+		}
+		const siteDirectory = await this.root.getDirectoryHandle(siteDirName);
+		return opfsFileExists(
+			siteDirectory,
+			INITIAL_OPFS_SYNC_COMPLETE_FILENAME
+		);
 	}
 
 	/**

--- a/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
+++ b/packages/playground/website/src/lib/state/opfs/opfs-site-storage.ts
@@ -34,8 +34,6 @@ export {
 
 // TODO: Decide on metadata filename
 const SITE_METADATA_FILENAME = 'wp-runtime.json';
-const INITIAL_OPFS_SYNC_COMPLETE_FILENAME =
-	'.wp-playground-initial-opfs-sync-complete';
 
 // Use a symbol to mark legacy site metadata to avoid serializing it to JSON.
 // @TODO: Remove this backcompat code after 2024-12-01.
@@ -215,33 +213,6 @@ class OpfsSiteStorage {
 		for (const name of namesToDelete) {
 			await siteDirectory.removeEntry(name, { recursive: true });
 		}
-	}
-
-	async markInitialOpfsSyncComplete(slug: string): Promise<void> {
-		const siteDirName = await this.findExistingSiteDirName(slug);
-		if (!siteDirName) {
-			throw new Error(`Site with slug '${slug}' does not exist.`);
-		}
-		await opfsWriteFile(
-			joinPaths(
-				OPFS_SITES_ROOT_PATH,
-				siteDirName,
-				INITIAL_OPFS_SYNC_COMPLETE_FILENAME
-			),
-			'1'
-		);
-	}
-
-	async isInitialOpfsSyncComplete(slug: string): Promise<boolean> {
-		const siteDirName = await this.findExistingSiteDirName(slug);
-		if (!siteDirName) {
-			throw new Error(`Site with slug '${slug}' does not exist.`);
-		}
-		const siteDirectory = await this.root.getDirectoryHandle(siteDirName);
-		return opfsFileExists(
-			siteDirectory,
-			INITIAL_OPFS_SYNC_COMPLETE_FILENAME
-		);
 	}
 
 	/**

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -421,8 +421,9 @@ export function bootSiteClient(
  * `initialOpfsSyncPending` means the OPFS copy never reached the point where
  * it could be trusted as a complete WordPress filesystem. A partial directory
  * can still contain `wp-config.php` and the SQLite database, so checking for
- * those files alone would boot from a corrupt snapshot. Drop the partial files
- * and let the normal first-boot path recreate WordPress, then sync it again.
+ * those files alone would boot from a corrupt snapshot. If the sync-complete
+ * marker exists, only the metadata update was interrupted. Otherwise, drop the
+ * partial files and let the normal first-boot path recreate WordPress.
  */
 async function recoverInterruptedInitialOpfsSync(
 	site: SiteInfo,
@@ -434,11 +435,31 @@ async function recoverInterruptedInitialOpfsSync(
 		getState: () => PlaygroundReduxState;
 	}
 ) {
+	const storage = opfsSiteStorage;
+	if (!storage) {
+		throw new Error(
+			'Cannot recover interrupted OPFS sync because OPFS site storage is unavailable.'
+		);
+	}
+
 	site = await recoverRemoteBlueprintBundleIfNeeded(site, {
 		dispatch,
 		getState,
 	});
-	await opfsSiteStorage!.resetSiteFiles(site.slug);
+	if (await storage.isInitialOpfsSyncComplete(site.slug)) {
+		await dispatch(
+			updateSiteMetadata({
+				slug: site.slug,
+				changes: {
+					initialOpfsSyncPending: false,
+					whenLastUsed: Date.now(),
+				},
+			})
+		);
+		return selectSiteBySlug(getState(), site.slug)!;
+	}
+
+	await storage.resetSiteFiles(site.slug);
 	return site;
 }
 
@@ -503,11 +524,16 @@ function originalUrlParamsToSearchParams(
 
 function hasBundledResource(value: unknown) {
 	const stack = [value];
+	const seen = new WeakSet<object>();
 	while (stack.length) {
 		const current = stack.pop();
 		if (!current || typeof current !== 'object') {
 			continue;
 		}
+		if (seen.has(current)) {
+			continue;
+		}
+		seen.add(current);
 		if (Array.isArray(current)) {
 			stack.push(...current);
 			continue;
@@ -564,6 +590,13 @@ async function syncInitialOpfsFilesInBackground({
 				);
 			}
 		);
+		const storage = opfsSiteStorage;
+		if (!storage) {
+			throw new Error(
+				'Cannot finish initial OPFS sync because OPFS site storage is unavailable.'
+			);
+		}
+		await storage.markInitialOpfsSyncComplete(siteSlug);
 		await dispatch(
 			updateSiteMetadata({
 				slug: siteSlug,

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -3,12 +3,7 @@ import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
 import {
 	getDirectoryPathForSlug,
 	legacyOpfsPathSymbol,
-	opfsSiteStorage,
 } from '../opfs/opfs-site-storage';
-import {
-	isTraversableFilesystemBackend,
-	persistBlueprintBundle,
-} from '../opfs/opfs-blueprint-bundle-storage';
 import {
 	addClientInfo,
 	removeClientInfo,
@@ -23,10 +18,7 @@ import {
 } from '@wp-playground/blueprints';
 import { logger } from '@php-wasm/logger';
 import { type SyncProgress, setupPostMessageRelay } from '@php-wasm/web';
-import {
-	resolveRemoteBlueprint,
-	startPlaygroundWeb,
-} from '@wp-playground/client';
+import { startPlaygroundWeb } from '@wp-playground/client';
 import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
 import { getRemoteUrl } from '../../config';
 import {
@@ -38,9 +30,7 @@ import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import {
 	isAutosavedSite,
 	selectSiteBySlug,
-	shouldResetInitialOpfsSync,
-	type SiteInfo,
-	updateSite,
+	hasInterruptedInitialOpfsSync,
 	updateSiteMetadata,
 } from './slice-sites';
 // @ts-ignore
@@ -56,7 +46,6 @@ import {
 } from './error-utils';
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
-import { applyQueryOverrides } from '../url/resolve-blueprint-from-url';
 
 export function bootSiteClient(
 	siteSlug: string,
@@ -70,7 +59,7 @@ export function bootSiteClient(
 		signal.onabort = () => {
 			dispatch(removeClientInfo(siteSlug));
 		};
-		let site = selectSiteBySlug(getState(), siteSlug);
+		const site = selectSiteBySlug(getState(), siteSlug);
 
 		let mountDescriptor = undefined;
 		if (site.metadata.storage === 'opfs') {
@@ -107,23 +96,14 @@ export function bootSiteClient(
 			} as const;
 		}
 
-		const needsInitialOpfsSync = shouldResetInitialOpfsSync(site);
-		if (needsInitialOpfsSync) {
-			try {
-				site = await recoverInterruptedInitialOpfsSync(site, {
-					dispatch,
-					getState,
-				});
-			} catch (e) {
-				logger.error(e);
-				dispatch(
-					setActiveSiteError({
-						error: 'site-boot-failed',
-						details: e,
-					})
-				);
-				return;
-			}
+		const hasInterruptedSync = hasInterruptedInitialOpfsSync(site);
+		if (hasInterruptedSync) {
+			dispatch(
+				setActiveSiteError({
+					error: 'initial-opfs-sync-interrupted',
+				})
+			);
+			return;
 		}
 
 		let isWordPressInstalled = false;
@@ -205,7 +185,10 @@ export function bootSiteClient(
 		 * Only then, on subsequent boots, we can synchronize WordPress files
 		 * back from OPFS to MEMFS.
 		 */
-		const isFirstOpfsBoot = needsInitialOpfsSync && !isWordPressInstalled;
+		const isFirstOpfsBoot =
+			site.metadata.initialOpfsSyncPending === true &&
+			site.metadata.storage === 'opfs' &&
+			!isWordPressInstalled;
 		const mounts: MountDescriptor[] = [];
 		let mountDescriptorForInitialOpfsSync: typeof mountDescriptor =
 			undefined;
@@ -416,137 +399,6 @@ export function bootSiteClient(
 }
 
 /**
- * Restarts an interrupted first OPFS sync from the saved setup recipe.
- *
- * `initialOpfsSyncPending` means the OPFS copy never reached the point where
- * it could be trusted as a complete WordPress filesystem. A partial directory
- * can still contain `wp-config.php` and the SQLite database, so checking for
- * those files alone would boot from a corrupt snapshot. If the sync-complete
- * marker exists, only the metadata update was interrupted. Otherwise, drop the
- * partial files and let the normal first-boot path recreate WordPress.
- */
-async function recoverInterruptedInitialOpfsSync(
-	site: SiteInfo,
-	{
-		dispatch,
-		getState,
-	}: {
-		dispatch: PlaygroundDispatch;
-		getState: () => PlaygroundReduxState;
-	}
-) {
-	const storage = opfsSiteStorage;
-	if (!storage) {
-		throw new Error(
-			'Cannot recover interrupted OPFS sync because OPFS site storage is unavailable.'
-		);
-	}
-
-	site = await recoverRemoteBlueprintBundleIfNeeded(site, {
-		dispatch,
-		getState,
-	});
-	if (await storage.isInitialOpfsSyncComplete(site.slug)) {
-		await dispatch(
-			updateSiteMetadata({
-				slug: site.slug,
-				changes: {
-					initialOpfsSyncPending: false,
-					whenLastUsed: Date.now(),
-				},
-			})
-		);
-		return selectSiteBySlug(getState(), site.slug)!;
-	}
-
-	await storage.resetSiteFiles(site.slug);
-	return site;
-}
-
-async function recoverRemoteBlueprintBundleIfNeeded(
-	site: SiteInfo,
-	{
-		dispatch,
-		getState,
-	}: {
-		dispatch: PlaygroundDispatch;
-		getState: () => PlaygroundReduxState;
-	}
-) {
-	const source = site.metadata.originalBlueprintSource;
-	if (
-		source?.type !== 'remote-url' ||
-		isTraversableFilesystemBackend(site.metadata.originalBlueprint) ||
-		!hasBundledResource(site.metadata.originalBlueprint)
-	) {
-		return site;
-	}
-
-	const recoveredBlueprint = await applyQueryOverrides(
-		await resolveRemoteBlueprint(source.url),
-		originalUrlParamsToSearchParams(site.originalUrlParams)
-	);
-	if (!isTraversableFilesystemBackend(recoveredBlueprint)) {
-		return site;
-	}
-	await persistBlueprintBundle(site.slug, recoveredBlueprint);
-	await dispatch(
-		updateSite({
-			slug: site.slug,
-			changes: {
-				metadata: {
-					...site.metadata,
-					originalBlueprint: recoveredBlueprint,
-					originalBlueprintSource: {
-						type: 'opfs-site',
-					},
-				},
-			},
-		})
-	);
-	return selectSiteBySlug(getState(), site.slug)!;
-}
-
-function originalUrlParamsToSearchParams(
-	originalUrlParams: SiteInfo['originalUrlParams']
-) {
-	const searchParams = new URLSearchParams();
-	for (const [key, value] of Object.entries(
-		originalUrlParams?.searchParams ?? {}
-	)) {
-		const values = Array.isArray(value) ? value : [value];
-		for (const item of values) {
-			searchParams.append(key, item);
-		}
-	}
-	return searchParams;
-}
-
-function hasBundledResource(value: unknown) {
-	const stack = [value];
-	const seen = new WeakSet<object>();
-	while (stack.length) {
-		const current = stack.pop();
-		if (!current || typeof current !== 'object') {
-			continue;
-		}
-		if (seen.has(current)) {
-			continue;
-		}
-		seen.add(current);
-		if (Array.isArray(current)) {
-			stack.push(...current);
-			continue;
-		}
-		if ((current as { resource?: unknown }).resource === 'bundled') {
-			return true;
-		}
-		stack.push(...Object.values(current));
-	}
-	return false;
-}
-
-/**
  * Copies files created during a saved site's first boot from MEMFS into OPFS.
  *
  * The iframe is already usable when this runs. Redux keeps showing sync
@@ -590,13 +442,6 @@ async function syncInitialOpfsFilesInBackground({
 				);
 			}
 		);
-		const storage = opfsSiteStorage;
-		if (!storage) {
-			throw new Error(
-				'Cannot finish initial OPFS sync because OPFS site storage is unavailable.'
-			);
-		}
-		await storage.markInitialOpfsSyncComplete(siteSlug);
 		await dispatch(
 			updateSiteMetadata({
 				slug: siteSlug,

--- a/packages/playground/website/src/lib/state/redux/boot-site-client.ts
+++ b/packages/playground/website/src/lib/state/redux/boot-site-client.ts
@@ -3,7 +3,12 @@ import { loadDirectoryHandle } from '../opfs/opfs-directory-handle-storage';
 import {
 	getDirectoryPathForSlug,
 	legacyOpfsPathSymbol,
+	opfsSiteStorage,
 } from '../opfs/opfs-site-storage';
+import {
+	isTraversableFilesystemBackend,
+	persistBlueprintBundle,
+} from '../opfs/opfs-blueprint-bundle-storage';
 import {
 	addClientInfo,
 	removeClientInfo,
@@ -18,7 +23,10 @@ import {
 } from '@wp-playground/blueprints';
 import { logger } from '@php-wasm/logger';
 import { type SyncProgress, setupPostMessageRelay } from '@php-wasm/web';
-import { startPlaygroundWeb } from '@wp-playground/client';
+import {
+	resolveRemoteBlueprint,
+	startPlaygroundWeb,
+} from '@wp-playground/client';
 import type { MountDescriptor, PlaygroundClient } from '@wp-playground/remote';
 import { getRemoteUrl } from '../../config';
 import {
@@ -30,6 +38,9 @@ import type { PlaygroundDispatch, PlaygroundReduxState } from './store';
 import {
 	isAutosavedSite,
 	selectSiteBySlug,
+	shouldResetInitialOpfsSync,
+	type SiteInfo,
+	updateSite,
 	updateSiteMetadata,
 } from './slice-sites';
 // @ts-ignore
@@ -45,6 +56,7 @@ import {
 } from './error-utils';
 import { PHPMYADMIN_INSTALL_PATH } from '@wp-playground/tools';
 import { phpExtensionQueryArgsToExtensionsArray } from '../url/php-extension-query';
+import { applyQueryOverrides } from '../url/resolve-blueprint-from-url';
 
 export function bootSiteClient(
 	siteSlug: string,
@@ -58,7 +70,7 @@ export function bootSiteClient(
 		signal.onabort = () => {
 			dispatch(removeClientInfo(siteSlug));
 		};
-		const site = selectSiteBySlug(getState(), siteSlug);
+		let site = selectSiteBySlug(getState(), siteSlug);
 
 		let mountDescriptor = undefined;
 		if (site.metadata.storage === 'opfs') {
@@ -93,6 +105,25 @@ export function bootSiteClient(
 				},
 				mountpoint: '/wordpress',
 			} as const;
+		}
+
+		const needsInitialOpfsSync = shouldResetInitialOpfsSync(site);
+		if (needsInitialOpfsSync) {
+			try {
+				site = await recoverInterruptedInitialOpfsSync(site, {
+					dispatch,
+					getState,
+				});
+			} catch (e) {
+				logger.error(e);
+				dispatch(
+					setActiveSiteError({
+						error: 'site-boot-failed',
+						details: e,
+					})
+				);
+				return;
+			}
 		}
 
 		let isWordPressInstalled = false;
@@ -174,10 +205,7 @@ export function bootSiteClient(
 		 * Only then, on subsequent boots, we can synchronize WordPress files
 		 * back from OPFS to MEMFS.
 		 */
-		const isFirstOpfsBoot =
-			site.metadata.initialOpfsSyncPending === true &&
-			site.metadata.storage === 'opfs' &&
-			!isWordPressInstalled;
+		const isFirstOpfsBoot = needsInitialOpfsSync && !isWordPressInstalled;
 		const mounts: MountDescriptor[] = [];
 		let mountDescriptorForInitialOpfsSync: typeof mountDescriptor =
 			undefined;
@@ -333,15 +361,6 @@ export function bootSiteClient(
 					: undefined,
 			})
 		);
-		// `initialOpfsSyncPending` is a recovery flag, not the source of truth.
-		// If OPFS already contains WordPress files, the initial sync either
-		// completed earlier or is no longer needed. Clear the stale flag so
-		// future boots mount OPFS normally.
-		const hasStaleInitialOpfsSyncPendingFlag =
-			site.metadata.initialOpfsSyncPending === true &&
-			site.metadata.storage === 'opfs' &&
-			isWordPressInstalled;
-
 		if (mountDescriptorForInitialOpfsSync) {
 			void syncInitialOpfsFilesInBackground({
 				playground: connectedPlayground,
@@ -355,9 +374,6 @@ export function bootSiteClient(
 				const metadataChanges = {
 					...(site.metadata.storage !== 'none'
 						? { whenLastUsed: Date.now() }
-						: {}),
-					...(hasStaleInitialOpfsSyncPendingFlag
-						? { initialOpfsSyncPending: false }
 						: {}),
 				};
 				if (Object.keys(metadataChanges).length > 0) {
@@ -397,6 +413,111 @@ export function bootSiteClient(
 
 		signal.onabort = null;
 	};
+}
+
+/**
+ * Restarts an interrupted first OPFS sync from the saved setup recipe.
+ *
+ * `initialOpfsSyncPending` means the OPFS copy never reached the point where
+ * it could be trusted as a complete WordPress filesystem. A partial directory
+ * can still contain `wp-config.php` and the SQLite database, so checking for
+ * those files alone would boot from a corrupt snapshot. Drop the partial files
+ * and let the normal first-boot path recreate WordPress, then sync it again.
+ */
+async function recoverInterruptedInitialOpfsSync(
+	site: SiteInfo,
+	{
+		dispatch,
+		getState,
+	}: {
+		dispatch: PlaygroundDispatch;
+		getState: () => PlaygroundReduxState;
+	}
+) {
+	site = await recoverRemoteBlueprintBundleIfNeeded(site, {
+		dispatch,
+		getState,
+	});
+	await opfsSiteStorage!.resetSiteFiles(site.slug);
+	return site;
+}
+
+async function recoverRemoteBlueprintBundleIfNeeded(
+	site: SiteInfo,
+	{
+		dispatch,
+		getState,
+	}: {
+		dispatch: PlaygroundDispatch;
+		getState: () => PlaygroundReduxState;
+	}
+) {
+	const source = site.metadata.originalBlueprintSource;
+	if (
+		source?.type !== 'remote-url' ||
+		isTraversableFilesystemBackend(site.metadata.originalBlueprint) ||
+		!hasBundledResource(site.metadata.originalBlueprint)
+	) {
+		return site;
+	}
+
+	const recoveredBlueprint = await applyQueryOverrides(
+		await resolveRemoteBlueprint(source.url),
+		originalUrlParamsToSearchParams(site.originalUrlParams)
+	);
+	if (!isTraversableFilesystemBackend(recoveredBlueprint)) {
+		return site;
+	}
+	await persistBlueprintBundle(site.slug, recoveredBlueprint);
+	await dispatch(
+		updateSite({
+			slug: site.slug,
+			changes: {
+				metadata: {
+					...site.metadata,
+					originalBlueprint: recoveredBlueprint,
+					originalBlueprintSource: {
+						type: 'opfs-site',
+					},
+				},
+			},
+		})
+	);
+	return selectSiteBySlug(getState(), site.slug)!;
+}
+
+function originalUrlParamsToSearchParams(
+	originalUrlParams: SiteInfo['originalUrlParams']
+) {
+	const searchParams = new URLSearchParams();
+	for (const [key, value] of Object.entries(
+		originalUrlParams?.searchParams ?? {}
+	)) {
+		const values = Array.isArray(value) ? value : [value];
+		for (const item of values) {
+			searchParams.append(key, item);
+		}
+	}
+	return searchParams;
+}
+
+function hasBundledResource(value: unknown) {
+	const stack = [value];
+	while (stack.length) {
+		const current = stack.pop();
+		if (!current || typeof current !== 'object') {
+			continue;
+		}
+		if (Array.isArray(current)) {
+			stack.push(...current);
+			continue;
+		}
+		if ((current as { resource?: unknown }).resource === 'bundled') {
+			return true;
+		}
+		stack.push(...Object.values(current));
+	}
+	return false;
 }
 
 /**

--- a/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
+++ b/packages/playground/website/src/lib/state/redux/persist-temporary-site.ts
@@ -6,7 +6,10 @@ import {
 	opfsSiteStorage,
 	getDirectoryPathForSlug,
 } from '../opfs/opfs-site-storage';
-import { persistBlueprintBundle } from '../opfs/opfs-blueprint-bundle-storage';
+import {
+	isTraversableFilesystemBackend,
+	persistBlueprintBundle,
+} from '../opfs/opfs-blueprint-bundle-storage';
 import type { TraversableFilesystemBackend } from '@wp-playground/storage';
 import type { PlaygroundReduxState } from './store';
 import type store from './store';
@@ -100,15 +103,8 @@ export function persistTemporarySite(
 		let bundleToPersist: TraversableFilesystemBackend | null = null;
 
 		const originalBlueprint = siteInfo.metadata.originalBlueprint;
-		if (
-			originalBlueprint &&
-			typeof originalBlueprint === 'object' &&
-			'read' in originalBlueprint &&
-			'listFiles' in originalBlueprint &&
-			'isDir' in originalBlueprint
-		) {
-			bundleToPersist =
-				originalBlueprint as unknown as TraversableFilesystemBackend;
+		if (isTraversableFilesystemBackend(originalBlueprint)) {
+			bundleToPersist = originalBlueprint;
 		}
 
 		let bundleWasPersisted = false;

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
@@ -3,8 +3,8 @@ import {
 	getAutosavedSitesToPrune,
 	getSitePublicPersistence,
 	getSitesSortedByRecency,
+	hasInterruptedInitialOpfsSync,
 	isAutosavedSite,
-	shouldResetInitialOpfsSync,
 	wasSiteRecentlyInteractedWith,
 } from './site-lifecycle';
 import type { SiteInfo } from './slice-sites';
@@ -135,26 +135,37 @@ describe('autosaved site helpers', () => {
 		).toBe(false);
 	});
 
-	it('resets only OPFS sites with a pending initial sync', () => {
+	it('identifies stored OPFS sites with an interrupted initial sync', () => {
 		expect(
-			shouldResetInitialOpfsSync(
+			hasInterruptedInitialOpfsSync(
 				createSite('pending-opfs', {
+					loadedFromStorage: true,
 					storage: 'opfs',
 					initialOpfsSyncPending: true,
 				})
 			)
 		).toBe(true);
 		expect(
-			shouldResetInitialOpfsSync(
+			hasInterruptedInitialOpfsSync(
+				createSite('fresh-pending-opfs', {
+					storage: 'opfs',
+					initialOpfsSyncPending: true,
+				})
+			)
+		).toBe(false);
+		expect(
+			hasInterruptedInitialOpfsSync(
 				createSite('finished-opfs', {
+					loadedFromStorage: true,
 					storage: 'opfs',
 					initialOpfsSyncPending: false,
 				})
 			)
 		).toBe(false);
 		expect(
-			shouldResetInitialOpfsSync(
+			hasInterruptedInitialOpfsSync(
 				createSite('temporary', {
+					loadedFromStorage: true,
 					storage: 'none',
 					initialOpfsSyncPending: true,
 				})
@@ -179,10 +190,13 @@ describe('site recency helpers', () => {
 
 function createSite(
 	slug: string,
-	metadata: Partial<SiteInfo['metadata']> = {}
+	options: Partial<SiteInfo['metadata']> &
+		Pick<Partial<SiteInfo>, 'loadedFromStorage'> = {}
 ): SiteInfo {
+	const { loadedFromStorage, ...metadata } = options;
 	return {
 		slug,
+		loadedFromStorage,
 		metadata: {
 			storage: 'opfs',
 			id: slug,

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
@@ -4,6 +4,7 @@ import {
 	getSitePublicPersistence,
 	getSitesSortedByRecency,
 	isAutosavedSite,
+	shouldResetInitialOpfsSync,
 	wasSiteRecentlyInteractedWith,
 } from './site-lifecycle';
 import type { SiteInfo } from './slice-sites';
@@ -130,6 +131,33 @@ describe('autosaved site helpers', () => {
 					whenLastUsed: now - RECENT_AUTOSAVE_RESTORE_WINDOW_MS - 1,
 				}),
 				now
+			)
+		).toBe(false);
+	});
+
+	it('resets only OPFS sites with a pending initial sync', () => {
+		expect(
+			shouldResetInitialOpfsSync(
+				createSite('pending-opfs', {
+					storage: 'opfs',
+					initialOpfsSyncPending: true,
+				})
+			)
+		).toBe(true);
+		expect(
+			shouldResetInitialOpfsSync(
+				createSite('finished-opfs', {
+					storage: 'opfs',
+					initialOpfsSyncPending: false,
+				})
+			)
+		).toBe(false);
+		expect(
+			shouldResetInitialOpfsSync(
+				createSite('temporary', {
+					storage: 'none',
+					initialOpfsSyncPending: true,
+				})
 			)
 		).toBe(false);
 	});

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.spec.ts
@@ -155,6 +155,15 @@ describe('autosaved site helpers', () => {
 		).toBe(false);
 		expect(
 			hasInterruptedInitialOpfsSync(
+				createSite('recreated-loaded-opfs', {
+					loadedFromStorage: false,
+					storage: 'opfs',
+					initialOpfsSyncPending: true,
+				})
+			)
+		).toBe(false);
+		expect(
+			hasInterruptedInitialOpfsSync(
 				createSite('finished-opfs', {
 					loadedFromStorage: true,
 					storage: 'opfs',

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
@@ -78,6 +78,20 @@ export function isExplicitlySavedSite(site: SiteInfo) {
 }
 
 /**
+ * Indicates whether an interrupted first OPFS sync should be rebuilt.
+ *
+ * `initialOpfsSyncPending` is cleared only after a full MEMFS-to-OPFS copy.
+ * While it remains set, the OPFS directory may contain enough files to look
+ * installed but not enough to boot reliably.
+ */
+export function shouldResetInitialOpfsSync(site: SiteInfo) {
+	return (
+		site.metadata.storage === 'opfs' &&
+		site.metadata.initialOpfsSyncPending === true
+	);
+}
+
+/**
  * Returns the persistence value exposed by the public site-management API.
  *
  * Persistence describes a stored Playground, so temporary Playgrounds do not

--- a/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
+++ b/packages/playground/website/src/lib/state/redux/site-lifecycle.ts
@@ -78,15 +78,16 @@ export function isExplicitlySavedSite(site: SiteInfo) {
 }
 
 /**
- * Indicates whether an interrupted first OPFS sync should be rebuilt.
+ * Indicates whether the restored site has an interrupted first OPFS sync.
  *
  * `initialOpfsSyncPending` is cleared only after a full MEMFS-to-OPFS copy.
- * While it remains set, the OPFS directory may contain enough files to look
- * installed but not enough to boot reliably.
+ * While it remains set on a site loaded from storage, the OPFS directory may
+ * contain enough files to look installed but not enough to boot reliably.
  */
-export function shouldResetInitialOpfsSync(site: SiteInfo) {
+export function hasInterruptedInitialOpfsSync(site: SiteInfo) {
 	return (
 		site.metadata.storage === 'opfs' &&
+		site.loadedFromStorage === true &&
 		site.metadata.initialOpfsSyncPending === true
 	);
 }

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -1,0 +1,140 @@
+describe('resetAutosavedSiteSpec', () => {
+	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
+	let resetSiteFiles: ReturnType<typeof vi.fn>;
+	let resolveRuntimeConfiguration: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.resetModules();
+		persistBlueprintBundle = vi.fn();
+		resetSiteFiles = vi.fn();
+		resolveRuntimeConfiguration = vi.fn();
+
+		vi.doMock('@php-wasm/logger', () => ({
+			logger: {
+				error: vi.fn(),
+			},
+		}));
+		vi.doMock('@wp-playground/common', () => ({
+			RecommendedPHPVersion: '8.3',
+		}));
+		vi.doMock('@wp-playground/blueprints', () => ({
+			BlueprintFetchError: class BlueprintFetchError extends Error {},
+			BlueprintReflection: {
+				create: vi.fn(async () => ({
+					getVersion: () => 2,
+				})),
+			},
+			InvalidBlueprintError: class InvalidBlueprintError extends Error {},
+			resolveRuntimeConfiguration,
+		}));
+		vi.doMock('../opfs/opfs-blueprint-bundle-storage', () => ({
+			isTraversableFilesystemBackend: (value: unknown) =>
+				typeof value === 'object' &&
+				value !== null &&
+				typeof (value as { read?: unknown }).read === 'function' &&
+				typeof (value as { listFiles?: unknown }).listFiles ===
+					'function' &&
+				typeof (value as { isDir?: unknown }).isDir === 'function',
+			persistBlueprintBundle,
+		}));
+		vi.doMock('../opfs/opfs-site-storage', () => ({
+			opfsSiteStorage: {
+				resetSiteFiles,
+			},
+		}));
+		vi.doMock('../playground-identity', () => ({
+			getAutosaveFingerprintFromURL: () => 'fingerprint',
+		}));
+		vi.doMock('../url/resolve-blueprint-from-url', () => ({
+			applyQueryOverrides: vi.fn(),
+			resolveBlueprintFromURL: vi.fn(async () => ({
+				blueprint: createBundleBlueprint(),
+				source: { type: 'inline-string' },
+			})),
+		}));
+		vi.doMock('./slice-ui', () => ({
+			setActiveSiteError: vi.fn((payload) => ({
+				type: 'ui/setActiveSiteError',
+				payload,
+			})),
+		}));
+		vi.doMock('./store', () => ({
+			selectActiveSite: vi.fn(),
+			setActiveSite: vi.fn((slug) => ({
+				type: 'ui/setActiveSite',
+				payload: slug,
+			})),
+		}));
+	});
+
+	afterEach(() => {
+		vi.doUnmock('@php-wasm/logger');
+		vi.doUnmock('@wp-playground/common');
+		vi.doUnmock('@wp-playground/blueprints');
+		vi.doUnmock('../opfs/opfs-blueprint-bundle-storage');
+		vi.doUnmock('../opfs/opfs-site-storage');
+		vi.doUnmock('../playground-identity');
+		vi.doUnmock('../url/resolve-blueprint-from-url');
+		vi.doUnmock('./slice-ui');
+		vi.doUnmock('./store');
+	});
+
+	it('does not replace a persisted bundle before validating the new setup', async () => {
+		resolveRuntimeConfiguration.mockRejectedValue(new Error('Invalid setup'));
+		const { resetAutosavedSiteSpec } = await import('./slice-sites');
+		const resetSite = resetAutosavedSiteSpec(
+			'autosaved-site',
+			new URL('https://playground.test/?blueprint-url=https://example.com')
+		);
+
+		await expect(
+			resetSite(createDispatch() as any, createGetState() as any)
+		).rejects.toThrow('Invalid setup');
+
+		expect(persistBlueprintBundle).not.toHaveBeenCalled();
+		expect(resetSiteFiles).not.toHaveBeenCalled();
+	});
+});
+
+function createGetState() {
+	return () => ({
+		sites: {
+			ids: ['autosaved-site'],
+			entities: {
+				'autosaved-site': {
+					slug: 'autosaved-site',
+					metadata: {
+						id: 'autosaved-site',
+						name: 'Autosaved site',
+						storage: 'opfs',
+						persistence: 'autosave',
+						originalBlueprint: {},
+						originalBlueprintSource: { type: 'none' },
+						runtimeConfiguration: {
+							phpVersion: '8.3',
+							wpVersion: 'latest',
+							intl: false,
+							networking: true,
+							extraLibraries: [],
+							constants: {},
+						},
+					},
+				},
+			},
+			opfsSitesLoadingState: 'loaded',
+			firstTemporarySiteCreated: false,
+		},
+	});
+}
+
+function createDispatch() {
+	return vi.fn(async (action) => action);
+}
+
+function createBundleBlueprint() {
+	return {
+		read: vi.fn(),
+		listFiles: vi.fn(),
+		isDir: vi.fn(),
+	};
+}

--- a/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.spec.ts
@@ -1,4 +1,4 @@
-describe('resetAutosavedSiteSpec', () => {
+describe('stored site specs', () => {
 	let persistBlueprintBundle: ReturnType<typeof vi.fn>;
 	let resetSiteFiles: ReturnType<typeof vi.fn>;
 	let resolveRuntimeConfiguration: ReturnType<typeof vi.fn>;
@@ -94,7 +94,35 @@ describe('resetAutosavedSiteSpec', () => {
 		expect(persistBlueprintBundle).not.toHaveBeenCalled();
 		expect(resetSiteFiles).not.toHaveBeenCalled();
 	});
+
+	it('does not persist a bundle for a new stored site before validating setup', async () => {
+		resolveRuntimeConfiguration.mockRejectedValue(new Error('Invalid setup'));
+		const { setStoredSiteSpec } = await import('./slice-sites');
+		const addSite = setStoredSiteSpec(
+			'Autosaved site',
+			new URL('https://playground.test/?blueprint-url=https://example.com'),
+			'autosaved-site',
+			{ persistence: 'autosave' }
+		);
+
+		await expect(
+			addSite(createDispatch() as any, createEmptyGetState() as any)
+		).rejects.toThrow('Invalid setup');
+
+		expect(persistBlueprintBundle).not.toHaveBeenCalled();
+	});
 });
+
+function createEmptyGetState() {
+	return () => ({
+		sites: {
+			ids: [],
+			entities: {},
+			opfsSitesLoadingState: 'loaded',
+			firstTemporarySiteCreated: false,
+		},
+	});
+}
 
 function createGetState() {
 	return () => ({

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -50,9 +50,9 @@ export {
 	getSiteRecencyTimestamp,
 	getSitesSortedByRecency,
 	getSitePublicPersistence,
+	hasInterruptedInitialOpfsSync,
 	isAutosavedSite,
 	isExplicitlySavedSite,
-	shouldResetInitialOpfsSync,
 	wasSiteRecentlyInteractedWith,
 } from './site-lifecycle';
 export type {
@@ -68,6 +68,7 @@ const DEFAULT_BLUEPRINT =
  */
 export interface SiteInfo {
 	slug: string;
+	loadedFromStorage?: boolean;
 	originalUrlParams?: {
 		searchParams?: Record<string, string | string[]>;
 		hash?: string;
@@ -137,7 +138,10 @@ export const OPFSSitesLoaded = (sites: SiteInfo[]) => {
 		const currentSites = getState().sites.entities;
 		const allSites = { ...currentSites };
 		sites.forEach((site) => {
-			allSites[site.slug] = site;
+			allSites[site.slug] = {
+				...site,
+				loadedFromStorage: true,
+			};
 		});
 		dispatch(sitesSlice.actions.setSites(allSites));
 		dispatch(setOPFSSitesLoadingState('loaded'));

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -22,6 +22,10 @@ import {
 	type ResolvedBlueprint,
 	applyQueryOverrides,
 } from '../url/resolve-blueprint-from-url';
+import {
+	isTraversableFilesystemBackend,
+	persistBlueprintBundle,
+} from '../opfs/opfs-blueprint-bundle-storage';
 import { logger } from '@php-wasm/logger';
 import { setActiveSiteError, type SiteError } from './slice-ui';
 import { RecommendedPHPVersion } from '@wp-playground/common';
@@ -48,6 +52,7 @@ export {
 	getSitePublicPersistence,
 	isAutosavedSite,
 	isExplicitlySavedSite,
+	shouldResetInitialOpfsSync,
 	wasSiteRecentlyInteractedWith,
 } from './site-lifecycle';
 export type {
@@ -568,6 +573,13 @@ export function setStoredSiteSpec(
 			preferredSlug || deriveSlugFromSiteName(slugBaseName),
 			{ unavailableSlugs: sites.map((site) => site.slug) }
 		);
+		let originalBlueprintSource = resolvedBlueprint.source!;
+		if (isTraversableFilesystemBackend(resolvedBlueprint.blueprint)) {
+			await persistBlueprintBundle(siteSlug, resolvedBlueprint.blueprint);
+			originalBlueprintSource = {
+				type: 'opfs-site',
+			};
+		}
 		const newSiteInfo: SiteInfo = {
 			slug: siteSlug,
 			originalUrlParams,
@@ -583,7 +595,7 @@ export function setStoredSiteSpec(
 					playgroundUrlWithQueryApiArgs
 				),
 				originalBlueprint: resolvedBlueprint.blueprint,
-				originalBlueprintSource: resolvedBlueprint.source!,
+				originalBlueprintSource,
 				runtimeConfiguration: await resolveRuntimeConfiguration(
 					resolvedBlueprint.blueprint
 				)!,

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -577,6 +577,9 @@ export function setStoredSiteSpec(
 			preferredSlug || deriveSlugFromSiteName(slugBaseName),
 			{ unavailableSlugs: sites.map((site) => site.slug) }
 		);
+		const runtimeConfiguration = (await resolveRuntimeConfiguration(
+			resolvedBlueprint.blueprint
+		))!;
 		let originalBlueprintSource = resolvedBlueprint.source!;
 		if (isTraversableFilesystemBackend(resolvedBlueprint.blueprint)) {
 			await persistBlueprintBundle(siteSlug, resolvedBlueprint.blueprint);
@@ -600,9 +603,7 @@ export function setStoredSiteSpec(
 				),
 				originalBlueprint: resolvedBlueprint.blueprint,
 				originalBlueprintSource,
-				runtimeConfiguration: await resolveRuntimeConfiguration(
-					resolvedBlueprint.blueprint
-				)!,
+				runtimeConfiguration,
 			},
 		};
 

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -639,6 +639,9 @@ export function resetAutosavedSiteSpec(
 		const resolvedBlueprint = await resolveSiteBlueprintFromUrl(
 			playgroundUrlWithQueryApiArgs
 		);
+		const runtimeConfiguration = (await resolveRuntimeConfiguration(
+			resolvedBlueprint.blueprint
+		))!;
 		let originalBlueprintSource = resolvedBlueprint.source!;
 		if (isTraversableFilesystemBackend(resolvedBlueprint.blueprint)) {
 			await persistBlueprintBundle(siteSlug, resolvedBlueprint.blueprint);
@@ -646,9 +649,6 @@ export function resetAutosavedSiteSpec(
 				type: 'opfs-site',
 			};
 		}
-		const runtimeConfiguration = (await resolveRuntimeConfiguration(
-			resolvedBlueprint.blueprint
-		))!;
 		// Validate the new setup before deleting the old WordPress files so a
 		// broken Blueprint URL does not destroy the existing autosave.
 		// `isAutosavedSite()` requires OPFS storage; an autosaved site cannot be

--- a/packages/playground/website/src/lib/state/redux/slice-sites.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-sites.ts
@@ -639,6 +639,13 @@ export function resetAutosavedSiteSpec(
 		const resolvedBlueprint = await resolveSiteBlueprintFromUrl(
 			playgroundUrlWithQueryApiArgs
 		);
+		let originalBlueprintSource = resolvedBlueprint.source!;
+		if (isTraversableFilesystemBackend(resolvedBlueprint.blueprint)) {
+			await persistBlueprintBundle(siteSlug, resolvedBlueprint.blueprint);
+			originalBlueprintSource = {
+				type: 'opfs-site',
+			};
+		}
 		const runtimeConfiguration = (await resolveRuntimeConfiguration(
 			resolvedBlueprint.blueprint
 		))!;
@@ -652,6 +659,7 @@ export function resetAutosavedSiteSpec(
 			updateSite({
 				slug: siteSlug,
 				changes: {
+					loadedFromStorage: false,
 					originalUrlParams: getOriginalUrlParams(
 						playgroundUrlWithQueryApiArgs
 					),
@@ -673,7 +681,7 @@ export function resetAutosavedSiteSpec(
 								playgroundUrlWithQueryApiArgs
 							),
 						originalBlueprint: resolvedBlueprint.blueprint,
-						originalBlueprintSource: resolvedBlueprint.source!,
+						originalBlueprintSource,
 						runtimeConfiguration,
 					},
 				},

--- a/packages/playground/website/src/lib/state/redux/slice-ui.ts
+++ b/packages/playground/website/src/lib/state/redux/slice-ui.ts
@@ -8,6 +8,7 @@ export type SiteError =
 	| 'directory-handle-permission-denied'
 	| 'directory-handle-directory-does-not-exist'
 	| 'directory-handle-unknown-error'
+	| 'initial-opfs-sync-interrupted'
 	// @TODO: Improve name?
 	| 'site-boot-failed'
 	| 'github-artifact-expired'


### PR DESCRIPTION
## What it does

This PR makes browser-stored Playgrounds show an interrupted-save error instead of trying to boot a WordPress directory whose first OPFS sync never finished, and preserves bundled Blueprint files so recreated sites can still use their bundled resources.

When the first MEMFS-to-OPFS copy is interrupted, Playground now shows “Browser storage save was interrupted” before mounting `/wordpress`. The user no longer gets a generic boot failure from a stored WordPress directory that was never fully copied.

When a browser-stored site is created from a Blueprint bundle, Playground stores the bundle files in that site’s OPFS directory. Later, if the site is recreated from its stored setup, `resource: "bundled"` still points at files that exist in browser storage.

## Rationale

One failure starts when a user opens a Playground URL that creates an autosaved browser-stored site, then closes or reloads the tab before the first save finishes. By that point, OPFS can already contain `wp-runtime.json` with `initialOpfsSyncPending: true`, while the `/wordpress` tree is only partly copied from MEMFS.

On the next page load, `opfsSiteStorage.list()` reads `wp-runtime.json` and adds the site to Redux. Before this PR, `bootSiteClient()` could mount that same partial OPFS directory as `/wordpress` and try to boot it. It would not boot because the initial sync never finished. The visible result was a generic boot failure from broken stored files, not a message that the browser-storage save was interrupted.

With this PR, `bootSiteClient()` checks whether an OPFS site was loaded from storage while `initialOpfsSyncPending` is still true. If so, it stops before mounting `/wordpress` and shows the dedicated interrupted-save error. Intentional autosave recreation clears `loadedFromStorage`, so a site that is being recreated on purpose can still run its first copy again.

A second failure starts with a browser-stored site created from a Blueprint bundle, such as `blueprint.json` plus `plugin.zip`. If `blueprint.json` installs `plugin.zip` through `resource: "bundled"`, saving only the Blueprint declaration loses the file the declaration points to. Before this PR, later recreation could ask the Blueprint runner for `plugin.zip`, but that file existed only in the original in-memory bundle. Recreation failed because the stored setup no longer included the bundled resource.

With this PR, the bundle is copied into the stored site's OPFS directory and recorded as `opfs-site`, so recreation reads the bundled files from OPFS. The runtime configuration is resolved before bundle files are copied, so invalid setup data does not leave stray bundle storage or replace a previous stored bundle.

## Testing instructions

```bash
npm exec nx test playground-website
npm exec nx run playground-website:typecheck
npm exec nx run playground-website:lint
```

The added tests cover interrupted initial OPFS sync detection, intentional autosave recreation, persisted Blueprint bundle loading, traversable-filesystem detection, validation before bundle persistence, and the interrupted-save error text.
